### PR TITLE
feat(events): 450-char description limit + withdraw approved events (US-26.4b)

### DIFF
--- a/docs/features/26-events.md
+++ b/docs/features/26-events.md
@@ -26,7 +26,7 @@ Two types of events exist: **camp events** (submitted by a team Lead, anchored t
 
 **Acceptance Criteria:**
 - Submission form accessible from the team page
-- Fields: title (≤ 80 chars), description (≤ 300 chars), category, date/time, duration, location note, is_recurring, recurrence pattern, priority rank
+- Fields: title (≤ 80 chars), description (≤ 450 chars), category, date/time, duration, location note, is_recurring, recurrence pattern, priority rank
 - Event is anchored to the team's GuideCamp; GuideCamp is auto-created on first submission if not yet present
 - Submission creates a GuideEvent in `Pending` status
 - Submitter receives email confirmation on submission
@@ -58,6 +58,19 @@ Two types of events exist: **camp events** (submitted by a team Lead, anchored t
 - On Reject or Request Edit: submitter receives email with the reason
 - On Approve: submitter receives confirmation email
 - All decisions logged as append-only ModerationAction records
+
+### US-26.4b: Withdrawing an Approved Event
+
+**As a** moderator or the original submitter
+**I want to** withdraw an approved event
+**So that** it is hidden from the published guide
+
+**Acceptance Criteria:**
+
+- Withdraw action available to GuideModerator/Admin on any Approved event (moderation queue)
+- Withdraw action available to the original submitter on their own Approved event (barrio events page or individual submission view)
+- Transitions status to `Withdrawn`; event no longer returned by the public API
+- No email sent on withdrawal
 
 ### US-26.5: Submitter Responds to Rejection / Edit Request
 **As a** submitter (barrio organiser or individual human)
@@ -134,12 +147,13 @@ Draft --> Pending           (Submit)
 Pending --> Approved        (Moderator: Approve)
 Pending --> Rejected        (Moderator: Reject)
 Pending --> ResubmitRequested (Moderator: Request Edit)
+Pending --> Withdrawn       (Submitter: withdraw)
 Rejected --> Pending        (Submitter: resubmit)
 ResubmitRequested --> Pending (Submitter: resubmit)
-Approved --> Deactivated    (Admin: soft delete — hides from guide, preserves audit trail)
+Approved --> Withdrawn      (Submitter or Moderator: withdraw — hides from guide)
 ```
 
-Hard deletion is blocked if any ModerationAction exists for the event.
+Hard deletion is not supported; `Withdrawn` is the terminal state for events removed from the guide.
 
 ## Authorization Model
 

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -208,7 +208,7 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
         await repo.SaveEventAndModerationActionAsync(guideEvent, action, ct);
     }
 
-    public Task<IReadOnlyList<Event>> GetAllEventsForDashboardAsync(CancellationToken ct = default)
+public Task<IReadOnlyList<Event>> GetAllEventsForDashboardAsync(CancellationToken ct = default)
         => repo.GetAllEventsForDashboardAsync(ct);
 
     public async Task<(IReadOnlyList<Event> Events, EventGuideSettings? Settings)> GetApprovedEventsForExportAsync(CancellationToken ct = default)

--- a/src/Humans.Domain/Entities/Event.cs
+++ b/src/Humans.Domain/Entities/Event.cs
@@ -42,7 +42,7 @@ public class Event
     public string Title { get; set; } = string.Empty;
 
     /// <summary>
-    /// Event description (≤ 300 chars).
+    /// Event description (≤ 450 chars).
     /// </summary>
     public string Description { get; set; } = string.Empty;
 
@@ -136,11 +136,11 @@ public class Event
     }
 
     /// <summary>
-    /// Withdraw the submission.
+    /// Withdraw the submission. Available from Draft, Pending, or Approved.
     /// </summary>
     public void Withdraw(IClock clock)
     {
-        if (Status is not (EventStatus.Draft or EventStatus.Pending))
+        if (Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Approved))
             throw new InvalidOperationException($"Cannot withdraw event in {Status} state");
         Status = EventStatus.Withdrawn;
         LastUpdatedAt = clock.GetCurrentInstant();

--- a/src/Humans.Domain/Enums/EventStatus.cs
+++ b/src/Humans.Domain/Enums/EventStatus.cs
@@ -20,6 +20,6 @@ public enum EventStatus
     /// <summary>Moderator requested edits before approval.</summary>
     ResubmitRequested = 4,
 
-    /// <summary>Withdrawn by the submitter.</summary>
+    /// <summary>Withdrawn by the submitter or a moderator — hidden from published guide.</summary>
     Withdrawn = 5
 }

--- a/src/Humans.Infrastructure/Data/Configurations/EventConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/EventConfiguration.cs
@@ -12,7 +12,7 @@ public class EventConfiguration : IEntityTypeConfiguration<Event>
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.Title).HasMaxLength(80).IsRequired();
-        builder.Property(e => e.Description).HasMaxLength(300).IsRequired();
+        builder.Property(e => e.Description).HasMaxLength(450).IsRequired();
         builder.Property(e => e.LocationNote).HasMaxLength(120);
         builder.Property(e => e.RecurrenceDays).HasMaxLength(100);
         builder.Property(e => e.AdminNotes).HasMaxLength(1000);

--- a/src/Humans.Infrastructure/Migrations/20260519000001_IncreaseEventDescriptionTo450.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260519000001_IncreaseEventDescriptionTo450.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519000001_IncreaseEventDescriptionTo450")]
+    partial class IncreaseEventDescriptionTo450
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260519000001_IncreaseEventDescriptionTo450.cs
+++ b/src/Humans.Infrastructure/Migrations/20260519000001_IncreaseEventDescriptionTo450.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseEventDescriptionTo450 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "description",
+                table: "events",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(300)",
+                oldMaxLength: 300);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "description",
+                table: "events",
+                type: "character varying(300)",
+                maxLength: 300,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(450)",
+                oldMaxLength: 450);
+        }
+    }
+}

--- a/src/Humans.Web/Controllers/BarrioEventsController.cs
+++ b/src/Humans.Web/Controllers/BarrioEventsController.cs
@@ -60,7 +60,7 @@ public class BarrioEventsController(
                 Status = e.Status,
                 PriorityRank = e.PriorityRank,
                 CanEdit = e.Status is EventStatus.Rejected or EventStatus.ResubmitRequested or EventStatus.Pending,
-                CanWithdraw = e.Status == EventStatus.Pending
+                CanWithdraw = e.Status is EventStatus.Pending or EventStatus.Approved
             }).ToList()
         };
 
@@ -265,7 +265,7 @@ public class BarrioEventsController(
         var guideEvent = await guide.GetCampEventAsync(eventId, camp.Id);
         if (guideEvent == null) return NotFound();
 
-        if (guideEvent.Status != EventStatus.Pending)
+        if (guideEvent.Status is not (EventStatus.Pending or EventStatus.Approved))
         {
             SetError("This event cannot be withdrawn in its current state.");
             return RedirectToAction(nameof(Index), new { slug });

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -62,7 +62,7 @@ public class EventsController(
                 DurationMinutes = e.DurationMinutes,
                 Status = e.Status,
                 CanEdit = e.Status is EventStatus.Draft or EventStatus.Rejected or EventStatus.ResubmitRequested,
-                CanWithdraw = e.Status is EventStatus.Draft or EventStatus.Pending
+                CanWithdraw = e.Status is EventStatus.Draft or EventStatus.Pending or EventStatus.Approved
             }).ToList()
         };
 
@@ -262,7 +262,7 @@ public class EventsController(
         var guideEvent = await guide.GetUserEventAsync(eventId, user.Id);
         if (guideEvent == null) return NotFound();
 
-        if (guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending))
+        if (guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Approved))
         {
             SetError("This event cannot be withdrawn in its current state.");
             return RedirectToAction(nameof(MySubmissions));

--- a/src/Humans.Web/Controllers/EventsModerationController.cs
+++ b/src/Humans.Web/Controllers/EventsModerationController.cs
@@ -106,6 +106,35 @@ public class EventsModerationController(
         return await ProcessActionAsync(model.EventId, EventModerationActionType.Rejected, model.Reason);
     }
 
+    [HttpPost("Withdraw")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Withdraw(ModerationActionFormModel model)
+    {
+        var moderator = await GetCurrentUserInfoAsync();
+        if (moderator == null) return Challenge();
+
+        var guideEvent = await guide.GetEventForModerationAsync(model.EventId);
+        if (guideEvent == null)
+        {
+            SetError("Event not found.");
+            return RedirectToAction(nameof(Index), new { tab = EventStatus.Approved });
+        }
+
+        if (guideEvent.Status != EventStatus.Approved)
+        {
+            SetError("This event is not in an approved state.");
+            return RedirectToAction(nameof(Index), new { tab = EventStatus.Approved });
+        }
+
+        await guide.WithdrawEventAsync(guideEvent);
+
+        logger.LogInformation("Moderator {UserId} withdrew event '{Title}' ({EventId})",
+            moderator.Id, guideEvent.Title, model.EventId);
+
+        SetSuccess($"Event \"{guideEvent.Title}\" withdrawn.");
+        return RedirectToAction(nameof(Index), new { tab = EventStatus.Approved });
+    }
+
     [HttpPost("RequestEdit")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RequestEdit(ModerationActionFormModel model)

--- a/src/Humans.Web/Models/Events/BarrioEventViewModels.cs
+++ b/src/Humans.Web/Models/Events/BarrioEventViewModels.cs
@@ -57,7 +57,7 @@ public class CampEventFormViewModel
     public string Title { get; set; } = string.Empty;
 
     [Required]
-    [MaxLength(300)]
+    [MaxLength(450)]
     public string Description { get; set; } = string.Empty;
 
     [Required]

--- a/src/Humans.Web/Models/Events/IndividualEventViewModels.cs
+++ b/src/Humans.Web/Models/Events/IndividualEventViewModels.cs
@@ -50,7 +50,7 @@ public class IndividualEventFormViewModel
     public string Title { get; set; } = string.Empty;
 
     [Required]
-    [MaxLength(300)]
+    [MaxLength(450)]
     public string Description { get; set; } = string.Empty;
 
     [Required]

--- a/src/Humans.Web/Views/EventsModeration/Index.cshtml
+++ b/src/Humans.Web/Views/EventsModeration/Index.cshtml
@@ -168,6 +168,23 @@ else
                                 }
                             </div>
 
+                            @if (evt.Status == EventStatus.Approved)
+                            {
+                                <div class="col-md-4">
+                                    <div class="card">
+                                        <div class="card-body">
+                                            <h6 class="card-title">Actions</h6>
+                                            <form method="post" asp-action="Withdraw">
+                                                @Html.AntiForgeryToken()
+                                                <input type="hidden" name="EventId" value="@evt.Id" />
+                                                <button type="submit" class="btn btn-outline-secondary w-100" data-confirm="Withdraw this event? It will be hidden from the guide.">
+                                                    <i class="fa-solid fa-eye-slash me-1"></i>Withdraw
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
+                            }
                             @if (evt.Status == EventStatus.Pending)
                             {
                                 <div class="col-md-4">


### PR DESCRIPTION
## Summary

- Increases the event description field limit from 300 to 450 characters (domain, EF config, view model validation, spec doc, migration)
- Extends the `Withdraw` flow to cover `Approved` events — submitters can withdraw their own approved event from the barrio/individual submissions page; moderators can withdraw any approved event from the moderation queue
- No new status value: reuses `Withdrawn` for both pre- and post-approval withdrawals
- No email sent on withdrawal of an approved event

## Changes

- `Event.Withdraw()` guard extended to allow `Approved` as source state
- `CanWithdraw` mapping updated in barrio and individual event controllers to include `Approved`
- New `Withdraw` POST action added to `EventsModerationController` for approved events
- State machine in `docs/features/26-events.md` updated to document `Pending → Withdrawn` and `Approved → Withdrawn` transitions

## Test plan

- [ ] Submit a camp event → approve it → withdraw it as the camp Lead — verify status becomes Withdrawn and it disappears from the public guide
- [ ] Submit an individual event → approve it → withdraw it as the submitter — same
- [ ] Approve an event → withdraw it as a GuideModerator from the moderation queue Approved tab
- [ ] Confirm no email is sent on any of the above withdrawals
- [ ] Verify a description of 301–450 chars is accepted on both camp and individual event forms
- [ ] Confirm the migration runs cleanly on a fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)