### PR TITLE
fix(teams): baseline NoObsoleteNavReads violation in TeamService

### DIFF
--- a/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
@@ -74,6 +74,7 @@ src/Humans.Application/Services/Teams/TeamService.cs:Team#18
 src/Humans.Application/Services/Teams/TeamService.cs:Team#19
 src/Humans.Application/Services/Teams/TeamService.cs:Team#2
 src/Humans.Application/Services/Teams/TeamService.cs:Team#20
+src/Humans.Application/Services/Teams/TeamService.cs:Team#21
 src/Humans.Application/Services/Teams/TeamService.cs:Team#3
 src/Humans.Application/Services/Teams/TeamService.cs:Team#4
 src/Humans.Application/Services/Teams/TeamService.cs:Team#5


### PR DESCRIPTION
## Problem

`origin/main` fails the `No_new_obsolete_nav_reads` architecture test:

```
Rule 'NoObsoleteNavReads' detected 1 NEW violation(s) not in baseline.
  + src/Humans.Application/Services/Teams/TeamService.cs:Team#21 # L1801
```

## Cause

The flagged reads are `tm.Team.Name` / `tjr.Team.Name` in `TeamService.ContributeForUserAsync` (the Teams GDPR export contributor). Both are **same-section** reads of `TeamMember.Team` / `TeamJoinRequest.Team` — neither nav is `[Obsolete]`. The ratchet is a coarse text heuristic that flags every `.Team` token because *other* sections carry `[Obsolete]` navs named `Team`. Twenty identical in-section reads are already in the baseline for this same file (`Team#1..#20`).

## Fix

Add `TeamService.cs:Team#21` to `NoObsoleteNavReads.baseline.txt` — the ratchet's sanctioned path for false positives. One-line change, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)