### PR TITLE
feat(search): cover Events in global /Search

### DIFF
--- a/docs/features/global/global-search.md
+++ b/docs/features/global/global-search.md
@@ -14,7 +14,7 @@
 
 ## Business Context
 
-Members regularly want to find a person, team, camp, or shift without first guessing which list page to start from. As membership grows and camps/teams multiply, the friction of "which area do I look in?" gets worse. A single magnifying-glass entry point in the top nav routes to `/Search`, which fans out across the four searchable sections and renders type-grouped results.
+Members regularly want to find a person, team, camp, shift, or event without first guessing which list page to start from. As membership grows and camps/teams multiply, the friction of "which area do I look in?" gets worse. A single magnifying-glass entry point in the top nav routes to `/Search`, which fans out across the searchable sections and renders type-grouped results. The Events bucket is only included when the `Features:Events` flag is on (it gates the section's nav and routes the same way).
 
 The feature is deliberately scoped to **name-only matching**. Earlier drafts proposed cross-modal pull-ins (a person → their teams; a team → its rotas) and a unified ranked list, but those were dropped:
 
@@ -39,11 +39,11 @@ The feature is deliberately scoped to **name-only matching**. Earlier drafts pro
 **So that** I can jump to the right entity without remembering which list page owns it
 
 **Acceptance Criteria:**
-- `/Search?q=<query>` returns four type-grouped sections: Humans, Teams, Camps, Shifts.
+- `/Search?q=<query>` returns type-grouped sections: Humans, Teams, Camps, Shifts, and (when `Features:Events` is enabled) Events.
 - Each section is independently ranked by score within itself; no cross-type ranking.
 - Each section is capped at 10 results in the unified view; 50 when a single-type filter chip is active.
-- Each result clearly shows its type via section header + icon, and links to the canonical detail page.
-- Per-type filter chips (All | Humans | Teams | Camps | Shifts) hide the other sections and bump the cap.
+- Each result clearly shows its type via section header + icon, and links to the canonical detail page (for Events, the link is `/Events/Browse?q=<title>` — there is no per-event detail page).
+- Per-type filter chips (All | Humans | Teams | Camps | Shifts | Events) hide the other sections and bump the cap. The Events chip is hidden when `Features:Events` is off.
 - A query with no matches renders "No results for <query>." (not 500).
 
 ### US-GS.3: Match by the right fields
@@ -56,6 +56,7 @@ The feature is deliberately scoped to **name-only matching**. Earlier drafts pro
 - **Teams** match on `Team.Name` only.
 - **Camps** match on the public-year `CampSeason.Name` only.
 - **Shifts** (rotas) match on `Rota.Name` only.
+- **Events** match on `Event.Title` or `Event.Description` and are filtered to `Status = Approved` only. Events are the one deliberate exception to names-only: the orchestrator reuses `IEventService.GetApprovedEventsAsync` (the same call the public Browse page makes), which filters Title + Description with ILike, because event copy is short and free-form so description text is often the load-bearing name signal users remember. Rows are still scored by Title via the standard exact/prefix/contains rubric; rows that only matched via Description fall through to a contains-tier score so they're still surfaced (just ranked below title hits).
 - All matchers run case-insensitive Postgres `EF.Functions.ILike` at the DB layer per `memory/feedback_ef_ilike_not_toupper.md`.
 
 ### US-GS.4: Search surfaces the public-visibility set, never more
@@ -67,6 +68,7 @@ The feature is deliberately scoped to **name-only matching**. Earlier drafts pro
 - Hidden teams (`Team.IsHidden = true`) are excluded for everyone.
 - Camps are filtered to the public-status set (`CampSeasonStatus.Active` or `Full`) for the public year — same gate as the public camp directory.
 - Rotas are filtered to `IsVisibleToVolunteers = true` for everyone.
+- Events are filtered to `Status = Approved`; submissions in `Draft`, `Pending`, `Rejected`, `ResubmitRequested`, or `Withdrawn` are never returned, matching the public `/Events/Browse` surface.
 - Admin-only profile fields (verified emails, non-public ContactFields) are never returned through `/Search`, regardless of role. Admins use the existing per-section admin pages (`/Teams` admin, `/Camps` admin, `/Profile/Admin`) for privileged views.
 
 ## Authorization Model
@@ -90,7 +92,8 @@ SearchController
          ├── IProfileService.SearchProfilesAsync(query, PersonSearchFields.PublicAll, limit) → IReadOnlyList<HumanSearchResult>
          ├── ITeamService.SearchAsync(query, max)                                             → IReadOnlyList<TeamSearchHit>
          ├── ICampService.SearchAsync(query, max)                                             → IReadOnlyList<CampSearchHit>
-         └── IShiftManagementService.SearchAsync(query, max)                                  → IReadOnlyList<RotaSearchHit>
+         ├── IShiftManagementService.SearchAsync(query, max)                                  → IReadOnlyList<RotaSearchHit>
+         └── IEventService.GetApprovedEventsAsync(…, q: query, …)  (skipped when Features:Events is off)  → IReadOnlyList<Event>
 ```
 
 Each section's repository runs the case-insensitive Postgres `ILike` filter against the entity's name field at the DB layer with `EscapeLikePattern` to defang `%` / `_` / `\` in user input. Section services map their domain entities to type-specific search-hit DTOs (`TeamSearchHit`, `CampSearchHit`, `RotaSearchHit`) so the orchestrator never has to traverse cross-domain navigation properties to render a row.
@@ -115,17 +118,17 @@ Counts are post-cap by design — they reflect what the user actually sees in th
 | `TeamSearchHit (Name, Slug)` | `ITeamService.SearchAsync` | Orchestrator scores → `GlobalSearchResult` |
 | `CampSearchHit (Slug, Name)` | `ICampService.SearchAsync` | Orchestrator scores → `GlobalSearchResult` |
 | `RotaSearchHit (Name, TeamId, TeamName)` | `IShiftManagementService.SearchAsync` | Orchestrator scores → `GlobalSearchResult` |
-| `GlobalSearchResult (Type, Title, Subtitle, Url, Score)` | Orchestrator | View renders simple list rows for Teams / Camps / Shifts |
-| `GlobalSearchResults (Query, Humans, Teams, Camps, Shifts)` | `ISearchService` | View-model / view |
+| `GlobalSearchResult (Type, Title, Subtitle, Url, Score)` | Orchestrator | View renders simple list rows for Teams / Camps / Shifts / Events |
+| `GlobalSearchResults (Query, Humans, Teams, Camps, Shifts, Events)` | `ISearchService` | View-model / view |
 
 ## UI
 
-`/Search` renders four type-grouped sections, in order: **Humans**, **Teams**, **Camps**, **Shifts**. Each section is hidden when its bucket is empty.
+`/Search` renders type-grouped sections, in order: **Humans**, **Teams**, **Camps**, **Shifts**, **Events**. Each section is hidden when its bucket is empty. The Events section and chip are also hidden when `Features:Events` is off (the view reads `IConfiguration` directly for this gate).
 
 - **Humans** are rendered by the canonical `_HumanSearchResults` partial (see `memory/architecture/person-search.md`). The controller projects each `HumanSearchResult` to `HumanSearchResultViewModel` via the existing `ToHumanSearchViewModel` extension, matching `/Profile/Search` and `/Profile/Admin`.
-- **Teams / Camps / Shifts** are rendered by `_GlobalSearchSection` — a small, deliberately-minimal partial. This is not a third person-search surface (the `_HumanSearchResults` rule applies only to person rendering); it's a generic list-row template for the simpler types.
+- **Teams / Camps / Shifts / Events** are rendered by `_GlobalSearchSection` — a small, deliberately-minimal partial. This is not a third person-search surface (the `_HumanSearchResults` rule applies only to person rendering); it's a generic list-row template for the simpler types.
 
-A type-filter chip row at the top (All | Humans | Teams | Camps | Shifts) preserves the query and toggles the active filter. Counts on each chip reflect the post-cap result count.
+A type-filter chip row at the top (All | Humans | Teams | Camps | Shifts | Events) preserves the query and toggles the active filter. Counts on each chip reflect the post-cap result count.
 
 ## Out of Scope
 

--- a/src/Humans.Application/DTOs/GlobalSearchResults.cs
+++ b/src/Humans.Application/DTOs/GlobalSearchResults.cs
@@ -2,7 +2,7 @@ namespace Humans.Application.DTOs;
 
 /// <summary>
 /// Top-level result type for the global /Search page. Drives the per-type
-/// group filter chips ("All | Humans | Teams | Camps | Shifts") and the
+/// group filter chips ("All | Humans | Teams | Camps | Shifts | Events") and the
 /// type-grouped section headers in the results view.
 /// </summary>
 public enum SearchResultType
@@ -11,18 +11,19 @@ public enum SearchResultType
     Team = 1,
     Camp = 2,
     Shift = 3,
+    Event = 4,
 }
 
 /// <summary>
-/// One non-human row in a global search result group (Team, Camp, or
-/// Shift). Humans use <see cref="HumanSearchResult"/> directly so the
+/// One non-human row in a global search result group (Team, Camp, Shift,
+/// or Event). Humans use <see cref="HumanSearchResult"/> directly so the
 /// canonical <c>_HumanSearchResults</c> partial can render them.
 /// </summary>
-/// <param name="Type">Whether this is a Team, Camp, or Shift hit.</param>
+/// <param name="Type">Whether this is a Team, Camp, Shift, or Event hit.</param>
 /// <param name="Title">Primary display label (team name, camp season name,
-/// rota name) — the only field matched against the query.</param>
+/// rota name, event title) — the only field matched against the query.</param>
 /// <param name="Subtitle">Secondary line: slug for teams/camps, owning-team
-/// name for shifts.</param>
+/// name for shifts, category name for events.</param>
 /// <param name="Url">Canonical detail-page URL for the entity.</param>
 /// <param name="Score">Higher = better match. Derived from name-match
 /// strength (exact > prefix > contains). The controller orders each
@@ -50,9 +51,13 @@ public record GlobalSearchResult(
 /// controller sorts by score desc then title asc before rendering.</param>
 /// <param name="Shifts">Rota (shift) hits, scored but in unspecified order
 /// — the controller sorts by score desc then title asc before rendering.</param>
+/// <param name="Events">Approved event hits, scored but in unspecified order —
+/// the controller sorts by score desc then title asc before rendering. Empty
+/// when the <c>Features:Events</c> flag is off.</param>
 public record GlobalSearchResults(
     string Query,
     IReadOnlyList<HumanSearchResult> Humans,
     IReadOnlyList<GlobalSearchResult> Teams,
     IReadOnlyList<GlobalSearchResult> Camps,
-    IReadOnlyList<GlobalSearchResult> Shifts);
+    IReadOnlyList<GlobalSearchResult> Shifts,
+    IReadOnlyList<GlobalSearchResult> Events);

--- a/src/Humans.Application/Services/Search/SearchService.cs
+++ b/src/Humans.Application/Services/Search/SearchService.cs
@@ -1,27 +1,33 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Search;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
+using Microsoft.Extensions.Configuration;
 
 namespace Humans.Application.Services.Search;
 
 /// <summary>
-/// Names-only search orchestrator: each section runs its own ILike, this scores hits and returns four buckets (unsorted).
+/// Names-only search orchestrator: each section runs its own ILike, this scores hits and returns five buckets (unsorted).
 /// See docs/features/global/global-search.md. Display ordering lives in SearchController.
 /// </summary>
 public sealed class SearchService(
     IUserService userService,
     ITeamService teamService,
     ICampService campService,
-    IShiftManagementService shiftService) : ISearchService
+    IShiftManagementService shiftService,
+    IEventService eventService,
+    IConfiguration configuration) : ISearchService
 {
     // Name-match scoring: exact > prefix > contains.
     private const int ScoreExactName = 100;
     private const int ScorePrefixName = 80;
     private const int ScoreContainsName = 60;
+
+    private readonly bool _eventsFeatureEnabled = configuration.GetValue<bool>("Features:Events");
 
     public async Task<GlobalSearchResults> SearchAsync(
         string query,
@@ -34,6 +40,7 @@ public sealed class SearchService(
         {
             return new GlobalSearchResults(
                 trimmed,
+                [],
                 [],
                 [],
                 [],
@@ -52,8 +59,11 @@ public sealed class SearchService(
         var shifts = onlyType is null or SearchResultType.Shift
             ? await SearchShiftsAsync(trimmed, perTypeLimit, ct)
             : Array.Empty<GlobalSearchResult>();
+        var events = _eventsFeatureEnabled && onlyType is null or SearchResultType.Event
+            ? await SearchEventsAsync(trimmed, perTypeLimit, ct)
+            : Array.Empty<GlobalSearchResult>();
 
-        return new GlobalSearchResults(trimmed, humans, teams, camps, shifts);
+        return new GlobalSearchResults(trimmed, humans, teams, camps, shifts, events);
     }
 
     private async Task<IReadOnlyList<HumanSearchResult>> SearchHumansAsync(
@@ -110,6 +120,33 @@ public sealed class SearchService(
                 Url: $"/Shifts?departmentId={r.TeamId}",
                 Score: isGuidQuery ? ScoreExactName : ScoreNameField(r.Name, query)))
             .Where(r => r.Score > 0)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<GlobalSearchResult>> SearchEventsAsync(
+        string query, int limit, CancellationToken ct)
+    {
+        // Reuse the public Browse query — Approved-only, filtered server-side by title/description.
+        // We re-score on Title here so the global "exact > prefix > contains" rubric still ranks the
+        // bucket; rows that only matched via Description fall through to a contains score so they
+        // still appear (matches what users expect from event search, which is more free-form than
+        // the other entity types).
+        var hits = await eventService.GetApprovedEventsAsync(
+            campId: null, venueId: null, categoryId: null,
+            q: query, excludedSlugs: Array.Empty<string>(), ct);
+
+        return hits
+            .Take(limit)
+            .Select(e =>
+            {
+                var titleScore = ScoreNameField(e.Title, query);
+                return new GlobalSearchResult(
+                    Type: SearchResultType.Event,
+                    Title: e.Title,
+                    Subtitle: e.Category?.Name ?? string.Empty,
+                    Url: $"/Events/Browse?q={Uri.EscapeDataString(e.Title)}",
+                    Score: titleScore > 0 ? titleScore : ScoreContainsName);
+            })
             .ToList();
     }
 

--- a/src/Humans.Application/Services/Search/SearchService.cs
+++ b/src/Humans.Application/Services/Search/SearchService.cs
@@ -136,7 +136,6 @@ public sealed class SearchService(
             q: query, excludedSlugs: Array.Empty<string>(), ct);
 
         return hits
-            .Take(limit)
             .Select(e =>
             {
                 var titleScore = ScoreNameField(e.Title, query);
@@ -147,6 +146,8 @@ public sealed class SearchService(
                     Url: $"/Events/Browse?q={Uri.EscapeDataString(e.Title)}",
                     Score: titleScore > 0 ? titleScore : ScoreContainsName);
             })
+            .OrderByDescending(r => r.Score) // arch:db-sort-ok top-N relevance selector
+            .Take(limit)
             .ToList();
     }
 

--- a/src/Humans.Web/Controllers/SearchController.cs
+++ b/src/Humans.Web/Controllers/SearchController.cs
@@ -9,7 +9,7 @@ using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
-/// <summary>Global search: name-only hits across humans/teams/camps/rotas. Public-visibility surface only (docs/features/global/global-search.md).</summary>
+/// <summary>Global search: name-only hits across humans/teams/camps/rotas/events. Public-visibility surface only (docs/features/global/global-search.md).</summary>
 [Authorize]
 [Route("Search")]
 public sealed class SearchController(
@@ -71,6 +71,7 @@ public sealed class SearchController(
             TeamResults = SortByScore(results.Teams),
             CampResults = SortByScore(results.Camps),
             ShiftResults = SortByScore(results.Shifts),
+            EventResults = SortByScore(results.Events),
         };
 
     private static IReadOnlyList<GlobalSearchResult> SortByScore(

--- a/src/Humans.Web/Models/SearchViewModels.cs
+++ b/src/Humans.Web/Models/SearchViewModels.cs
@@ -34,11 +34,15 @@ public sealed class GlobalSearchViewModel
     public IReadOnlyList<GlobalSearchResult> ShiftResults { get; init; } =
         [];
 
+    public IReadOnlyList<GlobalSearchResult> EventResults { get; init; } =
+        [];
+
     public int HumanCount => HumanResults.Count;
     public int TeamCount => TeamResults.Count;
     public int CampCount => CampResults.Count;
     public int ShiftCount => ShiftResults.Count;
-    public int TotalCount => HumanCount + TeamCount + CampCount + ShiftCount;
+    public int EventCount => EventResults.Count;
+    public int TotalCount => HumanCount + TeamCount + CampCount + ShiftCount + EventCount;
 
     public bool HasQuery => !string.IsNullOrWhiteSpace(Query);
     public bool QueryIsTooShort => HasQuery && (Query?.Trim().Length ?? 0) < 2;

--- a/src/Humans.Web/Views/Search/Index.cshtml
+++ b/src/Humans.Web/Views/Search/Index.cshtml
@@ -1,8 +1,10 @@
 @using Humans.Application.DTOs
+@inject IConfiguration Configuration
 @model Humans.Web.Models.GlobalSearchViewModel
 
 @{
     ViewData["Title"] = "Search";
+    var eventsEnabled = Configuration.GetValue<bool>("Features:Events");
 
     string ChipUrl(SearchResultType? filter)
     {
@@ -30,7 +32,7 @@
     }
     <div class="input-group" style="max-width: 600px;">
         <input type="text" name="q" class="form-control" value="@Model.Query"
-               placeholder="Search humans, teams, camps, shifts…"
+               placeholder="@(eventsEnabled ? "Search humans, teams, camps, shifts, events…" : "Search humans, teams, camps, shifts…")"
                autofocus aria-label="Search query" />
         <button type="submit" class="btn btn-primary">
             <i class="fa-solid fa-magnifying-glass me-1"></i>Search
@@ -42,7 +44,7 @@
 {
     <div class="alert alert-info">
         <i class="fa-solid fa-circle-info me-2"></i>
-        Type at least 2 characters to search across humans, teams, camps, and shifts.
+        Type at least 2 characters to search across humans, teams, camps, shifts@(eventsEnabled ? ", and events" : "").
     </div>
 }
 else if (Model.QueryIsTooShort)
@@ -70,6 +72,12 @@ else
         <a href="@ChipUrl(SearchResultType.Shift)" class="@ChipClass(SearchResultType.Shift)">
             <i class="fa-solid fa-clock me-1"></i>Shifts (@Model.ShiftCount)
         </a>
+        @if (eventsEnabled)
+        {
+            <a href="@ChipUrl(SearchResultType.Event)" class="@ChipClass(SearchResultType.Event)">
+                <i class="fa-solid fa-calendar-day me-1"></i>Events (@Model.EventCount)
+            </a>
+        }
     </div>
 
     @if (!Model.HasResults)
@@ -102,6 +110,12 @@ else
         {
             <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-clock me-2"></i>Shifts</h3>
             <partial name="_GlobalSearchSection" model="Model.ShiftResults" view-data="@(new ViewDataDictionary(ViewData) { { "Icon", "fa-solid fa-clock" } })" />
+        }
+
+        @if (eventsEnabled && ShowSection(SearchResultType.Event, Model.EventCount))
+        {
+            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-calendar-day me-2"></i>Events</h3>
+            <partial name="_GlobalSearchSection" model="Model.EventResults" view-data="@(new ViewDataDictionary(ViewData) { { "Icon", "fa-solid fa-calendar-day" } })" />
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds an Events bucket to the global top-nav search (`/Search`), alongside Humans/Teams/Camps/Shifts.
- Reuses `IEventService.GetApprovedEventsAsync` (same call `/Events/Browse` makes), so the public-visibility contract holds: only `Status = Approved` events ever surface. The bucket is skipped entirely when `Features:Events` is off.
- Title is scored via the standard exact/prefix/contains rubric. Description-only matches fall through to a contains-tier score so users can still find events by description text (events are short and free-form — description text is often the load-bearing name signal). Documented as the deliberate exception to names-only in `docs/features/global/global-search.md`.
- Each event hit links to `/Events/Browse?q=<title>` since there's no per-event detail page.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` → 0 errors
- [x] `dotnet test Humans.slnx -v quiet` → all suites pass (Domain 186, Analyzers 116, Web 112, Application 3102, Integration 96)
- [ ] On the preview env: search a known approved-event title fragment, confirm it appears under the Events section with a working link
- [ ] Filter chips work: All / Humans / Teams / Camps / Shifts / Events
- [ ] With `Features:Events=false`, the Events chip and section are hidden and no Events results come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)