### PR TITLE
Fix PR surface report comment permission

### DIFF
--- a/.github/workflows/pr-surface-report.yml
+++ b/.github/workflows/pr-surface-report.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## What

Fixes the PR Surface Report workflow permission used to post/update its PR conversation comment.

## Why

PR #730 generated the surface report successfully, but the comment step failed with `Resource not accessible by integration` when calling `POST /repos/peterdrier/Humans/issues/730/comments`. The workflow token had `issues: write` but only `pull-requests: read`; PR conversation comments require pull-request write capability in this repository.

## Existing surface checked

Existing workflow only. No new durable surface.

## UI changes / screenshots

None.

## Checklist

- [x] **Section labeled** ? Infrastructure / Build / CI.
- [x] **Targeting `main` on `peterdrier/Humans`**.
- [x] **Branched off `origin/main`**, not `upstream/main`.
- [x] **Issue refs are qualified** ? PR #730 referenced in body.
- [x] **EF migrations** ? none.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No.
- [x] **Reuse-first checked** ? one existing workflow permission changed.
- [x] **Build + test pass locally** ? not run; workflow-only permission change.
- [x] **Nav coverage** ? no app pages.
- [x] **No magic strings** ? not applicable.
- [x] **Dates/times via NodaTime**, icons via Font Awesome 6 ? no runtime code.

## Reviewer notes

This keeps `issues: write` and changes `pull-requests: read` to `pull-requests: write`. The generated report and migration gate had already succeeded on #730; only the comment API call failed.

## Test plan

- [x] `git diff --check`
- [x] `python -B scripts/pr-surface-report.py --base origin/main --head HEAD --output local-pr-surface-report.md --json-output local-pr-surface-report.json`
