### PR TITLE
chore(shifts): consolidate shift-date formatting, tidy auth + comments

### DIFF
--- a/src/Humans.Application/Extensions/DateFormattingExtensions.cs
+++ b/src/Humans.Application/Extensions/DateFormattingExtensions.cs
@@ -5,6 +5,12 @@ namespace Humans.Application.Extensions;
 
 public static class DateFormattingExtensions
 {
+    /// <summary>
+    /// Formats a date as "Wed Jul 1". Mirrors the Web-layer ToDisplayShiftDate() extension.
+    /// </summary>
+    public static string ToDisplayShiftDate(this LocalDate date) =>
+        date.DayOfWeek.ToString()[..3] + " " + date.ToString("MMM d", CultureInfo.InvariantCulture);
+
     public static string ToIsoDateString(this LocalDate value) =>
         value.ToString("yyyy-MM-dd", null);
 

--- a/src/Humans.Application/Extensions/DateFormattingExtensions.cs
+++ b/src/Humans.Application/Extensions/DateFormattingExtensions.cs
@@ -9,7 +9,7 @@ public static class DateFormattingExtensions
     /// Formats a date as "Wed Jul 1". Mirrors the Web-layer ToDisplayShiftDate() extension.
     /// </summary>
     public static string ToDisplayShiftDate(this LocalDate date) =>
-        date.DayOfWeek.ToString()[..3] + " " + date.ToString("MMM d", CultureInfo.InvariantCulture);
+        date.DayOfWeek.ToString()[..3] + " " + date.ToString("MMM d", null);
 
     public static string ToIsoDateString(this LocalDate value) =>
         value.ToString("yyyy-MM-dd", null);

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Application.Enums;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Repositories;
@@ -823,7 +824,7 @@ public sealed class ShiftManagementService(
             var dayStart = dayDate.AtStartOfDayInZone(tz).ToInstant();
             var dayEnd = dayDate.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
             var periodLabel = dayOffset < 0 ? "Set-up" : dayOffset <= es.EventEndOffset ? "Event" : "Strike";
-            var dateLabel = dayDate.DayOfWeek.ToString()[..3] + " " + dayDate.ToString("MMM d", null);
+            var dateLabel = dayDate.ToDisplayShiftDate();
 
             var overlapping = shifts.Where(s =>
             {
@@ -864,7 +865,7 @@ public sealed class ShiftManagementService(
             var dayDate = es.GateOpeningDate.PlusDays(dayOffset);
             var dayStart = dayDate.AtStartOfDayInZone(tz).ToInstant();
             var dayEnd = dayDate.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
-            var dateLabel = dayDate.DayOfWeek.ToString()[..3] + " " + dayDate.ToString("MMM d", null);
+            var dateLabel = dayDate.ToDisplayShiftDate();
 
             var overlapping = shifts.Where(s =>
             {
@@ -1517,7 +1518,7 @@ public sealed class ShiftManagementService(
             var dayDate = es.GateOpeningDate.PlusDays(dayOffset);
             var dayStart = dayDate.AtStartOfDayInZone(tz).ToInstant();
             var dayEnd = dayDate.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
-            var dateLabel = dayDate.DayOfWeek.ToString()[..3] + " " + dayDate.ToString("MMM d", null);
+            var dateLabel = dayDate.ToDisplayShiftDate();
 
             var overlapping = shifts.Where(s =>
             {
@@ -1575,7 +1576,7 @@ public sealed class ShiftManagementService(
             .Select(off =>
             {
                 var date = es.GateOpeningDate.PlusDays(off);
-                var label = date.DayOfWeek.ToString()[..3] + " " + date.ToString("MMM d", null);
+                var label = date.ToDisplayShiftDate();
                 var dayPeriod = off < 0 ? ShiftPeriod.Build : off <= es.EventEndOffset ? ShiftPeriod.Event : ShiftPeriod.Strike;
                 return new CoverageHeatmapDay(off, date, label, dayPeriod);
             })

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
@@ -102,7 +101,7 @@ public sealed class ShiftSignupService(
         viewInvalidator.InvalidateUser(userId);
         viewInvalidator.InvalidateShift(shiftId);
 
-        var shiftDate = FormatShiftDate(es.GateOpeningDate.PlusDays(shift.DayOffset));
+        var shiftDate = es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate();
         var statusSuffix = autoConfirm ? "confirmed" : "pending";
         await auditLogService.LogAsync(
             AuditAction.ShiftSignupCreated, nameof(ShiftSignup), signup.Id,
@@ -279,7 +278,7 @@ public sealed class ShiftSignupService(
 
         await auditLogService.LogAsync(
             AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), signup.Id,
-            $"shift '{shift.Rota.Name}' on {FormatShiftDate(es.GateOpeningDate.PlusDays(shift.DayOffset))}",
+            $"shift '{shift.Rota.Name}' on {es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()}",
             enrollerUserId,
             userId, nameof(User));
 
@@ -403,7 +402,7 @@ public sealed class ShiftSignupService(
         {
             await auditLogService.LogAsync(
                 AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), auditedSignup.Id,
-                $"'{rota.Name}' on {FormatShiftDate(es.GateOpeningDate.PlusDays(dayOffset))} (range)",
+                $"'{rota.Name}' on {es.GateOpeningDate.PlusDays(dayOffset).ToDisplayShiftDate()} (range)",
                 enrollerUserId,
                 userId, nameof(User));
         }
@@ -527,7 +526,7 @@ public sealed class ShiftSignupService(
                 .Select(s => s.DayOffset)
                 .ToList();
             var dayList = string.Join(", ", alreadySignedUpDays.Select(offset =>
-                FormatShiftDate(es.GateOpeningDate.PlusDays(offset))));
+                es.GateOpeningDate.PlusDays(offset).ToDisplayShiftDate()));
             skipMessages.Add($"Already signed up for day(s): {dayList}.");
 
             shiftsInRange = shiftsInRange.Where(s => !activeShiftIds.Contains(s.Id)).ToList();
@@ -556,7 +555,7 @@ public sealed class ShiftSignupService(
         if (conflictingDays.Count > 0)
         {
             var dayList = string.Join(", ", conflictingDays.Select(offset =>
-                FormatShiftDate(es.GateOpeningDate.PlusDays(offset))));
+                es.GateOpeningDate.PlusDays(offset).ToDisplayShiftDate()));
 
             if (!skipConflicts)
                 return SignupResult.Fail($"Time conflict on day(s): {dayList}.");
@@ -591,7 +590,7 @@ public sealed class ShiftSignupService(
         if (fullDays.Count > 0)
         {
             var dayList = string.Join(", ", fullDays.Select(offset =>
-                FormatShiftDate(es.GateOpeningDate.PlusDays(offset))));
+                es.GateOpeningDate.PlusDays(offset).ToDisplayShiftDate()));
             var capacityWarning = $"Day(s) {dayList} are at capacity.";
             warning = warning is null ? capacityWarning : $"{warning} {capacityWarning}";
         }
@@ -613,7 +612,7 @@ public sealed class ShiftSignupService(
             if (fullEeDays.Count > 0)
             {
                 var eeDayList = string.Join(", ", fullEeDays.Select(offset =>
-                    FormatShiftDate(es.GateOpeningDate.PlusDays(offset))));
+                    es.GateOpeningDate.PlusDays(offset).ToDisplayShiftDate()));
                 var eeWarning = $"Early entry capacity reached for day(s): {eeDayList}.";
                 warning = warning is null ? eeWarning : $"{warning} {eeWarning}";
             }
@@ -662,7 +661,7 @@ public sealed class ShiftSignupService(
             await auditLogService.LogAsync(
                 AuditAction.ShiftSignupCreated,
                 nameof(ShiftSignup), auditedSignup.Id,
-                $"'{rota.Name}' on {FormatShiftDate(es.GateOpeningDate.PlusDays(dayOffset))} (range, {statusSuffix})",
+                $"'{rota.Name}' on {es.GateOpeningDate.PlusDays(dayOffset).ToDisplayShiftDate()} (range, {statusSuffix})",
                 userId,
                 userId, nameof(User));
         }
@@ -1011,7 +1010,7 @@ public sealed class ShiftSignupService(
 
             var es = rota.EventSettings;
             var shiftDate = es.GateOpeningDate.PlusDays(shift.DayOffset);
-            var enrichedDescription = $"{changeDescription} ({rotaName}, {FormatShiftDate(shiftDate)})";
+            var enrichedDescription = $"{changeDescription} ({rotaName}, {shiftDate.ToDisplayShiftDate()})";
 
             var team = await TeamService.GetTeamAsync(teamId);
             var coordinatorIds = team?.Members
@@ -1037,10 +1036,6 @@ public sealed class ShiftSignupService(
             logger.LogError(ex, "Failed to dispatch ShiftSignupChange notification for signup {SignupId}", signup.Id);
         }
     }
-
-    // Mirrors the Web-layer ToDisplayShiftDate() extension. Format: "Wed Jul 1".
-    private static string FormatShiftDate(LocalDate date) =>
-        date.DayOfWeek.ToString()[..3] + " " + date.ToString("MMM d", CultureInfo.InvariantCulture);
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)
     {

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -304,11 +304,9 @@ public class ShiftAdminController(
 
     [HttpPost("Rotas/{rotaId}/Move")]
     [ValidateAntiForgeryToken]
+    [Authorize(Policy = PolicyNames.VolunteerManager)]
     public async Task<IActionResult> MoveRota(string slug, Guid rotaId, MoveRotaModel model)
     {
-        if (!RoleChecks.IsVolunteerManager(User))
-            return Forbid();
-
         var (teamError, user, team) = await ResolveDepartmentManagementAsync(slug);
         if (teamError is not null) return teamError;
 


### PR DESCRIPTION
## Summary

- **Task 1 — date-format dedup:** Added `ToDisplayShiftDate(this LocalDate)` to the existing `DateFormattingExtensions` class. Replaced 4 inlined `DayOfWeek.ToString()[..3] + date.ToString("MMM d", null)` expressions in `ShiftManagementService` and removed the private `FormatShiftDate()` helper from `ShiftSignupService`, replacing its 9 call sites with the shared extension. Dropped the now-unused `System.Globalization` using from `ShiftSignupService`.
- **Task 2 — MoveRota auth:** Converted the inline `if (!RoleChecks.IsVolunteerManager(User)) return Forbid();` body guard in `ShiftAdminController.MoveRota` to `[Authorize(Policy = PolicyNames.VolunteerManager)]`. The `IsVolunteerManager` result at line 765 is still inline because it drives a data branch (helper method return value), not a gate.
- **Task 3 — banner comments:** No `// ====` or `// ----` dividers found in either service; no-op.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet` — 0 new failures (2 pre-existing Pay integration failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)