### PR TITLE
techdebt(issues,governance): DTO return + display sort to controllers

### DIFF
--- a/src/Humans.Application/Interfaces/Issues/IIssuesService.cs
+++ b/src/Humans.Application/Interfaces/Issues/IIssuesService.cs
@@ -34,7 +34,7 @@ public interface IIssuesService : IApplicationService
         IReadOnlyList<string>? reporterRoles,
         CancellationToken ct = default);
 
-    Task<Issue?> GetIssueByIdAsync(Guid id, CancellationToken ct = default);
+    Task<IssueDetail?> GetIssueByIdAsync(Guid id, CancellationToken ct = default);
 
     Task<IReadOnlyList<IssueListSnapshot>> GetIssueListAsync(
         IssueListFilter filter,

--- a/src/Humans.Application/Interfaces/Issues/IssueDtos.cs
+++ b/src/Humans.Application/Interfaces/Issues/IssueDtos.cs
@@ -32,3 +32,30 @@ public sealed record IssueListFilter(
     int Limit = 100);
 
 public sealed record DistinctReporterRow(Guid UserId, string DisplayName, int Count);
+
+/// <summary>
+/// Single-issue projection for the detail view, API get, and resource-based
+/// authorization. Display names are resolved by the consumer via
+/// <c>IUserService</c> from the user-id fields; the thread is fetched
+/// separately via <c>GetThreadAsync</c>.
+/// </summary>
+public sealed record IssueDetail(
+    Guid Id,
+    IssueStatus Status,
+    IssueCategory Category,
+    string? Section,
+    string Title,
+    string Description,
+    string? PageUrl,
+    string? UserAgent,
+    string? AdditionalContext,
+    string? ScreenshotStoragePath,
+    Guid ReporterUserId,
+    Guid? AssigneeUserId,
+    Guid? ResolvedByUserId,
+    int? GitHubIssueNumber,
+    LocalDate? DueDate,
+    Instant CreatedAt,
+    Instant UpdatedAt,
+    Instant? ResolvedAt,
+    int CommentCount);

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -49,7 +49,7 @@ public class DashboardService(
 
         // Applications + term expiry state
         var applications = await applicationDecisionService.GetUserApplicationsAsync(userId, cancellationToken);
-        var latestApplication = applications.Count > 0 ? applications[0] : null;
+        var latestApplication = applications.MaxBy(a => a.SubmittedAt);
         var latestApplicationSnapshot = latestApplication is null
             ? null
             : new DashboardApplication(

--- a/src/Humans.Application/Services/Governance/GovernanceIndexService.cs
+++ b/src/Humans.Application/Services/Governance/GovernanceIndexService.cs
@@ -13,7 +13,7 @@ public sealed class GovernanceIndexService(
     public async Task<GovernanceIndexData> GetIndexDataAsync(Guid userId, CancellationToken ct = default)
     {
         var applications = await applicationDecisionService.GetUserApplicationsAsync(userId, ct);
-        var latestApplication = applications.Count > 0 ? applications[0] : null;
+        var latestApplication = applications.MaxBy(a => a.SubmittedAt);
         var statutesContent = await legalDocService.GetDocumentContentAsync("statutes");
 
         var snapshot = await userService.GetAllUserInfosAsync(ct).ConfigureAwait(false);

--- a/src/Humans.Application/Services/Issues/IssuesService.cs
+++ b/src/Humans.Application/Services/Issues/IssuesService.cs
@@ -179,13 +179,32 @@ public sealed class IssuesService(
 
     // ─── Reads ───
 
-    public async Task<Issue?> GetIssueByIdAsync(Guid id, CancellationToken ct = default)
+    public async Task<IssueDetail?> GetIssueByIdAsync(Guid id, CancellationToken ct = default)
     {
         var issue = await repo.GetByIdAsync(id, ct);
-        if (issue is null) return null;
-        await StitchCrossDomainNavsAsync([issue], ct);
-        return issue;
+        return issue is null ? null : MapDetail(issue);
     }
+
+    private static IssueDetail MapDetail(Issue issue) => new(
+        issue.Id,
+        issue.Status,
+        issue.Category,
+        issue.Section,
+        issue.Title,
+        issue.Description,
+        issue.PageUrl,
+        issue.UserAgent,
+        issue.AdditionalContext,
+        issue.ScreenshotStoragePath,
+        issue.ReporterUserId,
+        issue.AssigneeUserId,
+        issue.ResolvedByUserId,
+        issue.GitHubIssueNumber,
+        issue.DueDate,
+        issue.CreatedAt,
+        issue.UpdatedAt,
+        issue.ResolvedAt,
+        issue.Comments.Count);
 
     public async Task<IReadOnlyList<IssueListSnapshot>> GetIssueListAsync(
         IssueListFilter filter,
@@ -251,7 +270,7 @@ public sealed class IssuesService(
     public async Task<IReadOnlyList<IssueThreadEvent>> GetThreadAsync(
         Guid issueId, CancellationToken ct = default)
     {
-        var issue = await GetIssueByIdAsync(issueId, ct)
+        var issue = await repo.GetByIdAsync(issueId, ct)
             ?? throw new InvalidOperationException($"Issue {issueId} not found");
 
         // Audit entries for the four Issue-related actions.
@@ -909,49 +928,4 @@ public sealed class IssuesService(
                 issue.Id);
         }
     }
-
-    // In-memory join for [Obsolete] cross-domain nav props (design-rules §6b).
-#pragma warning disable CS0618
-    private async Task StitchCrossDomainNavsAsync(
-        IReadOnlyList<Issue> issues, CancellationToken ct)
-    {
-        if (issues.Count == 0) return;
-
-        var userIds = new HashSet<Guid>();
-        foreach (var i in issues)
-        {
-            userIds.Add(i.ReporterUserId);
-            if (i.AssigneeUserId.HasValue) userIds.Add(i.AssigneeUserId.Value);
-            if (i.ResolvedByUserId.HasValue) userIds.Add(i.ResolvedByUserId.Value);
-            foreach (var c in i.Comments)
-            {
-                if (c.SenderUserId.HasValue) userIds.Add(c.SenderUserId.Value);
-            }
-        }
-
-        var users1 = userIds.Count == 0
-            ? null
-            : await users.GetByIdsAsync(userIds.ToList(), ct);
-
-        foreach (var i in issues)
-        {
-            if (users1 is not null && users1.TryGetValue(i.ReporterUserId, out var rep))
-                i.Reporter = rep;
-            if (i.AssigneeUserId is { } aid && users1 is not null &&
-                users1.TryGetValue(aid, out var assignee))
-                i.Assignee = assignee;
-            if (i.ResolvedByUserId is { } rbid && users1 is not null &&
-                users1.TryGetValue(rbid, out var resolver))
-                i.ResolvedByUser = resolver;
-            foreach (var c in i.Comments)
-            {
-                if (c.SenderUserId is { } sid && users1 is not null &&
-                    users1.TryGetValue(sid, out var sender))
-                {
-                    c.SenderUser = sender;
-                }
-            }
-        }
-    }
-#pragma warning restore CS0618
 }

--- a/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
@@ -29,7 +29,6 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
         await WithContextAsync(async ctx => await ctx.Applications
             .Include(a => a.StateHistory)
             .Where(a => a.UserId == userId)
-            .OrderByDescending(a => a.SubmittedAt)
             .ToListAsync(ct), ct);
 
     public async Task<bool> AnySubmittedForUserAsync(Guid userId, CancellationToken ct = default) =>
@@ -154,8 +153,6 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
             .AsNoTracking()
             .Include(a => a.BoardVotes)
             .Where(a => a.Status == ApplicationStatus.Submitted)
-            .OrderBy(a => a.MembershipTier)
-            .ThenBy(a => a.SubmittedAt)
             .ToListAsync(ct), ct);
 
     public async Task<bool> HasBoardVotesAsync(Guid applicationId, CancellationToken ct = default) =>
@@ -270,8 +267,6 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
                 && a.ResolvedAt != null
                 && a.ResolvedAt.Value >= windowStart
                 && a.ResolvedAt.Value < windowEnd)
-            .OrderBy(a => a.MembershipTier)
-            .ThenBy(a => a.ResolvedAt)
             .ToListAsync(ct), ct);
 
     public async Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(

--- a/src/Humans.Infrastructure/Repositories/Issues/IssuesRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Issues/IssuesRepository.cs
@@ -29,7 +29,7 @@ internal sealed class IssuesRepository(IDbContextFactory<HumansDbContext> factor
         await using var db = await factory.CreateDbContextAsync(ct);
         return await db.Issues
             .AsNoTracking()
-            .Include(i => i.Comments.OrderBy(c => c.CreatedAt))
+            .Include(i => i.Comments)
             .FirstOrDefaultAsync(i => i.Id == id, ct);
     }
 
@@ -134,7 +134,7 @@ internal sealed class IssuesRepository(IDbContextFactory<HumansDbContext> factor
         await using var db = await factory.CreateDbContextAsync(ct);
         return await db.Issues
             .AsNoTracking()
-            .Include(i => i.Comments.OrderBy(c => c.CreatedAt))
+            .Include(i => i.Comments)
             .Where(i => i.ReporterUserId == userId)
             .ToListAsync(ct);
     }

--- a/src/Humans.Web/Authorization/Requirements/IssuesAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/IssuesAuthorizationHandler.cs
@@ -1,5 +1,5 @@
+using Humans.Application.Interfaces.Issues;
 using Humans.Domain.Constants;
-using Humans.Domain.Entities;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Humans.Web.Authorization.Requirements;
@@ -18,12 +18,12 @@ namespace Humans.Web.Authorization.Requirements;
 /// Reads from claims only (RoleAssignmentClaimsTransformation populates them per-request,
 /// cached 60s) — no DB hit.
 /// </summary>
-public class IssuesAuthorizationHandler : AuthorizationHandler<IssuesOperationRequirement, Issue>
+public class IssuesAuthorizationHandler : AuthorizationHandler<IssuesOperationRequirement, IssueDetail>
 {
     protected override Task HandleRequirementAsync(
         AuthorizationHandlerContext context,
         IssuesOperationRequirement requirement,
-        Issue resource)
+        IssueDetail resource)
     {
         if (context.User.IsInRole(RoleNames.Admin))
         {

--- a/src/Humans.Web/Controllers/GovernanceApplicationsController.cs
+++ b/src/Humans.Web/Controllers/GovernanceApplicationsController.cs
@@ -37,15 +37,17 @@ public class GovernanceApplicationsController(
 
         var viewModel = new ApplicationIndexViewModel
         {
-            Applications = applications.Select(a => new ApplicationSummaryViewModel
-            {
-                Id = a.Id,
-                Status = a.Status,
-                MembershipTier = a.MembershipTier,
-                SubmittedAt = a.SubmittedAt.ToDateTimeUtc(),
-                ResolvedAt = a.ResolvedAt?.ToDateTimeUtc(),
-                StatusBadgeClass = a.Status.GetBadgeClass()
-            }).ToList(),
+            Applications = applications
+                .OrderByDescending(a => a.SubmittedAt)
+                .Select(a => new ApplicationSummaryViewModel
+                {
+                    Id = a.Id,
+                    Status = a.Status,
+                    MembershipTier = a.MembershipTier,
+                    SubmittedAt = a.SubmittedAt.ToDateTimeUtc(),
+                    ResolvedAt = a.ResolvedAt?.ToDateTimeUtc(),
+                    StatusBadgeClass = a.Status.GetBadgeClass()
+                }).ToList(),
             CanSubmitNew = !hasPendingApplication,
             IsApprovedColaborador = isApprovedColaborador
         };

--- a/src/Humans.Web/Controllers/GovernanceBoardVotingController.cs
+++ b/src/Humans.Web/Controllers/GovernanceBoardVotingController.cs
@@ -32,7 +32,10 @@ public class GovernanceBoardVotingController(
                     UserId = m.UserId
                 })
                 .ToList(),
-            Applications = applications.Select(a =>
+            Applications = applications
+                .OrderBy(a => a.MembershipTier)
+                .ThenBy(a => a.SubmittedAt)
+                .Select(a =>
             {
                 var appVm = new BoardVotingApplicationViewModel
                 {

--- a/src/Humans.Web/Controllers/IssuesApiController.cs
+++ b/src/Humans.Web/Controllers/IssuesApiController.cs
@@ -10,9 +10,6 @@ using Humans.Domain.Enums;
 using Humans.Web.Filters;
 using Humans.Web.Models;
 
-// Obsolete nav props (Reporter/Assignee/ResolvedByUser/SenderUser) stitched in-memory by IssuesService; see design-rules §15i.
-#pragma warning disable CS0618
-
 namespace Humans.Web.Controllers;
 
 [ApiController]
@@ -237,7 +234,7 @@ public class IssuesApiController(IIssuesService issues, IUserServiceRead users, 
         }
     }
 
-    private static object MapList(Issue i, IReadOnlyDictionary<Guid, UserInfo>? displayUsers = null) => new
+    private static object MapDetailIssue(IssueDetail i, IReadOnlyDictionary<Guid, UserInfo>? displayUsers = null) => new
     {
         i.Id,
         Status = i.Status.ToString(),
@@ -263,7 +260,7 @@ public class IssuesApiController(IIssuesService issues, IUserServiceRead users, 
         CreatedAt = i.CreatedAt.ToDateTimeUtc(),
         UpdatedAt = i.UpdatedAt.ToDateTimeUtc(),
         ResolvedAt = i.ResolvedAt?.ToDateTimeUtc(),
-        CommentCount = i.Comments.Count
+        CommentCount = i.CommentCount
     };
 
     private static object MapList(IssueListSnapshot i) => new
@@ -293,11 +290,11 @@ public class IssuesApiController(IIssuesService issues, IUserServiceRead users, 
     };
 
     private static object MapDetail(
-        Issue i,
+        IssueDetail i,
         IReadOnlyList<IssueThreadEvent> thread,
         IReadOnlyDictionary<Guid, UserInfo> displayUsers) => new
         {
-            issue = MapList(i, displayUsers),
+            issue = MapDetailIssue(i, displayUsers),
             thread = thread.Select(e => e switch
             {
                 IssueCommentEvent c => (object)new
@@ -322,7 +319,7 @@ public class IssuesApiController(IIssuesService issues, IUserServiceRead users, 
             })
         };
 
-    private async Task<IReadOnlyDictionary<Guid, UserInfo>> GetIssueDisplayUsersAsync(Issue issue)
+    private async Task<IReadOnlyDictionary<Guid, UserInfo>> GetIssueDisplayUsersAsync(IssueDetail issue)
     {
         var ids = new HashSet<Guid> { issue.ReporterUserId };
         if (issue.AssigneeUserId is { } assigneeId) ids.Add(assigneeId);

--- a/src/Humans.Web/Controllers/IssuesController.cs
+++ b/src/Humans.Web/Controllers/IssuesController.cs
@@ -7,14 +7,10 @@ using Humans.Application.Interfaces.Issues;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization.Requirements;
 using Humans.Web.Helpers;
 using Humans.Web.Models;
-
-// Obsolete nav props (Reporter/Assignee/ResolvedByUser/SenderUser) stitched in-memory by IssuesService; see design-rules §15i.
-#pragma warning disable CS0618
 
 namespace Humans.Web.Controllers;
 
@@ -425,7 +421,7 @@ public class IssuesController(
     };
 
     private static IssueDetailViewModel MapDetailViewModel(
-        Issue i,
+        IssueDetail i,
         IReadOnlyList<IssueThreadEvent> thread,
         IReadOnlyDictionary<Guid, UserInfo> displayUsers,
         bool isHandler,
@@ -480,7 +476,7 @@ public class IssuesController(
         };
     }
 
-    private async Task<IReadOnlyDictionary<Guid, UserInfo>> GetIssueDisplayUsersAsync(Issue issue)
+    private async Task<IReadOnlyDictionary<Guid, UserInfo>> GetIssueDisplayUsersAsync(IssueDetail issue)
     {
         var ids = new HashSet<Guid> { issue.ReporterUserId };
         if (issue.AssigneeUserId is { } assigneeId) ids.Add(assigneeId);

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -158,7 +158,7 @@ public class ProfileController(
         var pendingConsentCount = snapshot.PendingConsentCount;
 
         var applications = await applicationDecisionService.GetUserApplicationsAsync(info.Id, ct);
-        var latestApplication = applications.Count > 0 ? applications[0] : null;
+        var latestApplication = applications.MaxBy(a => a.SubmittedAt);
 
         var campaignGrants = await campaignService.GetActiveOrCompletedGrantsForUserAsync(info.Id, ct);
 

--- a/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
@@ -30,7 +30,6 @@ Humans.Application.Interfaces.Events.IEventService.GetPreferenceAsync:Humans.Dom
 Humans.Application.Interfaces.Events.IEventService.GetUserEventAsync:Humans.Domain.Entities.Event
 Humans.Application.Interfaces.Events.IEventService.GetUserSubmissionsAsync:Humans.Domain.Entities.Event
 Humans.Application.Interfaces.Events.IEventService.GetVenueAsync:Humans.Domain.Entities.EventVenue
-Humans.Application.Interfaces.Issues.IIssuesService.GetIssueByIdAsync:Humans.Domain.Entities.Issue
 Humans.Application.Interfaces.Shifts.IShiftManagementService.GetActiveAsync:Humans.Domain.Entities.EventSettings
 Humans.Application.Interfaces.Shifts.IShiftManagementService.GetBrowseShiftsAsync:Humans.Domain.Entities.Shift
 Humans.Application.Interfaces.Shifts.IShiftManagementService.GetByIdAsync:Humans.Domain.Entities.EventSettings

--- a/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
@@ -65,13 +65,6 @@ src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleSyncOutboxReposit
 src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleSyncOutboxRepository.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/GoogleIntegration/SyncSettingsRepository.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:OrderBy#1
-src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:OrderBy#2
-src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:OrderBy#3
-src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:OrderByDescending#1
-src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:ThenBy#1
-src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:ThenBy#2
-src/Humans.Infrastructure/Repositories/Issues/IssuesRepository.cs:OrderBy#1
-src/Humans.Infrastructure/Repositories/Issues/IssuesRepository.cs:OrderBy#2
 src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs:OrderByDescending#2
 src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs:OrderByDescending#3

--- a/tests/Humans.Application.Tests/Authorization/IssuesAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/IssuesAuthorizationHandlerTests.cs
@@ -1,9 +1,11 @@
 using System.Security.Claims;
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Issues;
 using Humans.Domain.Constants;
-using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Authorization.Requirements;
 using Microsoft.AspNetCore.Authorization;
+using NodaTime;
 using Xunit;
 
 namespace Humans.Application.Tests.Authorization;
@@ -51,7 +53,7 @@ public sealed class IssuesAuthorizationHandlerTests
         (await EvaluateAsync(user, issue)).Should().BeFalse();
     }
 
-    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, Issue resource)
+    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, IssueDetail resource)
     {
         var requirement = IssuesOperationRequirement.Handle;
         var context = new AuthorizationHandlerContext([requirement], user, resource);
@@ -59,17 +61,26 @@ public sealed class IssuesAuthorizationHandlerTests
         return context.HasSucceeded;
     }
 
-    private static Issue CreateIssue(string? section)
-    {
-        return new Issue
-        {
-            Id = Guid.NewGuid(),
-            ReporterUserId = Guid.NewGuid(),
-            Section = section,
-            Title = "test",
-            Description = "test",
-        };
-    }
+    private static IssueDetail CreateIssue(string? section) => new(
+        Id: Guid.NewGuid(),
+        Status: IssueStatus.Triage,
+        Category: IssueCategory.Bug,
+        Section: section,
+        Title: "test",
+        Description: "test",
+        PageUrl: null,
+        UserAgent: null,
+        AdditionalContext: null,
+        ScreenshotStoragePath: null,
+        ReporterUserId: Guid.NewGuid(),
+        AssigneeUserId: null,
+        ResolvedByUserId: null,
+        GitHubIssueNumber: null,
+        DueDate: null,
+        CreatedAt: Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt: Instant.FromUtc(2026, 1, 1, 0, 0),
+        ResolvedAt: null,
+        CommentCount: 0);
 
     private static ClaimsPrincipal CreateUserWithRoles(params string[] roles)
     {

--- a/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
@@ -69,6 +69,27 @@ public class IssuesApiControllerTests
         };
     }
 
+    private static IssueDetail MakeIssueDetail(Issue issue) => new(
+        issue.Id,
+        issue.Status,
+        issue.Category,
+        issue.Section,
+        issue.Title,
+        issue.Description,
+        issue.PageUrl,
+        issue.UserAgent,
+        issue.AdditionalContext,
+        issue.ScreenshotStoragePath,
+        issue.ReporterUserId,
+        issue.AssigneeUserId,
+        issue.ResolvedByUserId,
+        issue.GitHubIssueNumber,
+        issue.DueDate,
+        issue.CreatedAt,
+        issue.UpdatedAt,
+        issue.ResolvedAt,
+        issue.Comments.Count);
+
     private static IssueListSnapshot MakeIssueSnapshot(Issue issue) => new(
         issue.Id,
         issue.Status,
@@ -216,7 +237,7 @@ public class IssuesApiControllerTests
     {
         var id = Guid.NewGuid();
         _issues.GetIssueByIdAsync(id, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<Issue?>(null));
+            .Returns(Task.FromResult<IssueDetail?>(null));
 
         var result = await _sut.Get(id);
 
@@ -228,7 +249,7 @@ public class IssuesApiControllerTests
     {
         var issue = MakeIssue();
         _issues.GetIssueByIdAsync(issue.Id, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<Issue?>(issue));
+            .Returns(Task.FromResult<IssueDetail?>(MakeIssueDetail(issue)));
 
         var thread = new IssueThreadEvent[]
         {
@@ -276,7 +297,7 @@ public class IssuesApiControllerTests
         // stay consistent with the list endpoint, without reading User.Email.
         var issue = MakeIssue();
         _issues.GetIssueByIdAsync(issue.Id, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<Issue?>(issue));
+            .Returns(Task.FromResult<IssueDetail?>(MakeIssueDetail(issue)));
         _issues.GetThreadAsync(issue.Id, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<IssueThreadEvent>>([]));
 

--- a/tests/Humans.Application.Tests/Repositories/ApplicationRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ApplicationRepositoryTests.cs
@@ -58,8 +58,10 @@ public sealed class ApplicationRepositoryTests : IDisposable
     }
 
     [HumansFact]
-    public async Task GetByUserIdAsync_ReturnsApplicationsOrderedBySubmittedAtDescending()
+    public async Task GetByUserIdAsync_ReturnsAllApplicationsForUser()
     {
+        // Display ordering (SubmittedAt desc) now lives in the controller per the
+        // DisplaySortInControllers rule; the repository only scopes by user.
         var userId = Guid.NewGuid();
         var older = SeedApp(userId, submittedAt: Instant.FromUtc(2026, 1, 1, 0, 0));
         var newer = SeedApp(userId, submittedAt: Instant.FromUtc(2026, 3, 1, 0, 0));
@@ -67,8 +69,7 @@ public sealed class ApplicationRepositoryTests : IDisposable
         var result = await _repo.GetByUserIdAsync(userId);
 
         result.Should().HaveCount(2);
-        result[0].Id.Should().Be(newer.Id);
-        result[1].Id.Should().Be(older.Id);
+        result.Select(a => a.Id).Should().BeEquivalentTo([older.Id, newer.Id]);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
@@ -522,7 +522,7 @@ public sealed class ApplicationDecisionServiceTests : ServiceTestHarness
     // --- GetUserApplicationsAsync ---
 
     [HumansFact]
-    public async Task GetUserApplicationsAsync_ReturnsAllStatusesOrderedBySubmittedAtDesc()
+    public async Task GetUserApplicationsAsync_ReturnsAllStatusesForUser()
     {
         var userId = Guid.NewGuid();
         var app1 = new MemberApplication
@@ -559,10 +559,11 @@ public sealed class ApplicationDecisionServiceTests : ServiceTestHarness
 
         var result = await _service.GetUserApplicationsAsync(userId);
 
+        // Display ordering (SubmittedAt desc) now lives in the controller per the
+        // DisplaySortInControllers rule; the service returns all of the user's
+        // applications regardless of order.
         result.Should().HaveCount(3);
-        result[0].Id.Should().Be(app3.Id);
-        result[1].Id.Should().Be(app2.Id);
-        result[2].Id.Should().Be(app1.Id);
+        result.Select(a => a.Id).Should().BeEquivalentTo([app1.Id, app2.Id, app3.Id]);
     }
 
     [HumansFact]


### PR DESCRIPTION
## Job A — Application service entity-boundary (ApplicationServiceEntityReadReturns)

`IIssuesService.GetIssueByIdAsync` now returns a new `IssueDetail` DTO instead of the `Issue` entity.

- Added `IssueDetail` projection record in `IssueDtos.cs` (fields needed by the detail view, API get, and resource-based auth).
- `IssuesAuthorizationHandler` resource type changed `Issue` → `IssueDetail`.
- Both controllers' detail/get mappers and `GetIssueDisplayUsersAsync` consume `IssueDetail`; API tests + auth handler tests updated.
- `GetThreadAsync` now fetches the entity directly from the repo (it re-sorts the merged thread itself), so the orphaned in-memory nav stitching helper and the now-unused `CS0618` pragmas were dropped from the two controllers.
- Removed the baseline line `Humans.Application.Interfaces.Issues.IIssuesService.GetIssueByIdAsync:Humans.Domain.Entities.Issue`.

## Job B — Display sort belongs in controllers (DisplaySortInControllers)

- **IssuesRepository**: dropped the two `Comments.OrderBy(CreatedAt)` Include-orderings (`OrderBy#1`, `OrderBy#2`) — redundant because `GetThreadAsync` and the GDPR export re-sort downstream.
- **ApplicationRepository**:
  - `GetByUserIdAsync` `OrderByDescending(SubmittedAt)` → `GovernanceApplicationsController.Index`.
  - `GetAllSubmittedWithVotesAsync` `OrderBy(Tier).ThenBy(SubmittedAt)` → `GovernanceBoardVotingController.BoardVoting`.
  - `GetApprovedInWindowAsync` `OrderBy(Tier).ThenBy(ResolvedAt)` dropped — feeds a `(UserId, Tier)` digest with no controller consumer; ordering is invisible to the output.
  - The pagination `OrderBy(SubmittedAt)` in `GetFilteredAsync` stays put (feeds `Skip`/`Take`) and keeps its `OrderBy#1` baseline line.
- Repo/service ordering tests retargeted to assert the returned set rather than order, since ordering is now the controller's responsibility.
- Removed baseline lines: `IssuesRepository OrderBy#1,#2`; `ApplicationRepository OrderBy#2,#3, OrderByDescending#1, ThenBy#1,#2`.

## Verification

`dotnet build Humans.slnx -v q` — 0 errors.
`dotnet test Humans.slnx -v q --filter "FullyQualifiedName~Application"` — all passing (Analyzers 35, Domain 16, Application 3260/1 skipped, Integration 2).

🤖 Generated with Claude Code