### PR TITLE
techdebt(camps,cityplanning,consent): move display sort from repositories to controllers

### DIFF
--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -821,9 +821,10 @@ internal sealed class CampRepository : ICampRepository
             .AsNoTracking()
             .Include(m => m.CampSeason)
                 .ThenInclude(s => s.Camp)
+            // Display ordering (year desc, then camp name) is applied by the
+            // consumer (MyCampsViewComponent) per
+            // memory/architecture/display-sort-in-controllers.md.
             .Where(m => m.UserId == userId && m.Status != CampMemberStatus.Removed)
-            .OrderByDescending(m => m.CampSeason.Year)
-            .ThenBy(m => m.CampSeason.Name)
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Infrastructure/Repositories/CityPlanning/CityPlanningRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/CityPlanning/CityPlanningRepository.cs
@@ -59,10 +59,12 @@ internal sealed class CityPlanningRepository(IDbContextFactory<HumansDbContext> 
         Guid campSeasonId, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
+        // Display ordering (newest first) is applied by the controller
+        // (CityPlanningApiController.GetCampPolygonHistory) per
+        // memory/architecture/display-sort-in-controllers.md.
         return await ctx.CampPolygonHistories
             .AsNoTracking()
             .Where(h => h.CampSeasonId == campSeasonId)
-            .OrderByDescending(h => h.ModifiedAt)
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Web/Controllers/CityPlanningApiController.cs
+++ b/src/Humans.Web/Controllers/CityPlanningApiController.cs
@@ -72,7 +72,9 @@ public class CityPlanningApiController(
     public async Task<IActionResult> GetCampPolygonHistory(Guid campSeasonId, CancellationToken cancellationToken)
     {
         var history = await cityPlanningService.GetCampPolygonHistoryAsync(campSeasonId, cancellationToken);
-        var response = history.Select(h => new
+        var response = history
+            .OrderByDescending(h => h.ModifiedAt)
+            .Select(h => new
         {
             id = h.Id,
             modifiedByDisplayName = h.ModifiedByDisplayName,

--- a/src/Humans.Web/Controllers/CityPlanningApiController.cs
+++ b/src/Humans.Web/Controllers/CityPlanningApiController.cs
@@ -75,14 +75,14 @@ public class CityPlanningApiController(
         var response = history
             .OrderByDescending(h => h.ModifiedAt)
             .Select(h => new
-        {
-            id = h.Id,
-            modifiedByDisplayName = h.ModifiedByDisplayName,
-            modifiedAt = h.ModifiedAt.ToDisplayDateTime(),
-            areaSqm = h.AreaSqm,
-            note = h.Note,
-            geoJson = h.GeoJson,
-        });
+            {
+                id = h.Id,
+                modifiedByDisplayName = h.ModifiedByDisplayName,
+                modifiedAt = h.ModifiedAt.ToDisplayDateTime(),
+                areaSqm = h.AreaSqm,
+                note = h.Note,
+                geoJson = h.GeoJson,
+            });
         return Ok(response);
     }
 

--- a/src/Humans.Web/ViewComponents/MyCampsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/MyCampsViewComponent.cs
@@ -31,11 +31,11 @@ public class MyCampsViewComponent(ICampService campService, ILogger<MyCampsViewC
                     Memberships = g
                         .OrderBy(m => m.CampName, StringComparer.OrdinalIgnoreCase)
                         .Select(m => new MyCampsMembership
-                    {
-                        CampSlug = m.CampSlug,
-                        CampName = m.CampName,
-                        Status = m.Status
-                    }).ToList()
+                        {
+                            CampSlug = m.CampSlug,
+                            CampName = m.CampName,
+                            Status = m.Status
+                        }).ToList()
                 })
                 .ToList();
 

--- a/src/Humans.Web/ViewComponents/MyCampsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/MyCampsViewComponent.cs
@@ -28,7 +28,9 @@ public class MyCampsViewComponent(ICampService campService, ILogger<MyCampsViewC
                 .Select(g => new MyCampsYearGroup
                 {
                     Year = g.Key,
-                    Memberships = g.Select(m => new MyCampsMembership
+                    Memberships = g
+                        .OrderBy(m => m.CampName, StringComparer.OrdinalIgnoreCase)
+                        .Select(m => new MyCampsMembership
                     {
                         CampSlug = m.CampSlug,
                         CampName = m.CampName,

--- a/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
@@ -30,8 +30,6 @@ src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#7
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#8
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#9
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderByDescending#1
-src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderByDescending#2
-src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:ThenBy#1
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderBy#2
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderByDescending#1

--- a/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
@@ -37,7 +37,6 @@ src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderBy#2
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:ThenBy#1
 src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:ThenBy#2
-src/Humans.Infrastructure/Repositories/CityPlanning/CityPlanningRepository.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/Consent/ConsentRepository.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/Consent/ConsentRepository.cs:OrderByDescending#2
 src/Humans.Infrastructure/Repositories/Consent/ConsentRepository.cs:OrderByDescending#3

--- a/tests/Humans.Application.Tests/Repositories/CityPlanningRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/CityPlanningRepositoryTests.cs
@@ -119,8 +119,12 @@ public sealed class CityPlanningRepositoryTests : IDisposable
     }
 
     [HumansFact(Timeout = 10000)]
-    public async Task GetHistoryForCampSeasonAsync_ReturnsDescendingByModifiedAt()
+    public async Task GetHistoryForCampSeasonAsync_ReturnsAllEntriesForCampSeason()
     {
+        // Display ordering (newest first) moved to the controller
+        // (CityPlanningApiController.GetCampPolygonHistory) per
+        // memory/architecture/display-sort-in-controllers.md, so the repository
+        // only guarantees membership, not order.
         var campSeasonId = Guid.NewGuid();
         var userId = Guid.NewGuid();
 
@@ -133,8 +137,7 @@ public sealed class CityPlanningRepositoryTests : IDisposable
         var result = await _repo.GetHistoryForCampSeasonAsync(campSeasonId);
 
         result.Should().HaveCount(2);
-        result[0].AreaSqm.Should().Be(200.0);
-        result[1].AreaSqm.Should().Be(100.0);
+        result.Select(h => h.AreaSqm).Should().BeEquivalentTo([100.0, 200.0]);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
@@ -473,7 +473,7 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
-    public async Task GetCampPolygonHistoryAsync_ReturnsEntriesInDescendingOrder_WithDisplayNamesFromUserService()
+    public async Task GetCampPolygonHistoryAsync_ReturnsEntries_WithDisplayNamesFromUserService()
     {
         var campSeasonId = Guid.NewGuid();
         var userId = NewUserId();
@@ -497,10 +497,13 @@ public sealed class CityPlanningServiceTests : ServiceTestHarness
 
         var history = await _sut.GetCampPolygonHistoryAsync(campSeasonId);
 
+        // Display ordering (newest first) moved to the controller
+        // (CityPlanningApiController.GetCampPolygonHistory) per
+        // memory/architecture/display-sort-in-controllers.md, so the service
+        // only guarantees the entries and the display-name mapping, not order.
         history.Should().HaveCount(2);
-        history[0].AreaSqm.Should().Be(200.0); // Most recent first
-        history[1].AreaSqm.Should().Be(100.0);
-        history[0].ModifiedByDisplayName.Should().Be("Test User");
+        history.Select(h => h.AreaSqm).Should().BeEquivalentTo([100.0, 200.0]);
+        history.Should().OnlyContain(h => h.ModifiedByDisplayName == "Test User");
     }
 
     [HumansFact(Timeout = 10000)]


### PR DESCRIPTION
Moves pure display orderings out of the Camps, CityPlanning, and Consent repositories into their presentation-layer consumers, per `memory/architecture/display-sort-in-controllers.md` (display sort belongs above the service boundary). Conservative: orderings that feed top-N/single selectors, that are needed for downstream correctness, or whose returned DTO lacks the sort key were left in place.

## Moved (2 orderings → 3 baseline lines removed)

- **CityPlanning** — `CityPlanningRepository.GetHistoryForCampSeasonAsync`: `OrderByDescending(ModifiedAt)` → `CityPlanningApiController.GetCampPolygonHistory`. Single consumer; DTO carries `ModifiedAt`; endpoint documented "newest first". Removes baseline `CityPlanning/CityPlanningRepository.cs:OrderByDescending#1`.
- **Camps** — `CampRepository.GetUserMembershipsAsync`: `OrderByDescending(Year).ThenBy(Name)` → `MyCampsViewComponent`. Single consumer (`GetCampMembershipsForUserAsync`); the component already orders year-groups descending, so only the within-year camp-name sort was added there; `CampMembershipSummary` carries both keys. Removes baseline `Camps/CampRepository.cs:OrderByDescending#2` and `Camps/CampRepository.cs:ThenBy#1`.

Two CityPlanning tests (repository + service) that asserted descending order were updated to assert membership only, since ordering moved up a layer.

## Left in place (with reasons)

**Camps — CampRepository:**
- `Include(b => b.Images.OrderBy(SortOrder))` ×3 — EF Include-nested collection ordering, not a top-level query sort.
- `GetCampsWithLeadsForYearAsync` (OrderBy Name) — many disparate consumers incl. cross-section (CityPlanning/Events) controllers, none re-sort.
- `GetPendingSeasonsAsync` (OrderBy CreatedAt) — `CampSeasonInfo` DTO does not carry `CreatedAt`; returned shape lacks the sort key.
- settings `OrderBy(Id).First*()` ×4 + `GetLatestSeasonAsync` `OrderByDescending(Year).FirstOrDefault()` — top-1/single selectors, not display.
- `GetSeasonMembersAsync` (OrderBy RequestedAt) — shared by `GetCampMembersAsync`, whose pending list relies on the order (not re-sorted); multiple controller consumers.

**Camps — CampRoleRepository:**
- `ListDefinitionsAsync` (OrderBy SortOrder, ThenBy Name) — multiple consumers, some use the result for filtering (non-display); SortOrder is a canonical domain order.
- `GetAssignmentsForSeasonAsync` (OrderBy SortOrder, ThenBy AssignedAt) — single service consumer (`BuildPanelAsync`) that fully reconstructs the order; left conservatively (borderline; consumer is a service, not a controller).
- `GetAllAssignmentsForUserAsync` (OrderByDescending AssignedAt) — feeds GDPR export (`UserDataSlice`), parallel to the already-`arch:db-sort-ok` legacy-lead export sort.

**CityPlanning:** no other display sorts.

**Consent — ConsentRepository (all left):**
- `GetByUserIdsAndVersionAsync` `OrderByDescending(ConsentedAt).FirstOrDefault()` — top-1 selector ("latest consent").
- `GetAllForUserAsync` / `GetAllForUserIdsAsync` `OrderByDescending(ConsentedAt)` — shared by `GetConsentDashboardAsync`, which relies on the descending order for correctness (`FirstOrDefault` picks the latest consent per document version); also feeds GDPR export.

## Verification

`dotnet build Humans.slnx -v q` clean; `dotnet test ... --filter FullyQualifiedName~Application` green (3260 passed); Web tests green; DisplaySortInControllers ratchet green.

🤖 Generated with Claude Code
