### PR TITLE
Show sender email next to facilitated-message contact-info checkbox

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1948,7 +1948,8 @@ public class ProfileController(
         var viewModel = new SendMessageViewModel
         {
             RecipientId = id,
-            RecipientDisplayName = targetInfo.BurnerName
+            RecipientDisplayName = targetInfo.BurnerName,
+            SenderEmail = currentUser.Email ?? string.Empty
         };
 
         return View(viewModel);
@@ -1978,6 +1979,7 @@ public class ProfileController(
 
         model.RecipientId = id;
         model.RecipientDisplayName = targetUser.BurnerName;
+        model.SenderEmail = currentUser.Email ?? string.Empty;
 
         if (!ModelState.IsValid)
             return View(model);

--- a/src/Humans.Web/Models/SendMessageViewModel.cs
+++ b/src/Humans.Web/Models/SendMessageViewModel.cs
@@ -12,4 +12,6 @@ public class SendMessageViewModel
     public string Message { get; set; } = string.Empty;
 
     public bool IncludeContactInfo { get; set; } = true;
+
+    public string SenderEmail { get; set; } = string.Empty;
 }

--- a/src/Humans.Web/Views/Profile/SendMessage.cshtml
+++ b/src/Humans.Web/Views/Profile/SendMessage.cshtml
@@ -33,7 +33,13 @@
 
             <div class="mb-3 form-check">
                 <input asp-for="IncludeContactInfo" class="form-check-input" type="checkbox" />
-                <label asp-for="IncludeContactInfo" class="form-check-label">@Localizer["SendMessage_IncludeContactInfo"]</label>
+                <label asp-for="IncludeContactInfo" class="form-check-label">
+                    @Localizer["SendMessage_IncludeContactInfo"]
+                    @if (!string.IsNullOrEmpty(Model.SenderEmail))
+                    {
+                        <span class="text-muted">(@Model.SenderEmail)</span>
+                    }
+                </label>
                 <div class="form-text">@Localizer["SendMessage_IncludeContactInfoHelp"]</div>
             </div>
 


### PR DESCRIPTION
## Summary
- The Profile "Send message" form's "Include my contact info" checkbox didn't show which email address would actually be shared. Reply-To on the outbound email is set from the sender's address only when this box is ticked, so the consequence of leaving it unchecked (replies go to the system mailer, not the sender) was invisible.
- Surfaces the sender's effective email in muted text next to the checkbox label, populated from `UserInfo.Email` on both GET and the re-render path after validation errors.
- Default remains checked for everyone.

## Test plan
- [ ] Open another user's profile → Send message → confirm the address appears next to "Include my contact info".
- [ ] Submit with an empty message → re-rendered form still shows the address.
- [ ] Send with the box checked → recipient's reply lands at the sender's address (Reply-To header set).
- [ ] Send with the box unchecked → body says "no contact info shared"; reply goes to the system From address (unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)