### PR TITLE
fix(profile): skip tombstones in Stub Profile backfill + EnsureStub guard

### DIFF
--- a/src/Humans.Application/Services/Profiles/ProfileService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileService.cs
@@ -63,6 +63,15 @@ public sealed class ProfileService(IProfileRepository profileRepository,
             var existing = await profileRepository.GetByUserIdAsync(userId, ct);
             if (existing is not null) return;
 
+            var info = await userService.GetUserInfoAsync(userId, ct);
+            if (info is { IsTombstone: true })
+            {
+                logger.LogError(
+                    "EnsureStubProfileAsync called for tombstone user {UserId} (MergedAt={MergedAt}) — refusing to create Stub Profile",
+                    userId, info.MergedAt);
+                return;
+            }
+
             var now = clock.GetCurrentInstant();
             var profile = new Profile
             {

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -193,16 +193,25 @@ public sealed record UserInfo(
     public bool IsDeletionPending => DeletionRequestedAt.HasValue;
 
     /// <summary>
+    /// Sentinel <see cref="DisplayName"/> value written by
+    /// <see cref="Humans.Application.Interfaces.Repositories.IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>
+    /// to mark GDPR-deleted users. Read by <see cref="IsTombstone"/>; the
+    /// shared constant ties write-path and read-path together so a rename
+    /// can't silently break tombstone detection.
+    /// </summary>
+    public const string GdprAnonymizedDisplayName = "Deleted User";
+
+    /// <summary>
     /// True when the user row is a tombstone — either a merge-source
     /// (<see cref="MergedAt"/> set) or a GDPR-anonymized record (DisplayName
-    /// rewritten to <c>"Deleted User"</c> by
+    /// rewritten to <see cref="GdprAnonymizedDisplayName"/> by
     /// <see cref="Humans.Application.Interfaces.Repositories.IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>).
     /// Callers that materialize new per-user rows (Stub Profile, etc.) MUST
     /// short-circuit on this so they don't resurrect the tombstone.
     /// </summary>
     public bool IsTombstone =>
         MergedAt is not null
-        || string.Equals(DisplayName, "Deleted User", StringComparison.Ordinal);
+        || string.Equals(DisplayName, GdprAnonymizedDisplayName, StringComparison.Ordinal);
 
     /// <summary>First verified primary email; null when none loaded.</summary>
     public string? PrimaryEmail => UserEmails

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -192,6 +192,18 @@ public sealed record UserInfo(
     /// <summary>Deletion request pending — mirrors <see cref="User.IsDeletionPending"/>.</summary>
     public bool IsDeletionPending => DeletionRequestedAt.HasValue;
 
+    /// <summary>
+    /// True when the user row is a tombstone — either a merge-source
+    /// (<see cref="MergedAt"/> set) or a GDPR-anonymized record (DisplayName
+    /// rewritten to <c>"Deleted User"</c> by
+    /// <see cref="Humans.Application.Interfaces.Repositories.IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>).
+    /// Callers that materialize new per-user rows (Stub Profile, etc.) MUST
+    /// short-circuit on this so they don't resurrect the tombstone.
+    /// </summary>
+    public bool IsTombstone =>
+        MergedAt is not null
+        || string.Equals(DisplayName, "Deleted User", StringComparison.Ordinal);
+
     /// <summary>First verified primary email; null when none loaded.</summary>
     public string? PrimaryEmail => UserEmails
         .Where(e => e.IsPrimary && e.IsVerified)

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
+using Humans.Application;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -538,7 +539,7 @@ internal sealed class UserRepository(IDbContextFactory<HumansDbContext> factory)
         var originalDisplayName = user.DisplayName;
         var preferredLanguage = user.PreferredLanguage;
 
-        user.DisplayName = "Deleted User";
+        user.DisplayName = UserInfo.GdprAnonymizedDisplayName;
         user.ProfilePictureUrl = null;
         user.PhoneNumber = null;
         user.PhoneNumberConfirmed = false;

--- a/src/Humans.Web/Controllers/ProfileBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileBackfillAdminController.cs
@@ -51,7 +51,7 @@ public sealed class ProfileBackfillAdminController(
     private async Task<IReadOnlyList<MissingProfileRow>> GetUsersMissingProfileAsync(CancellationToken ct)
     {
         IReadOnlyList<MissingProfileRow> rows = (await _userService.GetAllUserInfosAsync(ct).ConfigureAwait(false))
-            .Where(u => u.Profile is null)
+            .Where(u => u.Profile is null && !u.IsTombstone)
             .Select(u => new MissingProfileRow(
                 u.Id,
                 u.Email ?? string.Empty,

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -49,6 +49,7 @@ public sealed class ProfileServiceTests : ServiceTestHarness
             NullLogger<ProfileService>.Instance);
 
         _userService.StubGetUserInfosFromContext(Db);
+        _userService.StubGetUserInfoFromContext(Db);
     }
 
     // --- Profile save flow ---
@@ -609,6 +610,32 @@ public sealed class ProfileServiceTests : ServiceTestHarness
 #pragma warning restore VSTHRD003
 
         await fakeRepo.Received(1).AddAsync(Arg.Any<Profile>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task EnsureStubProfileAsync_MergedTombstone_NoOps()
+    {
+        var userId = Guid.NewGuid();
+        var user = await SeedUserAsync(userId);
+        user.MergedAt = Clock.GetCurrentInstant();
+        await Db.SaveChangesAsync();
+
+        await _service.EnsureStubProfileAsync(userId);
+
+        (await Db.Profiles.AnyAsync(p => p.UserId == userId)).Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task EnsureStubProfileAsync_DeletedTombstone_NoOps()
+    {
+        var userId = Guid.NewGuid();
+        var user = await SeedUserAsync(userId);
+        user.DisplayName = "Deleted User";
+        await Db.SaveChangesAsync();
+
+        await _service.EnsureStubProfileAsync(userId);
+
+        (await Db.Profiles.AnyAsync(p => p.UserId == userId)).Should().BeFalse();
     }
 
     // ==========================================================================


### PR DESCRIPTION
## Summary

- `ProfileBackfillAdminController` listed (and would have backfilled) Stub Profiles for merge-source and GDPR-anonymized tombstone Users, resurrecting a presence the merge/deletion was meant to terminate.
- Adds `UserInfo.IsTombstone` (`MergedAt` set, or `DisplayName == "Deleted User"` — matching the literals `UserRepository` writes in `AnonymizeForMergeAsync` / `ApplyExpiredDeletionAnonymizationAsync`) and filters the backfill query on it. The admin page and Run action share `GetUsersMissingProfileAsync`, so a single filter cleans up both.
- Adds a guard in `ProfileService.EnsureStubProfileAsync` that short-circuits + logs an error if ever invoked for a tombstone. Defense-in-depth tripwire — no live caller hits this branch today; new-account paths stopped producing missing-profile rows on 2026-05-04.

## Why now

The §15i Stub Profile invariant is enforced on all current signup paths, so the underlying problem is fixed forward. What remains is cleanup of the pre-invariant backlog via the admin tool — and that tool needs to refuse to recreate Profile rows for tombstones.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — green.
- [x] `dotnet test Humans.slnx -v quiet` — 3502 passed, 2 skipped, 0 failed across all suites.
- [x] New tests: `EnsureStubProfileAsync_MergedTombstone_NoOps`, `EnsureStubProfileAsync_DeletedTombstone_NoOps`.
- [ ] Preview env: visit `/Profile/Admin/Backfill` and verify any merged/deleted users that previously appeared no longer show; Run remaining backlog and confirm the materialized count matches only non-tombstone rows.