### PR TITLE
fix(search): remove the 10/50 per-type result caps on global search

### DIFF
--- a/docs/features/global/global-search.md
+++ b/docs/features/global/global-search.md
@@ -41,9 +41,9 @@ The feature is deliberately scoped to **name-only matching**. Earlier drafts pro
 **Acceptance Criteria:**
 - `/Search?q=<query>` returns type-grouped sections: Humans, Teams, Camps, Shifts, and (when `Features:Events` is enabled) Events.
 - Each section is independently ranked by score within itself; no cross-type ranking.
-- Each section is capped at 10 results in the unified view; 50 when a single-type filter chip is active.
+- All matches are returned per section — there is no result cap (the dataset is small enough at ~500-user scale that capping only hid people users were looking for).
 - Each result clearly shows its type via section header + icon, and links to the canonical detail page (for Events, the link is `/Events/Browse?q=<title>` — there is no per-event detail page).
-- Per-type filter chips (All | Humans | Teams | Camps | Shifts | Events) hide the other sections and bump the cap. The Events chip is hidden when `Features:Events` is off.
+- Per-type filter chips (All | Humans | Teams | Camps | Shifts | Events) hide the other sections. The Events chip is hidden when `Features:Events` is off.
 - A query with no matches renders "No results for <query>." (not 500).
 
 ### US-GS.3: Match by the right fields
@@ -88,7 +88,7 @@ If privileged search is added later, the right shape is per-bucket scope (TeamsA
 
 ```
 SearchController
-   └── ISearchService.SearchAsync(query, onlyType, limit)
+   └── ISearchService.SearchAsync(query, onlyType)
          ├── IProfileService.SearchProfilesAsync(query, PersonSearchFields.PublicAll, limit) → IReadOnlyList<HumanSearchResult>
          ├── ITeamService.SearchAsync(query, max)                                             → IReadOnlyList<TeamSearchHit>
          ├── ICampService.SearchAsync(query, max)                                             → IReadOnlyList<CampSearchHit>
@@ -108,7 +108,7 @@ The orchestrator scores each hit by name-match strength:
 
 Display ordering is a presentation concern and lives in `SearchController.BuildViewModel` per `memory/architecture/display-sort-in-controllers.md` — the service returns scored but unsorted buckets. Each non-human bucket sorts by `Score desc, Title asc` at the controller; the humans bucket sorts by `BurnerName asc`, matching `/Profile/Search`.
 
-Counts are post-cap by design — they reflect what the user actually sees in the page. There is no separate `CountMatchingAsync` per section; total-match counts at scale (~500 users) aren't worth the second query.
+Counts reflect every match — there is no cap, so the chip count is the true number of hits the user can scroll to. There is no separate `CountMatchingAsync` per section; the buckets are already the full result set.
 
 ## DTOs
 
@@ -128,7 +128,7 @@ Counts are post-cap by design — they reflect what the user actually sees in th
 - **Humans** are rendered by the canonical `_HumanSearchResults` partial (see `memory/architecture/person-search.md`). The controller projects each `HumanSearchResult` to `HumanSearchResultViewModel` via the existing `ToHumanSearchViewModel` extension, matching `/Profile/Search` and `/Profile/Admin`.
 - **Teams / Camps / Shifts / Events** are rendered by `_GlobalSearchSection` — a small, deliberately-minimal partial. This is not a third person-search surface (the `_HumanSearchResults` rule applies only to person rendering); it's a generic list-row template for the simpler types.
 
-A type-filter chip row at the top (All | Humans | Teams | Camps | Shifts | Events) preserves the query and toggles the active filter. Counts on each chip reflect the post-cap result count.
+A type-filter chip row at the top (All | Humans | Teams | Camps | Shifts | Events) preserves the query and toggles the active filter. Counts on each chip reflect the full match count.
 
 ## Out of Scope
 

--- a/src/Humans.Application/Interfaces/Search/ISearchService.cs
+++ b/src/Humans.Application/Interfaces/Search/ISearchService.cs
@@ -35,15 +35,12 @@ public interface ISearchService : IApplicationService
     /// </summary>
     /// <param name="query">User-entered text. Trimmed and matched
     /// case-insensitively per <c>memory/feedback_ef_ilike_not_toupper.md</c>.</param>
-    /// <param name="onlyType">When set, skip the other three section
-    /// queries entirely and return all matches for the chosen type up to
-    /// <paramref name="perTypeLimit"/>. Used by the per-type filter chips
-    /// on /Search.</param>
-    /// <param name="perTypeLimit">Maximum hits per type bucket.</param>
+    /// <param name="onlyType">When set, skip the other section queries
+    /// entirely and return all matches for the chosen type. Used by the
+    /// per-type filter chips on /Search.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<GlobalSearchResults> SearchAsync(
         string query,
         SearchResultType? onlyType = null,
-        int perTypeLimit = 10,
         CancellationToken ct = default);
 }

--- a/src/Humans.Application/Services/Search/SearchService.cs
+++ b/src/Humans.Application/Services/Search/SearchService.cs
@@ -29,10 +29,14 @@ public sealed class SearchService(
 
     private readonly bool _eventsFeatureEnabled = configuration.GetValue<bool>("Features:Events");
 
+    // No per-type cap: at ~500-user scale a name match returns a handful of rows,
+    // and capping made people miss matches (issue: too-hard-to-find-people). Each
+    // section's SearchAsync still takes a max, so pass an effectively-unbounded one.
+    private const int Unlimited = int.MaxValue;
+
     public async Task<GlobalSearchResults> SearchAsync(
         string query,
         SearchResultType? onlyType = null,
-        int perTypeLimit = 10,
         CancellationToken ct = default)
     {
         var trimmed = query.Trim();
@@ -48,19 +52,19 @@ public sealed class SearchService(
         }
 
         var humans = onlyType is null or SearchResultType.Human
-            ? await SearchHumansAsync(trimmed, perTypeLimit, ct)
+            ? await SearchHumansAsync(trimmed, Unlimited, ct)
             : Array.Empty<HumanSearchResult>();
         var teams = onlyType is null or SearchResultType.Team
-            ? await SearchTeamsAsync(trimmed, perTypeLimit, ct)
+            ? await SearchTeamsAsync(trimmed, Unlimited, ct)
             : Array.Empty<GlobalSearchResult>();
         var camps = onlyType is null or SearchResultType.Camp
-            ? await SearchCampsAsync(trimmed, perTypeLimit, ct)
+            ? await SearchCampsAsync(trimmed, Unlimited, ct)
             : Array.Empty<GlobalSearchResult>();
         var shifts = onlyType is null or SearchResultType.Shift
-            ? await SearchShiftsAsync(trimmed, perTypeLimit, ct)
+            ? await SearchShiftsAsync(trimmed, Unlimited, ct)
             : Array.Empty<GlobalSearchResult>();
         var events = _eventsFeatureEnabled && onlyType is null or SearchResultType.Event
-            ? await SearchEventsAsync(trimmed, perTypeLimit, ct)
+            ? await SearchEventsAsync(trimmed, Unlimited, ct)
             : Array.Empty<GlobalSearchResult>();
 
         return new GlobalSearchResults(trimmed, humans, teams, camps, shifts, events);

--- a/src/Humans.Web/Controllers/SearchController.cs
+++ b/src/Humans.Web/Controllers/SearchController.cs
@@ -36,8 +36,7 @@ public sealed class SearchController(
     {
         try
         {
-            var results = await searchService.SearchAsync(
-                trimmed, filter, PerTypeLimit(filter), ct);
+            var results = await searchService.SearchAsync(trimmed, filter, ct);
             return BuildViewModel(results, filter);
         }
         catch (OperationCanceledException)
@@ -52,10 +51,6 @@ public sealed class SearchController(
             return new GlobalSearchViewModel { Query = trimmed, Filter = filter };
         }
     }
-
-    // Filter-chip view goes deeper (50); unified view stays at 10 per bucket.
-    private static int PerTypeLimit(SearchResultType? filter) =>
-        filter.HasValue ? 50 : 10;
 
     private static GlobalSearchViewModel BuildViewModel(
         GlobalSearchResults results, SearchResultType? filter) =>


### PR DESCRIPTION
## What

`/Search` capped each type bucket at **10 results** in the unified view and **50** under a single-type filter chip. Searching a common name (e.g. `?q=ben`) silently hid most matches — confusing and made people genuinely hard to find. Nobody asked for the cap.

This removes it. Every match per section is now returned and rendered.

## Why it's safe at this scale

~500 users, in-memory cache, name-only matching → a query returns a handful of rows. Unbounded buckets are cheaper and simpler than the cap was (per `CLAUDE.md` scale guidance).

## Changes

- `ISearchService.SearchAsync` — dropped the `perTypeLimit` parameter (only `SearchController` called it; no test asserted on it).
- `SearchService` — passes an `Unlimited` (`int.MaxValue`) constant to each section's still-capped `SearchAsync`; section interfaces/impls untouched.
- `SearchController` — deleted the `PerTypeLimit` helper.
- `docs/features/global/global-search.md` — updated the cap statements and the orchestrator signature.

## Side effect (improvement)

Human search iterated the cache and `break`'d at the limit *before* the controller sorted, so the unified view was showing "first 10 found, then alphabetized" — not the 10 best. With no cap it returns and sorts **all** matches.

## Verification

- `dotnet build Humans.slnx` — succeeds.
- `dotnet test Humans.slnx` — 3,744 pass, 2 pre-existing skips, 0 fail.
- Chip counts (`Humans (N)`) were already `bucket.Count`, so they now show the true match count instead of a capped one. No "see more" UI was tied to the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)