### PR TITLE
Route ticket email matching through user read model

### DIFF
--- a/src/Humans.Application/DTOs/TicketSyncDtos.cs
+++ b/src/Humans.Application/DTOs/TicketSyncDtos.cs
@@ -4,16 +4,6 @@ using NodaTime;
 namespace Humans.Application.DTOs;
 
 /// <summary>
-/// A single user email entry, shaped for building the
-/// email → userId lookup that <see cref="Humans.Application.Services.Tickets.TicketSyncService"/>
-/// uses to match vendor buyer/attendee emails to users.
-/// Read-only projection owned by <c>ITicketRepository</c>.
-/// Only verified emails are included — unverified emails are not trustworthy
-/// enough to drive ticket-to-user matching (issue nobodies-collective/Humans#645).
-/// </summary>
-public record UserEmailLookupEntry(string Email, Guid UserId);
-
-/// <summary>
 /// An attendee row projected for the event-participation reconciliation pass.
 /// Only includes attendees with a non-null <c>MatchedUserId</c>, scoped to a
 /// single vendor event (matching <see cref="TicketSyncService"/> behavior).

--- a/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
@@ -57,25 +57,6 @@ public interface ITicketRepository : IRepository
     /// </summary>
     Task ResetSyncStateLastSyncAsync(CancellationToken ct = default);
 
-    // ── Email lookup (cross-section projection over user_emails) ─────────────
-
-    /// <summary>
-    /// Returns every row of <c>user_emails</c> projected to the three fields
-    /// needed to build the email → userId lookup. Read-only; ordering is
-    /// unspecified — the service performs grouping and OAuth tie-breaking in
-    /// memory.
-    /// </summary>
-    /// <remarks>
-    /// This projection is narrow (three columns) and non-mutating, so reading
-    /// it from the Tickets repository does not violate table ownership — the
-    /// Profile section's owning service (<c>IUserEmailService</c>) does not
-    /// expose a shape that fits bulk email-matching. If TicketSync ever needs
-    /// to <i>write</i> user-email data, it must go through
-    /// <c>IUserEmailService</c> instead.
-    /// </remarks>
-    Task<IReadOnlyList<UserEmailLookupEntry>> GetAllUserEmailLookupEntriesAsync(
-        CancellationToken ct = default);
-
     // ── TicketOrder reads (all detached / AsNoTracking) ──────────────────────
 
     /// <summary>

--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -29,6 +29,7 @@ public sealed class TicketSyncService(
     IOptions<TicketVendorSettings> settings,
     ILogger<TicketSyncService> logger,
     ITicketCacheInvalidator ticketCache,
+    IUserServiceRead userServiceRead,
     IUserService userService,
     ICampaignService campaignService,
     IShiftManagementService shiftManagementService) : ITicketSyncService, IUserMerge
@@ -195,13 +196,16 @@ public sealed class TicketSyncService(
     private async Task<Dictionary<string, Guid>> BuildEmailLookupAsync(CancellationToken ct)
     {
         // Verified emails only (#645); gmail/googlemail-normalized; verified-collision = LogError, unmatched.
-        var entries = await ticketRepository.GetAllUserEmailLookupEntriesAsync(ct);
+        var users = await userServiceRead.GetAllUserInfosAsync(ct);
+        var entries = users.SelectMany(user => user.UserEmails
+            .Where(email => email.IsVerified)
+            .Select(email => (email.Email, user.Id)));
 
         var lookup = new Dictionary<string, Guid>(NormalizingEmailComparer.Instance);
         var grouped = entries.GroupBy(e => e.Email, NormalizingEmailComparer.Instance);
         foreach (var group in grouped)
         {
-            var distinctUserIds = group.Select(e => e.UserId).Distinct().ToList();
+            var distinctUserIds = group.Select(e => e.Id).Distinct().ToList();
 
             if (distinctUserIds.Count == 1)
             {

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -25,7 +25,6 @@ namespace Humans.Infrastructure.Repositories.Tickets;
 /// and <c>TicketingBudgetRepository</c> (design-rules §15b).
 /// </remarks>
 [Grandfathered("HUM0025", justification: "Tickets-section table also read by TicketingBudgetRepository; route the Budget bridge through ITicketServiceRead.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "TicketOrders")]
-[Grandfathered("HUM0025", justification: "Cross-section read of UserEmails for attendee matching; migrate to an IUserEmailService bulk lookup.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserEmails")]
 internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factory) : ITicketRepository
 {
     // ── TicketSyncState ──────────────────────────────────────────────────────
@@ -62,20 +61,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
         await ctx.SaveChangesAsync(ct);
     }
 
-    // ── User email lookup ────────────────────────────────────────────────────
-
-    public async Task<IReadOnlyList<UserEmailLookupEntry>> GetAllUserEmailLookupEntriesAsync(
-        CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        // Verified-only: an unverified email isn't trustworthy enough to drive
-        // ticket → user matching (issue nobodies-collective/Humans#645).
-        return await ctx.Set<UserEmail>()
-            .AsNoTracking()
-            .Where(ue => ue.IsVerified)
-            .Select(ue => new UserEmailLookupEntry(ue.Email, ue.UserId))
-            .ToListAsync(ct);
-    }
 
     // ── TicketOrder reads (detached) ─────────────────────────────────────────
 

--- a/tests/Humans.Application.Tests/Infrastructure/ServiceTestHarness.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/ServiceTestHarness.cs
@@ -94,6 +94,7 @@ public abstract class ServiceTestHarness : IDisposable
 
         svc.StubGetUserInfoFromContext(Db);
         svc.StubGetUserInfosFromDb(DbOptions);
+        svc.StubGetAllUserInfosFromDb(DbOptions);
 
         return svc;
     }

--- a/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -82,6 +82,32 @@ internal static class UserInfoStubHelpers
     }
 
     /// <summary>
+    /// Stubs GetAllUserInfosAsync to read from the provided DbContext options
+    /// (new context per call, includes UserEmails + Profile slice).
+    /// </summary>
+    public static IUserService StubGetAllUserInfosFromDb(this IUserService userService, DbContextOptions<HumansDbContext> options)
+    {
+        userService
+            .GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                using var db = new HumansDbContext(options);
+                var users = db.Users.AsNoTracking()
+                    .Include(u => u.UserEmails)
+                    .ToList();
+                var userIds = users.Select(u => u.Id).ToList();
+                var profiles = db.Profiles.AsNoTracking()
+                    .Where(p => userIds.Contains(p.UserId))
+                    .ToDictionary(p => p.UserId);
+                IReadOnlyCollection<UserInfo> result = users
+                    .Select(u => u.ToUserInfo(u.UserEmails.ToList(), profiles.GetValueOrDefault(u.Id)))
+                    .ToList();
+                return Task.FromResult(result);
+            });
+        return userService;
+    }
+
+    /// <summary>
     /// Stubs GetUserInfosAsync to read from a long-lived DbContext (uses AsNoTracking but reuses
     /// the same instance — fine for in-memory tests that share one ctx).
     /// </summary>

--- a/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
@@ -138,52 +138,6 @@ public sealed class TicketRepositoryTests : IDisposable
         rows[1].VendorOrderId.Should().Be("ord_new");
     }
 
-    // ── GetAllUserEmailLookupEntriesAsync ────────────────────────────────────
-
-    [HumansFact]
-    public async Task GetAllUserEmailLookupEntriesAsync_ReturnsOnlyVerifiedRows()
-    {
-        var user = new User
-        {
-            Id = Guid.NewGuid(),
-            UserName = "u@x.com",
-            Email = "u@x.com",
-            DisplayName = "U",
-        };
-        _dbContext.Users.Add(user);
-        _dbContext.UserEmails.Add(new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = user.Id,
-            Email = "primary@example.com",
-            Provider = "Google",
-            ProviderKey = "test-primary",
-            IsGoogle = true,
-            IsVerified = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant(),
-        });
-        _dbContext.UserEmails.Add(new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = user.Id,
-            Email = "alt@example.com",
-            IsGoogle = false,
-            IsVerified = false,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant(),
-        });
-        await _dbContext.SaveChangesAsync();
-
-        var entries = await _repo.GetAllUserEmailLookupEntriesAsync();
-
-        // Verified-only: the unverified "alt@example.com" row must NOT be returned
-        // (issue nobodies-collective/Humans#645).
-        entries.Should().HaveCount(1);
-        entries.Should().Contain(e => e.Email == "primary@example.com");
-        entries.Should().NotContain(e => e.Email == "alt@example.com");
-    }
-
     // ── GetMatchedAttendeesForEventAsync ─────────────────────────────────────
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceNullOrderTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceNullOrderTests.cs
@@ -49,7 +49,7 @@ public sealed class TicketSyncServiceNullOrderTests : ServiceTestHarness
         });
 
         _stripeService = Substitute.For<IStripeService>();
-        _userService = Substitute.For<IUserService>();
+        _userService = NewDbBackedUserService();
         _userService.GetAllParticipationsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([]);
         _campaignService = Substitute.For<ICampaignService>();
@@ -66,6 +66,7 @@ public sealed class TicketSyncServiceNullOrderTests : ServiceTestHarness
             settings,
             NullLogger<TicketSyncService>.Instance,
             Substitute.For<ITicketCacheInvalidator>(),
+            _userService,
             _userService,
             _campaignService,
             _shiftManagementService);

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -43,7 +43,7 @@ public sealed class TicketSyncServiceTests : ServiceTestHarness
         });
 
         _stripeService = Substitute.For<IStripeService>();
-        _userService = Substitute.For<IUserService>();
+        _userService = NewDbBackedUserService();
         _userService.GetAllParticipationsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([]);
         _campaignService = Substitute.For<ICampaignService>();
@@ -60,6 +60,7 @@ public sealed class TicketSyncServiceTests : ServiceTestHarness
             settings,
             NullLogger<TicketSyncService>.Instance,
             Substitute.For<ITicketCacheInvalidator>(),
+            _userService,
             _userService,
             _campaignService,
             _shiftManagementService);
@@ -265,6 +266,7 @@ public sealed class TicketSyncServiceTests : ServiceTestHarness
             settings,
             NullLogger<TicketSyncService>.Instance,
             Substitute.For<ITicketCacheInvalidator>(),
+            _userService,
             Substitute.For<IUserService>(),
             Substitute.For<ICampaignService>(),
             Substitute.For<IShiftManagementService>());

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketSyncService_ReassignCacheTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketSyncService_ReassignCacheTests.cs
@@ -55,6 +55,7 @@ public sealed class TicketSyncService_ReassignCacheTests
             Options.Create(new TicketVendorSettings { EventId = "ev_t07", ApiKey = "k", SyncIntervalMinutes = 15 }),
             NullLogger<TicketSyncService>.Instance,
             invalidator,
+            Substitute.For<IUserServiceRead>(),
             Substitute.For<IUserService>(),
             Substitute.For<ICampaignService>(),
             Substitute.For<IShiftManagementService>());


### PR DESCRIPTION
## Summary
- route TicketSyncService verified-email matching through IUserServiceRead/UserInfo
- remove the Tickets repository user_emails projection and HUM0025 grandfathering
- update ticket sync tests to use DB-backed UserInfo read stubs

## Verification
- dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-restore --filter "FullyQualifiedName~TicketSyncService" -v minimal
- dotnet build Humans.slnx --no-incremental -v minimal
- dotnet ef migrations has-pending-model-changes --project src/Humans.Infrastructure --startup-project src/Humans.Web --no-build

## Warning delta
- total unique warnings: 395 -> 394
- HUM0025 unique warnings: 335 -> 334
- removed TicketRepository direct UserEmails access