### PR TITLE
chore(gitignore): ignore .artifacts/ (dotted SDK artifacts dir)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ packages/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+.artifacts/
 
 # Test Results
 [Tt]est[Rr]esult*/


### PR DESCRIPTION
`.gitignore` already had `artifacts/`, but the **dotted** `.artifacts/` variant is a distinct name and was never covered — so when a local/Docker build emits to `.artifacts/`, it shows up as untracked.

It surfaced now because PR #708 removed the broad `[Dd]ebug/` rule (which was incidentally hiding the `debug/` build output sitting inside that un-ignored `.artifacts/` folder). Removing `[Dd]ebug/` was correct for the `/Debug` source section; this closes the remaining gap so the artifacts output dir is ignored wholesale.

Local-only build output — nothing was ever committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)