### PR TITLE
fix(agent): ship grounding docs to prod + preload FAQ from real questions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,14 @@ RUN groupadd -r appuser && useradd -r -g appuser -s /sbin/nologin appuser
 # Copy published files
 COPY --from=build /app/publish .
 
+# Ship the agent's grounding docs. These are read at runtime from
+# ContentRootPath/docs/{sections,features} by AgentSectionDocReader and
+# AgentFeatureSpecReader; they are NOT part of `dotnet publish` output, so copy
+# them explicitly or the agent's fetch_section_guide / fetch_feature_spec tools
+# fail silently in the container (the index also ships empty).
+COPY docs/sections/ ./docs/sections/
+COPY docs/features/ ./docs/features/
+
 # Set ownership
 RUN chown -R appuser:appuser /app
 

--- a/src/Humans.Application/Interfaces/IAgentPreloadAugmentor.cs
+++ b/src/Humans.Application/Interfaces/IAgentPreloadAugmentor.cs
@@ -8,4 +8,5 @@ public interface IAgentPreloadAugmentor
     string BuildAccessMatrixMarkdown();
     string BuildGlossariesMarkdown();
     string BuildRouteMapMarkdown();
+    string BuildFaqMarkdown();
 }

--- a/src/Humans.Infrastructure/Services/Preload/AgentPreloadCorpusBuilder.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentPreloadCorpusBuilder.cs
@@ -47,6 +47,8 @@ public sealed class AgentPreloadCorpusBuilder(
             sb.AppendLine(augmentor.BuildGlossariesMarkdown());
             sb.AppendLine();
             sb.AppendLine(augmentor.BuildRouteMapMarkdown());
+            sb.AppendLine();
+            sb.AppendLine(augmentor.BuildFaqMarkdown());
         }
 
         var result = sb.ToString();

--- a/src/Humans.Web/Health/AgentDocsHealthCheck.cs
+++ b/src/Humans.Web/Health/AgentDocsHealthCheck.cs
@@ -12,11 +12,20 @@ namespace Humans.Web.Health;
 /// the preload index ships empty. This check turns that into a visible Degraded
 /// status instead. Skipped (Healthy) when the agent feature is disabled.
 /// </summary>
-public sealed class AgentDocsHealthCheck(IAgentSettingsStore store, AgentSectionDocReader sections) : IHealthCheck
+public sealed class AgentDocsHealthCheck(
+    IAgentSettingsStore store,
+    AgentSectionDocReader sections,
+    AgentFeatureSpecReader features) : IHealthCheck
 {
     // A section that is always whitelisted and always preloaded (Tier1) — if its
-    // doc cannot be read, the docs folder is missing or unreadable.
+    // doc cannot be read, docs/sections is missing or unreadable.
     private const string ProbeSection = "Shifts";
+
+    // A stable feature-spec canary — docs/sections and docs/features are copied as
+    // separate Dockerfile layers, so a partial packaging regression can drop one
+    // without the other. Probe both so the health signal covers both runtime
+    // dependencies (fetch_section_guide and fetch_feature_spec).
+    private const string ProbeFeature = "26-events";
 
     public async Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
@@ -25,11 +34,18 @@ public sealed class AgentDocsHealthCheck(IAgentSettingsStore store, AgentSection
         if (!store.Current.Enabled)
             return HealthCheckResult.Healthy("agent disabled");
 
-        var body = await sections.ReadAsync(ProbeSection, cancellationToken);
-        return string.IsNullOrEmpty(body)
-            ? HealthCheckResult.Degraded(
+        var sectionBody = await sections.ReadAsync(ProbeSection, cancellationToken);
+        if (string.IsNullOrEmpty(sectionBody))
+            return HealthCheckResult.Degraded(
                 $"agent grounding docs missing — docs/sections/{ProbeSection}.md unreadable at ContentRootPath; " +
-                "fetch_section_guide/fetch_feature_spec will fail and the preload index will be empty")
-            : HealthCheckResult.Healthy();
+                "fetch_section_guide will fail and the preload index will be empty");
+
+        var featureBody = await features.ReadAsync(ProbeFeature, cancellationToken);
+        if (string.IsNullOrEmpty(featureBody))
+            return HealthCheckResult.Degraded(
+                $"agent grounding docs missing — docs/features/{ProbeFeature}.md unreadable at ContentRootPath; " +
+                "fetch_feature_spec will fail");
+
+        return HealthCheckResult.Healthy();
     }
 }

--- a/src/Humans.Web/Health/AgentDocsHealthCheck.cs
+++ b/src/Humans.Web/Health/AgentDocsHealthCheck.cs
@@ -1,0 +1,35 @@
+using Humans.Application.Interfaces.Stores;
+using Humans.Infrastructure.Services.Preload;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Humans.Web.Health;
+
+/// <summary>
+/// Verifies the agent's grounding docs are present at runtime. The section/feature
+/// guides are read from ContentRootPath/docs/{sections,features}; if the deployment
+/// drops that folder (e.g. the Dockerfile stops copying it), every
+/// <c>fetch_section_guide</c> / <c>fetch_feature_spec</c> call fails silently and
+/// the preload index ships empty. This check turns that into a visible Degraded
+/// status instead. Skipped (Healthy) when the agent feature is disabled.
+/// </summary>
+public sealed class AgentDocsHealthCheck(IAgentSettingsStore store, AgentSectionDocReader sections) : IHealthCheck
+{
+    // A section that is always whitelisted and always preloaded (Tier1) — if its
+    // doc cannot be read, the docs folder is missing or unreadable.
+    private const string ProbeSection = "Shifts";
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (!store.Current.Enabled)
+            return HealthCheckResult.Healthy("agent disabled");
+
+        var body = await sections.ReadAsync(ProbeSection, cancellationToken);
+        return string.IsNullOrEmpty(body)
+            ? HealthCheckResult.Degraded(
+                $"agent grounding docs missing — docs/sections/{ProbeSection}.md unreadable at ContentRootPath; " +
+                "fetch_section_guide/fetch_feature_spec will fail and the preload index will be empty")
+            : HealthCheckResult.Healthy();
+    }
+}

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -15,6 +15,97 @@ public static class SectionHelpContent
     public static IEnumerable<(string Section, string Body)> AllGlossaries() =>
         Glossaries.Select(kv => (Section: kv.Key, Body: kv.Value));
 
+    /// <summary>
+    /// Frequently-asked questions distilled from real production agent conversations
+    /// (audit 2026-05-23). Preloaded every turn via <see cref="Humans.Application.Interfaces.IAgentPreloadAugmentor"/>
+    /// so the agent answers these directly instead of routing to support. Routes, button
+    /// labels, and procedures were verified against the live controllers and views; the
+    /// ticket-policy answers were confirmed with the organisers.
+    /// </summary>
+    public const string Faq = """
+        ## Tickets
+
+        **Q: Can I transfer my ticket to my partner / someone else?**
+        Yes. The preferred way is in-app: go to /Tickets/Transfers and request a transfer to the
+        receiver (they need their own Humans account). The tickets team approves it and the ticket is
+        reissued in their name. You can also email tickets@nobodies.team, but the in-app request is
+        better — same team either way, and the app makes it clear who is sending and receiving. One
+        request per ticket.
+
+        **Q: I bought a ticket under a different email address.**
+        Add that email at /Profile/Me/Emails. The order relinks to your account automatically on the
+        next sync (within ~15 minutes). If it was your login email and you cannot re-add it, that needs
+        an admin.
+
+        **Q: I'm working shifts — when do I get my early-entry ticket?**
+        Early entry is automatic for people working shifts — generally from the day before your first
+        shift. For specifics, contact the volunteer coordinators.
+
+        **Q: How many shifts do I need to work to get a ticket?**
+        Working shifts does not earn you an entry ticket (for 2026). What it gets you is early-entry
+        access and cantina food. You still need your own event ticket.
+
+        **Q: How do I get a low-income / discount ticket?**
+        The low-income ticket process ran in March 2026 and has since closed.
+
+        **Q: I have an acompañante / reduced-mobility companion ticket.**
+        Email tickets@nobodies.team — they handle companion and accessibility ticket requests.
+
+        ## Shifts
+
+        **Q: Where do I see my shifts?**
+        /Shifts/Mine — your personal shift list. The main /Shifts page is for browsing and signing up.
+
+        **Q: How do I sign up for a shift?**
+        Browse open shifts at /Shifts, hit Sign Up on the slot (or "Sign up for N dates" for a
+        multi-day block). You will get a confirmation showing the phase, dates, and when you are
+        expected on site. Most shifts confirm immediately; some need coordinator approval. A coordinator
+        can also "voluntell" (directly assign) you.
+
+        **Q: How do I cancel / decline / withdraw from a shift? (I signed up by mistake)**
+        Go to /Shifts/Mine. Each shift has a Bail / Withdraw button — it asks for confirmation, then
+        removes you. For a multi-day block, Bail drops all days at once.
+
+        **Q: My shifts aren't showing up.**
+        Check /Shifts/Mine directly. If a confirmed shift is genuinely missing there, report it via
+        /Issues.
+
+        **Q: Which shifts need help / are understaffed?**
+        Browse /Shifts and look for slots with open spots — you can filter by department, dates, and
+        phase.
+
+        ## Profile
+
+        **Q: What's missing to complete my profile?**
+        Two separate things. To be an active member, all you need is your name and to have signed the
+        required consent documents — check /Legal; access does not depend on a "100% profile". The
+        completion bar on your Home dashboard tracks profile enrichment: profile picture (the biggest
+        single chunk), bio, pronouns, city/country, date of birth, what you'd like to contribute,
+        emergency contact, languages, your burner history (or ticking "no prior burn experience"), and
+        shift-type preferences. Fill any of these at /Profile/Me.
+
+        **Q: How do I change my email / add a new one?**
+        Go to /Profile/Me/Emails, add the new address (you will get a verification link sent to it),
+        then set it as your primary. Your sign-in is tied to your Google login / magic-link, which is
+        separate from the addresses listed here.
+
+        ## Account & privacy
+
+        **Q: How do I delete my account / download my data?**
+        Go to /Profile/Me/Privacy — export your data or delete your account there.
+
+        ## About the assistant / out of scope
+
+        **Q: Are you an AI? What can you do?**
+        Yes — I'm an AI helper built into the app. I answer questions about how the Humans system works
+        (shifts, teams, camps, profiles, governance, tickets) and can look up your own teams, roles, and
+        history. I can't act for you (sign you up, edit your profile) or see other people's data.
+
+        **Q: Car sharing / forum / external community / other comms channels?**
+        That's outside the Humans app. The main site is https://nobodies.team/ — links for the community
+        channels (Discord, Telegram, WhatsApp) are in the footer there.
+        """;
+
     private static readonly Dictionary<string, string> Guides = new(StringComparer.Ordinal)
     {
         ["Teams"] = """

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -269,7 +269,8 @@ var healthChecks = builder.Services.AddHealthChecks()
     .AddCheck<SmtpHealthCheck>("smtp")
     .AddCheck<GitHubHealthCheck>("github")
     .AddCheck<GoogleWorkspaceHealthCheck>("google-workspace")
-    .AddCheck<AnthropicHealthCheck>("anthropic-api-reachable");
+    .AddCheck<AnthropicHealthCheck>("anthropic-api-reachable")
+    .AddCheck<AgentDocsHealthCheck>("agent-grounding-docs");
 
 // Hangfire health check reads JobStorage.Current; only register it when
 // the rest of the Hangfire stack is wired (i.e. outside Testing).

--- a/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
+++ b/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
@@ -46,4 +46,9 @@ public sealed class AgentPreloadAugmentor : IAgentPreloadAugmentor
         - /Feedback — submit a bug, feature request, or question
         - /Agent — conversational helper (this tool's own history page)
         """;
+
+    public string BuildFaqMarkdown() =>
+        "# Frequently Asked Questions" + Environment.NewLine + Environment.NewLine +
+        "Distilled from real user questions. Prefer these answers; they are verified against the live app." +
+        Environment.NewLine + Environment.NewLine + SectionHelpContent.Faq;
 }

--- a/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
+++ b/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
@@ -1,0 +1,41 @@
+using AwesomeAssertions;
+using Humans.Web.Services.Agent;
+using Xunit;
+
+namespace Humans.Web.Tests.Services;
+
+/// <summary>
+/// The FAQ block is preloaded every turn and exists specifically to fix the
+/// answers the production agent got wrong (ticket transfer and shift withdrawal
+/// are self-service, not admin-only). These pin the load-bearing facts.
+/// </summary>
+public class AgentPreloadAugmentorTests
+{
+    private static string Faq() => new AgentPreloadAugmentor().BuildFaqMarkdown();
+
+    [HumansFact]
+    public void Faq_points_to_self_service_ticket_transfer()
+    {
+        var faq = Faq();
+        faq.Should().Contain("/Tickets/Transfers");
+        faq.Should().Contain("tickets@nobodies.team");
+    }
+
+    [HumansFact]
+    public void Faq_explains_self_service_shift_withdrawal()
+    {
+        var faq = Faq();
+        faq.Should().Contain("/Shifts/Mine");
+        faq.Should().Contain("Bail");
+    }
+
+    [HumansFact]
+    public void Faq_covers_the_recurring_ticket_and_profile_questions()
+    {
+        var faq = Faq();
+        faq.Should().Contain("early-entry");                 // early-entry-for-shifts policy
+        faq.Should().Contain("/Profile/Me/Emails");          // bought-under-other-email + change email
+        faq.Should().Contain("/Profile/Me/Privacy");         // delete account / data export
+        faq.Should().Contain("https://nobodies.team/");      // external comms channels
+    }
+}


### PR DESCRIPTION
## Summary

Two fixes from the production agent-log audit (2026-05-23, 25 conversations).

### 1. Ship the agent's grounding docs to production
The agent reads `docs/sections/*.md` and `docs/features/*.md` at runtime (`AgentSectionDocReader` / `AgentFeatureSpecReader`, via `ContentRootPath`) to serve `fetch_section_guide` / `fetch_feature_spec` and to build the preload section index. The `Dockerfile` only copied `src/` and published the web project, so **`docs/` was never in the image** — in prod every doc fetch returned `null`, the preload index shipped empty, and the agent silently degraded to glossaries + route map (it couldn't retrieve a single procedure, and bailed to `route_to_issue` whenever one was needed). It "worked" locally only because `ContentRootPath` there is the repo root, which has `docs/`.

- `Dockerfile`: copy `docs/sections` + `docs/features` into `/app` (chowned to `appuser`).
- `AgentDocsHealthCheck`: when the agent is enabled, probe a known section (`Shifts`) → **Degraded** if unreadable, so a future deploy that drops docs surfaces in `/health` instead of breaking silently. Healthy when disabled. `/health/live` (the Docker liveness gate) runs no checks, so this can't affect container health/deploys.

### 2. Preload a FAQ distilled from the real questions
Users repeatedly asked the same things — ticket transfer, shift withdrawal, "what's missing on my profile", ticket bought under another email — and the agent punted or gave **wrong** answers (it told users ticket transfer and shift withdrawal were admin-only; both are self-service at `/Tickets/Transfers` and `/Shifts/Mine`). Glossaries define terms but carry no procedures.

- `SectionHelpContent.Faq` (code-embedded) emitted every turn via `IAgentPreloadAugmentor.BuildFaqMarkdown()`, alongside the glossaries/route map that already work in prod — so it's robust even if doc deployment regresses.
- Answers verified against the live controllers/views; ticket-policy answers confirmed with the organisers.

## Testing
- `dotnet build Humans.slnx -v quiet` — 0 errors.
- `dotnet test Humans.slnx -v quiet` — Web.Tests 155/155 (incl. 3 new FAQ tests), Application.Tests 3260/3260.
- 2 pre-existing failures in `StorePayActionTests` (Store order page returns 302) — **confirmed failing on clean `origin/main`**, unrelated to this diff (no payment code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)