### PR TITLE
refactor(camps): cross-section callers use ICampServiceRead via CampInfo + LINQ

### DIFF
--- a/src/Humans.Application/Services/CityPlanning/CityPlanningService.cs
+++ b/src/Humans.Application/Services/CityPlanning/CityPlanningService.cs
@@ -30,7 +30,7 @@ public sealed class CityPlanningService(
     public async Task<List<CampPolygonDto>> GetCampPolygonsAsync(
         int year, CancellationToken cancellationToken = default)
     {
-        var displayData = await campService.GetCampSeasonDisplayDataForYearAsync(year, cancellationToken);
+        var displayData = await BuildSeasonDisplayDataAsync(year, cancellationToken);
         var seasonIds = displayData.Keys.ToList();
 
         var polygons = await repo.GetPolygonsByCampSeasonIdsAsync(seasonIds, cancellationToken);
@@ -63,7 +63,7 @@ public sealed class CityPlanningService(
     public async Task<List<CampSeasonSummaryDto>> GetCampSeasonsWithoutCampPolygonAsync(
         int year, CancellationToken cancellationToken = default)
     {
-        var displayData = await campService.GetCampSeasonDisplayDataForYearAsync(year, cancellationToken);
+        var displayData = await BuildSeasonDisplayDataAsync(year, cancellationToken);
         var seasonIds = displayData.Keys.ToList();
 
         var polygonSeasonIds = await repo.GetCampSeasonIdsWithPolygonAsync(seasonIds, cancellationToken);
@@ -75,6 +75,21 @@ public sealed class CityPlanningService(
                 kvp.Key, kvp.Value.Name, kvp.Value.CampSlug,
                 SpaceSizeToSqm(kvp.Value.SpaceRequirement), kvp.Value.SoundZone))
             .ToList();
+    }
+
+    /// <summary>
+    /// Builds the season-id → display-data map via LINQ over the cached
+    /// <see cref="ICampServiceRead.GetCampsForYearAsync"/> projection, avoiding
+    /// the ICampService-only <c>GetCampSeasonDisplayDataForYearAsync</c>.
+    /// </summary>
+    private async Task<Dictionary<Guid, CampSeasonDisplayData>> BuildSeasonDisplayDataAsync(
+        int year, CancellationToken cancellationToken)
+    {
+        var camps = await campService.GetCampsForYearAsync(year, cancellationToken);
+        return camps
+            .SelectMany(c => c.Seasons, (c, s) =>
+                (SeasonId: s.Id, Data: new CampSeasonDisplayData(s.Name, c.Slug, s.SoundZone, s.SpaceRequirement, c.Id)))
+            .ToDictionary(x => x.SeasonId, x => x.Data);
     }
 
     // Keep in sync with SpaceSize enum — adding a new enum value requires a matching case here.
@@ -438,7 +453,7 @@ public sealed class CityPlanningService(
 
     public async Task<string> ExportAsGeoJsonAsync(int year, CancellationToken cancellationToken = default)
     {
-        var displayData = await campService.GetCampSeasonDisplayDataForYearAsync(year, cancellationToken);
+        var displayData = await BuildSeasonDisplayDataAsync(year, cancellationToken);
         var seasonIds = displayData.Keys.ToList();
 
         var polygons = await repo.GetPolygonsByCampSeasonIdsAsync(seasonIds, cancellationToken);

--- a/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
@@ -410,10 +410,10 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
         await _sut.SaveCampPolygonAsync(season2026Id, """{"type":"Feature"}""", 100, userId);
         await _sut.SaveCampPolygonAsync(season2027Id, """{"type":"Feature"}""", 200, userId);
 
-        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+        _campService.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>
             {
-                [season2026Id] = new("Test Camp 2026", "test-camp", null, null, camp2026Id)
+                MakeCampInfo(camp2026Id, "test-camp", [MakeCampSeasonInfo(season2026Id, camp2026Id, 2026, "Test Camp 2026")])
             });
 
         var result = await _sut.GetCampPolygonsAsync(2026);
@@ -426,17 +426,19 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task GetCampSeasonsWithoutCampPolygonAsync_ExcludesSeasonsWithPolygon()
     {
+        var campWithId = Guid.NewGuid();
+        var campWithoutId = Guid.NewGuid();
         var seasonWithId = Guid.NewGuid();
         var seasonWithoutId = Guid.NewGuid();
         var userId = NewUserId();
 
         await _sut.SaveCampPolygonAsync(seasonWithId, """{"type":"Feature"}""", 100, userId);
 
-        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+        _campService.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>
             {
-                [seasonWithId] = new("Camp With", "camp-with", null, null, Guid.NewGuid()),
-                [seasonWithoutId] = new("Camp Without", "camp-without", null, null, Guid.NewGuid())
+                MakeCampInfo(campWithId, "camp-with", [MakeCampSeasonInfo(seasonWithId, campWithId, 2026, "Camp With")]),
+                MakeCampInfo(campWithoutId, "camp-without", [MakeCampSeasonInfo(seasonWithoutId, campWithoutId, 2026, "Camp Without")])
             });
 
         var result = await _sut.GetCampSeasonsWithoutCampPolygonAsync(2026);
@@ -448,16 +450,17 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task ExportAsGeoJsonAsync_ReturnsFeatureCollection()
     {
+        var campId = Guid.NewGuid();
         var campSeasonId = Guid.NewGuid();
         var userId = NewUserId();
         const string geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]},"properties":{}}""";
 
         await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 100.0, userId);
 
-        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+        _campService.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>
             {
-                [campSeasonId] = new("Test Camp", "test-camp", null, null, Guid.NewGuid())
+                MakeCampInfo(campId, "test-camp", [MakeCampSeasonInfo(campSeasonId, campId, 2026, "Test Camp")])
             });
 
         var result = await _sut.ExportAsGeoJsonAsync(2026);
@@ -533,10 +536,10 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
         const string geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[]]}}""";
         await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 100.0, userId);
 
-        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+        _campService.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>
             {
-                [campSeasonId] = new("Test Camp", "test-camp", SoundZone.Blue, null, campId)
+                MakeCampInfo(campId, "test-camp", [MakeCampSeasonInfo(campSeasonId, campId, 2026, "Test Camp", SoundZone.Blue)])
             });
 
         var polygons = await _sut.GetCampPolygonsAsync(2026);
@@ -553,10 +556,10 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
         const string geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[]]}}""";
         await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 100.0, userId);
 
-        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+        _campService.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>
             {
-                [campSeasonId] = new("Test Camp", "test-camp", null, null, campId)
+                MakeCampInfo(campId, "test-camp", [MakeCampSeasonInfo(campSeasonId, campId, 2026, "Test Camp")])
             });
 
         var polygons = await _sut.GetCampPolygonsAsync(2026);
@@ -656,5 +659,8 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
         new(id, campId, string.Empty, year, null, name, string.Empty, string.Empty,
             [], CampSeasonStatus.Pending, YesNoMaybe.No, YesNoMaybe.No, AdultPlayspacePolicy.No,
             0, soundZone, null, null, 0, null, null);
+
+    private static CampInfo MakeCampInfo(Guid id, string slug, IReadOnlyList<CampSeasonInfo> seasons) =>
+        new(id, slug, string.Empty, string.Empty, false, 0, seasons);
 
 }


### PR DESCRIPTION
## Summary

- Removes `CityPlanningService`'s use of `ICampService`-only `GetCampSeasonDisplayDataForYearAsync` — replaces the three call-sites (`GetCampPolygonsAsync`, `GetCampSeasonsWithoutCampPolygonAsync`, `ExportAsGeoJsonAsync`) with a private `BuildSeasonDisplayDataAsync` helper that projects via LINQ over `ICampServiceRead.GetCampsForYearAsync`. All fields required by `CampSeasonDisplayData` (`Name`, `CampSlug`, `SoundZone`, `SpaceRequirement`, `CampId`) are already present on `CampSeasonInfo`/`CampInfo`.
- Updates the five affected `CityPlanningServiceTests` to mock `GetCampsForYearAsync` (returning `CampInfo`) instead of the removed call.
- No new interface methods, no new DB queries, no EF/migration changes.

## Consumers left on full `ICampService` — with reasons

**`CityPlanningService`** — still injects `ICampService` because `CanUserEditAsync` calls `IsUserCampLeadAsync(userId, campId)`, which queries `CampRoleAssignment` (the Lead special-role table). That data is not present in the `CampInfo` projection (only `Season.Members[Status=Active]` are loaded; role assignments have no reverse nav from `CampSeason` and cannot be included without a domain-entity change).

**`CityPlanningController`** — still injects `ICampService` because `FindUserLeadCampAsync` and the `Index`/`BarrioMap` actions call `GetCampLeadSeasonIdForYearAsync(userId, year)`, which also queries `CampRoleAssignment`. Same root cause as above.

**`CityPlanningApiController`** — same: `FindUserLeadCampIdAsync` calls `GetCampLeadSeasonIdForYearAsync`. Cannot downgrade.

**`NotificationMeterProvider`** — `GetPendingMembershipCountForLeadAsync` requires (1) the set of camps where the user holds the Lead special role, and (2) pending-member counts in those camps. Neither is in `CampInfo`: lead role data isn't loaded, and only `Status=Active` members are included in the projection.

## No `CampInfo` properties added

All fields needed by `BuildSeasonDisplayDataAsync` were already on `CampSeasonInfo`/`CampInfo`. The `GetCampSeasonDisplayDataForYearAsync` method remains on `ICampService` — it just has zero callers inside `CityPlanningService` now.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet` — all pass (2 pre-existing `StorePayActionTests` Stripe failures excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)