### PR TITLE
fix(auth): route ResolveCampEventManagementAsync through CampOperationRequirement.SubmitEvent

### DIFF
--- a/src/Humans.Web/Authorization/Requirements/CampAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/CampAuthorizationHandler.cs
@@ -7,13 +7,13 @@ namespace Humans.Web.Authorization.Requirements;
 
 /// <summary>
 /// Resource-based authorization handler for camp operations.
-/// Evaluates whether a user can perform management operations on a specific Camp.
 ///
 /// Authorization logic:
-/// - Admin: allow any camp
-/// - CampAdmin: allow any camp
-/// - Camp lead: allow only their assigned camp
-/// - Everyone else: deny
+/// - Admin / CampAdmin: allow any camp (both operations).
+/// - <see cref="CampOperationRequirement.Manage"/>: Camp lead for the resource camp.
+/// - <see cref="CampOperationRequirement.SubmitEvent"/>: Lead OR Workshop role holder
+///   for the resource camp (resolved via <see cref="ICampService.IsUserCampEventManagerAsync"/>).
+/// - Everyone else: deny.
 /// </summary>
 public class CampAuthorizationHandler(ICampService campService) : AuthorizationHandler<CampOperationRequirement>
 {
@@ -30,27 +30,26 @@ public class CampAuthorizationHandler(ICampService campService) : AuthorizationH
         if (campId is null)
             return;
 
-        await HandleCampRequirementAsync(context, requirement, campId.Value);
-    }
-
-    private async Task HandleCampRequirementAsync(
-        AuthorizationHandlerContext context,
-        CampOperationRequirement requirement,
-        Guid campId)
-    {
-        // Admin and CampAdmin can manage any camp
         if (RoleChecks.IsCampAdmin(context.User))
         {
             context.Succeed(requirement);
             return;
         }
 
-        // Check if user is a lead for this specific camp
         var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
         if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
             return;
 
-        if (await campService.IsUserCampLeadAsync(userId, campId))
+        var allowed = requirement.OperationName switch
+        {
+            nameof(CampOperationRequirement.Manage) =>
+                await campService.IsUserCampLeadAsync(userId, campId.Value),
+            nameof(CampOperationRequirement.SubmitEvent) =>
+                await campService.IsUserCampEventManagerAsync(userId, campId.Value),
+            _ => false
+        };
+
+        if (allowed)
         {
             context.Succeed(requirement);
         }

--- a/src/Humans.Web/Authorization/Requirements/CampOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/CampOperationRequirement.cs
@@ -12,6 +12,13 @@ public sealed class CampOperationRequirement : IAuthorizationRequirement
 {
     public static readonly CampOperationRequirement Manage = new(nameof(Manage));
 
+    /// <summary>
+    /// Authorizes camp-event submission (<c>BarrioEventsController</c>): Lead OR
+    /// Workshop role holder, plus CampAdmin / Admin. Resolved through
+    /// <see cref="Humans.Application.Interfaces.Camps.ICampService.IsUserCampEventManagerAsync"/>.
+    /// </summary>
+    public static readonly CampOperationRequirement SubmitEvent = new(nameof(SubmitEvent));
+
     public string OperationName { get; }
 
     private CampOperationRequirement(string operationName)

--- a/src/Humans.Web/Controllers/HumansCampControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansCampControllerBase.cs
@@ -61,8 +61,8 @@ public abstract class HumansCampControllerBase(
 
     /// <summary>
     /// Like <see cref="ResolveCampManagementAsync"/> but authorizes via
-    /// <see cref="ICampService.IsUserCampEventManagerAsync"/> — Lead OR Workshop
-    /// (plus CampAdmin/Admin). Used by <c>BarrioEventsController</c> so Workshop
+    /// <see cref="CampOperationRequirement.SubmitEvent"/> — Lead OR Workshop
+    /// (plus CampAdmin / Admin). Used by <c>BarrioEventsController</c> so Workshop
     /// Leads can submit camp events on behalf of their camp without inheriting
     /// the broader Camp Lead authority surface.
     /// </summary>
@@ -80,13 +80,8 @@ public abstract class HumansCampControllerBase(
             return (currentUserError, null!, camp);
         }
 
-        // CampAdmin / Admin retain blanket authority — same shape as the Manage handler.
-        if (Authorization.RoleChecks.IsCampAdmin(User))
-        {
-            return (null, user, camp);
-        }
-
-        if (await campService.IsUserCampEventManagerAsync(user.Id, camp.Id))
+        var result = await authorizationService.AuthorizeAsync(User, camp, CampOperationRequirement.SubmitEvent);
+        if (result.Succeeded)
         {
             return (null, user, camp);
         }

--- a/tests/Humans.Application.Tests/Authorization/CampAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/CampAuthorizationHandlerTests.cs
@@ -18,12 +18,20 @@ public sealed class CampAuthorizationHandlerTests
     private static readonly Guid LeadCampId = Guid.NewGuid();
     private static readonly Guid OtherCampId = Guid.NewGuid();
     private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly Guid WorkshopUserId = Guid.NewGuid();
 
     public CampAuthorizationHandlerTests()
     {
         _handler = new CampAuthorizationHandler(_campService);
         _campService.IsUserCampLeadAsync(UserId, LeadCampId, Arg.Any<CancellationToken>()).Returns(true);
         _campService.IsUserCampLeadAsync(UserId, OtherCampId, Arg.Any<CancellationToken>()).Returns(false);
+
+        // SubmitEvent flows through IsUserCampEventManagerAsync (Lead OR Workshop).
+        // Lead users also satisfy the event-manager check for the camp they lead.
+        _campService.IsUserCampEventManagerAsync(UserId, LeadCampId, Arg.Any<CancellationToken>()).Returns(true);
+        _campService.IsUserCampEventManagerAsync(UserId, OtherCampId, Arg.Any<CancellationToken>()).Returns(false);
+        _campService.IsUserCampEventManagerAsync(WorkshopUserId, LeadCampId, Arg.Any<CancellationToken>()).Returns(true);
+        _campService.IsUserCampEventManagerAsync(WorkshopUserId, OtherCampId, Arg.Any<CancellationToken>()).Returns(false);
     }
 
     public static TheoryData<string, string, bool> CampAuthorizationCases => new()
@@ -52,18 +60,54 @@ public sealed class CampAuthorizationHandlerTests
         var campLookup = CreateCampLookup(campKind);
         var campId = camp.Id;
 
-        var result = await EvaluateAsync(user, camp);
-        var lookupResult = await EvaluateAsync(user, campLookup);
-        var idResult = await EvaluateAsync(user, campId);
+        var result = await EvaluateAsync(user, camp, CampOperationRequirement.Manage);
+        var lookupResult = await EvaluateAsync(user, campLookup, CampOperationRequirement.Manage);
+        var idResult = await EvaluateAsync(user, campId, CampOperationRequirement.Manage);
 
         result.Should().Be(expected);
         lookupResult.Should().Be(expected);
         idResult.Should().Be(expected);
     }
 
-    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, object resource)
+    public static TheoryData<string, string, bool> SubmitEventCases => new()
     {
-        var requirement = CampOperationRequirement.Manage;
+        { "admin", "other", true },
+        { "camp-admin", "other", true },
+        { "lead", "lead", true },          // Lead role holder
+        { "lead", "other", false },
+        { "workshop", "lead", true },      // Workshop role holder for the camp
+        { "workshop", "other", false },    // Workshop role holder, but not for THIS camp
+        { "regular", "lead", false },      // role holder for a non-Lead/Workshop role
+        { "anonymous", "lead", false },
+        { "invalid-id", "lead", false },
+    };
+
+    [HumansTheory]
+    [MemberData(nameof(SubmitEventCases))]
+    public async Task SubmitEvent_authorization_matches_expected_scenarios(
+        string userKind,
+        string campKind,
+        bool expected)
+    {
+        var regularUserId = Guid.NewGuid();
+        _campService.IsUserCampEventManagerAsync(regularUserId, LeadCampId, Arg.Any<CancellationToken>()).Returns(false);
+
+        var user = CreateUser(userKind, regularUserId);
+        var camp = CreateCamp(campKind);
+        var campLookup = CreateCampLookup(campKind);
+        var campId = camp.Id;
+
+        var result = await EvaluateAsync(user, camp, CampOperationRequirement.SubmitEvent);
+        var lookupResult = await EvaluateAsync(user, campLookup, CampOperationRequirement.SubmitEvent);
+        var idResult = await EvaluateAsync(user, campId, CampOperationRequirement.SubmitEvent);
+
+        result.Should().Be(expected);
+        lookupResult.Should().Be(expected);
+        idResult.Should().Be(expected);
+    }
+
+    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, object resource, CampOperationRequirement requirement)
+    {
         var context = new AuthorizationHandlerContext([requirement], user, resource);
 
         await _handler.HandleAsync(context);
@@ -100,6 +144,7 @@ public sealed class CampAuthorizationHandlerTests
             "admin" => CreateUserWithRoles(RoleNames.Admin),
             "camp-admin" => CreateUserWithRoles(RoleNames.CampAdmin),
             "lead" => CreateUserWithId(UserId),
+            "workshop" => CreateUserWithId(WorkshopUserId),
             "regular" => CreateUserWithId(regularUserId),
             "anonymous" => new ClaimsPrincipal(new ClaimsIdentity()),
             "invalid-id" => new ClaimsPrincipal(new ClaimsIdentity(


### PR DESCRIPTION
## Summary

Codex review on [nobodies-collective/Humans#775](https://github.com/nobodies-collective/Humans/pull/775#discussion_r3269953304) flagged that the new `ResolveCampEventManagementAsync` helper on `HumansCampControllerBase` (introduced with the Workshop-Lead split in peterdrier/Humans#657) used an inline `IsCampAdmin` + service call instead of routing through `IAuthorizationService` + handler. All six `BarrioEventsController` actions go through that gate, so the inline check is a real violation of `docs/architecture/code-review-rules.md` and `docs/architecture/design-rules.md` §11.

This PR refactors to the established pattern without changing the resolved permissions.

- Add `CampOperationRequirement.SubmitEvent`.
- Extend `CampAuthorizationHandler` to branch on `OperationName`: `Manage` uses `IsUserCampLeadAsync`; `SubmitEvent` uses `IsUserCampEventManagerAsync` (Lead OR Workshop). CampAdmin / Admin retain blanket authority for both.
- Replace the inline block in `ResolveCampEventManagementAsync` with `AuthorizeAsync(User, camp, CampOperationRequirement.SubmitEvent)`.
- Extend `CampAuthorizationHandlerTests` with a `SubmitEvent` theory covering admin / camp-admin / lead / workshop / regular / anonymous / invalid-id across lead-camp vs other-camp (9 new cases).

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — green (0 errors)
- [x] `dotnet test ... --filter CampAuthorizationHandlerTests` — 16/16 passed (7 Manage + 9 SubmitEvent)
- [ ] Preview env: verify Workshop Lead can still POST event submissions for their camp (`/Barrios/{slug}/Events/Create`) and gets 403 for a camp they don't hold a role on
- [ ] Preview env: verify CampAdmin retains blanket access on `BarrioEventsController` actions