### PR TITLE
Move Cantina roster link from top nav to Admin sidebar

### DIFF
--- a/docs/sections/Cantina.md
+++ b/docs/sections/Cantina.md
@@ -45,7 +45,7 @@ None — Cantina owns no tables. The section is a pure read/aggregate compositio
 | Actor | Capabilities |
 |-------|--------------|
 | Admin, CantinaAdmin | View weekly/daily roster and download CSV |
-| All other authenticated humans | **HTTP 403** on the routes; CANTINA nav link is hidden |
+| All other authenticated humans | **HTTP 403** on the routes; Cantina admin sidebar entry is hidden |
 | Anonymous | Standard `[Authorize]` challenge — redirected to sign-in |
 
 `CantinaAdmin` is a grantable role (the permissions page surfaces it via `RoleNames.All`), aligned with the other per-area `<Area>AdminOrAdmin` policies. There is no team-name-based access path.
@@ -62,7 +62,7 @@ None — Cantina owns no tables. The section is a pure read/aggregate compositio
 
 ## Negative Access Rules
 
-- Pre-volunteer humans (Guest dashboard, profile not yet active) **cannot** see the CANTINA nav link — the link is gated by the same `CantinaAdminOrAdmin` policy used by the controller (`authorize-policy="CantinaAdminOrAdmin"` in `_Layout`).
+- Pre-volunteer humans (Guest dashboard, profile not yet active) **cannot** see the Cantina admin sidebar entry — it lives under the `Cantina` group in `AdminNavTree` and is gated by the same `CantinaAdminOrAdmin` policy used by the controller. The entry is reachable only via the Admin shell (`/Admin/*`); there is no member-shell top-nav link.
 - Any human (including Cantina-team members and Cantina coordinators) **cannot** see another human's `MedicalConditions` through this section — the field is not in the DTO and not in the view. The only surface for medical data remains `_VolunteerProfileBadges` with `ShowMedical=true` (NoInfoAdmin / Admin only).
 - Authenticated humans who fail the access gate **cannot** read the roster or download the CSV — both routes return HTTP 403 (`Forbid()`), not a redirect.
 - Team coordinators and Cantina-team members **cannot** see the roster on that basis alone — access requires the `Admin` or `CantinaAdmin` role. Team membership grants nothing here.

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -5825,7 +5825,6 @@
   <data name="Cantina_Matrix_OtherIntolerance" xml:space="preserve"><value>Other intolerance</value></data>
   <data name="Cantina_Matrix_OtherIntoleranceText" xml:space="preserve"><value>Other intolerance text</value></data>
   <data name="Cantina_Matrix_Totals" xml:space="preserve"><value>TOTALS</value></data>
-  <data name="Nav_Cantina" xml:space="preserve"><value>Cantina</value></data>
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -5825,7 +5825,6 @@
   <data name="Cantina_Matrix_OtherIntolerance" xml:space="preserve"><value>Other intolerance</value></data>
   <data name="Cantina_Matrix_OtherIntoleranceText" xml:space="preserve"><value>Other intolerance text</value></data>
   <data name="Cantina_Matrix_Totals" xml:space="preserve"><value>TOTALS</value></data>
-  <data name="Nav_Cantina" xml:space="preserve"><value>Cantina</value></data>
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -5851,7 +5851,6 @@
   <data name="Cantina_Matrix_OtherIntolerance" xml:space="preserve"><value>Otra intolerancia</value></data>
   <data name="Cantina_Matrix_OtherIntoleranceText" xml:space="preserve"><value>Texto de otra intolerancia</value></data>
   <data name="Cantina_Matrix_Totals" xml:space="preserve"><value>TOTALES</value></data>
-  <data name="Nav_Cantina" xml:space="preserve"><value>Cantina</value></data>
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Primero cuéntanos tus necesidades alimentarias.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Un momento — necesitamos tu información alimentaria antes de apuntarte a este turno.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Opcional</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -5825,7 +5825,6 @@
   <data name="Cantina_Matrix_OtherIntolerance" xml:space="preserve"><value>Other intolerance</value></data>
   <data name="Cantina_Matrix_OtherIntoleranceText" xml:space="preserve"><value>Other intolerance text</value></data>
   <data name="Cantina_Matrix_Totals" xml:space="preserve"><value>TOTALS</value></data>
-  <data name="Nav_Cantina" xml:space="preserve"><value>Cantina</value></data>
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -5825,7 +5825,6 @@
   <data name="Cantina_Matrix_OtherIntolerance" xml:space="preserve"><value>Other intolerance</value></data>
   <data name="Cantina_Matrix_OtherIntoleranceText" xml:space="preserve"><value>Other intolerance text</value></data>
   <data name="Cantina_Matrix_Totals" xml:space="preserve"><value>TOTALS</value></data>
-  <data name="Nav_Cantina" xml:space="preserve"><value>Cantina</value></data>
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2414,7 +2414,6 @@
   <data name="Cantina_Matrix_OtherIntolerance" xml:space="preserve"><value>Other intolerance</value></data>
   <data name="Cantina_Matrix_OtherIntoleranceText" xml:space="preserve"><value>Other intolerance text</value></data>
   <data name="Cantina_Matrix_Totals" xml:space="preserve"><value>TOTALS</value></data>
-  <data name="Nav_Cantina" xml:space="preserve"><value>Cantina</value></data>
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -29,6 +29,9 @@ public static class AdminNavTree
             new("Workload",  "ShiftWorkloadAdmin", "Index",   null, null, "fa-solid fa-scale-unbalanced", PolicyNames.ShiftDashboardAccess),
             new("Early entry", "EarlyEntryRoster", "Index", null, null, "fa-solid fa-door-open",       PolicyNames.ShiftDashboardAccess)
         ]),
+        new("Cantina", [
+            new("Roster", "Cantina", "Roster", null, null, "fa-solid fa-utensils", PolicyNames.CantinaAdminOrAdmin)
+        ]),
         new("Money", [
             new("Finance",        "Finance",      "Index",   null, null, "fa-solid fa-coins",        PolicyNames.FinanceAdminOrAdmin),
             new("Store catalog",  "StoreAdmin",   "Catalog", null, null, "fa-solid fa-tags",         PolicyNames.StoreCatalogAdmin),

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -139,9 +139,6 @@
                         <li class="nav-item" authorize-policy="IsActiveMember">
                             <a class="nav-link" asp-area="" asp-controller="Budget" asp-action="Summary">Budget</a>
                         </li>
-                        <li class="nav-item" authorize-policy="CantinaAdminOrAdmin">
-                            <a class="nav-link" asp-area="" asp-controller="Cantina" asp-action="Roster">@Localizer["Nav_Cantina"]</a>
-                        </li>
                         <li class="nav-item" authorize-policy="AnyAdminRole">
                             <a class="nav-link nav-restricted" asp-area="" asp-controller="Admin" asp-action="Index">@Localizer["Nav_Admin"]</a>
                         </li>


### PR DESCRIPTION
## Summary

- `/Cantina/Roster` is gated by `CantinaAdminOrAdmin` (Admin or grantable `CantinaAdmin` role) — it's an admin surface, not a member surface, so it belongs in the Admin sidebar alongside the other per-area admin entries.
- Removes the top-nav entry in `_Layout.cshtml` and adds a new `Cantina` group with a `Roster` entry to `AdminNavTree`.
- Drops the now-unused `Nav_Cantina` resource key from all 7 locale `.resx` files.
- Updates `docs/sections/Cantina.md` so the access description references the Admin sidebar instead of `_Layout`.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx --filter "AdminSidebar|Cantina"` — all green
- [ ] Visit `/Admin` as an Admin/CantinaAdmin user — confirm new `Cantina` group with `Roster` entry appears
- [ ] Visit `/` as the same user — confirm the old top-nav `Cantina` link is gone
- [ ] Visit `/Cantina/Roster` directly — confirm it still renders (controller policy unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)