### PR TITLE
techdebt(googleintegration): route DriveActivityMonitor audit writes through IAuditLogService

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IDriveActivityMonitorRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IDriveActivityMonitorRepository.cs
@@ -1,5 +1,4 @@
 using NodaTime;
-using Humans.Domain.Entities;
 using Humans.Domain.Attributes;
 
 namespace Humans.Application.Interfaces.Repositories;
@@ -7,9 +6,8 @@ namespace Humans.Application.Interfaces.Repositories;
 /// <summary>
 /// Repository for the persistent state owned by the Drive Activity monitor:
 /// the per-job "last run at" marker (stored in <c>system_settings</c> under a
-/// dedicated key), the anomaly audit-log entries the monitor emits, and the
-/// fallback lookup from a Google-OAuth <c>people/{id}</c> to a local user's
-/// email via the ASP.NET Identity login tables.
+/// dedicated key) and the fallback lookup from a Google-OAuth <c>people/{id}</c>
+/// to a local user's email via the ASP.NET Identity login tables.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -19,11 +17,10 @@ namespace Humans.Application.Interfaces.Repositories;
 /// respective services (e.g. <c>EmailOutboxService</c>).
 /// </para>
 /// <para>
-/// Anomaly audit entries are persisted here rather than through
-/// <c>IAuditLogService</c> so the write is atomic with the marker advance —
-/// the pre-§15 implementation relied on a shared Scoped <c>DbContext</c> to
-/// get that guarantee. <c>IAuditLogService</c> will migrate to the §15 pattern
-/// under issue #552; at that point this method can delegate to it.
+/// Anomaly audit entries are <em>not</em> persisted here — the service emits
+/// them through <c>IAuditLogService.LogAsync</c>, so the only section that
+/// writes <c>audit_log_entries</c> is the AuditLog section's repository
+/// (design-rules §2c / the AuditLog write boundary).
 /// </para>
 /// <para>
 /// The Identity login / user read is a cross-section fallback used only when
@@ -44,23 +41,15 @@ public interface IDriveActivityMonitorRepository : IRepository
     Task<Instant?> GetLastRunTimestampAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Persists the anomaly audit entries detected during this run, and — when
-    /// <paramref name="newLastRunAt"/> is not <c>null</c> — advances the
-    /// last-run marker. Everything commits in a single transaction so audit
-    /// entries and the marker never diverge.
+    /// Advances the last-run marker when <paramref name="newLastRunAt"/> is not
+    /// <c>null</c>; a <c>null</c> value is a no-op.
     /// </summary>
-    /// <param name="anomalies">
-    /// Fully-populated <see cref="AuditLogEntry"/> rows with their <c>Id</c>
-    /// and <c>OccurredAt</c> already set by the caller. The repository only
-    /// adds them to the context and saves.
-    /// </param>
     /// <param name="newLastRunAt">
     /// The instant to store as <c>DriveActivityMonitor:LastRunAt</c>. When
     /// <c>null</c>, the marker is left as-is so the next run re-processes the
     /// same window — used when at least one resource failed to query.
     /// </param>
-    Task PersistAnomaliesAsync(
-        IReadOnlyList<AuditLogEntry> anomalies,
+    Task AdvanceLastRunMarkerAsync(
         Instant? newLastRunAt,
         CancellationToken ct = default);
 

--- a/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Extensions;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -15,6 +16,7 @@ public sealed class DriveActivityMonitorService(
     IGoogleDriveActivityClient driveActivityClient,
     ITeamResourceService teamResourceService,
     IDriveActivityMonitorRepository repository,
+    IAuditLogService auditLogService,
     IClock clock,
     ILogger<DriveActivityMonitorService> logger) : IDriveActivityMonitorService
 {
@@ -56,7 +58,7 @@ public sealed class DriveActivityMonitorService(
 
         logger.LogDebug("Drive activity monitor checking events since {LookbackTime}", filterTime);
 
-        var anomalies = new List<AuditLogEntry>();
+        var anomalies = new List<(Guid ResourceId, string Description)>();
 
         foreach (var resource in resources)
         {
@@ -84,16 +86,7 @@ public sealed class DriveActivityMonitorService(
                         "Anomalous permission change detected on {ResourceName} ({GoogleId}) by {Actor}: {Description}",
                         resource.Name, resource.GoogleId, actorEmail ?? "unknown", description);
 
-                    anomalies.Add(new AuditLogEntry
-                    {
-                        Id = Guid.NewGuid(),
-                        Action = AuditAction.AnomalousPermissionDetected,
-                        EntityType = nameof(GoogleResource),
-                        EntityId = resource.Id,
-                        Description = $"{JobName}: {description}",
-                        OccurredAt = clock.GetCurrentInstant(),
-                        ActorUserId = null,
-                    });
+                    anomalies.Add((resource.Id, description));
                 }
 
                 // Reached only if the async enumerable completed without
@@ -152,7 +145,22 @@ public sealed class DriveActivityMonitorService(
             newMarker = now;
         }
 
-        await repository.PersistAnomaliesAsync(anomalies, newMarker, cancellationToken);
+        // Persist the monitor's own state (the last-run marker) first, then emit
+        // the audit entries through IAuditLogService so the only writer of
+        // audit_log_entries is the AuditLog section's repository. Audit is logged
+        // after the business save (per IAuditLogService) and regardless of the
+        // marker outcome — anomalies must surface even on a partial-failure run.
+        await repository.AdvanceLastRunMarkerAsync(newMarker, cancellationToken);
+
+        foreach (var (resourceId, description) in anomalies)
+        {
+            await auditLogService.LogAsync(
+                AuditAction.AnomalousPermissionDetected,
+                nameof(GoogleResource),
+                resourceId,
+                description,
+                JobName);
+        }
 
         // All-resources-failed = connector outage (revoked key / network). Throw so Hangfire records a failed run, not a hollow success.
         if (hadFailures && !anyResourceQueried)

--- a/src/Humans.Infrastructure/Repositories/GoogleIntegration/DriveActivityMonitorRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/GoogleIntegration/DriveActivityMonitorRepository.cs
@@ -13,8 +13,9 @@ namespace Humans.Infrastructure.Repositories.GoogleIntegration;
 /// EF-backed implementation of <see cref="IDriveActivityMonitorRepository"/>.
 /// The only non-test file that touches the <c>DriveActivityMonitor:LastRunAt</c>
 /// row in <c>DbContext.SystemSettings</c> after the Google Integration §15
-/// migration lands. Anomaly audit entries go through this repository so the
-/// write is transactionally atomic with the last-run marker update.
+/// migration lands. Anomaly audit entries are written by the AuditLog section
+/// via <c>IAuditLogService</c> (the service layer owns that cross-section call);
+/// this repository only persists the monitor's own state.
 /// Uses <see cref="IDbContextFactory{TContext}"/> so the repository can be
 /// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
 /// </summary>
@@ -54,12 +55,11 @@ internal sealed class DriveActivityMonitorRepository(
         return null;
     }
 
-    public async Task PersistAnomaliesAsync(
-        IReadOnlyList<AuditLogEntry> anomalies,
+    public async Task AdvanceLastRunMarkerAsync(
         Instant? newLastRunAt,
         CancellationToken ct = default)
     {
-        if (anomalies.Count == 0 && newLastRunAt is null)
+        if (newLastRunAt is null)
         {
             // Nothing to persist — avoid opening a context.
             return;
@@ -67,29 +67,21 @@ internal sealed class DriveActivityMonitorRepository(
 
         await using var ctx = await factory.CreateDbContextAsync(ct);
 
-        if (anomalies.Count > 0)
+        var value = newLastRunAt.Value.ToInvariantInstantString();
+        var setting = await ctx.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == LastRunSettingKey, ct);
+
+        if (setting is not null)
         {
-            ctx.AuditLogEntries.AddRange(anomalies);
+            setting.Value = value;
         }
-
-        if (newLastRunAt is not null)
+        else
         {
-            var value = newLastRunAt.Value.ToInvariantInstantString();
-            var setting = await ctx.SystemSettings
-                .FirstOrDefaultAsync(s => s.Key == LastRunSettingKey, ct);
-
-            if (setting is not null)
+            ctx.SystemSettings.Add(new SystemSetting
             {
-                setting.Value = value;
-            }
-            else
-            {
-                ctx.SystemSettings.Add(new SystemSetting
-                {
-                    Key = LastRunSettingKey,
-                    Value = value,
-                });
-            }
+                Key = LastRunSettingKey,
+                Value = value,
+            });
         }
 
         await ctx.SaveChangesAsync(ct);

--- a/tests/Humans.Application.Tests/Architecture/Baselines/OnlyAuditLogRepositoryWritesAuditLogEntries.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/OnlyAuditLogRepositoryWritesAuditLogEntries.baseline.txt
@@ -3,10 +3,7 @@
 # Stable keys only — line numbers are informational and stripped for diffing.
 # Generated 2026-05-12 (align/auditlog Phase 2 Step 4).
 #
-# Known violation: DriveActivityMonitorRepository calls ctx.AuditLogEntries.AddRange
-# directly. Follow-up target: GoogleIntegration /section-align will switch
-# PersistAnomaliesAsync to call IAuditLogService.LogAsync per anomaly.
-#
-# When this violation is fixed, remove the line below from this file.
-
-src/Humans.Infrastructure/Repositories/GoogleIntegration/DriveActivityMonitorRepository.cs:AuditLogEntries-write#1
+# No known violations remain. The DriveActivityMonitorRepository write was
+# fixed (2026-05-25): the service now emits anomalies through
+# IAuditLogService.LogAsync per anomaly, so AuditLogRepository is the sole
+# writer of audit_log_entries.

--- a/tests/Humans.Application.Tests/Architecture/DriveActivityMonitorArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/DriveActivityMonitorArchitectureTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Repositories.GoogleIntegration;
@@ -32,6 +33,8 @@ public class DriveActivityMonitorArchitectureTests
             because: "the last-run marker in SystemSettings goes through the owned repository (design-rules §3)");
         paramTypes.Should().Contain(typeof(ITeamResourceService),
             because: "the list of monitored resources comes from the team-resource section service, not a cross-section DB read");
+        paramTypes.Should().Contain(typeof(IAuditLogService),
+            because: "anomaly audit entries are emitted through IAuditLogService (design-rules §2c / AuditLog write boundary)");
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Architecture/DriveActivityMonitorArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/DriveActivityMonitorArchitectureTests.cs
@@ -29,7 +29,7 @@ public class DriveActivityMonitorArchitectureTests
         paramTypes.Should().Contain(typeof(IGoogleDriveActivityClient),
             because: "Google Drive Activity API / Directory API calls go through the shape-neutral connector");
         paramTypes.Should().Contain(typeof(IDriveActivityMonitorRepository),
-            because: "SystemSettings and audit-log writes go through the owned repository (design-rules §3)");
+            because: "the last-run marker in SystemSettings goes through the owned repository (design-rules §3)");
         paramTypes.Should().Contain(typeof(ITeamResourceService),
             because: "the list of monitored resources comes from the team-resource section service, not a cross-section DB read");
     }

--- a/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
@@ -14,29 +15,33 @@ namespace Humans.Application.Tests.GoogleIntegration;
 /// <summary>
 /// Behavioral tests for the §15-migrated
 /// <see cref="DriveActivityMonitorService"/>. The service is a dispatcher
-/// over three collaborators — <see cref="IGoogleDriveActivityClient"/>,
-/// <see cref="ITeamResourceService"/>, and
-/// <see cref="IDriveActivityMonitorRepository"/> — so tests substitute all
-/// three and pin down: self-initiated changes get filtered, anomaly descriptions
-/// are built correctly, partial-failure keeps the last-run marker, and the
-/// happy path advances the marker.
+/// over four collaborators — <see cref="IGoogleDriveActivityClient"/>,
+/// <see cref="ITeamResourceService"/>,
+/// <see cref="IDriveActivityMonitorRepository"/>, and
+/// <see cref="IAuditLogService"/> — so tests substitute all four and pin down:
+/// self-initiated changes get filtered, anomaly descriptions are built
+/// correctly and emitted through <see cref="IAuditLogService"/>,
+/// partial-failure keeps the last-run marker, and the happy path advances it.
 /// </summary>
 public class DriveActivityMonitorServiceTests
 {
     private readonly IGoogleDriveActivityClient _client;
     private readonly ITeamResourceService _teamResources;
     private readonly IDriveActivityMonitorRepository _repository;
+    private readonly IAuditLogService _auditLog;
     private readonly FakeClock _clock;
     private readonly DriveActivityMonitorService _service;
 
     private const string ServiceAccountEmail = "humans-sa@example.iam.gserviceaccount.com";
     private const string ServiceAccountClientId = "1234567890";
+    private const string JobName = "DriveActivityMonitorJob";
 
     public DriveActivityMonitorServiceTests()
     {
         _client = Substitute.For<IGoogleDriveActivityClient>();
         _teamResources = Substitute.For<ITeamResourceService>();
         _repository = Substitute.For<IDriveActivityMonitorRepository>();
+        _auditLog = Substitute.For<IAuditLogService>();
         _clock = new FakeClock(Instant.FromUtc(2026, 4, 22, 10, 0));
 
         _client.IsConfigured.Returns(true);
@@ -44,7 +49,7 @@ public class DriveActivityMonitorServiceTests
         _client.GetServiceAccountClientIdAsync(Arg.Any<CancellationToken>()).Returns(ServiceAccountClientId);
 
         _service = new DriveActivityMonitorService(
-            _client, _teamResources, _repository, _clock,
+            _client, _teamResources, _repository, _auditLog, _clock,
             NullLogger<DriveActivityMonitorService>.Instance);
     }
 
@@ -58,7 +63,9 @@ public class DriveActivityMonitorServiceTests
 
         count.Should().Be(0);
         _client.DidNotReceiveWithAnyArgs().QueryActivityAsync(null!, null!, CancellationToken.None);
-        await _repository.DidNotReceiveWithAnyArgs().PersistAnomaliesAsync(null!, null, CancellationToken.None);
+        await _repository.DidNotReceiveWithAnyArgs().AdvanceLastRunMarkerAsync(null, CancellationToken.None);
+        await _auditLog.DidNotReceiveWithAnyArgs().LogAsync(
+            default, null!, default, null!, default(string)!);
     }
 
     [HumansFact]
@@ -82,10 +89,12 @@ public class DriveActivityMonitorServiceTests
 
         count.Should().Be(0);
         // Marker still advances because no failures occurred.
-        await _repository.Received(1).PersistAnomaliesAsync(
-            Arg.Is<IReadOnlyList<AuditLogEntry>>(a => a.Count == 0),
+        await _repository.Received(1).AdvanceLastRunMarkerAsync(
             _clock.GetCurrentInstant(),
             Arg.Any<CancellationToken>());
+        // No anomalies → no audit entries emitted.
+        await _auditLog.DidNotReceiveWithAnyArgs().LogAsync(
+            default, null!, default, null!, default(string)!);
     }
 
     [HumansFact]
@@ -103,17 +112,18 @@ public class DriveActivityMonitorServiceTests
         var count = await _service.CheckForAnomalousActivityAsync();
 
         count.Should().Be(1);
-        await _repository.Received(1).PersistAnomaliesAsync(
-            Arg.Is<IReadOnlyList<AuditLogEntry>>(a =>
-                a.Count == 1 &&
-                a[0].Action == AuditAction.AnomalousPermissionDetected &&
-                a[0].EntityType == nameof(GoogleResource) &&
-                a[0].EntityId == resource.Id &&
-                a[0].Description.Contains("Sensitive-Drive") &&
-                a[0].Description.Contains("intruder@example.com") &&
-                a[0].Description.Contains("added writer")),
+        await _repository.Received(1).AdvanceLastRunMarkerAsync(
             _clock.GetCurrentInstant(),
             Arg.Any<CancellationToken>());
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.AnomalousPermissionDetected,
+            nameof(GoogleResource),
+            resource.Id,
+            Arg.Is<string>(d =>
+                d.Contains("Sensitive-Drive", StringComparison.Ordinal) &&
+                d.Contains("intruder@example.com", StringComparison.Ordinal) &&
+                d.Contains("added writer", StringComparison.Ordinal)),
+            JobName);
     }
 
     [HumansFact]
@@ -134,12 +144,12 @@ public class DriveActivityMonitorServiceTests
         var count = await _service.CheckForAnomalousActivityAsync();
 
         count.Should().Be(1);
-        await _repository.Received(1).PersistAnomaliesAsync(
-            Arg.Is<IReadOnlyList<AuditLogEntry>>(a =>
-                a.Count == 1 &&
-                a[0].Description.Contains("resolved@example.com")),
-            _clock.GetCurrentInstant(),
-            Arg.Any<CancellationToken>());
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.AnomalousPermissionDetected,
+            nameof(GoogleResource),
+            resource.Id,
+            Arg.Is<string>(d => d.Contains("resolved@example.com", StringComparison.Ordinal)),
+            JobName);
 
         // Directory API should be hit exactly once per unique people/ id (per-run cache).
         await _client.Received(1).TryResolvePersonEmailAsync("people/9999", Arg.Any<CancellationToken>());
@@ -165,11 +175,12 @@ public class DriveActivityMonitorServiceTests
         var count = await _service.CheckForAnomalousActivityAsync();
 
         count.Should().Be(1);
-        await _repository.Received(1).PersistAnomaliesAsync(
-            Arg.Is<IReadOnlyList<AuditLogEntry>>(a =>
-                a.Count == 1 && a[0].Description.Contains("localdb@example.com")),
-            _clock.GetCurrentInstant(),
-            Arg.Any<CancellationToken>());
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.AnomalousPermissionDetected,
+            nameof(GoogleResource),
+            resource.Id,
+            Arg.Is<string>(d => d.Contains("localdb@example.com", StringComparison.Ordinal)),
+            JobName);
     }
 
     [HumansFact]
@@ -192,10 +203,16 @@ public class DriveActivityMonitorServiceTests
         var count = await _service.CheckForAnomalousActivityAsync();
 
         count.Should().Be(1);
-        await _repository.Received(1).PersistAnomaliesAsync(
-            Arg.Is<IReadOnlyList<AuditLogEntry>>(a => a.Count == 1),
+        // Partial failure → marker not advanced, but the anomaly is still audited.
+        await _repository.Received(1).AdvanceLastRunMarkerAsync(
             null,
             Arg.Any<CancellationToken>());
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.AnomalousPermissionDetected,
+            nameof(GoogleResource),
+            ok.Id,
+            Arg.Any<string>(),
+            JobName);
     }
 
     [HumansFact]
@@ -211,10 +228,11 @@ public class DriveActivityMonitorServiceTests
 
         count.Should().Be(0);
         // 404 is expected and does NOT count as a failure — marker advances.
-        await _repository.Received(1).PersistAnomaliesAsync(
-            Arg.Is<IReadOnlyList<AuditLogEntry>>(a => a.Count == 0),
+        await _repository.Received(1).AdvanceLastRunMarkerAsync(
             _clock.GetCurrentInstant(),
             Arg.Any<CancellationToken>());
+        await _auditLog.DidNotReceiveWithAnyArgs().LogAsync(
+            default, null!, default, null!, default(string)!);
     }
 
     [HumansFact]
@@ -233,10 +251,11 @@ public class DriveActivityMonitorServiceTests
         var count = await _service.CheckForAnomalousActivityAsync();
 
         count.Should().Be(0);
-        await _repository.Received(1).PersistAnomaliesAsync(
-            Arg.Is<IReadOnlyList<AuditLogEntry>>(a => a.Count == 0),
+        await _repository.Received(1).AdvanceLastRunMarkerAsync(
             null,
             Arg.Any<CancellationToken>());
+        await _auditLog.DidNotReceiveWithAnyArgs().LogAsync(
+            default, null!, default, null!, default(string)!);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Repositories/DriveActivityMonitorRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/DriveActivityMonitorRepositoryTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.GoogleIntegration;
 
@@ -94,34 +93,18 @@ public sealed class DriveActivityMonitorRepositoryTests : IDisposable
     }
 
     [HumansFact(Timeout = 10000)]
-    public async Task PersistAnomaliesAsync_InsertsAnomaliesAndAdvancesMarkerAtomically()
+    public async Task AdvanceLastRunMarkerAsync_AdvancesMarker()
     {
         var marker = Instant.FromUtc(2026, 4, 22, 11, 0);
-        var entry = new AuditLogEntry
-        {
-            Id = Guid.NewGuid(),
-            Action = AuditAction.AnomalousPermissionDetected,
-            EntityType = nameof(GoogleResource),
-            EntityId = Guid.NewGuid(),
-            Description = "test anomaly",
-            OccurredAt = marker,
-        };
 
-        await _repository.PersistAnomaliesAsync([entry], marker);
-
-        await using var verify = _factory.CreateDbContext();
-        var savedEntry = await verify.AuditLogEntries
-            .AsNoTracking()
-            .FirstOrDefaultAsync(a => a.Id == entry.Id);
-        savedEntry.Should().NotBeNull();
-        savedEntry.Action.Should().Be(AuditAction.AnomalousPermissionDetected);
+        await _repository.AdvanceLastRunMarkerAsync(marker);
 
         var marker2 = await _repository.GetLastRunTimestampAsync();
         marker2.Should().Be(marker);
     }
 
     [HumansFact]
-    public async Task PersistAnomaliesAsync_WithNullMarker_InsertsAnomaliesButDoesNotAdvanceMarker()
+    public async Task AdvanceLastRunMarkerAsync_WithNullMarker_DoesNotAdvanceMarker()
     {
         var existingMarker = Instant.FromUtc(2026, 4, 21, 9, 0);
         _seedContext.SystemSettings.Add(new SystemSetting
@@ -131,39 +114,23 @@ public sealed class DriveActivityMonitorRepositoryTests : IDisposable
         });
         await _seedContext.SaveChangesAsync();
 
-        var entry = new AuditLogEntry
-        {
-            Id = Guid.NewGuid(),
-            Action = AuditAction.AnomalousPermissionDetected,
-            EntityType = nameof(GoogleResource),
-            EntityId = Guid.NewGuid(),
-            Description = "partial failure run",
-            OccurredAt = existingMarker,
-        };
-
-        await _repository.PersistAnomaliesAsync([entry], newLastRunAt: null);
-
-        await using var verify = _factory.CreateDbContext();
-        var entryCount = await verify.AuditLogEntries.CountAsync();
-        entryCount.Should().Be(1);
+        await _repository.AdvanceLastRunMarkerAsync(newLastRunAt: null);
 
         var marker = await _repository.GetLastRunTimestampAsync();
         marker.Should().Be(existingMarker, because: "null newLastRunAt means the partial failure path — marker should not advance");
     }
 
     [HumansFact]
-    public async Task PersistAnomaliesAsync_WithNoAnomaliesAndNullMarker_IsNoOp()
+    public async Task AdvanceLastRunMarkerAsync_WithNullMarker_IsNoOp()
     {
-        await _repository.PersistAnomaliesAsync(
-            [], newLastRunAt: null);
+        await _repository.AdvanceLastRunMarkerAsync(newLastRunAt: null);
 
         await using var verify = _factory.CreateDbContext();
-        (await verify.AuditLogEntries.CountAsync()).Should().Be(0);
         (await verify.SystemSettings.CountAsync()).Should().Be(0);
     }
 
     [HumansFact]
-    public async Task PersistAnomaliesAsync_UpdatesExistingMarkerRowInPlace()
+    public async Task AdvanceLastRunMarkerAsync_UpdatesExistingMarkerRowInPlace()
     {
         var original = Instant.FromUtc(2026, 4, 21, 9, 0);
         _seedContext.SystemSettings.Add(new SystemSetting
@@ -174,7 +141,7 @@ public sealed class DriveActivityMonitorRepositoryTests : IDisposable
         await _seedContext.SaveChangesAsync();
 
         var next = Instant.FromUtc(2026, 4, 22, 10, 0);
-        await _repository.PersistAnomaliesAsync([], next);
+        await _repository.AdvanceLastRunMarkerAsync(next);
 
         await using var verify = _factory.CreateDbContext();
         var rows = await verify.SystemSettings


### PR DESCRIPTION
## What

Fixes the one remaining `OnlyAuditLogRepositoryWritesAuditLogEntries` violation: `DriveActivityMonitorRepository` was writing anomaly audit rows directly via `ctx.AuditLogEntries.AddRange(anomalies)`, which breaks the hard rule that only the AuditLog section's repository may write `audit_log_entries`.

## How

- **`DriveActivityMonitorService`** — builds a local `List<(Guid ResourceId, string Description)>` of detected anomalies instead of `AuditLogEntry` objects, then emits **one `IAuditLogService.LogAsync(...)` per anomaly** (the existing background-job overload — no new public surface added).
- **`DriveActivityMonitorRepository`** — `PersistAnomaliesAsync` becomes `AdvanceLastRunMarkerAsync`; it now persists only its own `SystemSettings` last-run marker and no longer references `ctx.AuditLogEntries`.
- **Interface + XML docs** updated to match.
- **Baseline** line removed (the ratchet soft-fails on stale entries once the violation is gone).

## Audit-data mapping (1:1 with the prior `AuditLogEntry`)

| Old `AuditLogEntry` field | New `LogAsync` source |
|---|---|
| `Action = AuditAction.AnomalousPermissionDetected` | `action` arg |
| `EntityType = nameof(GoogleResource)` | `entityType` arg |
| `EntityId = resource.Id` | `entityId` arg |
| `Description = $"{JobName}: {description}"` | passed raw `description`; the job overload prepends `$"{jobName}: "` itself, reproducing the exact string |
| `OccurredAt = clock.GetCurrentInstant()` | set inside `AuditLogService` from the same injected `IClock` |
| `ActorUserId = null` | job overload always sets null |

## Ordering / partial-failure behaviour preserved

Audit entries are emitted **after** the last-run marker persist (per `IAuditLogService`'s "audit after the business save" contract) and **regardless of marker outcome** — anomalies still surface on partial-failure runs, exactly as before (previously they were written even when `newMarker == null`).

## Verification

- `dotnet build Humans.slnx -v q` — 0 errors (only pre-existing unrelated warnings)
- `dotnet test Humans.slnx -v q --filter "FullyQualifiedName~Application"` — all green (Humans.Application.Tests: 3260 passed, 0 failed)

Tests in the DriveActivityMonitor service/repository suites updated to assert against `IAuditLogService.LogAsync` and `AdvanceLastRunMarkerAsync`.

🤖 Generated with Claude Code