### PR TITLE
Surface availability calendar prominently on My Shifts

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -4424,6 +4424,12 @@
   <data name="Shifts_SaveAvailability" xml:space="preserve">
     <value>Desar disponibilitat</value>
   </data>
+  <data name="Shifts_AvailabilityPromptText" xml:space="preserve">
+    <value>Abans de buscar torns, marca els dies que estàs disponible: els coordinadors ho fan servir per assignar-te torns.</value>
+  </data>
+  <data name="Shifts_SetAvailabilityCta" xml:space="preserve">
+    <value>Indica la teva disponibilitat</value>
+  </data>
   <data name="Shifts_DaysSelected" xml:space="preserve">
     <value>dies seleccionats</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -4424,6 +4424,12 @@
   <data name="Shifts_SaveAvailability" xml:space="preserve">
     <value>Verfügbarkeit speichern</value>
   </data>
+  <data name="Shifts_AvailabilityPromptText" xml:space="preserve">
+    <value>Markiere vor der Schichtsuche die Tage, an denen du verfügbar bist – Koordinatoren nutzen das für die Schichtzuteilung.</value>
+  </data>
+  <data name="Shifts_SetAvailabilityCta" xml:space="preserve">
+    <value>Verfügbarkeit angeben</value>
+  </data>
   <data name="Shifts_DaysSelected" xml:space="preserve">
     <value>Tage ausgewählt</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -4424,6 +4424,12 @@
   <data name="Shifts_SaveAvailability" xml:space="preserve">
     <value>Guardar disponibilidad</value>
   </data>
+  <data name="Shifts_AvailabilityPromptText" xml:space="preserve">
+    <value>Antes de buscar turnos, marca los días que estás disponible: los coordinadores lo usan para asignarte turnos.</value>
+  </data>
+  <data name="Shifts_SetAvailabilityCta" xml:space="preserve">
+    <value>Indica tu disponibilidad</value>
+  </data>
   <data name="Shifts_DaysSelected" xml:space="preserve">
     <value>días seleccionados</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -4424,6 +4424,12 @@
   <data name="Shifts_SaveAvailability" xml:space="preserve">
     <value>Enregistrer la disponibilité</value>
   </data>
+  <data name="Shifts_AvailabilityPromptText" xml:space="preserve">
+    <value>Avant de parcourir les créneaux, indiquez les jours où vous êtes disponible : les coordinateurs s'en servent pour vous attribuer des créneaux.</value>
+  </data>
+  <data name="Shifts_SetAvailabilityCta" xml:space="preserve">
+    <value>Indiquez vos disponibilités</value>
+  </data>
   <data name="Shifts_DaysSelected" xml:space="preserve">
     <value>jours sélectionnés</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -4424,6 +4424,12 @@
   <data name="Shifts_SaveAvailability" xml:space="preserve">
     <value>Salva disponibilità</value>
   </data>
+  <data name="Shifts_AvailabilityPromptText" xml:space="preserve">
+    <value>Prima di cercare i turni, segna i giorni in cui sei disponibile: i coordinatori li usano per assegnarti i turni.</value>
+  </data>
+  <data name="Shifts_SetAvailabilityCta" xml:space="preserve">
+    <value>Indica la tua disponibilità</value>
+  </data>
   <data name="Shifts_DaysSelected" xml:space="preserve">
     <value>giorni selezionati</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1817,6 +1817,8 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>General Availability</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Mark which days you're available to help. Coordinators can see who's in the pool when assigning shifts.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Save Availability</value></data>
+  <data name="Shifts_AvailabilityPromptText" xml:space="preserve"><value>Before browsing shifts, mark the days you're available — coordinators use it to match you with shifts.</value></data>
+  <data name="Shifts_SetAvailabilityCta" xml:space="preserve"><value>Set your availability</value></data>
   <data name="Shifts_DaysSelected" xml:space="preserve"><value>days selected</value></data>
   <data name="Shifts_SlotsFull" xml:space="preserve"><value>Some days still need help but all available slots are currently full. Check back later in case spots open up.</value></data>
   <data name="Shifts_ConfirmSignup_Title" xml:space="preserve"><value>Confirm your {0} sign-up</value></data>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -55,6 +55,17 @@
     {
         var es = Model.EventSettings;
 
+        @* Prominent availability prompt — jumps to the calendar grid lower on the page so members find it before manually browsing shifts. *@
+        <div class="card border-primary mb-4">
+            <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
+                <div class="d-flex align-items-center gap-2">
+                    <i class="fa-solid fa-calendar-check fs-4 text-primary"></i>
+                    <span>@Localizer["Shifts_AvailabilityPromptText"]</span>
+                </div>
+                <a href="#availability-calendar" class="btn btn-primary">@Localizer["Shifts_SetAvailabilityCta"]</a>
+            </div>
+        </div>
+
         @if (Model.Upcoming.Count > 0)
         {
             <div class="card mb-4">
@@ -217,7 +228,7 @@
             (Localizer["Shifts_Event"].Value, "bg-success", 0, es.EventEndOffset),
             (Localizer["Shifts_Strike"].Value, "bg-secondary", es.EventEndOffset + 1, es.StrikeEndOffset)
         };
-        <div class="card mb-4">
+        <div class="card mb-4" id="availability-calendar">
             <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_GeneralAvailability"]</h5></div>
             <div class="card-body">
                 <p class="text-muted small">@Localizer["Shifts_AvailabilityHelp"]</p>


### PR DESCRIPTION
## What
The General Availability calendar on `/Shifts/Mine` was buried at the bottom of the page, below the Upcoming / Pending / Past shift-status cards. Members (per Diego's report) signed up for shifts manually before ever finding it.

This adds a **prominent primary-bordered prompt card at the top of `/Shifts/Mine`** (immediately after the Browse/My Shifts tabs and temp-data alerts, before the status cards). It contains a short prompt and a **"Set your availability"** CTA button that scrolls to the existing calendar grid via a new `#availability-calendar` anchor.

## Changes
- `src/Humans.Web/Views/Shifts/Mine.cshtml` — added the prompt card (renders only when an active event is configured, i.e. when the calendar actually exists below) and an `id="availability-calendar"` anchor on the existing calendar card. Used `fa-solid fa-calendar-check` (Font Awesome — the icon set the layout actually loads).
- `SharedResource.resx` + 5 locale files (ca/de/es/fr/it) — new keys `Shifts_AvailabilityPromptText` and `Shifts_SetAvailabilityCta`.

## Acceptance criteria
- [x] Availability tool is discoverable near the top of `/Shifts/Mine` — no scrolling required to find the entry point.
- [x] Onboarding-progress integration intentionally **not** bundled (flagged needs-scoping in the issue).
- [ ] Reporter notification via in-app issue `iss:1f2a442f` — in-app action, not a code change; flagged for whoever closes the in-app issue.

## Scope notes
- Discoverability-only, per the issue's scope limit.
- Kept the diff focused so it reconciles cleanly with the sibling PR for nobodies-collective/Humans#791 (collapsible status sections on the same view) — my change only touches the top-of-page region and the calendar card's `id`.

## Pre-existing observation (not changed)
`src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml` uses `class="bi bi-chevron-right"` (Bootstrap Icons), but the layout only loads Font Awesome, so that icon never renders. Out of scope here; flagging for follow-up.

Refs nobodies-collective/Humans#792