### PR TITLE
fix(mailer): scope import to Website group + reset miswritten marketing opt-ins

### DIFF
--- a/docs/sections/Mailer.md
+++ b/docs/sections/Mailer.md
@@ -5,8 +5,9 @@ Orchestrates Humans ↔ MailerLite synchronisation. Inbound import + outbound au
 ## Concepts
 
 - **MailerLite subscriber** — a row in ML's `subscribers` collection. Has `status ∈ {active, unsubscribed, unconfirmed, bounced, junk}` and `subscribed_at` / `unsubscribed_at` / `opted_in_at` timestamps. Tracks the `groups` the subscriber belongs to.
-- **Import plan** — the classified result of pulling every ML subscriber and matching against Humans's user/email/preference state. Built fresh on every preview/commit; never persisted between runs.
-- **Apply** — executes an import plan: creates contacts, attaches verified users, deletes unverified UserEmail rows that block contact creation, updates Marketing preferences per the conflict rule, writes one summary audit.
+- **Import plan** — the classified result of pulling the MailerLite `Website` group's subscribers and matching against Humans's user/email/preference state, plus a Humans-side pass that flags Marketing opt-ins the prior whole-account import wrongly set (see **Reset**). Built fresh on every preview/commit; never persisted between runs.
+- **Apply** — executes an import plan: creates contacts, attaches verified users, deletes unverified UserEmail rows that block contact creation, updates Marketing preferences per the conflict rule, resets (deletes → null) Marketing flags caught by the reset pass, writes one summary audit.
+- **Reset (marketing flag)** — a Humans-side cleanup decision: a Marketing opt-in written by the erroneous whole-account import (`UpdateSource = "MailerLiteSync"`, opted-in, no prior consent) on someone **not** in the `Website` group is deleted, reverting the category to "no preference" (null) — never to opt-out. GDPR remediation; cutoff for "prior consent" is hardcoded in `MailerImportService.BadImportCutoff`.
 - **Audience** — a code-defined `IMailerAudience` implementation whose `MailerLiteGroupName` starts with `"Humans - "`. Membership is computed from Humans state and synced into the ML group by `MailerAudienceSyncService` (daily Hangfire job + on-demand admin button).
 
 ## Data Model
@@ -36,7 +37,8 @@ All routes are `AdminOnly`.
 - Every outbound write targets an ML group whose `Name` starts with `"Humans - "`. `MailerLiteClient` runtime-rejects writes against non-`"Humans - "` groups with `InvalidOperationException`. Pinned by `MailerLiteClientWriteGuardTests`.
 - All `IMailerAudience` implementations target group names starting with `"Humans - "`. Pinned by `MailerArchitectureTests.AllAudiences_UseHumansPrefix`. Audience keys and group names are unique across registrations (pinned by `AllAudiences_HaveUniqueGroupNamesAndKeys`).
 - `MailerImportService` and `MailerAudienceSyncService` live in `Humans.Application` and never reference `Microsoft.EntityFrameworkCore`. Pinned by architecture tests.
-- Every write to `CommunicationPreference[Marketing]` goes through `CommunicationPreferenceService.UpdatePreferenceAsync` and produces a `CommunicationPreferenceChanged` audit entry on real state changes (not idempotent confirms).
+- The import (`MailerImportService`) ingests **only** the MailerLite group named `Website` (resolved by name; throws if the group is absent) — never the whole account. The reset pass excludes anyone in that group of any status, since the import already owns their pref (active → opt-in, unsubscribed/bounced → opt-out). Pinned by `MailerImportServiceWebsiteScopeTests`.
+- Every write to `CommunicationPreference[Marketing]` goes through `CommunicationPreferenceService` — `UpdatePreferenceAsync` for opt state, `ResetPreferenceAsync` to delete the row (→ null) — and produces a `CommunicationPreferenceChanged` audit entry on real state changes (not idempotent confirms).
 - `ApplyAsync` is idempotent: a second run against unchanged ML+Humans state writes zero per-row entries and exactly one `MailerLiteReconciliationCompleted` summary entry.
 - `SyncAsync` is idempotent: a second run against unchanged audience+ML state writes zero ML mutations and exactly one `MailerLiteAudienceSyncCompleted` summary entry whose counts are all zero.
 - Bounced/junk subscribers always set `OptedOut = true` regardless of any Humans-side timestamp. Delivery facts override preferences.

--- a/src/Humans.Application/Interfaces/Mailer/Dtos/ImportPlan.cs
+++ b/src/Humans.Application/Interfaces/Mailer/Dtos/ImportPlan.cs
@@ -11,6 +11,7 @@ public sealed record ImportPlan(
         VerifiedFlipToOptIn: Decisions.Count(d => d.Outcome == SubscriberOutcome.VerifiedFlipToOptIn),
         VerifiedFlipToOptOut: Decisions.Count(d => d.Outcome == SubscriberOutcome.VerifiedFlipToOptOut),
         VerifiedKeepHumansPref: Decisions.Count(d => d.Outcome == SubscriberOutcome.VerifiedKeepHumansPref),
+        ResetMarketingFlag: Decisions.Count(d => d.Outcome == SubscriberOutcome.ResetMarketingFlag),
         AmbiguousMultipleVerified: Decisions.Count(d => d.Outcome == SubscriberOutcome.AmbiguousMultipleVerified),
         UnconfirmedSkipped: Decisions.Count(d => d.Outcome == SubscriberOutcome.UnconfirmedSkipped));
 }
@@ -22,5 +23,6 @@ public sealed record ImportPlanCounts(
     int VerifiedFlipToOptIn,
     int VerifiedFlipToOptOut,
     int VerifiedKeepHumansPref,
+    int ResetMarketingFlag,
     int AmbiguousMultipleVerified,
     int UnconfirmedSkipped);

--- a/src/Humans.Application/Interfaces/Mailer/Dtos/ImportResult.cs
+++ b/src/Humans.Application/Interfaces/Mailer/Dtos/ImportResult.cs
@@ -8,6 +8,7 @@ public sealed record ImportResult(
     int PrefsFlippedToOptIn,
     int PrefsFlippedToOptOut,
     int PrefsKeptByConflict,
+    int MarketingFlagsReset,
     int UnverifiedEmailsReplaced,
     int AmbiguousSkipped,
     int UnconfirmedSkipped,
@@ -21,6 +22,7 @@ public sealed record ImportResult(
         $"{HumansCreated} humans created, " +
         $"{PrefsFlippedToOptIn} flipped to opt-in, {PrefsFlippedToOptOut} flipped to opt-out, " +
         $"{PrefsKeptByConflict} kept by conflict-rule, " +
+        $"{MarketingFlagsReset} marketing flags reset, " +
         $"{UnverifiedEmailsReplaced} unverified emails replaced, " +
         $"{AmbiguousSkipped} ambiguous skipped, " +
         $"{UnconfirmedSkipped} unconfirmed skipped, " +

--- a/src/Humans.Application/Interfaces/Mailer/Dtos/SubscriberDecision.cs
+++ b/src/Humans.Application/Interfaces/Mailer/Dtos/SubscriberDecision.cs
@@ -27,6 +27,16 @@ public enum SubscriberOutcome
 
     /// <summary>Verified human match, user touched Humans' pref more recently than ML — keep Humans' state.</summary>
     VerifiedKeepHumansPref,
+
+    /// <summary>
+    /// Existing human, opted-in to Marketing by the erroneous whole-account
+    /// MailerLite import (<c>UpdateSource = "MailerLiteSync"</c>), who is not an
+    /// active member of the Website group and has no genuine prior consent —
+    /// delete the Marketing pref row to revert to "no preference recorded"
+    /// (null), not opt-out. GDPR remediation; discovered from the Humans side,
+    /// not from an ML subscriber.
+    /// </summary>
+    ResetMarketingFlag,
 }
 
 public sealed record SubscriberDecision(

--- a/src/Humans.Application/Interfaces/Profiles/ICommunicationPreferenceService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/ICommunicationPreferenceService.cs
@@ -82,6 +82,17 @@ public interface ICommunicationPreferenceService : IApplicationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Deletes the preference row for a user+category, reverting the category to
+    /// the "no preference recorded" (null) state — distinct from an explicit
+    /// opt-out. No-op if no row exists. Logs an audit entry when a row is
+    /// removed. Used by the Mailer import GDPR remediation to undo Marketing
+    /// opt-ins the erroneous whole-account import set.
+    /// </summary>
+    Task ResetPreferenceAsync(
+        Guid userId, MessageCategory category, string source,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Generates a time-limited unsubscribe token encoding userId + category.
     /// Token expires after ~90 days.
     /// </summary>

--- a/src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs
@@ -82,6 +82,15 @@ public interface ICommunicationPreferenceRepository : IRepository
     Task UpdateAsync(CommunicationPreference preference, CancellationToken ct = default);
 
     /// <summary>
+    /// Deletes the single <c>communication_preferences</c> row for a user+category,
+    /// returning the category to its "no row recorded" (null) state — distinct
+    /// from an explicit opt-out. Returns true if a row was deleted, false if none
+    /// existed. Used by the Mailer import GDPR remediation.
+    /// </summary>
+    Task<bool> DeleteByUserAndCategoryAsync(
+        Guid userId, MessageCategory category, CancellationToken ct = default);
+
+    /// <summary>
     /// Bulk-moves <c>communication_preferences</c> rows from
     /// <paramref name="sourceUserId"/> to <paramref name="targetUserId"/> for the
     /// account-merge fold flow. Conflict rule per the fold spec: when source and

--- a/src/Humans.Application/Services/Mailer/MailerImportService.cs
+++ b/src/Humans.Application/Services/Mailer/MailerImportService.cs
@@ -19,11 +19,33 @@ public sealed class MailerImportService(
     IClock clock,
     ILogger<MailerImportService> logger) : IMailerImportService
 {
+    // The erroneous import pulled the whole MailerLite account; it must only ever
+    // ingest the "Website" group. Resolved by name at runtime (group ids aren't
+    // stable across environments). Reads of this group bypass the client's
+    // "Humans - " write-guard — it's a source, never written to.
+    private const string WebsiteGroupName = "Website";
+
+    // UpdateSource the import stamps on Marketing prefs it writes.
+    private const string SyncSource = "MailerLiteSync";
+
+    // Source label recorded on the audit entry when a flag is reset to null.
+    private const string ResetSource = "MailerLiteSyncReset";
+
+    // Marketing opt-ins written by the erroneous whole-account import carry no
+    // genuine prior consent. A Marketing pref whose SubscribedAt predates this
+    // instant was opted-in before the bad import and is preserved (≤5 known
+    // cases). Hardcoded — one-time GDPR remediation cutoff.
+    private static readonly Instant BadImportCutoff = Instant.FromUtc(2026, 5, 19, 0, 1, 1);
+
     public async Task<ImportPlan> BuildPlanAsync(CancellationToken ct = default)
     {
+        var websiteGroupId = await ResolveWebsiteGroupIdAsync(ct);
+
         var decisions = new List<SubscriberDecision>();
         var subs = new List<MailerLiteSubscriber>();
-        await foreach (var s in ml.ListSubscribersAsync(ct)) subs.Add(s);
+        await foreach (var s in ml.ListSubscribersAsync(ct))
+            if (s.GroupIds.Contains(websiteGroupId, StringComparer.Ordinal))
+                subs.Add(s);
 
         foreach (var s in subs)
         {
@@ -66,6 +88,17 @@ public sealed class MailerImportService(
             decisions.Add(new SubscriberDecision(s.Email, s.Status,
                 SubscriberOutcome.CreateNewHuman, null, null, null));
         }
+
+        // GDPR remediation: revert Marketing opt-ins the erroneous whole-account
+        // import set on people who aren't in the Website group at all. Discovered
+        // from the Humans side — these users have no Website subscriber row, so they
+        // never appear in the subscriber loop above.
+        var websiteEmails = WebsiteSubscriberEmails(subs);
+        foreach (var u in await users.GetAllUserInfosAsync(ct))
+            if (IsResetCandidate(u, websiteEmails))
+                decisions.Add(new SubscriberDecision(
+                    u.Email ?? "(no verified email)", "n/a",
+                    SubscriberOutcome.ResetMarketingFlag, u.Id, null, null));
 
         return new ImportPlan(decisions, subs.Count);
     }
@@ -123,16 +156,22 @@ public sealed class MailerImportService(
     {
         var start = clock.GetCurrentInstant();
         int created = 0, flippedIn = 0, flippedOut = 0, preserved = 0,
-            replacedUnverified = 0, vanishedBetweenPlanAndApply = 0, errors = 0;
+            replacedUnverified = 0, vanishedBetweenPlanAndApply = 0, marketingReset = 0, errors = 0;
         var pulledIds = new HashSet<string>(StringComparer.Ordinal);
 
-        // Re-pull ML so plan/apply are stateless.
+        var websiteGroupId = await ResolveWebsiteGroupIdAsync(ct);
+
+        // Re-pull ML so plan/apply are stateless. Website group only.
         var subsByEmail = new Dictionary<string, MailerLiteSubscriber>(StringComparer.OrdinalIgnoreCase);
+        var websiteSubs = new List<MailerLiteSubscriber>();
         await foreach (var s in ml.ListSubscribersAsync(ct))
         {
+            if (!s.GroupIds.Contains(websiteGroupId, StringComparer.Ordinal)) continue;
             subsByEmail[s.Email] = s;
+            websiteSubs.Add(s);
             pulledIds.Add(s.Id);
         }
+        var websiteEmails = WebsiteSubscriberEmails(websiteSubs);
 
         var (toProcess, throttled) = ApplyThrottle(plan.Decisions, maxPerOutcome);
 
@@ -140,6 +179,14 @@ public sealed class MailerImportService(
         {
             try
             {
+                // Reset candidates aren't ML subscribers — handle before the subsByEmail guard.
+                if (d.Outcome == SubscriberOutcome.ResetMarketingFlag)
+                {
+                    if (await TryResetMarketingFlagAsync(d.TargetUserId!.Value, websiteEmails, ct))
+                        marketingReset++;
+                    continue;
+                }
+
                 if (!subsByEmail.TryGetValue(d.Email, out var subscriber))
                 {
                     vanishedBetweenPlanAndApply++;
@@ -205,6 +252,7 @@ public sealed class MailerImportService(
             PrefsFlippedToOptIn: flippedIn,
             PrefsFlippedToOptOut: flippedOut,
             PrefsKeptByConflict: preserved,
+            MarketingFlagsReset: marketingReset,
             UnverifiedEmailsReplaced: replacedUnverified,
             AmbiguousSkipped: plan.Counts.AmbiguousMultipleVerified,
             UnconfirmedSkipped: plan.Counts.UnconfirmedSkipped,
@@ -278,7 +326,56 @@ public sealed class MailerImportService(
         }
 
         await prefs.UpdatePreferenceAsync(userId, MessageCategory.Marketing,
-            optedOut: mlOptedOut, source: "MailerLiteSync", ct);
+            optedOut: mlOptedOut, source: SyncSource, ct);
         return mlOptedOut ? DeltaResult.FlippedToOptOut : DeltaResult.FlippedToOptIn;
+    }
+
+    private async Task<string> ResolveWebsiteGroupIdAsync(CancellationToken ct)
+    {
+        var groups = await ml.ListGroupsAsync(ct);
+        var website = groups.FirstOrDefault(g =>
+            string.Equals(g.Name, WebsiteGroupName, StringComparison.OrdinalIgnoreCase));
+        return website?.Id
+            ?? throw new InvalidOperationException(
+                $"MailerLite group '{WebsiteGroupName}' not found — refusing to import or reset " +
+                "(would otherwise sweep the whole account / reset every opted-in human).");
+    }
+
+    private static HashSet<string> WebsiteSubscriberEmails(IEnumerable<MailerLiteSubscriber> websiteSubs) =>
+        websiteSubs
+            .Select(s => s.Email)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// A user is a reset candidate when their Marketing pref was opted-in by the
+    /// erroneous import (<see cref="SyncSource"/>), they have no genuine prior
+    /// consent (a <c>SubscribedAt</c> predating <see cref="BadImportCutoff"/>),
+    /// and they are not a member of the Website group at all (by any of their
+    /// emails). Website members — active or not — are owned by the import loop
+    /// (active → opt-in, unsubscribed/bounced → opt-out), so opt-ins survive only
+    /// for active members and an explicit unsubscribe stays opt-out rather than
+    /// being nulled here. Non-members are pure collateral: the row is deleted to
+    /// revert to "no preference" (null).
+    /// </summary>
+    private static bool IsResetCandidate(UserInfo user, HashSet<string> websiteEmails)
+    {
+        var marketing = user.CommunicationPreferences
+            .FirstOrDefault(c => c.Category == MessageCategory.Marketing);
+        if (marketing is null || marketing.OptedOut) return false;
+        if (!string.Equals(marketing.UpdateSource, SyncSource, StringComparison.Ordinal)) return false;
+        if (marketing.SubscribedAt is { } subscribedAt && subscribedAt < BadImportCutoff) return false;
+        return !user.UserEmails.Any(e => websiteEmails.Contains(e.Email));
+    }
+
+    // Re-checks the predicate against current cache state so a pref the user set
+    // between preview and commit isn't clobbered, then deletes the row (→ null).
+    private async Task<bool> TryResetMarketingFlagAsync(
+        Guid userId, HashSet<string> websiteEmails, CancellationToken ct)
+    {
+        var info = await users.GetUserInfoAsync(userId, ct);
+        if (info is null || !IsResetCandidate(info, websiteEmails))
+            return false;
+        await prefs.ResetPreferenceAsync(userId, MessageCategory.Marketing, ResetSource, ct);
+        return true;
     }
 }

--- a/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
+++ b/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
@@ -226,6 +226,31 @@ public sealed class CommunicationPreferenceService(
             userId, category, optedOut, inboxEnabled, source);
     }
 
+    public async Task ResetPreferenceAsync(
+        Guid userId, MessageCategory category, string source,
+        CancellationToken cancellationToken = default)
+    {
+        if (category.IsAlwaysOn())
+        {
+            logger.LogWarning("Attempted to reset always-on preference {Category} for user {UserId} — ignored", category, userId);
+            return;
+        }
+
+        var deleted = await repository.DeleteByUserAndCategoryAsync(userId, category, cancellationToken);
+        if (!deleted)
+            return;
+
+        await auditLog.LogAsync(
+            AuditAction.CommunicationPreferenceChanged,
+            "User", userId,
+            $"{category} reset to no preference (null) via {source}",
+            "CommunicationPreferenceService");
+
+        logger.LogInformation(
+            "User {UserId} communication preference {Category} reset to null via {Source}",
+            userId, category, source);
+    }
+
     public string GenerateUnsubscribeToken(Guid userId, MessageCategory category) =>
         tokenProvider.GenerateToken(userId, category);
 

--- a/src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs
@@ -143,6 +143,21 @@ internal sealed class CommunicationPreferenceRepository(IDbContextFactory<Humans
         await ctx.SaveChangesAsync(ct);
     }
 
+    public async Task<bool> DeleteByUserAndCategoryAsync(
+        Guid userId, MessageCategory category, CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        var pref = await ctx.CommunicationPreferences
+            .FirstOrDefaultAsync(cp => cp.UserId == userId && cp.Category == category, ct);
+        if (pref is null) return false;
+
+        // Tracked Remove → EntityState.Deleted, so UserInfoSaveChangesInterceptor
+        // refreshes the user's cached preferences after the row is gone.
+        ctx.CommunicationPreferences.Remove(pref);
+        await ctx.SaveChangesAsync(ct);
+        return true;
+    }
+
     public async Task<int> ReassignToUserAsync(
         Guid sourceUserId, Guid targetUserId, Instant updatedAt,
         CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -254,6 +254,7 @@ public sealed class MailerAdminController(
             || D(a.VerifiedFlipToOptIn, b.VerifiedFlipToOptIn)
             || D(a.VerifiedFlipToOptOut, b.VerifiedFlipToOptOut)
             || D(a.VerifiedKeepHumansPref, b.VerifiedKeepHumansPref)
+            || D(a.ResetMarketingFlag, b.ResetMarketingFlag)
             || D(a.AmbiguousMultipleVerified, b.AmbiguousMultipleVerified)
             || D(a.UnconfirmedSkipped, b.UnconfirmedSkipped);
     }

--- a/src/Humans.Web/Views/Mailer/Admin/Import.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/Import.cshtml
@@ -47,6 +47,10 @@
                     <td>Human exists — keep Humans' pref (user touched recently)</td>
                     <td class="text-end">@Model.Plan.Counts.VerifiedKeepHumansPref.ToString("N0")</td>
                 </tr>
+                <tr>
+                    <td>Human exists — reset marketing flag (opt-in, not in Website group → null)</td>
+                    <td class="text-end">@Model.Plan.Counts.ResetMarketingFlag.ToString("N0")</td>
+                </tr>
                 <tr class="text-muted">
                     <td>Skipped — same email on multiple humans</td>
                     <td class="text-end">@Model.Plan.Counts.AmbiguousMultipleVerified.ToString("N0")</td>
@@ -73,6 +77,7 @@
         (Outcome: SubscriberOutcome.VerifiedFlipToOptIn,       Label: "Human Exists — Flip Marketing to Opt-In"),
         (Outcome: SubscriberOutcome.VerifiedFlipToOptOut,      Label: "Human Exists — Flip Marketing to Opt-Out"),
         (Outcome: SubscriberOutcome.VerifiedKeepHumansPref,    Label: "Human Exists — Keep Humans' Pref"),
+        (Outcome: SubscriberOutcome.ResetMarketingFlag,        Label: "Human Exists — Reset Marketing Flag"),
         (Outcome: SubscriberOutcome.AmbiguousMultipleVerified, Label: "Skipped — Same Email on Multiple Humans"),
         (Outcome: SubscriberOutcome.UnconfirmedSkipped,        Label: "Skipped — Unconfirmed in ML"),
     };

--- a/tests/Humans.Application.Tests/Services/Mailer/ImportResultTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/ImportResultTests.cs
@@ -12,6 +12,7 @@ public class ImportResultTests
         int prefsFlippedToOptIn = 2,
         int prefsFlippedToOptOut = 1,
         int prefsKeptByConflict = 1,
+        int marketingFlagsReset = 0,
         int unverifiedEmailsReplaced = 0,
         int ambiguousSkipped = 0,
         int unconfirmedSkipped = 5,
@@ -25,6 +26,7 @@ public class ImportResultTests
             PrefsFlippedToOptIn: prefsFlippedToOptIn,
             PrefsFlippedToOptOut: prefsFlippedToOptOut,
             PrefsKeptByConflict: prefsKeptByConflict,
+            MarketingFlagsReset: marketingFlagsReset,
             UnverifiedEmailsReplaced: unverifiedEmailsReplaced,
             AmbiguousSkipped: ambiguousSkipped,
             UnconfirmedSkipped: unconfirmedSkipped,
@@ -48,6 +50,7 @@ public class ImportResultTests
             humansCreated: 3,
             prefsFlippedToOptIn: 2,
             prefsFlippedToOptOut: 1,
+            marketingFlagsReset: 6,
             unconfirmedSkipped: 5,
             vanishedBetweenPlanAndApply: 1,
             decisionsThrottled: 4,
@@ -60,6 +63,7 @@ public class ImportResultTests
         summary.Should().Contain("3 humans created");
         summary.Should().Contain("2 flipped to opt-in");
         summary.Should().Contain("1 flipped to opt-out");
+        summary.Should().Contain("6 marketing flags reset");
         summary.Should().Contain("5 unconfirmed skipped");
         summary.Should().Contain("1 vanished");
         summary.Should().Contain("4 throttled");

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceClassifierTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceClassifierTests.cs
@@ -19,18 +19,18 @@ public class MailerImportServiceClassifierTests
     private static MailerLiteSubscriber Active(string email) =>
         new("ml-id", email, "active", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0), null, Instant.FromUtc(2026, 1, 1, 0, 0),
-            null, null, []);
+            null, null, [ClassifierHarness.WebsiteGroupId]);
 
     private static MailerLiteSubscriber Unsubscribed(string email, Instant? unsubscribedAt = null) =>
         new("ml-id", email, "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             unsubscribedAt ?? Instant.FromUtc(2026, 3, 1, 0, 0),
             Instant.FromUtc(2026, 1, 1, 0, 0),
-            null, null, []);
+            null, null, [ClassifierHarness.WebsiteGroupId]);
 
     private static MailerLiteSubscriber Unconfirmed(string email) =>
         new("ml-id", email, "unconfirmed", "form",
-            null, null, null, null, null, []);
+            null, null, null, null, null, [ClassifierHarness.WebsiteGroupId]);
 
     [HumansFact]
     public async Task Classifies_UnconfirmedAsSkipped()
@@ -207,6 +207,8 @@ public class MailerImportServiceClassifierTests
 /// </summary>
 internal sealed class ClassifierHarness
 {
+    public const string WebsiteGroupId = "grp-website";
+
     private readonly IMailerLiteService _ml = Substitute.For<IMailerLiteService>();
     private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
     private readonly IUserService _users = Substitute.For<IUserService>();
@@ -278,6 +280,14 @@ internal sealed class ClassifierHarness
         _prefs
             .GetPreferenceOrNullAsync(Arg.Any<Guid>(), Arg.Any<MessageCategory>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<CommunicationPreferenceSnapshot?>(null));
+
+        // Website group must resolve, and BuildPlanAsync's reset pass enumerates all users.
+        _ml.ListGroupsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailerLiteGroup>>(
+                [new MailerLiteGroup(WebsiteGroupId, "Website", Instant.FromUtc(2020, 1, 1, 0, 0), 0, 0, 0, 0, 0)]));
+        _users
+            .GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>([]));
 
         Service = new MailerImportService(
             _ml,

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceConflictRuleTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceConflictRuleTests.cs
@@ -24,7 +24,7 @@ public class MailerImportServiceConflictRuleTests
 
         var bounced = new MailerLiteSubscriber(
             "ml-id", "user@x.com", "bounced", "api",
-            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, null, null, []);
+            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, null, null, [ApplyHarness.WebsiteGroupId]);
 
         harness.MlReturns(bounced);
         harness.SetVerifiedMatch("user@x.com", userId);
@@ -50,7 +50,7 @@ public class MailerImportServiceConflictRuleTests
             "ml-id", "user@x.com", "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             Instant.FromUtc(2026, 4, 1, 0, 0), // UnsubscribedAt = 2026-04-01 (older than Humans)
-            null, null, null, []);
+            null, null, null, [ApplyHarness.WebsiteGroupId]);
 
         harness.MlReturns(unsubscribed);
         harness.SetVerifiedMatch("user@x.com", userId);
@@ -76,7 +76,7 @@ public class MailerImportServiceConflictRuleTests
             "ml-id", "user@x.com", "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             Instant.FromUtc(2026, 4, 1, 0, 0), // UnsubscribedAt = 2026-04-01
-            null, null, null, []);
+            null, null, null, [ApplyHarness.WebsiteGroupId]);
 
         harness.MlReturns(unsubscribed);
         harness.SetVerifiedMatch("user@x.com", userId);
@@ -106,6 +106,8 @@ public class MailerImportServiceConflictRuleTests
 /// </summary>
 internal sealed class ApplyHarness
 {
+    public const string WebsiteGroupId = "grp-website";
+
     private readonly IMailerLiteService _ml = Substitute.For<IMailerLiteService>();
     private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
     private readonly ICommunicationPreferenceService _prefs = Substitute.For<ICommunicationPreferenceService>();
@@ -121,6 +123,11 @@ internal sealed class ApplyHarness
             Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<Guid?>(), Arg.Any<string?>())
             .Returns(Task.CompletedTask);
+
+        // ApplyAsync resolves + filters by the Website group.
+        _ml.ListGroupsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailerLiteGroup>>(
+                [new MailerLiteGroup(WebsiteGroupId, "Website", Instant.FromUtc(2020, 1, 1, 0, 0), 0, 0, 0, 0, 0)]));
 
         Prefs = new PrefsVerifier(_prefs);
 

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceIdempotencyTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceIdempotencyTests.cs
@@ -56,12 +56,13 @@ public class MailerImportServiceIdempotencyTests
 internal sealed class IdempotencyHarness
 {
     private const string Email = "idempotent@x.com";
+    private const string WebsiteGroupId = "grp-website";
 
     // The ML subscriber is active (OptedOut=false when status="active").
     private static readonly MailerLiteSubscriber ActiveSubscriber =
         new("ml-id", Email, "active", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0), null, Instant.FromUtc(2026, 1, 1, 0, 0),
-            null, null, []);
+            null, null, [WebsiteGroupId]);
 
     private readonly Guid _userId = Guid.NewGuid();
 
@@ -69,6 +70,7 @@ internal sealed class IdempotencyHarness
     private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
     private readonly IAccountProvisioningService _provisioning = Substitute.For<IAccountProvisioningService>();
     private readonly ICommunicationPreferenceService _prefs = Substitute.For<ICommunicationPreferenceService>();
+    private readonly IUserService _users = Substitute.For<IUserService>();
 
     public AuditCounter Audit { get; }
     public MailerImportService Service { get; }
@@ -78,6 +80,14 @@ internal sealed class IdempotencyHarness
         // ML always returns the same single active subscriber.
         _ml.ListSubscribersAsync(Arg.Any<CancellationToken>())
             .Returns(_ => new[] { ActiveSubscriber }.ToAsyncEnumerable());
+
+        // Website group resolves; reset pass finds no candidate users.
+        _ml.ListGroupsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailerLiteGroup>>(
+                [new MailerLiteGroup(WebsiteGroupId, "Website", Instant.FromUtc(2020, 1, 1, 0, 0), 0, 0, 0, 0, 0)]));
+        _users
+            .GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>([]));
 
         // Pass 1: no verified human match → CreateContact path.
         _userEmails
@@ -106,7 +116,7 @@ internal sealed class IdempotencyHarness
         Service = new MailerImportService(
             _ml,
             _userEmails,
-            Substitute.For<IUserService>(),
+            _users,
             _provisioning,
             _prefs,
             Audit.Mock,

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceThrottleTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceThrottleTests.cs
@@ -141,6 +141,8 @@ public class MailerImportServiceThrottleTests
 
 internal sealed class ThrottleHarness
 {
+    public const string WebsiteGroupId = "grp-website";
+
     private readonly IMailerLiteService _ml = Substitute.For<IMailerLiteService>();
     private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
     private readonly IAccountProvisioningService _provisioning = Substitute.For<IAccountProvisioningService>();
@@ -164,6 +166,11 @@ internal sealed class ThrottleHarness
             .GetPreferenceOrNullAsync(Arg.Any<Guid>(), Arg.Any<MessageCategory>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<CommunicationPreferenceSnapshot?>(null));
 
+        // ApplyAsync resolves + filters by the Website group.
+        _ml.ListGroupsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailerLiteGroup>>(
+                [new MailerLiteGroup(WebsiteGroupId, "Website", Instant.FromUtc(2020, 1, 1, 0, 0), 0, 0, 0, 0, 0)]));
+
         Service = new MailerImportService(
             _ml, _userEmails, Substitute.For<IUserService>(),
             _provisioning, _prefs, _audit,
@@ -174,17 +181,17 @@ internal sealed class ThrottleHarness
     public static MailerLiteSubscriber Active(string email) =>
         new("ml-id", email, "active", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0), null,
-            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, []);
+            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, [WebsiteGroupId]);
 
     public static MailerLiteSubscriber Unsubscribed(string email) =>
         new("ml-id", email, "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             Instant.FromUtc(2026, 3, 1, 0, 0),
-            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, []);
+            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, [WebsiteGroupId]);
 
     public static MailerLiteSubscriber Unconfirmed(string email) =>
         new("ml-id", email, "unconfirmed", "form",
-            null, null, null, null, null, []);
+            null, null, null, null, null, [WebsiteGroupId]);
 
     public void SetMlSubscribers(params MailerLiteSubscriber[] subscribers)
     {

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceWebsiteScopeTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceWebsiteScopeTests.cs
@@ -1,0 +1,281 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Mailer.Dtos;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Mailer;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Mailer;
+
+/// <summary>
+/// Covers the GDPR remediation: the import is scoped to the "Website" group, and
+/// Marketing opt-ins the erroneous whole-account import left on people outside
+/// that group are reset to null (row deleted), not opt-out.
+/// </summary>
+public class MailerImportServiceWebsiteScopeTests
+{
+    // After the 2026-05-19T00:01:01Z cutoff hardcoded in MailerImportService.
+    private static readonly Instant AfterCutoff = Instant.FromUtc(2026, 5, 19, 12, 0);
+    // Before the cutoff — represents genuine prior consent.
+    private static readonly Instant BeforeCutoff = Instant.FromUtc(2026, 5, 18, 0, 0);
+
+    [HumansFact]
+    public async Task BuildPlan_ExcludesSubscribersOutsideWebsiteGroup()
+    {
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(
+            WebsiteScopeHarness.Active("in@x.com", inWebsite: true),
+            WebsiteScopeHarness.Active("out@x.com", inWebsite: false));
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.TotalPulled.Should().Be(1);
+        plan.Decisions.Should().ContainSingle(d => d.Email == "in@x.com");
+        plan.Decisions.Should().NotContain(d => d.Email == "out@x.com");
+    }
+
+    [HumansFact]
+    public async Task BuildPlan_AddsResetDecision_ForSyncOptInOutsideWebsite()
+    {
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Active("member@x.com", inWebsite: true));
+
+        var ghostId = Guid.NewGuid();
+        harness.SetUsers(Human(ghostId, "ghost@x.com",
+            optedOut: false, source: "MailerLiteSync", subscribedAt: AfterCutoff));
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Decisions.Should().ContainSingle(d =>
+            d.Outcome == SubscriberOutcome.ResetMarketingFlag && d.TargetUserId == ghostId);
+        plan.Counts.ResetMarketingFlag.Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task BuildPlan_NoReset_ForActiveWebsiteMember()
+    {
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Active("member@x.com", inWebsite: true));
+
+        var id = Guid.NewGuid();
+        harness.SetUsers(Human(id, "member@x.com",
+            optedOut: false, source: "MailerLiteSync", subscribedAt: AfterCutoff));
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Counts.ResetMarketingFlag.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task BuildPlan_NoReset_ForUnsubscribedWebsiteSubscriber()
+    {
+        // In the Website group but unsubscribed in ML. The import loop owns them
+        // (flips to opt-out, honouring the explicit unsubscribe), so the reset pass
+        // must NOT also null them — no double decision, no erasing an unsubscribe.
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Unsubscribed("lapsed@x.com", inWebsite: true));
+
+        var id = Guid.NewGuid();
+        harness.SetUsers(Human(id, "lapsed@x.com",
+            optedOut: false, source: "MailerLiteSync", subscribedAt: AfterCutoff));
+        harness.MatchVerified("lapsed@x.com", id);
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Counts.ResetMarketingFlag.Should().Be(0);
+        plan.Decisions.Should().NotContain(d => d.Outcome == SubscriberOutcome.ResetMarketingFlag);
+        // They're still handled by the import's verified-match path, not dropped.
+        plan.Decisions.Should().Contain(d => d.Email == "lapsed@x.com");
+    }
+
+    [HumansFact]
+    public async Task BuildPlan_NoReset_ForPriorConsent()
+    {
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Active("member@x.com", inWebsite: true));
+
+        var id = Guid.NewGuid();
+        harness.SetUsers(Human(id, "early@x.com",
+            optedOut: false, source: "MailerLiteSync", subscribedAt: BeforeCutoff));
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Counts.ResetMarketingFlag.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task BuildPlan_NoReset_ForUserSetOptIn()
+    {
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Active("member@x.com", inWebsite: true));
+
+        var id = Guid.NewGuid();
+        harness.SetUsers(Human(id, "self@x.com",
+            optedOut: false, source: "Profile", subscribedAt: AfterCutoff));
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Counts.ResetMarketingFlag.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task BuildPlan_NoReset_ForOptOut()
+    {
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Active("member@x.com", inWebsite: true));
+
+        var id = Guid.NewGuid();
+        harness.SetUsers(Human(id, "out@x.com",
+            optedOut: true, source: "MailerLiteSync", subscribedAt: null));
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Counts.ResetMarketingFlag.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task Apply_ResetDecision_DeletesPrefToNull()
+    {
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Active("member@x.com", inWebsite: true));
+
+        var ghostId = Guid.NewGuid();
+        harness.SetUserInfo(ghostId, Human(ghostId, "ghost@x.com",
+            optedOut: false, source: "MailerLiteSync", subscribedAt: AfterCutoff));
+
+        var plan = new ImportPlan(
+            [new SubscriberDecision("ghost@x.com", "n/a", SubscriberOutcome.ResetMarketingFlag, ghostId, null, null)],
+            TotalPulled: 1);
+
+        var result = await harness.Service.ApplyAsync(plan, maxPerOutcome: null);
+
+        result.MarketingFlagsReset.Should().Be(1);
+        await harness.Prefs.Received(1).ResetPreferenceAsync(
+            ghostId, MessageCategory.Marketing, "MailerLiteSyncReset", Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Apply_ResetDecision_SkippedWhenNoLongerCandidate()
+    {
+        // User flipped their own opt-in (source Profile) between preview and commit.
+        var harness = new WebsiteScopeHarness();
+        harness.SetSubscribers(WebsiteScopeHarness.Active("member@x.com", inWebsite: true));
+
+        var id = Guid.NewGuid();
+        harness.SetUserInfo(id, Human(id, "self@x.com",
+            optedOut: false, source: "Profile", subscribedAt: AfterCutoff));
+
+        var plan = new ImportPlan(
+            [new SubscriberDecision("self@x.com", "n/a", SubscriberOutcome.ResetMarketingFlag, id, null, null)],
+            TotalPulled: 1);
+
+        var result = await harness.Service.ApplyAsync(plan, maxPerOutcome: null);
+
+        result.MarketingFlagsReset.Should().Be(0);
+        await harness.Prefs.DidNotReceive().ResetPreferenceAsync(
+            Arg.Any<Guid>(), Arg.Any<MessageCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task BuildPlan_Throws_WhenWebsiteGroupMissing()
+    {
+        var harness = new WebsiteScopeHarness(includeWebsiteGroup: false);
+        harness.SetSubscribers(WebsiteScopeHarness.Active("anyone@x.com", inWebsite: false));
+
+        var act = async () => await harness.Service.BuildPlanAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Website*");
+    }
+
+    private static UserInfo Human(
+        Guid id, string email, bool optedOut, string source, Instant? subscribedAt)
+    {
+        var pref = new CommunicationPreference
+        {
+            Id = Guid.NewGuid(),
+            UserId = id,
+            Category = MessageCategory.Marketing,
+            OptedOut = optedOut,
+            UpdatedAt = Instant.FromUtc(2026, 5, 19, 12, 0),
+            UpdateSource = source,
+            SubscribedAt = subscribedAt,
+        };
+        var ue = new UserEmail { Id = Guid.NewGuid(), UserId = id, Email = email, IsVerified = true, IsPrimary = true };
+        return UserInfo.Create(new User { Id = id }, [ue], [], [], null, [], [], [], [pref]);
+    }
+}
+
+internal sealed class WebsiteScopeHarness
+{
+    public const string WebsiteGroupId = "grp-website";
+    private const string OtherGroupId = "grp-other";
+
+    private readonly IMailerLiteService _ml = Substitute.For<IMailerLiteService>();
+    private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
+    private readonly IUserService _users = Substitute.For<IUserService>();
+
+    public ICommunicationPreferenceService Prefs { get; } = Substitute.For<ICommunicationPreferenceService>();
+    public MailerImportService Service { get; }
+
+    public WebsiteScopeHarness(bool includeWebsiteGroup = true)
+    {
+        var groups = includeWebsiteGroup
+            ? new List<MailerLiteGroup> { new(WebsiteGroupId, "Website", Instant.FromUtc(2020, 1, 1, 0, 0), 0, 0, 0, 0, 0) }
+            : [];
+        _ml.ListGroupsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailerLiteGroup>>(groups));
+
+        // Default: no verified / unverified match → unmatched subscribers become CreateNewHuman.
+        _userEmails.GetDistinctVerifiedUserIdsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>([]));
+        _userEmails.FindAnyEmailRowByAddressAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<(Guid, Guid)?>(null));
+
+        // Default: no reset-candidate users.
+        _users.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>([]));
+
+        Service = new MailerImportService(
+            _ml, _userEmails, _users,
+            Substitute.For<IAccountProvisioningService>(),
+            Prefs,
+            Substitute.For<IAuditLogService>(),
+            new FakeClock(Instant.FromUtc(2026, 5, 20, 0, 0)),
+            NullLogger<MailerImportService>.Instance);
+    }
+
+    public static MailerLiteSubscriber Active(string email, bool inWebsite) =>
+        new("ml-" + email, email, "active", "api",
+            Instant.FromUtc(2026, 1, 1, 0, 0), null, Instant.FromUtc(2026, 1, 1, 0, 0),
+            null, null, [inWebsite ? WebsiteGroupId : OtherGroupId]);
+
+    public static MailerLiteSubscriber Unsubscribed(string email, bool inWebsite) =>
+        new("ml-" + email, email, "unsubscribed", "api",
+            Instant.FromUtc(2026, 1, 1, 0, 0), Instant.FromUtc(2026, 3, 1, 0, 0),
+            Instant.FromUtc(2026, 1, 1, 0, 0),
+            null, null, [inWebsite ? WebsiteGroupId : OtherGroupId]);
+
+    public void SetSubscribers(params MailerLiteSubscriber[] subscribers) =>
+        _ml.ListSubscribersAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => subscribers.ToAsyncEnumerable());
+
+    public void SetUsers(params UserInfo[] users) =>
+        _users.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>(users));
+
+    public void MatchVerified(string email, Guid userId) =>
+        _userEmails.GetDistinctVerifiedUserIdsAsync(email, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>([userId]));
+
+    public void SetUserInfo(Guid id, UserInfo info) =>
+        _users.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(info));
+}

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
@@ -78,7 +78,8 @@ public class MailerAdminControllerTests
     private static ImportResult StubResult() =>
         new(TotalPulled: 10, HumansCreated: 2,
             PrefsFlippedToOptIn: 2, PrefsFlippedToOptOut: 1,
-            PrefsKeptByConflict: 0, UnverifiedEmailsReplaced: 0,
+            PrefsKeptByConflict: 0, MarketingFlagsReset: 0,
+            UnverifiedEmailsReplaced: 0,
             AmbiguousSkipped: 0, UnconfirmedSkipped: 0,
             VanishedBetweenPlanAndApply: 0, DecisionsThrottled: 0,
             Errors: 0, Elapsed: Duration.Zero);
@@ -98,6 +99,7 @@ public class MailerAdminControllerTests
             VerifiedFlipToOptIn: 0,
             VerifiedFlipToOptOut: 0,
             VerifiedKeepHumansPref: 0,
+            ResetMarketingFlag: 0,
             AmbiguousMultipleVerified: 0,
             UnconfirmedSkipped: 0);
 
@@ -303,6 +305,7 @@ public class MailerAdminControllerTests
             VerifiedFlipToOptIn: 5,
             VerifiedFlipToOptOut: 0,
             VerifiedKeepHumansPref: 0,
+            ResetMarketingFlag: 0,
             AmbiguousMultipleVerified: 0,
             UnconfirmedSkipped: 0);
 


### PR DESCRIPTION
## Why

The `/Mailer/Admin/Import` flow pulled the **entire** MailerLite account, ingesting the non-marketing lists created two days ago. This inflated the marketing universe and is a GDPR concern — people who never consented to marketing were marked opted-in.

## What

**1. Import scoped to the `Website` group.** `MailerImportService.BuildPlanAsync`/`ApplyAsync` resolve the ML group named `Website` by name and process only its subscribers. Resolution throws if the group is absent — it never silently falls back to the whole account (which would also mass-reset). The filter lives in the import service only; audience sync still reads all groups.

**2. Reset miswritten opt-ins to null.** New `ICommunicationPreferenceService.ResetPreferenceAsync` **deletes** the `CommunicationPreference` row (→ null, *not* opt-out), backed by repo `DeleteByUserAndCategoryAsync`. The existing `UserInfoSaveChangesInterceptor` refreshes the cache on delete.

A new `ResetMarketingFlag` outcome flags a user when **all** hold:
- Marketing pref `UpdateSource == "MailerLiteSync"` and opted-in
- no genuine prior consent — `SubscribedAt` is null or ≥ `2026-05-19T00:01:01Z` (hardcoded `BadImportCutoff`)
- not in the `Website` group (by any of their emails)

Website members of any status are owned by the import loop (active → opt-in, unsubscribed/bounced → opt-out), so an explicit unsubscribe stays opt-out rather than being nulled. The predicate is re-checked at commit time so a pref the user sets between preview and apply isn't clobbered.

**3. New preview category.** "Human Exists — Reset Marketing Flag" appears in the import preview summary table and as a collapsible detail list (with matched human), plus the result summary and the >10% drift guard.

## Notes
- No EF migration — row deletes only.
- `Website` group name and the cutoff instant are hardcoded consts (one-time remediation).
- Updated `docs/sections/Mailer.md` (the "pulls every subscriber" line was now inaccurate).

## Tests
- New `MailerImportServiceWebsiteScopeTests` (10 cases): group filtering, reset-candidate selection (and every exclusion — active member, in-group any status, prior consent, user-set opt-in, opted-out), apply deletes the pref, apply re-check guard, missing-group throw.
- Existing Mailer harnesses updated for the Website filter; full suite green (3735 passed, 2 pre-existing skips, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)