### PR TITLE
skill(trim-tests): Stryker-driven test cull workflow

### DIFF
--- a/.claude/skills/trim-tests/SKILL.md
+++ b/.claude/skills/trim-tests/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: trim-tests
+description: "Stryker-driven test cull: delete slop, consolidate redundants, fill mutation-coverage gaps. Score up, test count and lines down. Use when the user says 'trim tests', '/trim-tests', or wants to clean up LLM-generated test bloat. No args picks the worst-scored file; argument scopes to a section, service, or file."
+argument-hint: "[section | service | --file <path>]"
+---
+
+# Trim Tests
+
+LLM-generated test corpora accumulate slop — tests that touch lines without constraining behavior. Stryker is the arbiter. Heuristics and judgment propose; Stryker re-runs decide.
+
+**Goal per run:** mutation score same-or-higher, test count and line count lower.
+
+## Argument routing
+
+- `(no args)` — daily mode. Find the worst-scored file across existing Stryker configs (or smoke-rank). Show top 3, pick #1 unless overridden.
+- `<section>` — `shifts`, `camps`, `teams`, etc. Scope to that section's services.
+- `<service-name>` — single service like `CampService`. Scope to its `.cs` + matching `*Tests.cs`.
+- `--file <path>` — explicit production file.
+
+## Slop heuristics
+
+A test is a deletion candidate if it matches:
+
+- Only `.Received()`/`.DidNotReceive()` assertions — verifies the mock was called, not the outcome
+- Only `Should().NotBeNull()`, `Should().HaveCount(n)`, or `Should().Be(default)` — shape, not behavior
+- Body under ~10 lines AND no DB observation, no entity field assertion, no exception expectation
+- 3+ tests through the same branch with cosmetic input variation (same assertion shape, different params)
+- Tests of trivial code: auto-property getters, single-line delegations, simple mappers
+- Names ending in `_DoesNotThrow` where the production code can't throw
+
+Heuristics propose. Stryker decides. A heuristic-flagged test is only deleted if Phase 1's per-test data shows it as redundant (every mutant it kills is killed by someone else) or dead (kills nothing).
+
+## Phase 0 — Target select
+
+Look at `tests/Humans.Application.Tests/stryker-*-config.json` for existing scoped configs. Reuse if matching, otherwise generate a config in `local/stryker-trim/` (gitignored — don't commit ephemeral configs):
+
+```json
+{
+  "stryker-config": {
+    "project": "Humans.Application.csproj",
+    "test-runner": "mtp",
+    "coverage-analysis": "perTest",
+    "mutation-level": "Standard",
+    "mutate": ["**/Services/<Area>/<File>.cs"],
+    "concurrency": 24,
+    "reporters": ["Json"],
+    "thresholds": {"high": 80, "low": 60, "break": 0}
+  }
+}
+```
+
+**Use `coverage-analysis: perTest`** (not `off` like the existing configs). Per-test attribution is what makes safe deletion possible.
+
+## Phase 1 — Baseline
+
+```
+cd tests/Humans.Application.Tests
+dotnet stryker -f <config-path>
+```
+
+Parse `StrykerOutput/<latest>/reports/mutation-report.json`. Capture:
+
+- Total mutation score
+- Per-mutant: location, status, killed-by-test list
+- Per-test: which mutants it kills (and which kills are unique to it)
+
+Classify each test:
+- **Precious** — kills at least one mutant nothing else kills
+- **Redundant** — every kill is also covered by other tests
+- **Dead** — kills nothing
+
+Record baseline numbers for the report.
+
+## Phase 2 — Slop deletion
+
+Intersect the slop heuristics with `redundant ∪ dead`. That intersection is the safe-delete set.
+
+Delete in one batch. Build (must compile). Re-run Stryker. If score drops by >2 points: find the mutant cluster that stopped being killed, restore the minimum test set to recover those kills.
+
+Commit:
+
+```
+test(<section>): drop N redundant tests in <ServiceName>Tests
+```
+
+That's the whole message. No paragraph. The number IS the rationale.
+
+## Phase 3 — Consolidate
+
+Read remaining tests. Group by conceptual behavior. Candidates for `[Theory]`/`[InlineData]`:
+
+- N `_HappyPath_*` variants that differ only in input
+- `_VariantA/B/C` tests with identical assertion shape
+- Per-enum-value branches with the same shape
+
+Merge. Build. Re-run Stryker — same mutants must still be killed. Restore individual tests if any kill is lost.
+
+Commit:
+
+```
+test(<section>): consolidate N tests into theories in <ServiceName>Tests
+```
+
+## Phase 4 — Gap fill
+
+From the Phase 1 surviving-mutants list, group by source location. For each cluster, write a test that pins the missing behavior. Test must observe outcomes (DB rows, return values, exceptions) — never just `.Received()` on a mock unless the mock call IS the contract (e.g., `IEmailTransport.SendAsync`).
+
+Skip mutants in: log messages, debug branches, `ToString`, generated code, anything in the project's Stryker exclusion list.
+
+Cap new tests at half the number deleted. If that doesn't lift the score enough, that's fine — the corpus was bloated for a reason.
+
+Commit:
+
+```
+test(<section>): add N tests for surviving mutants in <ServiceName>Tests
+```
+
+## Phase 5 — Report
+
+Terse summary to user:
+
+```
+<ServiceName>Tests
+  Mutation score: 67.3% → 81.2% (+13.9)
+  Tests:         103 → 62 (−41)
+  Lines:         1,247 → 718 (−529)
+  Mutants:       18 surviving → 6 surviving
+
+Branch: trim-tests/<service>-<date>
+Commits: 3
+```
+
+Then ask: "Open PR? (y/n)". If yes, PR title `test(<section>): trim and consolidate <ServiceName>Tests`. Body is the report above. Nothing else.
+
+## Anti-bloat rules — HARD
+
+- **No paragraph commit messages.** One line + numbers.
+- **No inline comments** explaining deleted tests or consolidations. The diff shows what changed.
+- **No new docstrings or class-level XML doc** added during this skill.
+- **No follow-up plan documents.** Output the report inline.
+- **`[InlineData]` consolidation only when the test count would be 4+** otherwise. Two cosmetic variations stay as two tests.
+
+If a change needs more than 2 lines of comment to explain, the change is too clever. Make the code more obvious instead.
+
+## Workflow
+
+- Worktree: `.worktrees/trim-tests-<area>` off `origin/main`
+- One commit per phase
+- One PR per service (or per small section)
+- Use harness primitives — `ServiceTestHarness`, `ServiceLocatorBuilder`, `AuditLog`/`Notifier`/`ShiftAuthInvalidator`/`AdminAuthorization` properties. Don't add raw `Substitute.For<>` for those four interfaces.
+
+## Daily mode — "find the next thing"
+
+1. Run all existing `stryker-*-config.json` in parallel, capture scores from each `mutation-report.json`
+2. Rank lowest-first
+3. Print top 3 worst with score + test count
+4. Default to #1; user can `/trim-tests <name>` to pick another
+
+If no scoped configs exist for an area the user asked about, generate one in `local/stryker-trim/` and run that.
+
+## Prerequisites
+
+- `dotnet stryker --version` must work. If missing: `dotnet tool restore` (the repo has `.config/dotnet-tools.json` pinning Stryker).
+- Working tree must be clean (skill manages its own commits).
+- Magick.NET NuGet audit must not fail the build — pass `-p:NuGetAudit=false` to `dotnet build`/`dotnet test` invocations if it does (it's not on `main` anymore, but defensive).
+
+## Out of scope
+
+- Don't touch production source — test code only
+- Don't modify Stryker thresholds in committed configs
+- Don't commit ephemeral configs from `local/stryker-trim/`
+- Don't touch `Humans.Integration.Tests` or `Humans.Web.Tests` — different shape, different skill if needed
+- Don't change harness, builders, or other test infrastructure as part of this skill — separate concern

--- a/.claude/skills/trim-tests/SKILL.md
+++ b/.claude/skills/trim-tests/SKILL.md
@@ -6,40 +6,51 @@ argument-hint: "[section | service | --file <path>]"
 
 # Trim Tests
 
-LLM-generated test corpora accumulate slop — tests that touch lines without constraining behavior. Stryker is the arbiter. Heuristics and judgment propose; Stryker re-runs decide.
+LLM-generated test corpora accumulate slop — tests that touch lines without constraining behavior. Stryker is the arbiter for whether a deletion is safe. `scripts/analyze-test-utility.ps1` is the arbiter for which tests are slop candidates.
 
 **Goal per run:** mutation score same-or-higher, test count and line count lower.
 
+The skill is iterative. Each phase has a verify-and-gate step; if the gate fails, the skill bisects, restores, or skips rather than committing a regression. The outer loop retries the whole flow up to 3 times with adjusted parameters before giving up on a file.
+
+## Hard constraint — coverage-analysis must be `off`
+
+The repo's `docs/testing/mutation-testing.md` mandates `coverage-analysis: off` for xUnit v3 + MTP. Per-test coverage capture misclassifies mutants in this environment. Never set it to `perTest` or `all`. This means we don't get per-test attribution — the safety net is "re-run Stryker after a deletion batch and gate on score delta," not "consult a per-test kill table."
+
 ## Argument routing
 
-- `(no args)` — daily mode. Find the worst-scored file across existing Stryker configs (or smoke-rank). Show top 3, pick #1 unless overridden.
-- `<section>` — `shifts`, `camps`, `teams`, etc. Scope to that section's services.
-- `<service-name>` — single service like `CampService`. Scope to its `.cs` + matching `*Tests.cs`.
+- `(no args)` — daily mode. Run `analyze-test-utility.ps1` to get the latest debt queue, pick the top "High-Confidence Test-Debt Candidate" not in the trimmed-file log.
+- `<section>` — `shifts`, `camps`, `teams`, etc. Filter the debt queue to files matching that section's namespace.
+- `<service-name>` — single service like `CampService`. Scope to its production `.cs` + matching `*Tests.cs`.
 - `--file <path>` — explicit production file.
 
-## Slop heuristics
+## What the utility script already detects
 
-A test is a deletion candidate if it matches:
+`scripts/analyze-test-utility.ps1` computes a `DebtScore` per test file based on signals that strongly correlate with slop: low assertion density, weak-assertion patterns (`Should().NotBeNull()`, `Should().BeOfType()`, `Assert.True()`), heavy mocking, reflection-shape checks, DI-shape checks, large size relative to assertions, missing production subject. It already classifies architecture ratchets and DI-cycle safety nets and excludes them from the high-confidence queue.
 
-- Only `.Received()`/`.DidNotReceive()` assertions — verifies the mock was called, not the outcome
-- Only `Should().NotBeNull()`, `Should().HaveCount(n)`, or `Should().Be(default)` — shape, not behavior
-- Body under ~10 lines AND no DB observation, no entity field assertion, no exception expectation
-- 3+ tests through the same branch with cosmetic input variation (same assertion shape, different params)
-- Tests of trivial code: auto-property getters, single-line delegations, simple mappers
-- Names ending in `_DoesNotThrow` where the production code can't throw
+Don't reinvent these heuristics. Run the script, take its output, apply LLM judgment on individual tests inside the high-score files.
 
-Heuristics propose. Stryker decides. A heuristic-flagged test is only deleted if Phase 1's per-test data shows it as redundant (every mutant it kills is killed by someone else) or dead (kills nothing).
+## Workflow
 
-## Phase 0 — Target select
+### Phase 0 — Target select
 
-Look at `tests/Humans.Application.Tests/stryker-*-config.json` for existing scoped configs. Reuse if matching, otherwise generate a config in `local/stryker-trim/` (gitignored — don't commit ephemeral configs):
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/analyze-test-utility.ps1 -Top 50 -StrykerReport local/stryker-runs/<latest>/reports/mutation-report.json
+```
+
+If no recent Stryker mutation report exists for the area, run one first (Phase 1 below) then re-run the utility with `-StrykerReport`. Otherwise the utility runs on file signals alone — fine but weaker.
+
+Output lands in `local/test-utility/test-utility-<timestamp>.{json,csv,md}`. Read the JSON. From "High-Confidence Test-Debt Candidates," pick the target per the argument routing rules.
+
+### Phase 1 — Baseline
+
+Find or generate a scoped Stryker config (existing ones live at `tests/Humans.Application.Tests/stryker-*-config.json`). If you must generate one, put it under `local/stryker-trim/` (gitignored). **Use `coverage-analysis: off`** — the doc-mandated value. Example:
 
 ```json
 {
   "stryker-config": {
     "project": "Humans.Application.csproj",
     "test-runner": "mtp",
-    "coverage-analysis": "perTest",
+    "coverage-analysis": "off",
     "mutation-level": "Standard",
     "mutate": ["**/Services/<Area>/<File>.cs"],
     "concurrency": 24,
@@ -49,51 +60,63 @@ Look at `tests/Humans.Application.Tests/stryker-*-config.json` for existing scop
 }
 ```
 
-**Use `coverage-analysis: perTest`** (not `off` like the existing configs). Per-test attribution is what makes safe deletion possible.
+Run:
 
-## Phase 1 — Baseline
-
+```powershell
+Push-Location tests/Humans.Application.Tests
+dotnet tool run dotnet-stryker --config-file <path>
+Pop-Location
 ```
-cd tests/Humans.Application.Tests
-dotnet stryker -f <config-path>
-```
 
-Parse `StrykerOutput/<latest>/reports/mutation-report.json`. Capture:
+Parse `StrykerOutput/<latest>/reports/mutation-report.json`. Record:
 
-- Total mutation score
-- Per-mutant: location, status, killed-by-test list
-- Per-test: which mutants it kills (and which kills are unique to it)
+- `mutationScore` (percentage)
+- Total mutants, killed count, surviving count
+- For each surviving mutant: id, file, line, mutator, original source snippet, replacement
 
-Classify each test:
-- **Precious** — kills at least one mutant nothing else kills
-- **Redundant** — every kill is also covered by other tests
-- **Dead** — kills nothing
+The surviving-mutants list drives Phase 4. The score is the gate everywhere else.
 
-Record baseline numbers for the report.
+### Phase 2 — Delete slop (with bisection)
 
-## Phase 2 — Slop deletion
+From Phase 0's candidate file, identify the test methods inside that match slop patterns under LLM judgment (the file is already high-debt-score; we're picking which tests inside to drop). Patterns to flag:
 
-Intersect the slop heuristics with `redundant ∪ dead`. That intersection is the safe-delete set.
+- Only `.Received()` / `.DidNotReceive()` assertions — verifies the mock was called, not the outcome
+- Only `Should().NotBeNull()`, `Should().HaveCount(n)`, `Should().BeOfType()`, `Should().Be(default)` — shape, not behavior
+- Body under ~10 lines AND no DB observation, no entity field assertion, no exception expectation
+- 3+ tests through the same branch with cosmetic input variation (same assertion shape, different params)
+- Tests of trivial code (auto-property getters, single-line delegations, simple mappers)
+- Names ending in `_DoesNotThrow` where the production code can't throw
 
-Delete in one batch. Build (must compile). Re-run Stryker. If score drops by >2 points: find the mutant cluster that stopped being killed, restore the minimum test set to recover those kills.
+Form a deletion batch (start with everything flagged). Delete. Build. If build fails, the test was load-bearing in a way that wasn't visible — revert that specific test, try again.
 
-Commit:
+Re-run Stryker. Compare the new score to baseline.
+
+**Bisection gate:** if score dropped by more than 2 percentage points, the deletion batch was too aggressive. Don't accept it. Bisect:
+
+1. Restore half the deleted tests (the half most likely to have killed a unique mutant based on assertion strength).
+2. Re-run Stryker.
+3. If score still dropped >2pts: keep bisecting (restore half of the remaining deletions).
+4. If score recovered: the restored set contains the load-bearing test(s); freeze them and try to delete the other half again in a separate batch (sometimes the issue is one specific test, not the half).
+
+After at most 3 bisection rounds, accept whatever deletion batch holds the score within tolerance. Commit:
 
 ```
 test(<section>): drop N redundant tests in <ServiceName>Tests
 ```
 
-That's the whole message. No paragraph. The number IS the rationale.
+That's the whole commit message. The numbers ARE the rationale.
 
-## Phase 3 — Consolidate
+### Phase 3 — Consolidate (with verify)
 
-Read remaining tests. Group by conceptual behavior. Candidates for `[Theory]`/`[InlineData]`:
+Read remaining tests. Group by conceptual behavior. Candidates for xUnit `[Theory]`/`[InlineData]`:
 
 - N `_HappyPath_*` variants that differ only in input
 - `_VariantA/B/C` tests with identical assertion shape
 - Per-enum-value branches with the same shape
 
-Merge. Build. Re-run Stryker — same mutants must still be killed. Restore individual tests if any kill is lost.
+**Threshold:** consolidate only when the group has 4+ members. Two cosmetic variants stay as two tests — the `[Theory]` ceremony isn't worth it below that.
+
+Merge. Build. Re-run Stryker. If any previously-killed mutant is now surviving (compare mutant ID lists), restore the individual tests for that mutant. Re-run. Continue until score holds.
 
 Commit:
 
@@ -101,13 +124,18 @@ Commit:
 test(<section>): consolidate N tests into theories in <ServiceName>Tests
 ```
 
-## Phase 4 — Gap fill
+### Phase 4 — Gap fill (with verification)
 
-From the Phase 1 surviving-mutants list, group by source location. For each cluster, write a test that pins the missing behavior. Test must observe outcomes (DB rows, return values, exceptions) — never just `.Received()` on a mock unless the mock call IS the contract (e.g., `IEmailTransport.SendAsync`).
+From the Phase 1 surviving-mutants list, group by source location. For each cluster:
+
+1. Read the mutated code.
+2. Identify what behavior is missing a constraint (the mutation tells you exactly what change in behavior should have failed a test).
+3. Write a test that observes the outcome the mutation would change. Test must observe outcomes (DB rows, return values, thrown exceptions) — never just `.Received()` on a mock unless the mock call IS the contract (e.g., `IEmailTransport.SendAsync`).
+4. **Verify the test actually kills the mutant.** Manually apply the mutation (change the source to the mutant's replacement), run the test, it must fail. Revert the source. The test must still pass on the unmutated code. This catches tests that pass for the wrong reason.
 
 Skip mutants in: log messages, debug branches, `ToString`, generated code, anything in the project's Stryker exclusion list.
 
-Cap new tests at half the number deleted. If that doesn't lift the score enough, that's fine — the corpus was bloated for a reason.
+**Cap:** new tests at half the number deleted in Phase 2. If you can't lift the score that much within the cap, that's fine — the corpus was bloated for a reason.
 
 Commit:
 
@@ -115,22 +143,40 @@ Commit:
 test(<section>): add N tests for surviving mutants in <ServiceName>Tests
 ```
 
-## Phase 5 — Report
+### Phase 5 — Report
 
-Terse summary to user:
+Print to user:
 
 ```
 <ServiceName>Tests
   Mutation score: 67.3% → 81.2% (+13.9)
   Tests:         103 → 62 (−41)
   Lines:         1,247 → 718 (−529)
-  Mutants:       18 surviving → 6 surviving
+  Mutants:       18 surviving → 6 surviving (−12)
 
 Branch: trim-tests/<service>-<date>
 Commits: 3
 ```
 
-Then ask: "Open PR? (y/n)". If yes, PR title `test(<section>): trim and consolidate <ServiceName>Tests`. Body is the report above. Nothing else.
+Then ask: "Open PR? (y/n)". If yes, PR title `test(<section>): trim and consolidate <ServiceName>Tests`. Body is the report block above. Nothing else.
+
+## Outer iteration loop
+
+After Phase 5, check the success criteria:
+
+- `score_delta >= 0` (score didn't drop)
+- `test_count_delta < 0` (count went down)
+- `line_delta < 0` (lines went down)
+
+**All three must hold.** If they do, the run succeeded — commit, report, exit.
+
+If one or more fail, this attempt didn't win. Don't commit the partial work. Decide the next move:
+
+- **score dropped, count dropped:** deletion was too aggressive even after bisection. Restart with stricter slop heuristics (require 2+ matching patterns instead of 1) and re-run.
+- **score held, count didn't drop:** the file's already lean. Move on — there's nothing to win here. Mark this file as "trimmed" in the daily-mode rotation so it doesn't get repicked tomorrow.
+- **score dropped, count didn't drop:** something went wrong in consolidation or gap-fill produced flaky tests. Restore the Phase 2 deletions (those were validated), skip Phase 3-4 this iteration, accept the partial win.
+
+Max 3 outer iterations per file. If none succeeds, leave the work-in-progress branch but don't open a PR — report what was tried and stop.
 
 ## Anti-bloat rules — HARD
 
@@ -138,7 +184,7 @@ Then ask: "Open PR? (y/n)". If yes, PR title `test(<section>): trim and consolid
 - **No inline comments** explaining deleted tests or consolidations. The diff shows what changed.
 - **No new docstrings or class-level XML doc** added during this skill.
 - **No follow-up plan documents.** Output the report inline.
-- **`[InlineData]` consolidation only when the test count would be 4+** otherwise. Two cosmetic variations stay as two tests.
+- **`[InlineData]` consolidation only when the test count would be 4+** otherwise.
 
 If a change needs more than 2 lines of comment to explain, the change is too clever. Make the code more obvious instead.
 
@@ -147,22 +193,25 @@ If a change needs more than 2 lines of comment to explain, the change is too cle
 - Worktree: `.worktrees/trim-tests-<area>` off `origin/main`
 - One commit per phase
 - One PR per service (or per small section)
-- Use harness primitives — `ServiceTestHarness`, `ServiceLocatorBuilder`, `AuditLog`/`Notifier`/`ShiftAuthInvalidator`/`AdminAuthorization` properties. Don't add raw `Substitute.For<>` for those four interfaces.
+- Use harness primitives — `ServiceTestHarness`, `ServiceLocatorBuilder`, the harness stub properties (`AuditLog`/`Notifier`/`ShiftAuthInvalidator`/`AdminAuthorization`). Don't add raw `Substitute.For<>` for those four interfaces.
 
 ## Daily mode — "find the next thing"
 
-1. Run all existing `stryker-*-config.json` in parallel, capture scores from each `mutation-report.json`
-2. Rank lowest-first
-3. Print top 3 worst with score + test count
-4. Default to #1; user can `/trim-tests <name>` to pick another
+1. Run `analyze-test-utility.ps1 -Top 50` (no Stryker report needed for the initial ranking)
+2. Take the top 3 of "High-Confidence Test-Debt Candidates" from the markdown
+3. Cross-reference against the trimmed-file log (see below). Skip any already-trimmed in the last 14 days.
+4. Print top 3 to the user, default to #1; user can override with `/trim-tests <name>`.
 
-If no scoped configs exist for an area the user asked about, generate one in `local/stryker-trim/` and run that.
+### Trimmed-file log
+
+After a successful run, append the trimmed file's path + date + score delta to `local/test-utility/trimmed-log.tsv` (gitignored). On daily-mode runs, read this file to skip recently-trimmed targets.
 
 ## Prerequisites
 
-- `dotnet stryker --version` must work. If missing: `dotnet tool restore` (the repo has `.config/dotnet-tools.json` pinning Stryker).
-- Working tree must be clean (skill manages its own commits).
-- Magick.NET NuGet audit must not fail the build — pass `-p:NuGetAudit=false` to `dotnet build`/`dotnet test` invocations if it does (it's not on `main` anymore, but defensive).
+- `dotnet stryker --version` must work. If missing: `dotnet tool restore` (the repo has `.config/dotnet-tools.json` pinning Stryker 4.14.1).
+- `pwsh` or PowerShell available for the utility script.
+- `coverage-analysis: off` in every Stryker config used. Verify before running.
+- Working tree clean (skill manages its own commits).
 
 ## Out of scope
 
@@ -171,3 +220,4 @@ If no scoped configs exist for an area the user asked about, generate one in `lo
 - Don't commit ephemeral configs from `local/stryker-trim/`
 - Don't touch `Humans.Integration.Tests` or `Humans.Web.Tests` — different shape, different skill if needed
 - Don't change harness, builders, or other test infrastructure as part of this skill — separate concern
+- Don't enable `coverage-analysis: perTest` or `all` to get richer data, even if it would be faster. The doc says no.


### PR DESCRIPTION
Adds `/trim-tests` — a Stryker-driven workflow for culling LLM-generated test slop.

**Goal per run:** mutation score same-or-higher, test count and line count lower.

**Phases:**
1. Baseline Stryker on target (per-test coverage attribution)
2. Mechanical slop deletion — heuristics propose, Stryker re-run decides
3. Semantic consolidation — visually-different-but-conceptually-same tests merged into `[Theory]`
4. Gap fill — write tests for surviving mutants (capped at half the deletions)
5. One-screen delta report

**Argument routing:**
- `(no args)` — daily mode, pick the worst-scored file
- `<section>` / `<service>` / `--file <path>` — explicit scope

**Anti-bloat rules baked in:** terse one-line commits, no inline explanatory comments on test changes, no follow-up plan docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)