### PR TITLE
Fold user email storage into Users repository

### DIFF
--- a/src/Humans.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Humans.Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,7 +7,7 @@ HUM0002 | Humans.Architecture   | Error    | Write to Identity-derived User colu
 HUM0003 | Humans.Architecture   | Error    | UserManager.FindByEmailAsync / FindByNameAsync called from Application or Web
 HUM0004 | Humans.Architecture   | Error    | Profile.IsSuspended written outside allowlisted dual-writers
 HUM0005 | Humans.Architecture   | Error    | IUserEmailService.UpdateEmailAsync called from outside AccountController
-HUM0006 | Humans.Architecture   | Error    | IUserEmailRepository.UpdateEmailAsync called from outside UserEmailService
+HUM0006 | Humans.Architecture   | Error    | IUserRepository.ApplyUserEmailReconcilePlanAsync called from outside approved user-email services
 HUM0007 | Humans.Architecture   | Error    | Concurrency token metadata is forbidden in live source
 HUM0008 | Humans.Architecture   | Error    | Controller constructor injects HumansDbContext
 HUM0009 | Humans.Architecture   | Error    | Class uses HumansDbContext but does not implement IRepository (downgrades to Warning for classes carrying [Grandfathered("HUM0009", ...)])

--- a/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
+++ b/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Humans.Analyzers;
 /// Pins the single legitimate call chain for the OAuth reconcile primitive:
 /// <c>AccountController</c> → <c>IUserEmailService.ReconcileOAuthIdentityAsync</c> →
 /// <c>IUserService.ApplyUserEmailReconcilePlanAsync</c> ->
-/// <c>IUserEmailRepository.ApplyReconcilePlanAsync</c>. Any other call site is forbidden.
+/// <c>IUserRepository.ApplyUserEmailReconcilePlanAsync</c>. Any other call site is forbidden.
 /// </summary>
 /// <remarks>
 /// See <c>memory/architecture/email-mutation-paths.md</c>. The atom names this
@@ -39,9 +39,9 @@ public sealed class EmailMutationPathsAnalyzer : DiagnosticAnalyzer
 
     public static readonly DiagnosticDescriptor RepositoryCallerRule = new(
         id: RepositoryCallerDiagnosticId,
-        title: "IUserEmailRepository.ApplyReconcilePlanAsync may only be called from approved user-email storage services",
+        title: "IUserRepository.ApplyUserEmailReconcilePlanAsync may only be called from approved user-email storage services",
         messageFormat:
-            "IUserEmailRepository.ApplyReconcilePlanAsync may only be called from UserService " +
+            "IUserRepository.ApplyUserEmailReconcilePlanAsync may only be called from UserService " +
             "or UserEmailService. " +
             "See memory/architecture/email-mutation-paths.md.",
         category: AnalyzerCategories.Architecture,
@@ -55,9 +55,9 @@ public sealed class EmailMutationPathsAnalyzer : DiagnosticAnalyzer
     ];
 
     private const string ServiceInterface = "Humans.Application.Interfaces.Profiles.IUserEmailService";
-    private const string RepositoryInterface = "Humans.Application.Interfaces.Repositories.IUserEmailRepository";
+    private const string RepositoryInterface = "Humans.Application.Interfaces.Repositories.IUserRepository";
     private const string ServiceMethodName = "ReconcileOAuthIdentityAsync";
-    private const string RepositoryMethodName = "ApplyReconcilePlanAsync";
+    private const string RepositoryMethodName = "ApplyUserEmailReconcilePlanAsync";
     private const string AllowedServiceCaller = "Humans.Web.Controllers.AccountController";
     private static readonly ImmutableHashSet<string> AllowedRepositoryCallers =
         ImmutableHashSet.Create(

--- a/src/Humans.Analyzers/IdentityColumnReadAnalyzer.cs
+++ b/src/Humans.Analyzers/IdentityColumnReadAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Humans.Analyzers;
 /// <c>UserName</c>, <c>NormalizedUserName</c>). Read paths go through
 /// <c>UserInfo.Email</c> / <c>UserInfo.PrimaryEmail</c> /
 /// <c>IUserEmailService.GetPrimaryEmailAsync</c> /
-/// <c>IUserEmailRepository</c> instead. Pairs with HUM0002 (writes) and
+/// <c>IUserEmailService</c> instead. Pairs with HUM0002 (writes) and
 /// HUM0003 (FindByEmailAsync/FindByNameAsync).
 ///
 /// Issue nobodies-collective/Humans#506.
@@ -31,7 +31,7 @@ public sealed class IdentityColumnReadAnalyzer : DiagnosticAnalyzer
         "NormalizedUserName) are virtual overrides that compute from " +
         "UserEmails or Id; reading them couples application code to a " +
         "vestigial Identity field. Use UserInfo.Email / UserInfo.PrimaryEmail " +
-        "via IUserService, or IUserEmailService / IUserEmailRepository for " +
+        "via IUserService, or IUserEmailService for " +
         "direct UserEmail-backed lookups.";
 
     public static readonly DiagnosticDescriptor Rule = new(

--- a/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
@@ -387,10 +388,10 @@ public interface IUserEmailService : IApplicationService
     /// <summary>
     /// Sets the user's canonical Google Workspace identity to the given verified
     /// email row. Single-transaction exclusive flip via
-    /// <see cref="IUserEmailRepository.SetGoogleExclusiveAsync"/>: the target row's
+    /// <see cref="IUserRepository.SetUserEmailGoogleExclusiveAsync"/>: the target row's
     /// <see cref="UserEmail.IsGoogle"/> goes to true, every sibling row for the
     /// same user is cleared. Owner-gated via
-    /// <see cref="IUserEmailRepository.GetByIdAndUserIdAsync"/>; returns
+    /// <see cref="IUserRepository.GetUserEmailByIdAndUserIdAsync"/>; returns
     /// <c>false</c> if the row is not found for this user or is not verified.
     /// Service-auth-free per the design rules: the controller authorizes against
     /// <paramref name="userId"/>, which is the <b>target</b> user (not the actor).
@@ -408,7 +409,7 @@ public interface IUserEmailService : IApplicationService
     /// invariant violation that bypasses <see cref="SetGoogleAsync"/>).
     /// Returns <c>false</c> when the row is not found for this user or is
     /// already cleared. Owner-gated via
-    /// <see cref="IUserEmailRepository.GetByIdAndUserIdAsync"/>.
+    /// <see cref="IUserRepository.GetUserEmailByIdAndUserIdAsync"/>.
     /// </summary>
     Task<bool> ClearGoogleAsync(
         Guid userId, Guid userEmailId, Guid actorUserId,

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.UserEmails.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.UserEmails.cs
@@ -1,49 +1,46 @@
 using Humans.Application.DTOs;
 using Humans.Domain.Entities;
 using NodaTime;
-using Humans.Domain.Attributes;
 
 namespace Humans.Application.Interfaces.Repositories;
 
 /// <summary>
-/// Repository for the <c>user_emails</c> table.
-/// The only non-test file that may write to this DbSet.
+/// User-owned storage operations for the <c>user_emails</c> table.
 /// </summary>
-[Section("Humans")]
-public interface IUserEmailRepository : IRepository
+public partial interface IUserRepository
 {
     /// <summary>
     /// Returns all emails for a user, read-only, ordered by
     /// <c>DisplayOrder</c> then <c>CreatedAt</c>.
     /// </summary>
-    Task<IReadOnlyList<UserEmail>> GetByUserIdReadOnlyAsync(
+    Task<IReadOnlyList<UserEmail>> GetUserEmailsByUserIdReadOnlyAsync(
         Guid userId, CancellationToken ct = default);
 
     /// <summary>
     /// Returns detached entities intended to be mutated in-memory and passed back
-    /// to <see cref="UpdateAsync"/> or <see cref="UpdateBatchAsync"/>. The returned
+    /// to <see cref="UpdateUserEmailAsync"/> or <see cref="UpdateUserEmailsAsync"/>. The returned
     /// entities are NOT tracked — callers must explicitly hand mutated entities
     /// back to a write method for persistence.
     /// </summary>
-    Task<IReadOnlyList<UserEmail>> GetByUserIdForMutationAsync(
+    Task<IReadOnlyList<UserEmail>> GetUserEmailsByUserIdForMutationAsync(
         Guid userId, CancellationToken ct = default);
 
     /// <summary>
     /// Returns a single email by id and user id, tracked for modification.
     /// </summary>
-    Task<UserEmail?> GetByIdAndUserIdAsync(
+    Task<UserEmail?> GetUserEmailByIdAndUserIdAsync(
         Guid emailId, Guid userId, CancellationToken ct = default);
 
     /// <summary>
     /// Returns a single email by id, read-only.
     /// </summary>
-    Task<UserEmail?> GetByIdReadOnlyAsync(Guid emailId, CancellationToken ct = default);
+    Task<UserEmail?> GetUserEmailByIdReadOnlyAsync(Guid emailId, CancellationToken ct = default);
 
     /// <summary>
     /// Checks whether an email (or gmail/googlemail alternate) already
     /// exists for this user.
     /// </summary>
-    Task<bool> ExistsForUserAsync(
+    Task<bool> UserEmailExistsForUserAsync(
         Guid userId, string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default);
 
@@ -51,7 +48,7 @@ public interface IUserEmailRepository : IRepository
     /// Checks whether a verified email (or gmail/googlemail alternate) exists
     /// for a different user. Used for conflict/merge detection.
     /// </summary>
-    Task<bool> ExistsVerifiedForOtherUserAsync(
+    Task<bool> VerifiedUserEmailExistsForOtherUserAsync(
         Guid userId, string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default);
 
@@ -59,7 +56,7 @@ public interface IUserEmailRepository : IRepository
     /// Returns the first verified email matching the normalized (or alternate)
     /// address that belongs to a different user. For merge flow.
     /// </summary>
-    Task<UserEmail?> GetConflictingVerifiedEmailAsync(
+    Task<UserEmail?> GetConflictingVerifiedUserEmailAsync(
         Guid excludeEmailId, string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default);
 
@@ -76,7 +73,7 @@ public interface IUserEmailRepository : IRepository
     /// row touched. Returns the count of <c>user_emails</c> rows ultimately
     /// attributed to <paramref name="targetUserId"/>.
     /// </summary>
-    Task<int> ReassignToUserAsync(
+    Task<int> ReassignUserEmailsToUserAsync(
         Guid sourceUserId, Guid targetUserId, Instant updatedAt,
         CancellationToken ct = default);
 
@@ -88,7 +85,7 @@ public interface IUserEmailRepository : IRepository
     /// deleted CLR property.
     /// </summary>
     Task<IReadOnlyList<UserEmailLegacyBackfillSnapshot>>
-        GetLegacyBackfillSnapshotsByUserIdAsync(
+        GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(
             Guid userId, CancellationToken ct = default);
 
     /// <summary>
@@ -96,21 +93,34 @@ public interface IUserEmailRepository : IRepository
     /// scan to detect overlapping addresses across users. Trivial to load in
     /// full at ~500-user scale.
     /// </summary>
-    Task<IReadOnlyList<UserEmail>> GetAllAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<UserEmail>> GetAllUserEmailsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the subset of <paramref name="userIds"/> that have at least one
+    /// <see cref="UserEmail"/> row.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetUserIdsHavingAnyUserEmailAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default);
 
     /// <summary>
     /// Removes every <see cref="UserEmail"/> row for the given user. Used
     /// during account merge/duplicate-resolve to wipe the source's addresses
     /// before anonymization.
     /// </summary>
-    Task RemoveAllForUserAndSaveAsync(Guid userId, CancellationToken ct = default);
+    Task RemoveAllUserEmailsForUserAndSaveAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes every <see cref="UserEmail"/> row for the given users.
+    /// </summary>
+    Task RemoveAllUserEmailsForUsersAndSaveAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default);
 
     /// <summary>
     /// Marks a single email as verified and bumps <see cref="UserEmail.UpdatedAt"/>
     /// to <paramref name="now"/>. Returns false if the email does not exist.
     /// Used by <c>AccountMergeService.AcceptAsync</c> to complete a merge.
     /// </summary>
-    Task<bool> MarkVerifiedAsync(
+    Task<bool> MarkUserEmailVerifiedAsync(
         Guid emailId, Instant now, CancellationToken ct = default);
 
     /// <summary>
@@ -118,7 +128,7 @@ public interface IUserEmailRepository : IRepository
     /// exist. Used by <c>AccountMergeService.RejectAsync</c> to clear the
     /// pending unverified address on rejection.
     /// </summary>
-    Task<bool> RemoveByIdAsync(Guid emailId, CancellationToken ct = default);
+    Task<bool> RemoveUserEmailByIdAsync(Guid emailId, CancellationToken ct = default);
 
     /// <summary>
     /// Returns every <see cref="UserEmail"/> row whose <c>Email</c> matches one
@@ -126,7 +136,7 @@ public interface IUserEmailRepository : IRepository
     /// Used by the Google admin workspace-accounts list to match Google-side
     /// accounts to human records without loading the full table.
     /// </summary>
-    Task<IReadOnlyList<UserEmail>> GetByEmailsAsync(
+    Task<IReadOnlyList<UserEmail>> GetUserEmailsByEmailsAsync(
         IReadOnlyCollection<string> emails, CancellationToken ct = default);
 
     /// <summary>
@@ -134,14 +144,14 @@ public interface IUserEmailRepository : IRepository
     /// <c>Email</c> equal to <paramref name="email"/> (case-insensitive),
     /// irrespective of user. Used by admin account-linking flows.
     /// </summary>
-    Task<bool> AnyWithEmailAsync(string email, CancellationToken ct = default);
+    Task<bool> AnyUserEmailWithEmailAsync(string email, CancellationToken ct = default);
 
     /// <summary>
     /// Returns a mapping of userId → verified notification-target email for all users
     /// that have one. If a user has multiple verified notification-target emails,
     /// one is picked arbitrarily.
     /// </summary>
-    Task<Dictionary<Guid, string>> GetAllNotificationTargetEmailsAsync(
+    Task<Dictionary<Guid, string>> GetAllNotificationTargetUserEmailsAsync(
         CancellationToken ct = default);
 
     /// <summary>
@@ -150,14 +160,14 @@ public interface IUserEmailRepository : IRepository
     /// "who hasn't bought") so secondary verified addresses are discoverable
     /// even when they differ from the notification-target email.
     /// </summary>
-    Task<IReadOnlyList<Guid>> SearchUserIdsByVerifiedEmailAsync(
+    Task<IReadOnlyList<Guid>> SearchUserIdsByVerifiedUserEmailAsync(
         string searchTerm, CancellationToken ct = default);
 
     /// <summary>
     /// Finds a verified UserEmail matching the normalized (or alternate) address,
     /// returning minimal User info for conflict checking.
     /// </summary>
-    Task<UserEmailWithUser?> FindVerifiedWithUserAsync(
+    Task<UserEmailWithUser?> FindVerifiedUserEmailWithUserAsync(
         string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default);
 
@@ -168,7 +178,7 @@ public interface IUserEmailRepository : IRepository
     /// Used by account provisioning to dedupe incoming contacts against
     /// every known email for every user.
     /// </summary>
-    Task<UserEmail?> FindByNormalizedEmailAsync(
+    Task<UserEmail?> FindUserEmailByNormalizedEmailAsync(
         string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default);
 
@@ -176,7 +186,7 @@ public interface IUserEmailRepository : IRepository
     /// Returns the email address for a verified email owned by the user,
     /// or null if not found or not verified.
     /// </summary>
-    Task<string?> GetVerifiedEmailAddressAsync(
+    Task<string?> GetVerifiedUserEmailAddressAsync(
         Guid userId, Guid emailId, CancellationToken ct = default);
 
     /// <summary>
@@ -184,14 +194,14 @@ public interface IUserEmailRepository : IRepository
     /// the given string exactly (no gmail/googlemail aliasing). Returns
     /// <c>null</c> if no verified row matches.
     /// </summary>
-    Task<Guid?> GetUserIdByVerifiedEmailAsync(
+    Task<Guid?> GetUserIdByVerifiedUserEmailAsync(
         string email, CancellationToken ct = default);
 
     /// <summary>
     /// Returns distinct user ids whose email starts with <paramref name="prefix"/>
     /// and ends with <paramref name="suffix"/>.
     /// </summary>
-    Task<IReadOnlyList<Guid>> GetUserIdsByEmailPrefixAndSuffixAsync(
+    Task<IReadOnlyList<Guid>> GetUserIdsByUserEmailPrefixAndSuffixAsync(
         string prefix,
         string suffix,
         CancellationToken ct = default);
@@ -205,18 +215,18 @@ public interface IUserEmailRepository : IRepository
     /// address is verified for more than one user (invariant violation —
     /// treat as ambiguous / return null to the caller).
     /// </summary>
-    Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedEmailAsync(
+    Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedUserEmailAsync(
         string email, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the distinct UserIds whose verified UserEmail matches the given
     /// normalized address (or its gmail/googlemail alternate). Same matching
-    /// semantics as <see cref="FindVerifiedWithUserAsync"/>, but returns the
+    /// semantics as <see cref="FindVerifiedUserEmailWithUserAsync"/>, but returns the
     /// full set rather than picking one arbitrary owner — so classifiers can
     /// detect service-level uniqueness drift instead of silently attaching to
     /// the wrong account.
     /// </summary>
-    Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserIdsAsync(
+    Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserEmailUserIdsAsync(
         string normalizedEmail, string? alternateEmail, CancellationToken ct = default);
 
     /// <summary>
@@ -225,7 +235,7 @@ public interface IUserEmailRepository : IRepository
     /// Used by @nobodies.team provisioning to block a prefix that is already
     /// attached to another human regardless of verification state.
     /// </summary>
-    Task<Guid?> GetOtherUserIdHavingEmailAsync(
+    Task<Guid?> GetOtherUserIdHavingUserEmailAsync(
         string email, Guid excludeUserId, CancellationToken ct = default);
 
     /// <summary>
@@ -241,7 +251,7 @@ public interface IUserEmailRepository : IRepository
     /// (gmail/googlemail alternate, lowercase, trimmed). Sole legitimate
     /// caller: <c>UserEmailService.ReconcileOAuthIdentityAsync</c>.
     /// </summary>
-    Task<UserEmail?> FindOtherUsersVerifiedRowAsync(
+    Task<UserEmail?> FindOtherUsersVerifiedUserEmailRowAsync(
         string normalizedEmail, string? alternateEmail, Guid excludeUserId,
         CancellationToken ct = default);
 
@@ -257,7 +267,7 @@ public interface IUserEmailRepository : IRepository
     /// <c>UserEmailService.ReconcileOAuthIdentityAsync</c>. All parameters
     /// are optional; a no-op call is allowed but pointless.
     /// </summary>
-    Task ApplyReconcilePlanAsync(
+    Task ApplyUserEmailReconcilePlanAsync(
         UserEmail? displacedRowToDelete,
         UserEmail? rowToDelete,
         UserEmail? rowToUpdate,
@@ -271,21 +281,21 @@ public interface IUserEmailRepository : IRepository
     /// on every row whose <c>IsGoogle</c> value changes. Owner-gate
     /// (userId match) is performed by the caller.
     /// </summary>
-    Task SetGoogleExclusiveAsync(Guid userId, Guid userEmailId, Instant updatedAt, CancellationToken cancellationToken = default);
+    Task SetUserEmailGoogleExclusiveAsync(Guid userId, Guid userEmailId, Instant updatedAt, CancellationToken cancellationToken = default);
 
-    Task AddAsync(UserEmail email, CancellationToken ct = default);
-    Task RemoveAsync(UserEmail email, CancellationToken ct = default);
-    Task RemoveAllForUserAsync(Guid userId, CancellationToken ct = default);
+    Task AddUserEmailAsync(UserEmail email, CancellationToken ct = default);
+    Task RemoveUserEmailAsync(UserEmail email, CancellationToken ct = default);
+    Task RemoveAllUserEmailsForUserAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
     /// Persists changes to a single <see cref="UserEmail"/> entity by attaching it
     /// to a fresh context and marking it as Modified.
     /// </summary>
-    Task UpdateAsync(UserEmail email, CancellationToken ct = default);
+    Task UpdateUserEmailAsync(UserEmail email, CancellationToken ct = default);
 
     /// <summary>
     /// Persists changes to multiple <see cref="UserEmail"/> entities in one
     /// SaveChanges call. Each entity is attached and marked as Modified.
     /// </summary>
-    Task UpdateBatchAsync(IReadOnlyList<UserEmail> emails, CancellationToken ct = default);
+    Task UpdateUserEmailsAsync(IReadOnlyList<UserEmail> emails, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -25,16 +25,17 @@ public partial interface IUserRepository : IRepository
     // ==========================================================================
 
     /// <summary>
-    /// Loads a single user by id with the <see cref="User.UserEmails"/>
-    /// collection populated. Read-only (AsNoTracking). Returns null if the
-    /// user does not exist.
+    /// Loads a single user by id. Read-only (AsNoTracking). Returns null if
+    /// the user does not exist. <see cref="User.UserEmails"/> is owned by
+    /// the UserEmail methods on this repository and is not populated by this method.
     /// </summary>
     Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
-    /// Batched user fetch keyed by id with each user's
-    /// <see cref="User.UserEmails"/> collection populated. Missing users are
-    /// absent from the returned dictionary. Read-only (AsNoTracking).
+    /// Batched user fetch keyed by id. Missing users are absent from the
+    /// returned dictionary. Read-only (AsNoTracking). <see cref="User.UserEmails"/>
+    /// is owned by the UserEmail methods on this repository and is not populated by
+    /// this method.
     /// </summary>
     Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(
         IReadOnlyCollection<Guid> userIds,
@@ -47,10 +48,11 @@ public partial interface IUserRepository : IRepository
     Task<IReadOnlyList<User>> GetAllAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Finds a user whose <c>Email</c> or <c>GoogleEmail</c> matches the given
+    /// Finds a user whose legacy <c>GoogleEmail</c> shadow column matches the given
     /// normalized address (case-insensitive). If <paramref name="alternateEmail"/>
-    /// is non-null, also matches users whose email matches the alternate form
-    /// (gmail.com ↔ googlemail.com). Read-only.
+    /// is non-null, also matches the alternate form. Canonical
+    /// <c>user_emails</c> matching is owned by the UserEmail methods on this repository.
+    /// Read-only.
     /// </summary>
     Task<User?> GetByEmailOrAlternateAsync(
         string normalizedEmail, string? alternateEmail, CancellationToken ct = default);
@@ -60,7 +62,7 @@ public partial interface IUserRepository : IRepository
     /// whose legacy <c>GoogleEmail</c> shadow column matches the given address
     /// (case-insensitive), or null if no such user exists.
     /// </summary>
-    [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. Use IUserEmailRepository.GetOtherUserIdHavingEmailAsync (matches the user_emails table — the canonical location for Google identity once UserEmail.IsGoogle is sole source of truth).")]
+    [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. Use IUserRepository.GetOtherUserIdHavingUserEmailAsync (matches the user_emails table — the canonical location for Google identity once UserEmail.IsGoogle is sole source of truth).")]
     Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
         string email, Guid excludeUserId, CancellationToken ct = default);
 
@@ -152,14 +154,14 @@ public partial interface IUserRepository : IRepository
 
     /// <summary>
     /// Returns userIds of users that have at least one row in
-    /// <c>AspNetUserLogins</c> but zero rows in <c>user_emails</c>. Used by the
-    /// EmailProblems admin scan to surface ghost auth artifacts (case 8).
+    /// <c>AspNetUserLogins</c>. Used by <c>IUserService</c> together with
+    /// UserEmail methods on this repository to surface ghost auth artifacts.
     /// </summary>
-    Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<Guid>> GetUserIdsWithExternalLoginsAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Permanently deletes users after the caller has cleared cross-section
-    /// references. Also removes user_emails and AspNetUserLogins rows for
+    /// references and UserEmail rows. Also removes AspNetUserLogins rows for
     /// those users. Returns the number of user rows deleted.
     /// </summary>
     Task<int> DeleteUsersAsync(
@@ -219,19 +221,21 @@ public partial interface IUserRepository : IRepository
         Guid userId, ContactSource source, CancellationToken ct = default);
 
     /// <summary>
-    /// Purges (anonymizes + locks out) a user: removes all UserEmail rows and
-    /// all AspNetUserLogins rows for the user, overwrites <c>Email</c>/
+    /// Purges (anonymizes + locks out) a user: removes all AspNetUserLogins
+    /// rows for the user, overwrites <c>Email</c>/
     /// <c>NormalizedEmail</c>/<c>UserName</c>/<c>NormalizedUserName</c> with a
     /// sentinel <c>purged-{guid}@deleted.local</c> address, prepends "Purged"
     /// to the display name, and permanently locks out the account. Atomic:
-    /// email removal, login removal, and user anonymization happen in one
+    /// login removal and user anonymization happen in one
     /// <c>SaveChangesAsync</c>. Returns the original display name if the user
     /// was purged; null if the user did not exist.
     /// </summary>
     /// <remarks>
-    /// Used by <c>IUserService.PurgeAsync</c>. Removes <c>UserEmail</c> rows so
-    /// the unique-index constraint does not block a future account creation
-    /// reusing the same email. Also removes <c>AspNetUserLogins</c> rows so a
+    /// Used by <c>IUserService.PurgeAsync</c>. <c>IUserService</c> removes
+    /// <c>UserEmail</c> rows through this repository before calling
+    /// this method so the unique-index constraint does not block a future
+    /// account creation reusing the same email. Also removes
+    /// <c>AspNetUserLogins</c> rows so a
     /// re-signup via the same Google identity is not blocked by an orphan login
     /// pointing at a tombstoned, locked-out user. Does not touch Profile or
     /// other section-owned rows — those are either retained (audit) or removed
@@ -257,9 +261,9 @@ public partial interface IUserRepository : IRepository
 
     /// <summary>
     /// Applies the identity-level fields of the GDPR expiry anonymization in
-    /// one atomic save: renames the user to <c>Deleted User</c> + sentinel
-    /// email, removes every <c>UserEmail</c> row and every
-    /// <c>AspNetUserLogins</c> row, clears phone/picture/iCal token, clears
+    /// one save: renames the user to <c>Deleted User</c> + sentinel
+    /// email, removes every <c>AspNetUserLogins</c> row, clears
+    /// phone/picture/iCal token, clears
     /// all deletion fields, sets the security stamp, and permanently locks
     /// out the account. Returns a small summary of the prior identity
     /// (effective email, display name, preferred language) or <c>null</c> if

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -95,10 +95,10 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Purges a human at the User aggregate — removes all UserEmail rows for
-    /// the user, anonymizes the email/display name, and permanently locks out
-    /// the account. Returns the prior display name on success, or <c>null</c>
-    /// if the user did not exist. Invalidates the UserInfo cache on
+    /// Purges a human at the User aggregate — removes all UserEmail rows
+    /// through <c>IUserRepository</c>, anonymizes the display name, and
+    /// permanently locks out the account. Returns the prior display name on
+    /// success, or <c>null</c> if the user did not exist. Invalidates the UserInfo cache on
     /// success so downstream consumers see the purged view. Cross-section
     /// invalidation (ActiveTeams cache, etc.) is owned by the caller —
     /// <see cref="IAccountDeletionService.PurgeAsync"/> is the orchestrator
@@ -108,10 +108,10 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
 
     /// <summary>
     /// Applies the identity-level fields of the GDPR expiry anonymization
-    /// on the User aggregate in one atomic save — renames to
-    /// <c>Deleted User</c> + sentinel email, removes <c>UserEmail</c> rows,
-    /// clears phone/picture/iCal/deletion fields, sets the security stamp,
-    /// and permanently locks out the account. Returns the pre-write identity
+    /// on the User aggregate — removes <c>UserEmail</c> rows through
+    /// <c>IUserRepository</c>, renames to <c>Deleted User</c>, clears
+    /// phone/picture/iCal/deletion fields, sets the security stamp, and
+    /// permanently locks out the account. Returns the pre-write identity
     /// slice or <c>null</c> if the user does not exist. Invalidates the
     /// UserInfo cache on success. Cross-section cascade (team
     /// memberships, role assignments, profile anonymization, shift cleanup)
@@ -387,9 +387,9 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
 
     /// <summary>
     /// Permanently deletes the requested user rows after the caller has cleared
-    /// cross-section references. Also removes the users' email rows and
-    /// external login rows. Requires the current authenticated user to hold
-    /// the full Admin role.
+    /// cross-section references. Removes the users' email rows through
+    /// <c>IUserRepository</c> and removes external login rows through
+    /// <c>IUserRepository</c>. Requires the current authenticated user to hold the full Admin role.
     /// </summary>
     Task<int> DeleteUsersAsync(
         IReadOnlyCollection<Guid> userIds,

--- a/src/Humans.Application/Services/Profiles/AccountMergeService.cs
+++ b/src/Humans.Application/Services/Profiles/AccountMergeService.cs
@@ -18,7 +18,7 @@ namespace Humans.Application.Services.Profiles;
 // AcceptAsync fans out IUserMerge across sections to re-FK source→target, then tombstones source via AnonymizeForMergeAsync.
 public sealed class AccountMergeService(
     IAccountMergeRepository mergeRepository,
-    IUserEmailRepository userEmailRepository,
+    IUserRepository userRepository,
     IAuditLogService auditLogService,
     IUserInfoInvalidator userInfoInvalidator,
     ILogger<AccountMergeService> logger,
@@ -94,7 +94,7 @@ public sealed class AccountMergeService(
                 IsolationLevel = IsolationLevel.ReadCommitted
             },
             TransactionScopeAsyncFlowOption.Enabled);
-        var verified = await userEmailRepository.MarkVerifiedAsync(request.PendingEmailId, now, ct);
+        var verified = await userRepository.MarkUserEmailVerifiedAsync(request.PendingEmailId, now, ct);
         if (!verified)
             throw new InvalidOperationException(
                 $"Pending email {request.PendingEmailId} no longer exists. Cannot complete merge.");
@@ -227,7 +227,7 @@ public sealed class AccountMergeService(
             TransactionScopeAsyncFlowOption.Enabled))
         {
             // Best-effort remove the target's pending email.
-            await userEmailRepository.RemoveByIdAsync(request.PendingEmailId, ct);
+            await userRepository.RemoveUserEmailByIdAsync(request.PendingEmailId, ct);
 
             request.Status = AccountMergeRequestStatus.Rejected;
             request.ResolvedAt = now;

--- a/src/Humans.Application/Services/Profiles/DuplicateAccountService.cs
+++ b/src/Humans.Application/Services/Profiles/DuplicateAccountService.cs
@@ -17,7 +17,6 @@ namespace Humans.Application.Services.Profiles;
 public sealed class DuplicateAccountService(
     IUserRepository userRepository,
     IUserService userService,
-    IUserEmailRepository userEmailRepository,
     IAuditLogService auditLogService,
     IUserInfoInvalidator userInfoInvalidator,
     ITeamService teamService,
@@ -215,7 +214,7 @@ public sealed class DuplicateAccountService(
                 await roleAssignmentService.RevokeAllActiveAsync(sourceUserId, ct);
 
                 // 5. Delete source's email rows.
-                await userEmailRepository.RemoveAllForUserAndSaveAsync(sourceUserId, ct);
+                await userRepository.RemoveAllUserEmailsForUserAndSaveAsync(sourceUserId, ct);
 
                 // 6. Anonymize source. NOTE: does NOT migrate VolunteerHistory/Languages (asymmetric vs AccountMergeService.AcceptAsync).
                 await userRepository.AnonymizeForMergeByUserIdAsync(sourceUserId, ct);

--- a/src/Humans.Application/Services/Profiles/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profiles/UserEmailService.cs
@@ -15,7 +15,7 @@ using Humans.Application.Interfaces.Profiles;
 namespace Humans.Application.Services.Profiles;
 
 public sealed class UserEmailService(
-    IUserEmailRepository repository,
+    IUserRepository repository,
     IUserService userService,
     UserManager<User> userManager,
     IClock clock,
@@ -59,7 +59,7 @@ public sealed class UserEmailService(
     public async Task<(bool CanAdd, int MinutesUntilResend, Guid? PendingEmailId)>
         GetEmailCooldownInfoAsync(Guid pendingEmailId, CancellationToken ct = default)
     {
-        var pendingRecord = await repository.GetByIdReadOnlyAsync(pendingEmailId, ct);
+        var pendingRecord = await repository.GetUserEmailByIdReadOnlyAsync(pendingEmailId, ct);
 
         if (pendingRecord?.VerificationSentAt.HasValue == true)
         {
@@ -109,7 +109,7 @@ public sealed class UserEmailService(
         if (!new EmailAddressAttribute().IsValid(email))
             throw new ValidationException("Please enter a valid email address.");
 
-        if (await repository.ExistsForUserAsync(userId, normalizedEmail, alternateEmail, cancellationToken))
+        if (await repository.UserEmailExistsForUserAsync(userId, normalizedEmail, alternateEmail, cancellationToken))
             throw new ValidationException("This email address is already in your account.");
 
         if (await MergeService.HasPendingForUserAndEmailAsync(
@@ -149,7 +149,7 @@ public sealed class UserEmailService(
             ?? throw new InvalidOperationException("User not found.");
 
         // see nobodies-collective/Humans#611 — token is bound to this row's Id via the purpose suffix.
-        var pendingEmail = await repository.GetByIdAndUserIdAsync(emailId, userId, cancellationToken);
+        var pendingEmail = await repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, cancellationToken);
         if (pendingEmail is null || pendingEmail.IsVerified || pendingEmail.Provider is not null)
         {
             throw new ValidationException("No email pending verification.");
@@ -166,7 +166,7 @@ public sealed class UserEmailService(
 
         var normalizedPendingEmail = EmailNormalization.NormalizeForComparison(pendingEmail.Email);
         var alternatePendingEmail = GetAlternateComparableEmail(normalizedPendingEmail);
-        var conflictingEmail = await repository.GetConflictingVerifiedEmailAsync(
+        var conflictingEmail = await repository.GetConflictingVerifiedUserEmailAsync(
             pendingEmail.Id, normalizedPendingEmail, alternatePendingEmail, cancellationToken);
 
         if (conflictingEmail is not null)
@@ -206,7 +206,7 @@ public sealed class UserEmailService(
         Guid userId, Guid emailId, Guid actorUserId,
         CancellationToken cancellationToken = default)
     {
-        var pendingEmail = await repository.GetByIdAndUserIdAsync(emailId, userId, cancellationToken);
+        var pendingEmail = await repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, cancellationToken);
         if (pendingEmail is null || pendingEmail.IsVerified || pendingEmail.Provider is not null)
         {
             throw new ValidationException("No email pending verification.");
@@ -215,7 +215,7 @@ public sealed class UserEmailService(
         // Mirror VerifyEmailAsync duplicate-handling: create merge request when address verified on another account.
         var normalizedPendingEmail = EmailNormalization.NormalizeForComparison(pendingEmail.Email);
         var alternatePendingEmail = GetAlternateComparableEmail(normalizedPendingEmail);
-        var conflictingEmail = await repository.GetConflictingVerifiedEmailAsync(
+        var conflictingEmail = await repository.GetConflictingVerifiedUserEmailAsync(
             pendingEmail.Id, normalizedPendingEmail, alternatePendingEmail, cancellationToken);
 
         if (conflictingEmail is not null)
@@ -281,7 +281,7 @@ public sealed class UserEmailService(
     public async Task<bool> DeleteEmailAsync(
         Guid userId, Guid emailId, CancellationToken cancellationToken = default)
     {
-        var email = await repository.GetByIdAndUserIdAsync(emailId, userId, cancellationToken)
+        var email = await repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, cancellationToken)
             ?? throw new InvalidOperationException("Email not found.");
 
         if (!string.IsNullOrEmpty(email.Provider))
@@ -303,7 +303,7 @@ public sealed class UserEmailService(
         // Block deletion of the last verified row — post email-decoupling, base.Email is null and the user would silently lose all notifications.
         if (email.IsVerified)
         {
-            var allEmails = await repository.GetByUserIdForMutationAsync(userId, cancellationToken);
+            var allEmails = await repository.GetUserEmailsByUserIdForMutationAsync(userId, cancellationToken);
             var verifiedRemaining = allEmails.Count(e => e.IsVerified && e.Id != emailId);
 
             if (verifiedRemaining == 0)
@@ -333,14 +333,14 @@ public sealed class UserEmailService(
 
     public Task RemoveAllEmailsAsync(
         Guid userId, CancellationToken cancellationToken = default) =>
-        repository.RemoveAllForUserAsync(userId, cancellationToken);
+        repository.RemoveAllUserEmailsForUserAsync(userId, cancellationToken);
 
     /// <inheritdoc />
     public async Task ReassignAsync(Guid mergedFromUserId, Guid mergedToUserId, Guid actorUserId, Instant now,
         CancellationToken ct)
     {
         // Caller invalidates cache AFTER the ambient TransactionScope commits — see AccountMergeService.AcceptAsync.
-        await repository.ReassignToUserAsync(
+        await repository.ReassignUserEmailsToUserAsync(
             mergedFromUserId, mergedToUserId, now, ct);
     }
 
@@ -389,7 +389,7 @@ public sealed class UserEmailService(
 
     public Task<string?> GetVerifiedEmailAddressAsync(
         Guid userId, Guid emailId, CancellationToken cancellationToken = default) =>
-        repository.GetVerifiedEmailAddressAsync(userId, emailId, cancellationToken);
+        repository.GetVerifiedUserEmailAddressAsync(userId, emailId, cancellationToken);
 
     public async Task<Dictionary<Guid, bool>> GetNobodiesTeamEmailStatusByUserAsync(
         CancellationToken cancellationToken = default)
@@ -438,7 +438,7 @@ public sealed class UserEmailService(
         if (userIds.Count == 0)
             return new Dictionary<Guid, string>();
 
-        var allNotificationTargets = await repository.GetAllNotificationTargetEmailsAsync(cancellationToken);
+        var allNotificationTargets = await repository.GetAllNotificationTargetUserEmailsAsync(cancellationToken);
 
         var result = new Dictionary<Guid, string>(userIds.Count);
         foreach (var userId in userIds)
@@ -467,7 +467,7 @@ public sealed class UserEmailService(
     {
         var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
         var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
-        return await repository.FindVerifiedWithUserAsync(normalizedEmail, alternateEmail, cancellationToken);
+        return await repository.FindVerifiedUserEmailWithUserAsync(normalizedEmail, alternateEmail, cancellationToken);
     }
 
     public async Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserIdsAsync(
@@ -475,23 +475,23 @@ public sealed class UserEmailService(
     {
         var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
         var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
-        return await repository.GetDistinctVerifiedUserIdsAsync(normalizedEmail, alternateEmail, cancellationToken);
+        return await repository.GetDistinctVerifiedUserEmailUserIdsAsync(normalizedEmail, alternateEmail, cancellationToken);
     }
 
     public Task<Guid?> GetUserIdByVerifiedEmailAsync(
         string email, CancellationToken cancellationToken = default) =>
-        repository.GetUserIdByVerifiedEmailAsync(email, cancellationToken);
+        repository.GetUserIdByVerifiedUserEmailAsync(email, cancellationToken);
 
     public Task<IReadOnlyList<Guid>> GetUserIdsByEmailPrefixAndSuffixAsync(
         string prefix,
         string suffix,
         CancellationToken cancellationToken = default) =>
-        repository.GetUserIdsByEmailPrefixAndSuffixAsync(prefix, suffix, cancellationToken);
+        repository.GetUserIdsByUserEmailPrefixAndSuffixAsync(prefix, suffix, cancellationToken);
 
     public async Task<Guid?> GetUserIdByExactEmailAsync(string email, CancellationToken ct = default)
     {
         // Returns null on zero matches OR ambiguous matches; only non-null when exactly one user verified-holds the address.
-        var userIds = await repository.GetDistinctUserIdsByVerifiedEmailAsync(email, ct);
+        var userIds = await repository.GetDistinctUserIdsByVerifiedUserEmailAsync(email, ct);
         return userIds.Count == 1 ? userIds[0] : null;
     }
 
@@ -563,7 +563,7 @@ public sealed class UserEmailService(
         if (userIds.Count == 0)
             return new Dictionary<Guid, string>();
 
-        var all = await repository.GetAllNotificationTargetEmailsAsync(cancellationToken);
+        var all = await repository.GetAllNotificationTargetUserEmailsAsync(cancellationToken);
         return all
             .Where(kv => userIds.Contains(kv.Key))
             .ToDictionary(kv => kv.Key, kv => kv.Value);
@@ -571,20 +571,20 @@ public sealed class UserEmailService(
 
     public Task<IReadOnlyList<Guid>> SearchUserIdsByVerifiedEmailAsync(
         string searchTerm, CancellationToken cancellationToken = default)
-        => repository.SearchUserIdsByVerifiedEmailAsync(searchTerm, cancellationToken);
+        => repository.SearchUserIdsByVerifiedUserEmailAsync(searchTerm, cancellationToken);
 
     public Task<Guid?> GetOtherUserIdHavingEmailAsync(
         string email, Guid excludeUserId, CancellationToken cancellationToken = default)
-        => repository.GetOtherUserIdHavingEmailAsync(email, excludeUserId, cancellationToken);
+        => repository.GetOtherUserIdHavingUserEmailAsync(email, excludeUserId, cancellationToken);
 
     public Task<bool> IsEmailLinkedToAnyUserAsync(
         string email, CancellationToken cancellationToken = default) =>
-        repository.AnyWithEmailAsync(email, cancellationToken);
+        repository.AnyUserEmailWithEmailAsync(email, cancellationToken);
 
     public async Task<IReadOnlyList<UserEmailMatch>> MatchByEmailsAsync(
         IReadOnlyCollection<string> emails, CancellationToken cancellationToken = default)
     {
-        var rows = await repository.GetByEmailsAsync(emails, cancellationToken);
+        var rows = await repository.GetUserEmailsByEmailsAsync(emails, cancellationToken);
         return rows
             .Select(r => new UserEmailMatch(
                 r.Email, r.UserId, r.IsPrimary, r.IsVerified, r.UpdatedAt))
@@ -668,7 +668,7 @@ public sealed class UserEmailService(
     {
         var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
         var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
-        var match = await repository.FindByNormalizedEmailAsync(
+        var match = await repository.FindUserEmailByNormalizedEmailAsync(
             normalizedEmail, alternateEmail, cancellationToken);
         return match?.UserId;
     }
@@ -679,7 +679,7 @@ public sealed class UserEmailService(
     {
         var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
         var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
-        var match = await repository.FindByNormalizedEmailAsync(
+        var match = await repository.FindUserEmailByNormalizedEmailAsync(
             normalizedEmail, alternateEmail, cancellationToken);
         if (match is null) return null;
         return (match.UserId, match.Id);
@@ -690,11 +690,11 @@ public sealed class UserEmailService(
         Guid userId, Guid userEmailId, Guid actorUserId,
         CancellationToken cancellationToken = default)
     {
-        var row = await repository.GetByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
+        var row = await repository.GetUserEmailByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
         if (row is null || !row.IsVerified) return false;
 
         // Capture previous Google email for audit description.
-        var allEmails = await repository.GetByUserIdReadOnlyAsync(userId, cancellationToken);
+        var allEmails = await repository.GetUserEmailsByUserIdReadOnlyAsync(userId, cancellationToken);
         var previousGoogle = allEmails.FirstOrDefault(e => e.IsGoogle && e.Id != row.Id);
 
         var updated = await userService.UpdateUserEmailAsync(
@@ -723,11 +723,11 @@ public sealed class UserEmailService(
         Guid userId, Guid userEmailId, Guid actorUserId,
         CancellationToken cancellationToken = default)
     {
-        var row = await repository.GetByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
+        var row = await repository.GetUserEmailByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
         if (row is null || !row.IsGoogle) return false;
 
         // Only allow clearing IsGoogle on a duplicate — clearing the sole IsGoogle row → ZeroIsGoogle violation.
-        var allEmails = await repository.GetByUserIdReadOnlyAsync(userId, cancellationToken);
+        var allEmails = await repository.GetUserEmailsByUserIdReadOnlyAsync(userId, cancellationToken);
         if (allEmails.Count(e => e.IsGoogle) <= 1) return false;
 
         var updated = await userService.UpdateUserEmailAsync(
@@ -752,11 +752,11 @@ public sealed class UserEmailService(
         Guid userId, Guid userEmailId, Guid actorUserId,
         CancellationToken cancellationToken = default)
     {
-        var row = await repository.GetByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
+        var row = await repository.GetUserEmailByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
         if (row is null || !row.IsPrimary) return false;
 
         // Only allow clearing IsPrimary on a duplicate verified row — must mirror the scanner's verified filter to avoid ZeroIsPrimary.
-        var allEmails = await repository.GetByUserIdReadOnlyAsync(userId, cancellationToken);
+        var allEmails = await repository.GetUserEmailsByUserIdReadOnlyAsync(userId, cancellationToken);
         if (allEmails.Count(e => e.IsPrimary && e.IsVerified) <= 1) return false;
 
         var updated = await userService.UpdateUserEmailAsync(
@@ -816,7 +816,7 @@ public sealed class UserEmailService(
     {
         // Orphans are UserEmail rows whose UserId is missing or merged. Iterating UserInfo can't find rows for
         // non-existent users, so the repo's full-table scan is still required here.
-        var allEmails = await repository.GetAllAsync(ct);
+        var allEmails = await repository.GetAllUserEmailsAsync(ct);
         var liveUserIds = (await userService.GetAllUserInfosAsync(ct).ConfigureAwait(false))
             .Where(u => u.MergedToUserId is null)
             .Select(u => u.Id)
@@ -831,7 +831,7 @@ public sealed class UserEmailService(
     /// <inheritdoc />
     public async Task<bool> DeleteByIdAsync(Guid emailId, CancellationToken ct = default)
     {
-        var row = await repository.GetByIdReadOnlyAsync(emailId, ct);
+        var row = await repository.GetUserEmailByIdReadOnlyAsync(emailId, ct);
         if (row is null) return false;
 
         return await userService.RemoveUserEmailAsync(
@@ -848,7 +848,7 @@ public sealed class UserEmailService(
         Guid userId, Guid userEmailId, Guid actorUserId,
         CancellationToken cancellationToken = default)
     {
-        var row = await repository.GetByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
+        var row = await repository.GetUserEmailByIdAndUserIdAsync(userEmailId, userId, cancellationToken);
         if (row is null) return false;
         if (string.IsNullOrEmpty(row.Provider) || string.IsNullOrEmpty(row.ProviderKey))
             return false;
@@ -856,7 +856,7 @@ public sealed class UserEmailService(
         var user = await userManager.FindByIdAsync(userId.ToString());
         if (user is null) return false;
 
-        // Capture before RemoveAsync may detach the entity.
+        // Capture before RemoveUserEmailAsync may detach the entity.
         var provider = row.Provider;
         var providerKey = row.ProviderKey;
         var email = row.Email;
@@ -908,7 +908,7 @@ public sealed class UserEmailService(
         CancellationToken cancellationToken = default)
     {
         var now = clock.GetCurrentInstant();
-        var rows = (await repository.GetByUserIdForMutationAsync(userId, cancellationToken)).ToList();
+        var rows = (await repository.GetUserEmailsByUserIdForMutationAsync(userId, cancellationToken)).ToList();
 
         var tagged = rows.FirstOrDefault(r =>
             string.Equals(r.Provider, provider, StringComparison.Ordinal) &&
@@ -929,14 +929,14 @@ public sealed class UserEmailService(
         // Cross-user check before any mutation. Normalize via gmail/googlemail alternate so dot-aliases can't bypass the displacement gate.
         var normalizedClaim = EmailNormalization.NormalizeForComparison(claimEmail);
         var alternateClaim = GetAlternateComparableEmail(normalizedClaim);
-        var blocker = await repository.FindOtherUsersVerifiedRowAsync(
+        var blocker = await repository.FindOtherUsersVerifiedUserEmailRowAsync(
             normalizedClaim, alternateClaim, userId, cancellationToken);
 
         // 2. CrossUserBlocked: another user verified-holds the claim and provider's claim is unverified — no mutation, audit the attempt.
         if (blocker is not null && !claimEmailVerified)
         {
             // Load displaced user rows for diagnostic only (rare path).
-            var blockerRows = await repository.GetByUserIdForMutationAsync(
+            var blockerRows = await repository.GetUserEmailsByUserIdForMutationAsync(
                 blocker.UserId, cancellationToken);
 
             var blockedDescription = await BuildCrossUserDiagnosticAsync(
@@ -980,7 +980,7 @@ public sealed class UserEmailService(
 
         if (blocker is not null && claimEmailVerified)
         {
-            var displacedUsersRows = await repository.GetByUserIdForMutationAsync(
+            var displacedUsersRows = await repository.GetUserEmailsByUserIdForMutationAsync(
                 blocker.UserId, cancellationToken);
             displacedUserLeftWithoutVerifiedEmail = displacedUsersRows
                 .Count(r => r.IsVerified && r.Id != blocker.Id) == 0;

--- a/src/Humans.Application/Services/Users/UserEmailProviderBackfillService.cs
+++ b/src/Humans.Application/Services/Users/UserEmailProviderBackfillService.cs
@@ -13,7 +13,6 @@ namespace Humans.Application.Services.Users;
 // One-shot backfill: tags UserEmail rows with Provider/ProviderKey from AspNetUserLogins; flips IsGoogle from the legacy shadow column.
 public sealed class UserEmailProviderBackfillService(
     IUserRepository userRepository,
-    IUserEmailRepository userEmailRepository,
     UserManager<User> userManager,
     IAuditLogService auditLogService,
     IClock clock,
@@ -37,14 +36,14 @@ public sealed class UserEmailProviderBackfillService(
 
             legacyGoogleEmails.TryGetValue(user.Id, out var legacyGoogleEmail);
 
-            var snapshots = (await userEmailRepository
-                .GetLegacyBackfillSnapshotsByUserIdAsync(user.Id, cancellationToken))
+            var snapshots = (await userRepository
+                .GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(user.Id, cancellationToken))
                 .ToList();
             if (snapshots.Count == 0)
                 continue;
 
             var logins = await userManager.GetLoginsAsync(user);
-            var emails = (await userEmailRepository.GetByUserIdForMutationAsync(user.Id, cancellationToken))
+            var emails = (await userRepository.GetUserEmailsByUserIdForMutationAsync(user.Id, cancellationToken))
                 .ToList();
             var updates = new List<UserEmail>();
             var taggedRowIds = new HashSet<Guid>();
@@ -121,7 +120,7 @@ public sealed class UserEmailProviderBackfillService(
             }
 
             if (updates.Count > 0)
-                await userEmailRepository.UpdateBatchAsync(updates, cancellationToken);
+                await userRepository.UpdateUserEmailsAsync(updates, cancellationToken);
         }
 
         logger.LogInformation(

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -17,7 +17,6 @@ namespace Humans.Application.Services.Users;
 
 public sealed class UserService(
     IUserRepository repo,
-    IUserEmailRepository userEmailRepo,
     ICommunicationPreferenceRepository communicationPreferenceRepo,
     IAdminAuthorizationService adminAuthorization,
     IClock clock,
@@ -41,7 +40,7 @@ public sealed class UserService(
         var user = await repo.GetByIdAsync(userId, ct);
         if (user is null) return null;
 
-        var userEmails = await userEmailRepo.GetByUserIdReadOnlyAsync(userId, ct);
+        var userEmails = await repo.GetUserEmailsByUserIdReadOnlyAsync(userId, ct);
         var participations = await repo.GetEventParticipationsByUserIdAsync(userId, ct);
         var externalLoginsMap = await repo.GetExternalLoginsByUserIdsAsync([userId], ct);
         var externalLogins = externalLoginsMap.TryGetValue(userId, out var logins)
@@ -75,7 +74,7 @@ public sealed class UserService(
 
         var userIds = users.Select(u => u.Id).ToList();
 
-        var allEmails = await userEmailRepo.GetAllAsync(ct);
+        var allEmails = await repo.GetAllUserEmailsAsync(ct);
         var emailsByUser = allEmails
             .GroupBy(e => e.UserId)
             .ToDictionary(g => g.Key, g => (IReadOnlyList<UserEmail>)g.ToList());
@@ -149,18 +148,40 @@ public sealed class UserService(
             "it indicates a DI registration mistake — IUserService should resolve " +
             "to CachingUserService.");
 
-    public Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default) =>
-        repo.GetByIdAsync(userId, ct);
+    public async Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default)
+    {
+        var user = await repo.GetByIdAsync(userId, ct);
+        if (user is null)
+            return null;
 
-    public Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(
-        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
-        repo.GetByIdsAsync(userIds, ct);
+        await HydrateUserEmailsAsync(user, ct);
+        return user;
+    }
 
-    public Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default) =>
-        repo.GetAllAsync(ct);
+    public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
+    {
+        var users = await repo.GetByIdsAsync(userIds, ct);
+        if (users.Count == 0)
+            return users;
+
+        await HydrateUserEmailsAsync(users.Values, ct);
+        return users;
+    }
+
+    public async Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default)
+    {
+        var users = await repo.GetAllAsync(ct);
+        await HydrateUserEmailsAsync(users, ct);
+        return users;
+    }
 
     public async Task<string?> PurgeOwnDataAsync(Guid userId, CancellationToken ct = default)
     {
+        if (await repo.GetByIdAsync(userId, ct) is null)
+            return null;
+
+        await repo.RemoveAllUserEmailsForUserAndSaveAsync(userId, ct);
         var displayName = await repo.PurgeAsync(userId, ct);
         if (displayName is null)
             return null;
@@ -174,20 +195,70 @@ public sealed class UserService(
         Guid userId, CancellationToken ct = default)
     {
         // Own-data only — cross-section cascade lives in IAccountDeletionService.
+        if (await repo.GetByIdAsync(userId, ct) is null)
+            return null;
+
+        await repo.RemoveAllUserEmailsForUserAndSaveAsync(userId, ct);
         return await repo.ApplyExpiredDeletionAnonymizationAsync(userId, ct);
     }
 
-    public Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default)
+    public async Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default)
     {
         var normalized = EmailNormalization.NormalizeForComparison(email);
         var alternate = GetAlternateEmail(normalized);
-        return repo.GetByEmailOrAlternateAsync(normalized, alternate, ct);
+
+        var matchingUserIds = await repo.GetDistinctVerifiedUserEmailUserIdsAsync(normalized, alternate, ct);
+        if (matchingUserIds.Count > 0)
+            return await GetByIdAsync(matchingUserIds[0], ct);
+
+        var legacyUser = await repo.GetByEmailOrAlternateAsync(normalized, alternate, ct);
+        if (legacyUser is null)
+            return null;
+
+        await HydrateUserEmailsAsync(legacyUser, ct);
+        return legacyUser;
     }
 
     [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. Use IUserEmailService.GetOtherUserIdHavingEmailAsync.")]
     public Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
         string email, Guid excludeUserId, CancellationToken ct = default) =>
         repo.GetOtherUserIdHavingGoogleEmailAsync(email, excludeUserId, ct);
+
+    private async Task HydrateUserEmailsAsync(User user, CancellationToken ct)
+    {
+        var emails = await repo.GetUserEmailsByUserIdReadOnlyAsync(user.Id, ct);
+        AttachUserEmails(user, emails);
+    }
+
+    private async Task HydrateUserEmailsAsync(IEnumerable<User> users, CancellationToken ct)
+    {
+        var userList = users.ToList();
+        if (userList.Count == 0)
+            return;
+
+        var userIds = userList.Select(u => u.Id).ToHashSet();
+        var emailsByUser = (await repo.GetAllUserEmailsAsync(ct))
+            .Where(e => userIds.Contains(e.UserId))
+            .GroupBy(e => e.UserId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<UserEmail>)g.ToList());
+
+        foreach (var user in userList)
+        {
+            var emails = emailsByUser.TryGetValue(user.Id, out var found)
+                ? found
+                : [];
+            AttachUserEmails(user, emails);
+        }
+    }
+
+    private static void AttachUserEmails(User user, IEnumerable<UserEmail> emails)
+    {
+        if (user.UserEmails.Count > 0)
+            return;
+
+        foreach (var email in emails)
+            user.UserEmails.Add(email);
+    }
 
     public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
         Instant now, CancellationToken ct = default) =>
@@ -593,7 +664,7 @@ public sealed class UserService(
         if (!new EmailAddressAttribute().IsValid(email))
             throw new ValidationException("Please enter a valid email address.");
 
-        var existing = await userEmailRepo.FindByNormalizedEmailAsync(normalizedEmail, alternateEmail, ct);
+        var existing = await repo.FindUserEmailByNormalizedEmailAsync(normalizedEmail, alternateEmail, ct);
         if (existing is not null && existing.UserId == userId)
         {
             if (command.IgnoreExisting)
@@ -638,7 +709,7 @@ public sealed class UserService(
 
         if (command.MarkVerified)
         {
-            var email = await userEmailRepo.GetByIdAndUserIdAsync(emailId, userId, ct)
+            var email = await repo.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct)
                 ?? throw new InvalidOperationException("Email not found.");
 
             if (email.IsVerified || email.Provider is not null)
@@ -646,7 +717,7 @@ public sealed class UserService(
 
             email.IsVerified = true;
             email.UpdatedAt = clock.GetCurrentInstant();
-            await userEmailRepo.UpdateAsync(email, ct);
+            await repo.UpdateUserEmailAsync(email, ct);
             await EnsurePrimaryInvariantAsync(userId, ct);
             await EnsureGoogleInvariantAsync(userId, ct);
             changed = true;
@@ -664,9 +735,9 @@ public sealed class UserService(
 
         if (command.Google == UserEmailGoogleChange.MakeGoogle)
         {
-            var row = await userEmailRepo.GetByIdAndUserIdAsync(emailId, userId, ct);
+            var row = await repo.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct);
             if (row is null || !row.IsVerified) return false;
-            await userEmailRepo.SetGoogleExclusiveAsync(userId, emailId, clock.GetCurrentInstant(), ct);
+            await repo.SetUserEmailGoogleExclusiveAsync(userId, emailId, clock.GetCurrentInstant(), ct);
             changed = true;
         }
         else if (command.Google == UserEmailGoogleChange.ClearDuplicateGoogle)
@@ -676,11 +747,11 @@ public sealed class UserService(
 
         if (command.ChangeVisibility)
         {
-            var row = await userEmailRepo.GetByIdAndUserIdAsync(emailId, userId, ct)
+            var row = await repo.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct)
                 ?? throw new InvalidOperationException("Email not found.");
             row.Visibility = command.Visibility;
             row.UpdatedAt = clock.GetCurrentInstant();
-            await userEmailRepo.UpdateAsync(row, ct);
+            await repo.UpdateUserEmailAsync(row, ct);
             changed = true;
         }
 
@@ -693,7 +764,7 @@ public sealed class UserService(
         UserEmailRemoveCommand command,
         CancellationToken ct = default)
     {
-        var email = await userEmailRepo.GetByIdAndUserIdAsync(emailId, userId, ct)
+        var email = await repo.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct)
             ?? throw new InvalidOperationException("Email not found.");
 
         var hasProvider = !string.IsNullOrEmpty(email.Provider);
@@ -704,7 +775,7 @@ public sealed class UserService(
 
         if (command.PreserveLastVerifiedEmail && email.IsVerified)
         {
-            var allEmails = await userEmailRepo.GetByUserIdForMutationAsync(userId, ct);
+            var allEmails = await repo.GetUserEmailsByUserIdForMutationAsync(userId, ct);
             var verifiedRemaining = allEmails.Count(e => e.IsVerified && e.Id != emailId);
 
             if (verifiedRemaining == 0)
@@ -715,7 +786,7 @@ public sealed class UserService(
             }
         }
 
-        await userEmailRepo.RemoveAsync(email, ct);
+        await repo.RemoveUserEmailAsync(email, ct);
 
         if (command.RepairInvariants)
         {
@@ -731,7 +802,7 @@ public sealed class UserService(
         UserEmailReconcilePlanCommand command,
         CancellationToken ct = default)
     {
-        await userEmailRepo.ApplyReconcilePlanAsync(
+        await repo.ApplyUserEmailReconcilePlanAsync(
             displacedRowToDelete: command.DisplacedRowToDelete,
             rowToDelete: command.RowToDelete,
             rowToUpdate: command.RowToUpdate,
@@ -859,7 +930,7 @@ public sealed class UserService(
         }
 
         // see nobodies-collective/Humans#687 — User.GoogleEmail deprecated, not exported.
-        var userEmails = await userEmailRepo.GetByUserIdReadOnlyAsync(userId, ct);
+        var userEmails = await repo.GetUserEmailsByUserIdReadOnlyAsync(userId, ct);
         var googleEmail = userEmails
             .Where(e => e.IsVerified && e.IsGoogle)
             .Select(e => e.Email)
@@ -1021,7 +1092,7 @@ public sealed class UserService(
 
     private async Task SetPrimaryEmailAsync(Guid userId, Guid emailId, CancellationToken ct)
     {
-        var emails = (await userEmailRepo.GetByUserIdForMutationAsync(userId, ct)).ToList();
+        var emails = (await repo.GetUserEmailsByUserIdForMutationAsync(userId, ct)).ToList();
 
         var target = emails.FirstOrDefault(e => e.Id == emailId)
             ?? throw new InvalidOperationException("Email not found.");
@@ -1043,40 +1114,40 @@ public sealed class UserService(
         }
 
         if (changed.Count > 0)
-            await userEmailRepo.UpdateBatchAsync(changed, ct);
+            await repo.UpdateUserEmailsAsync(changed, ct);
     }
 
     private async Task<bool> ClearDuplicatePrimaryAsync(Guid userId, Guid emailId, CancellationToken ct)
     {
-        var row = await userEmailRepo.GetByIdAndUserIdAsync(emailId, userId, ct);
+        var row = await repo.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct);
         if (row is null || !row.IsPrimary) return false;
 
-        var allEmails = await userEmailRepo.GetByUserIdReadOnlyAsync(userId, ct);
+        var allEmails = await repo.GetUserEmailsByUserIdReadOnlyAsync(userId, ct);
         if (allEmails.Count(e => e.IsPrimary && e.IsVerified) <= 1) return false;
 
         row.IsPrimary = false;
         row.UpdatedAt = clock.GetCurrentInstant();
-        await userEmailRepo.UpdateAsync(row, ct);
+        await repo.UpdateUserEmailAsync(row, ct);
         return true;
     }
 
     private async Task<bool> ClearDuplicateGoogleAsync(Guid userId, Guid emailId, CancellationToken ct)
     {
-        var row = await userEmailRepo.GetByIdAndUserIdAsync(emailId, userId, ct);
+        var row = await repo.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct);
         if (row is null || !row.IsGoogle) return false;
 
-        var allEmails = await userEmailRepo.GetByUserIdReadOnlyAsync(userId, ct);
+        var allEmails = await repo.GetUserEmailsByUserIdReadOnlyAsync(userId, ct);
         if (allEmails.Count(e => e.IsGoogle) <= 1) return false;
 
         row.IsGoogle = false;
         row.UpdatedAt = clock.GetCurrentInstant();
-        await userEmailRepo.UpdateAsync(row, ct);
+        await repo.UpdateUserEmailAsync(row, ct);
         return true;
     }
 
     private async Task EnsurePrimaryInvariantAsync(Guid userId, CancellationToken ct)
     {
-        var emails = (await userEmailRepo.GetByUserIdForMutationAsync(userId, ct)).ToList();
+        var emails = (await repo.GetUserEmailsByUserIdForMutationAsync(userId, ct)).ToList();
         var verified = emails.Where(e => e.IsVerified).ToList();
         if (verified.Count == 0)
             return;
@@ -1105,12 +1176,12 @@ public sealed class UserService(
         }
 
         if (changed.Count > 0)
-            await userEmailRepo.UpdateBatchAsync(changed, ct);
+            await repo.UpdateUserEmailsAsync(changed, ct);
     }
 
     private async Task EnsureGoogleInvariantAsync(Guid userId, CancellationToken ct)
     {
-        var emails = (await userEmailRepo.GetByUserIdForMutationAsync(userId, ct)).ToList();
+        var emails = (await repo.GetUserEmailsByUserIdForMutationAsync(userId, ct)).ToList();
         var verified = emails.Where(e => e.IsVerified).ToList();
         if (verified.Count == 0)
             return;
@@ -1139,12 +1210,12 @@ public sealed class UserService(
         }
 
         if (changed.Count > 0)
-            await userEmailRepo.UpdateBatchAsync(changed, ct);
+            await repo.UpdateUserEmailsAsync(changed, ct);
     }
 
     private async Task AddRowWithInvariantsAsync(UserEmail row, CancellationToken ct)
     {
-        await userEmailRepo.AddAsync(row, ct);
+        await repo.AddUserEmailAsync(row, ct);
         await EnsurePrimaryInvariantAsync(row.UserId, ct);
         await EnsureGoogleInvariantAsync(row.UserId, ct);
     }
@@ -1243,14 +1314,23 @@ public sealed class UserService(
             "scans the cached UserInfo snapshot for MergedToUserId tombstones. If this is " +
             "being called on the inner UserService it indicates a DI registration mistake.");
 
-    public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) =>
-        repo.GetUsersWithLoginsButNoEmailsAsync(ct);
+    public async Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default)
+    {
+        var loginUserIds = await repo.GetUserIdsWithExternalLoginsAsync(ct);
+        if (loginUserIds.Count == 0)
+            return [];
+
+        var withEmail = await repo.GetUserIdsHavingAnyUserEmailAsync(loginUserIds, ct);
+        var withEmailSet = withEmail.ToHashSet();
+        return loginUserIds.Where(id => !withEmailSet.Contains(id)).ToList();
+    }
 
     public async Task<int> DeleteUsersAsync(
         IReadOnlyCollection<Guid> userIds,
         CancellationToken ct = default)
     {
         await adminAuthorization.RequireCurrentUserIsAdminAsync(ct);
+        await repo.RemoveAllUserEmailsForUsersAndSaveAsync(userIds, ct);
         return await repo.DeleteUsersAsync(userIds, ct);
     }
 

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -55,8 +55,8 @@ public class User : IdentityUser<Guid>
 
     /// <inheritdoc />
 #pragma warning disable CS0809 // Obsolete override of non-obsolete base — intentional.
-    [Obsolete("NormalizedEmail is shadow-populated by Identity. Use User.Email or IUserEmailRepository for canonical email lookup.", DiagnosticId = "HUM_USER_NORMALIZEDEMAIL", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/635")]
-    [Architecture.ExpiresOn("2026-06-01", reason: "Issue #635 — Identity shadow column; application reads should go through User.Email / IUserEmailRepository.")]
+    [Obsolete("NormalizedEmail is shadow-populated by Identity. Use User.Email or IUserEmailService for canonical email lookup.", DiagnosticId = "HUM_USER_NORMALIZEDEMAIL", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/635")]
+    [Architecture.ExpiresOn("2026-06-01", reason: "Issue #635 — Identity shadow column; application reads should go through User.Email / IUserEmailService.")]
     public override string? NormalizedEmail
     {
         get => Email?.ToUpperInvariant();

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs
@@ -2,22 +2,17 @@ using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Profiles;
-using Humans.Application.Architecture;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 
-namespace Humans.Infrastructure.Repositories.Profiles;
+namespace Humans.Infrastructure.Repositories.Users;
 
-/// <summary>EF-backed <see cref="IUserEmailRepository"/>.</summary>
-[Grandfathered("HUM0025", justification: "UserEmails is also accessed by UserRepository to build UserInfo; converge analyzer ownership on the read model boundary.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserEmails")]
-[Grandfathered("HUM0025", justification: "Audited Users.GoogleEmail/GoogleEmailStatus/Email bridge write; route through IUserService.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "Users")]
-internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> factory) : IUserEmailRepository
+internal sealed partial class UserRepository
 {
-    public async Task<IReadOnlyList<UserEmail>> GetByUserIdReadOnlyAsync(
+    public async Task<IReadOnlyList<UserEmail>> GetUserEmailsByUserIdReadOnlyAsync(
         Guid userId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(e => e.UserId == userId)
@@ -26,40 +21,40 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .ToListAsync(ct);
     }
 
-    public async Task<IReadOnlyList<UserEmail>> GetByUserIdForMutationAsync(
+    public async Task<IReadOnlyList<UserEmail>> GetUserEmailsByUserIdForMutationAsync(
         Guid userId, CancellationToken ct = default)
     {
         // With IDbContextFactory the context is short-lived, so returned entities
         // are detached. Callers must pass mutated entities explicitly back to
-        // UpdateAsync / UpdateBatchAsync.
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        // UpdateUserEmailAsync / UpdateUserEmailsAsync.
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(e => e.UserId == userId)
             .ToListAsync(ct);
     }
 
-    public async Task<UserEmail?> GetByIdAndUserIdAsync(
+    public async Task<UserEmail?> GetUserEmailByIdAndUserIdAsync(
         Guid emailId, Guid userId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .FirstOrDefaultAsync(e => e.Id == emailId && e.UserId == userId, ct);
     }
 
-    public async Task<UserEmail?> GetByIdReadOnlyAsync(Guid emailId, CancellationToken ct = default)
+    public async Task<UserEmail?> GetUserEmailByIdReadOnlyAsync(Guid emailId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == emailId, ct);
     }
 
-    public async Task<bool> ExistsForUserAsync(
+    public async Task<bool> UserEmailExistsForUserAsync(
         Guid userId, string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return alternateEmail is null
             ? await ctx.UserEmails.AnyAsync(
                 e => e.UserId == userId && EF.Functions.ILike(e.Email, normalizedEmail), ct)
@@ -69,11 +64,11 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
                      EF.Functions.ILike(e.Email, alternateEmail)), ct);
     }
 
-    public async Task<bool> ExistsVerifiedForOtherUserAsync(
+    public async Task<bool> VerifiedUserEmailExistsForOtherUserAsync(
         Guid userId, string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return alternateEmail is null
             ? await ctx.UserEmails.AnyAsync(
                 e => e.UserId != userId && e.IsVerified &&
@@ -84,11 +79,11 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
                      EF.Functions.ILike(e.Email, alternateEmail)), ct);
     }
 
-    public async Task<UserEmail?> GetConflictingVerifiedEmailAsync(
+    public async Task<UserEmail?> GetConflictingVerifiedUserEmailAsync(
         Guid excludeEmailId, string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return alternateEmail is null
             ? await ctx.UserEmails.FirstOrDefaultAsync(
                 e => e.Id != excludeEmailId && e.IsVerified &&
@@ -100,9 +95,9 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
     }
 
     public async Task<IReadOnlyList<UserEmailLegacyBackfillSnapshot>>
-        GetLegacyBackfillSnapshotsByUserIdAsync(Guid userId, CancellationToken ct = default)
+        GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(Guid userId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(e => e.UserId == userId)
@@ -118,17 +113,32 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .ToListAsync(ct);
     }
 
-    public async Task<IReadOnlyList<UserEmail>> GetAllAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<UserEmail>> GetAllUserEmailsAsync(CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .ToListAsync(ct);
     }
 
-    public async Task RemoveAllForUserAndSaveAsync(Guid userId, CancellationToken ct = default)
+    public async Task<IReadOnlyList<Guid>> GetUserIdsHavingAnyUserEmailAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        if (userIds.Count == 0)
+            return [];
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.UserEmails
+            .AsNoTracking()
+            .Where(e => userIds.Contains(e.UserId))
+            .Select(e => e.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+    }
+
+    public async Task RemoveAllUserEmailsForUserAndSaveAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var emails = await ctx.UserEmails
             .Where(e => e.UserId == userId)
             .ToListAsync(ct);
@@ -140,11 +150,23 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task<int> ReassignToUserAsync(
+    public async Task RemoveAllUserEmailsForUsersAndSaveAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        await ctx.UserEmails
+            .Where(e => userIds.Contains(e.UserId))
+            .ExecuteDeleteAsync(ct);
+    }
+
+    public async Task<int> ReassignUserEmailsToUserAsync(
         Guid sourceUserId, Guid targetUserId, Instant updatedAt,
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
 
         var sourceRows = await ctx.UserEmails
             .Where(e => e.UserId == sourceUserId)
@@ -190,10 +212,10 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .CountAsync(e => e.UserId == targetUserId, ct);
     }
 
-    public async Task<bool> MarkVerifiedAsync(
+    public async Task<bool> MarkUserEmailVerifiedAsync(
         Guid emailId, Instant now, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var email = await ctx.UserEmails.FirstOrDefaultAsync(e => e.Id == emailId, ct);
         if (email is null)
             return false;
@@ -204,9 +226,9 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         return true;
     }
 
-    public async Task<bool> RemoveByIdAsync(Guid emailId, CancellationToken ct = default)
+    public async Task<bool> RemoveUserEmailByIdAsync(Guid emailId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var email = await ctx.UserEmails.FirstOrDefaultAsync(e => e.Id == emailId, ct);
         if (email is null)
             return false;
@@ -216,13 +238,13 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         return true;
     }
 
-    public async Task<IReadOnlyList<UserEmail>> GetByEmailsAsync(
+    public async Task<IReadOnlyList<UserEmail>> GetUserEmailsByEmailsAsync(
         IReadOnlyCollection<string> emails, CancellationToken ct = default)
     {
         if (emails.Count == 0)
             return [];
 
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         // Lower-case both sides for a case-insensitive IN comparison.
         // UserEmail.Email is a plain text column; explicit invariant lowering
         // keeps the translation provider-neutral. The .NET-side LINQ to Entities
@@ -236,27 +258,21 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
 #pragma warning restore MA0011
     }
 
-    public async Task<bool> AnyWithEmailAsync(string email, CancellationToken ct = default)
+    public async Task<bool> AnyUserEmailWithEmailAsync(string email, CancellationToken ct = default)
     {
         // Escape '_' and '%' in the input so ILIKE treats them as literals,
         // otherwise the collision check can report false positives
         // (e.g. john_doe@... matching johnXdoe@...).
         var escaped = EscapeLikePattern(email);
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AnyAsync(ue => EF.Functions.ILike(ue.Email, escaped, "\\"), ct);
     }
 
-    private static string EscapeLikePattern(string value)
-        => value
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
-
-    public async Task<Dictionary<Guid, string>> GetAllNotificationTargetEmailsAsync(
+    public async Task<Dictionary<Guid, string>> GetAllNotificationTargetUserEmailsAsync(
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(e => e.IsVerified && e.IsPrimary)
@@ -269,7 +285,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .ToDictionaryAsync(x => x.UserId, x => x.Email, ct);
     }
 
-    public async Task<IReadOnlyList<Guid>> SearchUserIdsByVerifiedEmailAsync(
+    public async Task<IReadOnlyList<Guid>> SearchUserIdsByVerifiedUserEmailAsync(
         string searchTerm, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(searchTerm))
@@ -280,7 +296,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         // "aXb"). Pass '\' as the explicit escape character.
         var pattern = $"%{EscapeLikePattern(searchTerm.Trim())}%";
 
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(e => e.IsVerified && EF.Functions.ILike(e.Email, pattern, "\\"))
@@ -289,10 +305,10 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .ToListAsync(ct);
     }
 
-    public async Task<string?> GetVerifiedEmailAddressAsync(
+    public async Task<string?> GetVerifiedUserEmailAddressAsync(
         Guid userId, Guid emailId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(ue => ue.Id == emailId && ue.UserId == userId && ue.IsVerified)
@@ -300,11 +316,11 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<Guid?> GetUserIdByVerifiedEmailAsync(
+    public async Task<Guid?> GetUserIdByVerifiedUserEmailAsync(
         string email, CancellationToken ct = default)
     {
         var escaped = EscapeLikePattern(email);
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(ue => EF.Functions.ILike(ue.Email, escaped, "\\") && ue.IsVerified)
@@ -312,12 +328,12 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<IReadOnlyList<Guid>> GetUserIdsByEmailPrefixAndSuffixAsync(
+    public async Task<IReadOnlyList<Guid>> GetUserIdsByUserEmailPrefixAndSuffixAsync(
         string prefix,
         string suffix,
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(ue => ue.Email.StartsWith(prefix) && ue.Email.EndsWith(suffix))
@@ -326,11 +342,11 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .ToListAsync(ct);
     }
 
-    public async Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedEmailAsync(
+    public async Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedUserEmailAsync(
         string email, CancellationToken ct = default)
     {
         var escaped = EscapeLikePattern(email);
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(ue => EF.Functions.ILike(ue.Email, escaped, "\\") && ue.IsVerified)
@@ -339,10 +355,10 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .ToListAsync(ct);
     }
 
-    public async Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserIdsAsync(
+    public async Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserEmailUserIdsAsync(
         string normalizedEmail, string? alternateEmail, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var query = ctx.UserEmails.AsNoTracking().Where(ue => ue.IsVerified);
 
         query = alternateEmail is null
@@ -353,7 +369,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         return await query.Select(ue => ue.UserId).Distinct().ToListAsync(ct);
     }
 
-    public async Task<Guid?> GetOtherUserIdHavingEmailAsync(
+    public async Task<Guid?> GetOtherUserIdHavingUserEmailAsync(
         string email, Guid excludeUserId, CancellationToken ct = default)
     {
         // Filter UserId != excludeUserId inside the query (not after FirstOrDefault)
@@ -361,7 +377,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         // cross-user conflict. Escape ILIKE wildcards so '_' and '%' in the address
         // are treated as literals, matching the prior exact-comparison semantics.
         var escaped = EscapeLikePattern(email);
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
             .AsNoTracking()
             .Where(ue => EF.Functions.ILike(ue.Email, escaped, "\\") && ue.UserId != excludeUserId)
@@ -369,13 +385,13 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task SetGoogleExclusiveAsync(
+    public async Task SetUserEmailGoogleExclusiveAsync(
         Guid userId,
         Guid userEmailId,
         Instant updatedAt,
         CancellationToken cancellationToken = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(cancellationToken);
+        await using var ctx = await _factory.CreateDbContextAsync(cancellationToken);
         await using var tx = await ctx.Database.BeginTransactionAsync(cancellationToken);
 
         var rows = await ctx.UserEmails
@@ -394,24 +410,24 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         await tx.CommitAsync(cancellationToken);
     }
 
-    public async Task AddAsync(UserEmail email, CancellationToken ct = default)
+    public async Task AddUserEmailAsync(UserEmail email, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         ctx.UserEmails.Add(email);
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task RemoveAsync(UserEmail email, CancellationToken ct = default)
+    public async Task RemoveUserEmailAsync(UserEmail email, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         ctx.Attach(email);
         ctx.UserEmails.Remove(email);
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task RemoveAllForUserAsync(Guid userId, CancellationToken ct = default)
+    public async Task RemoveAllUserEmailsForUserAsync(Guid userId, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var emails = await ctx.UserEmails
             .Where(e => e.UserId == userId)
             .ToListAsync(ct);
@@ -420,11 +436,11 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task<UserEmailWithUser?> FindVerifiedWithUserAsync(
+    public async Task<UserEmailWithUser?> FindVerifiedUserEmailWithUserAsync(
         string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var query = ctx.UserEmails
             .AsNoTracking()
             .Where(ue => ue.IsVerified);
@@ -459,7 +475,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             user.LastLoginAt);
     }
 
-    public async Task<UserEmail?> FindByNormalizedEmailAsync(
+    public async Task<UserEmail?> FindUserEmailByNormalizedEmailAsync(
         string normalizedEmail, string? alternateEmail,
         CancellationToken ct = default)
     {
@@ -469,7 +485,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         var escapedEmail = EscapeLikePattern(normalizedEmail);
         var escapedAlternate = alternateEmail is null ? null : EscapeLikePattern(alternateEmail);
 
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         return escapedAlternate is null
             ? await ctx.UserEmails
                 .AsNoTracking()
@@ -482,18 +498,18 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
                          EF.Functions.ILike(e.Email, escapedAlternate, "\\"), ct);
     }
 
-    public async Task UpdateAsync(UserEmail email, CancellationToken ct = default)
+    public async Task UpdateUserEmailAsync(UserEmail email, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         ctx.Attach(email);
         ctx.Entry(email).State = EntityState.Modified;
         ExcludeLegacyShadowsFromUpdate(ctx.Entry(email));
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task UpdateBatchAsync(IReadOnlyList<UserEmail> emails, CancellationToken ct = default)
+    public async Task UpdateUserEmailsAsync(IReadOnlyList<UserEmail> emails, CancellationToken ct = default)
     {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         foreach (var email in emails)
         {
             ctx.Attach(email);
@@ -504,7 +520,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
     }
 
     // The legacy IsOAuth / DisplayOrder columns are mapped as EF shadow
-    // properties; detached UpdateAsync would write the CLR default (false / 0)
+    // properties; detached UpdateUserEmailAsync would write the CLR default (false / 0)
     // and silently erase legacy values that the provider backfill still depends
     // on. Drop the columns from the UPDATE until PR 7 removes them entirely.
     private static void ExcludeLegacyShadowsFromUpdate(
@@ -514,14 +530,14 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
         entry.Property("DisplayOrder").IsModified = false;
     }
 
-    public async Task<UserEmail?> FindOtherUsersVerifiedRowAsync(
+    public async Task<UserEmail?> FindOtherUsersVerifiedUserEmailRowAsync(
         string normalizedEmail, string? alternateEmail, Guid excludeUserId,
         CancellationToken ct = default)
     {
         var escaped = EscapeLikePattern(normalizedEmail);
         var escapedAlternate = alternateEmail is null ? null : EscapeLikePattern(alternateEmail);
 
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         var query = ctx.UserEmails
             .Where(e => e.IsVerified && e.UserId != excludeUserId);
 
@@ -533,7 +549,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
                      EF.Functions.ILike(e.Email, escapedAlternate, "\\"), ct);
     }
 
-    public async Task ApplyReconcilePlanAsync(
+    public async Task ApplyUserEmailReconcilePlanAsync(
         UserEmail? displacedRowToDelete,
         UserEmail? rowToDelete,
         UserEmail? rowToUpdate,
@@ -544,7 +560,7 @@ internal sealed class UserEmailRepository(IDbContextFactory<HumansDbContext> fac
             && rowToUpdate is null && rowToInsert is null)
             return;
 
-        await using var ctx = await factory.CreateDbContextAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
         await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
         if (displacedRowToDelete is not null)

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -11,9 +11,8 @@ using Humans.Infrastructure.Data;
 namespace Humans.Infrastructure.Repositories.Users;
 
 /// <summary>EF-backed <see cref="IUserRepository"/>.</summary>
-[Grandfathered("HUM0025", justification: "Cross-section read of UserEmails (Profiles-owned); route through IUserEmailService.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserEmails")]
 [Grandfathered("HUM0025", justification: "Identity UserLogins also accessed by DriveActivityMonitorRepository; converge on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserLogins")]
-[Grandfathered("HUM0025", justification: "Users is also accessed by UserEmailRepository and DriveActivityMonitorRepository; converge on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "Users")]
+[Grandfathered("HUM0025", justification: "Users is also accessed by DriveActivityMonitorRepository; converge on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "Users")]
 internal sealed partial class UserRepository : IUserRepository
 {
     private readonly IDbContextFactory<HumansDbContext> _factory;
@@ -37,7 +36,6 @@ internal sealed partial class UserRepository : IUserRepository
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.Users
             .AsNoTracking()
-            .Include(u => u.UserEmails)
             .FirstOrDefaultAsync(u => u.Id == userId, ct);
     }
 
@@ -50,7 +48,6 @@ internal sealed partial class UserRepository : IUserRepository
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         var list = await ctx.Users
             .AsNoTracking()
-            .Include(u => u.UserEmails)
             .Where(u => userIds.Contains(u.Id))
             .ToListAsync(ct);
 
@@ -59,11 +56,9 @@ internal sealed partial class UserRepository : IUserRepository
 
     public async Task<IReadOnlyList<User>> GetAllAsync(CancellationToken ct = default)
     {
-        // Include UserEmails so computed User.Email isn't null.
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.Users
             .AsNoTracking()
-            .Include(u => u.UserEmails)
             .ToListAsync(ct);
     }
 
@@ -71,38 +66,17 @@ internal sealed partial class UserRepository : IUserRepository
         string normalizedEmail, string? alternateEmail, CancellationToken ct = default)
     {
         // ILIKE: escape '_' / '%' in input or alex_smith@... matches alexXsmith@...
-        // Lookup verifies user_emails first; falls back to legacy GoogleEmail shadow column.
+        // Canonical UserEmail lookup is owned by the UserEmail methods on this
+        // repository; this is the legacy GoogleEmail shadow-column fallback only.
         var escapedEmail = EscapeLikePattern(normalizedEmail);
         var escapedAlternate = alternateEmail is null ? null : EscapeLikePattern(alternateEmail);
 
         await using var ctx = await _factory.CreateDbContextAsync(ct);
 
-        var userIdByEmail = escapedAlternate is null
-            ? await ctx.UserEmails
-                .Where(e => e.IsVerified && EF.Functions.ILike(e.Email, escapedEmail, "\\"))
-                .Select(e => (Guid?)e.UserId)
-                .FirstOrDefaultAsync(ct)
-            : await ctx.UserEmails
-                .Where(e => e.IsVerified && (
-                    EF.Functions.ILike(e.Email, escapedEmail, "\\") ||
-                    EF.Functions.ILike(e.Email, escapedAlternate, "\\")))
-                .Select(e => (Guid?)e.UserId)
-                .FirstOrDefaultAsync(ct);
-
-        if (userIdByEmail is not null)
-        {
-            return await ctx.Users
-                .AsNoTracking()
-                .Include(u => u.UserEmails)
-                .FirstOrDefaultAsync(u => u.Id == userIdByEmail.Value, ct);
-        }
-
-        // Fallback: legacy GoogleEmail shadow column.
         if (escapedAlternate is null)
         {
             return await ctx.Users
                 .AsNoTracking()
-                .Include(u => u.UserEmails)
                 .FirstOrDefaultAsync(u =>
                     EF.Property<string?>(u, "GoogleEmail") != null
                     && EF.Functions.ILike(EF.Property<string?>(u, "GoogleEmail")!, escapedEmail, "\\"),
@@ -111,7 +85,6 @@ internal sealed partial class UserRepository : IUserRepository
 
         return await ctx.Users
             .AsNoTracking()
-            .Include(u => u.UserEmails)
             .FirstOrDefaultAsync(u =>
                 EF.Property<string?>(u, "GoogleEmail") != null && (
                     EF.Functions.ILike(EF.Property<string?>(u, "GoogleEmail")!, escapedEmail, "\\") ||
@@ -309,27 +282,14 @@ internal sealed partial class UserRepository : IUserRepository
         return true;
     }
 
-    public async Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<Guid>> GetUserIdsWithExternalLoginsAsync(CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
-
-        var loginUserIds = await ctx.Set<IdentityUserLogin<Guid>>()
+        return await ctx.Set<IdentityUserLogin<Guid>>()
             .AsNoTracking()
             .Select(l => l.UserId)
             .Distinct()
             .ToListAsync(ct);
-
-        if (loginUserIds.Count == 0) return [];
-
-        var withEmail = await ctx.UserEmails
-            .AsNoTracking()
-            .Where(e => loginUserIds.Contains(e.UserId))
-            .Select(e => e.UserId)
-            .Distinct()
-            .ToListAsync(ct);
-
-        var withEmailSet = withEmail.ToHashSet();
-        return loginUserIds.Where(id => !withEmailSet.Contains(id)).ToList();
     }
 
     public async Task<bool> SetContactSourceIfNullAsync(
@@ -354,10 +314,6 @@ internal sealed partial class UserRepository : IUserRepository
 
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        await ctx.UserEmails
-            .Where(e => userIds.Contains(e.UserId))
-            .ExecuteDeleteAsync(ct);
 
         await ctx.Set<IdentityUserLogin<Guid>>()
             .Where(l => userIds.Contains(l.UserId))
@@ -502,10 +458,6 @@ internal sealed partial class UserRepository : IUserRepository
 #pragma warning disable HUM_USER_DISPLAYNAME // Purge returns and rewrites the legacy label for audit/debug flows.
         var displayName = user.DisplayName;
 
-        // Free the unique index and null out User.Email.
-        var userEmails = await ctx.UserEmails.Where(e => e.UserId == userId).ToListAsync(ct);
-        ctx.UserEmails.RemoveRange(userEmails);
-
         // Drop external logins so a returning Google user can land on a fresh
         // account, not this tombstone. See nobodies-collective/Humans#661.
         var logins = await ctx.Set<IdentityUserLogin<Guid>>()
@@ -552,9 +504,7 @@ internal sealed partial class UserRepository : IUserRepository
         Guid userId, CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var user = await ctx.Users
-            .Include(u => u.UserEmails)
-            .FirstOrDefaultAsync(u => u.Id == userId, ct);
+        var user = await ctx.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
 
         if (user is null)
             return null;
@@ -569,9 +519,6 @@ internal sealed partial class UserRepository : IUserRepository
         user.ProfilePictureUrl = null;
         user.PhoneNumber = null;
         user.PhoneNumberConfirmed = false;
-
-        // Free the unique index and prevent email-lookup discovery.
-        ctx.UserEmails.RemoveRange(user.UserEmails);
 
         // Drop external logins for the same reason — see nobodies-collective/Humans#661.
         var logins = await ctx.Set<IdentityUserLogin<Guid>>()

--- a/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
@@ -25,7 +25,6 @@ internal static class ProfileSectionExtensions
         IConfiguration configuration)
     {
         // Profile section — see #504. Singleton repos so CachingUserService injects directly without scope-factory.
-        services.AddSingleton<IUserEmailRepository, UserEmailRepository>();
         services.AddSingleton<ICommunicationPreferenceRepository, CommunicationPreferenceRepository>();
         services.AddSingleton<IAccountMergeRepository, AccountMergeRepository>();
 

--- a/tests/Humans.Analyzers.Tests/CrossSectionRepositoryInjectionAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/CrossSectionRepositoryInjectionAnalyzerTests.cs
@@ -213,7 +213,7 @@ public class CrossSectionRepositoryInjectionAnalyzerTests
         // The arch-test ServiceBoundaryArchitectureTests.ServiceSection folds
         // Users + Profile + Profiles to "Humans" (one ownership section). The
         // analyzer must apply the same fold so that a Services.Users service
-        // injecting a [Section("Humans")]-tagged repo (e.g. IUserEmailRepository)
+        // injecting a [Section("Humans")]-tagged repo
         // is not flagged as cross-section.
         var source = """
             namespace Humans.Domain.Attributes
@@ -237,10 +237,6 @@ public class CrossSectionRepositoryInjectionAnalyzerTests
 
                 [Humans.Domain.Attributes.Section("Humans")]
                 public interface IUserRepository : IRepository { }
-
-                [Humans.Domain.Attributes.Section("Humans")]
-                public interface IUserEmailRepository : IRepository { }
-
                 [Humans.Domain.Attributes.Section("Humans")]
                 public interface IProfileRepository : IRepository { }
             }
@@ -256,7 +252,6 @@ public class CrossSectionRepositoryInjectionAnalyzerTests
                 {
                     public UserService(
                         Humans.Application.Interfaces.Repositories.IUserRepository users,
-                        Humans.Application.Interfaces.Repositories.IUserEmailRepository emails,
                         Humans.Application.Interfaces.Repositories.IProfileRepository profiles) { }
                 }
             }

--- a/tests/Humans.Analyzers.Tests/EmailMutationPathsAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/EmailMutationPathsAnalyzerTests.cs
@@ -15,9 +15,9 @@ public class EmailMutationPathsAnalyzerTests
 
         namespace Humans.Application.Interfaces.Repositories
         {
-            public interface IUserEmailRepository
+            public interface IUserRepository
             {
-                System.Threading.Tasks.Task ApplyReconcilePlanAsync(object? a, object? b, object? c, object? d);
+                System.Threading.Tasks.Task ApplyUserEmailReconcilePlanAsync(object? a, object? b, object? c, object? d);
             }
         }
         """;
@@ -90,9 +90,9 @@ public class EmailMutationPathsAnalyzerTests
                 public class SomeOtherService
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Repositories.IUserEmailRepository repo)
+                        Humans.Application.Interfaces.Repositories.IUserRepository repo)
                     {
-                        await repo.ApplyReconcilePlanAsync(null, null, null, null);
+                        await repo.ApplyUserEmailReconcilePlanAsync(null, null, null, null);
                     }
                 }
             }
@@ -116,9 +116,9 @@ public class EmailMutationPathsAnalyzerTests
                 public class UserEmailService
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Repositories.IUserEmailRepository repo)
+                        Humans.Application.Interfaces.Repositories.IUserRepository repo)
                     {
-                        await repo.ApplyReconcilePlanAsync(null, null, null, null);
+                        await repo.ApplyUserEmailReconcilePlanAsync(null, null, null, null);
                     }
                 }
             }
@@ -142,9 +142,9 @@ public class EmailMutationPathsAnalyzerTests
                 public class UserService
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Repositories.IUserEmailRepository repo)
+                        Humans.Application.Interfaces.Repositories.IUserRepository repo)
                     {
-                        await repo.ApplyReconcilePlanAsync(null, null, null, null);
+                        await repo.ApplyUserEmailReconcilePlanAsync(null, null, null, null);
                     }
                 }
             }
@@ -205,11 +205,11 @@ public class EmailMutationPathsAnalyzerTests
     {
         var source = InterfaceStubs + """
 
-            namespace Humans.Infrastructure.Repositories.Profiles
+            namespace Humans.Infrastructure.Repositories.Users
             {
-                public class UserEmailRepository : Humans.Application.Interfaces.Repositories.IUserEmailRepository
+                public class UserRepository : Humans.Application.Interfaces.Repositories.IUserRepository
                 {
-                    public async System.Threading.Tasks.Task ApplyReconcilePlanAsync(
+                    public async System.Threading.Tasks.Task ApplyUserEmailReconcilePlanAsync(
                         object? a, object? b, object? c, object? d)
                     {
                         await System.Threading.Tasks.Task.CompletedTask;
@@ -222,9 +222,9 @@ public class EmailMutationPathsAnalyzerTests
                 public class Sneaky
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Infrastructure.Repositories.Profiles.UserEmailRepository concrete)
+                        Humans.Infrastructure.Repositories.Users.UserRepository concrete)
                     {
-                        await concrete.ApplyReconcilePlanAsync(null, null, null, null);
+                        await concrete.ApplyUserEmailReconcilePlanAsync(null, null, null, null);
                     }
                 }
             }
@@ -282,9 +282,9 @@ public class EmailMutationPathsAnalyzerTests
                 public class SomeBackgroundJob
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Repositories.IUserEmailRepository repo)
+                        Humans.Application.Interfaces.Repositories.IUserRepository repo)
                     {
-                        await repo.ApplyReconcilePlanAsync(null, null, null, null);
+                        await repo.ApplyUserEmailReconcilePlanAsync(null, null, null, null);
                     }
                 }
             }

--- a/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/DisplaySortInControllers.baseline.txt
@@ -50,8 +50,8 @@ src/Humans.Infrastructure/Repositories/Users/UserRepository.ContactFields.cs:Ord
 src/Humans.Infrastructure/Repositories/Users/UserRepository.ContactFields.cs:ThenBy#1
 src/Humans.Infrastructure/Repositories/Users/UserRepository.Profiles.cs:OrderByDescending#1
 src/Humans.Infrastructure/Repositories/Users/UserRepository.Profiles.cs:ThenBy#1
-src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs:OrderBy#1
-src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs:ThenBy#1
+src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs:OrderBy#1
+src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs:ThenBy#1
 src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs:OrderBy#1
 src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs:OrderBy#2
 src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs:OrderBy#3

--- a/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
@@ -47,7 +47,6 @@ public class ServiceBoundaryArchitectureTests
             [typeof(ITicketingBudgetRepository)] = "Tickets",
             [typeof(ITicketRepository)] = "Tickets",
             [typeof(ITicketTransferRepository)] = "Tickets",
-            [typeof(IUserEmailRepository)] = "Humans",
             [typeof(IUserRepository)] = "Humans",
             [typeof(IVolunteerTrackingRepository)] = "Shifts",
         };
@@ -100,7 +99,6 @@ public class ServiceBoundaryArchitectureTests
     public void Users_and_profiles_share_one_repository_ownership_section()
     {
         RepositoryOwners[typeof(IUserRepository)].Should().Be("Humans");
-        RepositoryOwners[typeof(IUserEmailRepository)].Should().Be("Humans");
         ServiceSection(typeof(Humans.Application.Services.Users.UserService)).Should().Be("Humans");
         ServiceSection(typeof(Humans.Application.Services.Profiles.ProfileService)).Should().Be("Humans");
     }

--- a/tests/Humans.Application.Tests/Architecture/UserArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/UserArchitectureTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
-using AccountProvisioningService = Humans.Application.Services.Users.AccountProvisioningService;
 using UserService = Humans.Application.Services.Users.UserService;
 
 namespace Humans.Application.Tests.Architecture;
@@ -21,21 +20,6 @@ namespace Humans.Application.Tests.Architecture;
 /// </summary>
 public class UserArchitectureTests
 {
-    public static TheoryData<Type, Type> ForbiddenConstructorEdges => new()
-    {
-        { typeof(AccountProvisioningService), typeof(IUserEmailRepository) },
-    };
-
-    [HumansTheory]
-    [MemberData(nameof(ForbiddenConstructorEdges))]
-    public void User_services_do_not_take_forbidden_constructor_edges(Type serviceType, Type dependencyType)
-    {
-        var ctor = serviceType.GetConstructors().Single();
-        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
-
-        paramTypes.Should().NotContain(dependencyType);
-    }
-
     [HumansFact]
     public void UserService_has_expected_cache_and_invalidation_shape()
     {
@@ -93,8 +77,8 @@ public class UserArchitectureTests
         var typesToScan = new[]
         {
             typeof(IUserEmailService),
-            typeof(Humans.Infrastructure.Repositories.Profiles.UserEmailRepository),
-            typeof(IUserEmailRepository),
+            typeof(Humans.Infrastructure.Repositories.Users.UserRepository),
+            typeof(IUserRepository),
         };
 
         foreach (var t in typesToScan)
@@ -143,7 +127,6 @@ public class UserArchitectureTests
         // singleton is exposed under both interface keys.
         var services = new ServiceCollection();
         services.AddSingleton(Substitute.For<IUserRepository>());
-        services.AddSingleton(Substitute.For<IUserEmailRepository>());
         services.AddSingleton(Substitute.For<ICommunicationPreferenceRepository>());
         services.AddSingleton(Substitute.For<IServiceScopeFactory>());
         services.AddSingleton(Substitute.For<ILogger<CachingUserService>>());

--- a/tests/Humans.Application.Tests/Repositories/UserRepositoryUserEmailsTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/UserRepositoryUserEmailsTests.cs
@@ -2,7 +2,7 @@ using AwesomeAssertions;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Repositories.Profiles;
+using Humans.Infrastructure.Repositories.Users;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using NodaTime;
@@ -10,21 +10,21 @@ using NodaTime;
 namespace Humans.Application.Tests.Repositories;
 
 /// <summary>
-/// Repository tests for <see cref="UserEmailRepository"/> — PR 4 Task 4.
+/// Repository tests for <see cref="UserRepository"/> — PR 4 Task 4.
 /// </summary>
-public sealed class UserEmailRepositoryTests : IDisposable
+public sealed class UserRepositoryUserEmailTests : IDisposable
 {
     private readonly HumansDbContext _dbContext;
-    private readonly UserEmailRepository _repo;
+    private readonly UserRepository _repo;
 
-    public UserEmailRepositoryTests()
+    public UserRepositoryUserEmailTests()
     {
         var options = new DbContextOptionsBuilder<HumansDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
         _dbContext = new HumansDbContext(options);
-        _repo = new UserEmailRepository(new TestDbContextFactory(options));
+        _repo = new UserRepository(new TestDbContextFactory(options));
     }
 
     public void Dispose()
@@ -33,7 +33,7 @@ public sealed class UserEmailRepositoryTests : IDisposable
     }
 
     [HumansFact]
-    public async Task SetGoogleExclusiveAsync_FlipsExclusively()
+    public async Task SetUserEmailGoogleExclusiveAsync_FlipsExclusively()
     {
         var userId = Guid.NewGuid();
         var rowA = await SeedVerifiedAsync(userId, "a@x.test", isGoogle: true);
@@ -41,7 +41,7 @@ public sealed class UserEmailRepositoryTests : IDisposable
         var rowC = await SeedVerifiedAsync(userId, "c@x.test", isGoogle: false);
 
         var updatedAt = Instant.FromUtc(2026, 4, 30, 12, 0);
-        await _repo.SetGoogleExclusiveAsync(userId, rowB.Id, updatedAt, CancellationToken.None);
+        await _repo.SetUserEmailGoogleExclusiveAsync(userId, rowB.Id, updatedAt, CancellationToken.None);
 
         var reloadedA = await GetByIdAsync(rowA.Id);
         var reloadedB = await GetByIdAsync(rowB.Id);

--- a/tests/Humans.Application.Tests/Services/AccountMergeServiceAdminMergeTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountMergeServiceAdminMergeTests.cs
@@ -17,7 +17,7 @@ namespace Humans.Application.Tests.Services;
 public class AccountMergeServiceAdminMergeTests
 {
     private readonly IAccountMergeRepository _mergeRepo = Substitute.For<IAccountMergeRepository>();
-    private readonly IUserEmailRepository _userEmailRepo = Substitute.For<IUserEmailRepository>();
+    private readonly IUserRepository _userEmailRepo = Substitute.For<IUserRepository>();
     private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
     private readonly IUserInfoInvalidator _userInfoInvalidator = Substitute.For<IUserInfoInvalidator>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
@@ -56,7 +56,7 @@ public class AccountMergeServiceAdminMergeTests
             Arg.Any<NodaTime.Instant>(), Arg.Any<CancellationToken>());
         await _userService.Received(1).AnonymizeForMergeAsync(src, tgt,
             Arg.Any<NodaTime.Instant>(), Arg.Any<CancellationToken>());
-        await _userEmailRepo.DidNotReceive().MarkVerifiedAsync(
+        await _userEmailRepo.DidNotReceive().MarkUserEmailVerifiedAsync(
             Arg.Any<Guid>(), Arg.Any<NodaTime.Instant>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -212,7 +212,7 @@ public class AccountProvisioningServiceTests
         public Task<IReadOnlyList<Guid>> GetMergedSourceIdsAsync(
             Guid targetUserId, CancellationToken ct = default) =>
             throw new NotSupportedException();
-        public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) =>
+        public Task<IReadOnlyList<Guid>> GetUserIdsWithExternalLoginsAsync(CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<int> DeleteUsersAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
             throw new NotSupportedException();
@@ -286,6 +286,106 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<bool> WriteBackStateIfNullAsync(
             Guid userId, ProfileState state, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<UserEmail>> GetUserEmailsByUserIdReadOnlyAsync(
+            Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<UserEmail>> GetUserEmailsByUserIdForMutationAsync(
+            Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<UserEmail?> GetUserEmailByIdAndUserIdAsync(
+            Guid emailId, Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<UserEmail?> GetUserEmailByIdReadOnlyAsync(Guid emailId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> UserEmailExistsForUserAsync(
+            Guid userId, string normalizedEmail, string? alternateEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> VerifiedUserEmailExistsForOtherUserAsync(
+            Guid userId, string normalizedEmail, string? alternateEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<UserEmail?> GetConflictingVerifiedUserEmailAsync(
+            Guid excludeEmailId, string normalizedEmail, string? alternateEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<int> ReassignUserEmailsToUserAsync(
+            Guid sourceUserId, Guid targetUserId, Instant updatedAt, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<UserEmailLegacyBackfillSnapshot>>
+            GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(
+                Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<UserEmail>> GetAllUserEmailsAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetUserIdsHavingAnyUserEmailAsync(
+            IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task RemoveAllUserEmailsForUserAndSaveAsync(Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task RemoveAllUserEmailsForUsersAndSaveAsync(
+            IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> MarkUserEmailVerifiedAsync(
+            Guid emailId, Instant now, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> RemoveUserEmailByIdAsync(Guid emailId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<UserEmail>> GetUserEmailsByEmailsAsync(
+            IReadOnlyCollection<string> emails, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> AnyUserEmailWithEmailAsync(string email, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<Dictionary<Guid, string>> GetAllNotificationTargetUserEmailsAsync(
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> SearchUserIdsByVerifiedUserEmailAsync(
+            string searchTerm, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<UserEmailWithUser?> FindVerifiedUserEmailWithUserAsync(
+            string normalizedEmail, string? alternateEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<UserEmail?> FindUserEmailByNormalizedEmailAsync(
+            string normalizedEmail, string? alternateEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<string?> GetVerifiedUserEmailAddressAsync(
+            Guid userId, Guid emailId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<Guid?> GetUserIdByVerifiedUserEmailAsync(
+            string email, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetUserIdsByUserEmailPrefixAndSuffixAsync(
+            string prefix, string suffix, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedUserEmailAsync(
+            string email, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserEmailUserIdsAsync(
+            string normalizedEmail, string? alternateEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<Guid?> GetOtherUserIdHavingUserEmailAsync(
+            string email, Guid excludeUserId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<UserEmail?> FindOtherUsersVerifiedUserEmailRowAsync(
+            string normalizedEmail, string? alternateEmail, Guid excludeUserId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task ApplyUserEmailReconcilePlanAsync(
+            UserEmail? displacedRowToDelete,
+            UserEmail? rowToDelete,
+            UserEmail? rowToUpdate,
+            UserEmail? rowToInsert,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task SetUserEmailGoogleExclusiveAsync(
+            Guid userId, Guid userEmailId, Instant updatedAt, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+        public Task AddUserEmailAsync(UserEmail email, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task RemoveUserEmailAsync(UserEmail email, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task RemoveAllUserEmailsForUserAsync(Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task UpdateUserEmailAsync(UserEmail email, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task UpdateUserEmailsAsync(IReadOnlyList<UserEmail> emails, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 
@@ -717,14 +817,11 @@ public class AccountProvisioningServiceTests
     }
 
     [HumansFact]
-    public async Task FindOrCreateUserByEmailAsync_GoesThroughIUserEmailService_NotIUserEmailRepository()
+    public async Task FindOrCreateUserByEmailAsync_RoutesEmailRowsThroughIUserEmailService()
     {
-        // Issue nobodies-collective/Humans#687: AccountProvisioningService no
-        // longer references IUserEmailRepository. The fixture wires
-        // FindAnyUserIdByEmailAsync + AddProvisionedEmailAsync through the
-        // mocked IUserEmailService — if the service called the repository
-        // directly the fixture wouldn't satisfy the lookups and the test
-        // wouldn't produce a row. The presence of the row proves the route.
+        // Issue nobodies-collective/Humans#687: email-row policy still routes
+        // through IUserEmailService even though Users now owns the underlying
+        // repository storage methods.
         var result = await _service.FindOrCreateUserByEmailAsync(
             "jane@example.com", "Jane", ContactSource.MailerLite);
 

--- a/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
+++ b/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
@@ -40,7 +40,7 @@ public sealed class DependencyCycleResolutionTests : ServiceTestHarness
         services.AddSingleton<IMemoryCache>(_ => new MemoryCache(new MemoryCacheOptions()));
 
         services.AddScoped<IUserRepository>(_ => Substitute.For<IUserRepository>());
-        services.AddScoped<IUserEmailRepository>(_ => Substitute.For<IUserEmailRepository>());
+        services.AddScoped<IUserRepository>(_ => Substitute.For<IUserRepository>());
         services.AddScoped<ICommunicationPreferenceRepository>(_ => Substitute.For<ICommunicationPreferenceRepository>());
         services.AddScoped<IUserInfoInvalidator>(_ => Substitute.For<IUserInfoInvalidator>());
         services.AddScoped<IRoleAssignmentRepository>(_ => Substitute.For<IRoleAssignmentRepository>());
@@ -94,7 +94,7 @@ public sealed class DependencyCycleResolutionTests : ServiceTestHarness
         services.AddSingleton<IMemoryCache>(_ => new MemoryCache(new MemoryCacheOptions()));
 
         services.AddScoped<IUserRepository>(_ => Substitute.For<IUserRepository>());
-        services.AddScoped<IUserEmailRepository>(_ => Substitute.For<IUserEmailRepository>());
+        services.AddScoped<IUserRepository>(_ => Substitute.For<IUserRepository>());
         services.AddScoped<ICommunicationPreferenceRepository>(_ => Substitute.For<ICommunicationPreferenceRepository>());
         services.AddScoped<IUserInfoInvalidator>(_ => Substitute.For<IUserInfoInvalidator>());
         services.AddScoped<IRoleAssignmentRepository>(_ => Substitute.For<IRoleAssignmentRepository>());

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -25,7 +25,6 @@ public sealed class ProfileServiceTests : ServiceTestHarness
     private readonly ProfileEditorService _editor;
     private readonly IUserRepository _userRepository;
     private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly IUserEmailRepository _userEmailRepository;
     private readonly ICommunicationPreferenceRepository _communicationPreferenceRepository = Substitute.For<ICommunicationPreferenceRepository>();
     private readonly InMemoryFileStorage _fileStorage = new();
 
@@ -38,10 +37,8 @@ public sealed class ProfileServiceTests : ServiceTestHarness
     {
         // Real repositories backed by an IDbContextFactory wrapping the in-memory store.
         _userRepository = new UserRepository(DbFactory, Clock);
-        _userEmailRepository = new UserEmailRepository(DbFactory);
         var storageUserService = new UserService(
             _userRepository,
-            _userEmailRepository,
             _communicationPreferenceRepository,
             AdminAuthorization,
             Clock,
@@ -407,7 +404,6 @@ public sealed class ProfileServiceTests : ServiceTestHarness
     /// </summary>
     private UserService BuildUserServiceWith(IUserRepository userRepository) => new(
         userRepository,
-        _userEmailRepository,
         _communicationPreferenceRepository,
         AdminAuthorization,
         Clock,

--- a/tests/Humans.Application.Tests/Services/UserEmailProviderBackfillServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailProviderBackfillServiceTests.cs
@@ -19,7 +19,6 @@ namespace Humans.Application.Tests.Services;
 public class UserEmailProviderBackfillServiceTests
 {
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
-    private readonly IUserEmailRepository _userEmailRepository = Substitute.For<IUserEmailRepository>();
     private readonly UserManager<User> _userManager;
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 4, 30, 12, 0));
@@ -33,7 +32,6 @@ public class UserEmailProviderBackfillServiceTests
 
         _service = new UserEmailProviderBackfillService(
             _userRepository,
-            _userEmailRepository,
             _userManager,
             _auditLogService,
             _clock,
@@ -58,13 +56,13 @@ public class UserEmailProviderBackfillServiceTests
         _userRepository.GetLegacyGoogleEmailsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string>());
-        _userEmailRepository.GetLegacyBackfillSnapshotsByUserIdAsync(
+        _userRepository.GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(
                 userId, Arg.Any<CancellationToken>())
             .Returns([
                 new DTOs.UserEmailLegacyBackfillSnapshot(
                     emailId, userId, "user@example.com", true, null, null, false, false)
             ]);
-        _userEmailRepository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _userRepository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns([email]);
         _userManager.GetLoginsAsync(user)
             .Returns(new List<UserLoginInfo> { new("Google", "sub-A", "Google") });
@@ -75,7 +73,7 @@ public class UserEmailProviderBackfillServiceTests
         result.ProviderRowsUpdated.Should().Be(1);
         email.Provider.Should().Be("Google");
         email.ProviderKey.Should().Be("sub-A");
-        await _userEmailRepository.Received().UpdateBatchAsync(
+        await _userRepository.Received().UpdateUserEmailsAsync(
             Arg.Is<IReadOnlyList<UserEmail>>(rows => rows.Count >= 1 && rows.Any(r => r.Id == emailId)),
             Arg.Any<CancellationToken>());
     }
@@ -110,7 +108,7 @@ public class UserEmailProviderBackfillServiceTests
         _userRepository.GetLegacyGoogleEmailsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string> { [userId] = "user@nobodies.team" });
-        _userEmailRepository.GetLegacyBackfillSnapshotsByUserIdAsync(
+        _userRepository.GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(
                 userId, Arg.Any<CancellationToken>())
             .Returns([
                 new DTOs.UserEmailLegacyBackfillSnapshot(
@@ -118,7 +116,7 @@ public class UserEmailProviderBackfillServiceTests
                 new DTOs.UserEmailLegacyBackfillSnapshot(
                     otherRowId, userId, "personal@example.com", true, null, null, false, false)
             ]);
-        _userEmailRepository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _userRepository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns([googleRow, otherRow]);
         _userManager.GetLoginsAsync(user).Returns(new List<UserLoginInfo>());
 
@@ -155,7 +153,7 @@ public class UserEmailProviderBackfillServiceTests
         _userRepository.GetLegacyGoogleEmailsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string>());
-        _userEmailRepository.GetLegacyBackfillSnapshotsByUserIdAsync(
+        _userRepository.GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(
                 userId, Arg.Any<CancellationToken>())
             .Returns([
                 new DTOs.UserEmailLegacyBackfillSnapshot(
@@ -163,7 +161,7 @@ public class UserEmailProviderBackfillServiceTests
                 new DTOs.UserEmailLegacyBackfillSnapshot(
                     otherRowId, userId, "secondary@example.com", true, null, null, false, false)
             ]);
-        _userEmailRepository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _userRepository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns([oauthRow, otherRow]);
         _userManager.GetLoginsAsync(user).Returns(new List<UserLoginInfo>());
 
@@ -195,13 +193,13 @@ public class UserEmailProviderBackfillServiceTests
         _userRepository.GetLegacyGoogleEmailsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string>());
-        _userEmailRepository.GetLegacyBackfillSnapshotsByUserIdAsync(
+        _userRepository.GetUserEmailLegacyBackfillSnapshotsByUserIdAsync(
                 userId, Arg.Any<CancellationToken>())
             .Returns([
                 new DTOs.UserEmailLegacyBackfillSnapshot(
                     emailId, userId, "user@example.com", true, "Google", "sub-A", false, false)
             ]);
-        _userEmailRepository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _userRepository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns([email]);
         _userManager.GetLoginsAsync(user)
             .Returns(new List<UserLoginInfo> { new("Google", "sub-A", "Google") });
@@ -209,7 +207,7 @@ public class UserEmailProviderBackfillServiceTests
         var result = await _service.RunAsync();
 
         result.ProviderRowsUpdated.Should().Be(0);
-        await _userEmailRepository.DidNotReceive().UpdateBatchAsync(
+        await _userRepository.DidNotReceive().UpdateUserEmailsAsync(
             Arg.Any<IReadOnlyList<UserEmail>>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceReconcileOAuthTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceReconcileOAuthTests.cs
@@ -23,7 +23,7 @@ namespace Humans.Application.Tests.Services;
 /// </summary>
 public class UserEmailServiceReconcileOAuthTests
 {
-    private readonly IUserEmailRepository _repository = Substitute.For<IUserEmailRepository>();
+    private readonly IUserRepository _repository = Substitute.For<IUserRepository>();
     private readonly IAccountMergeService _mergeService = Substitute.For<IAccountMergeService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly UserManager<User> _userManager;
@@ -66,7 +66,7 @@ public class UserEmailServiceReconcileOAuthTests
         UserEmailReconcilePlanCommand command,
         CancellationToken ct)
     {
-        await _repository.ApplyReconcilePlanAsync(
+        await _repository.ApplyUserEmailReconcilePlanAsync(
             command.DisplacedRowToDelete,
             command.RowToDelete,
             command.RowToUpdate,
@@ -96,7 +96,7 @@ public class UserEmailServiceReconcileOAuthTests
                 Provider = Provider, ProviderKey = ProviderKey,
             },
         };
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(rows);
 
         var result = await _service.ReconcileOAuthIdentityAsync(
@@ -105,7 +105,7 @@ public class UserEmailServiceReconcileOAuthTests
 
         result.Outcome.Should().Be(ReconcileOutcome.NoChange);
         result.AffectedRowId.Should().Be(rowId);
-        await _repository.DidNotReceive().ApplyReconcilePlanAsync(
+        await _repository.DidNotReceive().ApplyUserEmailReconcilePlanAsync(
             Arg.Any<UserEmail?>(), Arg.Any<UserEmail?>(),
             Arg.Any<UserEmail?>(), Arg.Any<UserEmail?>(),
             Arg.Any<CancellationToken>());
@@ -132,7 +132,7 @@ public class UserEmailServiceReconcileOAuthTests
             Provider = Provider,
             ProviderKey = ProviderKey,
         };
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { tagged });
 
         var result = await _service.ReconcileOAuthIdentityAsync(
@@ -143,9 +143,9 @@ public class UserEmailServiceReconcileOAuthTests
         result.AffectedRowId.Should().Be(rowId);
         result.PreviousEmail.Should().Be("old@example.com");
         tagged.Email.Should().Be("new@example.com");
-        // The data change is applied atomically via ApplyReconcilePlanAsync —
+        // The data change is applied atomically via ApplyUserEmailReconcilePlanAsync —
         // rewrite is a single row-to-update with no delete and no insert.
-        await _repository.Received(1).ApplyReconcilePlanAsync(
+        await _repository.Received(1).ApplyUserEmailReconcilePlanAsync(
             displacedRowToDelete: Arg.Is<UserEmail?>(r => r == null),
             rowToDelete: Arg.Is<UserEmail?>(r => r == null),
             rowToUpdate: Arg.Is<UserEmail?>(r => r != null && r.Id == rowId),
@@ -192,7 +192,7 @@ public class UserEmailServiceReconcileOAuthTests
             IsPrimary = false,
             IsGoogle = false,
         };
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { oldRow, sibling });
 
         var result = await _service.ReconcileOAuthIdentityAsync(
@@ -211,7 +211,7 @@ public class UserEmailServiceReconcileOAuthTests
 
         // Atomic plan: update the sibling AND delete the old tagged row in
         // one transaction.
-        await _repository.Received(1).ApplyReconcilePlanAsync(
+        await _repository.Received(1).ApplyUserEmailReconcilePlanAsync(
             displacedRowToDelete: Arg.Is<UserEmail?>(r => r == null),
             rowToDelete: Arg.Is<UserEmail?>(r => r != null && r.Id == oldRowId),
             rowToUpdate: Arg.Is<UserEmail?>(r => r != null && r.Id == siblingId),
@@ -242,7 +242,7 @@ public class UserEmailServiceReconcileOAuthTests
             IsPrimary = true,
             IsGoogle = true,
         };
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { sibling });
 
         var result = await _service.ReconcileOAuthIdentityAsync(
@@ -257,7 +257,7 @@ public class UserEmailServiceReconcileOAuthTests
         sibling.IsPrimary.Should().BeTrue("sibling kept its IsPrimary — no old row to flip it from");
         sibling.IsGoogle.Should().BeTrue("sibling kept its IsGoogle — no old row to flip it from");
         // Atomic plan: update the sibling, no delete (no old tagged row).
-        await _repository.Received(1).ApplyReconcilePlanAsync(
+        await _repository.Received(1).ApplyUserEmailReconcilePlanAsync(
             displacedRowToDelete: Arg.Is<UserEmail?>(r => r == null),
             rowToDelete: Arg.Is<UserEmail?>(r => r == null),
             rowToUpdate: Arg.Is<UserEmail?>(r => r != null && r.Id == siblingId),
@@ -271,11 +271,11 @@ public class UserEmailServiceReconcileOAuthTests
     public async Task NewRowCreated_NoTaggedRow_NoSibling_NoCrossUser_InsertsVerifiedTaggedRow()
     {
         var userId = Guid.NewGuid();
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail>());
 
         UserEmail? planned = null;
-        await _repository.ApplyReconcilePlanAsync(
+        await _repository.ApplyUserEmailReconcilePlanAsync(
             Arg.Any<UserEmail?>(),
             Arg.Any<UserEmail?>(),
             Arg.Any<UserEmail?>(),
@@ -320,7 +320,7 @@ public class UserEmailServiceReconcileOAuthTests
         };
         // Signing user has no rows at all → reconcile would NewRowCreate, but
         // cross-user check fires first.
-        _repository.GetByUserIdForMutationAsync(signingUserId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(signingUserId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail>());
         // Displaced user retains another verified row after the delete, so the
         // "left without verified email" flag stays false.
@@ -332,9 +332,9 @@ public class UserEmailServiceReconcileOAuthTests
             IsVerified = true,
             IsPrimary = false,
         };
-        _repository.GetByUserIdForMutationAsync(displacedUserId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(displacedUserId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { displacedRow, displacedSurvivor });
-        _repository.FindOtherUsersVerifiedRowAsync(
+        _repository.FindOtherUsersVerifiedUserEmailRowAsync(
                 Arg.Any<string>(), Arg.Any<string?>(), signingUserId, Arg.Any<CancellationToken>())
             .Returns(displacedRow);
 
@@ -350,7 +350,7 @@ public class UserEmailServiceReconcileOAuthTests
 
         // Atomic plan: the displaced row is deleted AND the signing user's
         // NewRowCreated insert happens in the same transaction.
-        await _repository.Received(1).ApplyReconcilePlanAsync(
+        await _repository.Received(1).ApplyUserEmailReconcilePlanAsync(
             displacedRowToDelete: Arg.Is<UserEmail?>(r => r != null && r.Id == displacedRowId),
             rowToDelete: Arg.Is<UserEmail?>(r => r == null),
             rowToUpdate: Arg.Is<UserEmail?>(r => r == null),
@@ -383,13 +383,13 @@ public class UserEmailServiceReconcileOAuthTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.GetByUserIdForMutationAsync(signingUserId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(signingUserId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail>());
         // Displaced user has ONLY the row being displaced — after the delete
         // they're left with zero verified emails.
-        _repository.GetByUserIdForMutationAsync(displacedUserId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(displacedUserId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { displacedRow });
-        _repository.FindOtherUsersVerifiedRowAsync(
+        _repository.FindOtherUsersVerifiedUserEmailRowAsync(
                 Arg.Any<string>(), Arg.Any<string?>(), signingUserId, Arg.Any<CancellationToken>())
             .Returns(displacedRow);
 
@@ -438,9 +438,9 @@ public class UserEmailServiceReconcileOAuthTests
             Provider = Provider,
             ProviderKey = ProviderKey,
         };
-        _repository.GetByUserIdForMutationAsync(signingUserId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(signingUserId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { tagged });
-        _repository.FindOtherUsersVerifiedRowAsync(
+        _repository.FindOtherUsersVerifiedUserEmailRowAsync(
                 Arg.Any<string>(), Arg.Any<string?>(), signingUserId, Arg.Any<CancellationToken>())
             .Returns(blocker);
 
@@ -457,7 +457,7 @@ public class UserEmailServiceReconcileOAuthTests
         // No mutation: signing user's tagged row keeps its old email; blocker
         // row is not removed; no new row is inserted; no atomic plan applied.
         tagged.Email.Should().Be("old@example.com");
-        await _repository.DidNotReceive().ApplyReconcilePlanAsync(
+        await _repository.DidNotReceive().ApplyUserEmailReconcilePlanAsync(
             Arg.Any<UserEmail?>(), Arg.Any<UserEmail?>(),
             Arg.Any<UserEmail?>(), Arg.Any<UserEmail?>(),
             Arg.Any<CancellationToken>());

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
@@ -20,7 +20,7 @@ namespace Humans.Application.Tests.Services;
 
 public class UserEmailServiceTests
 {
-    private readonly IUserEmailRepository _repository = Substitute.For<IUserEmailRepository>();
+    private readonly IUserRepository _repository = Substitute.For<IUserRepository>();
     private readonly IAccountMergeService _mergeService = Substitute.For<IAccountMergeService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly ITicketServiceRead _ticketServiceRead = Substitute.For<ITicketServiceRead>();
@@ -96,7 +96,7 @@ public class UserEmailServiceTests
     {
         var userId = Guid.NewGuid();
         var emailId = Guid.NewGuid();
-        _repository.GetByIdReadOnlyAsync(emailId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdReadOnlyAsync(emailId, Arg.Any<CancellationToken>())
             .Returns(new UserEmail
             {
                 Id = emailId,
@@ -118,7 +118,7 @@ public class UserEmailServiceTests
     {
         var userId = Guid.NewGuid();
         var emailId = Guid.NewGuid();
-        _repository.GetByIdReadOnlyAsync(emailId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdReadOnlyAsync(emailId, Arg.Any<CancellationToken>())
             .Returns(new UserEmail
             {
                 Id = emailId,
@@ -140,7 +140,7 @@ public class UserEmailServiceTests
     {
         var userId = Guid.NewGuid();
         var emailId = Guid.NewGuid();
-        _repository.GetByIdReadOnlyAsync(emailId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdReadOnlyAsync(emailId, Arg.Any<CancellationToken>())
             .Returns(new UserEmail
             {
                 Id = emailId,
@@ -166,7 +166,7 @@ public class UserEmailServiceTests
         var normalized = EmailNormalization.NormalizeForComparison(email);
         var alternate = GetAlternateComparableEmail(normalized);
 
-        if (await _repository.ExistsForUserAsync(userId, normalized, alternate, ct))
+        if (await _repository.UserEmailExistsForUserAsync(userId, normalized, alternate, ct))
             return new UserEmailAddResult(Guid.Empty, Added: false, IsConflict: false);
 
         var now = _clock.GetCurrentInstant();
@@ -186,7 +186,7 @@ public class UserEmailServiceTests
             UpdatedAt = now,
         };
 
-        await _repository.AddAsync(row, ct);
+        await _repository.AddUserEmailAsync(row, ct);
         await EnsurePrimaryInvariantForTestAsync(userId, ct);
         await EnsureGoogleInvariantForTestAsync(userId, ct);
         await _userInfoInvalidator.InvalidateAsync(userId, ct);
@@ -203,14 +203,14 @@ public class UserEmailServiceTests
 
         if (command.MarkVerified)
         {
-            var row = await _repository.GetByIdAndUserIdAsync(emailId, userId, ct)
+            var row = await _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct)
                 ?? throw new InvalidOperationException("Email not found.");
             if (row.IsVerified || row.Provider is not null)
                 throw new System.ComponentModel.DataAnnotations.ValidationException("No email pending verification.");
 
             row.IsVerified = true;
             row.UpdatedAt = _clock.GetCurrentInstant();
-            await _repository.UpdateAsync(row, ct);
+            await _repository.UpdateUserEmailAsync(row, ct);
             await EnsurePrimaryInvariantForTestAsync(userId, ct);
             await EnsureGoogleInvariantForTestAsync(userId, ct);
             changed = true;
@@ -218,7 +218,7 @@ public class UserEmailServiceTests
 
         if (command.Primary == UserEmailPrimaryChange.MakePrimary)
         {
-            var rows = (await _repository.GetByUserIdForMutationAsync(userId, ct)).ToList();
+            var rows = (await _repository.GetUserEmailsByUserIdForMutationAsync(userId, ct)).ToList();
             var target = rows.FirstOrDefault(e => e.Id == emailId)
                 ?? throw new InvalidOperationException("Email not found.");
             if (!target.IsVerified)
@@ -232,47 +232,47 @@ public class UserEmailServiceTests
                 row.UpdatedAt = now;
             }
             if (changedRows.Count > 0)
-                await _repository.UpdateBatchAsync(changedRows, ct);
+                await _repository.UpdateUserEmailsAsync(changedRows, ct);
             changed |= changedRows.Count > 0;
         }
         else if (command.Primary == UserEmailPrimaryChange.ClearDuplicatePrimary)
         {
-            var row = await _repository.GetByIdAndUserIdAsync(emailId, userId, ct);
+            var row = await _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct);
             if (row is null || !row.IsPrimary) return false;
-            var rows = await _repository.GetByUserIdReadOnlyAsync(userId, ct);
+            var rows = await _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, ct);
             if (rows.Count(e => e.IsPrimary && e.IsVerified) <= 1) return false;
             row.IsPrimary = false;
             row.UpdatedAt = _clock.GetCurrentInstant();
-            await _repository.UpdateAsync(row, ct);
+            await _repository.UpdateUserEmailAsync(row, ct);
             changed = true;
         }
 
         if (command.Google == UserEmailGoogleChange.MakeGoogle)
         {
-            var row = await _repository.GetByIdAndUserIdAsync(emailId, userId, ct);
+            var row = await _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct);
             if (row is null || !row.IsVerified) return false;
-            await _repository.SetGoogleExclusiveAsync(userId, emailId, _clock.GetCurrentInstant(), ct);
+            await _repository.SetUserEmailGoogleExclusiveAsync(userId, emailId, _clock.GetCurrentInstant(), ct);
             changed = true;
         }
         else if (command.Google == UserEmailGoogleChange.ClearDuplicateGoogle)
         {
-            var row = await _repository.GetByIdAndUserIdAsync(emailId, userId, ct);
+            var row = await _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct);
             if (row is null || !row.IsGoogle) return false;
-            var rows = await _repository.GetByUserIdReadOnlyAsync(userId, ct);
+            var rows = await _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, ct);
             if (rows.Count(e => e.IsGoogle) <= 1) return false;
             row.IsGoogle = false;
             row.UpdatedAt = _clock.GetCurrentInstant();
-            await _repository.UpdateAsync(row, ct);
+            await _repository.UpdateUserEmailAsync(row, ct);
             changed = true;
         }
 
         if (command.ChangeVisibility)
         {
-            var row = await _repository.GetByIdAndUserIdAsync(emailId, userId, ct)
+            var row = await _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct)
                 ?? throw new InvalidOperationException("Email not found.");
             row.Visibility = command.Visibility;
             row.UpdatedAt = _clock.GetCurrentInstant();
-            await _repository.UpdateAsync(row, ct);
+            await _repository.UpdateUserEmailAsync(row, ct);
             changed = true;
         }
 
@@ -287,7 +287,7 @@ public class UserEmailServiceTests
         UserEmailRemoveCommand command,
         CancellationToken ct)
     {
-        var row = await _repository.GetByIdAndUserIdAsync(emailId, userId, ct)
+        var row = await _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, ct)
             ?? throw new InvalidOperationException("Email not found.");
         var hasProvider = !string.IsNullOrEmpty(row.Provider);
         if (command.Mode == UserEmailRemovalMode.PlainEmail && hasProvider) return false;
@@ -295,13 +295,13 @@ public class UserEmailServiceTests
 
         if (command.PreserveLastVerifiedEmail && row.IsVerified)
         {
-            var rows = await _repository.GetByUserIdForMutationAsync(userId, ct);
+            var rows = await _repository.GetUserEmailsByUserIdForMutationAsync(userId, ct);
             if (rows.Count(e => e.IsVerified && e.Id != emailId) == 0)
                 throw new System.ComponentModel.DataAnnotations.ValidationException(
                     "Cannot remove your last verified email. Add another verified email first so you can still receive system notifications.");
         }
 
-        await _repository.RemoveAsync(row, ct);
+        await _repository.RemoveUserEmailAsync(row, ct);
         if (command.RepairInvariants)
         {
             await EnsurePrimaryInvariantForTestAsync(userId, ct);
@@ -313,7 +313,7 @@ public class UserEmailServiceTests
 
     private async Task EnsurePrimaryInvariantForTestAsync(Guid userId, CancellationToken ct)
     {
-        var rows = (await _repository.GetByUserIdForMutationAsync(userId, ct)).ToList();
+        var rows = (await _repository.GetUserEmailsByUserIdForMutationAsync(userId, ct)).ToList();
         var verified = rows.Where(e => e.IsVerified).ToList();
         if (verified.Count == 0) return;
         var current = verified.Where(e => e.IsPrimary).ToList();
@@ -329,12 +329,12 @@ public class UserEmailServiceTests
             row.UpdatedAt = now;
         }
         if (changed.Count > 0)
-            await _repository.UpdateBatchAsync(changed, ct);
+            await _repository.UpdateUserEmailsAsync(changed, ct);
     }
 
     private async Task EnsureGoogleInvariantForTestAsync(Guid userId, CancellationToken ct)
     {
-        var rows = (await _repository.GetByUserIdForMutationAsync(userId, ct)).ToList();
+        var rows = (await _repository.GetUserEmailsByUserIdForMutationAsync(userId, ct)).ToList();
         var verified = rows.Where(e => e.IsVerified).ToList();
         if (verified.Count == 0) return;
         var current = verified.Where(e => e.IsGoogle).ToList();
@@ -350,7 +350,7 @@ public class UserEmailServiceTests
             row.UpdatedAt = now;
         }
         if (changed.Count > 0)
-            await _repository.UpdateBatchAsync(changed, ct);
+            await _repository.UpdateUserEmailsAsync(changed, ct);
     }
 
     private static string? GetAlternateComparableEmail(string normalizedEmail)
@@ -410,7 +410,7 @@ public class UserEmailServiceTests
                 IsVerified = true, IsPrimary = true
             }
         };
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(emails);
 
         await _service.SetPrimaryAsync(userId, targetId);
@@ -433,7 +433,7 @@ public class UserEmailServiceTests
                 IsVerified = false, IsPrimary = false
             }
         };
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(emails);
 
         var act = async () => await _service.SetPrimaryAsync(userId, targetId);
@@ -473,16 +473,16 @@ public class UserEmailServiceTests
             // is a no-op and only DeleteEmailAsync's own invalidation runs.
             IsGoogle = true,
         };
-        _repository.GetByIdAndUserIdAsync(deletingId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(deletingId, userId, Arg.Any<CancellationToken>())
             .Returns(deleting);
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { deleting, keeping });
         _userManager.GetLoginsAsync(Arg.Any<User>())
             .Returns(new List<UserLoginInfo> { new("Google", "sub-123", "Google") });
 
         await _service.DeleteEmailAsync(userId, deletingId);
 
-        await _repository.Received(1).RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.Received(1).InvalidateAsync(userId, Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -505,13 +505,13 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = false,
         };
-        _repository.GetByIdAndUserIdAsync(providerRowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(providerRowId, userId, Arg.Any<CancellationToken>())
             .Returns(providerRow);
 
         var result = await _service.DeleteEmailAsync(userId, providerRowId);
 
         result.Should().BeFalse();
-        await _repository.DidNotReceive().RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -530,9 +530,9 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.GetByIdAndUserIdAsync(emailId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, Arg.Any<CancellationToken>())
             .Returns(only);
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { only });
         _userManager.GetLoginsAsync(Arg.Any<User>())
             .Returns(new List<UserLoginInfo>());
@@ -540,7 +540,7 @@ public class UserEmailServiceTests
         var act = async () => await _service.DeleteEmailAsync(userId, emailId);
 
         await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
-        await _repository.DidNotReceive().RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -564,15 +564,15 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.GetByIdAndUserIdAsync(emailId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, Arg.Any<CancellationToken>())
             .Returns(only);
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { only });
 
         var act = async () => await _service.DeleteEmailAsync(userId, emailId);
 
         await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
-        await _repository.DidNotReceive().RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -584,7 +584,7 @@ public class UserEmailServiceTests
         // entirely.
         var userId = Guid.NewGuid();
         var emailId = Guid.NewGuid();
-        _repository.GetByIdAndUserIdAsync(emailId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(emailId, userId, Arg.Any<CancellationToken>())
             .Returns(new UserEmail
             {
                 Id = emailId,
@@ -596,7 +596,7 @@ public class UserEmailServiceTests
 
         await _service.DeleteEmailAsync(userId, emailId);
 
-        await _repository.Received(1).RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         // GetLoginsAsync should not even be called since the verified branch is skipped.
         await _userManager.DidNotReceive().GetLoginsAsync(Arg.Any<User>());
     }
@@ -624,15 +624,15 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = false,
         };
-        _repository.GetByIdAndUserIdAsync(primaryId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(primaryId, userId, Arg.Any<CancellationToken>())
             .Returns(primary);
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { primary, secondary });
 
         var act = async () => await _service.DeleteEmailAsync(userId, primaryId);
 
         await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
-        await _repository.DidNotReceive().RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -658,9 +658,9 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.GetByIdAndUserIdAsync(ticketEmailId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(ticketEmailId, userId, Arg.Any<CancellationToken>())
             .Returns(ticketEmail);
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { ticketEmail, primary });
         _ticketServiceRead.GetTicketOrdersAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<TicketOrderInfo>>([
@@ -694,7 +694,7 @@ public class UserEmailServiceTests
         var act = async () => await _service.DeleteEmailAsync(userId, ticketEmailId);
 
         await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
-        await _repository.DidNotReceive().RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -719,11 +719,11 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsGoogle = false,
         };
-        _repository.GetByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
             .Returns(rowB);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { rowA, rowB });
-        _repository.SetGoogleExclusiveAsync(
+        _repository.SetUserEmailGoogleExclusiveAsync(
             userId, rowBId, Arg.Any<Instant>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask)
             .AndDoes(_ =>
@@ -737,7 +737,7 @@ public class UserEmailServiceTests
         result.Should().BeTrue();
         rowA.IsGoogle.Should().BeFalse();
         rowB.IsGoogle.Should().BeTrue();
-        await _repository.Received(1).SetGoogleExclusiveAsync(
+        await _repository.Received(1).SetUserEmailGoogleExclusiveAsync(
             userId, rowBId, Arg.Any<Instant>(), Arg.Any<CancellationToken>());
     }
 
@@ -747,15 +747,15 @@ public class UserEmailServiceTests
         var ownerId = Guid.NewGuid();
         var otherId = Guid.NewGuid();
         var rowId = Guid.NewGuid();
-        // Owner-gate: GetByIdAndUserIdAsync(rowId, otherId) returns null because
+        // Owner-gate: GetUserEmailByIdAndUserIdAsync(rowId, otherId) returns null because
         // the row is owned by ownerId, not otherId.
-        _repository.GetByIdAndUserIdAsync(rowId, otherId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, otherId, Arg.Any<CancellationToken>())
             .Returns((UserEmail?)null);
 
         var result = await _service.SetGoogleAsync(otherId, rowId, otherId);
 
         result.Should().BeFalse();
-        await _repository.DidNotReceive().SetGoogleExclusiveAsync(
+        await _repository.DidNotReceive().SetUserEmailGoogleExclusiveAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
@@ -774,14 +774,14 @@ public class UserEmailServiceTests
             IsVerified = false,
             IsGoogle = false,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
 
         var result = await _service.SetGoogleAsync(userId, rowId, userId);
 
         result.Should().BeFalse();
         row.IsGoogle.Should().BeFalse();
-        await _repository.DidNotReceive().SetGoogleExclusiveAsync(
+        await _repository.DidNotReceive().SetUserEmailGoogleExclusiveAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
@@ -812,16 +812,16 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsGoogle = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { row, sibling });
 
         var result = await _service.ClearGoogleAsync(userId, rowId, actorId);
 
         result.Should().BeTrue();
         row.IsGoogle.Should().BeFalse();
-        await _repository.Received(1).UpdateAsync(row, Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateUserEmailAsync(row, Arg.Any<CancellationToken>());
         await _userInfoInvalidator.Received(1).InvalidateAsync(
             userId, Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
         await _auditLogService.Received(1).LogAsync(
@@ -845,13 +845,13 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsGoogle = false,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
 
         var result = await _service.ClearGoogleAsync(userId, rowId, userId);
 
         result.Should().BeFalse();
-        await _repository.DidNotReceive().UpdateAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().UpdateUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -871,16 +871,16 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsGoogle = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { row });
 
         var result = await _service.ClearGoogleAsync(userId, rowId, userId);
 
         result.Should().BeFalse();
         row.IsGoogle.Should().BeTrue();
-        await _repository.DidNotReceive().UpdateAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().UpdateUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
     }
@@ -909,19 +909,19 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsGoogle = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowAId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowAId, userId, Arg.Any<CancellationToken>())
             .Returns(rowA);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { rowA, rowB });
 
         var result = await _service.ClearGoogleAsync(userId, rowAId, userId);
 
         result.Should().BeTrue();
         // Only the targeted row should have flowed through UpdateAsync —
-        // SetGoogleExclusiveAsync (which would touch siblings) must not fire.
-        await _repository.DidNotReceive().SetGoogleExclusiveAsync(
+        // SetUserEmailGoogleExclusiveAsync (which would touch siblings) must not fire.
+        await _repository.DidNotReceive().SetUserEmailGoogleExclusiveAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
-        await _repository.Received(1).UpdateAsync(rowA, Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateUserEmailAsync(rowA, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -948,16 +948,16 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { row, sibling });
 
         var result = await _service.ClearPrimaryAsync(userId, rowId, actorId);
 
         result.Should().BeTrue();
         row.IsPrimary.Should().BeFalse();
-        await _repository.Received(1).UpdateAsync(row, Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateUserEmailAsync(row, Arg.Any<CancellationToken>());
         await _auditLogService.Received(1).LogAsync(
             AuditAction.UserEmailPrimaryCleared,
             nameof(User), userId,
@@ -983,16 +983,16 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { row });
 
         var result = await _service.ClearPrimaryAsync(userId, rowId, userId);
 
         result.Should().BeFalse();
         row.IsPrimary.Should().BeTrue();
-        await _repository.DidNotReceive().UpdateAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().UpdateUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
     }
@@ -1024,16 +1024,16 @@ public class UserEmailServiceTests
             IsVerified = false,
             IsPrimary = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { row, unverifiedSibling });
 
         var result = await _service.ClearPrimaryAsync(userId, rowId, userId);
 
         result.Should().BeFalse();
         row.IsPrimary.Should().BeTrue();
-        await _repository.DidNotReceive().UpdateAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().UpdateUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -1063,14 +1063,14 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { row, sibling });
 
         await _service.ClearPrimaryAsync(userId, rowId, userId);
 
-        await _repository.DidNotReceive().GetByUserIdForMutationAsync(
+        await _repository.DidNotReceive().GetUserEmailsByUserIdForMutationAsync(
             userId, Arg.Any<CancellationToken>());
     }
 
@@ -1147,7 +1147,7 @@ public class UserEmailServiceTests
     public async Task UnlinkAsync_RemovesAspNetUserLoginsAndEmailRow()
     {
         // Provider-attached row is removed from both the AspNetUserLogins table
-        // (via UserManager.RemoveLoginAsync) and user_emails (via _repo.RemoveAsync).
+        // (via UserManager.RemoveLoginAsync) and user_emails (via _repo.RemoveUserEmailAsync).
         // FullProfile cache is invalidated and an audit log entry is written.
         var userId = Guid.NewGuid();
         var actorId = Guid.NewGuid();
@@ -1162,7 +1162,7 @@ public class UserEmailServiceTests
             IsVerified = true,
         };
         var user = new User { Id = userId };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
         _userManager.RemoveLoginAsync(user, "Google", "sub-Z")
@@ -1172,7 +1172,7 @@ public class UserEmailServiceTests
 
         result.Should().BeTrue();
         await _userManager.Received(1).RemoveLoginAsync(user, "Google", "sub-Z");
-        await _repository.Received(1).RemoveAsync(row, Arg.Any<CancellationToken>());
+        await _repository.Received(1).RemoveUserEmailAsync(row, Arg.Any<CancellationToken>());
         await _userInfoInvalidator.Received(1).InvalidateAsync(userId, Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
         await _auditLogService.Received(1).LogAsync(
             AuditAction.UserEmailUnlinked,
@@ -1198,7 +1198,7 @@ public class UserEmailServiceTests
             ProviderKey = null,
             IsVerified = true,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
 
         var result = await _service.UnlinkAsync(userId, rowId, actorId);
@@ -1206,7 +1206,7 @@ public class UserEmailServiceTests
         result.Should().BeFalse();
         await _userManager.DidNotReceive().RemoveLoginAsync(
             Arg.Any<User>(), Arg.Any<string>(), Arg.Any<string>());
-        await _repository.DidNotReceive().RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
         await _auditLogService.DidNotReceive().LogAsync(
@@ -1228,9 +1228,9 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsGoogle = false,
         };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
-        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { row });
 
         await _service.SetGoogleAsync(userId, rowId, userId);
@@ -1254,16 +1254,16 @@ public class UserEmailServiceTests
         // leaving the user with NO primary row. The helper promotes the first
         // verified row regardless of domain.
         var userId = Guid.NewGuid();
-        _repository.ExistsForUserAsync(
+        _repository.UserEmailExistsForUserAsync(
             userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         UserEmail? added = null;
-        await _repository.AddAsync(
+        await _repository.AddUserEmailAsync(
             Arg.Do<UserEmail>(e => added = e),
             Arg.Any<CancellationToken>());
 
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(_ => added is null ? new List<UserEmail>() : new List<UserEmail> { added });
 
         await _service.AddVerifiedEmailAsync(userId, "alice@gmail.com");
@@ -1286,16 +1286,16 @@ public class UserEmailServiceTests
             IsVerified = true,
             IsPrimary = true,
         };
-        _repository.ExistsForUserAsync(
+        _repository.UserEmailExistsForUserAsync(
             userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         UserEmail? added = null;
-        await _repository.AddAsync(
+        await _repository.AddUserEmailAsync(
             Arg.Do<UserEmail>(e => added = e),
             Arg.Any<CancellationToken>());
 
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(_ => added is null
                 ? new List<UserEmail> { existingPrimary }
                 : new List<UserEmail> { existingPrimary, added });
@@ -1321,7 +1321,7 @@ public class UserEmailServiceTests
         _userManager.GenerateUserTokenAsync(
                 Arg.Any<User>(), Arg.Any<string>(), Arg.Any<string>())
             .Returns("tok-123");
-        _repository.ExistsForUserAsync(
+        _repository.UserEmailExistsForUserAsync(
                 userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(false);
         // UserInfo has NO UserEmail rows (the primary was deleted) but the legacy column lingers.
@@ -1331,14 +1331,14 @@ public class UserEmailServiceTests
         var result = await _service.AddEmailAsync(userId, "katja@gmail.com");
 
         result.EmailId.Should().NotBe(Guid.Empty);
-        await _repository.Received(1).AddAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).AddUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
     public async Task AddEmailAsync_AddressAlreadyHeldAsUserEmailRow_ThrowsValidationException()
     {
         var userId = Guid.NewGuid();
-        _repository.ExistsForUserAsync(
+        _repository.UserEmailExistsForUserAsync(
                 userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -1379,7 +1379,7 @@ public class UserEmailServiceTests
             IsPrimary = false,
         };
         var user = new User { Id = userId };
-        _repository.GetByIdAndUserIdAsync(googleRowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(googleRowId, userId, Arg.Any<CancellationToken>())
             .Returns(googleRow);
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
         _userManager.RemoveLoginAsync(user, "Google", "sub-Z")
@@ -1387,7 +1387,7 @@ public class UserEmailServiceTests
 
         // After RemoveAsync, the helper sees only the secondary (mock simulates
         // the post-removal state).
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { secondary });
 
         var result = await _service.UnlinkAsync(userId, googleRowId, actorId);
@@ -1424,13 +1424,13 @@ public class UserEmailServiceTests
             IsPrimary = true,
         };
         var user = new User { Id = userId };
-        _repository.GetByIdAndUserIdAsync(googleRowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(googleRowId, userId, Arg.Any<CancellationToken>())
             .Returns(googleRow);
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
         _userManager.RemoveLoginAsync(user, "Google", "sub-Z")
             .Returns(IdentityResult.Success);
 
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<UserEmail> { primary });
 
         var result = await _service.UnlinkAsync(userId, googleRowId, actorId);
@@ -1458,7 +1458,7 @@ public class UserEmailServiceTests
             IsVerified = true,
         };
         var user = new User { Id = userId };
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
         _userManager.RemoveLoginAsync(user, "Google", "sub-Z")
@@ -1468,7 +1468,7 @@ public class UserEmailServiceTests
         var result = await _service.UnlinkAsync(userId, rowId, actorId);
 
         result.Should().BeFalse();
-        await _repository.DidNotReceive().RemoveAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
         await _userInfoInvalidator.DidNotReceive().InvalidateAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
         await _auditLogService.DidNotReceive().LogAsync(
@@ -1510,11 +1510,11 @@ public class UserEmailServiceTests
 
         var user = new User { Id = userId, DisplayName = "U" };
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
-        _repository.GetByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
             .Returns(rowB);
-        _repository.GetByIdAndUserIdAsync(rowAId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowAId, userId, Arg.Any<CancellationToken>())
             .Returns((UserEmail?)null);
-        _repository.GetConflictingVerifiedEmailAsync(
+        _repository.GetConflictingVerifiedUserEmailAsync(
                 rowBId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns((UserEmail?)null);
         _userManager.VerifyUserTokenAsync(
@@ -1529,7 +1529,7 @@ public class UserEmailServiceTests
         rowB.IsVerified.Should().BeTrue();
         // Row A was never loaded — VerifyEmailAsync must look up by the
         // emailId argument, not enumerate the user's other pending rows.
-        await _repository.DidNotReceive().GetByIdAndUserIdAsync(
+        await _repository.DidNotReceive().GetUserEmailByIdAndUserIdAsync(
             rowAId, userId, Arg.Any<CancellationToken>());
     }
 
@@ -1554,7 +1554,7 @@ public class UserEmailServiceTests
 
         var user = new User { Id = userId, DisplayName = "U" };
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
-        _repository.GetByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
             .Returns(rowB);
         // Token from row A's link is NOT valid against row B's purpose suffix.
         _userManager.VerifyUserTokenAsync(
@@ -1585,7 +1585,7 @@ public class UserEmailServiceTests
 
         var user = new User { Id = userId, DisplayName = "U" };
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(verified);
 
         var act = async () => await _service.VerifyEmailAsync(userId, rowId, "any-token");
@@ -1612,7 +1612,7 @@ public class UserEmailServiceTests
 
         var user = new User { Id = userId, DisplayName = "U" };
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(oauth);
 
         var act = async () => await _service.VerifyEmailAsync(userId, rowId, "any-token");
@@ -1640,9 +1640,9 @@ public class UserEmailServiceTests
             VerificationSentAt = _clock.GetCurrentInstant(),
         };
 
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(pending);
-        _repository.GetConflictingVerifiedEmailAsync(
+        _repository.GetConflictingVerifiedUserEmailAsync(
                 rowId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns((UserEmail?)null);
 
@@ -1651,7 +1651,7 @@ public class UserEmailServiceTests
         result.MergeRequestCreated.Should().BeFalse();
         result.Email.Should().Be("pending@example.com");
         pending.IsVerified.Should().BeTrue();
-        await _repository.Received(1).UpdateAsync(pending, Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateUserEmailAsync(pending, Arg.Any<CancellationToken>());
         await _userInfoInvalidator.Received(1).InvalidateAsync(
             userId, Arg.Any<CancellationToken>(), Arg.Any<string>(), Arg.Any<string>());
         await _auditLogService.Received(1).LogAsync(
@@ -1689,9 +1689,9 @@ public class UserEmailServiceTests
             IsVerified = true,
         };
 
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(pending);
-        _repository.GetConflictingVerifiedEmailAsync(
+        _repository.GetConflictingVerifiedUserEmailAsync(
                 rowId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(conflicting);
         _mergeService.HasPendingForEmailIdAsync(rowId, Arg.Any<CancellationToken>())
@@ -1708,7 +1708,7 @@ public class UserEmailServiceTests
                 && m.PendingEmailId == rowId
                 && m.Status == AccountMergeRequestStatus.Pending),
             Arg.Any<CancellationToken>());
-        await _repository.DidNotReceive().UpdateAsync(
+        await _repository.DidNotReceive().UpdateUserEmailAsync(
             Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
 
@@ -1717,7 +1717,7 @@ public class UserEmailServiceTests
     {
         var userId = Guid.NewGuid();
         var rowId = Guid.NewGuid();
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns((UserEmail?)null);
 
         var act = async () => await _service.AdminMarkVerifiedAsync(userId, rowId, Guid.NewGuid());
@@ -1730,7 +1730,7 @@ public class UserEmailServiceTests
     {
         var userId = Guid.NewGuid();
         var rowId = Guid.NewGuid();
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(new UserEmail
             {
                 Id = rowId,
@@ -1752,7 +1752,7 @@ public class UserEmailServiceTests
         // not via this admin path — even an admin shouldn't bypass that.
         var userId = Guid.NewGuid();
         var rowId = Guid.NewGuid();
-        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(new UserEmail
             {
                 Id = rowId,
@@ -1795,11 +1795,11 @@ public class UserEmailServiceTests
             UpdatedAt = Instant.FromUtc(2026, 4, 10, 0, 0),
         };
 
-        _repository.ExistsForUserAsync(userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+        _repository.UserEmailExistsForUserAsync(userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         UserEmail? added = null;
-        _repository.AddAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>())
+        _repository.AddUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>())
             .Returns(call =>
             {
                 added = call.Arg<UserEmail>();
@@ -1807,7 +1807,7 @@ public class UserEmailServiceTests
             });
 
         // After AddAsync, repository returns both rows.
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(_ => new List<UserEmail> { personalRow, added! });
 
         await _service.AddVerifiedEmailAsync(userId, "alice@nobodies.team");
@@ -1826,15 +1826,15 @@ public class UserEmailServiceTests
         var userId = Guid.NewGuid();
         UserEmail? added = null;
 
-        _repository.ExistsForUserAsync(userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+        _repository.UserEmailExistsForUserAsync(userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(false);
-        _repository.AddAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>())
+        _repository.AddUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>())
             .Returns(call =>
             {
                 added = call.Arg<UserEmail>();
                 return Task.CompletedTask;
             });
-        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
             .Returns(_ => added is null ? new List<UserEmail>() : new List<UserEmail> { added });
 
         await _service.AddProvisionedEmailAsync(userId, "alice@example.com");
@@ -1848,12 +1848,12 @@ public class UserEmailServiceTests
     public async Task AddProvisionedEmailAsync_RowAlreadyExistsForUser_IsIdempotent()
     {
         var userId = Guid.NewGuid();
-        _repository.ExistsForUserAsync(userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+        _repository.UserEmailExistsForUserAsync(userId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         await _service.AddProvisionedEmailAsync(userId, "alice@example.com");
 
         await _repository.DidNotReceive()
-            .AddAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+            .AddUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
@@ -8,6 +8,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Repositories.Profiles;
 using Humans.Infrastructure.Repositories.Users;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -22,12 +23,10 @@ public sealed class UserServiceProfileOnboardingMutationTests : ServiceTestHarne
     public UserServiceProfileOnboardingMutationTests()
     {
         var userRepository = new UserRepository(DbFactory, Clock);
-        var userEmailRepository = new UserEmailRepository(DbFactory);
         var communicationPreferenceRepository = Substitute.For<ICommunicationPreferenceRepository>();
 
         _service = new UserService(
             userRepository,
-            userEmailRepository,
             communicationPreferenceRepository,
             AdminAuthorization,
             Clock,
@@ -78,6 +77,87 @@ public sealed class UserServiceProfileOnboardingMutationTests : ServiceTestHarne
             string.Equals(s.SectionName, GdprExportSections.Account, StringComparison.Ordinal));
         var accountJson = System.Text.Json.JsonSerializer.Serialize(accountSlice.Data);
         accountJson.Should().Contain("\"Email\":\"g@example.com\"");
+    }
+
+    [HumansFact]
+    public async Task GetByIdAsync_HydratesUserEmailsThroughUserRepository()
+    {
+        var userId = Guid.NewGuid();
+        SeedUser(userId, "Hydrated User");
+        var email = new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "hydrated@example.com",
+            IsVerified = true,
+            IsPrimary = true,
+        };
+        Db.UserEmails.Add(email);
+        await Db.SaveChangesAsync();
+
+        var user = await _service.GetByIdAsync(userId);
+
+        user.Should().NotBeNull();
+        user!.UserEmails.Should().ContainSingle(e =>
+            e.Id == email.Id && e.Email == "hydrated@example.com");
+    }
+
+    [HumansFact]
+    public async Task GetUsersWithLoginsButNoEmailsAsync_ComposesLoginAndUserEmailRepositories()
+    {
+        var userWithEmail = SeedUser(Guid.NewGuid(), "Has Email");
+        var userWithoutEmail = SeedUser(Guid.NewGuid(), "Ghost Login");
+        await Db.Set<IdentityUserLogin<Guid>>().AddRangeAsync(
+            new IdentityUserLogin<Guid>
+            {
+                UserId = userWithEmail.Id,
+                LoginProvider = "Google",
+                ProviderKey = "has-email-sub",
+                ProviderDisplayName = "Google",
+            },
+            new IdentityUserLogin<Guid>
+            {
+                UserId = userWithoutEmail.Id,
+                LoginProvider = "Google",
+                ProviderKey = "ghost-sub",
+                ProviderDisplayName = "Google",
+            });
+        Db.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userWithEmail.Id,
+            Email = "has-email@example.com",
+            IsVerified = true,
+            IsPrimary = true,
+        });
+        await Db.SaveChangesAsync();
+
+        var result = await _service.GetUsersWithLoginsButNoEmailsAsync();
+
+        result.Should().Equal([userWithoutEmail.Id]);
+    }
+
+    [HumansFact]
+    public async Task PurgeOwnDataAsync_RemovesUserEmailsThroughUserRepository()
+    {
+        var user = SeedUser(Guid.NewGuid(), "Purge Me");
+        Db.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Email = "purge-me@example.com",
+            IsVerified = true,
+            IsPrimary = true,
+        });
+        await Db.SaveChangesAsync();
+
+        var displayName = await _service.PurgeOwnDataAsync(user.Id);
+
+        displayName.Should().Be("Purge Me");
+        var remaining = await Db.UserEmails.AsNoTracking()
+            .Where(e => e.UserId == user.Id)
+            .ToListAsync();
+        remaining.Should().BeEmpty();
     }
 
     [HumansFact]
@@ -442,7 +522,6 @@ public sealed class UserServiceProfileOnboardingMutationTests : ServiceTestHarne
     private UserService BuildWithUserRepository(IUserRepository userRepository) =>
         new(
             userRepository,
-            new UserEmailRepository(DbFactory),
             Substitute.For<ICommunicationPreferenceRepository>(),
             AdminAuthorization,
             Clock,

--- a/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFoldTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFoldTests.cs
@@ -90,16 +90,16 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         await AcceptAsync(requestId, adminId);
 
         await using var assertScope = factory.Services.CreateAsyncScope();
-        var emailRepo = assertScope.ServiceProvider.GetRequiredService<IUserEmailRepository>();
+        var emailRepo = assertScope.ServiceProvider.GetRequiredService<IUserRepository>();
 
-        var targetEmails = await emailRepo.GetByUserIdReadOnlyAsync(targetId);
+        var targetEmails = await emailRepo.GetUserEmailsByUserIdReadOnlyAsync(targetId);
         var collapsed = targetEmails.Should()
             .ContainSingle(e => string.Equals(e.Email, sharedEmail, StringComparison.OrdinalIgnoreCase)).Subject;
         collapsed.IsVerified.Should().BeTrue("source's verified flag should OR-combine into the target row");
         collapsed.IsPrimary.Should().BeTrue("target's authoritative IsPrimary should be preserved");
         collapsed.IsGoogle.Should().BeTrue("target's authoritative IsGoogle should be preserved");
 
-        var sourceEmails = await emailRepo.GetByUserIdReadOnlyAsync(sourceId);
+        var sourceEmails = await emailRepo.GetUserEmailsByUserIdReadOnlyAsync(sourceId);
         sourceEmails.Should().NotContain(e => string.Equals(e.Email, sharedEmail, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -124,16 +124,16 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         await AcceptAsync(requestId, adminId);
 
         await using var assertScope = factory.Services.CreateAsyncScope();
-        var emailRepo = assertScope.ServiceProvider.GetRequiredService<IUserEmailRepository>();
+        var emailRepo = assertScope.ServiceProvider.GetRequiredService<IUserRepository>();
 
-        var targetEmails = await emailRepo.GetByUserIdReadOnlyAsync(targetId);
+        var targetEmails = await emailRepo.GetUserEmailsByUserIdReadOnlyAsync(targetId);
 
         // Same address collapses to a single target row.
         targetEmails.Should().ContainSingle(e => string.Equals(e.Email, collapseEmail, StringComparison.OrdinalIgnoreCase));
         // Source-only address re-FK'd onto target.
         targetEmails.Should().ContainSingle(e => string.Equals(e.Email, sourceOnlyEmail, StringComparison.OrdinalIgnoreCase));
 
-        var sourceEmails = await emailRepo.GetByUserIdReadOnlyAsync(sourceId);
+        var sourceEmails = await emailRepo.GetUserEmailsByUserIdReadOnlyAsync(sourceId);
         sourceEmails.Should().BeEmpty();
     }
 


### PR DESCRIPTION
## Summary
- fold `IUserEmailRepository` into the partial `IUserRepository` surface and move the EF implementation into `UserRepository.UserEmails`
- remove the separate `UserEmailRepository` registration and update user/email services to use the Users-owned repository storage methods
- update HUM0006 analyzer coverage and architecture tests so the approved OAuth reconcile primitive is now `IUserRepository.ApplyUserEmailReconcilePlanAsync`
- remove stale source/test references to the deleted repository and keep the existing `IUserEmailService` orchestration boundary intact

## Verification
- `dotnet build Humans.slnx --disable-build-servers -v minimal` (0 warnings, 0 errors)
- `dotnet test tests\Humans.Application.Tests\Humans.Application.Tests.csproj --disable-build-servers -v minimal`
- `dotnet test tests\Humans.Analyzers.Tests\Humans.Analyzers.Tests.csproj --no-build --disable-build-servers -v minimal`
- `dotnet ef migrations has-pending-model-changes --project src\Humans.Infrastructure --startup-project src\Humans.Web --context HumansDbContext --no-build`
- `git diff --check`

## HUM0025 Count
- `src/Humans.Infrastructure` + `src/Humans.Application`: 18 on current `origin/main`, 15 on this branch (`-3`)
- no DB/model changes; EF reports no pending model changes