### PR TITLE
feat(agent): submit chat on Enter (Shift+Enter for newline)

### DIFF
--- a/src/Humans.Web/wwwroot/js/agent/widget.js
+++ b/src/Humans.Web/wwwroot/js/agent/widget.js
@@ -65,9 +65,11 @@
 
     // Enter submits the message; Shift+Enter inserts a newline (textarea default).
     // Guard on sendBtn.disabled so rapid Enter can't double-send while a turn is in-flight.
+    // Skip while an IME composition is active so confirming a CJK candidate with
+    // Enter doesn't submit mid-compose.
     if (input) {
         input.addEventListener('keydown', function (e) {
-            if (e.key === 'Enter' && !e.shiftKey) {
+            if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
                 e.preventDefault();
                 if (!sendBtn.disabled) {
                     composer.requestSubmit();

--- a/src/Humans.Web/wwwroot/js/agent/widget.js
+++ b/src/Humans.Web/wwwroot/js/agent/widget.js
@@ -63,6 +63,19 @@
         closeBtn.addEventListener('click', function () { panel.style.display = 'none'; });
     }
 
+    // Enter submits the message; Shift+Enter inserts a newline (textarea default).
+    // Guard on sendBtn.disabled so rapid Enter can't double-send while a turn is in-flight.
+    if (input) {
+        input.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                if (!sendBtn.disabled) {
+                    composer.requestSubmit();
+                }
+            }
+        });
+    }
+
     composer.addEventListener('submit', async function (e) {
         e.preventDefault();
         const message = input.value.trim();


### PR DESCRIPTION
The agent chat composer (`#agentInput`) is a `<textarea>`, so pressing Enter inserted a newline and users had to click **Send** with the mouse — friction reported by Ben/Roshi (`iss:dfb70f82`).

Added a `keydown` handler in `wwwroot/js/agent/widget.js`:
- **Enter** (no modifier) → `composer.requestSubmit()` (runs the existing submit handler)
- **Shift+Enter** → newline (textarea default, not prevented)
- Guarded on `sendBtn.disabled` so rapid Enter can't double-send while a turn is streaming
- Send button unchanged for mouse users

**Acceptance criteria:** all met (Enter submits / Shift+Enter newline / button works / reporter notifiable via `iss:dfb70f82`).

Refs nobodies-collective/Humans#754

🤖 Generated with [Claude Code](https://claude.com/claude-code)