### PR TITLE
Consolidate Camps repositories

### DIFF
--- a/docs/architecture/service-data-access-map.md
+++ b/docs/architecture/service-data-access-map.md
@@ -637,7 +637,7 @@ Folder: `src/Humans.Application/Services/Camps/`. Owns `Camps`,
 
 ### CampService (Scoped — wrapped by CachingCampService Singleton decorator)
 
-Repositories: `ICampRepository`, `ICampRoleRepository`.
+Repository: `ICampRepository`.
 
 | Table | R/W |
 |-------|-----|
@@ -673,7 +673,7 @@ Implements `ICampService`, `ICampServiceRead`, `IUserMerge`,
 
 ### CampRoleService (Scoped)
 
-Repository: `ICampRoleRepository`.
+Repository: `ICampRepository`.
 
 | Table | R/W |
 |-------|-----|

--- a/docs/sections/Camps.md
+++ b/docs/sections/Camps.md
@@ -10,7 +10,7 @@
   src/Humans.Infrastructure/Data/Configurations/Camps/**
   src/Humans.Infrastructure/Data/Configurations/Camps/CampMemberConfiguration.cs
   src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
-  src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs
+  src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs
   src/Humans.Web/Controllers/CampController.cs
   src/Humans.Web/Controllers/CampAdminController.cs
   src/Humans.Web/Controllers/CampApiController.cs
@@ -290,7 +290,7 @@ Admin pages live under `/Camps/Admin/*` — never `/Admin/Camps/*` (per `docs/ar
 - Filesystem I/O for camp images is abstracted behind the shared `IFileStorage` abstraction (Application interface + `FileSystemFileStorage` implementation in `Humans.Infrastructure`, rooted at `wwwroot/`); the service never touches `System.IO`.
 - **Cross-domain navs stripped:** `CampLead.User` (issue nobodies-collective/Humans#542) — consumers route through `IUserService.GetByIdsAsync(...)`.
 - `CampContactService` has no owned DB tables and does not inject `HumansDbContext`; it retains its `IMemoryCache` rate-limit usage since that's a request-acceleration cache, not canonical domain data.
-- `CampRoleService` lives in `Humans.Application.Services.Camps.CampRoleService` and goes through `ICampRoleRepository` (`Humans.Application.Interfaces.Repositories`) for all data access. It owns `camp_role_definitions` and `camp_role_assignments` and never imports `Microsoft.EntityFrameworkCore`. Display-name stitching for `AssignedByUserId` routes through `IUserService.GetByIdsAsync`. Plain pass-through (no caching decorator); add `IMemoryCache` later if list-of-definitions reads dominate.
+- `CampRoleService` lives in `Humans.Application.Services.Camps.CampRoleService` and goes through `ICampRepository` (`Humans.Application.Interfaces.Repositories`) for all data access. The role-heavy methods are grouped in `CampRepository.Roles.cs`; `CampRepository` owns `camp_role_definitions` and `camp_role_assignments` alongside the rest of the Camps tables and never imports `Microsoft.EntityFrameworkCore` into Application. Display-name stitching for `AssignedByUserId` routes through `IUserService.GetByIdsAsync`. Plain pass-through (no caching decorator); add `IMemoryCache` later if list-of-definitions reads dominate.
 - **Architecture test** — `tests/Humans.Application.Tests/Architecture/CampsArchitectureTests.cs`.
 - **Read/write interface split.** `ICampServiceRead` (5 methods: GetCampsForYearAsync, GetCampBySlugAsync, GetCampSeasonByIdAsync, GetSettingsAsync, SearchAsync) is the cross-section read surface — returns only CampInfo-family projections (CampInfo with computed `Active`, CampSeasonInfo), CampSettingsInfo, CampSearchHit; no EF entities. `ICampService : ICampServiceRead` adds writes, cache invalidation, per-user/lead/membership reads, and Camps-internal reads. External sections inject `ICampServiceRead`. CampLookup/CampSeasonLookup were folded into CampInfo/CampSeasonInfo. See `memory/architecture/section-read-write-split.md`.
 

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.Roles.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.Roles.cs
@@ -1,14 +1,11 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
-using Humans.Domain.Attributes;
 
 namespace Humans.Application.Interfaces.Repositories;
 
 /// <summary>
-/// Repository for the camp-roles aggregate: <c>camp_role_definitions</c> and
-/// <c>camp_role_assignments</c>. The only non-test file that touches those
-/// DbSets after the AddCampRoles migration lands.
+/// Camp role operations on <see cref="ICampRepository"/>.
 /// </summary>
 /// <remarks>
 /// Reads are <c>AsNoTracking</c>. Mutating methods load tracked entities and
@@ -17,8 +14,7 @@ namespace Humans.Application.Interfaces.Repositories;
 /// context. Cross-domain navigation is not resolved here; the application
 /// service stitches display names from <see cref="Users.IUserService"/>.
 /// </remarks>
-[Section("Camps")]
-public interface ICampRoleRepository : IRepository
+public partial interface ICampRepository
 {
     // Definitions
 

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -7,9 +7,9 @@ namespace Humans.Application.Interfaces.Repositories;
 
 /// <summary>
 /// Repository for the camps aggregate: <c>camps</c>, <c>camp_seasons</c>,
-/// <c>camp_leads</c>, <c>camp_images</c>, <c>camp_historical_names</c>, and
-/// <c>camp_settings</c>. The only non-test file that touches those DbSets
-/// after the Camps migration lands.
+/// <c>camp_members</c>, <c>camp_role_definitions</c>,
+/// <c>camp_role_assignments</c>, <c>camp_leads</c>, <c>camp_images</c>,
+/// <c>camp_historical_names</c>, and <c>camp_settings</c>.
 /// </summary>
 /// <remarks>
 /// Reads are <c>AsNoTracking</c>. Mutating methods load tracked entities and
@@ -21,7 +21,7 @@ namespace Humans.Application.Interfaces.Repositories;
 /// <see cref="Users.IUserService"/> per design-rules §6.
 /// </remarks>
 [Section("Camps")]
-public interface ICampRepository : IRepository
+public partial interface ICampRepository : IRepository
 {
     // ==========================================================================
     // Reads — Camp

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -15,8 +15,7 @@ using NodaTime;
 namespace Humans.Application.Services.Camps;
 
 public sealed class CampRoleService(
-    ICampRoleRepository repo,
-    ICampRepository campRepo,
+    ICampRepository repo,
     ICampService campService,
     IUserServiceRead userService,
     IUserEmailService userEmailService,
@@ -427,7 +426,7 @@ public sealed class CampRoleService(
         // (2) Walk legacy camp_leads → CampRoleAssignment against Camp Lead role.
         if (campLead is null)
             throw new InvalidOperationException("Camp Lead special role definition is missing after seed.");
-        var leadSnapshots = await campRepo.GetLeadMigrationSnapshotsAsync(ct);
+        var leadSnapshots = await repo.GetLeadMigrationSnapshotsAsync(ct);
         var leadsMigrated = 0;
         var leadsAlreadyMigrated = 0;
         var skippedCampSlugs = new List<string>();
@@ -437,7 +436,7 @@ public sealed class CampRoleService(
             ct.ThrowIfCancellationRequested();
 
             // Pick a target season for the migration.
-            var seasonId = await campRepo.GetCampSeasonForLeadMigrationAsync(lead.CampId, ct);
+            var seasonId = await repo.GetCampSeasonForLeadMigrationAsync(lead.CampId, ct);
             if (seasonId is null)
             {
                 logger.LogWarning(

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -23,7 +23,6 @@ namespace Humans.Application.Services.Camps;
 public sealed class CampService : ICampService, IUserDataContributor, IUserMerge, IEarlyEntryProvider
 {
     private readonly ICampRepository _repo;
-    private readonly ICampRoleRepository _roleRepo;
     private readonly IUserServiceRead _userService;
     private readonly IAuditLogService _auditLog;
     private readonly ISystemTeamSync _systemTeamSync;
@@ -42,7 +41,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
 
     public CampService(
         ICampRepository repo,
-        ICampRoleRepository roleRepo,
         IUserServiceRead userService,
         IAuditLogService auditLog,
         ISystemTeamSync systemTeamSync,
@@ -55,7 +53,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         ILogger<CampService> logger)
     {
         _repo = repo;
-        _roleRepo = roleRepo;
         _userService = userService;
         _auditLog = auditLog;
         _systemTeamSync = systemTeamSync;
@@ -119,7 +116,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             ConfirmedByUserId = createdByUserId,
         };
 
-        var leadDef = await _roleRepo.GetSpecialDefinitionAsync(CampSpecialRole.Lead, cancellationToken);
+        var leadDef = await _repo.GetSpecialDefinitionAsync(CampSpecialRole.Lead, cancellationToken);
         CampRoleAssignment? leadAssignment = null;
         if (leadDef is not null)
         {
@@ -281,7 +278,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         IReadOnlyList<Camp> leadCamps = [];
         if (userId.HasValue)
         {
-            var leadCampIdList = await _roleRepo.GetCampIdsBySpecialRolesForUserAsync(
+            var leadCampIdList = await _repo.GetCampIdsBySpecialRolesForUserAsync(
                 userId.Value, LeadOnly, cancellationToken);
             leadCampIds = leadCampIdList.ToHashSet();
             // Re-derive from the already-loaded year camps (avoids a second camp load);
@@ -1083,7 +1080,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
     public Task<Guid?> GetCampLeadSeasonIdForYearAsync(
         Guid userId, int year, CancellationToken cancellationToken = default) =>
         // Source of truth: CampRoleAssignment against the Camp Lead special role.
-        _roleRepo.GetCampSpecialRoleSeasonIdForYearAsync(
+        _repo.GetCampSpecialRoleSeasonIdForYearAsync(
             userId, year, CampSpecialRole.Lead, cancellationToken);
 
     // --- Authorization checks ---
@@ -1095,13 +1092,13 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
     public Task<bool> IsUserCampLeadAsync(
         Guid userId, Guid campId, CancellationToken cancellationToken = default) =>
         // Source of truth: CampRoleAssignment against the Camp Lead special role.
-        _roleRepo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOnly, cancellationToken);
+        _repo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOnly, cancellationToken);
 
     public async Task<IReadOnlyList<CampInfo>> GetEventManagedCampsAsync(
         Guid userId, int year, CancellationToken cancellationToken = default)
     {
         // Role-based: camps where the user holds Lead or Workshop for any season.
-        var roleCampIds = await _roleRepo.GetCampIdsBySpecialRolesForUserAsync(
+        var roleCampIds = await _repo.GetCampIdsBySpecialRolesForUserAsync(
             userId, LeadOrWorkshop, cancellationToken);
 
         var allCampIds = roleCampIds.ToHashSet();
@@ -1121,7 +1118,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         // Authorizes camp-event submission (EventsController). Lead OR Workshop on
         // the camp's current season. Camp leads inherit Workshop power because the
         // role set is the OR — no separate "lead-implies-workshop" logic.
-        _roleRepo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOrWorkshop, cancellationToken);
+        _repo.IsUserSpecialRoleHolderForCampAsync(userId, campId, LeadOrWorkshop, cancellationToken);
 
     public async Task<CampMemberLookup?> GetCampMemberStatusAsync(Guid campMemberId, CancellationToken cancellationToken = default)
     {
@@ -1359,7 +1356,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         var leadUserIds = new HashSet<Guid>();
         foreach (var season in camp.Seasons)
         {
-            foreach (var leadUserId in await _roleRepo.GetSpecialRoleHolderUserIdsForSeasonAsync(
+            foreach (var leadUserId in await _repo.GetSpecialRoleHolderUserIdsForSeasonAsync(
                 season.Id, CampSpecialRole.Lead, cancellationToken))
             {
                 leadUserIds.Add(leadUserId);
@@ -1739,7 +1736,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
         Guid userId, CancellationToken cancellationToken = default) =>
         // Source of truth: pending-membership count over camps where the user
         // holds the Camp Lead special role.
-        _roleRepo.CountPendingMembershipsForSpecialRoleHolderAsync(
+        _repo.CountPendingMembershipsForSpecialRoleHolderAsync(
             userId, CampSpecialRole.Lead, cancellationToken);
 
     public async Task<IReadOnlyList<CampMembershipSummary>> GetCampMembershipsForUserAsync(
@@ -1767,7 +1764,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
     {
         // AccountMergeService.AcceptAsync wraps the save in its TransactionScope.
         // Camp Lead is a CampRoleAssignment now, so the role-side reassignment moves leads too.
-        await _roleRepo.ReassignAssignmentsToUserAsync(sourceUserId, targetUserId, updatedAt, ct);
+        await _repo.ReassignAssignmentsToUserAsync(sourceUserId, targetUserId, updatedAt, ct);
 
         // Lead moves change Barrio Leads team membership + lead-badge cache for both users.
         await _systemTeamSync.SyncMembershipForUserAsync(sourceUserId, SystemTeamType.BarrioLeads, ct);
@@ -1792,7 +1789,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             LeftAt = cl.LeftAt.ToInvariantInstantString()
         }).ToList();
 
-        var roleAssignments = await _roleRepo.GetAllAssignmentsForUserAsync(userId, ct);
+        var roleAssignments = await _repo.GetAllAssignmentsForUserAsync(userId, ct);
 
         var shapedRoles = roleAssignments.Select(a => new
         {

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs
@@ -1,4 +1,3 @@
-using Humans.Application.Architecture;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -8,13 +7,11 @@ using NodaTime;
 
 namespace Humans.Infrastructure.Repositories.Camps;
 
-[Grandfathered("HUM0025", justification: "Camps-section table also accessed by CampRepository; converge the Camps repositories on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "CampMembers")]
-[Grandfathered("HUM0025", justification: "Camps-section table also accessed by CampRepository; converge the Camps repositories on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "CampRoleAssignments")]
-internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> factory) : ICampRoleRepository
+internal sealed partial class CampRepository
 {
     public async Task<IReadOnlyList<CampRoleDefinition>> ListDefinitionsAsync(bool includeDeactivated, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var query = ctx.CampRoleDefinitions.AsNoTracking().AsQueryable();
         if (!includeDeactivated)
             query = query.Where(d => d.DeactivatedAt == null);
@@ -23,13 +20,13 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<CampRoleDefinition?> GetDefinitionByIdAsync(Guid id, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleDefinitions.AsNoTracking().FirstOrDefaultAsync(d => d.Id == id, ct);
     }
 
     public async Task<CampRoleDefinition?> GetDefinitionBySlugAsync(string slug, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var lowered = slug.ToLowerInvariant();
         return await ctx.CampRoleDefinitions.AsNoTracking()
 #pragma warning disable MA0011 // EF LINQ: ToLower() translates to SQL lower()
@@ -41,14 +38,14 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     {
         if (specialRole == CampSpecialRole.None)
             throw new ArgumentException("CampSpecialRole.None has no special definition.", nameof(specialRole));
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleDefinitions.AsNoTracking()
             .FirstOrDefaultAsync(d => d.SpecialRole == specialRole, ct);
     }
 
     public async Task<IReadOnlyList<CampSpecialRole>> GetExistingSpecialRolesAsync(CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleDefinitions.AsNoTracking()
             .Where(d => d.SpecialRole != CampSpecialRole.None)
             .Select(d => d.SpecialRole)
@@ -61,7 +58,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     {
         if (specialRoles.Count == 0) return false;
         var roleList = specialRoles.ToList();
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .AnyAsync(a => a.CampMember.UserId == userId
                 && a.CampSeason.CampId == campId
@@ -74,7 +71,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     {
         if (specialRoles.Count == 0) return [];
         var roleList = specialRoles.ToList();
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Where(a => a.CampMember.UserId == userId
                 && roleList.Contains(a.Definition.SpecialRole)
@@ -87,7 +84,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<Guid?> GetCampSpecialRoleSeasonIdForYearAsync(
         Guid userId, int year, CampSpecialRole specialRole, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Where(a => a.CampMember.UserId == userId
                 && a.CampSeason.Year == year
@@ -101,7 +98,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<int> CountPendingMembershipsForSpecialRoleHolderAsync(
         Guid userId, CampSpecialRole specialRole, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         // Camps where the user holds the given special role on any active season.
         var leadCampIds = ctx.CampRoleAssignments.AsNoTracking()
             .Where(a => a.CampMember.UserId == userId
@@ -121,7 +118,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<IReadOnlyList<Guid>> GetSpecialRoleHolderUserIdsAsync(
         CampSpecialRole specialRole, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Where(a => a.Definition.SpecialRole == specialRole
                 && a.Definition.DeactivatedAt == null)
@@ -133,7 +130,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<IReadOnlyList<Guid>> GetSpecialRoleHolderUserIdsForSeasonAsync(
         Guid campSeasonId, CampSpecialRole specialRole, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments
             .AsNoTracking()
             .Where(a => a.CampSeasonId == campSeasonId
@@ -147,7 +144,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<bool> IsSpecialRoleHolderAnywhereAsync(
         Guid userId, CampSpecialRole specialRole, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .AnyAsync(a => a.CampMember.UserId == userId
                 && a.Definition.SpecialRole == specialRole
@@ -156,7 +153,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<bool> DefinitionSlugExistsAsync(string slug, Guid? excludingId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var lowered = slug.ToLowerInvariant();
         var query = ctx.CampRoleDefinitions.AsNoTracking()
 #pragma warning disable MA0011 // EF LINQ: ToLower() translates to SQL lower()
@@ -169,7 +166,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<bool> DefinitionNameExistsAsync(string name, Guid? excludingId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var lowered = name.ToLowerInvariant();
         var query = ctx.CampRoleDefinitions.AsNoTracking()
 #pragma warning disable MA0011 // EF LINQ: ToLower() translates to SQL lower()
@@ -182,14 +179,14 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task AddDefinitionAsync(CampRoleDefinition definition, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         ctx.CampRoleDefinitions.Add(definition);
         await ctx.SaveChangesAsync(ct);
     }
 
     public async Task<bool> UpdateDefinitionAsync(Guid id, Action<CampRoleDefinition> mutate, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var def = await ctx.CampRoleDefinitions.FirstOrDefaultAsync(d => d.Id == id, ct);
         if (def is null) return false;
         mutate(def);
@@ -199,7 +196,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<IReadOnlyList<CampRoleAssignment>> GetAssignmentsForSeasonAsync(Guid campSeasonId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Include(a => a.Definition)
             .Include(a => a.CampMember)
@@ -210,7 +207,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<CampRoleAssignment?> GetAssignmentByIdAsync(Guid assignmentId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Include(a => a.CampMember)
             .FirstOrDefaultAsync(a => a.Id == assignmentId, ct);
@@ -218,14 +215,14 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<int> CountAssignmentsForSeasonAndDefinitionAsync(Guid campSeasonId, Guid definitionId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .CountAsync(a => a.CampSeasonId == campSeasonId && a.CampRoleDefinitionId == definitionId, ct);
     }
 
     public async Task<bool> AssignmentExistsAsync(Guid campSeasonId, Guid definitionId, Guid campMemberId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .AnyAsync(a => a.CampSeasonId == campSeasonId
                         && a.CampRoleDefinitionId == definitionId
@@ -234,7 +231,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<bool> AddAssignmentAsync(CampRoleAssignment assignment, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         ctx.CampRoleAssignments.Add(assignment);
         try
         {
@@ -250,7 +247,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<bool> DeleteAssignmentAsync(Guid assignmentId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var assignment = await ctx.CampRoleAssignments.FirstOrDefaultAsync(a => a.Id == assignmentId, ct);
         if (assignment is null) return false;
         ctx.CampRoleAssignments.Remove(assignment);
@@ -260,7 +257,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
 
     public async Task<int> DeleteAllForMemberAsync(Guid campMemberId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         // Load-then-RemoveRange so unit tests using the EF InMemory provider
         // still cover the path. ExecuteDeleteAsync would be cheaper at scale
         // but is not supported by the InMemory provider.
@@ -276,7 +273,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<IReadOnlyList<CampRoleAssignment>> GetAllAssignmentsForUserAsync(
         Guid userId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Include(a => a.Definition)
             .Include(a => a.CampMember)
@@ -289,7 +286,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<IReadOnlyList<(Guid CampSeasonId, Guid DefinitionId, int Count)>> GetAssignmentCountsForYearAsync(
         int year, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var rows = await ctx.CampRoleAssignments.AsNoTracking()
             .Where(a => a.CampSeason.Year == year)
             .GroupBy(a => new { a.CampSeasonId, a.CampRoleDefinitionId })
@@ -301,7 +298,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
     public async Task<IReadOnlyList<CampRoleAssignment>> GetAssignmentsForDefinitionInYearAsync(
         Guid definitionId, int year, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         // Display sort happens in the service (CampRoleService.BuildDrillDownAsync).
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Include(a => a.CampMember)
@@ -313,7 +310,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
         IReadOnlyCollection<int> years, CancellationToken ct = default)
     {
         if (years.Count == 0) return [];
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var yearList = years.Distinct().ToList();
         return await ctx.CampRoleAssignments.AsNoTracking()
             .Include(a => a.CampMember)
@@ -333,7 +330,7 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
         Guid sourceUserId, Guid targetUserId, Instant updatedAt,
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
 
         // CampRoleAssignment is keyed by CampMemberId, not UserId. To "move
         // by user" we walk source's CampMembers and find target's CampMember
@@ -427,3 +424,4 @@ internal sealed class CampRoleRepository(IDbContextFactory<HumansDbContext> fact
             .CountAsync(a => a.CampMember.UserId == targetUserId, ct);
     }
 }
+

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -1,4 +1,3 @@
-using Humans.Application.Architecture;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -10,9 +9,7 @@ using NodaTime;
 namespace Humans.Infrastructure.Repositories.Camps;
 
 /// <summary>EF-backed <see cref="ICampRepository"/>.</summary>
-[Grandfathered("HUM0025", justification: "Camps-section table also accessed by CampRoleRepository; converge the Camps repositories on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "CampMembers")]
-[Grandfathered("HUM0025", justification: "Camps-section table also accessed by CampRoleRepository; converge the Camps repositories on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "CampRoleAssignments")]
-internal sealed class CampRepository : ICampRepository
+internal sealed partial class CampRepository : ICampRepository
 {
     private readonly IDbContextFactory<HumansDbContext> _factory;
 

--- a/src/Humans.Web/Extensions/Sections/CampsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/CampsSectionExtensions.cs
@@ -48,7 +48,6 @@ internal static class CampsSectionExtensions
         // Registered under both ICampRoleService and IGoogleGroupMembershipSource so
         // the Google sync orchestrator can enumerate the Camps claim alongside the
         // Teams claim. Mirrors the Teams pattern in TeamsSectionExtensions.
-        services.AddSingleton<ICampRoleRepository, CampRoleRepository>();
         services.AddScoped<CampsCampRoleService>();
         services.AddScoped<ICampRoleService>(sp => sp.GetRequiredService<CampsCampRoleService>());
         services.AddScoped<IGoogleGroupMembershipSource>(sp => sp.GetRequiredService<CampsCampRoleService>());

--- a/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
@@ -25,11 +25,11 @@ src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#7
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#8
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderBy#9
 src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:OrderByDescending#1
-src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderBy#1
-src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderBy#2
-src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:OrderByDescending#1
-src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:ThenBy#1
-src/Humans.Infrastructure/Repositories/Camps/CampRoleRepository.cs:ThenBy#2
+src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs:OrderBy#1
+src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs:OrderBy#2
+src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs:OrderByDescending#1
+src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs:ThenBy#1
+src/Humans.Infrastructure/Repositories/Camps/CampRepository.Roles.cs:ThenBy#2
 src/Humans.Infrastructure/Repositories/Consent/ConsentRepository.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/Consent/ConsentRepository.cs:OrderByDescending#2
 src/Humans.Infrastructure/Repositories/Consent/ConsentRepository.cs:OrderByDescending#3

--- a/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
@@ -23,7 +23,6 @@ public class ServiceBoundaryArchitectureTests
             [typeof(ICalendarRepository)] = "Calendar",
             [typeof(ICampaignRepository)] = "Campaigns",
             [typeof(ICampRepository)] = "Camps",
-            [typeof(ICampRoleRepository)] = "Camps",
             [typeof(ICityPlanningRepository)] = "CityPlanning",
             [typeof(ICommunicationPreferenceRepository)] = "Humans",
             [typeof(IConsentRepository)] = "Consent",

--- a/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
@@ -31,12 +31,10 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
         _userEmailService = Substitute.For<IUserEmailService>();
         _campService = Substitute.For<ICampService>();
 
-        var repo = new CampRoleRepository(DbFactory);
-        var campRepo = new CampRepository(DbFactory);
+        var repo = new CampRepository(DbFactory);
 
         _service = new CampRoleService(
             repo,
-            campRepo,
             _campService,
             _userService,
             _userEmailService,

--- a/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
@@ -29,7 +29,6 @@ public sealed class CampServiceEarlyEntryTests : ServiceTestHarness
         _fileStorage = new InMemoryFileStorage();
 
         var repo = new CampRepository(DbFactory);
-        var roleRepo = new CampRoleRepository(DbFactory);
 
         _userService = NewDbBackedUserService();
 
@@ -39,7 +38,6 @@ public sealed class CampServiceEarlyEntryTests : ServiceTestHarness
 
         _service = new CampService(
             repo,
-            roleRepo,
             _userService,
             AuditLog,
             Substitute.For<ISystemTeamSync>(),

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -31,7 +31,6 @@ public sealed class CampServiceTests : ServiceTestHarness
         _fileStorage = new InMemoryFileStorage();
 
         var repo = new CampRepository(DbFactory);
-        var roleRepo = new CampRoleRepository(DbFactory);
 
         _userService = NewDbBackedUserService();
 
@@ -41,7 +40,6 @@ public sealed class CampServiceTests : ServiceTestHarness
 
         _service = new CampService(
             repo,
-            roleRepo,
             _userService,
             AuditLog,
             Substitute.For<ISystemTeamSync>(),

--- a/tests/Humans.Testing/HumansFactAttribute.cs
+++ b/tests/Humans.Testing/HumansFactAttribute.cs
@@ -14,7 +14,7 @@ public sealed class HumansFactAttribute : FactAttribute
         [CallerLineNumber] int sourceLineNumber = -1)
         : base(sourceFilePath, sourceLineNumber)
     {
-        base.Timeout = DefaultTimeoutFor(sourceFilePath);
+        base.Timeout = DefaultTimeout;
     }
 
     public new int Timeout
@@ -42,8 +42,5 @@ public sealed class HumansFactAttribute : FactAttribute
     public new string? SkipWhen { get => base.SkipWhen; set => base.SkipWhen = value; }
     public new Type[]? SkipExceptions { get => base.SkipExceptions; set => base.SkipExceptions = value; }
 
-    private static int DefaultTimeoutFor(string? sourceFilePath) =>
-        sourceFilePath?.Contains("Humans.Integration.Tests", StringComparison.Ordinal) == true
-            ? 30000
-            : 30000;
+    private const int DefaultTimeout = 30000;
 }


### PR DESCRIPTION
## Summary
- Fold `ICampRoleRepository` into `ICampRepository` and rename the implementation file to `CampRepository.Roles.cs`.
- Remove the separate `CampRoleRepository` DI registration; Camps services now use one repository contract.
- Update architecture/docs/tests for the single Camps repository shape.
- Collapse the now-identical `HumansFactAttribute` timeout branch that was breaking a fresh solution build on `origin/main`.

## Warning impact
- Non-incremental build: `unique_hum0025=286` on this branch.
- `CampMembers` / `CampRoleAssignments` HUM0025 bucket: `0` remaining.
- This branch is based on current `origin/main`, so it does not include the separate Shifts PR warning reduction.

## Verification
- `dotnet build Humans.slnx --disable-build-servers -v minimal`
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --disable-build-servers -v minimal --filter "FullyQualifiedName~Camp"`
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --disable-build-servers -v minimal --filter "FullyQualifiedName~Architecture"`
- `dotnet build Humans.slnx --disable-build-servers --no-incremental -v minimal`
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --no-build --disable-build-servers -v minimal`
- `dotnet ef migrations has-pending-model-changes --project src/Humans.Infrastructure --startup-project src/Humans.Web --context HumansDbContext --no-build`