### PR TITLE
Improve shift card readability: larger sans-serif text, higher contrast

### DIFF
--- a/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
+++ b/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
@@ -284,7 +284,7 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                                 <div class="progress flex-grow-1" style="height: 6px;">
                                     <div class="progress-bar @rangeFillColor" role="progressbar" style="width: @rangeFillPercent%;" aria-valuenow="@totalConfirmed" aria-valuemin="0" aria-valuemax="@totalMax"></div>
                                 </div>
-                                <small class="text-nowrap @(anyUnderstaffed ? "text-danger fw-bold" : "text-muted")">@totalConfirmed/@totalMax</small>
+                                <span class="shift-fill-count text-nowrap @(anyUnderstaffed ? "text-danger" : "")">@totalConfirmed/@totalMax</span>
                             </div>
                         </td>
                         <td>
@@ -322,7 +322,7 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                                     <div class="progress flex-grow-1" style="height: 6px;">
                                         <div class="progress-bar @dayFillColor" role="progressbar" style="width: @dayFillPercent%;" aria-valuenow="@item.ConfirmedCount" aria-valuemin="0" aria-valuemax="@item.Shift.MaxVolunteers"></div>
                                     </div>
-                                    <small class="text-nowrap @(understaffed ? "text-danger fw-bold" : "text-muted")">@item.ConfirmedCount/@item.Shift.MaxVolunteers</small>
+                                    <span class="shift-fill-count text-nowrap @(understaffed ? "text-danger" : "")">@item.ConfirmedCount/@item.Shift.MaxVolunteers</span>
                                 </div>
                             </td>
                             <td>
@@ -359,7 +359,7 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                         @if (!string.IsNullOrEmpty(item.Shift.Description))
                         {
                             <tr class="d-none range-detail-@rangeKey @(isFull ? "table-secondary" : "")">
-                                <td colspan="4" class="text-muted small pt-0 pb-1 border-0">
+                                <td colspan="4" class="shift-description pt-0 pb-1 border-0">
                                     @Html.SanitizedMarkdown(item.Shift.Description)
                                 </td>
                             </tr>
@@ -419,7 +419,7 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                     @if (!string.IsNullOrEmpty(item.Shift.Description))
                     {
                         <tr class="@(isFull ? "table-secondary" : "")">
-                            <td colspan="4" class="text-muted small pt-0 pb-1 border-0">
+                            <td colspan="4" class="shift-description pt-0 pb-1 border-0">
                                 @Html.SanitizedMarkdown(item.Shift.Description)
                             </td>
                         </tr>

--- a/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
+++ b/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
@@ -382,7 +382,7 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                                 <div class="progress flex-grow-1" style="height: 6px;">
                                     <div class="progress-bar @singleFillColor" role="progressbar" style="width: @singleFillPercent%;" aria-valuenow="@item.ConfirmedCount" aria-valuemin="0" aria-valuemax="@item.Shift.MaxVolunteers"></div>
                                 </div>
-                                <small class="text-nowrap @(understaffed ? "text-danger fw-bold" : "text-muted")">@item.ConfirmedCount/@item.Shift.MaxVolunteers</small>
+                                <span class="shift-fill-count text-nowrap @(understaffed ? "text-danger" : "")">@item.ConfirmedCount/@item.Shift.MaxVolunteers</span>
                             </div>
                         </td>
                         <td>

--- a/src/Humans.Web/Views/Shared/_EventRotaTable.cshtml
+++ b/src/Humans.Web/Views/Shared/_EventRotaTable.cshtml
@@ -64,7 +64,7 @@
                             <div class="progress flex-grow-1" style="height: 6px;">
                                 <div class="progress-bar @fillColor" role="progressbar" style="width: @fillPercent%;" aria-valuenow="@item.ConfirmedCount" aria-valuemin="0" aria-valuemax="@shift.MaxVolunteers"></div>
                             </div>
-                            <small class="text-nowrap @(understaffed ? "text-danger fw-bold" : "text-muted")">@item.ConfirmedCount/@shift.MaxVolunteers</small>
+                            <span class="shift-fill-count text-nowrap @(understaffed ? "text-danger" : "")">@item.ConfirmedCount/@shift.MaxVolunteers</span>
                         </div>
                     </td>
                     @if (item.Signups.Count > 0)
@@ -113,7 +113,7 @@
                 @if (!string.IsNullOrEmpty(shift.Description))
                 {
                     <tr class="@(isFull ? "table-secondary" : "")">
-                        <td colspan="8" class="text-muted small pt-0 pb-1 border-0">
+                        <td colspan="8" class="shift-description pt-0 pb-1 border-0">
                             @Html.SanitizedMarkdown(shift.Description)
                         </td>
                     </tr>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -367,7 +367,7 @@
                     </div>
                     @if (!string.IsNullOrEmpty(rotaGroup.Rota.Description))
                     {
-                        <div class="text-muted small mt-1">@Html.SanitizedMarkdown(rotaGroup.Rota.Description)</div>
+                        <div class="shift-description mt-1">@Html.SanitizedMarkdown(rotaGroup.Rota.Description)</div>
                     }
                 </div>
                 <div class="collapse" id="@urgRotaId">
@@ -523,7 +523,7 @@
                                         </div>
                                         @if (!string.IsNullOrEmpty(rotaGroup.Rota.Description))
                                         {
-                                            <div class="text-muted small mt-1">@Html.SanitizedMarkdown(rotaGroup.Rota.Description)</div>
+                                            <div class="shift-description mt-1">@Html.SanitizedMarkdown(rotaGroup.Rota.Description)</div>
                                         }
                                     </div>
                                     <div class="collapse" id="@rotaId">

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1978,3 +1978,20 @@ a.notification-row-line:hover .notification-title {
     color: var(--h-text-secondary);
     font-size: .75rem;
 }
+
+/* ── Shift card readability (issue #755) ───────────────────────────────
+   Larger sans-serif text and higher-contrast ink so shift descriptions and
+   fill counts on /Shifts and team rota views scan easily and pass WCAG AA
+   against the parchment card background. */
+.shift-description {
+    font-family: var(--h-font-body);
+    font-size: .95rem;        /* up from .small (~0.875em), restores full body scale */
+    line-height: 1.5;
+    color: var(--h-aged-ink-light);  /* #5a4535 — ~6.5:1 on parchment card (AA) */
+}
+.shift-fill-count {
+    font-family: var(--h-font-body);
+    font-size: .95rem;        /* up from <small> (~0.875em) */
+    font-weight: 600;
+    color: var(--h-aged-ink); /* #3d2b1f — high contrast on parchment card */
+}


### PR DESCRIPTION
## Summary
Shift descriptions and fill counts on `/Shifts` (and the shared `_EventRotaTable` / `_BuildStrikeRotaTable` partials, also reused on onboarding/widget gallery views) rendered as `text-muted small` — sepia `#8b7355` at ~0.875em, ~3.3:1 contrast against the parchment card background, failing WCAG AA. The reporter (Ben D / Roshi) said they actively recoil from reading the shift view.

## Changes
Two scoped CSS classes added to `site.css` and applied in the markup:
- **`.shift-description`** — body sans-serif (`Source Sans 3`), `.95rem`, `aged-ink-light` (`#5a4535`, ~6.5:1 → AA pass). Applied to shift descriptions in both rota partials and the rota-level description in `Shifts/Index.cshtml`.
- **`.shift-fill-count`** — body sans-serif, `.95rem`, weight 600, `aged-ink` (`#3d2b1f`, high contrast). Applied to the `X/Y` filled ratio in all four spots across the partials. Understaffed counts retain the red emphasis (`text-danger`).

Styling-only — no card restructuring. Tables keep `table-responsive` wrapping; no width changes, so mobile cards still fit.

## Acceptance criteria
- [x] Shift description and counts readable at arm's length — bumped from `.small`/`<small>` (~0.875em) back to full body scale (`.95rem`)
- [x] Text passes WCAG AA against the card background — descriptions ~6.5:1, counts ~9.8:1 (was ~3.3:1, failing)
- [x] Font is sans-serif consistent with the app — explicit `var(--h-font-body)` = `Source Sans 3`, the app body font
- [x] Mobile layout still fits — modest `.95rem`, no width changes, `table-responsive` preserved
- [x] Reporter notified via in-app issue `iss:9eee16ce` — see issue comment

Refs nobodies-collective/Humans#755