### PR TITLE
chore(audit): rephrase CommunicationPreferenceChanged description (set to True/False)

### DIFF
--- a/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
+++ b/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
@@ -159,9 +159,7 @@ public sealed class CommunicationPreferenceService(
             await repository.UpdateAsync(pref, cancellationToken);
         }
 
-        var description = optedOut
-            ? $"{category} opted out via {source}"
-            : $"{category} opted in via {source}";
+        var description = $"{category} set to {!optedOut} via {source}";
 
         await auditLog.LogAsync(
             AuditAction.CommunicationPreferenceChanged,
@@ -216,7 +214,7 @@ public sealed class CommunicationPreferenceService(
             await repository.UpdateAsync(pref, cancellationToken);
         }
 
-        var description = $"{category} set to OptedOut={optedOut}, InboxEnabled={inboxEnabled} via {source}";
+        var description = $"{category} set to {!optedOut}, Inbox set to {inboxEnabled} via {source}";
 
         await auditLog.LogAsync(
             AuditAction.CommunicationPreferenceChanged,


### PR DESCRIPTION
## Summary
- Drop double-negative "OptedOut=True" from audit description; use the project's audit convention "Set to True/False"
- Also normalize the 1-arg overload (was "opted in/out") to the same shape for consistency
- LogInformation lines unchanged (ops debugging, not audit)

Before: \`Marketing set to OptedOut=True, InboxEnabled=True via Profile\`
After:  \`Marketing set to False, Inbox set to True via Profile\`

## Test plan
- [ ] Build clean (verified locally)
- [ ] Existing CommunicationPreference tests pass (verified — 16/16)
- [ ] Visit Profile, toggle a category, confirm new audit text on /Admin/Logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)