### PR TITLE
Reduce user-service tech debt

### DIFF
--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -815,12 +815,13 @@ public sealed class UserService(
             .Where(e => e.IsVerified && e.IsGoogle)
             .Select(e => e.Email)
             .FirstOrDefault();
+        var effectiveEmail = SelectEffectiveEmail(userEmails, user.IdentityEmailColumn);
 
 #pragma warning disable HUM_USER_DISPLAYNAME // GDPR export must include the legacy Identity column value.
         var shaped = new
         {
             user.Id,
-            user.Email,
+            Email = effectiveEmail,
             user.DisplayName,
             user.PreferredLanguage,
             GoogleEmail = googleEmail,
@@ -951,6 +952,15 @@ public sealed class UserService(
             commPrefsSlice
         ];
     }
+
+    private static string? SelectEffectiveEmail(
+        IReadOnlyCollection<UserEmail> userEmails,
+        string? fallbackEmail) =>
+        userEmails
+            .Where(e => e.IsVerified)
+            .OrderByDescending(e => e.IsPrimary)
+            .Select(e => e.Email)
+            .FirstOrDefault() ?? fallbackEmail;
 
     private async Task SetPrimaryEmailAsync(Guid userId, Guid emailId, CancellationToken ct)
     {

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -509,7 +509,9 @@ public sealed class CachingUserService(
     {
         if (TryGet(userId, out var info))
             return RehydrateUser(info);
-        return await WithInnerAsync(inner => inner.GetByIdAsync(userId, ct));
+
+        var users = await WithInnerAsync(inner => inner.GetByIdsAsync([userId], ct));
+        return users.TryGetValue(userId, out var user) ? user : null;
     }
 
     public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(

--- a/src/Humans.Web/Controllers/AdminDuplicateAccountsController.cs
+++ b/src/Humans.Web/Controllers/AdminDuplicateAccountsController.cs
@@ -12,12 +12,12 @@ namespace Humans.Web.Controllers;
 [Authorize(Policy = PolicyNames.AdminOnly)]
 [Route("Admin/DuplicateAccounts")]
 public class AdminDuplicateAccountsController(
-    IUserService userService,
+    IUserServiceRead userService,
     IDuplicateAccountService duplicateService,
     ITeamServiceRead teamService,
     ILogger<AdminDuplicateAccountsController> logger) : HumansControllerBase(userService)
 {
-    private readonly IUserService _userService = userService;
+    private readonly IUserServiceRead _userService = userService;
 
     [HttpGet("")]
     public async Task<IActionResult> Index()

--- a/src/Humans.Web/Controllers/AdminMergeController.cs
+++ b/src/Humans.Web/Controllers/AdminMergeController.cs
@@ -12,12 +12,12 @@ namespace Humans.Web.Controllers;
 [Authorize(Policy = PolicyNames.AdminOnly)]
 [Route("Admin/MergeRequests")]
 public class AdminMergeController(
-    IUserService userService,
+    IUserServiceRead userService,
     IAccountMergeService mergeService,
     ITeamServiceRead teamService,
     ILogger<AdminMergeController> logger) : HumansControllerBase(userService)
 {
-    private readonly IUserService _userService = userService;
+    private readonly IUserServiceRead _userService = userService;
 
     [HttpGet("")]
     public async Task<IActionResult> Index()

--- a/src/Humans.Web/Controllers/HumansTeamControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansTeamControllerBase.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Humans.Web.Controllers;
 
 public abstract class HumansTeamControllerBase(
-    IUserService userService,
+    IUserServiceRead userService,
     ITeamServiceRead teamService,
     IAuthorizationService authorizationService) : HumansControllerBase(userService)
 {

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -16,7 +16,7 @@ namespace Humans.Web.Controllers;
 [Authorize(Policy = PolicyNames.AdminOnly)]
 [Route("Profile/Admin")]
 public class ProfileAdminController(
-    IUserService userService,
+    IUserServiceRead userService,
     IEmailProblemsService emailProblems,
     IAccountMergeService accountMerge,
     IUserEmailService userEmails,

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -24,7 +24,7 @@ public class ShiftAdminController(
     IShiftSignupService signupService,
     IShiftView shiftView,
     IGeneralAvailabilityService availabilityService,
-    IUserService userService,
+    IUserServiceRead userService,
     IAuthorizationService authorizationService,
     IClock clock,
     ShiftAdminPageBuilder pageBuilder,

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -24,7 +24,7 @@ namespace Humans.Web.Controllers;
 public class TeamController(
     ITeamService teamService,
     ITeamPageService teamPageService,
-    IUserService userService,
+    IUserServiceRead userService,
     INotificationService notificationService,
     IGoogleSyncService googleSyncService,
     ITeamResourceService teamResourceService,
@@ -34,7 +34,7 @@ public class TeamController(
     IClock clock,
     ILogger<TeamController> logger) : HumansControllerBase(userService)
 {
-    private readonly IUserService _userService = userService;
+    private readonly IUserServiceRead _userService = userService;
     private readonly INotificationService _notificationService = notificationService;
 
     [AllowAnonymous]

--- a/tests/Humans.Application.Tests/GoogleIntegration/EmailProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/EmailProvisioningServiceTests.cs
@@ -142,13 +142,6 @@ public class EmailProvisioningServiceTests
 
     private static void StubTargetUser(ProvisioningFixture f, Guid userId, string? oauthEmail = "target@example.com")
     {
-        f.UserService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new User
-            {
-                Id = userId,
-                Email = oauthEmail,
-                DisplayName = "Target",
-            });
         f.UserService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(WrapInUserInfo(userId, new Profile { FirstName = "Target", LastName = "Two" }));
     }

--- a/tests/Humans.Application.Tests/Infrastructure/ServiceTestHarness.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/ServiceTestHarness.cs
@@ -66,8 +66,8 @@ public abstract class ServiceTestHarness : IDisposable
 
     /// <summary>
     /// Creates an NSubstitute <see cref="IUserService"/> whose reader methods
-    /// (<c>GetByIdAsync</c>, <c>GetByIdsAsync</c>, <c>GetUserInfoAsync</c>,
-    /// <c>GetUserInfosAsync</c>) are wired to read from this harness's in-memory DB.
+    /// (<c>GetByIdsAsync</c>, <c>GetUserInfoAsync</c>, <c>GetUserInfosAsync</c>)
+    /// are wired to read from this harness's in-memory DB.
     /// Mirrors the production behavior of the User stitcher without requiring the real
     /// caching/repository stack. Use for services that depend on <see cref="IUserService"/>
     /// for cross-domain user lookups.
@@ -75,14 +75,6 @@ public abstract class ServiceTestHarness : IDisposable
     private protected IUserService NewDbBackedUserService()
     {
         var svc = Substitute.For<IUserService>();
-
-        svc.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(ci =>
-            {
-                var id = ci.Arg<Guid>();
-                using var db = new HumansDbContext(DbOptions);
-                return Task.FromResult(db.Users.AsNoTracking().FirstOrDefault(u => u.Id == id));
-            });
 
         svc.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(ci =>

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
@@ -150,7 +150,6 @@ public sealed class TicketTransferService_OnwardTransferTests
             });
         var carol = new User { Id = UserC, DisplayName = "Carol", PreferredLanguage = "en" };
         var carolProfile = new Profile { BurnerName = "Carol", FirstName = "Carol", LastName = "Cohen" };
-        _userService.GetByIdAsync(UserC, Arg.Any<CancellationToken>()).Returns(carol);
         _userService.GetUserInfoAsync(UserC, Arg.Any<CancellationToken>())
             .Returns(UserInfo.Create(
                 user: carol,

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
@@ -477,8 +477,6 @@ public class UserEmailServiceTests
             .Returns(deleting);
         _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { deleting, keeping });
-        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new User { Id = userId });
         _userManager.GetLoginsAsync(Arg.Any<User>())
             .Returns(new List<UserLoginInfo> { new("Google", "sub-123", "Google") });
 
@@ -536,8 +534,6 @@ public class UserEmailServiceTests
             .Returns(only);
         _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { only });
-        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new User { Id = userId });
         _userManager.GetLoginsAsync(Arg.Any<User>())
             .Returns(new List<UserLoginInfo>());
 

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -24,6 +24,12 @@ public class CachingUserServiceTests
         typeof(User).GetProperty("DisplayName")
         ?? throw new InvalidOperationException("User.DisplayName property missing.");
 
+    private static readonly System.Reflection.MethodInfo GetByIdAsyncMethod =
+        typeof(CachingUserService).GetMethod(
+            "GetByIdAsync",
+            [typeof(Guid), typeof(CancellationToken)])
+        ?? throw new InvalidOperationException("CachingUserService.GetByIdAsync method missing.");
+
     private readonly IUserService _inner = Substitute.For<IUserService>();
 
     private CachingUserService CreateSut()
@@ -76,6 +82,20 @@ public class CachingUserServiceTests
 
     private static string LegacyDisplayName(User user) =>
         (string?)LegacyDisplayNameProperty.GetValue(user) ?? string.Empty;
+
+    private static async Task<User?> InvokeGetByIdAsync(CachingUserService sut, Guid userId)
+    {
+        var task = (Task<User?>)GetByIdAsyncMethod.Invoke(
+            sut,
+            [userId, CancellationToken.None])!;
+        return await task;
+    }
+
+    private void InnerShouldNotHaveReceivedGetById()
+    {
+        _inner.ReceivedCalls().Should().NotContain(call =>
+            string.Equals(call.GetMethodInfo().Name, "GetByIdAsync", StringComparison.Ordinal));
+    }
 
     [HumansFact]
     public async Task GetUserInfoAsync_DictMiss_DelegatesToInnerAndCaches()
@@ -523,6 +543,27 @@ public class CachingUserServiceTests
     }
 
     [HumansFact]
+    public async Task GetByIdAsync_ColdCache_UsesBatchFallback()
+    {
+        var userId = Guid.NewGuid();
+        var user = WithLegacyDisplayName(SampleUser(userId), "Fresh");
+        _inner.GetByIdsAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1 && ids.Contains(userId)),
+            Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, User> { [userId] = user });
+
+        var sut = CreateSut();
+
+        var result = await InvokeGetByIdAsync(sut, userId);
+
+        result.Should().BeSameAs(user);
+        InnerShouldNotHaveReceivedGetById();
+        await _inner.Received(1).GetByIdsAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1 && ids.Contains(userId)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task GetByIdAsync_WarmCache_ServesFromDict_NoInnerCall()
     {
         var userId = Guid.NewGuid();
@@ -533,13 +574,13 @@ public class CachingUserServiceTests
         var sut = CreateSut();
         await sut.GetUserInfoAsync(userId); // prime
 
-        var user = await sut.GetByIdAsync(userId);
+        var user = await InvokeGetByIdAsync(sut, userId);
 
         user.Should().NotBeNull();
         LegacyDisplayName(user).Should().Be("Cached");
 
         // GetByIdAsync should not have been delegated.
-        await _inner.DidNotReceive().GetByIdAsync(userId, Arg.Any<CancellationToken>());
+        InnerShouldNotHaveReceivedGetById();
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
@@ -76,6 +76,11 @@ public sealed class UserServiceProfileOnboardingMutationTests : ServiceTestHarne
         json.Should().Contain("\"IsOAuth\":true");
         json.Should().Contain("\"IsNotificationTarget\":true");
         json.Should().NotContain("\"IsPrimary\":");
+
+        var accountSlice = slices.Single(s =>
+            string.Equals(s.SectionName, GdprExportSections.Account, StringComparison.Ordinal));
+        var accountJson = System.Text.Json.JsonSerializer.Serialize(accountSlice.Data);
+        accountJson.Should().Contain("\"Email\":\"g@example.com\"");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary
- Narrow read-only web controller dependencies from `IUserService` to `IUserServiceRead`
- Use `UserEmail` rows directly for GDPR account email export instead of the legacy `User.Email` override
- Route `CachingUserService.GetByIdAsync` cache misses through the batch lookup path
- Remove stale obsolete `GetByIdAsync` stubs from application tests

## Verification
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Controller"`
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --disable-build-servers -v q --filter "FullyQualifiedName~UserServiceProfileOnboardingMutationTests"`
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --disable-build-servers -v q --filter "FullyQualifiedName~CachingUserServiceTests"`
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --disable-build-servers -v q --filter "FullyQualifiedName~EmailProvisioningServiceTests|FullyQualifiedName~TicketTransferService_OnwardTransferTests|FullyQualifiedName~UserEmailServiceTests|FullyQualifiedName~TeamServiceTests|FullyQualifiedName~CampaignServiceTests|FullyQualifiedName~CampServiceTests|FullyQualifiedName~FeedbackServiceTests|FullyQualifiedName~IssuesServiceTests|FullyQualifiedName~RoleAssignmentServiceTests"`
- `dotnet test Humans.slnx --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Application"`
- `dotnet build Humans.slnx --disable-build-servers -v q`