### PR TITLE
fix(agent): case-insensitive section guide lookup for Linux

### DIFF
--- a/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
@@ -5,8 +5,8 @@ namespace Humans.Infrastructure.Services.Preload;
 /// <summary>Reads a whitelisted <c>docs/sections/{key}.md</c> file relative to the content root.</summary>
 public sealed class AgentSectionDocReader(IHostEnvironment env)
 {
-    private static readonly IReadOnlySet<string> Whitelist =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> Whitelist =
+        new(StringComparer.OrdinalIgnoreCase)
         {
             "Onboarding", "Teams", "LegalAndConsent", "Governance", "Shifts",
             "Tickets", "Profiles", "Auth", "Budget", "Camps",
@@ -15,8 +15,12 @@ public sealed class AgentSectionDocReader(IHostEnvironment env)
 
     public async Task<string?> ReadAsync(string key, CancellationToken cancellationToken)
     {
-        if (!Whitelist.Contains(key)) return null;
-        var path = Path.Combine(env.ContentRootPath, "docs", "sections", $"{key}.md");
+        // Resolve the caller-supplied key to the canonical-cased whitelist entry so the
+        // on-disk filename matches exactly on case-sensitive filesystems (Linux deployment).
+        // LLMs routinely lowercase the key (e.g. "shifts"), which clears the case-insensitive
+        // whitelist but would otherwise miss "Shifts.md" via a case-sensitive File.Exists.
+        if (!Whitelist.TryGetValue(key, out var canonicalKey)) return null;
+        var path = Path.Combine(env.ContentRootPath, "docs", "sections", $"{canonicalKey}.md");
         if (!File.Exists(path)) return null;
         return await File.ReadAllTextAsync(path, cancellationToken);
     }

--- a/tests/Humans.Application.Tests/Agent/AgentSectionDocReaderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentSectionDocReaderTests.cs
@@ -1,0 +1,89 @@
+using AwesomeAssertions;
+using Xunit;
+
+namespace Humans.Application.Tests.Agent;
+
+/// <summary>
+/// Guards the case-insensitive whitelist + canonical-cased path resolution
+/// (nobodies-collective/Humans#789). LLMs routinely lowercase the section key
+/// (e.g. "shifts"); the reader must canonicalize it to the on-disk filename
+/// ("Shifts.md") so the lookup works on case-sensitive filesystems (Linux).
+/// </summary>
+public class AgentSectionDocReaderTests
+{
+    [HumansTheory]
+    [InlineData("Shifts")]
+    [InlineData("shifts")]
+    [InlineData("SHIFTS")]
+    public async Task ReadAsync_resolves_any_casing_to_the_canonical_guide(string key)
+    {
+        var env = new TestHostEnvironment();
+        var reader = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
+
+        var content = await reader.ReadAsync(key, CancellationToken.None);
+
+        var canonical = await File.ReadAllTextAsync(
+            Path.Combine(env.ContentRootPath, "docs", "sections", "Shifts.md"),
+            CancellationToken.None);
+
+        content.Should().Be(canonical, "any casing of a whitelisted key must resolve to docs/sections/Shifts.md");
+    }
+
+    /// <summary>
+    /// Proves the canonicalization is independent of the host filesystem's case sensitivity:
+    /// a content root containing ONLY the canonical-cased file "Profiles.md" is read
+    /// successfully even when the caller supplies a lowercased "profiles" key. The reader
+    /// must build the path from the whitelist's canonical entry, not the raw key.
+    /// </summary>
+    [HumansFact]
+    public async Task ReadAsync_uses_canonical_filename_not_caller_casing()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "humans-doc-reader-" + Guid.NewGuid().ToString("N"));
+        var sectionsDir = Path.Combine(root, "docs", "sections");
+        Directory.CreateDirectory(sectionsDir);
+        try
+        {
+            const string body = "# Profiles guide\nbody";
+            await File.WriteAllTextAsync(Path.Combine(sectionsDir, "Profiles.md"), body);
+
+            var env = new TestHostEnvironment { ContentRootPath = root };
+            var reader = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
+
+            var content = await reader.ReadAsync("profiles", CancellationToken.None);
+
+            content.Should().Be(body);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [HumansFact]
+    public async Task ReadAsync_returns_null_for_non_whitelisted_key()
+    {
+        var env = new TestHostEnvironment();
+        var reader = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
+
+        var content = await reader.ReadAsync("NotASection", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "docs", "sections")))
+            dir = dir.Parent;
+        return dir?.FullName ?? AppContext.BaseDirectory;
+    }
+
+    private sealed class TestHostEnvironment : Microsoft.Extensions.Hosting.IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "Humans.Application.Tests";
+        public string ContentRootPath { get; set; } = RepoRoot();
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.PhysicalFileProvider(RepoRoot());
+    }
+}


### PR DESCRIPTION
## Problem
`fetch_section_guide` failed to load valid section guides on the Linux deployment container. `AgentSectionDocReader` whitelisted section keys **case-insensitively** but then built the `docs/sections/{key}.md` path from the **raw caller-supplied key**. LLMs routinely lowercase the key (e.g. `shifts`/`profile`), which cleared the case-insensitive whitelist but missed `Shifts.md`/`Profiles.md` via case-sensitive `File.Exists`, returning `null`. The dispatcher then reported `Unknown section: {key}` and the assistant gave up ("section guide could not be loaded").

## Fix
After the whitelist check, resolve the key to the **canonical-cased** whitelist entry via `HashSet.TryGetValue` and build the path from that, rather than the raw key. The `HashSet` already stores the canonical casing.

## Tests
New `AgentSectionDocReaderTests`:
- Mixed-casing theory (`Shifts`/`shifts`/`SHIFTS`) all resolve to the real `docs/sections/Shifts.md`.
- Temp content root containing only `Profiles.md` is read via a lowercased `profiles` key — proves the lookup is independent of the host filesystem's case sensitivity.
- Non-whitelisted key returns `null`.

## Acceptance criteria
- [x] `ReadAsync("shifts")`, `ReadAsync("SHIFTS")`, `ReadAsync("Shifts")` all resolve to `docs/sections/Shifts.md` on a case-sensitive filesystem.
- [x] A test covers a lowercased key against the case-sensitive path behavior.
- [x] The assistant can answer Shifts/Profiles questions end-to-end — dispatcher passes the LLM key to the now-canonicalizing reader; `Unknown section` no longer fires on casing mismatch.

Refs nobodies-collective/Humans#789

🤖 Generated with [Claude Code](https://claude.com/claude-code)