### PR TITLE
feat(shifts): pull team role hours into the workload report

### DIFF
--- a/docs/features/shifts/workload-dashboard.md
+++ b/docs/features/shifts/workload-dashboard.md
@@ -83,7 +83,7 @@ planned    += estimate × SlotCount                     # per-department
 filled     += estimate × assignedSlotCount             # per-department
 ```
 
-Pending signups contribute to the per-user `PendingSignupCount` only, never to hours. Roles with a null `EstimatedHours` contribute nothing. Role assignments are current holders (no per-event-year history); role hours show only when the active event has at least one shift.
+Pending signups contribute to the per-user `PendingSignupCount` only, never to hours. Roles with a null `EstimatedHours` contribute nothing. Roles on **deactivated** teams are excluded (deactivation doesn't clear role assignments, so stale holders would otherwise leak in). Role assignments are current holders (no per-event-year history); role hours show only when the active event has at least one shift.
 
 ### Inclusion rule
 

--- a/docs/features/shifts/workload-dashboard.md
+++ b/docs/features/shifts/workload-dashboard.md
@@ -7,7 +7,8 @@
 -->
 <!-- freshness:flag-on-change
   Workload math (Confirmed-only hours, MaxVolunteers cap, all-day window),
-  pending-vs-confirmed split, role-hours follow-up, or scope of
+  pending-vs-confirmed split, role-hours mapping (RolePeriod → column;
+  per-holder annual estimate; dept planned = estimate × slots), or scope of
   admin-only/hidden inclusion may have changed.
 -->
 
@@ -17,21 +18,22 @@
 
 Coordinators and admins balancing the event need an at-a-glance view of "who is doing how much" so they can spot burnout candidates (too many confirmed hours), idle volunteers (no signups), and under-staffed departments (low coverage). The existing `/Shifts/Dashboard` answers operational questions per-department; this view answers the cross-event distribution question — sliced three ways on one page.
 
-Asked by Peter for the 2026 cycle. Scoped to **shift-based** workload only — role-based hours (the time a `TeamRoleDefinition` is estimated to require) are deferred until `TeamRoleDefinition.EstimatedHours` lands as a separate field. Once that ships, a follow-up extends `WorkloadByPersonRow` with `RoleHours` and unifies the burnout signal.
+Asked by Peter for the 2026 cycle. Combines **shift-based** workload (Confirmed shift hours) with **role-based** workload — each `TeamRoleDefinition.EstimatedHours` (whole hours per year) a person holds, mapped to the column matching the role's `RolePeriod`. Year-round roles get their own column; Build/Event/Strike roles fold into the matching shift-period column.
 
 ## User Stories
 
 ### US-WL.1: Admin Sees Per-Person Workload
 
 **As an** Admin / NoInfoAdmin / VolunteerCoordinator
-**I want to** see every volunteer with at least one shift signup, with their Confirmed hours and Pending count
+**I want to** see every volunteer with shift signups or role assignments, with their hours split by period and Pending count
 **So that** I can identify volunteers nearing burnout and volunteers who have queued work but no approved work
 
 **Acceptance Criteria:**
-- Row per user with `≥ 1` Pending or Confirmed signup for the active event
-- Columns: Display name, Confirmed hours, Confirmed signup count, Pending signup count
-- Pending signups do **not** contribute to Confirmed hours (no burnout inflation from queued work)
-- Display order: descending by Confirmed hours, then ascending by display name (sort is applied in the controller, not the service)
+- Row per user with `≥ 1` Pending/Confirmed signup **or** a role assignment carrying estimated hours, for the active event
+- Columns: Display name, Confirmed signup count, Pending signup count, Year-round / Build / Event / Strike hours, Total
+- Confirmed shift hours land in their shift period's column; a held role's `EstimatedHours` (full annual estimate, per holder) lands in the column matching the role's `RolePeriod`
+- Pending signups do **not** contribute to hours (no burnout inflation from queued work)
+- Display order: descending by Total hours, then ascending by display name (sort is applied in the controller, not the service)
 - Click a column header to re-sort asc/desc client-side
 
 ### US-WL.2: Admin Sees Per-Shift Coverage
@@ -55,26 +57,33 @@ Asked by Peter for the 2026 cycle. Scoped to **shift-based** workload only — r
 **So that** I can find departments that are under-staffed at the planning level
 
 **Acceptance Criteria:**
-- Row per department (any team owning at least one rota with shifts in the event)
+- Row per department: any team owning at least one rota with shifts in the event, **or** owning a role with estimated hours
 - Columns: Department, Rota count, Shift count, Planned slots, Filled slots, Coverage %, Planned hours, Filled hours
 - `FilledSlots` and `FilledHours` cap at `MaxVolunteers` per shift (over-enrolled shifts cannot drive coverage above 100 %)
+- Role estimates fold into `Planned hours` (estimate × slots) and `Filled hours` (estimate × assigned slots); slot counts and Coverage % stay shift-only
 - Default order: team name ascending (sort is applied in the controller)
 - Client-side column sort
 
 ## Data Model
 
-No new tables. Derived entirely from existing `event_settings`, `rotas`, `shifts`, `shift_signups`, and `teams`.
+No new tables. Derived from existing `event_settings`, `rotas`, `shifts`, `shift_signups`, `teams`, and team role definitions/assignments (`TeamRoleDefinition.EstimatedHours` + `RolePeriod`, read via the cached `TeamInfo` projection).
 
 ### Hour math
 
 ```
+# Shift hours
 hours       = shift.IsAllDay ? (AllDayWindowEnd − AllDayWindowStart) : shift.Duration.TotalHours
 planned    += hours × shift.MaxVolunteers              # per-department
 filled     += hours × min(confirmed, MaxVolunteers)    # per-department
-confirmed  += hours                                    # per-user, only for Confirmed signups
+confirmed  += hours                                    # per-user, only for Confirmed signups, by shift period
+
+# Role hours (estimate = TeamRoleDefinition.EstimatedHours, whole hours/year)
+per-user   += estimate                                 # each holder, into the role's RolePeriod column
+planned    += estimate × SlotCount                     # per-department
+filled     += estimate × assignedSlotCount             # per-department
 ```
 
-Pending signups contribute to the per-user `PendingSignupCount` only, never to hours.
+Pending signups contribute to the per-user `PendingSignupCount` only, never to hours. Roles with a null `EstimatedHours` contribute nothing. Role assignments are current holders (no per-event-year history); role hours show only when the active event has at least one shift.
 
 ### Inclusion rule
 
@@ -94,20 +103,17 @@ Gated to `PolicyNames.ShiftDashboardAccess` at the controller — same narrow po
 
 ## Architecture
 
-`WorkloadService` lives in `Humans.Application.Services.Shifts.Workload` — read-only, no DbSet writes. Reads per-rota shift + signup rows through `IShiftView.GetRotasAsync`; uses `IShiftManagementRepository` only for the active-event lookup and an inlined distinct over `GetShiftsForEventAsync` to derive the set of rota ids to walk (no new interface method — see `memory/architecture/interface-method-additions-are-debt.md`). Cross-section name stitching via `ITeamService.GetByIdsWithParentsAsync` and `IUserService.GetUserInfosAsync`.
+`WorkloadService` lives in `Humans.Application.Services.Shifts.Workload` — read-only, no DbSet writes. Reads per-rota shift + signup rows through `IShiftView.GetRotasAsync`; uses `IShiftManagementRepository` only for the active-event lookup and an inlined distinct over `GetShiftsForEventAsync` to derive the set of rota ids to walk (no new interface method — see `memory/architecture/interface-method-additions-are-debt.md`). Cross-section name stitching via `ITeamService.GetByIdsWithParentsAsync` and `IUserService.GetUserInfosAsync`. Role hours come from `ITeamServiceRead.GetTeamsAsync` — the cached `TeamInfo` projection already carries each team's role definitions (with `EstimatedHours`, `RolePeriod`, `SlotCount`) and assignment holder ids, so no new cross-section method was added.
 
 **Cache:** No service-level cache. Source data lives in the Shifts-section per-rota cache owned by `CachingShiftViewService` (§15 Option B at the section level). Signup / shift / rota mutations evict the affected rota cache entries via `IShiftViewInvalidator`, so workload totals stay consistent without a parallel cache key. The aggregation itself is microsecond-scale CPU work over a few hundred rotas at our ~500-user scale.
 
 **Display sort:** The service returns unsorted lists; `ShiftWorkloadAdminController.SortForDisplay` applies the default ordering before passing the report to the view. Per `memory/architecture/display-sort-in-controllers.md` — sorting in the service would leak presentation into the data layer.
 
-## Deferred — Role-based hours
-
-Acceptance criterion *"Year filter is supported"* and the role-hours dimension (a `TeamRoleDefinition.EstimatedHours` contribution to per-person totals) are **deferred**:
+## Deferred — Year filter
 
 - **Year filter** — there is no multi-year surface on `IShiftManagementService` today. The view uses the active event. Easy follow-up once a year-based lookup lands.
-- **Role hours** — `TeamRoleDefinition.EstimatedHours` does not exist yet. Filed as a separate issue. Once it ships, extend `WorkloadByPersonRow` with `RoleHours` and unify the burnout signal across shift hours + role hours.
 
-Upstream issue stays open via `Refs nobodies-collective/Humans#734` until both follow-ups land.
+Role-based hours (the original #734 follow-up) are now implemented — see the per-person/per-department hour math above. Role hours only surface when the active event has at least one shift (the report short-circuits to empty for a shift-less event); revisit if year-round role workload needs to show before any shifts exist.
 
 ## Related Features
 

--- a/src/Humans.Application/DTOs/Shifts/Workload/WorkloadReport.cs
+++ b/src/Humans.Application/DTOs/Shifts/Workload/WorkloadReport.cs
@@ -2,13 +2,14 @@ namespace Humans.Application.DTOs.Shifts.Workload;
 
 /// <summary>
 /// Site-wide workload aggregations sliced "three ways to slice the cake":
-/// per-person, per-rota, per-department. Counts and hours derive from
-/// shift signups only — role hours are deferred until role data carries an
-/// EstimatedHours field (nobodies-collective/Humans#734 follow-up).
+/// per-person, per-rota, per-department. Hours combine shift signups with
+/// team role estimates (<c>TeamRoleDefinition.EstimatedHours</c>), mapped to
+/// the role's <c>RolePeriod</c>. Per-rota stays shift-only — roles are
+/// team-scoped, not rota-scoped.
 /// </summary>
 /// <param name="EventSettingsId">The event the rows describe.</param>
 /// <param name="EventYear">Display label.</param>
-/// <param name="ByPerson">Per-volunteer rows; one row per user with at least one Pending or Confirmed signup.</param>
+/// <param name="ByPerson">Per-volunteer rows; one row per user with at least one signup or role assignment.</param>
 /// <param name="ByRota">Per-rota roll-up: planned hours / slots vs filled.</param>
 /// <param name="ByDepartment">Per-department roll-up: planned hours / slots vs filled.</param>
 public record WorkloadReport(
@@ -19,22 +20,24 @@ public record WorkloadReport(
     IReadOnlyList<WorkloadByDepartmentRow> ByDepartment);
 
 /// <summary>
-/// Per-person workload row. Confirmed hours are split by shift period so the
-/// UI can show Build/Event/Strike load alongside the total. Pending signups
-/// are reported as a count only — they don't inflate hours so a coordinator
-/// can spot "lots queued, none approved" patterns without false-positive
-/// burnout signals. Role hours are deferred (#734).
+/// Per-person workload row. Confirmed shift hours are split by shift period
+/// (Build/Event/Strike); role estimates are added to the column matching the
+/// role's <c>RolePeriod</c>, with year-round roles in their own column. Pending
+/// signups are reported as a count only — they don't inflate hours so a
+/// coordinator can spot "lots queued, none approved" patterns without
+/// false-positive burnout signals.
 /// </summary>
 public record WorkloadByPersonRow(
     Guid UserId,
     string DisplayName,
     int ConfirmedSignupCount,
     int PendingSignupCount,
+    decimal YearRoundHours,
     decimal BuildHours,
     decimal EventHours,
     decimal StrikeHours)
 {
-    public decimal TotalHours => BuildHours + EventHours + StrikeHours;
+    public decimal TotalHours => YearRoundHours + BuildHours + EventHours + StrikeHours;
 }
 
 /// <summary>
@@ -55,8 +58,12 @@ public record WorkloadByRotaRow(
 
 /// <summary>
 /// Per-department roll-up: planned vs filled hours and slots across every
-/// shift on rotas owned by the department. <see cref="TeamSlug"/> is the URL
-/// slug for linking to <c>/Teams/{slug}/Shifts</c>.
+/// shift on rotas owned by the department. <see cref="PlannedHours"/> /
+/// <see cref="FilledHours"/> also fold in the department's role estimates
+/// (planned = estimate × slots, filled = estimate × assigned slots); slot
+/// counts and coverage stay shift-only. A department with roles but no rotas
+/// still gets a row. <see cref="TeamSlug"/> is the URL slug for linking to
+/// <c>/Teams/{slug}/Shifts</c>.
 /// </summary>
 public record WorkloadByDepartmentRow(
     Guid TeamId,

--- a/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
+++ b/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
@@ -243,13 +243,21 @@ public sealed class WorkloadService(
 
     private sealed record RoleDeptHours(string TeamName, string TeamSlug, decimal PlannedHours, decimal FilledHours);
 
+    // Roles on deactivated teams are excluded — deactivation doesn't clear role
+    // assignments, so a retired team's stale holders would otherwise leak in.
+    private static IEnumerable<TeamRoleDefinitionSnapshot> ActiveRoles(
+        IReadOnlyDictionary<Guid, TeamInfo> allTeams) =>
+        allTeams.Values
+            .Where(t => t.IsActive)
+            .SelectMany(t => t.RoleDefinitions ?? []);
+
     // Per holder: each assigned user contributes the role's full annual estimate,
     // bucketed by the role's period (year-round in its own bucket).
     private static Dictionary<Guid, RolePersonHours> BuildRolePersonHours(
         IReadOnlyDictionary<Guid, TeamInfo> allTeams)
     {
         var perUser = new Dictionary<Guid, RolePersonHours>();
-        foreach (var role in allTeams.Values.SelectMany(t => t.RoleDefinitions ?? []))
+        foreach (var role in ActiveRoles(allTeams))
         {
             if (role.EstimatedHours is not { } est) continue;
             foreach (var assignment in role.Assignments)
@@ -268,7 +276,7 @@ public sealed class WorkloadService(
         IReadOnlyDictionary<Guid, TeamInfo> allTeams)
     {
         var perTeam = new Dictionary<Guid, RoleDeptHours>();
-        foreach (var role in allTeams.Values.SelectMany(t => t.RoleDefinitions ?? []))
+        foreach (var role in ActiveRoles(allTeams))
         {
             if (role.EstimatedHours is not { } est) continue;
             var assigned = role.Assignments.Count(a => a.AssignedUserId.HasValue);

--- a/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
+++ b/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
@@ -53,9 +53,15 @@ public sealed class WorkloadService(
             ? await teamService.GetByIdsWithParentsAsync(teamIds, ct)
             : new Dictionary<Guid, Team>();
 
+        // Role estimates come from the cached team projection (definitions carry
+        // EstimatedHours + RolePeriod; assignments carry the holder's user id).
+        var allTeams = await teamService.GetTeamsAsync(ct);
+        var rolePersonHours = BuildRolePersonHours(allTeams);
+        var roleDeptHours = BuildRoleDeptHours(allTeams);
+
         var byRota = BuildByRota(entries, teamLookup);
-        var byDepartment = BuildByDepartment(entries, teamLookup);
-        var byPerson = await BuildByPersonAsync(entries, es, ct);
+        var byDepartment = BuildByDepartment(entries, teamLookup, roleDeptHours);
+        var byPerson = await BuildByPersonAsync(entries, es, rolePersonHours, ct);
 
         return new WorkloadReport(
             EventSettingsId: es.Id,
@@ -103,10 +109,12 @@ public sealed class WorkloadService(
 
     private static List<WorkloadByDepartmentRow> BuildByDepartment(
         IReadOnlyList<(Rota Rota, Shift Shift)> entries,
-        IReadOnlyDictionary<Guid, Team> teamLookup) =>
-        entries
+        IReadOnlyDictionary<Guid, Team> teamLookup,
+        IReadOnlyDictionary<Guid, RoleDeptHours> roleDeptHours)
+    {
+        var rows = entries
             .GroupBy(e => e.Rota.TeamId)
-            .Select(g =>
+            .ToDictionary(g => g.Key, g =>
             {
                 var hoursPerShift = g.ToDictionary(e => e.Shift.Id, e => HoursOf(e.Shift));
                 var plannedSlots = g.Sum(e => e.Shift.MaxVolunteers);
@@ -130,17 +138,42 @@ public sealed class WorkloadService(
                     FilledSlots: filledSlots,
                     PlannedHours: plannedHours,
                     FilledHours: filledHours);
-            })
-            .ToList();
+            });
+
+        // Fold role hours into the matching department; create rows for teams
+        // that own roles but no rotas in this event.
+        foreach (var (teamId, role) in roleDeptHours)
+        {
+            rows[teamId] = rows.TryGetValue(teamId, out var existing)
+                ? existing with
+                {
+                    PlannedHours = existing.PlannedHours + role.PlannedHours,
+                    FilledHours = existing.FilledHours + role.FilledHours,
+                }
+                : new WorkloadByDepartmentRow(
+                    TeamId: teamId,
+                    TeamName: role.TeamName,
+                    TeamSlug: role.TeamSlug,
+                    RotaCount: 0,
+                    ShiftCount: 0,
+                    PlannedSlots: 0,
+                    FilledSlots: 0,
+                    PlannedHours: role.PlannedHours,
+                    FilledHours: role.FilledHours);
+        }
+
+        return rows.Values.ToList();
+    }
 
     private async Task<List<WorkloadByPersonRow>> BuildByPersonAsync(
         IReadOnlyList<(Rota Rota, Shift Shift)> entries,
         EventSettings es,
+        IReadOnlyDictionary<Guid, RolePersonHours> rolePersonHours,
         CancellationToken ct)
     {
         // Confirmed → per-phase hours; Pending → count only (don't inflate
         // burnout from queued work).
-        var perUser = new Dictionary<Guid, (int Confirmed, int Pending, decimal Build, decimal Event, decimal Strike)>();
+        var perUser = new Dictionary<Guid, (int Confirmed, int Pending, decimal YearRound, decimal Build, decimal Event, decimal Strike)>();
         foreach (var (_, shift) in entries)
         {
             var hours = HoursOf(shift);
@@ -155,17 +188,30 @@ public sealed class WorkloadService(
                 {
                     totals = period switch
                     {
-                        ShiftPeriod.Build => (totals.Confirmed + 1, totals.Pending, totals.Build + hours, totals.Event, totals.Strike),
-                        ShiftPeriod.Event => (totals.Confirmed + 1, totals.Pending, totals.Build, totals.Event + hours, totals.Strike),
-                        _ => (totals.Confirmed + 1, totals.Pending, totals.Build, totals.Event, totals.Strike + hours),
+                        ShiftPeriod.Build => totals with { Confirmed = totals.Confirmed + 1, Build = totals.Build + hours },
+                        ShiftPeriod.Event => totals with { Confirmed = totals.Confirmed + 1, Event = totals.Event + hours },
+                        _ => totals with { Confirmed = totals.Confirmed + 1, Strike = totals.Strike + hours },
                     };
                 }
                 else
                 {
-                    totals = (totals.Confirmed, totals.Pending + 1, totals.Build, totals.Event, totals.Strike);
+                    totals = totals with { Pending = totals.Pending + 1 };
                 }
                 perUser[signup.UserId] = totals;
             }
+        }
+
+        // Fold role estimates in; a role-only holder (no signups) still gets a row.
+        foreach (var (userId, role) in rolePersonHours)
+        {
+            perUser.TryGetValue(userId, out var totals);
+            perUser[userId] = totals with
+            {
+                YearRound = totals.YearRound + role.YearRound,
+                Build = totals.Build + role.Build,
+                Event = totals.Event + role.Event,
+                Strike = totals.Strike + role.Strike,
+            };
         }
 
         if (perUser.Count == 0) return new List<WorkloadByPersonRow>();
@@ -183,10 +229,66 @@ public sealed class WorkloadService(
                     DisplayName: name,
                     ConfirmedSignupCount: kvp.Value.Confirmed,
                     PendingSignupCount: kvp.Value.Pending,
+                    YearRoundHours: kvp.Value.YearRound,
                     BuildHours: kvp.Value.Build,
                     EventHours: kvp.Value.Event,
                     StrikeHours: kvp.Value.Strike);
             })
             .ToList();
     }
+
+    // ── Role-hours aggregation off the cached TeamInfo projection ──────────────────
+
+    private sealed record RolePersonHours(decimal YearRound, decimal Build, decimal Event, decimal Strike);
+
+    private sealed record RoleDeptHours(string TeamName, string TeamSlug, decimal PlannedHours, decimal FilledHours);
+
+    // Per holder: each assigned user contributes the role's full annual estimate,
+    // bucketed by the role's period (year-round in its own bucket).
+    private static Dictionary<Guid, RolePersonHours> BuildRolePersonHours(
+        IReadOnlyDictionary<Guid, TeamInfo> allTeams)
+    {
+        var perUser = new Dictionary<Guid, RolePersonHours>();
+        foreach (var role in allTeams.Values.SelectMany(t => t.RoleDefinitions ?? []))
+        {
+            if (role.EstimatedHours is not { } est) continue;
+            foreach (var assignment in role.Assignments)
+            {
+                if (assignment.AssignedUserId is not { } userId) continue;
+                perUser.TryGetValue(userId, out var h);
+                h ??= new RolePersonHours(0, 0, 0, 0);
+                perUser[userId] = AddByPeriod(h, role.Period, est);
+            }
+        }
+        return perUser;
+    }
+
+    // Per department: planned = estimate × slots, filled = estimate × assigned slots.
+    private static Dictionary<Guid, RoleDeptHours> BuildRoleDeptHours(
+        IReadOnlyDictionary<Guid, TeamInfo> allTeams)
+    {
+        var perTeam = new Dictionary<Guid, RoleDeptHours>();
+        foreach (var role in allTeams.Values.SelectMany(t => t.RoleDefinitions ?? []))
+        {
+            if (role.EstimatedHours is not { } est) continue;
+            var assigned = role.Assignments.Count(a => a.AssignedUserId.HasValue);
+            perTeam.TryGetValue(role.TeamId, out var h);
+            h ??= new RoleDeptHours(role.TeamName, role.TeamSlug, 0, 0);
+            perTeam[role.TeamId] = h with
+            {
+                PlannedHours = h.PlannedHours + est * role.SlotCount,
+                FilledHours = h.FilledHours + est * assigned,
+            };
+        }
+        return perTeam;
+    }
+
+    private static RolePersonHours AddByPeriod(RolePersonHours h, RolePeriod period, int est) =>
+        period switch
+        {
+            RolePeriod.Build => h with { Build = h.Build + est },
+            RolePeriod.Event => h with { Event = h.Event + est },
+            RolePeriod.Strike => h with { Strike = h.Strike + est },
+            _ => h with { YearRound = h.YearRound + est },
+        };
 }

--- a/src/Humans.Web/Views/ShiftWorkloadAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftWorkloadAdmin/Index.cshtml
@@ -28,11 +28,10 @@
     }
 
     <p class="text-muted">
-        Shift-based workload aggregations across the whole event, sliced by person, rota, and
-        department. Per-person hours are split by <strong>Build / Event / Strike</strong>; role hours are
-        deferred to a follow-up — see
-        <a href="https://github.com/nobodies-collective/Humans/issues/734">issue #734</a>.
-        Counts and hours derive from <strong>Confirmed</strong> shift signups; pending signups
+        Workload aggregations across the whole event, sliced by person, rota, and
+        department. Per-person hours are split by <strong>Year-round / Build / Event / Strike</strong>:
+        Confirmed shift hours land in their shift period, and team role estimates
+        (<strong>hours/year</strong>) land in the column matching the role's period. Pending signups
         are reported separately so queued work doesn't inflate the burnout signal.
     </p>
 

--- a/src/Humans.Web/Views/ShiftWorkloadAdmin/_WorkloadByDepartment.cshtml
+++ b/src/Humans.Web/Views/ShiftWorkloadAdmin/_WorkloadByDepartment.cshtml
@@ -3,7 +3,7 @@
 
 @if (Model.Count == 0)
 {
-    <div class="alert alert-info">No departments own any rotas in this event.</div>
+    <div class="alert alert-info">No departments own rotas or roles in this event.</div>
     return;
 }
 

--- a/src/Humans.Web/Views/ShiftWorkloadAdmin/_WorkloadByPerson.cshtml
+++ b/src/Humans.Web/Views/ShiftWorkloadAdmin/_WorkloadByPerson.cshtml
@@ -7,7 +7,7 @@
 
 @if (Model.Count == 0)
 {
-    <div class="alert alert-info">No humans have signed up for shifts yet.</div>
+    <div class="alert alert-info">No humans have shift signups or role assignments yet.</div>
     return;
 }
 
@@ -18,7 +18,7 @@
                 <th data-sort>Human</th>
                 <th data-sort class="text-end">Confirmed signups</th>
                 <th data-sort class="text-end">Pending signups</th>
-                <th data-sort class="text-end" title="Role hours — coming soon (#734)">Role</th>
+                <th data-sort class="text-end" title="Estimated hours from year-round team roles">Year-round</th>
                 <th data-sort class="text-end">Build</th>
                 <th data-sort class="text-end">Event</th>
                 <th data-sort class="text-end">Strike</th>
@@ -32,7 +32,7 @@
                     <td data-value="@row.DisplayName"><vc:human user-id="@row.UserId" layout="Text" link="Admin" /></td>
                     <td class="text-end" data-value="@row.ConfirmedSignupCount">@row.ConfirmedSignupCount</td>
                     <td class="text-end" data-value="@row.PendingSignupCount">@row.PendingSignupCount</td>
-                    <td class="text-end text-muted" data-value="0" title="Role hours — coming soon (#734)">—</td>
+                    <td class="text-end" data-value="@row.YearRoundHours.ToString("0.##", inv)">@row.YearRoundHours.ToString("0.##")</td>
                     <td class="text-end" data-value="@row.BuildHours.ToString("0.##", inv)">@row.BuildHours.ToString("0.##")</td>
                     <td class="text-end" data-value="@row.EventHours.ToString("0.##", inv)">@row.EventHours.ToString("0.##")</td>
                     <td class="text-end" data-value="@row.StrikeHours.ToString("0.##", inv)">@row.StrikeHours.ToString("0.##")</td>

--- a/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
@@ -300,7 +300,8 @@ public sealed class WorkloadServiceTests : ServiceTestHarness
         StubTeams(
             TeamWithRoles(oldTeam.Id, "OldTeam", "oldteam",
                 Role(oldTeam.Id, "OldTeam", "oldteam", RolePeriod.YearRound, estimatedHours: 40, slotCount: 1, alice.Id))
-            with { IsActive = false });
+            with
+            { IsActive = false });
 
         var report = await _service.GetForActiveEventAsync();
         report.Should().NotBeNull();

--- a/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
@@ -40,6 +40,11 @@ public sealed class WorkloadServiceTests : ServiceTestHarness
         _teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(call => GetTeamsByIdsAsync(call.Arg<IReadOnlyCollection<Guid>>()));
 
+        // Role hours come from the cached TeamInfo projection; default to none so
+        // shift-only tests are unaffected. Role tests override via StubTeams.
+        _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+
         _service = new WorkloadService(repo, view, _teamService, NewDbBackedUserService());
     }
 
@@ -156,6 +161,129 @@ public sealed class WorkloadServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task ByPerson_RoleHours_MappedByPeriod_YearRoundIntoOwnColumn_OthersFoldIntoShiftColumns()
+    {
+        // Event has shifts (so the report isn't short-circuited). Alice holds two
+        // roles: a year-round role (10h) and a Build-period role (4h), plus a
+        // 5h Event shift signup. Year-round lands in its own column; Build role
+        // hours fold into the Build shift column.
+        var es = await SeedEventAsync();
+        var team = await SeedWorkloadTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es);
+        var eventShift = await SeedShiftAsync(rota, dayOffset: 1, hours: 5);
+        var alice = await SeedUserWithProfileAsync("Alice");
+        await SeedSignupAsync(eventShift, alice.Id, SignupStatus.Confirmed);
+
+        StubTeams(TeamWithRoles(team.Id, "Gate", "gate",
+            Role(team.Id, "Gate", "gate", RolePeriod.YearRound, estimatedHours: 10, slotCount: 1, alice.Id),
+            Role(team.Id, "Gate", "gate", RolePeriod.Build, estimatedHours: 4, slotCount: 1, alice.Id)));
+
+        var report = await _service.GetForActiveEventAsync();
+        report.Should().NotBeNull();
+        var row = report.ByPerson.Single(p => p.UserId == alice.Id);
+        row.YearRoundHours.Should().Be(10m);
+        row.BuildHours.Should().Be(4m);
+        row.EventHours.Should().Be(5m);
+        row.StrikeHours.Should().Be(0m);
+        row.TotalHours.Should().Be(19m);
+    }
+
+    [HumansFact]
+    public async Task ByPerson_RoleOnlyHolder_AppearsWithNoSignups()
+    {
+        // The event has a shift (someone else, or none) so the report renders.
+        // Bob holds only a year-round role and has zero shift signups — he must
+        // still appear, with his role hours.
+        var es = await SeedEventAsync();
+        var team = await SeedWorkloadTeamAsync("Board");
+        var rota = await SeedRotaAsync(team, es);
+        await SeedShiftAsync(rota, dayOffset: 1, hours: 5); // un-signed shift, just to render the report
+
+        var bob = await SeedUserWithProfileAsync("Bob");
+        StubTeams(TeamWithRoles(team.Id, "Board", "board",
+            Role(team.Id, "Board", "board", RolePeriod.YearRound, estimatedHours: 12, slotCount: 1, bob.Id)));
+
+        var report = await _service.GetForActiveEventAsync();
+        report.Should().NotBeNull();
+        var row = report.ByPerson.Single(p => p.UserId == bob.Id);
+        row.YearRoundHours.Should().Be(12m);
+        row.TotalHours.Should().Be(12m);
+        row.ConfirmedSignupCount.Should().Be(0);
+        row.PendingSignupCount.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task ByPerson_RoleWithoutEstimatedHours_ContributesNothing()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedWorkloadTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es);
+        var shift = await SeedShiftAsync(rota, dayOffset: 1, hours: 5);
+        var alice = await SeedUserWithProfileAsync("Alice");
+        await SeedSignupAsync(shift, alice.Id, SignupStatus.Confirmed);
+
+        StubTeams(TeamWithRoles(team.Id, "Gate", "gate",
+            Role(team.Id, "Gate", "gate", RolePeriod.YearRound, estimatedHours: null, slotCount: 1, alice.Id)));
+
+        var report = await _service.GetForActiveEventAsync();
+        report.Should().NotBeNull();
+        var row = report.ByPerson.Single(p => p.UserId == alice.Id);
+        row.YearRoundHours.Should().Be(0m);
+        row.TotalHours.Should().Be(5m); // shift only
+    }
+
+    [HumansFact]
+    public async Task ByDepartment_FoldsRolePlannedAndFilledHours()
+    {
+        // Gate has a 4h shift with 3 slots, 0 confirmed → shift planned 12, filled 0.
+        // Gate also owns a 10h role with 2 slots, 1 filled → role planned 20, filled 10.
+        var es = await SeedEventAsync();
+        var team = await SeedWorkloadTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es);
+        await SeedShiftAsync(rota, dayOffset: 1, hours: 4, max: 3);
+        var alice = await SeedUserWithProfileAsync("Alice");
+
+        StubTeams(TeamWithRoles(team.Id, "Gate", "gate",
+            Role(team.Id, "Gate", "gate", RolePeriod.Event, estimatedHours: 10, slotCount: 2, alice.Id)));
+
+        var report = await _service.GetForActiveEventAsync();
+        report.Should().NotBeNull();
+        var dept = report.ByDepartment.Single(d => d.TeamId == team.Id);
+        dept.PlannedHours.Should().Be(32m); // 12 shift + 20 role
+        dept.FilledHours.Should().Be(10m); // 0 shift + 10 role
+        dept.PlannedSlots.Should().Be(3); // slots remain shift-only
+    }
+
+    [HumansFact]
+    public async Task ByDepartment_RoleOnlyTeam_AppearsWithZeroShiftColumns()
+    {
+        // Gate has shifts (renders the report). Board owns a role but no rotas —
+        // it must still appear as a department row, with shift columns at zero.
+        var es = await SeedEventAsync();
+        var gate = await SeedWorkloadTeamAsync("Gate");
+        var gateRota = await SeedRotaAsync(gate, es);
+        await SeedShiftAsync(gateRota, dayOffset: 1, hours: 4);
+
+        var board = await SeedWorkloadTeamAsync("Board");
+        var bob = await SeedUserWithProfileAsync("Bob");
+
+        StubTeams(
+            TeamWithRoles(board.Id, "Board", "board",
+                Role(board.Id, "Board", "board", RolePeriod.YearRound, estimatedHours: 8, slotCount: 1, bob.Id)));
+
+        var report = await _service.GetForActiveEventAsync();
+        report.Should().NotBeNull();
+        var dept = report.ByDepartment.Single(d => d.TeamId == board.Id);
+        dept.TeamName.Should().Be("Board");
+        dept.TeamSlug.Should().Be("board");
+        dept.RotaCount.Should().Be(0);
+        dept.ShiftCount.Should().Be(0);
+        dept.PlannedSlots.Should().Be(0);
+        dept.PlannedHours.Should().Be(8m);
+        dept.FilledHours.Should().Be(8m);
+    }
+
+    [HumansFact]
     public async Task ByRota_IncludesAdminOnlyAndHiddenRotas()
     {
         // Workload view is admin-only — coordinators need full visibility for
@@ -209,6 +337,32 @@ public sealed class WorkloadServiceTests : ServiceTestHarness
         var report = await _service.GetForActiveEventAsync();
         report.Should().NotBeNull();
         report.ByPerson.Single(p => p.UserId == alice.Id).BuildHours.Should().Be(10m); // 18:00 - 08:00
+    }
+
+    // ── Role-hours fixtures (cached TeamInfo projection the service reads) ─────────
+
+    private void StubTeams(params TeamInfo[] teams) =>
+        _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(teams.ToDictionary(t => t.Id));
+
+    private static TeamInfo TeamWithRoles(
+        Guid teamId, string name, string slug, params TeamRoleDefinitionSnapshot[] roles) =>
+        new(teamId, name, null, slug,
+            IsActive: true, IsSystemTeam: false, SystemTeamType.None, RequiresApproval: false,
+            IsPublicPage: true, IsHidden: false, IsPromotedToDirectory: false,
+            CreatedAt: Instant.FromUtc(2026, 1, 1, 0, 0), Members: [],
+            RoleDefinitions: roles);
+
+    private static TeamRoleDefinitionSnapshot Role(
+        Guid teamId, string teamName, string teamSlug,
+        RolePeriod period, int? estimatedHours, int slotCount, params Guid?[] assignedUserIds)
+    {
+        var assignments = assignedUserIds
+            .Select((uid, i) => new TeamRoleAssignmentSnapshot(Guid.NewGuid(), Guid.NewGuid(), i, uid))
+            .ToList();
+        return new TeamRoleDefinitionSnapshot(
+            Guid.NewGuid(), teamId, teamName, teamSlug, "Role", null, slotCount, estimatedHours,
+            [], 0, false, period, true, assignments);
     }
 
     // ── Test-local seeders (Workload-specific shape; harness covers User/Team/etc.) ─

--- a/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/Workload/WorkloadServiceTests.cs
@@ -284,6 +284,31 @@ public sealed class WorkloadServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task RoleHours_FromInactiveTeams_AreExcluded()
+    {
+        // A retired (deactivated) team can still carry role assignments — they
+        // aren't cleared on deactivation — but its role hours must not leak into
+        // the workload report.
+        var es = await SeedEventAsync();
+        var gate = await SeedWorkloadTeamAsync("Gate");
+        var rota = await SeedRotaAsync(gate, es);
+        await SeedShiftAsync(rota, dayOffset: 1, hours: 5); // renders the report
+
+        var oldTeam = await SeedWorkloadTeamAsync("OldTeam");
+        var alice = await SeedUserWithProfileAsync("Alice");
+
+        StubTeams(
+            TeamWithRoles(oldTeam.Id, "OldTeam", "oldteam",
+                Role(oldTeam.Id, "OldTeam", "oldteam", RolePeriod.YearRound, estimatedHours: 40, slotCount: 1, alice.Id))
+            with { IsActive = false });
+
+        var report = await _service.GetForActiveEventAsync();
+        report.Should().NotBeNull();
+        report.ByPerson.Should().NotContain(p => p.UserId == alice.Id);
+        report.ByDepartment.Should().NotContain(d => d.TeamId == oldTeam.Id);
+    }
+
+    [HumansFact]
     public async Task ByRota_IncludesAdminOnlyAndHiddenRotas()
     {
         // Workload view is admin-only — coordinators need full visibility for


### PR DESCRIPTION
## What

`/Shifts/Admin/Workload` never pulled in role hours — the per-person "Role" column was a hard-coded `—` placeholder, and neither tab counted `TeamRoleDefinition.EstimatedHours` (which has since landed). This wires role estimates into the report.

## How role hours map

Each role a person holds contributes its **full annual `EstimatedHours`** (per holder), bucketed by the role's `RolePeriod`:

| RolePeriod | Lands in column |
|---|---|
| `YearRound` | **Year-round** (renamed from the old "Role" placeholder) |
| `Build` / `Event` / `Strike` | the matching shift-period column (folded in with shift hours) |

**Per-person tab:** new `Year-round` column; Build/Event/Strike now combine shift + role hours; `Total` includes everything. Role-only holders (a role but zero shift signups) now get a row.

**Per-department tab:** role estimates fold into `Planned hours` (estimate × slots) and `Filled hours` (estimate × assigned slots). Slot counts and Coverage % stay shift-only. Teams owning roles but no rotas now get a row.

## Notes / decisions (confirmed with Peter)

- `EstimatedHours` is annual and per-holder — no proration, no year filtering (assignments are current holders). "Most is bunched around the event anyway."
- Roles with a null `EstimatedHours` contribute nothing.
- Role hours surface once the active event has ≥1 shift (the report still short-circuits to empty for a shift-less event) — documented as a known edge.

## Surface

No new cross-section interface methods. Role data comes from the existing cached `TeamInfo` projection via `ITeamServiceRead.GetTeamsAsync` (already carries role definitions with `EstimatedHours`/`RolePeriod`/`SlotCount` + assignment holder ids). One new DTO field (`WorkloadByPersonRow.YearRoundHours`); two private records + helpers inside `WorkloadService`.

## Tests

5 new `WorkloadServiceTests` (period mapping, role-only holder, null estimate, dept fold-in, role-only dept). Full Application suite green (3265 passed, 1 pre-existing skip).

Implements the role-hours follow-up tracked in nobodies-collective/Humans#734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)