### PR TITLE
Camp detail Roles/Roster cards + decouple from legacy camp_leads

### DIFF
--- a/docs/superpowers/plans/2026-05-20-camp-roster-roles.md
+++ b/docs/superpowers/plans/2026-05-20-camp-roster-roles.md
@@ -1,0 +1,886 @@
+# Camp detail Roles + Roster cards & legacy CampLead read-decouple — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Source the `/Barrios/{slug}` detail page's leads from the role system, add read-only Roles + Roster cards, and decouple every live code path from the legacy `camp_leads` table (physical drop deferred to `nobodies-collective/Humans#774`).
+
+**Architecture:** The new source of truth is `CampRoleAssignment` (special role `CampSpecialRole.Lead`), already used by `/Edit/Members` and by authorization. This plan repoints the detail page, camp creation, and the remaining readers/writers/fallbacks onto it. The legacy `CampLead` entity/table stay mapped but orphaned after this PR.
+
+**Tech Stack:** ASP.NET Core MVC (Razor), EF Core (Npgsql), NodaTime, xUnit + NSubstitute + AwesomeAssertions, `ServiceTestHarness` (in-memory `HumansDbContext`).
+
+**Spec:** `docs/superpowers/specs/2026-05-20-camp-detail-roles-roster-and-lead-decouple-design.md`
+
+**Branch / worktree:** `feat/camp-roster-roles` at `H:\source\Humans\.worktrees\camp-roster-roles` (already created off `origin/main`).
+
+**Build/test commands (run from worktree root):**
+- `dotnet build Humans.slnx -v quiet`
+- `dotnet test Humans.slnx -v quiet`
+- Single test class: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CampServiceTests"`
+
+**Conventions that bind this work:**
+- No EF migration in this PR (no schema change). Do **not** delete `CampLead`/`CampLeadRole`/`CampLeadConfiguration`/`Camp.Leads` nav/`CampLeads` DbSet — those generate a drop and belong to #774.
+- Never block sign-in or camp registration; degrade gracefully (`no-startup-guards`).
+- Resource-based auth only; services stay auth-free.
+
+---
+
+## File Structure
+
+**Phase 1 — detail page cards**
+- Modify: `src/Humans.Web/Models/Camp/CampRoleRowViewModel.cs` — add `IsLeadRole`.
+- Modify: `src/Humans.Web/Controllers/CampController.cs` — `BuildRolesPanelAsync` maps `IsLeadRole`; `Details`/`SeasonDetails` build the read-only panel + roster; `MapCampDetailViewModel` drops `Leads`, gains panel/roster/`CanSeeFullCamp`.
+- Modify: `src/Humans.Web/Models/CampViewModels.cs` — `CampDetailViewModel`: remove `Leads`, add `RolesPanel`, `Roster`, `CanSeeFullCamp`.
+- Create: `src/Humans.Web/Views/Camp/_CampRolesCard.cshtml` — read-only roles card.
+- Create: `src/Humans.Web/Views/Camp/_CampRosterCard.cshtml` — member grid.
+- Modify: `src/Humans.Web/Views/Camp/Details.cshtml` — replace Leads card with `_CampRolesCard`; add `_CampRosterCard` above About.
+
+**Phase 2 — fix the source (camp creation)**
+- Modify: `src/Humans.Application/Interfaces/Repositories/ICampRepository.cs` — `CreateCampAsync` signature.
+- Modify: `src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs` — `CreateCampAsync` impl.
+- Modify: `src/Humans.Infrastructure/Services/Camps/CachingCampService.cs` — decorator passthrough if present.
+- Modify: `src/Humans.Application/Services/Camps/CampService.cs` — `CreateCampAsync` builds member + Camp Lead assignment.
+- Modify: `tests/Humans.Application.Tests/Services/CampServiceTests.cs` — update creation test.
+
+**Phase 3 — repoint remaining legacy readers**
+- `CampController.Contact`; `CampService.GetCampDirectoryAsync`; `CampService.GetCampLeadSeasonIdForYearAsync`; `CampAdminPageBuilder` + `CampAdmin/Index.cshtml`; `CampCsvExportBuilder`; `CityPlanningController` + `CityPlanningApiController`; `CampService.ContributeForUserAsync` (GDPR); `CampService.GetCampEditDataAsync` / `Edit.cshtml`. Repo: add bulk lead-userids-by-season-for-year query + repoint `GetCampsByLeadUserIdAsync`/`GetCampLeadSeasonIdForYearAsync`.
+
+**Phase 4 — strip fallbacks + remove dead writes/methods**
+- `CampService.IsUserCampLeadAsync` / `IsUserCampEventManagerAsync` / `GetPendingMembershipCountForLeadAsync` (fallbacks); `CampService.ReassignAsync` (drop legacy call); `DevPersonaSeeder`; delete dead `AddLeadAsync`/`RemoveLeadAsync` + repo lead methods + `CampLeadInfo`/`CampLeadSummary`/`CampLeadViewModel`.
+
+---
+
+## Phase 1 — Detail page Roles + Roster cards
+
+### Task 1: Add `IsLeadRole` to the role row view model
+
+**Files:**
+- Modify: `src/Humans.Web/Models/Camp/CampRoleRowViewModel.cs`
+
+- [ ] **Step 1: Add the property**
+
+```csharp
+namespace Humans.Web.Models.Camp;
+
+public sealed class CampRoleRowViewModel
+{
+    public required Guid DefinitionId { get; init; }
+    public required string Name { get; init; }
+    public required string? Description { get; init; }
+    public required int SlotCount { get; init; }
+    public required int MinimumRequired { get; init; }
+    public required IReadOnlyList<CampRoleSlotViewModel> FilledSlots { get; init; }
+    public required int EmptySlotCount { get; init; }
+    public required bool OverCapacity { get; init; }
+    public required int CurrentCount { get; init; }
+    /// <summary>True when the backing definition's SpecialRole is Lead — the only row shown to non-member viewers on the public detail page.</summary>
+    public required bool IsLeadRole { get; init; }
+}
+```
+
+- [ ] **Step 2: Populate it in the controller mapper**
+
+In `src/Humans.Web/Controllers/CampController.cs`, `BuildRolesPanelAsync`, the `panelData.Rows.Select(r => new CampRoleRowViewModel { ... })` block — add:
+
+```csharp
+            IsLeadRole = r.Definition.SpecialRole == CampSpecialRole.Lead,
+```
+
+(Add `using Humans.Domain.Enums;` if not already imported — it is.)
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: success (the only consumer so far is `BuildRolesPanelAsync`; `Members.cshtml` ignores the new field).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Models/Camp/CampRoleRowViewModel.cs src/Humans.Web/Controllers/CampController.cs
+git commit -m "feat(camps): flag Camp Lead row in roles panel view model"
+```
+
+---
+
+### Task 2: Extend `CampDetailViewModel` for the two cards
+
+**Files:**
+- Modify: `src/Humans.Web/Models/CampViewModels.cs`
+
+- [ ] **Step 1: Replace the `Leads` property with panel/roster fields**
+
+In `CampDetailViewModel`, delete `public List<CampLeadViewModel> Leads { get; set; } = [];` and add:
+
+```csharp
+    /// <summary>Read-only roles panel for the displayed season (null when anonymous or no season). Sourced from CampRoleAssignment.</summary>
+    public Camp.CampRolesPanelViewModel? RolesPanel { get; set; }
+    /// <summary>Active members of the displayed season. Populated only when CanSeeFullCamp is true.</summary>
+    public List<CampMemberRowViewModel> Roster { get; set; } = [];
+    /// <summary>True when the viewer may see all roles + the roster: CampAdmin (any camp) or an Active member of this camp.</summary>
+    public bool CanSeeFullCamp { get; set; }
+```
+
+(`CampLeadViewModel` stays defined — still used by `CampEditViewModel`/`CampSummaryRowViewModel` until Phase 3/4.)
+
+- [ ] **Step 2: Build — expect failures in `CampController` and `Details.cshtml`**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: FAIL — `CampController.MapCampDetailViewModel` still sets `Leads`; `Details.cshtml` still reads `Model.Leads`. These are fixed in Tasks 3–6. (Compile errors are the failing "test" for this structural task.)
+
+- [ ] **Step 3: Commit after Task 6 (this VM change ships with its consumers).**
+
+---
+
+### Task 3: Build the read-only panel + roster in `Details`/`SeasonDetails`
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/CampController.cs`
+
+- [ ] **Step 1: Update `MapCampDetailViewModel` to stop setting `Leads`**
+
+Remove the `Leads = campDetail.Leads.Select(...)` initializer block from `MapCampDetailViewModel`. Leave the rest. The method now produces a VM with `RolesPanel`/`Roster`/`CanSeeFullCamp` left at defaults; the action fills them.
+
+- [ ] **Step 2: Add a helper to assemble cards data, call it from both actions**
+
+Add a private helper to `CampController`:
+
+```csharp
+    private async Task PopulateDetailCardsAsync(
+        CampDetailViewModel vm, CampDetailData campDetail, bool isCampAdmin,
+        CancellationToken ct)
+    {
+        if (User.Identity?.IsAuthenticated != true || campDetail.CurrentSeason is null)
+        {
+            return; // anonymous / no season → no cards
+        }
+
+        vm.CanSeeFullCamp = isCampAdmin || vm.Membership.Status == CampMemberStatusSummaryView.Active;
+
+        // Read-only roles panel (same source as /Edit/Members).
+        vm.RolesPanel = await BuildRolesPanelAsync(
+            campDetail.Slug, campDetail.CurrentSeason.Id, canManage: false, ct);
+
+        if (vm.CanSeeFullCamp)
+        {
+            var members = await _campService.GetCampMembersAsync(campDetail.CurrentSeason.Id);
+            vm.Roster = members.Active
+                .Select(m => new CampMemberRowViewModel
+                {
+                    CampMemberId = m.CampMemberId,
+                    UserId = m.UserId,
+                    RequestedAt = m.RequestedAt,
+                    ConfirmedAt = m.ConfirmedAt,
+                    HasEarlyEntry = m.HasEarlyEntry,
+                    Status = m.Status,
+                })
+                .ToList();
+        }
+    }
+```
+
+Note: `GetCampMembersAsync` returns `CampMemberListData` whose `.Active` items are `CampMemberRow(CampMemberId, UserId, DisplayName, RequestedAt, ConfirmedAt, HasEarlyEntry, Status)`. Confirm property names against `CampMemberRow` and adjust the mapping if they differ.
+
+- [ ] **Step 3: Call the helper in `Details`**
+
+In `Details`, after `var membership = ...` and before `return View(...)`:
+
+```csharp
+        var vm = MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership);
+        await PopulateDetailCardsAsync(vm, campDetail, isCampAdmin, ct);
+        return View(vm);
+```
+
+Apply the identical change in `SeasonDetails` (it shares the `nameof(Details)` view).
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: now only `Details.cshtml` fails (still references `Model.Leads`). Fixed in Task 6.
+
+---
+
+### Task 4: Create the read-only Roles card partial
+
+**Files:**
+- Create: `src/Humans.Web/Views/Camp/_CampRolesCard.cshtml`
+
+- [ ] **Step 1: Write the partial**
+
+```cshtml
+@model Humans.Web.Models.CampDetailViewModel
+@{
+    if (Model.RolesPanel is null) { return; }
+    // Non-member viewers see only the Camp Lead row, and only its filled assignees
+    // (matches the prior "Leads" card). Members/CampAdmin see every active role + open slots.
+    var rows = Model.CanSeeFullCamp
+        ? Model.RolesPanel.Rows
+        : Model.RolesPanel.Rows.Where(r => r.IsLeadRole && r.FilledSlots.Count > 0).ToList();
+    if (rows.Count == 0) { return; }
+}
+<div class="card mb-4">
+    <div class="card-header">
+        <i class="fa-solid fa-user-shield me-1"></i> @(Model.CanSeeFullCamp ? "Roles" : "Leads")
+    </div>
+    <ul class="list-group list-group-flush">
+        @foreach (var role in rows)
+        {
+            <li class="list-group-item">
+                <div class="d-flex justify-content-between align-items-center">
+                    <strong>@role.Name</strong>
+                    @if (Model.CanSeeFullCamp)
+                    {
+                        <small class="text-muted">@role.CurrentCount / @role.SlotCount</small>
+                    }
+                </div>
+                @foreach (var slot in role.FilledSlots)
+                {
+                    <div class="mt-1"><vc:human user-id="@slot.UserId" /></div>
+                }
+                @if (Model.CanSeeFullCamp && role.EmptySlotCount > 0)
+                {
+                    <div class="mt-1 text-muted fst-italic small">@role.EmptySlotCount open</div>
+                }
+            </li>
+        }
+    </ul>
+</div>
+```
+
+- [ ] **Step 2: No build yet** — wired in Task 6.
+
+---
+
+### Task 5: Create the Roster card partial
+
+**Files:**
+- Create: `src/Humans.Web/Views/Camp/_CampRosterCard.cshtml`
+
+- [ ] **Step 1: Write the partial**
+
+```cshtml
+@model Humans.Web.Models.CampDetailViewModel
+@{
+    if (!Model.CanSeeFullCamp || Model.CurrentSeason is null) { return; }
+}
+<div class="card mb-4">
+    <div class="card-header">
+        <i class="fa-solid fa-users me-1"></i> Roster @Model.CurrentSeason.Year
+        <span class="text-muted">(@Model.Roster.Count)</span>
+    </div>
+    <div class="card-body">
+        @if (Model.Roster.Count == 0)
+        {
+            <p class="text-center text-muted mb-0">No humans recorded for this season yet.</p>
+        }
+        else
+        {
+            <div class="row g-3">
+                @foreach (var member in Model.Roster)
+                {
+                    <div class="col-6 col-sm-4 col-md-3">
+                        <vc:human user-id="@member.UserId" layout="Card" size="102" />
+                    </div>
+                }
+            </div>
+        }
+    </div>
+</div>
+```
+
+- [ ] **Step 2: No build yet** — wired in Task 6.
+
+---
+
+### Task 6: Wire both cards into `Details.cshtml`, remove the Leads card
+
+**Files:**
+- Modify: `src/Humans.Web/Views/Camp/Details.cshtml`
+
+- [ ] **Step 1: Add the Roster card above About (left column, `col-md-8`)**
+
+Immediately before the `@* Blurb *@` About card (`<div class="card mb-4">` containing the `About` header inside `if (Model.CurrentSeason != null)`), insert:
+
+```cshtml
+            <partial name="_CampRosterCard" model="Model" />
+```
+
+- [ ] **Step 2: Replace the Leads card with the Roles card (right column, `col-md-4`)**
+
+Delete the entire `@* Leads (only if authenticated) *@` block (the `@if (User.Identity?.IsAuthenticated == true && Model.Leads.Count > 0) { ... }` card) and replace with:
+
+```cshtml
+        @* Roles (replaces the legacy Leads card; sourced from CampRoleAssignment) *@
+        <partial name="_CampRolesCard" model="Model" />
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: success — no remaining `Model.Leads` references on the detail path.
+
+- [ ] **Step 4: Commit Phase 1 view-side**
+
+```bash
+git add src/Humans.Web/Models/CampViewModels.cs src/Humans.Web/Controllers/CampController.cs src/Humans.Web/Views/Camp/_CampRolesCard.cshtml src/Humans.Web/Views/Camp/_CampRosterCard.cshtml src/Humans.Web/Views/Camp/Details.cshtml
+git commit -m "feat(camps): detail page Roles + Roster cards sourced from role system
+
+Replaces the legacy camp_leads-backed Leads card with a read-only Roles card
+(Camp Lead row for everyone logged-in; all roles + roster for members/CampAdmin)
+and a Roster card above About. Fixes detail/Members lead mismatch."
+```
+
+---
+
+### Task 7: Manual verification on preview
+
+- [ ] **Step 1:** After the PR opens and the preview env (`https://{pr_id}.n.burn.camp`) is up, sign in (dev login) and confirm on a camp where you are a lead:
+  - Right column shows **Roles** with you **and** any role-panel-added lead (e.g. Hannah).
+  - Left column shows **Roster** above About with the season's Active members.
+  - As a logged-in non-member: only **Leads** (Camp Lead row) shows, no Roster.
+  - As CampAdmin on another camp: both cards show.
+  - Logged out: neither card shows.
+
+---
+
+## Phase 2 — Fix the source: camp creation writes a Camp Lead role assignment
+
+### Task 8: Change `ICampRepository.CreateCampAsync` to persist member + lead assignment atomically
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Repositories/ICampRepository.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs`
+
+- [ ] **Step 1: Change the interface signature**
+
+Replace the existing `CreateCampAsync(Camp, CampSeason, CampLead, ...)` with:
+
+```csharp
+    /// <summary>
+    /// Persist a new camp with its initial season, the creator's Active CampMember,
+    /// an optional Camp Lead role assignment (null when the Lead role definition is
+    /// not yet seeded), and optional historical names in a single transaction.
+    /// </summary>
+    Task CreateCampAsync(
+        Camp camp,
+        CampSeason initialSeason,
+        CampMember creatorMember,
+        CampRoleAssignment? creatorLeadAssignment,
+        IReadOnlyList<CampHistoricalName>? historicalNames,
+        CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Update the repo implementation**
+
+In `CampRepository.CreateCampAsync`, add the camp, season, `creatorMember`, then `creatorLeadAssignment` when non-null, then names, and `SaveChangesAsync` once. Concretely:
+
+```csharp
+    public async Task CreateCampAsync(
+        Camp camp,
+        CampSeason initialSeason,
+        CampMember creatorMember,
+        CampRoleAssignment? creatorLeadAssignment,
+        IReadOnlyList<CampHistoricalName>? historicalNames,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.Camps.Add(camp);
+        ctx.CampSeasons.Add(initialSeason);
+        ctx.CampMembers.Add(creatorMember);
+        if (creatorLeadAssignment is not null)
+        {
+            ctx.CampRoleAssignments.Add(creatorLeadAssignment);
+        }
+        if (historicalNames is { Count: > 0 })
+        {
+            ctx.CampHistoricalNames.AddRange(historicalNames);
+        }
+        await ctx.SaveChangesAsync(ct);
+    }
+```
+
+Match the existing field name for the context factory (`_factory`) and the DbSet names (`ctx.CampMembers`, `ctx.CampRoleAssignments`) by checking the current file; adjust if they differ.
+
+- [ ] **Step 3: Build — expect failure at the `CampService` call site (fixed in Task 9) and the caching decorator (Task 10).**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: FAIL — `CampService.CreateCampAsync` and `CachingCampService` still pass a `CampLead`.
+
+---
+
+### Task 9: `CampService.CreateCampAsync` builds member + Camp Lead assignment
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Camps/CampService.cs`
+
+- [ ] **Step 1: Replace the legacy `CampLead` construction**
+
+In `CreateCampAsync`, delete the `var lead = new CampLead { ... }` block (lines ~107–114) and replace the `_repo.CreateCampAsync(camp, season, lead, historicalNameEntities, ...)` call with member + optional assignment construction:
+
+```csharp
+        var member = new CampMember
+        {
+            Id = Guid.NewGuid(),
+            CampSeasonId = season.Id,
+            UserId = createdByUserId,
+            Status = CampMemberStatus.Active,
+            RequestedAt = now,
+            ConfirmedAt = now,
+            ConfirmedByUserId = createdByUserId,
+        };
+
+        var leadDef = await _roleRepo.GetSpecialDefinitionAsync(CampSpecialRole.Lead, cancellationToken);
+        CampRoleAssignment? leadAssignment = null;
+        if (leadDef is not null)
+        {
+            leadAssignment = new CampRoleAssignment
+            {
+                Id = Guid.NewGuid(),
+                CampSeasonId = season.Id,
+                CampRoleDefinitionId = leadDef.Id,
+                CampMemberId = member.Id,
+                AssignedAt = now,
+                AssignedByUserId = createdByUserId,
+            };
+        }
+        else
+        {
+            logger.LogWarning(
+                "Camp Lead role definition missing while creating camp {CampId}; creator added as Active member without a lead assignment. Run 'Seed system roles'.",
+                camp.Id);
+        }
+
+        await _repo.CreateCampAsync(camp, season, member, leadAssignment, historicalNameEntities, cancellationToken);
+```
+
+`_roleRepo` is the existing `ICampRoleRepository` field (confirm the field name in the ctor — used by `IsUserCampLeadAsync`). `logger` is the existing `ILogger<CampService>` field. Keep the existing `AuditAction.CampCreated` log and the `SyncMembershipForUserAsync(createdByUserId, SystemTeamType.BarrioLeads, ...)` call that follow — the BarrioLeads sync now reads role assignments, so the creator is correctly synced.
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: FAIL only at `CachingCampService` (Task 10).
+
+---
+
+### Task 10: Fix the `CachingCampService` decorator for the new signature
+
+**Files:**
+- Modify: `src/Humans.Infrastructure/Services/Camps/CachingCampService.cs`
+
+- [ ] **Step 1: Update the `CreateCampAsync` override**
+
+Find the `CreateCampAsync` override (decorator passthrough). Change its signature to match the new `ICampService.CreateCampAsync` (its public signature is unchanged — it still takes the registration params, not the repo entities). **Only** the `ICampRepository.CreateCampAsync` changed, so `CachingCampService` likely needs **no signature change** unless it forwards repo entities. Verify: if `CachingCampService` only decorates `ICampService` (params-based), no change is needed here — remove this task. If a decorator references `CampLead`, update it.
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: success.
+
+---
+
+### Task 11: Update the camp-creation test to assert the role assignment
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/CampServiceTests.cs`
+
+- [ ] **Step 1: Replace the legacy-lead assertion in `CreateCampAsync_NewCamp_CreatesCampWithPendingSeason`**
+
+The test currently constructs `CampService` with a substitute `ICampRoleService` and asserts a `Db.CampLeads` row. The creation path now uses `ICampRoleRepository` directly (real `CampRoleRepository` is already injected as `roleRepo`). Seed a Camp Lead definition first, then assert a role assignment + Active member:
+
+```csharp
+        await SeedSettingsAsync();
+        var leadDef = new Humans.Domain.Entities.CampRoleDefinition
+        {
+            Id = Guid.NewGuid(),
+            Name = "Camp Lead",
+            Slug = "camp-lead",
+            SlotCount = 2,
+            MinimumRequired = 1,
+            SpecialRole = CampSpecialRole.Lead,
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant(),
+        };
+        Db.CampRoleDefinitions.Add(leadDef);
+        await Db.SaveChangesAsync();
+
+        var userId = Guid.NewGuid();
+        var camp = await _service.CreateCampAsync(
+            userId, "Camp Funhouse", "camp@fun.com", "+34612345678",
+            "https://instagram.com/funhouse", null,
+            isSwissCamp: false, timesAtNowhere: 0,
+            MakeSeasonData(), historicalNames: null, year: 2026);
+
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+        season.Status.Should().Be(CampSeasonStatus.Pending);
+
+        var member = await Db.CampMembers.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.CampSeasonId == season.Id && m.UserId == userId);
+        member.Should().NotBeNull();
+        member!.Status.Should().Be(CampMemberStatus.Active);
+
+        var assignment = await Db.CampRoleAssignments.AsNoTracking()
+            .FirstOrDefaultAsync(a => a.CampMemberId == member.Id);
+        assignment.Should().NotBeNull();
+        assignment!.CampRoleDefinitionId.Should().Be(leadDef.Id);
+```
+
+- [ ] **Step 2: Add a no-definition test (graceful degrade)**
+
+```csharp
+    [HumansFact]
+    public async Task CreateCampAsync_NoLeadDefinition_CreatesCampAndActiveMemberWithoutAssignment()
+    {
+        await SeedSettingsAsync();
+        var userId = Guid.NewGuid();
+
+        var camp = await _service.CreateCampAsync(
+            userId, "Camp Seedless", "c@s.com", "+34600000001", null, null,
+            false, 0, MakeSeasonData(), null, 2026);
+
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+        (await Db.CampMembers.AsNoTracking().AnyAsync(m => m.CampSeasonId == season.Id && m.UserId == userId))
+            .Should().BeTrue();
+        (await Db.CampRoleAssignments.AsNoTracking().AnyAsync(a => a.CampSeasonId == season.Id))
+            .Should().BeFalse();
+    }
+```
+
+- [ ] **Step 3: Run the camp service tests**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CampServiceTests"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit Phase 2**
+
+```bash
+git add src/Humans.Application/Interfaces/Repositories/ICampRepository.cs src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs src/Humans.Infrastructure/Services/Camps/CachingCampService.cs src/Humans.Application/Services/Camps/CampService.cs tests/Humans.Application.Tests/Services/CampServiceTests.cs
+git commit -m "feat(camps): camp creation writes Camp Lead role assignment, not legacy CampLead
+
+Creator becomes an Active CampMember + Camp Lead CampRoleAssignment atomically.
+Degrades to member-only (logged) when the Lead definition is unseeded."
+```
+
+---
+
+## Phase 3 — Repoint remaining legacy readers
+
+> Each task swaps a `camp_leads` read for the role system. The `ICampRoleRepository` already exposes the primitives: `GetCampSpecialRoleSeasonIdForYearAsync`, `GetCampIdsBySpecialRolesForUserAsync`, `GetSpecialRoleHolderUserIdsAsync`, `IsUserSpecialRoleHolderForCampAsync`. Where a per-camp/season list of lead user-ids is needed, add the repo method in Task 12.
+
+### Task 12: Add a "lead user-ids by season" repo query
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Repositories/ICampRoleRepository.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs`
+- Modify: `tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs` (or a repo test if one exists)
+
+- [ ] **Step 1: Add the interface method**
+
+```csharp
+    /// <summary>
+    /// Returns the distinct user ids holding the given special role on the
+    /// specified season (non-deactivated definition). Used to source the camp
+    /// detail "Contact the leads" recipient list and admin/CSV lead columns.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetSpecialRoleHolderUserIdsForSeasonAsync(
+        Guid campSeasonId, CampSpecialRole specialRole, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement (mirror `GetSpecialRoleHolderUserIdsAsync`, scoped to season)**
+
+```csharp
+    public async Task<IReadOnlyList<Guid>> GetSpecialRoleHolderUserIdsForSeasonAsync(
+        Guid campSeasonId, CampSpecialRole specialRole, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampRoleAssignments
+            .AsNoTracking()
+            .Where(a => a.CampSeasonId == campSeasonId
+                && a.Definition.SpecialRole == specialRole
+                && a.Definition.DeactivatedAt == null)
+            .Select(a => a.CampMember.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+    }
+```
+
+- [ ] **Step 3: Test** (add to the role-service/repo test file using `ServiceTestHarness` — seed a camp/season/definition/member/assignment, assert the returned user-id set). Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CampRole"` → PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Repositories/ICampRoleRepository.cs src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+git commit -m "feat(camps): repo query for special-role holders by season"
+```
+
+---
+
+### Task 13: Repoint `CampController.Contact` recipients
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/CampController.cs`
+
+- [ ] **Step 1:** In the `Contact` POST action, replace the recipient argument `camp.Leads.Select(l => l.UserId).Distinct().ToList()` with role-sourced lead user-ids for the camp's current season. Resolve the season (`camp.Seasons.OrderByDescending(s => s.Year).First()`), then call a `campRoleService`/`campService` method that wraps `GetSpecialRoleHolderUserIdsForSeasonAsync(seasonId, CampSpecialRole.Lead)`. Add a thin `ICampRoleService.GetSeasonLeadUserIdsAsync(Guid campSeasonId, CancellationToken)` that delegates to the repo method from Task 12, and call it here.
+
+- [ ] **Step 2:** Build + run camp web/controller tests if any. Run: `dotnet build Humans.slnx -v quiet` → success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "fix(camps): Contact-the-leads notifies role-based leads, not legacy table"
+```
+
+---
+
+### Task 14: Repoint directory pinning (`GetCampsByLeadUserIdAsync`)
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Camps/CampService.cs` (`GetCampDirectoryAsync`, line ~257)
+
+- [ ] **Step 1:** Replace `leadCamps = await _repo.GetCampsByLeadUserIdAsync(userId.Value, ct)` with a role-based camp-id lookup: `var leadCampIdList = await _roleRepo.GetCampIdsBySpecialRolesForUserAsync(userId.Value, [CampSpecialRole.Lead], ct);` then build `leadCampIds = leadCampIdList.ToHashSet();`. The downstream code only uses `leadCampIds` (a `HashSet<Guid>`) for ordering and `MyCamps`; re-derive `leadCamps` from the already-loaded `camps` collection: `leadCamps = camps.Where(c => leadCampIds.Contains(c.Id)).ToList();` (avoids a second camp load). Verify the `MyCamps` block below still compiles with this.
+
+- [ ] **Step 2:** Build → success. Add/extend a `CampServiceTests` case asserting a role-only lead's camp is pinned/listed in `MyCamps`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "fix(camps): directory 'my camps' pin uses role-based leads"
+```
+
+---
+
+### Task 15: Repoint `GetCampLeadSeasonIdForYearAsync`
+
+**Files:**
+- Modify: `src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs` (line ~416) **or** `src/Humans.Application/Services/Camps/CampService.cs` (line ~1153)
+
+- [ ] **Step 1:** The service method `CampService.GetCampLeadSeasonIdForYearAsync` currently delegates to the legacy repo join. Repoint it to `_roleRepo.GetCampSpecialRoleSeasonIdForYearAsync(userId, year, CampSpecialRole.Lead, ct)` and stop calling the legacy `_repo.GetCampLeadSeasonIdForYearAsync`. (Callers: `StoreService`, `CityPlanningController` — behavior preserved.)
+
+- [ ] **Step 2:** Build → success. Run store/cityplanning tests if present. Add a `CampServiceTests` case: role-lead of a camp participating in year Y → returns that season id; non-lead → null.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "fix(camps): lead-season-for-year resolves via role system"
+```
+
+---
+
+### Task 16: Repoint CampAdmin index leads (`CampAdminPageBuilder` + view)
+
+**Files:**
+- Modify: `src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs` (line ~90)
+- Modify: `src/Humans.Web/Views/CampAdmin/Index.cshtml` (line ~418)
+
+- [ ] **Step 1:** `CampAdminPageBuilder` builds `CampSummaryRowViewModel.Leads` from `c.Leads`. Replace with role-sourced lead user-ids per season. The builder iterates camps with a season; for each season call the bulk year query (Task 12 method) — or, to avoid N+1 at admin scale (small), call `GetSpecialRoleHolderUserIdsForSeasonAsync` per season. Map results to `CampLeadViewModel { UserId = id }` (LeadId unused on the admin view; set `Guid.Empty`). Confirm `Index.cshtml` only renders `lead.UserId` via `<vc:human>` (line ~418 loop) — it does; the `LeadId` is not rendered.
+
+- [ ] **Step 2:** Build → success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "fix(camps): CampAdmin index leads sourced from role system"
+```
+
+---
+
+### Task 17: Repoint CSV export leads (`CampCsvExportBuilder`)
+
+**Files:**
+- Modify: `src/Humans.Web/Models/CampAdmin/CampCsvExportBuilder.cs` (lines ~19, ~37)
+
+- [ ] **Step 1:** This builder reads `c.Leads`. Inject the lead user-ids per season (from Task 12's method) into the builder's inputs rather than reading `camp.Leads`. If the builder is a pure mapper over loaded `Camp` entities, change its caller (the CampAdmin controller/export action) to pass a `IReadOnlyDictionary<Guid seasonId, IReadOnlyList<Guid> leadUserIds>` and have the builder format names from that. Resolve names via `IUserService` as the builder already does for leads.
+
+- [ ] **Step 2:** Build → success. Add/adjust a `CampCsvExportBuilder` unit test if one exists.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "fix(camps): CSV export leads column sourced from role system"
+```
+
+---
+
+### Task 18: Repoint CityPlanning lead checks
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/CityPlanningController.cs` (line ~296)
+- Modify: `src/Humans.Web/Controllers/CityPlanningApiController.cs` (line ~46)
+
+- [ ] **Step 1:** Both use `c.Leads.Any(l => l.UserId == userId)` to decide "is this user a lead of this camp." Replace with `await campService.IsUserCampLeadAsync(userId, c.Id, ct)` (already role-first). If the surrounding code iterates a list of camps to find the user's camp, prefer `_roleRepo.GetCampIdsBySpecialRolesForUserAsync` once and intersect, to avoid per-camp calls. (Lines ~48/~68 already use `GetCampLeadSeasonIdForYearAsync`, repointed in Task 15 — no further change there.)
+
+- [ ] **Step 2:** Build → success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "fix(cityplanning): camp-lead check uses role system"
+```
+
+---
+
+### Task 19: Drop the legacy GDPR slice + Edit-page leads source
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Camps/CampService.cs` (`ContributeForUserAsync` ~1858; `GetCampEditDataAsync` ~239)
+
+- [ ] **Step 1: GDPR** — in `ContributeForUserAsync`, remove the legacy `leadAssignments`/`shapedLeads` block and the `new UserDataSlice(GdprExportSections.CampLeadAssignments, shapedLeads)` entry. Keep the `CampRoleAssignments` slice (already emitted). Remove the now-unused `_repo.GetAllLeadAssignmentsForUserAsync` call.
+
+- [ ] **Step 2: Edit page** — `GetCampEditDataAsync` populates `editData.Leads` from `camp.Leads`, surfaced read-only on `Edit.cshtml`. Since lead management now lives entirely on `/Edit/Members` (roles panel), source `editData.Leads` from role assignments for the season **or** drop the leads display from `Edit.cshtml` and stop populating it. Check `Edit.cshtml` for `Model.Leads` usage and pick the lighter option; if dropped, also remove the `Leads` mapping in `PopulateEditReadOnlyFieldsAsync` / `MapToEditViewModel`.
+
+- [ ] **Step 3:** Build → success. Run GDPR contributor tests if present (`dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Gdpr"` or `~CampService`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "refactor(camps): drop legacy GDPR lead slice + Edit-page legacy leads"
+```
+
+---
+
+## Phase 4 — Strip fallbacks + remove dead writes/methods
+
+### Task 20: Strip the legacy fallbacks in `CampService`
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Camps/CampService.cs`
+
+- [ ] **Step 1:** In `IsUserCampLeadAsync` (~1173), remove the trailing `return await _repo.IsUserActiveLeadAsync(...)` fallback so the method returns the role-side result only:
+
+```csharp
+    public Task<bool> IsUserCampLeadAsync(
+        Guid userId, Guid campId, CancellationToken cancellationToken = default) =>
+        _roleRepo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOnly, cancellationToken);
+```
+
+- [ ] **Step 2:** In `IsUserCampEventManagerAsync` (~1189), remove the `_repo.IsUserActiveLeadAsync` fallback similarly:
+
+```csharp
+    public Task<bool> IsUserCampEventManagerAsync(
+        Guid userId, Guid campId, CancellationToken cancellationToken = default) =>
+        _roleRepo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOrWorkshop, cancellationToken);
+```
+
+- [ ] **Step 3:** In `GetPendingMembershipCountForLeadAsync` (~1806), remove the `if (roleSide > 0) return roleSide; return await _repo.CountPendingMembershipsForLeadAsync(...)` fallback — return the role-side count directly.
+
+- [ ] **Step 4:** Build → expect `LeadOnly` constant still referenced (keep it). Run the camp auth/service tests. Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CampService"` → PASS (existing role-side tests should already cover these; add a test that a user with **no** role assignment is **not** a lead even if a legacy `CampLead` row exists, to lock the fallback removal).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "refactor(camps): role assignment is sole source of lead truth (drop legacy fallbacks)"
+```
+
+---
+
+### Task 21: Drop the legacy account-merge reassignment
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Camps/CampService.cs` (`ReassignAsync` ~1840)
+
+- [ ] **Step 1:** Remove the `await _repo.ReassignLeadsToUserAsync(...)` call and its two `_systemTeamSync.SyncMembershipForUserAsync(..., BarrioLeads, ...)` only if they were solely for the legacy reassignment — keep the BarrioLeads sync calls (still valid; role-based) and the `_leadBadgeInvalidator.Invalidate(...)` calls. Role-side reassignment is handled by `ICampRoleRepository.ReassignAssignmentsToUserAsync` — confirm `AccountMergeService` already fans out to a role-side `IUserMerge`/reassign; if `CampService.ReassignAsync` is the camps merge entry, call `_roleRepo.ReassignAssignmentsToUserAsync(sourceUserId, targetUserId, updatedAt, ct)` here instead of the legacy method.
+
+- [ ] **Step 2:** Build → success. Run account-merge tests: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Merge"` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "refactor(camps): account-merge reassigns role assignments, not legacy leads"
+```
+
+---
+
+### Task 22: Repoint `DevPersonaSeeder` to role assignments
+
+**Files:**
+- Modify: `src/Humans.Web/Infrastructure/DevPersonaSeeder.cs` (lines ~378–388)
+
+- [ ] **Step 1:** Replace the `await campService.AddLeadAsync(camp.Id, leadUserId)` call (and its `camp.Leads.Any(...)` pre-check) with: ensure a Camp Lead definition exists (the dev role seeder `DevelopmentCampRoleSeeder` seeds these — ensure it runs first), then add an Active member + Camp Lead assignment via `campService.AddMemberAndAssignRoleInActiveSeasonAsync(camp.Id, leadDefId, leadUserId, actorUserId, ct)` (resolve `leadDefId` via `campRoleService.GetDefinitionBySlugAsync("camp-lead")`). Keep idempotency (skip if already assigned).
+
+- [ ] **Step 2:** Build → success. Manually verify dev login still yields a working camp-lead persona (preview env or `dotnet run`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "chore(dev): persona seeder creates camp-lead via role assignment"
+```
+
+---
+
+### Task 23: Delete now-dead legacy C# (no schema change)
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Camps/ICampService.cs`, `src/Humans.Application/Services/Camps/CampService.cs`, `src/Humans.Infrastructure/Services/Camps/CachingCampService.cs`
+- Modify: `src/Humans.Application/Interfaces/Repositories/ICampRepository.cs`, `src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs`
+- Modify: `src/Humans.Application/Interfaces/Camps/ICampService.cs` (DTOs) and any unused VM file
+
+- [ ] **Step 1: Verify zero callers** before each deletion:
+
+```bash
+git grep -n "AddLeadAsync\|RemoveLeadAsync\|IsUserActiveLeadAsync\|CountActiveLeadsAsync\|GetLeadForMutationAsync\|UpdateLeadAsync\|GetAllLeadAssignmentsForUserAsync\|ReassignLeadsToUserAsync\|GetCampsByLeadUserIdAsync\|CountPendingMembershipsForLeadAsync\|GetCampLeadSeasonIdForYearAsync" -- 'src/**'
+```
+
+Each remaining hit must be only the declaration/implementation (no live caller) — Phases 2–4 removed the callers.
+
+- [ ] **Step 2: Delete the dead methods** from `ICampService`/`CampService`/`CachingCampService` (`AddLeadAsync`, `RemoveLeadAsync`) and from `ICampRepository`/`CampRepository` (`IsUserActiveLeadAsync`, `CountActiveLeadsAsync`, `AddLeadAsync`, `GetLeadForMutationAsync`, `UpdateLeadAsync`, `GetAllLeadAssignmentsForUserAsync`, `ReassignLeadsToUserAsync`, `GetCampsByLeadUserIdAsync`, legacy `GetCampLeadSeasonIdForYearAsync`, `CountPendingMembershipsForLeadAsync`). **Keep** `EnsureActiveMemberForMigrationAsync` and the seed plumbing (used by the still-present admin button).
+
+- [ ] **Step 3: Delete now-unused DTOs/VMs** — `CampLeadInfo`, `CampLeadSummary` (in `ICampService.cs`) and `CampLeadViewModel` (in `CampViewModels.cs`) **only if** `git grep` shows zero remaining references. If `CampInfo.Leads`/`CampLookup.Leads`/`CampEditData.Leads` still expose them, remove those properties too (verify no view/consumer references remain). Leave any that still have live consumers and note them.
+
+- [ ] **Step 4: Do NOT touch** `CampLead.cs`, `CampLeadRole.cs`, `CampLeadConfiguration.cs`, `Camp.Leads` nav, `CampLeads` DbSet (schema-bound → #774).
+
+- [ ] **Step 5: Full build + snapshot check** — removing only C# methods/DTOs must not change the EF model snapshot:
+
+```bash
+dotnet build Humans.slnx -v quiet
+git diff --exit-code src/Humans.Infrastructure/Migrations/HumansDbContextModelSnapshot.cs
+```
+
+Expected: build success; snapshot diff empty. If the snapshot changed, you removed a schema-bound member — revert that deletion (it belongs to #774).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "refactor(camps): delete dead legacy CampLead C# (entity/table retained for #774)"
+```
+
+---
+
+### Task 24: Full suite + architecture tests + grep gate
+
+- [ ] **Step 1: Run everything**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all green.
+
+- [ ] **Step 2: Confirm the table is orphaned in live code** (entity/config/migrations may still mention it):
+
+```bash
+git grep -nE "camp\.Leads|ctx\.CampLeads|\.Leads\b" -- 'src/Humans.Web/**' 'src/Humans.Application/**' 'src/Humans.Infrastructure/Services/**' 'src/Humans.Infrastructure/Repositories/**'
+```
+
+Expected: no live read/write of camp leads remains (matches only unrelated `.Leads` like `SubteamLeads`, if any — verify each hit).
+
+- [ ] **Step 3: Snapshot gate** (belt-and-suspenders, no migration expected):
+
+```bash
+git diff --exit-code src/Humans.Infrastructure/Migrations/HumansDbContextModelSnapshot.cs
+```
+
+Expected: empty.
+
+- [ ] **Step 4: Open the PR** (per workflow — squash on merge to peter `main`):
+
+```bash
+gh pr create --repo peterdrier/Humans --base main --head feat/camp-roster-roles \
+  --title "Camp detail Roles/Roster cards + decouple from legacy camp_leads" \
+  --body "Adds read-only Roles + Roster cards to /Barrios/{slug} sourced from CampRoleAssignment, fixes camp creation to write role assignments, and repoints every live reader/writer/fallback off camp_leads. Physical table drop deferred to nobodies-collective/Humans#774. Spec: docs/superpowers/specs/2026-05-20-camp-detail-roles-roster-and-lead-decouple-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 5: Run the EF migration reviewer** — N/A (no migration in this PR). Note in the PR that the migration lives in #774.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** Part A → Tasks 1–7; Part B → Tasks 8–11; Part C → Tasks 12–19; Part D → Tasks 20–23; testing/rollout → Tasks 7, 11, 24.
+- **Type consistency:** `IsLeadRole` (Task 1) is consumed in `_CampRolesCard.cshtml` (Task 4). `RolesPanel`/`Roster`/`CanSeeFullCamp` (Task 2) are set in Task 3 and read in Tasks 4–6. New repo method `GetSpecialRoleHolderUserIdsForSeasonAsync` (Task 12) is used in Tasks 13/16/17.
+- **Open verifications flagged inline** (confirm against current code during execution): exact `CampMemberRow` property names; whether `CachingCampService` needs a `CreateCampAsync` change (Task 10); whether `Edit.cshtml` renders `Model.Leads` (Task 19); exact `_roleRepo`/`_factory` field names; DbSet names (`CampMembers`, `CampRoleAssignments`, `CampRoleDefinitions`).

--- a/docs/superpowers/specs/2026-05-20-camp-detail-roles-roster-and-lead-decouple-design.md
+++ b/docs/superpowers/specs/2026-05-20-camp-detail-roles-roster-and-lead-decouple-design.md
@@ -1,0 +1,124 @@
+# Camp detail page: Roles + Roster cards, and decoupling from legacy `camp_leads`
+
+**Date:** 2026-05-20
+**Branch:** `feat/camp-roster-roles`
+**Section:** Camps
+**Related:** `nobodies-collective/Humans#753` (CampLead → CampRoleAssignment, PR #657), `nobodies-collective/Humans#774` (deferred physical drop)
+
+## Problem
+
+The camp detail page `/Barrios/{slug}` (`CampController.Details`) still renders its **Leads** card from the legacy `camp_leads` table (`BuildLeadSummariesAsync(camp.Leads)`), while the management page `/Barrios/{slug}/Edit/Members` renders leads/roles from the **new** `CampRoleAssignment` system (`campRoleService.BuildPanelAsync`). Result: a lead added through the new Roles panel (e.g. "Hannah") appears on `/Edit/Members` but **not** on the public detail page.
+
+Authorization (`IsUserCampLeadAsync` → `CampAuthorizationHandler`) and the Barrio-Leads system-team sync were already migrated to the role system in #657, with legacy fallbacks retained. But a cluster of **display, notification, directory, dev-seed, account-merge, and camp-creation** paths still read from or write to `camp_leads`.
+
+## Goals
+
+1. **Fix the detail page** to source leads/roles from `CampRoleAssignment` (the new way), consistent with `/Edit/Members`.
+2. **Add two cards** to the detail page (modeled on `/Teams/{slug}` → `_RosterSection.cshtml`):
+   - **Roles** (right column, replacing the Leads card)
+   - **Roster** (left column, above About)
+3. **Decouple the full lead lifecycle from `camp_leads`** — creation, reads, account-merge, dev-seed — and **strip the transitional legacy fallbacks**, so no live code path depends on the legacy table.
+
+## Non-goals (deferred to `nobodies-collective#774`)
+
+Only the **physical** removal is deferred, because it changes the EF snapshot/schema and is governed by the `no-column-drops-for-decoupling` hard rule (drop waits for a separate PR after prod verification):
+
+- The `DropCampLeads` EF migration.
+- Deleting the `CampLead` entity, `CampLeadRole` enum, `CampLeadConfiguration`, and the `Camp.Leads` navigation / `CampLeads` DbSet.
+- Retiring `SeedSystemRolesAndMigrateLeadsAsync` + `EnsureActiveMemberForMigrationAsync` (one-time migration plumbing).
+- Final `git grep CampLead` zero-hit + docs.
+
+**The dividing line:** *anything whose removal changes the EF model snapshot → #774; everything else → this PR.* After this PR the legacy entity/table remain mapped but **orphaned** (no reads, no writes).
+
+**Pre-condition (confirmed by Peter, 2026-05-20):** every environment has run "Seed system roles" on `/Camps/Admin`, so existing legacy leads already exist as role assignments. This is what makes the fallback removal safe.
+
+## Part A — UI: Roles + Roster cards
+
+### Layout (`Views/Camp/Details.cshtml`)
+
+```
+LEFT (col-md-8)                       RIGHT (col-md-4)
+  [carousel / name / badges]            Links & Contact
+  ★ Roster   (NEW)                      Times participating
+  About (blurb)                         ★ Roles   (replaces Leads)
+  Community / Vibes / Culture           My membership
+  Placement (lead/admin/cityplanning)   Actions
+```
+
+### Visibility matrix
+
+| Viewer | Roles card | Roster card |
+|--------|-----------|-------------|
+| Anonymous | hidden (login gate kept) | hidden |
+| Logged-in, not a member, not CampAdmin | **Camp Lead role only** (assignees) | hidden |
+| Active member of this camp | **all active roles** + assignees + open slots (read-only) | shown |
+| CampAdmin (any camp) | all active roles (read-only) | shown |
+
+- "Can see the rest" gate: `isCampAdmin || Membership.Status == Active`. (Leads are Active members post-migration, so they see everything.)
+- Management controls stay on `/Edit/Members`; these cards are **read-only**.
+- The Roles card replaces the existing Leads card. For a non-member it is functionally today's Leads card, but sourced correctly (so Hannah shows).
+
+### Data flow
+
+- Controller `Details`/`SeasonDetails` build a read-only roles view model from `campRoleService.BuildPanelAsync(currentSeason.Id)` (same source as `/Edit/Members`), plus an Active-member roster from `campService.GetCampMembersAsync(currentSeason.Id).Active`.
+- Built only when authenticated and a current season exists. Roster fetched only when the viewer passes the "see the rest" gate.
+
+### New view pieces
+
+- `Views/Camp/_CampRolesCard.cshtml` — read-only roles table (Role → assignee `<vc:human>` / "Open"), filtered to the Camp Lead row for non-members. Mirrors `Team/_RosterSection.cshtml` styling.
+- `Views/Camp/_CampRosterCard.cshtml` — `<vc:human layout="Card">` grid of Active members.
+- `CampDetailViewModel` gains `RolesPanel` (reuse `CampRolesPanelViewModel` with `CanManage=false`) and `Roster` (list of user ids / `CampMemberRowViewModel`). The legacy `Leads` property is removed from the view model once the card is gone.
+
+## Part B — Fix the source (camp creation)
+
+`CampService.CreateCampAsync` currently writes a `CampLead` for the creator (the reason new camps would otherwise show no leads under role-only reads). Change it to:
+
+- Create an Active `CampMember` for the creator on the new season, then a `CampRoleAssignment` for the Camp Lead special role (reuse the same path the seed/`AssignAsync` use).
+- If the Camp Lead role **definition** is missing (un-seeded env), log a warning and still create the camp — never block registration (`no-startup-guards`).
+- Stop writing the legacy `CampLead` row.
+
+## Part C — Repoint remaining legacy **reads** to the role system
+
+| Site | Current (legacy) | Change |
+|------|------------------|--------|
+| `Camp/Details.cshtml` ← `BuildCampDetailDataAsync` → `BuildLeadSummariesAsync(camp.Leads)` | reads `camp.Leads` | drop; detail page uses `BuildPanelAsync` (Part A) |
+| `CampController.Contact` (line ~209) | `camp.Leads.Select(UserId)` for notify recipients | role-holders of Camp Lead for the season |
+| `CampService.GetCampEditDataAsync` (line ~239) | `BuildLeadSummariesAsync(camp.Leads)` → Edit page `model.Leads` | source from role assignments (or drop if `/Edit/Members` already covers it) |
+| `CampService.GetCampDirectoryAsync` → `CampRepository.GetCampsByLeadUserIdAsync` | `b.Leads.Any(...)` | query `CampRoleAssignment` (Camp Lead) |
+| `CampService.GetCampLeadSeasonIdForYearAsync` → `CampRepository.GetCampLeadSeasonIdForYearAsync` (used by `StoreService`, `CityPlanningController`) | joins `ctx.CampLeads` | join `CampRoleAssignment`/`CampMember` for the year |
+| `CampAdminPageBuilder` (line ~90) + `CampAdmin/Index.cshtml` (line ~418) | `c.Leads` | role-holders |
+| `CampCsvExportBuilder` (lines ~19, ~37) | `c.Leads` | role-holders |
+| `CityPlanningController` (line ~296) + `CityPlanningApiController` (line ~46) | `c.Leads.Any(...)` | `IsUserCampLeadAsync` / role query |
+| `CampService.ContributeForUserAsync` (GDPR, line ~1858) | `GetAllLeadAssignmentsForUserAsync` (legacy slice) | drop the legacy `CampLeadAssignments` slice (role slice already emitted) |
+| `CachingCampService.GetCampsWithLeadsForYearAsync` path | `.Include(c => c.Leads...)` | drop the unused `Leads` include |
+
+Already repointed in #657 (no work): `CampRepository.GetActiveLeadUserIdsAsync`, `IsLeadAnywhereAsync` (Barrio-Leads sync).
+
+## Part D — Remove legacy **writes** and **fallback** branches
+
+- **Strip fallbacks** (role assignment becomes the sole source): legacy `_repo.IsUserActiveLeadAsync` branch in `CampService.IsUserCampLeadAsync` and `IsUserCampEventManagerAsync`; legacy branch in `GetPendingMembershipCountForLeadAsync`; legacy join in `GetCampLeadSeasonIdForYearAsync` (Part C).
+- **Account merge:** `CampService.ReassignAsync` → drop the `ReassignLeadsToUserAsync` call; merge is covered by reassigning the role side (`CampMember.UserId`). Verify no orphaned legacy rows matter (table is orphaned post-seed).
+- **Dev seed:** `DevPersonaSeeder` (line ~383) → write `CampMember` + `CampRoleAssignment` (Camp Lead) instead of `AddLeadAsync`.
+- **Remove now-dead C# methods** (pure C#, no schema change): `ICampService.AddLeadAsync`/`RemoveLeadAsync` (+ `CampService` impls + `CachingCampService` decorators), `ICampRepository.IsUserActiveLeadAsync`/`CountActiveLeadsAsync`/`AddLeadAsync`/`GetLeadForMutationAsync`/`UpdateLeadAsync`/`GetAllLeadAssignmentsForUserAsync`/`ReassignLeadsToUserAsync`/`GetCampsByLeadUserIdAsync`(legacy form), and the `CampLeadInfo`/`CampLeadSummary`/`CampLeadViewModel` DTOs once unused.
+- **Keep** (schema-bound → #774): `CampLead` entity, `Camp.Leads` nav, `CampLeads` DbSet, `CampLeadConfiguration`, `CampLeadRole` enum, `EnsureActiveMemberForMigrationAsync` + the seed button.
+
+## Authorization
+
+No new authorization surface. Detail-page cards reuse the existing computed `(isLead, isCampAdmin)` + `Membership` state already resolved in `Details`. Read-only — no new mutating endpoints. CampAdmin breadth comes from the existing `RoleChecks.IsCampAdmin` / `CampAuthorizationHandler`.
+
+## Testing
+
+- Service tests (`ServiceTestHarness`): `CreateCampAsync` creates an Active member + Camp Lead assignment (not a legacy row); `IsUserCampLeadAsync` true via role only (no legacy fallback); directory pin, store/cityplanning season lookup, contact recipients resolve via role holders; account-merge moves lead via role side.
+- Detail-page view-model tests: non-member sees Camp Lead row only; member sees all roles + roster; anonymous sees neither; CampAdmin sees both for any camp.
+- Architecture tests stay green (Camps section boundaries).
+- No EF migration in this PR → EF reviewer N/A here; runs on #774.
+
+## Rollout / risk
+
+- Reversible: legacy table left intact; only C# read/write paths change. If a regression appears, revert the PR — data is unchanged.
+- Safe because all envs are seeded (confirmed) — role assignments are complete for existing leads.
+- QA auto-deploys on merge to peter `main`; prod via the promote PR. No operator step required at deploy (seed already run).
+
+## Open item
+
+`nobodies-collective#774` currently bundles the code decouple **and** the physical drop. This PR takes the code-decouple half; #774 should be **re-scoped to the physical drop only** and reference this branch. (Confirm before editing the issue.)

--- a/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
@@ -40,6 +40,13 @@ public interface ICampRoleService : IApplicationService
 
     Task<CampRolesPanelData> BuildPanelAsync(Guid campSeasonId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns the distinct user ids holding the Camp Lead special role on the
+    /// given season. Sources the facilitated-contact recipient list from the
+    /// role system instead of the legacy camp_leads table. Read-only.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetSeasonLeadUserIdsAsync(Guid campSeasonId, CancellationToken ct = default);
+
     Task<AssignCampRoleOutcome> AssignAsync(Guid campSeasonId, Guid roleDefinitionId, Guid campMemberId, Guid actorUserId, CancellationToken ct = default);
 
     /// <summary>

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -586,7 +586,6 @@ public record CampEditData(
     SpaceSize? SpaceRequirement,
     SoundZone? SoundZone,
     ElectricalGrid? ElectricalGrid,
-    IReadOnlyList<CampLeadSummary> Leads,
     IReadOnlyList<CampImageSummary> Images,
     IReadOnlyList<CampHistoricalNameSummary> HistoricalNames);
 

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -14,7 +14,7 @@ namespace Humans.Application.Interfaces.Camps;
 /// <remarks>
 /// Surface-budget recent history (newest first):
 /// <list type="bullet">
-///   <item>58→56 — Camp Lead detail/roster decouple (issue nobodies-collective/Humans#753 follow-up): removed AddLeadAsync/RemoveLeadAsync — Camp Lead is now a CampRoleAssignment, managed via the Roles panel on /Edit/Members. EnsureActiveMemberForMigrationAsync stays for the still-present "Seed system roles" admin button until the table drops in #774.</item>
+///   <item>58→56 — detail/roster decouple (#753 follow-up): removed AddLeadAsync/RemoveLeadAsync. Camp Lead → CampRoleAssignment; EnsureActiveMemberForMigrationAsync stays until #774 drops table.</item>
 ///   <item>57→58 — US-26 unified MySubmissions: added GetEventManagedCampsAsync — returns the list of camps a user may manage events for (unions CampRoleAssignment Lead/Workshop rows + legacy CampLead table). Authorized by consolidating BarrioEventsController into EventsController.</item>
 ///   <item>56→57 — Camp Lead retirement event-management split (issue nobodies-collective/Humans#753): added IsUserCampEventManagerAsync — Lead OR Workshop OR-check that authorizes barrio event actions.</item>
 /// </list>

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -14,12 +14,12 @@ namespace Humans.Application.Interfaces.Camps;
 /// <remarks>
 /// Surface-budget recent history (newest first):
 /// <list type="bullet">
+///   <item>58→56 — Camp Lead detail/roster decouple (issue nobodies-collective/Humans#753 follow-up): removed AddLeadAsync/RemoveLeadAsync — Camp Lead is now a CampRoleAssignment, managed via the Roles panel on /Edit/Members. EnsureActiveMemberForMigrationAsync stays for the still-present "Seed system roles" admin button until the table drops in #774.</item>
 ///   <item>57→58 — US-26 unified MySubmissions: added GetEventManagedCampsAsync — returns the list of camps a user may manage events for (unions CampRoleAssignment Lead/Workshop rows + legacy CampLead table). Authorized by consolidating BarrioEventsController into EventsController.</item>
-///   <item>56→57 — Camp Lead retirement event-management split (issue nobodies-collective/Humans#753): added IsUserCampEventManagerAsync — Lead OR Workshop OR-check that authorizes barrio event actions. Once the legacy CampLead table drops, AddLeadAsync/RemoveLeadAsync/EnsureActiveMemberForMigrationAsync retire (57→54 net).</item>
-///   <item>55→56 — Camp Lead retirement (issue nobodies-collective/Humans#753): added EnsureActiveMemberForMigrationAsync — needed by the admin "Seed system roles" button to land legacy CampLead rows on the role-assignment side. Once the follow-up table-drop PR lands, this and the AddLeadAsync/RemoveLeadAsync pair (55→52 net) will both retire.</item>
+///   <item>56→57 — Camp Lead retirement event-management split (issue nobodies-collective/Humans#753): added IsUserCampEventManagerAsync — Lead OR Workshop OR-check that authorizes barrio event actions.</item>
 /// </list>
 /// </remarks>
-[SurfaceBudget(58)]
+[SurfaceBudget(56)]
 public interface ICampService : IApplicationService
 {
     // Registration
@@ -54,15 +54,9 @@ public interface ICampService : IApplicationService
         CancellationToken cancellationToken = default);
     /// <summary>
     /// Gets camps participating in a year — every camp that has any season
-    /// for the year, with the year-filtered season(s) and active leads
-    /// populated.
+    /// for the year, with the year-filtered season(s) populated. Leads are no
+    /// longer carried here; they live in the role system (Camp Lead special role).
     /// </summary>
-    /// <remarks>
-    /// T-06: <see cref="CampInfo.Leads"/> is always populated (non-null;
-    /// may be empty). The legacy "leads not loaded" branch was retired
-    /// when this method moved onto the <c>CachingCampService</c>
-    /// projection, which always carries leads.
-    /// </remarks>
     Task<IReadOnlyList<CampInfo>> GetCampsForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPublicSummary>> GetCampPublicSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPlacementSummary>> GetCampPlacementSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
@@ -95,10 +89,6 @@ public interface ICampService : IApplicationService
     // Camp updates
     Task<CampUpdateResult> UpdateCampAsync(CampUpdateInput input, CancellationToken cancellationToken = default);
     Task DeleteCampAsync(Guid campId, CancellationToken cancellationToken = default);
-
-    // Lead management
-    Task<CampLead> AddLeadAsync(Guid campId, Guid userId, CancellationToken cancellationToken = default);
-    Task RemoveLeadAsync(Guid leadId, CancellationToken cancellationToken = default);
 
     // Historical names
     Task AddHistoricalNameAsync(Guid campId, string name, CancellationToken cancellationToken = default);
@@ -284,8 +274,7 @@ public sealed record CampLookup(
     Guid Id,
     string Slug,
     string ContactEmail,
-    IReadOnlyList<CampSeasonInfo> Seasons,
-    IReadOnlyList<CampLeadInfo> Leads);
+    IReadOnlyList<CampSeasonInfo> Seasons);
 
 public sealed record CampSettingsInfo(
     int PublicYear,
@@ -316,12 +305,6 @@ public sealed record CampSeasonLookup(
 /// comfortably under the ~50 MB §15 budget for a 500-user-scale projection.
 /// </para>
 /// <para>
-/// <b>Leads invariant.</b> <see cref="Leads"/> is always non-null. The
-/// legacy "null means not loaded" semantic was retired in T-06 — the
-/// cached projection always carries leads. May still be empty when the
-/// camp genuinely has no active leads.
-/// </para>
-/// <para>
 /// <b>EeGrantedCount cross-table invariant.</b>
 /// <see cref="CampSeasonInfo.EeGrantedCount"/> is computed from
 /// <c>camp_members.HasEarlyEntry</c> WHERE <c>Status = Active</c>. The
@@ -344,8 +327,7 @@ public sealed record CampInfo(
     string ContactPhone,
     bool IsSwissCamp,
     int TimesAtNowhere,
-    IReadOnlyList<CampSeasonInfo> Seasons,
-    IReadOnlyList<CampLeadInfo> Leads);
+    IReadOnlyList<CampSeasonInfo> Seasons);
 
 public sealed record CampSeasonInfo(
     Guid Id,
@@ -368,12 +350,6 @@ public sealed record CampSeasonInfo(
     int EeSlotCount,
     int? EeGrantedCount,
     int? JoinedMemberCount);
-
-// CampLookup / CampInfo.Leads is populated only from camp loads that apply the
-// filtered Include `.Include(c => c.Leads.Where(l => l.LeftAt == null))`, so
-// every CampLeadInfo in scope is active. An IsActive field here would be
-// invariantly true and misleading — leave it out.
-public sealed record CampLeadInfo(Guid Id, Guid UserId);
 
 public sealed record CampSeasonMemberInfo(
     Guid Id,
@@ -550,13 +526,7 @@ public record CampDetailData(
     bool HideHistoricalNames,
     IReadOnlyList<string> HistoricalNames,
     IReadOnlyList<string> ImageUrls,
-    IReadOnlyList<CampLeadSummary> Leads,
     CampSeasonDetailData? CurrentSeason);
-
-public record CampLeadSummary(
-    Guid LeadId,
-    Guid UserId,
-    string DisplayName);
 
 public record CampEditData(
     Guid CampId,

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -59,12 +59,6 @@ public interface ICampRepository : IRepository
         CancellationToken ct = default);
 
     /// <summary>
-    /// Returns camps where the user has an active lead assignment, with
-    /// seasons, images, and leads included (FK-only). Read-only.
-    /// </summary>
-    Task<IReadOnlyList<Camp>> GetCampsByLeadUserIdAsync(Guid userId, CancellationToken ct = default);
-
-    /// <summary>
     /// Returns count of seasons in Pending status across all years.
     /// </summary>
     Task<int> CountPendingSeasonsAsync(CancellationToken ct = default);
@@ -228,46 +222,15 @@ public interface ICampRepository : IRepository
     Task<IReadOnlyList<(Guid Id, string Name, string CampSlug, SpaceSize? SpaceRequirement)>>
         GetSeasonBriefsForYearAsync(int year, CancellationToken ct = default);
 
-    /// <summary>
-    /// Returns the season id where the user has an active lead assignment on
-    /// a camp participating in the given year. Null if none.
-    /// </summary>
-    Task<Guid?> GetCampLeadSeasonIdForYearAsync(Guid userId, int year, CancellationToken ct = default);
-
     // ==========================================================================
-    // Writes / reads — Lead
+    // Reads — Lead (legacy camp_leads; only the role-backed team-sync read and the
+    // one-shot seed-migration snapshot remain. Entity/table kept until #774.)
     // ==========================================================================
 
     /// <summary>
-    /// Returns true if the user currently has an active lead assignment on
-    /// the camp.
-    /// </summary>
-    Task<bool> IsUserActiveLeadAsync(Guid userId, Guid campId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the count of currently-active leads on the camp.
-    /// </summary>
-    Task<int> CountActiveLeadsAsync(Guid campId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Persist a new lead assignment.
-    /// </summary>
-    Task AddLeadAsync(CampLead lead, CancellationToken ct = default);
-
-    /// <summary>
-    /// Load a lead for mutation (tracked). Null if not found.
-    /// </summary>
-    Task<CampLead?> GetLeadForMutationAsync(Guid leadId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Persist changes to a previously-loaded lead.
-    /// </summary>
-    Task UpdateLeadAsync(CampLead lead, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the distinct set of user ids who currently have an active lead
-    /// assignment on any camp. Used by <c>SystemTeamSyncJob</c> to sync the
-    /// Barrio Leads team membership.
+    /// Returns the distinct set of user ids who currently hold the Camp Lead
+    /// special role on any camp. Used by <c>SystemTeamSyncJob</c> to sync the
+    /// Barrio Leads team membership. (Reads CampRoleAssignment, not camp_leads.)
     /// </summary>
     Task<IReadOnlyList<Guid>> GetActiveLeadUserIdsAsync(CancellationToken ct = default);
 
@@ -292,17 +255,10 @@ public interface ICampRepository : IRepository
         Guid campId, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns true if the user currently leads any camp.
+    /// Returns true if the user currently holds the Camp Lead special role on any
+    /// camp. Used by <c>SystemTeamSyncJob</c>. (Reads CampRoleAssignment, not camp_leads.)
     /// </summary>
     Task<bool> IsLeadAnywhereAsync(Guid userId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns all (read-only, AsNoTracking) lead assignments — active and
-    /// historical — for the user, with parent <c>Camp</c> loaded for slug
-    /// access. Used by the GDPR export contributor.
-    /// </summary>
-    Task<IReadOnlyList<CampLead>> GetAllLeadAssignmentsForUserAsync(
-        Guid userId, CancellationToken ct = default);
 
     // ==========================================================================
     // Writes / reads — Historical names
@@ -470,13 +426,6 @@ public interface ICampRepository : IRepository
     Task<IReadOnlyList<Guid>> GetPendingRequesterUserIdsForSeasonAsync(
         Guid campSeasonId, CancellationToken ct = default);
 
-    /// <summary>
-    /// Total count of Pending membership rows across all seasons belonging to
-    /// camps where <paramref name="userId"/> is an active lead. Read-only.
-    /// </summary>
-    Task<int> CountPendingMembershipsForLeadAsync(
-        Guid userId, CancellationToken ct = default);
-
     /// <summary>Returns (CampSeasonId, UserId, Status) for the member, or null if not found. Read-only.</summary>
     Task<(Guid CampSeasonId, Guid UserId, CampMemberStatus Status)?> GetMemberLookupAsync(
         Guid campMemberId, CancellationToken ct = default);
@@ -495,28 +444,6 @@ public interface ICampRepository : IRepository
 
     Task<int> GetGrantedCountForSeasonAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default);
-
-    // ==========================================================================
-    // Account-merge fold
-    // ==========================================================================
-
-    /// <summary>
-    /// Account-merge fold: bulk-moves <c>CampLead</c> rows from
-    /// <paramref name="sourceUserId"/> to <paramref name="targetUserId"/> in
-    /// a single save. Conflict on the active <c>(CampId, UserId)</c> unique
-    /// index is resolved target-wins: if target already has an active lead
-    /// row for the same camp, the source row is dropped; otherwise the
-    /// source row is re-FK'd to target. <c>CampLead</c> has no
-    /// <c>UpdatedAt</c>, so <paramref name="updatedAt"/> is unused for this
-    /// table and accepted for caller-side symmetry. Returns the count of
-    /// CampLead rows attributed to <paramref name="targetUserId"/> after the
-    /// move (active + closed combined).
-    /// </summary>
-    Task<int> ReassignLeadsToUserAsync(
-        Guid sourceUserId,
-        Guid targetUserId,
-        Instant updatedAt,
-        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -260,6 +260,15 @@ public interface ICampRepository : IRepository
     /// </summary>
     Task<bool> IsLeadAnywhereAsync(Guid userId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns all (read-only, AsNoTracking) legacy <c>camp_leads</c> rows — active
+    /// and historical — for the user, with parent <c>Camp</c> loaded for slug access.
+    /// Used by the GDPR export contributor: while the legacy table still holds
+    /// per-user rows (until #774 drops it), Article 15 export must include them.
+    /// </summary>
+    Task<IReadOnlyList<CampLead>> GetAllLeadAssignmentsForUserAsync(
+        Guid userId, CancellationToken ct = default);
+
     // ==========================================================================
     // Writes / reads — Historical names
     // ==========================================================================

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -99,13 +99,15 @@ public interface ICampRepository : IRepository
     // ==========================================================================
 
     /// <summary>
-    /// Persist a new camp with its initial season, creator lead, and optional
-    /// historical names in a single transaction.
+    /// Persist a new camp with its initial season, the creator's Active CampMember,
+    /// an optional Camp Lead role assignment (null when the Lead role definition is
+    /// not yet seeded), and optional historical names in a single transaction.
     /// </summary>
     Task CreateCampAsync(
         Camp camp,
         CampSeason initialSeason,
-        CampLead creatorLead,
+        CampMember creatorMember,
+        CampRoleAssignment? creatorLeadAssignment,
         IReadOnlyList<CampHistoricalName>? historicalNames,
         CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Repositories/ICampRoleRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRoleRepository.cs
@@ -87,6 +87,14 @@ public interface ICampRoleRepository : IRepository
         CampSpecialRole specialRole, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns the distinct user ids holding the given special role on the
+    /// specified season (non-deactivated definition). Used to source the camp
+    /// detail "Contact the leads" recipient list and admin/CSV lead columns.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetSpecialRoleHolderUserIdsForSeasonAsync(
+        Guid campSeasonId, CampSpecialRole specialRole, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns true if the user currently holds the given special role on any
     /// camp/season. Used by <c>SystemTeamSyncJob</c> for the Barrio Leads team
     /// member-check path.

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -47,6 +47,9 @@ public sealed class CampRoleService(
         return definition is null ? null : CreateCampRoleDefinitionInfo(definition);
     }
 
+    public Task<IReadOnlyList<Guid>> GetSeasonLeadUserIdsAsync(Guid campSeasonId, CancellationToken ct = default) =>
+        repo.GetSpecialRoleHolderUserIdsForSeasonAsync(campSeasonId, CampSpecialRole.Lead, ct);
+
     public async Task<CampRoleDefinition> CreateDefinitionAsync(CreateCampRoleDefinitionInput input, Guid actorUserId, CancellationToken ct = default)
     {
         ValidateMinimumRequired(input.SlotCount, input.MinimumRequired);

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -104,14 +104,37 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
 
         var season = CreateSeasonFromData(camp.Id, year, name, seasonData, now);
 
-        var lead = new CampLead
+        var member = new CampMember
         {
             Id = Guid.NewGuid(),
-            CampId = camp.Id,
+            CampSeasonId = season.Id,
             UserId = createdByUserId,
-            Role = CampLeadRole.CoLead,
-            JoinedAt = now
+            Status = CampMemberStatus.Active,
+            RequestedAt = now,
+            ConfirmedAt = now,
+            ConfirmedByUserId = createdByUserId,
         };
+
+        var leadDef = await _roleRepo.GetSpecialDefinitionAsync(CampSpecialRole.Lead, cancellationToken);
+        CampRoleAssignment? leadAssignment = null;
+        if (leadDef is not null)
+        {
+            leadAssignment = new CampRoleAssignment
+            {
+                Id = Guid.NewGuid(),
+                CampSeasonId = season.Id,
+                CampRoleDefinitionId = leadDef.Id,
+                CampMemberId = member.Id,
+                AssignedAt = now,
+                AssignedByUserId = createdByUserId,
+            };
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Camp Lead role definition missing while creating camp {CampId}; creator added as Active member without a lead assignment. Run 'Seed system roles'.",
+                camp.Id);
+        }
 
         List<CampHistoricalName>? historicalNameEntities = null;
         if (historicalNames is { Count: > 0 })
@@ -126,7 +149,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             }).ToList();
         }
 
-        await _repo.CreateCampAsync(camp, season, lead, historicalNameEntities, cancellationToken);
+        await _repo.CreateCampAsync(camp, season, member, leadAssignment, historicalNameEntities, cancellationToken);
 
         await _auditLog.LogAsync(
             AuditAction.CampCreated, nameof(Camp), camp.Id,

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -273,12 +273,18 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         var camps = await GetCampEntitiesForYearAsync(year, cancellationToken);
 
         // Lead camps: pin to top of listing + build "my pending camps" panel.
+        // Lead status comes from the role system (Camp Lead special role on any
+        // season), not the legacy camp_leads table.
         var leadCampIds = new HashSet<Guid>();
         IReadOnlyList<Camp> leadCamps = [];
         if (userId.HasValue)
         {
-            leadCamps = await _repo.GetCampsByLeadUserIdAsync(userId.Value, cancellationToken);
-            leadCampIds = leadCamps.Select(c => c.Id).ToHashSet();
+            var leadCampIdList = await _roleRepo.GetCampIdsBySpecialRolesForUserAsync(
+                userId.Value, LeadOnly, cancellationToken);
+            leadCampIds = leadCampIdList.ToHashSet();
+            // Re-derive from the already-loaded year camps (avoids a second camp load);
+            // MyCamps only needs camps that have a season for this year anyway.
+            leadCamps = camps.Where(c => leadCampIds.Contains(c.Id)).ToList();
         }
 
         var cards = ApplyCampDirectoryFilter(

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -212,8 +212,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             return null;
         }
 
-        var leadSummaries = await BuildLeadSummariesAsync(camp.Leads, cancellationToken);
-
         return new CampDetailData(
             camp.Id,
             camp.Slug,
@@ -224,7 +222,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             camp.HideHistoricalNames,
             camp.HistoricalNames.Select(h => h.Name).ToList(),
             camp.Images.OrderBy(i => i.SortOrder).Select(i => $"/{i.StoragePath}").ToList(),
-            leadSummaries,
             CreateCampSeasonDetailData(season));
     }
 
@@ -469,8 +466,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             camp.ContactPhone,
             camp.IsSwissCamp,
             camp.TimesAtNowhere,
-            camp.Seasons.Select(s => CreateCampSeasonInfo(s, camp.Slug, includeEarlyEntryGrantCount: true)).ToList(),
-            camp.Leads.Select(l => new CampLeadInfo(l.Id, l.UserId)).ToList());
+            camp.Seasons.Select(s => CreateCampSeasonInfo(s, camp.Slug, includeEarlyEntryGrantCount: true)).ToList());
     }
 
     private static CampLookup CreateCampLookup(Camp camp) =>
@@ -478,8 +474,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             camp.Id,
             camp.Slug,
             camp.ContactEmail,
-            camp.Seasons.Select(s => CreateCampSeasonInfo(s, camp.Slug, includeEarlyEntryGrantCount: false)).ToList(),
-            camp.Leads.Select(l => new CampLeadInfo(l.Id, l.UserId)).ToList());
+            camp.Seasons.Select(s => CreateCampSeasonInfo(s, camp.Slug, includeEarlyEntryGrantCount: false)).ToList());
 
     private static CampSeasonInfo CreateCampSeasonInfo(
         CampSeason season,
@@ -546,27 +541,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         return camp.WebOrSocialUrl is not null
             ? [new CampLink { Url = camp.WebOrSocialUrl }]
             : [];
-    }
-
-    private async Task<IReadOnlyList<CampLeadSummary>> BuildLeadSummariesAsync(
-        IEnumerable<CampLead> leads,
-        CancellationToken cancellationToken)
-    {
-        var activeLeads = leads.Where(l => l.IsActive).ToList();
-        if (activeLeads.Count == 0)
-        {
-            return [];
-        }
-
-        var userIds = activeLeads.Select(l => l.UserId).Distinct().ToList();
-        var users = await _userService.GetUserInfosAsync(userIds, cancellationToken);
-
-        return activeLeads
-            .Select(l => new CampLeadSummary(
-                l.Id,
-                l.UserId,
-                users.TryGetValue(l.UserId, out var user) ? user.BurnerName : string.Empty))
-            .ToList();
     }
 
     private CampSeasonDetailData CreateCampSeasonDetailData(CampSeason season)
@@ -1064,69 +1038,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
 
     }
 
-    // --- Lead management ---
-
-    public async Task<CampLead> AddLeadAsync(
-        Guid campId, Guid userId, CancellationToken cancellationToken = default)
-    {
-        if (await _repo.IsUserActiveLeadAsync(userId, campId, cancellationToken))
-        {
-            throw new InvalidOperationException("This user is already an active lead.");
-        }
-
-        var activeCount = await _repo.CountActiveLeadsAsync(campId, cancellationToken);
-        if (activeCount >= 5)
-        {
-            throw new InvalidOperationException("Camp already has the maximum of 5 leads.");
-        }
-
-        var now = _clock.GetCurrentInstant();
-        var lead = new CampLead
-        {
-            Id = Guid.NewGuid(),
-            CampId = campId,
-            UserId = userId,
-            Role = CampLeadRole.CoLead,
-            JoinedAt = now
-        };
-
-        await _repo.AddLeadAsync(lead, cancellationToken);
-
-        await _auditLog.LogAsync(
-            AuditAction.CampLeadAdded, nameof(CampLead), lead.Id,
-            "Added as camp lead",
-            userId,
-            relatedEntityId: campId, relatedEntityType: nameof(Camp));
-
-        await _systemTeamSync.SyncMembershipForUserAsync(userId, SystemTeamType.BarrioLeads, cancellationToken);
-
-        return lead;
-    }
-
-    public async Task RemoveLeadAsync(Guid leadId, CancellationToken cancellationToken = default)
-    {
-        var lead = await _repo.GetLeadForMutationAsync(leadId, cancellationToken)
-            ?? throw new InvalidOperationException("Lead not found.");
-
-        var activeCount = await _repo.CountActiveLeadsAsync(lead.CampId, cancellationToken);
-        if (activeCount <= 1)
-        {
-            throw new InvalidOperationException(
-                "Cannot remove the last lead. A camp must have at least one lead.");
-        }
-
-        lead.LeftAt = _clock.GetCurrentInstant();
-        await _repo.UpdateLeadAsync(lead, cancellationToken);
-
-        await _auditLog.LogAsync(
-            AuditAction.CampLeadRemoved, nameof(CampLead), leadId,
-            "Removed from camp leads",
-            lead.UserId,
-            relatedEntityId: lead.CampId, relatedEntityType: nameof(Camp));
-
-        await _systemTeamSync.SyncMembershipForUserAsync(lead.UserId, SystemTeamType.BarrioLeads, cancellationToken);
-    }
-
     // --- Historical names ---
 
     public async Task AddHistoricalNameAsync(
@@ -1452,7 +1363,17 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         {
             return;
         }
-        foreach (var leadUserId in camp.Leads.Where(l => l.LeftAt is null).Select(l => l.UserId).Distinct())
+        // Leads come from the role system (Camp Lead special role on each season).
+        var leadUserIds = new HashSet<Guid>();
+        foreach (var season in camp.Seasons)
+        {
+            foreach (var leadUserId in await _roleRepo.GetSpecialRoleHolderUserIdsForSeasonAsync(
+                season.Id, CampSpecialRole.Lead, cancellationToken))
+            {
+                leadUserIds.Add(leadUserId);
+            }
+        }
+        foreach (var leadUserId in leadUserIds)
         {
             _leadBadgeInvalidator.Invalidate(leadUserId);
         }

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -1851,8 +1851,8 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
     public async Task ReassignAsync(Guid sourceUserId, Guid targetUserId, Guid actorUserId, Instant updatedAt,
         CancellationToken ct)
     {
-        // Section ownership splits the tables; AccountMergeService.AcceptAsync wraps both saves in its TransactionScope.
-        await _repo.ReassignLeadsToUserAsync(sourceUserId, targetUserId, updatedAt, ct);
+        // AccountMergeService.AcceptAsync wraps the save in its TransactionScope.
+        // Camp Lead is a CampRoleAssignment now, so the role-side reassignment moves leads too.
         await _roleRepo.ReassignAssignmentsToUserAsync(sourceUserId, targetUserId, updatedAt, ct);
 
         // Lead moves change Barrio Leads team membership + lead-badge cache for both users.

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -1787,9 +1787,18 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)
     {
-        // Camp Lead is now a CampRoleAssignment (special role Lead), so the GDPR
-        // export carries leads inside the role-assignment slice — no separate
-        // legacy camp_leads slice.
+        // Camp Lead is now a CampRoleAssignment. The legacy camp_leads table still
+        // holds per-user rows until #774 drops it, so Article 15 export must keep
+        // including them alongside the role-assignment slice (design-rules §8a).
+        var legacyLeads = await _repo.GetAllLeadAssignmentsForUserAsync(userId, ct);
+        var shapedLeads = legacyLeads.Select(cl => new
+        {
+            CampSlug = cl.Camp.Slug,
+            cl.Role,
+            JoinedAt = cl.JoinedAt.ToInvariantInstantString(),
+            LeftAt = cl.LeftAt.ToInvariantInstantString()
+        }).ToList();
+
         var roleAssignments = await _roleRepo.GetAllAssignmentsForUserAsync(userId, ct);
 
         var shapedRoles = roleAssignments.Select(a => new
@@ -1803,6 +1812,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
 
         return
         [
+            new UserDataSlice(GdprExportSections.CampLeadAssignments, shapedLeads),
             new UserDataSlice(GdprExportSections.CampRoleAssignments, shapedRoles)
         ];
     }

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -259,8 +259,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             return null;
         }
 
-        var leadSummaries = await BuildLeadSummariesAsync(camp.Leads, cancellationToken);
-        return CreateCampEditData(camp, season, leadSummaries);
+        return CreateCampEditData(camp, season);
     }
 
     public async Task<CampDirectoryResult> GetCampDirectoryAsync(
@@ -597,7 +596,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             season.NameLockDate.HasValue && today >= season.NameLockDate.Value);
     }
 
-    private CampEditData CreateCampEditData(Camp camp, CampSeason season, IReadOnlyList<CampLeadSummary> leads)
+    private CampEditData CreateCampEditData(Camp camp, CampSeason season)
     {
         var today = _clock.GetCurrentInstant().InUtc().Date;
 
@@ -633,7 +632,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             season.SpaceRequirement,
             season.SoundZone,
             season.ElectricalGrid,
-            leads,
             camp.Images
                 .OrderBy(i => i.SortOrder)
                 .Select(i => new CampImageSummary(i.Id, $"/{i.StoragePath}", i.SortOrder))
@@ -1899,16 +1897,9 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)
     {
-        var leadAssignments = await _repo.GetAllLeadAssignmentsForUserAsync(userId, ct);
-
-        var shapedLeads = leadAssignments.Select(cl => new
-        {
-            CampSlug = cl.Camp.Slug,
-            cl.Role,
-            JoinedAt = cl.JoinedAt.ToInvariantInstantString(),
-            LeftAt = cl.LeftAt.ToInvariantInstantString()
-        }).ToList();
-
+        // Camp Lead is now a CampRoleAssignment (special role Lead), so the GDPR
+        // export carries leads inside the role-assignment slice — no separate
+        // legacy camp_leads slice.
         var roleAssignments = await _roleRepo.GetAllAssignmentsForUserAsync(userId, ct);
 
         var shapedRoles = roleAssignments.Select(a => new
@@ -1922,7 +1913,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
 
         return
         [
-            new UserDataSlice(GdprExportSections.CampLeadAssignments, shapedLeads),
             new UserDataSlice(GdprExportSections.CampRoleAssignments, shapedRoles)
         ];
     }

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -1189,21 +1189,10 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
     private static readonly IReadOnlyCollection<CampSpecialRole> LeadOrWorkshop =
         [CampSpecialRole.Lead, CampSpecialRole.Workshop];
 
-    public async Task<bool> IsUserCampLeadAsync(
-        Guid userId, Guid campId, CancellationToken cancellationToken = default)
-    {
-        // Post-migration source of truth: CampRoleAssignment against the Camp Lead
-        // special role. Legacy CampLead fallback covers the deploy window before
-        // the "Seed system roles" admin button runs on this env (issue
-        // nobodies-collective/Humans#753). Removed when the legacy table drops in
-        // the follow-up PR.
-        if (await _roleRepo.IsUserSpecialRoleHolderForCampAsync(
-            userId, campId, LeadOnly, cancellationToken))
-        {
-            return true;
-        }
-        return await _repo.IsUserActiveLeadAsync(userId, campId, cancellationToken);
-    }
+    public Task<bool> IsUserCampLeadAsync(
+        Guid userId, Guid campId, CancellationToken cancellationToken = default) =>
+        // Source of truth: CampRoleAssignment against the Camp Lead special role.
+        _roleRepo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOnly, cancellationToken);
 
     public async Task<IReadOnlyList<CampLookup>> GetEventManagedCampsAsync(
         Guid userId, int year, CancellationToken cancellationToken = default)
@@ -1212,11 +1201,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         var roleCampIds = await _roleRepo.GetCampIdsBySpecialRolesForUserAsync(
             userId, LeadOrWorkshop, cancellationToken);
 
-        // Legacy fallback: camps where the user is an active lead via the old CampLead table.
-        var legacyCamps = await _repo.GetCampsByLeadUserIdAsync(userId, cancellationToken);
-        var legacyCampIds = legacyCamps.Select(c => c.Id);
-
-        var allCampIds = roleCampIds.Union(legacyCampIds).ToHashSet();
+        var allCampIds = roleCampIds.ToHashSet();
         if (allCampIds.Count == 0) return [];
 
         // Filter the year's full camp list down to the ones the user manages.
@@ -1228,21 +1213,12 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             .ToList();
     }
 
-    public async Task<bool> IsUserCampEventManagerAsync(
-        Guid userId, Guid campId, CancellationToken cancellationToken = default)
-    {
-        // Authorizes camp-event submission (EventsController). Lead OR
-        // Workshop on the camp's current season. Camp leads inherit Workshop
-        // power because the role set is the OR — no separate "lead-implies-
-        // workshop" logic. Legacy CampLead fallback covers the deploy window
-        // before the "Seed system roles" admin button runs.
-        if (await _roleRepo.IsUserSpecialRoleHolderForCampAsync(
-            userId, campId, LeadOrWorkshop, cancellationToken))
-        {
-            return true;
-        }
-        return await _repo.IsUserActiveLeadAsync(userId, campId, cancellationToken);
-    }
+    public Task<bool> IsUserCampEventManagerAsync(
+        Guid userId, Guid campId, CancellationToken cancellationToken = default) =>
+        // Authorizes camp-event submission (EventsController). Lead OR Workshop on
+        // the camp's current season. Camp leads inherit Workshop power because the
+        // role set is the OR — no separate "lead-implies-workshop" logic.
+        _roleRepo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOrWorkshop, cancellationToken);
 
     public async Task<CampMemberLookup?> GetCampMemberStatusAsync(Guid campMemberId, CancellationToken cancellationToken = default)
     {
@@ -1845,19 +1821,12 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         return result;
     }
 
-    public async Task<int> GetPendingMembershipCountForLeadAsync(
-        Guid userId, CancellationToken cancellationToken = default)
-    {
-        // Post-migration source of truth: pending-membership count over camps
-        // where the user holds the Camp Lead special role. Falls back to the
-        // legacy CampLead count during the seed-button transition window so
-        // unmigrated leads still see their badge (issue
-        // nobodies-collective/Humans#753).
-        var roleSide = await _roleRepo.CountPendingMembershipsForSpecialRoleHolderAsync(
+    public Task<int> GetPendingMembershipCountForLeadAsync(
+        Guid userId, CancellationToken cancellationToken = default) =>
+        // Source of truth: pending-membership count over camps where the user
+        // holds the Camp Lead special role.
+        _roleRepo.CountPendingMembershipsForSpecialRoleHolderAsync(
             userId, CampSpecialRole.Lead, cancellationToken);
-        if (roleSide > 0) return roleSide;
-        return await _repo.CountPendingMembershipsForLeadAsync(userId, cancellationToken);
-    }
 
     public async Task<IReadOnlyList<CampMembershipSummary>> GetCampMembershipsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default)

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -1179,19 +1179,11 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
                 kv.Value.CampId));
     }
 
-    public async Task<Guid?> GetCampLeadSeasonIdForYearAsync(
-        Guid userId, int year, CancellationToken cancellationToken = default)
-    {
-        // Post-migration source of truth: CampRoleAssignment against the Camp Lead
-        // special role. Legacy CampLead fallback covers the deploy window before
-        // the "Seed system roles" admin button runs on this env (issue
-        // nobodies-collective/Humans#753). Removed when the legacy table drops in
-        // the follow-up PR.
-        var fromRole = await _roleRepo.GetCampSpecialRoleSeasonIdForYearAsync(
+    public Task<Guid?> GetCampLeadSeasonIdForYearAsync(
+        Guid userId, int year, CancellationToken cancellationToken = default) =>
+        // Source of truth: CampRoleAssignment against the Camp Lead special role.
+        _roleRepo.GetCampSpecialRoleSeasonIdForYearAsync(
             userId, year, CampSpecialRole.Lead, cancellationToken);
-        if (fromRole is not null) return fromRole;
-        return await _repo.GetCampLeadSeasonIdForYearAsync(userId, year, cancellationToken);
-    }
 
     // --- Authorization checks ---
 

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -435,6 +435,19 @@ internal sealed class CampRepository : ICampRepository
                 && a.Definition.DeactivatedAt == null, ct);
     }
 
+    public async Task<IReadOnlyList<CampLead>> GetAllLeadAssignmentsForUserAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        // GDPR export of legacy camp_leads rows until #774 drops the table.
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampLeads
+            .AsNoTracking()
+            .Include(cl => cl.Camp)
+            .Where(cl => cl.UserId == userId)
+            .OrderByDescending(cl => cl.JoinedAt) // arch:db-sort-ok — GDPR export ordering
+            .ToListAsync(ct);
+    }
+
     public async Task<IReadOnlyList<LeadMigrationSnapshot>> GetLeadMigrationSnapshotsAsync(
         CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -27,7 +27,6 @@ internal sealed class CampRepository : ICampRepository
         return await ctx.Camps
             .AsNoTracking()
             .Include(b => b.Seasons)
-            .Include(b => b.Leads.Where(l => l.LeftAt == null))
             .Include(b => b.HistoricalNames)
             .Include(b => b.Images.OrderBy(i => i.SortOrder))
             .FirstOrDefaultAsync(b => b.Slug == normalizedSlug, ct);
@@ -42,7 +41,6 @@ internal sealed class CampRepository : ICampRepository
             .AsNoTracking()
             .Include(b => b.Seasons)
                 .ThenInclude(s => s.Members.Where(m => m.Status == CampMemberStatus.Active))
-            .Include(b => b.Leads.Where(l => l.LeftAt == null))
             .Include(b => b.HistoricalNames)
             .Include(b => b.Images.OrderBy(i => i.SortOrder))
             .FirstOrDefaultAsync(b => b.Id == campId, ct);
@@ -71,7 +69,6 @@ internal sealed class CampRepository : ICampRepository
             .AsNoTracking()
             .Include(c => c.Seasons.Where(s => s.Year == year))
                 .ThenInclude(s => s.Members.Where(m => m.Status == CampMemberStatus.Active))
-            .Include(c => c.Leads.Where(l => l.LeftAt == null))
             .Where(c => c.Seasons.Any(s => s.Year == year));
 
         if (statusFilter is { Count: > 0 })
@@ -81,19 +78,6 @@ internal sealed class CampRepository : ICampRepository
 
         return await query
             .OrderBy(c => c.Seasons.Where(s => s.Year == year).Select(s => s.Name).FirstOrDefault())
-            .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<Camp>> GetCampsByLeadUserIdAsync(
-        Guid userId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.Camps
-            .AsNoTracking()
-            .Include(b => b.Seasons)
-            .Include(b => b.Images.OrderBy(i => i.SortOrder))
-            .Include(b => b.Leads)
-            .Where(b => b.Leads.Any(l => l.UserId == userId && l.LeftAt == null))
             .ToListAsync(ct);
     }
 
@@ -111,7 +95,6 @@ internal sealed class CampRepository : ICampRepository
         return await ctx.CampSeasons
             .AsNoTracking()
             .Include(s => s.Camp)
-            .ThenInclude(c => c.Leads.Where(l => l.LeftAt == null))
             .Where(s => s.Status == CampSeasonStatus.Pending)
             .OrderBy(s => s.CreatedAt)
             .ToListAsync(ct);
@@ -418,68 +401,9 @@ internal sealed class CampRepository : ICampRepository
         return rows.Select(r => (r.Id, r.Name, r.CampSlug, r.SpaceRequirement)).ToList();
     }
 
-    public async Task<Guid?> GetCampLeadSeasonIdForYearAsync(
-        Guid userId, int year, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.CampLeads
-            .AsNoTracking()
-            .Where(l => l.UserId == userId && l.LeftAt == null)
-            .Join(ctx.CampSeasons,
-                l => l.CampId,
-                s => s.CampId,
-                (l, s) => s)
-            .Where(s => s.Year == year)
-            .Select(s => (Guid?)s.Id)
-            .FirstOrDefaultAsync(ct);
-    }
-
-    // Leads
-
-    public async Task<bool> IsUserActiveLeadAsync(
-        Guid userId, Guid campId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.CampLeads
-            .AsNoTracking()
-            .AnyAsync(l => l.CampId == campId && l.UserId == userId && l.LeftAt == null, ct);
-    }
-
-    public async Task<int> CountActiveLeadsAsync(Guid campId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.CampLeads
-            .AsNoTracking()
-            .CountAsync(l => l.CampId == campId && l.LeftAt == null, ct);
-    }
-
-    public async Task AddLeadAsync(CampLead lead, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        ctx.CampLeads.Add(lead);
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    public async Task<CampLead?> GetLeadForMutationAsync(
-        Guid leadId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var lead = await ctx.CampLeads.FindAsync([leadId], ct);
-        if (lead is null)
-        {
-            return null;
-        }
-
-        ctx.Entry(lead).State = EntityState.Detached;
-        return lead;
-    }
-
-    public async Task UpdateLeadAsync(CampLead lead, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        ctx.CampLeads.Update(lead);
-        await ctx.SaveChangesAsync(ct);
-    }
+    // Leads (legacy camp_leads — only the seed-migration snapshot + role-backed
+    // team-sync reads remain; mutation/query methods retired with the Camp Lead
+    // role move. Entity/table kept until nobodies-collective/Humans#774.)
 
     public async Task<IReadOnlyList<Guid>> GetActiveLeadUserIdsAsync(
         CancellationToken ct = default)
@@ -509,18 +433,6 @@ internal sealed class CampRepository : ICampRepository
             .AnyAsync(a => a.CampMember.UserId == userId
                 && a.Definition.SpecialRole == CampSpecialRole.Lead
                 && a.Definition.DeactivatedAt == null, ct);
-    }
-
-    public async Task<IReadOnlyList<CampLead>> GetAllLeadAssignmentsForUserAsync(
-        Guid userId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.CampLeads
-            .AsNoTracking()
-            .Include(cl => cl.Camp)
-            .Where(cl => cl.UserId == userId)
-            .OrderByDescending(cl => cl.JoinedAt)
-            .ToListAsync(ct);
     }
 
     public async Task<IReadOnlyList<LeadMigrationSnapshot>> GetLeadMigrationSnapshotsAsync(
@@ -912,25 +824,6 @@ internal sealed class CampRepository : ICampRepository
             .ToListAsync(ct);
     }
 
-    public async Task<int> CountPendingMembershipsForLeadAsync(
-        Guid userId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var leadCampIds = ctx.CampLeads
-            .AsNoTracking()
-            .Where(l => l.UserId == userId && l.LeftAt == null)
-            .Select(l => l.CampId);
-
-        // Only seasons still open (Active/Full) — closed seasons keep rows for audit but shouldn't nag.
-        return await ctx.CampMembers
-            .AsNoTracking()
-            .Where(m => m.Status == CampMemberStatus.Pending
-                && leadCampIds.Contains(m.CampSeason.CampId)
-                && (m.CampSeason.Status == CampSeasonStatus.Active
-                    || m.CampSeason.Status == CampSeasonStatus.Full))
-            .CountAsync(ct);
-    }
-
     public async Task<(Guid CampSeasonId, Guid UserId, CampMemberStatus Status)?> GetMemberLookupAsync(
         Guid campMemberId, CancellationToken ct = default)
     {
@@ -940,46 +833,6 @@ internal sealed class CampRepository : ICampRepository
             .Select(m => new { m.CampSeasonId, m.UserId, m.Status })
             .FirstOrDefaultAsync(ct);
         return row is null ? null : (row.CampSeasonId, row.UserId, row.Status);
-    }
-
-    // Account-merge fold
-
-    public async Task<int> ReassignLeadsToUserAsync(
-        Guid sourceUserId, Guid targetUserId, Instant updatedAt,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-
-        // Canonical uniqueness is the partial index on (CampId, UserId) WHERE LeftAt IS NULL —
-        // only active source rows can collide with active target rows.
-        var sourceRows = await ctx.CampLeads
-            .Where(l => l.UserId == sourceUserId)
-            .ToListAsync(ct);
-
-        var targetActiveCampIds = await ctx.CampLeads
-            .Where(l => l.UserId == targetUserId && l.LeftAt == null)
-            .Select(l => l.CampId)
-            .ToListAsync(ct);
-        var targetActiveCampIdSet = new HashSet<Guid>(targetActiveCampIds);
-
-        foreach (var src in sourceRows)
-        {
-            if (src.LeftAt == null && targetActiveCampIdSet.Contains(src.CampId))
-            {
-                // Target wins; closed source rows for the same camp still re-FK below.
-                ctx.CampLeads.Remove(src);
-            }
-            else
-            {
-                // UserId is init-only — mutate via change-tracker.
-                ctx.Entry(src).Property(nameof(CampLead.UserId)).CurrentValue = targetUserId;
-            }
-        }
-
-        await ctx.SaveChangesAsync(ct);
-
-        return await ctx.CampLeads
-            .CountAsync(l => l.UserId == targetUserId, ct);
     }
 
     // Early Entry

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -167,14 +167,19 @@ internal sealed class CampRepository : ICampRepository
     public async Task CreateCampAsync(
         Camp camp,
         CampSeason initialSeason,
-        CampLead creatorLead,
+        CampMember creatorMember,
+        CampRoleAssignment? creatorLeadAssignment,
         IReadOnlyList<CampHistoricalName>? historicalNames,
         CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         ctx.Camps.Add(camp);
         ctx.CampSeasons.Add(initialSeason);
-        ctx.CampLeads.Add(creatorLead);
+        ctx.CampMembers.Add(creatorMember);
+        if (creatorLeadAssignment is not null)
+        {
+            ctx.CampRoleAssignments.Add(creatorLeadAssignment);
+        }
         if (historicalNames is { Count: > 0 })
         {
             foreach (var name in historicalNames)

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs
@@ -127,6 +127,20 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<Guid>> GetSpecialRoleHolderUserIdsForSeasonAsync(
+        Guid campSeasonId, CampSpecialRole specialRole, CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.CampRoleAssignments
+            .AsNoTracking()
+            .Where(a => a.CampSeasonId == campSeasonId
+                && a.Definition.SpecialRole == specialRole
+                && a.Definition.DeactivatedAt == null)
+            .Select(a => a.CampMember.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+    }
+
     public async Task<bool> IsSpecialRoleHolderAnywhereAsync(
         Guid userId, CampSpecialRole specialRole, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
+++ b/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
@@ -78,24 +78,16 @@ public sealed class CachingCampService(
         return await LoadSettingsAsync(cancellationToken);
     }
 
-    // Lead authz delegates straight to the inner service. CampInfo.Leads is
-    // still built from the legacy CampLead table, but the source of truth is
-    // now CampRoleAssignment with SpecialRole = Lead (issue
-    // nobodies-collective/Humans#753). Answering from camp.Leads would
-    // false-negative every role-assigned lead. The follow-up PR that retires
-    // CampLead re-introduces a smarter cached path.
+    // Lead authz delegates straight to the inner service — the source of truth
+    // is CampRoleAssignment (SpecialRole = Lead), not the CampInfo projection.
     public Task<bool> IsUserCampLeadAsync(
         Guid userId, Guid campId, CancellationToken cancellationToken = default) =>
         WithInner(inner => inner.IsUserCampLeadAsync(userId, campId, cancellationToken));
 
     public Task<bool> IsUserCampEventManagerAsync(
-        Guid userId, Guid campId, CancellationToken cancellationToken = default)
-    {
-        // Workshop-role holders are not modeled in CampInfo.Leads (which is
-        // strictly Camp Lead). Delegate to the inner service so the Lead OR
-        // Workshop check sees the role-assignment table directly.
-        return WithInner(inner => inner.IsUserCampEventManagerAsync(userId, campId, cancellationToken));
-    }
+        Guid userId, Guid campId, CancellationToken cancellationToken = default) =>
+        // Delegate so the Lead OR Workshop check sees the role-assignment table directly.
+        WithInner(inner => inner.IsUserCampEventManagerAsync(userId, campId, cancellationToken));
 
     public Task<IReadOnlyList<CampLookup>> GetEventManagedCampsAsync(
         Guid userId, int year, CancellationToken cancellationToken = default) =>
@@ -250,25 +242,6 @@ public sealed class CachingCampService(
         await WithInner(inner => inner.DeleteCampAsync(campId, cancellationToken));
         // Tombstone without flipping warmth — preserves the all-rows invariant.
         DeleteKey(campId);
-    }
-
-    public async Task<CampLead> AddLeadAsync(
-        Guid campId, Guid userId, CancellationToken cancellationToken = default)
-    {
-        var result = await WithInner(inner => inner.AddLeadAsync(campId, userId, cancellationToken));
-        await InvalidateCampAsync(campId, cancellationToken);
-        return result;
-    }
-
-    public async Task RemoveLeadAsync(Guid leadId, CancellationToken cancellationToken = default)
-    {
-        // No campId on the API surface — scan the snapshot; fall back to RefreshAll.
-        var campId = FindCampIdByLeadId(leadId);
-        await WithInner(inner => inner.RemoveLeadAsync(leadId, cancellationToken));
-        if (campId is not null)
-            await InvalidateCampAsync(campId.Value, cancellationToken);
-        else
-            RefreshAll();
     }
 
     public async Task AddHistoricalNameAsync(
@@ -616,15 +589,6 @@ public sealed class CachingCampService(
             await InvalidateCampAsync(season.CampId, ct);
     }
 
-    private Guid? FindCampIdByLeadId(Guid leadId)
-    {
-        foreach (var camp in Values)
-        {
-            if (camp.Leads.Any(l => l.Id == leadId)) return camp.Id;
-        }
-        return null;
-    }
-
     // Projection + filter helpers
 
     private static CampInfo ProjectCampInfo(Camp camp) => new(
@@ -634,8 +598,7 @@ public sealed class CachingCampService(
         camp.ContactPhone,
         camp.IsSwissCamp,
         camp.TimesAtNowhere,
-        camp.Seasons.Select(s => ProjectSeasonInfo(s, camp.Slug)).ToList(),
-        camp.Leads.Where(l => l.LeftAt is null).Select(l => new CampLeadInfo(l.Id, l.UserId)).ToList());
+        camp.Seasons.Select(s => ProjectSeasonInfo(s, camp.Slug)).ToList());
 
     private static CampSeasonInfo ProjectSeasonInfo(CampSeason season, string campSlug) => new(
         season.Id,

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -1087,18 +1087,10 @@ public class CampController(
         var editData = await _campService.GetCampEditDataAsync(model.CampId, model.Year);
         if (editData is null)
         {
-            model.Leads = [];
             model.Images = [];
             return;
         }
 
-        model.Leads = editData.Leads
-            .Select(lead => new CampLeadViewModel
-            {
-                LeadId = lead.LeadId,
-                UserId = lead.UserId
-            })
-            .ToList();
         model.Images = editData.Images
             .Select(image => new CampImageViewModel
             {
@@ -1140,12 +1132,6 @@ public class CampController(
             SpaceRequirement = editData.SpaceRequirement,
             SoundZone = editData.SoundZone,
             ElectricalGrid = editData.ElectricalGrid,
-            Leads = editData.Leads
-                .Select(lead => new CampLeadViewModel
-                {
-                    LeadId = lead.LeadId,
-                    UserId = lead.UserId
-                }).ToList(),
             Images = editData.Images
                 .Select(image => new CampImageViewModel
                 {

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -108,7 +108,7 @@ public class CampController(
         await PopulateCityPlanningViewBagAsync(currentUser, ct);
 
         var vm = MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership);
-        await PopulateDetailCardsAsync(vm, campDetail, isCampAdmin, ct);
+        await PopulateDetailCardsAsync(vm, campDetail, currentUser, isCampAdmin, ct);
         return View(vm);
     }
 
@@ -130,7 +130,7 @@ public class CampController(
         await PopulateCityPlanningViewBagAsync(currentUser, ct);
 
         var vm = MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership);
-        await PopulateDetailCardsAsync(vm, campDetail, isCampAdmin, ct);
+        await PopulateDetailCardsAsync(vm, campDetail, currentUser, isCampAdmin, ct);
         return View(nameof(Details), vm);
     }
 
@@ -1201,23 +1201,26 @@ public class CampController(
     /// viewers or seasonless camps.
     /// </summary>
     private async Task PopulateDetailCardsAsync(
-        CampDetailViewModel vm, CampDetailData campDetail, bool isCampAdmin,
+        CampDetailViewModel vm, CampDetailData campDetail, UserInfo? currentUser, bool isCampAdmin,
         CancellationToken ct)
     {
-        if (User.Identity?.IsAuthenticated != true || campDetail.CurrentSeason is null)
+        if (currentUser is null || campDetail.CurrentSeason is null)
         {
             return; // anonymous / no season → no cards
         }
-
-        vm.CanSeeFullCamp = isCampAdmin || vm.Membership.Status == CampMemberStatusSummaryView.Active;
 
         // Read-only roles panel (same source as /Edit/Members).
         vm.RolesPanel = await BuildRolesPanelAsync(
             campDetail.Slug, campDetail.CurrentSeason.Id, canManage: false, ct);
 
+        // Full-camp access is decided by membership in the *displayed* season, not the
+        // open-season membership VM — that VM is NoOpenSeason for Pending/closed seasons,
+        // which would wrongly hide the roster from real members (e.g. the camp creator).
+        var members = await _campService.GetCampMembersAsync(campDetail.CurrentSeason.Id);
+        vm.CanSeeFullCamp = isCampAdmin || members.Active.Any(m => m.UserId == currentUser.Id);
+
         if (vm.CanSeeFullCamp)
         {
-            var members = await _campService.GetCampMembersAsync(campDetail.CurrentSeason.Id);
             vm.Roster = members.Active
                 .Select(m => new CampMemberRowViewModel
                 {

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -107,7 +107,9 @@ public class CampController(
         var membership = await ResolveCurrentUserMembershipStateAsync(campDetail.Id, currentUser);
         await PopulateCityPlanningViewBagAsync(currentUser, ct);
 
-        return View(MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership));
+        var vm = MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership);
+        await PopulateDetailCardsAsync(vm, campDetail, isCampAdmin, ct);
+        return View(vm);
     }
 
     [AllowAnonymous]
@@ -127,7 +129,9 @@ public class CampController(
         var membership = await ResolveCurrentUserMembershipStateAsync(campDetail.Id, currentUser);
         await PopulateCityPlanningViewBagAsync(currentUser, ct);
 
-        return View(nameof(Details), MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership));
+        var vm = MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership);
+        await PopulateDetailCardsAsync(vm, campDetail, isCampAdmin, ct);
+        return View(nameof(Details), vm);
     }
 
     private async Task<CampMembershipStateViewModel> ResolveCurrentUserMembershipStateAsync(Guid campId, UserInfo? currentUser)
@@ -1167,12 +1171,6 @@ public class CampController(
             TimesAtNowhere = campDetail.TimesAtNowhere,
             HistoricalNames = [.. campDetail.HistoricalNames],
             ImageUrls = [.. campDetail.ImageUrls],
-            Leads = campDetail.Leads
-            .Select(lead => new CampLeadViewModel
-            {
-                LeadId = lead.LeadId,
-                UserId = lead.UserId
-            }).ToList(),
             CurrentSeason = campDetail.CurrentSeason is null
             ? null
             : new CampSeasonDetailViewModel
@@ -1202,6 +1200,44 @@ public class CampController(
             IsCurrentUserCampAdmin = isCampAdmin,
             Membership = membership
         };
+
+    /// <summary>
+    /// Fills the read-only Roles panel and (for full-camp viewers) the Roster on the
+    /// detail VM. Sourced from CampRoleAssignment — the same data as /Edit/Members —
+    /// so the detail page never disagrees with the roles panel. No-op for anonymous
+    /// viewers or seasonless camps.
+    /// </summary>
+    private async Task PopulateDetailCardsAsync(
+        CampDetailViewModel vm, CampDetailData campDetail, bool isCampAdmin,
+        CancellationToken ct)
+    {
+        if (User.Identity?.IsAuthenticated != true || campDetail.CurrentSeason is null)
+        {
+            return; // anonymous / no season → no cards
+        }
+
+        vm.CanSeeFullCamp = isCampAdmin || vm.Membership.Status == CampMemberStatusSummaryView.Active;
+
+        // Read-only roles panel (same source as /Edit/Members).
+        vm.RolesPanel = await BuildRolesPanelAsync(
+            campDetail.Slug, campDetail.CurrentSeason.Id, canManage: false, ct);
+
+        if (vm.CanSeeFullCamp)
+        {
+            var members = await _campService.GetCampMembersAsync(campDetail.CurrentSeason.Id);
+            vm.Roster = members.Active
+                .Select(m => new CampMemberRowViewModel
+                {
+                    CampMemberId = m.CampMemberId,
+                    UserId = m.UserId,
+                    RequestedAt = m.RequestedAt,
+                    ConfirmedAt = m.ConfirmedAt,
+                    HasEarlyEntry = m.HasEarlyEntry,
+                    Status = m.Status,
+                })
+                .ToList();
+        }
+    }
 
     private void ValidatePhoneE164(string? phone, string fieldName)
     {

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -194,10 +194,17 @@ public class CampController(
             return View(model);
         }
 
-        var campDisplayName = camp.Seasons
+        var latestSeason = camp.Seasons
             .OrderByDescending(s => s.Year)
-            .FirstOrDefault()?.Name ?? slug;
+            .FirstOrDefault();
+        var campDisplayName = latestSeason?.Name ?? slug;
         var senderEmail = currentUser.Email!;
+
+        // Recipients are sourced from the role system (Camp Lead special role on the
+        // latest season), not the legacy camp_leads table.
+        var leadUserIds = latestSeason is null
+            ? []
+            : await campRoleService.GetSeasonLeadUserIdsAsync(latestSeason.Id);
 
         try
         {
@@ -210,7 +217,7 @@ public class CampController(
                 senderEmail,
                 model.Message,
                 model.IncludeContactInfo,
-                camp.Leads.Select(l => l.UserId).Distinct().ToList(),
+                leadUserIds,
                 $"/Barrios/{slug}");
 
             if (result.RateLimited)

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -402,6 +402,7 @@ public class CampController(
             EmptySlotCount = r.EmptySlotCount,
             OverCapacity = r.OverCapacity,
             CurrentCount = r.CurrentCount,
+            IsLeadRole = r.Definition.SpecialRole == CampSpecialRole.Lead,
         }).ToList();
 
         return new CampRolesPanelViewModel

--- a/src/Humans.Web/Controllers/CityPlanningApiController.cs
+++ b/src/Humans.Web/Controllers/CityPlanningApiController.cs
@@ -41,9 +41,12 @@ public class CityPlanningApiController(
 
     private async Task<Guid?> FindUserLeadCampIdAsync(Guid userId, int year, CancellationToken ct)
     {
+        // Lead status comes from the role system (Camp Lead special role on a season
+        // of this year), not the legacy camp_leads table.
+        var leadSeasonId = await campService.GetCampLeadSeasonIdForYearAsync(userId, year, ct);
+        if (leadSeasonId is null) return null;
         var camps = await campService.GetCampsForYearAsync(year, ct);
-        return camps
-            .FirstOrDefault(c => c.Leads.Any(l => l.UserId == userId))?.Id;
+        return camps.FirstOrDefault(c => c.Seasons.Any(s => s.Id == leadSeasonId.Value))?.Id;
     }
 
     /// <summary>Returns current map state: settings, all camp polygons, unmapped seasons.</summary>

--- a/src/Humans.Web/Controllers/CityPlanningController.cs
+++ b/src/Humans.Web/Controllers/CityPlanningController.cs
@@ -291,9 +291,12 @@ public class CityPlanningController(
 
     private async Task<CampInfo?> FindUserLeadCampAsync(Guid userId, int year, CancellationToken ct)
     {
+        // Lead status comes from the role system (Camp Lead special role on a season
+        // of this year), not the legacy camp_leads table.
+        var leadSeasonId = await campService.GetCampLeadSeasonIdForYearAsync(userId, year, ct);
+        if (leadSeasonId is null) return null;
         var camps = await campService.GetCampsForYearAsync(year, ct);
-        return camps.FirstOrDefault(c =>
-            c.Leads.Any(l => l.UserId == userId));
+        return camps.FirstOrDefault(c => c.Seasons.Any(s => s.Id == leadSeasonId.Value));
     }
 
     private static (string Slug, string Name) LeadCampDisplay(bool isMapAdmin, CampInfo? userCamp, int year)

--- a/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
@@ -8,6 +8,7 @@ using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Camps;
 using Humans.Application.Configuration;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -43,6 +44,7 @@ public sealed class DevPersonaSeeder(
     ISystemTeamSync systemTeamSync,
     IUserService userService,
     ICampService campService,
+    ICampRoleService campRoleService,
     IClock clock,
     IMemoryCache cache,
     IOptions<CityPlanningOptions> cityPlanningOptions,
@@ -375,22 +377,29 @@ public sealed class DevPersonaSeeder(
 
     private async Task<bool> EnsureCampLeadAsync(CampLookup camp, Guid leadUserId)
     {
-        if (camp.Leads.Any(l => l.UserId == leadUserId))
+        // Idempotent: skip if the user already holds the Camp Lead role.
+        if (await campService.IsUserCampLeadAsync(leadUserId, camp.Id))
             return false;
 
-        try
+        var leadDef = await campRoleService.GetDefinitionBySlugAsync(CampSystemRoles.CampLeadSlug);
+        if (leadDef is null)
         {
-            await campService.AddLeadAsync(camp.Id, leadUserId);
-            return true;
-        }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("already an active lead", StringComparison.Ordinal))
-        {
-            // Idempotent: lead was added between the pre-check and AddLeadAsync.
             logger.LogInformation(
-                "DEV: camp lead {UserId} for {CampId} already active — skipping",
-                leadUserId, camp.Id);
+                "DEV: Camp Lead role definition missing — skipping lead seed for {CampId}. Run 'Seed system roles'.",
+                camp.Id);
             return false;
         }
+
+        // Adds an Active CampMember (idempotent) + the Camp Lead role assignment.
+        var outcome = await campService.AddMemberAndAssignRoleInActiveSeasonAsync(
+            camp.Id, leadDef.Id, leadUserId, leadUserId);
+        if (outcome == AssignCampRoleOutcome.Assigned)
+            return true;
+
+        logger.LogInformation(
+            "DEV: camp lead {UserId} for {CampId} not newly assigned ({Outcome}) — skipping",
+            leadUserId, camp.Id, outcome);
+        return false;
     }
 
     /// <summary>

--- a/src/Humans.Web/Models/Camp/CampRoleRowViewModel.cs
+++ b/src/Humans.Web/Models/Camp/CampRoleRowViewModel.cs
@@ -11,4 +11,6 @@ public sealed class CampRoleRowViewModel
     public required int EmptySlotCount { get; init; }
     public required bool OverCapacity { get; init; }
     public required int CurrentCount { get; init; }
+    /// <summary>True when the backing definition's SpecialRole is Lead — the only row shown to non-member viewers on the public detail page.</summary>
+    public required bool IsLeadRole { get; init; }
 }

--- a/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
@@ -69,12 +69,17 @@ public sealed class CampAdminPageBuilder(
         };
     }
 
-    private Task<List<CampSummaryRowViewModel>> BuildSummariesAsync(IReadOnlyList<CampInfo> campsWithLeads)
+    private async Task<List<CampSummaryRowViewModel>> BuildSummariesAsync(IReadOnlyList<CampInfo> campsWithLeads)
     {
-        return Task.FromResult(campsWithLeads.Select(c =>
+        var rows = new List<CampSummaryRowViewModel>(campsWithLeads.Count);
+        foreach (var c in campsWithLeads)
         {
             var season = c.Seasons.FirstOrDefault();
-            return new CampSummaryRowViewModel
+            // Leads come from the role system (Camp Lead special role on the season).
+            IReadOnlyList<Guid> leadUserIds = season is null
+                ? []
+                : await campRoleService.GetSeasonLeadUserIdsAsync(season.Id);
+            rows.Add(new CampSummaryRowViewModel
             {
                 Name = season?.Name ?? c.Slug,
                 Slug = c.Slug,
@@ -87,13 +92,14 @@ public sealed class CampAdminPageBuilder(
                 EeSlotCount = season?.EeSlotCount ?? 0,
                 EeGrantedCount = season?.EeGrantedCount ?? 0,
                 JoinedMemberCount = season?.JoinedMemberCount ?? 0,
-                Leads = c.Leads
-                    .Select(l => new CampLeadViewModel
+                Leads = leadUserIds
+                    .Select(id => new CampLeadViewModel
                     {
-                        LeadId = l.Id,
-                        UserId = l.UserId
+                        LeadId = Guid.Empty,
+                        UserId = id
                     }).ToList()
-            };
-        }).ToList());
+            });
+        }
+        return rows;
     }
 }

--- a/src/Humans.Web/Models/CampAdmin/CampCsvExportBuilder.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampCsvExportBuilder.cs
@@ -7,7 +7,8 @@ namespace Humans.Web.Models.CampAdmin;
 
 public sealed record CampCsvExport(byte[] Content, string ContentType, string FileName);
 
-public sealed class CampCsvExportBuilder(ICampService campService, IUserService userService)
+public sealed class CampCsvExportBuilder(
+    ICampService campService, ICampRoleService campRoleService, IUserService userService)
 {
     public async Task<CampCsvExport> BuildAsync()
     {
@@ -15,8 +16,17 @@ public sealed class CampCsvExportBuilder(ICampService campService, IUserService 
         var year = settings.PublicYear;
         var camps = await campService.GetCampsForYearAsync(year);
 
-        var leadUserIds = camps
-            .SelectMany(c => c.Leads.Select(l => l.UserId))
+        // Leads come from the role system (Camp Lead special role on the season).
+        var leadsBySeason = new Dictionary<Guid, IReadOnlyList<Guid>>();
+        foreach (var camp in camps)
+        {
+            var season = camp.Seasons.FirstOrDefault();
+            if (season is null) continue;
+            leadsBySeason[season.Id] = await campRoleService.GetSeasonLeadUserIdsAsync(season.Id);
+        }
+
+        var leadUserIds = leadsBySeason.Values
+            .SelectMany(ids => ids)
             .Distinct()
             .ToList();
         var leadUsers = await userService.GetUserInfosAsync(leadUserIds);
@@ -34,10 +44,11 @@ public sealed class CampCsvExportBuilder(ICampService campService, IUserService 
             var season = camp.Seasons.FirstOrDefault();
             if (season is null) continue;
 
-            var leads = string.Join("; ", camp.Leads
-                .Select(l =>
+            var seasonLeadIds = leadsBySeason.TryGetValue(season.Id, out var ids) ? ids : [];
+            var leads = string.Join("; ", seasonLeadIds
+                .Select(id =>
                 {
-                    var user = leadUsers.TryGetValue(l.UserId, out var u) ? u : null;
+                    var user = leadUsers.TryGetValue(id, out var u) ? u : null;
                     return $"{user?.BurnerName ?? string.Empty} <{user?.Email ?? string.Empty}>";
                 }));
 

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -50,7 +50,12 @@ public class CampDetailViewModel
     public int TimesAtNowhere { get; set; }
     public List<string> HistoricalNames { get; set; } = [];
     public List<string> ImageUrls { get; set; } = [];
-    public List<CampLeadViewModel> Leads { get; set; } = [];
+    /// <summary>Read-only roles panel for the displayed season (null when anonymous or no season). Sourced from CampRoleAssignment.</summary>
+    public Camp.CampRolesPanelViewModel? RolesPanel { get; set; }
+    /// <summary>Active members of the displayed season. Populated only when CanSeeFullCamp is true.</summary>
+    public List<CampMemberRowViewModel> Roster { get; set; } = [];
+    /// <summary>True when the viewer may see all roles + the roster: CampAdmin (any camp) or an Active member of this camp.</summary>
+    public bool CanSeeFullCamp { get; set; }
     public CampSeasonDetailViewModel? CurrentSeason { get; set; }
     public bool IsCurrentUserLead { get; set; }
     public bool IsCurrentUserCampAdmin { get; set; }

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -147,7 +147,6 @@ public class CampEditViewModel : CampRegisterViewModel
     public Guid SeasonId { get; set; }
     public int Year { get; set; }
     public bool IsNameLocked { get; set; }
-    public List<CampLeadViewModel> Leads { get; set; } = [];
     public List<CampImageViewModel> Images { get; set; } = [];
     public List<CampHistoricalNameViewModel> ExistingHistoricalNames { get; set; } = [];
     public List<CampMemberRowViewModel> PendingMembers { get; set; } = [];

--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -93,6 +93,8 @@
         {
             var season = Model.CurrentSeason;
 
+            <partial name="_CampRosterCard" model="Model" />
+
             @* Blurb *@
             <div class="card mb-4">
                 <div class="card-header">
@@ -297,23 +299,8 @@
             </div>
         }
 
-        @* Leads (only if authenticated) *@
-        @if (User.Identity?.IsAuthenticated == true && Model.Leads.Count > 0)
-        {
-            <div class="card mb-4">
-                <div class="card-header">
-                    <i class="fa-solid fa-user-shield me-1"></i> Leads
-                </div>
-                <ul class="list-group list-group-flush">
-                    @foreach (var lead in Model.Leads)
-                    {
-                        <li class="list-group-item">
-                            <vc:human user-id="@lead.UserId" />
-                        </li>
-                    }
-                </ul>
-            </div>
-        }
+        @* Roles (replaces the legacy Leads card; sourced from CampRoleAssignment) *@
+        <partial name="_CampRolesCard" model="Model" />
 
         @* My membership (authenticated only — never shown to anonymous visitors) *@
         @if (User.Identity?.IsAuthenticated == true && Model.Membership.Status != CampMemberStatusSummaryView.NoOpenSeason)

--- a/src/Humans.Web/Views/Camp/_CampRolesCard.cshtml
+++ b/src/Humans.Web/Views/Camp/_CampRolesCard.cshtml
@@ -1,0 +1,37 @@
+@model Humans.Web.Models.CampDetailViewModel
+@{
+    if (Model.RolesPanel is null) { return; }
+    // Non-member viewers see only the Camp Lead row, and only its filled assignees
+    // (matches the prior "Leads" card). Members/CampAdmin see every active role + open slots.
+    var rows = Model.CanSeeFullCamp
+        ? Model.RolesPanel.Rows
+        : Model.RolesPanel.Rows.Where(r => r.IsLeadRole && r.FilledSlots.Count > 0).ToList();
+    if (rows.Count == 0) { return; }
+}
+<div class="card mb-4">
+    <div class="card-header">
+        <i class="fa-solid fa-user-shield me-1"></i> @(Model.CanSeeFullCamp ? "Roles" : "Leads")
+    </div>
+    <ul class="list-group list-group-flush">
+        @foreach (var role in rows)
+        {
+            <li class="list-group-item">
+                <div class="d-flex justify-content-between align-items-center">
+                    <strong>@role.Name</strong>
+                    @if (Model.CanSeeFullCamp)
+                    {
+                        <small class="text-muted">@role.CurrentCount / @role.SlotCount</small>
+                    }
+                </div>
+                @foreach (var slot in role.FilledSlots)
+                {
+                    <div class="mt-1"><vc:human user-id="@slot.UserId" /></div>
+                }
+                @if (Model.CanSeeFullCamp && role.EmptySlotCount > 0)
+                {
+                    <div class="mt-1 text-muted fst-italic small">@role.EmptySlotCount open</div>
+                }
+            </li>
+        }
+    </ul>
+</div>

--- a/src/Humans.Web/Views/Camp/_CampRosterCard.cshtml
+++ b/src/Humans.Web/Views/Camp/_CampRosterCard.cshtml
@@ -1,0 +1,27 @@
+@model Humans.Web.Models.CampDetailViewModel
+@{
+    if (!Model.CanSeeFullCamp || Model.CurrentSeason is null) { return; }
+}
+<div class="card mb-4">
+    <div class="card-header">
+        <i class="fa-solid fa-users me-1"></i> Roster @Model.CurrentSeason.Year
+        <span class="text-muted">(@Model.Roster.Count)</span>
+    </div>
+    <div class="card-body">
+        @if (Model.Roster.Count == 0)
+        {
+            <p class="text-center text-muted mb-0">No humans recorded for this season yet.</p>
+        }
+        else
+        {
+            <div class="row g-3">
+                @foreach (var member in Model.Roster)
+                {
+                    <div class="col-6 col-sm-4 col-md-3">
+                        <vc:human user-id="@member.UserId" layout="Card" size="102" />
+                    </div>
+                }
+            </div>
+        }
+    </div>
+</div>

--- a/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
@@ -21,7 +21,6 @@ src/Humans.Infrastructure/Repositories/Campaigns/CampaignRepository.cs:OrderByDe
 src/Humans.Infrastructure/Repositories/Campaigns/CampaignRepository.cs:OrderByDescending#6
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#10
-src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#11
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#2
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#3
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#4
@@ -32,7 +31,6 @@ src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#8
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#9
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderByDescending#2
-src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderByDescending#3
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:ThenBy#1
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderBy#2

--- a/tests/Humans.Application.Tests/Architecture/CampsArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/CampsArchitectureTests.cs
@@ -218,23 +218,6 @@ public class CampsArchitectureTests
             because: "the T-06 SaveChanges interceptor was retired in favour of decorator-only invalidation pinned by ICampRepository_HasNoUnexpectedConsumers — see CachingCampService remarks");
     }
 
-    // ── CampInfo projection — leads invariant ───────────────────────────────
-
-    /// <summary>
-    /// T-06 leads invariant: <see cref="CampInfo.Leads"/> is always populated
-    /// (non-null; may be empty). The legacy "null = not loaded" branch was
-    /// retired when reads moved onto the cached projection.
-    /// </summary>
-    [HumansFact]
-    public void CampInfo_LeadsPropertyIsNonNullable()
-    {
-        var leadsProp = typeof(CampInfo).GetProperty(nameof(CampInfo.Leads))!;
-        var nullability = new System.Reflection.NullabilityInfoContext()
-            .Create(leadsProp);
-        nullability.WriteState.Should().Be(System.Reflection.NullabilityState.NotNull,
-            because: "T-06: CampInfo.Leads is always populated. The legacy 'null means not loaded' branch was retired when GetCampsForYearAsync moved onto the CachingCampService projection.");
-    }
-
     // ── CampLead ─────────────────────────────────────────────────────────────
 
     [HumansFact]
@@ -320,7 +303,6 @@ public class CampsArchitectureTests
         {
             typeof(CampDetailData),
             typeof(CampSeasonDetailData),
-            typeof(CampLeadSummary),
         };
 
         var eeProperties = publicDetailTypes

--- a/tests/Humans.Application.Tests/Authorization/CampAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/CampAuthorizationHandlerTests.cs
@@ -135,8 +135,7 @@ public sealed class CampAuthorizationHandlerTests
             },
             Slug: "camp",
             ContactEmail: "camp@example.com",
-            Seasons: [],
-            Leads: []);
+            Seasons: []);
 
     private static ClaimsPrincipal CreateUser(string kind, Guid regularUserId) =>
         kind switch

--- a/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
@@ -58,7 +58,25 @@ public sealed class CampRepositoryTests : IDisposable
     {
         var camp = BuildCamp("new-camp");
         var season = BuildSeason(camp.Id, CampSeasonStatus.Pending, 2026);
-        var lead = BuildLead(camp.Id, Guid.NewGuid());
+        var leadDef = await SeedSpecialRoleDefinitionAsync(CampSpecialRole.Lead);
+        var member = new CampMember
+        {
+            Id = Guid.NewGuid(),
+            CampSeasonId = season.Id,
+            UserId = Guid.NewGuid(),
+            Status = CampMemberStatus.Active,
+            RequestedAt = _clock.GetCurrentInstant(),
+            ConfirmedAt = _clock.GetCurrentInstant(),
+        };
+        var assignment = new CampRoleAssignment
+        {
+            Id = Guid.NewGuid(),
+            CampSeasonId = season.Id,
+            CampRoleDefinitionId = leadDef.Id,
+            CampMemberId = member.Id,
+            AssignedAt = _clock.GetCurrentInstant(),
+            AssignedByUserId = member.UserId,
+        };
         var history = new List<CampHistoricalName>
         {
             new()
@@ -71,12 +89,13 @@ public sealed class CampRepositoryTests : IDisposable
             }
         };
 
-        await _repo.CreateCampAsync(camp, season, lead, history);
+        await _repo.CreateCampAsync(camp, season, member, assignment, history);
 
         var persistedCamp = await _dbContext.Camps.AsNoTracking().FirstAsync(c => c.Id == camp.Id);
         persistedCamp.Slug.Should().Be("new-camp");
         (await _dbContext.CampSeasons.AsNoTracking().CountAsync(s => s.CampId == camp.Id)).Should().Be(1);
-        (await _dbContext.CampLeads.AsNoTracking().CountAsync(l => l.CampId == camp.Id)).Should().Be(1);
+        (await _dbContext.CampMembers.AsNoTracking().CountAsync(m => m.CampSeasonId == season.Id)).Should().Be(1);
+        (await _dbContext.CampRoleAssignments.AsNoTracking().CountAsync(a => a.CampSeasonId == season.Id)).Should().Be(1);
         (await _dbContext.CampHistoricalNames.AsNoTracking().CountAsync(h => h.CampId == camp.Id)).Should().Be(1);
     }
 

--- a/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
@@ -100,32 +100,8 @@ public sealed class CampRepositoryTests : IDisposable
     }
 
     // ==========================================================================
-    // IsUserActiveLeadAsync / CountActiveLeadsAsync / GetActiveLeadUserIdsAsync
+    // GetActiveLeadUserIdsAsync (role-backed)
     // ==========================================================================
-
-    [HumansFact]
-    public async Task IsUserActiveLeadAsync_ReturnsTrue_WhenActive()
-    {
-        var userId = Guid.NewGuid();
-        var camp = await SeedCampAsync("active-lead-camp");
-        await SeedLeadAsync(camp.Id, userId, leftAt: null);
-
-        var result = await _repo.IsUserActiveLeadAsync(userId, camp.Id);
-
-        result.Should().BeTrue();
-    }
-
-    [HumansFact]
-    public async Task IsUserActiveLeadAsync_ReturnsFalse_WhenLeft()
-    {
-        var userId = Guid.NewGuid();
-        var camp = await SeedCampAsync("left-lead-camp");
-        await SeedLeadAsync(camp.Id, userId, leftAt: _clock.GetCurrentInstant());
-
-        var result = await _repo.IsUserActiveLeadAsync(userId, camp.Id);
-
-        result.Should().BeFalse();
-    }
 
     [HumansFact]
     public async Task GetActiveLeadUserIdsAsync_ReturnsDistinctActiveLeadUsers()
@@ -312,20 +288,6 @@ public sealed class CampRepositoryTests : IDisposable
         await _dbContext.SaveChangesAsync();
     }
 
-    private async Task SeedLeadAsync(Guid campId, Guid userId, Instant? leftAt)
-    {
-        _dbContext.CampLeads.Add(new CampLead
-        {
-            Id = Guid.NewGuid(),
-            CampId = campId,
-            UserId = userId,
-            Role = CampLeadRole.CoLead,
-            JoinedAt = _clock.GetCurrentInstant(),
-            LeftAt = leftAt
-        });
-        await _dbContext.SaveChangesAsync();
-    }
-
     private async Task SeedSettingsAsync()
     {
         _dbContext.CampSettings.Add(new CampSettings
@@ -367,15 +329,6 @@ public sealed class CampRepositoryTests : IDisposable
         MemberCount = 10,
         CreatedAt = _clock.GetCurrentInstant(),
         UpdatedAt = _clock.GetCurrentInstant()
-    };
-
-    private CampLead BuildLead(Guid campId, Guid userId) => new()
-    {
-        Id = Guid.NewGuid(),
-        CampId = campId,
-        UserId = userId,
-        Role = CampLeadRole.CoLead,
-        JoinedAt = _clock.GetCurrentInstant()
     };
 
     private async Task<CampRoleDefinition> SeedSpecialRoleDefinitionAsync(CampSpecialRole specialRole)

--- a/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
@@ -119,8 +119,7 @@ public sealed class CachingCampServiceTests : ServiceTestHarness
                 ContactPhone: "+34000000000",
                 IsSwissCamp: false,
                 TimesAtNowhere: 1,
-                Seasons: [],
-                Leads: [])
+                Seasons: [])
         };
         _innerSubstitute
             .GetCampsForYearAsync(2023, Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
@@ -751,6 +751,56 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
     }
 
     // ==========================================================================
+    // GetSeasonLeadUserIdsAsync
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetSeasonLeadUserIdsAsync_ReturnsLeadHolders_ExcludesOtherRolesAndSeasons()
+    {
+        var (_, season) = await SeedCampWithSeasonAsync();
+        var (_, otherSeason) = await SeedCampWithSeasonAsync();
+
+        var leadDef = new CampRoleDefinition
+        {
+            Id = Guid.NewGuid(),
+            Name = CampSystemRoles.CampLeadName,
+            Slug = CampSystemRoles.CampLeadSlug,
+            SlotCount = 2,
+            MinimumRequired = 1,
+            SpecialRole = CampSpecialRole.Lead,
+            CreatedAt = Clock.GetCurrentInstant(),
+            UpdatedAt = Clock.GetCurrentInstant(),
+        };
+        Db.CampRoleDefinitions.Add(leadDef);
+        var regularDef = await SeedDefinitionAsync("Greeter");
+        await Db.SaveChangesAsync();
+
+        var leadUser = Guid.NewGuid();
+        var leadMember = await SeedActiveMemberAsync(season.Id, leadUser);
+        var regularMember = await SeedActiveMemberAsync(season.Id);
+        var otherSeasonLead = await SeedActiveMemberAsync(otherSeason.Id);
+
+        Db.CampRoleAssignments.Add(NewAssignment(season.Id, leadDef.Id, leadMember.Id));
+        Db.CampRoleAssignments.Add(NewAssignment(season.Id, regularDef.Id, regularMember.Id));
+        Db.CampRoleAssignments.Add(NewAssignment(otherSeason.Id, leadDef.Id, otherSeasonLead.Id));
+        await Db.SaveChangesAsync();
+
+        var result = await _service.GetSeasonLeadUserIdsAsync(season.Id);
+
+        result.Should().ContainSingle().Which.Should().Be(leadUser);
+    }
+
+    private CampRoleAssignment NewAssignment(Guid seasonId, Guid definitionId, Guid memberId) => new()
+    {
+        Id = Guid.NewGuid(),
+        CampSeasonId = seasonId,
+        CampRoleDefinitionId = definitionId,
+        CampMemberId = memberId,
+        AssignedAt = Clock.GetCurrentInstant(),
+        AssignedByUserId = _actorUserId,
+    };
+
+    // ==========================================================================
     // System role immutability + seeding (issue nobodies-collective/Humans#753)
     // ==========================================================================
 

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -290,6 +290,27 @@ public sealed class CampServiceTests : ServiceTestHarness
         result.Should().BeFalse();
     }
 
+    [HumansFact]
+    public async Task IsUserCampLeadAsync_LegacyCampLeadRowOnly_ReturnsFalse()
+    {
+        // Locks the removal of the legacy CampLead fallback: a camp_leads row with
+        // no matching CampRoleAssignment no longer confers lead status.
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        var legacyUserId = Guid.NewGuid();
+        Db.CampLeads.Add(new CampLead
+        {
+            Id = Guid.NewGuid(),
+            CampId = camp.Id,
+            UserId = legacyUserId,
+            Role = CampLeadRole.CoLead,
+            JoinedAt = Clock.GetCurrentInstant(),
+        });
+        await Db.SaveChangesAsync();
+
+        (await _service.IsUserCampLeadAsync(legacyUserId, camp.Id)).Should().BeFalse();
+    }
+
     // ==========================================================================
     // IsUserCampEventManagerAsync (issue nobodies-collective/Humans#753)
     // ==========================================================================

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -251,22 +251,6 @@ public sealed class CampServiceTests : ServiceTestHarness
     }
 
     // ==========================================================================
-    // AddLeadAsync
-    // ==========================================================================
-
-    [HumansFact]
-    public async Task AddLeadAsync_UnderMax_AddsLead()
-    {
-        await SeedSettingsAsync();
-        var camp = await CreateTestCamp();
-        var newLeadId = Guid.NewGuid();
-
-        var lead = await _service.AddLeadAsync(camp.Id, newLeadId);
-
-        lead.UserId.Should().Be(newLeadId);
-    }
-
-    // ==========================================================================
     // IsUserCampLeadAsync
     // ==========================================================================
 

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Users;
@@ -272,6 +273,31 @@ public sealed class CampServiceTests : ServiceTestHarness
         var camp = await CreateTestCamp();
         var result = await _service.IsUserCampLeadAsync(Guid.NewGuid(), camp.Id);
         result.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task ContributeForUserAsync_ExportsLegacyCampLeadRows_UntilTableDrops()
+    {
+        // §8a GDPR completeness: the legacy camp_leads table still holds per-user
+        // rows until #774 drops it, so the Article 15 export must include them.
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        var userId = Guid.NewGuid();
+        Db.CampLeads.Add(new CampLead
+        {
+            Id = Guid.NewGuid(),
+            CampId = camp.Id,
+            UserId = userId,
+            Role = CampLeadRole.CoLead,
+            JoinedAt = Clock.GetCurrentInstant(),
+        });
+        await Db.SaveChangesAsync();
+
+        var slices = await ((IUserDataContributor)_service).ContributeForUserAsync(userId, CancellationToken.None);
+
+        var leadSlice = slices.Should()
+            .ContainSingle(s => s.SectionName == GdprExportSections.CampLeadAssignments).Subject;
+        ((System.Collections.IEnumerable)leadSlice.Data!).Cast<object>().Should().ContainSingle();
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -141,6 +141,19 @@ public sealed class CampServiceTests : ServiceTestHarness
         result.Camps.Should().NotContain(c => c.Id == camp.Id);
     }
 
+    [HumansFact]
+    public async Task GetCampLeadSeasonIdForYearAsync_RoleLeadResolvesSeason_NonLeadNull()
+    {
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+
+        (await _service.GetCampLeadSeasonIdForYearAsync(camp.CreatedByUserId, 2026))
+            .Should().Be(season.Id);
+        (await _service.GetCampLeadSeasonIdForYearAsync(Guid.NewGuid(), 2026))
+            .Should().BeNull();
+    }
+
     // ==========================================================================
     // ApproveSeasonAsync
     // ==========================================================================

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -123,6 +123,25 @@ public sealed class CampServiceTests : ServiceTestHarness
     }
 
     // ==========================================================================
+    // GetCampDirectoryAsync — role-based lead pinning
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetCampDirectoryAsync_RoleLeadPendingCamp_AppearsInMyCamps()
+    {
+        await SeedSettingsAsync();
+        // CreateTestCamp seeds the Camp Lead role + makes the creator a role-based
+        // lead; the new camp's season is Pending (not yet public).
+        var camp = await CreateTestCamp();
+
+        var result = await _service.GetCampDirectoryAsync(camp.CreatedByUserId);
+
+        // Pending camps aren't in the public listing, but a role-lead sees theirs in MyCamps.
+        result.MyCamps.Should().ContainSingle(c => c.Id == camp.Id);
+        result.Camps.Should().NotContain(c => c.Id == camp.Id);
+    }
+
+    // ==========================================================================
     // ApproveSeasonAsync
     // ==========================================================================
 

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -61,6 +61,7 @@ public sealed class CampServiceTests : ServiceTestHarness
     public async Task CreateCampAsync_NewCamp_CreatesCampWithPendingSeason()
     {
         await SeedSettingsAsync();
+        var leadDef = await SeedSpecialDefinitionAsync(CampSpecialRole.Lead);
         var userId = Guid.NewGuid();
 
         var camp = await _service.CreateCampAsync(
@@ -72,18 +73,39 @@ public sealed class CampServiceTests : ServiceTestHarness
         camp.Slug.Should().Be("camp-funhouse");
         camp.CreatedByUserId.Should().Be(userId);
 
-        var season = await Db.CampSeasons
+        var season = await Db.CampSeasons.AsNoTracking()
             .FirstOrDefaultAsync(s => s.CampId == camp.Id);
         season.Should().NotBeNull();
         season.Status.Should().Be(CampSeasonStatus.Pending);
         season.Year.Should().Be(2026);
         season.Name.Should().Be("Camp Funhouse");
 
-        var lead = await Db.CampLeads
-            .FirstOrDefaultAsync(l => l.CampId == camp.Id);
-        lead.Should().NotBeNull();
-        lead.UserId.Should().Be(userId);
-        lead.Role.Should().Be(CampLeadRole.CoLead);
+        var member = await Db.CampMembers.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.CampSeasonId == season.Id && m.UserId == userId);
+        member.Should().NotBeNull();
+        member!.Status.Should().Be(CampMemberStatus.Active);
+
+        var assignment = await Db.CampRoleAssignments.AsNoTracking()
+            .FirstOrDefaultAsync(a => a.CampMemberId == member.Id);
+        assignment.Should().NotBeNull();
+        assignment!.CampRoleDefinitionId.Should().Be(leadDef.Id);
+    }
+
+    [HumansFact]
+    public async Task CreateCampAsync_NoLeadDefinition_CreatesCampAndActiveMemberWithoutAssignment()
+    {
+        await SeedSettingsAsync();
+        var userId = Guid.NewGuid();
+
+        var camp = await _service.CreateCampAsync(
+            userId, "Camp Seedless", "c@s.com", "+34600000001", null, null,
+            false, 0, MakeSeasonData(), null, 2026);
+
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+        (await Db.CampMembers.AsNoTracking().AnyAsync(m => m.CampSeasonId == season.Id && m.UserId == userId))
+            .Should().BeTrue();
+        (await Db.CampRoleAssignments.AsNoTracking().AnyAsync(a => a.CampSeasonId == season.Id))
+            .Should().BeFalse();
     }
 
     [HumansFact]
@@ -210,30 +232,6 @@ public sealed class CampServiceTests : ServiceTestHarness
         var lead = await _service.AddLeadAsync(camp.Id, newLeadId);
 
         lead.UserId.Should().Be(newLeadId);
-    }
-
-    [HumansFact]
-    public async Task AddLeadAsync_AtMaxLeads_Throws()
-    {
-        await SeedSettingsAsync();
-        var camp = await CreateTestCamp();
-        // Add 4 more leads (1 creator + 4 = 5 max)
-        for (var i = 0; i < 4; i++)
-            await _service.AddLeadAsync(camp.Id, Guid.NewGuid());
-
-        var act = () => _service.AddLeadAsync(camp.Id, Guid.NewGuid());
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*maximum*");
-    }
-
-    [HumansFact]
-    public async Task RemoveLeadAsync_LastLead_Throws()
-    {
-        await SeedSettingsAsync();
-        var camp = await CreateTestCamp();
-        var lead = await Db.CampLeads.FirstAsync(l => l.CampId == camp.Id);
-
-        var act = () => _service.RemoveLeadAsync(lead.Id);
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*last lead*");
     }
 
     // ==========================================================================
@@ -584,7 +582,6 @@ public sealed class CampServiceTests : ServiceTestHarness
         detail.Links.Should().ContainSingle(link => link.Url == "https://example.com/fallback");
         detail.HistoricalNames.Should().Contain("Old Fallback");
         detail.ImageUrls.Should().ContainSingle("/uploads/camps/fallback.jpg");
-        detail.Leads.Should().ContainSingle(lead => lead.DisplayName == "Camp Lead");
         detail.CurrentSeason.Should().NotBeNull();
         detail.CurrentSeason!.Year.Should().Be(2026);
         detail.CurrentSeason.IsNameLocked.Should().BeTrue();
@@ -745,7 +742,8 @@ public sealed class CampServiceTests : ServiceTestHarness
         result.Outcome.Should().Be(CampMemberRequestOutcome.NoOpenSeason);
         result.Message.Should().Be("Camp is not open for membership this year.");
         result.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Error);
-        (await Db.CampMembers.AsNoTracking().AnyAsync()).Should().BeFalse();
+        // The creator is an Active member; assert no row was created for the requester.
+        (await Db.CampMembers.AsNoTracking().AnyAsync(m => m.UserId == userId)).Should().BeFalse();
     }
 
     [HumansFact]
@@ -763,7 +761,8 @@ public sealed class CampServiceTests : ServiceTestHarness
         second.Outcome.Should().Be(CampMemberRequestOutcome.AlreadyPending);
         second.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Info);
         second.CampMemberId.Should().Be(first.CampMemberId);
-        (await Db.CampMembers.AsNoTracking().CountAsync()).Should().Be(1);
+        // Scope to the requester — the camp creator also has an Active member row.
+        (await Db.CampMembers.AsNoTracking().CountAsync(m => m.UserId == userId)).Should().Be(1);
     }
 
     [HumansFact]
@@ -1183,6 +1182,7 @@ public sealed class CampServiceTests : ServiceTestHarness
     public async Task GetPendingMembershipCountForLeadAsync_CountsPendingOnActiveSeasonsForLeadsCamps()
     {
         await SeedSettingsAsync();
+        await SeedSpecialDefinitionAsync(CampSpecialRole.Lead);
         var leadUserId = Guid.NewGuid();
         await SeedUserAsync(leadUserId, "Lead Larry");
         var camp = await _service.CreateCampAsync(
@@ -1216,12 +1216,15 @@ public sealed class CampServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
-    public async Task GetCampMembersAsync_NoLongerSynthesizesLeadRows_AfterCampLeadRetirement()
+    public async Task GetCampMembersAsync_ReturnsOnlyRealCampMemberRows_AfterCampLeadRetirement()
     {
         // Issue nobodies-collective/Humans#753: the IsLead union into the
-        // active-members list was removed. Active members come only from
-        // CampMember rows. Leads now show up via the Roles panel.
+        // active-members list was removed. Active members come only from real
+        // CampMember rows — no synthesis. The camp creator is now a real Active
+        // member (+ Camp Lead role assignment), so they appear via their own row,
+        // not a synthesized one.
         await SeedSettingsAsync();
+        await SeedSpecialDefinitionAsync(CampSpecialRole.Lead);
         var leadUserId = Guid.NewGuid();
         await SeedUserAsync(leadUserId, "Lead Larry");
         var camp = await _service.CreateCampAsync(
@@ -1237,12 +1240,11 @@ public sealed class CampServiceTests : ServiceTestHarness
 
         var members = await _service.GetCampMembersAsync(season.Id);
 
-        // Only the approved member appears — the lead (who has no CampMember row)
-        // is no longer synthesized.
-        members.Active.Should().HaveCount(1);
-        members.Active[0].UserId.Should().Be(memberUserId);
-        members.Active[0].CampMemberId.Should().Be(req.CampMemberId);
-        members.Active.Should().NotContain(r => r.UserId == leadUserId);
+        // Two real Active members: the creator-lead (real row) + the approved member.
+        members.Active.Should().HaveCount(2);
+        members.Active.Should().Contain(r => r.UserId == memberUserId && r.CampMemberId == req.CampMemberId);
+        var creatorRow = members.Active.Should().ContainSingle(r => r.UserId == leadUserId).Subject;
+        creatorRow.CampMemberId.Should().NotBe(Guid.Empty);
     }
 
     [HumansFact]
@@ -1286,6 +1288,14 @@ public sealed class CampServiceTests : ServiceTestHarness
 
     private async Task<Camp> CreateTestCamp()
     {
+        // Production seeds the Camp Lead special role in every env, so creation
+        // produces a role-based lead. Mirror that here (idempotent) so the
+        // creator is an Active member + Camp Lead assignment.
+        if (!await Db.CampRoleDefinitions.AnyAsync(d => d.SpecialRole == CampSpecialRole.Lead))
+        {
+            await SeedSpecialDefinitionAsync(CampSpecialRole.Lead);
+        }
+
         return await _service.CreateCampAsync(
             Guid.NewGuid(), "Test Camp", "test@camp.com", "+34600000000",
             null, null, false, 1, MakeSeasonData(), null, 2026);

--- a/tests/Humans.Application.Tests/Services/Tickets/OnsiteRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/OnsiteRosterServiceTests.cs
@@ -162,8 +162,7 @@ public class OnsiteRosterServiceTests
                             Humans.Domain.Enums.YesNoMaybe.Yes, Humans.Domain.Enums.YesNoMaybe.No,
                             Humans.Domain.Enums.AdultPlayspacePolicy.No,
                             1, null, null, null, 0, null, null),
-                    },
-                    new List<CampLeadInfo>()),
+                    }),
             });
 
         _camps.GetCampMembersByYearAsync(2026, Arg.Any<CancellationToken>())


### PR DESCRIPTION
Adds read-only **Roles** + **Roster** cards to `/Barrios/{slug}` sourced from `CampRoleAssignment`, fixes camp creation to write role assignments, and repoints every live reader/writer/fallback off `camp_leads`. Physical table drop deferred to nobodies-collective/Humans#774.

## What changed
- **Detail page (Part A):** new `_CampRolesCard` (Camp Lead row for any logged-in viewer; all roles + open slots for members/CampAdmin) replaces the legacy Leads card, plus a `_CampRosterCard` above About. Both sourced from the same data as `/Edit/Members` — fixes the detail/Members lead mismatch.
- **Camp creation (Part B):** the creator becomes an Active `CampMember` + Camp Lead `CampRoleAssignment` atomically; degrades to member-only (logged) when the Lead definition is unseeded.
- **Repointed readers (Part C):** Contact-the-leads, directory "my camps" pin, lead-season-for-year, CampAdmin index leads, CSV export, CityPlanning lead checks, GDPR export slice, Edit-page leads — all now role-sourced. New repo query `GetSpecialRoleHolderUserIdsForSeasonAsync` + `ICampRoleService.GetSeasonLeadUserIdsAsync`.
- **Stripped fallbacks + dead code (Part D):** `IsUserCampLeadAsync`/`IsUserCampEventManagerAsync`/`GetPendingMembershipCountForLeadAsync` are role-only; account-merge reassigns role assignments; DevPersonaSeeder creates leads via role assignment; deleted the dead legacy lead C# (methods + `CampInfo.Leads`/`CampLookup.Leads`/`CampDetailData.Leads`/`CampLeadInfo`/`CampLeadSummary`). `ICampService` SurfaceBudget 58→56.

## Not in this PR
- **No EF migration / no schema change.** The `CampLead` entity/config/`CampLeads` DbSet/`Camp.Leads` nav and the seed/sync plumbing (`GetActiveLeadUserIdsAsync`, `IsLeadAnywhereAsync`, `GetLeadMigrationSnapshotsAsync`, `EnsureActiveMemberForMigrationAsync`) are retained for the physical drop in nobodies-collective/Humans#774. EF snapshot is unchanged.

## Testing
- Full suite green (the two `Pay_*`/Stripe integration failures are pre-existing and reproduce on the base branch — unrelated, environment-dependent).
- Added: camp-creation role-assignment + graceful-degrade tests, role-lead directory pin, lead-season-for-year, season-scoped lead-holder query, and a legacy-`CampLead`-row-alone-is-not-a-lead guard.
- EF migration reviewer: N/A (no migration). The drop lives in nobodies-collective/Humans#774.

Spec: `docs/superpowers/specs/2026-05-20-camp-detail-roles-roster-and-lead-decouple-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)