### PR TITLE
feat(shifts): team-level coordinator rota message

### DIFF
--- a/docs/superpowers/specs/2026-05-27-team-rotas-coordinator-message-design.md
+++ b/docs/superpowers/specs/2026-05-27-team-rotas-coordinator-message-design.md
@@ -1,0 +1,284 @@
+# Team-Level Coordinator Message (Email All Rotas in a Team)
+
+**Status:** spec / awaiting Peter review · **Branch:** `feat/shifts-team-rotas-message` · **Date:** 2026-05-27
+**Driving rules:** [`docs/architecture/peters-hard-rules.md`](../../architecture/peters-hard-rules.md), reuse-first discipline (CLAUDE.md), [`docs/sections/Shifts.md`](../../sections/Shifts.md)
+**Builds on:** existing per-rota coordinator message feature (`IRotaCoordinatorMessageService.SendRotaMessageAsync`, `EmailRota` action, issue nobodies-collective/Humans#732)
+
+## Goal
+
+Give a department coordinator a single action that sends a personalised email to **every active signup across all current/upcoming rotas in a team** — the team-level analog of the existing per-rota "Email everyone with a shift" action. Each recipient sees their own shift list (across all included rotas) plus the coordinator's message. Replies route to the coordinator (`Reply-To`), not the shared `humans@` mailbox.
+
+## Non-goals
+
+- Changing the `From:` header. We keep `From = humans@nobodies.team` and `Reply-To = coordinator's email`, mirroring the per-rota feature. (Peter confirmed during brainstorm — the existing Reply-To behaviour is sufficient.)
+- Re-visiting the per-rota UI. The existing compose view already shows recipient count in two places; no change there.
+- Per-rota selection UI. The audience is computed from "team's current/upcoming rotas" — no rota checklist.
+- Sending across teams, or to people who are team members but have no active signup.
+
+## Surface
+
+### Entry point
+
+`Views/ShiftAdmin/Index.cshtml` — new action card at the bottom, sibling to the existing "Create a rota" form. Brief copy ("Send a message to everyone signed up across this team's upcoming rotas") and a single **Compose…** button that navigates to the new compose page. Visibility gate matches the per-rota "Email" link: rendered only when `CanManageDepartmentAsync(user, team)` is true.
+
+### Routes
+
+Mirror the per-rota shape, drop `rotaId`:
+
+| Verb | Path | Action |
+|------|------|--------|
+| GET  | `/Teams/{slug}/Shifts/Email` | render compose form |
+| POST | `/Teams/{slug}/Shifts/Email` | dispatch |
+
+Both live on `ShiftAdminController` (same controller as the per-rota actions).
+
+### Compose view
+
+`Views/ShiftAdmin/EmailTeamRotas.cshtml` — visually identical to `EmailRota.cshtml`:
+
+- Left column: message textarea (1–4000 chars), validation summary, submit button with the count baked into the label (`Send to {N} humans`), Cancel link back to `/Teams/{slug}/Shifts`.
+- Right column: recipients card with count in the header (`Recipients ({N})`) and an unordered list of recipient names. The card additionally surfaces `RotaCount` ("…across {RotaCount} rotas") so the coordinator sees the scope.
+- Same `RecipientCount == 0 → disabled submit` behaviour and empty-state copy.
+- Breadcrumb: Teams → Shifts → "Email everyone".
+- `TempData` toast on POST success/error (reuses `vc:temp-data-alerts`).
+
+## Service
+
+Per the **Reuse-First Change Discipline** (CLAUDE.md): extend the existing interface rather than add a sibling service.
+
+### Interface additions — `IRotaCoordinatorMessageService`
+
+```csharp
+Task<TeamRotasMessageDispatchResult> SendTeamRotasMessageAsync(
+    Guid teamId,
+    Guid senderUserId,
+    string messageText,
+    CancellationToken ct);
+
+Task<TeamRotasRecipientPreview> GetTeamRotasRecipientPreviewAsync(
+    Guid teamId,
+    CancellationToken ct);
+
+public sealed record TeamRotasMessageDispatchResult(
+    bool Succeeded,
+    int RecipientCount,
+    int RotaCount,
+    string TeamName,
+    string? Error = null);
+
+public sealed record TeamRotasRecipientPreview(
+    string TeamName,
+    int RotaCount,
+    IReadOnlyList<string> RecipientNames);
+```
+
+`RecipientCount` is derivable from `RecipientNames.Count`; not stored separately to avoid drift.
+
+### Repository ownership
+
+Per Peter's hard rules ("A table must only exist in one repository"), the Rota table is owned by **`ShiftManagementRepository`** — that's where the rota CRUD and `GetRotasByDepartmentAsync(teamId, eventSettingsId, ct)` lookup live today. The new team-level path uses that repository for rota discovery instead of inventing a parallel `IRotaRepository`. The existing `IShiftSignupRepository.GetRotaWithShiftsAsync` cross-table read used by the per-rota path is recognised tech debt and not extended here.
+
+`RotaCoordinatorMessageService`'s constructor therefore picks up one additional same-section repository dependency: `IShiftManagementRepository`. Service-to-repository within a section is the canonical layer call per the hard rules.
+
+### Implementation — `RotaCoordinatorMessageService`
+
+Internal refactor: pull the per-recipient personalisation + dispatch loop out of `SendRotaMessageAsync` into a private helper shared by both public methods:
+
+```csharp
+// Generic over TRequest so we don't introduce a new public interface
+// (ICoordinatorMessageRequest) just to share the loop. Per-rota path
+// closes TRequest = CoordinatorRotaMessageRequest, team path closes
+// TRequest = CoordinatorTeamRotasMessageRequest.
+private async Task<DispatchSummary> DispatchToRecipientsAsync<TRequest>(
+    IReadOnlyList<RotaSignupGroup> rotaGroups,        // active signups partitioned by rota
+    UserInfo sender,
+    Func<UserInfo, IReadOnlyList<RotaShiftGroup>, TRequest> buildRequest,
+    Func<TRequest, CancellationToken, Task> enqueue,
+    CancellationToken ct);
+
+private sealed record RotaSignupGroup(
+    Guid RotaId,
+    string RotaName,
+    EventSettings EventSettings,                       // carries the rota's timezone
+    IReadOnlyList<ShiftSignup> Signups);
+```
+
+Each rota carries its own `EventSettings` (and therefore its own timezone), so the helper takes signups partitioned by rota — the per-rota path passes a single-element list, the team path passes one element per included rota. The shift-line formatter (`BuildShiftLines`) is invoked **per rota group** so each rota's shifts render in its own timezone, then the recipient's lines are concatenated/grouped for the rendered body.
+
+The helper:
+
+1. Flattens all signups across rota groups, then groups by `UserId` (dedupe — one email per human even if they have signups across multiple rotas).
+2. Fetches recipient + sender `UserInfo` via `IUserServiceRead.GetUserInfosAsync` (one round-trip).
+3. Per recipient: for each rota the recipient has signups in, builds shift lines in that rota's timezone (chronological), producing a list of `RotaShiftGroup(RotaName, ShiftLines)`. Single-rota call collapses naturally to one group.
+4. Calls `requestBuilder` (per-rota path returns `CoordinatorRotaMessageRequest`, team path returns `CoordinatorTeamRotasMessageRequest`) and the matching `enqueue` lambda calling `IEmailService.Send…Async`.
+5. Per-recipient enqueue failures isolated by try/catch + counter, matching today's behaviour (separate `skipped` and `failed` counts kept).
+6. Returns `(QueuedCount, SkippedCount, FailedCount, RecipientNames)` for the caller to log + audit.
+
+`SendTeamRotasMessageAsync` orchestration:
+
+1. Resolve active event via `IShiftManagementRepository.GetActiveEventSettingsAsync(ct)`. If none → `Failure("No active event")`.
+2. Load team via `ITeamServiceRead.GetTeamByIdAsync(teamId, ct)` (cross-section read).
+3. Load rotas in the team for the active event via `IShiftManagementRepository.GetRotasByDepartmentAsync(teamId, eventSettings.Id, ct)`, then filter to `r.Shifts.Any(s => s.EndsAt > clock.GetCurrentInstant())`. If the existing method does not eager-load `Shifts`, add a sibling `GetRotasByDepartmentWithShiftsAsync(...)` — least-surface variant.
+4. Load active signups for those rotas via `IShiftSignupRepository.GetActiveByRotaIdsAsync(rotaIds, ct)` — new batch method on the existing repository, analog of `GetActiveByRotaAsync`.
+5. Partition signups by `RotaId`, build `RotaSignupGroup`s, call `DispatchToRecipientsAsync`.
+6. Single audit row (see §Audit).
+7. Return `TeamRotasMessageDispatchResult`.
+
+`GetTeamRotasRecipientPreviewAsync` reuses steps 1–4 to feed the GET action, then returns names + counts only (no email dispatch).
+
+### What stays the same on the per-rota path
+
+`SendRotaMessageAsync`'s public signature, return type, audit, and email rendering are unchanged. The only edit is calling the new shared helper for the dispatch loop. No behavioural change visible to callers or recipients.
+
+## Audience
+
+**Included rotas** = rotas where `Rota.TeamId == teamId`, scoped to the currently active `EventSettings`, AND `Rota.Shifts.Any(s => s.EndsAt > now)`. "Has at least one shift not yet ended" — covers rotas mid-event and rotas not yet started, excludes finished events. Active-event scoping matches the existing `GetRotasByDepartmentAsync(teamId, eventSettingsId)` lookup; out-of-event rotas (past burns) are not surfaced.
+
+**Recipients** = distinct users with `ShiftSignup.State ∈ { Pending, Confirmed }` on any shift in any included rota.
+
+**Per-recipient body** lists *their own* shifts in the included rotas only, grouped by rota name (alphabetical), chronological within each rota, formatted in the rota's timezone via the existing NodaTime helper.
+
+**Empty audience** (0 recipients) is a valid display state — form renders, submit disabled, no dispatch.
+
+## Email composition
+
+### Request DTO
+
+```csharp
+public sealed record CoordinatorTeamRotasMessageRequest(
+    Guid RecipientUserId,
+    string RecipientEmail,
+    string RecipientDisplayName,
+    string SenderDisplayName,
+    string SenderEmail,
+    string TeamName,
+    string MessageText,
+    IReadOnlyList<RotaShiftGroup> ShiftGroups);    // grouped by rota for rendering
+
+public sealed record RotaShiftGroup(string RotaName, IReadOnlyList<string> ShiftLines);
+```
+
+### Renderer — `IEmailRenderer.RenderCoordinatorTeamRotasMessage`
+
+- **Subject:** new localization key `Email_CoordinatorTeamRotasMessage_Subject`, formatted with `{TeamName}`.
+- **Body:** HTML, same composition pattern as `RenderCoordinatorRotaMessage`:
+  - sender line (display name + `mailto:` to coordinator),
+  - message text (HTML-encoded, newlines → `<br />`),
+  - "Your shifts in {TeamName}:" header,
+  - per `RotaShiftGroup`: rota name bolded, then `<ul><li>` of shift lines (HTML-encoded).
+- Composed by `IEmailBodyComposer` for the standard footer/unsubscribe wrap; plain-text fallback auto-generated.
+
+### Email service — `OutboxEmailService`
+
+New method `SendCoordinatorTeamRotasMessageAsync(CoordinatorTeamRotasMessageRequest req, CancellationToken ct)`, structurally identical to `SendCoordinatorRotaMessageAsync`:
+
+- renders via `IEmailRenderer`,
+- enqueues to outbox with `MessageCategory.VolunteerUpdates`,
+- sets `ReplyTo = req.SenderEmail`,
+- `From` left to global `Email:FromAddress` config (= `humans@nobodies.team`).
+
+## Authorization & audit
+
+### Authorization
+
+Reuse `ShiftAdminController.ResolveDepartmentManagementAsync(slug)` → `CanManageDepartmentAsync` (VolunteerManager OR DeptCoordinator; NoInfoAdmin excluded). No new policy, no new claim. POST carries `[ValidateAntiForgeryToken]`.
+
+### Audit
+
+- New enum value `AuditAction.CoordinatorTeamRotasMessageSent`.
+- One audit row per dispatch (not per recipient), written from `SendTeamRotasMessageAsync` after the dispatch loop completes.
+- `EntityType = "Team"`, `EntityId = teamId`. Audit is the horizontal section; recording a Team-section entity ID from a Shifts-section caller is a tag, not a cross-section repository/DbContext call, so it does not violate the hard rules. Pattern matches existing Shifts→Team audit references already in use.
+- Payload (JSON): `{ teamSlug, teamName, recipientCount, rotaCount, messageExcerpt }` (excerpt: first 200 chars of message text, mirrors per-rota audit).
+
+## Section boundaries (sanity)
+
+This feature stays inside the Shifts section's call graph:
+
+- **Controller → Service:** `ShiftAdminController` → `IRotaCoordinatorMessageService` (same section).
+- **Service → Service (cross-section, read-only):** `IRotaCoordinatorMessageService` → `ITeamServiceRead.GetTeamBySlugAsync` / `GetTeamByIdAsync` (Teams section, via the `IServiceRead` contract — the approved cross-section pattern).
+- **Service → Service (cross-section, read-only):** → `IUserServiceRead.GetUserInfosAsync` (Users section, already used by the per-rota path).
+- **Service → Service:** → `IEmailService` (Email cross-cut).
+- **Service → Repository (same section):** `IShiftManagementRepository` (owns Rota + EventSettings tables), `IShiftSignupRepository` — both Shifts-owned.
+- **Service → Audit:** `IAuditService` (horizontal section).
+
+No new cross-section coupling, no new DbContext access from a non-repository, no service reaching into another section's repository.
+
+## Files
+
+### New
+
+- `src/Humans.Application/Services/Shifts/Models/TeamRotasMessageDispatchResult.cs`
+- `src/Humans.Application/Services/Shifts/Models/TeamRotasRecipientPreview.cs`
+- `src/Humans.Application/Services/Email/Models/CoordinatorTeamRotasMessageRequest.cs` (+ `RotaShiftGroup`)
+- `src/Humans.Web/Models/Shifts/EmailTeamRotasViewModel.cs`
+- `src/Humans.Web/Views/ShiftAdmin/EmailTeamRotas.cshtml`
+- New `AuditAction.CoordinatorTeamRotasMessageSent` enum value
+- New localization keys (EN + ES):
+  - `EmailTeamRotas_Title`, `EmailTeamRotas_Heading`, `EmailTeamRotas_Breadcrumb`,
+  - `EmailTeamRotas_MessageLabel`, `EmailTeamRotas_MessageHelp`,
+  - `EmailTeamRotas_Send`, `EmailTeamRotas_RecipientsHeading`, `EmailTeamRotas_NoRecipients`,
+  - `EmailTeamRotas_RotaCount`,
+  - `Email_CoordinatorTeamRotasMessage_Subject`,
+  - `ShiftAdmin_Index_EmailEveryoneCard_Heading`, `ShiftAdmin_Index_EmailEveryoneCard_Body`, `ShiftAdmin_Index_EmailEveryoneCard_Cta`.
+
+### Modified
+
+- `src/Humans.Application/Interfaces/Shifts/IRotaCoordinatorMessageService.cs` — add 2 methods + 2 records.
+- `src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs` — implement new methods, factor private dispatch helper, inject `IShiftManagementRepository`, no behavioural change to existing method.
+- `src/Humans.Application/Interfaces/Shifts/IShiftSignupRepository.cs` — add `GetActiveByRotaIdsAsync(IReadOnlyCollection<Guid> rotaIds, CancellationToken)` (batch analog of `GetActiveByRotaAsync`).
+- `src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs` — implement the multi-rota variant.
+- `src/Humans.Application/Interfaces/Shifts/IShiftManagementRepository.cs` + `src/Humans.Infrastructure/Repositories/Shifts/ShiftManagementRepository.cs` — if `GetRotasByDepartmentAsync` doesn't already eager-load `Shifts` + `EventSettings`, add `GetRotasByDepartmentWithShiftsAsync(teamId, eventSettingsId, ct)`. If it does, reuse as-is.
+- `src/Humans.Application/Interfaces/Email/IEmailService.cs` + `src/Humans.Application/Services/Email/OutboxEmailService.cs` — add `SendCoordinatorTeamRotasMessageAsync`.
+- `src/Humans.Infrastructure/Services/EmailRenderer.cs` — add `RenderCoordinatorTeamRotasMessage`.
+- `src/Humans.Web/Controllers/ShiftAdminController.cs` — two new actions (`EmailTeamRotas` GET + POST).
+- `src/Humans.Web/Views/ShiftAdmin/Index.cshtml` — new "Email everyone in upcoming rotas" card at the bottom.
+- `src/Humans.Domain/Enums/AuditAction.cs` — new enum value.
+- Resource files: `Strings.en.resx`, `Strings.es.resx` (and any Email-specific resx the existing renderer reads from).
+
+## Tests
+
+Follow the test patterns the per-rota feature established. No EF-InMemory (per [`memory/architecture/no-ef-inmemory.md`](../../../memory/architecture/no-ef-inmemory.md) or current test-suite reshaping direction).
+
+### Service unit tests — `RotaCoordinatorMessageServiceTests.TeamScoped`
+
+- **Recipient dedup:** user with signups in 3 rotas in the team receives **one** email, not 3.
+- **Upcoming/current filter:** rota whose every shift is in the past is excluded; rota with a future shift is included; rota mid-event (started, not ended) is included.
+- **State filter:** Withdrawn/Cancelled signups excluded; Pending + Confirmed included.
+- **Per-recipient body:** each recipient's body lists only their shifts, grouped by rota name, chronological within rota.
+- **Per-recipient failure isolation:** mock `IEmailService` to throw on recipient #2; recipients #1 and #3 still receive; `FailureCount = 1`.
+- **Audit written once** with correct `EntityType="Team"`, `EntityId=teamId`, and payload counts.
+- **Zero-recipient case:** matches per-rota convention — returns `Failure("no active signups…")`, no email enqueued, no audit row. (The GET form already disables submit at 0 recipients; the service guard is defence-in-depth.)
+- **Preview helper:** returns same names/counts as a dry-run dispatch.
+- **Per-rota path unchanged:** existing `SendRotaMessageAsync` tests continue to pass after the helper extraction.
+
+### Controller tests — `ShiftAdminControllerTests.EmailTeamRotas`
+
+- **Authorization:** non-coordinator → 403 / forbidden; VolunteerManager → 200; DeptCoordinator → 200; NoInfoAdmin → 403.
+- **Anti-forgery:** POST without token → 400.
+- **GET happy path:** view model populated with team name, recipient count + names, rota count.
+- **POST happy path:** calls `SendTeamRotasMessageAsync`, sets success `TempData`, redirects to `/Teams/{slug}/Shifts`.
+- **POST validation:** empty message → re-renders view with validation error, no service call.
+- **POST zero recipients:** service returns `Failure`; controller surfaces error `TempData` and re-renders the form (same as per-rota).
+- **POST service failure:** error `TempData`, re-render or redirect (match per-rota convention).
+
+### Renderer test
+
+- `RenderCoordinatorTeamRotasMessage` produces subject with team name; body contains sender mailto, HTML-encoded message text, per-rota shift groups in expected HTML shape.
+
+### E2E (if the per-rota path has Playwright coverage)
+
+Parallel scenario: coordinator logs in, navigates to `/Teams/{slug}/Shifts`, clicks "Compose…", sees recipient count, types message, sends, sees toast. Otherwise skip — don't add E2E unilaterally.
+
+## Risks & open questions
+
+- **Email fan-out volume.** A team with many active signups across many rotas could send hundreds of emails. Outbox handles delivery rate, but the dispatch loop holds the request open until enqueue completes. If this becomes painful, move dispatch behind a background job (Hangfire) — not in scope here, but trivial follow-up.
+- **Subject template wording (EN/ES).** Peter to confirm wording when implementing localisation. Default proposal: EN `"Message from your {TeamName} coordinator"`, ES `"Mensaje del coordinador de {TeamName}"`.
+- **"Upcoming/current" cut precision.** Spec defines `Shifts.Any(s => s.EndsAt > now)`. Alternative would be `StartsAt > now` (excludes mid-event). Going with `EndsAt` to match "current"; flip if Peter wants stricter "future-only".
+
+## Out of scope
+
+- Background-job dispatch (see risks).
+- Multi-team broadcast (e.g., "all rotas in all teams I coordinate").
+- Coordinator selection UI for rotas within the team.
+- Modifying the `From:` header (Peter declined — Reply-To suffices).
+- Confirm-before-send modal or banner-style count (Peter declined — existing side-card + count-in-button treatment carries over).

--- a/src/Humans.Application/Interfaces/Email/IEmailRenderer.cs
+++ b/src/Humans.Application/Interfaces/Email/IEmailRenderer.cs
@@ -116,6 +116,21 @@ public interface IEmailRenderer
         string? culture = null);
 
     /// <summary>
+    /// Team-level "email all rotas" message from a coordinator to a single signup.
+    /// Body contains the coordinator's free-text message plus the recipient's
+    /// shifts grouped by rota (each group already chronological and formatted in
+    /// the rota's timezone).
+    /// </summary>
+    EmailContent RenderCoordinatorTeamRotasMessage(
+        string recipientName,
+        string senderName,
+        string? senderEmail,
+        string teamName,
+        string messageText,
+        IReadOnlyList<RotaShiftGroup> shiftGroups,
+        string? culture = null);
+
+    /// <summary>
     /// Magic link login email for an existing user.
     /// </summary>
     EmailContent RenderMagicLinkLogin(string displayName, string magicLinkUrl, string? culture = null);

--- a/src/Humans.Application/Interfaces/Email/IEmailService.cs
+++ b/src/Humans.Application/Interfaces/Email/IEmailService.cs
@@ -243,6 +243,18 @@ public interface IEmailService : IApplicationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Sends a personalized team-level coordinator message to a single signup,
+    /// covering all current/upcoming rotas in the team. The body carries the
+    /// coordinator's free-text message plus the recipient's shifts grouped by
+    /// rota (each rota in its own timezone). Category is
+    /// <see cref="MessageCategory.VolunteerUpdates"/>; replies go to the
+    /// coordinator's email when supplied.
+    /// </summary>
+    Task SendCoordinatorTeamRotasMessageAsync(
+        CoordinatorTeamRotasMessageRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Sends a magic link login email to an existing user.
     /// </summary>
     Task SendMagicLinkLoginAsync(
@@ -400,6 +412,29 @@ public record CoordinatorRotaMessageRequest(
     string MessageText,
     IReadOnlyList<string> ShiftLines,
     string? Culture = null);
+
+/// <summary>
+/// Payload for a coordinator team-level "email all rotas" message to a single signup.
+/// <see cref="ShiftGroups"/> are pre-rendered, per-rota lists of chronologically-ordered
+/// shift labels for the recipient (each rota's shifts in the rota's own timezone) — the
+/// renderer HTML-encodes them, it does not parse or sort them.
+/// </summary>
+public record CoordinatorTeamRotasMessageRequest(
+    string RecipientEmail,
+    string RecipientName,
+    string SenderName,
+    string? SenderEmail,
+    string TeamName,
+    string MessageText,
+    IReadOnlyList<RotaShiftGroup> ShiftGroups,
+    string? Culture = null);
+
+/// <summary>
+/// A recipient's shifts on a single rota, ready for the team-level coordinator
+/// message renderer. <see cref="ShiftLines"/> are already chronological and
+/// formatted in the rota's timezone.
+/// </summary>
+public sealed record RotaShiftGroup(string RotaName, IReadOnlyList<string> ShiftLines);
 
 /// <summary>
 /// Payload for enqueuing a campaign-code email.

--- a/src/Humans.Application/Interfaces/Shifts/IRotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IRotaCoordinatorMessageService.cs
@@ -33,7 +33,62 @@ public interface IRotaCoordinatorMessageService : IApplicationService
         Guid senderUserId,
         string messageText,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Queues one personalised email per recipient across every current/upcoming
+    /// rota in the given team in the active event. Recipients = distinct users with
+    /// a Pending or Confirmed signup on any shift in any included rota — deduped
+    /// across rotas so each human receives one email. Body lists the recipient's
+    /// own shifts grouped by rota, each rota in its own timezone.
+    /// </summary>
+    /// <param name="teamId">Team whose rotas' signups receive the message.</param>
+    /// <param name="senderUserId">Coordinator sending the message. Used for
+    /// audit attribution and the Reply-To header.</param>
+    /// <param name="messageText">Free-text body composed by the coordinator.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Outcome with recipient + rota counts and team name for the
+    /// coordinator-facing success message; failure shape on misconfiguration
+    /// (no active event, team has no upcoming rotas, etc.).</returns>
+    Task<TeamRotasMessageDispatchResult> SendTeamRotasMessageAsync(
+        Guid teamId,
+        Guid senderUserId,
+        string messageText,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the recipient names + counts the team-level compose form needs to
+    /// preview audience size — same audience definition as
+    /// <see cref="SendTeamRotasMessageAsync"/>, but no email is enqueued.
+    /// </summary>
+    Task<TeamRotasRecipientPreview> GetTeamRotasRecipientPreviewAsync(
+        Guid teamId,
+        CancellationToken ct = default);
 }
+
+/// <summary>
+/// Outcome of <see cref="IRotaCoordinatorMessageService.SendTeamRotasMessageAsync"/>.
+/// </summary>
+public sealed record TeamRotasMessageDispatchResult(
+    bool Succeeded,
+    int RecipientCount,
+    int RotaCount,
+    string? TeamName,
+    string? Error)
+{
+    public static TeamRotasMessageDispatchResult Success(int recipientCount, int rotaCount, string teamName) =>
+        new(true, recipientCount, rotaCount, teamName, null);
+
+    public static TeamRotasMessageDispatchResult Failure(string error) =>
+        new(false, 0, 0, null, error);
+}
+
+/// <summary>
+/// Preview payload for the team-level compose form: who would receive the message
+/// and across how many rotas, without enqueuing anything.
+/// </summary>
+public sealed record TeamRotasRecipientPreview(
+    int RotaCount,
+    IReadOnlyList<string> RecipientNames);
 
 /// <summary>
 /// Outcome of <see cref="IRotaCoordinatorMessageService.SendRotaMessageAsync"/>.

--- a/src/Humans.Application/Services/Email/OutboxEmailService.cs
+++ b/src/Humans.Application/Services/Email/OutboxEmailService.cs
@@ -258,6 +258,32 @@ public sealed class OutboxEmailService(
     }
 
     /// <inheritdoc />
+    public async Task SendCoordinatorTeamRotasMessageAsync(
+        CoordinatorTeamRotasMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var content = renderer.RenderCoordinatorTeamRotasMessage(
+            request.RecipientName,
+            request.SenderName,
+            request.SenderEmail,
+            request.TeamName,
+            request.MessageText,
+            request.ShiftGroups,
+            request.Culture);
+
+        await EnqueueAsync(
+            request.RecipientEmail,
+            request.RecipientName,
+            content,
+            "coordinator_team_rotas_message",
+            cancellationToken,
+            replyTo: request.SenderEmail,
+            category: MessageCategory.VolunteerUpdates);
+    }
+
+    /// <inheritdoc />
     public async Task SendMagicLinkLoginAsync(
         string toEmail,
         string displayName,

--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -2,6 +2,7 @@ using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -17,9 +18,12 @@ namespace Humans.Application.Services.Shifts;
 /// </summary>
 public sealed class RotaCoordinatorMessageService(
     IShiftSignupRepository signupRepo,
+    IShiftManagementRepository mgmtRepo,
+    ITeamServiceRead teamService,
     IUserServiceRead userService,
     IEmailService emailService,
     IAuditLogService auditLogService,
+    IClock clock,
     ILogger<RotaCoordinatorMessageService> logger) : IRotaCoordinatorMessageService
 {
     public async Task<RotaMessageDispatchResult> SendRotaMessageAsync(
@@ -43,13 +47,218 @@ public sealed class RotaCoordinatorMessageService(
         if (signups.Count == 0)
             return RotaMessageDispatchResult.Failure("This rota has no active signups to email.");
 
-        var byUser = signups
-            .GroupBy(s => s.UserId)
-            .ToDictionary(g => g.Key, g => g.ToList());
-
         var senderInfos = await userService.GetUserInfosAsync([senderUserId], ct);
         if (!senderInfos.TryGetValue(senderUserId, out var sender))
             return RotaMessageDispatchResult.Failure("Sender not found.");
+
+        var groups = new[]
+        {
+            new RotaSignupGroup(rota.Id, rota.Name, eventSettings, signups)
+        };
+
+        var summary = await DispatchToRecipientsAsync(
+            groups,
+            buildRequest: (recipient, shiftGroups) => new CoordinatorRotaMessageRequest(
+                RecipientEmail: recipient.Email!,
+                RecipientName: recipient.BurnerName,
+                SenderName: sender.BurnerName,
+                SenderEmail: sender.Email,
+                RotaName: rota.Name,
+                MessageText: messageText,
+                // Per-rota body keeps the flat shift-list shape; there is exactly
+                // one group in this path so the flatten is trivial.
+                ShiftLines: shiftGroups[0].ShiftLines,
+                Culture: recipient.PreferredLanguage),
+            enqueue: (req, token) => emailService.SendCoordinatorRotaMessageAsync(req, token),
+            logScope: ("rota", rota.Id.ToString()),
+            ct);
+
+        var auditSuffix = string.Empty;
+        if (summary.Skipped > 0) auditSuffix += $" ({summary.Skipped} skipped: no email or missing user)";
+        if (summary.Failed > 0) auditSuffix += $" ({summary.Failed} failed: enqueue error)";
+
+        await auditLogService.LogAsync(
+            AuditAction.CoordinatorRotaMessageSent,
+            nameof(Rota), rota.Id,
+            $"Sent rota message '{Truncate(messageText, 120)}' to {summary.Queued} recipient(s) on '{rota.Name}'"
+                + auditSuffix,
+            senderUserId);
+
+        // Total-failure path: every enqueue threw. Audit row already records
+        // the failures; surface a Failure result so the controller does not
+        // render a misleading "Queued 0 email(s)" success toast.
+        if (summary.Queued == 0 && summary.Failed > 0)
+            return RotaMessageDispatchResult.Failure(
+                $"Failed to enqueue any emails ({summary.Failed} enqueue error(s)); check server logs.");
+
+        return RotaMessageDispatchResult.Success(summary.Queued, rota.Name);
+    }
+
+    public async Task<TeamRotasMessageDispatchResult> SendTeamRotasMessageAsync(
+        Guid teamId,
+        Guid senderUserId,
+        string messageText,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(messageText))
+            return TeamRotasMessageDispatchResult.Failure("Message body is required.");
+
+        var team = await teamService.GetTeamAsync(teamId);
+        if (team is null)
+            return TeamRotasMessageDispatchResult.Failure("Team not found.");
+
+        var groups = await BuildTeamRotaGroupsAsync(teamId, ct);
+        if (groups.Count == 0)
+            return TeamRotasMessageDispatchResult.Failure(
+                "This team has no upcoming rotas with active signups to email.");
+
+        var senderInfos = await userService.GetUserInfosAsync([senderUserId], ct);
+        if (!senderInfos.TryGetValue(senderUserId, out var sender))
+            return TeamRotasMessageDispatchResult.Failure("Sender not found.");
+
+        var summary = await DispatchToRecipientsAsync(
+            groups,
+            buildRequest: (recipient, shiftGroups) => new CoordinatorTeamRotasMessageRequest(
+                RecipientEmail: recipient.Email!,
+                RecipientName: recipient.BurnerName,
+                SenderName: sender.BurnerName,
+                SenderEmail: sender.Email,
+                TeamName: team.Name,
+                MessageText: messageText,
+                ShiftGroups: shiftGroups,
+                Culture: recipient.PreferredLanguage),
+            enqueue: (req, token) => emailService.SendCoordinatorTeamRotasMessageAsync(req, token),
+            logScope: ("team", teamId.ToString()),
+            ct);
+
+        var auditSuffix = string.Empty;
+        if (summary.Skipped > 0) auditSuffix += $" ({summary.Skipped} skipped: no email or missing user)";
+        if (summary.Failed > 0) auditSuffix += $" ({summary.Failed} failed: enqueue error)";
+
+        await auditLogService.LogAsync(
+            AuditAction.CoordinatorTeamRotasMessageSent,
+            nameof(Team), teamId,
+            $"Sent team-wide rota message '{Truncate(messageText, 120)}' to {summary.Queued} recipient(s) "
+                + $"across {groups.Count} rota(s) in '{team.Name}'"
+                + auditSuffix,
+            senderUserId);
+
+        if (summary.Queued == 0 && summary.Failed > 0)
+            return TeamRotasMessageDispatchResult.Failure(
+                $"Failed to enqueue any emails ({summary.Failed} enqueue error(s)); check server logs.");
+
+        return TeamRotasMessageDispatchResult.Success(summary.Queued, groups.Count, team.Name);
+    }
+
+    public async Task<TeamRotasRecipientPreview> GetTeamRotasRecipientPreviewAsync(
+        Guid teamId,
+        CancellationToken ct = default)
+    {
+        var groups = await BuildTeamRotaGroupsAsync(teamId, ct);
+        if (groups.Count == 0)
+            return new TeamRotasRecipientPreview(0, []);
+
+        var recipientIds = groups
+            .SelectMany(g => g.Signups)
+            .Select(s => s.UserId)
+            .Distinct()
+            .ToList();
+
+        if (recipientIds.Count == 0)
+            return new TeamRotasRecipientPreview(groups.Count, []);
+
+        var infos = await userService.GetUserInfosAsync(recipientIds, ct);
+        var names = recipientIds
+            .Select(id => infos.TryGetValue(id, out var u) ? u.BurnerName : null)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n!)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new TeamRotasRecipientPreview(groups.Count, names);
+    }
+
+    /// <summary>
+    /// Loads the team's current/upcoming rotas in the active event, paired with
+    /// their active (Pending/Confirmed) signups. A rota is included if any of
+    /// its shifts has not yet ended (so events mid-flight still count). Returns
+    /// an empty list if no active event, the team has no rotas in it, or no
+    /// rota in the team has any future shifts with active signups.
+    /// </summary>
+    private async Task<IReadOnlyList<RotaSignupGroup>> BuildTeamRotaGroupsAsync(
+        Guid teamId,
+        CancellationToken ct)
+    {
+        var eventSettings = await mgmtRepo.GetActiveEventSettingsAsync(ct);
+        if (eventSettings is null) return [];
+
+        var rotas = await mgmtRepo.GetRotasByDepartmentAsync(teamId, eventSettings.Id, ct);
+        if (rotas.Count == 0) return [];
+
+        var now = clock.GetCurrentInstant();
+
+        var groups = new List<RotaSignupGroup>(rotas.Count);
+        foreach (var rota in rotas)
+        {
+            // Per-rota EventSettings carries the timezone — the eager-load on
+            // GetRotasByDepartmentAsync attached it; keep the reference for
+            // downstream shift-line formatting.
+            var rotaEs = rota.EventSettings
+                ?? throw new InvalidOperationException(
+                    $"Rota {rota.Id} loaded without EventSettings — repository contract broken.");
+
+            var hasFutureShift = rota.Shifts.Any(s => s.GetAbsoluteEnd(rotaEs) > now);
+            if (!hasFutureShift) continue;
+
+            // ShiftSignup.Shift may not be populated when reached via the
+            // Shift.ShiftSignups eager-load (AsNoTracking skips reverse-nav
+            // fix-up); set it explicitly so the shift-line formatter can read
+            // IsAllDay/StartTime/Duration without another DB round-trip.
+            var activeSignups = rota.Shifts
+                .SelectMany(s => s.ShiftSignups
+                    .Where(ss => ss.Status is SignupStatus.Pending or SignupStatus.Confirmed)
+                    .Select(ss => { ss.Shift = s; return ss; }))
+                .ToList();
+
+            if (activeSignups.Count == 0) continue;
+
+            groups.Add(new RotaSignupGroup(rota.Id, rota.Name, rotaEs, activeSignups));
+        }
+
+        return groups;
+    }
+
+    /// <summary>
+    /// Generic per-recipient dispatch loop shared by the per-rota and team-level
+    /// paths. Groups signups by user (dedupe across rotas), looks up recipients,
+    /// builds per-recipient shift-group lists in each rota's timezone, then
+    /// invokes the caller's <paramref name="buildRequest"/> + <paramref name="enqueue"/>.
+    /// Per-recipient failures isolated; aggregate counts returned for audit.
+    /// </summary>
+    private async Task<DispatchSummary> DispatchToRecipientsAsync<TRequest>(
+        IReadOnlyList<RotaSignupGroup> rotaGroups,
+        Func<UserInfo, IReadOnlyList<RotaShiftGroup>, TRequest> buildRequest,
+        Func<TRequest, CancellationToken, Task> enqueue,
+        (string Type, string Id) logScope,
+        CancellationToken ct)
+    {
+        // userId -> list of (group, signup) so we can later partition per recipient per rota.
+        var byUser = new Dictionary<Guid, List<(RotaSignupGroup Group, ShiftSignup Signup)>>();
+        foreach (var group in rotaGroups)
+        {
+            foreach (var signup in group.Signups)
+            {
+                if (!byUser.TryGetValue(signup.UserId, out var list))
+                {
+                    list = new List<(RotaSignupGroup, ShiftSignup)>();
+                    byUser[signup.UserId] = list;
+                }
+                list.Add((group, signup));
+            }
+        }
+
+        if (byUser.Count == 0)
+            return new DispatchSummary(0, 0, 0, []);
 
         var recipientIds = byUser.Keys.ToList();
         var recipientInfos = await userService.GetUserInfosAsync(recipientIds, ct);
@@ -57,13 +266,15 @@ public sealed class RotaCoordinatorMessageService(
         var queued = 0;
         var skipped = 0;
         var failed = 0;
-        foreach (var (userId, userSignups) in byUser)
+        var queuedNames = new List<string>();
+
+        foreach (var (userId, entries) in byUser)
         {
             if (!recipientInfos.TryGetValue(userId, out var recipient))
             {
                 logger.LogWarning(
-                    "Skipping rota-email recipient {UserId} on rota {RotaId}: user not found",
-                    userId, rotaId);
+                    "Skipping coordinator-message recipient {UserId} on {ScopeType} {ScopeId}: user not found",
+                    userId, logScope.Type, logScope.Id);
                 skipped++;
                 continue;
             }
@@ -72,64 +283,49 @@ public sealed class RotaCoordinatorMessageService(
             if (string.IsNullOrWhiteSpace(email))
             {
                 logger.LogWarning(
-                    "Skipping rota-email recipient {UserId} on rota {RotaId}: no email address",
-                    userId, rotaId);
+                    "Skipping coordinator-message recipient {UserId} on {ScopeType} {ScopeId}: no email address",
+                    userId, logScope.Type, logScope.Id);
                 skipped++;
                 continue;
             }
 
-            var shiftLines = BuildShiftLines(userSignups, eventSettings);
+            var shiftGroups = entries
+                .GroupBy(e => e.Group.RotaId)
+                .Select(g =>
+                {
+                    var group = g.First().Group;
+                    var lines = BuildShiftLines(
+                        g.Select(e => e.Signup).ToList(),
+                        group.EventSettings);
+                    return new RotaShiftGroup(group.RotaName, lines);
+                })
+                .OrderBy(g => g.RotaName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
-            var request = new CoordinatorRotaMessageRequest(
-                RecipientEmail: email,
-                RecipientName: recipient.BurnerName,
-                SenderName: sender.BurnerName,
-                SenderEmail: sender.Email,
-                RotaName: rota.Name,
-                MessageText: messageText,
-                ShiftLines: shiftLines,
-                Culture: recipient.PreferredLanguage);
+            var request = buildRequest(recipient, shiftGroups);
 
             // Per-recipient enqueue is isolated: a transient outbox-write
             // failure on one recipient must not unwind the loop and leave
             // the audit row unwritten or earlier enqueues unaccounted for.
-            // Matches the fan-out pattern in AttendeeContactImportService.
             try
             {
-                await emailService.SendCoordinatorRotaMessageAsync(request, ct);
+                await enqueue(request, ct);
                 queued++;
+                queuedNames.Add(recipient.BurnerName);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 failed++;
                 logger.LogError(ex,
-                    "Failed to enqueue rota email for recipient {UserId} on rota {RotaId}",
-                    userId, rotaId);
+                    "Failed to enqueue coordinator-message email for recipient {UserId} on {ScopeType} {ScopeId}",
+                    userId, logScope.Type, logScope.Id);
             }
         }
 
-        var auditSuffix = string.Empty;
-        if (skipped > 0) auditSuffix += $" ({skipped} skipped: no email or missing user)";
-        if (failed > 0) auditSuffix += $" ({failed} failed: enqueue error)";
-
-        await auditLogService.LogAsync(
-            AuditAction.CoordinatorRotaMessageSent,
-            nameof(Rota), rota.Id,
-            $"Sent rota message '{Truncate(messageText, 120)}' to {queued} recipient(s) on '{rota.Name}'"
-                + auditSuffix,
-            senderUserId);
-
-        // Total-failure path: every enqueue threw. Audit row already records
-        // the failures; surface a Failure result so the controller does not
-        // render a misleading "Queued 0 email(s)" success toast.
-        if (queued == 0 && failed > 0)
-            return RotaMessageDispatchResult.Failure(
-                $"Failed to enqueue any emails ({failed} enqueue error(s)); check server logs.");
-
-        return RotaMessageDispatchResult.Success(queued, rota.Name);
+        return new DispatchSummary(queued, skipped, failed, queuedNames);
     }
 
-    // Chronologically ordered "ddd MMMM d [@ HH:mm]" lines in the event's timezone.
+    // Chronologically ordered "ddd MMMM d [@ HH:mm]" lines in the rota's timezone.
     private static IReadOnlyList<string> BuildShiftLines(
         IReadOnlyList<ShiftSignup> userSignups,
         EventSettings eventSettings)
@@ -159,4 +355,16 @@ public sealed class RotaCoordinatorMessageService(
 
     private static string Truncate(string text, int max) =>
         text.Length <= max ? text : text[..max] + "…";
+
+    private sealed record RotaSignupGroup(
+        Guid RotaId,
+        string RotaName,
+        EventSettings EventSettings,
+        IReadOnlyList<ShiftSignup> Signups);
+
+    private sealed record DispatchSummary(
+        int Queued,
+        int Skipped,
+        int Failed,
+        IReadOnlyList<string> QueuedRecipientNames);
 }

--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -172,7 +172,6 @@ public sealed class RotaCoordinatorMessageService(
             .Select(id => infos.TryGetValue(id, out var u) ? u.BurnerName : null)
             .Where(n => !string.IsNullOrWhiteSpace(n))
             .Select(n => n!)
-            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         return new TeamRotasRecipientPreview(groups.Count, names);
@@ -258,7 +257,7 @@ public sealed class RotaCoordinatorMessageService(
         }
 
         if (byUser.Count == 0)
-            return new DispatchSummary(0, 0, 0, []);
+            return new DispatchSummary(0, 0, 0);
 
         var recipientIds = byUser.Keys.ToList();
         var recipientInfos = await userService.GetUserInfosAsync(recipientIds, ct);
@@ -266,7 +265,6 @@ public sealed class RotaCoordinatorMessageService(
         var queued = 0;
         var skipped = 0;
         var failed = 0;
-        var queuedNames = new List<string>();
 
         foreach (var (userId, entries) in byUser)
         {
@@ -311,7 +309,6 @@ public sealed class RotaCoordinatorMessageService(
             {
                 await enqueue(request, ct);
                 queued++;
-                queuedNames.Add(recipient.BurnerName);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -322,7 +319,7 @@ public sealed class RotaCoordinatorMessageService(
             }
         }
 
-        return new DispatchSummary(queued, skipped, failed, queuedNames);
+        return new DispatchSummary(queued, skipped, failed);
     }
 
     // Chronologically ordered "ddd MMMM d [@ HH:mm]" lines in the rota's timezone.
@@ -365,6 +362,5 @@ public sealed class RotaCoordinatorMessageService(
     private sealed record DispatchSummary(
         int Queued,
         int Skipped,
-        int Failed,
-        IReadOnlyList<string> QueuedRecipientNames);
+        int Failed);
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -174,4 +174,5 @@ public enum AuditAction
     ContainerPlacementCleared,
     ContainerPlacementNotesUpdated,
     CoordinatorRotaMessageSent,
+    CoordinatorTeamRotasMessageSent,
 }

--- a/src/Humans.Infrastructure/Services/EmailRenderer.cs
+++ b/src/Humans.Infrastructure/Services/EmailRenderer.cs
@@ -202,6 +202,53 @@ public class EmailRenderer(
                     senderLine));
         });
 
+    public EmailContent RenderCoordinatorTeamRotasMessage(
+        string recipientName,
+        string senderName,
+        string? senderEmail,
+        string teamName,
+        string messageText,
+        IReadOnlyList<RotaShiftGroup> shiftGroups,
+        string? culture = null)
+        => RenderLocalized(culture, () =>
+        {
+            ArgumentNullException.ThrowIfNull(shiftGroups);
+
+            var sanitizedMessage = HtmlEncode(messageText).Replace("\n", "<br />", StringComparison.Ordinal);
+
+            // Per-rota groups: bold rota name then <ul><li> shift lines.
+            // Empty-groups fallback mirrors the per-rota renderer.
+            string shiftGroupsHtml;
+            if (shiftGroups.Count == 0 || shiftGroups.All(g => g.ShiftLines.Count == 0))
+            {
+                shiftGroupsHtml = $"<p><em>{HtmlEncode(L("Email_CoordinatorRotaMessage_NoShifts"))}</em></p>";
+            }
+            else
+            {
+                shiftGroupsHtml = string.Concat(shiftGroups.Select(g =>
+                {
+                    var lines = g.ShiftLines.Count == 0
+                        ? string.Empty
+                        : "<ul>" + string.Concat(g.ShiftLines.Select(line => $"<li>{HtmlEncode(line)}</li>")) + "</ul>";
+                    return $"<p><strong>{HtmlEncode(g.RotaName)}</strong></p>{lines}";
+                }));
+            }
+
+            var senderLine = !string.IsNullOrEmpty(senderEmail)
+                ? $"<p><strong>{HtmlEncode(senderName)}</strong> &mdash; <a href=\"mailto:{HtmlEncode(senderEmail)}\">{HtmlEncode(senderEmail)}</a></p>"
+                : $"<p><strong>{HtmlEncode(senderName)}</strong></p>";
+
+            return new EmailContent(
+                Lf("Email_CoordinatorTeamRotasMessage_Subject", HtmlEncode(teamName)),
+                Lf("Email_CoordinatorTeamRotasMessage_Body",
+                    HtmlEncode(recipientName),
+                    HtmlEncode(senderName),
+                    HtmlEncode(teamName),
+                    sanitizedMessage,
+                    shiftGroupsHtml,
+                    senderLine));
+        });
+
     public EmailContent RenderMagicLinkLogin(string displayName, string magicLinkUrl, string? culture = null)
         => RenderLocalized(culture, () => new EmailContent(
             L("Email_MagicLinkLogin_Subject"),

--- a/src/Humans.Infrastructure/Services/SmtpEmailService.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailService.cs
@@ -242,6 +242,18 @@ public class SmtpEmailService(
         metrics.RecordEmailSent("coordinator_rota_message");
     }
 
+    public async Task SendCoordinatorTeamRotasMessageAsync(
+        CoordinatorTeamRotasMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var content = renderer.RenderCoordinatorTeamRotasMessage(
+            request.RecipientName, request.SenderName, request.SenderEmail,
+            request.TeamName, request.MessageText, request.ShiftGroups, request.Culture);
+        await SendEmailAsync(request.RecipientEmail, content.Subject, content.HtmlBody, cancellationToken, request.SenderEmail);
+        metrics.RecordEmailSent("coordinator_team_rotas_message");
+    }
+
     public async Task SendMagicLinkLoginAsync(
         string toEmail, string displayName, string magicLinkUrl,
         string? culture = null, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Services/StubEmailService.cs
+++ b/src/Humans.Infrastructure/Services/StubEmailService.cs
@@ -222,6 +222,18 @@ public class StubEmailService(ILogger<StubEmailService> logger) : IEmailService
         return Task.CompletedTask;
     }
 
+    public Task SendCoordinatorTeamRotasMessageAsync(
+        CoordinatorTeamRotasMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        logger.LogInformation(
+            "[STUB] Would send coordinator team-rotas message to {Email} ({RecipientName}) from {SenderName} for team {TeamName} ({RotaCount} rota(s)) [Culture: {Culture}]",
+            request.RecipientEmail, request.RecipientName, request.SenderName, request.TeamName,
+            request.ShiftGroups.Count, request.Culture);
+        return Task.CompletedTask;
+    }
+
     public Task SendMagicLinkLoginAsync(
         string toEmail, string displayName, string magicLinkUrl,
         string? culture = null, CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -409,6 +409,58 @@ public class ShiftAdminController(
             .ToList();
     }
 
+    // Team-level coordinator message — siblings of the per-rota EmailRota actions
+    // above. Same management gate, same Reply-To behaviour, audit attached to the
+    // Team entity.
+    [HttpGet("Email")]
+    public async Task<IActionResult> EmailTeamRotas(string slug)
+    {
+        var (teamError, _, team) = await ResolveDepartmentManagementAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var preview = await rotaMessenger.GetTeamRotasRecipientPreviewAsync(team.Id);
+
+        var vm = new EmailTeamRotasViewModel
+        {
+            TeamSlug = slug,
+            TeamName = team.Name,
+            RotaCount = preview.RotaCount,
+            RecipientCount = preview.RecipientNames.Count,
+            RecipientNames = preview.RecipientNames,
+        };
+        return View(vm);
+    }
+
+    [HttpPost("Email")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> EmailTeamRotas(string slug, EmailTeamRotasViewModel model)
+    {
+        var (teamError, user, team) = await ResolveDepartmentManagementAsync(slug);
+        if (teamError is not null) return teamError;
+
+        // Repopulate display fields before any return-with-error path so the
+        // re-rendered form still shows the recipient list and counts.
+        var preview = await rotaMessenger.GetTeamRotasRecipientPreviewAsync(team.Id);
+        model.TeamSlug = slug;
+        model.TeamName = team.Name;
+        model.RotaCount = preview.RotaCount;
+        model.RecipientCount = preview.RecipientNames.Count;
+        model.RecipientNames = preview.RecipientNames;
+
+        if (!ModelState.IsValid)
+            return View(model);
+
+        var result = await rotaMessenger.SendTeamRotasMessageAsync(team.Id, user.Id, model.Message);
+        if (!result.Succeeded)
+        {
+            ModelState.AddModelError(string.Empty, result.Error ?? "Failed to queue team rota emails.");
+            return View(model);
+        }
+
+        SetSuccess($"Queued {result.RecipientCount} email(s) across {result.RotaCount} rota(s) in '{result.TeamName}'.");
+        return RedirectToAction(nameof(Index), new { slug });
+    }
+
     [HttpPost("Rotas/{rotaId}/Delete")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteRota(string slug, Guid rotaId)

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -426,7 +426,9 @@ public class ShiftAdminController(
             TeamName = team.Name,
             RotaCount = preview.RotaCount,
             RecipientCount = preview.RecipientNames.Count,
-            RecipientNames = preview.RecipientNames,
+            RecipientNames = preview.RecipientNames
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
         };
         return View(vm);
     }
@@ -445,7 +447,9 @@ public class ShiftAdminController(
         model.TeamName = team.Name;
         model.RotaCount = preview.RotaCount;
         model.RecipientCount = preview.RecipientNames.Count;
-        model.RecipientNames = preview.RecipientNames;
+        model.RecipientNames = preview.RecipientNames
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
         if (!ModelState.IsValid)
             return View(model);

--- a/src/Humans.Web/Models/Shifts/EmailTeamRotasViewModel.cs
+++ b/src/Humans.Web/Models/Shifts/EmailTeamRotasViewModel.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Humans.Web.Models.Shifts;
+
+/// <summary>
+/// Compose-form model for the coordinator "email everyone across this team's
+/// upcoming rotas" action. Team-level analog of <see cref="EmailRotaViewModel"/>.
+/// </summary>
+public sealed class EmailTeamRotasViewModel
+{
+    public string TeamSlug { get; set; } = string.Empty;
+    public string TeamName { get; set; } = string.Empty;
+    public int RotaCount { get; set; }
+    public int RecipientCount { get; set; }
+    public IReadOnlyList<string> RecipientNames { get; set; } = [];
+
+    [Required]
+    [StringLength(4000, MinimumLength = 1)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2308,6 +2308,19 @@
   <data name="EmailRota_Success" xml:space="preserve"><value>Queued {0} email(s) to recipients on rota '{1}'.</value><comment>{0} = recipient count, {1} = rota name</comment></data>
   <data name="EmailRota_NoActiveSignups" xml:space="preserve"><value>This rota has no active signups to email.</value></data>
 
+  <!-- Coordinator Team Rotas Message ("Email everyone in upcoming rotas") -->
+  <data name="Email_CoordinatorTeamRotasMessage_Subject" xml:space="preserve"><value>A message about your shifts with {0}</value><comment>{0} = team name (HTML-encoded)</comment></data>
+  <data name="Email_CoordinatorTeamRotasMessage_Body" xml:space="preserve"><value>&lt;p&gt;Dear {0},&lt;/p&gt;&lt;p&gt;A message from the coordinator of &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;FYI, your shifts across this team's upcoming rotas:&lt;/p&gt;{4}&lt;p&gt;Thank you,&lt;/p&gt;{5}</value><comment>{0}=recipient name, {1}=sender name, {2}=team name, {3}=message body, {4}=per-rota shift groups HTML, {5}=sender contact block HTML</comment></data>
+  <data name="EmailTeamRotas_Title" xml:space="preserve"><value>Email team: {0}</value><comment>{0} = team name</comment></data>
+  <data name="EmailTeamRotas_Breadcrumb" xml:space="preserve"><value>Email team</value></data>
+  <data name="EmailTeamRotas_Heading" xml:space="preserve"><value>Email everyone in upcoming rotas: {0}</value><comment>{0} = team name</comment></data>
+  <data name="EmailTeamRotas_RecipientsHeading" xml:space="preserve"><value>Recipients ({0})</value><comment>{0} = recipient count</comment></data>
+  <data name="EmailTeamRotas_RotaCount" xml:space="preserve"><value>across {0} rota(s)</value><comment>{0} = rota count</comment></data>
+  <data name="EmailTeamRotas_NoRecipients" xml:space="preserve"><value>No one is signed up to this team's upcoming rotas yet.</value></data>
+  <data name="EmailTeamRotas_MessageLabel" xml:space="preserve"><value>Your message</value></data>
+  <data name="EmailTeamRotas_MessageHelp" xml:space="preserve"><value>Plain text only. Each recipient will see this body plus their own shift list across the team's upcoming rotas.</value></data>
+  <data name="EmailTeamRotas_Send" xml:space="preserve"><value>Send to {0} recipient(s)</value><comment>{0} = recipient count</comment></data>
+
   <data name="AdminHumans_MissingConsents" xml:space="preserve"><value>Missing Consents</value></data>
   <data name="AdminHumans_IncompleteSignup" xml:space="preserve"><value>Incomplete Signup</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Import my Google photo</value></data>

--- a/src/Humans.Web/Views/ShiftAdmin/EmailTeamRotas.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/EmailTeamRotas.cshtml
@@ -1,0 +1,72 @@
+@model Humans.Web.Models.Shifts.EmailTeamRotasViewModel
+@{
+    ViewData["Title"] = string.Format(Localizer["EmailTeamRotas_Title"].Value, Model.TeamName);
+}
+
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-controller="Team" asp-action="Index">@Localizer["Teams_Title"]</a></li>
+            <li class="breadcrumb-item"><a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@Model.TeamSlug">@Localizer["Shifts_Title"]</a></li>
+            <li class="breadcrumb-item active" aria-current="page">@Localizer["EmailTeamRotas_Breadcrumb"]</li>
+        </ol>
+    </nav>
+
+    <h2>@string.Format(Localizer["EmailTeamRotas_Heading"].Value, Model.TeamName)</h2>
+
+    <vc:temp-data-alerts />
+
+    <div class="row mt-3">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-body">
+                    <form asp-action="EmailTeamRotas" asp-route-slug="@Model.TeamSlug" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" asp-for="TeamSlug" />
+                        <input type="hidden" asp-for="TeamName" />
+
+                        <div asp-validation-summary="ModelOnly" class="alert alert-danger"></div>
+
+                        <div class="mb-3">
+                            <label asp-for="Message" class="form-label">@Localizer["EmailTeamRotas_MessageLabel"]</label>
+                            <textarea asp-for="Message" class="form-control" rows="10" maxlength="4000" required></textarea>
+                            <span asp-validation-for="Message" class="text-danger"></span>
+                            <div class="form-text">@Localizer["EmailTeamRotas_MessageHelp"]</div>
+                        </div>
+
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-primary" @(Model.RecipientCount == 0 ? "disabled" : null)>
+                                @string.Format(Localizer["EmailTeamRotas_Send"].Value, Model.RecipientCount)
+                            </button>
+                            <a asp-action="Index" asp-route-slug="@Model.TeamSlug" class="btn btn-outline-secondary">@Localizer["Common_Cancel"]</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-4">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">@string.Format(Localizer["EmailTeamRotas_RecipientsHeading"].Value, Model.RecipientCount)</h5>
+                    <small class="text-muted">@string.Format(Localizer["EmailTeamRotas_RotaCount"].Value, Model.RotaCount)</small>
+                </div>
+                <div class="card-body">
+                    @if (Model.RecipientCount == 0)
+                    {
+                        <p class="text-muted mb-0">@Localizer["EmailTeamRotas_NoRecipients"]</p>
+                    }
+                    else
+                    {
+                        <ul class="list-unstyled mb-0 small">
+                            @foreach (var name in Model.RecipientNames)
+                            {
+                                <li>@name</li>
+                            }
+                        </ul>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -1041,6 +1041,20 @@
                 </form>
             </div>
         </div>
+
+        @* Email Everyone in Upcoming Rotas *@
+        <div class="card mb-4">
+            <div class="card-header"><h5 class="mb-0">Email everyone in upcoming rotas</h5></div>
+            <div class="card-body">
+                <p class="mb-2">
+                    Send a single message to every human signed up on any of this team's current or upcoming rotas.
+                    Each recipient gets one email listing their own shifts; replies come back to you.
+                </p>
+                <a asp-action="EmailTeamRotas" asp-route-slug="@Model.Department.Slug" class="btn btn-outline-primary">
+                    Compose&hellip;
+                </a>
+            </div>
+        </div>
     }
 </div>
 

--- a/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
@@ -379,16 +379,17 @@ public sealed class RotaCoordinatorMessageServiceTests
             .Returns([pastOnlyRota, futureRota]);
 
         var sender = Guid.NewGuid();
-        StubUsers(sender, userA, userB);
+        // After past-only-rota filtering, only userB survives as a recipient,
+        // so StubUsers is called with userB alone. The past-only rota's userA
+        // is referenced above only to populate the filtered-out rota.
+        _ = userA;
+        StubUsers(sender, userB);
 
         await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "hello");
 
-        // userB's email queued; userA (past-only rota) skipped.
+        // Exactly one email queued, to userB; past-only rota produced no work.
         await _emailService.Received(1).SendCoordinatorTeamRotasMessageAsync(
-            Arg.Is<CoordinatorTeamRotasMessageRequest>(r => r.RecipientEmail == "b@example.com"),
-            Arg.Any<CancellationToken>());
-        await _emailService.DidNotReceive().SendCoordinatorTeamRotasMessageAsync(
-            Arg.Is<CoordinatorTeamRotasMessageRequest>(r => r.RecipientEmail == "a@example.com"),
+            Arg.Any<CoordinatorTeamRotasMessageRequest>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -402,25 +403,25 @@ public sealed class RotaCoordinatorMessageServiceTests
         var sender = Guid.NewGuid();
         var confirmed = Guid.NewGuid();
         var pending = Guid.NewGuid();
-        var withdrawn = Guid.NewGuid();
+        var bailed = Guid.NewGuid();
 
-        var rota = MakeTeamRota(teamId, es, "Rota1", [(shift, [confirmed, pending, withdrawn])]);
+        var rota = MakeTeamRota(teamId, es, "Rota1", [(shift, [confirmed, pending, bailed])]);
         // Override the default Confirmed status on two of the three signups.
         rota.Shifts.First().ShiftSignups.First(s => s.UserId == pending).Status = SignupStatus.Pending;
-        rota.Shifts.First().ShiftSignups.First(s => s.UserId == withdrawn).Status = SignupStatus.Withdrawn;
+        rota.Shifts.First().ShiftSignups.First(s => s.UserId == bailed).Status = SignupStatus.Bailed;
 
         _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
             .Returns([rota]);
 
-        // Withdrawn user is filtered before user lookup, so only the two active
+        // Bailed user is filtered before user lookup, so only the two active
         // recipients are stubbed; if the service ever called GetUserInfosAsync
-        // for the withdrawn id, the test would surface that via the wrong count.
+        // for the bailed id, the test would surface that via the wrong count.
         StubUsers(sender, confirmed, pending);
 
         var result = await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "hello");
 
         result.Succeeded.Should().BeTrue();
-        result.RecipientCount.Should().Be(2, "withdrawn is excluded; pending + confirmed are kept");
+        result.RecipientCount.Should().Be(2, "bailed is excluded; pending + confirmed are kept");
         await _emailService.Received(2).SendCoordinatorTeamRotasMessageAsync(
             Arg.Any<CoordinatorTeamRotasMessageRequest>(),
             Arg.Any<CancellationToken>());

--- a/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Shifts;
 using Humans.Application.Tests.Infrastructure;
@@ -9,6 +10,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
+using NodaTime.Testing;
 using NSubstitute;
 
 namespace Humans.Application.Tests.Services.Shifts;
@@ -17,17 +19,22 @@ namespace Humans.Application.Tests.Services.Shifts;
 /// Orchestration tests for <see cref="RotaCoordinatorMessageService"/>:
 /// recipient fan-out, per-recipient shift list, audit log, and the failure shapes
 /// (missing message body, missing rota, missing signups). Issue
-/// nobodies-collective/Humans#732.
+/// nobodies-collective/Humans#732. Team-scoped variants cover the
+/// <c>SendTeamRotasMessageAsync</c> path (fan-out across all current/upcoming
+/// rotas in a team, deduped by user).
 /// </summary>
 public sealed class RotaCoordinatorMessageServiceTests
 {
     private readonly IShiftSignupRepository _signupRepo = Substitute.For<IShiftSignupRepository>();
+    private readonly IShiftManagementRepository _mgmtRepo = Substitute.For<IShiftManagementRepository>();
+    private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 6, 15, 12, 0));
 
     private RotaCoordinatorMessageService CreateSut() =>
-        new(_signupRepo, _userService, _emailService, _auditLog,
+        new(_signupRepo, _mgmtRepo, _teamService, _userService, _emailService, _auditLog, _clock,
             NullLogger<RotaCoordinatorMessageService>.Instance);
 
     [HumansFact]
@@ -311,6 +318,339 @@ public sealed class RotaCoordinatorMessageServiceTests
             sender,
             Arg.Any<Guid?>(),
             Arg.Any<string?>());
+    }
+
+    // ============================================================
+    // SendTeamRotasMessageAsync — team-scoped fan-out across all
+    // current/upcoming rotas in a team.
+    // ============================================================
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_RejectsBlankMessage()
+    {
+        var result = await CreateSut().SendTeamRotasMessageAsync(Guid.NewGuid(), Guid.NewGuid(), "   ");
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Contain("required");
+        await _emailService.DidNotReceiveWithAnyArgs().SendCoordinatorTeamRotasMessageAsync(null!);
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_ReturnsFailure_WhenTeamMissing()
+    {
+        var teamId = Guid.NewGuid();
+        _teamService.GetTeamAsync(teamId).Returns((TeamInfo?)null);
+
+        var result = await CreateSut().SendTeamRotasMessageAsync(teamId, Guid.NewGuid(), "hello");
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Contain("Team not found");
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_ReturnsFailure_WhenNoActiveEvent()
+    {
+        var (teamId, _) = StubTeam();
+        _mgmtRepo.GetActiveEventSettingsAsync(Arg.Any<CancellationToken>())
+            .Returns((EventSettings?)null);
+
+        var result = await CreateSut().SendTeamRotasMessageAsync(teamId, Guid.NewGuid(), "hello");
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Contain("no upcoming rotas");
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_ExcludesRotasWithNoFutureShifts()
+    {
+        var (teamId, _) = StubTeam();
+        var es = StubEvent();
+
+        var pastShift = MakeShift(Guid.Empty, dayOffset: -30, startHour: 10);
+        var futureShift = MakeShift(Guid.Empty, dayOffset: 30, startHour: 14);
+
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+
+        var pastOnlyRota = MakeTeamRota(teamId, es, "PastOnly", [(pastShift, [userA])]);
+        var futureRota = MakeTeamRota(teamId, es, "Future", [(futureShift, [userB])]);
+
+        _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
+            .Returns([pastOnlyRota, futureRota]);
+
+        var sender = Guid.NewGuid();
+        StubUsers(sender, userA, userB);
+
+        await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "hello");
+
+        // userB's email queued; userA (past-only rota) skipped.
+        await _emailService.Received(1).SendCoordinatorTeamRotasMessageAsync(
+            Arg.Is<CoordinatorTeamRotasMessageRequest>(r => r.RecipientEmail == "b@example.com"),
+            Arg.Any<CancellationToken>());
+        await _emailService.DidNotReceive().SendCoordinatorTeamRotasMessageAsync(
+            Arg.Is<CoordinatorTeamRotasMessageRequest>(r => r.RecipientEmail == "a@example.com"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_FiltersInactiveSignupStatuses()
+    {
+        var (teamId, _) = StubTeam();
+        var es = StubEvent();
+
+        var shift = MakeShift(Guid.Empty, dayOffset: 30, startHour: 10);
+        var sender = Guid.NewGuid();
+        var confirmed = Guid.NewGuid();
+        var pending = Guid.NewGuid();
+        var withdrawn = Guid.NewGuid();
+
+        var rota = MakeTeamRota(teamId, es, "Rota1", [(shift, [confirmed, pending, withdrawn])]);
+        // Override the default Confirmed status on two of the three signups.
+        rota.Shifts.First().ShiftSignups.First(s => s.UserId == pending).Status = SignupStatus.Pending;
+        rota.Shifts.First().ShiftSignups.First(s => s.UserId == withdrawn).Status = SignupStatus.Withdrawn;
+
+        _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
+            .Returns([rota]);
+
+        // Withdrawn user is filtered before user lookup, so only the two active
+        // recipients are stubbed; if the service ever called GetUserInfosAsync
+        // for the withdrawn id, the test would surface that via the wrong count.
+        StubUsers(sender, confirmed, pending);
+
+        var result = await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "hello");
+
+        result.Succeeded.Should().BeTrue();
+        result.RecipientCount.Should().Be(2, "withdrawn is excluded; pending + confirmed are kept");
+        await _emailService.Received(2).SendCoordinatorTeamRotasMessageAsync(
+            Arg.Any<CoordinatorTeamRotasMessageRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_DedupesRecipient_AcrossMultipleRotas()
+    {
+        var (teamId, _) = StubTeam();
+        var es = StubEvent();
+
+        var userA = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+
+        var shiftR1 = MakeShift(Guid.Empty, dayOffset: 30, startHour: 9);
+        var shiftR2 = MakeShift(Guid.Empty, dayOffset: 31, startHour: 14);
+
+        var rotaA = MakeTeamRota(teamId, es, "Aardvark", [(shiftR1, [userA])]);
+        var rotaB = MakeTeamRota(teamId, es, "Beaver", [(shiftR2, [userA])]);
+
+        _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
+            .Returns([rotaA, rotaB]);
+
+        StubUsers(sender, userA);
+
+        var result = await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "hello");
+
+        result.Succeeded.Should().BeTrue();
+        result.RecipientCount.Should().Be(1, "user appears in two rotas but should receive exactly one email");
+        result.RotaCount.Should().Be(2);
+
+        await _emailService.Received(1).SendCoordinatorTeamRotasMessageAsync(
+            Arg.Is<CoordinatorTeamRotasMessageRequest>(r =>
+                r.RecipientEmail == "a@example.com"
+                && r.ShiftGroups.Count == 2
+                && r.ShiftGroups.Any(g => g.RotaName == "Aardvark")
+                && r.ShiftGroups.Any(g => g.RotaName == "Beaver")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_GroupsShiftsByRota_InAlphabeticalRotaOrder()
+    {
+        var (teamId, _) = StubTeam();
+        var es = StubEvent();
+        var userA = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+
+        var shiftZ = MakeShift(Guid.Empty, dayOffset: 30, startHour: 9);
+        var shiftA = MakeShift(Guid.Empty, dayOffset: 31, startHour: 14);
+
+        var zRota = MakeTeamRota(teamId, es, "Zebra", [(shiftZ, [userA])]);
+        var aRota = MakeTeamRota(teamId, es, "Antelope", [(shiftA, [userA])]);
+
+        _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
+            .Returns([zRota, aRota]);
+
+        StubUsers(sender, userA);
+
+        CoordinatorTeamRotasMessageRequest? captured = null;
+        await _emailService.SendCoordinatorTeamRotasMessageAsync(
+            Arg.Do<CoordinatorTeamRotasMessageRequest>(r => captured = r),
+            Arg.Any<CancellationToken>());
+
+        await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "hello");
+
+        captured.Should().NotBeNull();
+        captured!.ShiftGroups[0].RotaName.Should().Be("Antelope", "rotas grouped alphabetically by name");
+        captured.ShiftGroups[1].RotaName.Should().Be("Zebra");
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_WritesOneAuditEntry_OnTeamEntity()
+    {
+        var (teamId, _) = StubTeam();
+        var es = StubEvent();
+        var userA = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+
+        var shift = MakeShift(Guid.Empty, dayOffset: 30, startHour: 10);
+        var rota = MakeTeamRota(teamId, es, "Rota1", [(shift, [userA])]);
+
+        _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
+            .Returns([rota]);
+        StubUsers(sender, userA);
+
+        await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "schedule change");
+
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.CoordinatorTeamRotasMessageSent,
+            nameof(Team),
+            teamId,
+            Arg.Is<string>(d => d.Contains("schedule change") && d.Contains("Test Team")),
+            sender,
+            Arg.Any<Guid?>(),
+            Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task SendTeamRotasMessageAsync_IsolatesPerRecipientFailures()
+    {
+        var (teamId, _) = StubTeam();
+        var es = StubEvent();
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+
+        var shift = MakeShift(Guid.Empty, dayOffset: 30, startHour: 10);
+        var rota = MakeTeamRota(teamId, es, "Rota1", [(shift, [userA, userB])]);
+
+        _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
+            .Returns([rota]);
+        StubUsers(sender, userA, userB);
+
+        _emailService
+            .When(s => s.SendCoordinatorTeamRotasMessageAsync(
+                Arg.Is<CoordinatorTeamRotasMessageRequest>(r => r.RecipientEmail == "a@example.com"),
+                Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("simulated outbox blip"));
+
+        var result = await CreateSut().SendTeamRotasMessageAsync(teamId, sender, "hi");
+
+        result.Succeeded.Should().BeTrue("partial dispatch returns success");
+        result.RecipientCount.Should().Be(1);
+        await _emailService.Received(1).SendCoordinatorTeamRotasMessageAsync(
+            Arg.Is<CoordinatorTeamRotasMessageRequest>(r => r.RecipientEmail == "b@example.com"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetTeamRotasRecipientPreviewAsync_ReturnsDedupedNamesAndRotaCount()
+    {
+        var (teamId, _) = StubTeam();
+        var es = StubEvent();
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+
+        var shift1 = MakeShift(Guid.Empty, dayOffset: 30, startHour: 10);
+        var shift2 = MakeShift(Guid.Empty, dayOffset: 31, startHour: 12);
+        var rota1 = MakeTeamRota(teamId, es, "R1", [(shift1, [userA, userB])]);
+        var rota2 = MakeTeamRota(teamId, es, "R2", [(shift2, [userA])]);
+
+        _mgmtRepo.GetRotasByDepartmentAsync(teamId, es.Id, Arg.Any<CancellationToken>())
+            .Returns([rota1, rota2]);
+
+        _userService.GetUserInfosAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(c => c.Contains(userA) && c.Contains(userB)),
+            Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo>
+                {
+                    [userA] = MakeUserInfoWithEmail(userA, "a@example.com", "Alice"),
+                    [userB] = MakeUserInfoWithEmail(userB, "b@example.com", "Bob"),
+                }));
+
+        var preview = await CreateSut().GetTeamRotasRecipientPreviewAsync(teamId);
+
+        preview.RotaCount.Should().Be(2);
+        preview.RecipientNames.Should().BeEquivalentTo(["Alice", "Bob"]);
+    }
+
+    private (Guid TeamId, TeamInfo Team) StubTeam()
+    {
+        var teamId = Guid.NewGuid();
+        var team = new TeamInfo(
+            teamId, "Test Team", null, "test-team",
+            IsActive: true, IsSystemTeam: false, SystemTeamType: SystemTeamType.None,
+            RequiresApproval: false, IsPublicPage: false, IsHidden: false,
+            IsPromotedToDirectory: false, CreatedAt: Instant.MinValue,
+            Members: []);
+        _teamService.GetTeamAsync(teamId).Returns(team);
+        return (teamId, team);
+    }
+
+    private EventSettings StubEvent()
+    {
+        var es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = "Test Event",
+            TimeZoneId = "UTC",
+            GateOpeningDate = new LocalDate(2026, 6, 1),
+            BuildStartOffset = -30,
+            EventEndOffset = 60,
+            StrikeEndOffset = 90,
+            IsShiftBrowsingOpen = true,
+            IsActive = true,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        };
+        _mgmtRepo.GetActiveEventSettingsAsync(Arg.Any<CancellationToken>())
+            .Returns(es);
+        return es;
+    }
+
+    /// <summary>
+    /// Builds a team-scoped Rota with EventSettings wired up and Shift+ShiftSignup
+    /// collections populated as the team-level path expects (via Rota.Shifts →
+    /// Shift.ShiftSignups). Each tuple is (shift, recipient user ids); all signups
+    /// default to Confirmed status.
+    /// </summary>
+    private static Rota MakeTeamRota(
+        Guid teamId,
+        EventSettings es,
+        string name,
+        IReadOnlyList<(Shift Shift, Guid[] UserIds)> shiftsWithSignups)
+    {
+        var rota = new Rota
+        {
+            Id = Guid.NewGuid(),
+            EventSettingsId = es.Id,
+            TeamId = teamId,
+            Name = name,
+            Priority = ShiftPriority.Normal,
+            Policy = SignupPolicy.Public,
+            Period = RotaPeriod.Event,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            EventSettings = es,
+        };
+        foreach (var (shift, userIds) in shiftsWithSignups)
+        {
+            shift.RotaId = rota.Id;
+            foreach (var uid in userIds)
+            {
+                shift.ShiftSignups.Add(MakeSignup(uid, shift));
+            }
+            rota.Shifts.Add(shift);
+        }
+        return rota;
     }
 
     private static Rota MakeRota(out EventSettings es)


### PR DESCRIPTION
## Summary

- Coordinators can send one message to every active signup across all current/upcoming rotas in a team — the team-level analog of the existing per-rota "Email a rota" action. Each recipient gets one email (deduped across rotas) listing their own shifts grouped by rota in each rota's timezone.
- `From = humans@nobodies.team`, `Reply-To = coordinator` (mirrors per-rota header pattern). UI lands as a card at the bottom of `/Teams/{slug}/Shifts`, gated on `CanManageDepartment`.
- Extends `IRotaCoordinatorMessageService` with `SendTeamRotasMessageAsync` + `GetTeamRotasRecipientPreviewAsync` (Reuse-First Discipline — single interface owns both shapes). Existing `SendRotaMessageAsync` non-behaviourally refactored to share the dispatch loop with the new path.
- Spec: [`docs/superpowers/specs/2026-05-27-team-rotas-coordinator-message-design.md`](docs/superpowers/specs/2026-05-27-team-rotas-coordinator-message-design.md) (first commit).

## Test plan

- [ ] Preview env: confirm new "Email everyone in upcoming rotas" card appears below the Create-Rota form on `/Teams/{slug}/Shifts` for coordinators; absent for non-coordinators.
- [ ] Click **Compose…** → URL is `/Teams/{slug}/Shifts/Email`; recipient count and "across N rotas" subtitle match the actual fan-out.
- [ ] Send to a team with multi-rota signups: outbox shows one row per distinct user, `ReplyTo = coordinator email`, `From = humans@`.
- [ ] Email body: sender mailto link, message preserved (newlines → `<br />`), per-rota groups present with chronological shift list in each rota's timezone.
- [ ] Audit row written once per dispatch with `Action = CoordinatorTeamRotasMessageSent`, `EntityType = "Team"`, `EntityId = teamId`.
- [ ] Negative paths: empty message → validation error; team with no upcoming rotas → submit disabled with empty-state copy.
- [ ] Per-rota regression: existing `EmailRota` flow unchanged (single rota, ReplyTo = coordinator, audit on Rota entity).
- [ ] Unit tests: `dotnet test tests/Humans.Application.Tests` green for the new `SendTeamRotasMessageAsync_*` and `GetTeamRotasRecipientPreviewAsync_*` cases + existing per-rota cases still pass after the helper extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)