### PR TITLE
techdebt(googleintegration): move display sort from repositories to controllers

### DIFF
--- a/src/Humans.Infrastructure/Repositories/GoogleIntegration/SyncSettingsRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/GoogleIntegration/SyncSettingsRepository.cs
@@ -21,7 +21,7 @@ internal sealed class SyncSettingsRepository(IDbContextFactory<HumansDbContext> 
         await using var ctx = await factory.CreateDbContextAsync(ct);
         // Cross-domain nav UpdatedByUser intentionally NOT loaded — callers
         // resolve display names via IUserService (design-rules §6).
-        // Display ordering by ServiceType is the controller's job (GoogleController.SyncSettings).
+        // Display ordering is the controller's job (display-sort-in-controllers atom).
         return await ctx.SyncServiceSettings
             .AsNoTracking()
             .ToListAsync(ct);

--- a/src/Humans.Infrastructure/Repositories/GoogleIntegration/SyncSettingsRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/GoogleIntegration/SyncSettingsRepository.cs
@@ -21,9 +21,9 @@ internal sealed class SyncSettingsRepository(IDbContextFactory<HumansDbContext> 
         await using var ctx = await factory.CreateDbContextAsync(ct);
         // Cross-domain nav UpdatedByUser intentionally NOT loaded — callers
         // resolve display names via IUserService (design-rules §6).
+        // Display ordering by ServiceType is the controller's job (GoogleController.SyncSettings).
         return await ctx.SyncServiceSettings
             .AsNoTracking()
-            .OrderBy(s => s.ServiceType)
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -36,7 +36,9 @@ public class GoogleController(
         [FromServices] ISyncSettingsService syncSettingsService,
         [FromServices] IUserServiceRead userService)
     {
-        var settings = await syncSettingsService.GetAllAsync();
+        var settings = (await syncSettingsService.GetAllAsync())
+            .OrderBy(s => s.ServiceType)
+            .ToList();
 
         // In-memory join: resolve UpdatedByUser display names via IUserServiceRead
         // rather than an EF .Include across the section boundary (design-rules §6).

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -37,7 +37,9 @@ public class GoogleController(
         [FromServices] IUserServiceRead userService)
     {
         var settings = (await syncSettingsService.GetAllAsync())
-            .OrderBy(s => s.ServiceType)
+            // Sort by the enum's string name to match the prior EF ordering
+            // (ServiceType is stored via .HasConversion<string>()).
+            .OrderBy(s => s.ServiceType.ToString(), StringComparer.Ordinal)
             .ToList();
 
         // In-memory join: resolve UpdatedByUser display names via IUserServiceRead

--- a/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
@@ -63,7 +63,6 @@ src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleResourceRepositor
 src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleResourceRepository.cs:OrderBy#2
 src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleSyncOutboxRepository.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleSyncOutboxRepository.cs:OrderByDescending#1
-src/Humans.Infrastructure/Repositories/GoogleIntegration/SyncSettingsRepository.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:OrderBy#2
 src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs:OrderBy#3


### PR DESCRIPTION
Rule `DisplaySortInControllers`, GoogleIntegration section. Per-ordering verdict:

**Moved (1):**
- `SyncSettingsRepository.cs` OrderBy#1 — `GetAllAsync` ordered `SyncServiceSettings` by `ServiceType`. Pure display sort: the only caller chain is `SyncSettingsService.GetAllAsync` → `GoogleController.SyncSettings`, which builds the admin view model. No `.Take`/pagination/processing dependency; `SyncServiceSettingsInfo` exposes `ServiceType`, so the controller can sort. Moved the `OrderBy(s => s.ServiceType)` into the controller after the service call. Baseline line removed.

**Left in repository (4):**
- `GoogleSyncOutboxRepository.cs` OrderByDescending#1 — `GetRecentAsync` is a top-N selector (`OrderByDescending(OccurredAt).Take(take)`). Order is part of the query result definition. Kept.
- `GoogleSyncOutboxRepository.cs` OrderBy#1 — `GetProcessingBatchAsync` drives FIFO processing order (`OrderBy(OccurredAt).Take(batchSize)`). Processing correctness, not display. Kept.
- `GoogleResourceRepository.cs` OrderBy#1 — `GetActiveByTeamIdAsync` is consumed only by services (`GoogleWorkspaceSyncService`, `TeamResourceService`) and an infrastructure job, never by a controller. Not a controller-reachable display sort, and `GoogleWorkspaceSyncService` is out of scope. Kept.
- `GoogleResourceRepository.cs` OrderBy#2 — `GetActiveByTeamIdsAsync`, same as above. Kept.

**Baseline lines removed:**
- `src/Humans.Infrastructure/Repositories/GoogleIntegration/SyncSettingsRepository.cs:OrderBy#1`

**Files touched:** `SyncSettingsRepository.cs`, `GoogleController.cs`, `DisplaySortInControllers.baseline.txt`

Build: green. Tests: green (`FullyQualifiedName~Application`, 3260 passed, architecture ratchet included).

🤖 Generated with Claude Code