### PR TITLE
Refresh UserEmail HUM0025 grandfathering

### DIFF
--- a/src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs
@@ -10,7 +10,7 @@ using Humans.Infrastructure.Data;
 namespace Humans.Infrastructure.Repositories.Profiles;
 
 /// <summary>EF-backed <see cref="IUserEmailRepository"/>.</summary>
-[Grandfathered("HUM0025", justification: "UserEmails is also accessed by UserRepository and TicketRepository; converge on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserEmails")]
+[Grandfathered("HUM0025", justification: "UserEmails is also accessed by UserRepository to build UserInfo; converge analyzer ownership on the read model boundary.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserEmails")]
 [Grandfathered("HUM0025", justification: "Audited Users.GoogleEmail/GoogleEmailStatus/Email bridge write; route through IUserService.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "Users")]
 internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> factory) : IUserEmailRepository
 {


### PR DESCRIPTION
## Summary
- update UserEmailRepository's HUM0025 grandfathering note after TicketRepository stopped reading UserEmails
- clarify that the remaining overlap is UserRepository building the UserInfo read model

## Verification
- dotnet build src/Humans.Infrastructure/Humans.Infrastructure.csproj -v minimal