### PR TITLE
chore(teams): drop dead [Range] attrs on role-definition hours models

### DIFF
--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -495,8 +495,6 @@ public class CreateRoleDefinitionModel
     [MaxLength(2000)]
     public string? Description { get; set; }
     public int SlotCount { get; set; } = 1;
-
-    [Range(0, int.MaxValue, ErrorMessage = "Estimated hours must be 0 or greater.")]
     public int? EstimatedHours { get; set; }
     public List<string> Priorities { get; set; } = ["None"];
     public int SortOrder { get; set; }
@@ -511,8 +509,6 @@ public class EditRoleDefinitionModel
     [MaxLength(2000)]
     public string? Description { get; set; }
     public int SlotCount { get; set; }
-
-    [Range(0, int.MaxValue, ErrorMessage = "Estimated hours must be 0 or greater.")]
     public int? EstimatedHours { get; set; }
     public List<string> Priorities { get; set; } = [];
     public int SortOrder { get; set; }


### PR DESCRIPTION
Follow-up cleanup to #732.

The `[Range(0, int.MaxValue)]` attributes added to `CreateRoleDefinitionModel` / `EditRoleDefinitionModel.EstimatedHours` were **dead validation**: `TeamAdminController.CreateRole`/`EditRole` never check `ModelState.IsValid`, and there's no global invalid-model filter — so they never fired and rendered no message. They only misled future readers into thinking negative hours were rejected.

Removed both. The `min="0"` input attribute stays as the client-side UX nudge. Per the decision on #732, negative role hours are intentionally **not** server-guarded.

Net −4 lines. `[MaxLength]` still uses the same namespace, so no orphaned import. Web project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)