### PR TITLE
Convert calendar writes to typed mutation surface

### DIFF
--- a/src/Humans.Application/Interfaces/Calendar/CalendarEventInfo.cs
+++ b/src/Humans.Application/Interfaces/Calendar/CalendarEventInfo.cs
@@ -18,7 +18,8 @@ namespace Humans.Application.Interfaces.Calendar;
 /// (<see cref="Services.Calendar.CalendarOccurrenceExpander"/>).
 /// </para>
 /// <para>
-/// Exception writes (<c>CancelOccurrenceAsync</c> / <c>OverrideOccurrenceAsync</c>)
+/// Occurrence mutations (<see cref="CancelCalendarOccurrenceMutation"/> /
+/// <see cref="OverrideCalendarOccurrenceMutation"/>)
 /// upsert into the <c>calendar_event_exceptions</c> child table but the cache
 /// is keyed by the <em>parent</em> event id — these writes evict the parent
 /// <see cref="CalendarEventInfo"/> entry, NOT a separate exception row. The

--- a/src/Humans.Application/Interfaces/Calendar/ICalendarService.cs
+++ b/src/Humans.Application/Interfaces/Calendar/ICalendarService.cs
@@ -14,34 +14,53 @@ public interface ICalendarService : IApplicationService
 
     Task<CalendarEventDetail?> GetEventByIdAsync(Guid id, CancellationToken ct = default);
 
-    Task<CalendarEvent> CreateEventAsync(CreateCalendarEventDto dto, Guid createdByUserId, CancellationToken ct = default);
-
-    Task<CalendarEventMutationResult> CreateEventWithResultAsync(CreateCalendarEventDto dto, Guid createdByUserId, CancellationToken ct = default);
-
-    Task<CalendarEvent> UpdateEventAsync(Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct = default);
-
-    Task<CalendarEventMutationResult> UpdateEventWithResultAsync(Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct = default);
-
-    Task DeleteEventAsync(Guid id, Guid deletedByUserId, CancellationToken ct = default);
-
-    Task CancelOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default);
-
-    Task OverrideOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, OverrideOccurrenceDto dto, Guid userId, CancellationToken ct = default);
+    Task<CalendarMutationResult> MutateCalendarAsync(
+        CalendarMutation mutation,
+        Guid actorUserId,
+        CancellationToken ct = default);
 }
 
-public sealed record CalendarEventMutationResult(
+public abstract record CalendarMutation;
+
+public sealed record CreateCalendarEventMutation(
+    CreateCalendarEventDto Event) : CalendarMutation;
+
+public sealed record UpdateCalendarEventMutation(
+    Guid EventId,
+    UpdateCalendarEventDto Event) : CalendarMutation;
+
+public sealed record DeleteCalendarEventMutation(
+    Guid EventId) : CalendarMutation;
+
+public sealed record CancelCalendarOccurrenceMutation(
+    Guid EventId,
+    Instant OriginalOccurrenceStartUtc) : CalendarMutation;
+
+public sealed record OverrideCalendarOccurrenceMutation(
+    Guid EventId,
+    Instant OriginalOccurrenceStartUtc,
+    OverrideOccurrenceDto Override) : CalendarMutation;
+
+public sealed record CalendarMutationResult(
     bool Succeeded,
     bool NotFound,
     CalendarEvent? Event,
+    Guid? AffectedEventId,
     string? ValidationMemberName,
     string? ErrorMessage)
 {
-    public static CalendarEventMutationResult Success(CalendarEvent ev) => new(true, false, ev, null, null);
+    public static CalendarMutationResult Success(CalendarEvent ev) =>
+        new(true, false, ev, ev.Id, null, null);
 
-    public static CalendarEventMutationResult Missing(string message) => new(false, true, null, null, message);
+    public static CalendarMutationResult Success(Guid affectedEventId) =>
+        new(true, false, null, affectedEventId, null, null);
 
-    public static CalendarEventMutationResult ValidationFailed(string memberName, string message) =>
-        new(false, false, null, memberName, message);
+    public static CalendarMutationResult Missing(Guid affectedEventId, string message) =>
+        new(false, true, null, affectedEventId, null, message);
 
-    public static CalendarEventMutationResult Failed(string message) => new(false, false, null, null, message);
+    public static CalendarMutationResult ValidationFailed(string memberName, string message) =>
+        new(false, false, null, null, memberName, message);
+
+    public static CalendarMutationResult Failed(string message) =>
+        new(false, false, null, null, null, message);
 }

--- a/src/Humans.Application/Services/Calendar/CalendarService.cs
+++ b/src/Humans.Application/Services/Calendar/CalendarService.cs
@@ -53,7 +53,74 @@ public sealed class CalendarService(
         return ev is null ? null : ToDetail(ev);
     }
 
-    public async Task<CalendarEvent> CreateEventAsync(CreateCalendarEventDto dto, Guid createdByUserId, CancellationToken ct = default)
+    public async Task<CalendarMutationResult> MutateCalendarAsync(
+        CalendarMutation mutation,
+        Guid actorUserId,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            return mutation switch
+            {
+                CreateCalendarEventMutation create =>
+                    CalendarMutationResult.Success(
+                        await ApplyCreateMutationCoreAsync(create.Event, actorUserId, ct)),
+
+                UpdateCalendarEventMutation update =>
+                    CalendarMutationResult.Success(
+                        await ApplyUpdateMutationCoreAsync(update.EventId, update.Event, actorUserId, ct)),
+
+                DeleteCalendarEventMutation delete =>
+                    await ApplyDeleteMutationCoreAsync(delete.EventId, actorUserId, ct)
+                        ? CalendarMutationResult.Success(delete.EventId)
+                        : CalendarMutationResult.Missing(delete.EventId, "Calendar event not found."),
+
+                CancelCalendarOccurrenceMutation cancel =>
+                    await ApplyOccurrenceMutationAsync(
+                        cancel.EventId,
+                        cancel.OriginalOccurrenceStartUtc,
+                        actorUserId,
+                        null,
+                        ct),
+
+                OverrideCalendarOccurrenceMutation occurrenceOverride =>
+                    await ApplyOccurrenceMutationAsync(
+                        occurrenceOverride.EventId,
+                        occurrenceOverride.OriginalOccurrenceStartUtc,
+                        actorUserId,
+                        occurrenceOverride.Override,
+                        ct),
+
+                _ => CalendarMutationResult.Failed(
+                    $"Unsupported calendar mutation type '{mutation.GetType().Name}'.")
+            };
+        }
+        catch (ValidationException ex)
+        {
+            logger.LogWarning("Calendar mutation rejected: {Reason}", ex.Message);
+            return CalendarMutationResult.ValidationFailed(CalendarValidationMemberName(ex), ex.Message);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning("Calendar mutation target not found: {Reason}", ex.Message);
+            var eventId = MutationEventId(mutation);
+            return eventId is { } id
+                ? CalendarMutationResult.Missing(id, "Calendar event not found.")
+                : CalendarMutationResult.Failed("Calendar event not found.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning("Calendar mutation rejected: {Reason}", ex.Message);
+            return CalendarMutationResult.Failed(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to apply calendar mutation {MutationType}", mutation.GetType().Name);
+            return CalendarMutationResult.Failed("Failed to apply calendar mutation.");
+        }
+    }
+
+    private async Task<CalendarEvent> ApplyCreateMutationCoreAsync(CreateCalendarEventDto dto, Guid createdByUserId, CancellationToken ct)
     {
         ValidateRecurrenceRule(dto.RecurrenceRule);
         ValidateTimezone(dto.RecurrenceTimezone);
@@ -105,33 +172,6 @@ public sealed class CalendarService(
         return ev;
     }
 
-    public async Task<CalendarEventMutationResult> CreateEventWithResultAsync(
-        CreateCalendarEventDto dto,
-        Guid createdByUserId,
-        CancellationToken ct = default)
-    {
-        try
-        {
-            var ev = await CreateEventAsync(dto, createdByUserId, ct);
-            return CalendarEventMutationResult.Success(ev);
-        }
-        catch (ValidationException ex)
-        {
-            logger.LogWarning(ex, "Calendar event create rejected: {Reason}", ex.Message);
-            return CalendarEventMutationResult.ValidationFailed(CalendarValidationMemberName(ex), ex.Message);
-        }
-        catch (InvalidOperationException ex)
-        {
-            logger.LogWarning(ex, "Calendar event create rejected: {Reason}", ex.Message);
-            return CalendarEventMutationResult.Failed(ex.Message);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to create calendar event");
-            return CalendarEventMutationResult.Failed("Failed to create calendar event.");
-        }
-    }
-
     // Reject malformed RRULE at write time so reads can't crash during occurrence expansion.
     internal static void ValidateRecurrenceRule(string? rrule)
     {
@@ -158,6 +198,15 @@ public sealed class CalendarService(
         ex.Message.Contains("timezone", StringComparison.OrdinalIgnoreCase)
             ? nameof(CreateCalendarEventDto.RecurrenceTimezone)
             : nameof(CreateCalendarEventDto.RecurrenceRule);
+
+    private static Guid? MutationEventId(CalendarMutation mutation) => mutation switch
+    {
+        UpdateCalendarEventMutation update => update.EventId,
+        DeleteCalendarEventMutation delete => delete.EventId,
+        CancelCalendarOccurrenceMutation cancel => cancel.EventId,
+        OverrideCalendarOccurrenceMutation occurrenceOverride => occurrenceOverride.EventId,
+        _ => null
+    };
 
     // Denormalised RRULE end (UNTIL or COUNT-bounded last-occurrence) for SQL window prefilter.
     // Returns null only for truly open-ended rules.
@@ -233,7 +282,7 @@ public sealed class CalendarService(
         return lastStart.Plus(duration);
     }
 
-    public async Task<CalendarEvent> UpdateEventAsync(Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct = default)
+    private async Task<CalendarEvent> ApplyUpdateMutationCoreAsync(Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct)
     {
         ValidateRecurrenceRule(dto.RecurrenceRule);
         ValidateTimezone(dto.RecurrenceTimezone);
@@ -266,7 +315,7 @@ public sealed class CalendarService(
         if (!found || mutated is null)
             throw new InvalidOperationException($"CalendarEvent {id} not found.");
 
-        // Audit best-effort: DB write already committed. See CreateEventAsync.
+        // Audit best-effort: DB write already committed. See ApplyCreateMutationCoreAsync.
         try
         {
             await audit.LogAsync(
@@ -285,46 +334,13 @@ public sealed class CalendarService(
         return mutated;
     }
 
-    public async Task<CalendarEventMutationResult> UpdateEventWithResultAsync(
-        Guid id,
-        UpdateCalendarEventDto dto,
-        Guid updatedByUserId,
-        CancellationToken ct = default)
-    {
-        try
-        {
-            var ev = await UpdateEventAsync(id, dto, updatedByUserId, ct);
-            return CalendarEventMutationResult.Success(ev);
-        }
-        catch (ValidationException ex)
-        {
-            logger.LogWarning(ex, "Calendar event {EventId} update rejected: {Reason}", id, ex.Message);
-            return CalendarEventMutationResult.ValidationFailed(CalendarValidationMemberName(ex), ex.Message);
-        }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
-        {
-            logger.LogWarning(ex, "Calendar event {EventId} not found during update", id);
-            return CalendarEventMutationResult.Missing("Calendar event not found.");
-        }
-        catch (InvalidOperationException ex)
-        {
-            logger.LogWarning(ex, "Calendar event {EventId} update rejected: {Reason}", id, ex.Message);
-            return CalendarEventMutationResult.Failed(ex.Message);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to update calendar event {EventId}", id);
-            return CalendarEventMutationResult.Failed("Failed to update calendar event.");
-        }
-    }
-
-    public async Task DeleteEventAsync(Guid id, Guid deletedByUserId, CancellationToken ct = default)
+    private async Task<bool> ApplyDeleteMutationCoreAsync(Guid id, Guid deletedByUserId, CancellationToken ct)
     {
         var now = clock.GetCurrentInstant();
         var result = await repo.SoftDeleteAsync(id, now, ct);
-        if (result is null) return;
+        if (result is null) return false;
 
-        // Audit best-effort: soft-delete already committed. See CreateEventAsync.
+        // Audit best-effort: soft-delete already committed. See ApplyCreateMutationCoreAsync.
         try
         {
             await audit.LogAsync(
@@ -339,33 +355,44 @@ public sealed class CalendarService(
                 "Audit-log write failed AFTER calendar event {EventId} ('{Title}') was deleted by {UserId}. Soft-delete was committed; reconcile audit trail manually.",
                 id, result.Value.Title, deletedByUserId);
         }
+
+        return true;
     }
 
-    public async Task CancelOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default)
+    private async Task<CalendarMutationResult> ApplyOccurrenceMutationAsync(
+        Guid eventId,
+        Instant originalOccurrenceStartUtc,
+        Guid userId,
+        OverrideOccurrenceDto? occurrenceOverride,
+        CancellationToken ct)
     {
-        await UpsertExceptionAsync(eventId, originalOccurrenceStartUtc, userId,
-            apply: x => x.IsCancelled = true,
-            auditAction: AuditAction.CalendarOccurrenceCancelled,
-            auditDescription: $"Cancelled occurrence {originalOccurrenceStartUtc}",
-            ct);
-    }
+        if (occurrenceOverride is null)
+        {
+            await UpsertExceptionAsync(eventId, originalOccurrenceStartUtc, userId,
+                apply: x => x.IsCancelled = true,
+                auditAction: AuditAction.CalendarOccurrenceCancelled,
+                auditDescription: $"Cancelled occurrence {originalOccurrenceStartUtc}",
+                ct);
+        }
+        else
+        {
+            await UpsertExceptionAsync(eventId, originalOccurrenceStartUtc, userId,
+                apply: x =>
+                {
+                    x.IsCancelled = false;
+                    x.OverrideStartUtc = occurrenceOverride.OverrideStartUtc;
+                    x.OverrideEndUtc = occurrenceOverride.OverrideEndUtc;
+                    x.OverrideTitle = occurrenceOverride.OverrideTitle;
+                    x.OverrideDescription = occurrenceOverride.OverrideDescription;
+                    x.OverrideLocation = occurrenceOverride.OverrideLocation;
+                    x.OverrideLocationUrl = occurrenceOverride.OverrideLocationUrl;
+                },
+                auditAction: AuditAction.CalendarOccurrenceOverridden,
+                auditDescription: $"Overrode occurrence {originalOccurrenceStartUtc}",
+                ct);
+        }
 
-    public async Task OverrideOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, OverrideOccurrenceDto dto, Guid userId, CancellationToken ct = default)
-    {
-        await UpsertExceptionAsync(eventId, originalOccurrenceStartUtc, userId,
-            apply: x =>
-            {
-                x.IsCancelled = false;
-                x.OverrideStartUtc = dto.OverrideStartUtc;
-                x.OverrideEndUtc = dto.OverrideEndUtc;
-                x.OverrideTitle = dto.OverrideTitle;
-                x.OverrideDescription = dto.OverrideDescription;
-                x.OverrideLocation = dto.OverrideLocation;
-                x.OverrideLocationUrl = dto.OverrideLocationUrl;
-            },
-            auditAction: AuditAction.CalendarOccurrenceOverridden,
-            auditDescription: $"Overrode occurrence {originalOccurrenceStartUtc}",
-            ct);
+        return CalendarMutationResult.Success(eventId);
     }
 
     private async Task UpsertExceptionAsync(
@@ -384,7 +411,7 @@ public sealed class CalendarService(
             apply: apply,
             ct: ct);
 
-        // Audit best-effort: exception upsert already committed (see CreateEventAsync).
+        // Audit best-effort: exception upsert already committed (see ApplyCreateMutationCoreAsync).
         try
         {
             await audit.LogAsync(

--- a/src/Humans.Infrastructure/Services/Calendar/CachingCalendarService.cs
+++ b/src/Humans.Infrastructure/Services/Calendar/CachingCalendarService.cs
@@ -79,64 +79,21 @@ public sealed class CachingCalendarService(
             .ToDictionary(id => id, id => teamsById[id].Name);
     }
 
-    // Writes — delegate then refresh
+    // Writes — single mutation surface delegates then refreshes the affected event.
 
-    public async Task<CalendarEvent> CreateEventAsync(
-        CreateCalendarEventDto dto, Guid createdByUserId, CancellationToken ct = default)
+    public async Task<CalendarMutationResult> MutateCalendarAsync(
+        CalendarMutation mutation,
+        Guid actorUserId,
+        CancellationToken ct = default)
     {
-        var result = await WithInner(inner => inner.CreateEventAsync(dto, createdByUserId, ct));
-        await InvalidateEventAsync(result.Id, ct);
+        var result = await WithInner(inner => inner.MutateCalendarAsync(mutation, actorUserId, ct));
+        if (result.AffectedEventId is { } eventId)
+        {
+            // Refresh the affected parent; not-found deletes can tombstone stale cache entries.
+            await InvalidateEventAsync(eventId, ct);
+        }
+
         return result;
-    }
-
-    public async Task<CalendarEventMutationResult> CreateEventWithResultAsync(
-        CreateCalendarEventDto dto, Guid createdByUserId, CancellationToken ct = default)
-    {
-        var result = await WithInner(inner => inner.CreateEventWithResultAsync(dto, createdByUserId, ct));
-        if (result.Succeeded && result.Event is not null)
-            await InvalidateEventAsync(result.Event.Id, ct);
-        return result;
-    }
-
-    public async Task<CalendarEvent> UpdateEventAsync(
-        Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct = default)
-    {
-        var result = await WithInner(inner => inner.UpdateEventAsync(id, dto, updatedByUserId, ct));
-        await InvalidateEventAsync(id, ct);
-        return result;
-    }
-
-    public async Task<CalendarEventMutationResult> UpdateEventWithResultAsync(
-        Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct = default)
-    {
-        var result = await WithInner(inner => inner.UpdateEventWithResultAsync(id, dto, updatedByUserId, ct));
-        if (result.Succeeded)
-            await InvalidateEventAsync(id, ct);
-        return result;
-    }
-
-    public async Task DeleteEventAsync(Guid id, Guid deletedByUserId, CancellationToken ct = default)
-    {
-        await WithInner(inner => inner.DeleteEventAsync(id, deletedByUserId, ct));
-        await InvalidateEventAsync(id, ct);
-    }
-
-    public async Task CancelOccurrenceAsync(
-        Guid eventId, Instant originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default)
-    {
-        // Exception writes evict the PARENT — Exceptions list is embedded in CalendarEventInfo.
-        await WithInner(inner => inner.CancelOccurrenceAsync(
-            eventId, originalOccurrenceStartUtc, userId, ct));
-        await InvalidateEventAsync(eventId, ct);
-    }
-
-    public async Task OverrideOccurrenceAsync(
-        Guid eventId, Instant originalOccurrenceStartUtc, OverrideOccurrenceDto dto,
-        Guid userId, CancellationToken ct = default)
-    {
-        await WithInner(inner => inner.OverrideOccurrenceAsync(
-            eventId, originalOccurrenceStartUtc, dto, userId, ct));
-        await InvalidateEventAsync(eventId, ct);
     }
 
     private Task InvalidateEventAsync(Guid eventId, CancellationToken ct) =>
@@ -168,10 +125,4 @@ public sealed class CachingCalendarService(
         return await action(inner);
     }
 
-    private async Task WithInner(Func<ICalendarService, Task> action)
-    {
-        await using var scope = scopeFactory.CreateAsyncScope();
-        var inner = scope.ServiceProvider.GetRequiredKeyedService<ICalendarService>(InnerServiceKey);
-        await action(inner);
-    }
 }

--- a/src/Humans.Web/Controllers/CalendarController.cs
+++ b/src/Humans.Web/Controllers/CalendarController.cs
@@ -197,12 +197,14 @@ public class CalendarController : HumansControllerBase
             return View(form);
         }
 
-        var result = await _calendar.CreateEventWithResultAsync(new CreateCalendarEventDto(
-            form.Title, form.Description, form.Location, form.LocationUrl,
-            form.OwningTeamId, start, end, form.IsAllDay,
-            form.IsRecurring ? form.RecurrenceRule : null,
-            form.IsRecurring ? form.RecurrenceTimezone : null),
-            createdByUserId: RequireCurrentUserId(), ct);
+        var result = await _calendar.MutateCalendarAsync(
+            new CreateCalendarEventMutation(new CreateCalendarEventDto(
+                form.Title, form.Description, form.Location, form.LocationUrl,
+                form.OwningTeamId, start, end, form.IsAllDay,
+                form.IsRecurring ? form.RecurrenceRule : null,
+                form.IsRecurring ? form.RecurrenceTimezone : null)),
+            RequireCurrentUserId(),
+            ct);
 
         if (result.Succeeded && result.Event is not null)
         {
@@ -263,12 +265,14 @@ public class CalendarController : HumansControllerBase
             return View(form);
         }
 
-        var result = await _calendar.UpdateEventWithResultAsync(id, new UpdateCalendarEventDto(
-            form.Title, form.Description, form.Location, form.LocationUrl,
-            form.OwningTeamId, start, end, form.IsAllDay,
-            form.IsRecurring ? form.RecurrenceRule : null,
-            form.IsRecurring ? form.RecurrenceTimezone : null),
-            updatedByUserId: RequireCurrentUserId(), ct);
+        var result = await _calendar.MutateCalendarAsync(
+            new UpdateCalendarEventMutation(id, new UpdateCalendarEventDto(
+                form.Title, form.Description, form.Location, form.LocationUrl,
+                form.OwningTeamId, start, end, form.IsAllDay,
+                form.IsRecurring ? form.RecurrenceRule : null,
+                form.IsRecurring ? form.RecurrenceTimezone : null)),
+            RequireCurrentUserId(),
+            ct);
 
         if (result.NotFound) return NotFound();
         if (result.Succeeded) return RedirectToAction(nameof(Event), new { id });
@@ -332,7 +336,16 @@ public class CalendarController : HumansControllerBase
         var ev = await _calendar.GetEventByIdAsync(id, ct);
         if (ev is null) return NotFound();
 
-        await _calendar.DeleteEventAsync(id, deletedByUserId: RequireCurrentUserId(), ct);
+        var result = await _calendar.MutateCalendarAsync(
+            new DeleteCalendarEventMutation(id),
+            RequireCurrentUserId(),
+            ct);
+        if (result.NotFound) return NotFound();
+        if (!result.Succeeded)
+        {
+            SetError(result.ErrorMessage ?? "Failed to delete calendar event.");
+        }
+
         return RedirectToAction(nameof(Index));
     }
 
@@ -344,7 +357,16 @@ public class CalendarController : HumansControllerBase
         if (ev is null) return NotFound();
 
         var original = OccurrenceOverrideFormViewModel.ParseOriginal(originalStartUtc);
-        await _calendar.CancelOccurrenceAsync(id, original, RequireCurrentUserId(), ct);
+        var result = await _calendar.MutateCalendarAsync(
+            new CancelCalendarOccurrenceMutation(id, original),
+            RequireCurrentUserId(),
+            ct);
+        if (result.NotFound) return NotFound();
+        if (!result.Succeeded)
+        {
+            SetError(result.ErrorMessage ?? "Failed to cancel calendar occurrence.");
+        }
+
         return RedirectToAction(nameof(Event), new { id });
     }
 
@@ -384,11 +406,20 @@ public class CalendarController : HumansControllerBase
             ? LocalDateTime.FromDateTime(e).InZoneLeniently(zone).ToInstant()
             : null;
 
-        await _calendar.OverrideOccurrenceAsync(id, original,
-            new OverrideOccurrenceDto(overrideStart, overrideEnd,
-                form.OverrideTitle, form.OverrideDescription,
-                form.OverrideLocation, form.OverrideLocationUrl),
-            RequireCurrentUserId(), ct);
+        var result = await _calendar.MutateCalendarAsync(
+            new OverrideCalendarOccurrenceMutation(
+                id,
+                original,
+                new OverrideOccurrenceDto(overrideStart, overrideEnd,
+                    form.OverrideTitle, form.OverrideDescription,
+                    form.OverrideLocation, form.OverrideLocationUrl)),
+            RequireCurrentUserId(),
+            ct);
+        if (result.NotFound) return NotFound();
+        if (!result.Succeeded)
+        {
+            SetError(result.ErrorMessage ?? "Failed to update calendar occurrence.");
+        }
 
         return RedirectToAction(nameof(Event), new { id });
     }
@@ -408,7 +439,7 @@ public class CalendarController : HumansControllerBase
 
     private void AddCalendarEventMutationError(
         CalendarEventFormViewModel form,
-        CalendarEventMutationResult result)
+        CalendarMutationResult result)
     {
         var memberName = string.Equals(
                 result.ValidationMemberName,

--- a/tests/Humans.Application.Tests/Architecture/CalendarArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/CalendarArchitectureTests.cs
@@ -90,6 +90,23 @@ public class CalendarArchitectureTests
     }
 
     [HumansFact]
+    public void CalendarService_ExposesSingleTypedMutationSurface()
+    {
+        var methodNames = typeof(ICalendarService)
+            .GetMethods()
+            .Select(m => m.Name)
+            .ToArray();
+
+        methodNames.Should().BeEquivalentTo(
+            [
+                nameof(ICalendarService.GetOccurrencesInWindowAsync),
+                nameof(ICalendarService.GetEventByIdAsync),
+                nameof(ICalendarService.MutateCalendarAsync)
+            ],
+            because: "Calendar writes should extend the typed CalendarMutation command family, not grow one public method per event operation");
+    }
+
+    [HumansFact]
     public void CachingCalendarService_IsSealed()
     {
         typeof(CachingCalendarService).IsSealed.Should().BeTrue(

--- a/tests/Humans.Application.Tests/Services/Calendar/CachingCalendarServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Calendar/CachingCalendarServiceTests.cs
@@ -178,7 +178,7 @@ public class CachingCalendarServiceTests
     }
 
     [HumansFact]
-    public async Task CreateEventAsync_DelegatesToInner_AndRefreshesCacheEntry()
+    public async Task MutateCalendarAsync_Create_DelegatesToInner_AndRefreshesCacheEntry()
     {
         var teamId = Guid.NewGuid();
         var dto = new CreateCalendarEventDto(
@@ -193,8 +193,11 @@ public class CachingCalendarServiceTests
 
         var created = BuildEvent(teamId: teamId, title: "New",
             start: dto.StartUtc, end: dto.EndUtc);
-        _inner.CreateEventAsync(dto, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(created);
+        _inner.MutateCalendarAsync(
+                Arg.Is<CreateCalendarEventMutation>(m => ReferenceEquals(m.Event, dto)),
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(CalendarMutationResult.Success(created));
 
         // After-write refresh: the decorator routes through ReplaceAsync, which
         // drives LoadRowAsync → _repo.GetEventByIdAsync, then upserts into the dict.
@@ -202,20 +205,28 @@ public class CachingCalendarServiceTests
             .Returns(created);
 
         var sut = CreateSut();
-        var result = await sut.CreateEventAsync(dto, Guid.NewGuid());
+        var result = await sut.MutateCalendarAsync(
+            new CreateCalendarEventMutation(dto),
+            Guid.NewGuid());
 
-        result.Should().BeSameAs(created);
+        result.Succeeded.Should().BeTrue();
+        result.Event.Should().BeSameAs(created);
         sut.ContainsKey(created.Id).Should().BeTrue(
             because: "after-write refresh inserts the new event into the cache");
         await _repo.Received(1).GetEventByIdAsync(created.Id, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
-    public async Task DeleteEventAsync_RemovesEntryFromCache_WhenRepoReturnsNull()
+    public async Task MutateCalendarAsync_Delete_RemovesEntryFromCache_WhenMutationReturnsNotFound()
     {
         var ev = BuildEvent(title: "To be deleted");
         _repo.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(new List<CalendarEvent> { ev });
+        _inner.MutateCalendarAsync(
+                Arg.Is<DeleteCalendarEventMutation>(m => m.EventId == ev.Id),
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(CalendarMutationResult.Missing(ev.Id, "Calendar event not found."));
 
         // The inner soft-deletes; the post-delete re-fetch returns null
         // because the repo's GetEventByIdAsync filters soft-deleted rows.
@@ -226,15 +237,21 @@ public class CachingCalendarServiceTests
         await WarmAsync(sut);
         sut.ContainsKey(ev.Id).Should().BeTrue();
 
-        await sut.DeleteEventAsync(ev.Id, Guid.NewGuid());
+        var result = await sut.MutateCalendarAsync(
+            new DeleteCalendarEventMutation(ev.Id),
+            Guid.NewGuid());
 
+        result.NotFound.Should().BeTrue();
         sut.ContainsKey(ev.Id).Should().BeFalse(
-            because: "soft-deleted event must be evicted from cache (tombstoned via DeleteKey)");
-        await _inner.Received(1).DeleteEventAsync(ev.Id, Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+            because: "not-found deletes still identify the affected key and must tombstone stale cache entries");
+        await _inner.Received(1).MutateCalendarAsync(
+            Arg.Is<DeleteCalendarEventMutation>(m => m.EventId == ev.Id),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
-    public async Task CancelOccurrenceAsync_EvictsParentEventEntry_NotJustException()
+    public async Task MutateCalendarAsync_CancelOccurrence_EvictsParentEventEntry_NotJustException()
     {
         // T-08 invariant: the cache is keyed by parent event id; exception
         // writes refresh the PARENT entry (which re-loads its Exceptions list).
@@ -266,17 +283,28 @@ public class CachingCalendarServiceTests
             });
         _repo.GetEventByIdAsync(eventId, Arg.Any<CancellationToken>())
             .Returns(after);
+        _inner.MutateCalendarAsync(
+                Arg.Is<CancelCalendarOccurrenceMutation>(m =>
+                    m.EventId == eventId && m.OriginalOccurrenceStartUtc == originalStart),
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(CalendarMutationResult.Success(eventId));
 
         var sut = CreateSut();
         await WarmAsync(sut);
 
-        await sut.CancelOccurrenceAsync(eventId, originalStart, Guid.NewGuid());
+        await sut.MutateCalendarAsync(
+            new CancelCalendarOccurrenceMutation(eventId, originalStart),
+            Guid.NewGuid());
 
         // The decorator did re-fetch (parent eviction + repopulation).
         await _repo.Received(1).GetEventByIdAsync(eventId, Arg.Any<CancellationToken>());
         // The inner service was actually called.
-        await _inner.Received(1).CancelOccurrenceAsync(
-            eventId, originalStart, Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _inner.Received(1).MutateCalendarAsync(
+            Arg.Is<CancelCalendarOccurrenceMutation>(m =>
+                m.EventId == eventId && m.OriginalOccurrenceStartUtc == originalStart),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
         // The cached event now has the exception attached.
         sut.TryGet(eventId, out var refreshed).Should().BeTrue();
         refreshed.Exceptions.Should().HaveCount(1);
@@ -284,9 +312,9 @@ public class CachingCalendarServiceTests
     }
 
     [HumansFact]
-    public async Task OverrideOccurrenceAsync_EvictsParentEventEntry_NotJustException()
+    public async Task MutateCalendarAsync_OverrideOccurrence_EvictsParentEventEntry_NotJustException()
     {
-        // Same invariant as CancelOccurrenceAsync — override writes also flow
+        // Same invariant as cancel occurrence — override writes also flow
         // through parent-event eviction + refresh.
         var eventId = Guid.NewGuid();
         var originalStart = Instant.FromUtc(2026, 9, 1, 10, 0);
@@ -320,7 +348,16 @@ public class CachingCalendarServiceTests
         var sut = CreateSut();
         await WarmAsync(sut);
 
-        await sut.OverrideOccurrenceAsync(eventId, originalStart, dto, Guid.NewGuid());
+        _inner.MutateCalendarAsync(
+                Arg.Is<OverrideCalendarOccurrenceMutation>(m =>
+                    m.EventId == eventId && m.OriginalOccurrenceStartUtc == originalStart),
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(CalendarMutationResult.Success(eventId));
+
+        await sut.MutateCalendarAsync(
+            new OverrideCalendarOccurrenceMutation(eventId, originalStart, dto),
+            Guid.NewGuid());
 
         await _repo.Received(1).GetEventByIdAsync(eventId, Arg.Any<CancellationToken>());
         sut.TryGet(eventId, out var refreshed).Should().BeTrue();

--- a/tests/Humans.Application.Tests/Services/CalendarServiceValidationTests.cs
+++ b/tests/Humans.Application.Tests/Services/CalendarServiceValidationTests.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using AwesomeAssertions;
 using Humans.Application.DTOs.Calendar;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Calendar;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Services.Calendar;
@@ -109,7 +110,7 @@ public class CalendarServiceValidationTests
     }
 
     [HumansFact]
-    public async Task CreateEventWithResultAsync_returns_validation_member_for_malformed_recurrence()
+    public async Task MutateCalendarAsync_create_returns_validation_member_for_malformed_recurrence()
     {
         var repo = Substitute.For<ICalendarRepository>();
         var service = BuildService(repo);
@@ -125,7 +126,9 @@ public class CalendarServiceValidationTests
             RecurrenceRule: "FREQ=NOT_A_REAL_FREQ",
             RecurrenceTimezone: "Europe/Madrid");
 
-        var result = await service.CreateEventWithResultAsync(dto, Guid.NewGuid());
+        var result = await service.MutateCalendarAsync(
+            new CreateCalendarEventMutation(dto),
+            Guid.NewGuid());
 
         result.Succeeded.Should().BeFalse();
         result.ValidationMemberName.Should().Be(nameof(CreateCalendarEventDto.RecurrenceRule));
@@ -134,7 +137,7 @@ public class CalendarServiceValidationTests
     }
 
     [HumansFact]
-    public async Task UpdateEventWithResultAsync_returns_validation_member_for_unknown_timezone()
+    public async Task MutateCalendarAsync_update_returns_validation_member_for_unknown_timezone()
     {
         var service = BuildService(Substitute.For<ICalendarRepository>());
         var dto = new UpdateCalendarEventDto(
@@ -149,7 +152,9 @@ public class CalendarServiceValidationTests
             RecurrenceRule: "FREQ=DAILY",
             RecurrenceTimezone: "Europe/Madird");
 
-        var result = await service.UpdateEventWithResultAsync(Guid.NewGuid(), dto, Guid.NewGuid());
+        var result = await service.MutateCalendarAsync(
+            new UpdateCalendarEventMutation(Guid.NewGuid(), dto),
+            Guid.NewGuid());
 
         result.Succeeded.Should().BeFalse();
         result.ValidationMemberName.Should().Be(nameof(CreateCalendarEventDto.RecurrenceTimezone));
@@ -160,12 +165,11 @@ public class CalendarServiceValidationTests
     // PR #585 follow-up — audit-best-effort invariant
     // ==========================================================================
     //
-    // The §15 caching decorator (CachingCalendarService) keys invalidation off
-    // the inner result's Succeeded flag (or, for void overloads, the absence
-    // of a thrown exception). If the audit-log call re-raises AFTER the DB
-    // write committed, the inner's WithResultAsync catch-all would have
-    // returned Failed — which would make the decorator skip invalidation,
-    // leaving the cache silently stale. Codex P1 on PR #585.
+    // The §15 caching decorator keys invalidation off MutateCalendarAsync's
+    // Succeeded flag and AffectedEventId. If the audit-log call re-raises
+    // AFTER the DB write committed, the mutation would return Failed — which
+    // would make the decorator skip invalidation, leaving the cache silently
+    // stale. Codex P1 on PR #585.
     //
     // The fix wraps each _audit.LogAsync call in try-catch (LogCritical and
     // continue). These tests pin the new invariant: a post-write audit
@@ -173,7 +177,7 @@ public class CalendarServiceValidationTests
     // DB write (so the decorator invalidates correctly).
 
     [HumansFact]
-    public async Task CreateEventWithResultAsync_AuditThrowsAfterWrite_StillReturnsSuccess()
+    public async Task MutateCalendarAsync_create_AuditThrowsAfterWrite_StillReturnsSuccess()
     {
         var repo = Substitute.For<ICalendarRepository>();
         var audit = Substitute.For<IAuditLogService>();
@@ -194,7 +198,9 @@ public class CalendarServiceValidationTests
             RecurrenceRule: null,
             RecurrenceTimezone: null);
 
-        var result = await service.CreateEventWithResultAsync(dto, Guid.NewGuid());
+        var result = await service.MutateCalendarAsync(
+            new CreateCalendarEventMutation(dto),
+            Guid.NewGuid());
 
         result.Succeeded.Should().BeTrue(
             because: "the DB write committed; audit failure is best-effort and must not void the result " +
@@ -205,7 +211,7 @@ public class CalendarServiceValidationTests
     }
 
     [HumansFact]
-    public async Task UpdateEventWithResultAsync_AuditThrowsAfterWrite_StillReturnsSuccess()
+    public async Task MutateCalendarAsync_update_AuditThrowsAfterWrite_StillReturnsSuccess()
     {
         var repo = Substitute.For<ICalendarRepository>();
         var eventId = Guid.NewGuid();
@@ -249,7 +255,9 @@ public class CalendarServiceValidationTests
             RecurrenceRule: null,
             RecurrenceTimezone: null);
 
-        var result = await service.UpdateEventWithResultAsync(eventId, dto, Guid.NewGuid());
+        var result = await service.MutateCalendarAsync(
+            new UpdateCalendarEventMutation(eventId, dto),
+            Guid.NewGuid());
 
         result.Succeeded.Should().BeTrue(
             because: "the DB write committed; audit failure is best-effort and must not void the result");
@@ -258,7 +266,7 @@ public class CalendarServiceValidationTests
     }
 
     [HumansFact]
-    public async Task DeleteEventAsync_AuditThrowsAfterWrite_DoesNotThrow()
+    public async Task MutateCalendarAsync_delete_AuditThrowsAfterWrite_StillReturnsSuccess()
     {
         var repo = Substitute.For<ICalendarRepository>();
         var eventId = Guid.NewGuid();
@@ -275,14 +283,17 @@ public class CalendarServiceValidationTests
 
         var service = BuildService(repo, audit);
 
-        // Void overload — re-throwing audit would also skip the decorator's
-        // post-delete invalidation, leaving the soft-deleted event in cache.
-        var act = async () => await service.DeleteEventAsync(eventId, Guid.NewGuid());
-        await act.Should().NotThrowAsync();
+        var result = await service.MutateCalendarAsync(
+            new DeleteCalendarEventMutation(eventId),
+            Guid.NewGuid());
+
+        result.Succeeded.Should().BeTrue(
+            because: "the soft-delete committed; audit failure is best-effort and must not void the result");
+        result.AffectedEventId.Should().Be(eventId);
     }
 
     [HumansFact]
-    public async Task CancelOccurrenceAsync_AuditThrowsAfterWrite_DoesNotThrow()
+    public async Task MutateCalendarAsync_cancel_AuditThrowsAfterWrite_StillReturnsSuccess()
     {
         var repo = Substitute.For<ICalendarRepository>();
         var audit = Substitute.For<IAuditLogService>();
@@ -295,9 +306,16 @@ public class CalendarServiceValidationTests
 
         var service = BuildService(repo, audit);
 
-        var act = async () => await service.CancelOccurrenceAsync(
-            Guid.NewGuid(), Instant.FromUtc(2026, 6, 1, 10, 0), Guid.NewGuid());
-        await act.Should().NotThrowAsync();
+        var eventId = Guid.NewGuid();
+        var result = await service.MutateCalendarAsync(
+            new CancelCalendarOccurrenceMutation(
+                eventId,
+                Instant.FromUtc(2026, 6, 1, 10, 0)),
+            Guid.NewGuid());
+
+        result.Succeeded.Should().BeTrue(
+            because: "the exception upsert committed; audit failure is best-effort and must not void the result");
+        result.AffectedEventId.Should().Be(eventId);
     }
 
     private static CalendarService BuildService(ICalendarRepository repo)

--- a/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
+++ b/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using AwesomeAssertions;
 using Humans.Application.DTOs.Calendar;
 using Humans.Application.Interfaces.Calendar;
@@ -15,7 +14,7 @@ namespace Humans.Integration.Tests.Services;
 public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassFixture<HumansWebApplicationFactory>
 {
     [HumansFact]
-    public async Task CreateEventAsync_persists_and_GetEventById_returns_it()
+    public async Task MutateCalendarAsync_create_persists_and_GetEventById_returns_it()
     {
         await using var scope = factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
@@ -27,7 +26,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var start = Instant.FromUtc(2026, 5, 1, 17, 0);
         var end = Instant.FromUtc(2026, 5, 1, 18, 0);
 
-        var created = await svc.CreateEventAsync(
+        var created = await ApplyCreateMutationAsync(svc,
             new CreateCalendarEventDto(
                 Title: "Community call",
                 Description: "Monthly sync",
@@ -61,13 +60,13 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var team = await SeedTeamAsync(db, $"T-{Guid.NewGuid():N}");
         var userId = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        await svc.CreateEventAsync(new CreateCalendarEventDto(
+        await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Inside", null, null, null, team.Id,
             Instant.FromUtc(2026, 6, 15, 17, 0),
             Instant.FromUtc(2026, 6, 15, 18, 0),
             false, null, null), userId);
 
-        await svc.CreateEventAsync(new CreateCalendarEventDto(
+        await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Outside", null, null, null, team.Id,
             Instant.FromUtc(2027, 1, 1, 0, 0),
             Instant.FromUtc(2027, 1, 1, 1, 0),
@@ -94,12 +93,12 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var b = await SeedTeamAsync(db, $"B-{Guid.NewGuid():N}");
         var uid = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        await svc.CreateEventAsync(new CreateCalendarEventDto(
+        await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "A-evt", null, null, null, a.Id,
             Instant.FromUtc(2026, 6, 15, 17, 0),
             Instant.FromUtc(2026, 6, 15, 18, 0), false, null, null), uid);
 
-        await svc.CreateEventAsync(new CreateCalendarEventDto(
+        await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "B-evt", null, null, null, b.Id,
             Instant.FromUtc(2026, 6, 15, 19, 0),
             Instant.FromUtc(2026, 6, 15, 20, 0), false, null, null), uid);
@@ -123,12 +122,12 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var team = await SeedTeamAsync(db, $"T-{Guid.NewGuid():N}");
         var uid = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        var ev = await svc.CreateEventAsync(new CreateCalendarEventDto(
+        var ev = await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "DoomedEvent", null, null, null, team.Id,
             Instant.FromUtc(2026, 6, 15, 17, 0),
             Instant.FromUtc(2026, 6, 15, 18, 0), false, null, null), uid);
 
-        await svc.DeleteEventAsync(ev.Id, uid);
+        await ApplyDeleteMutationAsync(svc, ev.Id, uid);
 
         var occ = await svc.GetOccurrencesInWindowAsync(
             Instant.FromUtc(2026, 6, 1, 0, 0),
@@ -154,7 +153,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var firstLocal = new LocalDateTime(2026, 3, 24, 19, 0);
         var firstUtc = firstLocal.InZoneLeniently(zone).ToInstant();
 
-        await svc.CreateEventAsync(new CreateCalendarEventDto(
+        await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Tuesday call", null, null, null, team.Id,
             StartUtc: firstUtc,
             EndUtc: firstUtc.Plus(Duration.FromHours(1)),
@@ -186,7 +185,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var team = await SeedTeamAsync(db, $"T-{Guid.NewGuid():N}");
         var uid = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        await svc.CreateEventAsync(new CreateCalendarEventDto(
+        await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Old", null, null, null, team.Id,
             StartUtc: Instant.FromUtc(2024, 1, 7, 18, 0),
             EndUtc: Instant.FromUtc(2024, 1, 7, 19, 0),
@@ -215,14 +214,14 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
 
         var first = new LocalDateTime(2026, 5, 5, 19, 0).InZoneLeniently(zone).ToInstant();
 
-        var ev = await svc.CreateEventAsync(new CreateCalendarEventDto(
+        var ev = await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Weekly", null, null, null, team.Id,
             first, first.Plus(Duration.FromHours(1)),
             false, "FREQ=WEEKLY;BYDAY=TU;COUNT=4", "Europe/Madrid"), uid);
 
         // Cancel the 3rd occurrence (2026-05-19 19:00 Madrid).
         var cancel = new LocalDateTime(2026, 5, 19, 19, 0).InZoneLeniently(zone).ToInstant();
-        await svc.CancelOccurrenceAsync(ev.Id, cancel, uid);
+        await ApplyCancelOccurrenceMutationAsync(svc, ev.Id, cancel, uid);
 
         var occ = await svc.GetOccurrencesInWindowAsync(
             Instant.FromUtc(2026, 5, 1, 0, 0),
@@ -246,7 +245,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
 
         var first = new LocalDateTime(2026, 5, 5, 19, 0).InZoneLeniently(zone).ToInstant();
 
-        var ev = await svc.CreateEventAsync(new CreateCalendarEventDto(
+        var ev = await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Weekly", null, null, null, team.Id,
             first, first.Plus(Duration.FromHours(1)),
             false, "FREQ=WEEKLY;BYDAY=TU;COUNT=4", "Europe/Madrid"), uid);
@@ -255,7 +254,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var original = new LocalDateTime(2026, 5, 12, 19, 0).InZoneLeniently(zone).ToInstant();
         var moved = new LocalDateTime(2026, 5, 12, 20, 0).InZoneLeniently(zone).ToInstant();
 
-        await svc.OverrideOccurrenceAsync(ev.Id, original, new OverrideOccurrenceDto(
+        await ApplyOverrideOccurrenceMutationAsync(svc, ev.Id, original, new OverrideOccurrenceDto(
             OverrideStartUtc: moved,
             OverrideEndUtc: moved.Plus(Duration.FromHours(1)),
             OverrideTitle: "Special week",
@@ -284,12 +283,12 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var team = await SeedTeamAsync(db, $"T-{Guid.NewGuid():N}");
         var uid = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        var ev = await svc.CreateEventAsync(new CreateCalendarEventDto(
+        var ev = await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Original", null, null, null, team.Id,
             Instant.FromUtc(2026, 7, 1, 17, 0),
             Instant.FromUtc(2026, 7, 1, 18, 0), false, null, null), uid);
 
-        await svc.UpdateEventAsync(ev.Id, new UpdateCalendarEventDto(
+        await ApplyUpdateMutationAsync(svc, ev.Id, new UpdateCalendarEventDto(
             "Updated", "new desc", "Hall", null, team.Id,
             Instant.FromUtc(2026, 7, 2, 17, 0),
             Instant.FromUtc(2026, 7, 2, 18, 0), false, null, null), uid);
@@ -302,7 +301,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     }
 
     [HumansFact]
-    public async Task CreateEvent_rejects_malformed_rrule()
+    public async Task MutateCalendarAsync_create_rejects_malformed_rrule()
     {
         await using var scope = factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
@@ -311,20 +310,23 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var team = await SeedTeamAsync(db, $"T-{Guid.NewGuid():N}");
         var uid = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        var act = async () => await svc.CreateEventAsync(new CreateCalendarEventDto(
-            "Bad", null, null, null, team.Id,
-            Instant.FromUtc(2026, 5, 1, 17, 0),
-            Instant.FromUtc(2026, 5, 1, 18, 0),
-            false,
-            RecurrenceRule: "FREQ=NOT_A_REAL_FREQ",
-            RecurrenceTimezone: "Europe/Madrid"), uid);
+        var result = await svc.MutateCalendarAsync(
+            new CreateCalendarEventMutation(new CreateCalendarEventDto(
+                "Bad", null, null, null, team.Id,
+                Instant.FromUtc(2026, 5, 1, 17, 0),
+                Instant.FromUtc(2026, 5, 1, 18, 0),
+                false,
+                RecurrenceRule: "FREQ=NOT_A_REAL_FREQ",
+                RecurrenceTimezone: "Europe/Madrid")),
+            uid);
 
-        await act.Should().ThrowAsync<ValidationException>()
-            .WithMessage("*Recurrence rule is malformed*");
+        result.Succeeded.Should().BeFalse();
+        result.ValidationMemberName.Should().Be(nameof(CreateCalendarEventDto.RecurrenceRule));
+        result.ErrorMessage.Should().Contain("Recurrence rule is malformed");
     }
 
     [HumansFact]
-    public async Task UpdateEvent_rejects_malformed_rrule()
+    public async Task MutateCalendarAsync_update_rejects_malformed_rrule()
     {
         await using var scope = factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
@@ -333,21 +335,24 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var team = await SeedTeamAsync(db, $"T-{Guid.NewGuid():N}");
         var uid = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        var ev = await svc.CreateEventAsync(new CreateCalendarEventDto(
+        var ev = await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "Original", null, null, null, team.Id,
             Instant.FromUtc(2026, 5, 1, 17, 0),
             Instant.FromUtc(2026, 5, 1, 18, 0), false, null, null), uid);
 
-        var act = async () => await svc.UpdateEventAsync(ev.Id, new UpdateCalendarEventDto(
-            "Updated", null, null, null, team.Id,
-            Instant.FromUtc(2026, 5, 2, 17, 0),
-            Instant.FromUtc(2026, 5, 2, 18, 0),
-            false,
-            RecurrenceRule: "FREQ=NOT_A_REAL_FREQ",
-            RecurrenceTimezone: "Europe/Madrid"), uid);
+        var result = await svc.MutateCalendarAsync(
+            new UpdateCalendarEventMutation(ev.Id, new UpdateCalendarEventDto(
+                "Updated", null, null, null, team.Id,
+                Instant.FromUtc(2026, 5, 2, 17, 0),
+                Instant.FromUtc(2026, 5, 2, 18, 0),
+                false,
+                RecurrenceRule: "FREQ=NOT_A_REAL_FREQ",
+                RecurrenceTimezone: "Europe/Madrid")),
+            uid);
 
-        await act.Should().ThrowAsync<ValidationException>()
-            .WithMessage("*Recurrence rule is malformed*");
+        result.Succeeded.Should().BeFalse();
+        result.ValidationMemberName.Should().Be(nameof(CreateCalendarEventDto.RecurrenceRule));
+        result.ErrorMessage.Should().Contain("Recurrence rule is malformed");
     }
 
     [HumansFact]
@@ -360,14 +365,72 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
         var team = await SeedTeamAsync(db, $"T-{Guid.NewGuid():N}");
         var uid = await SeedUserAsync(scope, $"calsvc-{Guid.NewGuid():N}@test.local");
 
-        var ev = await svc.CreateEventAsync(new CreateCalendarEventDto(
+        var ev = await ApplyCreateMutationAsync(svc, new CreateCalendarEventDto(
             "ToDelete", null, null, null, team.Id,
             Instant.FromUtc(2026, 8, 1, 10, 0),
             Instant.FromUtc(2026, 8, 1, 11, 0), false, null, null), uid);
 
-        await svc.DeleteEventAsync(ev.Id, uid);
+        await ApplyDeleteMutationAsync(svc, ev.Id, uid);
 
         (await svc.GetEventByIdAsync(ev.Id)).Should().BeNull();
+    }
+
+    private static async Task<CalendarEvent> ApplyCreateMutationAsync(
+        ICalendarService svc,
+        CreateCalendarEventDto dto,
+        Guid createdByUserId)
+    {
+        var result = await svc.MutateCalendarAsync(
+            new CreateCalendarEventMutation(dto),
+            createdByUserId);
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
+        result.Event.Should().NotBeNull();
+        return result.Event!;
+    }
+
+    private static async Task ApplyUpdateMutationAsync(
+        ICalendarService svc,
+        Guid eventId,
+        UpdateCalendarEventDto dto,
+        Guid updatedByUserId)
+    {
+        var result = await svc.MutateCalendarAsync(
+            new UpdateCalendarEventMutation(eventId, dto),
+            updatedByUserId);
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
+    }
+
+    private static async Task ApplyDeleteMutationAsync(ICalendarService svc, Guid eventId, Guid deletedByUserId)
+    {
+        var result = await svc.MutateCalendarAsync(
+            new DeleteCalendarEventMutation(eventId),
+            deletedByUserId);
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
+    }
+
+    private static async Task ApplyCancelOccurrenceMutationAsync(
+        ICalendarService svc,
+        Guid eventId,
+        Instant originalOccurrenceStartUtc,
+        Guid userId)
+    {
+        var result = await svc.MutateCalendarAsync(
+            new CancelCalendarOccurrenceMutation(eventId, originalOccurrenceStartUtc),
+            userId);
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
+    }
+
+    private static async Task ApplyOverrideOccurrenceMutationAsync(
+        ICalendarService svc,
+        Guid eventId,
+        Instant originalOccurrenceStartUtc,
+        OverrideOccurrenceDto dto,
+        Guid userId)
+    {
+        var result = await svc.MutateCalendarAsync(
+            new OverrideCalendarOccurrenceMutation(eventId, originalOccurrenceStartUtc, dto),
+            userId);
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
     }
 
     private static async Task<Team> SeedTeamAsync(HumansDbContext db, string name)


### PR DESCRIPTION
## Summary
- replace calendar's one-method-per-write API with a single typed `MutateCalendarAsync(CalendarMutation, actorUserId)` surface
- convert controller, caching decorator, validation paths, and integration tests to the new mutation records
- add an architecture guard so future calendar writes extend the typed mutation family instead of growing `ICalendarService`

## Verification
- `dotnet restore Humans.slnx --disable-build-servers -v q`
- `dotnet build Humans.slnx --disable-build-servers -v q`
- `dotnet test tests\Humans.Application.Tests\Humans.Application.Tests.csproj --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Calendar"`
- `dotnet test tests\Humans.Integration.Tests\Humans.Integration.Tests.csproj --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Calendar"`
- `dotnet test tests\Humans.Web.Tests\Humans.Web.Tests.csproj --no-build --disable-build-servers -v q`
- `dotnet test Humans.slnx --no-build --disable-build-servers -v q --filter "FullyQualifiedName!~StorePayActionTests"`

## Note
A full unfiltered solution test run still has the existing `StorePayActionTests` auth/redirect failures: both Stripe pay tests get `302` from `GET /Store/Order/{id}` while trying to harvest the antiforgery token. The calendar-filtered integration tests pass.