### PR TITLE
Strip expiring cross-section team navigations

### DIFF
--- a/src/Humans.Application/DTOs/AdminLegalDocumentListItem.cs
+++ b/src/Humans.Application/DTOs/AdminLegalDocumentListItem.cs
@@ -5,9 +5,8 @@ namespace Humans.Application.DTOs;
 /// <summary>
 /// Admin-facing row for the legal-documents list. Stitched by
 /// <c>AdminLegalDocumentService</c> from <c>LegalDocument</c> plus the
-/// owning <c>Team</c> so the controller doesn't rely on the cross-domain
-/// <c>LegalDocument.Team</c> nav (schedule-for-strip per the Legal &amp;
-/// Consent section invariants).
+/// owning <c>Team</c> so the controller doesn't cross the Legal/Teams
+/// section boundary.
 /// </summary>
 public sealed record AdminLegalDocumentListItem(
     Guid Id,

--- a/src/Humans.Application/Interfaces/Legal/ILegalDocumentSyncService.cs
+++ b/src/Humans.Application/Interfaces/Legal/ILegalDocumentSyncService.cs
@@ -62,11 +62,11 @@ public interface ILegalDocumentSyncService : IApplicationService
 
     /// <summary>
     /// Gets every active+required legal document whose <c>TeamId</c> is in
-    /// <paramref name="teamIds"/>, with the <see cref="LegalDocument.Team"/>
-    /// and <see cref="LegalDocument.Versions"/> navigation properties
-    /// populated. Used by the consent dashboard to build the "documents per
-    /// team" grouping without crossing the section boundary into
-    /// <c>DbContext.LegalDocuments</c> from the Application layer.
+    /// <paramref name="teamIds"/>, with team names stitched by TeamId and
+    /// <see cref="LegalDocument.Versions"/> populated. Used by the consent
+    /// dashboard to build the "documents per team" grouping without crossing
+    /// the section boundary into <c>DbContext.LegalDocuments</c> from the
+    /// Application layer.
     /// </summary>
     Task<IReadOnlyList<ActiveRequiredLegalDocumentSnapshot>> GetActiveRequiredDocumentsForTeamsAsync(
         IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default);

--- a/src/Humans.Application/Interfaces/Repositories/ILegalDocumentRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ILegalDocumentRepository.cs
@@ -21,10 +21,8 @@ namespace Humans.Application.Interfaces.Repositories;
 /// <see cref="IProfileRepository"/>, <see cref="IUserRepository"/>, etc.
 ///
 /// <para>
-/// <see cref="Humans.Domain.Entities.LegalDocument.Team"/> is a cross-domain
-/// nav that this section's invariants document schedules for strip. This
-/// repository never <c>.Include</c>s it; callers that need team data call
-/// <see cref="Teams.ITeamService"/> and stitch by
+/// Legal documents carry a cross-section TeamId only. Callers that need team
+/// data call <see cref="Teams.ITeamService"/> and stitch by
 /// <see cref="Humans.Domain.Entities.LegalDocument.TeamId"/>.
 /// </para>
 /// </remarks>
@@ -74,7 +72,7 @@ public interface ILegalDocumentRepository : IRepository
 
     /// <summary>
     /// Returns active, required legal documents for any of the given teams with
-    /// <c>Team</c> and <c>Versions</c> included. Read-only (AsNoTracking).
+    /// <c>Versions</c> included. Read-only (AsNoTracking).
     /// </summary>
     Task<IReadOnlyList<LegalDocument>> GetActiveRequiredDocumentsForTeamsAsync(
         IReadOnlyCollection<Guid> teamIds, CancellationToken ct = default);

--- a/src/Humans.Domain/Entities/BudgetLineItem.cs
+++ b/src/Humans.Domain/Entities/BudgetLineItem.cs
@@ -13,16 +13,6 @@ public class BudgetLineItem
     public string Description { get; set; } = string.Empty;
     public decimal Amount { get; set; }
     public Guid? ResponsibleTeamId { get; set; }
-
-    /// <summary>
-    /// Cross-domain navigation to the responsible team. Do not use — callers
-    /// resolve team slices via <c>ITeamService</c>, keyed off
-    /// <see cref="ResponsibleTeamId"/>. Retained only so EF's configured FK
-    /// constraint stays modelled.
-    /// </summary>
-    [Architecture.ExpiresOn("2026-06-01", reason: "Stream C typed-FK conversion — readers must stitch via ITeamService.")]
-    [Obsolete("Cross-domain nav. Use ResponsibleTeamId + ITeamService to resolve the team.")]
-    public Team? ResponsibleTeam { get; set; }
     public string? Notes { get; set; }
 
     /// <summary>

--- a/src/Humans.Domain/Entities/GoogleResource.cs
+++ b/src/Humans.Domain/Entities/GoogleResource.cs
@@ -39,16 +39,6 @@ public class GoogleResource
     public Guid TeamId { get; set; }
 
     /// <summary>
-    /// Cross-domain navigation to the owning team. Do not use — callers resolve
-    /// team slices via <c>ITeamService</c>, keyed off <see cref="TeamId"/>. Retained
-    /// only so EF's configured relationship keeps the FK constraint (see
-    /// <see cref="Humans.Infrastructure"/> GoogleResourceConfiguration / TeamConfiguration).
-    /// </summary>
-    [Architecture.ExpiresOn("2026-06-01", reason: "Stream C typed-FK conversion — readers must stitch via ITeamService.")]
-    [Obsolete("Cross-domain nav. Use TeamId + ITeamService to resolve the team.")]
-    public Team Team { get; set; } = null!;
-
-    /// <summary>
     /// When the resource was provisioned.
     /// </summary>
     public Instant ProvisionedAt { get; init; }

--- a/src/Humans.Domain/Entities/LegalDocument.cs
+++ b/src/Humans.Domain/Entities/LegalDocument.cs
@@ -25,15 +25,6 @@ public class LegalDocument
     public Guid TeamId { get; set; }
 
     /// <summary>
-    /// Cross-domain navigation to the owning <see cref="Team"/>. Kept so EF's
-    /// snapshot remains in sync with the schema; do not read in application
-    /// code — resolve via <c>ITeamService</c>. See design-rules §6c.
-    /// </summary>
-    [Architecture.ExpiresOn("2026-06-01", reason: "peterdrier#719 — Legal section migrated off LegalDocument.Team. Schedule-for-strip in a follow-up PR once prod-verified.")]
-    [Obsolete("Cross-domain nav — resolve via ITeamService instead of navigating LegalDocument.Team. See design-rules §6c.")]
-    public Team Team { get; set; } = null!;
-
-    /// <summary>
     /// Grace period in days before membership becomes inactive due to missing re-consent.
     /// </summary>
     public int GracePeriodDays { get; set; } = 7;

--- a/src/Humans.Domain/Entities/Team.cs
+++ b/src/Humans.Domain/Entities/Team.cs
@@ -155,15 +155,6 @@ public class Team
     public ICollection<TeamJoinRequest> JoinRequests { get; } = new List<TeamJoinRequest>();
 
     /// <summary>
-    /// Reverse navigation kept solely so EF can declare the FK + cascade behavior
-    /// for <c>LegalDocument.Team</c>. Not read by application code — query via
-    /// <c>ILegalDocumentSyncService</c>. Collection-side nav is left unmarked to
-    /// avoid the obsolete-nav scanner false-positive on <c>DbContext.LegalDocuments</c>
-    /// (same identifier).
-    /// </summary>
-    public ICollection<LegalDocument> LegalDocuments { get; } = new List<LegalDocument>();
-
-    /// <summary>
     /// Navigation property to role definitions.
     /// </summary>
     public ICollection<TeamRoleDefinition> RoleDefinitions { get; } = new List<TeamRoleDefinition>();

--- a/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetLineItemConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetLineItemConfiguration.cs
@@ -27,9 +27,10 @@ public class BudgetLineItemConfiguration : IEntityTypeConfiguration<BudgetLineIt
         builder.Property(l => l.CreatedAt).IsRequired();
         builder.Property(l => l.UpdatedAt).IsRequired();
 
-#pragma warning disable CS0618 // Obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasOne(l => l.ResponsibleTeam).WithMany().HasForeignKey(l => l.ResponsibleTeamId).OnDelete(DeleteBehavior.SetNull);
-#pragma warning restore CS0618
+        builder.HasOne<Team>()
+            .WithMany()
+            .HasForeignKey(l => l.ResponsibleTeamId)
+            .OnDelete(DeleteBehavior.SetNull);
 
         builder.HasIndex(l => new { l.BudgetCategoryId, l.SortOrder });
         builder.HasIndex(l => l.ResponsibleTeamId).HasFilter("\"ResponsibleTeamId\" IS NOT NULL");

--- a/src/Humans.Infrastructure/Data/Configurations/GoogleResourceConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/GoogleResourceConfiguration.cs
@@ -46,5 +46,14 @@ public class GoogleResourceConfiguration : IEntityTypeConfiguration<GoogleResour
         builder.HasIndex(gr => new { gr.TeamId, gr.GoogleId })
             .HasFilter("\"IsActive\" = true")
             .IsUnique();
+
+        // Restrict (not SetNull): GoogleResource.TeamId is non-nullable, so
+        // SetNull would produce a NOT NULL violation on team delete. Teams
+        // should never be hard-deleted if resources exist; callers must unlink
+        // resources first.
+        builder.HasOne<Team>()
+            .WithMany()
+            .HasForeignKey(gr => gr.TeamId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/Humans.Infrastructure/Data/Configurations/Legal/LegalDocumentConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Legal/LegalDocumentConfiguration.cs
@@ -41,12 +41,10 @@ public class LegalDocumentConfiguration : IEntityTypeConfiguration<LegalDocument
         builder.Property(ld => ld.LastSyncedAt)
             .IsRequired();
 
-#pragma warning disable CS0618 // LegalDocument.Team is an obsolete cross-domain nav (peterdrier#719); EF config still references it so the snapshot stays in sync until a follow-up PR strips both.
-        builder.HasOne(ld => ld.Team)
-            .WithMany(t => t.LegalDocuments)
+        builder.HasOne<Team>()
+            .WithMany()
             .HasForeignKey(ld => ld.TeamId)
             .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
 
         builder.HasMany(ld => ld.Versions)
             .WithOne(v => v.LegalDocument)

--- a/src/Humans.Infrastructure/Data/Configurations/Teams/TeamConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Teams/TeamConfiguration.cs
@@ -110,19 +110,6 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
             .HasForeignKey(jr => jr.TeamId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        // google_resources is owned by TeamResourceService. The Team → GoogleResource
-        // navigation was removed to enforce ownership — the relationship is now
-        // configured from the GoogleResource side only via its Team nav property.
-        // Restrict (not SetNull): GoogleResource.TeamId is non-nullable, so SetNull
-        // would produce a NOT NULL violation on team delete. Teams should never be
-        // hard-deleted if resources exist — the caller must unlink resources first.
-#pragma warning disable CS0618 // GoogleResource.Team is an obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasMany<GoogleResource>()
-            .WithOne(gr => gr.Team)
-            .HasForeignKey(gr => gr.TeamId)
-            .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
-
         builder.HasIndex(t => t.Slug)
             .IsUnique();
 

--- a/src/Humans.Infrastructure/Repositories/Legal/LegalDocumentRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Legal/LegalDocumentRepository.cs
@@ -84,8 +84,8 @@ internal sealed class LegalDocumentRepository(IDbContextFactory<HumansDbContext>
         if (teamIds.Count == 0) return [];
 
         await using var ctx = await factory.CreateDbContextAsync(ct);
-        // LegalDocument.Team is a cross-section nav — callers stitch team
-        // names via ITeamService (memory/architecture/no-cross-section-ef-joins.md).
+        // Team is cross-section data; callers stitch team names via
+        // ITeamService (memory/architecture/no-cross-section-ef-joins.md).
         return await ctx.LegalDocuments
             .AsNoTracking()
             .Where(d => d.IsActive && d.IsRequired && teamIds.Contains(d.TeamId))

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -61,16 +61,18 @@ public sealed class ConsentServiceTests : ServiceTestHarness
                 if (teamIds.Count == 0)
                     return (IReadOnlyList<ActiveRequiredLegalDocumentSnapshot>)[];
 
-#pragma warning disable CS0618 // Test stub uses LegalDocument.Team to populate the snapshot's TeamName; production stitches via ITeamService.
+                var teamNamesById = await Db.Teams
+                    .AsNoTracking()
+                    .Where(t => teamIds.Contains(t.Id))
+                    .ToDictionaryAsync(t => t.Id, t => t.Name);
+
                 var documents = await Db.LegalDocuments
                     .AsNoTracking()
                     .Where(d => d.IsActive && d.IsRequired && teamIds.Contains(d.TeamId))
-                    .Include(d => d.Team)
                     .Include(d => d.Versions)
                     .ToListAsync();
 
-                return documents.Select(ToActiveRequiredDocumentSnapshot).ToList();
-#pragma warning restore CS0618
+                return documents.Select(d => ToActiveRequiredDocumentSnapshot(d, teamNamesById)).ToList();
             });
 
         var consentRepository = new ConsentRepository(DbFactory);
@@ -229,13 +231,14 @@ public sealed class ConsentServiceTests : ServiceTestHarness
             userId, SystemTeamType.Coordinators, Arg.Any<CancellationToken>());
     }
 
-#pragma warning disable CS0618 // Test stub mirrors the legacy Include(d => d.Team) read path; prod stitches via ITeamService.
-    private static ActiveRequiredLegalDocumentSnapshot ToActiveRequiredDocumentSnapshot(LegalDocument document) =>
+    private static ActiveRequiredLegalDocumentSnapshot ToActiveRequiredDocumentSnapshot(
+        LegalDocument document,
+        IReadOnlyDictionary<Guid, string> teamNamesById) =>
         new(
             document.Id,
             document.Name,
             document.TeamId,
-            document.Team.Name,
+            teamNamesById.GetValueOrDefault(document.TeamId, string.Empty),
             document.LastSyncedAt,
             document.Versions.Select(v => new LegalDocumentVersionSnapshot(
                 v.Id,
@@ -248,7 +251,6 @@ public sealed class ConsentServiceTests : ServiceTestHarness
                 v.RequiresReConsent,
                 v.CreatedAt,
                 v.ChangesSummary)).ToList());
-#pragma warning restore CS0618
 
     [HumansFact]
     public async Task SubmitConsentAsync_RecordsMetric()


### PR DESCRIPTION
## Summary
- Removes expiring cross-section team navigation properties from BudgetLineItem, LegalDocument, GoogleResource, and the reverse Team.LegalDocuments collection.
- Keeps scalar FK columns and configures EF relationships navigationlessly, preserving the relational model without a migration.
- Updates consent test stubs and docs/comments to stitch team names by TeamId instead of using LegalDocument.Team.

## Verification
- `dotnet build Humans.slnx --no-incremental -v minimal`
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --filter "FullyQualifiedName~ConsentServiceTests" -v minimal`
- `dotnet ef migrations has-pending-model-changes --project src/Humans.Infrastructure --startup-project src/Humans.Web --no-build`

## Notes
- Build warning count drops by the three `HUM0010` deadline warnings; remaining `HUM0024` warnings are separate cross-section relationship debt/analyzer-policy questions.