### PR TITLE
feat(mailer): add Marketing audience

### DIFF
--- a/docs/sections/Mailer.md
+++ b/docs/sections/Mailer.md
@@ -64,6 +64,7 @@ All routes are `AdminOnly`.
 - **Users**: writes via `IAccountProvisioningService.FindOrCreateUserByEmailAsync`; reads `IUserService.GetByIdAsync` (tombstone follow), `IUserService.GetCountByContactSourceAsync`.
 - **Tickets**: `ITicketQueryService.GetUserIdsWithTicketsAsync` — audience-side ticket-holder enumeration for `TicketNoShiftsAudience` and `HasTicketAudience`. Scoped to the active vendor event by the cached decorator (see `TicketSyncState.VendorEventId`).
 - **Shifts**: `IShiftView.GetUsersAsync` + `IUserService.GetAllUserInfosAsync` — cached per-user shift signups, used by `TicketNoShiftsAudience` and `HasShiftAudience` (encode Pending/Confirmed-on-active-event via `ShiftUserView.HasShift`).
+- **Users**: `IUserService.GetAllUserInfosAsync` — audience-side enumeration of explicit Marketing opt-ins for `MarketingAudience` (`UserInfo.MarketingOptedOut == false`).
 - **AuditLog**: writes via `IAuditLogService.LogAsync` (job overload).
 
 ## Architecture

--- a/src/Humans.Application/Services/Mailer/Audiences/MarketingAudience.cs
+++ b/src/Humans.Application/Services/Mailer/Audiences/MarketingAudience.cs
@@ -1,0 +1,25 @@
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Users;
+
+namespace Humans.Application.Services.Mailer.Audiences;
+
+/// <summary>
+/// "Humans - Marketing" — humans who have explicitly opted in to the Marketing
+/// communication category (<see cref="UserInfo.MarketingOptedOut"/> == false).
+/// Users with no Marketing preference row (default-off) are excluded.
+/// </summary>
+public sealed class MarketingAudience(IUserService users) : IMailerAudience
+{
+    public string Key => "marketing";
+    public string DisplayName => "Marketing opt-ins";
+    public string MailerLiteGroupName => "Humans - Marketing";
+
+    public async Task<IReadOnlySet<Guid>> ComputeMemberUserIdsAsync(CancellationToken ct)
+    {
+        var allUsers = await users.GetAllUserInfosAsync(ct);
+        return allUsers
+            .Where(u => u.MarketingOptedOut == false)
+            .Select(u => u.Id)
+            .ToHashSet();
+    }
+}

--- a/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
@@ -51,6 +51,7 @@ internal static class MailerSectionExtensions
         services.AddScoped<IMailerAudience, TicketNoShiftsAudience>();
         services.AddScoped<IMailerAudience, HasShiftAudience>();
         services.AddScoped<IMailerAudience, HasTicketAudience>();
+        services.AddScoped<IMailerAudience, MarketingAudience>();
         services.AddTransient<MailerAudienceSyncJob>();
 
         return services;

--- a/tests/Humans.Application.Tests/Services/Mailer/Audiences/MarketingAudienceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/Audiences/MarketingAudienceTests.cs
@@ -1,0 +1,75 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Mailer.Audiences;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Mailer.Audiences;
+
+public class MarketingAudienceTests
+{
+    [HumansFact]
+    public async Task ComputeMemberUserIdsAsync_ReturnsOnlyExplicitMarketingOptIns()
+    {
+        var optedIn = Guid.NewGuid();     // OptedOut=false → IN
+        var optedOut = Guid.NewGuid();    // OptedOut=true  → OUT
+        var noPrefRow = Guid.NewGuid();   // no row         → OUT (default off)
+
+        var audience = NewAudience(new[]
+        {
+            UserWithMarketingPref(optedIn, optedOut: false),
+            UserWithMarketingPref(optedOut, optedOut: true),
+            UserWithoutMarketingPref(noPrefRow),
+        });
+
+        var members = await audience.ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEquivalentTo([optedIn]);
+    }
+
+    [HumansFact]
+    public async Task ComputeMemberUserIdsAsync_NoUsers_ReturnsEmpty()
+    {
+        var audience = NewAudience([]);
+
+        var members = await audience.ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void Metadata_UsesHumansPrefix()
+    {
+        var audience = NewAudience([]);
+        audience.Key.Should().Be("marketing");
+        audience.MailerLiteGroupName.Should().Be("Humans - Marketing");
+        audience.MailerLiteGroupName.Should().StartWith("Humans - ");
+    }
+
+    private static MarketingAudience NewAudience(IReadOnlyList<UserInfo> userInfos)
+    {
+        var users = Substitute.For<IUserService>();
+        users.GetAllUserInfosAsync(Arg.Any<CancellationToken>()).Returns(userInfos);
+        return new MarketingAudience(users);
+    }
+
+    private static UserInfo UserWithMarketingPref(Guid userId, bool optedOut) =>
+        UserInfo.Create(
+            new User { Id = userId, DisplayName = "u", PreferredLanguage = "en" },
+            [], [], [], profile: null, [], [], [],
+            [new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = MessageCategory.Marketing,
+                OptedOut = optedOut,
+                UpdatedAt = Instant.FromUnixTimeSeconds(0),
+                UpdateSource = "Test",
+            }]);
+
+    private static UserInfo UserWithoutMarketingPref(Guid userId) =>
+        UserInfoStubHelpers.MakeUserInfo(userId);
+}


### PR DESCRIPTION
## Summary
- New `MarketingAudience` (`IMailerAudience`) → ML group **"Humans - Marketing"**, key `marketing`.
- Members = users with `UserInfo.MarketingOptedOut == false` (explicit opt-in to `MessageCategory.Marketing`). No-preference-row users (default off) are excluded.
- Registered next to the existing audiences in `MailerSectionExtensions`; dashboard + on-demand sync pick it up via the existing `IEnumerable<IMailerAudience>` registration.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `MarketingAudienceTests` (3 cases: explicit opt-in / opt-out / no-row) + `MailerArchitectureTests` (8 pins incl. unique key + "Humans - " prefix) — all green
- [ ] Verify on QA: `/Mailer/Admin` shows the new audience card; `/Mailer/Admin/Audiences/marketing/Debug` previews the right cohort; on-demand sync writes one `MailerLiteAudienceSyncCompleted` audit row

🤖 Generated with [Claude Code](https://claude.com/claude-code)