### PR TITLE
refactor(teams): cross-section callers project TeamInfo via LINQ instead of entity nav

### DIFF
--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -49,6 +49,13 @@ public record TeamInfo(
         GoogleGroupPrefix is null
             ? null
             : $"{GoogleGroupPrefix}@{DomainConstants.GoogleGroupDomain}";
+
+    /// <summary>
+    /// Whether this team appears in the directory as its own entry.
+    /// Mirrors <c>Team.IsInDirectory</c>: top-level teams always qualify;
+    /// sub-teams qualify only when <see cref="IsPromotedToDirectory"/> is set.
+    /// </summary>
+    public bool IsInDirectory => ParentTeamId is null || IsPromotedToDirectory;
 }
 
 public record TeamMemberInfo(

--- a/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
+++ b/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
@@ -10,7 +10,7 @@ namespace Humans.Application.Services.AuditLog;
 public sealed class AuditViewerService(
     IAuditLogService auditLog,
     IUserServiceRead userService,
-    ITeamService teamService,
+    ITeamServiceRead teamService,
     ITeamResourceService teamResourceService) : IAuditViewerService
 {
     public async Task<IReadOnlyList<AuditEvent>> GetRecentAsync(int count, CancellationToken ct = default)
@@ -207,8 +207,10 @@ public sealed class AuditViewerService(
     private async Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(
         IReadOnlyList<Guid> teamIds, CancellationToken ct)
     {
-        var teams = await teamService.GetByIdsWithParentsAsync(teamIds, ct);
-        return teams.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Name, kvp.Value.Slug));
+        var all = await teamService.GetTeamsAsync(ct);
+        return teamIds
+            .Where(all.ContainsKey)
+            .ToDictionary(id => id, id => (all[id].Name, all[id].Slug));
     }
 
     private static (List<Guid> UserIds, List<Guid> TeamIds, List<Guid> ResourceIds) CollectIds(IReadOnlyList<AuditLogEntry> entries)

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -1296,8 +1296,7 @@ public sealed class GoogleWorkspaceSyncService(
 
         // Filter to resources whose team is still active.
         if (driveResources.Count == 0) return 0;
-        var teamIds = driveResources.Select(r => r.TeamId).Distinct().ToList();
-        var teamsById = await teamService.GetByIdsWithParentsAsync(teamIds, cancellationToken);
+        var teamsById = await teamService.GetTeamsAsync(cancellationToken);
         var filtered = driveResources
             .Where(r => teamsById.TryGetValue(r.TeamId, out var t) && t.IsActive)
             .ToList();
@@ -1408,8 +1407,7 @@ public sealed class GoogleWorkspaceSyncService(
         var driveResources = await resourceRepository.GetActiveDriveFoldersAsync(cancellationToken);
 
         if (driveResources.Count == 0) return 0;
-        var teamIds = driveResources.Select(r => r.TeamId).Distinct().ToList();
-        var teamsById = await teamService.GetByIdsWithParentsAsync(teamIds, cancellationToken);
+        var teamsById = await teamService.GetTeamsAsync(cancellationToken);
 
         var restricted = driveResources
             .Where(r => r.RestrictInheritedAccess

--- a/src/Humans.Application/Services/Legal/AdminLegalDocumentService.cs
+++ b/src/Humans.Application/Services/Legal/AdminLegalDocumentService.cs
@@ -13,7 +13,7 @@ namespace Humans.Application.Services.Legal;
 public sealed partial class AdminLegalDocumentService(
     ILegalDocumentRepository repository,
     ILegalDocumentSyncService legalDocumentSyncService,
-    ITeamService teamService,
+    ITeamServiceRead teamService,
     IOptions<GitHubSettings> githubSettings,
     IClock clock) : IAdminLegalDocumentService
 {
@@ -29,9 +29,8 @@ public sealed partial class AdminLegalDocumentService(
 
         var now = clock.GetCurrentInstant();
 
-        // Stitch team names in memory (no .Include).
-        var teamIds = documents.Select(d => d.TeamId).Distinct().ToList();
-        var teams = await teamService.GetByIdsWithParentsAsync(teamIds, cancellationToken);
+        // Stitch team names in memory via the cached read model (no .Include).
+        var teams = await teamService.GetTeamsAsync(cancellationToken);
 
         return documents
             .Select(d =>

--- a/src/Humans.Application/Services/Legal/LegalDocumentSyncService.cs
+++ b/src/Humans.Application/Services/Legal/LegalDocumentSyncService.cs
@@ -14,7 +14,7 @@ public sealed class LegalDocumentSyncService(
     ILegalDocumentRepository repository,
     IGitHubLegalDocumentConnector gitHub,
     INotificationService notificationService,
-    ITeamService teamService,
+    ITeamServiceRead teamService,
     IUserServiceRead userService,
     IClock clock,
     ILogger<LegalDocumentSyncService> logger) : ILegalDocumentSyncService
@@ -181,9 +181,8 @@ public sealed class LegalDocumentSyncService(
         var documents = await repository.GetActiveRequiredDocumentsForTeamsAsync(teamIds, cancellationToken);
         if (documents.Count == 0) return [];
 
-        // Team names via ITeamService — no cross-section EF join (memory/architecture/no-cross-section-ef-joins.md).
-        var distinctTeamIds = documents.Select(d => d.TeamId).Distinct().ToList();
-        var teams = await teamService.GetByIdsWithParentsAsync(distinctTeamIds, cancellationToken);
+        // Team names via ITeamServiceRead — no cross-section EF join (memory/architecture/no-cross-section-ef-joins.md).
+        var teams = await teamService.GetTeamsAsync(cancellationToken);
 
         return documents.Select(d =>
         {

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -618,8 +618,7 @@ public sealed class ShiftManagementService(
             eventSettingsId, urgencyTeamIds, minDayOffset, maxDayOffset);
 
         // Resolve team names in one batch (no cross-domain Include).
-        var teamIds = shifts.Select(s => s.Rota.TeamId).Distinct().ToList();
-        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIds);
+        var teamLookup = await TeamService.GetTeamsAsync();
 
         var now = clock.GetCurrentInstant();
         var urgentShifts = shifts
@@ -678,8 +677,7 @@ public sealed class ShiftManagementService(
         }
 
         // Cross-domain lookups via services.
-        var teamIds = shifts.Select(s => s.Rota.TeamId).Distinct().ToList();
-        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIds);
+        var teamLookup = await TeamService.GetTeamsAsync();
 
         IReadOnlyDictionary<Guid, UserInfo>? userLookup = null;
         if (includeSignups)
@@ -950,8 +948,7 @@ public sealed class ShiftManagementService(
         var teamIdsWithRotas = await repo.GetTeamIdsWithRotasInEventAsync(eventSettingsId, ct);
         if (teamIdsWithRotas.Count == 0) return [];
 
-        // Brings rota-owning teams + parents in one lookup (avoids second hop for sub-team rotas).
-        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIdsWithRotas, ct);
+        var teamLookup = await TeamService.GetTeamsAsync(ct);
 
         var allRotas = await repo.GetRotasWithShiftsAndSignupsAsync(
             eventSettingsId, teamIdsWithRotas.ToList(), ct);
@@ -1016,9 +1013,9 @@ public sealed class ShiftManagementService(
         var teamIds = await repo.GetTeamIdsWithRotasInEventAsync(eventSettingsId);
         if (teamIds.Count == 0) return [];
 
-        // Filter parents back out — only rota-owning teams belong in the department dropdown.
+        // Filter to rota-owning teams only (the read cache covers all teams including parents).
         var rotaOwningIds = teamIds.ToHashSet();
-        var teams = await TeamService.GetByIdsWithParentsAsync(teamIds);
+        var teams = await TeamService.GetTeamsAsync();
         return teams.Values
             .Where(t => rotaOwningIds.Contains(t.Id))
             .Select(t => (t.Id, t.Name))
@@ -1115,12 +1112,8 @@ public sealed class ShiftManagementService(
         var staleThreshold = clock.GetCurrentInstant().Minus(Duration.FromDays(3));
         var stalePendingCount = await repo.GetStalePendingSignupCountAsync(shiftIds, staleThreshold);
 
-        // Teams resolved via ITeamService — no cross-domain navigation.
-        var teamIdsOnRotas = shifts
-            .Select(s => s.Rota.TeamId)
-            .Distinct()
-            .ToList();
-        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIdsOnRotas);
+        // Teams resolved via the cached read model — no cross-domain navigation.
+        var teamLookup = await TeamService.GetTeamsAsync();
 
         var departments = BuildDepartmentRows(shifts, confirmedCounts, es, teamLookup);
 
@@ -1142,7 +1135,7 @@ public sealed class ShiftManagementService(
         IReadOnlyList<Shift> shifts,
         Dictionary<Guid, int> confirmedCounts,
         EventSettings es,
-        IReadOnlyDictionary<Guid, Team> teamLookup)
+        IReadOnlyDictionary<Guid, TeamInfo> teamLookup)
     {
         // Helper: resolve the department ID (parent team if any, else own team) for a shift.
         Guid DeptIdOf(Shift s)
@@ -1297,25 +1290,8 @@ public sealed class ShiftManagementService(
         if (pendingCounts.Count == 0)
             return [];
 
-        // Walk up parents until fixed-point (GetByIdsWithParentsAsync gives one level per call).
-        var teamMeta = new Dictionary<Guid, Team>();
-        var pendingFetch = pendingCounts.Keys.ToHashSet();
-        while (pendingFetch.Count > 0)
-        {
-            var toFetch = pendingFetch.Where(id => !teamMeta.ContainsKey(id)).ToList();
-            if (toFetch.Count == 0) break;
-
-            var fetched = await TeamService.GetByIdsWithParentsAsync(toFetch);
-            foreach (var kvp in fetched)
-            {
-                teamMeta[kvp.Key] = kvp.Value;
-            }
-
-            pendingFetch = fetched.Values
-                .Where(t => t.ParentTeamId.HasValue && !teamMeta.ContainsKey(t.ParentTeamId.Value))
-                .Select(t => t.ParentTeamId!.Value)
-                .ToHashSet();
-        }
+        // All teams (including inactive) loaded once from the in-process cache.
+        var teamMeta = await TeamService.GetTeamsAsync();
 
         var relevantTeamIds = new HashSet<Guid>(pendingCounts.Keys);
         foreach (var id in pendingCounts.Keys.ToList())
@@ -1329,10 +1305,9 @@ public sealed class ShiftManagementService(
             }
         }
 
-        var teamsById = await TeamService.GetTeamsAsync();
         var coordsRaw = relevantTeamIds
-            .Where(teamsById.ContainsKey)
-            .SelectMany(id => teamsById[id].Members
+            .Where(teamMeta.ContainsKey)
+            .SelectMany(id => teamMeta[id].Members
                 .Where(m => m.Role == TeamMemberRole.Coordinator)
                 .Select(m => new TeamCoordinatorRef(id, m.UserId)))
             .ToList();
@@ -1497,8 +1472,7 @@ public sealed class ShiftManagementService(
         var shiftIds = shifts.Select(s => s.Id).ToList();
         var confirmedCounts = await repo.GetConfirmedSignupCountsByShiftAsync(shiftIds);
 
-        var teamIdsOnRotas = shifts.Select(s => s.Rota.TeamId).Distinct().ToList();
-        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIdsOnRotas);
+        var teamLookup = await TeamService.GetTeamsAsync();
 
         (Guid Id, string Name) DeptOf(Shift s)
         {
@@ -1568,8 +1542,7 @@ public sealed class ShiftManagementService(
         var shiftIds = allShifts.Select(s => s.Id).ToList();
         var confirmedCounts = await repo.GetConfirmedSignupCountsByShiftAsync(shiftIds);
 
-        var teamIds = allShifts.Select(s => s.Rota.TeamId).Distinct().ToList();
-        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIds);
+        var teamLookup = await TeamService.GetTeamsAsync();
 
         var days = dayOffsets
             .Select(off =>
@@ -1582,7 +1555,7 @@ public sealed class ShiftManagementService(
             .ToList();
 
         // Display team: top-level → self; promoted subteam → self; non-promoted subteam → parent.
-        Team? DisplayTeamFor(Shift s)
+        TeamInfo? DisplayTeamFor(Shift s)
         {
             if (!teamLookup.TryGetValue(s.Rota.TeamId, out var team)) return null;
             if (team.ParentTeamId is null) return team;

--- a/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
+++ b/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
@@ -17,7 +17,7 @@ namespace Humans.Application.Services.Shifts.Workload;
 public sealed class WorkloadService(
     IShiftManagementRepository repo,
     IShiftView view,
-    ITeamService teamService,
+    ITeamServiceRead teamService,
     IUserServiceRead userService) : IWorkloadService
 {
     private static readonly decimal AllDayShiftHours = (decimal)Duration.FromTicks(
@@ -48,10 +48,7 @@ public sealed class WorkloadService(
             .SelectMany(v => v.Shifts.Select(s => (Rota: v.Rota!, Shift: s)))
             .ToList();
 
-        var teamIds = entries.Select(e => e.Rota.TeamId).Distinct().ToList();
-        var teamLookup = teamIds.Count > 0
-            ? await teamService.GetByIdsWithParentsAsync(teamIds, ct)
-            : new Dictionary<Guid, Team>();
+        var teamLookup = await teamService.GetTeamsAsync(ct);
 
         var byRota = BuildByRota(entries, teamLookup);
         var byDepartment = BuildByDepartment(entries, teamLookup);
@@ -71,7 +68,7 @@ public sealed class WorkloadService(
     // Unsorted; controller assembles display order (display-sort-in-controllers).
     private static List<WorkloadByRotaRow> BuildByRota(
         IReadOnlyList<(Rota Rota, Shift Shift)> entries,
-        IReadOnlyDictionary<Guid, Team> teamLookup) =>
+        IReadOnlyDictionary<Guid, TeamInfo> teamLookup) =>
         entries
             .GroupBy(e => e.Rota.Id)
             .Select(g =>
@@ -103,7 +100,7 @@ public sealed class WorkloadService(
 
     private static List<WorkloadByDepartmentRow> BuildByDepartment(
         IReadOnlyList<(Rota Rota, Shift Shift)> entries,
-        IReadOnlyDictionary<Guid, Team> teamLookup) =>
+        IReadOnlyDictionary<Guid, TeamInfo> teamLookup) =>
         entries
             .GroupBy(e => e.Rota.TeamId)
             .Select(g =>

--- a/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
+++ b/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
@@ -38,9 +38,9 @@ public class AuditViewerServiceTests
             (actor, "Frank"),
             (viewer, "Peter"));
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -123,9 +123,9 @@ public class AuditViewerServiceTests
 
         var userService = StubUserService();
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -160,9 +160,9 @@ public class AuditViewerServiceTests
 
         var userService = StubUserService((actor, "Frank"));
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -177,7 +177,7 @@ public class AuditViewerServiceTests
         result.Items[0].ActorDisplayName.Should().Be("Frank");
     }
 
-    private static (IAuditLogService, IUserService, ITeamService, ITeamResourceService) MakeServices(
+    private static (IAuditLogService, IUserService, ITeamServiceRead, ITeamResourceService) MakeServices(
         AuditLogEntry entry, Guid actor, Guid viewer, string actorName, string viewerName)
     {
         var auditLog = Substitute.For<IAuditLogService>();
@@ -188,9 +188,9 @@ public class AuditViewerServiceTests
             (actor, actorName),
             (viewer, viewerName));
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class AdminLegalDocumentServiceTests : ServiceTestHarness
 {
     private readonly ILegalDocumentRepository _repository;
     private readonly FakeLegalDocumentSyncService _syncService;
-    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
     private readonly AdminLegalDocumentService _service;
     private readonly Team _team;
 
@@ -46,14 +46,14 @@ public sealed class AdminLegalDocumentServiceTests : ServiceTestHarness
 
         // Team-name stitch: return the seed team when queried.
         _teamService
-            .GetByIdsWithParentsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(ci =>
+            .GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>
             {
-                var ids = ci.ArgAt<IReadOnlyCollection<Guid>>(0);
-                IReadOnlyDictionary<Guid, Team> map = ids.Contains(_team.Id)
-                    ? new Dictionary<Guid, Team> { [_team.Id] = _team }
-                    : new Dictionary<Guid, Team>();
-                return Task.FromResult(map);
+                [_team.Id] = new TeamInfo(
+                    Id: _team.Id, Name: _team.Name, Description: _team.Description, Slug: _team.Slug,
+                    IsActive: _team.IsActive, IsSystemTeam: _team.IsSystemTeam, SystemTeamType: _team.SystemTeamType,
+                    RequiresApproval: _team.RequiresApproval, IsPublicPage: false, IsHidden: false,
+                    IsPromotedToDirectory: false, CreatedAt: _team.CreatedAt, Members: [])
             });
 
         _service = new AdminLegalDocumentService(

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
@@ -26,21 +26,18 @@ public sealed class ShiftManagementServiceCoveragePiesTests : ServiceTestHarness
     {
         _teamService = Substitute.For<ITeamService>();
 
-        // Resolve teams (with their parents) directly from the in-memory DB —
-        // the production wrapper does the same join in SQL.
-        _teamService.GetByIdsWithParentsAsync(
-                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(ci =>
-            {
-                var ids = ci.Arg<IReadOnlyCollection<Guid>>();
-                var direct = Db.Teams.Where(t => ids.Contains(t.Id)).AsEnumerable().ToList();
-                var parentIds = direct.Where(t => t.ParentTeamId.HasValue).Select(t => t.ParentTeamId!.Value).ToList();
-                var parents = parentIds.Count == 0
-                    ? []
-                    : Db.Teams.Where(t => parentIds.Contains(t.Id)).AsEnumerable().ToList();
-                var all = direct.Concat(parents).GroupBy(t => t.Id).Select(g => g.First());
-                return Task.FromResult<IReadOnlyDictionary<Guid, Team>>(all.ToDictionary(t => t.Id));
-            });
+        // Return all teams from the in-memory DB as TeamInfo so production
+        // code using GetTeamsAsync() can resolve names and parent chains.
+        _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyDictionary<Guid, TeamInfo>>(
+                Db.Teams.AsEnumerable().ToDictionary(
+                    t => t.Id,
+                    t => new TeamInfo(
+                        t.Id, t.Name, t.Description, t.Slug,
+                        t.IsActive, t.IsSystemTeam, t.SystemTeamType, t.RequiresApproval,
+                        t.IsPublicPage, t.IsHidden, t.IsPromotedToDirectory, t.CreatedAt,
+                        Members: [],
+                        ParentTeamId: t.ParentTeamId))));
 
         var serviceProvider = new ServiceLocatorBuilder()
             .With(_teamService)

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
@@ -50,18 +50,6 @@ public sealed class ShiftManagementServiceTests : ServiceTestHarness
             });
         _userService.StubGetUserInfosFromContext(Db);
 
-        _teamService.GetByIdsWithParentsAsync(
-                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(ci =>
-            {
-                var ids = ci.Arg<IReadOnlyCollection<Guid>>();
-                return Task.FromResult<IReadOnlyDictionary<Guid, Team>>(
-                    Db.Teams
-                        .Where(t => ids.Contains(t.Id))
-                        .AsEnumerable()
-                        .ToDictionary(t => t.Id));
-            });
-
         _teamService.GetAllTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromResult<IReadOnlyList<Team>>(Db.Teams.AsEnumerable().ToList()));
 

--- a/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
@@ -22,7 +22,7 @@ namespace Humans.Application.Tests.Services.Shifts.Workload;
 public sealed class WorkloadServiceTests : ServiceTestHarness
 {
     private readonly WorkloadService _service;
-    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
 
     public WorkloadServiceTests() : base(Instant.FromUtc(2026, 7, 1, 12, 0))
     {
@@ -37,17 +37,21 @@ public sealed class WorkloadServiceTests : ServiceTestHarness
             Substitute.For<IGeneralAvailabilityRepository>(),
             Substitute.For<IVolunteerTrackingRepository>());
 
-        _teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call => GetTeamsByIdsAsync(call.Arg<IReadOnlyCollection<Guid>>()));
+        _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => GetAllTeamInfosAsync());
 
         _service = new WorkloadService(repo, view, _teamService, NewDbBackedUserService());
     }
 
-    private async Task<IReadOnlyDictionary<Guid, Team>> GetTeamsByIdsAsync(IReadOnlyCollection<Guid> ids)
+    private async Task<IReadOnlyDictionary<Guid, TeamInfo>> GetAllTeamInfosAsync()
     {
-        if (ids.Count == 0) return new Dictionary<Guid, Team>();
-        var teams = await Db.Teams.Where(t => ids.Contains(t.Id)).ToListAsync();
-        return teams.ToDictionary(t => t.Id);
+        var teams = await Db.Teams.ToListAsync();
+        return teams.ToDictionary(t => t.Id, t => new TeamInfo(
+            Id: t.Id, Name: t.Name, Description: t.Description, Slug: t.Slug,
+            IsActive: t.IsActive, IsSystemTeam: t.IsSystemTeam, SystemTeamType: t.SystemTeamType,
+            RequiresApproval: t.RequiresApproval, IsPublicPage: false, IsHidden: false,
+            IsPromotedToDirectory: false, CreatedAt: t.CreatedAt, Members: [],
+            ParentTeamId: t.ParentTeamId));
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

- All 6 cross-section consumers of `ITeamService.GetByIdsWithParentsAsync` migrated to `ITeamServiceRead.GetTeamsAsync()` with in-memory LINQ lookup over `TeamInfo`
- `TeamInfo.IsInDirectory` computed property added (mirrors `Team.IsInDirectory = ParentTeamId is null || IsPromotedToDirectory`) — required by shift-dashboard heatmap/pies callers
- `AuditViewerService`, `AdminLegalDocumentService`, `LegalDocumentSyncService`, `WorkloadService` downgraded from `ITeamService` to `ITeamServiceRead` (they made no write calls)
- `ShiftManagementService` and `GoogleWorkspaceSyncService` stay on `ITeamService` (they call write-side methods like `GetTeamByIdAsync`, `GetUserCoordinatedTeamIdsAsync`, `GetAllTeamsAsync`, `GetUserTeamsAsync`)
- `GetByIdsWithParentsAsync` remains on `ITeamService` (still called from `ShiftBrowsePageBuilder` in Web layer) but is now unused by Application-layer callers
- Tests updated to mock `GetTeamsAsync()` returning `TeamInfo` projections instead of `GetByIdsWithParentsAsync` returning `Team` entities

## Test plan

- [ ] `dotnet build Humans.slnx -v quiet` — clean (0 errors)
- [ ] `dotnet test Humans.slnx -v quiet` — 3241/3242 Application pass (1 skipped), 2 pre-existing Stripe integration failures only

🤖 Generated with [Claude Code](https://claude.com/claude-code)