### PR TITLE
fix(roles): restore filter button group + strip Admin suffix on labels

### DIFF
--- a/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
+++ b/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
@@ -7,7 +7,7 @@
 
 <div class="card mb-4">
     <div class="card-body d-flex justify-content-between align-items-center">
-        <div class="d-flex flex-wrap gap-2">
+        <div class="btn-group" role="group">
             <a asp-action="Roles" asp-route-showInactive="@Model.ShowInactive"
                class="btn @(string.IsNullOrEmpty(Model.RoleFilter) ? "btn-primary" : "btn-outline-primary")">
                 @Localizer["AdminRoles_All"]
@@ -16,7 +16,7 @@
             {
                 <a asp-action="Roles" asp-route-role="@role" asp-route-showInactive="@Model.ShowInactive"
                    class="btn @(Model.RoleFilter == role ? "btn-primary" : "btn-outline-primary")">
-                    @role
+                    @(role != Humans.Domain.Constants.RoleNames.Admin && role.EndsWith("Admin", StringComparison.Ordinal) ? role[..^5] : role)
                 </a>
             }
         </div>

--- a/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
+++ b/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
@@ -1,3 +1,4 @@
+@using Humans.Domain.Constants
 @model Humans.Web.Models.AdminRoleAssignmentListViewModel
 
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -12,11 +13,14 @@
                class="btn @(string.IsNullOrEmpty(Model.RoleFilter) ? "btn-primary" : "btn-outline-primary")">
                 @Localizer["AdminRoles_All"]
             </a>
-            @foreach (var role in Humans.Domain.Constants.RoleNames.All)
+            @foreach (var role in RoleNames.All)
             {
+                var label = role != RoleNames.Admin && role.EndsWith(RoleNames.Admin, StringComparison.Ordinal)
+                    ? role[..^RoleNames.Admin.Length]
+                    : role;
                 <a asp-action="Roles" asp-route-role="@role" asp-route-showInactive="@Model.ShowInactive"
                    class="btn @(Model.RoleFilter == role ? "btn-primary" : "btn-outline-primary")">
-                    @(role != Humans.Domain.Constants.RoleNames.Admin && role.EndsWith("Admin", StringComparison.Ordinal) ? role[..^5] : role)
+                    @label
                 </a>
             }
         </div>


### PR DESCRIPTION
## What

The role-filter bar on **/Profile/Admin/Roles**:

1. **Restored the Bootstrap `btn-group`** grouping. PR #701 swapped it for separate buttons (`d-flex flex-wrap gap-2`) as a side effect of making the bar dynamic — that wasn't intended.
2. **Stripped the `Admin` suffix from the `*Admin` role *labels*** so the bar is shorter (`EventsAdmin` → Events, `TeamsAdmin` → Teams, `CampAdmin` → Camp, etc.). The bare **Admin** role keeps its name. The two `*Coordinator` roles are left as-is (not `*Admin`).

The `asp-route-role` filter value still uses the full role name (`EventsAdmin`), so filtering behavior is unchanged — only the displayed pill text is shorter.

## Test plan

- [x] `dotnet build src/Humans.Web` — 0 errors
- [ ] Visual check at `/Profile/Admin/Roles`: pills grouped, short labels, filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)