### PR TITLE
refactor(infra): fetch agent docs from GitHub at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,14 +48,6 @@ RUN groupadd -r appuser && useradd -r -g appuser -s /sbin/nologin appuser
 # Copy published files
 COPY --from=build /app/publish .
 
-# Ship the agent's grounding docs. These are read at runtime from
-# ContentRootPath/docs/{sections,features} by AgentSectionDocReader and
-# AgentFeatureSpecReader; they are NOT part of `dotnet publish` output, so copy
-# them explicitly or the agent's fetch_section_guide / fetch_feature_spec tools
-# fail silently in the container (the index also ships empty).
-COPY docs/sections/ ./docs/sections/
-COPY docs/features/ ./docs/features/
-
 # Set ownership
 RUN chown -R appuser:appuser /app
 

--- a/docs/sections/Agent.md
+++ b/docs/sections/Agent.md
@@ -68,7 +68,7 @@ Per-user message and token counters live in the Singleton `IAgentRateLimitStore`
 1. **Terms link, not gate.** The Assistant panel shows a persistent "AI Terms" link below the composer that opens `/Legal/agent-chat` (the rendered Agent Chat Terms from `nobodies-collective/legal`). There is no explicit consent step — opening the panel and sending a message constitutes use; the terms describe what's sent, retention, and rights. The team-required-doc consent flow (`IConsentService.GetPendingDocumentNamesAsync`) is intentionally NOT used here; agent use is opt-in, not a membership precondition.
 2. **Enabled gate.** If `AgentSettings.Enabled = false`, widget is hidden and `POST /Agent/Ask` returns `503 ServiceUnavailable`.
 3. **Rate limit.** Per-user daily and hourly caps from `AgentSettings`. Over-cap requests return `429 TooManyRequests` without hitting the provider.
-4. **Tool whitelist.** Only `fetch_feature_spec`, `fetch_section_guide`, `route_to_issue`, `get_audit_history`, `get_shift_details` are valid tool names. Unknown names return a tool error; filesystem is never touched outside `docs/sections/` and `docs/features/`.
+4. **Tool whitelist.** Only `fetch_feature_spec`, `fetch_section_guide`, `route_to_issue`, `get_audit_history`, `get_shift_details` are valid tool names. Unknown names return a tool error. `fetch_section_guide` is restricted to a whitelisted set of section keys; `fetch_feature_spec` accepts only filename-safe stems (letters, digits, `-`, `_`). Both fetch from `nobodies-collective/Humans@main` via `IGuideContentSource` and cannot read arbitrary paths.
 5. **Tool loop bound.** At most `AnthropicOptions.MaxToolCallsPerTurn` (default 3) tool calls per turn, enforced server-side.
 6. **Refusal logging.** Every refused turn writes an `AgentMessage` with `RefusalReason != null`.
 7. **Append-only conversations per user.** A user can only post to conversations they own. `AgentController` rejects cross-user access with 404.
@@ -124,7 +124,7 @@ Missing or wrong key → 401 (503 if the key is not configured). Unknown id → 
 ### Touch-and-clean guidance
 
 - Do **not** call the Anthropic SDK directly outside `AnthropicClient`.
-- Do **not** read `docs/sections/` or `docs/features/` outside `AgentSectionDocReader` / `AgentFeatureSpecReader`.
+- Do **not** fetch `docs/sections/` or `docs/features/` markdown outside `AgentSectionDocReader` / `AgentFeatureSpecReader`; both route through the shared `IGuideContentSource` (Octokit, cached) and enforce the whitelist + filename-safe-stem validation.
 - Do **not** add new tool names without updating both `AgentToolNames` and `IAgentToolDispatcher` whitelist; an unknown name must be a hard error, never a fallthrough.
 - Do **not** make `route_to_issue` (or any future handoff tool) write rows server-side. Handoffs are propose-only; the user submits.
 - `AgentSettings.PreloadConfig` defaults to `Tier1` (8 highest-signal sections in the index). If non-admin users start asking about sections outside that set and the model can't help, an admin can flip the live setting to `Tier2` at `/Agent/Admin/Settings` — both tiers fit Anthropic ITPM caps because section bodies route through tool calls, not preload.

--- a/src/Humans.Application/Interfaces/IGuideContentSource.cs
+++ b/src/Humans.Application/Interfaces/IGuideContentSource.cs
@@ -1,12 +1,23 @@
 namespace Humans.Application.Interfaces;
 
 /// <summary>
-/// Abstracts the GitHub fetch so GuideContentService is testable without network.
+/// Abstracts a GitHub markdown fetch against the configured Humans repo/branch so callers
+/// (GuideContentService, agent doc readers) are testable without network and share one
+/// Octokit client + token-resolution path.
 /// </summary>
 public interface IGuideContentSource
 {
     /// <summary>
-    /// Fetches the raw markdown for one guide file by stem (e.g. "Profiles" → Profiles.md).
+    /// Fetches the raw markdown for one guide file by stem (e.g. "Profiles" → Profiles.md)
+    /// from the configured guide folder (<c>GuideSettings.FolderPath</c>).
     /// </summary>
     Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches the raw markdown for one file from an arbitrary folder inside the same
+    /// configured Humans repo/branch (e.g. <c>docs/sections</c>, <c>docs/features</c>).
+    /// Throws Octokit's <c>NotFoundException</c> when the file is not present; callers
+    /// that want null-on-miss must catch it explicitly.
+    /// </summary>
+    Task<string> GetMarkdownAsync(string folderPath, string fileStem, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Infrastructure/Services/GitHubGuideContentSource.cs
+++ b/src/Humans.Infrastructure/Services/GitHubGuideContentSource.cs
@@ -34,13 +34,16 @@ public sealed class GitHubGuideContentSource : IGuideContentSource
         }
     }
 
-    public async Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default)
+    public Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default) =>
+        GetMarkdownAsync(_guideSettings.Value.FolderPath, fileStem, cancellationToken);
+
+    public async Task<string> GetMarkdownAsync(string folderPath, string fileStem, CancellationToken cancellationToken = default)
     {
         var settings = _guideSettings.Value;
-        var path = $"{settings.FolderPath.TrimEnd('/')}/{fileStem}.md";
+        var path = $"{folderPath.TrimEnd('/')}/{fileStem}.md";
 
         _logger.LogDebug(
-            "Fetching guide file {Path} from {Owner}/{Repository}@{Branch}",
+            "Fetching markdown file {Path} from {Owner}/{Repository}@{Branch}",
             path, settings.Owner, settings.Repository, settings.Branch);
 
         var rawBytes = await _client.Repository.Content.GetRawContentByRef(

--- a/src/Humans.Infrastructure/Services/Preload/AgentFeatureSpecReader.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentFeatureSpecReader.cs
@@ -42,6 +42,10 @@ public sealed class AgentFeatureSpecReader(
         }
         catch (NotFoundException)
         {
+            // 404 from GitHub — file is absent from the configured repo/branch. Log per
+            // memory/code/always-log-problems.md so a missing feature spec is visible in
+            // the prod log viewer rather than silently returning an empty preload entry.
+            logger.LogWarning("Agent feature spec {Stem} not found on GitHub (docs/features)", stem);
             return null;
         }
         catch (Exception ex)

--- a/src/Humans.Infrastructure/Services/Preload/AgentFeatureSpecReader.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentFeatureSpecReader.cs
@@ -1,17 +1,54 @@
-using Microsoft.Extensions.Hosting;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Octokit;
 
 namespace Humans.Infrastructure.Services.Preload;
 
-public sealed class AgentFeatureSpecReader(IHostEnvironment env)
+/// <summary>
+/// Reads a <c>docs/features/{stem}.md</c> file from the Humans repo on GitHub at runtime
+/// via the shared <see cref="IGuideContentSource"/>. Cached in memory with the Guide TTL.
+/// Returns <c>null</c> on miss (invalid stem, GitHub 404, or transient failure).
+/// </summary>
+public sealed class AgentFeatureSpecReader(
+    IGuideContentSource source,
+    IMemoryCache cache,
+    IOptions<GuideSettings> settings,
+    ILogger<AgentFeatureSpecReader> logger)
 {
+    internal const string FolderPath = "docs/features";
+    private const string CacheKeyPrefix = "agent:feature:";
+
     public async Task<string?> ReadAsync(string stem, CancellationToken cancellationToken)
     {
+        // Hard input validation — feature stems are filename-safe identifiers only.
+        // Prevents arbitrary-path traversal via a crafted stem (e.g. "../secrets").
         if (string.IsNullOrWhiteSpace(stem) ||
             stem.Any(c => !(char.IsLetterOrDigit(c) || c == '-' || c == '_')))
             return null;
 
-        var path = Path.Combine(env.ContentRootPath, "docs", "features", $"{stem}.md");
-        if (!File.Exists(path)) return null;
-        return await File.ReadAllTextAsync(path, cancellationToken);
+        var cacheKey = CacheKeyPrefix + stem;
+        if (cache.TryGetValue<string>(cacheKey, out var cached) && cached is not null)
+            return cached;
+
+        try
+        {
+            var body = await source.GetMarkdownAsync(FolderPath, stem, cancellationToken);
+            var ttl = TimeSpan.FromHours(Math.Max(1, settings.Value.CacheTtlHours));
+            cache.Set(cacheKey, body, new MemoryCacheEntryOptions { SlidingExpiration = ttl });
+            return body;
+        }
+        catch (NotFoundException)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to fetch agent feature spec {Stem} from GitHub; returning null", stem);
+            return null;
+        }
     }
 }

--- a/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
@@ -52,7 +52,10 @@ public sealed class AgentSectionDocReader(
         catch (NotFoundException)
         {
             // Whitelisted key but no file in the repo — treat as miss so the tool degrades
-            // cleanly rather than crashing the dispatcher.
+            // cleanly rather than crashing the dispatcher. Log per
+            // memory/code/always-log-problems.md so a missing section guide is visible in
+            // the prod log viewer (which only renders Warning+) instead of disappearing.
+            logger.LogWarning("Section guide {Section} not found on GitHub (docs/sections)", canonicalKey);
             return null;
         }
         catch (Exception ex)

--- a/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
@@ -1,10 +1,27 @@
-using Microsoft.Extensions.Hosting;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Octokit;
 
 namespace Humans.Infrastructure.Services.Preload;
 
-/// <summary>Reads a whitelisted <c>docs/sections/{key}.md</c> file relative to the content root.</summary>
-public sealed class AgentSectionDocReader(IHostEnvironment env)
+/// <summary>
+/// Reads a whitelisted <c>docs/sections/{key}.md</c> file from the Humans repo on GitHub
+/// at runtime via the shared <see cref="IGuideContentSource"/>. Cached in memory with the
+/// Guide TTL so per-tool-call round trips are avoided. Returns <c>null</c> on miss (unknown
+/// key, GitHub 404, or transient fetch failure) so the caller can degrade gracefully.
+/// </summary>
+public sealed class AgentSectionDocReader(
+    IGuideContentSource source,
+    IMemoryCache cache,
+    IOptions<GuideSettings> settings,
+    ILogger<AgentSectionDocReader> logger)
 {
+    internal const string FolderPath = "docs/sections";
+    private const string CacheKeyPrefix = "agent:section:";
+
     private static readonly HashSet<string> Whitelist =
         new(StringComparer.OrdinalIgnoreCase)
         {
@@ -16,13 +33,34 @@ public sealed class AgentSectionDocReader(IHostEnvironment env)
     public async Task<string?> ReadAsync(string key, CancellationToken cancellationToken)
     {
         // Resolve the caller-supplied key to the canonical-cased whitelist entry so the
-        // on-disk filename matches exactly on case-sensitive filesystems (Linux deployment).
-        // LLMs routinely lowercase the key (e.g. "shifts"), which clears the case-insensitive
-        // whitelist but would otherwise miss "Shifts.md" via a case-sensitive File.Exists.
+        // GitHub path matches exactly (GitHub paths are case-sensitive). LLMs routinely
+        // lowercase the key (e.g. "shifts"); the whitelist lookup is case-insensitive
+        // but the fetched filename must be canonical ("Shifts.md").
         if (!Whitelist.TryGetValue(key, out var canonicalKey)) return null;
-        var path = Path.Combine(env.ContentRootPath, "docs", "sections", $"{canonicalKey}.md");
-        if (!File.Exists(path)) return null;
-        return await File.ReadAllTextAsync(path, cancellationToken);
+
+        var cacheKey = CacheKeyPrefix + canonicalKey;
+        if (cache.TryGetValue<string>(cacheKey, out var cached) && cached is not null)
+            return cached;
+
+        try
+        {
+            var body = await source.GetMarkdownAsync(FolderPath, canonicalKey, cancellationToken);
+            var ttl = TimeSpan.FromHours(Math.Max(1, settings.Value.CacheTtlHours));
+            cache.Set(cacheKey, body, new MemoryCacheEntryOptions { SlidingExpiration = ttl });
+            return body;
+        }
+        catch (NotFoundException)
+        {
+            // Whitelisted key but no file in the repo — treat as miss so the tool degrades
+            // cleanly rather than crashing the dispatcher.
+            return null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to fetch agent section guide {Section} from GitHub; returning null", canonicalKey);
+            return null;
+        }
     }
 
     public IReadOnlySet<string> KnownSections => Whitelist;

--- a/src/Humans.Web/Extensions/Sections/AgentSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/AgentSectionExtensions.cs
@@ -31,6 +31,9 @@ internal static class AgentSectionExtensions
 
         services.AddScoped<IAgentAnthropicBalanceProvider, Humans.Infrastructure.Services.Anthropic.AnthropicBalanceProvider>();
 
+        // Singletons: stateless readers that own a per-stem MemoryCache slot via the shared
+        // IMemoryCache. IGuideContentSource is registered as a singleton by AddGuideSection,
+        // so capturing it here is safe.
         services.AddSingleton<AgentSectionDocReader>();
         services.AddSingleton<AgentFeatureSpecReader>();
         services.AddSingleton<IAgentPreloadCorpusBuilder, AgentPreloadCorpusBuilder>();

--- a/src/Humans.Web/Health/AgentDocsHealthCheck.cs
+++ b/src/Humans.Web/Health/AgentDocsHealthCheck.cs
@@ -5,12 +5,14 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 namespace Humans.Web.Health;
 
 /// <summary>
-/// Verifies the agent's grounding docs are present at runtime. The section/feature
-/// guides are read from ContentRootPath/docs/{sections,features}; if the deployment
-/// drops that folder (e.g. the Dockerfile stops copying it), every
-/// <c>fetch_section_guide</c> / <c>fetch_feature_spec</c> call fails silently and
-/// the preload index ships empty. This check turns that into a visible Degraded
-/// status instead. Skipped (Healthy) when the agent feature is disabled.
+/// Verifies the agent's grounding docs are reachable on GitHub at runtime. The
+/// section/feature guides are fetched live from <c>nobodies-collective/Humans@main</c>
+/// via <see cref="AgentSectionDocReader"/> / <see cref="AgentFeatureSpecReader"/>; if
+/// GitHub is unreachable, the token is wrong, or the canary file moves, every
+/// <c>fetch_section_guide</c> / <c>fetch_feature_spec</c> call returns null and the
+/// preload index ships empty. This check turns that into a visible Degraded status
+/// instead of Unhealthy (the agent feature is non-critical for the rest of the app).
+/// Skipped (Healthy) when the agent feature is disabled.
 /// </summary>
 public sealed class AgentDocsHealthCheck(
     IAgentSettingsStore store,
@@ -18,13 +20,12 @@ public sealed class AgentDocsHealthCheck(
     AgentFeatureSpecReader features) : IHealthCheck
 {
     // A section that is always whitelisted and always preloaded (Tier1) — if its
-    // doc cannot be read, docs/sections is missing or unreadable.
+    // doc cannot be fetched, GitHub connectivity for docs/sections is broken.
     private const string ProbeSection = "Shifts";
 
-    // A stable feature-spec canary — docs/sections and docs/features are copied as
-    // separate Dockerfile layers, so a partial packaging regression can drop one
-    // without the other. Probe both so the health signal covers both runtime
-    // dependencies (fetch_section_guide and fetch_feature_spec).
+    // A stable feature-spec canary — fetched from a different folder (docs/features)
+    // than sections, so a folder-level fetch regression on one folder doesn't mask
+    // the other.
     private const string ProbeFeature = "26-events";
 
     public async Task<HealthCheckResult> CheckHealthAsync(
@@ -37,14 +38,14 @@ public sealed class AgentDocsHealthCheck(
         var sectionBody = await sections.ReadAsync(ProbeSection, cancellationToken);
         if (string.IsNullOrEmpty(sectionBody))
             return HealthCheckResult.Degraded(
-                $"agent grounding docs missing — docs/sections/{ProbeSection}.md unreadable at ContentRootPath; " +
-                "fetch_section_guide will fail and the preload index will be empty");
+                $"agent grounding docs unreachable — docs/sections/{ProbeSection}.md could not be fetched from GitHub; " +
+                "fetch_section_guide will return errors and the preload index will be empty");
 
         var featureBody = await features.ReadAsync(ProbeFeature, cancellationToken);
         if (string.IsNullOrEmpty(featureBody))
             return HealthCheckResult.Degraded(
-                $"agent grounding docs missing — docs/features/{ProbeFeature}.md unreadable at ContentRootPath; " +
-                "fetch_feature_spec will fail");
+                $"agent grounding docs unreachable — docs/features/{ProbeFeature}.md could not be fetched from GitHub; " +
+                "fetch_feature_spec will return errors");
 
         return HealthCheckResult.Healthy();
     }

--- a/src/Humans.Web/Health/AgentDocsHealthCheck.cs
+++ b/src/Humans.Web/Health/AgentDocsHealthCheck.cs
@@ -1,23 +1,30 @@
+using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Stores;
 using Humans.Infrastructure.Services.Preload;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 
 namespace Humans.Web.Health;
 
 /// <summary>
 /// Verifies the agent's grounding docs are reachable on GitHub at runtime. The
-/// section/feature guides are fetched live from <c>nobodies-collective/Humans@main</c>
-/// via <see cref="AgentSectionDocReader"/> / <see cref="AgentFeatureSpecReader"/>; if
-/// GitHub is unreachable, the token is wrong, or the canary file moves, every
+/// section/feature guides are fetched live from <c>nobodies-collective/Humans@main</c>;
+/// if GitHub is unreachable, the token is wrong, or the canary file moves, every
 /// <c>fetch_section_guide</c> / <c>fetch_feature_spec</c> call returns null and the
 /// preload index ships empty. This check turns that into a visible Degraded status
 /// instead of Unhealthy (the agent feature is non-critical for the rest of the app).
 /// Skipped (Healthy) when the agent feature is disabled.
+///
+/// Goes through <see cref="IGuideContentSource"/> directly rather than the cached
+/// <see cref="AgentSectionDocReader"/> / <see cref="AgentFeatureSpecReader"/> so the
+/// probe genuinely re-tests GitHub on every call. A cached reader would refresh the
+/// sliding expiration off one warm fetch and keep reporting Healthy through a revoked
+/// token / outage / moved canary.
 /// </summary>
 public sealed class AgentDocsHealthCheck(
     IAgentSettingsStore store,
-    AgentSectionDocReader sections,
-    AgentFeatureSpecReader features) : IHealthCheck
+    IGuideContentSource source,
+    ILogger<AgentDocsHealthCheck> logger) : IHealthCheck
 {
     // A section that is always whitelisted and always preloaded (Tier1) — if its
     // doc cannot be fetched, GitHub connectivity for docs/sections is broken.
@@ -35,18 +42,36 @@ public sealed class AgentDocsHealthCheck(
         if (!store.Current.Enabled)
             return HealthCheckResult.Healthy("agent disabled");
 
-        var sectionBody = await sections.ReadAsync(ProbeSection, cancellationToken);
-        if (string.IsNullOrEmpty(sectionBody))
+        if (!await TryFetchAsync(AgentSectionDocReader.FolderPath, ProbeSection, cancellationToken))
             return HealthCheckResult.Degraded(
                 $"agent grounding docs unreachable — docs/sections/{ProbeSection}.md could not be fetched from GitHub; " +
                 "fetch_section_guide will return errors and the preload index will be empty");
 
-        var featureBody = await features.ReadAsync(ProbeFeature, cancellationToken);
-        if (string.IsNullOrEmpty(featureBody))
+        if (!await TryFetchAsync(AgentFeatureSpecReader.FolderPath, ProbeFeature, cancellationToken))
             return HealthCheckResult.Degraded(
                 $"agent grounding docs unreachable — docs/features/{ProbeFeature}.md could not be fetched from GitHub; " +
                 "fetch_feature_spec will return errors");
 
         return HealthCheckResult.Healthy();
+    }
+
+    private async Task<bool> TryFetchAsync(string folderPath, string stem, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var body = await source.GetMarkdownAsync(folderPath, stem, cancellationToken);
+            return !string.IsNullOrEmpty(body);
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Any source-side failure (404 on canary, network, auth) means GitHub
+            // reachability for the agent docs is broken — convert to Degraded via the
+            // caller. Log per memory/code/always-log-problems.md so the prod log viewer
+            // (Warning+) shows why /health/ready flipped to Degraded.
+            logger.LogWarning(
+                "Agent docs probe failed: {Folder}/{Stem}.md — {Message}",
+                folderPath, stem, ex.Message);
+            return false;
+        }
     }
 }

--- a/tests/Humans.Application.Tests/Agent/AgentPreloadCorpusBuilderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentPreloadCorpusBuilderTests.cs
@@ -1,9 +1,11 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
+using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Services.Preload;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Humans.Application.Tests.Agent;
 
@@ -68,26 +70,25 @@ public class AgentPreloadCorpusBuilderTests
 
     private static IAgentPreloadCorpusBuilder MakeBuilder()
     {
-        var env = new TestHostEnvironment();
         var cache = new MemoryCache(new MemoryCacheOptions());
-        var reader = new AgentSectionDocReader(env);
+        var reader = new AgentSectionDocReader(
+            new StubSource(),
+            cache,
+            Options.Create(new GuideSettings { CacheTtlHours = 6 }),
+            NullLogger<AgentSectionDocReader>.Instance);
         return new AgentPreloadCorpusBuilder(reader, cache);
     }
 
-    private static string RepoRoot()
+    /// <summary>
+    /// Returns synthetic section bodies whose H1 tagline contains the key — enough for the
+    /// builder's index assertions (it only reads the first non-empty line after the H1).
+    /// </summary>
+    private sealed class StubSource : IGuideContentSource
     {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "docs", "sections")))
-            dir = dir.Parent;
-        return dir?.FullName ?? AppContext.BaseDirectory;
-    }
+        public Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default) =>
+            Task.FromResult($"# {fileStem}\n\nTagline for {fileStem}.");
 
-    private sealed class TestHostEnvironment : IHostEnvironment
-    {
-        public string EnvironmentName { get; set; } = "Test";
-        public string ApplicationName { get; set; } = "Humans.Application.Tests";
-        public string ContentRootPath { get; set; } = RepoRoot();
-        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
-            new Microsoft.Extensions.FileProviders.PhysicalFileProvider(RepoRoot());
+        public Task<string> GetMarkdownAsync(string folderPath, string fileStem, CancellationToken cancellationToken = default) =>
+            Task.FromResult($"# {fileStem}\n\nTagline for {fileStem}.");
     }
 }

--- a/tests/Humans.Application.Tests/Agent/AgentSectionDocReaderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentSectionDocReaderTests.cs
@@ -1,4 +1,11 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Services.Preload;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Octokit;
 using Xunit;
 
 namespace Humans.Application.Tests.Agent;
@@ -6,8 +13,8 @@ namespace Humans.Application.Tests.Agent;
 /// <summary>
 /// Guards the case-insensitive whitelist + canonical-cased path resolution
 /// (nobodies-collective/Humans#789). LLMs routinely lowercase the section key
-/// (e.g. "shifts"); the reader must canonicalize it to the on-disk filename
-/// ("Shifts.md") so the lookup works on case-sensitive filesystems (Linux).
+/// (e.g. "shifts"); the reader must canonicalize it to the on-GitHub filename
+/// ("Shifts.md") because GitHub paths are case-sensitive.
 /// </summary>
 public class AgentSectionDocReaderTests
 {
@@ -15,75 +22,86 @@ public class AgentSectionDocReaderTests
     [InlineData("Shifts")]
     [InlineData("shifts")]
     [InlineData("SHIFTS")]
-    public async Task ReadAsync_resolves_any_casing_to_the_canonical_guide(string key)
+    public async Task ReadAsync_resolves_any_casing_to_the_canonical_section_file(string key)
     {
-        var env = new TestHostEnvironment();
-        var reader = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
+        var source = new FakeSource();
+        var reader = MakeReader(source);
 
         var content = await reader.ReadAsync(key, CancellationToken.None);
 
-        var canonical = await File.ReadAllTextAsync(
-            Path.Combine(env.ContentRootPath, "docs", "sections", "Shifts.md"),
-            CancellationToken.None);
-
-        content.Should().Be(canonical, "any casing of a whitelisted key must resolve to docs/sections/Shifts.md");
-    }
-
-    /// <summary>
-    /// Proves the canonicalization is independent of the host filesystem's case sensitivity:
-    /// a content root containing ONLY the canonical-cased file "Profiles.md" is read
-    /// successfully even when the caller supplies a lowercased "profiles" key. The reader
-    /// must build the path from the whitelist's canonical entry, not the raw key.
-    /// </summary>
-    [HumansFact]
-    public async Task ReadAsync_uses_canonical_filename_not_caller_casing()
-    {
-        var root = Path.Combine(Path.GetTempPath(), "humans-doc-reader-" + Guid.NewGuid().ToString("N"));
-        var sectionsDir = Path.Combine(root, "docs", "sections");
-        Directory.CreateDirectory(sectionsDir);
-        try
-        {
-            const string body = "# Profiles guide\nbody";
-            await File.WriteAllTextAsync(Path.Combine(sectionsDir, "Profiles.md"), body);
-
-            var env = new TestHostEnvironment { ContentRootPath = root };
-            var reader = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
-
-            var content = await reader.ReadAsync("profiles", CancellationToken.None);
-
-            content.Should().Be(body);
-        }
-        finally
-        {
-            Directory.Delete(root, recursive: true);
-        }
+        content.Should().NotBeNullOrEmpty();
+        source.LastFolder.Should().Be(AgentSectionDocReader.FolderPath);
+        source.LastStem.Should().Be("Shifts", "the reader must canonicalize the key, not pass caller casing");
     }
 
     [HumansFact]
     public async Task ReadAsync_returns_null_for_non_whitelisted_key()
     {
-        var env = new TestHostEnvironment();
-        var reader = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
+        var reader = MakeReader(new FakeSource());
 
         var content = await reader.ReadAsync("NotASection", CancellationToken.None);
 
         content.Should().BeNull();
     }
 
-    private static string RepoRoot()
+    [HumansFact]
+    public async Task ReadAsync_returns_null_when_github_returns_not_found()
     {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "docs", "sections")))
-            dir = dir.Parent;
-        return dir?.FullName ?? AppContext.BaseDirectory;
+        var source = new FakeSource { FailWith = new NotFoundException("missing", System.Net.HttpStatusCode.NotFound) };
+        var reader = MakeReader(source);
+
+        var content = await reader.ReadAsync("Shifts", CancellationToken.None);
+
+        content.Should().BeNull();
     }
 
-    private sealed class TestHostEnvironment : Microsoft.Extensions.Hosting.IHostEnvironment
+    [HumansFact]
+    public async Task ReadAsync_returns_null_on_transient_github_failure()
     {
-        public string EnvironmentName { get; set; } = "Test";
-        public string ApplicationName { get; set; } = "Humans.Application.Tests";
-        public string ContentRootPath { get; set; } = RepoRoot();
-        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
-            new Microsoft.Extensions.FileProviders.PhysicalFileProvider(RepoRoot());
+        var source = new FakeSource { FailWith = new InvalidOperationException("network down") };
+        var reader = MakeReader(source);
+
+        var content = await reader.ReadAsync("Shifts", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task ReadAsync_caches_successful_fetch()
+    {
+        var source = new FakeSource();
+        var reader = MakeReader(source);
+
+        await reader.ReadAsync("Shifts", CancellationToken.None);
+        await reader.ReadAsync("Shifts", CancellationToken.None);
+
+        source.CallCount.Should().Be(1);
+    }
+
+    private static AgentSectionDocReader MakeReader(FakeSource source) =>
+        new(
+            source,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new GuideSettings { CacheTtlHours = 6 }),
+            NullLogger<AgentSectionDocReader>.Instance);
+
+    private sealed class FakeSource : IGuideContentSource
+    {
+        public int CallCount { get; private set; }
+        public string? LastFolder { get; private set; }
+        public string? LastStem { get; private set; }
+        public Exception? FailWith { get; set; }
+
+        public Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException("Agent reader must use the folder-parameterized overload.");
+
+        public Task<string> GetMarkdownAsync(string folderPath, string fileStem, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            LastFolder = folderPath;
+            LastStem = fileStem;
+            if (FailWith is not null) throw FailWith;
+            return Task.FromResult($"# {fileStem}\n\nBody.");
+        }
     }
 }

--- a/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
@@ -340,9 +340,19 @@ public class AgentToolDispatcherTests
         Interfaces.Shifts.IShiftView? shiftView = null,
         Interfaces.Shifts.IShiftManagementService? shiftManagement = null)
     {
-        var env = new TestHostEnvironment();
-        var sections = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
-        var features = new Humans.Infrastructure.Services.Preload.AgentFeatureSpecReader(env);
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var guideSettings = Microsoft.Extensions.Options.Options.Create(
+            new Humans.Infrastructure.Configuration.GuideSettings { CacheTtlHours = 6 });
+        var source = new StubGuideSource();
+        var sections = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(
+            source, cache, guideSettings,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Humans.Infrastructure.Services.Preload.AgentSectionDocReader>.Instance);
+        var features = new Humans.Infrastructure.Services.Preload.AgentFeatureSpecReader(
+            source, cache, guideSettings,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Humans.Infrastructure.Services.Preload.AgentFeatureSpecReader>.Instance);
         var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<Humans.Infrastructure.Services.Agent.AgentToolDispatcher>.Instance;
         return new Humans.Infrastructure.Services.Agent.AgentToolDispatcher(
             sections,
@@ -351,6 +361,15 @@ public class AgentToolDispatcherTests
             shiftView ?? Substitute.For<Interfaces.Shifts.IShiftView>(),
             shiftManagement ?? Substitute.For<Interfaces.Shifts.IShiftManagementService>(),
             logger);
+    }
+
+    private sealed class StubGuideSource : Humans.Application.Interfaces.IGuideContentSource
+    {
+        public Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default) =>
+            Task.FromResult($"# {fileStem}");
+
+        public Task<string> GetMarkdownAsync(string folderPath, string fileStem, CancellationToken cancellationToken = default) =>
+            Task.FromResult($"# {fileStem}");
     }
 
     private static Interfaces.Shifts.IShiftView MakeViewFor(
@@ -390,20 +409,4 @@ public class AgentToolDispatcherTests
         public Task<IReadOnlyList<Humans.Application.Services.AuditLog.AuditEvent>> GetFilteredAsync(string? entityType, Guid? entityId, Guid? userId, IReadOnlyList<Humans.Domain.Enums.AuditAction>? actions, int limit, CancellationToken ct = default) => Task.FromResult(Events);
     }
 
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "docs", "sections")))
-            dir = dir.Parent;
-        return dir?.FullName ?? AppContext.BaseDirectory;
-    }
-
-    private sealed class TestHostEnvironment : Microsoft.Extensions.Hosting.IHostEnvironment
-    {
-        public string EnvironmentName { get; set; } = "Test";
-        public string ApplicationName { get; set; } = "Humans.Application.Tests";
-        public string ContentRootPath { get; set; } = RepoRoot();
-        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
-            new Microsoft.Extensions.FileProviders.PhysicalFileProvider(RepoRoot());
-    }
 }

--- a/tests/Humans.Application.Tests/Services/GuideContentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideContentServiceTests.cs
@@ -23,6 +23,9 @@ public class GuideContentServiceTests
             if (fail is not null) throw fail;
             return Task.FromResult(MarkdownFor(fileStem));
         }
+
+        public Task<string> GetMarkdownAsync(string folderPath, string fileStem, CancellationToken cancellationToken = default) =>
+            GetMarkdownAsync(fileStem, cancellationToken);
     }
 
     private sealed class StubRenderer : IGuideRenderer


### PR DESCRIPTION
## Summary

Stops baking `docs/sections` and `docs/features` into the Docker image and switches the agent's `fetch_section_guide` / `fetch_feature_spec` tools to fetch live from `nobodies-collective/Humans@main` via the existing GitHub content pattern.

- `AgentSectionDocReader` and `AgentFeatureSpecReader` now go through `IGuideContentSource` (Octokit-backed, `GitHubSettings` token, `IMemoryCache` with `GuideSettings.CacheTtlHours`).
- `IGuideContentSource` gains one folder-parameterized `GetMarkdownAsync` overload; the existing single-arg method delegates to it. `GuideContentService` is untouched.
- `Dockerfile`: drop the `docs/{sections,features}` COPY lines.
- `AgentDocsHealthCheck`: probes both folders via the live fetch; Degraded on miss; skipped when the agent is disabled.
- Whitelist + filename-safe stem validation preserved; `NotFoundException` and transient errors return null so tool calls degrade gracefully (never throw into the dispatcher).
- `docs/sections/Agent.md` invariant 4 + touch-and-clean note updated to reflect the GitHub-fetch path.

## Reuse path

The reuse-first option that adds the LEAST new surface is **extend `IGuideContentSource` with one folder-parameterized overload**. Considered and rejected:

- *New `IAgentDocContentSource` interface* — duplicates Octokit client + token resolution + caching plumbing; parallel pattern, exactly what the issue asks us not to do.
- *Agent-scoped `AgentDocsSettings` block* — extra configuration surface for no value; `GuideSettings` already targets `nobodies-collective/Humans@main` with a TTL.

Net additions: one interface method, zero new files in `src/`.

## Acceptance criteria

- [x] `fetch_section_guide` / `fetch_feature_spec` return live content from `nobodies-collective/Humans@main` (configured via shared `GuideSettings`).
- [x] `docs/sections` + `docs/features` COPY removed from `Dockerfile`.
- [x] Content cached; TTL = `GuideSettings.CacheTtlHours` (default 6h sliding).
- [x] `AgentDocsHealthCheck` probes both folders; `Degraded` on miss; `Healthy` when agent disabled.
- [x] Whitelist + stem validation preserved; invalid keys / GitHub 404 / transient errors return null, never throw.
- [x] Reuses the existing GitHub pattern (`IGuideContentSource`), not a parallel one.

## Out of scope

- nobodies-collective/Humans#789 (case-sensitivity of `fetch_section_guide` on Linux) is worth fixing together per the spec, but kept separate to keep this PR focused.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean (existing HUM0025 warnings unchanged).
- [x] `dotnet test` — Application/Web/Analyzers/Domain suites all pass (3210 + 190 + 161 + N). Integration tests require Docker (not available on this machine) and were not run; they don't exercise this code path.
- [x] Agent test surface specifically: 67 Agent tests pass after reader-constructor change.
- [ ] Smoke-verify in preview env: `fetch_section_guide(\"Shifts\")` returns body; `fetch_feature_spec(\"26-events\")` returns body; `/health/ready` reports `agent-grounding-docs` healthy.

Fixes nobodies-collective/Humans#796