### PR TITLE
chore(finance): adopt date helpers, self-resolve role gates

### DIFF
--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Tickets;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
+using Humans.Web.Extensions;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -693,7 +694,7 @@ public class FinanceController(
                 var monday = g.Key;
                 var sunday = monday.PlusDays(6);
                 return new CashFlowPeriodGroup(
-                    $"{monday.ToString("d MMM", System.Globalization.CultureInfo.InvariantCulture)} - {sunday.ToString("d MMM yyyy", System.Globalization.CultureInfo.InvariantCulture)}",
+                    $"{monday.ToDateTimeUnspecified().ToDisplayDayMonth()} - {sunday.ToDisplayDate()}",
                     monday,
                     sunday,
                     g.ToList());
@@ -714,7 +715,7 @@ public class FinanceController(
                 var firstDay = new LocalDate(g.Key.Year, g.Key.Month, 1);
                 var lastDay = firstDay.PlusDays(firstDay.Calendar.GetDaysInMonth(g.Key.Year, g.Key.Month) - 1);
                 return new CashFlowPeriodGroup(
-                    firstDay.ToString("MMM yyyy", System.Globalization.CultureInfo.InvariantCulture),
+                    firstDay.ToDateTimeUnspecified().ToDisplayMonthYear(),
                     firstDay,
                     lastDay,
                     g.ToList());

--- a/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
@@ -157,7 +157,7 @@
                             </td>
                             <td>@(item.ResponsibleTeamName ?? "\u2014")</td>
                             <td class="text-muted">@(item.Notes ?? "")</td>
-                            <td>@item.ExpectedDate?.ToString("d MMM yyyy", System.Globalization.CultureInfo.InvariantCulture)</td>
+                            <td>@item.ExpectedDate?.ToDisplayDate()</td>
                             @if (Model.CanEdit)
                             {
                                 <td class="text-end">
@@ -352,7 +352,7 @@
                                     <span class="badge bg-success">VAT Credit</span>
                                 }
                             </td>
-                            <td>@vat.SettlementDate.ToString("d MMM yyyy", System.Globalization.CultureInfo.InvariantCulture)</td>
+                            <td>@vat.SettlementDate.ToDisplayDate()</td>
                         </tr>
                     }
                 </tbody>

--- a/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
@@ -184,7 +184,7 @@
                             </td>
             <td>@(item.ResponsibleTeamName ?? "\u2014")</td>
                             <td class="text-muted">@(item.Notes ?? "")</td>
-                            <td>@item.ExpectedDate?.ToString("d MMM yyyy", System.Globalization.CultureInfo.InvariantCulture)</td>
+                            <td>@item.ExpectedDate?.ToDisplayDate()</td>
                             <td class="text-end">
                                 <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#@editId">
                                     <i class="fa-solid fa-pen"></i>
@@ -367,7 +367,7 @@
                                     <span class="badge bg-success">VAT Credit</span>
                                 }
                             </td>
-                            <td>@vat.SettlementDate.ToString("d MMM yyyy", System.Globalization.CultureInfo.InvariantCulture)</td>
+                            <td>@vat.SettlementDate.ToDisplayDate()</td>
                         </tr>
                     }
                 </tbody>


### PR DESCRIPTION
## Summary

- **datetime-display-formatting**: Replaced all `InvariantCulture` date format strings in Finance & Budget views and `FinanceController` with existing `DateTimeDisplayExtensions` helpers so display dates use `CurrentCulture` (Spanish) consistently.
- **auth-in-views-self-resolving**: `BudgetController.CanEdit` is state-gated (budget-year deleted check, group restricted check, team coordinator membership via `ICoordinatorTeamIds`) — left on view model per task guidance; noted below.

## Files changed

- `src/Humans.Web/Controllers/FinanceController.cs` — added `using Humans.Web.Extensions`; `GroupByWeek` label: `monday.ToDateTimeUnspecified().ToDisplayDayMonth()` + `sunday.ToDisplayDate()`; `GroupByMonth` label: `firstDay.ToDateTimeUnspecified().ToDisplayMonthYear()`.
- `src/Humans.Web/Views/Budget/CategoryDetail.cshtml` — lines 160 and 355: `ExpectedDate?.ToDisplayDate()` and `SettlementDate.ToDisplayDate()`.
- `src/Humans.Web/Views/Finance/CategoryDetail.cshtml` — same two substitutions as Budget/CategoryDetail.

## Deferred / noted

- **`FinanceController.BuildCashFlowModel`** — out of scope per task; needs a new `BudgetService` method.
- **`BudgetController.CanEdit`** — `BudgetOperationRequirement.Edit` is resource-based: handler checks `IsDeleted` on budget year, `IsRestricted` on group, and coordinator team membership. All three are STATE/DATA conditions, not role-only gates. Stays on view model.
- `CashFlow.cshtml:59` `yyyyMMdd` — used as an HTML element ID fragment, not a display string. Left as-is.
- `YearDetail.cshtml:203,208` `yyyy-MM-dd` — `<input type="date">` value attributes; must remain ISO 8601. Left as-is.
- `Finance/CategoryDetail.cshtml:255` and `Budget/CategoryDetail.cshtml:231` `yyyy-MM-dd` in date inputs — same reason, left as-is.

## Test plan

- [ ] Build passes: `dotnet build Humans.slnx -v quiet` — 0 errors (14 pre-existing warnings)
- [ ] Tests pass: all suites green; 2 pre-existing `StorePayActionTests` Stripe integration failures unrelated to this change
- [ ] Budget category detail page shows dates in Spanish locale format (e.g. "24 may 2026" not "24 May 2026")
- [ ] Finance category detail same
- [ ] Cash flow weekly labels and monthly labels render in Spanish locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)