### PR TITLE
Tech debt: add read-service loop rule and migrate team reads

### DIFF
--- a/.codex/skills/humans-tech-debt/references/humans-tech-debt-rules.md
+++ b/.codex/skills/humans-tech-debt/references/humans-tech-debt-rules.md
@@ -120,6 +120,25 @@ Fixing strategy:
 
 Do not collapse methods that represent real domain concepts, authorization boundaries, operational queue semantics, expensive server-side queries that cannot safely materialize, or intentionally bounded search/tool APIs.
 
+## Section Read-Service Rules
+
+When a section exposes both a full service interface and a `*ServiceRead` interface, code outside the owning section should depend on the read interface unless it truly writes, invalidates caches, performs an owning-section workflow, or needs an entity-only method that has no read-model equivalent yet.
+
+Read interfaces are the preferred cross-section boundary:
+
+- `ITeamServiceRead` returns `TeamInfo` / `TeamSearchHit` projections for external Teams reads; only Teams-owned write flows and entity-specific operations should inject `ITeamService`.
+- `IUserServiceRead` returns `UserInfo`, `HumanSearchResult`, `OnsiteUserRow`, and merge-chain read projections for external Users reads; write flows, identity mutations, account deletion, merge, and entity-only operations may keep `IUserService`.
+- `IConsentServiceRead` is the external Consent read surface; consent submission and consent-owned writes keep `IConsentService`.
+- When adding the same split to another section, first define a narrow `ISectionServiceRead` around the canonical cached projection, make the full service inherit it, register both interfaces to the same caching decorator, and migrate external read-only callers to the read interface.
+
+Migration strategy:
+
+- Search production code for full-service injections such as `IUserService`, `ITeamService`, `IConsentService`, and future `I*Service` interfaces that also have a `*ServiceRead`.
+- Ignore implementations, caching decorators, DI registrations, tests that intentionally exercise full-service behavior, and same-section write/orchestration flows.
+- For each external caller, inspect every method used. If all calls are available on the read interface, change the constructor/field/base class/helper parameter and update tests to substitute the read interface.
+- If a caller uses an entity-returning legacy method only to render display data, migrate the caller to the read projection (`UserInfo`, `TeamInfo`, `CampInfo`, etc.) instead of keeping the full interface.
+- Leave TODO-free notes only when a full-service dependency is intentionally retained because it writes or still needs an unmigrated entity-only operation.
+
 ## Safety Checks
 
 - Verify every change preserves behavior except for the intended simplification.

--- a/src/Humans.Web/Controllers/CalendarController.cs
+++ b/src/Humans.Web/Controllers/CalendarController.cs
@@ -17,13 +17,13 @@ namespace Humans.Web.Controllers;
 public class CalendarController : HumansControllerBase
 {
     private readonly ICalendarService _calendar;
-    private readonly ITeamService _teams;
+    private readonly ITeamServiceRead _teams;
     private readonly IClock _clock;
 
     public CalendarController(
         IUserService userService,
         ICalendarService calendar,
-        ITeamService teams,
+        ITeamServiceRead teams,
         IClock clock)
         : base(userService)
     {
@@ -50,7 +50,9 @@ public class CalendarController : HumansControllerBase
                      .Plus(Duration.FromDays(1));
 
         var occ = await _calendar.GetOccurrencesInWindowAsync(from, to, teamId, ct);
-        var teams = (await _teams.GetAllTeamsAsync(ct))
+        var teams = (await _teams.GetTeamsAsync(ct))
+            .Values
+            .Where(t => t.IsActive)
             .Select(t => new TeamOption(t.Id, t.Name))
             .ToList();
 
@@ -80,7 +82,9 @@ public class CalendarController : HumansControllerBase
                      .Plus(Duration.FromDays(1));
 
         var occ = await _calendar.GetOccurrencesInWindowAsync(from, to, teamId, ct);
-        var teams = (await _teams.GetAllTeamsAsync(ct))
+        var teams = (await _teams.GetTeamsAsync(ct))
+            .Values
+            .Where(t => t.IsActive)
             .Select(t => new TeamOption(t.Id, t.Name))
             .ToList();
 
@@ -118,7 +122,7 @@ public class CalendarController : HumansControllerBase
         [FromQuery] int? month,
         CancellationToken ct)
     {
-        var team = await _teams.GetTeamByIdAsync(teamId, ct);
+        var team = await _teams.GetTeamAsync(teamId, ct);
         if (team is null) return NotFound();
 
         var zone = GetViewerZone();
@@ -183,7 +187,7 @@ public class CalendarController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create(CalendarEventFormViewModel form, CancellationToken ct)
     {
-        var team = await _teams.GetTeamByIdAsync(form.OwningTeamId, ct);
+        var team = await _teams.GetTeamAsync(form.OwningTeamId, ct);
         if (team is null) return NotFound();
 
         TryResolveStartEnd(form, out var start, out var end);
@@ -391,7 +395,8 @@ public class CalendarController : HumansControllerBase
 
     private async Task<IReadOnlyList<TeamOption>> GetSelectableTeamsAsync(CancellationToken ct)
     {
-        return (await _teams.GetAllTeamsAsync(ct))
+        return (await _teams.GetTeamsAsync(ct))
+            .Values
             .Where(t => t.IsActive && !t.IsHidden)
             .Select(t => new TeamOption(t.Id, t.Name))
             .OrderBy(t => t.Name, StringComparer.CurrentCulture)

--- a/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
@@ -15,7 +15,7 @@ namespace Humans.Web.ViewComponents;
 /// (e.g. ticket-transfer detail) where the reviewer needs identity context
 /// without having to hover.
 /// </summary>
-public sealed class HumanSummaryViewComponent(IUserServiceRead userService, ITeamService teamService) : ViewComponent
+public sealed class HumanSummaryViewComponent(IUserServiceRead userService, ITeamServiceRead teamService) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync(Guid userId)
     {
@@ -45,11 +45,19 @@ public sealed class HumanSummaryViewComponent(IUserServiceRead userService, ITea
         }
 
         var profile = info.Profile;
-        var memberships = (await teamService.GetActiveTeamMembershipsForUserAsync(userId))
-            .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
+        var memberships = (await teamService.GetTeamsAsync())
+            .Values
+            .Where(t => t.IsActive && t.SystemTeamType != SystemTeamType.Volunteers)
+            .Select(t => new
+            {
+                TeamInfo = t,
+                Membership = t.Members.FirstOrDefault(m => m.UserId == userId)
+            })
+            .Where(m => m.Membership is not null)
+            .OrderBy(m => m.TeamInfo.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
-        var publicTeams = memberships.Where(m => !m.IsHidden).Select(m => m.TeamName).ToList();
-        var hiddenTeams = memberships.Where(m => m.IsHidden).Select(m => m.TeamName).ToList();
+        var publicTeams = memberships.Where(m => !m.TeamInfo.IsHidden).Select(m => m.TeamInfo.Name).ToList();
+        var hiddenTeams = memberships.Where(m => m.TeamInfo.IsHidden).Select(m => m.TeamInfo.Name).ToList();
 
         var effectivePictureUrl = profile.HasCustomPicture
             ? Url.Action(nameof(ProfileController.Picture), "Profile",

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -23,7 +23,7 @@ public class ProfileCardViewComponent(
     IUserServiceRead userService,
     IContactFieldService contactFieldService,
     IUserEmailService userEmailService,
-    ITeamService teamService,
+    ITeamServiceRead teamService,
     IRoleAssignmentService roleAssignmentService,
     IMembershipCalculator membershipCalculator,
     ICommunicationPreferenceService commPrefService) : ViewComponent
@@ -65,18 +65,26 @@ public class ProfileCardViewComponent(
         }
         var visibleEmails = await userEmailService.GetVisibleEmailsAsync(userId, accessLevel);
 
-        var userTeams = await teamService.GetUserTeamsAsync(userId);
-        var displayableTeams = userTeams
-            .Where(tm => tm.Team.SystemTeamType != SystemTeamType.Volunteers
-                && (viewMode != ProfileCardViewMode.Public || !tm.Team.IsHidden))
-            .OrderBy(tm => tm.Team.Name, StringComparer.Ordinal)
+        var teamsById = await teamService.GetTeamsAsync();
+        var displayableTeams = teamsById
+            .Values
+            .Where(t => t.IsActive
+                && t.SystemTeamType != SystemTeamType.Volunteers
+                && (viewMode != ProfileCardViewMode.Public || !t.IsHidden))
+            .Select(t => new
+            {
+                TeamInfo = t,
+                Membership = t.Members.FirstOrDefault(m => m.UserId == userId)
+            })
+            .Where(tm => tm.Membership is not null)
+            .OrderBy(tm => tm.TeamInfo.Name, StringComparer.Ordinal)
             .Select(tm => new TeamMembershipViewModel
             {
-                TeamId = tm.TeamId,
-                TeamName = tm.Team.DisplayName,
-                TeamSlug = tm.Team.Slug,
-                IsCoordinator = tm.Role == TeamMemberRole.Coordinator,
-                IsSystemTeam = tm.Team.IsSystemTeam
+                TeamId = tm.TeamInfo.Id,
+                TeamName = GetDisplayName(tm.TeamInfo, teamsById),
+                TeamSlug = tm.TeamInfo.Slug,
+                IsCoordinator = tm.Membership!.Role == TeamMemberRole.Coordinator,
+                IsSystemTeam = tm.TeamInfo.IsSystemTeam
             })
             .ToList();
 
@@ -149,4 +157,11 @@ public class ProfileCardViewComponent(
 
         return View(model);
     }
+
+    private static string GetDisplayName(
+        TeamInfo team,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById) =>
+        team.ParentTeamId is { } parentTeamId && teamsById.TryGetValue(parentTeamId, out var parent)
+            ? $"{parent.Name} - {team.Name}"
+            : team.Name;
 }

--- a/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
@@ -170,9 +170,3 @@ src/Humans.Web/TagHelpers/AuthorizeViewTagHelper.cs:User#1
 src/Humans.Web/ViewComponents/AdminNavTree.cs:User#1
 src/Humans.Web/ViewComponents/AdminSidebarViewComponent.cs:User#1
 src/Humans.Web/ViewComponents/AdminSidebarViewComponent.cs:User#2
-src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs:Team#1
-src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs:Team#2
-src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs:Team#3
-src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs:Team#4
-src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs:Team#5
-src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs:Team#6


### PR DESCRIPTION
## Summary
- add tech-debt loop guidance for `*ServiceRead` boundaries and read-model migrations
- migrate profile view components and calendar controller team reads to `ITeamServiceRead`/`TeamInfo`
- shrink the obsolete nav-read baseline for fixed `ProfileCardViewComponent` violations

## Verification
- `dotnet build Humans.slnx --disable-build-servers -v q`
- `dotnet test Humans.slnx --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Application|FullyQualifiedName~Architecture|FullyQualifiedName~ViewComponent"`
- `dotnet test Humans.slnx --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Application|FullyQualifiedName~Architecture|FullyQualifiedName~Calendar"`