### PR TITLE
feat(design): add Bootstrap component legos glossary to /ColorPalette

### DIFF
--- a/src/Humans.Web/Views/ColorPalette/Index.cshtml
+++ b/src/Humans.Web/Views/ColorPalette/Index.cshtml
@@ -89,6 +89,27 @@
         background: var(--h-bg-card);
         margin-bottom: 1rem;
     }
+    .cp-lego {
+        display: flex;
+        flex-direction: column;
+    }
+    .cp-lego-class {
+        font-size: 0.75rem;
+        color: var(--h-gold-dark);
+        background: var(--h-muted-bg);
+        padding: 0.1rem 0.4rem;
+        border-radius: var(--h-radius);
+    }
+    .cp-lego-blurb {
+        font-size: 0.8rem;
+        color: var(--h-text-secondary);
+        margin: 0.5rem 0 1rem;
+    }
+    .cp-lego-demo {
+        margin-top: auto;
+        padding-top: 1rem;
+        border-top: 1px dashed var(--h-border-light);
+    }
 </style>
 
 <div class="container-fluid py-4">
@@ -389,7 +410,295 @@
     </div>
 
     @* ============================== *@
-    @* SECTION 3: TYPOGRAPHY           *@
+    @* SECTION 3: BUILDING BLOCKS      *@
+    @* ============================== *@
+
+    @{
+        // Renders the name / class / blurb header shared by every "lego" card.
+        void LegoHead(string name, string cssClass, string blurb)
+        {
+            <h5 class="mb-1">@name</h5>
+            <code class="cp-lego-class">@cssClass</code>
+            <p class="cp-lego-blurb">@blurb</p>
+        }
+    }
+
+    <div class="cp-section">
+        <h2><i class="fa-solid fa-cubes me-2"></i>Components &mdash; Building Blocks</h2>
+        <p class="text-muted mb-4">
+            The standard Bootstrap "legos" you can assemble pages from. Each card shows the component
+            <strong>name</strong>, the <strong>CSS class</strong> you'd type, a note on <strong>when to reach for it</strong>,
+            and a live working example. (App-specific widgets built on top of these live in the admin-only
+            <a href="/WidgetGallery">Widget Gallery</a>.)
+        </p>
+
+        @* --- Actions & Menus --- *@
+        <h3>Actions &amp; Menus</h3>
+        <div class="cp-controls-grid mb-4">
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Button group", ".btn-group", "Joins related buttons into one segmented control — e.g. a List / Calendar / Map view toggle."); }
+                <div class="cp-lego-demo">
+                    <div class="btn-group" role="group" aria-label="View toggle">
+                        <button type="button" class="btn btn-outline-primary active">List</button>
+                        <button type="button" class="btn btn-outline-primary">Calendar</button>
+                        <button type="button" class="btn btn-outline-primary">Map</button>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Button toolbar", ".btn-toolbar", "Groups several button groups together with spacing — e.g. a mini formatting toolbar."); }
+                <div class="cp-lego-demo">
+                    <div class="btn-toolbar gap-2" role="toolbar">
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-outline-secondary btn-sm"><i class="fa-solid fa-bold"></i></button>
+                            <button type="button" class="btn btn-outline-secondary btn-sm"><i class="fa-solid fa-italic"></i></button>
+                        </div>
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-outline-secondary btn-sm"><i class="fa-solid fa-align-left"></i></button>
+                            <button type="button" class="btn btn-outline-secondary btn-sm"><i class="fa-solid fa-align-center"></i></button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Dropdown", ".dropdown / .dropdown-menu", "A button that reveals a menu of actions or links. Use for secondary actions that would clutter the page."); }
+                <div class="cp-lego-demo">
+                    <div class="dropdown">
+                        <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Actions</button>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="#">Edit</a></li>
+                            <li><a class="dropdown-item" href="#">Duplicate</a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item text-danger" href="#">Delete</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Split button", ".dropdown-toggle-split", "A primary action with a dropdown of related variants attached — e.g. Save / Save &amp; new."); }
+                <div class="cp-lego-demo">
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-success">Save</button>
+                        <button type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false"><span class="visually-hidden">Toggle dropdown</span></button>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="#">Save &amp; new</a></li>
+                            <li><a class="dropdown-item" href="#">Save as draft</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @* --- Inputs --- *@
+        <h3>Inputs</h3>
+        <div class="cp-controls-grid mb-4">
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Input group", ".input-group", "Attaches icons, text, or buttons to an input — e.g. a search box with a button, or an \"@\" username prefix."); }
+                <div class="cp-lego-demo">
+                    <div class="input-group mb-2">
+                        <span class="input-group-text"><i class="fa-solid fa-magnifying-glass"></i></span>
+                        <input type="text" class="form-control" placeholder="Search members...">
+                        <button class="btn btn-primary" type="button">Go</button>
+                    </div>
+                    <div class="input-group">
+                        <span class="input-group-text">@@</span>
+                        <input type="text" class="form-control" placeholder="username">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @* --- Navigation --- *@
+        <h3>Navigation</h3>
+        <div class="cp-controls-grid mb-4">
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Nav tabs", ".nav-tabs", "Switch between panels in the same region. Use for a handful of peer views of one thing (Profile / Teams / Activity)."); }
+                <div class="cp-lego-demo">
+                    <ul class="nav nav-tabs" role="tablist">
+                        <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#cp-tab-1" type="button" role="tab">Profile</button></li>
+                        <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#cp-tab-2" type="button" role="tab">Teams</button></li>
+                        <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#cp-tab-3" type="button" role="tab">Activity</button></li>
+                    </ul>
+                    <div class="tab-content pt-2">
+                        <div class="tab-pane fade show active" id="cp-tab-1" role="tabpanel">Profile panel.</div>
+                        <div class="tab-pane fade" id="cp-tab-2" role="tabpanel">Teams panel.</div>
+                        <div class="tab-pane fade" id="cp-tab-3" role="tabpanel">Activity panel.</div>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Nav pills", ".nav-pills", "Same idea as tabs with pill styling — often stacked vertically as a side menu."); }
+                <div class="cp-lego-demo">
+                    <ul class="nav nav-pills flex-column" style="max-width: 220px;">
+                        <li class="nav-item"><a class="nav-link active" href="#">Dashboard</a></li>
+                        <li class="nav-item"><a class="nav-link" href="#">Members</a></li>
+                        <li class="nav-item"><a class="nav-link" href="#">Settings</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Breadcrumb", ".breadcrumb", "Shows where you are in the hierarchy and the path back up. Use on nested pages."); }
+                <div class="cp-lego-demo">
+                    <nav aria-label="breadcrumb">
+                        <ol class="breadcrumb mb-0">
+                            <li class="breadcrumb-item"><a href="#">Home</a></li>
+                            <li class="breadcrumb-item"><a href="#">Teams</a></li>
+                            <li class="breadcrumb-item active" aria-current="page">Fire Safety</li>
+                        </ol>
+                    </nav>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Pagination", ".pagination", "Step through long lists a page at a time. Use when a list is too long to scroll comfortably."); }
+                <div class="cp-lego-demo">
+                    <nav aria-label="Page navigation">
+                        <ul class="pagination mb-0">
+                            <li class="page-item disabled"><a class="page-link" href="#">Prev</a></li>
+                            <li class="page-item active"><a class="page-link" href="#">1</a></li>
+                            <li class="page-item"><a class="page-link" href="#">2</a></li>
+                            <li class="page-item"><a class="page-link" href="#">3</a></li>
+                            <li class="page-item"><a class="page-link" href="#">Next</a></li>
+                        </ul>
+                    </nav>
+                </div>
+            </div>
+        </div>
+
+        @* --- Disclosure & Overlays --- *@
+        <h3>Disclosure &amp; Overlays</h3>
+        <div class="cp-controls-grid mb-4">
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Accordion", ".accordion", "Stacked collapsible sections, typically one open at a time. Use for FAQs or long forms split into steps."); }
+                <div class="cp-lego-demo">
+                    <div class="accordion" id="cp-accordion">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header"><button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#cp-acc-1">What is a Colaborador?</button></h2>
+                            <div id="cp-acc-1" class="accordion-collapse collapse show" data-bs-parent="#cp-accordion"><div class="accordion-body">An active contributor with project responsibilities.</div></div>
+                        </div>
+                        <div class="accordion-item">
+                            <h2 class="accordion-header"><button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cp-acc-2">What is an Asociado?</button></h2>
+                            <div id="cp-acc-2" class="accordion-collapse collapse" data-bs-parent="#cp-accordion"><div class="accordion-body">A voting member with governance rights.</div></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Collapse", ".collapse", "Show or hide a single region on toggle. The simpler cousin of the accordion."); }
+                <div class="cp-lego-demo">
+                    <button class="btn btn-outline-primary mb-2" type="button" data-bs-toggle="collapse" data-bs-target="#cp-collapse">Toggle details</button>
+                    <div class="collapse" id="cp-collapse"><div class="card card-body">Content revealed on toggle.</div></div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Modal", ".modal", "A focused dialog over a dimmed page. Use for confirmations or short forms that interrupt the flow."); }
+                <div class="cp-lego-demo">
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#cp-modal">Open modal</button>
+                    <div class="modal fade" id="cp-modal" tabindex="-1">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header"><h5 class="modal-title">Confirm action</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+                                <div class="modal-body">Are you sure you want to continue?</div>
+                                <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button><button type="button" class="btn btn-primary">Confirm</button></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Offcanvas", ".offcanvas", "A panel that slides in from a screen edge. Use for filters or a mobile menu that shouldn't take the whole screen."); }
+                <div class="cp-lego-demo">
+                    <button class="btn btn-outline-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#cp-offcanvas">Open panel</button>
+                    <div class="offcanvas offcanvas-end" tabindex="-1" id="cp-offcanvas">
+                        <div class="offcanvas-header"><h5 class="offcanvas-title">Filters</h5><button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button></div>
+                        <div class="offcanvas-body">Slide-in panel content.</div>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Tooltip", "data-bs-toggle=\"tooltip\"", "A tiny label on hover that explains an element. Use for icon-only buttons."); }
+                <div class="cp-lego-demo">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-toggle="tooltip" data-bs-title="I'm a tooltip!">Hover me</button>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Popover", "data-bs-toggle=\"popover\"", "A richer bubble (title + body) shown on click. Use for inline help that needs more than a tooltip."); }
+                <div class="cp-lego-demo">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-toggle="popover" data-bs-title="Popover title" data-bs-content="Richer content with a title and body.">Click me</button>
+                </div>
+            </div>
+        </div>
+
+        @* --- Feedback & Status --- *@
+        <h3>Feedback &amp; Status</h3>
+        <div class="cp-controls-grid mb-4">
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Spinner", ".spinner-border / .spinner-grow", "Indicates something is loading or working. Drop a small one inside a button while it saves."); }
+                <div class="cp-lego-demo">
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div>
+                        <div class="spinner-grow text-success" role="status"><span class="visually-hidden">Loading...</span></div>
+                        <button class="btn btn-primary" type="button" disabled><span class="spinner-border spinner-border-sm me-1"></span>Saving...</button>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Placeholder", ".placeholder", "Greyed skeleton blocks shown while real content loads, so the layout doesn't jump."); }
+                <div class="cp-lego-demo">
+                    <p class="placeholder-glow mb-0">
+                        <span class="placeholder col-7"></span>
+                        <span class="placeholder col-4"></span>
+                        <span class="placeholder col-6"></span>
+                        <span class="placeholder col-8"></span>
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        @* --- Content --- *@
+        <h3>Content</h3>
+        <div class="cp-controls-grid mb-4">
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("List group", ".list-group", "A styled vertical list of items, links, or actions — optionally with badges and active/disabled states."); }
+                <div class="cp-lego-demo">
+                    <ul class="list-group">
+                        <li class="list-group-item d-flex justify-content-between align-items-center">Inbox <span class="badge bg-primary rounded-pill">14</span></li>
+                        <li class="list-group-item active">Active item</li>
+                        <li class="list-group-item disabled">Disabled item</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Close button", ".btn-close", "The standard X dismiss control. Pair with alerts, modals, toasts, and offcanvas panels."); }
+                <div class="cp-lego-demo">
+                    <div class="d-flex gap-3 align-items-center">
+                        <button type="button" class="btn-close" aria-label="Close"></button>
+                        <div class="alert alert-warning alert-dismissible mb-0">Dismissible<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>
+                    </div>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Figure", ".figure", "An image paired with a caption underneath it."); }
+                <div class="cp-lego-demo">
+                    <figure class="figure mb-0">
+                        <div class="figure-img img-fluid rounded mb-1" style="width: 120px; height: 80px; background: var(--h-muted-bg);"></div>
+                        <figcaption class="figure-caption">A caption for the image above.</figcaption>
+                    </figure>
+                </div>
+            </div>
+            <div class="cp-variant-card cp-lego">
+                @{ LegoHead("Blockquote", ".blockquote", "A styled quotation with attribution."); }
+                <div class="cp-lego-demo">
+                    <figure class="mb-0">
+                        <blockquote class="blockquote"><p class="mb-0">Simplicity is the ultimate sophistication.</p></blockquote>
+                        <figcaption class="blockquote-footer mt-1">Leonardo da Vinci</figcaption>
+                    </figure>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @* ============================== *@
+    @* SECTION 4: TYPOGRAPHY           *@
     @* ============================== *@
 
     <div class="cp-section">
@@ -442,7 +751,7 @@
     </div>
 
     @* ============================== *@
-    @* SECTION 4: TABLES               *@
+    @* SECTION 5: TABLES               *@
     @* ============================== *@
 
     <div class="cp-section">
@@ -504,6 +813,10 @@
                 el.textContent = '(not set)';
             }
         });
+
+        // Bootstrap tooltips and popovers are opt-in — initialise the demos in the Building Blocks section.
+        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) { new bootstrap.Tooltip(el); });
+        document.querySelectorAll('[data-bs-toggle="popover"]').forEach(function (el) { new bootstrap.Popover(el); });
     });
 </script>
 }


### PR DESCRIPTION
## What

Expands the anonymous `/ColorPalette` design-reference page with a new **Components — Building Blocks** section: a glossary of the standard Bootstrap "legos" you assemble pages from.

Each card shows:
- the component **name** (e.g. *Button group*),
- the **CSS class** you'd type (`.btn-group`),
- a one-line **"when to reach for it"** note,
- a **live working example**.

Grouped into: Actions & Menus · Inputs · Navigation · Disclosure & Overlays · Feedback & Status · Content.

Components covered: button group, button toolbar, dropdown, split button, input group, nav tabs, nav pills, breadcrumb, pagination, accordion, collapse, modal, offcanvas, tooltip, popover, spinner, placeholder, list group, close button, figure, blockquote.

## Why

A shared vocabulary for design discussions — so "we should use a button group here" is a thing we can both say. Companion to the existing palette/controls/typography reference; app-specific widgets remain in the admin-only Widget Gallery (cross-linked from the new section).

## Notes

- Single-file change to `Views/ColorPalette/Index.cshtml`. No controller/route/nav changes — the page is already linked from the admin sidebar "Design" group.
- Interactive demos (dropdowns, tabs, accordion, modal, offcanvas) work live via the already-loaded Bootstrap 5.3.3 bundle. Tooltips/popovers are opt-in, initialised in the existing nonce'd Scripts block.
- A small `LegoHead` Razor local function keeps the repeated card header DRY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)