### PR TITLE
Remove public UserInfo DisplayName

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,13 +36,12 @@
           true warnings so existing violations surface without breaking the
           build; promote to error once they're all fixed (delete these
           entries).
-        - HUM_USER_DISPLAYNAME / HUM_USERINFO_DISPLAYNAME: [Obsolete] markers
-          on User.DisplayName and UserInfo.DisplayName. Legitimate consumers
-          (Identity claims, merge/purge/delete labels, GDPR export, dev
-          seeders, email greetings, admin merge UI) remain until UserInfo
-          handles are threaded through every Application-layer service entry
-          point per issue #691. Kept visible as warnings (not hidden via
-          NoWarn) so new render-path violations stay surfaced.
+        - HUM_USER_DISPLAYNAME: [Obsolete] marker on User.DisplayName.
+          Legitimate consumers (Identity claims, merge/purge/delete labels,
+          GDPR export, dev seeders, email greetings, admin merge UI) remain
+          until UserInfo handles are threaded through every Application-layer
+          service entry point per issue #691. Kept visible as warnings (not
+          hidden via NoWarn) so new render-path violations stay surfaced.
         - HUM_USER_GetById: [Obsolete] marker on IUserService.GetByIdAsync.
           Callers are being migrated to GetUserInfoAsync; remaining sites
           (e.g. CampaignService.cs:550 private-helper overload) ride the
@@ -54,7 +53,7 @@
           migrated through UserInfo / IUserEmailService. Promote to error
           once all reads are gone (delete this entry).
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009;HUM0010;HUM0011;HUM0014;HUM0017;HUM0018;HUM0019;HUM_USER_DISPLAYNAME;HUM_USERINFO_DISPLAYNAME;HUM_USER_GetById</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009;HUM0010;HUM0011;HUM0014;HUM0017;HUM0018;HUM0019;HUM_USER_DISPLAYNAME;HUM_USER_GetById</WarningsNotAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -1698,7 +1698,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         var users = userIds.Count == 0
             ? new Dictionary<Guid, UserInfo>()
             : await _userService.GetUserInfosAsync(userIds, cancellationToken);
-        var userMap = users.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.DisplayName);
+        var userMap = users.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.BurnerName);
 
         static string DisplayName(Guid userId, IReadOnlyDictionary<Guid, string> names) =>
             names.GetValueOrDefault(userId) ?? "Unknown";

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -822,11 +822,9 @@ public sealed class ExpenseReportService(
                 var category = await budgetService.GetCategoryByIdAsync(report.BudgetCategoryId);
                 var tag = BuildHoldedTag(category?.BudgetGroup?.Name, category?.Name);
 
-                var users = await userService.GetUserInfosAsync(
-                    [report.SubmitterUserId], ct);
-                var submitterName = users.TryGetValue(report.SubmitterUserId, out var user)
-                    ? user.DisplayName
-                    : "Unknown";
+                var submitterName = string.IsNullOrWhiteSpace(report.PayeeName)
+                    ? "Unknown"
+                    : report.PayeeName;
 
                 var now = clock.GetCurrentInstant();
 

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -102,7 +102,7 @@ public sealed class GoogleAdminService(
                     CreationTime: account.CreationTime,
                     LastLoginTime: account.LastLoginTime,
                     MatchedUserId: matched?.UserId,
-                    MatchedDisplayName: matchedUser?.DisplayName,
+                    MatchedDisplayName: matchedUser?.BurnerName,
                     IsUsedAsPrimary: isUsedAsPrimary,
                     IsEnrolledIn2Sv: account.IsEnrolledIn2Sv,
                     RecoveryEmail: account.RecoveryEmail));

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -1689,7 +1689,7 @@ public sealed class GoogleWorkspaceSyncService(
         {
             if (usersById.TryGetValue(match.UserId, out var user))
             {
-                result.TryAdd(match.Email, (user.DisplayName, match.UserId, user.ProfilePictureUrl));
+                result.TryAdd(match.Email, (user.BurnerName, match.UserId, user.ProfilePictureUrl));
             }
         }
 

--- a/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
@@ -234,7 +234,7 @@ public sealed class NotificationInboxService(
             return new Dictionary<Guid, string>();
 
         var users = await userService.GetUserInfosAsync(userIds, ct);
-        return users.ToDictionary(kv => kv.Key, kv => kv.Value.DisplayName);
+        return users.ToDictionary(kv => kv.Key, kv => kv.Value.BurnerName);
     }
 
     private static NotificationRowDto MapToRow(

--- a/src/Humans.Application/Services/Profiles/DuplicateAccountService.cs
+++ b/src/Humans.Application/Services/Profiles/DuplicateAccountService.cs
@@ -276,7 +276,7 @@ public sealed class DuplicateAccountService(
         return new DuplicateAccountInfo
         {
             UserId = userId,
-            DisplayName = info?.DisplayName ?? "Unknown",
+            DisplayName = info?.BurnerName ?? "Unknown",
             Email = info?.Email,
             ProfilePictureUrl = info?.ProfilePictureUrl,
             MembershipTier = membershipTier,

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -710,7 +710,7 @@ public sealed class ShiftManagementService(
                             userLookup?.TryGetValue(ss.UserId, out user);
                             return (
                                 ss.UserId,
-                                DisplayName: user?.DisplayName ?? string.Empty,
+                                DisplayName: user?.BurnerName ?? string.Empty,
                                 ss.Status);
                         })
                         .OrderBy(ss => ss.Status == SignupStatus.Confirmed ? 0 : 1)

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -649,7 +649,7 @@ public sealed class TicketTransferService(
             TicketTypeName: attendee.TicketTypeName,
             OriginalAttendeeStatus: attendee.Status,
             SenderUserId: r.SenderUserId,
-            SenderDisplayName: sender?.DisplayName ?? "(unknown)",
+            SenderDisplayName: sender?.BurnerName ?? "(unknown)",
             ReceiverUserId: r.ReceiverUserId,
             ReceiverLegalName: r.ReceiverLegalName,
             ReceiverEmail: r.ReceiverEmail,
@@ -658,7 +658,7 @@ public sealed class TicketTransferService(
             VendorResult: r.VendorResult,
             VendorMessage: r.VendorMessage,
             DecidedByUserId: r.DecidedByUserId,
-            DecidedByDisplayName: decider?.DisplayName,
+            DecidedByDisplayName: decider?.BurnerName,
             AdminNotes: r.AdminNotes,
             RequestedAt: r.RequestedAt,
             DecidedAt: r.DecidedAt);

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -125,7 +125,8 @@ public sealed record ProfileInfo(
 /// </summary>
 public sealed record UserInfo(
     Guid Id,
-    [property: Obsolete("Rendering callers must use UserInfo.BurnerName / <vc:human> — DisplayName is the raw legacy column mirror. See memory/architecture/burnername-is-the-display-name.md.", DiagnosticId = "HUM_USERINFO_DISPLAYNAME", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/691")] string DisplayName,
+    string BurnerName,
+    bool IsGdprAnonymized,
     string PreferredLanguage,
     string? FallbackPictureUrl,
     Instant CreatedAt,
@@ -150,15 +151,6 @@ public sealed record UserInfo(
     ProfileInfo? Profile,
     IReadOnlyList<CommunicationPreferenceInfo> CommunicationPreferences)
 {
-    /// <summary>
-    /// Canonical public-facing name: <see cref="ProfileInfo.BurnerName"/> when set, else <see cref="DisplayName"/>.
-    /// External render callers MUST use this — reading <see cref="DisplayName"/> directly leaks the legacy column.
-    /// </summary>
-    public string BurnerName =>
-        Profile is not null && !string.IsNullOrWhiteSpace(Profile.BurnerName)
-            ? Profile.BurnerName
-            : DisplayName;
-
     /// <summary>
     /// Canonical profile picture URL. Custom upload served from the file share via
     /// <c>/Profile/Picture?id={ProfileId}&amp;v={ticks}</c> when present, otherwise the
@@ -196,31 +188,30 @@ public sealed record UserInfo(
     public bool IsMerged => MergedAt is not null;
 
     /// <summary>
-    /// Sentinel <see cref="DisplayName"/> value written by
+    /// Sentinel value written to the legacy User.DisplayName column by
     /// <see cref="Humans.Application.Interfaces.Repositories.IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>
-    /// to mark GDPR-deleted users. Read by <see cref="IsTombstone"/>; the
-    /// shared constant ties write-path and read-path together so a rename
-    /// can't silently break tombstone detection.
+    /// to mark GDPR-deleted users. Read into <see cref="IsGdprAnonymized"/>
+    /// at creation time so the legacy name never becomes a public UserInfo field.
     /// </summary>
-    public const string GdprAnonymizedDisplayName = "Deleted User";
+    public const string GdprAnonymizedBurnerName = "Deleted User";
 
     /// <summary>
     /// True when the user row is a tombstone — a merge-source
-    /// (<see cref="MergedAt"/> set), a GDPR-anonymized record (DisplayName
-    /// rewritten to <see cref="GdprAnonymizedDisplayName"/> by
+    /// (<see cref="MergedAt"/> set), a GDPR-anonymized record (legacy User.DisplayName
+    /// resolved into <see cref="BurnerName"/> as <see cref="GdprAnonymizedBurnerName"/> by
     /// <see cref="Humans.Application.Interfaces.Repositories.IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>),
     /// or a legacy tombstone whose <see cref="Email"/> still ends in the
     /// sentinel <c>.local</c> suffix (pre-<c>MergedAt</c>-column merges and
     /// historic purges wrote <c>@merged.local</c> / <c>@deleted.local</c>
     /// addresses — those rows survive in production with neither
-    /// <see cref="MergedAt"/> nor the <see cref="GdprAnonymizedDisplayName"/>
+    /// <see cref="MergedAt"/> nor the <see cref="GdprAnonymizedBurnerName"/>
     /// marker set).
     /// Callers that materialize new per-user rows (Stub Profile, etc.) MUST
     /// short-circuit on this so they don't resurrect the tombstone.
     /// </summary>
     public bool IsTombstone =>
         MergedAt is not null
-        || string.Equals(DisplayName, GdprAnonymizedDisplayName, StringComparison.Ordinal)
+        || IsGdprAnonymized
         || (Email is { } email && email.EndsWith(".local", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>First verified primary email; null when none loaded.</summary>
@@ -403,9 +394,18 @@ public sealed record UserInfo(
                 c.UpdatedAt, c.UpdateSource, c.SubscribedAt))
             .ToList();
 
+#pragma warning disable CS0618, HUM_USER_DISPLAYNAME // User.DisplayName is only the creation-time fallback for profileless UserInfo.BurnerName.
+        var burnerName = profileInfo is not null && !string.IsNullOrWhiteSpace(profileInfo.BurnerName)
+            ? profileInfo.BurnerName
+            : user.DisplayName;
+        var isGdprAnonymized = string.Equals(
+            user.DisplayName, GdprAnonymizedBurnerName, StringComparison.Ordinal);
+#pragma warning restore CS0618, HUM_USER_DISPLAYNAME
+
         return new UserInfo(
             Id: user.Id,
-            DisplayName: user.DisplayName,
+            BurnerName: burnerName,
+            IsGdprAnonymized: isGdprAnonymized,
             PreferredLanguage: user.PreferredLanguage,
             FallbackPictureUrl: user.ProfilePictureUrl,
             CreatedAt: user.CreatedAt,

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -394,13 +394,13 @@ public sealed record UserInfo(
                 c.UpdatedAt, c.UpdateSource, c.SubscribedAt))
             .ToList();
 
-#pragma warning disable CS0618, HUM_USER_DISPLAYNAME // User.DisplayName is only the creation-time fallback for profileless UserInfo.BurnerName.
+#pragma warning disable CS0618 // User.DisplayName is only the creation-time fallback for profileless UserInfo.BurnerName.
         var burnerName = profileInfo is not null && !string.IsNullOrWhiteSpace(profileInfo.BurnerName)
             ? profileInfo.BurnerName
             : user.DisplayName;
         var isGdprAnonymized = string.Equals(
             user.DisplayName, GdprAnonymizedBurnerName, StringComparison.Ordinal);
-#pragma warning restore CS0618, HUM_USER_DISPLAYNAME
+#pragma warning restore CS0618
 
         return new UserInfo(
             Id: user.Id,

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -539,7 +539,7 @@ internal sealed class UserRepository(IDbContextFactory<HumansDbContext> factory)
         var originalDisplayName = user.DisplayName;
         var preferredLanguage = user.PreferredLanguage;
 
-        user.DisplayName = UserInfo.GdprAnonymizedDisplayName;
+        user.DisplayName = UserInfo.GdprAnonymizedBurnerName;
         user.ProfilePictureUrl = null;
         user.PhoneNumber = null;
         user.PhoneNumberConfirmed = false;

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -563,7 +563,7 @@ public sealed class CachingUserService(
 
     private static UserInfo WithUserFields(UserInfo current, User user)
     {
-#pragma warning disable CS0618, HUM_USER_DISPLAYNAME // User.DisplayName / ProfilePictureUrl are legacy user-column mirrors.
+#pragma warning disable CS0618 // User.DisplayName / ProfilePictureUrl are legacy user-column mirrors.
         return current with
         {
             BurnerName = ResolveBurnerName(user.DisplayName, current.Profile),
@@ -588,7 +588,7 @@ public sealed class CachingUserService(
             MergedAt = user.MergedAt,
             IdentityEmailColumn = user.IdentityEmailColumn,
         };
-#pragma warning restore CS0618, HUM_USER_DISPLAYNAME
+#pragma warning restore CS0618
     }
 
     private static string ResolveBurnerName(string legacyDisplayName, ProfileInfo? profile) =>
@@ -670,7 +670,7 @@ public sealed class CachingUserService(
     /// </summary>
     private static User RehydrateUser(UserInfo info)
     {
-#pragma warning disable CS0618, HUM_USER_DISPLAYNAME // Rehydrated legacy User.DisplayName now carries the resolved BurnerName fallback.
+#pragma warning disable CS0618 // Rehydrated legacy User.DisplayName now carries the resolved BurnerName fallback.
         var user = new User
         {
             Id = info.Id,
@@ -696,7 +696,7 @@ public sealed class CachingUserService(
             MergedAt = info.MergedAt,
             Email = info.IdentityEmailColumn,
         };
-#pragma warning restore CS0618, HUM_USER_DISPLAYNAME
+#pragma warning restore CS0618
 
         foreach (var e in info.UserEmails)
         {

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -563,10 +563,12 @@ public sealed class CachingUserService(
 
     private static UserInfo WithUserFields(UserInfo current, User user)
     {
-#pragma warning disable CS0618 // DisplayName / ProfilePictureUrl are part of the cached legacy user-column mirror.
+#pragma warning disable CS0618, HUM_USER_DISPLAYNAME // User.DisplayName / ProfilePictureUrl are legacy user-column mirrors.
         return current with
         {
-            DisplayName = user.DisplayName,
+            BurnerName = ResolveBurnerName(user.DisplayName, current.Profile),
+            IsGdprAnonymized = string.Equals(
+                user.DisplayName, UserInfo.GdprAnonymizedBurnerName, StringComparison.Ordinal),
             PreferredLanguage = user.PreferredLanguage,
             FallbackPictureUrl = user.ProfilePictureUrl,
             CreatedAt = user.CreatedAt,
@@ -586,8 +588,13 @@ public sealed class CachingUserService(
             MergedAt = user.MergedAt,
             IdentityEmailColumn = user.IdentityEmailColumn,
         };
-#pragma warning restore CS0618
+#pragma warning restore CS0618, HUM_USER_DISPLAYNAME
     }
+
+    private static string ResolveBurnerName(string legacyDisplayName, ProfileInfo? profile) =>
+        profile is not null && !string.IsNullOrWhiteSpace(profile.BurnerName)
+            ? profile.BurnerName
+            : legacyDisplayName;
 
     // ==========================================================================
     // Inner delegation — every other IUserService method passes through and
@@ -654,7 +661,7 @@ public sealed class CachingUserService(
     /// <summary>
     /// Inverse of <see cref="UserInfo.Create"/> for the User-side columns —
     /// rebuilds the read-only fields the section consumers actually touch
-    /// (DisplayName, Email/UserEmails, ProfilePictureUrl, GoogleEmailStatus,
+    /// (BurnerName fallback, Email/UserEmails, ProfilePictureUrl, GoogleEmailStatus,
     /// and the rest of the User columns UserInfo carries) plus the full
     /// <see cref="User.UserEmails"/> collection. Identity-machinery fields
     /// (PasswordHash, SecurityStamp, lockout, phone) are not carried in
@@ -663,11 +670,13 @@ public sealed class CachingUserService(
     /// </summary>
     private static User RehydrateUser(UserInfo info)
     {
-#pragma warning disable CS0618 // DisplayName is the legacy column this rehydration mirrors.
+#pragma warning disable CS0618, HUM_USER_DISPLAYNAME // Rehydrated legacy User.DisplayName now carries the resolved BurnerName fallback.
         var user = new User
         {
             Id = info.Id,
-            DisplayName = info.DisplayName,
+            DisplayName = info.IsGdprAnonymized
+                ? UserInfo.GdprAnonymizedBurnerName
+                : info.BurnerName,
             PreferredLanguage = info.PreferredLanguage,
             ProfilePictureUrl = info.ProfilePictureUrl,
             CreatedAt = info.CreatedAt,
@@ -687,7 +696,7 @@ public sealed class CachingUserService(
             MergedAt = info.MergedAt,
             Email = info.IdentityEmailColumn,
         };
-#pragma warning restore CS0618
+#pragma warning restore CS0618, HUM_USER_DISPLAYNAME
 
         foreach (var e in info.UserEmails)
         {

--- a/src/Humans.Web/Models/UsersDebugViewModel.cs
+++ b/src/Humans.Web/Models/UsersDebugViewModel.cs
@@ -37,8 +37,8 @@ public sealed record UserDebugRow(
         HasProfile: info.Profile is not null,
         HasTicket: info.HasTicket,
         MarketingOptedOut: info.MarketingOptedOut,
-        DisplayName: info.DisplayName,
-        BurnerName: info.Profile?.BurnerName ?? string.Empty,
+        DisplayName: info.BurnerName,
+        BurnerName: info.BurnerName,
         LegalName: info.Profile?.FullName ?? string.Empty,
         HasName: info.Profile is null ? null : info.HasRequiredNameFields,
         HasConsent: info.Profile is null

--- a/tests/Humans.Application.Tests/Services/AccountDeletionServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountDeletionServiceTests.cs
@@ -132,7 +132,7 @@ public class AccountDeletionServiceTests
             Arg.Any<Guid?>(), Arg.Any<string?>());
 
         await _emailService.Received(1).SendAccountDeletionRequestedAsync(
-            user.Email!, user.DisplayName,
+            user.Email!, user.BurnerName,
             Arg.Any<DateTime>(), user.PreferredLanguage, Arg.Any<CancellationToken>());
 
         // Shift-authorization cache must drop in-orchestrator (parity with
@@ -155,7 +155,7 @@ public class AccountDeletionServiceTests
         await _service.RequestDeletionAsync(userId);
 
         await _emailService.Received(1).SendAccountDeletionRequestedAsync(
-            "notif@example.com", user.DisplayName,
+            "notif@example.com", user.BurnerName,
             Arg.Any<DateTime>(), user.PreferredLanguage, Arg.Any<CancellationToken>());
     }
 

--- a/tests/Humans.Application.Tests/Services/Profiles/AdminHumanListAssemblerTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profiles/AdminHumanListAssemblerTests.cs
@@ -79,7 +79,7 @@ public class AdminHumanListAssemblerTests
 
     [HumansFact]
     public void Deleted_when_gdpr_anonymized_tombstone()
-        => StatusOf(Build(hasProfile: false, displayName: UserInfo.GdprAnonymizedDisplayName))
+        => StatusOf(Build(hasProfile: false, displayName: UserInfo.GdprAnonymizedBurnerName))
             .Should().Be(MembershipStatusLabels.Deleted);
 
     [HumansFact]
@@ -95,7 +95,7 @@ public class AdminHumanListAssemblerTests
     {
         // A merge-source row clears its deletion fields, but assert the order is robust regardless: a row that
         // is both a tombstone and suspended must read as the terminal tombstone, never Suspended.
-        var deletedButSuspended = Build(suspended: true, displayName: UserInfo.GdprAnonymizedDisplayName);
+        var deletedButSuspended = Build(suspended: true, displayName: UserInfo.GdprAnonymizedBurnerName);
         StatusOf(deletedButSuspended).Should().Be(MembershipStatusLabels.Deleted);
 
         var mergedTrumpsDeletion = Build(

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -126,7 +126,7 @@ public class CachingUserServiceTests
 
         var fresh = await sut.GetUserInfoAsync(userId);
         fresh.Should().NotBeNull();
-        fresh.DisplayName.Should().Be("After");
+        fresh.BurnerName.Should().Be("After");
 
         // Inner GetUserInfoAsync called only on the initial prime.
         await _inner.Received(1).GetUserInfoAsync(userId, Arg.Any<CancellationToken>());
@@ -174,7 +174,7 @@ public class CachingUserServiceTests
         await sut.InvalidateAsync(userId);
 
         var hit = await sut.GetUserInfoAsync(userId);
-        hit!.DisplayName.Should().Be("After");
+        hit!.BurnerName.Should().Be("After");
     }
 
     [HumansFact]
@@ -425,7 +425,7 @@ public class CachingUserServiceTests
 
         result.Should().NotBeNull();
         result.Id.Should().Be(userId);
-        result.DisplayName.Should().Be("Eight");
+        result.BurnerName.Should().Be("Octa");
         result.PreferredLanguage.Should().Be("es");
         result.GoogleEmailStatus.Should().Be(GoogleEmailStatus.Valid);
         result.UserEmails.Should().ContainSingle(e =>

--- a/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
@@ -35,7 +35,7 @@ public class UsersAdminDebugControllerTests
             {
                 Id = Guid.NewGuid(),
                 UserId = id,
-                BurnerName = "Burner",
+                BurnerName = displayName,
                 FirstName = "First",
                 LastName = "Last",
                 CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),


### PR DESCRIPTION
## Summary
- remove the public UserInfo.DisplayName surface and store resolved BurnerName on UserInfo creation
- migrate UserInfo display callers to BurnerName, with expense Holded contact using the legal payee snapshot
- keep GDPR tombstone detection through an explicit IsGdprAnonymized flag instead of exposing the raw legacy name

## Verification
- dotnet build /p:UseSharedCompilation=false --nologo --verbosity minimal
- dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --filter FullyQualifiedName~CachingUserServiceTests|FullyQualifiedName~AccountDeletionServiceTests|FullyQualifiedName~ExpenseReportServiceTests|FullyQualifiedName~TicketTransferServiceTests|FullyQualifiedName~AdminHumanListAssemblerTests /p:UseSharedCompilation=false
- dotnet test tests/Humans.Web.Tests/Humans.Web.Tests.csproj --filter FullyQualifiedName~UsersAdminDebugControllerTests /p:UseSharedCompilation=false