### PR TITLE
fix(profile): catch legacy .local-email tombstones in IsTombstone

### DIFF
--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -202,16 +202,23 @@ public sealed record UserInfo(
     public const string GdprAnonymizedDisplayName = "Deleted User";
 
     /// <summary>
-    /// True when the user row is a tombstone — either a merge-source
-    /// (<see cref="MergedAt"/> set) or a GDPR-anonymized record (DisplayName
+    /// True when the user row is a tombstone — a merge-source
+    /// (<see cref="MergedAt"/> set), a GDPR-anonymized record (DisplayName
     /// rewritten to <see cref="GdprAnonymizedDisplayName"/> by
-    /// <see cref="Humans.Application.Interfaces.Repositories.IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>).
+    /// <see cref="Humans.Application.Interfaces.Repositories.IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>),
+    /// or a legacy tombstone whose <see cref="Email"/> still ends in the
+    /// sentinel <c>.local</c> suffix (pre-<c>MergedAt</c>-column merges and
+    /// historic purges wrote <c>@merged.local</c> / <c>@deleted.local</c>
+    /// addresses — those rows survive in production with neither
+    /// <see cref="MergedAt"/> nor the <see cref="GdprAnonymizedDisplayName"/>
+    /// marker set).
     /// Callers that materialize new per-user rows (Stub Profile, etc.) MUST
     /// short-circuit on this so they don't resurrect the tombstone.
     /// </summary>
     public bool IsTombstone =>
         MergedAt is not null
-        || string.Equals(DisplayName, GdprAnonymizedDisplayName, StringComparison.Ordinal);
+        || string.Equals(DisplayName, GdprAnonymizedDisplayName, StringComparison.Ordinal)
+        || (Email is { } email && email.EndsWith(".local", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>First verified primary email; null when none loaded.</summary>
     public string? PrimaryEmail => UserEmails

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -638,6 +638,32 @@ public sealed class ProfileServiceTests : ServiceTestHarness
         (await Db.Profiles.AnyAsync(p => p.UserId == userId)).Should().BeFalse();
     }
 
+    [HumansFact]
+    public async Task EnsureStubProfileAsync_LegacyMergedLocalEmail_NoOps()
+    {
+        var userId = Guid.NewGuid();
+        var user = await SeedUserAsync(userId);
+        user.Email = $"legacy-{userId}@merged.local";
+        await Db.SaveChangesAsync();
+
+        await _service.EnsureStubProfileAsync(userId);
+
+        (await Db.Profiles.AnyAsync(p => p.UserId == userId)).Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task EnsureStubProfileAsync_LegacyDeletedLocalEmail_NoOps()
+    {
+        var userId = Guid.NewGuid();
+        var user = await SeedUserAsync(userId);
+        user.Email = $"purged-{userId}@deleted.local";
+        await Db.SaveChangesAsync();
+
+        await _service.EnsureStubProfileAsync(userId);
+
+        (await Db.Profiles.AnyAsync(p => p.UserId == userId)).Should().BeFalse();
+    }
+
     // ==========================================================================
     // Issue #474 — phase 5 service-ownership: every profile state mutation now
     // routes through ProfileService so the §15 caching decorator can keep the


### PR DESCRIPTION
## Summary

Follow-up to #677. Production still has pre-§15i merge/purge tombstones whose `User.MergedAt` is null and whose `DisplayName` isn't `"Deleted User"` — the `AddUserMergedToUserId` column landed on 2026-05-01, so merges before that have no `MergedAt`, and historic purges left a different marker shape. These rows survive with sentinel emails (`@merged.local`, `@deleted.local`, generally `.local`) and were still appearing on `/Profile/Admin/Backfill` after #677.

Extends `UserInfo.IsTombstone` to also short-circuit when `Email` ends in `".local"` (case-insensitive). One predicate change covers the backfill admin filter and the `EnsureStubProfileAsync` defense-in-depth guard, both of which already route through `IsTombstone`.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — green.
- [x] `dotnet test --filter ProfileServiceTests.EnsureStubProfileAsync` — 5/5 (added `_LegacyMergedLocalEmail_NoOps` and `_LegacyDeletedLocalEmail_NoOps`).
- [ ] Preview env: visit `/Profile/Admin/Backfill` and confirm the legacy merged/deleted rows that survived #677 no longer appear.