### PR TITLE
fix(google): stable Hangfire signature for ReconcileOneAsync

### DIFF
--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -56,6 +56,7 @@ Atomic rules. Fetch the body when the description's trigger matches your task. S
 - [`auth-in-views-self-resolving`](code/auth-in-views-self-resolving.md) — reusable views/components inject `IAuthorizationService` and resolve their own gates; don't pre-compute `Can…` bools on view models
 - [`controller-base-conventions`](code/controller-base-conventions.md) — inherit `HumansControllerBase`; use `GetCurrentUserAsync`/`SetSuccess`/`SetError`. No raw `_userManager` or `TempData["..."]`.
 - [`csv-and-pagination-helpers`](code/csv-and-pagination-helpers.md) — use `AppendCsvRow`/`ToCsvField` and `ClampPageSize()` instead of inline equivalents
+- [`hangfire-method-signature-stable`](code/hangfire-method-signature-stable.md) — methods invoked through Hangfire need a frozen serialization signature; pin the call site to a no-defaults overload and never add/reorder/change params on it (PR #663 incident — orphaned in-flight jobs after adding an optional `bool`)
 - [`culture-and-language`](code/culture-and-language.md) — use `CultureCatalog`/`CultureCodeExtensions`; no per-view language dictionaries
 - [`datetime-display-formatting`](code/datetime-display-formatting.md) — use `ToDisplayDate`/`ToDisplayDateTime`/`ToAuditTimestamp`; no inline format strings
 - [`iban-mask-in-logs`](code/iban-mask-in-logs.md) — IBAN output to logs / audit / errors must go through IbanFormatter.Mask

--- a/memory/code/hangfire-method-signature-stable.md
+++ b/memory/code/hangfire-method-signature-stable.md
@@ -1,0 +1,27 @@
+---
+name: hangfire-method-signature-stable
+description: Methods invoked through Hangfire (`backgroundJobs.Enqueue<I>(...)` / `.Schedule<I>(...)`) need a frozen serialization signature — pin the call site to a no-defaults overload, and never add/reorder/change parameter types on that overload
+---
+
+A method bound by `IBackgroundJobClient.Enqueue<TInterface>(expression)` / `.Schedule<TInterface>(expression, ...)` is captured as a specific `MethodInfo` and serialized as `(ParamType1, ParamType2, ...)` in Hangfire storage. At dequeue time Hangfire does **exact** signature matching against the live assembly. Any change to that signature — adding an optional parameter, changing a type, reordering — orphans every job already in the queue.
+
+**Why:** Production incident on PR #663: that PR added an optional `bool scheduleRetries = true` to the end of `IGoogleGroupSync.ReconcileOneAsync`. Compilation and tests passed (optional, end-of-list, default supplied). Deploy succeeded. But every `ReconcileOneAsync` job that was queued before the deploy now failed with `InvalidOperationException: The type ... does not contain a method with signature ReconcileOneAsync(String, SyncAction, CancellationToken, Int32)`, retrying 10 times before dropping. Fix lived in PR (this PR): add a 4-param overload matching the old shape and route the scheduler calls to it explicitly.
+
+**How to apply:**
+
+1. **Add a dedicated overload for the Hangfire boundary** — no default parameters, parameter list locked. This is the contract Hangfire serializes against.
+2. **In the scheduler, pass every parameter explicitly** (no relying on defaults), so the compiler binds to the no-defaults overload and the captured `MethodInfo` is stable:
+   ```csharp
+   // Good — binds to the 4-param overload, signature locked
+   backgroundJobs.Enqueue<IGoogleGroupSync>(
+       sync => sync.ReconcileOneAsync(groupKey, SyncAction.Execute, CancellationToken.None, 0));
+
+   // Bad — binds to whatever overload happens to be applicable today;
+   // adding a default param later silently re-binds it
+   backgroundJobs.Enqueue<IGoogleGroupSync>(
+       sync => sync.ReconcileOneAsync(groupKey, SyncAction.Execute, CancellationToken.None));
+   ```
+3. **Let the in-process method evolve freely** as a separate, fuller overload. Direct callers (services, tests) use it; the Hangfire shim delegates into it. New behavior knobs go on the in-process overload, never on the Hangfire-bound one.
+4. **If you ever do need to change the Hangfire-bound signature** (rename, type change, removal), drain the relevant queue first — pause enqueueing, let the queue empty, then deploy.
+
+**Related:** [`interface-method-additions-are-debt`](../architecture/interface-method-additions-are-debt.md) — the cousin rule for interfaces in general; the Hangfire boundary is stricter because the wire format is in storage, not just in source.

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleGroupSync.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleGroupSync.cs
@@ -57,4 +57,18 @@ public interface IGoogleGroupSync
         CancellationToken ct = default,
         int retryAttempt = 0,
         bool scheduleRetries = true);
+
+    // Hangfire serializes the exact MethodInfo at enqueue time; adding a
+    // parameter (even an optional one) to the method above leaves in-flight
+    // jobs unable to resolve. This 4-param overload preserves the pre-#663
+    // signature so jobs queued before that deploy can still deserialize.
+    // Overload resolution picks this for the unnamed-arg call sites in
+    // HangfireGoogleGroupSyncScheduler, so new jobs are also serialized
+    // against this signature. Do not remove without first draining queued
+    // ReconcileOneAsync jobs.
+    Task<ResourceSyncDiff> ReconcileOneAsync(
+        string groupKey,
+        SyncAction action,
+        CancellationToken ct,
+        int retryAttempt);
 }

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -81,6 +81,13 @@ public sealed class GoogleGroupSyncService(
         return new SyncPreviewResult { Diffs = diffs };
     }
 
+    public Task<ResourceSyncDiff> ReconcileOneAsync(
+        string groupKey,
+        SyncAction action,
+        CancellationToken ct,
+        int retryAttempt)
+        => ReconcileOneAsync(groupKey, action, ct, retryAttempt, scheduleRetries: true);
+
     public async Task<ResourceSyncDiff> ReconcileOneAsync(
         string groupKey,
         SyncAction action,

--- a/src/Humans.Infrastructure/GoogleIntegration/HangfireGoogleGroupSyncScheduler.cs
+++ b/src/Humans.Infrastructure/GoogleIntegration/HangfireGoogleGroupSyncScheduler.cs
@@ -6,10 +6,13 @@ namespace Humans.Infrastructure.GoogleIntegration;
 
 public sealed class HangfireGoogleGroupSyncScheduler(IBackgroundJobClient backgroundJobs) : IGoogleGroupSyncScheduler
 {
+    // Both call sites bind explicitly to the 4-param ReconcileOneAsync overload
+    // so the MethodInfo Hangfire serializes stays stable across changes to the
+    // 5-param overload's signature. See IGoogleGroupSync.ReconcileOneAsync.
     public void Enqueue(string groupKey)
     {
         backgroundJobs.Enqueue<IGoogleGroupSync>(
-            sync => sync.ReconcileOneAsync(groupKey, SyncAction.Execute, CancellationToken.None));
+            sync => sync.ReconcileOneAsync(groupKey, SyncAction.Execute, CancellationToken.None, 0));
     }
 
     public void Schedule(string groupKey, TimeSpan delay, int retryAttempt)


### PR DESCRIPTION
## Summary

- PR peterdrier/Humans#663 added an optional `bool scheduleRetries = true` to `IGoogleGroupSync.ReconcileOneAsync`. Hangfire stores the exact serialized `MethodInfo` signature at enqueue time and does exact-match resolution at dequeue, so every job queued before the #663 deploy now fails with `InvalidOperationException: ... does not contain a method with signature ReconcileOneAsync(String, SyncAction, CancellationToken, Int32)` (e.g. job 144756 in prod, ~10 retries before drop).
- Adds a 4-param overload matching the pre-#663 signature on the interface + impl, and pins both `HangfireGoogleGroupSyncScheduler` call sites to it by passing every parameter explicitly. The 4-param overload becomes the stable Hangfire contract; the 5-param overload stays as the rich in-process surface and can keep evolving.
- Adds `memory/code/hangfire-method-signature-stable.md` codifying the pattern.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test … --filter GoogleGroupSync|GoogleSyncRemoval|HangfireGoogleGroupSync` — 29/29 pass
- [ ] After QA deploy: confirm previously-failing Hangfire job 144756 (and any siblings with the old signature) resolves on next retry instead of hitting the type-not-found exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)