### PR TITLE
perf(tickets): skip no-op participation upserts in TicketSync

### DIFF
--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -460,30 +460,52 @@ public sealed class TicketSyncService(
             .GroupBy(x => x.UserId!.Value)
             .ToDictionary(g => g.Key, g => g.Min(x => x.CheckedInAt));
 
+        // Current participation state from the in-memory UserInfo cache (zero DB).
+        // Diffing against it lets us skip the per-user upsert — and the cache-slice
+        // refresh it triggers — for the vast majority of ticket-holders whose status
+        // hasn't changed since the last 15-minute sync.
+        var current = (await userService.GetAllParticipationsForYearAsync(year, ct))
+            .ToDictionary(ep => ep.UserId);
+
         foreach (var (userId, statuses) in userTicketStatuses)
         {
             var hasCheckedIn = statuses.Any(s => s == TicketAttendeeStatus.CheckedIn);
             var hasValidTicket = statuses.Any(s =>
                 s == TicketAttendeeStatus.Valid || s == TicketAttendeeStatus.CheckedIn);
 
+            current.TryGetValue(userId, out var existing);
+
             if (hasCheckedIn)
             {
                 Instant? checkedInAt = checkedInAtByUserId.TryGetValue(userId, out var ts)
                     ? ts
                     : null;
+
+                // Already Attended with the timestamp settled (or nothing new to
+                // record): the upsert would no-op. Attended is permanent and
+                // CheckedInAt is write-once.
+                if (existing is { Status: ParticipationStatus.Attended }
+                    && (checkedInAt is null || existing.CheckedInAt is not null))
+                    continue;
+
                 await userService.SetParticipationFromTicketSyncAsync(
                     userId, year, ParticipationStatus.Attended, checkedInAt, ct);
             }
             else if (hasValidTicket)
             {
+                // Already Attended (Ticketed can't downgrade it) or already the
+                // same Ticketed-from-sync state: the upsert would no-op.
+                if (existing is { Status: ParticipationStatus.Attended }
+                    or { Status: ParticipationStatus.Ticketed, Source: ParticipationSource.TicketSync })
+                    continue;
+
                 await userService.SetParticipationFromTicketSyncAsync(
                     userId, year, ParticipationStatus.Ticketed, checkedInAt: null, ct);
             }
         }
 
         // Clear stale Ticketed for users who no longer hold a valid ticket.
-        var allParticipations = await userService.GetAllParticipationsForYearAsync(year, ct);
-        var stalePreviousTicketed = allParticipations
+        var stalePreviousTicketed = current.Values
             .Where(ep => ep.Source == ParticipationSource.TicketSync
                 && ep.Status == ParticipationStatus.Ticketed);
 

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -537,6 +537,92 @@ public sealed class TicketSyncServiceTests : ServiceTestHarness
             (Instant?)null, Arg.Any<CancellationToken>());
     }
 
+    [HumansFact]
+    public async Task SyncEventParticipations_SkipsWrite_WhenCacheAlreadyMatches()
+    {
+        // User already recorded as Ticketed-from-sync for the active year, and the
+        // vendor still shows a valid ticket. Nothing changed, so the per-user upsert
+        // (and the cache-slice refresh it triggers) must be skipped entirely.
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        SeedUserEmail(userId, "alice@example.com", isOAuth: true);
+        await Db.SaveChangesAsync();
+
+        _shiftManagementService.GetActiveAsync()
+            .Returns(new EventSettings { Year = 2026 });
+
+        _userService.GetAllParticipationsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<EventParticipation>
+            {
+                new()
+                {
+                    UserId = userId,
+                    Year = 2026,
+                    Status = ParticipationStatus.Ticketed,
+                    Source = ParticipationSource.TicketSync
+                }
+            });
+
+        _vendorService.GetOrdersAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorOrderDto> { MakeOrderDto("ord_same", "Alice", "alice@example.com") });
+        _vendorService.GetIssuedTicketsAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorTicketDto>
+            {
+                MakeTicketDto("tkt_same", "ord_same", "Alice", "alice@example.com", status: "valid")
+            });
+
+        await _service.SyncOrdersAndAttendeesAsync();
+
+        await _userService.DidNotReceive().SetParticipationFromTicketSyncAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<ParticipationStatus>(),
+            Arg.Any<Instant?>(), Arg.Any<CancellationToken>());
+        await _userService.DidNotReceive().RemoveTicketSyncParticipationAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncEventParticipations_StillWrites_WhenTicketedHolderChecksIn()
+    {
+        // Cache shows Ticketed; vendor now reports checked-in. The status genuinely
+        // changes (Ticketed → Attended), so the upsert must still fire.
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        SeedUserEmail(userId, "alice@example.com", isOAuth: true);
+        await Db.SaveChangesAsync();
+
+        _shiftManagementService.GetActiveAsync()
+            .Returns(new EventSettings { Year = 2026 });
+
+        _userService.GetAllParticipationsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<EventParticipation>
+            {
+                new()
+                {
+                    UserId = userId,
+                    Year = 2026,
+                    Status = ParticipationStatus.Ticketed,
+                    Source = ParticipationSource.TicketSync
+                }
+            });
+
+        var checkInInstant = Instant.FromUtc(2026, 7, 8, 14, 30);
+
+        _vendorService.GetOrdersAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorOrderDto> { MakeOrderDto("ord_chk", "Alice", "alice@example.com") });
+        _vendorService.GetIssuedTicketsAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorTicketDto>
+            {
+                MakeTicketDto("tkt_chk", "ord_chk", "Alice", "alice@example.com",
+                    status: "checked_in", checkedInAt: checkInInstant)
+            });
+
+        await _service.SyncOrdersAndAttendeesAsync();
+
+        await _userService.Received(1).SetParticipationFromTicketSyncAsync(
+            userId, 2026, ParticipationStatus.Attended,
+            checkInInstant, Arg.Any<CancellationToken>());
+    }
+
     // ==========================================================================
     // Helpers
     // ==========================================================================


### PR DESCRIPTION
## Problem

`event_participations` (a **Users**-section table) was being hit directly in prod, a lot. The source is the `TicketSyncJob` — a Hangfire recurring job that runs **every 15 minutes**. Its `SyncEventParticipationsAsync` looped over *every* matched valid/checked-in ticket-holder and called `SetParticipationFromTicketSyncAsync` per user, **unconditionally**. Each call:

1. opened a fresh `DbContext` and did a `FirstOrDefaultAsync` existence-check SELECT in `UpsertParticipationAsync`, then
2. on any actual change, triggered a per-user cache-slice refresh SELECT (`GetEventParticipationsByUserIdAsync`) via `UserInfoSaveChangesInterceptor`.

So even when nothing changed, every ticket-holder cost ≥1 direct SELECT against `event_participations` every sync. At burn scale (hundreds of holders) that dominates the table's query volume.

No read path was bypassing the cache — all consumers go through the cached `IUserService`. This was the **write** path firing for no-op rows.

## Fix

Diff the desired vendor state against the in-memory `UserInfo` cache snapshot (`GetAllParticipationsForYearAsync`, zero DB) and only call the upsert for rows that **actually change**. The same snapshot is reused for the stale-`Ticketed` cleanup, removing a duplicate cache read.

Skip guards are **conservative** — only clear no-ops are skipped (already `Attended` with the check-in timestamp settled; already `Ticketed`-from-sync). Anything ambiguous falls through to the existing `SetParticipationFromTicketSyncAsync`, whose `Attended`-permanent / `CheckedInAt`-write-once rules still backstop correctness. Worst case the guard fails to skip and behaves exactly as before.

Net: per-sync direct hits on `event_participations` drop from ~N (every ticket-holder) to ~K (rows that changed). ~10 lines in `SyncEventParticipationsAsync`, no signatures touched.

## Tests

- `SyncEventParticipations_SkipsWrite_WhenCacheAlreadyMatches` — unchanged Ticketed holder ⇒ no upsert, no remove.
- `SyncEventParticipations_StillWrites_WhenTicketedHolderChecksIn` — Ticketed → checked-in ⇒ upsert still fires.
- Existing TicketSync participation tests unchanged and green (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)