### PR TITLE
Reduce legacy DisplayName diagnostics

### DIFF
--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -1,3 +1,4 @@
+using Humans.Application;
 using Humans.Application.Configuration;
 using Humans.Application.DTOs;
 using Humans.Application.Helpers;
@@ -630,6 +631,7 @@ public sealed class GoogleWorkspaceSyncService(
                 .Distinct()
                 .ToList();
             var emailsByUserId = await LoadEmailsForUserIdsAsync(allMemberUserIds, cancellationToken);
+            var usersById = await userService.GetUserInfosAsync(allMemberUserIds, cancellationToken);
 
             foreach (var resource in resources)
             {
@@ -651,7 +653,7 @@ public sealed class GoogleWorkspaceSyncService(
                     }
                     else
                     {
-                        membersByEmail[memberEmail] = (GetDisplayName(tm), GetUserId(tm), GetProfilePictureUrl(tm), [teamLink]);
+                        membersByEmail[memberEmail] = (tm.DisplayName, tm.UserId, tm.ProfilePictureUrl, [teamLink]);
                     }
                 }
 
@@ -672,7 +674,12 @@ public sealed class GoogleWorkspaceSyncService(
                     }
                     else
                     {
-                        membersByEmail[memberEmail] = (GetDisplayName(cm), GetUserId(cm), GetProfilePictureUrl(cm), [childTeamLink]);
+                        usersById.TryGetValue(cm.UserId, out var userInfo);
+                        membersByEmail[memberEmail] = (
+                            userInfo?.BurnerName ?? string.Empty,
+                            cm.UserId,
+                            userInfo?.ProfilePictureUrl,
+                            [childTeamLink]);
                     }
                 }
             }
@@ -1758,28 +1765,6 @@ public sealed class GoogleWorkspaceSyncService(
             .Select(e => e.Email)
             .FirstOrDefault();
     }
-
-    private static string GetDisplayName(TeamMember tm)
-    {
-#pragma warning disable CS0618 // Legacy TeamMember path; snapshot paths use UserInfo.BurnerName.
-        return tm.User?.DisplayName ?? string.Empty;
-#pragma warning restore CS0618
-    }
-
-    private static Guid GetUserId(TeamMember tm) => tm.UserId;
-
-    private static Guid GetUserId(TeamActiveMemberSnapshot tm) => tm.UserId;
-
-    private static string? GetProfilePictureUrl(TeamMember tm)
-    {
-#pragma warning disable CS0618
-        return tm.User?.ProfilePictureUrl;
-#pragma warning restore CS0618
-    }
-
-    private static string GetDisplayName(TeamActiveMemberSnapshot tm) => tm.DisplayName;
-
-    private static string? GetProfilePictureUrl(TeamActiveMemberSnapshot tm) => tm.ProfilePictureUrl;
 
     // ─── Group permission classifiers over DrivePermission DTO ───
 

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -395,11 +395,12 @@ public sealed record UserInfo(
             .ToList();
 
 #pragma warning disable CS0618 // User.DisplayName is only the creation-time fallback for profileless UserInfo.BurnerName.
+        var legacyDisplayName = user.DisplayName;
         var burnerName = profileInfo is not null && !string.IsNullOrWhiteSpace(profileInfo.BurnerName)
             ? profileInfo.BurnerName
-            : user.DisplayName;
+            : legacyDisplayName;
         var isGdprAnonymized = string.Equals(
-            user.DisplayName, GdprAnonymizedBurnerName, StringComparison.Ordinal);
+            legacyDisplayName, GdprAnonymizedBurnerName, StringComparison.Ordinal);
 #pragma warning restore CS0618
 
         return new UserInfo(

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -11,7 +11,7 @@ public class User : IdentityUser<Guid>
 {
     /// <summary>Legacy Identity column — fallback only. Render via UserInfo.BurnerName / &lt;vc:human&gt;.</summary>
     [PersonalData]
-    [Obsolete("Rendering callers must use UserInfo.BurnerName / <vc:human> per memory/architecture/burnername-is-the-display-name.md. Legitimate consumers: Identity claims, repository merge/purge/delete labels, GDPR export, debug screens.", DiagnosticId = "HUM_USER_DISPLAYNAME", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/691")]
+    [Obsolete("Rendering callers must use UserInfo.BurnerName / <vc:human> per memory/architecture/burnername-is-the-display-name.md. Legitimate consumers: creation-time BurnerName fallback, repository merge/purge/delete labels, GDPR export, debug screens.", DiagnosticId = "HUM_USER_DISPLAYNAME", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/691")]
     public string DisplayName { get; set; } = string.Empty;
 
     /// <summary>Preferred language code (e.g., "en", "es"). Defaults to English.</summary>

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -564,11 +564,12 @@ public sealed class CachingUserService(
     private static UserInfo WithUserFields(UserInfo current, User user)
     {
 #pragma warning disable CS0618 // User.DisplayName / ProfilePictureUrl are legacy user-column mirrors.
+        var legacyDisplayName = user.DisplayName;
         return current with
         {
-            BurnerName = ResolveBurnerName(user.DisplayName, current.Profile),
+            BurnerName = ResolveBurnerName(legacyDisplayName, current.Profile),
             IsGdprAnonymized = string.Equals(
-                user.DisplayName, UserInfo.GdprAnonymizedBurnerName, StringComparison.Ordinal),
+                legacyDisplayName, UserInfo.GdprAnonymizedBurnerName, StringComparison.Ordinal),
             PreferredLanguage = user.PreferredLanguage,
             FallbackPictureUrl = user.ProfilePictureUrl,
             CreatedAt = user.CreatedAt,

--- a/src/Humans.Web/Authorization/HumansUserClaimsPrincipalFactory.cs
+++ b/src/Humans.Web/Authorization/HumansUserClaimsPrincipalFactory.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
@@ -7,7 +8,7 @@ namespace Humans.Web.Authorization;
 
 /// <summary>
 /// Replaces the default <c>Name</c> claim (which Identity sources from
-/// <c>UserName</c>) with the user's <see cref="User.DisplayName"/>. After PR 1
+/// <c>UserName</c>) with the user's resolved BurnerName. After PR 1
 /// of the email-identity-decoupling spec, <c>UserName</c> is the user's GUID
 /// for any account created via the OAuth callback or magic-link signup, so
 /// reading <c>User.Identity.Name</c> would otherwise show a GUID in the topbar
@@ -17,14 +18,17 @@ namespace Humans.Web.Authorization;
 public sealed class HumansUserClaimsPrincipalFactory(
     UserManager<User> userManager,
     RoleManager<IdentityRole<Guid>> roleManager,
-    IOptions<IdentityOptions> options)
+    IOptions<IdentityOptions> options,
+    IUserServiceRead users)
     : UserClaimsPrincipalFactory<User, IdentityRole<Guid>>(userManager, roleManager, options)
 {
     protected override async Task<ClaimsIdentity> GenerateClaimsAsync(User user)
     {
         var identity = await base.GenerateClaimsAsync(user);
+        var info = await users.GetUserInfoAsync(user.Id);
+        var burnerName = info?.BurnerName;
 
-        if (!string.IsNullOrWhiteSpace(user.DisplayName))
+        if (!string.IsNullOrWhiteSpace(burnerName))
         {
             var nameClaimType = Options.ClaimsIdentity.UserNameClaimType;
             var existing = identity.FindFirst(nameClaimType);
@@ -32,7 +36,7 @@ public sealed class HumansUserClaimsPrincipalFactory(
             {
                 identity.RemoveClaim(existing);
             }
-            identity.AddClaim(new Claim(nameClaimType, user.DisplayName));
+            identity.AddClaim(new Claim(nameClaimType, burnerName));
         }
 
         return identity;

--- a/tests/Humans.Application.Tests/Infrastructure/ServiceTestHarness.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/ServiceTestHarness.cs
@@ -24,6 +24,10 @@ namespace Humans.Application.Tests.Infrastructure;
 /// </summary>
 public abstract class ServiceTestHarness : IDisposable
 {
+    private static readonly System.Reflection.PropertyInfo LegacyDisplayNameProperty =
+        typeof(User).GetProperty("DisplayName")
+        ?? throw new InvalidOperationException("User.DisplayName property missing.");
+
     private protected DbContextOptions<HumansDbContext> DbOptions { get; }
     private protected HumansDbContext Db { get; }
     private protected TestDbContextFactory DbFactory { get; }
@@ -112,11 +116,11 @@ public abstract class ServiceTestHarness : IDisposable
         var user = new User
         {
             Id = userId,
-            DisplayName = displayName,
             UserName = $"test-{userId}@test.com",
             Email = $"test-{userId}@test.com",
             PreferredLanguage = "en"
         };
+        LegacyDisplayNameProperty.SetValue(user, displayName);
         Db.Users.Add(user);
         return user;
     }

--- a/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -32,11 +32,20 @@ internal static class UserInfoStubHelpers
 
     public static UserInfo MakeUserInfo(Guid userId, Profile? profile = null, string displayName = "User")
         => UserInfo.Create(
-            new User { Id = userId, DisplayName = displayName, PreferredLanguage = "en" },
+            new User { Id = userId, PreferredLanguage = "en" },
             [],
             [],
             [],
-            profile: profile,
+            profile: profile ?? new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                BurnerName = displayName,
+                CreatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
+                UpdatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
+                State = Humans.Domain.Enums.ProfileState.Active,
+                IsApproved = true
+            },
             [],
             [],
             [],

--- a/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
@@ -114,7 +114,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task SubmitFeedbackAsync_CreatesReport()
     {
         var userId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = userId, DisplayName = "Test", Email = "t@t.com" });
+        SeedUser(userId, "Test").Email = "t@t.com";
         await Db.SaveChangesAsync();
 
         var report = await _service.SubmitFeedbackAsync(
@@ -134,7 +134,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task SubmitFeedbackAsync_SetsAdditionalContext()
     {
         var userId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = userId, Email = "u@test.com", DisplayName = "U" });
+        SeedUser(userId, "U").Email = "u@test.com";
         await Db.SaveChangesAsync();
 
         var report = await _service.SubmitFeedbackAsync(
@@ -148,7 +148,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task SubmitUserFeedbackAsync_BuildsSortedRoleContext()
     {
         var userId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = userId, Email = "u@test.com", DisplayName = "U" });
+        SeedUser(userId, "U").Email = "u@test.com";
         await Db.SaveChangesAsync();
 
         var report = await _service.SubmitUserFeedbackAsync(
@@ -203,7 +203,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task GetFeedbackListAsync_ReturnsReporterInfo()
     {
         var userId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = userId, DisplayName = "Alice", Email = "a@a.com" });
+        SeedUser(userId, "Alice").Email = "a@a.com";
         await Db.SaveChangesAsync();
 
         await _service.SubmitFeedbackAsync(
@@ -219,11 +219,9 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task GetFeedbackListAsync_ReporterName_PrefersBurnerName()
     {
-        // BurnerName-is-the-display-name rule: when a Profile exists,
-        // ReporterName must render the BurnerName, not the legacy User.DisplayName.
+        // BurnerName-is-the-display-name rule: ReporterName must render Profile.BurnerName.
         var userId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = userId, DisplayName = "Legal Name", Email = "a@a.com" });
-        Db.Profiles.Add(new Profile { Id = Guid.NewGuid(), UserId = userId, BurnerName = "Sparkle" });
+        SeedUser(userId, "Sparkle").Email = "a@a.com";
         await Db.SaveChangesAsync();
 
         await _service.SubmitFeedbackAsync(
@@ -239,14 +237,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task PostMessageAsync_AdminMessage_SetsLastAdminMessageAt_And_SendsEmail()
     {
         var userId = Guid.NewGuid();
-        var user = new User
-        {
-            Id = userId,
-            Email = "reporter@test.com",
-            DisplayName = "Reporter",
-            PreferredLanguage = "en"
-        };
-        Db.Users.Add(user);
+        SeedUser(userId, "Reporter").Email = "reporter@test.com";
 
         var report = new FeedbackReport
         {
@@ -282,12 +273,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task GetFeedbackByIdForViewerAsync_NonReporter_ReturnsNull()
     {
         var reporterId = Guid.NewGuid();
-        Db.Users.Add(new User
-        {
-            Id = reporterId,
-            Email = "reporter@test.com",
-            DisplayName = "Reporter"
-        });
+        SeedUser(reporterId, "Reporter").Email = "reporter@test.com";
         Db.FeedbackReports.Add(new FeedbackReport
         {
             Id = Guid.NewGuid(),
@@ -313,8 +299,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task PostMessageAsync_ReporterMessage_SetsLastReporterMessageAt_NoEmail()
     {
         var userId = Guid.NewGuid();
-        var user = new User { Id = userId, Email = "reporter@test.com", DisplayName = "Reporter" };
-        Db.Users.Add(user);
+        SeedUser(userId, "Reporter").Email = "reporter@test.com";
 
         var report = new FeedbackReport
         {
@@ -347,8 +332,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     public async Task GetActionableCountAsync_CountsOpenWithNoReply_And_AwaitingAdmin()
     {
         var userId = Guid.NewGuid();
-        var user = new User { Id = userId, Email = "u@test.com", DisplayName = "U" };
-        Db.Users.Add(user);
+        SeedUser(userId, "U").Email = "u@test.com";
 
         var now = Clock.GetCurrentInstant();
 
@@ -405,8 +389,8 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     {
         var bobId = Guid.NewGuid();
         var aliceId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = bobId, DisplayName = "Bob", Email = "b@b.com" });
-        Db.Users.Add(new User { Id = aliceId, DisplayName = "Alice", Email = "a@a.com" });
+        SeedUser(bobId, "Bob").Email = "b@b.com";
+        SeedUser(aliceId, "Alice").Email = "a@a.com";
         var now = Clock.GetCurrentInstant();
         Db.FeedbackReports.Add(new FeedbackReport
         {
@@ -455,7 +439,7 @@ public sealed class FeedbackServiceTests : ServiceTestHarness
     private async Task<FeedbackReport> CreateTestReport(FeedbackStatus status = FeedbackStatus.Open)
     {
         var userId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = userId, DisplayName = "Test", Email = $"{userId}@test.com" });
+        SeedUser(userId, "Test").Email = $"{userId}@test.com";
         await Db.SaveChangesAsync();
 
         var report = await _service.SubmitFeedbackAsync(

--- a/tests/Humans.Application.Tests/Services/IssuesServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/IssuesServiceTests.cs
@@ -89,7 +89,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     public async Task SubmitIssueAsync_lands_in_Triage_and_invalidates_nav_badge()
     {
         var userId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = userId, Email = "u@u.com", DisplayName = "U" });
+        SeedUser(userId, "U").Email = "u@u.com";
         await Db.SaveChangesAsync();
 
         var issue = await _service.SubmitIssueAsync(
@@ -113,7 +113,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
         var reporterId = Guid.NewGuid();
         var adminId = Guid.NewGuid();
         var ticketAdminId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = reporterId, Email = "r@x", DisplayName = "R" });
+        SeedUser(reporterId, "R").Email = "r@x";
         await Db.SaveChangesAsync();
 
         _roleService
@@ -239,16 +239,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     public async Task PostCommentAsync_handler_sends_email_and_notification_to_reporter()
     {
         var reporterId = Guid.NewGuid();
-        var reporter = new User
-        {
-            Id = reporterId,
-            Email = "reporter@test.com",
-            DisplayName = "Reporter",
-            PreferredLanguage = "en"
-        };
-        Db.Users.Add(reporter);
-        _userService.GetUserInfoAsync(reporterId, Arg.Any<CancellationToken>())
-            .Returns(reporter.ToUserInfo());
+        SeedUser(reporterId, "Reporter").Email = "reporter@test.com";
         await Db.SaveChangesAsync();
 
         var issueId = await SeedIssueRowAsync(reporterId, IssueStatus.Open, "Report Title");
@@ -364,7 +355,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
         // Stamp an assignee on the issue so the dispatch helper has somebody
         // to notify alongside the reporter.
         var assigneeId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = assigneeId, Email = "ass@x.com", DisplayName = "Assignee" });
+        SeedUser(assigneeId, "Assignee").Email = "ass@x.com";
         await Db.SaveChangesAsync();
         await _service.UpdateAssigneeAsync(issueId, assigneeId, Guid.NewGuid());
         _notificationService.ClearReceivedCalls();
@@ -443,10 +434,10 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     public async Task UpdateAssigneeAsync_audit_includes_old_and_new_names()
     {
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
-        var oldAssignee = new User { Id = Guid.NewGuid(), DisplayName = "Old Person", Email = "old@x.com" };
-        var newAssignee = new User { Id = Guid.NewGuid(), DisplayName = "New Person", Email = "new@x.com" };
-        Db.Users.Add(oldAssignee);
-        Db.Users.Add(newAssignee);
+        var oldAssignee = SeedUser(Guid.NewGuid(), "Old Person");
+        oldAssignee.Email = "old@x.com";
+        var newAssignee = SeedUser(Guid.NewGuid(), "New Person");
+        newAssignee.Email = "new@x.com";
         await Db.SaveChangesAsync();
 
         var actorId = Guid.NewGuid();
@@ -469,7 +460,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     {
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
         var newAssigneeId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = newAssigneeId, Email = "a@a.com", DisplayName = "Assignee" });
+        SeedUser(newAssigneeId, "Assignee").Email = "a@a.com";
         await Db.SaveChangesAsync();
 
         await _service.UpdateAssigneeAsync(issueId, newAssigneeId, Guid.NewGuid());
@@ -492,7 +483,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     {
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
         var actorId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = actorId, Email = "self@x.com", DisplayName = "Self" });
+        SeedUser(actorId, "Self").Email = "self@x.com";
         await Db.SaveChangesAsync();
 
         await _service.UpdateAssigneeAsync(issueId, actorId, actorId);
@@ -515,7 +506,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     {
         var (_, issueId) = await SeedIssueAsync(IssueStatus.Open);
         var assigneeId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = assigneeId, Email = "assignee@x.com", DisplayName = "Assignee" });
+        SeedUser(assigneeId, "Assignee").Email = "assignee@x.com";
         await Db.SaveChangesAsync();
 
         var result = await _service.UpdateAssigneeWithResultAsync(issueId, assigneeId, Guid.NewGuid());
@@ -716,12 +707,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     public async Task GetIssueListAsync_applies_updated_descending_limit()
     {
         var reporterId = Guid.NewGuid();
-        Db.Users.Add(new User
-        {
-            Id = reporterId,
-            Email = "reporter@example.org",
-            DisplayName = "Reporter"
-        });
+        SeedUser(reporterId, "Reporter").Email = "reporter@example.org";
 
         var older = new Issue
         {
@@ -833,8 +819,8 @@ public sealed class IssuesServiceTests : ServiceTestHarness
     {
         var aliceId = Guid.NewGuid();
         var bobId = Guid.NewGuid();
-        Db.Users.Add(new User { Id = aliceId, Email = "a@a.com", DisplayName = "Alice" });
-        Db.Users.Add(new User { Id = bobId, Email = "b@b.com", DisplayName = "Bob" });
+        SeedUser(aliceId, "Alice").Email = "a@a.com";
+        SeedUser(bobId, "Bob").Email = "b@b.com";
         await Db.SaveChangesAsync();
 
         await SeedIssueRowAsync(aliceId, IssueStatus.Open, "Alice's first");
@@ -861,13 +847,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
         var reporterId = Guid.NewGuid();
         if (!Db.Users.Any(u => u.Id == reporterId))
         {
-            Db.Users.Add(new User
-            {
-                Id = reporterId,
-                Email = $"{reporterId}@test.com",
-                DisplayName = "Reporter",
-                PreferredLanguage = "en"
-            });
+            SeedUser(reporterId, "Reporter").Email = $"{reporterId}@test.com";
             await Db.SaveChangesAsync();
         }
 
@@ -906,13 +886,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
         IssueStatus status, Instant resolvedAt, string? screenshotPath = null)
     {
         var reporterId = Guid.NewGuid();
-        Db.Users.Add(new User
-        {
-            Id = reporterId,
-            Email = $"{reporterId}@test.com",
-            DisplayName = "Reporter",
-            PreferredLanguage = "en"
-        });
+        SeedUser(reporterId, "Reporter").Email = $"{reporterId}@test.com";
         var issue = new Issue
         {
             Id = Guid.NewGuid(),
@@ -999,13 +973,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
         try
         {
             var reporterId = Guid.NewGuid();
-            Db.Users.Add(new User
-            {
-                Id = reporterId,
-                Email = $"{reporterId}@test.com",
-                DisplayName = "Reporter",
-                PreferredLanguage = "en"
-            });
+            SeedUser(reporterId, "Reporter").Email = $"{reporterId}@test.com";
             Db.Issues.Add(new Issue
             {
                 Id = issueId,
@@ -1042,13 +1010,7 @@ public sealed class IssuesServiceTests : ServiceTestHarness
         var oldResolved = Clock.GetCurrentInstant() - Duration.FromDays(200);
 
         var reporterId = Guid.NewGuid();
-        Db.Users.Add(new User
-        {
-            Id = reporterId,
-            Email = $"{reporterId}@test.com",
-            DisplayName = "Reporter",
-            PreferredLanguage = "en"
-        });
+        SeedUser(reporterId, "Reporter").Email = $"{reporterId}@test.com";
         var issueId = Guid.NewGuid();
         Db.Issues.Add(new Issue
         {

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -20,6 +20,10 @@ namespace Humans.Application.Tests.Services.Users;
 /// </summary>
 public class CachingUserServiceTests
 {
+    private static readonly System.Reflection.PropertyInfo LegacyDisplayNameProperty =
+        typeof(User).GetProperty("DisplayName")
+        ?? throw new InvalidOperationException("User.DisplayName property missing.");
+
     private readonly IUserService _inner = Substitute.For<IUserService>();
     private readonly IUserRepository _userRepo = Substitute.For<IUserRepository>();
     private readonly IUserEmailRepository _userEmailRepo = Substitute.For<IUserEmailRepository>();
@@ -41,7 +45,6 @@ public class CachingUserServiceTests
     private static User SampleUser(Guid? id = null) => new()
     {
         Id = id ?? Guid.NewGuid(),
-        DisplayName = "Alice",
         PreferredLanguage = "en",
         CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
     };
@@ -51,15 +54,35 @@ public class CachingUserServiceTests
         string displayName = "Alice",
         IReadOnlyList<EventParticipation>? eventParticipations = null) =>
         UserInfo.Create(
-            new User { Id = userId, DisplayName = displayName, PreferredLanguage = "en" },
+            new User { Id = userId, PreferredLanguage = "en" },
             userEmails: [],
             eventParticipations: eventParticipations ?? [],
             externalLogins: [],
-            profile: null,
+            profile: SampleProfile(userId, displayName),
             contactFields: [],
             profileLanguages: [],
             volunteerHistory: [],
             communicationPreferences: []);
+
+    private static Profile SampleProfile(Guid userId, string burnerName) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        BurnerName = burnerName,
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        State = ProfileState.Active,
+        IsApproved = true,
+    };
+
+    private static User WithLegacyDisplayName(User user, string displayName)
+    {
+        LegacyDisplayNameProperty.SetValue(user, displayName);
+        return user;
+    }
+
+    private static string LegacyDisplayName(User user) =>
+        (string?)LegacyDisplayNameProperty.GetValue(user) ?? string.Empty;
 
     [HumansFact]
     public async Task GetUserInfoAsync_DictMiss_DelegatesToInnerAndCaches()
@@ -107,7 +130,6 @@ public class CachingUserServiceTests
 
         // RefreshEntryAsync rebuild path: user repo + email repo + profile repo.
         var freshUser = SampleUser(userId);
-        freshUser.DisplayName = "After";
         _userRepo.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(freshUser);
         _userEmailRepo.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns([]);
@@ -117,7 +139,7 @@ public class CachingUserServiceTests
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, IReadOnlyList<(string Provider, string ProviderKey)>>());
         _profileRepo.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((Profile?)null);
+            .Returns(SampleProfile(userId, "After"));
 
         var sut = CreateSut();
         await sut.GetUserInfoAsync(userId); // prime
@@ -342,7 +364,6 @@ public class CachingUserServiceTests
         var user = new User
         {
             Id = userId,
-            DisplayName = "Eight",
             PreferredLanguage = "es",
             CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
             GoogleEmailStatus = GoogleEmailStatus.Valid,
@@ -478,7 +499,6 @@ public class CachingUserServiceTests
         var user = new User
         {
             Id = userId,
-            DisplayName = "Cached",
             PreferredLanguage = "es",
             ProfilePictureUrl = "https://example.com/pic.png",
             CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
@@ -499,7 +519,7 @@ public class CachingUserServiceTests
             user, [userEmail],
             eventParticipations: [],
             externalLogins: [],
-            profile: null,
+            profile: SampleProfile(userId, "Cached"),
             contactFields: [],
             profileLanguages: [],
             volunteerHistory: [],
@@ -518,9 +538,7 @@ public class CachingUserServiceTests
 
         result.Should().ContainKey(userId);
         var hit = result[userId];
-#pragma warning disable CS0618 // DisplayName legacy mirror — preservation is the point of this test.
-        hit.DisplayName.Should().Be("Cached");
-#pragma warning restore CS0618
+        LegacyDisplayName(hit).Should().Be("Cached");
         hit.ProfilePictureUrl.Should().Be("https://example.com/pic.png");
         hit.GoogleEmailStatus.Should().Be(GoogleEmailStatus.Valid);
         hit.UserEmails.Should().ContainSingle(e =>
@@ -541,10 +559,7 @@ public class CachingUserServiceTests
         _inner.GetUserInfoAsync(hitId, Arg.Any<CancellationToken>())
             .Returns(new ValueTask<UserInfo?>(info));
 
-        var missUser = SampleUser(missId);
-#pragma warning disable CS0618
-        missUser.DisplayName = "Fresh";
-#pragma warning restore CS0618
+        var missUser = WithLegacyDisplayName(SampleUser(missId), "Fresh");
         _inner.GetByIdsAsync(
             Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1 && ids.Contains(missId)),
             Arg.Any<CancellationToken>())
@@ -556,10 +571,8 @@ public class CachingUserServiceTests
         var result = await sut.GetByIdsAsync([hitId, missId]);
 
         result.Should().HaveCount(2);
-#pragma warning disable CS0618
-        result[hitId].DisplayName.Should().Be("Cached");
-        result[missId].DisplayName.Should().Be("Fresh");
-#pragma warning restore CS0618
+        LegacyDisplayName(result[hitId]).Should().Be("Cached");
+        LegacyDisplayName(result[missId]).Should().Be("Fresh");
 
         // Inner was called for the miss with only the missing id.
         await _inner.Received(1).GetByIdsAsync(
@@ -581,9 +594,7 @@ public class CachingUserServiceTests
         var user = await sut.GetByIdAsync(userId);
 
         user.Should().NotBeNull();
-#pragma warning disable CS0618
-        user.DisplayName.Should().Be("Cached");
-#pragma warning restore CS0618
+        LegacyDisplayName(user).Should().Be("Cached");
 
         // GetByIdAsync should not have been delegated.
         await _inner.DidNotReceive().GetByIdAsync(userId, Arg.Any<CancellationToken>());
@@ -723,7 +734,6 @@ public class CachingUserServiceTests
         var user = new User
         {
             Id = userId,
-            DisplayName = burnerName ?? "Display",
             PreferredLanguage = "en",
             CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
         };


### PR DESCRIPTION
## Summary
- route the Identity name claim through UserInfo.BurnerName instead of User.DisplayName
- use UserInfo-backed names in Google workspace sync child team rows
- migrate high-noise tests away from compile-time User.DisplayName initializers while preserving shared seeder behavior
- update the HUM_USER_DISPLAYNAME obsolete text to remove Identity claims from the legitimate-consumer list

## Verification
- dotnet test tests\Humans.Application.Tests\Humans.Application.Tests.csproj --filter FullyQualifiedName~TeamServiceTests.GetTeamEntityBySlugAsync_IncludesUserNavigation|FullyQualifiedName~WorkloadServiceTests --no-restore --nologo --verbosity minimal
- dotnet build Humans.slnx --configuration Release --disable-build-servers --nologo --verbosity quiet
- dotnet test Humans.slnx --no-build --configuration Release --verbosity quiet --blame-hang-timeout 2m --logger console;verbosity=minimal --filter FullyQualifiedName!~Integration

## Diagnostics
- HUM_USER_DISPLAYNAME warnings: 390 before, 298 after on rebuild (92 removed)
- no HUM_USER_DISPLAYNAME suppressions added