### PR TITLE
chore(notifications): move badge-count cache population into owning services

### DIFF
--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.DTOs;
@@ -36,6 +37,7 @@ public sealed class ApplicationDecisionService(
     INavBadgeCacheInvalidator navBadge,
     INotificationMeterCacheInvalidator notificationMeter,
     IVotingBadgeCacheInvalidator votingBadge,
+    IMemoryCache cache,
     IClock clock,
     ILogger<ApplicationDecisionService> logger) : IApplicationDecisionService, IUserDataContributor, IUserMerge
 {
@@ -585,9 +587,17 @@ public sealed class ApplicationDecisionService(
         return new ApplicationDecisionResult(true);
     }
 
+    private static readonly TimeSpan VotingBadgeCacheDuration = TimeSpan.FromMinutes(2);
+
     public Task<int> GetUnvotedApplicationCountAsync(
         Guid boardMemberUserId, CancellationToken ct = default) =>
-        repository.GetUnvotedCountForBoardMemberAsync(boardMemberUserId, ct);
+        cache.GetOrCreateAsync(
+            CacheKeys.VotingBadge(boardMemberUserId),
+            entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = VotingBadgeCacheDuration;
+                return repository.GetUnvotedCountForBoardMemberAsync(boardMemberUserId, ct);
+            })!;
 
     public Task<ApplicationAdminStats> GetAdminStatsAsync(CancellationToken ct = default) =>
         repository.GetAdminStatsAsync(ct);

--- a/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
@@ -170,9 +170,17 @@ public sealed class NotificationInboxService(
             InvalidateBadgeCaches([userId]);
     }
 
+    private static readonly TimeSpan BadgeCacheDuration = TimeSpan.FromMinutes(2);
+
     public Task<(int Actionable, int Informational)> GetUnreadBadgeCountsAsync(
         Guid userId, CancellationToken ct = default) =>
-        repo.GetUnreadBadgeCountsAsync(userId, ct);
+        cache.GetOrCreateAsync(
+            CacheKeys.NotificationBadgeCounts(userId),
+            entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = BadgeCacheDuration;
+                return repo.GetUnreadBadgeCountsAsync(userId, ct);
+            })!;
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)
     {

--- a/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
@@ -58,13 +58,7 @@ public class NavBadgesViewComponent(
         if (!Guid.TryParse(claim, out var currentUserId))
             return 0;
 
-        var cacheKey = CacheKeys.VotingBadge(currentUserId);
-        return await cache.GetOrCreateAsync(cacheKey, async entry =>
-        {
-            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
-
-            return await applicationDecisionService.GetUnvotedApplicationCountAsync(currentUserId);
-        });
+        return await applicationDecisionService.GetUnvotedApplicationCountAsync(currentUserId);
     }
 
     /// <summary>

--- a/src/Humans.Web/ViewComponents/NotificationBellViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NotificationBellViewComponent.cs
@@ -1,39 +1,28 @@
-using Humans.Application;
 using Humans.Application.Interfaces.Notifications;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Memory;
 using System.Security.Claims;
 
 namespace Humans.Web.ViewComponents;
 
-public class NotificationBellViewComponent(INotificationInboxService notificationInboxService, IMemoryCache cache)
+public class NotificationBellViewComponent(INotificationInboxService notificationInboxService)
     : ViewComponent
 {
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(2);
-
     public async Task<IViewComponentResult> InvokeAsync()
     {
         var userId = GetUserId();
         if (userId is null)
             return View(new NotificationBadgeViewModel());
 
-        var cacheKey = CacheKeys.NotificationBadgeCounts(userId.Value);
+        var (actionableCount, informationalCount) = await notificationInboxService.GetUnreadBadgeCountsAsync(userId.Value);
 
-        var model = await cache.GetOrCreateAsync(cacheKey, async entry =>
+        var model = new NotificationBadgeViewModel
         {
-            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+            ActionableUnreadCount = actionableCount,
+            InformationalUnreadCount = informationalCount,
+        };
 
-            var (actionableCount, informationalCount) = await notificationInboxService.GetUnreadBadgeCountsAsync(userId.Value);
-
-            return new NotificationBadgeViewModel
-            {
-                ActionableUnreadCount = actionableCount,
-                InformationalUnreadCount = informationalCount,
-            };
-        });
-
-        return View(model!);
+        return View(model);
     }
 
     private Guid? GetUserId()


### PR DESCRIPTION
## Summary

- **NotificationBellViewComponent**: dropped `IMemoryCache` injection; `GetOrCreateAsync` for `NotificationBadgeCounts` moved into `NotificationInboxService.GetUnreadBadgeCountsAsync` (service already injected `IMemoryCache`; same 2-min TTL; existing eviction via `InvalidateBadgeCaches` unchanged).
- **NavBadgesViewComponent / VotingBadge**: dropped `GetOrCreateAsync` from `GetPerUserVotingCountAsync`; caching moved into `ApplicationDecisionService.GetUnvotedApplicationCountAsync` (added `IMemoryCache` to constructor; same 2-min TTL; existing eviction via `IVotingBadgeCacheInvalidator.Invalidate` unchanged).
- **Eviction verified**: `CacheKeys.NotificationBadgeCounts(userId)` is removed by `NotificationInboxService.InvalidateBadgeCaches`; `CacheKeys.VotingBadge(userId)` is removed by `VotingBadgeCacheInvalidator.InvalidateVotingBadge`. Key names match.

## Skipped / deferred

**NavBadgeCounts** (review + feedback tuple in `NavBadgesViewComponent`): left in place. The key is a single static entry combining two service values. Moving each sub-count into its owning service (`AdminDashboardService.GetPendingReviewCountAsync` and `FeedbackService.GetActionableCountAsync`) would require separate cache keys per service, which the existing eviction (`cache.Remove(CacheKeys.NavBadgeCounts)`) would not clear. Fixing this without new eviction requires a new aggregate accessor method — new interface surface, which is out of scope per task constraints.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet` — all unit/analyzer/web tests pass; integration failures are pre-existing (Stripe + health endpoint, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)