### PR TITLE
techdebt(profiles): stitch AccountMerge display names via IUserService instead of cross-section Include

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IAccountMergeRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IAccountMergeRepository.cs
@@ -9,33 +9,30 @@ namespace Humans.Application.Interfaces.Repositories;
 /// (issue #557).
 /// </summary>
 /// <remarks>
-/// Read methods for admin listing eagerly include <see cref="AccountMergeRequest.TargetUser"/>,
-/// <see cref="AccountMergeRequest.SourceUser"/>, and <see cref="AccountMergeRequest.ResolvedByUser"/>
-/// because the admin view needs display info for all three in a single fetch.
-/// These are cross-domain navs from the merge table into <c>AspNetUsers</c>;
-/// we tolerate them here because the Users section owns no distinct
-/// "display-info" DTO and the merge table sits alongside user identity in the
-/// table ownership map (§8, Users/Identity section).
+/// Read methods return the merge-request rows with scalar user IDs only.
+/// Display info for the source/target/resolver users is stitched in
+/// <c>AccountMergeService</c> via <c>IUserService</c> (§6b), never via the
+/// cross-domain <c>AspNetUsers</c> navigation properties.
 /// </remarks>
 [Section("Humans")]
 public interface IAccountMergeRepository : IRepository
 {
     /// <summary>
     /// Returns all pending merge requests for admin review, ordered by
-    /// <c>CreatedAt</c> ascending. Includes the source and target User
-    /// navigation properties for display. Read-only (AsNoTracking).
+    /// <c>CreatedAt</c> ascending. Scalar user IDs only — the service stitches
+    /// display info via <c>IUserService</c>. Read-only (AsNoTracking).
     /// </summary>
     Task<IReadOnlyList<AccountMergeRequest>> GetPendingAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Returns a single merge request by id with source, target, and resolver
-    /// user navigation properties loaded. Tracked for modification.
+    /// Returns a single merge request by id. Scalar user IDs only — the service
+    /// stitches display info via <c>IUserService</c>. Tracked for modification.
     /// </summary>
     Task<AccountMergeRequest?> GetByIdAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns a single merge request by id without navigation properties.
-    /// Tracked for modification.
+    /// Returns a single merge request by id, read-only (AsNoTracking). Use when
+    /// the caller does not modify the entity.
     /// </summary>
     Task<AccountMergeRequest?> GetByIdPlainAsync(Guid id, CancellationToken ct = default);
 

--- a/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
@@ -15,7 +15,6 @@ src/Humans.Application/DTOs/Governance/BoardVotingDashboardRow.cs:User#1
 src/Humans.Application/DTOs/Governance/BoardVotingDetailData.cs:User#1
 src/Humans.Application/Interfaces/Legal/IAdminLegalDocumentService.cs:Team#1
 src/Humans.Application/Interfaces/Legal/ILegalDocumentSyncService.cs:Team#1
-src/Humans.Application/Interfaces/Repositories/IAccountMergeRepository.cs:ResolvedByUser#1
 src/Humans.Application/Interfaces/Repositories/ICalendarRepository.cs:OwningTeam#1
 src/Humans.Application/Interfaces/Repositories/ICampRepository.cs:User#1
 src/Humans.Application/Interfaces/Repositories/IFeedbackRepository.cs:AssignedToTeam#1


### PR DESCRIPTION
## Context

The layering backlog (`docs/architecture/tech-debt-2026-04-23.md:190`) flagged a Profile → User cross-section EF traversal:

> `AccountMergeRepository.cs:30,41-42` — `.Include(r => r.TargetUser).Include(r => r.SourceUser)` crosses Profile → User. Only used for `DisplayName` logging; resolve via `IUserService` before the transaction opens.

## What I found

**The code violation is already fixed.** In the current tree off `main`:

- `AccountMergeRepository.cs` has **no** `.Include(r => r.TargetUser)` / `.Include(r => r.SourceUser)` and reads no cross-domain navs — only scalar `TargetUserId`/`SourceUserId`. The GDPR query selects scalar fields only.
- `AccountMergeService` already resolves display info via `userService.GetUserInfosAsync(...)` **before** any `TransactionScope` opens (lines 41, 51), exactly the §6b in-memory stitch. The merge business logic (`FoldAsync`, `AcceptAsync`, `RejectAsync`) uses only scalar user IDs.
- Confirmed the `TargetUser`/`SourceUser` navs were logging/display-only — they are not referenced anywhere in the merge mutation logic. (In fact they're no longer referenced at all.)

What remained was **stale documentation + an orphaned baseline line**:

- The `IAccountMergeRepository` doc comments still *claimed* the read methods "eagerly include" the cross-domain `TargetUser`/`SourceUser`/`ResolvedByUser` navs — describing behavior the implementation no longer has.
- The `NoObsoleteNavReads` baseline carried `IAccountMergeRepository.cs:ResolvedByUser#1`, a false positive produced solely by the stale `<see cref="AccountMergeRequest.ResolvedByUser"/>` text in that doc comment (the ratchet rule is a coarse `.PropName` text heuristic; `ResolvedByUser` is an obsolete-nav name on other entities).

## What I changed

- **`IAccountMergeRepository.cs`** — rewrote the `<remarks>` and per-method `<summary>` docs to state scalar-IDs-only + service-side `IUserService` stitch. No signature or behavior change. `GetByIdPlainAsync` summary reworded from "without navigation properties" to its real distinction (read-only / AsNoTracking).
- **`NoObsoleteNavReads.baseline.txt`** — removed line `src/Humans.Application/Interfaces/Repositories/IAccountMergeRepository.cs:ResolvedByUser#1` (eliminated by removing the stale doc text).

## How display-name logging is preserved

Unchanged — `AccountMergeService` already resolves all user display info via `IUserService.GetUserInfosAsync(...)` before the transaction scope opens (the established §6b pattern). No log statement read `r.TargetUser.DisplayName` in the current code; the IDs-plus-stitch path was already in place.

## Transaction safety

No transaction code touched. No awaits reordered inside any `TransactionScope`, no parallelism added, no merge mutation logic changed. The pre-transaction `GetUserInfosAsync` calls were already present and are left as-is.

## Baseline lines removed

- `src/Humans.Application/Interfaces/Repositories/IAccountMergeRepository.cs:ResolvedByUser#1`

Left intact (excluded EF-config zone): `src/Humans.Infrastructure/Data/Configurations/Profiles/AccountMergeRequestConfiguration.cs:ResolvedByUser#1`.

## Files touched

- `src/Humans.Application/Interfaces/Repositories/IAccountMergeRepository.cs`
- `tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt`

`AccountMergeService.cs` and `AccountMergeRepository.cs` needed no changes — they already comply.

## Verification

- `dotnet build Humans.slnx -v q` — green (0 errors)
- `dotnet test Humans.slnx -v q --filter "FullyQualifiedName~Application"` — 3260 passed, 1 skipped, 0 failed
- `NoObsoleteNavReads` ratchet — green

🤖 Generated with Claude Code