### PR TITLE
test(infra): bump longRunningTestSeconds 1->10 to cut diagnostic noise

### DIFF
--- a/tests/xunit.runner.json
+++ b/tests/xunit.runner.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "methodDisplay": "method",
-  "longRunningTestSeconds": 1,
+  "longRunningTestSeconds": 10,
   "diagnosticMessages": false
 }


### PR DESCRIPTION
P6 from the test-system-reliability program (parent nobodies-collective/Humans#761).

`tests/xunit.runner.json` had `longRunningTestSeconds: 1`. Integration tests legitimately take 5–30s (`[HumansFact(Timeout = 30000)]`), so every run produced a wall of long-running-test diagnostics — training the team to ignore xUnit output and hiding real hang/slowdown signal. Bumped to 10s.

**Definition of done:** integration runs no longer emit long-running diagnostics for normal-duration tests, while real hangs still surface.

Refs nobodies-collective/Humans#768

🤖 Generated with [Claude Code](https://claude.com/claude-code)