### PR TITLE
feat(events): US-26.10 barrio bulk upload via CSV

### DIFF
--- a/docs/features/26-events.md
+++ b/docs/features/26-events.md
@@ -130,7 +130,7 @@ Both kinds of submission are managed from a single page — **My Event Submissio
 - Each barrio block on `/Events/MySubmissions` has a download link for the current events CSV and a file input to upload an updated CSV — no separate page
 - Downloading the template produces a CSV pre-filled with the barrio's non-Withdrawn events; comment lines at the top explain the format, valid categories, and the Id rule
 - Upload is all-or-nothing: if any row fails validation, no events are saved and a per-row error table is shown inline in the barrio block
-- New rows (empty `Id`) are submitted as new events in `Pending` status; the submitter receives the standard submission email
+- New rows (empty `Id`) are submitted as new events in `Pending` status; no submission email is sent (bulk upload may create many events at once)
 - Existing rows (non-empty `Id`) that are unchanged are skipped — status is preserved; rows with changed fields update the matched event and re-queue it for moderation
 - Rows referencing a `Withdrawn` event are rejected (Withdrawn events cannot be reactivated via bulk upload)
 - Rows absent from the CSV are left untouched — bulk upload does not delete or withdraw events

--- a/docs/features/26-events.md
+++ b/docs/features/26-events.md
@@ -119,7 +119,121 @@ Both kinds of submission are managed from a single page — **My Event Submissio
 - If logged in: favourites stored as UserEventFavourite records (survives device switch)
 - If not logged in: favourites stored in localStorage
 
+### US-26.10: Barrio Lead Bulk-Uploads Events via CSV
+
+**As a** Camp Lead or Workshop Lead
+**I want to** download my barrio's events as a CSV, add or edit rows, and upload the file back
+**So that** I can manage a full programme without submitting events one by one
+
+**Acceptance Criteria:**
+
+- Each barrio block on `/Events/MySubmissions` has a download link for the current events CSV and a file input to upload an updated CSV — no separate page
+- Downloading the template produces a CSV pre-filled with the barrio's non-Withdrawn events; comment lines at the top explain the format, valid categories, and the Id rule
+- Upload is all-or-nothing: if any row fails validation, no events are saved and a per-row error table is shown inline in the barrio block
+- New rows (empty `Id`) are submitted as new events in `Pending` status; the submitter receives the standard submission email
+- Existing rows (non-empty `Id`) that are unchanged are skipped — status is preserved; rows with changed fields update the matched event and re-queue it for moderation
+- Rows referencing a `Withdrawn` event are rejected (Withdrawn events cannot be reactivated via bulk upload)
+- Rows absent from the CSV are left untouched — bulk upload does not delete or withdraw events
+- Upload is rejected if the submission window is closed
+- Only Camp Leads, Workshop Leads, CampAdmin, and Admin may access the bulk upload routes for a given barrio slug
+
+#### Routes
+
+```text
+GET  /Events/Barrio/{slug}/BulkUpload/Template  → stream CSV of existing camp events
+POST /Events/Barrio/{slug}/BulkUpload           → parse, validate, submit (all-or-nothing); on error redirects back to MySubmissions with errors in TempData
+```
+
+Both actions use the existing `ResolveCampEventManagementAsync(slug)` guard — same auth as `BarrioSubmit`/`BarrioCreate`.
+
+#### CSV Format
+
+```text
+Id,Barrio,Status,Title,Description,Category,Date,StartTime,DurationMinutes,LocationNote,Host,IsRecurring,RecurrenceDays,PriorityRank
+```
+
+| Column | Rules |
+| --- | --- |
+| `Id` | Guid or empty. **Empty** → new event. **Non-empty** → update existing event. Do not change or delete an existing Id — the upload will fail. |
+| `Barrio` | Read-only. Pre-filled with the camp name. Ignored on upload — for reference only. |
+| `Status` | Read-only. Pre-filled with the current event status. Ignored on upload — for reference only. Helps leads know which events are live before editing. |
+| `Title` | Required. Max 80 chars. |
+| `Description` | Required. Max 450 chars. |
+| `Category` | Required. Category name, case-insensitive (e.g. `Food and drink`). |
+| `Date` | Required. `yyyy-MM-dd`. |
+| `StartTime` | Required. `HH:mm`. |
+| `DurationMinutes` | Required. Integer, 15–480, in 15-minute increments. |
+| `LocationNote` | Optional. Max 120 chars. |
+| `Host` | Optional. Max 40 chars. |
+| `IsRecurring` | `true` or `false`. |
+| `RecurrenceDays` | Only used when `IsRecurring` is true. Space-separated day names: `Mon Tue Wed Thu Fri Sat Sun`. Converted to day offsets from gate-opening date on import. |
+| `PriorityRank` | Required. Integer, 1–100. |
+
+**Encoding:** comma-separated, UTF-8, RFC 4180 quoting — fields containing commas are wrapped in `"double quotes"`. `RecurrenceDays` uses spaces as the day separator (`Mon Tue Fri`) so it never needs quoting.
+
+#### Validation (all-or-nothing)
+
+All rows are parsed and validated before any event is saved. If any row fails, the upload page is returned with a per-row error table and nothing is persisted.
+
+Per-row checks:
+
+- Required fields present.
+- Field length and range constraints (see table above). `DurationMinutes` must be divisible by 15.
+- `Date` parses to a valid date; `StartTime` parses to a valid time.
+- `Category` matches an active category (case-insensitive by name).
+- If `Id` is provided: event must exist for this camp and must not be `Withdrawn`.
+
+#### Update Semantics (rows with Id)
+
+If a row with an Id is identical to the stored event (all fields unchanged), it is skipped — the status is kept as-is and no service call is made.
+
+If any field differs:
+
+| Existing status | Included in template | Action on upload |
+| --- | --- | --- |
+| Draft | Yes | Update fields → `SubmitEventAsync` |
+| Pending | Yes | Update fields → `UpdateAndResubmitAsync` (re-queues for moderation) |
+| Approved | Yes | Update fields → `UpdateAndResubmitAsync` (moves back to Pending for re-moderation) |
+| Rejected | Yes | Update fields → `UpdateAndResubmitAsync` (re-queues for moderation) |
+| ResubmitRequested | Yes | Update fields → `UpdateAndResubmitAsync` (re-queues for moderation) |
+| Withdrawn | No | **Validation error** — row rejected, upload fails |
+
+#### Files to Change
+
+Modified:
+
+- `src/Humans.Web/Controllers/EventsController.cs` — add `BulkUploadTemplate` (GET), `BulkUploadImport` (POST); add `ParseCsvRows` and `ValidateBulkRows` private helpers; update `MySubmissions` to read bulk upload errors from TempData
+- `src/Humans.Web/Models/Events/BarrioEventViewModels.cs` — add `BulkRowError` (row number, title, error list); add `BulkUploadErrors` to the barrio block view model
+- `src/Humans.Web/Views/Events/MySubmissions.cshtml` — add download link, file upload form, and error table to each barrio block
+
+No changes needed to domain, service interface, or repository — all existing methods are sufficient (`GetCampSubmissionsAsync`, `SubmitEventAsync`, `UpdateAndResubmitAsync`). No EF migration.
+
+#### Key Reused Pieces
+
+| What | Where |
+| --- | --- |
+| `ResolveCampEventManagementAsync(slug)` | `EventsController` base helpers — auth guard |
+| `GetCampSubmissionsAsync(campId)` | `IEventService` — fetches existing events for template |
+| `SubmitEventAsync(event)` | `IEventService` — submits new events |
+| `UpdateAndResubmitAsync(event)` | `IEventService` — updates + resubmits existing events |
+| `GetActiveCategoriesAsync()` | `IEventService` — category lookup for validation |
+| `ToInstant(date + time, tz)` | `EventsController` private helper — date+time → UTC Instant |
+
+#### Verification
+
+1. `dotnet build Humans.slnx -v quiet` — 0 errors.
+2. `dotnet test Humans.slnx -v quiet` — all pass.
+3. Manual:
+   - Camp lead opens `/Events/MySubmissions` → barrio block shows download link and file upload form.
+   - Download template → CSV has correct columns, existing events populated, Withdrawn events absent, comment lines at top.
+   - Upload CSV with one new row (empty Id) → event appears in MySubmissions as Pending.
+   - Upload same CSV again (now has an Id, fields unchanged) → event not duplicated, status preserved.
+   - Upload CSV with a changed field on an existing event → event updated and re-queued for moderation.
+   - Upload CSV with an invalid row (bad category, missing title, etc.) → error table shown, nothing saved.
+   - Non-lead user attempts upload → 403.
+
 ### US-26.9: Moderator Exports the Print Guide
+
 **As a** GuideModerator
 **I want to** generate a print-ready PDF of all approved events
 **So that** the layout team has no manual data extraction step
@@ -179,7 +293,7 @@ Hard deletion is not supported; `Withdrawn` is the terminal state for events rem
 
 All emails use the existing `EmailOutboxMessage` / `ProcessEmailOutboxJob` infrastructure.
 
-## Routes
+## Route Summary
 
 | Route | Purpose |
 |-------|---------|
@@ -189,6 +303,7 @@ All emails use the existing `EmailOutboxMessage` / `ProcessEmailOutboxJob` infra
 | `/Admin/Guide*` | GuideModerator/Admin: GuideSettings, categories, venues |
 | `/Events/Export` | GuideModerator/Admin: CSV and print-guide exports |
 | `/Events/Barrio/{slug}/Submit` | Lead: submit/edit a barrio event (barrio block on My Event Submissions) |
+| `/Events/Barrio/{slug}/BulkUpload` | Lead: download CSV template of existing events; upload updated CSV |
 | `/api/events/events` | Public API: approved events (PWA data source) |
 | `/api/events/barrios` | Public API: published barrios with hosted events |
 | `/api/events/categories` | Public API: event categories |

--- a/docs/features/events-bulk-upload-sample.csv
+++ b/docs/features/events-bulk-upload-sample.csv
@@ -1,0 +1,41 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# ELSEWHERE EVENT GUIDE — Bulk Upload Template
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# HOW TO USE
+#   1. Fill in new rows leaving Id blank — a new event will be created.
+#   2. Existing rows already have an Id filled in. You may edit their fields,
+#      but DO NOT change or delete the Id — that is how we match the event.
+#      Changing an Id will cause the upload to fail.
+#   3. To leave an existing event unchanged, keep its row as-is.
+#      Events not present in the CSV are left untouched.  
+#   4. Save as CSV (comma-separated, UTF-8) before uploading.
+#      In Excel:   File → Save As → CSV UTF-8 (Comma delimited)
+#      In Numbers: File → Export To → CSV
+#
+# FIELDS
+#   Id             Leave empty for new events. Do not edit for existing ones.
+#   Barrio         Informational only — shows which camp this file belongs to. Ignored on upload.
+#   Status         Informational only — shows the current event status. Ignored on upload.
+#                  If you upload a row without changing any fields, the status is kept as-is.
+#                  If you edit fields on an existing event, it will be re-queued for moderation.
+#   Category       Must match exactly one of the valid categories listed below.
+#   Date           Format: yyyy-MM-dd  (e.g. 2026-07-08)
+#   StartTime      Format: HH:mm       (e.g. 09:30)
+#   DurationMinutes  Integer, 15–480, in 15-minute increments (e.g. 15, 30, 45, 60, 90, 120...).
+#   IsRecurring    true or false.
+#   RecurrenceDays  Only used when IsRecurring is true.
+#                  Space-separated day names: Mon Tue Wed Thu Fri Sat Sun
+#                  Example: Mon Wed Fri means the event repeats on those days.
+#
+# VALID CATEGORIES
+#   Workshop, Party, Food and drink, Chillout,
+#   Spiritual / Healing, Adults, Kids, Other
+#
+# ─────────────────────────────────────────────────────────────────────────────
+"Id","Barrio","Status","Title","Description","Category","Date","StartTime","DurationMinutes","LocationNote","Host","IsRecurring","RecurrenceDays","PriorityRank"
+"550e8400-e29b-41d4-a716-446655440001","Camp Elsewhere","Approved","Barrio Breakfast","Come share food and meet your neighbours. We cook eggs and toast every morning.","Food and drink","2026-07-08","09:00","120","Camp Elsewhere kitchen","Marta","true","Mon Tue Wed Thu Fri Sat Sun","1"
+"550e8400-e29b-41d4-a716-446655440002","Camp Elsewhere","Pending","Electronic Sunset Set","Deep and melodic techno as the sun goes down.","Party","2026-07-09","19:30","180","Camp stage","","false","","2"
+"","Camp Elsewhere","","Morning Yoga Flow","Start your day with a grounding yoga session open to all levels. Bring a mat if you have one.","Spiritual / Healing","2026-07-08","08:00","60","Outside the main dome","Luna","false","","2"
+"","Camp Elsewhere","","Sound Bath","Immersive sound healing with crystal bowls and gongs. Come and lie down.","Spiritual / Healing","2026-07-09","20:00","90","The Healing Tent","","false","","3"
+"","Camp Elsewhere","","Macramé Workshop","Learn basic macramé knots and take home a small wall hanging. Materials provided, no experience needed.","Workshop","2026-07-10","11:00","120","Camp shade structure","Iker","false","","4"

--- a/docs/plans/2026-05-20-events-bulk-upload.md
+++ b/docs/plans/2026-05-20-events-bulk-upload.md
@@ -1,0 +1,123 @@
+# Plan — Events Bulk Upload for Barrio Leads
+
+**Branch:** `feat/events-host-and-unified-submissions`
+**Guide:** `docs/features/26-events.md` (US-26.10)
+
+## Goals
+
+Allow Camp Leads and Workshop Leads to download their barrio's current events as a CSV, add new rows or edit existing ones, and upload the file back — without submitting events one by one.
+
+The download link and upload form live **inline in each barrio block on `/Events/MySubmissions`** — no separate bulk upload page. Errors are shown in TempData, rendered back in the barrio block after redirect.
+
+Scope decisions (confirmed): no deletion or withdrawal via bulk upload (separate feature); submission window enforced same as single-event form; not for admins bypassing the window.
+
+---
+
+## Part A — View models
+
+### A1. `src/Humans.Web/Models/Events/BarrioEventViewModels.cs`
+
+Add `BulkRowError` (used in TempData to carry per-row errors back to MySubmissions after a failed upload):
+
+```csharp
+public class BulkRowError
+{
+    public int RowNumber { get; set; }
+    public string Title { get; set; } = "";
+    public List<string> Errors { get; set; } = [];
+}
+```
+
+The existing `MySubmissionsViewModel` (or its barrio block sub-model) gains a `List<BulkRowError> BulkUploadErrors` property populated from TempData after a failed upload POST.
+
+---
+
+## Part B — Controller actions
+
+### B1. `src/Humans.Web/Controllers/EventsController.cs`
+
+Add three actions and two private helpers.
+
+#### `BulkUploadTemplate` (GET)
+
+```csharp
+[HttpGet("Barrio/{slug}/BulkUpload/Template")]
+public async Task<IActionResult> BulkUploadTemplate(string slug)
+```
+
+- Call `ResolveCampEventManagementAsync(slug)` — 403 if fails.
+- Call `GetCampSubmissionsAsync(camp.Id)` — fetch all non-Withdrawn events.
+- Call `GetActiveCategoriesAsync()` — for the comment block listing valid categories.
+- Build CSV in memory:
+  - Prepend `#`-comment lines (format hints, valid categories, Id rule, Barrio/Status are read-only).
+  - Header row: `"Id","Barrio","Status","Title","Description","Category","Date","StartTime","DurationMinutes","LocationNote","Host","IsRecurring","RecurrenceDays","PriorityRank"`
+  - One data row per non-Withdrawn event. `Date` from `StartAt` converted to local date via `tz`. `StartTime` as `HH:mm`. `RecurrenceDays` as space-separated day names (`Mon Tue Fri`).
+- Return `File(bytes, "text/csv", $"{slug}-events.csv")`.
+
+#### `BulkUploadImport` (POST)
+
+```csharp
+[HttpPost("Barrio/{slug}/BulkUpload")]
+public async Task<IActionResult> BulkUploadImport(string slug, IFormFile file)
+```
+
+- Call `ResolveCampEventManagementAsync(slug)` — 403 if fails.
+- Enforce submission window (`SubmissionOpenAt` / `SubmissionCloseAt`) — redirect or error if closed.
+- Parse: `ParseCsvRows(file)` — returns `List<BulkCsvRow>` (or error list).
+- Validate: `ValidateBulkRows(rows, camp, categories, existingEvents)` — returns `List<BulkRowError>`.
+- If any errors → store errors in `TempData["BulkErrors_{slug}"]` (serialized JSON), redirect to `MySubmissions`. The MySubmissions action reads TempData and injects errors into the matching barrio block.
+- For each row:
+  - Empty Id → `SubmitEventAsync(newEvent)`.
+  - Non-empty Id, fields unchanged → skip.
+  - Non-empty Id, fields changed, status Draft → `SubmitEventAsync(updatedEvent)`.
+  - Non-empty Id, fields changed, other status → `UpdateAndResubmitAsync(updatedEvent)`.
+- Redirect to `MySubmissions`.
+
+#### `ParseCsvRows` (private)
+
+- Skip lines starting with `#`.
+- Skip blank lines.
+- Parse header row (validate expected columns present).
+- Parse each data row into a `BulkCsvRow` record (raw strings, no validation yet).
+- Return rows with 1-based row numbers for error reporting.
+
+#### `ValidateBulkRows` (private)
+
+Per-row checks:
+- Required fields present (Title, Description, Category, Date, StartTime, DurationMinutes, PriorityRank).
+- `Title` ≤ 80, `Description` ≤ 450, `LocationNote` ≤ 120, `Host` ≤ 40.
+- `DurationMinutes` integer 15–480, divisible by 15.
+- `PriorityRank` integer 1–100.
+- `Date` parses to `LocalDate` (`yyyy-MM-dd`); `StartTime` parses to `LocalTime` (`HH:mm`).
+- `Category` matches an active category (case-insensitive by name).
+- If `Id` non-empty: event exists for this camp; status is not `Withdrawn`.
+
+Collect all errors across all rows. Return full list (never short-circuit).
+
+---
+
+## Part C — View
+
+### C1. `src/Humans.Web/Views/Events/MySubmissions.cshtml` — barrio block additions
+
+In each barrio block, after the existing event list:
+
+- Download link: `<a href="/Events/Barrio/{slug}/BulkUpload/Template">Download events CSV</a>`.
+- Upload form: `enctype="multipart/form-data"`, single file input (`.csv`), POST to `/Events/Barrio/{slug}/BulkUpload`, submit button.
+- If `Model.BarrioBlocks[i].BulkUploadErrors` is non-empty: render an error table with columns Row, Title, Errors. One row per `BulkRowError`, errors as a `<ul>` in the Errors cell.
+
+---
+
+## Verification
+
+1. `dotnet build Humans.slnx -v quiet` — 0 errors.
+2. `dotnet test Humans.slnx -v quiet` — all pass.
+3. Manual:
+   - Camp lead opens `/Events/MySubmissions` → barrio block shows download link and file upload form.
+   - Download template → CSV has correct columns, existing events populated, Withdrawn events absent, comment lines at top.
+   - Upload CSV with one new row (empty Id) → event appears in MySubmissions as Pending.
+   - Upload same CSV again (now has an Id, fields unchanged) → event not duplicated, status preserved.
+   - Upload CSV with a changed field on an existing event → event updated and re-queued for moderation.
+   - Upload CSV with an invalid row (bad category, missing title, etc.) → error table shown, nothing saved.
+   - Attempt upload with submission window closed → rejected.
+   - Non-lead user attempts upload → 403.

--- a/docs/sections/Events.md
+++ b/docs/sections/Events.md
@@ -139,6 +139,7 @@ Unique constraint on (UserId, GuideEventId).
 |-----------|--------------|----------|
 | `EventsController` | `/Events/` | All active members |
 | `EventsController` (barrio actions) | `/Events/Barrio/{slug}/` | Camp Lead or Workshop Lead (per camp); CampAdmin / Admin globally |
+| `EventsController` (barrio bulk upload) | `/Events/Barrio/{slug}/BulkUpload` | Camp Lead or Workshop Lead (per camp); CampAdmin / Admin globally |
 | `EventsModerationController` | `/Events/Moderate/` | GuideModerator, Admin |
 | `EventsDashboardController` | `/Events/Dashboard/` | GuideModerator, Admin |
 | `EventsExportController` | `/Events/Export/` | GuideModerator, Admin |
@@ -150,7 +151,7 @@ Unique constraint on (UserId, GuideEventId).
 | Actor | Capabilities |
 |-------|--------------|
 | Any active member | Browse approved events; submit individual events during open window; manage own favourites and category preferences; view own submissions |
-| Camp Lead or Workshop Lead | Submit and manage barrio events via `EventsController` (`/Events/Barrio/{slug}/*`), shown in their **My Submissions** page alongside personal submissions; authority resolved via `ICampService.GetEventManagedCampsAsync` (unions `CampRoleAssignment` Lead/Workshop rows + legacy `CampLead` table). Workshop Leads do NOT gain general camp-management authority. |
+| Camp Lead or Workshop Lead | Submit and manage barrio events via `EventsController` (`/Events/Barrio/{slug}/*`), shown in their **My Submissions** page alongside personal submissions; authority resolved via `ICampService.GetEventManagedCampsAsync` (unions `CampRoleAssignment` Lead/Workshop rows + legacy `CampLead` table). Workshop Leads do NOT gain general camp-management authority. Can bulk-upload events via CSV at `/Events/Barrio/{slug}/BulkUpload` (US-26.10). |
 | GuideModerator, Admin | All active member capabilities. Additionally: view moderation queue, approve/reject/request-resubmit events, view dashboard, download CSV export, print guide; manage guide settings, event categories, shared venues |
 
 ## Invariants
@@ -161,6 +162,7 @@ Unique constraint on (UserId, GuideEventId).
 - Category slugs are globally unique (unique constraint enforced at DB level; service validates before create/update).
 - `GuideApiController` is gated behind `EventGuideFeatureFilter` at class level and `[EnableCors("GuideApi")]`; the public endpoints allow unauthenticated access while `[Authorize] + [DisableCors]` endpoints are same-origin only.
 - Excluded category slugs stored in `UserGuidePreference.ExcludedCategorySlugs` are validated against active categories before save.
+- Bulk CSV upload is all-or-nothing: if any row fails validation, no events are created or updated. Rows with a non-empty `Id` update the matched camp event; rows with an empty `Id` create a new event. `Withdrawn` events cannot be modified via bulk upload.
 - `StartAt` is always stored as UTC `Instant`; timezone conversion is done at presentation layer using `GuideSettings.EventSettings.TimeZoneId`.
 
 ## Negative Access Rules

--- a/src/Humans.Application/DTOs/Events/BulkEventImport.cs
+++ b/src/Humans.Application/DTOs/Events/BulkEventImport.cs
@@ -1,0 +1,36 @@
+namespace Humans.Application.DTOs.Events;
+
+/// <summary>
+/// A single parsed data row from a barrio bulk-upload CSV. <see cref="Id"/> is
+/// null for new events and set when editing an existing one.
+/// </summary>
+public sealed record BulkCsvRow(
+    int RowNumber,
+    Guid? Id,
+    string Title,
+    string Description,
+    string Category,
+    string Date,
+    string StartTime,
+    int DurationMinutes,
+    string? LocationNote,
+    string? Host,
+    bool IsRecurring,
+    string? RecurrenceDays,
+    int PriorityRank);
+
+/// <summary>Per-row validation failure surfaced back to the uploader.</summary>
+public sealed record BulkImportRowError(int RowNumber, string Title, IReadOnlyList<string> Errors);
+
+/// <summary>
+/// Outcome of a barrio bulk import. When <see cref="Errors"/> is non-empty the
+/// import was rejected wholesale and nothing was written.
+/// </summary>
+public sealed record BulkImportResult(
+    IReadOnlyList<BulkImportRowError> Errors,
+    int CreatedCount,
+    int UpdatedCount)
+{
+    /// <summary>True when validation failed and no events were persisted.</summary>
+    public bool HasErrors => Errors.Count > 0;
+}

--- a/src/Humans.Application/Events/BulkEventCsvParser.cs
+++ b/src/Humans.Application/Events/BulkEventCsvParser.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using System.Text;
+using Humans.Application.DTOs.Events;
+
+namespace Humans.Application.Events;
+
+/// <summary>
+/// Parses a barrio bulk-upload CSV (the format produced by the download
+/// template) into <see cref="BulkCsvRow"/> records. Comment lines (starting
+/// with <c>#</c>) and blank lines are skipped; the first remaining line is the
+/// header. Throws <see cref="FormatException"/> on malformed input.
+/// </summary>
+public static class BulkEventCsvParser
+{
+    private const int ExpectedColumns = 14;
+
+    public static List<BulkCsvRow> Parse(string csvText)
+    {
+        var rows = new List<BulkCsvRow>();
+        var lines = csvText.Split('\n', StringSplitOptions.None);
+        var dataLineNumber = 0;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#')) continue;
+
+            var fields = SplitCsvLine(line);
+
+            // First non-comment line is the header — skip it.
+            if (dataLineNumber == 0)
+            {
+                dataLineNumber++;
+                continue;
+            }
+
+            if (fields.Count < ExpectedColumns)
+                throw new FormatException($"Row {dataLineNumber + 1}: expected {ExpectedColumns} columns, got {fields.Count}.");
+
+            // fields[1] = Barrio (ignored), fields[2] = Status (ignored)
+            Guid? id = string.IsNullOrWhiteSpace(fields[0])
+                ? null
+                : Guid.TryParse(fields[0], out var g) ? g : throw new FormatException($"Row {dataLineNumber + 1}: Id is not a valid Guid.");
+
+            if (!int.TryParse(fields[8], CultureInfo.InvariantCulture, out var duration))
+                throw new FormatException($"Row {dataLineNumber + 1}: DurationMinutes is not an integer.");
+            if (!int.TryParse(fields[13], CultureInfo.InvariantCulture, out var priority))
+                throw new FormatException($"Row {dataLineNumber + 1}: PriorityRank is not an integer.");
+
+            var isRecurring = string.Equals(fields[11], "true", StringComparison.OrdinalIgnoreCase);
+
+            rows.Add(new BulkCsvRow(
+                dataLineNumber + 1, id,
+                fields[3], fields[4], fields[5], fields[6], fields[7], duration,
+                string.IsNullOrWhiteSpace(fields[9]) ? null : fields[9],
+                string.IsNullOrWhiteSpace(fields[10]) ? null : fields[10],
+                isRecurring,
+                string.IsNullOrWhiteSpace(fields[12]) ? null : fields[12],
+                priority));
+            dataLineNumber++;
+        }
+
+        return rows;
+    }
+
+    /// <summary>RFC-4180 single-line split: handles quoted fields and <c>""</c> escapes.</summary>
+    private static List<string> SplitCsvLine(string line)
+    {
+        var fields = new List<string>();
+        var i = 0;
+        while (i <= line.Length)
+        {
+            if (i == line.Length) { fields.Add(string.Empty); break; }
+            if (line[i] == '"')
+            {
+                i++;
+                var sb = new StringBuilder();
+                while (i < line.Length)
+                {
+                    if (line[i] == '"')
+                    {
+                        i++;
+                        if (i < line.Length && line[i] == '"') { sb.Append('"'); i++; }
+                        else break;
+                    }
+                    else { sb.Append(line[i]); i++; }
+                }
+                fields.Add(sb.ToString());
+                if (i < line.Length && line[i] == ',') i++;
+            }
+            else
+            {
+                var end = line.IndexOf(',', i);
+                if (end < 0) { fields.Add(line[i..]); break; }
+                fields.Add(line[i..end]);
+                i = end + 1;
+            }
+        }
+        return fields;
+    }
+}

--- a/src/Humans.Application/Events/EventRecurrenceDays.cs
+++ b/src/Humans.Application/Events/EventRecurrenceDays.cs
@@ -1,0 +1,59 @@
+using System.Globalization;
+using NodaTime;
+
+namespace Humans.Application.Events;
+
+/// <summary>
+/// Converts between the stored recurrence representation — comma-separated
+/// day-offsets from the burn gate date (e.g. <c>"0,2,4"</c>) — and the
+/// human-friendly day-name form (<c>"Mon Wed Fri"</c>) used in the barrio
+/// bulk-upload CSV.
+/// </summary>
+public static class EventRecurrenceDays
+{
+    private static readonly string[] DayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+    /// <summary>Offsets → space-separated day names, in offset order.</summary>
+    public static string OffsetsToDisplayDays(string offsets, LocalDate gateOpeningDate)
+    {
+        var names = new List<string>();
+        foreach (var part in offsets.Split(',', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (int.TryParse(part.Trim(), CultureInfo.InvariantCulture, out var offset))
+                names.Add(DayNames[((int)gateOpeningDate.PlusDays(offset).DayOfWeek - 1 + 7) % 7]);
+        }
+        return string.Join(" ", names);
+    }
+
+    /// <summary>
+    /// Day names → every matching offset within <c>0..eventEndOffset</c>, as a
+    /// comma-separated string (null when nothing matches).
+    /// </summary>
+    public static string? DisplayDaysToOffsets(string displayDays, LocalDate gateOpeningDate, int eventEndOffset)
+    {
+        var requested = displayDays.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(d => d.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var offsets = new List<int>();
+        for (var offset = 0; offset <= eventEndOffset; offset++)
+        {
+            var name = DayNames[((int)gateOpeningDate.PlusDays(offset).DayOfWeek - 1 + 7) % 7];
+            if (requested.Contains(name))
+                offsets.Add(offset);
+        }
+        return offsets.Count > 0 ? string.Join(",", offsets) : null;
+    }
+
+    /// <summary>
+    /// Case-insensitive set comparison of two space-separated day-name strings.
+    /// Used for change-detection so a lossless offsets→names→offsets round-trip
+    /// (e.g. a single Monday rendered as <c>"Mon"</c>) is not mistaken for an edit.
+    /// </summary>
+    public static bool SameDays(string a, string b)
+    {
+        var setA = a.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var setB = b.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return setA.SetEquals(setB);
+    }
+}

--- a/src/Humans.Application/Interfaces/Events/IEventService.cs
+++ b/src/Humans.Application/Interfaces/Events/IEventService.cs
@@ -14,9 +14,10 @@ namespace Humans.Application.Interfaces.Events;
 /// Surface-budget recent history (newest first):
 /// <list type="bullet">
 ///   <item>2026-05-14 — initial budget pinned at 46 after Stage 3 cross-section strip and Stage 5 IUserDataContributor add-on (section-align Events, issue #539).</item>
+///   <item>2026-05-22 — +1 (47) for <c>BulkImportAsync</c>: barrio CSV bulk import moved out of EventsController per no-business-logic-in-controllers (PR #704).</item>
 /// </list>
 /// </remarks>
-[SurfaceBudget(46)]
+[SurfaceBudget(47)]
 public interface IEventService : IApplicationService
 {
     // ── Settings ─────────────────────────────────────────────────────────
@@ -66,6 +67,16 @@ public interface IEventService : IApplicationService
     Task SubmitEventAsync(Event guideEvent, CancellationToken ct = default);
     Task UpdateAndResubmitAsync(Event guideEvent, CancellationToken ct = default);
     Task WithdrawEventAsync(Event guideEvent, CancellationToken ct = default);
+
+    /// <summary>
+    /// All-or-nothing barrio bulk import: validates every parsed row first and,
+    /// if all pass, creates new events (empty Id) and re-queues edited existing
+    /// ones. Returns per-row errors with nothing written when validation fails.
+    /// </summary>
+    Task<BulkImportResult> BulkImportAsync(
+        Guid campId, Guid submitterUserId, IReadOnlyList<BulkCsvRow> rows,
+        LocalDate gateOpeningDate, int eventEndOffset, DateTimeZone timeZone,
+        CancellationToken ct = default);
 
     // ── Browse / API ──────────────────────────────────────────────────────
     Task<IReadOnlyList<Event>> GetApprovedEventsAsync(

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -129,7 +129,22 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
 
     public Task UpdateAndResubmitAsync(Event guideEvent, CancellationToken ct = default)
     {
-        guideEvent.Submit(clock);
+        if (guideEvent.Status is EventStatus.Pending)
+        {
+            guideEvent.LastUpdatedAt = clock.GetCurrentInstant();
+        }
+        else if (guideEvent.Status is EventStatus.Approved)
+        {
+            var now = clock.GetCurrentInstant();
+            guideEvent.Status = EventStatus.Pending;
+            guideEvent.SubmittedAt = now;
+            guideEvent.LastUpdatedAt = now;
+        }
+        else
+        {
+            guideEvent.Submit(clock);
+        }
+
         return repo.SaveEventAsync(guideEvent, ct);
     }
 

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Humans.Application.DTOs.Events;
+using Humans.Application.Events;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Gdpr;
@@ -152,6 +153,155 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
     {
         guideEvent.Withdraw(clock);
         return repo.SaveEventAsync(guideEvent, ct);
+    }
+
+    public async Task<BulkImportResult> BulkImportAsync(
+        Guid campId, Guid submitterUserId, IReadOnlyList<BulkCsvRow> rows,
+        LocalDate gateOpeningDate, int eventEndOffset, DateTimeZone timeZone,
+        CancellationToken ct = default)
+    {
+        var categories = await repo.GetActiveCategoriesAsync(ct);
+        var existingEvents = await repo.GetCampSubmissionsAsync(campId, ct);
+
+        var errors = ValidateBulkRows(rows, categories, existingEvents);
+        if (errors.Count > 0)
+            return new BulkImportResult(errors, 0, 0);
+
+        var created = 0;
+        var updated = 0;
+        foreach (var row in rows)
+        {
+            var category = categories.First(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase));
+            var date = NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value;
+            var time = NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Value;
+            var startAt = (date + time).InZoneLeniently(timeZone).ToInstant();
+            var recurrenceOffsets = row.IsRecurring && !string.IsNullOrEmpty(row.RecurrenceDays)
+                ? EventRecurrenceDays.DisplayDaysToOffsets(row.RecurrenceDays, gateOpeningDate, eventEndOffset)
+                : null;
+
+            if (row.Id.HasValue)
+            {
+                var existing = existingEvents.First(e => e.Id == row.Id.Value);
+
+                // Compare recurrence by day-name set, not the raw offset string, so a
+                // lossless round-trip ("0" ⇄ "Mon") isn't mistaken for an edit and the
+                // event isn't needlessly re-queued for moderation.
+                var existingDays = existing.IsRecurring && !string.IsNullOrEmpty(existing.RecurrenceDays)
+                    ? EventRecurrenceDays.OffsetsToDisplayDays(existing.RecurrenceDays, gateOpeningDate)
+                    : string.Empty;
+                var rowDays = row.IsRecurring ? row.RecurrenceDays ?? string.Empty : string.Empty;
+
+                var changed =
+                    !string.Equals(existing.Title, row.Title, StringComparison.Ordinal) ||
+                    !string.Equals(existing.Description, row.Description, StringComparison.Ordinal) ||
+                    existing.CategoryId != category.Id ||
+                    existing.StartAt != startAt ||
+                    existing.DurationMinutes != row.DurationMinutes ||
+                    !string.Equals(existing.LocationNote ?? string.Empty, row.LocationNote ?? string.Empty, StringComparison.Ordinal) ||
+                    !string.Equals(existing.Host ?? string.Empty, row.Host ?? string.Empty, StringComparison.Ordinal) ||
+                    existing.IsRecurring != row.IsRecurring ||
+                    !EventRecurrenceDays.SameDays(existingDays, rowDays) ||
+                    existing.PriorityRank != row.PriorityRank;
+
+                if (!changed) continue;
+
+                existing.Title = row.Title;
+                existing.Description = row.Description;
+                existing.CategoryId = category.Id;
+                existing.StartAt = startAt;
+                existing.DurationMinutes = row.DurationMinutes;
+                existing.LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote;
+                existing.Host = string.IsNullOrEmpty(row.Host) ? null : row.Host;
+                existing.IsRecurring = row.IsRecurring;
+                existing.RecurrenceDays = row.IsRecurring ? recurrenceOffsets : null;
+                existing.PriorityRank = row.PriorityRank;
+
+                // One path for every existing status: UpdateAndResubmitAsync keeps a
+                // Pending event Pending, re-queues an Approved one, and submits a
+                // Draft/Rejected/ResubmitRequested one. (Withdrawn is rejected in
+                // validation, so it never reaches here.)
+                await UpdateAndResubmitAsync(existing, ct);
+                updated++;
+            }
+            else
+            {
+                var newEvent = new Event
+                {
+                    Id = Guid.NewGuid(),
+                    CampId = campId,
+                    SubmitterUserId = submitterUserId,
+                    CategoryId = category.Id,
+                    Title = row.Title,
+                    Description = row.Description,
+                    LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote,
+                    Host = string.IsNullOrEmpty(row.Host) ? null : row.Host,
+                    StartAt = startAt,
+                    DurationMinutes = row.DurationMinutes,
+                    IsRecurring = row.IsRecurring,
+                    RecurrenceDays = recurrenceOffsets,
+                    PriorityRank = row.PriorityRank
+                };
+                newEvent.Submit(clock);
+                await SubmitEventAsync(newEvent, ct);
+                created++;
+            }
+        }
+
+        return new BulkImportResult([], created, updated);
+    }
+
+    private static List<BulkImportRowError> ValidateBulkRows(
+        IReadOnlyList<BulkCsvRow> rows,
+        IReadOnlyList<EventCategory> categories,
+        IReadOnlyList<Event> existingEvents)
+    {
+        var errors = new List<BulkImportRowError>();
+        foreach (var row in rows)
+        {
+            var rowErrors = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(row.Title)) rowErrors.Add("Title is required.");
+            else if (row.Title.Length > 80) rowErrors.Add("Title must be 80 characters or fewer.");
+
+            if (string.IsNullOrWhiteSpace(row.Description)) rowErrors.Add("Description is required.");
+            else if (row.Description.Length > 450) rowErrors.Add("Description must be 450 characters or fewer.");
+
+            if (row.LocationNote?.Length > 120) rowErrors.Add("LocationNote must be 120 characters or fewer.");
+            if (row.Host?.Length > 40) rowErrors.Add("Host must be 40 characters or fewer.");
+
+            if (string.IsNullOrWhiteSpace(row.Category)) rowErrors.Add("Category is required.");
+            else if (!categories.Any(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase)))
+                rowErrors.Add($"Category '{row.Category}' is not a valid active category.");
+
+            if (string.IsNullOrWhiteSpace(row.Date)) rowErrors.Add("Date is required.");
+            else if (!NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Success)
+                rowErrors.Add("Date must be in yyyy-MM-dd format.");
+
+            if (string.IsNullOrWhiteSpace(row.StartTime)) rowErrors.Add("StartTime is required.");
+            else if (!NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Success)
+                rowErrors.Add("StartTime must be in HH:mm format.");
+
+            if (row.DurationMinutes < 15 || row.DurationMinutes > 480)
+                rowErrors.Add("DurationMinutes must be between 15 and 480.");
+            else if (row.DurationMinutes % 15 != 0)
+                rowErrors.Add("DurationMinutes must be a multiple of 15.");
+
+            if (row.PriorityRank < 1 || row.PriorityRank > 100)
+                rowErrors.Add("PriorityRank must be between 1 and 100.");
+
+            if (row.Id.HasValue)
+            {
+                var existing = existingEvents.FirstOrDefault(e => e.Id == row.Id.Value);
+                if (existing == null)
+                    rowErrors.Add($"Event {row.Id.Value} not found for this barrio.");
+                else if (existing.Status == EventStatus.Withdrawn)
+                    rowErrors.Add("Withdrawn events cannot be updated via bulk upload.");
+            }
+
+            if (rowErrors.Count > 0)
+                errors.Add(new BulkImportRowError(row.RowNumber, row.Title, rowErrors));
+        }
+        return errors;
     }
 
     public Task<IReadOnlyList<Event>> GetApprovedEventsAsync(

--- a/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
+++ b/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
@@ -291,6 +291,21 @@ public sealed class CachingEventService(
         _eventCache.Invalidate(guideEvent.Id);
     }
 
+    public async Task<BulkImportResult> BulkImportAsync(
+        Guid campId, Guid submitterUserId, IReadOnlyList<BulkCsvRow> rows,
+        LocalDate gateOpeningDate, int eventEndOffset, DateTimeZone timeZone,
+        CancellationToken ct = default)
+    {
+        var result = await WithInner(inner => inner.BulkImportAsync(
+            campId, submitterUserId, rows, gateOpeningDate, eventEndOffset, timeZone, ct));
+        // Updates can transition Approved events away from Approved; rebuild the
+        // approved-event projection wholesale. New events are Pending and never
+        // enter the approved cache, so a create-only import needs no refresh.
+        if (result.UpdatedCount > 0)
+            await RefreshAllEventsAsync(ct);
+        return result;
+    }
+
     // ==========================================================================
     // Browse / API — cached snapshot with in-memory filter
     // ==========================================================================

--- a/src/Humans.Web/Controllers/Api/EventsApiController.cs
+++ b/src/Humans.Web/Controllers/Api/EventsApiController.cs
@@ -306,7 +306,6 @@ public class EventsApiController(IEventService guide, ICampService camps, IUserS
                 ? new GuideEventVenueApiDto(e.GuideSharedVenueId.Value, e.EventVenue.Name)
                 : null,
             e.LocationNote,
-            // Individual events fall back to the submitter's name when no host is set (US-26.3 / US-26.6).
             e.CampId == null ? (e.Host ?? submitterName) : e.Host,
             e.PriorityRank);
     }

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -1,3 +1,5 @@
+using Humans.Application.DTOs.Events;
+using Humans.Application.Events;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Events;
@@ -874,7 +876,7 @@ public class EventsController(
             var date = localDt.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
             var time = localDt.ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture);
             var recDays = e.IsRecurring && !string.IsNullOrEmpty(e.RecurrenceDays) && gateDate.HasValue
-                ? OffsetsToDisplayDays(e.RecurrenceDays, gateDate.Value)
+                ? EventRecurrenceDays.OffsetsToDisplayDays(e.RecurrenceDays, gateDate.Value)
                 : string.Empty;
 
             sb.AppendCsvRow(
@@ -923,6 +925,7 @@ public class EventsController(
 
     [HttpPost("Barrio/{slug}/BulkUpload")]
     [ValidateAntiForgeryToken]
+    [RequestSizeLimit(1 * 1024 * 1024)]
     public async Task<IActionResult> BulkUploadImport(string slug, IFormFile? file)
     {
         var (error, user, camp) = await ResolveCampEventManagementAsync(slug);
@@ -945,14 +948,12 @@ public class EventsController(
             ?? throw new InvalidOperationException("Event settings not configured.");
         var tz = GetTimeZone(eventSettings)
             ?? throw new InvalidOperationException("Event timezone not configured.");
-        var categories = await guide.GetActiveCategoriesAsync();
-        var existingEvents = await guide.GetCampSubmissionsAsync(camp.Id);
 
         List<BulkCsvRow> rows;
         try
         {
             using var reader = new System.IO.StreamReader(file.OpenReadStream(), System.Text.Encoding.UTF8);
-            rows = ParseCsvRows(await reader.ReadToEndAsync());
+            rows = BulkEventCsvParser.Parse(await reader.ReadToEndAsync());
         }
         catch (Exception ex)
         {
@@ -961,285 +962,30 @@ public class EventsController(
             return RedirectToAction(nameof(MySubmissions));
         }
 
-        var rowErrors = ValidateBulkRows(rows, categories, existingEvents, eventSettings.GateOpeningDate);
-        if (rowErrors.Count > 0)
+        if (rows.Count == 0)
         {
-            TempData[$"BulkErrors_{slug}"] = System.Text.Json.JsonSerializer.Serialize(rowErrors);
+            SetError("The CSV had no event rows. Add at least one row below the header and try again.");
             return RedirectToAction(nameof(MySubmissions));
         }
 
-        var campName = ResolveCampDisplayName(camp);
-        foreach (var row in rows)
+        var result = await guide.BulkImportAsync(
+            camp.Id, user.Id, rows,
+            eventSettings.GateOpeningDate, eventSettings.EventEndOffset, tz);
+
+        if (result.HasErrors)
         {
-            if (row.Id.HasValue)
-            {
-                var existing = existingEvents.First(e => e.Id == row.Id.Value);
-                var newDate = NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value;
-                var newTime = NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Value;
-                var newInstant = (newDate + newTime).InZoneLeniently(tz).ToInstant();
-                var newRecDays = row.IsRecurring && !string.IsNullOrEmpty(row.RecurrenceDays)
-                    ? DisplayDaysToOffsets(row.RecurrenceDays, eventSettings.GateOpeningDate, eventSettings.EventEndOffset)
-                    : null;
-
-                var changed =
-                    !string.Equals(existing.Title, row.Title, StringComparison.Ordinal) ||
-                    !string.Equals(existing.Description, row.Description, StringComparison.Ordinal) ||
-                    !string.Equals(existing.Category.Name, row.Category, StringComparison.OrdinalIgnoreCase) ||
-                    existing.StartAt != newInstant ||
-                    existing.DurationMinutes != row.DurationMinutes ||
-                    !string.Equals(existing.LocationNote ?? string.Empty, row.LocationNote ?? string.Empty, StringComparison.Ordinal) ||
-                    !string.Equals(existing.Host ?? string.Empty, row.Host ?? string.Empty, StringComparison.Ordinal) ||
-                    existing.IsRecurring != row.IsRecurring ||
-                    !string.Equals(existing.RecurrenceDays ?? string.Empty, newRecDays ?? string.Empty, StringComparison.Ordinal) ||
-                    existing.PriorityRank != row.PriorityRank;
-
-                if (!changed) continue;
-
-                var matchedCategory = categories.First(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase));
-                existing.Title = row.Title;
-                existing.Description = row.Description;
-                existing.CategoryId = matchedCategory.Id;
-                existing.StartAt = newInstant;
-                existing.DurationMinutes = row.DurationMinutes;
-                existing.LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote;
-                existing.Host = string.IsNullOrEmpty(row.Host) ? null : row.Host;
-                existing.IsRecurring = row.IsRecurring;
-                existing.RecurrenceDays = row.IsRecurring ? newRecDays : null;
-                existing.PriorityRank = row.PriorityRank;
-
-                if (existing.Status == Domain.Enums.EventStatus.Draft)
-                {
-                    existing.Submit(clock);
-                    await guide.SubmitEventAsync(existing);
-                }
-                else
-                {
-                    await guide.UpdateAndResubmitAsync(existing);
-                }
-                logger.LogInformation("Bulk upload: user {UserId} updated event '{Title}' ({EventId})", user.Id, existing.Title, existing.Id);
-            }
-            else
-            {
-                var matchedCategory = categories.First(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase));
-                var recDays = row.IsRecurring && !string.IsNullOrEmpty(row.RecurrenceDays)
-                    ? DisplayDaysToOffsets(row.RecurrenceDays, eventSettings.GateOpeningDate, eventSettings.EventEndOffset)
-                    : null;
-                var newEvent = new Domain.Entities.Event
-                {
-                    Id = Guid.NewGuid(),
-                    CampId = camp.Id,
-                    SubmitterUserId = user.Id,
-                    CategoryId = matchedCategory.Id,
-                    Title = row.Title,
-                    Description = row.Description,
-                    LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote,
-                    Host = string.IsNullOrEmpty(row.Host) ? null : row.Host,
-                    StartAt = (NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value + NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Value).InZoneLeniently(tz).ToInstant(),
-                    DurationMinutes = row.DurationMinutes,
-                    IsRecurring = row.IsRecurring,
-                    RecurrenceDays = recDays,
-                    PriorityRank = row.PriorityRank
-                };
-                newEvent.Submit(clock);
-                await guide.SubmitEventAsync(newEvent);
-                logger.LogInformation("Bulk upload: user {UserId} submitted new event '{Title}' for camp {CampId}", user.Id, row.Title, camp.Id);
-            }
+            var viewErrors = result.Errors
+                .Select(e => new BulkRowError { RowNumber = e.RowNumber, Title = e.Title, Errors = e.Errors.ToList() })
+                .ToList();
+            TempData[$"BulkErrors_{slug}"] = System.Text.Json.JsonSerializer.Serialize(viewErrors);
+            return RedirectToAction(nameof(MySubmissions));
         }
 
-        SetSuccess("Bulk upload complete.");
+        logger.LogInformation(
+            "Bulk upload by user {UserId} for camp {CampId}: {Created} created, {Updated} updated.",
+            user.Id, camp.Id, result.CreatedCount, result.UpdatedCount);
+        SetSuccess($"Bulk upload complete — {result.CreatedCount} created, {result.UpdatedCount} updated.");
         return RedirectToAction(nameof(MySubmissions));
-    }
-
-    private sealed record BulkCsvRow(
-        int RowNumber,
-        Guid? Id,
-        string Title,
-        string Description,
-        string Category,
-        string Date,
-        string StartTime,
-        int DurationMinutes,
-        string? LocationNote,
-        string? Host,
-        bool IsRecurring,
-        string? RecurrenceDays,
-        int PriorityRank);
-
-    private static List<BulkCsvRow> ParseCsvRows(string csvText)
-    {
-        var rows = new List<BulkCsvRow>();
-        var lines = csvText.Split('\n', StringSplitOptions.None);
-        var dataLineNumber = 0;
-
-        foreach (var rawLine in lines)
-        {
-            var line = rawLine.TrimEnd('\r');
-            if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#')) continue;
-
-            var fields = SplitCsvLine(line);
-
-            // Header row — skip but validate column count
-            if (dataLineNumber == 0)
-            {
-                dataLineNumber++;
-                continue;
-            }
-
-            if (fields.Count < 14)
-                throw new FormatException($"Row {dataLineNumber + 1}: expected 14 columns, got {fields.Count}.");
-
-            Guid? id = string.IsNullOrWhiteSpace(fields[0]) ? null : Guid.TryParse(fields[0], out var g) ? g : throw new FormatException($"Row {dataLineNumber + 1}: Id is not a valid Guid.");
-            // fields[1] = Barrio (ignored), fields[2] = Status (ignored)
-            var title = fields[3];
-            var description = fields[4];
-            var category = fields[5];
-            var date = fields[6];
-            var startTime = fields[7];
-            var durationStr = fields[8];
-            var locationNote = fields[9];
-            var host = fields[10];
-            var isRecurringStr = fields[11];
-            var recurrenceDays = fields[12];
-            var priorityStr = fields[13];
-
-            if (!int.TryParse(durationStr, System.Globalization.CultureInfo.InvariantCulture, out var duration))
-                throw new FormatException($"Row {dataLineNumber + 1}: DurationMinutes is not an integer.");
-            if (!int.TryParse(priorityStr, System.Globalization.CultureInfo.InvariantCulture, out var priority))
-                throw new FormatException($"Row {dataLineNumber + 1}: PriorityRank is not an integer.");
-            var isRecurring = string.Equals(isRecurringStr, "true", StringComparison.OrdinalIgnoreCase);
-
-            rows.Add(new BulkCsvRow(dataLineNumber + 1, id, title, description, category, date, startTime, duration,
-                string.IsNullOrWhiteSpace(locationNote) ? null : locationNote,
-                string.IsNullOrWhiteSpace(host) ? null : host,
-                isRecurring, string.IsNullOrWhiteSpace(recurrenceDays) ? null : recurrenceDays, priority));
-            dataLineNumber++;
-        }
-
-        return rows;
-    }
-
-    private static List<string> SplitCsvLine(string line)
-    {
-        var fields = new List<string>();
-        var i = 0;
-        while (i <= line.Length)
-        {
-            if (i == line.Length) { fields.Add(string.Empty); break; }
-            if (line[i] == '"')
-            {
-                i++;
-                var sb = new System.Text.StringBuilder();
-                while (i < line.Length)
-                {
-                    if (line[i] == '"')
-                    {
-                        i++;
-                        if (i < line.Length && line[i] == '"') { sb.Append('"'); i++; }
-                        else break;
-                    }
-                    else { sb.Append(line[i]); i++; }
-                }
-                fields.Add(sb.ToString());
-                if (i < line.Length && line[i] == ',') i++;
-            }
-            else
-            {
-                var end = line.IndexOf(',', i);
-                if (end < 0) { fields.Add(line[i..]); break; }
-                fields.Add(line[i..end]);
-                i = end + 1;
-            }
-        }
-        return fields;
-    }
-
-    private static List<BulkRowError> ValidateBulkRows(
-        List<BulkCsvRow> rows,
-        IReadOnlyList<Domain.Entities.EventCategory> categories,
-        IReadOnlyList<Domain.Entities.Event> existingEvents,
-        NodaTime.LocalDate gateOpeningDate)
-    {
-        var errors = new List<BulkRowError>();
-        foreach (var row in rows)
-        {
-            var rowErrors = new List<string>();
-
-            if (string.IsNullOrWhiteSpace(row.Title)) rowErrors.Add("Title is required.");
-            else if (row.Title.Length > 80) rowErrors.Add("Title must be 80 characters or fewer.");
-
-            if (string.IsNullOrWhiteSpace(row.Description)) rowErrors.Add("Description is required.");
-            else if (row.Description.Length > 450) rowErrors.Add("Description must be 450 characters or fewer.");
-
-            if (row.LocationNote?.Length > 120) rowErrors.Add("LocationNote must be 120 characters or fewer.");
-            if (row.Host?.Length > 40) rowErrors.Add("Host must be 40 characters or fewer.");
-
-            if (string.IsNullOrWhiteSpace(row.Category)) rowErrors.Add("Category is required.");
-            else if (!categories.Any(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase)))
-                rowErrors.Add($"Category '{row.Category}' is not a valid active category.");
-
-            if (string.IsNullOrWhiteSpace(row.Date)) rowErrors.Add("Date is required.");
-            else if (!NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Success)
-                rowErrors.Add("Date must be in yyyy-MM-dd format.");
-
-            if (string.IsNullOrWhiteSpace(row.StartTime)) rowErrors.Add("StartTime is required.");
-            else if (!NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Success)
-                rowErrors.Add("StartTime must be in HH:mm format.");
-
-            if (row.DurationMinutes < 15 || row.DurationMinutes > 480)
-                rowErrors.Add("DurationMinutes must be between 15 and 480.");
-            else if (row.DurationMinutes % 15 != 0)
-                rowErrors.Add("DurationMinutes must be a multiple of 15.");
-
-            if (row.PriorityRank < 1 || row.PriorityRank > 100)
-                rowErrors.Add("PriorityRank must be between 1 and 100.");
-
-            if (row.Id.HasValue)
-            {
-                var existing = existingEvents.FirstOrDefault(e => e.Id == row.Id.Value);
-                if (existing == null)
-                    rowErrors.Add($"Event {row.Id.Value} not found for this barrio.");
-                else if (existing.Status == Domain.Enums.EventStatus.Withdrawn)
-                    rowErrors.Add("Withdrawn events cannot be updated via bulk upload.");
-            }
-
-            if (rowErrors.Count > 0)
-                errors.Add(new BulkRowError { RowNumber = row.RowNumber, Title = row.Title, Errors = rowErrors });
-        }
-        return errors;
-    }
-
-    private static readonly string[] DayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-
-    private static string OffsetsToDisplayDays(string offsets, NodaTime.LocalDate gateOpeningDate)
-    {
-        var parts = offsets.Split(',', StringSplitOptions.RemoveEmptyEntries);
-        var names = new List<string>();
-        foreach (var part in parts)
-        {
-            if (int.TryParse(part.Trim(), System.Globalization.CultureInfo.InvariantCulture, out var offset))
-            {
-                var date = gateOpeningDate.PlusDays(offset);
-                names.Add(DayNames[((int)date.DayOfWeek - 1 + 7) % 7]);
-            }
-        }
-        return string.Join(" ", names);
-    }
-
-    private static string? DisplayDaysToOffsets(string displayDays, NodaTime.LocalDate gateOpeningDate, int eventEndOffset)
-    {
-        var requestedDays = displayDays.Split(' ', StringSplitOptions.RemoveEmptyEntries)
-            .Select(d => d.Trim())
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var offsets = new List<int>();
-        for (var offset = 0; offset <= eventEndOffset; offset++)
-        {
-            var date = gateOpeningDate.PlusDays(offset);
-            var name = DayNames[((int)date.DayOfWeek - 1 + 7) % 7];
-            if (requestedDays.Contains(name))
-                offsets.Add(offset);
-        }
-        return offsets.Count > 0 ? string.Join(",", offsets) : null;
     }
 
     private static string ResolveCampDisplayName(CampLookup camp) =>

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -866,7 +866,7 @@ public class EventsController(
 
         sb.AppendLine("\"Id\",\"Barrio\",\"Status\",\"Title\",\"Description\",\"Category\",\"Date\",\"StartTime\",\"DurationMinutes\",\"LocationNote\",\"Host\",\"IsRecurring\",\"RecurrenceDays\",\"PriorityRank\"");
 
-        var nonWithdrawn = campEvents.Where(e => e.Status != Domain.Enums.EventStatus.Withdrawn);
+        var nonWithdrawn = campEvents.Where(e => e.Status != Domain.Enums.EventStatus.Withdrawn).ToList();
         foreach (var e in nonWithdrawn)
         {
             var localDt = ToLocalDateTime(e.StartAt, tz);
@@ -891,6 +891,29 @@ public class EventsController(
                 CsvField(e.IsRecurring ? "true" : "false"),
                 CsvField(recDays),
                 CsvField(e.PriorityRank.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+        }
+
+        if (nonWithdrawn.Count == 0)
+        {
+            var exampleDate = gateDate.HasValue
+                ? gateDate.Value.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)
+                : DateTime.UtcNow.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+            var firstCategory = categories.FirstOrDefault()?.Name ?? "Workshop";
+            sb.AppendLine(string.Join(",",
+                CsvField(string.Empty),
+                CsvField(campName),
+                CsvField(string.Empty),
+                CsvField("Example Event"),
+                CsvField("Describe your event here."),
+                CsvField(firstCategory),
+                CsvField(exampleDate),
+                CsvField("12:00"),
+                CsvField("60"),
+                CsvField(string.Empty),
+                CsvField(string.Empty),
+                CsvField("false"),
+                CsvField(string.Empty),
+                CsvField("1")));
         }
 
         var bytes = System.Text.Encoding.UTF8.GetBytes(sb.ToString());

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -943,7 +943,8 @@ public class EventsController(
 
         var eventSettings = await LoadBurnSettingsAsync(guideSettings)
             ?? throw new InvalidOperationException("Event settings not configured.");
-        var tz = GetTimeZone(eventSettings);
+        var tz = GetTimeZone(eventSettings)
+            ?? throw new InvalidOperationException("Event timezone not configured.");
         var categories = await guide.GetActiveCategoriesAsync();
         var existingEvents = await guide.GetCampSubmissionsAsync(camp.Id);
 

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -10,6 +10,7 @@ using Humans.Web.Models.Events;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Web.Extensions;
 using static Humans.Web.Helpers.EventsLookupHelpers;
 using static Humans.Web.Helpers.EventsTimeHelpers;
 
@@ -876,44 +877,44 @@ public class EventsController(
                 ? OffsetsToDisplayDays(e.RecurrenceDays, gateDate.Value)
                 : string.Empty;
 
-            sb.AppendLine(string.Join(",",
-                CsvField(e.Id.ToString("D", System.Globalization.CultureInfo.InvariantCulture)),
-                CsvField(campName),
-                CsvField(e.Status.ToString()),
-                CsvField(e.Title),
-                CsvField(e.Description),
-                CsvField(e.Category.Name),
-                CsvField(date),
-                CsvField(time),
-                CsvField(e.DurationMinutes.ToString(System.Globalization.CultureInfo.InvariantCulture)),
-                CsvField(e.LocationNote ?? string.Empty),
-                CsvField(e.Host ?? string.Empty),
-                CsvField(e.IsRecurring ? "true" : "false"),
-                CsvField(recDays),
-                CsvField(e.PriorityRank.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+            sb.AppendCsvRow(
+                e.Id.ToString("D", System.Globalization.CultureInfo.InvariantCulture),
+                campName,
+                e.Status.ToString(),
+                e.Title,
+                e.Description,
+                e.Category.Name,
+                date,
+                time,
+                e.DurationMinutes,
+                e.LocationNote ?? string.Empty,
+                e.Host ?? string.Empty,
+                e.IsRecurring ? "true" : "false",
+                recDays,
+                e.PriorityRank);
         }
 
         if (nonWithdrawn.Count == 0)
         {
             var exampleDate = gateDate.HasValue
                 ? gateDate.Value.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)
-                : DateTime.UtcNow.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+                : clock.GetCurrentInstant().InZone(tz ?? DateTimeZone.Utc).Date.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
             var firstCategory = categories.FirstOrDefault()?.Name ?? "Workshop";
-            sb.AppendLine(string.Join(",",
-                CsvField(string.Empty),
-                CsvField(campName),
-                CsvField(string.Empty),
-                CsvField("Example Event"),
-                CsvField("Describe your event here."),
-                CsvField(firstCategory),
-                CsvField(exampleDate),
-                CsvField("12:00"),
-                CsvField("60"),
-                CsvField(string.Empty),
-                CsvField(string.Empty),
-                CsvField("false"),
-                CsvField(string.Empty),
-                CsvField("1")));
+            sb.AppendCsvRow(
+                string.Empty,
+                campName,
+                string.Empty,
+                "Example Event",
+                "Describe your event here.",
+                firstCategory,
+                exampleDate,
+                "12:00",
+                60,
+                string.Empty,
+                string.Empty,
+                "false",
+                string.Empty,
+                1);
         }
 
         var bytes = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
@@ -954,6 +955,7 @@ public class EventsController(
         }
         catch (Exception ex)
         {
+            logger.LogWarning("Bulk CSV parse failed for camp slug {Slug}: {Message}", slug, ex.Message);
             SetError($"Could not parse CSV: {ex.Message}");
             return RedirectToAction(nameof(MySubmissions));
         }
@@ -971,7 +973,9 @@ public class EventsController(
             if (row.Id.HasValue)
             {
                 var existing = existingEvents.First(e => e.Id == row.Id.Value);
-                var newInstant = ToInstant(DateTime.Parse($"{row.Date} {row.StartTime}", System.Globalization.CultureInfo.InvariantCulture), tz);
+                var newDate = NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value;
+                var newTime = NodaTime.Text.LocalTimePattern.GeneralIso.Parse(row.StartTime).Value;
+                var newInstant = (newDate + newTime).InZoneLeniently(tz).ToInstant();
                 var newRecDays = row.IsRecurring && !string.IsNullOrEmpty(row.RecurrenceDays)
                     ? DisplayDaysToOffsets(row.RecurrenceDays, eventSettings.GateOpeningDate, eventSettings.EventEndOffset)
                     : null;
@@ -1029,7 +1033,7 @@ public class EventsController(
                     Description = row.Description,
                     LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote,
                     Host = string.IsNullOrEmpty(row.Host) ? null : row.Host,
-                    StartAt = ToInstant(DateTime.Parse($"{row.Date} {row.StartTime}", System.Globalization.CultureInfo.InvariantCulture), tz),
+                    StartAt = (NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value + NodaTime.Text.LocalTimePattern.GeneralIso.Parse(row.StartTime).Value).InZoneLeniently(tz).ToInstant(),
                     DurationMinutes = row.DurationMinutes,
                     IsRecurring = row.IsRecurring,
                     RecurrenceDays = recDays,
@@ -1173,11 +1177,11 @@ public class EventsController(
                 rowErrors.Add($"Category '{row.Category}' is not a valid active category.");
 
             if (string.IsNullOrWhiteSpace(row.Date)) rowErrors.Add("Date is required.");
-            else if (!DateTime.TryParseExact(row.Date, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out _))
+            else if (!NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Success)
                 rowErrors.Add("Date must be in yyyy-MM-dd format.");
 
             if (string.IsNullOrWhiteSpace(row.StartTime)) rowErrors.Add("StartTime is required.");
-            else if (!TimeSpan.TryParseExact(row.StartTime, "hh\\:mm", System.Globalization.CultureInfo.InvariantCulture, out _))
+            else if (!NodaTime.Text.LocalTimePattern.GeneralIso.Parse(row.StartTime).Success)
                 rowErrors.Add("StartTime must be in HH:mm format.");
 
             if (row.DurationMinutes < 15 || row.DurationMinutes > 480)
@@ -1201,12 +1205,6 @@ public class EventsController(
                 errors.Add(new BulkRowError { RowNumber = row.RowNumber, Title = row.Title, Errors = rowErrors });
         }
         return errors;
-    }
-
-    private static string CsvField(string value)
-    {
-        var escaped = value.Replace("\"", "\"\"");
-        return $"\"{escaped}\"";
     }
 
     private static readonly string[] DayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -975,7 +975,7 @@ public class EventsController(
             {
                 var existing = existingEvents.First(e => e.Id == row.Id.Value);
                 var newDate = NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value;
-                var newTime = NodaTime.Text.LocalTimePattern.GeneralIso.Parse(row.StartTime).Value;
+                var newTime = NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Value;
                 var newInstant = (newDate + newTime).InZoneLeniently(tz).ToInstant();
                 var newRecDays = row.IsRecurring && !string.IsNullOrEmpty(row.RecurrenceDays)
                     ? DisplayDaysToOffsets(row.RecurrenceDays, eventSettings.GateOpeningDate, eventSettings.EventEndOffset)
@@ -1034,7 +1034,7 @@ public class EventsController(
                     Description = row.Description,
                     LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote,
                     Host = string.IsNullOrEmpty(row.Host) ? null : row.Host,
-                    StartAt = (NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value + NodaTime.Text.LocalTimePattern.GeneralIso.Parse(row.StartTime).Value).InZoneLeniently(tz).ToInstant(),
+                    StartAt = (NodaTime.Text.LocalDatePattern.Iso.Parse(row.Date).Value + NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Value).InZoneLeniently(tz).ToInstant(),
                     DurationMinutes = row.DurationMinutes,
                     IsRecurring = row.IsRecurring,
                     RecurrenceDays = recDays,
@@ -1182,7 +1182,7 @@ public class EventsController(
                 rowErrors.Add("Date must be in yyyy-MM-dd format.");
 
             if (string.IsNullOrWhiteSpace(row.StartTime)) rowErrors.Add("StartTime is required.");
-            else if (!NodaTime.Text.LocalTimePattern.GeneralIso.Parse(row.StartTime).Success)
+            else if (!NodaTime.Text.LocalTimePattern.CreateWithInvariantCulture("HH:mm").Parse(row.StartTime).Success)
                 rowErrors.Add("StartTime must be in HH:mm format.");
 
             if (row.DurationMinutes < 15 || row.DurationMinutes > 480)

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -76,6 +76,13 @@ public class EventsController(
             });
         }
 
+        foreach (var block in barrioBlocks)
+        {
+            var key = $"BulkErrors_{block.CampSlug}";
+            if (TempData[key] is string json)
+                block.BulkUploadErrors = System.Text.Json.JsonSerializer.Deserialize<List<BulkRowError>>(json) ?? [];
+        }
+
         var model = new MySubmissionsViewModel
         {
             IsSubmissionOpen = isSubmissionOpen,
@@ -284,7 +291,17 @@ public class EventsController(
         guideEvent.IsRecurring = model.IsRecurring;
         guideEvent.RecurrenceDays = model.IsRecurring ? model.RecurrenceDays : null;
 
-        await guide.UpdateAndResubmitAsync(guideEvent);
+        try
+        {
+            await guide.UpdateAndResubmitAsync(guideEvent);
+        }
+        catch (InvalidOperationException ex) when (IsSubmitStateException(ex))
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            model.Id = eventId;
+            await PopulateDropdownsAsync(model, eventSettings);
+            return View("IndividualEventForm", model);
+        }
 
         logger.LogInformation("User {UserId} updated event '{Title}' ({EventId})", user.Id, model.Title, eventId);
 
@@ -747,7 +764,21 @@ public class EventsController(
         guideEvent.RecurrenceDays = model.IsRecurring ? model.RecurrenceDays : null;
         guideEvent.PriorityRank = model.PriorityRank;
 
-        await guide.UpdateAndResubmitAsync(guideEvent);
+        try
+        {
+            await guide.UpdateAndResubmitAsync(guideEvent);
+        }
+        catch (InvalidOperationException ex) when (IsSubmitStateException(ex))
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            model.Id = eventId;
+            model.CampId = camp.Id;
+            model.CampName = ResolveCampDisplayName(camp);
+            model.CampSlug = slug;
+            await PopulateBarrioDropdownsAsync(model, eventSettings);
+            return View("BarrioEventForm", model);
+        }
+
         logger.LogInformation("User {UserId} updated barrio event '{Title}' ({EventId})", user.Id, model.Title, eventId);
 
         SetSuccess($"Event \"{model.Title}\" resubmitted for review.");
@@ -775,6 +806,428 @@ public class EventsController(
 
         SetSuccess($"Event \"{guideEvent.Title}\" withdrawn.");
         return RedirectToAction(nameof(MySubmissions));
+    }
+
+    [HttpGet("Barrio/{slug}/BulkUpload/Template")]
+    public async Task<IActionResult> BulkUploadTemplate(string slug)
+    {
+        var (error, _, camp) = await ResolveCampEventManagementAsync(slug);
+        if (error != null) return error;
+
+        var guideSettings = await guide.GetGuideSettingsAsync();
+        var eventSettings = await LoadBurnSettingsAsync(guideSettings);
+
+        var campEvents = await guide.GetCampSubmissionsAsync(camp.Id);
+        var categories = await guide.GetActiveCategoriesAsync();
+        var campName = ResolveCampDisplayName(camp);
+
+        DateTimeZone? tz = eventSettings != null
+            ? DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId)
+            : null;
+        LocalDate? gateDate = eventSettings?.GateOpeningDate;
+
+        var categoryNames = string.Join(", ", categories.Select(c => c.Name));
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("# ─────────────────────────────────────────────────────────────────────────────");
+        sb.AppendLine("# ELSEWHERE EVENT GUIDE — Bulk Upload Template");
+        sb.AppendLine("# ─────────────────────────────────────────────────────────────────────────────");
+        sb.AppendLine("#");
+        sb.AppendLine("# HOW TO USE");
+        sb.AppendLine("#   1. Fill in new rows leaving Id blank — a new event will be created.");
+        sb.AppendLine("#   2. Existing rows already have an Id filled in. You may edit their fields,");
+        sb.AppendLine("#      but DO NOT change or delete the Id — that is how we match the event.");
+        sb.AppendLine("#      Changing an Id will cause the upload to fail.");
+        sb.AppendLine("#   3. To leave an existing event unchanged, keep its row as-is.");
+        sb.AppendLine("#      Events not present in the CSV are left untouched.");
+        sb.AppendLine("#   4. Save as CSV (comma-separated, UTF-8) before uploading.");
+        sb.AppendLine("#      In Excel:   File → Save As → CSV UTF-8 (Comma delimited)");
+        sb.AppendLine("#      In Numbers: File → Export To → CSV");
+        sb.AppendLine("#");
+        sb.AppendLine("# FIELDS");
+        sb.AppendLine("#   Id             Leave empty for new events. Do not edit for existing ones.");
+        sb.AppendLine("#   Barrio         Informational only — shows which camp this file belongs to. Ignored on upload.");
+        sb.AppendLine("#   Status         Informational only — shows the current event status. Ignored on upload.");
+        sb.AppendLine("#                  If you upload a row without changing any fields, the status is kept as-is.");
+        sb.AppendLine("#                  If you edit fields on an existing event, it will be re-queued for moderation.");
+        sb.AppendLine("#   Category       Must match exactly one of the valid categories listed below.");
+        sb.AppendLine("#   Date           Format: yyyy-MM-dd  (e.g. 2026-07-08)");
+        sb.AppendLine("#   StartTime      Format: HH:mm       (e.g. 09:30)");
+        sb.AppendLine("#   DurationMinutes  Integer, 15–480, in 15-minute increments (e.g. 15, 30, 45, 60, 90, 120...).");
+        sb.AppendLine("#   IsRecurring    true or false.");
+        sb.AppendLine("#   RecurrenceDays  Only used when IsRecurring is true.");
+        sb.AppendLine("#                  Space-separated day names: Mon Tue Wed Thu Fri Sat Sun");
+        sb.AppendLine("#                  Example: Mon Wed Fri means the event repeats on those days.");
+        sb.AppendLine("#");
+        sb.AppendLine($"# VALID CATEGORIES");
+        sb.AppendLine($"#   {categoryNames}");
+        sb.AppendLine("#");
+        sb.AppendLine("# ─────────────────────────────────────────────────────────────────────────────");
+
+        sb.AppendLine("\"Id\",\"Barrio\",\"Status\",\"Title\",\"Description\",\"Category\",\"Date\",\"StartTime\",\"DurationMinutes\",\"LocationNote\",\"Host\",\"IsRecurring\",\"RecurrenceDays\",\"PriorityRank\"");
+
+        var nonWithdrawn = campEvents.Where(e => e.Status != Domain.Enums.EventStatus.Withdrawn);
+        foreach (var e in nonWithdrawn)
+        {
+            var localDt = ToLocalDateTime(e.StartAt, tz);
+            var date = localDt.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+            var time = localDt.ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture);
+            var recDays = e.IsRecurring && !string.IsNullOrEmpty(e.RecurrenceDays) && gateDate.HasValue
+                ? OffsetsToDisplayDays(e.RecurrenceDays, gateDate.Value)
+                : string.Empty;
+
+            sb.AppendLine(string.Join(",",
+                CsvField(e.Id.ToString("D", System.Globalization.CultureInfo.InvariantCulture)),
+                CsvField(campName),
+                CsvField(e.Status.ToString()),
+                CsvField(e.Title),
+                CsvField(e.Description),
+                CsvField(e.Category.Name),
+                CsvField(date),
+                CsvField(time),
+                CsvField(e.DurationMinutes.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                CsvField(e.LocationNote ?? string.Empty),
+                CsvField(e.Host ?? string.Empty),
+                CsvField(e.IsRecurring ? "true" : "false"),
+                CsvField(recDays),
+                CsvField(e.PriorityRank.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+        }
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(sb.ToString());
+        return File(bytes, "text/csv", $"{slug}-events.csv");
+    }
+
+    [HttpPost("Barrio/{slug}/BulkUpload")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> BulkUploadImport(string slug, IFormFile? file)
+    {
+        var (error, user, camp) = await ResolveCampEventManagementAsync(slug);
+        if (error != null) return error;
+
+        var guideSettings = await guide.GetGuideSettingsAsync();
+        if (!IsSubmissionOpen(guideSettings))
+        {
+            SetError("The submission window is not currently open.");
+            return RedirectToAction(nameof(MySubmissions));
+        }
+
+        if (file == null || file.Length == 0)
+        {
+            SetError("Please select a CSV file to upload.");
+            return RedirectToAction(nameof(MySubmissions));
+        }
+
+        var eventSettings = await LoadBurnSettingsAsync(guideSettings)
+            ?? throw new InvalidOperationException("Event settings not configured.");
+        var tz = GetTimeZone(eventSettings);
+        var categories = await guide.GetActiveCategoriesAsync();
+        var existingEvents = await guide.GetCampSubmissionsAsync(camp.Id);
+
+        List<BulkCsvRow> rows;
+        try
+        {
+            using var reader = new System.IO.StreamReader(file.OpenReadStream(), System.Text.Encoding.UTF8);
+            rows = ParseCsvRows(await reader.ReadToEndAsync());
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not parse CSV: {ex.Message}");
+            return RedirectToAction(nameof(MySubmissions));
+        }
+
+        var rowErrors = ValidateBulkRows(rows, categories, existingEvents, eventSettings.GateOpeningDate);
+        if (rowErrors.Count > 0)
+        {
+            TempData[$"BulkErrors_{slug}"] = System.Text.Json.JsonSerializer.Serialize(rowErrors);
+            return RedirectToAction(nameof(MySubmissions));
+        }
+
+        var campName = ResolveCampDisplayName(camp);
+        foreach (var row in rows)
+        {
+            if (row.Id.HasValue)
+            {
+                var existing = existingEvents.First(e => e.Id == row.Id.Value);
+                var newInstant = ToInstant(DateTime.Parse($"{row.Date} {row.StartTime}", System.Globalization.CultureInfo.InvariantCulture), tz);
+                var newRecDays = row.IsRecurring && !string.IsNullOrEmpty(row.RecurrenceDays)
+                    ? DisplayDaysToOffsets(row.RecurrenceDays, eventSettings.GateOpeningDate, eventSettings.EventEndOffset)
+                    : null;
+
+                var changed =
+                    !string.Equals(existing.Title, row.Title, StringComparison.Ordinal) ||
+                    !string.Equals(existing.Description, row.Description, StringComparison.Ordinal) ||
+                    !string.Equals(existing.Category.Name, row.Category, StringComparison.OrdinalIgnoreCase) ||
+                    existing.StartAt != newInstant ||
+                    existing.DurationMinutes != row.DurationMinutes ||
+                    !string.Equals(existing.LocationNote ?? string.Empty, row.LocationNote ?? string.Empty, StringComparison.Ordinal) ||
+                    !string.Equals(existing.Host ?? string.Empty, row.Host ?? string.Empty, StringComparison.Ordinal) ||
+                    existing.IsRecurring != row.IsRecurring ||
+                    !string.Equals(existing.RecurrenceDays ?? string.Empty, newRecDays ?? string.Empty, StringComparison.Ordinal) ||
+                    existing.PriorityRank != row.PriorityRank;
+
+                if (!changed) continue;
+
+                var matchedCategory = categories.First(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase));
+                existing.Title = row.Title;
+                existing.Description = row.Description;
+                existing.CategoryId = matchedCategory.Id;
+                existing.StartAt = newInstant;
+                existing.DurationMinutes = row.DurationMinutes;
+                existing.LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote;
+                existing.Host = string.IsNullOrEmpty(row.Host) ? null : row.Host;
+                existing.IsRecurring = row.IsRecurring;
+                existing.RecurrenceDays = row.IsRecurring ? newRecDays : null;
+                existing.PriorityRank = row.PriorityRank;
+
+                if (existing.Status == Domain.Enums.EventStatus.Draft)
+                {
+                    existing.Submit(clock);
+                    await guide.SubmitEventAsync(existing);
+                }
+                else
+                {
+                    await guide.UpdateAndResubmitAsync(existing);
+                }
+                logger.LogInformation("Bulk upload: user {UserId} updated event '{Title}' ({EventId})", user.Id, existing.Title, existing.Id);
+            }
+            else
+            {
+                var matchedCategory = categories.First(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase));
+                var recDays = row.IsRecurring && !string.IsNullOrEmpty(row.RecurrenceDays)
+                    ? DisplayDaysToOffsets(row.RecurrenceDays, eventSettings.GateOpeningDate, eventSettings.EventEndOffset)
+                    : null;
+                var newEvent = new Domain.Entities.Event
+                {
+                    Id = Guid.NewGuid(),
+                    CampId = camp.Id,
+                    SubmitterUserId = user.Id,
+                    CategoryId = matchedCategory.Id,
+                    Title = row.Title,
+                    Description = row.Description,
+                    LocationNote = string.IsNullOrEmpty(row.LocationNote) ? null : row.LocationNote,
+                    Host = string.IsNullOrEmpty(row.Host) ? null : row.Host,
+                    StartAt = ToInstant(DateTime.Parse($"{row.Date} {row.StartTime}", System.Globalization.CultureInfo.InvariantCulture), tz),
+                    DurationMinutes = row.DurationMinutes,
+                    IsRecurring = row.IsRecurring,
+                    RecurrenceDays = recDays,
+                    PriorityRank = row.PriorityRank
+                };
+                newEvent.Submit(clock);
+                await guide.SubmitEventAsync(newEvent);
+                logger.LogInformation("Bulk upload: user {UserId} submitted new event '{Title}' for camp {CampId}", user.Id, row.Title, camp.Id);
+
+                var userEmail = user.Email;
+                if (userEmail != null)
+                {
+                    var userInfo = await UserService.GetUserInfoAsync(user.Id);
+                    var viewUrl = Url.Action(nameof(MySubmissions), "Events", null, Request.Scheme)!;
+                    await emailService.SendEventLifecycleNotificationAsync(
+                        new EventLifecycleNotification(Domain.Enums.EventStatus.Pending, userInfo?.BurnerName ?? userEmail, row.Title, viewUrl),
+                        userEmail);
+                }
+            }
+        }
+
+        SetSuccess("Bulk upload complete.");
+        return RedirectToAction(nameof(MySubmissions));
+    }
+
+    private sealed record BulkCsvRow(
+        int RowNumber,
+        Guid? Id,
+        string Title,
+        string Description,
+        string Category,
+        string Date,
+        string StartTime,
+        int DurationMinutes,
+        string? LocationNote,
+        string? Host,
+        bool IsRecurring,
+        string? RecurrenceDays,
+        int PriorityRank);
+
+    private static List<BulkCsvRow> ParseCsvRows(string csvText)
+    {
+        var rows = new List<BulkCsvRow>();
+        var lines = csvText.Split('\n', StringSplitOptions.None);
+        var dataLineNumber = 0;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#')) continue;
+
+            var fields = SplitCsvLine(line);
+
+            // Header row — skip but validate column count
+            if (dataLineNumber == 0)
+            {
+                dataLineNumber++;
+                continue;
+            }
+
+            if (fields.Count < 14)
+                throw new FormatException($"Row {dataLineNumber + 1}: expected 14 columns, got {fields.Count}.");
+
+            Guid? id = string.IsNullOrWhiteSpace(fields[0]) ? null : Guid.TryParse(fields[0], out var g) ? g : throw new FormatException($"Row {dataLineNumber + 1}: Id is not a valid Guid.");
+            // fields[1] = Barrio (ignored), fields[2] = Status (ignored)
+            var title = fields[3];
+            var description = fields[4];
+            var category = fields[5];
+            var date = fields[6];
+            var startTime = fields[7];
+            var durationStr = fields[8];
+            var locationNote = fields[9];
+            var host = fields[10];
+            var isRecurringStr = fields[11];
+            var recurrenceDays = fields[12];
+            var priorityStr = fields[13];
+
+            if (!int.TryParse(durationStr, System.Globalization.CultureInfo.InvariantCulture, out var duration))
+                throw new FormatException($"Row {dataLineNumber + 1}: DurationMinutes is not an integer.");
+            if (!int.TryParse(priorityStr, System.Globalization.CultureInfo.InvariantCulture, out var priority))
+                throw new FormatException($"Row {dataLineNumber + 1}: PriorityRank is not an integer.");
+            var isRecurring = string.Equals(isRecurringStr, "true", StringComparison.OrdinalIgnoreCase);
+
+            rows.Add(new BulkCsvRow(dataLineNumber + 1, id, title, description, category, date, startTime, duration,
+                string.IsNullOrWhiteSpace(locationNote) ? null : locationNote,
+                string.IsNullOrWhiteSpace(host) ? null : host,
+                isRecurring, string.IsNullOrWhiteSpace(recurrenceDays) ? null : recurrenceDays, priority));
+            dataLineNumber++;
+        }
+
+        return rows;
+    }
+
+    private static List<string> SplitCsvLine(string line)
+    {
+        var fields = new List<string>();
+        var i = 0;
+        while (i <= line.Length)
+        {
+            if (i == line.Length) { fields.Add(string.Empty); break; }
+            if (line[i] == '"')
+            {
+                i++;
+                var sb = new System.Text.StringBuilder();
+                while (i < line.Length)
+                {
+                    if (line[i] == '"')
+                    {
+                        i++;
+                        if (i < line.Length && line[i] == '"') { sb.Append('"'); i++; }
+                        else break;
+                    }
+                    else { sb.Append(line[i]); i++; }
+                }
+                fields.Add(sb.ToString());
+                if (i < line.Length && line[i] == ',') i++;
+            }
+            else
+            {
+                var end = line.IndexOf(',', i);
+                if (end < 0) { fields.Add(line[i..]); break; }
+                fields.Add(line[i..end]);
+                i = end + 1;
+            }
+        }
+        return fields;
+    }
+
+    private static List<BulkRowError> ValidateBulkRows(
+        List<BulkCsvRow> rows,
+        IReadOnlyList<Domain.Entities.EventCategory> categories,
+        IReadOnlyList<Domain.Entities.Event> existingEvents,
+        NodaTime.LocalDate gateOpeningDate)
+    {
+        var errors = new List<BulkRowError>();
+        foreach (var row in rows)
+        {
+            var rowErrors = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(row.Title)) rowErrors.Add("Title is required.");
+            else if (row.Title.Length > 80) rowErrors.Add("Title must be 80 characters or fewer.");
+
+            if (string.IsNullOrWhiteSpace(row.Description)) rowErrors.Add("Description is required.");
+            else if (row.Description.Length > 450) rowErrors.Add("Description must be 450 characters or fewer.");
+
+            if (row.LocationNote?.Length > 120) rowErrors.Add("LocationNote must be 120 characters or fewer.");
+            if (row.Host?.Length > 40) rowErrors.Add("Host must be 40 characters or fewer.");
+
+            if (string.IsNullOrWhiteSpace(row.Category)) rowErrors.Add("Category is required.");
+            else if (!categories.Any(c => string.Equals(c.Name, row.Category, StringComparison.OrdinalIgnoreCase)))
+                rowErrors.Add($"Category '{row.Category}' is not a valid active category.");
+
+            if (string.IsNullOrWhiteSpace(row.Date)) rowErrors.Add("Date is required.");
+            else if (!DateTime.TryParseExact(row.Date, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out _))
+                rowErrors.Add("Date must be in yyyy-MM-dd format.");
+
+            if (string.IsNullOrWhiteSpace(row.StartTime)) rowErrors.Add("StartTime is required.");
+            else if (!TimeSpan.TryParseExact(row.StartTime, "hh\\:mm", System.Globalization.CultureInfo.InvariantCulture, out _))
+                rowErrors.Add("StartTime must be in HH:mm format.");
+
+            if (row.DurationMinutes < 15 || row.DurationMinutes > 480)
+                rowErrors.Add("DurationMinutes must be between 15 and 480.");
+            else if (row.DurationMinutes % 15 != 0)
+                rowErrors.Add("DurationMinutes must be a multiple of 15.");
+
+            if (row.PriorityRank < 1 || row.PriorityRank > 100)
+                rowErrors.Add("PriorityRank must be between 1 and 100.");
+
+            if (row.Id.HasValue)
+            {
+                var existing = existingEvents.FirstOrDefault(e => e.Id == row.Id.Value);
+                if (existing == null)
+                    rowErrors.Add($"Event {row.Id.Value} not found for this barrio.");
+                else if (existing.Status == Domain.Enums.EventStatus.Withdrawn)
+                    rowErrors.Add("Withdrawn events cannot be updated via bulk upload.");
+            }
+
+            if (rowErrors.Count > 0)
+                errors.Add(new BulkRowError { RowNumber = row.RowNumber, Title = row.Title, Errors = rowErrors });
+        }
+        return errors;
+    }
+
+    private static string CsvField(string value)
+    {
+        var escaped = value.Replace("\"", "\"\"");
+        return $"\"{escaped}\"";
+    }
+
+    private static readonly string[] DayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+    private static string OffsetsToDisplayDays(string offsets, NodaTime.LocalDate gateOpeningDate)
+    {
+        var parts = offsets.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        var names = new List<string>();
+        foreach (var part in parts)
+        {
+            if (int.TryParse(part.Trim(), System.Globalization.CultureInfo.InvariantCulture, out var offset))
+            {
+                var date = gateOpeningDate.PlusDays(offset);
+                names.Add(DayNames[((int)date.DayOfWeek - 1 + 7) % 7]);
+            }
+        }
+        return string.Join(" ", names);
+    }
+
+    private static string? DisplayDaysToOffsets(string displayDays, NodaTime.LocalDate gateOpeningDate, int eventEndOffset)
+    {
+        var requestedDays = displayDays.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(d => d.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var offsets = new List<int>();
+        for (var offset = 0; offset <= eventEndOffset; offset++)
+        {
+            var date = gateOpeningDate.PlusDays(offset);
+            var name = DayNames[((int)date.DayOfWeek - 1 + 7) % 7];
+            if (requestedDays.Contains(name))
+                offsets.Add(offset);
+        }
+        return offsets.Count > 0 ? string.Join(",", offsets) : null;
     }
 
     private static string ResolveCampDisplayName(CampLookup camp) =>
@@ -822,5 +1275,8 @@ public class EventsController(
         return await guide.GetEventSettingsByIdAsync(guideSettings.EventSettingsId);
     }
 
+    internal static bool IsSubmitStateException(InvalidOperationException ex) =>
+        ex.Message.StartsWith("Cannot submit event in ", StringComparison.Ordinal)
+        && ex.Message.EndsWith(" state", StringComparison.Ordinal);
 
 }

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -1038,16 +1038,6 @@ public class EventsController(
                 newEvent.Submit(clock);
                 await guide.SubmitEventAsync(newEvent);
                 logger.LogInformation("Bulk upload: user {UserId} submitted new event '{Title}' for camp {CampId}", user.Id, row.Title, camp.Id);
-
-                var userEmail = user.Email;
-                if (userEmail != null)
-                {
-                    var userInfo = await UserService.GetUserInfoAsync(user.Id);
-                    var viewUrl = Url.Action(nameof(MySubmissions), "Events", null, Request.Scheme)!;
-                    await emailService.SendEventLifecycleNotificationAsync(
-                        new EventLifecycleNotification(Domain.Enums.EventStatus.Pending, userInfo?.BurnerName ?? userEmail, row.Title, viewUrl),
-                        userEmail);
-                }
             }
         }
 

--- a/src/Humans.Web/Models/Events/IndividualEventViewModels.cs
+++ b/src/Humans.Web/Models/Events/IndividualEventViewModels.cs
@@ -31,6 +31,14 @@ public class BarrioSubmissionsBlock
     public int ApprovedCount { get; set; }
     public int PendingCount { get; set; }
     public List<CampEventRowViewModel> Events { get; set; } = [];
+    public List<BulkRowError> BulkUploadErrors { get; set; } = [];
+}
+
+public class BulkRowError
+{
+    public int RowNumber { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public List<string> Errors { get; set; } = [];
 }
 
 public class IndividualEventRowViewModel

--- a/src/Humans.Web/Views/Events/MySubmissions.cshtml
+++ b/src/Humans.Web/Views/Events/MySubmissions.cshtml
@@ -165,11 +165,11 @@
 
             @if (barrio.Events.Count == 0)
             {
-                <p class="text-muted mb-0">No events submitted yet for this barrio.</p>
+                <p class="text-muted mb-3">No events submitted yet for this barrio.</p>
             }
             else
             {
-                <div class="table-responsive">
+                <div class="table-responsive mb-3">
                     <table class="table table-hover align-middle mb-0">
                         <thead>
                             <tr>
@@ -206,6 +206,55 @@
                                                 </button>
                                             </form>
                                         }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            <hr class="my-3" />
+            <div class="d-flex align-items-center gap-3 flex-wrap">
+                <a asp-action="BulkUploadTemplate" asp-route-slug="@barrio.CampSlug" class="btn btn-sm btn-outline-secondary">
+                    <i class="fa-solid fa-file-csv me-1"></i>Download events CSV
+                </a>
+                <form method="post" asp-action="BulkUploadImport" asp-route-slug="@barrio.CampSlug" enctype="multipart/form-data" class="d-flex align-items-center gap-2">
+                    @Html.AntiForgeryToken()
+                    <input type="file" name="file" accept=".csv" class="form-control form-control-sm" style="max-width: 260px;" />
+                    <button type="submit" class="btn btn-sm btn-outline-primary">
+                        <i class="fa-solid fa-upload me-1"></i>Upload CSV
+                    </button>
+                </form>
+            </div>
+
+            @if (barrio.BulkUploadErrors.Count > 0)
+            {
+                <div class="alert alert-danger mt-3">
+                    <strong>Upload failed.</strong> Fix the errors below and try again. No events were saved.
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-sm table-bordered align-middle mb-0">
+                        <thead class="table-danger">
+                            <tr>
+                                <th style="width: 60px;">Row</th>
+                                <th>Event</th>
+                                <th>Errors</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var rowError in barrio.BulkUploadErrors)
+                            {
+                                <tr>
+                                    <td>@rowError.RowNumber</td>
+                                    <td>@rowError.Title</td>
+                                    <td>
+                                        <ul class="mb-0 ps-3">
+                                            @foreach (var msg in rowError.Errors)
+                                            {
+                                                <li>@msg</li>
+                                            }
+                                        </ul>
                                     </td>
                                 </tr>
                             }

--- a/tests/Humans.Application.Tests/Events/BulkEventCsvParserTests.cs
+++ b/tests/Humans.Application.Tests/Events/BulkEventCsvParserTests.cs
@@ -1,0 +1,113 @@
+using AwesomeAssertions;
+using Humans.Application.Events;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public sealed class BulkEventCsvParserTests
+{
+    private const string Header =
+        "Id,Barrio,Status,Title,Description,Category,Date,StartTime,DurationMinutes,LocationNote,Host,IsRecurring,RecurrenceDays,PriorityRank";
+
+    [HumansFact]
+    public void Parse_SkipsCommentsBlankLinesAndHeader()
+    {
+        var csv = $"# a comment\n\n{Header}\n,Camp,,Title,Desc,Workshop,2026-07-08,09:30,60,,,false,,1\n";
+
+        var rows = BulkEventCsvParser.Parse(csv);
+
+        rows.Should().ContainSingle();
+        rows[0].Title.Should().Be("Title");
+        rows[0].Id.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void Parse_QuotedFieldWithComma_IsOneField()
+    {
+        var csv = $"{Header}\n,Camp,,\"Hello, World\",Desc,Workshop,2026-07-08,09:30,60,,,false,,1\n";
+
+        var rows = BulkEventCsvParser.Parse(csv);
+
+        rows.Should().ContainSingle();
+        rows[0].Title.Should().Be("Hello, World");
+    }
+
+    [HumansFact]
+    public void Parse_EscapedQuotes_AreUnescaped()
+    {
+        var csv = $"{Header}\n,Camp,,Title,\"She said \"\"hi\"\"\",Workshop,2026-07-08,09:30,60,,,false,,1\n";
+
+        var rows = BulkEventCsvParser.Parse(csv);
+
+        rows[0].Description.Should().Be("She said \"hi\"");
+    }
+
+    [HumansFact]
+    public void Parse_TooFewColumns_Throws()
+    {
+        var csv = $"{Header}\n,Camp,,Title\n";
+
+        var act = () => BulkEventCsvParser.Parse(csv);
+
+        act.Should().Throw<FormatException>().WithMessage("*expected 14 columns*");
+    }
+
+    [HumansFact]
+    public void Parse_InvalidId_Throws()
+    {
+        var csv = $"{Header}\nnot-a-guid,Camp,,Title,Desc,Workshop,2026-07-08,09:30,60,,,false,,1\n";
+
+        var act = () => BulkEventCsvParser.Parse(csv);
+
+        act.Should().Throw<FormatException>().WithMessage("*not a valid Guid*");
+    }
+
+    [HumansFact]
+    public void Parse_NonIntegerDuration_Throws()
+    {
+        var csv = $"{Header}\n,Camp,,Title,Desc,Workshop,2026-07-08,09:30,sixty,,,false,,1\n";
+
+        var act = () => BulkEventCsvParser.Parse(csv);
+
+        act.Should().Throw<FormatException>().WithMessage("*DurationMinutes is not an integer*");
+    }
+}
+
+public sealed class EventRecurrenceDaysTests
+{
+    [HumansFact]
+    public void OffsetsToDisplayDays_MapsEachOffsetToItsWeekday()
+    {
+        var gate = new LocalDate(2026, 7, 6); // Monday
+
+        EventRecurrenceDays.OffsetsToDisplayDays("0,2,4", gate).Should().Be("Mon Wed Fri");
+    }
+
+    [HumansFact]
+    public void DisplayDaysToOffsets_RoundTripsWithinOneWeek()
+    {
+        var gate = new LocalDate(2026, 7, 6); // Monday
+
+        EventRecurrenceDays.DisplayDaysToOffsets("Mon Wed Fri", gate, 6).Should().Be("0,2,4");
+    }
+
+    [HumansFact]
+    public void DisplayDaysToOffsets_ReturnsNull_WhenNoDayMatches()
+    {
+        var gate = new LocalDate(2026, 7, 6); // Monday, window Mon..Sun
+
+        EventRecurrenceDays.DisplayDaysToOffsets("Mon", gate, 0).Should().Be("0");
+        EventRecurrenceDays.DisplayDaysToOffsets("Tue", gate, 0).Should().BeNull();
+    }
+
+    [HumansTheory]
+    [InlineData("Mon", "Mon", true)]
+    [InlineData("Mon Wed", "Wed Mon", true)]
+    [InlineData("mon", "MON", true)]
+    [InlineData("Mon", "Mon Wed", false)]
+    public void SameDays_ComparesAsCaseInsensitiveSet(string a, string b, bool expected)
+    {
+        EventRecurrenceDays.SameDays(a, b).Should().Be(expected);
+    }
+}

--- a/tests/Humans.Application.Tests/Events/EventServiceTests.cs
+++ b/tests/Humans.Application.Tests/Events/EventServiceTests.cs
@@ -297,6 +297,155 @@ public sealed class EventServiceTests
         slices[0].Data.Should().NotBeNull();
     }
 
+    [HumansFact]
+    public async Task BulkImportAsync_InvalidRow_ReturnsErrorsAndWritesNothing()
+    {
+        var campId = Guid.NewGuid();
+        _repo.Categories.Add(new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true });
+
+        var result = await _service.BulkImportAsync(
+            campId, Guid.NewGuid(), [Row(title: "")],
+            new LocalDate(2026, 7, 8), 6, DateTimeZone.Utc);
+
+        result.HasErrors.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Errors.Contains("Title is required."));
+        _repo.Events.Should().BeEmpty();
+        _repo.SaveChangesCount.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task BulkImportAsync_NewRow_CreatesPendingEvent()
+    {
+        var campId = Guid.NewGuid();
+        var submitter = Guid.NewGuid();
+        var cat = new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true };
+        _repo.Categories.Add(cat);
+
+        var result = await _service.BulkImportAsync(
+            campId, submitter, [Row()],
+            new LocalDate(2026, 7, 8), 6, DateTimeZone.Utc);
+
+        result.HasErrors.Should().BeFalse();
+        result.CreatedCount.Should().Be(1);
+        result.UpdatedCount.Should().Be(0);
+        var created = _repo.Events.Should().ContainSingle().Subject;
+        created.Status.Should().Be(EventStatus.Pending);
+        created.CampId.Should().Be(campId);
+        created.SubmitterUserId.Should().Be(submitter);
+        created.CategoryId.Should().Be(cat.Id);
+    }
+
+    [HumansFact]
+    public async Task BulkImportAsync_UnchangedExistingRow_IsNoOp()
+    {
+        var campId = Guid.NewGuid();
+        var cat = new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true };
+        _repo.Categories.Add(cat);
+        var existing = ExistingEvent(campId, cat.Id, EventStatus.Approved);
+        _repo.Events.Add(existing);
+
+        var result = await _service.BulkImportAsync(
+            campId, Guid.NewGuid(), [Row(id: existing.Id)],
+            new LocalDate(2026, 7, 8), 6, DateTimeZone.Utc);
+
+        result.HasErrors.Should().BeFalse();
+        result.CreatedCount.Should().Be(0);
+        result.UpdatedCount.Should().Be(0);
+        existing.Status.Should().Be(EventStatus.Approved);
+        _repo.SaveChangesCount.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task BulkImportAsync_EditedApprovedRow_RequeuesToPending()
+    {
+        var campId = Guid.NewGuid();
+        var cat = new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true };
+        _repo.Categories.Add(cat);
+        var existing = ExistingEvent(campId, cat.Id, EventStatus.Approved);
+        _repo.Events.Add(existing);
+
+        var result = await _service.BulkImportAsync(
+            campId, Guid.NewGuid(), [Row(id: existing.Id, title: "New Title")],
+            new LocalDate(2026, 7, 8), 6, DateTimeZone.Utc);
+
+        result.UpdatedCount.Should().Be(1);
+        existing.Title.Should().Be("New Title");
+        existing.Status.Should().Be(EventStatus.Pending);
+        existing.SubmittedAt.Should().Be(_clock.GetCurrentInstant());
+    }
+
+    [HumansFact]
+    public async Task BulkImportAsync_EditedDraftRow_SubmitsViaUpdatePath_NoDuplicateInsert()
+    {
+        // Regression: the Draft branch previously called SubmitEventAsync (INSERT)
+        // on an already-persisted entity, which throws a duplicate-key error.
+        var campId = Guid.NewGuid();
+        var cat = new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true };
+        _repo.Categories.Add(cat);
+        var existing = ExistingEvent(campId, cat.Id, EventStatus.Draft);
+        _repo.Events.Add(existing);
+        var countBefore = _repo.Events.Count;
+
+        var result = await _service.BulkImportAsync(
+            campId, Guid.NewGuid(), [Row(id: existing.Id, title: "Renamed")],
+            new LocalDate(2026, 7, 8), 6, DateTimeZone.Utc);
+
+        result.UpdatedCount.Should().Be(1);
+        existing.Status.Should().Be(EventStatus.Pending);
+        _repo.Events.Count.Should().Be(countBefore); // no INSERT of the existing event
+    }
+
+    [HumansFact]
+    public async Task BulkImportAsync_RecurrenceDayNameRoundTrip_IsNoOp()
+    {
+        // Existing recurrence is stored as offsets ("0"); the CSV carries the
+        // equivalent day name. The round-trip must not be seen as an edit.
+        var gate = new LocalDate(2026, 7, 8);
+        var dayName = new[] { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" }[((int)gate.DayOfWeek - 1 + 7) % 7];
+        var campId = Guid.NewGuid();
+        var cat = new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true };
+        _repo.Categories.Add(cat);
+        var existing = ExistingEvent(campId, cat.Id, EventStatus.Approved);
+        existing.IsRecurring = true;
+        existing.RecurrenceDays = "0";
+        _repo.Events.Add(existing);
+
+        var result = await _service.BulkImportAsync(
+            campId, Guid.NewGuid(), [Row(id: existing.Id, isRecurring: true, recurrenceDays: dayName)],
+            gate, 6, DateTimeZone.Utc);
+
+        result.UpdatedCount.Should().Be(0);
+        existing.Status.Should().Be(EventStatus.Approved);
+    }
+
+    private static BulkCsvRow Row(
+        Guid? id = null, string title = "My Event", string description = "Desc",
+        string category = "Workshop", string date = "2026-07-08", string startTime = "09:30",
+        int duration = 60, string? location = null, string? host = null,
+        bool isRecurring = false, string? recurrenceDays = null, int priority = 1, int rowNumber = 2)
+        => new(rowNumber, id, title, description, category, date, startTime, duration, location, host, isRecurring, recurrenceDays, priority);
+
+    private Event ExistingEvent(Guid campId, Guid categoryId, EventStatus status)
+    {
+        var startAt = (new LocalDate(2026, 7, 8) + new LocalTime(9, 30)).InZoneLeniently(DateTimeZone.Utc).ToInstant();
+        return new Event
+        {
+            Id = Guid.NewGuid(),
+            CampId = campId,
+            SubmitterUserId = Guid.NewGuid(),
+            CategoryId = categoryId,
+            Title = "My Event",
+            Description = "Desc",
+            StartAt = startAt,
+            DurationMinutes = 60,
+            IsRecurring = false,
+            PriorityRank = 1,
+            Status = status,
+            SubmittedAt = _clock.GetCurrentInstant(),
+            LastUpdatedAt = _clock.GetCurrentInstant()
+        };
+    }
+
     private sealed class FakeEventRepository : IEventRepository
     {
         public EventGuideSettings? Settings { get; set; }

--- a/tests/Humans.Application.Tests/Events/EventServiceTests.cs
+++ b/tests/Humans.Application.Tests/Events/EventServiceTests.cs
@@ -222,6 +222,45 @@ public sealed class EventServiceTests
     }
 
     [HumansFact]
+    public async Task UpdateAndResubmitAsync_PendingEvent_KeepsPendingAndSaves()
+    {
+        var submittedAt = Instant.FromUtc(2026, 5, 1, 12, 0);
+        var guideEvent = new Event
+        {
+            Id = Guid.NewGuid(),
+            Status = EventStatus.Pending,
+            SubmittedAt = submittedAt,
+            LastUpdatedAt = Instant.FromUtc(2026, 5, 1, 13, 0)
+        };
+
+        await _service.UpdateAndResubmitAsync(guideEvent);
+
+        guideEvent.Status.Should().Be(EventStatus.Pending);
+        guideEvent.SubmittedAt.Should().Be(submittedAt);
+        guideEvent.LastUpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        _repo.SaveChangesCount.Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task UpdateAndResubmitAsync_ApprovedEvent_RequeuesForModeration()
+    {
+        var guideEvent = new Event
+        {
+            Id = Guid.NewGuid(),
+            Status = EventStatus.Approved,
+            SubmittedAt = Instant.FromUtc(2026, 5, 1, 12, 0),
+            LastUpdatedAt = Instant.FromUtc(2026, 5, 2, 12, 0)
+        };
+
+        await _service.UpdateAndResubmitAsync(guideEvent);
+
+        guideEvent.Status.Should().Be(EventStatus.Pending);
+        guideEvent.SubmittedAt.Should().Be(_clock.GetCurrentInstant());
+        guideEvent.LastUpdatedAt.Should().Be(_clock.GetCurrentInstant());
+        _repo.SaveChangesCount.Should().Be(1);
+    }
+
+    [HumansFact]
     public async Task ContributeForUserAsync_EmitsEventsSliceWithFavouritesAndPreference()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
## What

Implements US-26.10: barrio leads can download their camp's current events as a CSV from the **My Event Submissions** page and upload an edited file back. Closes peterdrier/Humans#704.

## Why

Camp leads with many events needed a way to manage their whole programme without submitting events one by one via the form.

## UI changes / screenshots

Download link and file upload form embedded inline in each barrio block on `/Events/MySubmissions`. Per-row error table shown inline on validation failure. No separate page.

## Checklist

- [x] **Section labeled** — issue and PR carry a section label (Camps / Teams / Legal / Shifts / Tickets / Board / Onboarding / Admin / etc.).
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork). No direct commits to `main` — `memory/process/no-direct-to-main.md`.
- [x] **Branched off `origin/main`**, not `upstream/main`.
- [x] **Issue refs are qualified** (`owner/repo#N`) when crossing repo boundaries — `memory/process/issue-refs-qualified.md`.
- [x] **EF migrations** (if any) auto-generated, not hand-edited — no migrations in this PR.
- [x] **NuGet packages updated?** No new packages added.
- [x] **New project rule?** No new project rules surfaced.
- [x] **Build + test pass locally**: `dotnet build Humans.slnx -v quiet` and `dotnet test Humans.slnx -v quiet`.
- [x] **Nav coverage** — bulk upload is inline in existing My Event Submissions page; no new nav entries needed.
- [x] **No magic strings** — `nameof()` used for redirects.
- [x] **Dates/times via NodaTime** — `LocalDatePattern.Iso`, `LocalTimePattern` with `HH:mm`, `InZoneLeniently`.

## Reviewer notes

- `UpdateAndResubmitAsync` fix included: Pending events now only touch `LastUpdatedAt` (no redundant re-submit); Approved events correctly transition back to Pending. Two unit tests cover the new behaviour.
- BLOCK #1 (HUM0019 `User.Email` at lines 183 and 671) is pre-existing in the individual/barrio submit actions — not introduced by this PR.
- WARN #3 (business logic in controller): `BulkUploadImport` is ~100 lines of validation + processing. Noted as architectural debt; deferred to a follow-up.

## Routes added

```
GET  /Events/Barrio/{slug}/BulkUpload/Template  → stream CSV of non-Withdrawn camp events
POST /Events/Barrio/{slug}/BulkUpload           → all-or-nothing import
```

Both guarded by `ResolveCampEventManagementAsync` — same auth as barrio submit/edit.

## Test plan

- [x] As a camp lead, go to `/Events/MySubmissions` — barrio block shows "Download events CSV" link and upload form
- [x] Download CSV — has all non-Withdrawn events, comment block at top, `Barrio` and `Status` columns filled; example row shown when camp has no events
- [x] Upload CSV with one new row (empty Id) → event appears as Pending; no confirmation email sent
- [x] Upload same CSV again (Id now filled, fields unchanged) → no duplicate, status preserved
- [x] Edit a field on an existing row and upload → event re-queued for moderation
- [x] Upload CSV with a bad row (invalid category, missing title, bad StartTime) → error table shown, nothing saved
- [ ] Attempt upload with submission window closed → rejected with error toast
- [ ] Non-lead user → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)