### PR TITLE
Always show flagged users in the onboarding review queue

### DIFF
--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -32,13 +32,23 @@ public sealed class OnboardingService(
 
     public async Task<ReviewQueueData> GetReviewQueueAsync(CancellationToken ct = default)
     {
-        // Review queue = not approved, not rejected, oldest first.
-        var reviewable = (await userService.GetAllUserInfosAsync(ct).ConfigureAwait(false))
-            .Where(u => u.NeedsConsentReview)
+        // Invariant: anyone with ConsentCheckStatus.Flagged must appear in the queue so a CC can
+        // resolve them — even if a prior admin override flipped IsApproved=true or the profile was
+        // later rejected. Pending list keeps the original NeedsConsentReview gate.
+        var all = await userService.GetAllUserInfosAsync(ct).ConfigureAwait(false);
+
+        var flagged = all
+            .Where(u => u.Profile?.ConsentCheckStatus == ConsentCheckStatus.Flagged)
             .OrderBy(u => u.Profile!.CreatedAt)
             .ToList();
 
-        var allUserIds = reviewable.Select(u => u.Id).ToList();
+        var pending = all
+            .Where(u => u.NeedsConsentReview
+                && u.Profile!.ConsentCheckStatus != ConsentCheckStatus.Flagged)
+            .OrderBy(u => u.Profile!.CreatedAt)
+            .ToList();
+
+        var allUserIds = flagged.Concat(pending).Select(u => u.Id).ToList();
         var pendingAppUserIds = await applicationDecisionService
             .GetUserIdsWithPendingApplicationAsync(allUserIds, ct);
 
@@ -50,11 +60,6 @@ public sealed class OnboardingService(
                 snapshot.RequiredConsentCount - snapshot.PendingConsentCount,
                 snapshot.RequiredConsentCount);
         }
-
-        var flagged = reviewable
-            .Where(u => u.Profile!.ConsentCheckStatus == ConsentCheckStatus.Flagged)
-            .ToList();
-        var pending = reviewable.Except(flagged).ToList();
 
         // ReviewQueueData types PendingAppUserIds as HashSet<Guid>; Governance returns IReadOnlySet.
         var pendingAppHashSet = pendingAppUserIds.ToHashSet();

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -32,19 +32,19 @@ public sealed class OnboardingService(
 
     public async Task<ReviewQueueData> GetReviewQueueAsync(CancellationToken ct = default)
     {
-        // Invariant: anyone with ConsentCheckStatus.Flagged must appear in the queue so a CC can
-        // resolve them — even if a prior admin override flipped IsApproved=true or the profile was
-        // later rejected. Pending list keeps the original NeedsConsentReview gate.
+        // Invariant: anyone with an unresolved Flagged consent check must appear in the queue so a
+        // CC can resolve them — even if a prior admin override flipped IsApproved=true. Rejected
+        // profiles are excluded (see UserInfo.IsConsentCheckFlagged): Clear is blocked on them and
+        // the row would otherwise be unresolvable. Pending list keeps the NeedsConsentReview gate.
         var all = await userService.GetAllUserInfosAsync(ct).ConfigureAwait(false);
 
         var flagged = all
-            .Where(u => u.Profile?.ConsentCheckStatus == ConsentCheckStatus.Flagged)
+            .Where(u => u.IsConsentCheckFlagged)
             .OrderBy(u => u.Profile!.CreatedAt)
             .ToList();
 
         var pending = all
-            .Where(u => u.NeedsConsentReview
-                && u.Profile!.ConsentCheckStatus != ConsentCheckStatus.Flagged)
+            .Where(u => u.NeedsConsentReview && !u.IsConsentCheckFlagged)
             .OrderBy(u => u.Profile!.CreatedAt)
             .ToList();
 

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -303,6 +303,15 @@ public sealed record UserInfo(
     public bool NeedsConsentReview =>
         IsActive && HasRequiredNameFields && !Profile!.IsApproved;
 
+    /// <summary>
+    /// Carries an unresolved Flagged consent check. Excludes rejected profiles — those have already
+    /// been dealt with and the Clear mutation is blocked, so they'd be unresolvable in the queue.
+    /// Drives the /OnboardingReview flagged section.
+    /// </summary>
+    public bool IsConsentCheckFlagged =>
+        Profile?.ConsentCheckStatus == ConsentCheckStatus.Flagged
+        && Profile.RejectedAt is null;
+
     /// <summary>Builds <see cref="UserInfo"/> from the 8 contributing tables; snapshotting + ordering happen here so the cached payload is immutable.</summary>
     public static UserInfo Create(
         User user,

--- a/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
@@ -156,9 +156,8 @@ public sealed class OnboardingServiceTests
     [HumansFact]
     public async Task GetReviewQueueAsync_FlaggedUserAlreadyApproved_StillAppearsInFlagged()
     {
-        // Invariant: anyone with ConsentCheckStatus.Flagged must appear in the review queue,
-        // so a Consent Coordinator can resolve them — even if a prior admin override flipped
-        // IsApproved=true while the flag was still on the profile.
+        // Invariant: anyone with an unresolved Flagged consent check must appear in the review
+        // queue so a CC can resolve them — even if a prior admin override flipped IsApproved=true.
         var approvedFlaggedId = Guid.NewGuid();
         var now = Instant.FromUnixTimeSeconds(1);
         var approvedFlaggedProfile = new Profile
@@ -175,9 +174,49 @@ public sealed class OnboardingServiceTests
             UpdatedAt = now,
         };
 
+        StubReviewQueueDependencies(
+            [UserInfoStubHelpers.MakeUserInfo(approvedFlaggedId, approvedFlaggedProfile)]);
+
+        var data = await BuildSut().GetReviewQueueAsync();
+
+        data.Flagged.Should().ContainSingle(u => u.Id == approvedFlaggedId);
+        data.Pending.Should().NotContain(u => u.Id == approvedFlaggedId);
+    }
+
+    [HumansFact]
+    public async Task GetReviewQueueAsync_FlaggedUserAlreadyRejected_IsExcluded()
+    {
+        // Rejected profiles have already been dealt with — Clear is blocked with AlreadyRejected,
+        // so a flagged+rejected row would be unresolvable from the queue UI. Exclude them.
+        var rejectedFlaggedId = Guid.NewGuid();
+        var now = Instant.FromUnixTimeSeconds(1);
+        var rejectedFlaggedProfile = new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = rejectedFlaggedId,
+            BurnerName = "Burner",
+            FirstName = "Flagged",
+            LastName = "Rejected",
+            State = ProfileState.Active,
+            ConsentCheckStatus = ConsentCheckStatus.Flagged,
+            RejectedAt = now,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        StubReviewQueueDependencies(
+            [UserInfoStubHelpers.MakeUserInfo(rejectedFlaggedId, rejectedFlaggedProfile)]);
+
+        var data = await BuildSut().GetReviewQueueAsync();
+
+        data.Flagged.Should().NotContain(u => u.Id == rejectedFlaggedId);
+        data.Pending.Should().NotContain(u => u.Id == rejectedFlaggedId);
+    }
+
+    private void StubReviewQueueDependencies(IReadOnlyCollection<UserInfo> users)
+    {
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>(
-                [UserInfoStubHelpers.MakeUserInfo(approvedFlaggedId, approvedFlaggedProfile)]));
+            .Returns(Task.FromResult(users));
         _applicationDecisionService.GetUserIdsWithPendingApplicationAsync(
                 Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlySet<Guid>>(new HashSet<Guid>()));
@@ -188,10 +227,5 @@ public sealed class OnboardingServiceTests
                 RequiredConsentCount: 0,
                 PendingConsentCount: 0,
                 MissingConsentVersionIds: []));
-
-        var data = await BuildSut().GetReviewQueueAsync();
-
-        data.Flagged.Should().ContainSingle(u => u.Id == approvedFlaggedId);
-        data.Pending.Should().NotContain(u => u.Id == approvedFlaggedId);
     }
 }

--- a/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
@@ -150,5 +151,47 @@ public sealed class OnboardingServiceTests
             Arg.Is<UserProfileOnboardingCommand>(cmd =>
                 cmd.Mutation == UserProfileOnboardingMutation.SetConsentCheckPending),
             Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetReviewQueueAsync_FlaggedUserAlreadyApproved_StillAppearsInFlagged()
+    {
+        // Invariant: anyone with ConsentCheckStatus.Flagged must appear in the review queue,
+        // so a Consent Coordinator can resolve them — even if a prior admin override flipped
+        // IsApproved=true while the flag was still on the profile.
+        var approvedFlaggedId = Guid.NewGuid();
+        var now = Instant.FromUnixTimeSeconds(1);
+        var approvedFlaggedProfile = new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = approvedFlaggedId,
+            BurnerName = "Burner",
+            FirstName = "Flagged",
+            LastName = "Approved",
+            State = ProfileState.Active,
+            ConsentCheckStatus = ConsentCheckStatus.Flagged,
+            IsApproved = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>(
+                [UserInfoStubHelpers.MakeUserInfo(approvedFlaggedId, approvedFlaggedProfile)]));
+        _applicationDecisionService.GetUserIdsWithPendingApplicationAsync(
+                Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlySet<Guid>>(new HashSet<Guid>()));
+        _membershipCalculator.GetMembershipSnapshotAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new MembershipSnapshot(
+                Status: Humans.Domain.Enums.MembershipStatus.Pending,
+                IsVolunteerMember: false,
+                RequiredConsentCount: 0,
+                PendingConsentCount: 0,
+                MissingConsentVersionIds: []));
+
+        var data = await BuildSut().GetReviewQueueAsync();
+
+        data.Flagged.Should().ContainSingle(u => u.Id == approvedFlaggedId);
+        data.Pending.Should().NotContain(u => u.Id == approvedFlaggedId);
     }
 }


### PR DESCRIPTION
## Summary

In production, a user with `ConsentCheckStatus = Flagged` on their profile didn't appear in the `/OnboardingReview` Flagged section. Root cause: the queue was gating flagged users behind `UserInfo.NeedsConsentReview`, which is `IsActive && HasRequiredNameFields && !IsApproved`. Once an admin used `POST /Profile/{id}/Admin/Approve` (which sets `IsApproved = true` without touching `ConsentCheckStatus`), the flagged profile silently dropped out of the queue with no UI path left to resolve the flag.

Invariant established: **anyone with `ConsentCheckStatus.Flagged` must appear on `/OnboardingReview`, so a Consent Coordinator can resolve them — regardless of other profile state.**

Pending list still uses the original `NeedsConsentReview` gate (minus anyone who's flagged, to avoid double-listing).

## Test plan

- [x] New unit test `GetReviewQueueAsync_FlaggedUserAlreadyApproved_StillAppearsInFlagged` covers the bug case (flagged + `IsApproved=true`) — fails before the fix, passes after.
- [x] Existing `OnboardingServiceTests` still pass.
- [x] Full `Humans.Application.Tests` suite passes (3209/3210, 1 pre-existing skip).
- [ ] Integration tests require Docker (not running locally) — will run in CI.
- [ ] Verify in preview env: the originally-affected user now appears in `/OnboardingReview` Flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)