### PR TITLE
feat(camps): add EstimatedHours workload field to camp role definitions

### DIFF
--- a/docs/sections/Camps.md
+++ b/docs/sections/Camps.md
@@ -113,6 +113,7 @@ CampAdmin-managed catalogue of per-camp roles. Soft-deleted via `DeactivatedAt`;
 | Description | string? | Markdown |
 | SlotCount | int | Default 1; soft cap enforced in service, not in DB |
 | MinimumRequired | int | Default 1; cross-field validation enforces `0 ≤ MinimumRequired ≤ SlotCount` |
+| EstimatedHours | decimal? | Optional workload estimate in hours (`numeric(6,2)`). Informational only — gates nothing; exists for downstream workload aggregations (issue nobodies-collective/Humans#733). Admin-mutable even for special roles. Existing rows are NULL (no backfill). |
 | SortOrder | int | Display order on Camp Edit roles panel |
 | DeactivatedAt | Instant? | Null = active; non-null hides from new-assignment UI |
 | SpecialRole | CampSpecialRole | Default `None`. Marker for special, system-managed role definitions (`Lead`, `Workshop`) seeded by the CampAdmin "Seed system roles" action (issue nobodies-collective/Humans#753). `CampRoleService` rejects rename / slug change / sort-order change / min-required change / deactivation when `SpecialRole != None`; only `SlotCount` and `Description` are admin-mutable. Stored as string via `HasConversion<string>()`; column default `'None'` backfills existing rows on the AddColumn migration. |

--- a/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
@@ -127,7 +127,8 @@ public sealed record CreateCampRoleDefinitionInput(
     string? Description,
     int SlotCount,
     int MinimumRequired,
-    int SortOrder);
+    int SortOrder,
+    decimal? EstimatedHours = null);
 
 public sealed record UpdateCampRoleDefinitionInput(
     string Name,
@@ -135,7 +136,8 @@ public sealed record UpdateCampRoleDefinitionInput(
     string? Description,
     int SlotCount,
     int MinimumRequired,
-    int SortOrder);
+    int SortOrder,
+    decimal? EstimatedHours = null);
 
 public enum UpdateCampRoleDefinitionStatus
 {
@@ -163,7 +165,8 @@ public sealed record CampRoleDefinitionInfo(
     Instant CreatedAt,
     Instant UpdatedAt,
     Instant? DeactivatedAt,
-    CampSpecialRole SpecialRole)
+    CampSpecialRole SpecialRole,
+    decimal? EstimatedHours)
 {
     public bool IsActive => DeactivatedAt is null;
     public bool IsSpecial => SpecialRole != CampSpecialRole.None;

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -71,6 +71,7 @@ public sealed class CampRoleService(
             SlotCount = input.SlotCount,
             MinimumRequired = input.MinimumRequired,
             SortOrder = input.SortOrder,
+            EstimatedHours = input.EstimatedHours,
             CreatedAt = now,
             UpdatedAt = now,
         };
@@ -121,7 +122,8 @@ public sealed class CampRoleService(
             definition.CreatedAt,
             definition.UpdatedAt,
             definition.DeactivatedAt,
-            definition.SpecialRole);
+            definition.SpecialRole,
+            definition.EstimatedHours);
 
     private static CampRoleAssignmentInfo CreateCampRoleAssignmentInfo(CampRoleAssignment assignment) =>
         new(
@@ -167,6 +169,7 @@ public sealed class CampRoleService(
             def.SlotCount = input.SlotCount;
             def.MinimumRequired = input.MinimumRequired;
             def.SortOrder = input.SortOrder;
+            def.EstimatedHours = input.EstimatedHours;
             def.UpdatedAt = now;
         }, ct);
 

--- a/src/Humans.Domain/Entities/CampRoleDefinition.cs
+++ b/src/Humans.Domain/Entities/CampRoleDefinition.cs
@@ -30,6 +30,13 @@ public class CampRoleDefinition
     /// <summary>How many slots must be filled for the camp to be compliant. 0 ≤ MinimumRequired ≤ SlotCount. 0 = role not tracked in the compliance report.</summary>
     public int MinimumRequired { get; set; } = 1;
 
+    /// <summary>
+    /// Optional estimate of the workload, in hours, that holding this role represents.
+    /// Informational only — it gates nothing. Exists so downstream aggregations can
+    /// quantify workload across roles. Null means "not estimated".
+    /// </summary>
+    public decimal? EstimatedHours { get; set; }
+
     public int SortOrder { get; set; }
 
     public Instant CreatedAt { get; init; }

--- a/src/Humans.Infrastructure/Data/Configurations/Camps/CampRoleDefinitionConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Camps/CampRoleDefinitionConfiguration.cs
@@ -15,6 +15,9 @@ public class CampRoleDefinitionConfiguration : IEntityTypeConfiguration<CampRole
         builder.Property(d => d.Description).HasMaxLength(2000);
         builder.Property(d => d.Slug).HasMaxLength(60).IsRequired();
 
+        // Optional workload estimate in hours. Nullable — existing rows stay NULL.
+        builder.Property(d => d.EstimatedHours).HasPrecision(6, 2);
+
         builder.HasIndex(d => d.Name)
             .IsUnique()
             .HasDatabaseName("IX_camp_role_definitions_name_unique");

--- a/src/Humans.Infrastructure/Migrations/20260523151459_AddCampRoleEstimatedHours.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260523151459_AddCampRoleEstimatedHours.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523151459_AddCampRoleEstimatedHours")]
+    partial class AddCampRoleEstimatedHours
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260523151459_AddCampRoleEstimatedHours.cs
+++ b/src/Humans.Infrastructure/Migrations/20260523151459_AddCampRoleEstimatedHours.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCampRoleEstimatedHours : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "EstimatedHours",
+                table: "camp_role_definitions",
+                type: "numeric(6,2)",
+                precision: 6,
+                scale: 2,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EstimatedHours",
+                table: "camp_role_definitions");
+        }
+    }
+}

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -395,7 +395,7 @@ public class CampAdminController(
         try
         {
             var input = new CreateCampRoleDefinitionInput(
-                form.Name, form.Slug, form.Description, form.SlotCount, form.MinimumRequired, form.SortOrder);
+                form.Name, form.Slug, form.Description, form.SlotCount, form.MinimumRequired, form.SortOrder, form.EstimatedHours);
             await campRoleService.CreateDefinitionAsync(input, user.Id, ct);
             SetSuccess($"Created camp role '{form.Name}'.");
             return RedirectToAction(nameof(Roles));
@@ -427,6 +427,7 @@ public class CampAdminController(
             SlotCount = def.SlotCount,
             MinimumRequired = def.MinimumRequired,
             SortOrder = def.SortOrder,
+            EstimatedHours = def.EstimatedHours,
         });
     }
 
@@ -444,7 +445,7 @@ public class CampAdminController(
         try
         {
             var input = new UpdateCampRoleDefinitionInput(
-                form.Name, form.Slug, form.Description, form.SlotCount, form.MinimumRequired, form.SortOrder);
+                form.Name, form.Slug, form.Description, form.SlotCount, form.MinimumRequired, form.SortOrder, form.EstimatedHours);
             var result = await campRoleService.UpdateDefinitionAsync(id, input, user.Id, ct);
             return result.Status switch
             {

--- a/src/Humans.Web/Models/CampAdmin/CampRoleDefinitionFormViewModel.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampRoleDefinitionFormViewModel.cs
@@ -24,6 +24,10 @@ public sealed class CampRoleDefinitionFormViewModel : IValidatableObject
     [Range(0, 100)]
     public int MinimumRequired { get; set; } = 1;
 
+    [Range(0, 9999.99)]
+    [Display(Name = "Estimated hours")]
+    public decimal? EstimatedHours { get; set; }
+
     public int SortOrder { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext _)

--- a/src/Humans.Web/Views/CampAdmin/RoleForm.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/RoleForm.cshtml
@@ -72,6 +72,12 @@
                             <input asp-for="SortOrder" class="form-control" type="number" required />
                             <span asp-validation-for="SortOrder" class="text-danger"></span>
                         </div>
+                        <div class="col-md-4">
+                            <label asp-for="EstimatedHours" class="form-label">Estimated hours</label>
+                            <input asp-for="EstimatedHours" class="form-control" type="number" min="0" max="9999.99" step="0.25" />
+                            <div class="form-text">Optional workload estimate. Leave blank if unknown.</div>
+                            <span asp-validation-for="EstimatedHours" class="text-danger"></span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
@@ -115,6 +115,50 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task CreateDefinition_persists_estimated_hours()
+    {
+        var input = new CreateCampRoleDefinitionInput(
+            Name: "Build Lead", Slug: "build-lead", Description: null,
+            SlotCount: 1, MinimumRequired: 0, SortOrder: 70, EstimatedHours: 12.5m);
+
+        var result = await _service.CreateDefinitionAsync(input, _actorUserId);
+
+        var stored = await _service.GetDefinitionByIdAsync(result.Id);
+        stored!.EstimatedHours.Should().Be(12.5m);
+    }
+
+    [HumansFact]
+    public async Task CreateDefinition_allows_null_estimated_hours()
+    {
+        var input = new CreateCampRoleDefinitionInput(
+            Name: "Greeter", Slug: "greeter", Description: null,
+            SlotCount: 1, MinimumRequired: 0, SortOrder: 80);
+
+        var result = await _service.CreateDefinitionAsync(input, _actorUserId);
+
+        var stored = await _service.GetDefinitionByIdAsync(result.Id);
+        stored!.EstimatedHours.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task UpdateDefinition_sets_and_clears_estimated_hours()
+    {
+        var def = await SeedDefinitionAsync("Kitchen Lead", slotCount: 2);
+
+        var setInput = new UpdateCampRoleDefinitionInput(
+            Name: "Kitchen Lead", Slug: "kitchen-lead", Description: null,
+            SlotCount: 2, MinimumRequired: 1, SortOrder: 10, EstimatedHours: 8m);
+        await _service.UpdateDefinitionAsync(def.Id, setInput, _actorUserId);
+        (await _service.GetDefinitionByIdAsync(def.Id))!.EstimatedHours.Should().Be(8m);
+
+        var clearInput = new UpdateCampRoleDefinitionInput(
+            Name: "Kitchen Lead", Slug: "kitchen-lead", Description: null,
+            SlotCount: 2, MinimumRequired: 1, SortOrder: 10, EstimatedHours: null);
+        await _service.UpdateDefinitionAsync(def.Id, clearInput, _actorUserId);
+        (await _service.GetDefinitionByIdAsync(def.Id))!.EstimatedHours.Should().BeNull();
+    }
+
+    [HumansFact]
     public async Task CreateDefinition_rejects_duplicate_name()
     {
         await SeedDefinitionAsync("Consent Lead");


### PR DESCRIPTION
## Summary

Adds a nullable `EstimatedHours` field to the camp role definition so a CampAdmin can record the estimated workload, in hours, that holding a role represents. The value is **informational only** — it gates nothing — and exists so downstream aggregations can quantify workload across roles.

`CampRoleDefinition` is the role-definition entity with an admin edit UI (`/Camps/Admin/Roles` create/edit form) and a read model (`CampRoleDefinitionInfo`); it already carries the `SlotCount` / `MinimumRequired` numeric pattern, so `EstimatedHours` follows it exactly. The "Camp Lead" example in the issue maps to this entity's `CampSpecialRole`.

## Acceptance criteria

- [x] Role-definition entity has a nullable `EstimatedHours` field — `CampRoleDefinition.EstimatedHours` (`decimal?`)
- [x] EF config + additive migration, nullable, no backfill — `HasPrecision(6,2)`; migration `20260523151459_AddCampRoleEstimatedHours` adds `numeric(6,2)` NULL column; existing rows stay NULL
- [x] Admin role-edit UI lets the admin set / clear the value — added to the existing CampAdmin Roles create/edit form, using existing CampAdmin authorization (no permission/role-grant change)
- [x] Value included in the Role read model — `CampRoleDefinitionInfo.EstimatedHours`

## Notes

- Schema foundation only. Downstream aggregation/reporting is deferred (nobodies-collective/Humans#734, nobodies-collective/Humans#517).
- Migration is 100% EF-generated (no hand edits); snapshot diff contains only the new property.
- Added 3 service tests (set / null-default / set-then-clear round trips). All 40 `CampRoleServiceTests` pass; full solution build is green.
- Camps section doc (`docs/sections/Camps.md`) table updated.

Refs nobodies-collective/Humans#733

🤖 Generated with [Claude Code](https://claude.com/claude-code)