### PR TITLE
fix(metrics): arm gauge-refresh timer behind the migration barrier

### DIFF
--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -9,6 +9,7 @@ Atomic rules. Fetch the body when the description's trigger matches your task. T
 ## architecture/
 
 - [`audit-log-as-concurrency-safety-net`](architecture/audit-log-as-concurrency-safety-net.md) — audit log catches admin-clobbers-admin races at this scale; don't reach for `IsConcurrencyToken` / row versioning
+- [`background-db-work-after-migration-barrier`](architecture/background-db-work-after-migration-barrier.md) — DB-touching background workers (timers/pollers/pre-warmers) arm in `IHostedService.StartAsync`, never a constructor `Timer` or eager `GetRequiredService` before `app.Run()`; otherwise they race startup migrations (the #804 `p.Allergies` 42703 incident)
 - [`burnername-is-the-display-name`](architecture/burnername-is-the-display-name.md) — HARD RULE. When a Profile exists, `Profile.BurnerName` is the only name we render. `User.DisplayName` / `UserInfo.DisplayName` are legacy fields — fallback only. Use `<vc:human>`, `UserInfo.BurnerName`, or `FullProfile.DisplayName`.
 - [`caching-transparent`](architecture/caching-transparent.md) — no `Cached*` types in domain surface; `Full<Section>` is the §15 stitched-DTO pattern
 - [`cached-reads-no-shape-variants`](architecture/cached-reads-no-shape-variants.md) — once a read serves from an in-memory cache of the canonical DTO, do NOT offer `WithEmails` / `IncludeFoo` shape variants. The cache holds one shape — variants reintroduce EF-shaped thinking into a cache-first surface (PR #625 / issue #744).

--- a/memory/architecture/background-db-work-after-migration-barrier.md
+++ b/memory/architecture/background-db-work-after-migration-barrier.md
@@ -1,0 +1,17 @@
+---
+name: Background DB workers arm behind the migration barrier
+description: timers/pollers/pre-warmers that query the DB must arm in IHostedService.StartAsync — never a constructor Timer or an eager GetRequiredService before app.Run() — so they run after DatabaseMigrationHostedService applies migrations
+---
+
+Any background worker that touches the database (refresh timers, pollers, cache pre-warmers) must arm/start its work from `IHostedService.StartAsync`, **not** from a constructor and **not** from an eager `GetRequiredService<T>()` before `app.Run()`. The host runs every `IHostedLifecycleService.StartingAsync` — including `DatabaseMigrationHostedService`, which applies pending migrations — to completion before *any* `StartAsync`. Arming in the constructor escapes that barrier and can query a not-yet-migrated schema.
+
+**Why:** Incident on the #804 prod deploy (2026-05-25). `HumansMetricsService` armed a `Timer(dueTime: TimeSpan.Zero)` in its constructor, eager-resolved in `Program.cs` before `app.Run()`. The immediate first tick raced the `MoveDietaryMedicalToProfile` migration's `ADD COLUMN` and ran `SELECT … p."Allergies" … FROM profiles` before the column existed → `42703 column p.Allergies does not exist`. It was non-fatal (caught, retried in 60 s) but produced an alarming production error and looked exactly like impossible schema/history drift, costing real triage time. Note HTTP requests never hit it — Kestrel only starts listening in `StartAsync`, already behind the barrier — so the constructor-armed timer was the *only* thing that escaped.
+
+**How to apply:**
+
+- Register the worker with `AddHostedService`. If it's also injected elsewhere as a singleton, point the hosted registration at the same instance: `services.AddHostedService(sp => (TImpl)sp.GetRequiredService<IFace>())` (see `HttpStatusTracker` and `HumansMetricsService` in `TelemetryInfrastructureExtensions`).
+- Arm timers in `StartAsync`; stop in `StopAsync` and dispose in `Dispose`. `dueTime: Zero` is fine *there* — the barrier has already passed.
+- Do **not** arm a DB-touching timer in a constructor.
+- Do **not** add an eager `GetRequiredService<T>()` before `app.Run()` to "start a background timer immediately."
+
+**Related:** [`no-startup-guards`](no-startup-guards.md) (the worker must still never block boot — degrade and retry), [`crosscut-purity`](crosscut-purity.md) (Metrics/Audit/Email/Notification are crosscuts).

--- a/src/Humans.Application/Interfaces/Admin/AdminDatabaseDiagnostics.cs
+++ b/src/Humans.Application/Interfaces/Admin/AdminDatabaseDiagnostics.cs
@@ -12,7 +12,8 @@ public interface IAdminDatabaseDiagnosticsService : IApplicationService
 public sealed record DatabaseMigrationStatus(
     string? LastApplied,
     int AppliedCount,
-    int PendingCount);
+    int PendingCount,
+    IReadOnlyList<string> Applied);
 
 public sealed record AudienceSegmentation(
     int TotalAccounts,

--- a/src/Humans.Infrastructure/Hosting/DatabaseMigrationHostedService.cs
+++ b/src/Humans.Infrastructure/Hosting/DatabaseMigrationHostedService.cs
@@ -48,7 +48,9 @@ internal sealed class DatabaseMigrationHostedService(IServiceScopeFactory scopeF
             var pending = (await dbContext.Database.GetPendingMigrationsAsync(cancellationToken)).ToList();
             var applied = (await dbContext.Database.GetAppliedMigrationsAsync(cancellationToken)).ToList();
 
-            _logger.LogInformation(
+            // Warning level (not Information) so the per-boot migration breadcrumb survives
+            // production's default log filtering — makes "when did migrations run?" answerable.
+            _logger.LogWarning(
                 "Database {Database}: {AppliedCount} applied migrations, {PendingCount} pending",
                 dbName, applied.Count, pending.Count);
 
@@ -56,13 +58,13 @@ internal sealed class DatabaseMigrationHostedService(IServiceScopeFactory scopeF
             {
                 foreach (var migration in pending)
                 {
-                    _logger.LogInformation("Pending migration: {Migration}", migration);
+                    _logger.LogWarning("Applying pending migration: {Migration}", migration);
                 }
 
                 await dbContext.Database.MigrateAsync(cancellationToken);
 
                 var nowApplied = (await dbContext.Database.GetAppliedMigrationsAsync(cancellationToken)).ToList();
-                _logger.LogInformation(
+                _logger.LogWarning(
                     "Database {Database}: migrations complete — {AppliedCount} total applied",
                     dbName, nowApplied.Count);
             }

--- a/src/Humans.Infrastructure/Repositories/Admin/AdminDatabaseDiagnosticsRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Admin/AdminDatabaseDiagnosticsRepository.cs
@@ -17,7 +17,8 @@ internal sealed class AdminDatabaseDiagnosticsRepository(IDbContextFactory<Human
         return new DatabaseMigrationStatus(
             LastApplied: applied.LastOrDefault(),
             AppliedCount: applied.Count,
-            PendingCount: pending.Count());
+            PendingCount: pending.Count(),
+            Applied: applied);
     }
 
     public async Task<int> ClearHangfireLocksAsync(CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
@@ -18,7 +19,7 @@ namespace Humans.Infrastructure.Services;
 /// counters and observable gauges. Gauge values are refreshed every 60 seconds from
 /// the database via a background timer.
 /// </summary>
-public sealed class HumansMetricsService : IHumansMetrics, IDisposable
+public sealed class HumansMetricsService : IHumansMetrics, IHostedService, IDisposable
 {
     private static readonly Meter HumansMeter = new("Humans.Metrics");
 
@@ -36,7 +37,7 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<HumansMetricsService> _logger;
     private readonly IUserActivityTracker _activityTracker;
-    private readonly Timer _refreshTimer;
+    private Timer? _refreshTimer;
 
     private volatile GaugeSnapshot _snapshot = GaugeSnapshot.Empty;
 
@@ -156,12 +157,29 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
             description: "Distinct users with an authenticated request in the trailing window. In-memory only; resets on process restart.");
 
         // humans.email_outbox_pending lives on IMeters via ProcessEmailOutboxJob.
+    }
 
+    /// <summary>
+    /// Arms the gauge-refresh timer. Deliberately done here (StartAsync) rather than in the
+    /// constructor: the host runs every <see cref="IHostedLifecycleService"/>.StartingAsync —
+    /// including DatabaseMigrationHostedService, which applies pending migrations — to completion
+    /// before any StartAsync. Arming in the constructor (via an eager resolve before app.Run)
+    /// let the first refresh race schema migrations and query not-yet-migrated tables.
+    /// </summary>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
         _refreshTimer = new Timer(
             callback: _ => _ = RefreshSnapshotAsync(),
             state: null,
             dueTime: TimeSpan.Zero,
             period: TimeSpan.FromSeconds(60));
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _refreshTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        return Task.CompletedTask;
     }
 
     public void RecordEmailSent(string template)
@@ -341,7 +359,7 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
 
     public void Dispose()
     {
-        _refreshTimer.Dispose();
+        _refreshTimer?.Dispose();
     }
 
     private sealed record GaugeSnapshot

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -203,7 +203,8 @@ public class AdminController(
         {
             lastApplied = status.LastApplied,
             appliedCount = status.AppliedCount,
-            pendingCount = status.PendingCount
+            pendingCount = status.PendingCount,
+            recentApplied = status.Applied.TakeLast(20).Reverse().ToList()
         });
     }
 

--- a/src/Humans.Web/Extensions/Infrastructure/TelemetryInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/TelemetryInfrastructureExtensions.cs
@@ -15,6 +15,11 @@ internal static class TelemetryInfrastructureExtensions
         services.Configure<GitHubSettings>(configuration.GetSection(GitHubSettings.SectionName));
 
         services.AddSingleton<IHumansMetrics, HumansMetricsService>();
+        // Hosted so the gauge-refresh timer is armed in StartAsync — i.e. after the host has run
+        // DatabaseMigrationHostedService.StartingAsync (which applies pending migrations). Previously
+        // the timer was armed in the constructor via an eager resolve before app.Run(), which raced
+        // schema migrations on deploy and could query not-yet-migrated tables.
+        services.AddHostedService(sp => (HumansMetricsService)sp.GetRequiredService<IHumansMetrics>());
 
         // Process-local "who's online" registry — singleton so the dict survives across requests.
         services.AddSingleton<IUserActivityTracker, UserActivityTracker>();

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -464,8 +464,8 @@ DateTimeDisplayExtensions.Initialize(app.Services.GetRequiredService<IHttpContex
 // Post-Build so the parameterless enricher activator can read ambient HttpContext per log emission.
 CurrentUserEnricher.StaticAccessor = app.Services.GetRequiredService<IHttpContextAccessor>();
 
-// Eager resolve so the background gauge-refresh timer starts immediately.
-app.Services.GetRequiredService<IHumansMetrics>();
+// HumansMetricsService is registered AddHostedService — its gauge-refresh timer is armed in
+// StartAsync (after the migration barrier), so no eager pre-Run() resolve is needed here.
 
 // Localization diagnostic check
 {


### PR DESCRIPTION
## What this fixes

The `42703 column p.Allergies does not exist` error seen in production at 23:07 UTC on 2026-05-25 (≈3 min into the nobodies-collective/Humans#804 deploy) was a **startup race**, not schema drift. The DB was fine all along — column and history row both present.

### Root cause

`HumansMetricsService` armed its 60-second gauge-refresh `Timer(dueTime: TimeSpan.Zero)` **in its constructor**, eager-resolved in `Program.cs` *before* `app.Run()`:

```csharp
// Program.cs (old)
app.Services.GetRequiredService<IHumansMetrics>();   // before app.Run() → timer fires now
```

That escaped the migration barrier. `DatabaseMigrationHostedService` applies pending migrations in `StartingAsync`, which the host completes before *any* `StartAsync` — and Kestrel only starts listening in `StartAsync`, so **HTTP requests can never race a migration**. But this constructor-armed, fire-and-forget timer ran outside the lifecycle entirely. Its immediate first tick triggered the lazy user-cache warm → `SELECT … p."Allergies" … FROM profiles` → which landed before `MoveDietaryMedicalToProfile`'s `ADD COLUMN` committed.

Non-fatal: the refresh catches, logs `Failed to refresh metrics snapshot`, and retries in 60s. It self-healed the moment the migration finished. But it produced an alarming prod error that looked exactly like impossible history/schema drift.

## Changes

1. **`HumansMetricsService` → `IHostedService`.** Timer is now armed in `StartAsync` (after the migration barrier) and stopped in `StopAsync`. Registered via `AddHostedService` pointing at the same singleton instance — mirrors the existing `HttpStatusTracker` pattern in `TelemetryInfrastructureExtensions`. Removed the pre-`Run()` eager resolve in `Program.cs`.
2. **Migration logs at `Warning`.** `DatabaseMigrationHostedService` logs applied/pending counts, each applied migration, and completion at `Warning` (was `Information`), so the per-boot migration breadcrumb survives production's default log filtering. Answers "when did migrations actually run?".
3. **`/Admin/DbVersion` lists the last 20 migrations.** New `recentApplied` field (most-recent-first) alongside `lastApplied`/`appliedCount`/`pendingCount`.
4. **Memory atom** `architecture/background-db-work-after-migration-barrier.md` capturing the rule.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors (pre-existing HUM0025/HUM0014 warnings only, in untouched files).
- `dotnet test Humans.slnx -v quiet` — all pass **except** 2 pre-existing failures in `StorePayActionTests` (`GET /Store/Order/{id}` → 302 during antiforgery harvest). Confirmed identical failure on the untouched base (`git stash` → same 2/2 fail), so unrelated to this change. Flagging separately.