### PR TITLE
feat(admin-nav): Design group with Color palette + Components links

### DIFF
--- a/src/Humans.Web/Controllers/ColorPaletteController.cs
+++ b/src/Humans.Web/Controllers/ColorPaletteController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Humans.Web.Controllers;
 
-/// <summary>Anonymous design reference page (palette, controls, typography). No nav link.</summary>
+/// <summary>Anonymous design reference page (palette, controls, typography). Linked from the admin sidebar "Design" group.</summary>
 [AllowAnonymous]
 [Route("ColorPalette")]
 public class ColorPaletteController : Controller

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -14,7 +14,7 @@ namespace Humans.Web.Controllers;
 /// Admin-only catalog of every reusable UI widget — TagHelpers, ViewComponents, and
 /// shared partials — rendered against real data so designers and developers can see
 /// what exists, what it's called, and how it looks filled in. Companion to
-/// <c>/ColorPalette</c>. Admin dev tool — no nav link, access via URL directly.
+/// <c>/ColorPalette</c>. Admin dev tool — linked from the admin sidebar "Design" group.
 /// </summary>
 [Authorize(Policy = PolicyNames.AdminOnly)]
 [Route("WidgetGallery")]

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -89,6 +89,10 @@ public static class AdminNavTree
                  EnvironmentGate: env => !env.IsProduction()),
             new("Seed camp roles", "DevSeed", "SeedCampRoles", null, null, "fa-solid fa-user-tag",  PolicyNames.AdminOnly,
                  EnvironmentGate: env => !env.IsProduction())
+        ]),
+        new("Design", [
+            new("Color palette", "ColorPalette",  "Index", null, null, "fa-solid fa-palette", PolicyNames.AdminOnly),
+            new("Components",    "WidgetGallery", "Index", null, null, "fa-solid fa-shapes",  PolicyNames.AdminOnly)
         ])
     ];
 }


### PR DESCRIPTION
## What

Adds a **Design** group at the bottom of the admin left sidebar with two links:

- **Color palette** → `/ColorPalette`
- **Components** → `/WidgetGallery` (the reusable UI widget catalog, companion to the color palette)

Both pages already existed but were URL-only (their docstrings said "no nav link"). Now they're reachable from the admin nav. Both items are gated `AdminOnly`.

## Changes

- `AdminNavTree.cs` — new `Design` group after `Dev`, two `AdminOnly` items.
- `ColorPaletteController` / `WidgetGalleryController` — updated stale "no nav link" docstrings.

## Verification

- `dotnet build src/Humans.Web` — succeeded.
- `AdminSidebarViewComponentTests` — 5/5 pass (group list isn't hard-coded, so the new bottom group is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)