### PR TITLE
test(infra): migrate remaining service tests to ServiceTestHarness

### DIFF
--- a/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
@@ -2,42 +2,32 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Configuration;
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Legal;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Services.Legal;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
-using Humans.Application.Interfaces.Legal;
-using Humans.Application.Interfaces.Teams;
 using Humans.Infrastructure.Repositories.Legal;
 
 namespace Humans.Application.Tests.Services;
 
-public class AdminLegalDocumentServiceTests : IDisposable
+public sealed class AdminLegalDocumentServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly IDbContextFactory<HumansDbContext> _factory;
     private readonly ILegalDocumentRepository _repository;
-    private readonly FakeClock _clock;
     private readonly FakeLegalDocumentSyncService _syncService;
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly AdminLegalDocumentService _service;
     private readonly Team _team;
 
     public AdminLegalDocumentServiceTests()
+        : base(Instant.FromUtc(2026, 2, 15, 18, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _factory = new FakeDbContextFactory(options);
-        _repository = new LegalDocumentRepository(_factory);
-        _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 18, 0));
+        _repository = new LegalDocumentRepository(DbFactory);
         _syncService = new FakeLegalDocumentSyncService();
 
         _team = new Team
@@ -47,12 +37,12 @@ public class AdminLegalDocumentServiceTests : IDisposable
             Slug = "volunteers",
             IsActive = true,
             SystemTeamType = SystemTeamType.None,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
 
-        _dbContext.Teams.Add(_team);
-        _dbContext.SaveChanges();
+        Db.Teams.Add(_team);
+        Db.SaveChanges();
 
         // Team-name stitch: return the seed team when queried.
         _teamService
@@ -76,13 +66,7 @@ public class AdminLegalDocumentServiceTests : IDisposable
                 Repository = "repo",
                 Branch = "main"
             }),
-            _clock);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+            Clock);
     }
 
     [HumansFact]
@@ -167,23 +151,23 @@ public class AdminLegalDocumentServiceTests : IDisposable
         var document = await SeedDocumentAsync("Code of Conduct");
         var versionId = Guid.NewGuid();
 
-        _dbContext.DocumentVersions.Add(new DocumentVersion
+        Db.DocumentVersions.Add(new DocumentVersion
         {
             Id = versionId,
             LegalDocumentId = document.Id,
             VersionNumber = "v1",
             CommitSha = "abc123",
-            EffectiveFrom = _clock.GetCurrentInstant(),
-            CreatedAt = _clock.GetCurrentInstant()
+            EffectiveFrom = Clock.GetCurrentInstant(),
+            CreatedAt = Clock.GetCurrentInstant()
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var updated = await _service.UpdateVersionSummaryAsync(document.Id, versionId, "  Clarified scope  ");
 
         // Repository created its own DbContext via the factory; read the
         // refreshed value through a fresh context rather than the test's
         // change-tracker-polluted one.
-        await using var verifyCtx = _factory.CreateDbContext();
+        await using var verifyCtx = DbFactory.CreateDbContext();
         var version = await verifyCtx.DocumentVersions
             .AsNoTracking()
             .FirstOrDefaultAsync(v => v.Id == versionId);
@@ -217,19 +201,13 @@ public class AdminLegalDocumentServiceTests : IDisposable
             GracePeriodDays = 0,
             CurrentCommitSha = "seed",
             GitHubFolderPath = $"{name.ToLowerInvariant()}/",
-            CreatedAt = _clock.GetCurrentInstant(),
-            LastSyncedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            LastSyncedAt = Clock.GetCurrentInstant()
         };
 
-        _dbContext.LegalDocuments.Add(document);
-        await _dbContext.SaveChangesAsync();
+        Db.LegalDocuments.Add(document);
+        await Db.SaveChangesAsync();
         return document;
-    }
-
-    private sealed class FakeDbContextFactory(DbContextOptions<HumansDbContext> options)
-        : IDbContextFactory<HumansDbContext>
-    {
-        public HumansDbContext CreateDbContext() => new(options);
     }
 
     private sealed class FakeLegalDocumentSyncService : ILegalDocumentSyncService

--- a/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
@@ -2,7 +2,6 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Caching;
@@ -10,7 +9,6 @@ using Humans.Application.Services.Governance;
 using Humans.Domain;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using MemberApplication = Humans.Domain.Entities.Application;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
@@ -24,12 +22,10 @@ using Humans.Infrastructure.Repositories.Governance;
 
 namespace Humans.Application.Tests.Services;
 
-public sealed class ApplicationDecisionServiceTests : IDisposable
+public sealed class ApplicationDecisionServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
     private readonly ApplicationRepository _repository;
-    private readonly FakeClock _clock;
-    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IUserService _userService;
     private readonly IProfileService _profileService = Substitute.For<IProfileService>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
@@ -45,21 +41,9 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
 
     public ApplicationDecisionServiceTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
+        _repository = new ApplicationRepository(DbFactory);
+        _userService = NewDbBackedUserService();
 
-        _dbContext = new HumansDbContext(options);
-        _repository = new ApplicationRepository(new TestDbContextFactory(options));
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
-
-        // Default stubs — tests that need stitched user data override these.
-        _userService.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyDictionary<Guid, User>>(new Dictionary<Guid, User>()));
-        _userService.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<User?>(null));
-        _userService.StubGetUserInfosFromContext(_dbContext);
-        _userService.StubGetUserInfoFromContext(_dbContext);
         _userEmailService.GetNotificationTargetEmailsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyDictionary<Guid, string>>(new Dictionary<Guid, string>()));
@@ -78,13 +62,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
             _navBadge,
             _notificationMeter,
             _votingBadge,
-            _clock,
+            Clock,
             NullLogger<ApplicationDecisionService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
     }
 
     // --- Submit flow ---
@@ -100,7 +79,7 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
 
         result.Success.Should().BeTrue();
         result.ApplicationId.Should().NotBeNull();
-        var app = await _dbContext.Applications.FirstAsync();
+        var app = await Db.Applications.FirstAsync();
         app.MembershipTier.Should().Be(MembershipTier.Colaborador);
         app.Motivation.Should().Be("I want to contribute");
         app.Status.Should().Be(ApplicationStatus.Submitted);
@@ -115,7 +94,7 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
             userId, MembershipTier.Asociado, "Motivation",
             null, "My contribution", "I understand the role", "es");
 
-        var app = await _dbContext.Applications.FirstAsync();
+        var app = await Db.Applications.FirstAsync();
         app.SignificantContribution.Should().Be("My contribution");
         app.RoleUnderstanding.Should().Be("I understand the role");
     }
@@ -129,7 +108,7 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
             userId, MembershipTier.Colaborador, "Motivation",
             null, "Should be ignored", "Also ignored", "en");
 
-        var app = await _dbContext.Applications.FirstAsync();
+        var app = await Db.Applications.FirstAsync();
         app.SignificantContribution.Should().BeNull();
         app.RoleUnderstanding.Should().BeNull();
     }
@@ -157,7 +136,7 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
 
         result.Success.Should().BeFalse();
         result.ErrorKey.Should().Be("InvalidTier");
-        (await _dbContext.Applications.CountAsync()).Should().Be(0);
+        (await Db.Applications.CountAsync()).Should().Be(0);
     }
 
     [HumansFact]
@@ -169,7 +148,7 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
 
         result.Success.Should().BeFalse();
         result.ErrorKey.Should().Be("SignificantContributionRequired");
-        (await _dbContext.Applications.CountAsync()).Should().Be(0);
+        (await Db.Applications.CountAsync()).Should().Be(0);
     }
 
     [HumansFact]
@@ -197,8 +176,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
         var result = await _service.WithdrawAsync(app.Id, userId);
 
         result.Success.Should().BeTrue();
-        _dbContext.ChangeTracker.Clear();
-        var updated = await _dbContext.Applications.FirstAsync(a => a.Id == app.Id);
+        Db.ChangeTracker.Clear();
+        var updated = await Db.Applications.FirstAsync(a => a.Id == app.Id);
         updated.Status.Should().Be(ApplicationStatus.Withdrawn);
         _metrics.Received().RecordApplicationProcessed("withdrawn");
     }
@@ -208,8 +187,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var app = await SeedSubmittedApplicationAsync(userId);
-        app.Withdraw(_clock);
-        await _dbContext.SaveChangesAsync();
+        app.Withdraw(Clock);
+        await Db.SaveChangesAsync();
 
         var result = await _service.WithdrawAsync(app.Id, userId);
 
@@ -239,8 +218,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
         var result = await _service.ApproveAsync(app.Id, Guid.NewGuid(), "Approved", null);
 
         result.Success.Should().BeTrue();
-        _dbContext.ChangeTracker.Clear();
-        var updated = await _dbContext.Applications.FirstAsync(a => a.Id == app.Id);
+        Db.ChangeTracker.Clear();
+        var updated = await Db.Applications.FirstAsync(a => a.Id == app.Id);
         updated.Status.Should().Be(ApplicationStatus.Approved);
     }
 
@@ -251,9 +230,9 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
 
         await _service.ApproveAsync(app.Id, Guid.NewGuid(), null, null);
 
-        _dbContext.ChangeTracker.Clear();
-        var updated = await _dbContext.Applications.FirstAsync(a => a.Id == app.Id);
-        var today = _clock.GetCurrentInstant().InUtc().Date;
+        Db.ChangeTracker.Clear();
+        var updated = await Db.Applications.FirstAsync(a => a.Id == app.Id);
+        var today = Clock.GetCurrentInstant().InUtc().Date;
         var expectedExpiry = TermExpiryCalculator.ComputeTermExpiry(today);
         updated.TermExpiresAt.Should().Be(expectedExpiry);
     }
@@ -274,19 +253,19 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     public async Task ApproveAsync_DeletesBoardVotes()
     {
         var app = await SeedSubmittedApplicationAsync(Guid.NewGuid());
-        _dbContext.BoardVotes.Add(new BoardVote
+        Db.BoardVotes.Add(new BoardVote
         {
             Id = Guid.NewGuid(),
             ApplicationId = app.Id,
             BoardMemberUserId = Guid.NewGuid(),
             Vote = VoteChoice.Yay,
-            VotedAt = _clock.GetCurrentInstant()
+            VotedAt = Clock.GetCurrentInstant()
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.ApproveAsync(app.Id, Guid.NewGuid(), null, null);
 
-        var votes = await _dbContext.BoardVotes.Where(v => v.ApplicationId == app.Id).ToListAsync();
+        var votes = await Db.BoardVotes.Where(v => v.ApplicationId == app.Id).ToListAsync();
         votes.Should().BeEmpty();
     }
 
@@ -335,14 +314,14 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
         var app = await SeedSubmittedApplicationAsync(Guid.NewGuid());
         var voter1 = Guid.NewGuid();
         var voter2 = Guid.NewGuid();
-        await _dbContext.BoardVotes.AddRangeAsync(
+        await Db.BoardVotes.AddRangeAsync(
             new BoardVote
             {
                 Id = Guid.NewGuid(),
                 ApplicationId = app.Id,
                 BoardMemberUserId = voter1,
                 Vote = VoteChoice.Yay,
-                VotedAt = _clock.GetCurrentInstant()
+                VotedAt = Clock.GetCurrentInstant()
             },
             new BoardVote
             {
@@ -350,9 +329,9 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
                 ApplicationId = app.Id,
                 BoardMemberUserId = voter2,
                 Vote = VoteChoice.No,
-                VotedAt = _clock.GetCurrentInstant()
+                VotedAt = Clock.GetCurrentInstant()
             });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.ApproveAsync(app.Id, Guid.NewGuid(), null, null);
 
@@ -364,8 +343,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     public async Task ApproveAsync_NotSubmitted_ReturnsError()
     {
         var app = await SeedSubmittedApplicationAsync(Guid.NewGuid());
-        app.Withdraw(_clock);
-        await _dbContext.SaveChangesAsync();
+        app.Withdraw(Clock);
+        await Db.SaveChangesAsync();
 
         var result = await _service.ApproveAsync(app.Id, Guid.NewGuid(), null, null);
 
@@ -480,8 +459,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
         var result = await _service.RejectAsync(app.Id, Guid.NewGuid(), "Not ready", null);
 
         result.Success.Should().BeTrue();
-        _dbContext.ChangeTracker.Clear();
-        var updated = await _dbContext.Applications.FirstAsync(a => a.Id == app.Id);
+        Db.ChangeTracker.Clear();
+        var updated = await Db.Applications.FirstAsync(a => a.Id == app.Id);
         updated.Status.Should().Be(ApplicationStatus.Rejected);
         updated.DecisionNote.Should().Be("Not ready");
     }
@@ -490,19 +469,19 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     public async Task RejectAsync_DeletesBoardVotes()
     {
         var app = await SeedSubmittedApplicationAsync(Guid.NewGuid());
-        _dbContext.BoardVotes.Add(new BoardVote
+        Db.BoardVotes.Add(new BoardVote
         {
             Id = Guid.NewGuid(),
             ApplicationId = app.Id,
             BoardMemberUserId = Guid.NewGuid(),
             Vote = VoteChoice.No,
-            VotedAt = _clock.GetCurrentInstant()
+            VotedAt = Clock.GetCurrentInstant()
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.RejectAsync(app.Id, Guid.NewGuid(), "reason", null);
 
-        var votes = await _dbContext.BoardVotes.Where(v => v.ApplicationId == app.Id).ToListAsync();
+        var votes = await Db.BoardVotes.Where(v => v.ApplicationId == app.Id).ToListAsync();
         votes.Should().BeEmpty();
     }
 
@@ -535,8 +514,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     public async Task RejectAsync_NotSubmitted_ReturnsError()
     {
         var app = await SeedSubmittedApplicationAsync(Guid.NewGuid());
-        app.Withdraw(_clock);
-        await _dbContext.SaveChangesAsync();
+        app.Withdraw(Clock);
+        await Db.SaveChangesAsync();
 
         var result = await _service.RejectAsync(app.Id, Guid.NewGuid(), "reason", null);
 
@@ -556,8 +535,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
             UserId = userId,
             MembershipTier = MembershipTier.Colaborador,
             Motivation = "M1",
-            SubmittedAt = _clock.GetCurrentInstant() - Duration.FromDays(2),
-            UpdatedAt = _clock.GetCurrentInstant()
+            SubmittedAt = Clock.GetCurrentInstant() - Duration.FromDays(2),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         var app2 = new MemberApplication
         {
@@ -565,8 +544,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
             UserId = userId,
             MembershipTier = MembershipTier.Asociado,
             Motivation = "M2",
-            SubmittedAt = _clock.GetCurrentInstant() - Duration.FromDays(1),
-            UpdatedAt = _clock.GetCurrentInstant()
+            SubmittedAt = Clock.GetCurrentInstant() - Duration.FromDays(1),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         var app3 = new MemberApplication
         {
@@ -574,13 +553,13 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
             UserId = userId,
             MembershipTier = MembershipTier.Colaborador,
             Motivation = "M3",
-            SubmittedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            SubmittedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        await _dbContext.Applications.AddRangeAsync(app1, app2, app3);
-        app1.Approve(Guid.NewGuid(), "ok", _clock);
-        app2.Withdraw(_clock);
-        await _dbContext.SaveChangesAsync();
+        await Db.Applications.AddRangeAsync(app1, app2, app3);
+        app1.Approve(Guid.NewGuid(), "ok", Clock);
+        app2.Withdraw(Clock);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetUserApplicationsAsync(userId);
 
@@ -638,8 +617,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
                 new Dictionary<Guid, UserInfo> { [reviewerId] = reviewer.ToUserInfo() }));
 
         var app = await SeedSubmittedApplicationAsync(userId);
-        app.Approve(reviewerId, "Good", _clock);
-        await _dbContext.SaveChangesAsync();
+        app.Approve(reviewerId, "Good", Clock);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetUserApplicationDetailAsync(app.Id, userId);
 
@@ -672,8 +651,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var app = await SeedSubmittedApplicationAsync(userId);
-        app.Withdraw(_clock);
-        await _dbContext.SaveChangesAsync();
+        app.Withdraw(Clock);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetUserApplicationDetailAsync(app.Id, userId);
 
@@ -689,8 +668,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     {
         var submittedApp = await SeedSubmittedApplicationAsync(Guid.NewGuid());
         var approvedApp = await SeedSubmittedApplicationAsync(Guid.NewGuid());
-        approvedApp.Approve(Guid.NewGuid(), "ok", _clock);
-        await _dbContext.SaveChangesAsync();
+        approvedApp.Approve(Guid.NewGuid(), "ok", Clock);
+        await Db.SaveChangesAsync();
 
         var (items, totalCount) = await _service.GetFilteredApplicationsAsync(null, null, 1, 10);
 
@@ -705,8 +684,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     {
         await SeedSubmittedApplicationAsync(Guid.NewGuid());
         var approvedApp = await SeedSubmittedApplicationAsync(Guid.NewGuid());
-        approvedApp.Approve(Guid.NewGuid(), "ok", _clock);
-        await _dbContext.SaveChangesAsync();
+        approvedApp.Approve(Guid.NewGuid(), "ok", Clock);
+        await Db.SaveChangesAsync();
 
         var (items, totalCount) = await _service.GetFilteredApplicationsAsync("Approved", null, 1, 10);
 
@@ -811,8 +790,8 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
                 }));
 
         var app = await SeedSubmittedApplicationAsync(applicantId);
-        app.Approve(reviewerId, "Looks good", _clock);
-        await _dbContext.SaveChangesAsync();
+        app.Approve(reviewerId, "Looks good", Clock);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetApplicationDetailAsync(app.Id);
 
@@ -858,11 +837,11 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
             UserId = userId,
             MembershipTier = tier,
             Motivation = "Motivation",
-            SubmittedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            SubmittedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.Applications.Add(app);
-        await _dbContext.SaveChangesAsync();
+        Db.Applications.Add(app);
+        await Db.SaveChangesAsync();
         return app;
     }
 }

--- a/tests/Humans.Application.Tests/Services/BudgetServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/BudgetServiceTests.cs
@@ -1,60 +1,41 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Budget;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
 using BudgetServiceImpl = Humans.Application.Services.Budget.BudgetService;
 
 namespace Humans.Application.Tests.Services;
 
-public class BudgetServiceTests : IAsyncLifetime
+public sealed class BudgetServiceTests : ServiceTestHarness
 {
-    private readonly ServiceProvider _provider;
-    private readonly IDbContextFactory<HumansDbContext> _factory;
     private readonly BudgetRepository _repository;
     private readonly ITeamService _teamService;
-    private readonly FakeClock _clock;
     private readonly BudgetServiceImpl _service;
     private readonly Guid _yearId = Guid.NewGuid();
 
     public BudgetServiceTests()
+        : base(Instant.FromUtc(2026, 3, 31, 12, 0))
     {
-        var services = new ServiceCollection();
-        services.AddDbContextFactory<HumansDbContext>(options =>
-            options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
-        _provider = services.BuildServiceProvider();
-
-        _factory = _provider.GetRequiredService<IDbContextFactory<HumansDbContext>>();
-        _repository = new BudgetRepository(_factory, NullLogger<BudgetRepository>.Instance);
+        _repository = new BudgetRepository(DbFactory, NullLogger<BudgetRepository>.Instance);
         _teamService = Substitute.For<ITeamService>();
         var userService = Substitute.For<IUserService>();
         userService.GetMergedSourceIdsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(new HashSet<Guid>());
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 31, 12, 0));
 
         _service = new BudgetServiceImpl(
             _repository,
             _teamService,
             userService,
-            _clock,
+            Clock,
             NullLogger<BudgetServiceImpl>.Instance);
-    }
-
-    // xUnit v3 IAsyncLifetime: both methods return ValueTask.
-    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
-
-    public async ValueTask DisposeAsync()
-    {
-        await _provider.DisposeAsync();
     }
 
     // ─── VAT rate validation ─────────────────────────────────────────────────
@@ -133,7 +114,7 @@ public class BudgetServiceTests : IAsyncLifetime
             VatRate = 0
         };
 
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetLineItems.Add(lineItem);
             await ctx.SaveChangesAsync();
@@ -167,7 +148,7 @@ public class BudgetServiceTests : IAsyncLifetime
             Amount = 100m,
             VatRate = 0
         };
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetLineItems.Add(lineItem);
             await ctx.SaveChangesAsync();
@@ -293,7 +274,7 @@ public class BudgetServiceTests : IAsyncLifetime
         year.Name.Should().Be("Budget 2026");
         year.Status.Should().Be(BudgetYearStatus.Draft);
 
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
         var persistedYear = await ctx.BudgetYears
             .Include(y => y.Groups)
                 .ThenInclude(g => g.Categories)
@@ -325,7 +306,7 @@ public class BudgetServiceTests : IAsyncLifetime
     [HumansFact]
     public async Task UpdateYearStatusAsync_activating_closes_other_active_years()
     {
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetYears.Add(new BudgetYear
             {
@@ -346,7 +327,7 @@ public class BudgetServiceTests : IAsyncLifetime
 
         await _service.UpdateYearStatusAsync(_yearId, BudgetYearStatus.Active, Guid.NewGuid());
 
-        await using var ctx2 = await _factory.CreateDbContextAsync();
+        await using var ctx2 = await DbFactory.CreateDbContextAsync();
         var years = await ctx2.BudgetYears.ToListAsync();
 
         years.Single(y => string.Equals(y.Year, "2025", StringComparison.Ordinal)).Status
@@ -375,7 +356,7 @@ public class BudgetServiceTests : IAsyncLifetime
     [HumansFact]
     public async Task UpdateYearAsync_writes_field_audit_only_for_changed_fields()
     {
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetYears.Add(new BudgetYear
             {
@@ -389,7 +370,7 @@ public class BudgetServiceTests : IAsyncLifetime
 
         await _service.UpdateYearAsync(_yearId, "2026", "Budget Twenty Twenty Six", Guid.NewGuid());
 
-        await using var ctx2 = await _factory.CreateDbContextAsync();
+        await using var ctx2 = await DbFactory.CreateDbContextAsync();
         var auditEntries = await ctx2.BudgetAuditLogs
             .Where(a => a.BudgetYearId == _yearId)
             .ToListAsync();
@@ -403,7 +384,7 @@ public class BudgetServiceTests : IAsyncLifetime
     [HumansFact]
     public async Task DeleteYearAsync_refuses_when_year_is_active()
     {
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetYears.Add(new BudgetYear
             {
@@ -424,7 +405,7 @@ public class BudgetServiceTests : IAsyncLifetime
     [HumansFact]
     public async Task DeleteYearAsync_soft_deletes_when_draft()
     {
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetYears.Add(new BudgetYear
             {
@@ -438,7 +419,7 @@ public class BudgetServiceTests : IAsyncLifetime
 
         await _service.DeleteYearAsync(_yearId, Guid.NewGuid());
 
-        await using var ctx2 = await _factory.CreateDbContextAsync();
+        await using var ctx2 = await DbFactory.CreateDbContextAsync();
         var year = await ctx2.BudgetYears.SingleAsync(y => y.Id == _yearId);
         year.IsDeleted.Should().BeTrue();
         year.DeletedAt.Should().NotBeNull();
@@ -450,7 +431,7 @@ public class BudgetServiceTests : IAsyncLifetime
     [HumansFact]
     public async Task CreateGroupAsync_refuses_when_year_is_closed()
     {
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetYears.Add(new BudgetYear
             {
@@ -490,7 +471,7 @@ public class BudgetServiceTests : IAsyncLifetime
 
         changed.Should().BeGreaterThan(0);
 
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
         var revenueItems = await ctx.BudgetLineItems
             .Where(li => li.BudgetCategoryId == revenueCatId)
             .ToListAsync();
@@ -509,7 +490,7 @@ public class BudgetServiceTests : IAsyncLifetime
     [HumansFact]
     public async Task SyncTicketingActualsAsync_is_noop_when_no_ticketing_group()
     {
-        await using (var ctx = await _factory.CreateDbContextAsync())
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
         {
             ctx.BudgetYears.Add(new BudgetYear
             {
@@ -542,7 +523,7 @@ public class BudgetServiceTests : IAsyncLifetime
 
         created.Should().BeGreaterThan(0);
 
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
         var projectedRevenueItems = await ctx.BudgetLineItems
             .Where(li => li.BudgetCategoryId == revenueCatId
                 && li.Description.StartsWith("Projected:"))
@@ -583,7 +564,7 @@ public class BudgetServiceTests : IAsyncLifetime
 
         await _service.SyncTicketingActualsAsync(_yearId, actuals);
 
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
 
         // The projection was updated in-place before materialization.
         var projection = await ctx.TicketingProjections.SingleAsync(p => p.BudgetGroupId == groupId);
@@ -646,7 +627,7 @@ public class BudgetServiceTests : IAsyncLifetime
             Name = "Operations"
         };
 
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
         ctx.BudgetYears.Add(year);
         ctx.BudgetGroups.Add(group);
         ctx.BudgetCategories.Add(category);
@@ -663,7 +644,7 @@ public class BudgetServiceTests : IAsyncLifetime
         var revenueCatId = Guid.NewGuid();
         var feesCatId = Guid.NewGuid();
 
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
         ctx.BudgetYears.Add(new BudgetYear
         {
             Id = _yearId,
@@ -712,7 +693,7 @@ public class BudgetServiceTests : IAsyncLifetime
         decimal averageTicketPrice,
         decimal dailySalesRate)
     {
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
         var projection = await ctx.TicketingProjections.SingleAsync(p => p.BudgetGroupId == groupId);
         projection.StartDate = startDate;
         projection.EventDate = eventDate;

--- a/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
@@ -3,14 +3,11 @@ using Humans.Application.Interfaces.Camps;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Camps;
 using Humans.Infrastructure.Services.Camps;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
@@ -26,22 +23,14 @@ namespace Humans.Application.Tests.Services;
 ///   inner service instead of returning an empty list (PR #583 Codex P2).</item>
 /// </list>
 /// </summary>
-public sealed class CachingCampServiceTests : IDisposable
+public sealed class CachingCampServiceTests : ServiceTestHarness
 {
-    private readonly DbContextOptions<HumansDbContext> _options;
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 1, 12, 0));
     private readonly ServiceProvider _serviceProvider;
     private readonly ICampService _innerSubstitute;
     private readonly CachingCampService _service;
 
     public CachingCampServiceTests()
     {
-        _options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(_options);
-
         _innerSubstitute = Substitute.For<ICampService>();
         var services = new ServiceCollection();
         services.AddKeyedScoped<ICampService>(
@@ -49,18 +38,18 @@ public sealed class CachingCampServiceTests : IDisposable
             (_, _) => _innerSubstitute);
         _serviceProvider = services.BuildServiceProvider();
 
-        var repo = new CampRepository(new TestDbContextFactory(_options));
+        var repo = new CampRepository(DbFactory);
         _service = new CachingCampService(
             repo,
             _serviceProvider.GetRequiredService<IServiceScopeFactory>(),
-            _clock,
+            Clock,
             NullLogger<CachingCampService>.Instance);
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
-        _dbContext.Dispose();
         _serviceProvider.Dispose();
+        base.Dispose();
     }
 
     // ==========================================================================
@@ -90,10 +79,10 @@ public sealed class CachingCampServiceTests : IDisposable
         // call InvalidateCampAsync — this is the exact path the decorator's
         // write methods (SetEarlyEntryAsync, RemoveCampMemberAsync, …) take:
         // RefreshEntryAsync → _repo.GetByIdAsync → projection.
-        var third = _dbContext.CampMembers
+        var third = Db.CampMembers
             .First(m => m.CampSeasonId == season.Id && !m.HasEarlyEntry);
         third.HasEarlyEntry = true;
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.InvalidateCampAsync(camp.Id);
 
@@ -164,15 +153,15 @@ public sealed class CachingCampServiceTests : IDisposable
 
     private async Task SeedSettingsAsync(int publicYear, List<int> openSeasons)
     {
-        if (!await _dbContext.CampSettings.AnyAsync())
+        if (!await Db.CampSettings.AnyAsync())
         {
-            _dbContext.CampSettings.Add(new CampSettings
+            Db.CampSettings.Add(new CampSettings
             {
                 Id = Guid.Parse("00000000-0000-0000-0010-000000000001"),
                 PublicYear = publicYear,
                 OpenSeasons = openSeasons
             });
-            await _dbContext.SaveChangesAsync();
+            await Db.SaveChangesAsync();
         }
     }
 
@@ -185,8 +174,8 @@ public sealed class CachingCampServiceTests : IDisposable
             ContactEmail = "test@camp.com",
             ContactPhone = "+34600000000",
             CreatedByUserId = Guid.NewGuid(),
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant(),
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant(),
         };
         var season = new CampSeason
         {
@@ -206,27 +195,27 @@ public sealed class CachingCampServiceTests : IDisposable
             Vibes = [CampVibe.LiveMusic],
             AdultPlayspace = AdultPlayspacePolicy.No,
             MemberCount = 10,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant(),
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant(),
         };
-        _dbContext.Camps.Add(camp);
-        _dbContext.CampSeasons.Add(season);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        Db.CampSeasons.Add(season);
+        await Db.SaveChangesAsync();
         return (camp, season);
     }
 
     private async Task SeedActiveMemberAsync(Guid campSeasonId, bool hasEarlyEntry)
     {
-        _dbContext.CampMembers.Add(new CampMember
+        Db.CampMembers.Add(new CampMember
         {
             Id = Guid.NewGuid(),
             CampSeasonId = campSeasonId,
             UserId = Guid.NewGuid(),
             Status = CampMemberStatus.Active,
-            RequestedAt = _clock.GetCurrentInstant(),
-            ConfirmedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            ConfirmedAt = Clock.GetCurrentInstant(),
             HasEarlyEntry = hasEarlyEntry,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
     }
 }

--- a/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
@@ -6,43 +6,24 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Teams;
 using Humans.Infrastructure.Services.Teams;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public sealed class CachingTeamServiceTests : IDisposable
+public sealed class CachingTeamServiceTests : ServiceTestHarness
 {
-    private readonly DbContextOptions<HumansDbContext> _options;
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 1, 12, 0));
     private readonly ServiceProvider _serviceProvider;
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly CachingTeamService _service;
 
     public CachingTeamServiceTests()
     {
-        _options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(_options);
-
-        var userService = Substitute.For<IUserService>();
-        userService
-            .GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                var ids = callInfo.Arg<IReadOnlyCollection<Guid>>();
-                return Task.FromResult(LoadUsers(ids));
-            });
-        userService.StubGetUserInfosFromDb(_options);
+        var userService = NewDbBackedUserService();
 
         _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
         _roleAssignmentService
@@ -57,9 +38,8 @@ public sealed class CachingTeamServiceTests : IDisposable
             (_, _) => Substitute.For<ITeamService>());
         _serviceProvider = services.BuildServiceProvider();
 
-        ITeamRepository teamRepository = new TeamRepository(new TestDbContextFactory(_options));
         _service = new CachingTeamService(
-            teamRepository,
+            new TeamRepository(DbFactory),
             _serviceProvider.GetRequiredService<IServiceScopeFactory>(),
             NullLogger<CachingTeamService>.Instance);
     }
@@ -70,7 +50,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var user = SeedUser();
         var inactiveTeam = SeedTeam("Inactive", isActive: false);
         SeedTeamMember(inactiveTeam.Id, user.Id, TeamMemberRole.Coordinator);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.IsUserCoordinatorOfTeamAsync(inactiveTeam.Id, user.Id);
 
@@ -85,7 +65,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var child = SeedTeam("Child");
         child.ParentTeamId = inactiveParent.Id;
         SeedTeamMember(inactiveParent.Id, user.Id, TeamMemberRole.Coordinator);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.IsUserCoordinatorOfTeamAsync(child.Id, user.Id);
 
@@ -97,36 +77,24 @@ public sealed class CachingTeamServiceTests : IDisposable
     {
         var user = SeedUser("Alice");
         user.Email = null;
-        _dbContext.UserEmails.Add(new UserEmail
+        Db.UserEmails.Add(new UserEmail
         {
             Id = Guid.NewGuid(),
             UserId = user.Id,
             Email = "alice@example.test",
             IsVerified = true,
             IsPrimary = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         });
         var team = SeedTeam("Alpha");
         SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetTeamAsync(team.Id);
 
         var member = result!.Members.Should().ContainSingle().Subject;
         member.Email.Should().Be("alice@example.test");
-    }
-
-    private IReadOnlyDictionary<Guid, User> LoadUsers(IReadOnlyCollection<Guid> ids)
-    {
-        if (ids.Count == 0)
-            return new Dictionary<Guid, User>();
-
-        using var db = new HumansDbContext(_options);
-        return db.Users.AsNoTracking()
-            .Include(u => u.UserEmails)
-            .Where(u => ids.Contains(u.Id))
-            .ToDictionary(u => u.Id);
     }
 
     private User SeedUser(string displayName = "Test User")
@@ -140,7 +108,7 @@ public sealed class CachingTeamServiceTests : IDisposable
             Email = $"test-{userId}@test.com",
             PreferredLanguage = "en"
         };
-        _dbContext.Users.Add(user);
+        Db.Users.Add(user);
         return user;
     }
 
@@ -152,10 +120,10 @@ public sealed class CachingTeamServiceTests : IDisposable
             Name = name,
             Slug = name.ToLowerInvariant().Replace(" ", "-"),
             IsActive = isActive,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
         return team;
     }
 
@@ -167,9 +135,9 @@ public sealed class CachingTeamServiceTests : IDisposable
             TeamId = teamId,
             UserId = userId,
             Role = role,
-            JoinedAt = _clock.GetCurrentInstant()
+            JoinedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.TeamMembers.Add(member);
+        Db.TeamMembers.Add(member);
         return member;
     }
 
@@ -181,7 +149,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var team2 = SeedTeam("Beta");
         SeedTeamMember(team1.Id, user.Id, TeamMemberRole.Member);
         SeedTeamMember(team2.Id, user.Id, TeamMemberRole.Coordinator);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetUserTeamsAsync(user.Id);
 
@@ -197,8 +165,8 @@ public sealed class CachingTeamServiceTests : IDisposable
         var user = SeedUser("Alice");
         var team = SeedTeam("Alpha");
         var member = SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
-        member.LeftAt = _clock.GetCurrentInstant();
-        await _dbContext.SaveChangesAsync();
+        member.LeftAt = Clock.GetCurrentInstant();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetUserTeamsAsync(user.Id);
 
@@ -213,7 +181,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var child = SeedTeam("Logo");
         child.ParentTeamId = parent.Id;
         SeedTeamMember(child.Id, user.Id, TeamMemberRole.Member);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetUserTeamsAsync(user.Id);
 
@@ -232,7 +200,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var user = SeedUser("Alice");
         var team = SeedTeam("Alpha");
         SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Warm the cache + inverse index.
         var before = await _service.GetUserTeamsAsync(user.Id);
@@ -242,7 +210,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         // real path where mutation methods call InvalidateTeamsCache().
         var team2 = SeedTeam("Beta");
         SeedTeamMember(team2.Id, user.Id, TeamMemberRole.Coordinator);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         _service.InvalidateActiveTeamsCache();
 
         var after = await _service.GetUserTeamsAsync(user.Id);
@@ -264,7 +232,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         SeedTeamMember(t1.Id, bob.Id, TeamMemberRole.Member);
         SeedTeamMember(t2.Id, alice.Id, TeamMemberRole.Coordinator);
         SeedTeamMember(t3.Id, carol.Id, TeamMemberRole.Member);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var aliceTeams = (await _service.GetUserTeamsAsync(alice.Id))
             .Select(m => m.TeamId).ToHashSet();
@@ -284,7 +252,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var user = SeedUser("Alice");
         var team = SeedTeam("Alpha");
         SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // First call drives warmup (which uses repository, not inner service).
         await _service.GetUserTeamsAsync(user.Id);
@@ -304,7 +272,7 @@ public sealed class CachingTeamServiceTests : IDisposable
     public async Task GetUserTeamsAsync_UnknownUser_ReturnsEmptyWithoutInnerCall()
     {
         var team = SeedTeam("Alpha");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetUserTeamsAsync(Guid.NewGuid());
 
@@ -329,7 +297,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         SeedTeamMember(systemTeam.Id, user.Id, TeamMemberRole.Coordinator);
         SeedJoinRequest(managedTeam.Id, SeedUser("Requester A").Id);
         SeedJoinRequest(systemTeam.Id, SeedUser("Requester B").Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMyTeamMembershipsAsync(user.Id);
 
@@ -350,7 +318,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var team = SeedTeam("Alpha");
         SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
         SeedJoinRequest(team.Id, SeedUser("Requester").Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMyTeamMembershipsAsync(user.Id);
 
@@ -370,7 +338,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         SeedJoinRequest(department.Id, SeedUser("Direct Requester").Id);
         SeedJoinRequest(child.Id, SeedUser("Child Requester A").Id);
         SeedJoinRequest(child.Id, SeedUser("Child Requester B").Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMyTeamMembershipsAsync(user.Id);
 
@@ -393,7 +361,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         SeedTeamMember(parent.Id, user.Id, TeamMemberRole.Coordinator);
         SeedTeamMember(child.Id, user.Id, TeamMemberRole.Member);
         SeedJoinRequest(child.Id, SeedUser("Child Requester").Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMyTeamMembershipsAsync(user.Id);
 
@@ -409,7 +377,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var team = SeedTeam("Alpha");
         SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
         SeedJoinRequest(team.Id, SeedUser("Requester").Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMyTeamMembershipsAsync(user.Id);
 
@@ -425,7 +393,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var child = SeedTeam("Logo");
         child.ParentTeamId = parent.Id;
         SeedTeamMember(child.Id, user.Id, TeamMemberRole.Member);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMyTeamMembershipsAsync(user.Id);
 
@@ -440,7 +408,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var team = SeedTeam("Alpha");
         SeedTeamMember(team.Id, user.Id, TeamMemberRole.Coordinator);
         SeedJoinRequest(team.Id, SeedUser("Requester").Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Drive a first call to warm the cache (which uses the repository, not
         // the inner service).
@@ -468,7 +436,7 @@ public sealed class CachingTeamServiceTests : IDisposable
     public async Task RequestToJoinTeamAsync_InvalidatesCache()
     {
         var team = SeedTeam("Alpha");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Warm the cache so we can observe invalidation by counter.
         await _service.GetTeamAsync(team.Id);
@@ -483,7 +451,7 @@ public sealed class CachingTeamServiceTests : IDisposable
     public async Task WithdrawJoinRequestAsync_InvalidatesCache()
     {
         var team = SeedTeam("Alpha");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         await _service.GetTeamAsync(team.Id);
         var before = _service.BulkInvalidations;
 
@@ -496,7 +464,7 @@ public sealed class CachingTeamServiceTests : IDisposable
     public async Task RejectJoinRequestAsync_InvalidatesCache()
     {
         var team = SeedTeam("Alpha");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         await _service.GetTeamAsync(team.Id);
         var before = _service.BulkInvalidations;
 
@@ -509,7 +477,7 @@ public sealed class CachingTeamServiceTests : IDisposable
     public async Task ApproveJoinRequestAsync_InvalidatesCache()
     {
         var team = SeedTeam("Alpha");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         await _service.GetTeamAsync(team.Id);
         var before = _service.BulkInvalidations;
 
@@ -526,7 +494,7 @@ public sealed class CachingTeamServiceTests : IDisposable
         var team = SeedTeam("Alpha");
         SeedJoinRequest(team.Id, SeedUser("Requester A").Id);
         SeedJoinRequest(team.Id, SeedUser("Requester B").Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var info = await _service.GetTeamAsync(team.Id);
 
@@ -542,15 +510,15 @@ public sealed class CachingTeamServiceTests : IDisposable
             TeamId = teamId,
             UserId = userId,
             Status = TeamJoinRequestStatus.Pending,
-            RequestedAt = _clock.GetCurrentInstant()
+            RequestedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.TeamJoinRequests.Add(request);
+        Db.TeamJoinRequests.Add(request);
         return request;
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
-        _dbContext.Dispose();
         _serviceProvider.Dispose();
+        base.Dispose();
     }
 }

--- a/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
@@ -9,22 +9,17 @@ using Humans.Application.Services.Camps;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Camps;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public class CampRoleServiceTests : IDisposable
+public sealed class CampRoleServiceTests : ServiceTestHarness
 {
-    private readonly DbContextOptions<HumansDbContext> _options;
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly CampRoleService _service;
     private readonly IAuditLogService _auditLog;
     private readonly IUserService _userService;
@@ -34,20 +29,15 @@ public class CampRoleServiceTests : IDisposable
     private readonly Guid _actorUserId = Guid.NewGuid();
 
     public CampRoleServiceTests()
+        : base(Instant.FromUtc(2026, 4, 26, 12, 0))
     {
-        _options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(_options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 4, 26, 12, 0));
         _auditLog = Substitute.For<IAuditLogService>();
         _userService = Substitute.For<IUserService>();
         _userEmailService = Substitute.For<IUserEmailService>();
         _notificationEmitter = Substitute.For<INotificationEmitter>();
         _campService = Substitute.For<ICampService>();
 
-        var factory = new TestDbContextFactory(_options);
-        var repo = new CampRoleRepository(factory);
+        var repo = new CampRoleRepository(DbFactory);
 
         _service = new CampRoleService(
             repo,
@@ -57,14 +47,8 @@ public class CampRoleServiceTests : IDisposable
             _auditLog,
             _notificationEmitter,
             Options.Create(new GoogleWorkspaceOptions { Domain = "nobodies.team" }),
-            _clock,
+            Clock,
             NullLogger<CampRoleService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -266,7 +250,7 @@ public class CampRoleServiceTests : IDisposable
 
         outcome.Should().Be(AssignCampRoleOutcome.Assigned);
 
-        var assignments = await _dbContext.CampRoleAssignments.AsNoTracking().ToListAsync();
+        var assignments = await Db.CampRoleAssignments.AsNoTracking().ToListAsync();
         assignments.Should().HaveCount(1);
         assignments[0].CampMemberId.Should().Be(member.Id);
 
@@ -298,7 +282,7 @@ public class CampRoleServiceTests : IDisposable
         var outcome = await _service.AssignAsync(season.Id, def.Id, member.Id, _actorUserId);
 
         outcome.Should().Be(AssignCampRoleOutcome.MemberNotActive);
-        (await _dbContext.CampRoleAssignments.CountAsync()).Should().Be(0);
+        (await Db.CampRoleAssignments.CountAsync()).Should().Be(0);
     }
 
     [HumansFact]
@@ -382,12 +366,12 @@ public class CampRoleServiceTests : IDisposable
             .Returns(new CampMemberLookup(season.Id, member.UserId, CampMemberStatus.Active));
 
         await _service.AssignAsync(season.Id, def.Id, member.Id, _actorUserId);
-        var assignment = await _dbContext.CampRoleAssignments.FirstAsync();
+        var assignment = await Db.CampRoleAssignments.FirstAsync();
 
         var ok = await _service.UnassignAsync(assignment.Id, _actorUserId);
 
         ok.Should().BeTrue();
-        (await _dbContext.CampRoleAssignments.CountAsync()).Should().Be(0);
+        (await Db.CampRoleAssignments.CountAsync()).Should().Be(0);
 
         await _auditLog.Received(1).LogAsync(
             AuditAction.CampRoleUnassigned, nameof(CampRoleAssignment),
@@ -410,17 +394,17 @@ public class CampRoleServiceTests : IDisposable
         var member1 = await SeedActiveMemberAsync(season.Id);
         var member2 = await SeedActiveMemberAsync(season.Id);
 
-        _dbContext.CampRoleAssignments.Add(
+        Db.CampRoleAssignments.Add(
             new CampRoleAssignment
             {
                 Id = Guid.NewGuid(),
                 CampSeasonId = season.Id,
                 CampRoleDefinitionId = def1.Id,
                 CampMemberId = member1.Id,
-                AssignedAt = _clock.GetCurrentInstant(),
+                AssignedAt = Clock.GetCurrentInstant(),
                 AssignedByUserId = _actorUserId
             });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var users = new Dictionary<Guid, User>
         {
@@ -455,10 +439,10 @@ public class CampRoleServiceTests : IDisposable
         var m1 = await SeedActiveMemberAsync(season.Id);
         var m2 = await SeedActiveMemberAsync(season.Id);
 
-        await _dbContext.CampRoleAssignments.AddRangeAsync(
-            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def.Id, CampMemberId = m1.Id, AssignedAt = _clock.GetCurrentInstant(), AssignedByUserId = _actorUserId },
-            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def.Id, CampMemberId = m2.Id, AssignedAt = _clock.GetCurrentInstant(), AssignedByUserId = _actorUserId });
-        await _dbContext.SaveChangesAsync();
+        await Db.CampRoleAssignments.AddRangeAsync(
+            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def.Id, CampMemberId = m1.Id, AssignedAt = Clock.GetCurrentInstant(), AssignedByUserId = _actorUserId },
+            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def.Id, CampMemberId = m2.Id, AssignedAt = Clock.GetCurrentInstant(), AssignedByUserId = _actorUserId });
+        await Db.SaveChangesAsync();
 
         var users = new Dictionary<Guid, User>
         {
@@ -487,9 +471,9 @@ public class CampRoleServiceTests : IDisposable
         var consent = await SeedDefinitionAsync("Consent Lead", slotCount: 2, minimumRequired: 1);
         var member = await SeedActiveMemberAsync(season.Id);
 
-        _dbContext.CampRoleAssignments.Add(
-            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = consent.Id, CampMemberId = member.Id, AssignedAt = _clock.GetCurrentInstant(), AssignedByUserId = _actorUserId });
-        await _dbContext.SaveChangesAsync();
+        Db.CampRoleAssignments.Add(
+            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = consent.Id, CampMemberId = member.Id, AssignedAt = Clock.GetCurrentInstant(), AssignedByUserId = _actorUserId });
+        await Db.SaveChangesAsync();
 
         _campService.GetCampSeasonsForComplianceAsync(2026, CancellationToken.None)
             .Returns([(camp.Id, season.Name, camp.Slug, season.Id)]);
@@ -541,15 +525,15 @@ public class CampRoleServiceTests : IDisposable
         var def2 = await SeedDefinitionAsync("LNT");
         var member = await SeedActiveMemberAsync(season.Id);
 
-        await _dbContext.CampRoleAssignments.AddRangeAsync(
-            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def1.Id, CampMemberId = member.Id, AssignedAt = _clock.GetCurrentInstant(), AssignedByUserId = _actorUserId },
-            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def2.Id, CampMemberId = member.Id, AssignedAt = _clock.GetCurrentInstant(), AssignedByUserId = _actorUserId });
-        await _dbContext.SaveChangesAsync();
+        await Db.CampRoleAssignments.AddRangeAsync(
+            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def1.Id, CampMemberId = member.Id, AssignedAt = Clock.GetCurrentInstant(), AssignedByUserId = _actorUserId },
+            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = def2.Id, CampMemberId = member.Id, AssignedAt = Clock.GetCurrentInstant(), AssignedByUserId = _actorUserId });
+        await Db.SaveChangesAsync();
 
         var deletedCount = await _service.RemoveAllForMemberAsync(member.Id, _actorUserId);
 
         deletedCount.Should().Be(2);
-        (await _dbContext.CampRoleAssignments.CountAsync()).Should().Be(0);
+        (await Db.CampRoleAssignments.CountAsync()).Should().Be(0);
     }
 
     // ==========================================================================
@@ -563,16 +547,16 @@ public class CampRoleServiceTests : IDisposable
         var def = await SeedDefinitionAsync("Consent Lead", slug: "consent-lead");
         var member = await SeedActiveMemberAsync(season.Id);
 
-        _dbContext.CampRoleAssignments.Add(new CampRoleAssignment
+        Db.CampRoleAssignments.Add(new CampRoleAssignment
         {
             Id = Guid.NewGuid(),
             CampSeasonId = season.Id,
             CampRoleDefinitionId = def.Id,
             CampMemberId = member.Id,
-            AssignedAt = _clock.GetCurrentInstant(),
+            AssignedAt = Clock.GetCurrentInstant(),
             AssignedByUserId = _actorUserId,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _campService.GetSettingsAsync(Arg.Any<CancellationToken>())
             .Returns(new CampSettingsInfo(
@@ -594,16 +578,16 @@ public class CampRoleServiceTests : IDisposable
         var def = await SeedDefinitionAsync("Old", slug: "old", deactivated: true);
         var member = await SeedActiveMemberAsync(season.Id);
 
-        _dbContext.CampRoleAssignments.Add(new CampRoleAssignment
+        Db.CampRoleAssignments.Add(new CampRoleAssignment
         {
             Id = Guid.NewGuid(),
             CampSeasonId = season.Id,
             CampRoleDefinitionId = def.Id,
             CampMemberId = member.Id,
-            AssignedAt = _clock.GetCurrentInstant(),
+            AssignedAt = Clock.GetCurrentInstant(),
             AssignedByUserId = _actorUserId,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _campService.GetSettingsAsync(Arg.Any<CancellationToken>())
             .Returns(new CampSettingsInfo(
@@ -627,16 +611,16 @@ public class CampRoleServiceTests : IDisposable
         var def = await SeedDefinitionAsync("No Slug Yet", slug: "");
         var member = await SeedActiveMemberAsync(season.Id);
 
-        _dbContext.CampRoleAssignments.Add(new CampRoleAssignment
+        Db.CampRoleAssignments.Add(new CampRoleAssignment
         {
             Id = Guid.NewGuid(),
             CampSeasonId = season.Id,
             CampRoleDefinitionId = def.Id,
             CampMemberId = member.Id,
-            AssignedAt = _clock.GetCurrentInstant(),
+            AssignedAt = Clock.GetCurrentInstant(),
             AssignedByUserId = _actorUserId,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _campService.GetSettingsAsync(Arg.Any<CancellationToken>())
             .Returns(new CampSettingsInfo(
@@ -664,21 +648,21 @@ public class CampRoleServiceTests : IDisposable
             CampSeasonId = season.Id,
             UserId = Guid.NewGuid(),
             Status = CampMemberStatus.Removed,
-            RequestedAt = _clock.GetCurrentInstant(),
-            RemovedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            RemovedAt = Clock.GetCurrentInstant(),
         };
-        _dbContext.CampMembers.Add(inactiveMember);
+        Db.CampMembers.Add(inactiveMember);
 
         var activeMember = await SeedActiveMemberAsync(season.Id);
 
-        await _dbContext.CampRoleAssignments.AddRangeAsync(
+        await Db.CampRoleAssignments.AddRangeAsync(
             new CampRoleAssignment
             {
                 Id = Guid.NewGuid(),
                 CampSeasonId = season.Id,
                 CampRoleDefinitionId = def.Id,
                 CampMemberId = inactiveMember.Id,
-                AssignedAt = _clock.GetCurrentInstant(),
+                AssignedAt = Clock.GetCurrentInstant(),
                 AssignedByUserId = _actorUserId,
             },
             new CampRoleAssignment
@@ -687,10 +671,10 @@ public class CampRoleServiceTests : IDisposable
                 CampSeasonId = season.Id,
                 CampRoleDefinitionId = def.Id,
                 CampMemberId = activeMember.Id,
-                AssignedAt = _clock.GetCurrentInstant(),
+                AssignedAt = Clock.GetCurrentInstant(),
                 AssignedByUserId = _actorUserId,
             });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _campService.GetSettingsAsync(Arg.Any<CancellationToken>())
             .Returns(new CampSettingsInfo(
@@ -721,12 +705,12 @@ public class CampRoleServiceTests : IDisposable
             Slug = slug ?? Humans.Application.Helpers.SlugHelper.GenerateSlug(name) + "-" + Guid.NewGuid().ToString("N").Substring(0, 6),
             SlotCount = slotCount,
             MinimumRequired = minimumRequired,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant(),
-            DeactivatedAt = deactivated ? _clock.GetCurrentInstant() : null,
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant(),
+            DeactivatedAt = deactivated ? Clock.GetCurrentInstant() : null,
         };
-        _dbContext.CampRoleDefinitions.Add(def);
-        await _dbContext.SaveChangesAsync();
+        Db.CampRoleDefinitions.Add(def);
+        await Db.SaveChangesAsync();
         return def;
     }
 
@@ -745,9 +729,9 @@ public class CampRoleServiceTests : IDisposable
             Name = "Test Camp",
             Status = CampSeasonStatus.Active,
         };
-        _dbContext.Camps.Add(camp);
-        _dbContext.CampSeasons.Add(season);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        Db.CampSeasons.Add(season);
+        await Db.SaveChangesAsync();
         return (camp, season);
     }
 
@@ -759,12 +743,12 @@ public class CampRoleServiceTests : IDisposable
             CampSeasonId = seasonId,
             UserId = userId ?? Guid.NewGuid(),
             Status = CampMemberStatus.Active,
-            RequestedAt = _clock.GetCurrentInstant(),
-            ConfirmedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            ConfirmedAt = Clock.GetCurrentInstant(),
             ConfirmedByUserId = _actorUserId,
         };
-        _dbContext.CampMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        Db.CampMembers.Add(member);
+        await Db.SaveChangesAsync();
         return member;
     }
 }

--- a/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
@@ -9,20 +9,16 @@ using Humans.Application.Services.Camps;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Camps;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public class CampServiceEarlyEntryTests : IDisposable
+public sealed class CampServiceEarlyEntryTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly CampService _service;
     private readonly IAuditLogService _auditLog;
     private readonly IUserService _userService;
@@ -31,32 +27,15 @@ public class CampServiceEarlyEntryTests : IDisposable
     private readonly ICampRoleService _campRoleService;
 
     public CampServiceEarlyEntryTests()
+        : base(Instant.FromUtc(2026, 3, 13, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 13, 12, 0));
         _auditLog = Substitute.For<IAuditLogService>();
         _fileStorage = new InMemoryFileStorage();
 
-        var factory = new TestDbContextFactory(options);
-        var repo = new CampRepository(factory);
-        var roleRepo = new CampRoleRepository(factory);
+        var repo = new CampRepository(DbFactory);
+        var roleRepo = new CampRoleRepository(DbFactory);
 
-        // IUserService substitute — returns seeded users from the shared in-memory db.
-        _userService = Substitute.For<IUserService>();
-        _userService.GetByIdsAsync(
-            Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var ids = call.Arg<IReadOnlyCollection<Guid>>();
-                using var ctx = new HumansDbContext(options);
-                var users = ctx.Users.AsNoTracking().Where(u => ids.Contains(u.Id)).ToList();
-                return Task.FromResult<IReadOnlyDictionary<Guid, User>>(
-                    users.ToDictionary(u => u.Id));
-            });
-        _userService.StubGetUserInfosFromDb(options);
+        _userService = NewDbBackedUserService();
 
         _notificationEmitter = Substitute.For<INotificationEmitter>();
 
@@ -74,14 +53,8 @@ public class CampServiceEarlyEntryTests : IDisposable
             _notificationEmitter,
             Substitute.For<ICampLeadJoinRequestsBadgeCacheInvalidator>(),
             new Lazy<ICampRoleService>(() => _campRoleService),
-            _clock,
+            Clock,
             NullLogger<CampService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     // ==========================================================================
@@ -120,7 +93,7 @@ public class CampServiceEarlyEntryTests : IDisposable
 
         await _service.SetCampSeasonEeSlotCountAsync(season.Id, 13, actor);
 
-        var reloaded = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
+        var reloaded = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
         reloaded.EeSlotCount.Should().Be(13);
 
         await _auditLog.Received(1).LogAsync(
@@ -142,11 +115,11 @@ public class CampServiceEarlyEntryTests : IDisposable
         var actor = Guid.NewGuid();
         await _service.SetCampSeasonEeSlotCountAsync(season.Id, 3, actor);
 
-        var reloaded = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
+        var reloaded = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
         reloaded.EeSlotCount.Should().Be(3);
 
         // Existing grants persist — no auto-revoke.
-        var grantedCount = await _dbContext.CampMembers
+        var grantedCount = await Db.CampMembers
             .CountAsync(m => m.CampSeasonId == season.Id
                           && m.HasEarlyEntry
                           && m.Status == CampMemberStatus.Active);
@@ -159,15 +132,15 @@ public class CampServiceEarlyEntryTests : IDisposable
 
     private async Task SeedSettingsAsync()
     {
-        if (!await _dbContext.CampSettings.AnyAsync())
+        if (!await Db.CampSettings.AnyAsync())
         {
-            _dbContext.CampSettings.Add(new CampSettings
+            Db.CampSettings.Add(new CampSettings
             {
                 Id = Guid.Parse("00000000-0000-0000-0010-000000000001"),
                 PublicYear = 2026,
                 OpenSeasons = [2026]
             });
-            await _dbContext.SaveChangesAsync();
+            await Db.SaveChangesAsync();
         }
     }
 
@@ -180,8 +153,8 @@ public class CampServiceEarlyEntryTests : IDisposable
             ContactEmail = "test@camp.com",
             ContactPhone = "+34600000000",
             CreatedByUserId = Guid.NewGuid(),
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant(),
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant(),
         };
         var season = new CampSeason
         {
@@ -205,12 +178,12 @@ public class CampServiceEarlyEntryTests : IDisposable
             SpaceRequirement = SpaceSize.Sqm600,
             SoundZone = SoundZone.Yellow,
             ElectricalGrid = ElectricalGrid.Yellow,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant(),
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant(),
         };
-        _dbContext.Camps.Add(camp);
-        _dbContext.CampSeasons.Add(season);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        Db.CampSeasons.Add(season);
+        await Db.SaveChangesAsync();
         return (camp, season);
     }
 
@@ -222,12 +195,12 @@ public class CampServiceEarlyEntryTests : IDisposable
             CampSeasonId = campSeasonId,
             UserId = Guid.NewGuid(),
             Status = CampMemberStatus.Active,
-            RequestedAt = _clock.GetCurrentInstant(),
-            ConfirmedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            ConfirmedAt = Clock.GetCurrentInstant(),
             HasEarlyEntry = true,
         };
-        _dbContext.CampMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        Db.CampMembers.Add(member);
+        await Db.SaveChangesAsync();
         return member;
     }
 
@@ -239,12 +212,12 @@ public class CampServiceEarlyEntryTests : IDisposable
             CampSeasonId = campSeasonId,
             UserId = Guid.NewGuid(),
             Status = CampMemberStatus.Active,
-            RequestedAt = _clock.GetCurrentInstant(),
-            ConfirmedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            ConfirmedAt = Clock.GetCurrentInstant(),
             HasEarlyEntry = false,
         };
-        _dbContext.CampMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        Db.CampMembers.Add(member);
+        await Db.SaveChangesAsync();
         return member;
     }
 
@@ -263,7 +236,7 @@ public class CampServiceEarlyEntryTests : IDisposable
         var outcome = await _service.SetEarlyEntryAsync(camp.Id, member.Id, granted: true, actor);
 
         outcome.Should().Be(SetEarlyEntryOutcome.Success);
-        var reloaded = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
         reloaded.HasEarlyEntry.Should().BeTrue();
 
         await _auditLog.Received(1).LogAsync(
@@ -284,7 +257,7 @@ public class CampServiceEarlyEntryTests : IDisposable
         var outcome = await _service.SetEarlyEntryAsync(camp.Id, member.Id, granted: false, actor);
 
         outcome.Should().Be(SetEarlyEntryOutcome.Success);
-        var reloaded = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
         reloaded.HasEarlyEntry.Should().BeFalse();
 
         await _auditLog.Received(1).LogAsync(
@@ -307,7 +280,7 @@ public class CampServiceEarlyEntryTests : IDisposable
 
         outcome.Should().Be(SetEarlyEntryOutcome.SlotCapExceeded);
 
-        var reloaded = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == newMember.Id);
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == newMember.Id);
         reloaded.HasEarlyEntry.Should().BeFalse();
 
         await _auditLog.DidNotReceive().LogAsync(
@@ -328,16 +301,16 @@ public class CampServiceEarlyEntryTests : IDisposable
             CampSeasonId = season.Id,
             UserId = Guid.NewGuid(),
             Status = CampMemberStatus.Pending,
-            RequestedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
         };
-        _dbContext.CampMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        Db.CampMembers.Add(member);
+        await Db.SaveChangesAsync();
 
         var outcome = await _service.SetEarlyEntryAsync(camp.Id, member.Id, granted: true, Guid.NewGuid());
 
         outcome.Should().Be(SetEarlyEntryOutcome.MemberNotActive);
 
-        var reloaded = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
         reloaded.HasEarlyEntry.Should().BeFalse();
     }
 
@@ -373,7 +346,7 @@ public class CampServiceEarlyEntryTests : IDisposable
 
         outcome.Should().Be(SetEarlyEntryOutcome.MemberNotFound);
 
-        var reloaded = await _dbContext.CampMembers.AsNoTracking()
+        var reloaded = await Db.CampMembers.AsNoTracking()
             .FirstAsync(m => m.Id == memberInB.Id);
         reloaded.HasEarlyEntry.Should().BeFalse();
     }
@@ -391,7 +364,7 @@ public class CampServiceEarlyEntryTests : IDisposable
 
         await _service.RemoveCampMemberAsync(camp.Id, member.Id, Guid.NewGuid());
 
-        var reloaded = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
         reloaded.HasEarlyEntry.Should().BeFalse();
         reloaded.Status.Should().Be(CampMemberStatus.Removed);
     }
@@ -407,7 +380,7 @@ public class CampServiceEarlyEntryTests : IDisposable
 
         result.Succeeded.Should().BeTrue();
 
-        var reloaded = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id);
         reloaded.HasEarlyEntry.Should().BeFalse();
     }
 }

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -10,20 +10,16 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Camps;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public class CampServiceTests : IDisposable
+public sealed class CampServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly CampService _service;
     private readonly IAuditLogService _auditLog;
     private readonly IUserService _userService;
@@ -32,32 +28,15 @@ public class CampServiceTests : IDisposable
     private readonly ICampRoleService _campRoleService;
 
     public CampServiceTests()
+        : base(Instant.FromUtc(2026, 3, 13, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 13, 12, 0));
         _auditLog = Substitute.For<IAuditLogService>();
         _fileStorage = new InMemoryFileStorage();
 
-        var factory = new TestDbContextFactory(options);
-        var repo = new CampRepository(factory);
-        var roleRepo = new CampRoleRepository(factory);
+        var repo = new CampRepository(DbFactory);
+        var roleRepo = new CampRoleRepository(DbFactory);
 
-        // IUserService substitute — returns seeded users from the shared in-memory db.
-        _userService = Substitute.For<IUserService>();
-        _userService.GetByIdsAsync(
-            Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var ids = call.Arg<IReadOnlyCollection<Guid>>();
-                using var ctx = new HumansDbContext(options);
-                var users = ctx.Users.AsNoTracking().Where(u => ids.Contains(u.Id)).ToList();
-                return Task.FromResult<IReadOnlyDictionary<Guid, User>>(
-                    users.ToDictionary(u => u.Id));
-            });
-        _userService.StubGetUserInfosFromDb(options);
+        _userService = NewDbBackedUserService();
 
         _notificationEmitter = Substitute.For<INotificationEmitter>();
 
@@ -75,14 +54,8 @@ public class CampServiceTests : IDisposable
             _notificationEmitter,
             Substitute.For<ICampLeadJoinRequestsBadgeCacheInvalidator>(),
             new Lazy<ICampRoleService>(() => _campRoleService),
-            _clock,
+            Clock,
             NullLogger<CampService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     // ==========================================================================
@@ -104,14 +77,14 @@ public class CampServiceTests : IDisposable
         camp.Slug.Should().Be("camp-funhouse");
         camp.CreatedByUserId.Should().Be(userId);
 
-        var season = await _dbContext.CampSeasons
+        var season = await Db.CampSeasons
             .FirstOrDefaultAsync(s => s.CampId == camp.Id);
         season.Should().NotBeNull();
         season.Status.Should().Be(CampSeasonStatus.Pending);
         season.Year.Should().Be(2026);
         season.Name.Should().Be("Camp Funhouse");
 
-        var lead = await _dbContext.CampLeads
+        var lead = await Db.CampLeads
             .FirstOrDefaultAsync(l => l.CampId == camp.Id);
         lead.Should().NotBeNull();
         lead.UserId.Should().Be(userId);
@@ -141,12 +114,12 @@ public class CampServiceTests : IDisposable
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
-        var season = await _dbContext.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
         var adminId = Guid.NewGuid();
 
         await _service.ApproveSeasonAsync(season.Id, adminId, "Looks good");
 
-        var updated = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
+        var updated = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
         updated.Status.Should().Be(CampSeasonStatus.Active);
         updated.ReviewedByUserId.Should().Be(adminId);
         updated.ReviewNotes.Should().Be("Looks good");
@@ -162,11 +135,11 @@ public class CampServiceTests : IDisposable
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
-        var season = await _dbContext.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
 
         await _service.RejectSeasonAsync(season.Id, Guid.NewGuid(), "Not a real camp");
 
-        var updated = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
+        var updated = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
         updated.Status.Should().Be(CampSeasonStatus.Rejected);
         updated.ReviewNotes.Should().Be("Not a real camp");
     }
@@ -180,13 +153,13 @@ public class CampServiceTests : IDisposable
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
-        var season = await _dbContext.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
         await _service.ApproveSeasonAsync(season.Id, Guid.NewGuid(), null);
 
         // Open 2027 season in settings
-        var settings = await _dbContext.CampSettings.FirstAsync();
+        var settings = await Db.CampSettings.FirstAsync();
         settings.OpenSeasons = [2026, 2027];
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var newSeason = await _service.OptInToSeasonAsync(camp.Id, 2027);
 
@@ -200,12 +173,12 @@ public class CampServiceTests : IDisposable
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
-        var season = await _dbContext.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
         await _service.RejectSeasonAsync(season.Id, Guid.NewGuid(), "nope");
 
-        var settings = await _dbContext.CampSettings.FirstAsync();
+        var settings = await Db.CampSettings.FirstAsync();
         settings.OpenSeasons = [2026, 2027];
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var newSeason = await _service.OptInToSeasonAsync(camp.Id, 2027);
 
@@ -219,9 +192,9 @@ public class CampServiceTests : IDisposable
         var camp = await CreateTestCamp();
         // Don't approve or reject — season stays Pending
 
-        var settings = await _dbContext.CampSettings.FirstAsync();
+        var settings = await Db.CampSettings.FirstAsync();
         settings.OpenSeasons = [2026, 2027];
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var newSeason = await _service.OptInToSeasonAsync(camp.Id, 2027);
 
@@ -262,7 +235,7 @@ public class CampServiceTests : IDisposable
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
-        var lead = await _dbContext.CampLeads.FirstAsync(l => l.CampId == camp.Id);
+        var lead = await Db.CampLeads.FirstAsync(l => l.CampId == camp.Id);
 
         var act = () => _service.RemoveLeadAsync(lead.Id);
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*last lead*");
@@ -346,15 +319,15 @@ public class CampServiceTests : IDisposable
         await ApproveLatestSeasonAsync(zebraCamp.Id);
         await ApproveLatestSeasonAsync(alphaCamp.Id);
 
-        _dbContext.CampImages.Add(new CampImage
+        Db.CampImages.Add(new CampImage
         {
             Id = Guid.NewGuid(),
             CampId = zebraCamp.Id,
             StoragePath = "uploads/camps/zebra.jpg",
             SortOrder = 1,
-            UploadedAt = _clock.GetCurrentInstant()
+            UploadedAt = Clock.GetCurrentInstant()
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var summaries = await _service.GetCampPublicSummariesForYearAsync(2026);
 
@@ -449,21 +422,21 @@ public class CampServiceTests : IDisposable
 
         await ApproveLatestSeasonAsync(camp.Id);
 
-        var season = await _dbContext.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
         season.NameLockDate = new LocalDate(2026, 3, 1);
 
-        _dbContext.CampImages.Add(new CampImage
+        Db.CampImages.Add(new CampImage
         {
             Id = Guid.NewGuid(),
             CampId = camp.Id,
             StoragePath = "uploads/camps/fallback.jpg",
             SortOrder = 1,
-            UploadedAt = _clock.GetCurrentInstant()
+            UploadedAt = Clock.GetCurrentInstant()
         });
 
-        var settings = await _dbContext.CampSettings.FirstAsync();
+        var settings = await Db.CampSettings.FirstAsync();
         settings.PublicYear = 2027;
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var detail = await _service.BuildCampDetailDataBySlugAsync(camp.Slug);
 
@@ -567,15 +540,15 @@ public class CampServiceTests : IDisposable
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
-        var season = await _dbContext.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
         await _service.ApproveSeasonAsync(season.Id, Guid.NewGuid(), null);
 
         await _service.ChangeSeasonNameAsync(season.Id, "New Name");
 
-        var updated = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
+        var updated = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id);
         updated.Name.Should().Be("New Name");
 
-        var historical = await _dbContext.CampHistoricalNames
+        var historical = await Db.CampHistoricalNames
             .AsNoTracking()
             .FirstOrDefaultAsync(h => h.CampId == camp.Id && h.Source == CampNameSource.NameChange);
         historical.Should().NotBeNull();
@@ -587,12 +560,12 @@ public class CampServiceTests : IDisposable
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
-        var season = await _dbContext.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.FirstAsync(s => s.CampId == camp.Id);
         await _service.ApproveSeasonAsync(season.Id, Guid.NewGuid(), null);
 
         // Set lock date in the past
         season.NameLockDate = new LocalDate(2026, 3, 1);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.ChangeSeasonNameAsync(season.Id, "Too Late");
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*locked*");
@@ -615,7 +588,7 @@ public class CampServiceTests : IDisposable
 
         result.Outcome.Should().Be(CampMemberRequestOutcome.Created);
         result.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Success);
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == result.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == result.CampMemberId);
         member.Status.Should().Be(CampMemberStatus.Pending);
         member.UserId.Should().Be(userId);
     }
@@ -633,7 +606,7 @@ public class CampServiceTests : IDisposable
         result.Outcome.Should().Be(CampMemberRequestOutcome.NoOpenSeason);
         result.Message.Should().Be("Camp is not open for membership this year.");
         result.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Error);
-        (await _dbContext.CampMembers.AsNoTracking().AnyAsync()).Should().BeFalse();
+        (await Db.CampMembers.AsNoTracking().AnyAsync()).Should().BeFalse();
     }
 
     [HumansFact]
@@ -651,7 +624,7 @@ public class CampServiceTests : IDisposable
         second.Outcome.Should().Be(CampMemberRequestOutcome.AlreadyPending);
         second.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Info);
         second.CampMemberId.Should().Be(first.CampMemberId);
-        (await _dbContext.CampMembers.AsNoTracking().CountAsync()).Should().Be(1);
+        (await Db.CampMembers.AsNoTracking().CountAsync()).Should().Be(1);
     }
 
     [HumansFact]
@@ -667,7 +640,7 @@ public class CampServiceTests : IDisposable
 
         await _service.ApproveCampMemberAsync(camp.Id, request.CampMemberId, approverId);
 
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
         member.Status.Should().Be(CampMemberStatus.Active);
         member.ConfirmedByUserId.Should().Be(approverId);
         member.ConfirmedAt.Should().NotBeNull();
@@ -706,7 +679,7 @@ public class CampServiceTests : IDisposable
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not found*");
 
         // Camp B's pending row is untouched.
-        var memberB = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == requestInCampB.CampMemberId);
+        var memberB = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == requestInCampB.CampMemberId);
         memberB.Status.Should().Be(CampMemberStatus.Pending);
     }
 
@@ -722,7 +695,7 @@ public class CampServiceTests : IDisposable
 
         await _service.RejectCampMemberAsync(camp.Id, request.CampMemberId, Guid.NewGuid());
 
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
         member.Status.Should().Be(CampMemberStatus.Removed);
         member.RemovedAt.Should().NotBeNull();
 
@@ -768,7 +741,7 @@ public class CampServiceTests : IDisposable
 
         await _service.WithdrawCampMembershipRequestAsync(request.CampMemberId, userId);
 
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
         member.Status.Should().Be(CampMemberStatus.Removed);
     }
 
@@ -801,7 +774,7 @@ public class CampServiceTests : IDisposable
 
         result.Succeeded.Should().BeTrue();
 
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
         member.Status.Should().Be(CampMemberStatus.Removed);
     }
 
@@ -818,7 +791,7 @@ public class CampServiceTests : IDisposable
 
         await _service.RemoveCampMemberAsync(camp.Id, request.CampMemberId, Guid.NewGuid());
 
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
         member.Status.Should().Be(CampMemberStatus.Removed);
     }
 
@@ -830,14 +803,14 @@ public class CampServiceTests : IDisposable
         var season = new CampSeason { Id = Guid.NewGuid(), CampId = camp.Id, Year = 2026, Status = CampSeasonStatus.Active };
         var targetUserId = Guid.NewGuid();
         var leadUserId = Guid.NewGuid();
-        _dbContext.Camps.Add(camp);
-        _dbContext.CampSeasons.Add(season);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        Db.CampSeasons.Add(season);
+        await Db.SaveChangesAsync();
 
         var memberId = await _service.AddCampMemberAsLeadAsync(season.Id, targetUserId, leadUserId);
 
         memberId.Should().NotBe(Guid.Empty);
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == memberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == memberId);
         member.UserId.Should().Be(targetUserId);
         member.Status.Should().Be(CampMemberStatus.Active);
         member.ConfirmedByUserId.Should().Be(leadUserId);
@@ -860,14 +833,14 @@ public class CampServiceTests : IDisposable
             CampSeasonId = season.Id,
             UserId = userId,
             Status = CampMemberStatus.Active,
-            RequestedAt = _clock.GetCurrentInstant(),
-            ConfirmedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            ConfirmedAt = Clock.GetCurrentInstant(),
             ConfirmedByUserId = Guid.NewGuid(),
         };
-        _dbContext.Camps.Add(camp);
-        _dbContext.CampSeasons.Add(season);
-        _dbContext.CampMembers.Add(existing);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        Db.CampSeasons.Add(season);
+        Db.CampMembers.Add(existing);
+        await Db.SaveChangesAsync();
 
         var leadId = Guid.NewGuid();
         var memberId = await _service.AddCampMemberAsLeadAsync(season.Id, userId, leadId);
@@ -887,15 +860,15 @@ public class CampServiceTests : IDisposable
         var activeSeason = new CampSeason { Id = Guid.NewGuid(), CampId = camp.Id, Year = 2026, Status = CampSeasonStatus.Active };
         var targetUserId = Guid.NewGuid();
         var leadUserId = Guid.NewGuid();
-        _dbContext.Camps.Add(camp);
-        await _dbContext.CampSeasons.AddRangeAsync(inactiveSeason, activeSeason);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        await Db.CampSeasons.AddRangeAsync(inactiveSeason, activeSeason);
+        await Db.SaveChangesAsync();
 
         var result = await _service.AddCampMemberToActiveSeasonAsLeadAsync(camp.Id, targetUserId, leadUserId);
 
         result.Outcome.Should().Be(AddCampMemberAsLeadOutcome.Added);
         result.CampMemberId.Should().NotBeNull();
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == result.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == result.CampMemberId);
         member.CampSeasonId.Should().Be(activeSeason.Id);
     }
 
@@ -904,15 +877,15 @@ public class CampServiceTests : IDisposable
     {
         var camp = new Camp { Id = Guid.NewGuid(), Slug = "inactive-camp" };
         var season = new CampSeason { Id = Guid.NewGuid(), CampId = camp.Id, Year = 2026, Status = CampSeasonStatus.Pending };
-        _dbContext.Camps.Add(camp);
-        _dbContext.CampSeasons.Add(season);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        Db.CampSeasons.Add(season);
+        await Db.SaveChangesAsync();
 
         var result = await _service.AddCampMemberToActiveSeasonAsLeadAsync(
             camp.Id, Guid.NewGuid(), Guid.NewGuid());
 
         result.Outcome.Should().Be(AddCampMemberAsLeadOutcome.NoActiveSeason);
-        (await _dbContext.CampMembers.CountAsync()).Should().Be(0);
+        (await Db.CampMembers.CountAsync()).Should().Be(0);
     }
 
     [HumansFact]
@@ -920,9 +893,9 @@ public class CampServiceTests : IDisposable
     {
         var camp = new Camp { Id = Guid.NewGuid(), Slug = "inactive-role-camp" };
         var season = new CampSeason { Id = Guid.NewGuid(), CampId = camp.Id, Year = 2026, Status = CampSeasonStatus.Pending };
-        _dbContext.Camps.Add(camp);
-        _dbContext.CampSeasons.Add(season);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp);
+        Db.CampSeasons.Add(season);
+        await Db.SaveChangesAsync();
 
         var result = await _service.AddMemberAndAssignRoleInActiveSeasonAsync(
             camp.Id, Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
@@ -942,12 +915,12 @@ public class CampServiceTests : IDisposable
             CampSeasonId = season.Id,
             UserId = userId,
             Status = CampMemberStatus.Active,
-            RequestedAt = _clock.GetCurrentInstant(),
-            ConfirmedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            ConfirmedAt = Clock.GetCurrentInstant(),
             ConfirmedByUserId = Guid.NewGuid(),
         };
-        _dbContext.Camps.Add(camp); _dbContext.CampSeasons.Add(season); _dbContext.CampMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp); Db.CampSeasons.Add(season); Db.CampMembers.Add(member);
+        await Db.SaveChangesAsync();
 
         var result = await _service.LeaveCampAsync(member.Id, userId);
 
@@ -969,10 +942,10 @@ public class CampServiceTests : IDisposable
             CampSeasonId = season.Id,
             UserId = userId,
             Status = CampMemberStatus.Pending,
-            RequestedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
         };
-        _dbContext.Camps.Add(camp); _dbContext.CampSeasons.Add(season); _dbContext.CampMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp); Db.CampSeasons.Add(season); Db.CampMembers.Add(member);
+        await Db.SaveChangesAsync();
 
         await _service.WithdrawCampMembershipRequestAsync(member.Id, userId);
 
@@ -995,12 +968,12 @@ public class CampServiceTests : IDisposable
             CampSeasonId = season.Id,
             UserId = Guid.NewGuid(),
             Status = CampMemberStatus.Active,
-            RequestedAt = _clock.GetCurrentInstant(),
-            ConfirmedAt = _clock.GetCurrentInstant(),
+            RequestedAt = Clock.GetCurrentInstant(),
+            ConfirmedAt = Clock.GetCurrentInstant(),
             ConfirmedByUserId = Guid.NewGuid(),
         };
-        _dbContext.Camps.Add(camp); _dbContext.CampSeasons.Add(season); _dbContext.CampMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        Db.Camps.Add(camp); Db.CampSeasons.Add(season); Db.CampMembers.Add(member);
+        await Db.SaveChangesAsync();
 
         await _service.RemoveCampMemberAsync(camp.Id, memberId, Guid.NewGuid());
 
@@ -1018,12 +991,12 @@ public class CampServiceTests : IDisposable
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId, "Alice");
         var request = await _service.RequestCampMembershipAsync(camp.Id, userId);
-        var season = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
         _notificationEmitter.ClearReceivedCalls();
 
         await _service.WithdrawSeasonAsync(season.Id);
 
-        var member = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
+        var member = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == request.CampMemberId);
         member.Status.Should().Be(CampMemberStatus.Pending);
 
         await _notificationEmitter.Received(1).SendAsync(
@@ -1092,13 +1065,13 @@ public class CampServiceTests : IDisposable
         (await _service.GetPendingMembershipCountForLeadAsync(Guid.NewGuid())).Should().Be(0);
 
         // Approve one; count drops to 1.
-        var aliceReq = await _dbContext.CampMembers.AsNoTracking().FirstAsync(m => m.UserId == alice);
+        var aliceReq = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.UserId == alice);
         await _service.ApproveCampMemberAsync(camp.Id, aliceReq.Id, leadUserId);
         (await _service.GetPendingMembershipCountForLeadAsync(leadUserId)).Should().Be(1);
 
         // Withdraw the season; count drops to 0 (pending rows remain, but meter
         // filters to Active/Full seasons only).
-        var season = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
         await _service.WithdrawSeasonAsync(season.Id);
         (await _service.GetPendingMembershipCountForLeadAsync(leadUserId)).Should().Be(0);
     }
@@ -1114,7 +1087,7 @@ public class CampServiceTests : IDisposable
             leadUserId, "Lead Camp", "lc@camp.com", "+34600000010",
             null, null, false, 1, MakeSeasonData(), null, 2026);
         await ApproveLatestSeasonAsync(camp.Id);
-        var season = await _dbContext.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
 
         // A separate human requests and is approved.
         var memberUserId = Guid.NewGuid();
@@ -1186,7 +1159,7 @@ public class CampServiceTests : IDisposable
 
     private async Task ApproveLatestSeasonAsync(Guid campId)
     {
-        var season = await _dbContext.CampSeasons
+        var season = await Db.CampSeasons
             .Where(s => s.CampId == campId)
             .OrderByDescending(s => s.Year)
             .FirstAsync();
@@ -1196,21 +1169,21 @@ public class CampServiceTests : IDisposable
 
     private async Task SeedSettingsAsync()
     {
-        if (!await _dbContext.CampSettings.AnyAsync())
+        if (!await Db.CampSettings.AnyAsync())
         {
-            _dbContext.CampSettings.Add(new CampSettings
+            Db.CampSettings.Add(new CampSettings
             {
                 Id = Guid.Parse("00000000-0000-0000-0010-000000000001"),
                 PublicYear = 2026,
                 OpenSeasons = [2026]
             });
-            await _dbContext.SaveChangesAsync();
+            await Db.SaveChangesAsync();
         }
     }
 
     private async Task SeedUserAsync(Guid userId, string displayName)
     {
-        _dbContext.Users.Add(new User
+        Db.Users.Add(new User
         {
             Id = userId,
             UserName = $"{displayName.Replace(" ", string.Empty, StringComparison.Ordinal)}@example.com",
@@ -1218,6 +1191,6 @@ public class CampServiceTests : IDisposable
             DisplayName = displayName
         });
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
     }
 }

--- a/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
@@ -1,14 +1,11 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
-using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.DTOs;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using CampaignServiceImpl = Humans.Application.Services.Campaigns.CampaignService;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Teams;
@@ -20,47 +17,34 @@ using Humans.Infrastructure.Repositories.Campaigns;
 
 namespace Humans.Application.Tests.Services;
 
-public class CampaignServiceTests : IDisposable
+public sealed class CampaignServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly CampaignServiceImpl _service;
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-    private readonly ITeamService _teamService;
-    private readonly IUserService _userService;
-    private readonly IUserEmailService _userEmailService;
     private readonly ITicketVendorService _ticketVendorService;
 
     public CampaignServiceTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
-
-        var repository = new CampaignRepository(new TestDbContextFactory(options));
-        _teamService = Substitute.For<ITeamService>();
-        _userService = Substitute.For<IUserService>();
-        _userEmailService = Substitute.For<IUserEmailService>();
+        var repository = new CampaignRepository(DbFactory);
+        var teamService = Substitute.For<ITeamService>();
+        var userEmailService = Substitute.For<IUserEmailService>();
         _ticketVendorService = Substitute.For<ITicketVendorService>();
 
         // Default stubs: fetch data from the in-memory DbContext so the existing
         // seed helpers still drive the scenarios end-to-end.
-        _teamService
+        teamService
             .GetTeamAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(async call =>
             {
                 var teamId = call.ArgAt<Guid>(0);
-                var team = await _dbContext.Teams
+                var team = await Db.Teams
                     .Include(t => t.Members)
                     .FirstOrDefaultAsync(t => t.Id == teamId);
                 if (team is null)
                     return null;
 
                 var userIds = team.Members.Select(m => m.UserId).ToList();
-                var users = await _dbContext.Users
+                var users = await Db.Users
                     .Where(u => userIds.Contains(u.Id))
                     .ToDictionaryAsync(u => u.Id);
                 var members = team.Members
@@ -80,11 +64,11 @@ public class CampaignServiceTests : IDisposable
                     team.CreatedAt, members, team.ParentTeamId);
             });
 
-        _teamService
+        teamService
             .GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(async _ =>
             {
-                var list = await _dbContext.Teams
+                var list = await Db.Teams
                     .Include(t => t.Members)
                     .ToListAsync();
                 var dict = list.ToDictionary(
@@ -103,33 +87,14 @@ public class CampaignServiceTests : IDisposable
                 return (IReadOnlyDictionary<Guid, TeamInfo>)dict;
             });
 
-        _userService
-            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(async call =>
-            {
-                var id = call.ArgAt<Guid>(0);
-                return await _dbContext.Users.FirstOrDefaultAsync(u => u.Id == id);
-            });
+        var userService = NewDbBackedUserService();
 
-        _userService
-            .GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(async call =>
-            {
-                var ids = call.ArgAt<IReadOnlyCollection<Guid>>(0);
-                var list = await _dbContext.Users
-                    .Where(u => ids.Contains(u.Id))
-                    .ToListAsync();
-                return (IReadOnlyDictionary<Guid, User>)list.ToDictionary(u => u.Id);
-            });
-        _userService.StubGetUserInfosFromContext(_dbContext);
-        _userService.StubGetUserInfoFromContext(_dbContext);
-
-        _userEmailService
+        userEmailService
             .GetNotificationTargetEmailsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(async call =>
             {
                 var ids = call.ArgAt<IReadOnlyCollection<Guid>>(0);
-                var users = await _dbContext.Users
+                var users = await Db.Users
                     .Where(u => ids.Contains(u.Id))
                     .ToListAsync();
                 return (IReadOnlyDictionary<Guid, string>)users
@@ -144,21 +109,15 @@ public class CampaignServiceTests : IDisposable
 
         _service = new CampaignServiceImpl(
             repository,
-            _teamService,
-            _userEmailService,
-            _userService,
+            teamService,
+            userEmailService,
+            userService,
             Substitute.For<INotificationService>(),
             commPrefService,
             _emailService,
             _ticketVendorService,
-            _clock,
+            Clock,
             NullLogger<CampaignServiceImpl>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     // ==========================================================================
@@ -170,7 +129,7 @@ public class CampaignServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         SeedUser(userId);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.CreateAsync(
             "Test Campaign", "A description",
@@ -182,10 +141,10 @@ public class CampaignServiceTests : IDisposable
         result.Campaign!.Title.Should().Be("Test Campaign");
         result.Campaign.Description.Should().Be("A description");
         result.Campaign.Status.Should().Be(CampaignStatus.Draft);
-        result.Campaign.CreatedAt.Should().Be(_clock.GetCurrentInstant());
+        result.Campaign.CreatedAt.Should().Be(Clock.GetCurrentInstant());
         result.Campaign.CreatedByUserId.Should().Be(userId);
 
-        var inDb = await _dbContext.Campaigns.FindAsync(result.Campaign.Id);
+        var inDb = await Db.Campaigns.FindAsync(result.Campaign.Id);
         inDb.Should().NotBeNull();
         inDb.Status.Should().Be(CampaignStatus.Draft);
     }
@@ -200,7 +159,7 @@ public class CampaignServiceTests : IDisposable
 
         result.Success.Should().BeFalse();
         result.ErrorKey.Should().Be("TitleRequired");
-        (await _dbContext.Campaigns.CountAsync()).Should().Be(0);
+        (await Db.Campaigns.CountAsync()).Should().Be(0);
     }
 
     // ==========================================================================
@@ -214,7 +173,7 @@ public class CampaignServiceTests : IDisposable
 
         await _service.ImportCodesAsync(campaign.Id, ["CODE1", "CODE2", "CODE1", "CODE3"]);
 
-        var codes = await _dbContext.CampaignCodes
+        var codes = await Db.CampaignCodes
             .Where(c => c.CampaignId == campaign.Id)
             .ToListAsync();
         codes.Should().HaveCount(3);
@@ -231,7 +190,7 @@ public class CampaignServiceTests : IDisposable
         // Second import with overlap
         await _service.ImportCodesAsync(campaign.Id, ["CODE2", "CODE3"]);
 
-        var codes = await _dbContext.CampaignCodes
+        var codes = await Db.CampaignCodes
             .Where(c => c.CampaignId == campaign.Id)
             .ToListAsync();
         codes.Should().HaveCount(3);
@@ -256,7 +215,7 @@ public class CampaignServiceTests : IDisposable
                 s.DiscountType == DiscountType.Fixed &&
                 s.DiscountValue == 10m),
             Arg.Any<CancellationToken>());
-        var codes = await _dbContext.CampaignCodes
+        var codes = await Db.CampaignCodes
             .Where(c => c.CampaignId == campaign.Id)
             .Select(c => c.Code)
             .ToListAsync();
@@ -289,7 +248,7 @@ public class CampaignServiceTests : IDisposable
 
         await _service.ActivateAsync(campaign.Id);
 
-        var updated = await _dbContext.Campaigns.FindAsync(campaign.Id);
+        var updated = await Db.Campaigns.FindAsync(campaign.Id);
         updated!.Status.Should().Be(CampaignStatus.Active);
     }
 
@@ -330,7 +289,7 @@ public class CampaignServiceTests : IDisposable
 
         updated.Success.Should().BeTrue();
 
-        var refreshed = await _dbContext.Campaigns.FindAsync(campaign.Id);
+        var refreshed = await Db.Campaigns.FindAsync(campaign.Id);
         refreshed.Should().NotBeNull();
         refreshed.Title.Should().Be("Updated Campaign");
         refreshed.Description.Should().Be("Updated description");
@@ -361,20 +320,20 @@ public class CampaignServiceTests : IDisposable
     {
         var campaign = await SeedActiveCampaignWithCodesAsync(["A", "B", "C"]);
         var user = SeedUser(displayName: "Stats User");
-        var grantedCode = await _dbContext.CampaignCodes
+        var grantedCode = await Db.CampaignCodes
             .FirstAsync(c => c.CampaignId == campaign.Id && c.Code == "A");
 
-        _dbContext.CampaignGrants.Add(new CampaignGrant
+        Db.CampaignGrants.Add(new CampaignGrant
         {
             Id = Guid.NewGuid(),
             CampaignId = campaign.Id,
             CampaignCodeId = grantedCode.Id,
             UserId = user.Id,
-            AssignedAt = _clock.GetCurrentInstant(),
-            RedeemedAt = _clock.GetCurrentInstant(),
+            AssignedAt = Clock.GetCurrentInstant(),
+            RedeemedAt = Clock.GetCurrentInstant(),
             LatestEmailStatus = EmailOutboxStatus.Failed
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var page = await _service.GetDetailPageAsync(campaign.Id);
 
@@ -396,7 +355,7 @@ public class CampaignServiceTests : IDisposable
         var beta = SeedTeam("Beta Team");
         var alpha = SeedTeam("Alpha Team");
         SeedTeamMember(alpha.Id, user.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var page = await _service.GetSendWavePageAsync(campaign.Id, alpha.Id);
 
@@ -415,9 +374,9 @@ public class CampaignServiceTests : IDisposable
         var user = SeedUser(displayName: "Grant User");
         var team = SeedTeam("Grant Team");
         SeedTeamMember(team.Id, user.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         await _service.SendWaveAsync(campaign.Id, team.Id);
-        var grant = await _dbContext.CampaignGrants.SingleAsync();
+        var grant = await Db.CampaignGrants.SingleAsync();
 
         var campaignId = await _service.GetCampaignIdForGrantAsync(grant.Id);
 
@@ -435,7 +394,7 @@ public class CampaignServiceTests : IDisposable
 
         await _service.CompleteAsync(campaign.Id);
 
-        var updated = await _dbContext.Campaigns.FindAsync(campaign.Id);
+        var updated = await Db.Campaigns.FindAsync(campaign.Id);
         updated!.Status.Should().Be(CampaignStatus.Completed);
     }
 
@@ -464,13 +423,13 @@ public class CampaignServiceTests : IDisposable
         var user = SeedUser(displayName: "Alice");
         var team = SeedTeam("Alpha");
         SeedTeamMember(team.Id, user.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var count = await _service.SendWaveAsync(campaign.Id, team.Id);
 
         count.Should().Be(1);
 
-        var grants = await _dbContext.CampaignGrants
+        var grants = await Db.CampaignGrants
             .Where(g => g.CampaignId == campaign.Id)
             .ToListAsync();
         grants.Should().ContainSingle();
@@ -497,7 +456,7 @@ public class CampaignServiceTests : IDisposable
         var user = SeedUser(displayName: "Charlie");
         var team = SeedTeam("Gamma");
         SeedTeamMember(team.Id, user.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.SendWaveAsync(campaign.Id, team.Id);
 
@@ -522,7 +481,7 @@ public class CampaignServiceTests : IDisposable
         var team = SeedTeam("Delta");
         SeedTeamMember(team.Id, user1.Id);
         SeedTeamMember(team.Id, user2.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // First wave sends to both
         var count1 = await _service.SendWaveAsync(campaign.Id, team.Id);
@@ -543,7 +502,7 @@ public class CampaignServiceTests : IDisposable
         var team = SeedTeam("Zeta");
         SeedTeamMember(team.Id, user1.Id);
         SeedTeamMember(team.Id, user2.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.SendWaveAsync(campaign.Id, team.Id);
 
@@ -563,7 +522,7 @@ public class CampaignServiceTests : IDisposable
         var user = SeedUser(displayName: "O'Brien & Co");
         var team = SeedTeam("Eta");
         SeedTeamMember(team.Id, user.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.SendWaveAsync(campaign.Id, team.Id);
 
@@ -586,14 +545,14 @@ public class CampaignServiceTests : IDisposable
         var user = SeedUser(displayName: "Dave");
         var team = SeedTeam("Theta");
         SeedTeamMember(team.Id, user.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.SendWaveAsync(campaign.Id, team.Id);
         _emailService.ClearReceivedCalls();
 
-        var grant = await _dbContext.CampaignGrants.SingleAsync();
+        var grant = await Db.CampaignGrants.SingleAsync();
         grant.LatestEmailStatus = EmailOutboxStatus.Failed;
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.ResendToGrantAsync(grant.Id);
 
@@ -601,8 +560,8 @@ public class CampaignServiceTests : IDisposable
             Arg.Is<CampaignCodeEmailRequest>(r => r.CampaignGrantId == grant.Id),
             Arg.Any<CancellationToken>());
 
-        _dbContext.ChangeTracker.Clear();
-        var updatedGrant = await _dbContext.CampaignGrants.FindAsync(grant.Id);
+        Db.ChangeTracker.Clear();
+        var updatedGrant = await Db.CampaignGrants.FindAsync(grant.Id);
         updatedGrant!.LatestEmailStatus.Should().Be(EmailOutboxStatus.Queued);
     }
 
@@ -620,15 +579,15 @@ public class CampaignServiceTests : IDisposable
         var team = SeedTeam("Iota");
         SeedTeamMember(team.Id, user1.Id);
         SeedTeamMember(team.Id, user2.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.SendWaveAsync(campaign.Id, team.Id);
         _emailService.ClearReceivedCalls();
 
         // Mark one as failed
-        var grants = await _dbContext.CampaignGrants.ToListAsync();
+        var grants = await Db.CampaignGrants.ToListAsync();
         grants[0].LatestEmailStatus = EmailOutboxStatus.Failed;
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.RetryAllFailedAsync(campaign.Id);
 
@@ -637,8 +596,8 @@ public class CampaignServiceTests : IDisposable
             Arg.Is<CampaignCodeEmailRequest>(r => r.CampaignGrantId == grants[0].Id),
             Arg.Any<CancellationToken>());
 
-        _dbContext.ChangeTracker.Clear();
-        var retriedGrant = await _dbContext.CampaignGrants.FindAsync(grants[0].Id);
+        Db.ChangeTracker.Clear();
+        var retriedGrant = await Db.CampaignGrants.FindAsync(grants[0].Id);
         retriedGrant!.LatestEmailStatus.Should().Be(EmailOutboxStatus.Queued);
     }
 
@@ -658,19 +617,19 @@ public class CampaignServiceTests : IDisposable
         SeedTeamMember(team.Id, eligible.Id);
         SeedTeamMember(team.Id, alreadyGranted.Id);
         SeedTeamMember(team.Id, otherUser.Id);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Grant a code to alreadyGranted user manually
-        var code = await _dbContext.CampaignCodes.FirstAsync(c => c.CampaignId == campaign.Id);
-        _dbContext.CampaignGrants.Add(new CampaignGrant
+        var code = await Db.CampaignCodes.FirstAsync(c => c.CampaignId == campaign.Id);
+        Db.CampaignGrants.Add(new CampaignGrant
         {
             Id = Guid.NewGuid(),
             CampaignId = campaign.Id,
             CampaignCodeId = code.Id,
             UserId = alreadyGranted.Id,
-            AssignedAt = _clock.GetCurrentInstant()
+            AssignedAt = Clock.GetCurrentInstant()
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var preview = await _service.PreviewWaveSendAsync(campaign.Id, team.Id);
 
@@ -684,50 +643,6 @@ public class CampaignServiceTests : IDisposable
     // ==========================================================================
     // Helpers
     // ==========================================================================
-
-    private User SeedUser(Guid? id = null, string displayName = "Test User")
-    {
-        var userId = id ?? Guid.NewGuid();
-        var user = new User
-        {
-            Id = userId,
-            DisplayName = displayName,
-            UserName = $"test-{userId}@test.com",
-            Email = $"test-{userId}@test.com",
-            PreferredLanguage = "en"
-        };
-        _dbContext.Users.Add(user);
-        return user;
-    }
-
-    private Team SeedTeam(string name)
-    {
-        var team = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = name,
-            Slug = name.ToLowerInvariant().Replace(" ", "-"),
-            IsActive = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
-        };
-        _dbContext.Teams.Add(team);
-        return team;
-    }
-
-    private TeamMember SeedTeamMember(Guid teamId, Guid userId)
-    {
-        var member = new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = teamId,
-            UserId = userId,
-            Role = TeamMemberRole.Member,
-            JoinedAt = _clock.GetCurrentInstant()
-        };
-        _dbContext.TeamMembers.Add(member);
-        return member;
-    }
 
     private async Task<Campaign> SeedCampaignAsync(
         CampaignStatus status = CampaignStatus.Draft,
@@ -744,12 +659,12 @@ public class CampaignServiceTests : IDisposable
             EmailSubject = emailSubject,
             EmailBodyTemplate = emailBodyTemplate,
             Status = status,
-            CreatedAt = _clock.GetCurrentInstant(),
+            CreatedAt = Clock.GetCurrentInstant(),
             CreatedByUserId = creatorId
         };
-        _dbContext.Campaigns.Add(campaign);
-        await _dbContext.SaveChangesAsync();
-        _dbContext.ChangeTracker.Clear();
+        Db.Campaigns.Add(campaign);
+        await Db.SaveChangesAsync();
+        Db.ChangeTracker.Clear();
         return campaign;
     }
 
@@ -763,10 +678,10 @@ public class CampaignServiceTests : IDisposable
             emailSubject,
             emailBodyTemplate);
 
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         foreach (var code in codes)
         {
-            _dbContext.CampaignCodes.Add(new CampaignCode
+            Db.CampaignCodes.Add(new CampaignCode
             {
                 Id = Guid.NewGuid(),
                 CampaignId = campaign.Id,
@@ -774,8 +689,8 @@ public class CampaignServiceTests : IDisposable
                 ImportedAt = now
             });
         }
-        await _dbContext.SaveChangesAsync();
-        _dbContext.ChangeTracker.Clear();
+        await Db.SaveChangesAsync();
+        Db.ChangeTracker.Clear();
         return campaign;
     }
 }

--- a/tests/Humans.Application.Tests/Services/CityPlanning/ContainerPlacementPhaseTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanning/ContainerPlacementPhaseTests.cs
@@ -5,35 +5,28 @@ using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.CityPlanning;
 using Humans.Application.Tests.Infrastructure;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.CityPlanning;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.CityPlanning;
 
-public class ContainerPlacementPhaseTests
+public sealed class ContainerPlacementPhaseTests : ServiceTestHarness
 {
-    private readonly FakeClock _clock;
     private readonly ICampService _campService;
     private readonly CityPlanningService _sut;
 
     public ContainerPlacementPhaseTests()
+        : base(Instant.FromUtc(2026, 4, 26, 10, 0))
     {
-        var dbOptions = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _clock = new FakeClock(Instant.FromUtc(2026, 4, 26, 10, 0, 0));
         _campService = Substitute.For<ICampService>();
         _campService.GetSettingsAsync(Arg.Any<CancellationToken>())
             .Returns(new CampSettingsInfo(PublicYear: 2026, OpenSeasons: [], EeStartDate: null));
-        var repo = new CityPlanningRepository(new TestDbContextFactory(dbOptions));
+        var repo = new CityPlanningRepository(DbFactory);
         var options = new CityPlanningOptions { CityPlanningTeamSlug = "city-planning" };
         _sut = new CityPlanningService(
-            repo, _clock, Options.Create(options),
+            repo, Clock, Options.Create(options),
             _campService,
             Substitute.For<ITeamService>(),
             Substitute.For<IUserService>());
@@ -48,7 +41,7 @@ public class ContainerPlacementPhaseTests
 
         var settings = await _sut.GetSettingsAsync();
         settings.IsContainerPlacementOpen.Should().BeTrue();
-        settings.ContainerPlacementOpenedAt.Should().Be(_clock.GetCurrentInstant());
+        settings.ContainerPlacementOpenedAt.Should().Be(Clock.GetCurrentInstant());
         settings.ContainerPlacementClosedAt.Should().BeNull();
     }
 
@@ -62,6 +55,6 @@ public class ContainerPlacementPhaseTests
 
         var settings = await _sut.GetSettingsAsync();
         settings.IsContainerPlacementOpen.Should().BeFalse();
-        settings.ContainerPlacementClosedAt.Should().Be(_clock.GetCurrentInstant());
+        settings.ContainerPlacementClosedAt.Should().Be(Clock.GetCurrentInstant());
     }
 }

--- a/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
@@ -7,21 +7,17 @@ using Humans.Application.Services.CityPlanning;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.CityPlanning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public class CityPlanningServiceTests : IDisposable
+public sealed class CityPlanningServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly ICampService _campService;
     private readonly ITeamService _teamService;
     private readonly IUserService _userService;
@@ -29,18 +25,14 @@ public class CityPlanningServiceTests : IDisposable
     private readonly CityPlanningOptions _options = new() { CityPlanningTeamSlug = "city-planning" };
 
     public CityPlanningServiceTests()
+        : base(Instant.FromUtc(2026, 3, 15, 12, 0, 0))
     {
-        var dbOptions = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(dbOptions);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 15, 12, 0, 0));
         _campService = Substitute.For<ICampService>();
         _teamService = Substitute.For<ITeamService>();
         _userService = Substitute.For<IUserService>();
-        var repo = new CityPlanningRepository(new TestDbContextFactory(dbOptions));
+        var repo = new CityPlanningRepository(DbFactory);
         _sut = new CityPlanningService(
-            repo, _clock, Options.Create(_options),
+            repo, Clock, Options.Create(_options),
             _campService, _teamService, _userService);
     }
 
@@ -62,12 +54,6 @@ public class CityPlanningServiceTests : IDisposable
         volunteerHistory: [],
         communicationPreferences: []);
 
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
-    }
-
     // --- Helpers ---
 
     private void SetupCampSettings(int publicYear = 2026)
@@ -83,10 +69,10 @@ public class CityPlanningServiceTests : IDisposable
         {
             Year = year,
             IsPlacementOpen = placementOpen,
-            UpdatedAt = _clock.GetCurrentInstant()
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.CityPlanningSettings.Add(settings);
-        await _dbContext.SaveChangesAsync();
+        Db.CityPlanningSettings.Add(settings);
+        await Db.SaveChangesAsync();
         return settings;
     }
 
@@ -109,13 +95,13 @@ public class CityPlanningServiceTests : IDisposable
 
         await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 500.0, userId);
 
-        var polygon = await _dbContext.CampPolygons.AsNoTracking().SingleAsync(p => p.CampSeasonId == campSeasonId);
-        var history = await _dbContext.CampPolygonHistories.AsNoTracking().SingleAsync(h => h.CampSeasonId == campSeasonId);
+        var polygon = await Db.CampPolygons.AsNoTracking().SingleAsync(p => p.CampSeasonId == campSeasonId);
+        var history = await Db.CampPolygonHistories.AsNoTracking().SingleAsync(h => h.CampSeasonId == campSeasonId);
 
         polygon.GeoJson.Should().Be(geoJson);
         polygon.AreaSqm.Should().Be(500.0);
         history.Note.Should().Be("Saved");
-        history.ModifiedAt.Should().Be(_clock.GetCurrentInstant());
+        history.ModifiedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -129,9 +115,9 @@ public class CityPlanningServiceTests : IDisposable
         await _sut.SaveCampPolygonAsync(campSeasonId, geoJson1, 100.0, userId);
         await _sut.SaveCampPolygonAsync(campSeasonId, geoJson2, 200.0, userId);
 
-        var polygonCount = await _dbContext.CampPolygons.AsNoTracking().CountAsync(p => p.CampSeasonId == campSeasonId);
-        var historyCount = await _dbContext.CampPolygonHistories.AsNoTracking().CountAsync(h => h.CampSeasonId == campSeasonId);
-        var polygon = await _dbContext.CampPolygons.AsNoTracking().SingleAsync(p => p.CampSeasonId == campSeasonId);
+        var polygonCount = await Db.CampPolygons.AsNoTracking().CountAsync(p => p.CampSeasonId == campSeasonId);
+        var historyCount = await Db.CampPolygonHistories.AsNoTracking().CountAsync(h => h.CampSeasonId == campSeasonId);
+        var polygon = await Db.CampPolygons.AsNoTracking().SingleAsync(p => p.CampSeasonId == campSeasonId);
 
         polygonCount.Should().Be(1);
         historyCount.Should().Be(2);
@@ -157,7 +143,7 @@ public class CityPlanningServiceTests : IDisposable
         var result = await _sut.UpdatePlacementDatesAsync("2026-06-01T08:30", "2026-06-02T18:45");
 
         result.Success.Should().BeTrue();
-        var settings = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var settings = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         settings.PlacementOpensAt.Should().Be(new LocalDateTime(2026, 6, 1, 8, 30));
         settings.PlacementClosesAt.Should().Be(new LocalDateTime(2026, 6, 2, 18, 45));
     }
@@ -180,7 +166,7 @@ public class CityPlanningServiceTests : IDisposable
         var result = await _sut.UpdateLimitZoneFromUploadAsync(file, NewUserId());
 
         result.Success.Should().BeTrue();
-        var settings = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var settings = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         settings.LimitZoneGeoJson.Should().Be("""{"type":"FeatureCollection","features":[]}""");
     }
 
@@ -204,7 +190,7 @@ public class CityPlanningServiceTests : IDisposable
         var result = await _sut.UpdateOfficialZonesFromUploadAsync(file, NewUserId());
 
         result.Success.Should().BeTrue();
-        var settings = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var settings = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         settings.OfficialZonesGeoJson.Should().Be("""{"type":"FeatureCollection","features":[]}""");
     }
 
@@ -216,14 +202,14 @@ public class CityPlanningServiceTests : IDisposable
         const string originalGeoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}}""";
 
         var (_, historyEntry) = await _sut.SaveCampPolygonAsync(campSeasonId, originalGeoJson, 100.0, userId);
-        _clock.Advance(Duration.FromSeconds(1));
+        Clock.Advance(Duration.FromSeconds(1));
         await _sut.SaveCampPolygonAsync(campSeasonId, """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[5,0],[5,5],[0,0]]]}}""", 999.0, userId);
-        _clock.Advance(Duration.FromSeconds(1));
+        Clock.Advance(Duration.FromSeconds(1));
 
         await _sut.RestoreCampPolygonVersionAsync(campSeasonId, historyEntry.Id, userId);
 
-        var polygon = await _dbContext.CampPolygons.AsNoTracking().SingleAsync(p => p.CampSeasonId == campSeasonId);
-        var latestHistory = await _dbContext.CampPolygonHistories.AsNoTracking()
+        var polygon = await Db.CampPolygons.AsNoTracking().SingleAsync(p => p.CampSeasonId == campSeasonId);
+        var latestHistory = await Db.CampPolygonHistories.AsNoTracking()
             .OrderByDescending(h => h.ModifiedAt).FirstAsync(h => h.CampSeasonId == campSeasonId);
 
         polygon.GeoJson.Should().Be(originalGeoJson);
@@ -372,7 +358,7 @@ public class CityPlanningServiceTests : IDisposable
 
         settings.Year.Should().Be(2026);
         settings.IsPlacementOpen.Should().BeFalse();
-        (await _dbContext.CityPlanningSettings.AsNoTracking().CountAsync()).Should().Be(1);
+        (await Db.CityPlanningSettings.AsNoTracking().CountAsync()).Should().Be(1);
     }
 
     [HumansFact]
@@ -384,7 +370,7 @@ public class CityPlanningServiceTests : IDisposable
 
         result.Id.Should().Be(existing.Id);
         result.IsPlacementOpen.Should().BeTrue();
-        (await _dbContext.CityPlanningSettings.AsNoTracking().CountAsync()).Should().Be(1);
+        (await Db.CityPlanningSettings.AsNoTracking().CountAsync()).Should().Be(1);
     }
 
     [HumansFact]
@@ -395,9 +381,9 @@ public class CityPlanningServiceTests : IDisposable
 
         await _sut.OpenPlacementAsync(adminId);
 
-        var settings = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var settings = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         settings.IsPlacementOpen.Should().BeTrue();
-        settings.OpenedAt.Should().Be(_clock.GetCurrentInstant());
+        settings.OpenedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -408,9 +394,9 @@ public class CityPlanningServiceTests : IDisposable
 
         await _sut.ClosePlacementAsync(adminId);
 
-        var settings = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var settings = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         settings.IsPlacementOpen.Should().BeFalse();
-        settings.ClosedAt.Should().Be(_clock.GetCurrentInstant());
+        settings.ClosedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -501,9 +487,9 @@ public class CityPlanningServiceTests : IDisposable
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
                 new Dictionary<Guid, UserInfo> { [userId] = testUser.ToUserInfo() }));
 
-        _clock.Advance(Duration.FromSeconds(1));
+        Clock.Advance(Duration.FromSeconds(1));
         await _sut.SaveCampPolygonAsync(campSeasonId, """{"type":"Feature"}""", 100.0, userId);
-        _clock.Advance(Duration.FromSeconds(1));
+        Clock.Advance(Duration.FromSeconds(1));
         await _sut.SaveCampPolygonAsync(campSeasonId, """{"type":"Feature"}""", 200.0, userId);
 
         var history = await _sut.GetCampPolygonHistoryAsync(campSeasonId);
@@ -589,7 +575,7 @@ public class CityPlanningServiceTests : IDisposable
 
         await _sut.UpdatePlacementDatesAsync(opens, closes);
 
-        var settings = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var settings = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         settings.PlacementOpensAt.Should().Be(opens);
         settings.PlacementClosesAt.Should().Be(closes);
     }
@@ -598,15 +584,15 @@ public class CityPlanningServiceTests : IDisposable
     public async Task UpdatePlacementDatesAsync_ClearsDates_WhenNull()
     {
         await SeedMapSettingsAsync();
-        var seeded = await _dbContext.CityPlanningSettings.SingleAsync();
+        var seeded = await Db.CityPlanningSettings.SingleAsync();
         seeded.PlacementOpensAt = new LocalDateTime(2026, 4, 10, 18, 0);
         seeded.PlacementClosesAt = new LocalDateTime(2026, 4, 20, 23, 59);
-        await _dbContext.SaveChangesAsync();
-        _dbContext.Entry(seeded).State = EntityState.Detached;
+        await Db.SaveChangesAsync();
+        Db.Entry(seeded).State = EntityState.Detached;
 
         await _sut.UpdatePlacementDatesAsync(null, (LocalDateTime?)null);
 
-        var updated = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var updated = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         updated.PlacementOpensAt.Should().BeNull();
         updated.PlacementClosesAt.Should().BeNull();
     }
@@ -621,25 +607,25 @@ public class CityPlanningServiceTests : IDisposable
 
         await _sut.UpdateOfficialZonesAsync(geoJson, Guid.NewGuid());
 
-        var settings = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var settings = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         settings.OfficialZonesGeoJson.Should().Be(geoJson);
-        settings.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        settings.UpdatedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
     public async Task DeleteOfficialZonesAsync_SetsNull()
     {
         await SeedMapSettingsAsync();
-        var seeded = await _dbContext.CityPlanningSettings.SingleAsync();
+        var seeded = await Db.CityPlanningSettings.SingleAsync();
         seeded.OfficialZonesGeoJson = """{"type":"FeatureCollection","features":[]}""";
-        await _dbContext.SaveChangesAsync();
-        _dbContext.Entry(seeded).State = EntityState.Detached;
+        await Db.SaveChangesAsync();
+        Db.Entry(seeded).State = EntityState.Detached;
 
         await _sut.DeleteOfficialZonesAsync(Guid.NewGuid());
 
-        var updated = await _dbContext.CityPlanningSettings.AsNoTracking().SingleAsync();
+        var updated = await Db.CityPlanningSettings.AsNoTracking().SingleAsync();
         updated.OfficialZonesGeoJson.Should().BeNull();
-        updated.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        updated.UpdatedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
@@ -3,11 +3,11 @@ using Humans.Application;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Application.Tests.Infrastructure;
 using NSubstitute;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Profiles;
 using Humans.Infrastructure.Services.Profiles;
 using Microsoft.AspNetCore.DataProtection;
@@ -15,7 +15,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using CommunicationPreferenceService = Humans.Application.Services.Profiles.CommunicationPreferenceService;
 
 namespace Humans.Application.Tests.Services;
@@ -70,21 +69,13 @@ file sealed class StubAuditLogService : IAuditLogService
         Task.FromResult((IReadOnlySet<Guid>)new HashSet<Guid>());
 }
 
-public class CommunicationPreferenceServiceTests : IDisposable
+public sealed class CommunicationPreferenceServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly CommunicationPreferenceService _service;
 
     public CommunicationPreferenceServiceTests()
+        : base(Instant.FromUtc(2026, 4, 1, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 4, 1, 12, 0));
-
         var dataProtectionProvider = DataProtectionProvider.Create("TestApp");
 
         var emailSettings = Options.Create(new EmailSettings
@@ -92,8 +83,7 @@ public class CommunicationPreferenceServiceTests : IDisposable
             BaseUrl = "https://test.example.com"
         });
 
-        var repository = new CommunicationPreferenceRepository(
-            new Infrastructure.TestDbContextFactory(options));
+        var repository = new CommunicationPreferenceRepository(DbFactory);
 
         var tokenProvider = new UnsubscribeTokenProvider(
             dataProtectionProvider, emailSettings,
@@ -107,7 +97,7 @@ public class CommunicationPreferenceServiceTests : IDisposable
             .Returns(ci =>
             {
                 var userId = ci.Arg<Guid>();
-                var prefs = _dbContext.CommunicationPreferences
+                var prefs = Db.CommunicationPreferences
                     .Where(cp => cp.UserId == userId)
                     .ToList();
                 return new ValueTask<UserInfo?>(BuildStubUserInfo(userId, prefs));
@@ -117,7 +107,7 @@ public class CommunicationPreferenceServiceTests : IDisposable
             repository,
             userService,
             tokenProvider,
-            _clock,
+            Clock,
             new StubAuditLogService(),
             NullLogger<CommunicationPreferenceService>.Instance);
     }
@@ -141,12 +131,6 @@ public class CommunicationPreferenceServiceTests : IDisposable
             volunteerHistory: [],
             communicationPreferences: prefs);
 
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
-    }
-
     [HumansFact]
     public async Task GetPreferencesAsync_CreatesDefaultsForActiveCategories()
     {
@@ -162,7 +146,7 @@ public class CommunicationPreferenceServiceTests : IDisposable
         prefs.Should().NotContain(p => p.Category == MessageCategory.CommunityUpdates);
 
         // Rows should be persisted in the database
-        var dbCount = await _dbContext.CommunicationPreferences
+        var dbCount = await Db.CommunicationPreferences
             .Where(cp => cp.UserId == userId)
             .CountAsync();
         dbCount.Should().Be(8);
@@ -189,9 +173,9 @@ public class CommunicationPreferenceServiceTests : IDisposable
         await _service.UpdatePreferenceAsync(userId, MessageCategory.CampaignCodes, optedOut: true, source: "Test");
 
         // No rows should have been created (update was silently rejected)
-        var systemPref = await _dbContext.CommunicationPreferences
+        var systemPref = await Db.CommunicationPreferences
             .FirstOrDefaultAsync(cp => cp.UserId == userId && cp.Category == MessageCategory.System);
-        var campaignPref = await _dbContext.CommunicationPreferences
+        var campaignPref = await Db.CommunicationPreferences
             .FirstOrDefaultAsync(cp => cp.UserId == userId && cp.Category == MessageCategory.CampaignCodes);
 
         systemPref.Should().BeNull();

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -4,12 +4,10 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Interfaces;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using ConsentService = Humans.Application.Services.Consent.ConsentService;
 using Humans.Application.Interfaces.Legal;
 using Humans.Application.Interfaces.Notifications;
@@ -22,10 +20,8 @@ using Humans.Infrastructure.Repositories.Consent;
 
 namespace Humans.Application.Tests.Services;
 
-public class ConsentServiceTests : IDisposable
+public sealed class ConsentServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly ConsentService _service;
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
     private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
@@ -37,20 +33,13 @@ public class ConsentServiceTests : IDisposable
 
     public ConsentServiceTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
-
         var serviceProvider = Substitute.For<IServiceProvider>();
         serviceProvider.GetService(typeof(IMembershipCalculator)).Returns(_membershipCalculator);
         serviceProvider.GetService(typeof(IShiftSignupService)).Returns(_shiftSignupService);
 
         _legalDocumentSyncService
             .GetVersionByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo => _dbContext.DocumentVersions
+            .Returns(callInfo => Db.DocumentVersions
                 .Include(v => v.LegalDocument)
                 .Where(v => v.Id == callInfo.ArgAt<Guid>(0))
                 .Select(v => new LegalDocumentVersionSnapshot(
@@ -75,7 +64,7 @@ public class ConsentServiceTests : IDisposable
                     return (IReadOnlyList<ActiveRequiredLegalDocumentSnapshot>)[];
 
 #pragma warning disable CS0618 // Test stub uses LegalDocument.Team to populate the snapshot's TeamName; production stitches via ITeamService.
-                var documents = await _dbContext.LegalDocuments
+                var documents = await Db.LegalDocuments
                     .AsNoTracking()
                     .Where(d => d.IsActive && d.IsRequired && teamIds.Contains(d.TeamId))
                     .Include(d => d.Team)
@@ -86,8 +75,7 @@ public class ConsentServiceTests : IDisposable
 #pragma warning restore CS0618
             });
 
-        var factory = new TestDbContextFactory(options);
-        var consentRepository = new ConsentRepository(factory);
+        var consentRepository = new ConsentRepository(DbFactory);
 
         // Default: no merge tombstones — chain-follow short-circuits to the
         // single-id repo path.
@@ -107,8 +95,8 @@ public class ConsentServiceTests : IDisposable
                 FirstName = "First",
                 LastName = "Last",
                 State = ProfileState.Active,
-                CreatedAt = _clock.GetCurrentInstant(),
-                UpdatedAt = _clock.GetCurrentInstant()
+                CreatedAt = Clock.GetCurrentInstant(),
+                UpdatedAt = Clock.GetCurrentInstant()
             }));
 
         _service = new ConsentService(
@@ -119,14 +107,8 @@ public class ConsentServiceTests : IDisposable
             _userService,
             serviceProvider,
             _metrics,
-            _clock,
+            Clock,
             NullLogger<ConsentService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     private static UserInfo WrapInUserInfo(Profile profile) => UserInfo.Create(
@@ -157,13 +139,13 @@ public class ConsentServiceTests : IDisposable
         var result = await _service.SubmitConsentAsync(userId, versionId, true, "192.168.1.1", "TestAgent");
 
         result.Success.Should().BeTrue();
-        var record = await _dbContext.ConsentRecords.FirstAsync();
+        var record = await Db.ConsentRecords.FirstAsync();
         record.UserId.Should().Be(userId);
         record.DocumentVersionId.Should().Be(versionId);
         record.IpAddress.Should().Be("192.168.1.1");
         record.UserAgent.Should().Be("TestAgent");
         record.ExplicitConsent.Should().BeTrue();
-        record.ConsentedAt.Should().Be(_clock.GetCurrentInstant());
+        record.ConsentedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -175,7 +157,7 @@ public class ConsentServiceTests : IDisposable
 
         await _service.SubmitConsentAsync(userId, versionId, true, "127.0.0.1", "Agent");
 
-        var record = await _dbContext.ConsentRecords.FirstAsync();
+        var record = await Db.ConsentRecords.FirstAsync();
         var expectedHash = Convert.ToHexString(
             SHA256.HashData(Encoding.UTF8.GetBytes("Spanish text"))).ToLowerInvariant();
         record.ContentHash.Should().Be(expectedHash);
@@ -187,18 +169,18 @@ public class ConsentServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var versionId = Guid.NewGuid();
         SeedDocumentVersion(versionId, "Test Doc", new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" });
-        _dbContext.ConsentRecords.Add(new ConsentRecord
+        Db.ConsentRecords.Add(new ConsentRecord
         {
             Id = Guid.NewGuid(),
             UserId = userId,
             DocumentVersionId = versionId,
-            ConsentedAt = _clock.GetCurrentInstant(),
+            ConsentedAt = Clock.GetCurrentInstant(),
             IpAddress = "127.0.0.1",
             UserAgent = "Agent",
             ContentHash = "abc",
             ExplicitConsent = true
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SubmitConsentAsync(userId, versionId, true, "127.0.0.1", "Agent");
 
@@ -225,7 +207,7 @@ public class ConsentServiceTests : IDisposable
 
         await _service.SubmitConsentAsync(userId, versionId, true, "127.0.0.1", longAgent);
 
-        var record = await _dbContext.ConsentRecords.FirstAsync();
+        var record = await Db.ConsentRecords.FirstAsync();
         record.UserAgent.Should().HaveLength(500);
     }
 
@@ -332,8 +314,8 @@ public class ConsentServiceTests : IDisposable
             FirstName = "",
             LastName = "",
             State = ProfileState.Stub,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(WrapInUserInfo(stubProfile));
@@ -342,7 +324,7 @@ public class ConsentServiceTests : IDisposable
 
         result.Success.Should().BeFalse();
         result.ErrorKey.Should().Be("StubProfile");
-        (await _dbContext.ConsentRecords.CountAsync()).Should().Be(0);
+        (await Db.ConsentRecords.CountAsync()).Should().Be(0);
     }
 
     [HumansFact]
@@ -360,8 +342,8 @@ public class ConsentServiceTests : IDisposable
             FirstName = "First",
             LastName = "Last",
             State = ProfileState.Active,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(WrapInUserInfo(activeProfile));
@@ -369,7 +351,7 @@ public class ConsentServiceTests : IDisposable
         var result = await _service.SubmitConsentAsync(userId, versionId, true, "127.0.0.1", "Agent");
 
         result.Success.Should().BeTrue();
-        (await _dbContext.ConsentRecords.CountAsync()).Should().Be(1);
+        (await Db.ConsentRecords.CountAsync()).Should().Be(1);
     }
 
     // --- GetConsentDashboardAsync ---
@@ -387,7 +369,7 @@ public class ConsentServiceTests : IDisposable
         SeedTeam(teamId2, "Team B");
         SeedDocument(teamId1, "Doc A");
         SeedDocument(teamId2, "Doc B");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (groups, _) = await _service.GetConsentDashboardAsync(userId);
 
@@ -405,7 +387,7 @@ public class ConsentServiceTests : IDisposable
         SeedTeam(teamId, "Team");
         SeedDocument(teamId, "Active Doc");
         SeedDocument(teamId, "Inactive Doc", isActive: false);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (groups, _) = await _service.GetConsentDashboardAsync(userId);
 
@@ -418,7 +400,7 @@ public class ConsentServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var teamId = Guid.NewGuid();
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         _membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { teamId });
 
@@ -426,7 +408,7 @@ public class ConsentServiceTests : IDisposable
         var docId = Guid.NewGuid();
         var olderVersionId = Guid.NewGuid();
         var newerVersionId = Guid.NewGuid();
-        _dbContext.LegalDocuments.Add(new LegalDocument
+        Db.LegalDocuments.Add(new LegalDocument
         {
             Id = docId,
             Name = "Versioned Doc",
@@ -437,7 +419,7 @@ public class ConsentServiceTests : IDisposable
             CreatedAt = now,
             LastSyncedAt = now
         });
-        _dbContext.DocumentVersions.Add(new DocumentVersion
+        Db.DocumentVersions.Add(new DocumentVersion
         {
             Id = olderVersionId,
             LegalDocumentId = docId,
@@ -447,7 +429,7 @@ public class ConsentServiceTests : IDisposable
             Content = new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "old" },
             CreatedAt = now
         });
-        _dbContext.DocumentVersions.Add(new DocumentVersion
+        Db.DocumentVersions.Add(new DocumentVersion
         {
             Id = newerVersionId,
             LegalDocumentId = docId,
@@ -457,7 +439,7 @@ public class ConsentServiceTests : IDisposable
             Content = new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "new" },
             CreatedAt = now
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (groups, _) = await _service.GetConsentDashboardAsync(userId);
 
@@ -477,7 +459,7 @@ public class ConsentServiceTests : IDisposable
         SeedTeam(teamId, "Team");
         var versionId = SeedDocument(teamId, "Doc");
         SeedConsentRecord(userId, versionId);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (groups, _) = await _service.GetConsentDashboardAsync(userId);
 
@@ -495,7 +477,7 @@ public class ConsentServiceTests : IDisposable
 
         SeedTeam(teamId, "Team");
         SeedDocument(teamId, "Doc");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (groups, _) = await _service.GetConsentDashboardAsync(userId);
 
@@ -508,7 +490,7 @@ public class ConsentServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var teamId = Guid.NewGuid();
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         _membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { teamId });
 
@@ -517,7 +499,7 @@ public class ConsentServiceTests : IDisposable
         var v2 = SeedDocument(teamId, "Doc B");
         SeedConsentRecord(userId, v1, now - Duration.FromHours(2));
         SeedConsentRecord(userId, v2, now - Duration.FromHours(1));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (_, history) = await _service.GetConsentDashboardAsync(userId);
 
@@ -530,13 +512,13 @@ public class ConsentServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var teamId = Guid.NewGuid();
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         _membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { teamId });
 
         SeedTeam(teamId, "Team");
         SeedDocument(teamId, "Future Doc", effectiveFrom: now + Duration.FromDays(30));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (groups, _) = await _service.GetConsentDashboardAsync(userId);
 
@@ -574,11 +556,11 @@ public class ConsentServiceTests : IDisposable
             BurnerName = "Test",
             FirstName = "Jane",
             LastName = "Doe",
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>()).Returns(WrapInUserInfo(profile));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var detail = await _service.GetConsentReviewDetailAsync(versionId, userId);
 
@@ -601,11 +583,11 @@ public class ConsentServiceTests : IDisposable
             BurnerName = "Test",
             FirstName = "Jane",
             LastName = "Doe",
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>()).Returns(WrapInUserInfo(profile));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var detail = await _service.GetConsentReviewDetailAsync(versionId, userId);
 
@@ -651,7 +633,7 @@ public class ConsentServiceTests : IDisposable
         var versionId = Guid.NewGuid();
         SeedDocumentVersion(versionId, "Test Doc", new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" });
         SeedConsentRecord(sourceId, versionId);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Target's chain-follow set includes the source.
         _userService.GetMergedSourceIdsAsync(targetId, Arg.Any<CancellationToken>())
@@ -681,19 +663,19 @@ public class ConsentServiceTests : IDisposable
             Name = name,
             Slug = name.ToLowerInvariant().Replace(' ', '-'),
             IsActive = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
         return team;
     }
 
     private Guid SeedDocument(Guid teamId, string name, bool isActive = true, bool isRequired = true, Instant? effectiveFrom = null)
     {
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         var docId = Guid.NewGuid();
         var versionId = Guid.NewGuid();
-        _dbContext.LegalDocuments.Add(new LegalDocument
+        Db.LegalDocuments.Add(new LegalDocument
         {
             Id = docId,
             Name = name,
@@ -704,7 +686,7 @@ public class ConsentServiceTests : IDisposable
             CreatedAt = now,
             LastSyncedAt = now
         });
-        _dbContext.DocumentVersions.Add(new DocumentVersion
+        Db.DocumentVersions.Add(new DocumentVersion
         {
             Id = versionId,
             LegalDocumentId = docId,
@@ -719,13 +701,13 @@ public class ConsentServiceTests : IDisposable
 
     private void SeedConsentRecord(Guid userId, Guid versionId, Instant? consentedAt = null)
     {
-        _dbContext.ConsentRecords.Add(new ConsentRecord
+        Db.ConsentRecords.Add(new ConsentRecord
         {
             Id = Guid.NewGuid(),
             UserId = userId,
             DocumentVersionId = versionId,
             ExplicitConsent = true,
-            ConsentedAt = consentedAt ?? _clock.GetCurrentInstant(),
+            ConsentedAt = consentedAt ?? Clock.GetCurrentInstant(),
             IpAddress = "127.0.0.1",
             UserAgent = "test",
             ContentHash = "testhash"
@@ -735,17 +717,17 @@ public class ConsentServiceTests : IDisposable
     private void SeedDocumentVersion(Guid versionId, string documentName, Dictionary<string, string> content)
     {
         var teamId = Guid.NewGuid();
-        _dbContext.Teams.Add(new Team
+        Db.Teams.Add(new Team
         {
             Id = teamId,
             Name = "Volunteers",
             Slug = "volunteers",
             IsActive = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         });
         var docId = Guid.NewGuid();
-        _dbContext.LegalDocuments.Add(new LegalDocument
+        Db.LegalDocuments.Add(new LegalDocument
         {
             Id = docId,
             Name = documentName,
@@ -753,19 +735,19 @@ public class ConsentServiceTests : IDisposable
             IsRequired = true,
             IsActive = true,
             CurrentCommitSha = "abc123",
-            CreatedAt = _clock.GetCurrentInstant(),
-            LastSyncedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            LastSyncedAt = Clock.GetCurrentInstant()
         });
-        _dbContext.DocumentVersions.Add(new DocumentVersion
+        Db.DocumentVersions.Add(new DocumentVersion
         {
             Id = versionId,
             LegalDocumentId = docId,
             VersionNumber = "1.0",
             CommitSha = "abc123",
             Content = content,
-            EffectiveFrom = _clock.GetCurrentInstant() - Duration.FromDays(1),
-            CreatedAt = _clock.GetCurrentInstant()
+            EffectiveFrom = Clock.GetCurrentInstant() - Duration.FromDays(1),
+            CreatedAt = Clock.GetCurrentInstant()
         });
-        _dbContext.SaveChanges();
+        Db.SaveChanges();
     }
 }

--- a/tests/Humans.Application.Tests/Services/ContactFieldServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ContactFieldServiceTests.cs
@@ -1,14 +1,13 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using ContactFieldService = Humans.Application.Services.Profiles.ContactFieldService;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Auth;
@@ -18,42 +17,28 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Humans.Application.Tests.Services;
 
-public class ContactFieldServiceTests : IDisposable
+public sealed class ContactFieldServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
     private readonly ITeamService _teamService;
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IProfileRepository _profileRepository;
     private readonly IUserService _userService;
-    private readonly FakeClock _clock;
     private readonly ContactFieldService _service;
 
     public ContactFieldServiceTests()
+        : base(Instant.FromUtc(2024, 1, 15, 12, 0, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
         _teamService = Substitute.For<ITeamService>();
         _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
         _userService = Substitute.For<IUserService>();
-        _clock = new FakeClock(Instant.FromUtc(2024, 1, 15, 12, 0, 0));
 
-        var factory = new Infrastructure.TestDbContextFactory(options);
-        var repository = new ContactFieldRepository(factory);
-        _profileRepository = new ProfileRepository(factory, _clock);
+        var repository = new ContactFieldRepository(DbFactory);
+        _profileRepository = new ProfileRepository(DbFactory, Clock);
 
         _service = new ContactFieldService(
             repository, _profileRepository, _userService, _teamService, _roleAssignmentService,
             Substitute.For<IUserInfoInvalidator>(),
-            _clock, NullLogger<ContactFieldService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+            Clock, NullLogger<ContactFieldService>.Instance);
     }
 
     #region GetViewerAccessLevelAsync Tests
@@ -277,7 +262,7 @@ public class ContactFieldServiceTests : IDisposable
         await _service.SaveContactFieldsAsync(profile.Id, fields);
 
         // Assert
-        var savedFields = await _dbContext.ContactFields
+        var savedFields = await Db.ContactFields
             .Where(cf => cf.ProfileId == profile.Id)
             .ToListAsync();
         savedFields.Should().HaveCount(2);
@@ -296,11 +281,11 @@ public class ContactFieldServiceTests : IDisposable
             Value = "+34 612345678",
             Visibility = ContactFieldVisibility.AllActiveProfiles,
             DisplayOrder = 0,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.ContactFields.Add(existingField);
-        await _dbContext.SaveChangesAsync();
+        Db.ContactFields.Add(existingField);
+        await Db.SaveChangesAsync();
 
         var fields = new List<ContactFieldEditDto>
         {
@@ -311,7 +296,7 @@ public class ContactFieldServiceTests : IDisposable
         await _service.SaveContactFieldsAsync(profile.Id, fields);
 
         // Assert
-        var savedField = await _dbContext.ContactFields.AsNoTracking()
+        var savedField = await Db.ContactFields.AsNoTracking()
             .FirstOrDefaultAsync(cf => cf.Id == existingField.Id);
         savedField!.Value.Should().Be("+34 698765432");
         savedField.Visibility.Should().Be(ContactFieldVisibility.BoardOnly);
@@ -330,17 +315,17 @@ public class ContactFieldServiceTests : IDisposable
             Value = "+34 612345678",
             Visibility = ContactFieldVisibility.AllActiveProfiles,
             DisplayOrder = 0,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.ContactFields.Add(existingField);
-        await _dbContext.SaveChangesAsync();
+        Db.ContactFields.Add(existingField);
+        await Db.SaveChangesAsync();
 
         // Save empty list (delete all)
         await _service.SaveContactFieldsAsync(profile.Id, new List<ContactFieldEditDto>());
 
         // Assert
-        var remainingFields = await _dbContext.ContactFields
+        var remainingFields = await Db.ContactFields
             .Where(cf => cf.ProfileId == profile.Id)
             .ToListAsync();
         remainingFields.Should().BeEmpty();
@@ -358,7 +343,7 @@ public class ContactFieldServiceTests : IDisposable
 
         await _service.SaveContactFieldsAsync(profile.Id, fields);
 
-        var savedFields = await _dbContext.ContactFields
+        var savedFields = await Db.ContactFields
             .Where(cf => cf.ProfileId == profile.Id)
             .ToListAsync();
         savedFields.Should().HaveCount(1);
@@ -371,7 +356,7 @@ public class ContactFieldServiceTests : IDisposable
     // Stub IUserService.GetUserInfoAsync to return a UserInfo carrying the profile's ContactFields.
     private void StubUserInfo(Guid userId, Profile profile)
     {
-        var fields = _dbContext.ContactFields
+        var fields = Db.ContactFields
             .Where(cf => cf.ProfileId == profile.Id)
             .OrderBy(cf => cf.DisplayOrder)
             .ToList();
@@ -404,15 +389,15 @@ public class ContactFieldServiceTests : IDisposable
             TeamId = actualTeamId,
             UserId = userId,
             Role = role,
-            JoinedAt = _clock.GetCurrentInstant(),
+            JoinedAt = Clock.GetCurrentInstant(),
             Team = new Team
             {
                 Id = actualTeamId,
                 Name = "Test Team",
                 Slug = "test-team",
                 SystemTeamType = systemTeamType,
-                CreatedAt = _clock.GetCurrentInstant(),
-                UpdatedAt = _clock.GetCurrentInstant()
+                CreatedAt = Clock.GetCurrentInstant(),
+                UpdatedAt = Clock.GetCurrentInstant()
             }
         };
     }
@@ -425,11 +410,11 @@ public class ContactFieldServiceTests : IDisposable
             UserId = userId,
             FirstName = "Test",
             LastName = "User",
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.Profiles.Add(profile);
-        await _dbContext.SaveChangesAsync();
+        Db.Profiles.Add(profile);
+        await Db.SaveChangesAsync();
 
         // No store to populate — GetVisibleContactFieldsAsync now resolves profileId → userId
         // via IProfileRepository.GetOwnerUserIdAsync (scalar DB query).
@@ -440,7 +425,7 @@ public class ContactFieldServiceTests : IDisposable
     private async Task<Profile> CreateProfileWithFields(Guid userId)
     {
         var profile = await CreateProfile(userId);
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
 
         var fields = new List<ContactField>
         {
@@ -490,8 +475,8 @@ public class ContactFieldServiceTests : IDisposable
             }
         };
 
-        _dbContext.ContactFields.AddRange(fields);
-        await _dbContext.SaveChangesAsync();
+        Db.ContactFields.AddRange(fields);
+        await Db.SaveChangesAsync();
 
         return profile;
     }

--- a/tests/Humans.Application.Tests/Services/Containers/ContainerImageServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Containers/ContainerImageServiceTests.cs
@@ -8,41 +8,28 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Containers;
-using Microsoft.EntityFrameworkCore;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Containers;
 
-public class ContainerImageServiceTests : IDisposable
+public sealed class ContainerImageServiceTests : ServiceTestHarness
 {
-    private readonly DbContextOptions<HumansDbContext> _dbOptions;
-    private readonly FakeClock _clock;
     private readonly IFileStorage _fileStorage;
     private readonly ContainerService _sut;
-    private readonly Instant _startTime = Instant.FromUtc(2026, 5, 8, 10, 0, 0);
+    private static readonly Instant StartTime = Instant.FromUtc(2026, 5, 8, 10, 0, 0);
     private static readonly Guid CampId = Guid.Parse("00000000-0000-0000-0099-000000000001");
 
-    public ContainerImageServiceTests()
+    public ContainerImageServiceTests() : base(StartTime)
     {
-        _dbOptions = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _clock = new FakeClock(_startTime);
         _fileStorage = Substitute.For<IFileStorage>();
-        var repo = new ContainerRepository(new TestDbContextFactory(_dbOptions));
+        var repo = new ContainerRepository(DbFactory);
         _sut = new ContainerService(
             repo,
             _fileStorage,
             Substitute.For<ICampService>(),
             Substitute.For<IAuditLogService>(),
-            _clock);
-    }
-
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
+            Clock);
     }
 
     private static ContainerImageUpload FakeImage(string kind = "main") =>
@@ -50,7 +37,7 @@ public class ContainerImageServiceTests : IDisposable
 
     private async Task<Container> SeedContainerAsync(string? imagePath = null)
     {
-        await using var ctx = new HumansDbContext(_dbOptions);
+        await using var ctx = new HumansDbContext(DbOptions);
         var container = new Container
         {
             Id = Guid.NewGuid(),
@@ -59,8 +46,8 @@ public class ContainerImageServiceTests : IDisposable
             ImageStoragePath = imagePath,
             ImageContentType = imagePath is not null ? "image/jpeg" : null,
             ImageFileName = imagePath is not null ? "main.jpg" : null,
-            CreatedAt = _startTime,
-            UpdatedAt = _startTime,
+            CreatedAt = StartTime,
+            UpdatedAt = StartTime,
         };
         ctx.Containers.Add(container);
         await ctx.SaveChangesAsync();

--- a/tests/Humans.Application.Tests/Services/Containers/ContainerPlacementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Containers/ContainerPlacementServiceTests.cs
@@ -5,59 +5,45 @@ using Humans.Application.Interfaces.Camps;
 using Humans.Application.Services.Containers;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Containers;
-using Microsoft.EntityFrameworkCore;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Containers;
 
-public class ContainerPlacementServiceTests : IDisposable
+public sealed class ContainerPlacementServiceTests : ServiceTestHarness
 {
     private const int Year = 2026;
     private static readonly Guid CampId = Guid.Parse("00000000-0000-0000-0099-000000000002");
     private static readonly Guid ActorUserId = Guid.Parse("00000000-0000-0000-0099-000000000003");
 
-    private readonly DbContextOptions<HumansDbContext> _dbOptions;
-    private readonly FakeClock _clock;
     private readonly ContainerService _sut;
-    private readonly Instant _startTime = Instant.FromUtc(2026, 4, 26, 10, 0, 0);
 
     public ContainerPlacementServiceTests()
+        : base(Instant.FromUtc(2026, 4, 26, 10, 0))
     {
-        _dbOptions = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _clock = new FakeClock(_startTime);
-        var repo = new ContainerRepository(new TestDbContextFactory(_dbOptions));
+        var repo = new ContainerRepository(DbFactory);
         _sut = new ContainerService(
             repo,
             Substitute.For<IFileStorage>(),
             Substitute.For<ICampService>(),
             Substitute.For<IAuditLogService>(),
-            _clock);
-    }
-
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
+            Clock);
     }
 
     private async Task<Container> SeedContainerAsync()
     {
-        await using var ctx = new HumansDbContext(_dbOptions);
+        var now = Clock.GetCurrentInstant();
         var container = new Container
         {
             Id = Guid.NewGuid(),
             CampId = CampId,
             Name = "Container A",
-            CreatedAt = _startTime,
-            UpdatedAt = _startTime,
+            CreatedAt = now,
+            UpdatedAt = now,
         };
-        ctx.Containers.Add(container);
-        await ctx.SaveChangesAsync();
+        Db.Containers.Add(container);
+        await Db.SaveChangesAsync();
         return container;
     }
 
@@ -66,12 +52,12 @@ public class ContainerPlacementServiceTests : IDisposable
     {
         var container = await SeedContainerAsync();
         var geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[]]},"properties":{"center_lng":-0.137,"center_lat":41.699,"rotation_degrees":0}}""";
-        _clock.AdvanceSeconds(60);
+        Clock.AdvanceSeconds(60);
 
         var result = await _sut.SavePlacementAsync(container.Id, Year, geoJson, ActorUserId);
 
         result.LocationGeoJson.Should().Be(geoJson);
-        result.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        result.UpdatedAt.Should().Be(Clock.GetCurrentInstant());
         result.Year.Should().Be(Year);
     }
 

--- a/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
+++ b/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
@@ -18,10 +18,10 @@ using Humans.Application.Services.Profiles;
 using Humans.Application.Services.Shifts;
 using Humans.Application.Services.Teams;
 using Humans.Application.Services.Users;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -29,18 +29,14 @@ using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public class DependencyCycleResolutionTests
+public sealed class DependencyCycleResolutionTests : ServiceTestHarness
 {
     [HumansFact]
     public void IUserService_Resolves_WhenTeamServiceAndRoleAssignmentServiceAreRegistered()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
         var services = new ServiceCollection();
 
-        services.AddScoped(_ => new HumansDbContext(options));
+        services.AddScoped(_ => new HumansDbContext(DbOptions));
         services.AddSingleton<IMemoryCache>(_ => new MemoryCache(new MemoryCacheOptions()));
 
         services.AddScoped<IUserRepository>(_ => Substitute.For<IUserRepository>());
@@ -93,14 +89,10 @@ public class DependencyCycleResolutionTests
     [HumansFact]
     public void IUserService_And_IEmailService_Resolve_WhenRealEmailChainIsRegistered()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
         var services = new ServiceCollection();
         var userStore = Substitute.For<IUserStore<User>>();
 
-        services.AddScoped(_ => new HumansDbContext(options));
+        services.AddScoped(_ => new HumansDbContext(DbOptions));
         services.AddSingleton<IMemoryCache>(_ => new MemoryCache(new MemoryCacheOptions()));
 
         services.AddScoped<IUserRepository>(_ => Substitute.For<IUserRepository>());

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -3,30 +3,30 @@ using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public class EmailProblemsServiceTests
+public sealed class EmailProblemsServiceTests : ServiceTestHarness
 {
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 5, 5, 12, 0));
 
     private readonly List<UserInfo> _allInfos = [];
 
     public EmailProblemsServiceTests()
+        : base(Instant.FromUtc(2026, 5, 5, 12, 0))
     {
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromResult<IReadOnlyCollection<UserInfo>>(_allInfos.ToArray()));
     }
 
     private EmailProblemsService Sut => new(
-        _userEmailService, _userService, _clock);
+        _userEmailService, _userService, Clock);
 
     private static UserEmail Email(Guid userId, string address,
         bool isVerified = true, bool isPrimary = false, bool isGoogle = false) =>

--- a/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
@@ -11,21 +11,17 @@ using Humans.Application.Services.Expenses;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Expenses;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Expenses;
 
-public class ExpenseReportServiceTests
+public sealed class ExpenseReportServiceTests : ServiceTestHarness
 {
     private static readonly Instant FakeNow = Instant.FromUtc(2026, 5, 10, 12, 0);
 
-    private readonly IDbContextFactory<HumansDbContext> _factory;
     private readonly IExpenseRepository _expenseRepo;
     private readonly IFileStorage _fileStorage;
     private readonly IBudgetService _budgetService;
@@ -36,12 +32,9 @@ public class ExpenseReportServiceTests
     private readonly ExpenseReportService _sut;
 
     public ExpenseReportServiceTests()
+        : base(FakeNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _factory = new TestDbContextFactory(options);
-        _expenseRepo = new ExpenseRepository(_factory, NullLogger<ExpenseRepository>.Instance);
+        _expenseRepo = new ExpenseRepository(DbFactory, NullLogger<ExpenseRepository>.Instance);
 
         _fileStorage = Substitute.For<IFileStorage>();
         _budgetService = Substitute.For<IBudgetService>();
@@ -59,7 +52,7 @@ public class ExpenseReportServiceTests
             _profileService,
             _auditLogService,
             Substitute.For<IHoldedClient>(),
-            new FakeClock(FakeNow),
+            Clock,
             NullLogger<ExpenseReportService>.Instance);
     }
 
@@ -1398,7 +1391,7 @@ public class ExpenseReportServiceTests
             CreatedAt = now,
             UpdatedAt = now
         };
-        await using var ctx = await _factory.CreateDbContextAsync();
+        await using var ctx = await DbFactory.CreateDbContextAsync();
         ctx.ExpenseReports.Add(report);
         await ctx.SaveChangesAsync();
     }

--- a/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
@@ -10,22 +10,18 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Feedback;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using FeedbackApplicationService = Humans.Application.Services.Feedback.FeedbackService;
 
 namespace Humans.Application.Tests.Services;
 
-public class FeedbackServiceTests : IDisposable
+public sealed class FeedbackServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLog;
     private readonly IUserService _userService;
@@ -37,38 +33,14 @@ public class FeedbackServiceTests : IDisposable
     private readonly FeedbackApplicationService _service;
 
     public FeedbackServiceTests()
+        : base(Instant.FromUtc(2026, 3, 18, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 18, 12, 0));
         _emailService = Substitute.For<IEmailService>();
         _auditLog = Substitute.For<IAuditLogService>();
         var env = Substitute.For<IHostEnvironment>();
         env.ContentRootPath.Returns(Path.GetTempPath());
 
-        _userService = Substitute.For<IUserService>();
-        _userService
-            .GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var ids = (IReadOnlyCollection<Guid>)call[0]!;
-                var dict = _dbContext.Users
-                    .AsNoTracking()
-                    .Where(u => ids.Contains(u.Id))
-                    .ToDictionary(u => u.Id);
-                return Task.FromResult<IReadOnlyDictionary<Guid, User>>(dict);
-            });
-        _userService
-            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var id = (Guid)call[0]!;
-                return Task.FromResult(_dbContext.Users.AsNoTracking().FirstOrDefault(u => u.Id == id));
-            });
-        _userService.StubGetUserInfosFromContext(_dbContext);
-        _userService.StubGetUserInfoFromContext(_dbContext);
+        _userService = NewDbBackedUserService();
 
         _userEmailService = Substitute.For<IUserEmailService>();
         _userEmailService
@@ -76,7 +48,7 @@ public class FeedbackServiceTests : IDisposable
             .Returns(call =>
             {
                 var ids = (IReadOnlyCollection<Guid>)call[0]!;
-                IReadOnlyDictionary<Guid, string> dict = _dbContext.Users
+                IReadOnlyDictionary<Guid, string> dict = Db.Users
                     .AsNoTracking()
                     .Where(u => ids.Contains(u.Id) && u.Email != null)
                     .ToDictionary(u => u.Id, u => u.Email!);
@@ -88,7 +60,7 @@ public class FeedbackServiceTests : IDisposable
             .GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
-                var teams = _dbContext.Teams
+                var teams = Db.Teams
                     .Include(t => t.Members)
                     .AsNoTracking()
                     .ToList();
@@ -112,7 +84,7 @@ public class FeedbackServiceTests : IDisposable
             .Returns(call =>
             {
                 var id = call.ArgAt<Guid>(0);
-                var t = _dbContext.Teams
+                var t = Db.Teams
                     .Include(team => team.Members)
                     .AsNoTracking()
                     .FirstOrDefault(team => team.Id == id);
@@ -133,26 +105,20 @@ public class FeedbackServiceTests : IDisposable
         _notificationService = Substitute.For<INotificationService>();
         _navBadge = Substitute.For<INavBadgeCacheInvalidator>();
 
-        _repository = new FeedbackRepository(new TestDbContextFactory(options));
+        _repository = new FeedbackRepository(DbFactory);
 
         _service = new FeedbackApplicationService(
             _repository, _userService, _userEmailService, _teamService,
-            _emailService, _notificationService, _auditLog, _navBadge, _clock, env,
+            _emailService, _notificationService, _auditLog, _navBadge, Clock, env,
             NullLogger<FeedbackApplicationService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
     public async Task SubmitFeedbackAsync_CreatesReport()
     {
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = userId, DisplayName = "Test", Email = "t@t.com" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = userId, DisplayName = "Test", Email = "t@t.com" });
+        await Db.SaveChangesAsync();
 
         var report = await _service.SubmitFeedbackAsync(
             userId, FeedbackCategory.Bug, "Something broke",
@@ -171,8 +137,8 @@ public class FeedbackServiceTests : IDisposable
     public async Task SubmitFeedbackAsync_SetsAdditionalContext()
     {
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = userId, Email = "u@test.com", DisplayName = "U" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = userId, Email = "u@test.com", DisplayName = "U" });
+        await Db.SaveChangesAsync();
 
         var report = await _service.SubmitFeedbackAsync(
             userId, FeedbackCategory.Bug, "desc", "/page", "UA",
@@ -185,8 +151,8 @@ public class FeedbackServiceTests : IDisposable
     public async Task SubmitUserFeedbackAsync_BuildsSortedRoleContext()
     {
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = userId, Email = "u@test.com", DisplayName = "U" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = userId, Email = "u@test.com", DisplayName = "U" });
+        await Db.SaveChangesAsync();
 
         var report = await _service.SubmitUserFeedbackAsync(
             userId, FeedbackCategory.Bug, "desc", "/page", "UA",
@@ -202,7 +168,7 @@ public class FeedbackServiceTests : IDisposable
 
         await _service.UpdateStatusAsync(report.Id, FeedbackStatus.Resolved, Guid.NewGuid());
 
-        var updated = await _dbContext.FeedbackReports.AsNoTracking()
+        var updated = await Db.FeedbackReports.AsNoTracking()
             .FirstAsync(r => r.Id == report.Id);
         updated.Status.Should().Be(FeedbackStatus.Resolved);
         updated.ResolvedAt.Should().NotBeNull();
@@ -217,7 +183,7 @@ public class FeedbackServiceTests : IDisposable
         await _service.UpdateStatusAsync(report.Id, FeedbackStatus.Resolved, actorId);
         await _service.UpdateStatusAsync(report.Id, FeedbackStatus.Open, actorId);
 
-        var updated = await _dbContext.FeedbackReports.AsNoTracking()
+        var updated = await Db.FeedbackReports.AsNoTracking()
             .FirstAsync(r => r.Id == report.Id);
         updated.Status.Should().Be(FeedbackStatus.Open);
         updated.ResolvedAt.Should().BeNull();
@@ -240,8 +206,8 @@ public class FeedbackServiceTests : IDisposable
     public async Task GetFeedbackListAsync_ReturnsReporterInfo()
     {
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = userId, DisplayName = "Alice", Email = "a@a.com" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = userId, DisplayName = "Alice", Email = "a@a.com" });
+        await Db.SaveChangesAsync();
 
         await _service.SubmitFeedbackAsync(
             userId, FeedbackCategory.Bug, "a", "/a", null, null, null);
@@ -259,9 +225,9 @@ public class FeedbackServiceTests : IDisposable
         // BurnerName-is-the-display-name rule: when a Profile exists,
         // ReporterName must render the BurnerName, not the legacy User.DisplayName.
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = userId, DisplayName = "Legal Name", Email = "a@a.com" });
-        _dbContext.Profiles.Add(new Profile { Id = Guid.NewGuid(), UserId = userId, BurnerName = "Sparkle" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = userId, DisplayName = "Legal Name", Email = "a@a.com" });
+        Db.Profiles.Add(new Profile { Id = Guid.NewGuid(), UserId = userId, BurnerName = "Sparkle" });
+        await Db.SaveChangesAsync();
 
         await _service.SubmitFeedbackAsync(
             userId, FeedbackCategory.Bug, "a", "/a", null, null, null);
@@ -283,7 +249,7 @@ public class FeedbackServiceTests : IDisposable
             DisplayName = "Reporter",
             PreferredLanguage = "en"
         };
-        _dbContext.Users.Add(user);
+        Db.Users.Add(user);
 
         var report = new FeedbackReport
         {
@@ -293,11 +259,11 @@ public class FeedbackServiceTests : IDisposable
             Description = "Test",
             PageUrl = "/test",
             Status = FeedbackStatus.Open,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.FeedbackReports.Add(report);
-        await _dbContext.SaveChangesAsync();
+        Db.FeedbackReports.Add(report);
+        await Db.SaveChangesAsync();
 
         var adminId = Guid.NewGuid();
         var message = await _service.PostMessageAsync(report.Id, adminId, "Looking into it", isAdmin: true);
@@ -305,7 +271,7 @@ public class FeedbackServiceTests : IDisposable
         message.Content.Should().Be("Looking into it");
         message.SenderUserId.Should().Be(adminId);
 
-        var updated = await _dbContext.FeedbackReports.AsNoTracking()
+        var updated = await Db.FeedbackReports.AsNoTracking()
             .FirstAsync(r => r.Id == report.Id);
         updated.LastAdminMessageAt.Should().NotBeNull();
         updated.LastReporterMessageAt.Should().BeNull();
@@ -319,13 +285,13 @@ public class FeedbackServiceTests : IDisposable
     public async Task GetFeedbackByIdForViewerAsync_NonReporter_ReturnsNull()
     {
         var reporterId = Guid.NewGuid();
-        _dbContext.Users.Add(new User
+        Db.Users.Add(new User
         {
             Id = reporterId,
             Email = "reporter@test.com",
             DisplayName = "Reporter"
         });
-        _dbContext.FeedbackReports.Add(new FeedbackReport
+        Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
             UserId = reporterId,
@@ -333,13 +299,13 @@ public class FeedbackServiceTests : IDisposable
             Description = "Test",
             PageUrl = "/test",
             Status = FeedbackStatus.Open,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetFeedbackByIdForViewerAsync(
-            _dbContext.FeedbackReports.Single().Id,
+            Db.FeedbackReports.Single().Id,
             Guid.NewGuid(),
             isAdmin: false);
 
@@ -351,7 +317,7 @@ public class FeedbackServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var user = new User { Id = userId, Email = "reporter@test.com", DisplayName = "Reporter" };
-        _dbContext.Users.Add(user);
+        Db.Users.Add(user);
 
         var report = new FeedbackReport
         {
@@ -361,16 +327,16 @@ public class FeedbackServiceTests : IDisposable
             Description = "Test",
             PageUrl = "/test",
             Status = FeedbackStatus.Open,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.FeedbackReports.Add(report);
-        await _dbContext.SaveChangesAsync();
+        Db.FeedbackReports.Add(report);
+        await Db.SaveChangesAsync();
 
         var message = await _service.PostMessageAsync(report.Id, userId, "More details", isAdmin: false);
 
         message.Content.Should().Be("More details");
-        var updated = await _dbContext.FeedbackReports.AsNoTracking()
+        var updated = await Db.FeedbackReports.AsNoTracking()
             .FirstAsync(r => r.Id == report.Id);
         updated.LastReporterMessageAt.Should().NotBeNull();
         updated.LastAdminMessageAt.Should().BeNull();
@@ -385,12 +351,12 @@ public class FeedbackServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var user = new User { Id = userId, Email = "u@test.com", DisplayName = "U" };
-        _dbContext.Users.Add(user);
+        Db.Users.Add(user);
 
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
 
         // Open, no admin message -> actionable
-        _dbContext.FeedbackReports.Add(new FeedbackReport
+        Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
             UserId = userId,
@@ -403,7 +369,7 @@ public class FeedbackServiceTests : IDisposable
         });
 
         // Reporter replied after admin -> actionable
-        _dbContext.FeedbackReports.Add(new FeedbackReport
+        Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
             UserId = userId,
@@ -418,7 +384,7 @@ public class FeedbackServiceTests : IDisposable
         });
 
         // Resolved -> not actionable
-        _dbContext.FeedbackReports.Add(new FeedbackReport
+        Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
             UserId = userId,
@@ -431,7 +397,7 @@ public class FeedbackServiceTests : IDisposable
             ResolvedAt = now
         });
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var count = await _service.GetActionableCountAsync();
         count.Should().Be(2);
@@ -442,10 +408,10 @@ public class FeedbackServiceTests : IDisposable
     {
         var bobId = Guid.NewGuid();
         var aliceId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = bobId, DisplayName = "Bob", Email = "b@b.com" });
-        _dbContext.Users.Add(new User { Id = aliceId, DisplayName = "Alice", Email = "a@a.com" });
-        var now = _clock.GetCurrentInstant();
-        _dbContext.FeedbackReports.Add(new FeedbackReport
+        Db.Users.Add(new User { Id = bobId, DisplayName = "Bob", Email = "b@b.com" });
+        Db.Users.Add(new User { Id = aliceId, DisplayName = "Alice", Email = "a@a.com" });
+        var now = Clock.GetCurrentInstant();
+        Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
             UserId = bobId,
@@ -456,7 +422,7 @@ public class FeedbackServiceTests : IDisposable
             CreatedAt = now,
             UpdatedAt = now
         });
-        _dbContext.FeedbackReports.Add(new FeedbackReport
+        Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
             UserId = bobId,
@@ -467,7 +433,7 @@ public class FeedbackServiceTests : IDisposable
             CreatedAt = now,
             UpdatedAt = now
         });
-        _dbContext.FeedbackReports.Add(new FeedbackReport
+        Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
             UserId = aliceId,
@@ -478,7 +444,7 @@ public class FeedbackServiceTests : IDisposable
             CreatedAt = now,
             UpdatedAt = now
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var reporters = await _service.GetDistinctReportersAsync();
 
@@ -492,8 +458,8 @@ public class FeedbackServiceTests : IDisposable
     private async Task<FeedbackReport> CreateTestReport(FeedbackStatus status = FeedbackStatus.Open)
     {
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = userId, DisplayName = "Test", Email = $"{userId}@test.com" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = userId, DisplayName = "Test", Email = $"{userId}@test.com" });
+        await Db.SaveChangesAsync();
 
         var report = await _service.SubmitFeedbackAsync(
             userId, FeedbackCategory.Bug, "Test bug", "/test", null, null, null);

--- a/tests/Humans.Application.Tests/Services/IssuesServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/IssuesServiceTests.cs
@@ -12,24 +12,19 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Issues;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using IssuesApplicationService = Humans.Application.Services.Issues.IssuesService;
 
 namespace Humans.Application.Tests.Services;
 
-public class IssuesServiceTests : IDisposable
+public sealed class IssuesServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLog;
     private readonly IUserService _userService;
@@ -38,17 +33,12 @@ public class IssuesServiceTests : IDisposable
     private readonly INotificationService _notificationService;
     private readonly INavBadgeCacheInvalidator _navBadge;
     private readonly IIssuesBadgeCacheInvalidator _issuesBadge;
-    private readonly IMemoryCache _cache;
     private readonly IIssuesRepository _repository;
     private readonly IssuesApplicationService _service;
 
     public IssuesServiceTests()
+        : base(Instant.FromUtc(2026, 4, 29, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 4, 29, 12, 0));
         _emailService = Substitute.For<IEmailService>();
         _auditLog = Substitute.For<IAuditLogService>();
         _auditLog
@@ -60,27 +50,7 @@ public class IssuesServiceTests : IDisposable
         var env = Substitute.For<IHostEnvironment>();
         env.ContentRootPath.Returns(Path.GetTempPath());
 
-        _userService = Substitute.For<IUserService>();
-        _userService
-            .GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var ids = (IReadOnlyCollection<Guid>)call[0]!;
-                var dict = _dbContext.Users
-                    .AsNoTracking()
-                    .Where(u => ids.Contains(u.Id))
-                    .ToDictionary(u => u.Id);
-                return Task.FromResult<IReadOnlyDictionary<Guid, User>>(dict);
-            });
-        _userService
-            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var id = (Guid)call[0]!;
-                return Task.FromResult(_dbContext.Users.AsNoTracking().FirstOrDefault(u => u.Id == id));
-            });
-        _userService.StubGetUserInfosFromContext(_dbContext);
-        _userService.StubGetUserInfoFromContext(_dbContext);
+        _userService = NewDbBackedUserService();
 
         _userEmailService = Substitute.For<IUserEmailService>();
         _userEmailService
@@ -88,7 +58,7 @@ public class IssuesServiceTests : IDisposable
             .Returns(call =>
             {
                 var ids = (IReadOnlyCollection<Guid>)call[0]!;
-                IReadOnlyDictionary<Guid, string> dict = _dbContext.Users
+                IReadOnlyDictionary<Guid, string> dict = Db.Users
                     .AsNoTracking()
                     .Where(u => ids.Contains(u.Id) && u.Email != null)
                     .ToDictionary(u => u.Id, u => u.Email!);
@@ -103,21 +73,14 @@ public class IssuesServiceTests : IDisposable
         _notificationService = Substitute.For<INotificationService>();
         _navBadge = Substitute.For<INavBadgeCacheInvalidator>();
         _issuesBadge = Substitute.For<IIssuesBadgeCacheInvalidator>();
-        _cache = new MemoryCache(new MemoryCacheOptions());
 
-        _repository = new IssuesRepository(new TestDbContextFactory(options));
+        _repository = new IssuesRepository(DbFactory);
 
         _service = new IssuesApplicationService(
             _repository, _userService, _userEmailService, _roleService,
             _emailService, _notificationService, _auditLog, _navBadge,
-            _issuesBadge, _cache,
-            _clock, env, NullLogger<IssuesApplicationService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+            _issuesBadge, Cache,
+            Clock, env, NullLogger<IssuesApplicationService>.Instance);
     }
 
     // ==========================================================================
@@ -128,8 +91,8 @@ public class IssuesServiceTests : IDisposable
     public async Task SubmitIssueAsync_lands_in_Triage_and_invalidates_nav_badge()
     {
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = userId, Email = "u@u.com", DisplayName = "U" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = userId, Email = "u@u.com", DisplayName = "U" });
+        await Db.SaveChangesAsync();
 
         var issue = await _service.SubmitIssueAsync(
             userId, IssueCategory.Bug, "Title", "Desc",
@@ -142,7 +105,7 @@ public class IssuesServiceTests : IDisposable
         issue.Section.Should().Be(IssueSectionRouting.Tickets);
         _navBadge.Received(1).Invalidate();
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issue.Id);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issue.Id);
         stored.Status.Should().Be(IssueStatus.Triage);
     }
 
@@ -152,8 +115,8 @@ public class IssuesServiceTests : IDisposable
         var reporterId = Guid.NewGuid();
         var adminId = Guid.NewGuid();
         var ticketAdminId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = reporterId, Email = "r@x", DisplayName = "R" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = reporterId, Email = "r@x", DisplayName = "R" });
+        await Db.SaveChangesAsync();
 
         _roleService
             .GetActiveUserIdsInRoleAsync(RoleNames.Admin, Arg.Any<CancellationToken>())
@@ -247,7 +210,7 @@ public class IssuesServiceTests : IDisposable
 
         await _service.PostCommentAsync(issueId, reporterId, "Still broken", senderIsReporter: true);
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Status.Should().Be(IssueStatus.Open);
     }
 
@@ -258,7 +221,7 @@ public class IssuesServiceTests : IDisposable
 
         await _service.PostCommentAsync(issueId, reporterId, "Reopen please", senderIsReporter: true);
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.ResolvedAt.Should().BeNull();
         stored.ResolvedByUserId.Should().BeNull();
     }
@@ -270,7 +233,7 @@ public class IssuesServiceTests : IDisposable
 
         await _service.PostCommentAsync(issueId, reporterId, "Update", senderIsReporter: true);
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Status.Should().Be(IssueStatus.Open);
     }
 
@@ -285,10 +248,10 @@ public class IssuesServiceTests : IDisposable
             DisplayName = "Reporter",
             PreferredLanguage = "en"
         };
-        _dbContext.Users.Add(reporter);
+        Db.Users.Add(reporter);
         _userService.GetUserInfoAsync(reporterId, Arg.Any<CancellationToken>())
             .Returns(reporter.ToUserInfo());
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var issueId = await SeedIssueRowAsync(reporterId, IssueStatus.Open, "Report Title");
         var adminId = Guid.NewGuid();
@@ -343,7 +306,7 @@ public class IssuesServiceTests : IDisposable
             senderIsReporter: false,
             resolveOnPost: true);
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Status.Should().Be(IssueStatus.Resolved);
         stored.ResolvedByUserId.Should().Be(actorId);
     }
@@ -360,7 +323,7 @@ public class IssuesServiceTests : IDisposable
 
         await _service.UpdateStatusAsync(issueId, IssueStatus.Resolved, actorId);
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Status.Should().Be(IssueStatus.Resolved);
         stored.ResolvedAt.Should().NotBeNull();
         stored.ResolvedByUserId.Should().Be(actorId);
@@ -375,7 +338,7 @@ public class IssuesServiceTests : IDisposable
         await _service.UpdateStatusAsync(issueId, IssueStatus.Resolved, actorId);
         await _service.UpdateStatusAsync(issueId, IssueStatus.Open, actorId);
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Status.Should().Be(IssueStatus.Open);
         stored.ResolvedAt.Should().BeNull();
         stored.ResolvedByUserId.Should().BeNull();
@@ -403,8 +366,8 @@ public class IssuesServiceTests : IDisposable
         // Stamp an assignee on the issue so the dispatch helper has somebody
         // to notify alongside the reporter.
         var assigneeId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = assigneeId, Email = "ass@x.com", DisplayName = "Assignee" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = assigneeId, Email = "ass@x.com", DisplayName = "Assignee" });
+        await Db.SaveChangesAsync();
         await _service.UpdateAssigneeAsync(issueId, assigneeId, Guid.NewGuid());
         _notificationService.ClearReceivedCalls();
 
@@ -459,7 +422,7 @@ public class IssuesServiceTests : IDisposable
         result.Succeeded.Should().BeTrue();
         result.NotFound.Should().BeFalse();
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Status.Should().Be(IssueStatus.Resolved);
         stored.ResolvedByUserId.Should().Be(actorId);
     }
@@ -484,9 +447,9 @@ public class IssuesServiceTests : IDisposable
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
         var oldAssignee = new User { Id = Guid.NewGuid(), DisplayName = "Old Person", Email = "old@x.com" };
         var newAssignee = new User { Id = Guid.NewGuid(), DisplayName = "New Person", Email = "new@x.com" };
-        _dbContext.Users.Add(oldAssignee);
-        _dbContext.Users.Add(newAssignee);
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(oldAssignee);
+        Db.Users.Add(newAssignee);
+        await Db.SaveChangesAsync();
 
         var actorId = Guid.NewGuid();
         await _service.UpdateAssigneeAsync(issueId, oldAssignee.Id, actorId);
@@ -508,8 +471,8 @@ public class IssuesServiceTests : IDisposable
     {
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
         var newAssigneeId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = newAssigneeId, Email = "a@a.com", DisplayName = "Assignee" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = newAssigneeId, Email = "a@a.com", DisplayName = "Assignee" });
+        await Db.SaveChangesAsync();
 
         await _service.UpdateAssigneeAsync(issueId, newAssigneeId, Guid.NewGuid());
 
@@ -531,8 +494,8 @@ public class IssuesServiceTests : IDisposable
     {
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
         var actorId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = actorId, Email = "self@x.com", DisplayName = "Self" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = actorId, Email = "self@x.com", DisplayName = "Self" });
+        await Db.SaveChangesAsync();
 
         await _service.UpdateAssigneeAsync(issueId, actorId, actorId);
 
@@ -554,15 +517,15 @@ public class IssuesServiceTests : IDisposable
     {
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
         var assigneeId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = assigneeId, Email = "assignee@x.com", DisplayName = "Assignee" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = assigneeId, Email = "assignee@x.com", DisplayName = "Assignee" });
+        await Db.SaveChangesAsync();
 
         var result = await _service.UpdateAssigneeWithResultAsync(issueId, assigneeId, Guid.NewGuid());
 
         result.Succeeded.Should().BeTrue();
         result.NotFound.Should().BeFalse();
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.AssigneeUserId.Should().Be(assigneeId);
     }
 
@@ -589,7 +552,7 @@ public class IssuesServiceTests : IDisposable
 
         await _service.UpdateSectionAsync(issueId, IssueSectionRouting.Teams, actorId);
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Section.Should().Be(IssueSectionRouting.Teams);
 
         _navBadge.Received(1).Invalidate();
@@ -615,7 +578,7 @@ public class IssuesServiceTests : IDisposable
         result.Succeeded.Should().BeTrue();
         result.NotFound.Should().BeFalse();
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.Section.Should().Be(IssueSectionRouting.Teams);
     }
 
@@ -641,7 +604,7 @@ public class IssuesServiceTests : IDisposable
         result.Succeeded.Should().BeTrue();
         result.NotFound.Should().BeFalse();
 
-        var stored = await _dbContext.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
+        var stored = await Db.Issues.AsNoTracking().FirstAsync(i => i.Id == issueId);
         stored.GitHubIssueNumber.Should().Be(1234);
     }
 
@@ -675,8 +638,8 @@ public class IssuesServiceTests : IDisposable
         var svc = new IssuesApplicationService(
             repo, _userService, _userEmailService, _roleService,
             _emailService, _notificationService, _auditLog, _navBadge,
-            _issuesBadge, _cache,
-            _clock, env, NullLogger<IssuesApplicationService>.Instance);
+            _issuesBadge, Cache,
+            Clock, env, NullLogger<IssuesApplicationService>.Instance);
 
         await svc.GetIssueListAsync(new IssueListFilter(), Guid.NewGuid(), [], viewerIsAdmin: true);
 
@@ -703,8 +666,8 @@ public class IssuesServiceTests : IDisposable
         var svc = new IssuesApplicationService(
             repo, _userService, _userEmailService, _roleService,
             _emailService, _notificationService, _auditLog, _navBadge,
-            _issuesBadge, _cache,
-            _clock, env, NullLogger<IssuesApplicationService>.Instance);
+            _issuesBadge, Cache,
+            Clock, env, NullLogger<IssuesApplicationService>.Instance);
 
         var viewerId = Guid.NewGuid();
         await svc.GetIssueListAsync(
@@ -735,8 +698,8 @@ public class IssuesServiceTests : IDisposable
         var svc = new IssuesApplicationService(
             repo, _userService, _userEmailService, _roleService,
             _emailService, _notificationService, _auditLog, _navBadge,
-            _issuesBadge, _cache,
-            _clock, env, NullLogger<IssuesApplicationService>.Instance);
+            _issuesBadge, Cache,
+            Clock, env, NullLogger<IssuesApplicationService>.Instance);
 
         var viewerId = Guid.NewGuid();
         await svc.GetIssueListAsync(
@@ -755,7 +718,7 @@ public class IssuesServiceTests : IDisposable
     public async Task GetIssueListAsync_applies_updated_descending_limit()
     {
         var reporterId = Guid.NewGuid();
-        _dbContext.Users.Add(new User
+        Db.Users.Add(new User
         {
             Id = reporterId,
             Email = "reporter@example.org",
@@ -770,8 +733,8 @@ public class IssuesServiceTests : IDisposable
             Title = "Older",
             Description = "Description",
             Status = IssueStatus.Open,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant() - Duration.FromHours(2)
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant() - Duration.FromHours(2)
         };
         var newer = new Issue
         {
@@ -781,8 +744,8 @@ public class IssuesServiceTests : IDisposable
             Title = "Newer",
             Description = "Description",
             Status = IssueStatus.Open,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         var middle = new Issue
         {
@@ -792,11 +755,11 @@ public class IssuesServiceTests : IDisposable
             Title = "Middle",
             Description = "Description",
             Status = IssueStatus.Open,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant() - Duration.FromHours(1)
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant() - Duration.FromHours(1)
         };
-        await _dbContext.Issues.AddRangeAsync(older, newer, middle);
-        await _dbContext.SaveChangesAsync();
+        await Db.Issues.AddRangeAsync(older, newer, middle);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetIssueListAsync(
             new IssueListFilter(Limit: 2), reporterId, viewerRoles: [], viewerIsAdmin: true);
@@ -823,8 +786,8 @@ public class IssuesServiceTests : IDisposable
         var svc = new IssuesApplicationService(
             repo, _userService, _userEmailService, _roleService,
             _emailService, _notificationService, _auditLog, _navBadge,
-            _issuesBadge, _cache,
-            _clock, env, NullLogger<IssuesApplicationService>.Instance);
+            _issuesBadge, Cache,
+            Clock, env, NullLogger<IssuesApplicationService>.Instance);
 
         await svc.GetActionableCountForViewerAsync(
             Guid.NewGuid(), [], viewerIsAdmin: true);
@@ -850,8 +813,8 @@ public class IssuesServiceTests : IDisposable
         var svc = new IssuesApplicationService(
             repo, _userService, _userEmailService, _roleService,
             _emailService, _notificationService, _auditLog, _navBadge,
-            _issuesBadge, _cache,
-            _clock, env, NullLogger<IssuesApplicationService>.Instance);
+            _issuesBadge, Cache,
+            Clock, env, NullLogger<IssuesApplicationService>.Instance);
 
         var viewerId = Guid.NewGuid();
         await svc.GetActionableCountForViewerAsync(
@@ -872,9 +835,9 @@ public class IssuesServiceTests : IDisposable
     {
         var aliceId = Guid.NewGuid();
         var bobId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = aliceId, Email = "a@a.com", DisplayName = "Alice" });
-        _dbContext.Users.Add(new User { Id = bobId, Email = "b@b.com", DisplayName = "Bob" });
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(new User { Id = aliceId, Email = "a@a.com", DisplayName = "Alice" });
+        Db.Users.Add(new User { Id = bobId, Email = "b@b.com", DisplayName = "Bob" });
+        await Db.SaveChangesAsync();
 
         await SeedIssueRowAsync(aliceId, IssueStatus.Open, "Alice's first");
         await SeedIssueRowAsync(aliceId, IssueStatus.Open, "Alice's second");
@@ -898,16 +861,16 @@ public class IssuesServiceTests : IDisposable
         string? section = null)
     {
         var reporterId = Guid.NewGuid();
-        if (!_dbContext.Users.Any(u => u.Id == reporterId))
+        if (!Db.Users.Any(u => u.Id == reporterId))
         {
-            _dbContext.Users.Add(new User
+            Db.Users.Add(new User
             {
                 Id = reporterId,
                 Email = $"{reporterId}@test.com",
                 DisplayName = "Reporter",
                 PreferredLanguage = "en"
             });
-            await _dbContext.SaveChangesAsync();
+            await Db.SaveChangesAsync();
         }
 
         var issueId = await SeedIssueRowAsync(reporterId, status, "Title", section, withResolvedFields);
@@ -921,7 +884,7 @@ public class IssuesServiceTests : IDisposable
         string? section = null,
         bool withResolvedFields = false)
     {
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         var issue = new Issue
         {
             Id = Guid.NewGuid(),
@@ -936,8 +899,8 @@ public class IssuesServiceTests : IDisposable
             ResolvedAt = withResolvedFields ? now : null,
             ResolvedByUserId = withResolvedFields ? Guid.NewGuid() : null
         };
-        _dbContext.Issues.Add(issue);
-        await _dbContext.SaveChangesAsync();
+        Db.Issues.Add(issue);
+        await Db.SaveChangesAsync();
         return issue.Id;
     }
 
@@ -945,7 +908,7 @@ public class IssuesServiceTests : IDisposable
         IssueStatus status, Instant resolvedAt, string? screenshotPath = null)
     {
         var reporterId = Guid.NewGuid();
-        _dbContext.Users.Add(new User
+        Db.Users.Add(new User
         {
             Id = reporterId,
             Email = $"{reporterId}@test.com",
@@ -965,8 +928,8 @@ public class IssuesServiceTests : IDisposable
             ResolvedAt = status.IsTerminal() ? resolvedAt : null,
             ScreenshotStoragePath = screenshotPath
         };
-        _dbContext.Issues.Add(issue);
-        await _dbContext.SaveChangesAsync();
+        Db.Issues.Add(issue);
+        await Db.SaveChangesAsync();
         return issue.Id;
     }
 
@@ -977,7 +940,7 @@ public class IssuesServiceTests : IDisposable
     [HumansFact]
     public async Task PurgeExpiredAsync_DeletesTerminalIssuesOlderThanSixMonths()
     {
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         var oldResolved = now - Duration.FromDays(181);
 
         var toPurge = await SeedIssueWithResolvedAtAsync(IssueStatus.Resolved, oldResolved);
@@ -987,15 +950,15 @@ public class IssuesServiceTests : IDisposable
         var deleted = await _service.PurgeExpiredAsync();
 
         deleted.Should().Be(3);
-        _dbContext.Issues.Any(i => i.Id == toPurge).Should().BeFalse();
-        _dbContext.Issues.Any(i => i.Id == alsoPurgeWontFix).Should().BeFalse();
-        _dbContext.Issues.Any(i => i.Id == alsoPurgeDuplicate).Should().BeFalse();
+        Db.Issues.Any(i => i.Id == toPurge).Should().BeFalse();
+        Db.Issues.Any(i => i.Id == alsoPurgeWontFix).Should().BeFalse();
+        Db.Issues.Any(i => i.Id == alsoPurgeDuplicate).Should().BeFalse();
     }
 
     [HumansFact]
     public async Task PurgeExpiredAsync_KeepsTerminalIssuesYoungerThanSixMonths()
     {
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         var recentResolved = now - Duration.FromDays(179);
 
         var keep = await SeedIssueWithResolvedAtAsync(IssueStatus.Resolved, recentResolved);
@@ -1003,13 +966,13 @@ public class IssuesServiceTests : IDisposable
         var deleted = await _service.PurgeExpiredAsync();
 
         deleted.Should().Be(0);
-        _dbContext.Issues.Any(i => i.Id == keep).Should().BeTrue();
+        Db.Issues.Any(i => i.Id == keep).Should().BeTrue();
     }
 
     [HumansFact]
     public async Task PurgeExpiredAsync_NeverDeletesNonTerminalIssuesEvenWhenAncient()
     {
-        var ancient = _clock.GetCurrentInstant() - Duration.FromDays(365 * 5);
+        var ancient = Clock.GetCurrentInstant() - Duration.FromDays(365 * 5);
 
         var keepOpen = await SeedIssueWithResolvedAtAsync(IssueStatus.Open, ancient);
         var keepInProgress = await SeedIssueWithResolvedAtAsync(IssueStatus.InProgress, ancient);
@@ -1018,15 +981,15 @@ public class IssuesServiceTests : IDisposable
         var deleted = await _service.PurgeExpiredAsync();
 
         deleted.Should().Be(0);
-        _dbContext.Issues.Any(i => i.Id == keepOpen).Should().BeTrue();
-        _dbContext.Issues.Any(i => i.Id == keepInProgress).Should().BeTrue();
-        _dbContext.Issues.Any(i => i.Id == keepTriage).Should().BeTrue();
+        Db.Issues.Any(i => i.Id == keepOpen).Should().BeTrue();
+        Db.Issues.Any(i => i.Id == keepInProgress).Should().BeTrue();
+        Db.Issues.Any(i => i.Id == keepTriage).Should().BeTrue();
     }
 
     [HumansFact]
     public async Task PurgeExpiredAsync_DeletesScreenshotDirectory()
     {
-        var oldResolved = _clock.GetCurrentInstant() - Duration.FromDays(200);
+        var oldResolved = Clock.GetCurrentInstant() - Duration.FromDays(200);
 
         var issueId = Guid.NewGuid();
         var screenshotDir = Path.Combine(
@@ -1038,14 +1001,14 @@ public class IssuesServiceTests : IDisposable
         try
         {
             var reporterId = Guid.NewGuid();
-            _dbContext.Users.Add(new User
+            Db.Users.Add(new User
             {
                 Id = reporterId,
                 Email = $"{reporterId}@test.com",
                 DisplayName = "Reporter",
                 PreferredLanguage = "en"
             });
-            _dbContext.Issues.Add(new Issue
+            Db.Issues.Add(new Issue
             {
                 Id = issueId,
                 ReporterUserId = reporterId,
@@ -1058,7 +1021,7 @@ public class IssuesServiceTests : IDisposable
                 ResolvedAt = oldResolved,
                 ScreenshotStoragePath = $"uploads/issues/{issueId}/shot.png"
             });
-            await _dbContext.SaveChangesAsync();
+            await Db.SaveChangesAsync();
 
             var deleted = await _service.PurgeExpiredAsync();
 
@@ -1078,10 +1041,10 @@ public class IssuesServiceTests : IDisposable
         // Issue claims a screenshot path but the directory was already removed
         // (e.g. wiped manually, prior partial sweep). The DB delete must still
         // succeed.
-        var oldResolved = _clock.GetCurrentInstant() - Duration.FromDays(200);
+        var oldResolved = Clock.GetCurrentInstant() - Duration.FromDays(200);
 
         var reporterId = Guid.NewGuid();
-        _dbContext.Users.Add(new User
+        Db.Users.Add(new User
         {
             Id = reporterId,
             Email = $"{reporterId}@test.com",
@@ -1089,7 +1052,7 @@ public class IssuesServiceTests : IDisposable
             PreferredLanguage = "en"
         });
         var issueId = Guid.NewGuid();
-        _dbContext.Issues.Add(new Issue
+        Db.Issues.Add(new Issue
         {
             Id = issueId,
             ReporterUserId = reporterId,
@@ -1102,18 +1065,18 @@ public class IssuesServiceTests : IDisposable
             ResolvedAt = oldResolved,
             ScreenshotStoragePath = $"uploads/issues/{issueId}/missing.png"
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var deleted = await _service.PurgeExpiredAsync();
 
         deleted.Should().Be(1);
-        _dbContext.Issues.Any(i => i.Id == issueId).Should().BeFalse();
+        Db.Issues.Any(i => i.Id == issueId).Should().BeFalse();
     }
 
     [HumansFact]
     public async Task PurgeExpiredAsync_InvalidatesNavBadge()
     {
-        var oldResolved = _clock.GetCurrentInstant() - Duration.FromDays(200);
+        var oldResolved = Clock.GetCurrentInstant() - Duration.FromDays(200);
         await SeedIssueWithResolvedAtAsync(IssueStatus.Resolved, oldResolved);
 
         await _service.PurgeExpiredAsync();

--- a/tests/Humans.Application.Tests/Services/MagicLinkServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/MagicLinkServiceTests.cs
@@ -5,22 +5,18 @@ using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using MagicLinkService = Humans.Application.Services.Auth.MagicLinkService;
 
 namespace Humans.Application.Tests.Services;
 
-public class MagicLinkServiceTests : IDisposable
+public sealed class MagicLinkServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly UserManager<User> _userManager;
     private readonly IUserEmailService _userEmailService;
     private readonly IUserService _userService;
@@ -30,14 +26,8 @@ public class MagicLinkServiceTests : IDisposable
     private readonly MagicLinkService _service;
 
     public MagicLinkServiceTests()
+        : base(Instant.FromUtc(2026, 3, 25, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 25, 12, 0));
-
         var store = Substitute.For<IUserStore<User>>();
         _userManager = Substitute.For<UserManager<User>>(
             store, null, null, null, null, null, null, null, null);
@@ -69,15 +59,14 @@ public class MagicLinkServiceTests : IDisposable
             _emailService,
             _urlBuilder,
             _rateLimiter,
-            _clock,
+            Clock,
             NullLogger<MagicLinkService>.Instance);
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
-        _dbContext.Dispose();
         _userManager.Dispose();
-        GC.SuppressFinalize(this);
+        base.Dispose();
     }
 
     [HumansFact]
@@ -90,7 +79,7 @@ public class MagicLinkServiceTests : IDisposable
             UserName = "alice@gmail.com",
             Email = "alice@gmail.com",
             DisplayName = "Alice",
-            CreatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant()
         };
 
         _userEmailService
@@ -121,7 +110,7 @@ public class MagicLinkServiceTests : IDisposable
         {
             Id = userId,
             DisplayName = "Alice",
-            CreatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant()
         };
 
         _userEmailService
@@ -178,8 +167,8 @@ public class MagicLinkServiceTests : IDisposable
             UserName = "alice@gmail.com",
             Email = "alice@gmail.com",
             DisplayName = "Alice",
-            CreatedAt = _clock.GetCurrentInstant(),
-            MagicLinkSentAt = _clock.GetCurrentInstant() - Duration.FromSeconds(30) // 30s ago
+            CreatedAt = Clock.GetCurrentInstant(),
+            MagicLinkSentAt = Clock.GetCurrentInstant() - Duration.FromSeconds(30) // 30s ago
         };
 
         _userEmailService

--- a/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
@@ -4,11 +4,8 @@ using Humans.Application.Services.Email;
 using Humans.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
-using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Tests.Infrastructure;
-using Humans.Infrastructure.Data;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Infrastructure.Repositories.Email;
@@ -25,10 +22,8 @@ namespace Humans.Application.Tests.Services;
 /// <see cref="IImmediateOutboxProcessor"/>) are NSubstitute fakes so the Application
 /// service stays free of Infrastructure dependencies.
 /// </summary>
-public sealed class OutboxEmailServiceTests : IDisposable
+public sealed class OutboxEmailServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly OutboxEmailService _service;
     private readonly IEmailRenderer _renderer = Substitute.For<IEmailRenderer>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
@@ -39,19 +34,11 @@ public sealed class OutboxEmailServiceTests : IDisposable
 
     public OutboxEmailServiceTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
-
         // Default composer stub: returns the input HTML plus a stub plain text.
         _bodyComposer.Compose(Arg.Any<string>(), Arg.Any<string?>())
             .Returns(ci => ((string)ci[0], "plain-text-stub"));
 
-        var factory = new TestDbContextFactory(options);
-        var repo = new EmailOutboxRepository(factory);
+        var repo = new EmailOutboxRepository(DbFactory);
 
         _service = new OutboxEmailService(
             repo,
@@ -60,14 +47,9 @@ public sealed class OutboxEmailServiceTests : IDisposable
             _bodyComposer,
             _immediate,
             _metrics,
-            _clock,
+            Clock,
             _commPrefService,
             NullLogger<OutboxEmailService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
     }
 
     [HumansFact]
@@ -78,7 +60,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
 
         await _service.SendWelcomeEmailAsync("alice@example.com", "Alice", "en");
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().HaveCount(1);
 
         var msg = messages[0];
@@ -89,7 +71,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
         msg.PlainTextBody.Should().Be("plain-text-stub");
         msg.TemplateName.Should().Be("welcome");
         msg.Status.Should().Be(EmailOutboxStatus.Queued);
-        msg.CreatedAt.Should().Be(_clock.GetCurrentInstant());
+        msg.CreatedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -111,7 +93,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
 
         await _service.SendEmailVerificationAsync("bob@example.com", "Bob", "https://verify", culture: "en");
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().HaveCount(1);
 
         var msg = messages[0];
@@ -132,7 +114,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
             "charlie@example.com", "Charlie", "Dave", "Hey!",
             includeContactInfo: true, senderEmail: "dave@example.com", culture: "en");
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().HaveCount(1);
         messages[0].ReplyTo.Should().Be("dave@example.com");
     }
@@ -147,7 +129,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
             "charlie@example.com", "Charlie", "Dave", "Hey!",
             includeContactInfo: false, senderEmail: null, culture: "en");
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().HaveCount(1);
         messages[0].ReplyTo.Should().BeNull();
     }
@@ -161,7 +143,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
         await _service.SendApplicationApprovedAsync(
             "eve@example.com", "Eve", MembershipTier.Colaborador, "en");
 
-        var msg = await _dbContext.EmailOutboxMessages.SingleAsync();
+        var msg = await Db.EmailOutboxMessages.SingleAsync();
         msg.TemplateName.Should().Be("application_approved");
         msg.RecipientEmail.Should().Be("eve@example.com");
         _metrics.Received(1).RecordEmailQueued("application_approved");
@@ -201,7 +183,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
             "charlie@example.com", "Charlie", "Alpha Team", "alpha",
             []);
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().BeEmpty("the email should have been suppressed because the user opted out of TeamUpdates");
     }
 
@@ -227,7 +209,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
             "dana@example.com", "Dana", "Beta Team", "beta",
             []);
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().HaveCount(1, "opted-in user should receive the email");
         messages[0].RecipientEmail.Should().Be("dana@example.com");
         messages[0].TemplateName.Should().Be("added_to_team");
@@ -249,7 +231,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
         await _service.SendApplicationApprovedAsync(
             "eve@example.com", "Eve", MembershipTier.Colaborador, "en");
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().BeEmpty(
             "ApplicationApproved is now Governance-categorized and must be suppressed when opted out.");
     }
@@ -269,7 +251,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
         await _service.SendApplicationRejectedAsync(
             "frank@example.com", "Frank", MembershipTier.Asociado, "Insufficient tenure", "en");
 
-        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        var messages = await Db.EmailOutboxMessages.ToListAsync();
         messages.Should().BeEmpty(
             "ApplicationRejected is now Governance-categorized and must be suppressed when opted out.");
     }
@@ -296,7 +278,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
         await _service.SendApplicationApprovedAsync(
             "grace@example.com", "Grace", MembershipTier.Colaborador, "en");
 
-        var msg = await _dbContext.EmailOutboxMessages.SingleAsync();
+        var msg = await Db.EmailOutboxMessages.SingleAsync();
         msg.UserId.Should().Be(userId);
         msg.ExtraHeaders.Should().NotBeNull("List-Unsubscribe headers must be stamped for Governance emails.");
         _bodyComposer.Received().Compose(Arg.Any<string>(), "https://example.com/Unsubscribe/abc");
@@ -326,7 +308,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
             Code: "ABC123",
             ReplyTo: "reply@example.com"));
 
-        var msg = await _dbContext.EmailOutboxMessages.SingleAsync();
+        var msg = await Db.EmailOutboxMessages.SingleAsync();
         msg.RecipientEmail.Should().Be("zoe@example.com");
         msg.Subject.Should().Be("Subject Zoe");
         msg.HtmlBody.Should().Contain("Hello Zoe! Your code is ABC123.");
@@ -352,7 +334,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
 
         await _service.SendEventLifecycleNotificationAsync(request, "alice@example.com");
 
-        var msg = await _dbContext.EmailOutboxMessages.SingleAsync();
+        var msg = await Db.EmailOutboxMessages.SingleAsync();
         msg.RecipientEmail.Should().Be("alice@example.com");
         msg.RecipientName.Should().Be("Alice");
         msg.TemplateName.Should().Be("event_submitted");

--- a/tests/Humans.Application.Tests/Services/Profile/CommunicationPreferenceCountTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profile/CommunicationPreferenceCountTests.cs
@@ -1,40 +1,29 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Profiles;
 using Humans.Infrastructure.Services.Profiles;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
-using Humans.Application.Interfaces.Users;
 using CommunicationPreferenceService = Humans.Application.Services.Profiles.CommunicationPreferenceService;
 
 namespace Humans.Application.Tests.Services.Profiles;
 
-public class CommunicationPreferenceCountTests : IDisposable
+public sealed class CommunicationPreferenceCountTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
     private readonly CommunicationPreferenceService _service;
-    private readonly Instant _now = Instant.FromUtc(2026, 5, 1, 12, 0);
 
     public CommunicationPreferenceCountTests()
+        : base(Instant.FromUtc(2026, 5, 1, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-
-        var factory = new TestDbContextFactory(options);
-        var repository = new CommunicationPreferenceRepository(factory);
+        var repository = new CommunicationPreferenceRepository(DbFactory);
 
         var dataProtectionProvider = DataProtectionProvider.Create("TestApp");
         var emailSettings = Options.Create(new EmailSettings { BaseUrl = "https://test.example.com" });
@@ -43,54 +32,49 @@ public class CommunicationPreferenceCountTests : IDisposable
             NullLogger<UnsubscribeTokenProvider>.Instance);
 
         var auditLog = Substitute.For<IAuditLogService>();
-        var clock = new FakeClock(_now);
 
         _service = new CommunicationPreferenceService(
             repository,
             Substitute.For<IUserService>(),
             tokenProvider,
-            clock,
+            Clock,
             auditLog,
             NullLogger<CommunicationPreferenceService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
     public async Task GetCountByCategoryAndStateAsync_CountsOptedInAndOut()
     {
+        var now = Clock.GetCurrentInstant();
+
         // Seed: 5 users with Marketing OptedOut=false, 3 with OptedOut=true.
         for (var i = 0; i < 5; i++)
         {
-            _dbContext.CommunicationPreferences.Add(new CommunicationPreference
+            Db.CommunicationPreferences.Add(new CommunicationPreference
             {
                 Id = Guid.NewGuid(),
                 UserId = Guid.NewGuid(),
                 Category = MessageCategory.Marketing,
                 OptedOut = false,
-                UpdatedAt = _now,
+                UpdatedAt = now,
                 UpdateSource = "Test",
             });
         }
 
         for (var i = 0; i < 3; i++)
         {
-            _dbContext.CommunicationPreferences.Add(new CommunicationPreference
+            Db.CommunicationPreferences.Add(new CommunicationPreference
             {
                 Id = Guid.NewGuid(),
                 UserId = Guid.NewGuid(),
                 Category = MessageCategory.Marketing,
                 OptedOut = true,
-                UpdatedAt = _now,
+                UpdatedAt = now,
                 UpdateSource = "Test",
             });
         }
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         (await _service.GetCountByCategoryAndStateAsync(MessageCategory.Marketing, optedOut: false))
             .Should().Be(5);

--- a/tests/Humans.Application.Tests/Services/Profile/CommunicationPreferenceSubscribedAtTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profile/CommunicationPreferenceSubscribedAtTests.cs
@@ -1,41 +1,28 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Profiles;
 using Humans.Infrastructure.Services.Profiles;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
-using Humans.Application.Interfaces.Users;
 using CommunicationPreferenceService = Humans.Application.Services.Profiles.CommunicationPreferenceService;
 
 namespace Humans.Application.Tests.Services.Profiles;
 
-public class CommunicationPreferenceSubscribedAtTests : IDisposable
+public sealed class CommunicationPreferenceSubscribedAtTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly CommunicationPreferenceService _service;
-    private readonly Instant _start = Instant.FromUtc(2026, 5, 1, 12, 0);
 
     public CommunicationPreferenceSubscribedAtTests()
+        : base(Instant.FromUtc(2026, 5, 1, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(_start);
-
-        var factory = new TestDbContextFactory(options);
-        var repository = new CommunicationPreferenceRepository(factory);
+        var repository = new CommunicationPreferenceRepository(DbFactory);
 
         var dataProtectionProvider = DataProtectionProvider.Create("TestApp");
         var emailSettings = Options.Create(new EmailSettings { BaseUrl = "https://test.example.com" });
@@ -49,15 +36,9 @@ public class CommunicationPreferenceSubscribedAtTests : IDisposable
             repository,
             Substitute.For<IUserService>(),
             tokenProvider,
-            _clock,
+            Clock,
             auditLog,
             NullLogger<CommunicationPreferenceService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -85,7 +66,7 @@ public class CommunicationPreferenceSubscribedAtTests : IDisposable
         var firstStamp = (await _service.GetPreferencesAsync(userId))
             .Single(p => p.Category == MessageCategory.Marketing).SubscribedAt;
 
-        _clock.Advance(Duration.FromMilliseconds(10));
+        Clock.Advance(Duration.FromMilliseconds(10));
         await _service.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: true, source: "Profile");
         await _service.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: false, source: "Profile");
         var laterStamp = (await _service.GetPreferencesAsync(userId))
@@ -106,7 +87,7 @@ public class CommunicationPreferenceSubscribedAtTests : IDisposable
         var firstStamp = (await _service.GetPreferencesAsync(userId))
             .Single(p => p.Category == MessageCategory.Marketing).SubscribedAt;
 
-        _clock.Advance(Duration.FromMilliseconds(10));
+        Clock.Advance(Duration.FromMilliseconds(10));
 
         // No-op: already opted in, calling again with optedOut:false is idempotent — no state change, no overwrite
         await _service.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: false, source: "Profile");

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -2,13 +2,11 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Xunit;
 using ProfileService = Humans.Application.Services.Profiles.ProfileService;
 using Humans.Application.Interfaces.AuditLog;
@@ -18,10 +16,8 @@ using Humans.Infrastructure.Repositories.Profiles;
 
 namespace Humans.Application.Tests.Services;
 
-public class ProfileServiceTests : IDisposable
+public sealed class ProfileServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly ProfileService _service;
     private readonly IProfileRepository _profileRepository;
     private readonly IUserService _userService = Substitute.For<IUserService>();
@@ -38,18 +34,10 @@ public class ProfileServiceTests : IDisposable
 
     public ProfileServiceTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
-
         // Real repositories backed by an IDbContextFactory wrapping the in-memory store.
-        var factory = new TestDbContextFactory(options);
-        _profileRepository = new ProfileRepository(factory, _clock);
-        _userEmailRepository = new UserEmailRepository(factory);
-        _contactFieldRepository = new ContactFieldRepository(factory);
+        _profileRepository = new ProfileRepository(DbFactory, Clock);
+        _userEmailRepository = new UserEmailRepository(DbFactory);
+        _contactFieldRepository = new ContactFieldRepository(DbFactory);
 
         _service = new ProfileService(
             _profileRepository, _userService,
@@ -58,16 +46,10 @@ public class ProfileServiceTests : IDisposable
             _auditLogService,
             _fileStorage,
             Substitute.For<IUserInfoInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ProfileService>.Instance);
 
-        _userService.StubGetUserInfosFromContext(_dbContext);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+        _userService.StubGetUserInfosFromContext(Db);
     }
 
     // --- Profile save flow ---
@@ -82,7 +64,7 @@ public class ProfileServiceTests : IDisposable
         var profileId = await _service.SaveProfileAsync(userId, "Jane Doe", request, "en");
 
         profileId.Should().NotBe(Guid.Empty);
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.BurnerName.Should().Be("Flame");
         profile.FirstName.Should().Be("Jane");
         profile.LastName.Should().Be("Doe");
@@ -103,7 +85,7 @@ public class ProfileServiceTests : IDisposable
 
         await _service.SaveProfileAsync(userId, "Jane Doe", request, "en");
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.State.Should().Be(ProfileState.Active);
     }
 
@@ -120,7 +102,7 @@ public class ProfileServiceTests : IDisposable
 
         await _service.SaveProfileAsync(userId, "Stub", request, "en");
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.State.Should().Be(ProfileState.Stub);
     }
 
@@ -133,10 +115,10 @@ public class ProfileServiceTests : IDisposable
 
         await _service.SaveProfileAsync(userId, "Updated Person", request, "en");
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.BurnerName.Should().Be("NewName");
         profile.FirstName.Should().Be("Updated");
-        profile.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        profile.UpdatedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -160,7 +142,7 @@ public class ProfileServiceTests : IDisposable
 
         await _service.SaveProfileAsync(userId, "Test", request, "en");
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.DateOfBirth.Should().Be(new LocalDate(4, 2, 14));
     }
 
@@ -173,7 +155,7 @@ public class ProfileServiceTests : IDisposable
 
         await _service.SaveProfileAsync(userId, "Test", request, "en");
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.DateOfBirth.Should().BeNull();
     }
 
@@ -190,7 +172,7 @@ public class ProfileServiceTests : IDisposable
 
         await _service.SaveProfileAsync(userId, "Test", request, "en");
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         // Content-type column is the "has picture" marker + extension source.
         profile.ProfilePictureContentType.Should().Be("image/jpeg");
         // Bytes live on the file share, keyed under uploads/profile-pictures/.
@@ -208,7 +190,7 @@ public class ProfileServiceTests : IDisposable
         var request = MakeRequest(removeProfilePicture: true);
         await _service.SaveProfileAsync(userId, "Test", request, "en");
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.ProfilePictureContentType.Should().BeNull();
         _fileStorage.Files.Should().NotContainKey(PicKey(profileId, "image/png"));
     }
@@ -229,7 +211,7 @@ public class ProfileServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, withPicture: true);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.FirstAsync(p => p.UserId == userId);
 
         var result = await _service.GetProfilePictureAsync(profile.Id);
 
@@ -243,7 +225,7 @@ public class ProfileServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, withPicture: false);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.FirstAsync(p => p.UserId == userId);
 
         var result = await _service.GetProfilePictureAsync(profile.Id);
 
@@ -267,7 +249,7 @@ public class ProfileServiceTests : IDisposable
         // when the DB content-type column says a picture exists.
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, withPicture: true);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.FirstAsync(p => p.UserId == userId);
 
         var fsPayload = new byte[] { 9, 9, 9, 9 };
         await _fileStorage.SaveAsync(PicKey(profile.Id, "image/png"), fsPayload);
@@ -287,7 +269,7 @@ public class ProfileServiceTests : IDisposable
         // the file share is now the only source of truth.)
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, withPicture: true);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.FirstAsync(p => p.UserId == userId);
 
         await _fileStorage.DeleteAsync(PicKey(profile.Id, "image/png"));
 
@@ -304,12 +286,12 @@ public class ProfileServiceTests : IDisposable
         // the read path MUST NOT serve it. The content-type column is the gate.
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, withPicture: true);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.FirstAsync(p => p.UserId == userId);
 
         // Clear the gate as if anonymization had run.
-        var tracked = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
+        var tracked = await Db.Profiles.FirstAsync(p => p.UserId == userId);
         tracked.ProfilePictureContentType = null;
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Confirm the stale file is still on disk to make the gate meaningful.
         _fileStorage.Files.ContainsKey(PicKey(profile.Id, "image/png")).Should().BeTrue();
@@ -339,14 +321,14 @@ public class ProfileServiceTests : IDisposable
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId);
         var emailId = Guid.NewGuid();
-        _dbContext.UserEmails.Add(new UserEmail
+        Db.UserEmails.Add(new UserEmail
         {
             Id = emailId,
             UserId = userId,
             Email = "test@test.com",
-            VerificationSentAt = _clock.GetCurrentInstant() - Duration.FromMinutes(2),
+            VerificationSentAt = Clock.GetCurrentInstant() - Duration.FromMinutes(2),
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (canAdd, minutesUntilResend, pendingEmailId) = await _service.GetEmailCooldownInfoAsync(emailId);
 
@@ -361,14 +343,14 @@ public class ProfileServiceTests : IDisposable
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId);
         var emailId = Guid.NewGuid();
-        _dbContext.UserEmails.Add(new UserEmail
+        Db.UserEmails.Add(new UserEmail
         {
             Id = emailId,
             UserId = userId,
             Email = "test@test.com",
-            VerificationSentAt = _clock.GetCurrentInstant() - Duration.FromMinutes(6),
+            VerificationSentAt = Clock.GetCurrentInstant() - Duration.FromMinutes(6),
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (canAdd, minutesUntilResend, pendingEmailId) = await _service.GetEmailCooldownInfoAsync(emailId);
 
@@ -383,14 +365,14 @@ public class ProfileServiceTests : IDisposable
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId);
         var emailId = Guid.NewGuid();
-        _dbContext.UserEmails.Add(new UserEmail
+        Db.UserEmails.Add(new UserEmail
         {
             Id = emailId,
             UserId = userId,
             Email = "test@test.com",
             VerificationSentAt = null,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var (canAdd, minutesUntilResend, pendingEmailId) = await _service.GetEmailCooldownInfoAsync(emailId);
 
@@ -417,8 +399,8 @@ public class ProfileServiceTests : IDisposable
         {
             Id = profileId,
             UserId = userId,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
         mockRepo.GetByUserIdAsync(userId, Arg.Any<CancellationToken>()).Returns(profile);
 
@@ -468,7 +450,7 @@ public class ProfileServiceTests : IDisposable
         _auditLogService,
         _fileStorage,
         Substitute.For<IUserInfoInvalidator>(),
-        _clock,
+        Clock,
         NullLogger<ProfileService>.Instance);
 
     // --- Helpers ---
@@ -485,8 +467,8 @@ public class ProfileServiceTests : IDisposable
             ProfilePictureUrl = profilePictureUrl,
             PreferredLanguage = "en"
         };
-        _dbContext.Users.Add(user);
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(user);
+        await Db.SaveChangesAsync();
         return user;
     }
 
@@ -502,15 +484,15 @@ public class ProfileServiceTests : IDisposable
             FirstName = "Old",
             LastName = "User",
             IsApproved = isApproved,
-            CreatedAt = _clock.GetCurrentInstant() - Duration.FromDays(1),
-            UpdatedAt = _clock.GetCurrentInstant() - Duration.FromDays(1)
+            CreatedAt = Clock.GetCurrentInstant() - Duration.FromDays(1),
+            UpdatedAt = Clock.GetCurrentInstant() - Duration.FromDays(1)
         };
         if (withPicture)
         {
             profile.ProfilePictureContentType = "image/png";
         }
-        _dbContext.Profiles.Add(profile);
-        await _dbContext.SaveChangesAsync();
+        Db.Profiles.Add(profile);
+        await Db.SaveChangesAsync();
         if (withPicture)
         {
             await _fileStorage.SaveAsync(PicKey(profile.Id, "image/png"), [1, 2, 3]);
@@ -549,8 +531,8 @@ public class ProfileServiceTests : IDisposable
             MembershipTier = tier,
             IsApproved = isApproved,
             IsSuspended = isSuspended,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
     }
 
@@ -569,7 +551,7 @@ public class ProfileServiceTests : IDisposable
         // which proves the source is Provider, not IsGoogle.
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId);
-        _dbContext.UserEmails.Add(new UserEmail
+        Db.UserEmails.Add(new UserEmail
         {
             Id = Guid.NewGuid(),
             UserId = userId,
@@ -580,7 +562,7 @@ public class ProfileServiceTests : IDisposable
             ProviderKey = "sub-1",
             IsGoogle = false,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var slices = await _service.ContributeForUserAsync(userId, CancellationToken.None);
 
@@ -618,7 +600,7 @@ public class ProfileServiceTests : IDisposable
             _auditLogService,
             _fileStorage,
             Substitute.For<IUserInfoInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ProfileService>.Instance);
 
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
@@ -643,13 +625,13 @@ public class ProfileServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId);
-        _clock.Advance(Duration.FromHours(1));
+        Clock.Advance(Duration.FromHours(1));
 
         await _service.SetMembershipTierAsync(userId, MembershipTier.Colaborador);
 
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.MembershipTier.Should().Be(MembershipTier.Colaborador);
-        profile.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        profile.UpdatedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -660,7 +642,7 @@ public class ProfileServiceTests : IDisposable
         // No throw, no profile created — just a logged warning.
         await _service.SetMembershipTierAsync(unknownUserId, MembershipTier.Asociado);
 
-        var profileExists = await _dbContext.Profiles.AsNoTracking().AnyAsync(p => p.UserId == unknownUserId);
+        var profileExists = await Db.Profiles.AsNoTracking().AnyAsync(p => p.UserId == unknownUserId);
         profileExists.Should().BeFalse();
     }
 
@@ -675,10 +657,10 @@ public class ProfileServiceTests : IDisposable
             userId, reviewerId, ConsentCheckStatus.Cleared, "Looks good");
 
         result.Success.Should().BeTrue();
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.ConsentCheckStatus.Should().Be(ConsentCheckStatus.Cleared);
         profile.IsApproved.Should().BeTrue();
-        profile.ConsentCheckAt.Should().Be(_clock.GetCurrentInstant());
+        profile.ConsentCheckAt.Should().Be(Clock.GetCurrentInstant());
         profile.ConsentCheckedByUserId.Should().Be(reviewerId);
         profile.ConsentCheckNotes.Should().Be("Looks good");
     }
@@ -694,7 +676,7 @@ public class ProfileServiceTests : IDisposable
             userId, reviewerId, ConsentCheckStatus.Flagged, "Concern X");
 
         result.Success.Should().BeTrue();
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.ConsentCheckStatus.Should().Be(ConsentCheckStatus.Flagged);
         profile.IsApproved.Should().BeFalse();
     }
@@ -716,9 +698,9 @@ public class ProfileServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var profileId = await SeedUserWithProfileAsync(userId);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.Id == profileId);
-        profile.RejectedAt = _clock.GetCurrentInstant();
-        await _dbContext.SaveChangesAsync();
+        var profile = await Db.Profiles.FirstAsync(p => p.Id == profileId);
+        profile.RejectedAt = Clock.GetCurrentInstant();
+        await Db.SaveChangesAsync();
 
         var result = await _service.RecordConsentCheckAsync(
             userId, Guid.NewGuid(), ConsentCheckStatus.Cleared, null);
@@ -749,8 +731,8 @@ public class ProfileServiceTests : IDisposable
         var result = await _service.RejectSignupAsync(userId, reviewerId, "Spam account");
 
         result.Success.Should().BeTrue();
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
-        profile.RejectedAt.Should().Be(_clock.GetCurrentInstant());
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        profile.RejectedAt.Should().Be(Clock.GetCurrentInstant());
         profile.RejectedByUserId.Should().Be(reviewerId);
         profile.RejectionReason.Should().Be("Spam account");
         profile.IsApproved.Should().BeFalse();
@@ -761,9 +743,9 @@ public class ProfileServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var profileId = await SeedUserWithProfileAsync(userId);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.Id == profileId);
-        profile.RejectedAt = _clock.GetCurrentInstant();
-        await _dbContext.SaveChangesAsync();
+        var profile = await Db.Profiles.FirstAsync(p => p.Id == profileId);
+        profile.RejectedAt = Clock.GetCurrentInstant();
+        await Db.SaveChangesAsync();
 
         var result = await _service.RejectSignupAsync(userId, Guid.NewGuid(), null);
 
@@ -789,9 +771,9 @@ public class ProfileServiceTests : IDisposable
         var result = await _service.ApproveVolunteerAsync(userId, Guid.NewGuid());
 
         result.Success.Should().BeTrue();
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.IsApproved.Should().BeTrue();
-        profile.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        profile.UpdatedAt.Should().Be(Clock.GetCurrentInstant());
     }
 
     [HumansFact]
@@ -812,7 +794,7 @@ public class ProfileServiceTests : IDisposable
         var result = await _service.SetSuspendedAsync(userId, Guid.NewGuid(), suspended: true, "Disruptive");
 
         result.Success.Should().BeTrue();
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
 #pragma warning disable HUM_PROFILE_ISSUSPENDED
         profile.IsSuspended.Should().BeTrue();
 #pragma warning restore HUM_PROFILE_ISSUSPENDED
@@ -825,18 +807,18 @@ public class ProfileServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var profileId = await SeedUserWithProfileAsync(userId);
-        var profile = await _dbContext.Profiles.FirstAsync(p => p.Id == profileId);
+        var profile = await Db.Profiles.FirstAsync(p => p.Id == profileId);
 #pragma warning disable HUM_PROFILE_ISSUSPENDED
         profile.IsSuspended = true;
 #pragma warning restore HUM_PROFILE_ISSUSPENDED
         profile.State = ProfileState.Suspended;
         // SeedUserWithProfileAsync seeds BurnerName/FirstName/LastName, so identity is complete.
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SetSuspendedAsync(userId, Guid.NewGuid(), suspended: false, notes: null);
 
         result.Success.Should().BeTrue();
-        var fresh = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var fresh = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
 #pragma warning disable HUM_PROFILE_ISSUSPENDED
         fresh.IsSuspended.Should().BeFalse();
 #pragma warning restore HUM_PROFILE_ISSUSPENDED
@@ -862,7 +844,7 @@ public class ProfileServiceTests : IDisposable
         var set = await _service.SetConsentCheckPendingAsync(userId);
 
         set.Should().BeTrue();
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        var profile = await Db.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
         profile.ConsentCheckStatus.Should().Be(ConsentCheckStatus.Pending);
     }
 

--- a/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
@@ -2,11 +2,9 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Repositories;
-using Humans.Infrastructure.Data;
 using Humans.Domain.Entities;
 using Humans.Domain.Constants;
 using NSubstitute;
@@ -19,10 +17,8 @@ using Humans.Infrastructure.Repositories.Auth;
 
 namespace Humans.Application.Tests.Services;
 
-public class RoleAssignmentServiceTests : IDisposable
+public sealed class RoleAssignmentServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IRoleAssignmentRepository _repository;
     private readonly IUserService _userService;
     private readonly INavBadgeCacheInvalidator _navBadge;
@@ -30,29 +26,11 @@ public class RoleAssignmentServiceTests : IDisposable
     private readonly RoleAssignmentService _service;
 
     public RoleAssignmentServiceTests()
+        : base(Instant.FromUtc(2026, 2, 15, 15, 30))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
+        _repository = new RoleAssignmentRepository(DbFactory);
 
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 15, 30));
-
-        _repository = new RoleAssignmentRepository(new TestDbContextFactory(options));
-
-        _userService = Substitute.For<IUserService>();
-        _userService
-            .GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var ids = (IReadOnlyCollection<Guid>)call[0]!;
-                IReadOnlyDictionary<Guid, User> dict = _dbContext.Users
-                    .AsNoTracking()
-                    .Where(u => ids.Contains(u.Id))
-                    .ToDictionary(u => u.Id);
-                return Task.FromResult(dict);
-            });
-        _userService.StubGetUserInfosFromContext(_dbContext);
+        _userService = NewDbBackedUserService();
 
         _navBadge = Substitute.For<INavBadgeCacheInvalidator>();
         _claimsInvalidator = Substitute.For<IRoleAssignmentClaimsCacheInvalidator>();
@@ -66,14 +44,8 @@ public class RoleAssignmentServiceTests : IDisposable
             _navBadge,
             _claimsInvalidator,
             Substitute.For<IRoleAssignmentCacheInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<RoleAssignmentService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -81,7 +53,7 @@ public class RoleAssignmentServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
 
-        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", _clock.GetCurrentInstant());
+        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", Clock.GetCurrentInstant());
 
         result.Should().BeFalse();
     }
@@ -93,10 +65,10 @@ public class RoleAssignmentServiceTests : IDisposable
         await AddAssignmentAsync(
             userId,
             "Board",
-            _clock.GetCurrentInstant() - Duration.FromDays(20),
-            _clock.GetCurrentInstant() - Duration.FromDays(10));
+            Clock.GetCurrentInstant() - Duration.FromDays(20),
+            Clock.GetCurrentInstant() - Duration.FromDays(10));
 
-        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", _clock.GetCurrentInstant());
+        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", Clock.GetCurrentInstant());
 
         result.Should().BeFalse();
     }
@@ -108,10 +80,10 @@ public class RoleAssignmentServiceTests : IDisposable
         await AddAssignmentAsync(
             userId,
             "Board",
-            _clock.GetCurrentInstant() - Duration.FromDays(5),
+            Clock.GetCurrentInstant() - Duration.FromDays(5),
             null);
 
-        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", _clock.GetCurrentInstant());
+        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", Clock.GetCurrentInstant());
 
         result.Should().BeTrue();
     }
@@ -123,10 +95,10 @@ public class RoleAssignmentServiceTests : IDisposable
         await AddAssignmentAsync(
             userId,
             "Board",
-            _clock.GetCurrentInstant() + Duration.FromDays(10),
+            Clock.GetCurrentInstant() + Duration.FromDays(10),
             null);
 
-        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", _clock.GetCurrentInstant());
+        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", Clock.GetCurrentInstant());
 
         result.Should().BeTrue();
     }
@@ -138,10 +110,10 @@ public class RoleAssignmentServiceTests : IDisposable
         await AddAssignmentAsync(
             userId,
             "Lead",
-            _clock.GetCurrentInstant() - Duration.FromDays(5),
+            Clock.GetCurrentInstant() - Duration.FromDays(5),
             null);
 
-        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", _clock.GetCurrentInstant());
+        var result = await _service.HasOverlappingAssignmentAsync(userId, "Board", Clock.GetCurrentInstant());
 
         result.Should().BeFalse();
     }
@@ -172,7 +144,7 @@ public class RoleAssignmentServiceTests : IDisposable
         var assignment = await AddAssignmentAsync(
             userId,
             RoleNames.Board,
-            _clock.GetCurrentInstant() - Duration.FromDays(1),
+            Clock.GetCurrentInstant() - Duration.FromDays(1),
             null);
 
         var result = await _service.EndRoleAsync(
@@ -193,7 +165,7 @@ public class RoleAssignmentServiceTests : IDisposable
         var assignment = await AddAssignmentAsync(
             userId,
             RoleNames.Board,
-            _clock.GetCurrentInstant() - Duration.FromDays(1),
+            Clock.GetCurrentInstant() - Duration.FromDays(1),
             null,
             creatorId);
 
@@ -215,11 +187,11 @@ public class RoleAssignmentServiceTests : IDisposable
         await SeedUserAsync(user1, "Alice");
         await SeedUserAsync(user2, "Bob");
         await SeedUserAsync(creator, "Creator");
-        await AddAssignmentAsync(user1, RoleNames.Board, _clock.GetCurrentInstant() - Duration.FromDays(1), null, creator);
-        await AddAssignmentAsync(user2, RoleNames.Board, _clock.GetCurrentInstant() - Duration.FromDays(2), null, creator);
+        await AddAssignmentAsync(user1, RoleNames.Board, Clock.GetCurrentInstant() - Duration.FromDays(1), null, creator);
+        await AddAssignmentAsync(user2, RoleNames.Board, Clock.GetCurrentInstant() - Duration.FromDays(2), null, creator);
 
         var (items, total) = await _service.GetFilteredAsync(
-            roleFilter: RoleNames.Board, activeOnly: true, page: 1, pageSize: 50, _clock.GetCurrentInstant());
+            roleFilter: RoleNames.Board, activeOnly: true, page: 1, pageSize: 50, Clock.GetCurrentInstant());
 
         items.Should().HaveCount(2);
         total.Should().Be(2);
@@ -232,13 +204,13 @@ public class RoleAssignmentServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId, "Target");
-        await AddAssignmentAsync(userId, RoleNames.Board, _clock.GetCurrentInstant() - Duration.FromDays(10), null);
-        await AddAssignmentAsync(userId, RoleNames.Admin, _clock.GetCurrentInstant() - Duration.FromDays(5), null);
+        await AddAssignmentAsync(userId, RoleNames.Board, Clock.GetCurrentInstant() - Duration.FromDays(10), null);
+        await AddAssignmentAsync(userId, RoleNames.Admin, Clock.GetCurrentInstant() - Duration.FromDays(5), null);
 
         var count = await _service.RevokeAllActiveAsync(userId);
 
         count.Should().Be(2);
-        var remaining = await _dbContext.RoleAssignments
+        var remaining = await Db.RoleAssignments
             .AsNoTracking()
             .Where(ra => ra.UserId == userId)
             .ToListAsync();
@@ -253,7 +225,7 @@ public class RoleAssignmentServiceTests : IDisposable
         var assignerId = Guid.NewGuid();
         await SeedUserAsync(userId, "Target");
         await SeedUserAsync(assignerId, "Admin");
-        await AddAssignmentAsync(userId, RoleNames.Board, _clock.GetCurrentInstant() - Duration.FromDays(1), null);
+        await AddAssignmentAsync(userId, RoleNames.Board, Clock.GetCurrentInstant() - Duration.FromDays(1), null);
 
         var result = await _service.AssignRoleAsync(userId, RoleNames.Board, assignerId, null);
 
@@ -275,7 +247,7 @@ public class RoleAssignmentServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId, "Target");
-        await AddAssignmentAsync(userId, RoleNames.Board, _clock.GetCurrentInstant() - Duration.FromDays(1), null);
+        await AddAssignmentAsync(userId, RoleNames.Board, Clock.GetCurrentInstant() - Duration.FromDays(1), null);
 
         var slices = await _service.ContributeForUserAsync(userId, CancellationToken.None);
 
@@ -295,8 +267,8 @@ public class RoleAssignmentServiceTests : IDisposable
             PreferredLanguage = "en"
         };
 
-        _dbContext.Users.Add(user);
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(user);
+        await Db.SaveChangesAsync();
         return user;
     }
 
@@ -314,9 +286,9 @@ public class RoleAssignmentServiceTests : IDisposable
             CreatedByUserId = createdByUserId ?? Guid.NewGuid()
         };
 
-        _dbContext.RoleAssignments.Add(assignment);
+        Db.RoleAssignments.Add(assignment);
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         return assignment;
     }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/GeneralAvailabilityServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/GeneralAvailabilityServiceTests.cs
@@ -2,39 +2,26 @@ using AwesomeAssertions;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using GeneralAvailabilityService = Humans.Application.Services.Shifts.GeneralAvailabilityService;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class GeneralAvailabilityServiceTests : IDisposable
+public sealed class GeneralAvailabilityServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
     private readonly GeneralAvailabilityRepository _repo;
     private readonly GeneralAvailabilityService _service;
 
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     public GeneralAvailabilityServiceTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _repo = new GeneralAvailabilityRepository(new TestDbContextFactory(options));
-        _service = new GeneralAvailabilityService(_repo, Substitute.For<IShiftViewInvalidator>(), new FakeClock(TestNow));
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+        _repo = new GeneralAvailabilityRepository(DbFactory);
+        _service = new GeneralAvailabilityService(_repo, Substitute.For<IShiftViewInvalidator>(), Clock);
     }
 
     [HumansFact(Timeout = 10000)]
@@ -42,11 +29,11 @@ public class GeneralAvailabilityServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var esId = SeedEventSettings();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.SetAvailabilityAsync(userId, esId, [-3, -2, -1]);
 
-        var record = await _dbContext.GeneralAvailability
+        var record = await Db.GeneralAvailability
             .AsNoTracking()
             .FirstOrDefaultAsync(g => g.UserId == userId && g.EventSettingsId == esId);
         record.Should().NotBeNull();
@@ -58,7 +45,7 @@ public class GeneralAvailabilityServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var esId = SeedEventSettings();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // First set
         await _service.SetAvailabilityAsync(userId, esId, [-3, -2]);
@@ -66,7 +53,7 @@ public class GeneralAvailabilityServiceTests : IDisposable
         // Update
         await _service.SetAvailabilityAsync(userId, esId, [0, 1, 2]);
 
-        var records = await _dbContext.GeneralAvailability
+        var records = await Db.GeneralAvailability
             .AsNoTracking()
             .Where(g => g.UserId == userId && g.EventSettingsId == esId)
             .ToListAsync();
@@ -81,7 +68,7 @@ public class GeneralAvailabilityServiceTests : IDisposable
         var user2Id = Guid.NewGuid();
         var user3Id = Guid.NewGuid();
         var esId = SeedEventSettings();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.SetAvailabilityAsync(user1Id, esId, [-3, -2, -1]);
         await _service.SetAvailabilityAsync(user2Id, esId, [-2, 0, 1]);
@@ -105,12 +92,12 @@ public class GeneralAvailabilityServiceTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var esId = SeedEventSettings();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.SetAvailabilityAsync(userId, esId, [0, 1]);
         await _service.DeleteAsync(userId, esId);
 
-        var after = await _dbContext.GeneralAvailability
+        var after = await Db.GeneralAvailability
             .AsNoTracking()
             .FirstOrDefaultAsync(g => g.UserId == userId && g.EventSettingsId == esId);
         after.Should().BeNull();
@@ -138,7 +125,7 @@ public class GeneralAvailabilityServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(es);
+        Db.EventSettings.Add(es);
         return es.Id;
     }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/PromoteWidgetPendingSignupsAfterAdmissionTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/PromoteWidgetPendingSignupsAfterAdmissionTests.cs
@@ -9,22 +9,17 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
+public sealed class PromoteWidgetPendingSignupsAfterAdmissionTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IAuditLogService _auditLog;
     private readonly IMembershipCalculator _membership;
     private readonly ShiftManagementService _shiftMgmt;
@@ -38,13 +33,8 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
     private readonly Team _team;
 
     public PromoteWidgetPendingSignupsAfterAdmissionTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(TestNow);
         _auditLog = Substitute.For<IAuditLogService>();
         _membership = Substitute.For<IMembershipCalculator>();
         // Default: user has all required consents — exercises the existing
@@ -60,19 +50,19 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
         serviceProvider.GetService(typeof(ITeamService)).Returns(teamService);
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(roleAssignmentService);
 
-        var shiftRepo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var shiftRepo = new ShiftManagementRepository(DbFactory);
 
         _shiftMgmt = new ShiftManagementService(
             shiftRepo,
             _auditLog,
             Substitute.For<IAdminAuthorizationService>(),
             serviceProvider,
-            new MemoryCache(new MemoryCacheOptions()),
+            Cache,
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        _repo = new ShiftSignupRepository(_dbContext, _clock);
+        _repo = new ShiftSignupRepository(Db, Clock);
         _service = new ShiftSignupService(
             _repo,
             _shiftMgmt,
@@ -82,7 +72,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
             Substitute.For<IAdminAuthorizationService>(),
             Substitute.For<IShiftViewInvalidator>(),
             serviceProvider,
-            _clock,
+            Clock,
             NullLogger<ShiftSignupService>.Instance);
 
         _activeEvent = new EventSettings
@@ -99,7 +89,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(_activeEvent);
+        Db.EventSettings.Add(_activeEvent);
 
         _team = new Team
         {
@@ -111,14 +101,8 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(_team);
-        _dbContext.SaveChanges();
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+        Db.Teams.Add(_team);
+        Db.SaveChanges();
     }
 
     [HumansFact]
@@ -128,7 +112,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
 
         await _service.PromoteWidgetPendingSignupsAfterAdmissionAsync(_userId);
 
-        var reloaded = await _dbContext.ShiftSignups.AsNoTracking()
+        var reloaded = await Db.ShiftSignups.AsNoTracking()
             .FirstAsync(s => s.Id == signup.Id);
         Assert.Equal(SignupStatus.Confirmed, reloaded.Status);
     }
@@ -146,7 +130,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
 
         await _service.PromoteWidgetPendingSignupsAfterAdmissionAsync(_userId);
 
-        var reloaded = await _dbContext.ShiftSignups.AsNoTracking()
+        var reloaded = await Db.ShiftSignups.AsNoTracking()
             .FirstAsync(s => s.Id == signup.Id);
         Assert.Equal(SignupStatus.Pending, reloaded.Status);
     }
@@ -158,7 +142,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
 
         await _service.PromoteWidgetPendingSignupsAfterAdmissionAsync(_userId);
 
-        var reloaded = await _dbContext.ShiftSignups.AsNoTracking()
+        var reloaded = await Db.ShiftSignups.AsNoTracking()
             .FirstAsync(s => s.Id == signup.Id);
         Assert.Equal(SignupStatus.Pending, reloaded.Status);
     }
@@ -171,7 +155,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
 
         await _service.PromoteWidgetPendingSignupsAfterAdmissionAsync(_userId);
 
-        var block = await _dbContext.ShiftSignups.AsNoTracking()
+        var block = await Db.ShiftSignups.AsNoTracking()
             .Where(s => s.SignupBlockId == blockId)
             .ToListAsync();
         Assert.Equal(3, block.Count);
@@ -187,7 +171,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
 
         await _service.PromoteWidgetPendingSignupsAfterAdmissionAsync(_userId);
 
-        var reloaded = await _dbContext.ShiftSignups.AsNoTracking()
+        var reloaded = await Db.ShiftSignups.AsNoTracking()
             .FirstAsync(s => s.Id == signup.Id);
         Assert.Equal(SignupStatus.Pending, reloaded.Status);
     }
@@ -205,7 +189,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
 
         for (var i = 0; i < confirmedSoFar; i++)
         {
-            _dbContext.ShiftSignups.Add(new ShiftSignup
+            Db.ShiftSignups.Add(new ShiftSignup
             {
                 Id = Guid.NewGuid(),
                 UserId = Guid.NewGuid(),
@@ -225,8 +209,8 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.ShiftSignups.Add(signup);
-        _dbContext.SaveChanges();
+        Db.ShiftSignups.Add(signup);
+        Db.SaveChanges();
         return signup;
     }
 
@@ -249,10 +233,10 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
                 CreatedAt = TestNow,
                 UpdatedAt = TestNow
             };
-            _dbContext.ShiftSignups.Add(signup);
+            Db.ShiftSignups.Add(signup);
             ids.Add(signup.Id);
         }
-        _dbContext.SaveChanges();
+        Db.SaveChanges();
         return ids;
     }
 
@@ -271,7 +255,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = _activeEvent
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
         return rota;
     }
 
@@ -291,7 +275,7 @@ public class PromoteWidgetPendingSignupsAfterAdmissionTests : IDisposable
             UpdatedAt = TestNow,
             Rota = rota
         };
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -15,57 +15,43 @@ using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class ShiftDashboardMetricsTests : IDisposable
+public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
 {
     private static readonly Instant TestNow = Instant.FromUtc(2026, 7, 1, 12, 0);
 
-    private readonly HumansDbContext _dbContext;
     private readonly ShiftManagementService _service;
-    private readonly FakeClock _clock = new(TestNow);
 
     public ShiftDashboardMetricsTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-
         // The dashboard compute methods now reach cross-domain data through
         // ITicketQueryService / ITeamService / IUserService. Wire thin fakes that
         // read from the same in-memory DbContext so existing DbContext-based
         // test seed helpers still drive the scenarios end-to-end. The repository
         // is backed by the same in-memory options via TestDbContextFactory.
         var serviceProvider = Substitute.For<IServiceProvider>();
-        serviceProvider.GetService(typeof(ITeamService)).Returns(new FakeTeamService(_dbContext));
-        serviceProvider.GetService(typeof(ITicketQueryService)).Returns(new FakeTicketQueryService(_dbContext));
-        serviceProvider.GetService(typeof(IUserService)).Returns(new FakeUserService(_dbContext));
+        serviceProvider.GetService(typeof(ITeamService)).Returns(new FakeTeamService(Db));
+        serviceProvider.GetService(typeof(ITicketQueryService)).Returns(new FakeTicketQueryService(Db));
+        serviceProvider.GetService(typeof(IUserService)).Returns(new FakeUserService(Db));
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(Substitute.For<IRoleAssignmentService>());
 
-        var repo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var repo = new ShiftManagementRepository(DbFactory);
 
         _service = new ShiftManagementService(
             repo,
             Substitute.For<IAuditLogService>(),
             Substitute.For<IAdminAuthorizationService>(),
             serviceProvider,
-            new MemoryCache(new MemoryCacheOptions()),
+            Cache,
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -232,8 +218,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow.Minus(Duration.FromDays(3)),
             UpdatedAt = TestNow,
         };
-        _dbContext.ShiftSignups.Add(signup);
-        await _dbContext.SaveChangesAsync();
+        Db.ShiftSignups.Add(signup);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDashboardOverviewAsync(es.Id);
 
@@ -258,8 +244,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow.Minus(Duration.FromDays(3)).Minus(Duration.FromMinutes(1)),
             UpdatedAt = TestNow,
         };
-        _dbContext.ShiftSignups.Add(signup);
-        await _dbContext.SaveChangesAsync();
+        Db.ShiftSignups.Add(signup);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDashboardOverviewAsync(es.Id);
 
@@ -402,7 +388,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         for (var day = -5; day <= -1; day++)
         {
             var shift = await SeedShiftAsync(buildRota, dayOffset: day, min: 1, max: 3);
-            _dbContext.ShiftSignups.Add(new ShiftSignup
+            Db.ShiftSignups.Add(new ShiftSignup
             {
                 Id = Guid.NewGuid(),
                 ShiftId = shift.Id,
@@ -413,7 +399,7 @@ public class ShiftDashboardMetricsTests : IDisposable
                 UpdatedAt = TestNow,
             });
         }
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var coord = await SeedUserAsync("coord", TestNow.Minus(Duration.FromDays(2)));
         await SeedCoordinatorAsync(build, coord);
@@ -476,7 +462,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         var shift = await SeedShiftAsync(rota, dayOffset: 1, min: 1, max: 3);
         var user = await SeedUserAsync("u");
 
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             ShiftId = shift.Id,
@@ -485,7 +471,7 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDashboardTrendsAsync(es.Id, TrendWindow.Last7Days);
 
@@ -759,8 +745,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow.Minus(Duration.FromDays(60)),
             UpdatedAt = TestNow,
         };
-        _dbContext.EventSettings.Add(es);
-        await _dbContext.SaveChangesAsync();
+        Db.EventSettings.Add(es);
+        await Db.SaveChangesAsync();
         return es;
     }
 
@@ -777,8 +763,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         };
-        _dbContext.Teams.Add(team);
-        await _dbContext.SaveChangesAsync();
+        Db.Teams.Add(team);
+        await Db.SaveChangesAsync();
         return team;
     }
 
@@ -797,8 +783,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         };
-        _dbContext.Rotas.Add(rota);
-        await _dbContext.SaveChangesAsync();
+        Db.Rotas.Add(rota);
+        await Db.SaveChangesAsync();
         return rota;
     }
 
@@ -817,8 +803,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         };
-        _dbContext.Shifts.Add(shift);
-        await _dbContext.SaveChangesAsync();
+        Db.Shifts.Add(shift);
+        await Db.SaveChangesAsync();
         return shift;
     }
 
@@ -837,8 +823,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         };
-        _dbContext.Shifts.Add(shift);
-        await _dbContext.SaveChangesAsync();
+        Db.Shifts.Add(shift);
+        await Db.SaveChangesAsync();
         return shift;
     }
 
@@ -857,8 +843,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         };
-        _dbContext.Shifts.Add(shift);
-        await _dbContext.SaveChangesAsync();
+        Db.Shifts.Add(shift);
+        await Db.SaveChangesAsync();
         return shift;
     }
 
@@ -876,8 +862,8 @@ public class ShiftDashboardMetricsTests : IDisposable
             SecurityStamp = Guid.NewGuid().ToString(),
             CreatedAt = TestNow,
         };
-        _dbContext.Users.Add(user);
-        await _dbContext.SaveChangesAsync();
+        Db.Users.Add(user);
+        await Db.SaveChangesAsync();
         return user;
     }
 
@@ -886,7 +872,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         for (var i = 0; i < count; i++)
         {
             var user = await SeedUserAsync($"u-{shift.Id:N}-{i}");
-            _dbContext.ShiftSignups.Add(new ShiftSignup
+            Db.ShiftSignups.Add(new ShiftSignup
             {
                 Id = Guid.NewGuid(),
                 ShiftId = shift.Id,
@@ -896,12 +882,12 @@ public class ShiftDashboardMetricsTests : IDisposable
                 UpdatedAt = TestNow,
             });
         }
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
     }
 
     private async Task SeedOneSignupAsync(Shift shift, Guid userId, SignupStatus status)
     {
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             ShiftId = shift.Id,
@@ -910,12 +896,12 @@ public class ShiftDashboardMetricsTests : IDisposable
             CreatedAt = TestNow.Minus(Duration.FromHours(1)),
             UpdatedAt = TestNow,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
     }
 
     private async Task SeedTicketOrderAsync(Guid userId, TicketPaymentStatus status)
     {
-        _dbContext.TicketOrders.Add(new TicketOrder
+        Db.TicketOrders.Add(new TicketOrder
         {
             Id = Guid.NewGuid(),
             VendorOrderId = Guid.NewGuid().ToString("N"),
@@ -928,12 +914,12 @@ public class ShiftDashboardMetricsTests : IDisposable
             PurchasedAt = TestNow.Minus(Duration.FromDays(10)),
             SyncedAt = TestNow,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
     }
 
     private async Task SeedCoordinatorAsync(Team team, User user)
     {
-        _dbContext.TeamMembers.Add(new TeamMember
+        Db.TeamMembers.Add(new TeamMember
         {
             Id = Guid.NewGuid(),
             TeamId = team.Id,
@@ -941,14 +927,14 @@ public class ShiftDashboardMetricsTests : IDisposable
             Role = TeamMemberRole.Coordinator,
             JoinedAt = TestNow.Minus(Duration.FromDays(30)),
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
     }
 
     // ================================================================
     // Thin fakes for cross-domain service interfaces. Each method covers
     // only the service surface used by ShiftManagementService's dashboard
     // compute paths. All reads go through the same in-memory DbContext
-    // so the test seed helpers (_dbContext.*.Add) drive results end-to-end.
+    // so the test seed helpers (Db.*.Add) drive results end-to-end.
     // ================================================================
 
     private sealed class FakeTicketQueryService(HumansDbContext db) : ITicketQueryService

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
@@ -8,32 +8,24 @@ using Humans.Application.Services.Shifts;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class ShiftManagementServiceCoveragePiesTests : IDisposable
+public sealed class ShiftManagementServiceCoveragePiesTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
     private readonly ITeamService _teamService;
     private readonly ShiftManagementService _service;
 
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     public ShiftManagementServiceCoveragePiesTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
         _teamService = Substitute.For<ITeamService>();
 
         // Resolve teams (with their parents) directly from the in-memory DB —
@@ -43,11 +35,11 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             .Returns(ci =>
             {
                 var ids = ci.Arg<IReadOnlyCollection<Guid>>();
-                var direct = _dbContext.Teams.Where(t => ids.Contains(t.Id)).AsEnumerable().ToList();
+                var direct = Db.Teams.Where(t => ids.Contains(t.Id)).AsEnumerable().ToList();
                 var parentIds = direct.Where(t => t.ParentTeamId.HasValue).Select(t => t.ParentTeamId!.Value).ToList();
                 var parents = parentIds.Count == 0
                     ? []
-                    : _dbContext.Teams.Where(t => parentIds.Contains(t.Id)).AsEnumerable().ToList();
+                    : Db.Teams.Where(t => parentIds.Contains(t.Id)).AsEnumerable().ToList();
                 var all = direct.Concat(parents).GroupBy(t => t.Id).Select(g => g.First());
                 return Task.FromResult<IReadOnlyDictionary<Guid, Team>>(all.ToDictionary(t => t.Id));
             });
@@ -57,30 +49,24 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(Substitute.For<IRoleAssignmentService>());
         serviceProvider.GetService(typeof(IUserService)).Returns(Substitute.For<IUserService>());
 
-        var repo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var repo = new ShiftManagementRepository(DbFactory);
 
         _service = new ShiftManagementService(
             repo,
             Substitute.For<IAuditLogService>(),
             Substitute.For<IAdminAuthorizationService>(),
             serviceProvider,
-            new MemoryCache(new MemoryCacheOptions()),
+            Cache,
             Substitute.For<IShiftViewInvalidator>(),
-            new FakeClock(TestNow),
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
     public async Task EmptyEvent_ReturnsEmptyList()
     {
         var (es, _, _) = SeedDeptScenario();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -94,7 +80,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         var rota = AddRota(es, art, RotaPeriod.Event);
         AddShift(rota, dayOffset: 0, maxVolunteers: 5, durationHours: 4.0);
         AddShift(rota, dayOffset: 0, maxVolunteers: 3, durationHours: 2.0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -114,7 +100,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             dayOffset: 0, maxVolunteers: 2, durationHours: 4.0);
         AddShift(AddRota(es, lighting!, RotaPeriod.Event, name: "LightingRota"),
             dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -135,7 +121,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             dayOffset: 0, maxVolunteers: 2, durationHours: 4.0);
         AddShift(AddRota(es, lighting!, RotaPeriod.Event, name: "LightingRota"),
             dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -154,7 +140,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         var (es, art, lighting) = SeedDeptScenario(withSubteam: true, subteamPromoted: false);
         AddShift(AddRota(es, lighting!, RotaPeriod.Event, name: "LightingRota"),
             dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -173,7 +159,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         var rota = AddRota(es, art, RotaPeriod.Event);
         var shift = AddShift(rota, dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
         AddConfirmedSignup(shift); // 1/3 → 33.3% → 33 (away from zero)
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -232,11 +218,11 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        await _dbContext.Teams.AddRangeAsync(mango, appleSlice, banana);
+        await Db.Teams.AddRangeAsync(mango, appleSlice, banana);
 
         foreach (var t in new[] { mango, appleSlice, banana })
             AddShift(AddRota(es, t, RotaPeriod.Event), dayOffset: 0, maxVolunteers: 1, durationHours: 4.0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -258,7 +244,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         AddShift(visibleRota, dayOffset: 0, maxVolunteers: 2, durationHours: 4.0);
         AddShift(visibleRota, dayOffset: 0, maxVolunteers: 3, durationHours: 4.0, adminOnly: true);
         AddShift(hiddenRota, dayOffset: 0, maxVolunteers: 10, durationHours: 4.0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -273,7 +259,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         var rota = AddRota(es, art, RotaPeriod.Event);
         var shift = AddShift(rota, dayOffset: 0, maxVolunteers: 5, durationHours: 4.0);
         for (var i = 0; i < 7; i++) AddConfirmedSignup(shift);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -290,7 +276,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         AddConfirmedSignup(shift);
         AddConfirmedSignup(shift);
         AddConfirmedSignup(shift);
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             ShiftId = shift.Id,
@@ -299,7 +285,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         });
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             ShiftId = shift.Id,
@@ -308,7 +294,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -325,7 +311,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         shift.Duration = Duration.FromHours(24);
         AddConfirmedSignup(shift);
         AddConfirmedSignup(shift);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
@@ -342,7 +328,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         AddShift(rota, dayOffset: -7, maxVolunteers: 1, durationHours: 4.0);
         AddShift(rota, dayOffset: 2, maxVolunteers: 1, durationHours: 4.0);
         AddShift(rota, dayOffset: 8, maxVolunteers: 1, durationHours: 4.0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetDepartmentCoveragePiesAsync(
             es.Id,
@@ -370,7 +356,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(es);
+        Db.EventSettings.Add(es);
 
         var art = new Team
         {
@@ -383,7 +369,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(art);
+        Db.Teams.Add(art);
 
         Team? lighting = null;
         if (withSubteam)
@@ -400,7 +386,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
                 CreatedAt = TestNow,
                 UpdatedAt = TestNow
             };
-            _dbContext.Teams.Add(lighting);
+            Db.Teams.Add(lighting);
         }
 
         return (es, art, lighting);
@@ -422,7 +408,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
         return rota;
     }
 
@@ -444,7 +430,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 
@@ -459,7 +445,7 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.ShiftSignups.Add(s);
+        Db.ShiftSignups.Add(s);
         return s;
     }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
@@ -10,21 +10,17 @@ using Humans.Application.Services.Shifts;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class ShiftManagementServiceTests : IDisposable
+public sealed class ShiftManagementServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly ITeamService _teamService;
     private readonly IUserService _userService;
     private readonly IRoleAssignmentService _roleAssignmentService;
@@ -34,18 +30,13 @@ public class ShiftManagementServiceTests : IDisposable
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     public ShiftManagementServiceTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(TestNow);
         _teamService = Substitute.For<ITeamService>();
         _userService = Substitute.For<IUserService>();
         _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
 
-        // Default: users looked up by id resolve to the entities seeded in _dbContext
+        // Default: users looked up by id resolve to the entities seeded in Db
         // so the cross-section signup stitching in GetBrowseShiftsAsync returns the
         // correct DisplayName.
         _userService.GetByIdsAsync(
@@ -54,12 +45,12 @@ public class ShiftManagementServiceTests : IDisposable
             {
                 var ids = ci.Arg<IReadOnlyCollection<Guid>>();
                 return Task.FromResult<IReadOnlyDictionary<Guid, User>>(
-                    _dbContext.Users
+                    Db.Users
                         .Where(u => ids.Contains(u.Id))
                         .AsEnumerable()
                         .ToDictionary(u => u.Id));
             });
-        _userService.StubGetUserInfosFromContext(_dbContext);
+        _userService.StubGetUserInfosFromContext(Db);
 
         _teamService.GetByIdsWithParentsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -67,18 +58,18 @@ public class ShiftManagementServiceTests : IDisposable
             {
                 var ids = ci.Arg<IReadOnlyCollection<Guid>>();
                 return Task.FromResult<IReadOnlyDictionary<Guid, Team>>(
-                    _dbContext.Teams
+                    Db.Teams
                         .Where(t => ids.Contains(t.Id))
                         .AsEnumerable()
                         .ToDictionary(t => t.Id));
             });
 
         _teamService.GetAllTeamsAsync(Arg.Any<CancellationToken>())
-            .Returns(_ => Task.FromResult<IReadOnlyList<Team>>(_dbContext.Teams.AsEnumerable().ToList()));
+            .Returns(_ => Task.FromResult<IReadOnlyList<Team>>(Db.Teams.AsEnumerable().ToList()));
 
         _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromResult<IReadOnlyDictionary<Guid, TeamInfo>>(
-                _dbContext.Teams.AsEnumerable().ToDictionary(
+                Db.Teams.AsEnumerable().ToDictionary(
                     t => t.Id,
                     t => new TeamInfo(
                         t.Id, t.Name, t.Description, t.Slug,
@@ -92,7 +83,7 @@ public class ShiftManagementServiceTests : IDisposable
         serviceProvider.GetService(typeof(IUserService)).Returns(_userService);
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(_roleAssignmentService);
 
-        var repo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var repo = new ShiftManagementRepository(DbFactory);
 
         _auditLog = Substitute.For<IAuditLogService>();
         _service = new ShiftManagementService(
@@ -100,16 +91,10 @@ public class ShiftManagementServiceTests : IDisposable
             _auditLog,
             Substitute.For<IAdminAuthorizationService>(),
             serviceProvider,
-            new MemoryCache(new MemoryCacheOptions()),
+            Cache,
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     // ============================================================
@@ -142,7 +127,7 @@ public class ShiftManagementServiceTests : IDisposable
             Substitute.For<IServiceProvider>(),
             cache,
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
 
         var deleted = await service.DeleteEventAsync(eventId);
@@ -164,7 +149,7 @@ public class ShiftManagementServiceTests : IDisposable
     {
         // Arrange: rota with Period=Build, staffing grid for days -3 to -1
         var (es, rota) = SeedRotaScenario(RotaPeriod.Build);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var staffing = new List<DayStaffingInput>
         {
@@ -184,7 +169,7 @@ public class ShiftManagementServiceTests : IDisposable
 
         // Assert: 3 shifts created, all IsAllDay=true, correct DayOffsets.
         // StartTime/Duration are stored as the midnight/24h sentinel (don't-care for IsAllDay rows).
-        var shifts = await _dbContext.Shifts.Where(s => s.RotaId == rota.Id).ToListAsync();
+        var shifts = await Db.Shifts.Where(s => s.RotaId == rota.Id).ToListAsync();
         shifts.Should().HaveCount(3);
         shifts.Should().AllSatisfy(s =>
         {
@@ -199,7 +184,7 @@ public class ShiftManagementServiceTests : IDisposable
     public async Task CreateShiftAsync_CreatesShift_WhenInputMatchesRotaPeriodAndTeam()
     {
         var (_, rota) = SeedRotaScenario(RotaPeriod.Build);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.CreateShiftAsync(new CreateShiftInput(
             rota.Id,
@@ -217,7 +202,7 @@ public class ShiftManagementServiceTests : IDisposable
         result.Message.Should().Be("Shift created.");
         result.ShiftId.Should().NotBeNull();
 
-        var shift = await _dbContext.Shifts.SingleAsync();
+        var shift = await Db.Shifts.SingleAsync();
         shift.Id.Should().Be(result.ShiftId.Value);
         shift.RotaId.Should().Be(rota.Id);
         shift.Description.Should().Be("Gate crew");
@@ -235,7 +220,7 @@ public class ShiftManagementServiceTests : IDisposable
     public async Task CreateShiftAsync_ReturnsFailure_WhenDayOffsetOutsideRotaPeriod()
     {
         var (_, rota) = SeedRotaScenario(RotaPeriod.Build);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.CreateShiftAsync(new CreateShiftInput(
             rota.Id,
@@ -251,7 +236,7 @@ public class ShiftManagementServiceTests : IDisposable
 
         result.Succeeded.Should().BeFalse();
         result.Message.Should().Be("Shift date must fall within the rota's period.");
-        _dbContext.Shifts.Should().BeEmpty();
+        Db.Shifts.Should().BeEmpty();
     }
 
     [HumansFact]
@@ -259,7 +244,7 @@ public class ShiftManagementServiceTests : IDisposable
     {
         var (_, rota) = SeedRotaScenario(RotaPeriod.Build);
         var shift = SeedShift(rota, -4);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.UpdateShiftAsync(new UpdateShiftInput(
             shift.Id,
@@ -276,8 +261,8 @@ public class ShiftManagementServiceTests : IDisposable
         result.Message.Should().Be("Shift updated.");
         result.ShiftId.Should().Be(shift.Id);
 
-        _dbContext.ChangeTracker.Clear();
-        var updated = await _dbContext.Shifts.SingleAsync();
+        Db.ChangeTracker.Clear();
+        var updated = await Db.Shifts.SingleAsync();
         updated.Description.Should().Be("Updated gate crew");
         updated.DayOffset.Should().Be(-3);
         updated.StartTime.Should().Be(new LocalTime(9, 15));
@@ -293,7 +278,7 @@ public class ShiftManagementServiceTests : IDisposable
     {
         var (_, rota) = SeedRotaScenario(RotaPeriod.Build);
         var shift = SeedShift(rota, -4);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.UpdateShiftAsync(new UpdateShiftInput(
             shift.Id,
@@ -309,8 +294,8 @@ public class ShiftManagementServiceTests : IDisposable
         result.Succeeded.Should().BeFalse();
         result.Message.Should().Be("Shift not found.");
 
-        _dbContext.ChangeTracker.Clear();
-        var unchanged = await _dbContext.Shifts.SingleAsync();
+        Db.ChangeTracker.Clear();
+        var unchanged = await Db.Shifts.SingleAsync();
         unchanged.Description.Should().BeNull();
         unchanged.DayOffset.Should().Be(-4);
     }
@@ -320,7 +305,7 @@ public class ShiftManagementServiceTests : IDisposable
     {
         // Arrange: staffing grid with varying min/max per day
         var (es, rota) = SeedRotaScenario(RotaPeriod.Build);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var staffing = new List<DayStaffingInput>
         {
@@ -338,7 +323,7 @@ public class ShiftManagementServiceTests : IDisposable
         result.Succeeded.Should().BeTrue();
 
         // Assert: each shift has the min/max from its corresponding day in the grid
-        var shifts = await _dbContext.Shifts
+        var shifts = await Db.Shifts
             .Where(s => s.RotaId == rota.Id)
             .OrderBy(s => s.DayOffset)
             .ToListAsync();
@@ -356,7 +341,7 @@ public class ShiftManagementServiceTests : IDisposable
     {
         // Arrange: rota with Period=Event
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var staffing = new List<DayStaffingInput>
         {
@@ -370,7 +355,7 @@ public class ShiftManagementServiceTests : IDisposable
 
         result.Succeeded.Should().BeFalse();
         result.Message.Should().Be("Build/strike shift generation is only for Build or Strike rotas.");
-        _dbContext.Shifts.Should().BeEmpty();
+        Db.Shifts.Should().BeEmpty();
     }
 
     // ============================================================
@@ -382,7 +367,7 @@ public class ShiftManagementServiceTests : IDisposable
     {
         // Arrange: event rota, days 0-2, slots [(08:00, 4h), (14:00, 4h)]
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var timeSlots = new List<ShiftTimeSlotInput>
         {
@@ -404,7 +389,7 @@ public class ShiftManagementServiceTests : IDisposable
         result.CreatedCount.Should().Be(6);
 
         // Assert: 6 shifts (3 days × 2 slots), none IsAllDay
-        var shifts = await _dbContext.Shifts.Where(s => s.RotaId == rota.Id).ToListAsync();
+        var shifts = await Db.Shifts.Where(s => s.RotaId == rota.Id).ToListAsync();
         shifts.Should().HaveCount(6);
         shifts.Should().AllSatisfy(s => s.IsAllDay.Should().BeFalse());
 
@@ -423,7 +408,7 @@ public class ShiftManagementServiceTests : IDisposable
     {
         // Arrange: rota with Period=Build
         var (es, rota) = SeedRotaScenario(RotaPeriod.Build);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var timeSlots = new List<ShiftTimeSlotInput>
         {
@@ -441,7 +426,7 @@ public class ShiftManagementServiceTests : IDisposable
 
         result.Succeeded.Should().BeFalse();
         result.Message.Should().Be("Event shift generation is only for Event-period rotas.");
-        _dbContext.Shifts.Should().BeEmpty();
+        Db.Shifts.Should().BeEmpty();
     }
 
     // ============================================================
@@ -454,14 +439,14 @@ public class ShiftManagementServiceTests : IDisposable
         // Arrange
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
         var shift = SeedShift(rota, dayOffset: 1);
-        var confirmedUser = SeedUser("Alice");
-        var pendingUser = SeedUser("Bob");
-        var bailedUser = SeedUser("Charlie");
+        var confirmedUser = SeedUserLocal("Alice");
+        var pendingUser = SeedUserLocal("Bob");
+        var bailedUser = SeedUserLocal("Charlie");
 
         SeedSignup(shift, confirmedUser, SignupStatus.Confirmed);
         SeedSignup(shift, pendingUser, SignupStatus.Pending);
         SeedSignup(shift, bailedUser, SignupStatus.Bailed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var results = await _service.GetBrowseShiftsAsync(es.Id, includeSignups: true);
@@ -479,12 +464,12 @@ public class ShiftManagementServiceTests : IDisposable
         // Arrange
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
         var shift = SeedShift(rota, dayOffset: 1);
-        var confirmedUser = SeedUser("Zara");
-        var pendingUser = SeedUser("Alice");
+        var confirmedUser = SeedUserLocal("Zara");
+        var pendingUser = SeedUserLocal("Alice");
 
         SeedSignup(shift, confirmedUser, SignupStatus.Confirmed);
         SeedSignup(shift, pendingUser, SignupStatus.Pending);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var results = await _service.GetBrowseShiftsAsync(es.Id, includeSignups: true);
@@ -504,9 +489,9 @@ public class ShiftManagementServiceTests : IDisposable
         // Arrange
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
         var shift = SeedShift(rota, dayOffset: 1);
-        var user = SeedUser("Alice");
+        var user = SeedUserLocal("Alice");
         SeedSignup(shift, user, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var results = await _service.GetBrowseShiftsAsync(es.Id, includeSignups: false);
@@ -538,7 +523,7 @@ public class ShiftManagementServiceTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es
         };
-        _dbContext.Rotas.Add(importantRota);
+        Db.Rotas.Add(importantRota);
 
         var understaffedRota = new Rota
         {
@@ -553,22 +538,22 @@ public class ShiftManagementServiceTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es
         };
-        _dbContext.Rotas.Add(understaffedRota);
+        Db.Rotas.Add(understaffedRota);
 
         // Normal+staffed: MinVolunteers=2, two confirmed signups → meets minimum.
         var normalShift = SeedShift(normalStaffedRota, dayOffset: 1);
-        SeedSignup(normalShift, SeedUser("NormA"), SignupStatus.Confirmed);
-        SeedSignup(normalShift, SeedUser("NormB"), SignupStatus.Confirmed);
+        SeedSignup(normalShift, SeedUserLocal("NormA"), SignupStatus.Confirmed);
+        SeedSignup(normalShift, SeedUserLocal("NormB"), SignupStatus.Confirmed);
 
         // Important+staffed: still INCLUDED because of priority.
         var importantShift = SeedShift(importantRota, dayOffset: 1);
-        SeedSignup(importantShift, SeedUser("ImpA"), SignupStatus.Confirmed);
-        SeedSignup(importantShift, SeedUser("ImpB"), SignupStatus.Confirmed);
+        SeedSignup(importantShift, SeedUserLocal("ImpA"), SignupStatus.Confirmed);
+        SeedSignup(importantShift, SeedUserLocal("ImpB"), SignupStatus.Confirmed);
 
         // Normal+understaffed: zero confirmed signups, MinVolunteers=2 → understaffed → INCLUDED.
         var understaffedShift = SeedShift(understaffedRota, dayOffset: 1);
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var results = await _service.GetBrowseShiftsAsync(es.Id, priorityOnly: true);
@@ -612,8 +597,8 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(unpromotedSubTeam);
-        _dbContext.Teams.Add(promotedSubTeam);
+        Db.Teams.Add(unpromotedSubTeam);
+        Db.Teams.Add(promotedSubTeam);
 
         var unpromotedRota = new Rota
         {
@@ -641,13 +626,13 @@ public class ShiftManagementServiceTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es
         };
-        _dbContext.Rotas.Add(unpromotedRota);
-        _dbContext.Rotas.Add(promotedRota);
+        Db.Rotas.Add(unpromotedRota);
+        Db.Rotas.Add(promotedRota);
 
         SeedShift(parentRota, dayOffset: 1);
         SeedShift(unpromotedRota, dayOffset: 1);
         SeedShift(promotedRota, dayOffset: 1);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var results = await _service.GetBrowseShiftsAsync(es.Id, departmentId: parentTeamId);
 
@@ -677,7 +662,7 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(promotedSubTeam);
+        Db.Teams.Add(promotedSubTeam);
 
         var promotedRota = new Rota
         {
@@ -692,11 +677,11 @@ public class ShiftManagementServiceTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es
         };
-        _dbContext.Rotas.Add(promotedRota);
+        Db.Rotas.Add(promotedRota);
 
         SeedShift(parentRota, dayOffset: 1);
         SeedShift(promotedRota, dayOffset: 1);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var results = await _service.GetBrowseShiftsAsync(es.Id, departmentId: promotedSubTeam.Id);
 
@@ -734,8 +719,8 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(unpromotedSubTeam);
-        _dbContext.Teams.Add(promotedSubTeam);
+        Db.Teams.Add(unpromotedSubTeam);
+        Db.Teams.Add(promotedSubTeam);
 
         var unpromotedRota = new Rota
         {
@@ -763,13 +748,13 @@ public class ShiftManagementServiceTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es
         };
-        _dbContext.Rotas.Add(unpromotedRota);
-        _dbContext.Rotas.Add(promotedRota);
+        Db.Rotas.Add(unpromotedRota);
+        Db.Rotas.Add(promotedRota);
 
         SeedShift(parentRota, dayOffset: 1);
         SeedShift(unpromotedRota, dayOffset: 1);
         SeedShift(promotedRota, dayOffset: 1);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var results = await _service.GetUrgentShiftsAsync(es.Id, departmentId: parentTeamId);
 
@@ -783,7 +768,7 @@ public class ShiftManagementServiceTests : IDisposable
     // Helpers
     // ============================================================
 
-    private User SeedUser(string displayName)
+    private User SeedUserLocal(string displayName)
     {
         var user = new User
         {
@@ -795,7 +780,7 @@ public class ShiftManagementServiceTests : IDisposable
             NormalizedUserName = $"{displayName.ToUpperInvariant()}@TEST.COM",
             CreatedAt = TestNow
         };
-        _dbContext.Users.Add(user);
+        Db.Users.Add(user);
         return user;
     }
 
@@ -813,7 +798,7 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 
@@ -828,7 +813,7 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.ShiftSignups.Add(signup);
+        Db.ShiftSignups.Add(signup);
     }
 
     private (EventSettings es, Rota rota) SeedRotaScenario(RotaPeriod period)
@@ -847,7 +832,7 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(es);
+        Db.EventSettings.Add(es);
 
         var team = new Team
         {
@@ -859,7 +844,7 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
 
         var rota = new Rota
         {
@@ -873,7 +858,7 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
 
         rota.EventSettings = es;
 
@@ -1010,13 +995,13 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         }).ToList();
-        _dbContext.Shifts.AddRange(shifts);
+        Db.Shifts.AddRange(shifts);
 
         // 7 confirmed signups on the first 7 shifts
         var userId = Guid.NewGuid();
         for (var i = 0; i < 7; i++)
         {
-            _dbContext.ShiftSignups.Add(new ShiftSignup
+            Db.ShiftSignups.Add(new ShiftSignup
             {
                 Id = Guid.NewGuid(),
                 UserId = userId,
@@ -1027,7 +1012,7 @@ public class ShiftManagementServiceTests : IDisposable
             });
         }
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var (filled, total, ratio) = await _service.GetOverallCoverageAsync();
@@ -1073,8 +1058,8 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(existing);
-        await _dbContext.SaveChangesAsync();
+        Db.EventSettings.Add(existing);
+        await Db.SaveChangesAsync();
 
         var second = new EventSettings
         {
@@ -1114,7 +1099,7 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(existing);
+        Db.EventSettings.Add(existing);
 
         var inactive = new EventSettings
         {
@@ -1129,8 +1114,8 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(inactive);
-        await _dbContext.SaveChangesAsync();
+        Db.EventSettings.Add(inactive);
+        await Db.SaveChangesAsync();
 
         // Act: flip the inactive row to IsActive=true
         inactive.IsActive = true;
@@ -1158,8 +1143,8 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.VolunteerEventProfiles.Add(profile);
-        await _dbContext.SaveChangesAsync();
+        Db.VolunteerEventProfiles.Add(profile);
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.GetShiftProfileAsync(userId, includeMedical: false);
@@ -1182,8 +1167,8 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.VolunteerEventProfiles.Add(profile);
-        await _dbContext.SaveChangesAsync();
+        Db.VolunteerEventProfiles.Add(profile);
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.GetShiftProfileAsync(userId, includeMedical: true);
@@ -1203,9 +1188,9 @@ public class ShiftManagementServiceTests : IDisposable
         // Arrange: rota with one Confirmed signup
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
         var shift = SeedShift(rota, dayOffset: 1);
-        var user = SeedUser("Alice");
+        var user = SeedUserLocal("Alice");
         SeedSignup(shift, user, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act + Assert
         var act = () => _service.DeleteRotaAsync(rota.Id);
@@ -1219,8 +1204,8 @@ public class ShiftManagementServiceTests : IDisposable
         // Arrange: rota with two Pending signups (no Confirmed)
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
         var shift = SeedShift(rota, dayOffset: 1);
-        var user1 = SeedUser("Bob");
-        var user2 = SeedUser("Carol");
+        var user1 = SeedUserLocal("Bob");
+        var user2 = SeedUserLocal("Carol");
         var pending1 = new ShiftSignup
         {
             Id = Guid.NewGuid(),
@@ -1239,17 +1224,17 @@ public class ShiftManagementServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        await _dbContext.ShiftSignups.AddRangeAsync(pending1, pending2);
-        await _dbContext.SaveChangesAsync();
+        await Db.ShiftSignups.AddRangeAsync(pending1, pending2);
+        await Db.SaveChangesAsync();
 
         // Act
         await _service.DeleteRotaAsync(rota.Id);
 
         // Assert: rota gone, pending signups removed by cascade-delete. We query
         // through the service so we hit the same factory-managed context the
-        // delete used (the test's _dbContext caches the tracked rota).
+        // delete used (the test's Db caches the tracked rota).
         (await _service.GetRotaByIdAsync(rota.Id)).Should().BeNull();
-        (await _dbContext.ShiftSignups
+        (await Db.ShiftSignups
             .AsNoTracking()
             .Where(s => s.Id == pending1.Id || s.Id == pending2.Id)
             .ToListAsync())
@@ -1265,12 +1250,12 @@ public class ShiftManagementServiceTests : IDisposable
     {
         // Arrange: rota currently on team A, target team B (no parent).
         var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var targetTeamId = Guid.NewGuid();
         var actorUserId = Guid.NewGuid();
 
-        var sourceTeam = await _dbContext.Teams.FirstAsync(t => t.Id == rota.TeamId);
+        var sourceTeam = await Db.Teams.FirstAsync(t => t.Id == rota.TeamId);
         _teamService.GetTeamByIdAsync(rota.TeamId, Arg.Any<CancellationToken>())
             .Returns(sourceTeam);
         _teamService.GetTeamByIdAsync(targetTeamId, Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupRepositoryActiveCommittedTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupRepositoryActiveCommittedTests.cs
@@ -1,11 +1,9 @@
 using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
-using Microsoft.EntityFrameworkCore;
 using NodaTime;
-using NodaTime.Testing;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
@@ -13,26 +11,16 @@ namespace Humans.Application.Tests.Services.Shifts;
 /// Covers the narrow read used by Mailer audience computations:
 /// "users with at least one Pending or Confirmed signup for the given event".
 /// </summary>
-public class ShiftSignupRepositoryActiveCommittedTests : IDisposable
+public sealed class ShiftSignupRepositoryActiveCommittedTests : ServiceTestHarness
 {
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
-    private readonly HumansDbContext _dbContext;
     private readonly ShiftSignupRepository _repo;
 
     public ShiftSignupRepositoryActiveCommittedTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _repo = new ShiftSignupRepository(_dbContext, new FakeClock(TestNow));
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+        _repo = new ShiftSignupRepository(Db, Clock);
     }
 
     [HumansFact]
@@ -105,7 +93,7 @@ public class ShiftSignupRepositoryActiveCommittedTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         };
-        _dbContext.EventSettings.Add(es);
+        Db.EventSettings.Add(es);
 
         var team = new Team
         {
@@ -117,7 +105,7 @@ public class ShiftSignupRepositoryActiveCommittedTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
 
         var rota = new Rota
         {
@@ -132,7 +120,7 @@ public class ShiftSignupRepositoryActiveCommittedTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es,
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
 
         var shift = new Shift
         {
@@ -147,14 +135,14 @@ public class ShiftSignupRepositoryActiveCommittedTests : IDisposable
             UpdatedAt = TestNow,
             Rota = rota,
         };
-        _dbContext.Shifts.Add(shift);
-        await _dbContext.SaveChangesAsync();
+        Db.Shifts.Add(shift);
+        await Db.SaveChangesAsync();
         return (es, rota, shift);
     }
 
     private async Task AddSignupAsync(Shift shift, Guid userId, SignupStatus status)
     {
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             ShiftId = shift.Id,
@@ -163,6 +151,6 @@ public class ShiftSignupRepositoryActiveCommittedTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow,
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
     }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceCoverageGapTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceCoverageGapTests.cs
@@ -10,13 +10,11 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Shifts;
@@ -30,24 +28,17 @@ namespace Humans.Application.Tests.Services.Shifts;
 /// Lives in its own file so the notification mock can be captured as a field
 /// without disturbing the monster-sized <see cref="ShiftSignupServiceTests"/>.
 /// </summary>
-public class ShiftSignupServiceCoverageGapTests : IDisposable
+public sealed class ShiftSignupServiceCoverageGapTests : ServiceTestHarness
 {
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly INotificationService _notificationService;
     private readonly ITeamService _teamService;
     private readonly ShiftSignupService _service;
 
     public ShiftSignupServiceCoverageGapTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(TestNow);
         _notificationService = Substitute.For<INotificationService>();
         _teamService = Substitute.For<ITeamService>();
         var auditLog = Substitute.For<IAuditLogService>();
@@ -57,7 +48,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
         serviceProvider.GetService(typeof(ITeamService)).Returns(_teamService);
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(roleAssignmentService);
 
-        var shiftRepo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var shiftRepo = new ShiftManagementRepository(DbFactory);
         var shiftMgmt = new ShiftManagementService(
             shiftRepo,
             auditLog,
@@ -65,10 +56,10 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        var signupRepo = new ShiftSignupRepository(_dbContext, _clock);
+        var signupRepo = new ShiftSignupRepository(Db, Clock);
         var membership = Substitute.For<IMembershipCalculator>();
         membership.HasAllRequiredConsentsForTeamAsync(
                 Arg.Any<Guid>(), SystemTeamIds.Volunteers, Arg.Any<CancellationToken>())
@@ -83,14 +74,8 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             Substitute.For<IAdminAuthorizationService>(),
             Substitute.For<IShiftViewInvalidator>(),
             serviceProvider,
-            _clock,
+            Clock,
             NullLogger<ShiftSignupService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -104,7 +89,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
         _teamService.GetTeamAsync(rota.TeamId, Arg.Any<CancellationToken>())
             .Returns(BuildTeamInfoWithCoordinator(rota.TeamId, coordinatorId));
 
-        var signupA = await _dbContext.ShiftSignups.FirstAsync(s => s.UserId == userA);
+        var signupA = await Db.ShiftSignups.FirstAsync(s => s.UserId == userA);
 
         // Act
         var result = await _service.BailAsync(signupA.Id, userA, reason: null);
@@ -136,7 +121,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
         _teamService.GetTeamAsync(rota.TeamId, Arg.Any<CancellationToken>())
             .Returns(BuildTeamInfoWithCoordinator(rota.TeamId, coordinatorId));
 
-        var signupA = await _dbContext.ShiftSignups.FirstAsync(s => s.UserId == userA);
+        var signupA = await Db.ShiftSignups.FirstAsync(s => s.UserId == userA);
 
         // Act
         var result = await _service.BailAsync(signupA.Id, userA, reason: null);
@@ -173,7 +158,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(es);
+        Db.EventSettings.Add(es);
 
         var team = new Team
         {
@@ -185,7 +170,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
 
         var rota = new Rota
         {
@@ -200,7 +185,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
 
         var shift = new Shift
         {
@@ -215,11 +200,11 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             UpdatedAt = TestNow,
             Rota = rota
         };
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
 
         var userA = Guid.NewGuid();
         var userB = Guid.NewGuid();
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             ShiftId = shift.Id,
@@ -228,7 +213,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         });
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             ShiftId = shift.Id,
@@ -238,7 +223,7 @@ public class ShiftSignupServiceCoverageGapTests : IDisposable
             UpdatedAt = TestNow
         });
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         return (es, rota, shift, userA, userB);
     }
 

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceEarlyEntryTests.cs
@@ -3,13 +3,11 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Services.Shifts;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using ShiftSignupService = Humans.Application.Services.Shifts.ShiftSignupService;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Governance;
@@ -22,10 +20,8 @@ using Humans.Infrastructure.Repositories.Shifts;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class ShiftSignupServiceEarlyEntryTests : IDisposable
+public sealed class ShiftSignupServiceEarlyEntryTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IAuditLogService _auditLog;
     private readonly ShiftManagementService _shiftMgmt;
     private readonly ShiftSignupRepository _repo;
@@ -34,13 +30,8 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     public ShiftSignupServiceEarlyEntryTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(TestNow);
         _auditLog = Substitute.For<IAuditLogService>();
 
         var teamService = Substitute.For<ITeamService>();
@@ -49,7 +40,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
         serviceProvider.GetService(typeof(ITeamService)).Returns(teamService);
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(roleAssignmentService);
 
-        var shiftRepo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var shiftRepo = new ShiftManagementRepository(DbFactory);
 
         _shiftMgmt = new ShiftManagementService(
             shiftRepo,
@@ -58,10 +49,10 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        _repo = new ShiftSignupRepository(_dbContext, _clock);
+        _repo = new ShiftSignupRepository(Db, Clock);
         var membership = Substitute.For<IMembershipCalculator>();
         membership.HasAllRequiredConsentsForTeamAsync(
             Arg.Any<Guid>(), SystemTeamIds.Volunteers, Arg.Any<CancellationToken>())
@@ -75,14 +66,8 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             Substitute.For<IAdminAuthorizationService>(),
             Substitute.For<IShiftViewInvalidator>(),
             serviceProvider,
-            _clock,
+            Clock,
             NullLogger<ShiftSignupService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -98,7 +83,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
         var existingShift = SeedAllDayShift(rota, -3);
         var targetShift = SeedAllDayShift(rota, -2);
         SeedSignup(Guid.NewGuid(), existingShift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(Guid.NewGuid(), targetShift.Id);
 
@@ -121,7 +106,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
         SeedAllDayShift(rota, -2);
         var finalDayShift = SeedAllDayShift(rota, -1);
         SeedSignup(Guid.NewGuid(), finalDayShift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpRangeAsync(Guid.NewGuid(), rota.Id, -3, -1);
 
@@ -145,7 +130,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(eventSettings);
+        Db.EventSettings.Add(eventSettings);
 
         var team = new Team
         {
@@ -156,7 +141,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
 
         var rota = new Rota
         {
@@ -171,7 +156,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = eventSettings
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
 
         return (eventSettings, rota, team);
     }
@@ -194,13 +179,13 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             Rota = rota
         };
 
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 
     private void SeedSignup(Guid userId, Guid shiftId, SignupStatus status)
     {
-        _dbContext.ShiftSignups.Add(new ShiftSignup
+        Db.ShiftSignups.Add(new ShiftSignup
         {
             Id = Guid.NewGuid(),
             UserId = userId,

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceFilterIncompleteOnboardingTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceFilterIncompleteOnboardingTests.cs
@@ -10,13 +10,10 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Shifts;
@@ -25,22 +22,16 @@ namespace Humans.Application.Tests.Services.Shifts;
 /// Tests for <see cref="ShiftSignupService.FilterToIncompleteOnboardingAsync"/> —
 /// the coordinator-side Pending-list "Incomplete onboarding" filter chip helper.
 /// </summary>
-public class ShiftSignupServiceFilterIncompleteOnboardingTests : IDisposable
+public sealed class ShiftSignupServiceFilterIncompleteOnboardingTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
     private readonly IMembershipCalculator _membership;
     private readonly ShiftSignupService _service;
 
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     public ShiftSignupServiceFilterIncompleteOnboardingTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        var clock = new FakeClock(TestNow);
         var auditLog = Substitute.For<IAuditLogService>();
         _membership = Substitute.For<IMembershipCalculator>();
 
@@ -50,7 +41,7 @@ public class ShiftSignupServiceFilterIncompleteOnboardingTests : IDisposable
         serviceProvider.GetService(typeof(ITeamService)).Returns(teamService);
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(roleAssignmentService);
 
-        var shiftRepo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var shiftRepo = new ShiftManagementRepository(DbFactory);
         var shiftMgmt = new ShiftManagementService(
             shiftRepo,
             auditLog,
@@ -58,10 +49,10 @@ public class ShiftSignupServiceFilterIncompleteOnboardingTests : IDisposable
             serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             Substitute.For<IShiftViewInvalidator>(),
-            clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        var repo = new ShiftSignupRepository(_dbContext, clock);
+        var repo = new ShiftSignupRepository(Db, Clock);
         _service = new ShiftSignupService(
             repo,
             shiftMgmt,
@@ -71,14 +62,8 @@ public class ShiftSignupServiceFilterIncompleteOnboardingTests : IDisposable
             Substitute.For<IAdminAuthorizationService>(),
             Substitute.For<IShiftViewInvalidator>(),
             serviceProvider,
-            clock,
+            Clock,
             NullLogger<ShiftSignupService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceForcePendingTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceForcePendingTests.cs
@@ -9,22 +9,18 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class ShiftSignupServiceForcePendingTests : IDisposable
+public sealed class ShiftSignupServiceForcePendingTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IAuditLogService _auditLog;
     private readonly IMembershipCalculator _membership;
     private readonly ShiftManagementService _shiftMgmt;
@@ -36,13 +32,8 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
     private readonly Guid _userId = Guid.NewGuid();
 
     public ShiftSignupServiceForcePendingTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(TestNow);
         _auditLog = Substitute.For<IAuditLogService>();
         _membership = Substitute.For<IMembershipCalculator>();
 
@@ -52,7 +43,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
         serviceProvider.GetService(typeof(ITeamService)).Returns(teamService);
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(roleAssignmentService);
 
-        var shiftRepo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var shiftRepo = new ShiftManagementRepository(DbFactory);
 
         _shiftMgmt = new ShiftManagementService(
             shiftRepo,
@@ -61,10 +52,10 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
             serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        _repo = new ShiftSignupRepository(_dbContext, _clock);
+        _repo = new ShiftSignupRepository(Db, Clock);
         _service = new ShiftSignupService(
             _repo,
             _shiftMgmt,
@@ -74,14 +65,8 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
             Substitute.For<IAdminAuthorizationService>(),
             Substitute.For<IShiftViewInvalidator>(),
             serviceProvider,
-            _clock,
+            Clock,
             NullLogger<ShiftSignupService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -89,7 +74,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
     {
         SetUserConsents(false);
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(_userId, shift.Id, _userId);
 
@@ -102,7 +87,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
     {
         SetUserConsents(true);
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(_userId, shift.Id, _userId);
 
@@ -115,7 +100,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
     {
         SetUserConsents(false);
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(_userId, shift.Id, _userId);
 
@@ -133,12 +118,12 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
         {
             SeedAllDayShift(rota, day);
         }
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpRangeAsync(_userId, rota.Id, -3, -1, _userId);
 
         Assert.True(result.Success);
-        var blockSignups = await _dbContext.ShiftSignups
+        var blockSignups = await Db.ShiftSignups
             .Where(s => s.UserId == _userId)
             .ToListAsync();
         Assert.Equal(3, blockSignups.Count);
@@ -170,7 +155,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(es);
+        Db.EventSettings.Add(es);
 
         var team = new Team
         {
@@ -182,7 +167,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
 
         var rota = new Rota
         {
@@ -197,7 +182,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
             UpdatedAt = TestNow,
             EventSettings = es
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
 
         var shift = SeedShift(rota, dayOffset: 1, startHour: 10, durationHours: 4);
         return (es, rota, shift);
@@ -218,7 +203,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
             UpdatedAt = TestNow,
             Rota = rota
         };
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 
@@ -238,7 +223,7 @@ public class ShiftSignupServiceForcePendingTests : IDisposable
             UpdatedAt = TestNow,
             Rota = rota
         };
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceTests.cs
@@ -3,14 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Services.Shifts;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using ShiftSignupService = Humans.Application.Services.Shifts.ShiftSignupService;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Governance;
@@ -22,10 +20,8 @@ using Humans.Infrastructure.Repositories.Shifts;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
-public class ShiftSignupServiceTests : IDisposable
+public sealed class ShiftSignupServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IAuditLogService _auditLog;
     private readonly ShiftManagementService _shiftMgmt;
     private readonly ShiftSignupRepository _repo;
@@ -35,13 +31,8 @@ public class ShiftSignupServiceTests : IDisposable
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     public ShiftSignupServiceTests()
+        : base(TestNow)
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(TestNow);
         _auditLog = Substitute.For<IAuditLogService>();
 
         var teamService = Substitute.For<ITeamService>();
@@ -50,7 +41,7 @@ public class ShiftSignupServiceTests : IDisposable
         serviceProvider.GetService(typeof(ITeamService)).Returns(teamService);
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(roleAssignmentService);
 
-        var shiftRepo = new ShiftManagementRepository(new TestDbContextFactory(options));
+        var shiftRepo = new ShiftManagementRepository(DbFactory);
 
         _shiftMgmt = new ShiftManagementService(
             shiftRepo,
@@ -59,10 +50,10 @@ public class ShiftSignupServiceTests : IDisposable
             serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        _repo = new ShiftSignupRepository(_dbContext, _clock);
+        _repo = new ShiftSignupRepository(Db, Clock);
         var membership = Substitute.For<IMembershipCalculator>();
         membership.HasAllRequiredConsentsForTeamAsync(
             Arg.Any<Guid>(), SystemTeamIds.Volunteers, Arg.Any<CancellationToken>())
@@ -76,14 +67,8 @@ public class ShiftSignupServiceTests : IDisposable
             Substitute.For<IAdminAuthorizationService>(),
             Substitute.For<IShiftViewInvalidator>(),
             serviceProvider,
-            _clock,
+            Clock,
             NullLogger<ShiftSignupService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     // ============================================================
@@ -95,7 +80,7 @@ public class ShiftSignupServiceTests : IDisposable
     {
         var (es, rota, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -109,7 +94,7 @@ public class ShiftSignupServiceTests : IDisposable
     {
         var (es, rota, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -124,7 +109,7 @@ public class ShiftSignupServiceTests : IDisposable
         var (es, rota, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
         SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -140,7 +125,7 @@ public class ShiftSignupServiceTests : IDisposable
         var shift2 = SeedShift(rota, dayOffset: 1, startHour: 10, durationHours: 4);
         var userId = Guid.NewGuid();
         SeedSignup(userId, shift1.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // shift1: day 1, 10:00-14:00 — shift2: day 1, 10:00-14:00 (identical times)
         var result = await _service.SignUpAsync(userId, shift2.Id);
@@ -164,7 +149,7 @@ public class ShiftSignupServiceTests : IDisposable
         var allDay = SeedAllDayShift(rota, dayOffset: 1);
         var userId = Guid.NewGuid();
         SeedSignup(userId, nightWatch.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, allDay.Id);
 
@@ -187,7 +172,7 @@ public class ShiftSignupServiceTests : IDisposable
         var allDay = SeedAllDayShift(rota, dayOffset: 0);
         var userId = Guid.NewGuid();
         SeedSignup(userId, allDay.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, earlyShift.Id);
 
@@ -201,7 +186,7 @@ public class ShiftSignupServiceTests : IDisposable
         var (es, rota, shift) = SeedShiftScenario(SignupPolicy.Public);
         es.IsShiftBrowsingOpen = false;
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -215,7 +200,7 @@ public class ShiftSignupServiceTests : IDisposable
         var (es, rota, shift) = SeedShiftScenario(SignupPolicy.Public);
         shift.AdminOnly = true;
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -234,7 +219,7 @@ public class ShiftSignupServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Pending);
         var reviewerId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.ApproveAsync(signup.Id, reviewerId);
 
@@ -254,7 +239,7 @@ public class ShiftSignupServiceTests : IDisposable
         // User has pending signup for shift2 (same time slot)
         var pendingSignup = SeedSignup(userId, shift2.Id, SignupStatus.Pending);
         var reviewerId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.ApproveAsync(pendingSignup.Id, reviewerId);
 
@@ -273,7 +258,7 @@ public class ShiftSignupServiceTests : IDisposable
         var (es, rota, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.BailAsync(signup.Id, userId, "Can't make it");
 
@@ -292,7 +277,7 @@ public class ShiftSignupServiceTests : IDisposable
         es.EarlyEntryClose = TestNow - Duration.FromHours(1);
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.BailAsync(signup.Id, userId, null);
 
@@ -310,7 +295,7 @@ public class ShiftSignupServiceTests : IDisposable
         var (es, rota, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.VoluntellAsync(volunteerId, shift.Id, enrollerId);
 
@@ -344,7 +329,7 @@ public class ShiftSignupServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
         var reviewerId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.MarkNoShowAsync(signup.Id, reviewerId);
 
@@ -367,7 +352,7 @@ public class ShiftSignupServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
         var reviewerId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.MarkNoShowAsync(signup.Id, reviewerId);
 
@@ -389,14 +374,14 @@ public class ShiftSignupServiceTests : IDisposable
         for (var day = -5; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1);
 
         // Assert: 3 signups created, all share same SignupBlockId
         result.Success.Should().BeTrue();
-        var signups = await _dbContext.ShiftSignups
+        var signups = await Db.ShiftSignups
             .Where(s => s.UserId == userId)
             .ToListAsync();
         signups.Should().HaveCount(3);
@@ -414,11 +399,11 @@ public class ShiftSignupServiceTests : IDisposable
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
         // Find the day -2 shift and create an existing signup
-        await _dbContext.SaveChangesAsync();
-        var dayMinus2Shift = await _dbContext.Shifts
+        await Db.SaveChangesAsync();
+        var dayMinus2Shift = await Db.Shifts
             .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2);
         SeedSignup(userId, dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act: try to sign up for days -3 to -1
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1);
@@ -437,12 +422,12 @@ public class ShiftSignupServiceTests : IDisposable
         for (var day = -3; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
-        var dayMinus2Shift = await _dbContext.Shifts
+        var dayMinus2Shift = await Db.Shifts
             .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2);
         var existingSignup = SeedSignup(userId, dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1, skipConflicts: true);
@@ -452,13 +437,13 @@ public class ShiftSignupServiceTests : IDisposable
         result.Warning.Should().NotBeNull();
         result.Warning.Should().Contain("Already signed up");
 
-        var signups = await _dbContext.ShiftSignups
+        var signups = await Db.ShiftSignups
             .Where(s => s.UserId == userId)
             .ToListAsync();
         signups.Should().HaveCount(3); // 1 pre-existing + 2 new
         var newOffsets = signups
             .Where(s => s.Id != existingSignup.Id)
-            .Join(_dbContext.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
+            .Join(Db.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
             .OrderBy(o => o)
             .ToList();
         newOffsets.Should().Equal(-3, -1);
@@ -475,18 +460,18 @@ public class ShiftSignupServiceTests : IDisposable
         for (var day = -4; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
-        var dayMinus3Shift = await _dbContext.Shifts
+        var dayMinus3Shift = await Db.Shifts
             .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -3);
         SeedSignup(userId, dayMinus3Shift.Id, SignupStatus.Confirmed);
 
-        var dayMinus2Shift = await _dbContext.Shifts
+        var dayMinus2Shift = await Db.Shifts
             .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2);
         // SeedAllDayShift sets MaxVolunteers = 5; fill day -2 with 5 distinct other users.
         for (var i = 0; i < dayMinus2Shift.MaxVolunteers; i++)
             SeedSignup(Guid.NewGuid(), dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -4, -1, skipConflicts: true);
@@ -497,9 +482,9 @@ public class ShiftSignupServiceTests : IDisposable
         result.Warning.Should().Contain("Already signed up");
         result.Warning.Should().Contain("at capacity");
 
-        var newSignups = await _dbContext.ShiftSignups
+        var newSignups = await Db.ShiftSignups
             .Where(s => s.UserId == userId && s.SignupBlockId != null)
-            .Join(_dbContext.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
+            .Join(Db.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
             .OrderBy(o => o)
             .ToListAsync();
         newSignups.Should().Equal(-4, -1);
@@ -527,7 +512,7 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         otherRota.EventSettings = es; // nav property for in-memory provider
-        _dbContext.Rotas.Add(otherRota);
+        Db.Rotas.Add(otherRota);
 
         var conflictingShift = new Shift
         {
@@ -543,11 +528,11 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         conflictingShift.Rota = otherRota; // nav property for in-memory provider
-        _dbContext.Shifts.Add(conflictingShift);
+        Db.Shifts.Add(conflictingShift);
 
         var userId = Guid.NewGuid();
         SeedSignup(userId, conflictingShift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.SignUpRangeAsync(userId, buildRota.Id, -3, -1, skipConflicts: true);
@@ -557,9 +542,9 @@ public class ShiftSignupServiceTests : IDisposable
         result.Warning.Should().NotBeNull();
         result.Warning.Should().Contain("Time conflict");
 
-        var newOffsets = await _dbContext.ShiftSignups
+        var newOffsets = await Db.ShiftSignups
             .Where(s => s.UserId == userId && s.Shift.RotaId == buildRota.Id)
-            .Join(_dbContext.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
+            .Join(Db.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
             .OrderBy(o => o)
             .ToListAsync();
         newOffsets.Should().Equal(-3, -1);
@@ -575,11 +560,11 @@ public class ShiftSignupServiceTests : IDisposable
         var shifts = new List<Shift>();
         for (var day = -3; day <= -1; day++)
             shifts.Add(SeedAllDayShift(rota, day));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         foreach (var shift in shifts)
             SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1, skipConflicts: true);
@@ -589,7 +574,7 @@ public class ShiftSignupServiceTests : IDisposable
         result.Error.Should().NotBeNull();
         result.Error.Should().Contain("Nothing to add");
 
-        var totalSignups = await _dbContext.ShiftSignups.CountAsync(s => s.UserId == userId);
+        var totalSignups = await Db.ShiftSignups.CountAsync(s => s.UserId == userId);
         totalSignups.Should().Be(3); // only the 3 pre-existing
     }
 
@@ -618,7 +603,7 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         otherRota.EventSettings = es;
-        _dbContext.Rotas.Add(otherRota);
+        Db.Rotas.Add(otherRota);
 
         var crossRotaShift = new Shift
         {
@@ -634,16 +619,16 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         crossRotaShift.Rota = otherRota;
-        _dbContext.Shifts.Add(crossRotaShift);
+        Db.Shifts.Add(crossRotaShift);
 
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
-        var dayMinus3Shift = await _dbContext.Shifts
+        var dayMinus3Shift = await Db.Shifts
             .FirstAsync(s => s.RotaId == buildRota.Id && s.DayOffset == -3);
         SeedSignup(userId, dayMinus3Shift.Id, SignupStatus.Confirmed);  // already-signed-up case
         SeedSignup(userId, crossRotaShift.Id, SignupStatus.Confirmed);  // time-conflict case
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.SignUpRangeAsync(userId, buildRota.Id, -4, -1, skipConflicts: true);
@@ -654,9 +639,9 @@ public class ShiftSignupServiceTests : IDisposable
         result.Warning.Should().Contain("Already signed up");
         result.Warning.Should().Contain("Time conflict");
 
-        var newOffsets = await _dbContext.ShiftSignups
+        var newOffsets = await Db.ShiftSignups
             .Where(s => s.UserId == userId && s.Shift.RotaId == buildRota.Id && s.ShiftId != dayMinus3Shift.Id)
-            .Join(_dbContext.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
+            .Join(Db.Shifts, s => s.ShiftId, sh => sh.Id, (s, sh) => sh.DayOffset)
             .OrderBy(o => o)
             .ToListAsync();
         newOffsets.Should().Equal(-4, -1);
@@ -683,7 +668,7 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         otherRota.EventSettings = es;
-        _dbContext.Rotas.Add(otherRota);
+        Db.Rotas.Add(otherRota);
 
         var conflictingShift = new Shift
         {
@@ -699,11 +684,11 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         conflictingShift.Rota = otherRota;
-        _dbContext.Shifts.Add(conflictingShift);
+        Db.Shifts.Add(conflictingShift);
 
         var userId = Guid.NewGuid();
         SeedSignup(userId, conflictingShift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act — no skipConflicts argument; defaults to false.
         var result = await _service.SignUpRangeAsync(userId, buildRota.Id, -3, -1);
@@ -713,7 +698,7 @@ public class ShiftSignupServiceTests : IDisposable
         result.Error.Should().NotBeNull();
         result.Error.Should().Contain("Time conflict");
 
-        var newSignupCount = await _dbContext.ShiftSignups
+        var newSignupCount = await Db.ShiftSignups
             .Where(s => s.UserId == userId && s.Shift.RotaId == buildRota.Id)
             .CountAsync();
         newSignupCount.Should().Be(0);
@@ -739,13 +724,13 @@ public class ShiftSignupServiceTests : IDisposable
             var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
             signup.SignupBlockId = blockId;
         }
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         await _service.BailRangeAsync(blockId, userId);
 
         // Assert: all 3 signups now Bailed
-        var signups = await _dbContext.ShiftSignups
+        var signups = await Db.ShiftSignups
             .Where(s => s.SignupBlockId == blockId)
             .ToListAsync();
         signups.Should().HaveCount(3);
@@ -766,14 +751,14 @@ public class ShiftSignupServiceTests : IDisposable
             SeedAllDayShift(rota, day);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
 
         // Assert
         result.Success.Should().BeTrue();
-        var signups = await _dbContext.ShiftSignups
+        var signups = await Db.ShiftSignups
             .Where(s => s.UserId == volunteerId)
             .ToListAsync();
         signups.Should().HaveCount(3);
@@ -797,20 +782,20 @@ public class ShiftSignupServiceTests : IDisposable
             SeedAllDayShift(rota, day);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Pre-existing signup on day -2
-        var dayMinus2Shift = await _dbContext.Shifts
+        var dayMinus2Shift = await Db.Shifts
             .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2);
         SeedSignup(volunteerId, dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Act
         var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
 
         // Assert: only 2 new signups (day -3 and day -1), skipping day -2
         result.Success.Should().BeTrue();
-        var newSignups = await _dbContext.ShiftSignups
+        var newSignups = await Db.ShiftSignups
             .Where(s => s.UserId == volunteerId && s.Enrolled)
             .ToListAsync();
         newSignups.Should().HaveCount(2);
@@ -836,7 +821,7 @@ public class ShiftSignupServiceTests : IDisposable
     {
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -853,7 +838,7 @@ public class ShiftSignupServiceTests : IDisposable
     {
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -874,7 +859,7 @@ public class ShiftSignupServiceTests : IDisposable
         for (var day = -3; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1);
 
@@ -898,7 +883,7 @@ public class ShiftSignupServiceTests : IDisposable
         var targetUserId = Guid.NewGuid();
         var actorUserId = Guid.NewGuid();
         SeedSignup(sourceUserId, shift.Id, SignupStatus.Confirmed);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.ReassignAsync(sourceUserId, targetUserId, actorUserId, TestNow, CancellationToken.None);
 
@@ -916,7 +901,7 @@ public class ShiftSignupServiceTests : IDisposable
         var sourceUserId = Guid.NewGuid();
         var targetUserId = Guid.NewGuid();
         var actorUserId = Guid.NewGuid();
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.ReassignAsync(sourceUserId, targetUserId, actorUserId, TestNow, CancellationToken.None);
 
@@ -948,7 +933,7 @@ public class ShiftSignupServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.EventSettings.Add(es);
+        Db.EventSettings.Add(es);
 
         var team = new Team
         {
@@ -960,7 +945,7 @@ public class ShiftSignupServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
 
         var rota = new Rota
         {
@@ -974,7 +959,7 @@ public class ShiftSignupServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.Rotas.Add(rota);
+        Db.Rotas.Add(rota);
 
         // Set navigation properties for in-memory provider
         rota.EventSettings = es;
@@ -998,7 +983,7 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         shift.Rota = rota;
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 
@@ -1019,7 +1004,7 @@ public class ShiftSignupServiceTests : IDisposable
             UpdatedAt = TestNow
         };
         shift.Rota = rota;
-        _dbContext.Shifts.Add(shift);
+        Db.Shifts.Add(shift);
         return shift;
     }
 
@@ -1034,7 +1019,7 @@ public class ShiftSignupServiceTests : IDisposable
             CreatedAt = TestNow,
             UpdatedAt = TestNow
         };
-        _dbContext.ShiftSignups.Add(signup);
+        Db.ShiftSignups.Add(signup);
         return signup;
     }
 }

--- a/tests/Humans.Application.Tests/Services/TeamResourceServiceDeactivateTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamResourceServiceDeactivateTests.cs
@@ -4,14 +4,13 @@ using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Services.GoogleIntegration;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.GoogleIntegration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
@@ -24,26 +23,19 @@ namespace Humans.Application.Tests.Services;
 /// <see cref="IDbContextFactory{HumansDbContext}"/>-backed repository and a
 /// stubbed <see cref="ITeamResourceGoogleClient"/>.
 /// </summary>
-public class TeamResourceServiceDeactivateTests : IDisposable
+public sealed class TeamResourceServiceDeactivateTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly IAuditLogService _auditLogService;
     private readonly IGoogleDrivePermissionsClient _drivePermissions;
     private readonly TeamResourceService _service;
 
     public TeamResourceServiceDeactivateTests()
+        : base(Instant.FromUtc(2026, 4, 15, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 4, 15, 12, 0));
         _auditLogService = Substitute.For<IAuditLogService>();
         _drivePermissions = Substitute.For<IGoogleDrivePermissionsClient>();
 
-        var factory = new SingleContextFactory(options);
-        IGoogleResourceRepository repository = new GoogleResourceRepository(factory);
+        IGoogleResourceRepository repository = new GoogleResourceRepository(DbFactory);
 
         _service = new TeamResourceService(
             repository,
@@ -53,14 +45,8 @@ public class TeamResourceServiceDeactivateTests : IDisposable
             serviceProvider: Substitute.For<IServiceProvider>(),
             auditLogService: _auditLogService,
             resourceOptions: new TeamResourceManagementOptions(),
-            clock: _clock,
+            clock: Clock,
             logger: NullLogger<TeamResourceService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]
@@ -76,17 +62,17 @@ public class TeamResourceServiceDeactivateTests : IDisposable
         SeedResource(otherTeamId, "Safe Drive", GoogleResourceType.DriveFolder);
         // Already-inactive row on target team should not generate a duplicate audit.
         SeedResource(teamId, "Already inactive", GoogleResourceType.DriveFolder, isActive: false);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.DeactivateResourcesForTeamAsync(teamId);
 
-        var doomedRows = await _dbContext.GoogleResources
+        var doomedRows = await Db.GoogleResources
             .AsNoTracking()
             .Where(r => r.TeamId == teamId)
             .ToListAsync();
         doomedRows.Should().OnlyContain(r => !r.IsActive);
 
-        var safeRow = await _dbContext.GoogleResources
+        var safeRow = await Db.GoogleResources
             .AsNoTracking()
             .SingleAsync(r => r.TeamId == otherTeamId);
         safeRow.IsActive.Should().BeTrue();
@@ -113,11 +99,11 @@ public class TeamResourceServiceDeactivateTests : IDisposable
         SeedTeam(teamId, "Doomed");
         SeedResource(teamId, "Doomed Drive", GoogleResourceType.DriveFolder);
         SeedResource(teamId, "Doomed Group", GoogleResourceType.Group);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.DeactivateResourcesForTeamAsync(teamId, GoogleResourceType.DriveFolder);
 
-        var rows = await _dbContext.GoogleResources
+        var rows = await Db.GoogleResources
             .AsNoTracking()
             .Where(r => r.TeamId == teamId)
             .ToListAsync();
@@ -133,7 +119,7 @@ public class TeamResourceServiceDeactivateTests : IDisposable
         var teamId = Guid.NewGuid();
         SeedTeam(teamId, "Access");
         var resourceId = SeedResource(teamId, "Folder", GoogleResourceType.DriveFolder);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         _drivePermissions.SetInheritedPermissionsDisabledAsync(
                 Arg.Any<string>(),
                 true,
@@ -144,7 +130,7 @@ public class TeamResourceServiceDeactivateTests : IDisposable
 
         result.Succeeded.Should().BeTrue();
 
-        var stored = await _dbContext.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == resourceId);
+        var stored = await Db.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == resourceId);
         stored.RestrictInheritedAccess.Should().BeTrue();
     }
 
@@ -169,7 +155,7 @@ public class TeamResourceServiceDeactivateTests : IDisposable
         var knownId2 = Guid.NewGuid();
         var unknownId = Guid.NewGuid();
 
-        _dbContext.GoogleResources.Add(new GoogleResource
+        Db.GoogleResources.Add(new GoogleResource
         {
             Id = knownId1,
             TeamId = teamId,
@@ -177,9 +163,9 @@ public class TeamResourceServiceDeactivateTests : IDisposable
             GoogleId = "google-1",
             ResourceType = GoogleResourceType.DriveFolder,
             IsActive = true,
-            ProvisionedAt = _clock.GetCurrentInstant()
+            ProvisionedAt = Clock.GetCurrentInstant()
         });
-        _dbContext.GoogleResources.Add(new GoogleResource
+        Db.GoogleResources.Add(new GoogleResource
         {
             Id = knownId2,
             TeamId = teamId,
@@ -187,9 +173,9 @@ public class TeamResourceServiceDeactivateTests : IDisposable
             GoogleId = "google-2",
             ResourceType = GoogleResourceType.Group,
             IsActive = true,
-            ProvisionedAt = _clock.GetCurrentInstant()
+            ProvisionedAt = Clock.GetCurrentInstant()
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetResourceNamesByIdsAsync([knownId1, knownId2, unknownId]);
 
@@ -204,7 +190,7 @@ public class TeamResourceServiceDeactivateTests : IDisposable
     {
         var teamId = Guid.NewGuid();
         SeedTeam(teamId, "Empty");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.DeactivateResourcesForTeamAsync(teamId);
 
@@ -220,21 +206,21 @@ public class TeamResourceServiceDeactivateTests : IDisposable
 
     private void SeedTeam(Guid id, string name)
     {
-        _dbContext.Teams.Add(new Team
+        Db.Teams.Add(new Team
         {
             Id = id,
             Name = name,
             Slug = name.ToLowerInvariant(),
             IsActive = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         });
     }
 
     private Guid SeedResource(Guid teamId, string name, GoogleResourceType type, bool isActive = true)
     {
         var id = Guid.NewGuid();
-        _dbContext.GoogleResources.Add(new GoogleResource
+        Db.GoogleResources.Add(new GoogleResource
         {
             Id = id,
             TeamId = teamId,
@@ -243,24 +229,8 @@ public class TeamResourceServiceDeactivateTests : IDisposable
             Url = $"https://example.com/{name}",
             ResourceType = type,
             IsActive = isActive,
-            ProvisionedAt = _clock.GetCurrentInstant()
+            ProvisionedAt = Clock.GetCurrentInstant()
         });
         return id;
-    }
-
-    /// <summary>
-    /// Minimal <see cref="IDbContextFactory{HumansDbContext}"/> that reuses a
-    /// single in-memory DB across contexts. Each <c>CreateDbContextAsync</c>
-    /// returns a fresh <see cref="HumansDbContext"/> over the same
-    /// <see cref="DbContextOptions"/>, matching the production behavior where
-    /// the repository tears its context down per call.
-    /// </summary>
-    private sealed class SingleContextFactory(DbContextOptions<HumansDbContext> options)
-        : IDbContextFactory<HumansDbContext>
-    {
-        public HumansDbContext CreateDbContext() => new(options);
-
-        public Task<HumansDbContext> CreateDbContextAsync(CancellationToken ct = default) =>
-            Task.FromResult(new HumansDbContext(options));
     }
 }

--- a/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
@@ -2,7 +2,6 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -11,7 +10,6 @@ using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Services.Shifts;
 using Humans.Application.Tests.Infrastructure;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Teams;
 using RoleAssignmentService = Humans.Application.Services.Auth.RoleAssignmentService;
 using TeamService = Humans.Application.Services.Teams.TeamService;
@@ -27,23 +25,15 @@ using Humans.Infrastructure.Repositories.Shifts;
 
 namespace Humans.Application.Tests.Services;
 
-public class TeamRoleServiceTests : IDisposable
+public sealed class TeamRoleServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
     private readonly TeamService _service;
     private readonly IShiftAuthorizationInvalidator _shiftAuthInvalidator;
 
-    public TeamRoleServiceTests()
+    public TeamRoleServiceTests() : base(Instant.FromUtc(2026, 3, 11, 12, 0))
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 11, 12, 0));
-        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
         var roleAssignmentService = new RoleAssignmentService(
-            new RoleAssignmentRepository(new TestDbContextFactory(options)),
+            new RoleAssignmentRepository(DbFactory),
             Substitute.For<IUserService>(),
             Substitute.For<IAuditLogService>(),
             Substitute.For<INotificationEmitter>(),
@@ -51,56 +41,32 @@ public class TeamRoleServiceTests : IDisposable
             Substitute.For<INavBadgeCacheInvalidator>(),
             Substitute.For<IRoleAssignmentClaimsCacheInvalidator>(),
             Substitute.For<IRoleAssignmentCacheInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<RoleAssignmentService>.Instance);
         var serviceProvider = Substitute.For<IServiceProvider>();
-        var emailService = Substitute.For<IEmailService>();
-        var systemTeamSync = Substitute.For<ISystemTeamSync>();
         serviceProvider.GetService(typeof(ITeamService)).Returns(Substitute.For<ITeamService>());
         serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(roleAssignmentService);
-        serviceProvider.GetService(typeof(IEmailService)).Returns(emailService);
-        serviceProvider.GetService(typeof(ISystemTeamSync)).Returns(systemTeamSync);
+        serviceProvider.GetService(typeof(IEmailService)).Returns(Substitute.For<IEmailService>());
+        serviceProvider.GetService(typeof(ISystemTeamSync)).Returns(Substitute.For<ISystemTeamSync>());
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService
             .GetTeamResourceSummariesAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, TeamResourceSummary>());
         serviceProvider.GetService(typeof(ITeamResourceService)).Returns(teamResourceService);
-        var shiftRepo = new ShiftManagementRepository(new TestDbContextFactory(options));
         var shiftManagementService = new ShiftManagementService(
-            shiftRepo,
+            new ShiftManagementRepository(DbFactory),
             Substitute.For<IAuditLogService>(),
             Substitute.For<IAdminAuthorizationService>(),
             serviceProvider,
-            cache,
+            Cache,
             Substitute.For<IShiftViewInvalidator>(),
-            _clock,
+            Clock,
             NullLogger<ShiftManagementService>.Instance);
-        var teamRepo = new TeamRepository(new TestDbContextFactory(options));
-        var testUserService = Substitute.For<IUserService>();
-        testUserService
-            .GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                var ids = callInfo.Arg<IReadOnlyCollection<Guid>>();
-                if (ids.Count == 0)
-                    return Task.FromResult<IReadOnlyDictionary<Guid, User>>(new Dictionary<Guid, User>());
-                using var db = new HumansDbContext(options);
-                var users = db.Users.AsNoTracking().Where(u => ids.Contains(u.Id)).ToList();
-                return Task.FromResult<IReadOnlyDictionary<Guid, User>>(users.ToDictionary(u => u.Id));
-            });
-        testUserService
-            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                var id = callInfo.Arg<Guid>();
-                using var db = new HumansDbContext(options);
-                return Task.FromResult(db.Users.AsNoTracking().FirstOrDefault(u => u.Id == id));
-            });
-        testUserService.StubGetUserInfosFromDb(options);
-        serviceProvider.GetService(typeof(IUserService)).Returns(testUserService);
+        var userService = NewDbBackedUserService();
+        serviceProvider.GetService(typeof(IUserService)).Returns(userService);
         _shiftAuthInvalidator = Substitute.For<IShiftAuthorizationInvalidator>();
         _service = new TeamService(
-            teamRepo,
+            new TeamRepository(DbFactory),
             Substitute.For<IAuditLogService>(),
             Substitute.For<INotificationEmitter>(),
             shiftManagementService,
@@ -108,14 +74,8 @@ public class TeamRoleServiceTests : IDisposable
             _shiftAuthInvalidator,
             Substitute.For<IAdminAuthorizationService>(),
             serviceProvider,
-            _clock,
+            Clock,
             NullLogger<TeamService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     // ==========================================================================
@@ -128,7 +88,7 @@ public class TeamRoleServiceTests : IDisposable
         var admin = SeedUser("Admin");
         SeedAdminRole(admin);
         var team = SeedTeam("Volunteers", type: SystemTeamType.Volunteers);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.CreateRoleDefinitionAsync(
             team.Id, "Designer", null, 2,
@@ -144,7 +104,7 @@ public class TeamRoleServiceTests : IDisposable
         var admin = SeedUser("Admin");
         SeedAdminRole(admin);
         var team = SeedTeam("Test Team");
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.CreateRoleDefinitionAsync(
             team.Id, "Designer", "Designs things", 2,
@@ -158,7 +118,7 @@ public class TeamRoleServiceTests : IDisposable
         result.SortOrder.Should().Be(1);
         result.Priorities.Should().HaveCount(2);
 
-        var inDb = await _dbContext.Set<TeamRoleDefinition>()
+        var inDb = await Db.Set<TeamRoleDefinition>()
             .FirstOrDefaultAsync(d => d.Id == result.Id);
         inDb.Should().NotBeNull();
     }
@@ -177,7 +137,7 @@ public class TeamRoleServiceTests : IDisposable
         var mgmtRole = SeedRoleDefinition(team, "Coordinator", slotCount: 1, sortOrder: 0, isManagement: true);
         var member = SeedMember(team, user);
         SeedRoleAssignment(mgmtRole, member, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.DeleteRoleDefinitionAsync(mgmtRole.Id, admin.Id);
 
@@ -202,7 +162,7 @@ public class TeamRoleServiceTests : IDisposable
         var member2 = SeedMember(team, user2);
         SeedRoleAssignment(role, member1, slotIndex: 0);
         SeedRoleAssignment(role, member2, slotIndex: 1);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.UpdateRoleDefinitionAsync(
             role.Id, "Designer", null, 1,
@@ -220,7 +180,7 @@ public class TeamRoleServiceTests : IDisposable
         var team = SeedTeam("Test Team");
         var existingMgmt = SeedRoleDefinition(team, "Coordinator", slotCount: 1, sortOrder: 0, isManagement: true);
         var otherRole = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.UpdateRoleDefinitionAsync(
             otherRole.Id, "Designer", null, 2,
@@ -237,7 +197,7 @@ public class TeamRoleServiceTests : IDisposable
         SeedAdminRole(admin);
         var team = SeedTeam("Test Team");
         var role = SeedRoleDefinition(team, "Lead", slotCount: 1, sortOrder: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.UpdateRoleDefinitionAsync(
             role.Id, "Lead", null, 1,
@@ -253,7 +213,7 @@ public class TeamRoleServiceTests : IDisposable
         SeedAdminRole(admin);
         var team = SeedTeam("Test Team");
         var role = SeedRoleDefinition(team, "Lead", slotCount: 1, sortOrder: 0, isManagement: true);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.UpdateRoleDefinitionAsync(
             role.Id, "Lead", null, 1,
@@ -285,7 +245,7 @@ public class TeamRoleServiceTests : IDisposable
         var member2 = SeedMember(team, user2);
         SeedRoleAssignment(role, member1, slotIndex: 0);
         SeedRoleAssignment(role, member2, slotIndex: 1);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Flip IsManagement from false -> true while the role has assignees.
         await _service.UpdateRoleDefinitionAsync(
@@ -311,18 +271,18 @@ public class TeamRoleServiceTests : IDisposable
         var mgmtRole = SeedRoleDefinition(team, "Coordinator", slotCount: 2, sortOrder: 0, isManagement: true);
         var member = SeedMember(team, user, TeamMemberRole.Coordinator);
         SeedRoleAssignment(mgmtRole, member, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.ToggleRoleIsManagementAsync(mgmtRole.Id, admin.Id);
 
         result.IsManagement.Should().BeFalse();
 
-        _dbContext.ChangeTracker.Clear();
+        Db.ChangeTracker.Clear();
 
-        var roleInDb = await _dbContext.Set<TeamRoleDefinition>().AsNoTracking().FirstOrDefaultAsync(r => r.Id == mgmtRole.Id);
+        var roleInDb = await Db.Set<TeamRoleDefinition>().AsNoTracking().FirstOrDefaultAsync(r => r.Id == mgmtRole.Id);
         roleInDb!.IsManagement.Should().BeFalse();
 
-        var memberInDb = await _dbContext.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
+        var memberInDb = await Db.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
         memberInDb!.Role.Should().Be(TeamMemberRole.Member);
     }
 
@@ -336,7 +296,7 @@ public class TeamRoleServiceTests : IDisposable
         var role = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
         var member = SeedMember(team, user);
         SeedRoleAssignment(role, member, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.ToggleRoleIsManagementAsync(role.Id, admin.Id);
 
@@ -357,7 +317,7 @@ public class TeamRoleServiceTests : IDisposable
         var user = SeedUser("User");
         var role = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
         SeedMember(team, user);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.AssignToRoleAsync(role.Id, user.Id, admin.Id);
 
@@ -365,7 +325,7 @@ public class TeamRoleServiceTests : IDisposable
         result.TeamRoleDefinitionId.Should().Be(role.Id);
         result.SlotIndex.Should().Be(0);
 
-        var inDb = await _dbContext.Set<TeamRoleAssignment>()
+        var inDb = await Db.Set<TeamRoleAssignment>()
             .FirstOrDefaultAsync(a => a.Id == result.Id);
         inDb.Should().NotBeNull();
     }
@@ -379,7 +339,7 @@ public class TeamRoleServiceTests : IDisposable
         var user = SeedUser("User");
         var role = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
         // Deliberately not adding user as team member
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.AssignToRoleAsync(role.Id, user.Id, admin.Id);
 
@@ -387,7 +347,7 @@ public class TeamRoleServiceTests : IDisposable
         result.TeamRoleDefinitionId.Should().Be(role.Id);
 
         // Verify user was auto-added to team
-        var memberInDb = await _dbContext.TeamMembers
+        var memberInDb = await Db.TeamMembers
             .FirstOrDefaultAsync(tm => tm.TeamId == team.Id && tm.UserId == user.Id && tm.LeftAt == null);
         memberInDb.Should().NotBeNull();
     }
@@ -404,7 +364,7 @@ public class TeamRoleServiceTests : IDisposable
         var member1 = SeedMember(team, user1);
         SeedMember(team, user2);
         SeedRoleAssignment(role, member1, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var act = () => _service.AssignToRoleAsync(role.Id, user2.Id, admin.Id);
 
@@ -421,13 +381,13 @@ public class TeamRoleServiceTests : IDisposable
         var user = SeedUser("User");
         var mgmtRole = SeedRoleDefinition(team, "Coordinator", slotCount: 2, sortOrder: 0, isManagement: true);
         var member = SeedMember(team, user);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.AssignToRoleAsync(mgmtRole.Id, user.Id, admin.Id);
 
-        _dbContext.ChangeTracker.Clear();
+        Db.ChangeTracker.Clear();
 
-        var memberInDb = await _dbContext.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
+        var memberInDb = await Db.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
         memberInDb!.Role.Should().Be(TeamMemberRole.Coordinator);
     }
 
@@ -445,11 +405,11 @@ public class TeamRoleServiceTests : IDisposable
         var role = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
         var member = SeedMember(team, user);
         SeedRoleAssignment(role, member, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.UnassignFromRoleAsync(role.Id, member.Id, admin.Id);
 
-        var assignments = await _dbContext.Set<TeamRoleAssignment>()
+        var assignments = await Db.Set<TeamRoleAssignment>()
             .Where(a => a.TeamMemberId == member.Id)
             .ToListAsync();
         assignments.Should().BeEmpty();
@@ -465,13 +425,13 @@ public class TeamRoleServiceTests : IDisposable
         var mgmtRole = SeedRoleDefinition(team, "Coordinator", slotCount: 2, sortOrder: 0, isManagement: true);
         var member = SeedMember(team, user, TeamMemberRole.Coordinator);
         SeedRoleAssignment(mgmtRole, member, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.UnassignFromRoleAsync(mgmtRole.Id, member.Id, admin.Id);
 
-        _dbContext.ChangeTracker.Clear();
+        Db.ChangeTracker.Clear();
 
-        var memberInDb = await _dbContext.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
+        var memberInDb = await Db.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
         memberInDb!.Role.Should().Be(TeamMemberRole.Member);
     }
 
@@ -489,21 +449,21 @@ public class TeamRoleServiceTests : IDisposable
         var member2 = SeedMember(team2, user, TeamMemberRole.Coordinator);
         SeedRoleAssignment(mgmtRole1, member1, slotIndex: 0);
         SeedRoleAssignment(mgmtRole2, member2, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Unassign from team1's management role — but still coordinator on team2
         await _service.UnassignFromRoleAsync(mgmtRole1.Id, member1.Id, admin.Id);
 
-        _dbContext.ChangeTracker.Clear();
+        Db.ChangeTracker.Clear();
 
         // member1's Role demotes because the demotion check uses TeamMemberId,
         // and member1 and member2 are different TeamMember entities.
         // member1 has no other management assignments → demotes.
-        var member1InDb = await _dbContext.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member1.Id);
+        var member1InDb = await Db.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member1.Id);
         member1InDb!.Role.Should().Be(TeamMemberRole.Member);
 
         // member2 is unaffected
-        var member2InDb = await _dbContext.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member2.Id);
+        var member2InDb = await Db.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member2.Id);
         member2InDb!.Role.Should().Be(TeamMemberRole.Coordinator);
     }
 
@@ -521,21 +481,21 @@ public class TeamRoleServiceTests : IDisposable
         var role = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
         var member = SeedMember(team, user);
         SeedRoleAssignment(role, member, slotIndex: 0);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         await _service.LeaveTeamAsync(team.Id, user.Id);
 
         // Service now persists via its own DbContext; detach the tracker so we
         // re-read from the store rather than seeing the stale in-memory entity.
-        _dbContext.ChangeTracker.Clear();
+        Db.ChangeTracker.Clear();
 
-        var assignments = await _dbContext.Set<TeamRoleAssignment>()
+        var assignments = await Db.Set<TeamRoleAssignment>()
             .AsNoTracking()
             .Where(a => a.TeamMemberId == member.Id)
             .ToListAsync();
         assignments.Should().BeEmpty();
 
-        var memberInDb = await _dbContext.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
+        var memberInDb = await Db.TeamMembers.AsNoTracking().FirstOrDefaultAsync(m => m.Id == member.Id);
         memberInDb!.LeftAt.Should().NotBeNull();
     }
 
@@ -554,7 +514,7 @@ public class TeamRoleServiceTests : IDisposable
             Email = $"test-{userId}@test.com",
             PreferredLanguage = "en"
         };
-        _dbContext.Users.Add(user);
+        Db.Users.Add(user);
         return user;
     }
 
@@ -568,10 +528,10 @@ public class TeamRoleServiceTests : IDisposable
             SystemTeamType = type,
             IsActive = true,
             RequiresApproval = false,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.Teams.Add(team);
+        Db.Teams.Add(team);
         return team;
     }
 
@@ -583,9 +543,9 @@ public class TeamRoleServiceTests : IDisposable
             TeamId = team.Id,
             UserId = user.Id,
             Role = role,
-            JoinedAt = _clock.GetCurrentInstant()
+            JoinedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.TeamMembers.Add(member);
+        Db.TeamMembers.Add(member);
         return member;
     }
 
@@ -603,35 +563,35 @@ public class TeamRoleServiceTests : IDisposable
                 .Select(i => i == 0 ? SlotPriority.Critical : SlotPriority.Important)
                 .ToList(),
             SortOrder = sortOrder,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant()
         };
-        _dbContext.Set<TeamRoleDefinition>().Add(definition);
+        Db.Set<TeamRoleDefinition>().Add(definition);
         return definition;
     }
 
     private void SeedAdminRole(User user)
     {
-        _dbContext.RoleAssignments.Add(new RoleAssignment
+        Db.RoleAssignments.Add(new RoleAssignment
         {
             Id = Guid.NewGuid(),
             UserId = user.Id,
             RoleName = RoleNames.Admin,
-            ValidFrom = _clock.GetCurrentInstant() - Duration.FromDays(1),
-            CreatedAt = _clock.GetCurrentInstant(),
+            ValidFrom = Clock.GetCurrentInstant() - Duration.FromDays(1),
+            CreatedAt = Clock.GetCurrentInstant(),
             CreatedByUserId = user.Id
         });
     }
 
     private void SeedRoleAssignment(TeamRoleDefinition definition, TeamMember member, int slotIndex)
     {
-        _dbContext.Set<TeamRoleAssignment>().Add(new TeamRoleAssignment
+        Db.Set<TeamRoleAssignment>().Add(new TeamRoleAssignment
         {
             Id = Guid.NewGuid(),
             TeamRoleDefinitionId = definition.Id,
             TeamMemberId = member.Id,
             SlotIndex = slotIndex,
-            AssignedAt = _clock.GetCurrentInstant(),
+            AssignedAt = Clock.GetCurrentInstant(),
             AssignedByUserId = member.UserId
         });
     }

--- a/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
@@ -10,7 +10,6 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Tickets;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
@@ -18,10 +17,8 @@ using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public sealed class TicketQueryServiceTests : IDisposable
+public sealed class TicketQueryServiceTests : ServiceTestHarness
 {
-    private readonly DbContextOptions<HumansDbContext> _options;
-    private readonly HumansDbContext _dbContext;
     private readonly TicketRepository _repo;
     private readonly IBudgetService _budgetService = Substitute.For<IBudgetService>();
     private readonly ICampaignService _campaignService = Substitute.For<ICampaignService>();
@@ -33,12 +30,7 @@ public sealed class TicketQueryServiceTests : IDisposable
 
     public TicketQueryServiceTests()
     {
-        _options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(_options);
-        _repo = new TicketRepository(new TestDbContextFactory(_options));
+        _repo = new TicketRepository(DbFactory);
 
         _service = new TicketQueryService(
             _repo,
@@ -64,7 +56,7 @@ public sealed class TicketQueryServiceTests : IDisposable
         _userService.GetByIdsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, User>());
-        _userService.StubGetUserInfosFromDb(_options);
+        _userService.StubGetUserInfosFromDb(DbOptions);
 
         _userEmailService.GetNotificationEmailsByUserIdsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -76,11 +68,6 @@ public sealed class TicketQueryServiceTests : IDisposable
 
         _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, TeamInfo>());
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
     }
 
     [HumansFact]
@@ -132,8 +119,8 @@ public sealed class TicketQueryServiceTests : IDisposable
             ]
         };
 
-        _dbContext.TicketOrders.Add(order);
-        await _dbContext.SaveChangesAsync();
+        Db.TicketOrders.Add(order);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetSalesAggregatesAsync();
 
@@ -154,11 +141,11 @@ public sealed class TicketQueryServiceTests : IDisposable
     [HumansFact]
     public async Task GetSalesAggregatesAsync_ExcludesRefundedAndCancelledOrders()
     {
-        await _dbContext.TicketOrders.AddRangeAsync(
+        await Db.TicketOrders.AddRangeAsync(
             MakeOrder("ord_paid", TicketPaymentStatus.Paid, Instant.FromUtc(2026, 3, 2, 10, 0), 100m, 0m, 9.09m, 1, 0m),
             MakeOrder("ord_refunded", TicketPaymentStatus.Refunded, Instant.FromUtc(2026, 3, 2, 12, 0), 999m, 50m, 90m, 1, 200m),
             MakeOrder("ord_cancelled", TicketPaymentStatus.Cancelled, Instant.FromUtc(2026, 3, 3, 12, 0), 888m, 25m, 80m, 1, 100m));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetSalesAggregatesAsync();
 
@@ -176,7 +163,7 @@ public sealed class TicketQueryServiceTests : IDisposable
     public async Task GetAvailableTicketTypesAsync_ReturnsDistinctTypes()
     {
         var orderId = Guid.NewGuid();
-        _dbContext.TicketOrders.Add(new TicketOrder
+        Db.TicketOrders.Add(new TicketOrder
         {
             Id = orderId,
             VendorOrderId = "ord_ticket_type_options",
@@ -196,7 +183,7 @@ public sealed class TicketQueryServiceTests : IDisposable
                 MakeAttendee(orderId, "tkt_weekend_duplicate", "Weekend")
             ]
         });
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var types = await _service.GetAvailableTicketTypesAsync();
 
@@ -233,8 +220,8 @@ public sealed class TicketQueryServiceTests : IDisposable
             0m);
         previousYear.MatchedUserId = previousYearUserId;
 
-        await _dbContext.TicketOrders.AddRangeAsync(inYear, previousYear);
-        await _dbContext.SaveChangesAsync();
+        await Db.TicketOrders.AddRangeAsync(inYear, previousYear);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMatchedUserIdsForYearAsync(2026);
 
@@ -289,8 +276,8 @@ public sealed class TicketQueryServiceTests : IDisposable
             1,
             0m);
 
-        await _dbContext.TicketOrders.AddRangeAsync(latest, duplicateYear, earlier, unmatched);
-        await _dbContext.SaveChangesAsync();
+        await Db.TicketOrders.AddRangeAsync(latest, duplicateYear, earlier, unmatched);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetMatchedTicketYearsAsync();
 
@@ -306,13 +293,13 @@ public sealed class TicketQueryServiceTests : IDisposable
     {
         for (var i = 0; i < 5; i++)
         {
-            _dbContext.TicketOrders.Add(MakeOrder(
+            Db.TicketOrders.Add(MakeOrder(
                 $"ord_{i}", TicketPaymentStatus.Paid,
                 Instant.FromUtc(2026, 3, 1 + i, 10, 0),
                 100m, 0m, 9.09m, 1, 0m));
         }
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetOrdersPageAsync(
             null, "date", true, 1, 2, null, null, null);
@@ -324,11 +311,11 @@ public sealed class TicketQueryServiceTests : IDisposable
     [HumansFact(Timeout = 10000)]
     public async Task GetOrdersPageAsync_FiltersbyPaymentStatus()
     {
-        _dbContext.TicketOrders.Add(MakeOrder("ord_paid", TicketPaymentStatus.Paid,
+        Db.TicketOrders.Add(MakeOrder("ord_paid", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 3, 1, 10, 0), 100m, 0m, 9.09m, 1, 0m));
-        _dbContext.TicketOrders.Add(MakeOrder("ord_refund", TicketPaymentStatus.Refunded,
+        Db.TicketOrders.Add(MakeOrder("ord_refund", TicketPaymentStatus.Refunded,
             Instant.FromUtc(2026, 3, 2, 10, 0), 200m, 0m, 0m, 1, 0m));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetOrdersPageAsync(
             null, "date", true, 1, 25, "Paid", null, null);
@@ -340,11 +327,11 @@ public sealed class TicketQueryServiceTests : IDisposable
     [HumansFact]
     public async Task GetOrdersPageAsync_SortsByAmount()
     {
-        _dbContext.TicketOrders.Add(MakeOrder("ord_cheap", TicketPaymentStatus.Paid,
+        Db.TicketOrders.Add(MakeOrder("ord_cheap", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 3, 1, 10, 0), 50m, 0m, 0m, 1, 0m));
-        _dbContext.TicketOrders.Add(MakeOrder("ord_expensive", TicketPaymentStatus.Paid,
+        Db.TicketOrders.Add(MakeOrder("ord_expensive", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 3, 2, 10, 0), 500m, 0m, 0m, 1, 0m));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetOrdersPageAsync(
             null, "amount", false, 1, 25, null, null, null);
@@ -362,8 +349,8 @@ public sealed class TicketQueryServiceTests : IDisposable
     {
         var order = MakeOrder("ord_1", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 3, 1, 10, 0), 300m, 0m, 0m, 3, 0m);
-        _dbContext.TicketOrders.Add(order);
-        await _dbContext.SaveChangesAsync();
+        Db.TicketOrders.Add(order);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetAttendeesPageAsync(
             null, "name", false, 1, 2, null, null, null, null);
@@ -410,8 +397,8 @@ public sealed class TicketQueryServiceTests : IDisposable
                 }
             ]
         };
-        _dbContext.TicketOrders.Add(order);
-        await _dbContext.SaveChangesAsync();
+        Db.TicketOrders.Add(order);
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetAttendeesPageAsync(
             null, "name", false, 1, 25, "VIP", null, null, null);
@@ -423,11 +410,11 @@ public sealed class TicketQueryServiceTests : IDisposable
     [HumansFact]
     public async Task GetAttendeesPageAsync_FiltersByOrderId()
     {
-        _dbContext.TicketOrders.Add(MakeOrder("ord_A", TicketPaymentStatus.Paid,
+        Db.TicketOrders.Add(MakeOrder("ord_A", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 3, 1, 10, 0), 100m, 0m, 0m, 1, 0m));
-        _dbContext.TicketOrders.Add(MakeOrder("ord_B", TicketPaymentStatus.Paid,
+        Db.TicketOrders.Add(MakeOrder("ord_B", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 3, 2, 10, 0), 200m, 0m, 0m, 2, 0m));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var result = await _service.GetAttendeesPageAsync(
             null, "name", false, 1, 25, null, null, null, "ord_A");
@@ -446,7 +433,7 @@ public sealed class TicketQueryServiceTests : IDisposable
         var userWithout = CreateUser("No Ticket", "noticket@example.com");
 
         var orderId = Guid.NewGuid();
-        _dbContext.TicketOrders.Add(new TicketOrder
+        Db.TicketOrders.Add(new TicketOrder
         {
             Id = orderId,
             VendorOrderId = "ord_1",
@@ -461,7 +448,7 @@ public sealed class TicketQueryServiceTests : IDisposable
             MatchedUserId = userWithTicket.Id,
         });
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         // Wire service dependencies — both users are Volunteers members with Profiles.
         WireWhoHasntBoughtDependencies(userWithTicket, userWithout);
@@ -479,7 +466,7 @@ public sealed class TicketQueryServiceTests : IDisposable
         var userWithTicket = CreateUser("Has Ticket", "has@example.com");
         var userWithout = CreateUser("No Ticket", "no@example.com");
 
-        _dbContext.TicketOrders.Add(new TicketOrder
+        Db.TicketOrders.Add(new TicketOrder
         {
             Id = Guid.NewGuid(),
             VendorOrderId = "ord_1",
@@ -494,7 +481,7 @@ public sealed class TicketQueryServiceTests : IDisposable
             MatchedUserId = userWithTicket.Id,
         });
 
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         WireWhoHasntBoughtDependencies(userWithTicket, userWithout);
 
@@ -550,8 +537,8 @@ public sealed class TicketQueryServiceTests : IDisposable
             ]
         };
 
-        _dbContext.TicketOrders.Add(order);
-        await _dbContext.SaveChangesAsync();
+        Db.TicketOrders.Add(order);
+        await Db.SaveChangesAsync();
 
         var rows = await _service.GetAttendeeExportDataAsync();
 
@@ -564,11 +551,11 @@ public sealed class TicketQueryServiceTests : IDisposable
     [HumansFact]
     public async Task GetOrderExportDataAsync_ReturnsAllOrdersWithDetails()
     {
-        _dbContext.TicketOrders.Add(MakeOrder("ord_old", TicketPaymentStatus.Paid,
+        Db.TicketOrders.Add(MakeOrder("ord_old", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 1, 1, 10, 0), 100m, 5m, 9.09m, 1, 0m));
-        _dbContext.TicketOrders.Add(MakeOrder("ord_new", TicketPaymentStatus.Paid,
+        Db.TicketOrders.Add(MakeOrder("ord_new", TicketPaymentStatus.Paid,
             Instant.FromUtc(2026, 3, 1, 10, 0), 200m, 10m, 18.18m, 2, 0m));
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var rows = await _service.GetOrderExportDataAsync();
 

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceNullOrderTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceNullOrderTests.cs
@@ -11,13 +11,11 @@ using Humans.Application.Services.Tickets;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Tickets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
@@ -29,11 +27,8 @@ namespace Humans.Application.Tests.Services;
 /// the vendor; the service must fall back to the existing local row's parent,
 /// or skip with a warning when no local row exists.
 /// </summary>
-public class TicketSyncServiceNullOrderTests : IDisposable
+public sealed class TicketSyncServiceNullOrderTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly TestDbContextFactory _factory;
-    private readonly FakeClock _clock;
     private readonly ITicketVendorService _vendorService;
     private readonly IStripeService _stripeService;
     private readonly ICampaignService _campaignService;
@@ -44,13 +39,6 @@ public class TicketSyncServiceNullOrderTests : IDisposable
 
     public TicketSyncServiceNullOrderTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _factory = new TestDbContextFactory(options);
-        _dbContext = _factory.CreateDbContext();
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _vendorService = Substitute.For<ITicketVendorService>();
 
         var settings = Options.Create(new TicketVendorSettings
@@ -67,14 +55,14 @@ public class TicketSyncServiceNullOrderTests : IDisposable
         _campaignService = Substitute.For<ICampaignService>();
         _shiftManagementService = Substitute.For<IShiftManagementService>();
 
-        _ticketRepository = new TicketRepository(_factory);
+        _ticketRepository = new TicketRepository(DbFactory);
 
         _service = new TicketSyncService(
             _ticketRepository,
-            new TicketTransferRepository(_factory),
+            new TicketTransferRepository(DbFactory),
             _vendorService,
             _stripeService,
-            _clock,
+            Clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
             Substitute.For<ITicketCacheInvalidator>(),
@@ -83,19 +71,13 @@ public class TicketSyncServiceNullOrderTests : IDisposable
             _shiftManagementService);
 
         // Seed the singleton TicketSyncState row (required by the service)
-        _dbContext.TicketSyncStates.Add(new TicketSyncState
+        Db.TicketSyncStates.Add(new TicketSyncState
         {
             Id = 1,
             SyncStatus = TicketSyncStatus.Idle,
             VendorEventId = string.Empty
         });
-        _dbContext.SaveChanges();
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+        Db.SaveChanges();
     }
 
     // ==========================================================================
@@ -125,7 +107,7 @@ public class TicketSyncServiceNullOrderTests : IDisposable
             PurchasedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
             SyncedAt = Instant.FromUtc(2026, 1, 1, 0, 0)
         };
-        _dbContext.TicketOrders.Add(parentOrder);
+        Db.TicketOrders.Add(parentOrder);
 
         var existingAttendeeId = Guid.NewGuid();
         var existingAttendee = new TicketAttendee
@@ -141,8 +123,8 @@ public class TicketSyncServiceNullOrderTests : IDisposable
             VendorEventId = "ev_test_123",
             SyncedAt = Instant.FromUtc(2026, 1, 1, 0, 0)
         };
-        _dbContext.TicketAttendees.Add(existingAttendee);
-        await _dbContext.SaveChangesAsync();
+        Db.TicketAttendees.Add(existingAttendee);
+        await Db.SaveChangesAsync();
 
         // Vendor returns the same ticket, but now with null VendorOrderId
         // (as happens when TT returns API-issued tickets with no order association).
@@ -166,7 +148,7 @@ public class TicketSyncServiceNullOrderTests : IDisposable
         // Assert — the attendee row was upserted (not skipped)
         result.AttendeesSynced.Should().Be(1);
 
-        var dbAttendees = await _dbContext.TicketAttendees.AsNoTracking().ToListAsync();
+        var dbAttendees = await Db.TicketAttendees.AsNoTracking().ToListAsync();
         dbAttendees.Should().ContainSingle();
         dbAttendees[0].VendorTicketId.Should().Be("tkt_api_issued");
         dbAttendees[0].AttendeeName.Should().Be("Bob Recipient Updated");
@@ -206,7 +188,7 @@ public class TicketSyncServiceNullOrderTests : IDisposable
         // Assert — skipped; no attendee rows written
         result.AttendeesSynced.Should().Be(0);
 
-        var dbAttendees = await _dbContext.TicketAttendees.AsNoTracking().ToListAsync();
+        var dbAttendees = await Db.TicketAttendees.AsNoTracking().ToListAsync();
         dbAttendees.Should().BeEmpty();
     }
 
@@ -260,11 +242,11 @@ public class TicketSyncServiceNullOrderTests : IDisposable
         result.OrdersSynced.Should().Be(1);
         result.AttendeesSynced.Should().Be(1);
 
-        var dbAttendees = await _dbContext.TicketAttendees.AsNoTracking().ToListAsync();
+        var dbAttendees = await Db.TicketAttendees.AsNoTracking().ToListAsync();
         dbAttendees.Should().ContainSingle();
         dbAttendees[0].VendorTicketId.Should().Be("tkt_normal");
 
-        var dbOrders = await _dbContext.TicketOrders.AsNoTracking().ToListAsync();
+        var dbOrders = await Db.TicketOrders.AsNoTracking().ToListAsync();
         dbOrders.Should().ContainSingle();
         dbOrders[0].VendorOrderId.Should().Be("ord_normal");
     }

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -11,23 +11,18 @@ using Humans.Application.Services.Tickets;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Tickets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
 namespace Humans.Application.Tests.Services;
 
-public class TicketSyncServiceTests : IDisposable
+public sealed class TicketSyncServiceTests : ServiceTestHarness
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly TestDbContextFactory _factory;
-    private readonly FakeClock _clock;
     private readonly ITicketVendorService _vendorService;
     private readonly IStripeService _stripeService;
     private readonly ICampaignService _campaignService;
@@ -38,13 +33,6 @@ public class TicketSyncServiceTests : IDisposable
 
     public TicketSyncServiceTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _factory = new TestDbContextFactory(options);
-        _dbContext = _factory.CreateDbContext();
-        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _vendorService = Substitute.For<ITicketVendorService>();
 
         var settings = Options.Create(new TicketVendorSettings
@@ -61,14 +49,14 @@ public class TicketSyncServiceTests : IDisposable
         _campaignService = Substitute.For<ICampaignService>();
         _shiftManagementService = Substitute.For<IShiftManagementService>();
 
-        _ticketRepository = new TicketRepository(_factory);
+        _ticketRepository = new TicketRepository(DbFactory);
 
         _service = new TicketSyncService(
             _ticketRepository,
-            new TicketTransferRepository(_factory),
+            new TicketTransferRepository(DbFactory),
             _vendorService,
             _stripeService,
-            _clock,
+            Clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
             Substitute.For<ITicketCacheInvalidator>(),
@@ -77,19 +65,13 @@ public class TicketSyncServiceTests : IDisposable
             _shiftManagementService);
 
         // Seed the singleton TicketSyncState row
-        _dbContext.TicketSyncStates.Add(new TicketSyncState
+        Db.TicketSyncStates.Add(new TicketSyncState
         {
             Id = 1,
             SyncStatus = TicketSyncStatus.Idle,
             VendorEventId = string.Empty
         });
-        _dbContext.SaveChanges();
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
+        Db.SaveChanges();
     }
 
     // ==========================================================================
@@ -115,7 +97,7 @@ public class TicketSyncServiceTests : IDisposable
         result.OrdersSynced.Should().Be(2);
         result.AttendeesSynced.Should().Be(0);
 
-        var dbOrders = await _dbContext.TicketOrders.ToListAsync();
+        var dbOrders = await Db.TicketOrders.ToListAsync();
         dbOrders.Should().HaveCount(2);
         dbOrders.Select(o => o.VendorOrderId).Should().BeEquivalentTo("ord_001", "ord_002");
     }
@@ -131,7 +113,7 @@ public class TicketSyncServiceTests : IDisposable
         SeedUser(userId);
         // Seed email in LOWERCASE — order will use UPPERCASE to test case-insensitivity
         SeedUserEmail(userId, "alice@example.com", isOAuth: true);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         var orders = new List<VendorOrderDto>
         {
@@ -147,7 +129,7 @@ public class TicketSyncServiceTests : IDisposable
 
         result.OrdersMatched.Should().Be(1);
 
-        var dbOrder = await _dbContext.TicketOrders.SingleAsync();
+        var dbOrder = await Db.TicketOrders.SingleAsync();
         dbOrder.MatchedUserId.Should().Be(userId);
     }
 
@@ -182,7 +164,7 @@ public class TicketSyncServiceTests : IDisposable
         // Second sync
         await _service.SyncOrdersAndAttendeesAsync();
 
-        var dbOrders = await _dbContext.TicketOrders.ToListAsync();
+        var dbOrders = await Db.TicketOrders.ToListAsync();
         dbOrders.Should().ContainSingle();
         dbOrders[0].BuyerName.Should().Be("Alice Updated");
         dbOrders[0].TotalAmount.Should().Be(75m);
@@ -237,7 +219,7 @@ public class TicketSyncServiceTests : IDisposable
         var result = await _service.SyncOrdersAndAttendeesAsync();
 
         result.OrdersSynced.Should().Be(0);
-        var syncState = await _dbContext.TicketSyncStates.AsNoTracking()
+        var syncState = await Db.TicketSyncStates.AsNoTracking()
             .FirstAsync(s => s.Id == 1);
         syncState.SyncStatus.Should().Be(TicketSyncStatus.Idle);
         syncState.LastError.Should().BeNull();
@@ -253,7 +235,7 @@ public class TicketSyncServiceTests : IDisposable
 
         await act.Should().ThrowAsync<HttpRequestException>();
 
-        var syncState = await _dbContext.TicketSyncStates.AsNoTracking()
+        var syncState = await Db.TicketSyncStates.AsNoTracking()
             .FirstAsync(s => s.Id == 1);
         syncState.SyncStatus.Should().Be(TicketSyncStatus.Error);
         syncState.LastError.Should().Be("Unauthorized");
@@ -276,10 +258,10 @@ public class TicketSyncServiceTests : IDisposable
 
         var service = new TicketSyncService(
             _ticketRepository,
-            new TicketTransferRepository(_factory),
+            new TicketTransferRepository(DbFactory),
             _vendorService,
             _stripeService,
-            _clock,
+            Clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
             Substitute.For<ITicketCacheInvalidator>(),
@@ -325,10 +307,10 @@ public class TicketSyncServiceTests : IDisposable
         // Second sync with same data
         await _service.SyncOrdersAndAttendeesAsync();
 
-        var dbOrders = await _dbContext.TicketOrders.ToListAsync();
+        var dbOrders = await Db.TicketOrders.ToListAsync();
         dbOrders.Should().ContainSingle();
 
-        var dbAttendees = await _dbContext.TicketAttendees.ToListAsync();
+        var dbAttendees = await Db.TicketAttendees.ToListAsync();
         dbAttendees.Should().ContainSingle();
         dbAttendees[0].AttendeeName.Should().Be("Alice");
     }
@@ -354,7 +336,7 @@ public class TicketSyncServiceTests : IDisposable
 
         await _service.SyncOrdersAndAttendeesAsync();
 
-        var order = await _dbContext.TicketOrders.SingleAsync();
+        var order = await Db.TicketOrders.SingleAsync();
         order.VatAmount.Should().Be(28.64m);
     }
 
@@ -380,7 +362,7 @@ public class TicketSyncServiceTests : IDisposable
 
         await _service.SyncOrdersAndAttendeesAsync();
 
-        var syncedOrders = await _dbContext.TicketOrders
+        var syncedOrders = await Db.TicketOrders
             .OrderBy(o => o.VendorOrderId)
             .ToListAsync();
 
@@ -419,14 +401,14 @@ public class TicketSyncServiceTests : IDisposable
         result.OrdersSynced.Should().Be(500);
         result.AttendeesSynced.Should().Be(700);
 
-        var dbOrders = await _dbContext.TicketOrders.CountAsync();
+        var dbOrders = await Db.TicketOrders.CountAsync();
         dbOrders.Should().Be(500);
 
-        var dbAttendees = await _dbContext.TicketAttendees.CountAsync();
+        var dbAttendees = await Db.TicketAttendees.CountAsync();
         dbAttendees.Should().Be(700);
 
         // Sync state should be Idle after success
-        var syncState = await _dbContext.TicketSyncStates.AsNoTracking()
+        var syncState = await Db.TicketSyncStates.AsNoTracking()
             .FirstAsync(s => s.Id == 1);
         syncState.SyncStatus.Should().Be(TicketSyncStatus.Idle);
         syncState.LastSyncAt.Should().NotBeNull();
@@ -442,7 +424,7 @@ public class TicketSyncServiceTests : IDisposable
         var userId = Guid.NewGuid();
         SeedUser(userId);
         SeedUserEmail(userId, "alice@example.com", isOAuth: true);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _shiftManagementService.GetActiveAsync()
             .Returns(new EventSettings { Year = 2026 });
@@ -471,7 +453,7 @@ public class TicketSyncServiceTests : IDisposable
         var userId = Guid.NewGuid();
         SeedUser(userId);
         SeedUserEmail(userId, "alice@example.com", isOAuth: true);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _shiftManagementService.GetActiveAsync()
             .Returns(new EventSettings { Year = 2026 });
@@ -507,7 +489,7 @@ public class TicketSyncServiceTests : IDisposable
         var userId = Guid.NewGuid();
         SeedUser(userId);
         SeedUserEmail(userId, "alice@example.com", isOAuth: true);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _shiftManagementService.GetActiveAsync()
             .Returns(new EventSettings { Year = 2026 });
@@ -534,7 +516,7 @@ public class TicketSyncServiceTests : IDisposable
         var userId = Guid.NewGuid();
         SeedUser(userId);
         SeedUserEmail(userId, "alice@example.com", isOAuth: true);
-        await _dbContext.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         _shiftManagementService.GetActiveAsync()
             .Returns(new EventSettings { Year = 2026 });
@@ -559,26 +541,11 @@ public class TicketSyncServiceTests : IDisposable
     // Helpers
     // ==========================================================================
 
-    private User SeedUser(Guid? id = null, string displayName = "Test User")
-    {
-        var userId = id ?? Guid.NewGuid();
-        var user = new User
-        {
-            Id = userId,
-            DisplayName = displayName,
-            UserName = $"test-{userId}@test.com",
-            Email = $"test-{userId}@test.com",
-            PreferredLanguage = "en"
-        };
-        _dbContext.Users.Add(user);
-        return user;
-    }
-
     private UserEmail SeedUserEmail(
         Guid userId, string email,
         bool isOAuth = false, bool isVerified = true)
     {
-        var now = _clock.GetCurrentInstant();
+        var now = Clock.GetCurrentInstant();
         var userEmail = new UserEmail
         {
             Id = Guid.NewGuid(),
@@ -590,7 +557,7 @@ public class TicketSyncServiceTests : IDisposable
             CreatedAt = now,
             UpdatedAt = now
         };
-        _dbContext.UserEmails.Add(userEmail);
+        Db.UserEmails.Add(userEmail);
         return userEmail;
     }
 


### PR DESCRIPTION
## Summary

Mechanical migration of every service test file in `tests/Humans.Application.Tests/Services/` to inherit `ServiceTestHarness` (introduced in #659). Each file dropped its 100–170-line ctor scaffolding and switched to harness-provided `Db` / `Clock` / `Cache` / `DbFactory` / `NewDbBackedUserService()`.

## Final stats

- **41 files migrated** across 15 commits / 14 batches
- **1,360 insertions / 2,199 deletions** (net **−839 lines**)
- Full suite: **3,612 tests pass / 0 fail** (Domain 187, Analyzers 116, Web 112, Application 3,103, Integration 96)

## Biggest wins per file
- ShiftManagementServiceTests: 1309 → 1009 (−300)
- CampaignServiceTests: 781 → 559 (−222)
- ApplicationDecisionServiceTests: 868 → 695 (−173)
- ConsentServiceTests: 771 → 605 (−166)
- BudgetServiceTests: 723 → 595 (−128)
- IssuesServiceTests: 1133 → 1019 (−114)
- TicketSyncServiceTests: 637 → 533 (−104)

## Approach

- One commit per batch (2-3 files) for reviewable history; pushed every batch.
- Files where local `SeedUser`/`SeedTeam`/etc. signatures matched the harness AND callers used named args: dropped the local helpers (CampaignServiceTests, TicketSyncServiceTests).
- Files where signatures differed: kept local helpers, just renamed `_dbContext`→`Db`, `_clock`→`Clock` inside their bodies.
- Helpers using `NewDbBackedUserService()` always captured to a local before being passed to outer `.Returns(...)` — per `memory/code/nsubstitute-no-nested-substitute-factories.md`.
- Custom `Dispose` overrides where extra resources needed cleanup (`ServiceProvider`, `UserManager`, etc.).
- Several files renamed local `SeedUser(string)` → `SeedUserLocal(string)` to avoid signature collision with the harness overload.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — clean, 0 errors
- [x] `dotnet test Humans.slnx -v quiet` — 3,612 passed, 1 skipped, 0 failed
- [x] Each migrated file's filtered `dotnet test` run verified mid-batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)