### PR TITLE
fix(tickets): show the Early Entry pill on every holder stub surface

### DIFF
--- a/src/Humans.Application/DTOs/TicketTransferDtos.cs
+++ b/src/Humans.Application/DTOs/TicketTransferDtos.cs
@@ -92,4 +92,16 @@ public sealed record TicketStubInfo(
     TicketAttendeeStatus Status,
     bool HasPendingTransfer,
     Guid? PendingTransferRequestId,
-    LocalDate? EarlyEntryDate = null);
+    LocalDate? EarlyEntryDate)
+{
+    /// <summary>
+    /// Projects an attendee row into a stub, stamping the holder's earliest entry
+    /// date. Single mapper for every surface that renders a holder's own stubs
+    /// (homepage strip + transfer wizard) so the EE pill can never be dropped on
+    /// one surface and present on another. <paramref name="holderEarlyEntry"/> is
+    /// the viewer's EE (one value, shown on each of their stubs); null = no EE.
+    /// </summary>
+    public static TicketStubInfo From(MyAttendeeRowDto row, LocalDate? holderEarlyEntry) =>
+        new(row.AttendeeName, row.AttendeeEmail, row.VendorTicketId, row.Status,
+            row.HasPendingOutgoingTransfer, row.PendingTransferRequestId, holderEarlyEntry);
+}

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -5,7 +5,6 @@ using Humans.Web.Models;
 using Humans.Application.Interfaces.Dashboard;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Shifts;
-using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
@@ -17,8 +16,7 @@ public class HomeController(
     IOnboardingWidgetState widgetState,
     IConfiguration configuration,
     ConfigurationRegistry configRegistry,
-    ILogger<HomeController> logger,
-    ITicketTransferService ticketTransferService) : HumansControllerBase(userService)
+    ILogger<HomeController> logger) : HumansControllerBase(userService)
 {
     private readonly IUserService _userService = userService;
 
@@ -111,23 +109,6 @@ public class HomeController(
                 .ToList(),
             PendingCount = data.PendingSignupCount,
         };
-
-        var attendeeRows = await ticketTransferService.GetMyAttendeesAsync(user.Id, cancellationToken);
-
-        viewModel.MyAttendees = attendeeRows
-            .Select(a => new MyAttendeeRowVm(
-                AttendeeId: a.AttendeeId,
-                AttendeeName: a.AttendeeName,
-                AttendeeEmail: a.AttendeeEmail,
-                VendorTicketId: a.VendorTicketId,
-                TicketTypeName: a.TicketTypeName,
-                Status: a.Status,
-                CanSendTransfer: a.CanSendTransfer,
-                HasPendingOutgoingTransfer: a.HasPendingOutgoingTransfer,
-                PendingTransferRequestId: a.PendingTransferRequestId))
-            .ToList();
-
-        viewModel.PendingTransferOutCount = attendeeRows.Count(a => a.HasPendingOutgoingTransfer);
 
         return View("Dashboard", viewModel);
     }

--- a/src/Humans.Web/Controllers/TicketTransferController.cs
+++ b/src/Humans.Web/Controllers/TicketTransferController.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
 using Humans.Web.Models;
@@ -11,6 +12,7 @@ namespace Humans.Web.Controllers;
 [Route("Tickets/Transfers")]
 public sealed class TicketTransferController(
     ITicketTransferService service,
+    IEarlyEntryService earlyEntryService,
     IUserServiceRead userService,
     ILogger<TicketTransferController> logger) : HumansControllerBase(userService)
 {
@@ -23,7 +25,13 @@ public sealed class TicketTransferController(
 
         var mine = await service.GetMyAttendeesAsync(user.Id, ct);
         var transfers = await service.GetBySenderAsync(user.Id, ct);
-        return View("Index", new TicketTransferWizardViewModel { MyTickets = mine, MyTransfers = transfers });
+        var earlyEntry = await earlyEntryService.GetForUserAsync(user.Id, ct);
+        return View("Index", new TicketTransferWizardViewModel
+        {
+            MyTickets = mine,
+            MyTransfers = transfers,
+            HolderEarlyEntry = earlyEntry?.EarliestEntryDate,
+        });
     }
 
     // Step C: resolve the chosen (ticket, recipient) pair server-side and show the confirmation.
@@ -37,10 +45,12 @@ public sealed class TicketTransferController(
         var mine = await service.GetMyAttendeesAsync(user.Id, ct);
         var transfers = await service.GetBySenderAsync(user.Id, ct);
         var confirm = await service.GetConfirmationAsync(attendeeId, receiverUserId, user.Id, ct);
+        var earlyEntry = await earlyEntryService.GetForUserAsync(user.Id, ct);
         return View("Index", new TicketTransferWizardViewModel
         {
             MyTickets = mine,
             MyTransfers = transfers,
+            HolderEarlyEntry = earlyEntry?.EarliestEntryDate,
             Confirm = confirm,
             Error = confirm is null
                 ? "Couldn't set up that transfer — choose one of your tickets and a valid recipient (not yourself)."
@@ -70,10 +80,12 @@ public sealed class TicketTransferController(
             var mine = await service.GetMyAttendeesAsync(user.Id, ct);
             var transfers = await service.GetBySenderAsync(user.Id, ct);
             var confirm = await service.GetConfirmationAsync(attendeeId, receiverUserId, user.Id, ct);
+            var earlyEntry = await earlyEntryService.GetForUserAsync(user.Id, ct);
             return View("Index", new TicketTransferWizardViewModel
             {
                 MyTickets = mine,
                 MyTransfers = transfers,
+                HolderEarlyEntry = earlyEntry?.EarliestEntryDate,
                 Confirm = confirm,
                 Reason = reason,
                 Error = ex.Message,

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -49,20 +49,6 @@ public class DashboardViewModel
     public int UserTicketCount { get; set; }
     public string? TicketPurchaseUrl { get; set; }
 
-    /// <summary>Attendees on the user's orders (rendered when count > 1).</summary>
-    public IReadOnlyList<MyAttendeeRowVm> MyAttendees { get; set; } = [];
-
-    /// <summary>How many transfer requests this user has currently in Pending state.</summary>
-    public int PendingTransferOutCount { get; set; }
+    // The holder's ticket stubs are rendered by <vc:my-ticket-stubs user-id="…" />,
+    // which fetches attendees + Early Entry itself — no stub data plumbed here.
 }
-
-public sealed record MyAttendeeRowVm(
-    Guid AttendeeId,
-    string AttendeeName,
-    string? AttendeeEmail,
-    string VendorTicketId,
-    string TicketTypeName,
-    Humans.Domain.Enums.TicketAttendeeStatus Status,
-    bool CanSendTransfer,
-    bool HasPendingOutgoingTransfer,
-    Guid? PendingTransferRequestId);

--- a/src/Humans.Web/Models/TicketTransferViewModels.cs
+++ b/src/Humans.Web/Models/TicketTransferViewModels.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Tickets;
+using NodaTime;
 
 namespace Humans.Web.Models;
 
@@ -18,6 +19,11 @@ public sealed record TicketTransferIndexViewModel(
 public sealed class TicketTransferWizardViewModel
 {
     public IReadOnlyList<MyAttendeeRowDto> MyTickets { get; init; } = [];
+
+    /// <summary>The holder's earliest entry date (across sources), stamped onto each
+    /// selectable stub via <see cref="TicketStubInfo.From"/> so the EE pill matches
+    /// the homepage/profile. Null when the holder has no Early Entry.</summary>
+    public LocalDate? HolderEarlyEntry { get; init; }
 
     /// <summary>The user's own transfer requests (any status) — shown as a status/cancel list.</summary>
     public IReadOnlyList<TicketTransferRowDto> MyTransfers { get; init; } = [];

--- a/src/Humans.Web/ViewComponents/MyTicketStubsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/MyTicketStubsViewComponent.cs
@@ -1,0 +1,31 @@
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.EarlyEntry;
+using Humans.Application.Interfaces.Tickets;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.ViewComponents;
+
+/// <summary>
+/// Renders the current holder's ticket stubs as a bare flex-wrap strip (no card
+/// chrome), stamping each with the holder's Early Entry date. The single home for
+/// "my tickets as stubs" on the homepage dashboard; the transfer wizard shares the
+/// same <see cref="TicketStubInfo.From"/> mapper for its selectable list. Renders
+/// nothing when the holder has no visible tickets.
+/// </summary>
+public sealed class MyTicketStubsViewComponent(
+    ITicketTransferService transferService,
+    IEarlyEntryService earlyEntryService) : ViewComponent
+{
+    public async Task<IViewComponentResult> InvokeAsync(Guid userId)
+    {
+        var rows = await transferService.GetMyAttendeesAsync(userId, HttpContext.RequestAborted);
+        if (rows.Count == 0) return Content(string.Empty);
+
+        var earlyEntry = await earlyEntryService.GetForUserAsync(userId, HttpContext.RequestAborted);
+        var stubs = rows
+            .Select(r => TicketStubInfo.From(r, earlyEntry?.EarliestEntryDate))
+            .ToList();
+
+        return View(stubs);
+    }
+}

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -1,11 +1,7 @@
-@using Humans.Application.DTOs
 @using Humans.Domain.Enums
 @model Humans.Web.Models.DashboardViewModel
 @{
     ViewData["Title"] = Localizer["Dashboard_Title"].Value;
-    TicketStubInfo TicketStub(MyAttendeeRowVm a) =>
-        new(a.AttendeeName, a.AttendeeEmail, a.VendorTicketId, a.Status,
-            a.HasPendingOutgoingTransfer, a.PendingTransferRequestId);
 }
 
 <vc:temp-data-alerts />
@@ -184,19 +180,11 @@
                             }
                         </div>
                     </div>
-                    @if (Model.MyAttendees.Count > 0)
-                    {
-                        <div class="d-flex flex-wrap gap-3 mt-3">
-                            @foreach (var att in Model.MyAttendees)
-                            {
-                                <vc:ticket-stub stub="@TicketStub(att)" />
-                            }
-                        </div>
-                        <div class="mt-3">
-                            <a class="btn btn-sm btn-outline-secondary"
-                               asp-controller="TicketTransfer" asp-action="Index">Transfers…</a>
-                        </div>
-                    }
+                    <vc:my-ticket-stubs user-id="@Model.UserId" />
+                    <div class="mt-3">
+                        <a class="btn btn-sm btn-outline-secondary"
+                           asp-controller="TicketTransfer" asp-action="Index">Transfers…</a>
+                    </div>
                 }
                 else if (Model.ParticipationStatus == ParticipationStatus.NotAttending)
                 {

--- a/src/Humans.Web/Views/Shared/Components/MyTicketStubs/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/MyTicketStubs/Default.cshtml
@@ -1,0 +1,8 @@
+@model IReadOnlyList<Humans.Application.DTOs.TicketStubInfo>
+
+<div class="d-flex flex-wrap gap-3 mt-3">
+    @foreach (var stub in Model)
+    {
+        <vc:ticket-stub stub="@stub" />
+    }
+</div>

--- a/src/Humans.Web/Views/TicketTransfer/Index.cshtml
+++ b/src/Humans.Web/Views/TicketTransfer/Index.cshtml
@@ -9,9 +9,6 @@
         .Where(t => t.IsCurrentOwner && t.Status != TicketAttendeeStatus.Void)
         .ToList();
     var sendable = held.Where(t => t.CanSendTransfer).ToList();
-    TicketStubInfo Stub(MyAttendeeRowDto a) =>
-        new(a.AttendeeName, a.AttendeeEmail, a.VendorTicketId, a.Status,
-            a.HasPendingOutgoingTransfer, a.PendingTransferRequestId);
     string NotSendableReason(MyAttendeeRowDto t) =>
         t.HasPendingOutgoingTransfer ? "Transfer already pending"
         : t.Status == TicketAttendeeStatus.CheckedIn ? "Already checked in — can't be transferred"
@@ -47,7 +44,7 @@
                     {
                         <label class="d-flex align-items-center gap-3 m-0" style="cursor:pointer">
                             <input type="radio" name="attendeeId" value="@t.AttendeeId" required />
-                            <vc:ticket-stub stub="@Stub(t)" />
+                            <vc:ticket-stub stub="@TicketStubInfo.From(t, Model.HolderEarlyEntry)" />
                         </label>
                     }
                     else
@@ -55,7 +52,7 @@
                         <div class="d-flex align-items-center gap-3" style="opacity:.6">
                             <input type="radio" disabled />
                             <div>
-                                <vc:ticket-stub stub="@Stub(t)" />
+                                <vc:ticket-stub stub="@TicketStubInfo.From(t, Model.HolderEarlyEntry)" />
                                 <small class="text-muted d-block mt-1">@NotSendableReason(t)</small>
                             </div>
                         </div>

--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -479,12 +479,12 @@
                     </div>
                     <div class="wg-card-note">Renders one held ticket as a physical admission stub. Shared by the transfer wizard, the <code>/Profile/Me</code> ticket card, and the homepage. A pending outgoing transfer shows a diagonal "Transfer pending" stamp; voided tickets render muted with a struck name. The event label is currently a constant (open item to source from the active event).</div>
                     @ParamsBlock(
-                        ("stub", "<code>TicketStubInfo</code> — projection (attendee name + email, <code>VendorTicketId</code> serial, status, <code>HasPendingTransfer</code>, <code>PendingTransferRequestId</code>) from <code>ITicketServiceRead</code>")
+                        ("stub", "<code>TicketStubInfo</code> — projection (attendee name + email, <code>VendorTicketId</code> serial, status, <code>HasPendingTransfer</code>, <code>PendingTransferRequestId</code>, <code>EarlyEntryDate</code>) from <code>ITicketServiceRead</code>")
                     )
                     <div class="wg-card-example" style="display:flex; gap:16px; flex-wrap:wrap;">
-                        <vc:ticket-stub stub="@(new Humans.Application.DTOs.TicketStubInfo("Sample Human", "sample@example.com", "TKT-DEMO-001", Humans.Domain.Enums.TicketAttendeeStatus.Valid, false, null))" />
-                        <vc:ticket-stub stub="@(new Humans.Application.DTOs.TicketStubInfo("Sample Human", "sample@example.com", "TKT-DEMO-002", Humans.Domain.Enums.TicketAttendeeStatus.Valid, true, Guid.NewGuid()))" />
-                        <vc:ticket-stub stub="@(new Humans.Application.DTOs.TicketStubInfo("Sample Human", "sample@example.com", "TKT-DEMO-003", Humans.Domain.Enums.TicketAttendeeStatus.Void, false, null))" />
+                        <vc:ticket-stub stub="@(new Humans.Application.DTOs.TicketStubInfo("Sample Human", "sample@example.com", "TKT-DEMO-001", Humans.Domain.Enums.TicketAttendeeStatus.Valid, false, null, new NodaTime.LocalDate(2026, 8, 24)))" />
+                        <vc:ticket-stub stub="@(new Humans.Application.DTOs.TicketStubInfo("Sample Human", "sample@example.com", "TKT-DEMO-002", Humans.Domain.Enums.TicketAttendeeStatus.Valid, true, Guid.NewGuid(), null))" />
+                        <vc:ticket-stub stub="@(new Humans.Application.DTOs.TicketStubInfo("Sample Human", "sample@example.com", "TKT-DEMO-003", Humans.Domain.Enums.TicketAttendeeStatus.Void, false, null, null))" />
                     </div>
                 </div>
 

--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -1080,6 +1080,7 @@
                     <li><strong>Infrastructure tag helper</strong> — <code>NonceTagHelper</code>: applies CSP nonces to <code>&lt;script&gt;</code>/<code>&lt;style&gt;</code>; nothing visible to render.</li>
                     <li><strong>Volunteer-tracking heatmaps</strong> — <code>_VolunteerHeatmap</code>, <code>_VolunteerUnbookedHeatmap</code>: context-bound — requires full <code>VolunteerTrackingPageViewModel</code>, cannot render in isolation. See <a href="/Shifts/Dashboard/VolunteerTracking">/Shifts/Dashboard/VolunteerTracking</a>.</li>
                     <li><strong>Container card fragments</strong> — <code>_ContainerCardRow</code>, <code>_ContainerCardModals</code>, <code>_ContainerFormFields</code>: context-bound — render only as part of a populated <code>ContainerCardModel</code> on the container list/admin pages, with route values, placement state, and the parent modal-target form action. See <a href="/CityPlanning/BarrioMap/Admin/Containers/2026">/CityPlanning/BarrioMap/Admin/Containers/{year}</a>.</li>
+                    <li><strong>My ticket stubs</strong> — <code>MyTicketStubsViewComponent</code> (<code>&lt;vc:my-ticket-stubs&gt;</code>): can't render standalone — fetches the viewer's live visible attendees (<code>GetMyAttendeesAsync</code>) plus their cross-source Early Entry date, and renders nothing without them. The stub it draws is the <code>vc:ticket-stub</code> card above. See the homepage <a href="/">dashboard</a>.</li>
                 </ul>
             </section>
 

--- a/tests/Humans.Application.Tests/TicketStubInfoTests.cs
+++ b/tests/Humans.Application.Tests/TicketStubInfoTests.cs
@@ -1,0 +1,62 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using NodaTime;
+
+namespace Humans.Application.Tests;
+
+/// <summary>
+/// Covers <see cref="TicketStubInfo.From"/> — the single mapper that stamps the
+/// holder's Early Entry date onto a stub, used by the homepage strip and the
+/// transfer wizard so the EE pill can't be present on one surface and dropped on
+/// another.
+/// </summary>
+public class TicketStubInfoTests
+{
+    private static MyAttendeeRowDto Row(bool pending = false, Guid? pendingId = null) => new(
+        AttendeeId: Guid.NewGuid(),
+        AttendeeName: "Ada Lovelace",
+        AttendeeEmail: "ada@example.com",
+        VendorTicketId: "TKT-001",
+        TicketTypeName: "GA",
+        Status: TicketAttendeeStatus.Valid,
+        IsCurrentOwner: true,
+        CanSendTransfer: true,
+        HasPendingOutgoingTransfer: pending,
+        PendingTransferRequestId: pendingId);
+
+    [HumansFact]
+    public void From_StampsHolderEarlyEntry_AndMapsCoreFields()
+    {
+        var ee = new LocalDate(2026, 8, 24);
+        var row = Row();
+
+        var stub = TicketStubInfo.From(row, ee);
+
+        stub.AttendeeName.Should().Be(row.AttendeeName);
+        stub.AttendeeEmail.Should().Be(row.AttendeeEmail);
+        stub.VendorTicketId.Should().Be(row.VendorTicketId);
+        stub.Status.Should().Be(row.Status);
+        stub.EarlyEntryDate.Should().Be(ee);
+    }
+
+    [HumansFact]
+    public void From_NullHolderEarlyEntry_LeavesEarlyEntryDateNull()
+    {
+        var stub = TicketStubInfo.From(Row(), holderEarlyEntry: null);
+
+        stub.EarlyEntryDate.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void From_CarriesPendingTransferState()
+    {
+        var pendingId = Guid.NewGuid();
+
+        var stub = TicketStubInfo.From(Row(pending: true, pendingId: pendingId), holderEarlyEntry: null);
+
+        stub.HasPendingTransfer.Should().BeTrue();
+        stub.PendingTransferRequestId.Should().Be(pendingId);
+    }
+}

--- a/tests/Humans.Application.Tests/ViewComponents/MyTicketStubsViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/MyTicketStubsViewComponentTests.cs
@@ -1,0 +1,73 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.EarlyEntry;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using Humans.Web.ViewComponents;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Application.Tests.ViewComponents;
+
+/// <summary>
+/// Covers <see cref="MyTicketStubsViewComponent"/>: it renders the holder's stubs
+/// with the EE pill stamped, and renders nothing when the holder has no tickets.
+/// </summary>
+public class MyTicketStubsViewComponentTests
+{
+    private readonly ITicketTransferService _transfer = Substitute.For<ITicketTransferService>();
+    private readonly IEarlyEntryService _earlyEntry = Substitute.For<IEarlyEntryService>();
+
+    private MyTicketStubsViewComponent BuildSut() => new(_transfer, _earlyEntry)
+    {
+        ViewComponentContext = new ViewComponentContext
+        {
+            ViewContext = new ViewContext { HttpContext = new DefaultHttpContext() },
+        },
+    };
+
+    private static MyAttendeeRowDto Row() => new(
+        AttendeeId: Guid.NewGuid(),
+        AttendeeName: "Ada Lovelace",
+        AttendeeEmail: "ada@example.com",
+        VendorTicketId: "TKT-001",
+        TicketTypeName: "GA",
+        Status: TicketAttendeeStatus.Valid,
+        IsCurrentOwner: true,
+        CanSendTransfer: true,
+        HasPendingOutgoingTransfer: false,
+        PendingTransferRequestId: null);
+
+    [HumansFact]
+    public async Task Renders_StubsWithEarlyEntryStamped()
+    {
+        var userId = Guid.NewGuid();
+        var ee = new LocalDate(2026, 8, 24);
+        _transfer.GetMyAttendeesAsync(userId, Arg.Any<CancellationToken>()).Returns([Row()]);
+        _earlyEntry.GetForUserAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new UserEarlyEntry(ee, ["Camp: Flaming Lotus"]));
+
+        var result = await BuildSut().InvokeAsync(userId);
+
+        var view = result.Should().BeOfType<ViewViewComponentResult>().Subject;
+        var stubs = view.ViewData!.Model.Should().BeAssignableTo<IReadOnlyList<TicketStubInfo>>().Subject;
+        stubs.Should().ContainSingle().Which.EarlyEntryDate.Should().Be(ee);
+    }
+
+    [HumansFact]
+    public async Task RendersNothing_WhenHolderHasNoTickets()
+    {
+        var userId = Guid.NewGuid();
+        _transfer.GetMyAttendeesAsync(userId, Arg.Any<CancellationToken>()).Returns([]);
+
+        var result = await BuildSut().InvokeAsync(userId);
+
+        result.Should().BeOfType<ContentViewComponentResult>()
+            .Which.Content.Should().BeEmpty();
+        await _earlyEntry.DidNotReceive().GetForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/HomeControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/HomeControllerTests.cs
@@ -5,7 +5,6 @@ using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Dashboard;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Shifts;
-using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -36,7 +35,6 @@ public class HomeControllerTests
     private readonly IOnboardingWidgetState _widgetState = Substitute.For<IOnboardingWidgetState>();
     private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
     private readonly ConfigurationRegistry _configRegistry = new();
-    private readonly ITicketTransferService _ticketTransferService = Substitute.For<ITicketTransferService>();
 
     public HomeControllerTests()
     {
@@ -67,8 +65,7 @@ public class HomeControllerTests
             _widgetState,
             _configuration,
             _configRegistry,
-            NullLogger<HomeController>.Instance,
-            _ticketTransferService);
+            NullLogger<HomeController>.Instance);
 
         var claims = new List<Claim>
         {


### PR DESCRIPTION
## Problem

The Early Entry pill showed on `/Profile/Me` but **not** on the homepage (`/`) or the transfer wizard.

`<vc:ticket-stub>` is a dumb renderer of a complete `TicketStubInfo`; the pill only shows when `EarlyEntryDate` is populated, and that field was optional (`= null`). Four sites built the DTO and only `TicketHoldingsViewComponent` (profile) attached the EE date. The homepage and the transfer wizard each hand-rolled it and dropped the field.

## Fix (root cause, not a per-surface patch)

- **`TicketStubInfo.EarlyEntryDate` is now required** — omitting it is a compile error, so no future stub site can silently drop the pill.
- **One mapper** `TicketStubInfo.From(MyAttendeeRowDto, holderEarlyEntry)` replaces the two divergent inline view helpers (dashboard `TicketStub()` + wizard `Stub()`).
- **New `<vc:my-ticket-stubs user-id="…">`** renders the holder's bare stub strip. The dashboard embeds it and sheds its ticket-attendee plumbing: `MyAttendees`, `MyAttendeeRowVm`, the already-dead `PendingTransferOutCount`, and the `ITicketTransferService` dependency on `HomeController`.
- **Transfer wizard** stamps `HolderEarlyEntry` on its VM and maps stubs via `From`.

`TicketHoldingsViewComponent` (profile) already attached EE and renders a different ticket set (owned holdings), so it keeps its data source and just satisfies the now-required field.

## Tests

- `TicketStubInfoTests` — `From` stamps EE, maps core fields, carries pending state.
- `MyTicketStubsViewComponentTests` — renders stubs with EE stamped; renders nothing (and skips the EE lookup) when the holder has no tickets.
- `HomeControllerTests` updated for the dropped dependency.

Full `Humans.Web.Tests` (190) and the ticket/EE/view-component slice of `Humans.Application.Tests` (288) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)