### PR TITLE
chore(scripts): coordinator-SUT de-rank + Coverage Gap section in test-utility analyzer

### DIFF
--- a/.claude/skills/trim-tests/SKILL.md
+++ b/.claude/skills/trim-tests/SKILL.md
@@ -87,18 +87,25 @@ From Phase 0's candidate file, identify the test methods inside that match slop 
 - Tests of trivial code (auto-property getters, single-line delegations, simple mappers)
 - Names ending in `_DoesNotThrow` where the production code can't throw
 
+**Trap to avoid — same output, different code path.** Two tests that produce the same observable output (same return value, same expected string) can still exercise different branches in the SUT (different `if`-arms, distinct early returns, distinct try/catch paths, distinct prefix-strip / fragment-handling branches). Before deleting a test as "cosmetic variant of another," briefly trace its inputs through the SUT. If it's the only test that enters a particular conditional branch, keep it — Stryker may not have a mutator covering that branch, and the score-delta gate will pass while the coverage gap quietly opens. Phrase the check explicitly to yourself: *"is this test the only one whose inputs satisfy condition X in the SUT?"* If yes, don't delete.
+
 Form a deletion batch (start with everything flagged). Delete. Build. If build fails, the test was load-bearing in a way that wasn't visible — revert that specific test, try again.
 
-Re-run Stryker. Compare the new score to baseline.
+Re-run Stryker. Compare both score AND per-mutant kill diff against baseline.
 
-**Bisection gate:** if score dropped by more than 2 percentage points, the deletion batch was too aggressive. Don't accept it. Bisect:
+**Bisection gate — two conditions, BOTH must hold:**
+
+1. **Score must not drop by more than 2 percentage points.** Score gate is necessary but not sufficient — timeout reclassification can inflate it while real kills regress.
+2. **No mutant may go from Killed → Survived.** Compare mutant IDs across runs. A net-positive score with one or more Killed→Survived shifts means the deletion silently lost real coverage. The score-only gate misses this when timeouts shift in your favor.
+
+If either gate fails, bisect:
 
 1. Restore half the deleted tests (the half most likely to have killed a unique mutant based on assertion strength).
 2. Re-run Stryker.
-3. If score still dropped >2pts: keep bisecting (restore half of the remaining deletions).
-4. If score recovered: the restored set contains the load-bearing test(s); freeze them and try to delete the other half again in a separate batch (sometimes the issue is one specific test, not the half).
+3. If gate still fails: keep bisecting (restore half of the remaining deletions).
+4. If gate passes: the restored set contains the load-bearing test(s); freeze them and try to delete the other half again in a separate batch (sometimes the issue is one specific test, not the half).
 
-After at most 3 bisection rounds, accept whatever deletion batch holds the score within tolerance. Commit:
+After at most 3 bisection rounds, accept whatever deletion batch passes both gates. Commit:
 
 ```
 test(<section>): drop N redundant tests in <ServiceName>Tests

--- a/scripts/analyze-test-utility.ps1
+++ b/scripts/analyze-test-utility.ps1
@@ -121,11 +121,20 @@ $rows = foreach ($file in $testFiles) {
                 if ($prefixCounts.ContainsKey($prefix)) { $prefixCounts[$prefix]++ } else { $prefixCounts[$prefix] = 1 }
             }
             $methodMatchedCounts = @{}
+            $publicMethodSet = New-Object System.Collections.Generic.HashSet[string]
+            foreach ($pmName in $publicMethodNames) { [void]$publicMethodSet.Add($pmName) }
             foreach ($pmName in $publicMethodNames) {
-                $stripped = if ($pmName.EndsWith('Async', [StringComparison]::Ordinal)) { $pmName.Substring(0, $pmName.Length - 5) } else { $null }
                 $count = 0
                 if ($prefixCounts.ContainsKey($pmName)) { $count += $prefixCounts[$pmName] }
-                if ($stripped -and $prefixCounts.ContainsKey($stripped)) { $count += $prefixCounts[$stripped] }
+                if ($pmName.EndsWith('Async', [StringComparison]::Ordinal)) {
+                    $stripped = $pmName.Substring(0, $pmName.Length - 5)
+                    # Only attribute the stripped (sync-shaped) prefix to this async method
+                    # when there is no sync sibling on the same SUT — otherwise the sync
+                    # method already claims those tests via the exact-match branch above.
+                    if (-not $publicMethodSet.Contains($stripped) -and $prefixCounts.ContainsKey($stripped)) {
+                        $count += $prefixCounts[$stripped]
+                    }
+                }
                 if ($count -gt 0) { $methodMatchedCounts[$pmName] = $count }
             }
             if ($methodMatchedCounts.Count -gt 0) {

--- a/scripts/analyze-test-utility.ps1
+++ b/scripts/analyze-test-utility.ps1
@@ -90,6 +90,8 @@ $rows = foreach ($file in $testFiles) {
     $publicMethodNames = @()
     $untestedPublicMethods = @()
     $testsPerPublicMethod = 0.0
+    $maxTestsPerMethod = 0
+    $topMethodsByTestCount = ''
     if ($productionMatches.Count -gt 0) {
         $methodSet = New-Object System.Collections.Generic.HashSet[string]
         foreach ($prodRepoPath in $productionMatches) {
@@ -110,11 +112,28 @@ $rows = foreach ($file in $testFiles) {
             $testNameMatches = [regex]::Matches($text,
                 '(?m)^\s+public\s+(?:async\s+)?(?:Task<[^>]+>|Task|void|ValueTask|ValueTask<[^>]+>)\s+(\w+)\s*\(')
             $testedPrefixes = New-Object System.Collections.Generic.HashSet[string]
+            $prefixCounts = @{}
             foreach ($tm in $testNameMatches) {
                 $tn = $tm.Groups[1].Value
                 $idx = $tn.IndexOf('_')
                 $prefix = if ($idx -gt 0) { $tn.Substring(0, $idx) } else { $tn }
                 [void]$testedPrefixes.Add($prefix)
+                if ($prefixCounts.ContainsKey($prefix)) { $prefixCounts[$prefix]++ } else { $prefixCounts[$prefix] = 1 }
+            }
+            $methodMatchedCounts = @{}
+            foreach ($pmName in $publicMethodNames) {
+                $stripped = if ($pmName.EndsWith('Async', [StringComparison]::Ordinal)) { $pmName.Substring(0, $pmName.Length - 5) } else { $null }
+                $count = 0
+                if ($prefixCounts.ContainsKey($pmName)) { $count += $prefixCounts[$pmName] }
+                if ($stripped -and $prefixCounts.ContainsKey($stripped)) { $count += $prefixCounts[$stripped] }
+                if ($count -gt 0) { $methodMatchedCounts[$pmName] = $count }
+            }
+            if ($methodMatchedCounts.Count -gt 0) {
+                $maxTestsPerMethod = ($methodMatchedCounts.Values | Measure-Object -Maximum).Maximum
+                $topMethodsByTestCount = (($methodMatchedCounts.GetEnumerator() |
+                    Sort-Object Value -Descending |
+                    Select-Object -First 3 |
+                    ForEach-Object { "$($_.Key)($($_.Value))" }) -join ', ')
             }
             $untestedPublicMethods = @($publicMethodNames | Where-Object {
                 $name = $_
@@ -259,6 +278,8 @@ $rows = foreach ($file in $testFiles) {
         PublicMethodCount = $publicMethodNames.Count
         UntestedPublicMethods = $untestedPublicMethods
         TestsPerPublicMethod = $testsPerPublicMethod
+        MaxTestsPerMethod = $maxTestsPerMethod
+        TopMethodsByTestCount = $topMethodsByTestCount
         DebtScore = $score
         Recommendation = $recommendation
         Reasons = @($reasons)
@@ -388,6 +409,26 @@ foreach ($item in $gapCandidates) {
         $untestedNames += ", ... +$($item.UntestedPublicMethods.Count - 8) more"
     }
     $md.Add(('| {0} | {1} | `{2}` | {3} | {4} |' -f $item.UntestedPublicMethods.Count, $item.TestsPerPublicMethod, $item.Path, $item.PublicMethodCount, $untestedNames))
+}
+
+$concentrationCandidates = @($rows |
+    Where-Object {
+        $_.MaxTestsPerMethod -ge 5 -and
+        $_.Category -ne 'Architecture' -and
+        -not $_.IsDiCycleSafetyNet
+    } |
+    Sort-Object @{Expression = { $_.MaxTestsPerMethod }; Descending = $true }, @{Expression = { $_.Tests }; Descending = $true } |
+    Select-Object -First $Top)
+
+$md.Add('')
+$md.Add('## Test Concentration Candidates')
+$md.Add('')
+$md.Add('Files where a single SUT method has 5+ attributed tests. High concentration often means cosmetic-variation tests that could collapse to a `[Theory]` or be culled outright. Inspect the top method''s tests — if 8 of them differ only in input values with the same assertion shape, that''s a consolidation target.')
+$md.Add('')
+$md.Add('| Max Tests/Method | Tests | File | Top Methods (test count) |')
+$md.Add('| ---: | ---: | --- | --- |')
+foreach ($item in $concentrationCandidates) {
+    $md.Add(('| {0} | {1} | `{2}` | {3} |' -f $item.MaxTestsPerMethod, $item.Tests, $item.Path, $item.TopMethodsByTestCount))
 }
 
 if (-not [string]::IsNullOrWhiteSpace($StrykerReport)) {

--- a/scripts/analyze-test-utility.ps1
+++ b/scripts/analyze-test-utility.ps1
@@ -71,9 +71,13 @@ $rows = foreach ($file in $testFiles) {
     $lineCount = ($text -split "`n").Count
     $testCount = Count-Matches $text '(?m)^\s*\[(HumansFact|Fact|HumansTheory|Theory)\b'
     $classCount = Count-Matches $text '\b(public\s+)?(sealed\s+|static\s+|abstract\s+|partial\s+)*class\s+\w+'
-    $assertionCount = Count-Matches $text '(\.Should\(|\bAssert\.|\bReceived\(|\bDidNotReceive\(|\bVerify\(|\bMustHaveHappened)'
+    $assertionCount = Count-Matches $text '(\.Should\(|\bAssert\.|\b(?:Received|DidNotReceive)(?:WithAnyArgs)?\(|\bVerify\(|\bMustHaveHappened)'
     $weakAssertionCount = Count-Matches $text '(\.Should\(\)\.(NotBeNull|BeNull|BeOfType|BeAssignableTo|NotThrow|BeTrue|BeFalse)\b|\bAssert\.(NotNull|Null|IsType|IsAssignableFrom|True|False)\b)'
     $substituteCount = Count-Matches $text '\bSubstitute\.For<|\bMock<|\bNSubstitute\.'
+    $distinctMockTypes = @([regex]::Matches($text, '\bSubstitute\.For<([^>(]+(?:<[^>]+>)?)') |
+        ForEach-Object { $_.Groups[1].Value.Trim() } |
+        Sort-Object -Unique).Count
+    $isCoordinatorSut = $distinctMockTypes -ge 8
     $reflectionCount = Count-Matches $text '\btypeof\(|\.Get(Constructor|Method|Property|Properties|Interfaces|GenericArguments|CustomAttributes)|\.Namespace\b|\.Assembly\b'
     $diCount = Count-Matches $text '\bServiceCollection\b|\bBuildServiceProvider\b|\bGetRequiredService\b|\bIServiceCollection\b'
     $snapshotCount = Count-Matches $text '\bEnum\.GetValues\b|\.ToString\(\)\.Should\(\)\.Be\(|\.Should\(\)\.BeEquivalentTo\(new\[\]'
@@ -82,6 +86,46 @@ $rows = foreach ($file in $testFiles) {
     $subject = Get-TestSubjectName $repoPath
     $productionMatches = Find-ProductionMatches $subject
     $category = Get-Category $repoPath
+
+    $publicMethodNames = @()
+    $untestedPublicMethods = @()
+    $testsPerPublicMethod = 0.0
+    if ($productionMatches.Count -gt 0) {
+        $methodSet = New-Object System.Collections.Generic.HashSet[string]
+        foreach ($prodRepoPath in $productionMatches) {
+            $prodFullPath = Join-Path $Root $prodRepoPath.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+            if (-not (Test-Path $prodFullPath)) { continue }
+            $prodText = Get-Content -Raw -Path $prodFullPath
+            $prodClassName = [System.IO.Path]::GetFileNameWithoutExtension($prodFullPath)
+            $methodMatches = [regex]::Matches($prodText,
+                '(?m)^\s+public\s+(?:(?:async|virtual|override|static|sealed|new|unsafe|extern|partial)\s+)*(?:(?!class\b|interface\b|enum\b|struct\b|record\b)[\w<>?,\.\[\]]+\s+)+(\w+)\s*\(')
+            foreach ($mm in $methodMatches) {
+                $methodName = $mm.Groups[1].Value
+                if ($methodName -eq $prodClassName) { continue }
+                [void]$methodSet.Add($methodName)
+            }
+        }
+        $publicMethodNames = @($methodSet | Sort-Object)
+        if ($publicMethodNames.Count -gt 0 -and $testCount -gt 0) {
+            $testNameMatches = [regex]::Matches($text,
+                '(?m)^\s+public\s+(?:async\s+)?(?:Task<[^>]+>|Task|void|ValueTask|ValueTask<[^>]+>)\s+(\w+)\s*\(')
+            $testedPrefixes = New-Object System.Collections.Generic.HashSet[string]
+            foreach ($tm in $testNameMatches) {
+                $tn = $tm.Groups[1].Value
+                $idx = $tn.IndexOf('_')
+                $prefix = if ($idx -gt 0) { $tn.Substring(0, $idx) } else { $tn }
+                [void]$testedPrefixes.Add($prefix)
+            }
+            $untestedPublicMethods = @($publicMethodNames | Where-Object {
+                $name = $_
+                $stripped = if ($name.EndsWith('Async', [StringComparison]::Ordinal)) {
+                    $name.Substring(0, $name.Length - 5)
+                } else { $null }
+                -not $testedPrefixes.Contains($name) -and -not ($stripped -and $testedPrefixes.Contains($stripped))
+            })
+            $testsPerPublicMethod = [math]::Round($testCount / $publicMethodNames.Count, 2)
+        }
+    }
     $isPolicyRatchet = $category -eq 'Architecture' -and $ratchetCount -gt 0
     $isDiCycleSafetyNet =
         $repoPath -match 'DependencyCycle|DiResolution' -or
@@ -121,7 +165,10 @@ $rows = foreach ($file in $testFiles) {
                 $reasons.Add('mostly-shape-or-boolean-assertions')
             }
 
-            if ($substituteCount -ge 8 -and $substituteCount -gt $assertionCount) {
+            if ($isCoordinatorSut) {
+                $reasons.Add("coordinator-sut-$distinctMockTypes-mocks")
+            }
+            elseif ($substituteCount -ge 8 -and $substituteCount -gt $assertionCount) {
                 $score += 20
                 $reasons.Add('mock-heavy-relative-to-assertions')
             }
@@ -154,7 +201,7 @@ $rows = foreach ($file in $testFiles) {
                 $reasons.Add('large-test-file')
             }
 
-            if ($linesPerTest -ge 35) {
+            if ($linesPerTest -ge 35 -and -not $isCoordinatorSut) {
                 $score += 12
                 $reasons.Add('high-lines-per-test')
             }
@@ -200,6 +247,8 @@ $rows = foreach ($file in $testFiles) {
         Assertions = $assertionCount
         WeakAssertions = $weakAssertionCount
         Substitutes = $substituteCount
+        DistinctMockTypes = $distinctMockTypes
+        IsCoordinatorSut = $isCoordinatorSut
         ReflectionUses = $reflectionCount
         DiUses = $diCount
         IsDiCycleSafetyNet = $isDiCycleSafetyNet
@@ -207,6 +256,9 @@ $rows = foreach ($file in $testFiles) {
         RatchetUses = $ratchetCount
         AssertionsPerTest = if ($testCount -gt 0) { [math]::Round($assertionCount / $testCount, 2) } else { 0 }
         LinesPerTest = if ($testCount -gt 0) { [math]::Round($lineCount / $testCount, 1) } else { 0 }
+        PublicMethodCount = $publicMethodNames.Count
+        UntestedPublicMethods = $untestedPublicMethods
+        TestsPerPublicMethod = $testsPerPublicMethod
         DebtScore = $score
         Recommendation = $recommendation
         Reasons = @($reasons)
@@ -311,6 +363,31 @@ $md.Add('| Score | File | Tests | Assertions/Test | Lines/Test | Reasons |')
 $md.Add('| ---: | --- | ---: | ---: | ---: | --- |')
 foreach ($item in $highConfidence) {
     $md.Add(('| {0} | `{1}` | {2} | {3} | {4} | {5} |' -f $item.DebtScore, $item.Path, $item.Tests, $item.AssertionsPerTest, $item.LinesPerTest, ($item.Reasons -join ', ')))
+}
+
+$gapCandidates = @($rows |
+    Where-Object {
+        $_.PublicMethodCount -ge 3 -and
+        $_.UntestedPublicMethods.Count -ge 1 -and
+        $_.Category -ne 'Architecture' -and
+        -not $_.IsDiCycleSafetyNet
+    } |
+    Sort-Object @{Expression = { $_.UntestedPublicMethods.Count }; Descending = $true }, @{Expression = { $_.TestsPerPublicMethod } } |
+    Select-Object -First $Top)
+
+$md.Add('')
+$md.Add('## Coverage Gap Candidates')
+$md.Add('')
+$md.Add('Test files where the SUT''s public surface has methods with no direct test (test name does not start with `MethodName_`). Attribution is conservative — tests that exercise a method indirectly are not credited. Use this list to find missing tests, not bloated ones.')
+$md.Add('')
+$md.Add('| Untested | Tests/Method | File | Public Methods | Untested Method Names |')
+$md.Add('| ---: | ---: | --- | ---: | --- |')
+foreach ($item in $gapCandidates) {
+    $untestedNames = ($item.UntestedPublicMethods | Select-Object -First 8) -join ', '
+    if ($item.UntestedPublicMethods.Count -gt 8) {
+        $untestedNames += ", ... +$($item.UntestedPublicMethods.Count - 8) more"
+    }
+    $md.Add(('| {0} | {1} | `{2}` | {3} | {4} |' -f $item.UntestedPublicMethods.Count, $item.TestsPerPublicMethod, $item.Path, $item.PublicMethodCount, $untestedNames))
 }
 
 if (-not [string]::IsNullOrWhiteSpace($StrykerReport)) {

--- a/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Application.Constants;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Services;
+using Xunit;
 
 namespace Humans.Application.Tests.Services;
 
@@ -17,46 +18,32 @@ public class GuideHtmlPostprocessorTests
 
     private static readonly GuideHtmlPostprocessor Processor = new();
 
-    [HumansFact]
-    public void Rewrite_SiblingMdLink_BecomesGuideRoute()
+    [HumansTheory]
+    [InlineData("Profiles.md", "href=\"/Guide/Profiles\"")]
+    [InlineData("Glossary.md#coordinator", "href=\"/Guide/Glossary#coordinator\"")]
+    [InlineData("profiles.md", "href=\"/Guide/Profiles\"")]
+    public void Rewrite_KnownSiblingMdLink_MapsToGuideRoute(string href, string expectedHrefSnippet)
     {
-        const string html = """<a href="Profiles.md">Profiles</a>""";
+        var html = $"""<a href="{href}">text</a>""";
 
         var result = Processor.Rewrite(html, Settings, GuideFiles.All);
 
-        result.Should().Contain("""href="/Guide/Profiles" """.Trim());
+        result.Should().Contain(expectedHrefSnippet);
     }
 
-    [HumansFact]
-    public void Rewrite_SiblingMdWithFragment_PreservesFragment()
+    [HumansTheory]
+    [InlineData("NonExistent.md", "https://github.com/nobodies-collective/Humans/blob/main/docs/guide/NonExistent.md")]
+    [InlineData("https://example.com/foo", "https://example.com/foo")]
+    [InlineData("../sections/Teams.md", "https://github.com/nobodies-collective/Humans/blob/main/docs/sections/Teams.md")]
+    public void Rewrite_ExternalHref_GetsNewTabAttrs(string href, string expectedHrefSubstring)
     {
-        const string html = """<a href="Glossary.md#coordinator">Coordinator</a>""";
+        var html = $"""<a href="{href}">x</a>""";
 
         var result = Processor.Rewrite(html, Settings, GuideFiles.All);
 
-        result.Should().Contain("""href="/Guide/Glossary#coordinator" """.Trim());
-    }
-
-    [HumansFact]
-    public void Rewrite_SiblingMdCaseInsensitive_MatchesKnown()
-    {
-        const string html = """<a href="profiles.md">Profiles</a>""";
-
-        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
-
-        result.Should().Contain("/Guide/Profiles");
-    }
-
-    [HumansFact]
-    public void Rewrite_UnknownSiblingMd_LeftAsExternal()
-    {
-        const string html = """<a href="NonExistent.md">Link</a>""";
-
-        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
-
-        // Unknown siblings fall through to external github.com URL.
-        result.Should().Contain("https://github.com/nobodies-collective/Humans/blob/main/docs/guide/NonExistent.md");
+        result.Should().Contain(expectedHrefSubstring);
         result.Should().Contain("target=\"_blank\"");
+        result.Should().Contain("rel=\"noopener\"");
     }
 
     [HumansFact]
@@ -71,17 +58,6 @@ public class GuideHtmlPostprocessorTests
     }
 
     [HumansFact]
-    public void Rewrite_ExternalHttpLink_GetsNewTabAttrs()
-    {
-        const string html = """<a href="https://example.com/foo">x</a>""";
-
-        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
-
-        result.Should().Contain("target=\"_blank\"");
-        result.Should().Contain("rel=\"noopener\"");
-    }
-
-    [HumansFact]
     public void Rewrite_MailtoLink_LeftAsIs()
     {
         const string html = """<a href="mailto:a@b.com">a</a>""";
@@ -93,17 +69,6 @@ public class GuideHtmlPostprocessorTests
     }
 
     [HumansFact]
-    public void Rewrite_ParentRelativePath_BecomesGitHubBlobUrl()
-    {
-        const string html = """<a href="../sections/Teams.md">Section invariants</a>""";
-
-        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
-
-        result.Should().Contain("https://github.com/nobodies-collective/Humans/blob/main/docs/sections/Teams.md");
-        result.Should().Contain("target=\"_blank\"");
-    }
-
-    [HumansFact]
     public void Rewrite_ImageShortPath_BecomesRawGitHubUrl()
     {
         const string html = """<img src="img/screenshot.png" alt="x" />""";
@@ -111,16 +76,6 @@ public class GuideHtmlPostprocessorTests
         var result = Processor.Rewrite(html, Settings, GuideFiles.All);
 
         result.Should().Contain("""src="https://raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png" """.Trim());
-    }
-
-    [HumansFact]
-    public void Rewrite_ImageWithDocsGuidePrefix_AlsoRewritten()
-    {
-        const string html = """<img src="docs/guide/img/screenshot.png" alt="x" />""";
-
-        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
-
-        result.Should().Contain("https://raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png");
     }
 
     [HumansFact]
@@ -141,16 +96,6 @@ public class GuideHtmlPostprocessorTests
         var result = Processor.Rewrite(html, Settings, GuideFiles.All);
 
         result.Should().Contain("""<a href="/Profile/Me" class="guide-app-path"><code>/Profile/Me</code></a>""");
-    }
-
-    [HumansFact]
-    public void Rewrite_InlineCodeAppPathWithSegments_WrappedInAnchor()
-    {
-        const string html = "<code>/Profile/Me/Edit</code>";
-
-        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
-
-        result.Should().Contain("""href="/Profile/Me/Edit" """.Trim());
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
@@ -68,10 +68,16 @@ public class GuideHtmlPostprocessorTests
         result.Should().NotContain("target=\"_blank\"");
     }
 
-    [HumansFact]
-    public void Rewrite_ImageShortPath_BecomesRawGitHubUrl()
+    // Both rows must produce the same raw URL — row 2 exercises the
+    // prefix-stripping branch in RewriteImgSrc (line ~137) where the input
+    // already starts with the guide folder; without stripping, the result
+    // would have a doubled "docs/guide/" segment.
+    [HumansTheory]
+    [InlineData("img/screenshot.png")]
+    [InlineData("docs/guide/img/screenshot.png")]
+    public void Rewrite_ImageShortOrPrefixedPath_BecomesRawGitHubUrl(string src)
     {
-        const string html = """<img src="img/screenshot.png" alt="x" />""";
+        var html = $"""<img src="{src}" alt="x" />""";
 
         var result = Processor.Rewrite(html, Settings, GuideFiles.All);
 
@@ -88,14 +94,14 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("""src="https://cdn.example.com/x.png" """.Trim());
     }
 
-    [HumansFact]
-    public void Rewrite_InlineCodeAppPath_WrappedInAnchor()
+    [HumansTheory]
+    [InlineData("<p>Go to <code>/Profile/Me</code> to view your profile.</p>", "/Profile/Me")]
+    [InlineData("<code>/Profile/Me/Edit</code>", "/Profile/Me/Edit")]
+    public void Rewrite_InlineCodeAppPath_WrappedInAnchor(string html, string path)
     {
-        const string html = "<p>Go to <code>/Profile/Me</code> to view your profile.</p>";
-
         var result = Processor.Rewrite(html, Settings, GuideFiles.All);
 
-        result.Should().Contain("""<a href="/Profile/Me" class="guide-app-path"><code>/Profile/Me</code></a>""");
+        result.Should().Contain($"""<a href="{path}" class="guide-app-path"><code>{path}</code></a>""");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

Three related changes to the `/trim-tests` workflow tooling, plus a sample test trim demonstrating the workflow end-to-end:

### Analyzer (`scripts/analyze-test-utility.ps1`)

- **Bug fix.** Assertion regex missed `DidNotReceiveWithAnyArgs(` / `ReceivedWithAnyArgs(`. These NSubstitute variants are contract assertions for negative gateway checks and were being undercounted. Now matched.
- **Coordinator-SUT de-rank.** When a test file mocks ≥8 distinct interface types, the SUT is a coordinator (many collaborators by design). `mock-heavy-relative-to-assertions` (+20), `mock-heavy` (+10), and `high-lines-per-test` (+12) are structural signals for coordinators, not slop. They are now skipped when the coordinator flag fires. Adds a `coordinator-sut-N-mocks` reason tag for transparency.
- **New section: Coverage Gap Candidates.** Identifies SUT public methods with no direct test. Attribution: test names following `MethodName_Scenario_Outcome` convention; `Async` suffix on production methods is tolerated. Output: count of untested methods + tests-per-method ratio + first 8 untested method names per file.
- **New section: Test Concentration Candidates.** Per-method test count for files where the SUT is locatable. Surfaces files where one method has 5+ attributed tests — often cosmetic-variation tests that could collapse to a `[Theory]` or be culled. First pass found `GoogleGroupSync.ReconcileOneAsync` (17 tests, all distinct branches — not slop) and `GuideHtmlPostprocessor.Rewrite` (15 tests, ~40% method reduction available after trim).

### Sample trim (`tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs`)

End-to-end proof of the workflow on one concentration hotspot. Stryker baseline: 74.67% mutation score / 75 mutants. After 2 deletions + 3 theory consolidations + post-review fix-ups: **7 methods (15 logical cases), 78.67% mutation score**. Demonstrates the skill's full Phase 1-5 flow.

## Score deltas after the coordinator de-rank fix

| File | Before | After | Now flagged |
| --- | ---: | ---: | --- |
| `GoogleWorkspaceSyncServiceTests.cs` | 65 | 18 | no |
| `ExpenseReportServiceHoldedPollingTests.cs` | 65 | 8 | no |
| `AccountControllerOAuthReconcileTests.cs` | 58 | 26 | no |

## Coverage Gap section — top entries from a live run

- `TeamRepositoryTests`: 56 untested of 65 public methods (0.18 tests/method)
- `CachingCampServiceTests`: 55 untested of 57 (0.05 tests/method)
- `ShiftManagementServiceTests`: 38 untested of 49 (0.61 tests/method)
- `BudgetServiceTests`: 25 untested of 38 (0.55 tests/method)
- `OutboxEmailServiceTests`: 18 untested of 25 — most `Send*` methods uncovered

## Test plan

- [x] Re-run analyzer against repo; verify the three prior false positives drop below the 35 high-confidence cutoff
- [x] Spot-check the untested-methods list against `ShiftSignupService.cs` (regression-tested the `Async` suffix tolerance)
- [x] Verify gap section excludes Architecture tests and DI-cycle safety nets
- [x] Run Stryker baseline + post-trim on `GuideHtmlPostprocessor` to validate the trim is safe
- [x] Address PR review feedback (image prefix-strip branch restored via theory row; multi-segment inline-code case restored via theory row; async double-count fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)