### PR TITLE
chore(events): adopt date/CSV helpers, drop raw UserManager reads

### DIFF
--- a/src/Humans.Web/Controllers/Api/EventsApiController.cs
+++ b/src/Humans.Web/Controllers/Api/EventsApiController.cs
@@ -9,7 +9,6 @@ using Humans.Web.Helpers;
 using Humans.Web.Models.Events;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using NodaTime.Text;
@@ -20,8 +19,8 @@ namespace Humans.Web.Controllers.Api;
 [Route("api/events")]
 [EnableCors("EventsApi")]
 [ServiceFilter(typeof(EventsFeatureFilter))]
-public class EventsApiController(IEventService guide, ICampServiceRead camps, IUserServiceRead users, UserManager<User> userManager)
-    : ControllerBase
+public class EventsApiController(IEventService guide, ICampServiceRead camps, IUserServiceRead users)
+    : ApiControllerBase(users)
 {
     [HttpGet("events")]
     public async Task<IActionResult> GetEvents(
@@ -41,7 +40,7 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
         var events = await guide.GetApprovedEventsAsync(barrioId, null, null, q, excludedSlugs);
         var campsById = await LoadCampsByIdAsync(gateOpeningDate?.Year);
         var submitterInfoById = await EventsLookupHelpers.LoadSubmittersAsync(
-            users, events.Where(e => e.CampId == null).Select(e => e.SubmitterUserId).Distinct());
+            UserService, events.Where(e => e.CampId == null).Select(e => e.SubmitterUserId).Distinct());
 
         var results = new List<GuideEventApiDto>();
         foreach (var e in events)
@@ -79,7 +78,7 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
         var campsById = await LoadCampsByIdAsync(gateOpeningDate?.Year);
         var campName = ResolveCampName(e.CampId, campsById);
         var submitterName = e.CampId == null
-            ? (await users.GetUserInfoAsync(e.SubmitterUserId))?.BurnerName
+            ? (await UserService.GetUserInfoAsync(e.SubmitterUserId))?.BurnerName
             : null;
 
         return Ok(BuildEventDto(e, e.StartAt, ComputeDayOffset(e.StartAt, gateOpeningDate, tz), campName, submitterName));
@@ -158,10 +157,10 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
     [HttpGet("preferences")]
     public async Task<IActionResult> GetPreferences()
     {
-        var user = await userManager.GetUserAsync(User);
-        if (user == null) return Unauthorized();
+        var userId = GetCurrentUserId();
+        if (userId == null) return Unauthorized();
 
-        var slugs = await guide.GetExcludedCategorySlugsAsync(user.Id);
+        var slugs = await guide.GetExcludedCategorySlugsAsync(userId.Value);
         return Ok(new { excludedCategorySlugs = slugs });
     }
 
@@ -170,8 +169,8 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
     [HttpPut("preferences")]
     public async Task<IActionResult> UpdatePreferences([FromBody] UpdatePreferencesRequest request)
     {
-        var user = await userManager.GetUserAsync(User);
-        if (user == null) return Unauthorized();
+        var userId = GetCurrentUserId();
+        if (userId == null) return Unauthorized();
 
         var activeCategories = await guide.GetActiveCategoriesAsync();
         var activeSlugs = activeCategories.Select(c => c.Slug).ToList();
@@ -182,7 +181,7 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
         if (invalidSlugs.Count > 0)
             return BadRequest(new { error = $"Invalid category slugs: {string.Join(", ", invalidSlugs)}" });
 
-        await guide.SavePreferenceAsync(user.Id, request.ExcludedCategorySlugs);
+        await guide.SavePreferenceAsync(userId.Value, request.ExcludedCategorySlugs);
         return Ok(new { excludedCategorySlugs = request.ExcludedCategorySlugs });
     }
 
@@ -198,8 +197,8 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
     [HttpGet("favourites")]
     public async Task<IActionResult> GetFavourites()
     {
-        var user = await userManager.GetUserAsync(User);
-        if (user == null) return Unauthorized();
+        var userId = GetCurrentUserId();
+        if (userId == null) return Unauthorized();
 
         var guideSettings = await guide.GetGuideSettingsAsync();
         var eventSettings = await LoadBurnSettingsAsync(guideSettings);
@@ -208,10 +207,10 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
             : null;
         var gateOpeningDate = eventSettings?.GateOpeningDate;
 
-        var favourites = await guide.GetFavouritesWithEventsAsync(user.Id);
+        var favourites = await guide.GetFavouritesWithEventsAsync(userId.Value);
         var campsById = await LoadCampsByIdAsync(gateOpeningDate?.Year);
         var submitterInfoById = await EventsLookupHelpers.LoadSubmittersAsync(
-            users, favourites.Where(f => f.Event.CampId == null).Select(f => f.Event.SubmitterUserId).Distinct());
+            UserService, favourites.Where(f => f.Event.CampId == null).Select(f => f.Event.SubmitterUserId).Distinct());
         var results = favourites.Select(f =>
         {
             var e = f.Event;
@@ -228,10 +227,10 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
     [HttpPost("favourites/{eventId:guid}")]
     public async Task<IActionResult> AddFavourite(Guid eventId)
     {
-        var user = await userManager.GetUserAsync(User);
-        if (user == null) return Unauthorized();
+        var userId = GetCurrentUserId();
+        if (userId == null) return Unauthorized();
 
-        var added = await guide.AddFavouriteAsync(user.Id, eventId);
+        var added = await guide.AddFavouriteAsync(userId.Value, eventId);
         if (!added) return Conflict(new { error = "Already favourited" });
         return Ok(new { favourited = true });
     }
@@ -241,10 +240,10 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
     [HttpDelete("favourites/{eventId:guid}")]
     public async Task<IActionResult> RemoveFavourite(Guid eventId)
     {
-        var user = await userManager.GetUserAsync(User);
-        if (user == null) return Unauthorized();
+        var userId = GetCurrentUserId();
+        if (userId == null) return Unauthorized();
 
-        var removed = await guide.RemoveFavouriteAsync(user.Id, eventId);
+        var removed = await guide.RemoveFavouriteAsync(userId.Value, eventId);
         if (!removed) return NotFound();
         return Ok(new { unfavourited = true });
     }
@@ -253,10 +252,9 @@ public class EventsApiController(IEventService guide, ICampServiceRead camps, IU
 
     private async Task<List<string>> GetExcludedSlugsAsync()
     {
-        if (User.Identity?.IsAuthenticated != true) return [];
-        var user = await userManager.GetUserAsync(User);
-        if (user == null) return [];
-        return await guide.GetExcludedCategorySlugsAsync(user.Id);
+        var userId = GetCurrentUserId();
+        if (userId == null) return [];
+        return await guide.GetExcludedCategorySlugsAsync(userId.Value);
     }
 
     private async Task<BurnSettingsInfo?> LoadBurnSettingsAsync(EventGuideSettings? guideSettings)

--- a/src/Humans.Web/Controllers/EventsExportController.cs
+++ b/src/Humans.Web/Controllers/EventsExportController.cs
@@ -5,6 +5,7 @@ using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using Humans.Web.Extensions;
 using Humans.Web.Filters;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -55,23 +56,22 @@ public class EventsExportController(
 
             foreach (var (date, time) in GetOccurrences(e, eventSettings?.GateOpeningDate, tz))
             {
-                sb.AppendLine(string.Join(",",
-                    CsvEscape(e.Id.ToString()),
-                    CsvEscape(e.Title),
-                    CsvEscape(e.Description),
-                    CsvEscape(e.Category.Name),
-                    CsvEscape(campName),
-                    CsvEscape(venueName),
-                    CsvEscape(submitterName),
-                    CsvEscape(e.LocationNote ?? ""),
-                    CsvEscape(date),
-                    CsvEscape(time),
-                    e.DurationMinutes.ToString(CultureInfo.InvariantCulture),
+                sb.AppendCsvRow(
+                    e.Id.ToString(),
+                    e.Title,
+                    e.Description,
+                    e.Category.Name,
+                    campName,
+                    venueName,
+                    submitterName,
+                    e.LocationNote ?? "",
+                    date,
+                    time,
+                    e.DurationMinutes,
                     e.IsRecurring ? "Yes" : "No",
-                    e.PriorityRank.ToString(CultureInfo.InvariantCulture),
+                    e.PriorityRank,
                     e.Status.ToString(),
-                    CsvEscape(ToLocalDateTime(e.SubmittedAt, tz).ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture))
-                ));
+                    ToLocalDateTime(e.SubmittedAt, tz).ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture));
             }
         }
 
@@ -153,13 +153,6 @@ public class EventsExportController(
             results.Add((local.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), local.ToString("HH:mm", CultureInfo.InvariantCulture)));
         }
         return results;
-    }
-
-    private static string CsvEscape(string value)
-    {
-        if (value.Contains('"', StringComparison.Ordinal) || value.Contains(',', StringComparison.Ordinal) || value.Contains('\n', StringComparison.Ordinal))
-            return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
-        return value;
     }
 
     public sealed class PrintGuideViewModel

--- a/src/Humans.Web/Views/Events/MySubmissions.cshtml
+++ b/src/Humans.Web/Views/Events/MySubmissions.cshtml
@@ -19,7 +19,7 @@
         <i class="fa-solid fa-clock me-1"></i>
         @if (Model.SubmissionOpenAt.HasValue && Model.SubmissionCloseAt.HasValue)
         {
-            <text>Submission window: @Model.SubmissionOpenAt.Value.ToString("d MMM yyyy HH:mm") — @Model.SubmissionCloseAt.Value.ToString("d MMM yyyy HH:mm")</text>
+            <text>Submission window: @Model.SubmissionOpenAt.Value.ToDisplayDateTime() — @Model.SubmissionCloseAt.Value.ToDisplayDateTime()</text>
             if (Model.TimeZoneId != null)
             {
                 <text> (@Model.TimeZoneId)</text>

--- a/src/Humans.Web/Views/EventsModeration/Index.cshtml
+++ b/src/Humans.Web/Views/EventsModeration/Index.cshtml
@@ -134,7 +134,7 @@ else
                                     }
 
                                     <dt class="col-sm-3">Submitted</dt>
-                                    <dd class="col-sm-9">@evt.SubmittedAt.ToString("d MMM yyyy HH:mm")</dd>
+                                    <dd class="col-sm-9">@evt.SubmittedAt.ToDisplayDateTime()</dd>
                                 </dl>
 
                                 @if (evt.DuplicateCandidates.Count > 0)
@@ -163,7 +163,7 @@ else
                                             <li class="mb-2">
                                                 <span class="badge @h.ActionBadgeClass">@h.Action</span>
                                                 by <strong>@h.ActorName</strong>
-                                                <small class="text-muted">@h.CreatedAt.ToString("d MMM yyyy HH:mm")</small>
+                                                <small class="text-muted">@h.CreatedAt.ToDisplayDateTime()</small>
                                                 @if (!string.IsNullOrEmpty(h.Reason))
                                                 {
                                                     <br /><small class="text-muted fst-italic">@h.Reason</small>

--- a/tests/Humans.Web.Tests/Controllers/EventsApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EventsApiControllerTests.cs
@@ -9,7 +9,6 @@ using Humans.Domain.Enums;
 using Humans.Web.Controllers.Api;
 using Humans.Web.Models.Events;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using NSubstitute;
@@ -27,14 +26,9 @@ public class EventsApiControllerTests
     private readonly IEventService _guide = Substitute.For<IEventService>();
     private readonly ICampService _camps = Substitute.For<ICampService>();
     private readonly IUserService _users = Substitute.For<IUserService>();
-    private readonly UserManager<User> _userManager;
 
     public EventsApiControllerTests()
     {
-        var userStore = Substitute.For<IUserStore<User>>();
-        _userManager = Substitute.For<UserManager<User>>(
-            userStore, null, null, null, null, null, null, null, null);
-
         // No guide settings → no event-settings/timezone/gate-date lookups in the action.
         _guide.GetGuideSettingsAsync(Arg.Any<CancellationToken>())
             .Returns((EventGuideSettings?)null);
@@ -103,7 +97,7 @@ public class EventsApiControllerTests
 
     private EventsApiController BuildController()
     {
-        var controller = new EventsApiController(_guide, _camps, _users, _userManager)
+        var controller = new EventsApiController(_guide, _camps, _users)
         {
             ControllerContext = new ControllerContext
             {


### PR DESCRIPTION
## Summary

- **EventsExportController**: deleted private `CsvEscape` + `string.Join(",", ...)` pattern; replaced with `sb.AppendCsvRow(...)` via existing `CsvExtensions`; added `using Humans.Web.Extensions`
- **EventsApiController**: changed base from `ControllerBase` to `ApiControllerBase`; dropped `UserManager<User>` constructor parameter; replaced all `userManager.GetUserAsync(User)` read calls with `GetCurrentUserId()` from the base; substituted direct `users` field references with `UserService` property to satisfy the primary-constructor capture rule
- **MySubmissions.cshtml**: submission window open/close `DateTime` → `.ToDisplayDateTime()`
- **EventsModeration/Index.cshtml**: `SubmittedAt` and moderation history `CreatedAt` `DateTime` → `.ToDisplayDateTime()`
- **EventsApiControllerTests**: updated `BuildController` to 3-arg ctor; removed `_userManager` field

## Skipped / deferred

- `"ddd d MMM HH:mm"` / `"d MMM HH:mm"` formats in MySubmissions and EventsModeration accordion header/detail — no matching helper in `DateTimeDisplayExtensions` (nearest is `ToDisplayDateTime` = `"d MMM yyyy HH:mm"`)
- `LocalDateTime.ToString("dddd d MMM yyyy, HH:mm")` etc. in `Calendar/Event.cshtml` — no `LocalDateTime` overloads in the helpers
- `"yyyy-MM-dd"` / `"HH:mm"` in `EventsController.cs` lines 874/875/900/901 — these produce ISO-format data strings for CSV template download (machine-readable), not display text; not display helpers candidates

## Test plan

- [x] `dotnet build src/Humans.Web/Humans.Web.csproj -v quiet` — 0 errors, 0 warnings
- [x] `dotnet test Humans.Web.Tests` — 158/158 passed
- [x] `dotnet test Humans.Application.Tests` — 3241/3242 passed (1 pre-existing skip)
- [x] `dotnet test Humans.Domain.Tests` — 199/200 (1 pre-existing skip)
- [x] `dotnet test Humans.Analyzers.Tests` — 116/116 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)