### PR TITLE
Route Drive Activity user lookup through UserInfo

### DIFF
--- a/docs/architecture/service-data-access-map.md
+++ b/docs/architecture/service-data-access-map.md
@@ -598,20 +598,17 @@ Repository: `IDriveActivityMonitorRepository`.
 | Table | R/W |
 |-------|-----|
 | GoogleResources | R (via `ITeamResourceService`) |
-| Users | R (via repo `TryResolveEmailByGoogleUserIdAsync` — join with IdentityUserLogins) |
-| IdentityUserLogins | R (via repo) |
+| Users / IdentityUserLogins | R (via `IUserServiceRead.GetAllUserInfosAsync` / `UserInfo.ExternalLogins`) |
 | SystemSettings | R/W (key `DriveActivityMonitor:LastRunAt`) |
 
-**Cross-section reads (design-rule violations):** the
-`DriveActivityMonitorRepository` queries `Users` and `IdentityUserLogins`
-directly to resolve Google user ids → email. Audit-log writes have already
-been migrated to `IAuditLogService` (the prior `AuditLogEntries` direct
-read/write is gone). The remaining cleanup path is to inject
-`IUserService` for the email lookup so the repo only owns
-`SystemSettings`-key plumbing.
+Google `people/{id}` fallback resolution goes through the Users read-model:
+the service builds a per-run Google provider-key -> `UserInfo` index from
+`IUserServiceRead.GetAllUserInfosAsync` and uses `UserInfo.Email`. The
+repository owns only the `SystemSettings` key plumbing. Audit-log writes go
+through `IAuditLogService`.
 
 Cross-section calls via `IGoogleDriveActivityClient`,
-`ITeamResourceService`, `IAuditLogService`. No cache.
+`ITeamResourceService`, `IUserServiceRead`, `IAuditLogService`. No cache.
 
 ### GoogleRemovalNotificationService (Scoped)
 
@@ -1784,10 +1781,10 @@ remaining design-rule violations.
 
 | Table | Owning Section | Cross-Section Repo Readers (violations) |
 |-------|----------------|-----------------------------------------|
-| **Users** | Users | Profiles (`UserEmailRepository` writes `GoogleEmail`/`GoogleEmailStatus`/`Email` and the `UserEmailWithUser` read; `DuplicateAccountService` via `IUserRepository`), Google Integration (`DriveActivityMonitorRepository.TryResolveEmailByGoogleUserIdAsync` reads via IdentityUserLogins join) |
+| **Users** | Users | Profiles (`UserEmailRepository` writes `GoogleEmail`/`GoogleEmailStatus`/`Email` and the `UserEmailWithUser` read; `DuplicateAccountService` via `IUserRepository`) |
 | **UserEmails** | Profiles | Users (`UserRepository.Include(u => u.UserEmails)` — `UserInfo` projection bridge; tracked under HUM0025 grandfathering as the read-model boundary) |
 | **EventParticipations** | Users | Profiles (`DuplicateAccountService` via `IUserRepository`) |
-| **IdentityUserLogins** | Users | Google Integration (`DriveActivityMonitorRepository`), Profiles (`DuplicateAccountService` via `IUserRepository`) |
+| **IdentityUserLogins** | Users | Profiles (`DuplicateAccountService` via `IUserRepository`) |
 | **GoogleSyncOutboxEvents** | Google Integration | Teams (`TeamRepository` writes outbox events on team mutations) |
 
 ### Notable Cross-Section Patterns
@@ -1831,13 +1828,11 @@ remaining design-rule violations.
    via `IGoogleSyncOutboxRepository`. The atomicity benefit outweighs
    the boundary cost.
 
-6. **DriveActivityMonitor still reaches into the User identity tables.**
-   `DriveActivityMonitorRepository` joins `IdentityUserLogins` and `Users`
-   to resolve a Google `people/{client_id}` actor back to an email.
-   Audit-log writes have already been migrated to `IAuditLogService` (the
-   prior `AuditLogEntries` direct write is gone). The remaining cleanup
-   path is to inject `IUserService` for the email lookup so the repo only
-   owns its `SystemSettings`-key plumbing.
+6. **DriveActivityMonitor user fallback uses UserInfo.**
+   `DriveActivityMonitorService` resolves Google `people/{client_id}` actors
+   through Directory first, then through a per-run Google provider-key ->
+   `UserInfo` index from `IUserServiceRead.GetAllUserInfosAsync`. The
+   repository owns only its `SystemSettings` key.
 
 7. **SystemSettings has per-key ownership (no single owner service).**
    Each key is owned by the section whose repository accesses it; this

--- a/src/Humans.Application/Interfaces/Repositories/IDriveActivityMonitorRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IDriveActivityMonitorRepository.cs
@@ -1,13 +1,12 @@
-using NodaTime;
 using Humans.Domain.Attributes;
+using NodaTime;
 
 namespace Humans.Application.Interfaces.Repositories;
 
 /// <summary>
 /// Repository for the persistent state owned by the Drive Activity monitor:
-/// the per-job "last run at" marker (stored in <c>system_settings</c> under a
-/// dedicated key) and the fallback lookup from a Google-OAuth <c>people/{id}</c>
-/// to a local user's email via the ASP.NET Identity login tables.
+/// the per-job "last run at" marker stored in <c>system_settings</c> under a
+/// dedicated key.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -17,17 +16,10 @@ namespace Humans.Application.Interfaces.Repositories;
 /// respective services (e.g. <c>EmailOutboxService</c>).
 /// </para>
 /// <para>
-/// Anomaly audit entries are <em>not</em> persisted here — the service emits
+/// Anomaly audit entries are <em>not</em> persisted here; the service emits
 /// them through <c>IAuditLogService.LogAsync</c>, so the only section that
 /// writes <c>audit_log_entries</c> is the AuditLog section's repository
-/// (design-rules §2c / the AuditLog write boundary).
-/// </para>
-/// <para>
-/// The Identity login / user read is a cross-section fallback used only when
-/// the Directory API can't resolve a <c>people/{id}</c>. It returns the
-/// <c>User.Email</c> (OAuth primary email) directly rather than going through
-/// <c>IUserService</c> so the query stays a single join — matching the
-/// pre-migration behavior.
+/// (design-rules section 2c / the AuditLog write boundary).
 /// </para>
 /// </remarks>
 [Section("GoogleIntegration")]
@@ -47,19 +39,9 @@ public interface IDriveActivityMonitorRepository : IRepository
     /// <param name="newLastRunAt">
     /// The instant to store as <c>DriveActivityMonitor:LastRunAt</c>. When
     /// <c>null</c>, the marker is left as-is so the next run re-processes the
-    /// same window — used when at least one resource failed to query.
+    /// same window; used when at least one resource failed to query.
     /// </param>
     Task AdvanceLastRunMarkerAsync(
         Instant? newLastRunAt,
         CancellationToken ct = default);
-
-    /// <summary>
-    /// Resolves a Google-OAuth provider-key to the local user's <c>User.Email</c>
-    /// address, or <c>null</c> when no matching login or user exists.
-    /// Used as a last-resort fallback when the Directory API cannot resolve a
-    /// <c>people/{id}</c> actor (for example, deleted Workspace accounts whose
-    /// local user row still exists).
-    /// </summary>
-    Task<string?> TryResolveEmailByGoogleUserIdAsync(
-        string googleUserId, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
@@ -3,6 +3,7 @@ using NodaTime;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Application.Interfaces.GoogleIntegration;
@@ -16,11 +17,14 @@ public sealed class DriveActivityMonitorService(
     IGoogleDriveActivityClient driveActivityClient,
     ITeamResourceService teamResourceService,
     IDriveActivityMonitorRepository repository,
+    IUserServiceRead userService,
     IAuditLogService auditLogService,
     IClock clock,
     ILogger<DriveActivityMonitorService> logger) : IDriveActivityMonitorService
 {
     private const string JobName = "DriveActivityMonitorJob";
+    private static readonly IReadOnlyDictionary<string, UserInfo> EmptyGoogleUserInfoByProviderKey =
+        new Dictionary<string, UserInfo>(StringComparer.Ordinal);
 
     /// <inheritdoc />
     public async Task<int> CheckForAnomalousActivityAsync(CancellationToken cancellationToken = default)
@@ -41,6 +45,8 @@ public sealed class DriveActivityMonitorService(
 
         // Per-invocation cache for resolved people/ IDs to avoid repeated API calls.
         var peopleIdCache = new Dictionary<string, string>(StringComparer.Ordinal);
+        IReadOnlyDictionary<string, UserInfo>? googleUserInfoByProviderKey = null;
+        var googleUserInfoLookupUnavailable = false;
 
         // Seed the people ID cache with the service account's client_id so that
         // ResolvePersonNameAsync maps "people/{client_id}" back to the SA email.
@@ -78,9 +84,11 @@ public sealed class DriveActivityMonitorService(
                     }
 
                     var description = await BuildAnomalyDescriptionAsync(
-                        activity, resource.Name, peopleIdCache, cancellationToken);
+                        activity, resource.Name, peopleIdCache,
+                        GetGoogleUserInfoByProviderKeyAsync, cancellationToken);
                     var actorEmail = await GetActorEmailAsync(
-                        activity, peopleIdCache, cancellationToken);
+                        activity, peopleIdCache,
+                        GetGoogleUserInfoByProviderKeyAsync, cancellationToken);
 
                     logger.LogWarning(
                         "Anomalous permission change detected on {ResourceName} ({GoogleId}) by {Actor}: {Description}",
@@ -171,6 +179,37 @@ public sealed class DriveActivityMonitorService(
         }
 
         return anomalies.Count;
+
+        async Task<IReadOnlyDictionary<string, UserInfo>> GetGoogleUserInfoByProviderKeyAsync()
+        {
+            if (googleUserInfoByProviderKey is not null)
+            {
+                return googleUserInfoByProviderKey;
+            }
+
+            if (googleUserInfoLookupUnavailable)
+            {
+                return EmptyGoogleUserInfoByProviderKey;
+            }
+
+            try
+            {
+                googleUserInfoByProviderKey = await LoadGoogleUserInfoByProviderKeyAsync(cancellationToken);
+                return googleUserInfoByProviderKey;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                googleUserInfoLookupUnavailable = true;
+                logger.LogWarning(
+                    ex,
+                    "Could not load UserInfo Google login fallback for Drive Activity people ids; unresolved ids will be left raw for this run");
+                return EmptyGoogleUserInfoByProviderKey;
+            }
+        }
     }
 
     private static bool IsInitiatedByServiceAccount(
@@ -209,6 +248,7 @@ public sealed class DriveActivityMonitorService(
     private async Task<string?> GetActorEmailAsync(
         DriveActivityEvent activity,
         Dictionary<string, string> peopleIdCache,
+        Func<Task<IReadOnlyDictionary<string, UserInfo>>> getGoogleUserInfoByProviderKeyAsync,
         CancellationToken cancellationToken)
     {
         if (activity.Actors.Count == 0)
@@ -220,7 +260,11 @@ public sealed class DriveActivityMonitorService(
         {
             if (actor.KnownUserPersonName is not null)
             {
-                return await ResolvePersonNameAsync(actor.KnownUserPersonName, peopleIdCache, cancellationToken);
+                return await ResolvePersonNameAsync(
+                    actor.KnownUserPersonName,
+                    peopleIdCache,
+                    getGoogleUserInfoByProviderKeyAsync,
+                    cancellationToken);
             }
 
             if (actor.IsAdministrator)
@@ -241,9 +285,11 @@ public sealed class DriveActivityMonitorService(
         DriveActivityEvent activity,
         string resourceName,
         Dictionary<string, string> peopleIdCache,
+        Func<Task<IReadOnlyDictionary<string, UserInfo>>> getGoogleUserInfoByProviderKeyAsync,
         CancellationToken cancellationToken)
     {
-        var actorEmail = await GetActorEmailAsync(activity, peopleIdCache, cancellationToken) ?? "unknown actor";
+        var actorEmail = await GetActorEmailAsync(
+            activity, peopleIdCache, getGoogleUserInfoByProviderKeyAsync, cancellationToken) ?? "unknown actor";
         var permChange = activity.PermissionChange;
         var parts = new List<string>();
 
@@ -251,7 +297,8 @@ public sealed class DriveActivityMonitorService(
         {
             foreach (var perm in permChange.AddedPermissions)
             {
-                var target = await GetPermissionTargetAsync(perm, peopleIdCache, cancellationToken);
+                var target = await GetPermissionTargetAsync(
+                    perm, peopleIdCache, getGoogleUserInfoByProviderKeyAsync, cancellationToken);
                 var role = perm.Role ?? "unknown role";
                 parts.Add($"added {role} for {target}");
             }
@@ -261,7 +308,8 @@ public sealed class DriveActivityMonitorService(
         {
             foreach (var perm in permChange.RemovedPermissions)
             {
-                var target = await GetPermissionTargetAsync(perm, peopleIdCache, cancellationToken);
+                var target = await GetPermissionTargetAsync(
+                    perm, peopleIdCache, getGoogleUserInfoByProviderKeyAsync, cancellationToken);
                 var role = perm.Role ?? "unknown role";
                 parts.Add($"removed {role} for {target}");
             }
@@ -277,11 +325,16 @@ public sealed class DriveActivityMonitorService(
     private async Task<string> GetPermissionTargetAsync(
         DriveActivityPermission permission,
         Dictionary<string, string> peopleIdCache,
+        Func<Task<IReadOnlyDictionary<string, UserInfo>>> getGoogleUserInfoByProviderKeyAsync,
         CancellationToken cancellationToken)
     {
         if (permission.UserPersonName is not null)
         {
-            return await ResolvePersonNameAsync(permission.UserPersonName, peopleIdCache, cancellationToken);
+            return await ResolvePersonNameAsync(
+                permission.UserPersonName,
+                peopleIdCache,
+                getGoogleUserInfoByProviderKeyAsync,
+                cancellationToken);
         }
 
         if (permission.GroupEmail is not null)
@@ -303,11 +356,12 @@ public sealed class DriveActivityMonitorService(
     }
 
     /// <summary>
-    /// Resolves a "people/{id}" name to an email via cache → Admin Directory → local DB. Falls back to raw id.
+    /// Resolves a "people/{id}" name to an email via cache → Admin Directory → UserInfo. Falls back to raw id.
     /// </summary>
     private async Task<string> ResolvePersonNameAsync(
         string personName,
         Dictionary<string, string> peopleIdCache,
+        Func<Task<IReadOnlyDictionary<string, UserInfo>>> getGoogleUserInfoByProviderKeyAsync,
         CancellationToken cancellationToken)
     {
         if (!personName.StartsWith("people/", StringComparison.Ordinal))
@@ -321,11 +375,19 @@ public sealed class DriveActivityMonitorService(
             return cached;
         }
 
-        // Extract the numeric user ID from "people/123456789" for the local-DB fallback.
+        // Extract the numeric user ID from "people/123456789" for the UserInfo fallback.
         var googleUserId = personName["people/".Length..];
 
-        var resolved = await driveActivityClient.TryResolvePersonEmailAsync(personName, cancellationToken)
-            ?? await repository.TryResolveEmailByGoogleUserIdAsync(googleUserId, cancellationToken);
+        var resolved = await driveActivityClient.TryResolvePersonEmailAsync(personName, cancellationToken);
+
+        if (resolved is null)
+        {
+            var googleUserInfoByProviderKey = await getGoogleUserInfoByProviderKeyAsync();
+            if (googleUserInfoByProviderKey.TryGetValue(googleUserId, out var userInfo))
+            {
+                resolved = userInfo.Email;
+            }
+        }
 
         if (resolved is not null)
         {
@@ -338,5 +400,36 @@ public sealed class DriveActivityMonitorService(
         peopleIdCache[personName] = personName;
         logger.LogDebug("Could not resolve {PersonName} to an email address", personName);
         return personName;
+    }
+
+    private async Task<IReadOnlyDictionary<string, UserInfo>> LoadGoogleUserInfoByProviderKeyAsync(
+        CancellationToken cancellationToken)
+    {
+        var userInfos = await userService.GetAllUserInfosAsync(cancellationToken);
+        var result = new Dictionary<string, UserInfo>(StringComparer.Ordinal);
+        var ambiguous = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var userInfo in userInfos)
+        {
+            foreach (var login in userInfo.ExternalLogins)
+            {
+                if (!string.Equals(login.Provider, "Google", StringComparison.Ordinal))
+                    continue;
+
+                if (ambiguous.Contains(login.ProviderKey))
+                    continue;
+
+                if (result.TryAdd(login.ProviderKey, userInfo))
+                    continue;
+
+                result.Remove(login.ProviderKey);
+                ambiguous.Add(login.ProviderKey);
+                logger.LogWarning(
+                    "Skipping ambiguous Google provider key {ProviderKey} while resolving Drive Activity people id",
+                    login.ProviderKey);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
@@ -416,6 +416,9 @@ public sealed class DriveActivityMonitorService(
                 if (!string.Equals(login.Provider, "Google", StringComparison.Ordinal))
                     continue;
 
+                if (userInfo.Email is null)
+                    continue;
+
                 if (ambiguous.Contains(login.ProviderKey))
                     continue;
 

--- a/src/Humans.Infrastructure/Repositories/GoogleIntegration/DriveActivityMonitorRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/GoogleIntegration/DriveActivityMonitorRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
@@ -21,8 +20,6 @@ namespace Humans.Infrastructure.Repositories.GoogleIntegration;
 /// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
 /// </summary>
 [Grandfathered("HUM0025", justification: "Per-key SystemSettings access shared with EmailOutboxRepository (disjoint keys); split the table or route through an owning service.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "SystemSettings")]
-[Grandfathered("HUM0025", justification: "Cross-section read of Identity UserLogins; migrate to IUserService.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserLogins")]
-[Grandfathered("HUM0025", justification: "Cross-section read of the Users table; migrate to IUserService.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "Users")]
 internal sealed class DriveActivityMonitorRepository(
     IDbContextFactory<HumansDbContext> factory,
     ILogger<DriveActivityMonitorRepository> logger) : IDriveActivityMonitorRepository
@@ -89,41 +86,5 @@ internal sealed class DriveActivityMonitorRepository(
         }
 
         await ctx.SaveChangesAsync(ct);
-    }
-
-    public async Task<string?> TryResolveEmailByGoogleUserIdAsync(
-        string googleUserId, CancellationToken ct = default)
-    {
-        try
-        {
-            await using var ctx = await factory.CreateDbContextAsync(ct);
-
-            // ASP.NET Identity user logins for Google provider key → user id.
-            var login = await ctx.Set<IdentityUserLogin<Guid>>()
-                .AsNoTracking()
-                .FirstOrDefaultAsync(l =>
-                    l.ProviderKey == googleUserId &&
-                    l.LoginProvider == "Google",
-                    ct);
-
-            if (login is null)
-            {
-                return null;
-            }
-
-            var email = await ctx.Users
-                .AsNoTracking()
-                .Where(u => u.Id == login.UserId)
-                .Select(u => u.Email)
-                .FirstOrDefaultAsync(ct);
-
-            return email;
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex,
-                "Error resolving Google user id {GoogleUserId} via local DB", googleUserId);
-            return null;
-        }
     }
 }

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -11,8 +11,6 @@ using Humans.Infrastructure.Data;
 namespace Humans.Infrastructure.Repositories.Users;
 
 /// <summary>EF-backed <see cref="IUserRepository"/>.</summary>
-[Grandfathered("HUM0025", justification: "Identity UserLogins also accessed by DriveActivityMonitorRepository; converge on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "UserLogins")]
-[Grandfathered("HUM0025", justification: "Users is also accessed by DriveActivityMonitorRepository; converge on one owner.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "Users")]
 internal sealed partial class UserRepository : IUserRepository
 {
     private readonly IDbContextFactory<HumansDbContext> _factory;

--- a/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
@@ -1,7 +1,9 @@
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -28,6 +30,7 @@ public class DriveActivityMonitorServiceTests
     private readonly IGoogleDriveActivityClient _client;
     private readonly ITeamResourceService _teamResources;
     private readonly IDriveActivityMonitorRepository _repository;
+    private readonly IUserServiceRead _userService;
     private readonly IAuditLogService _auditLog;
     private readonly FakeClock _clock;
     private readonly DriveActivityMonitorService _service;
@@ -41,15 +44,17 @@ public class DriveActivityMonitorServiceTests
         _client = Substitute.For<IGoogleDriveActivityClient>();
         _teamResources = Substitute.For<ITeamResourceService>();
         _repository = Substitute.For<IDriveActivityMonitorRepository>();
+        _userService = Substitute.For<IUserServiceRead>();
         _auditLog = Substitute.For<IAuditLogService>();
         _clock = new FakeClock(Instant.FromUtc(2026, 4, 22, 10, 0));
 
         _client.IsConfigured.Returns(true);
         _client.GetServiceAccountEmailAsync(Arg.Any<CancellationToken>()).Returns(ServiceAccountEmail);
         _client.GetServiceAccountClientIdAsync(Arg.Any<CancellationToken>()).Returns(ServiceAccountClientId);
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>()).Returns([]);
 
         _service = new DriveActivityMonitorService(
-            _client, _teamResources, _repository, _auditLog, _clock,
+            _client, _teamResources, _repository, _userService, _auditLog, _clock,
             NullLogger<DriveActivityMonitorService>.Instance);
     }
 
@@ -153,10 +158,11 @@ public class DriveActivityMonitorServiceTests
 
         // Directory API should be hit exactly once per unique people/ id (per-run cache).
         await _client.Received(1).TryResolvePersonEmailAsync("people/9999", Arg.Any<CancellationToken>());
+        await _userService.DidNotReceive().GetAllUserInfosAsync(Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
-    public async Task CheckForAnomalousActivityAsync_FallsBackToLocalDbWhenDirectoryLookupFails()
+    public async Task CheckForAnomalousActivityAsync_FallsBackToUserInfoWhenDirectoryLookupFails()
     {
         var resource = BuildResource("Fallback-Drive");
         SeedResources(resource);
@@ -169,8 +175,12 @@ public class DriveActivityMonitorServiceTests
 
         _client.TryResolvePersonEmailAsync("people/42", Arg.Any<CancellationToken>())
             .Returns((string?)null);
-        _repository.TryResolveEmailByGoogleUserIdAsync("42", Arg.Any<CancellationToken>())
-            .Returns("localdb@example.com");
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                BuildUserInfo(
+                    "userinfo@example.com",
+                    new UserExternalLoginInfo("Google", "42"))
+            ]);
 
         var count = await _service.CheckForAnomalousActivityAsync();
 
@@ -179,7 +189,77 @@ public class DriveActivityMonitorServiceTests
             AuditAction.AnomalousPermissionDetected,
             nameof(GoogleResource),
             resource.Id,
-            Arg.Is<string>(d => d.Contains("localdb@example.com", StringComparison.Ordinal)),
+            Arg.Is<string>(d => d.Contains("userinfo@example.com", StringComparison.Ordinal)),
+            JobName);
+    }
+
+    [HumansFact]
+    public async Task CheckForAnomalousActivityAsync_LeavesRawPeopleIdWhenUserInfoFallbackFails()
+    {
+        var resource = BuildResource("Fallback-Failure-Drive");
+        SeedResources(resource);
+
+        var anomalousEvent = BuildPermissionChangeEvent(
+            actorPersonName: "people/42",
+            addedRole: "reader",
+            targetUser: "people/42");
+        SeedActivity(resource.GoogleId, anomalousEvent);
+
+        _client.TryResolvePersonEmailAsync("people/42", Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<IReadOnlyCollection<UserInfo>>(
+                new InvalidOperationException("user cache failed")));
+
+        var count = await _service.CheckForAnomalousActivityAsync();
+
+        count.Should().Be(1);
+        await _repository.Received(1).AdvanceLastRunMarkerAsync(
+            _clock.GetCurrentInstant(),
+            Arg.Any<CancellationToken>());
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.AnomalousPermissionDetected,
+            nameof(GoogleResource),
+            resource.Id,
+            Arg.Is<string>(d => d.Contains("people/42", StringComparison.Ordinal)),
+            JobName);
+    }
+
+    [HumansFact]
+    public async Task CheckForAnomalousActivityAsync_SkipsAmbiguousUserInfoProviderKeys()
+    {
+        var resource = BuildResource("Ambiguous-Drive");
+        SeedResources(resource);
+
+        var anomalousEvent = BuildPermissionChangeEvent(
+            actorPersonName: "people/42",
+            addedRole: "reader",
+            targetUser: "people/42");
+        SeedActivity(resource.GoogleId, anomalousEvent);
+
+        _client.TryResolvePersonEmailAsync("people/42", Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                BuildUserInfo(
+                    "first@example.com",
+                    new UserExternalLoginInfo("Google", "42")),
+                BuildUserInfo(
+                    "second@example.com",
+                    new UserExternalLoginInfo("Google", "42"))
+            ]);
+
+        var count = await _service.CheckForAnomalousActivityAsync();
+
+        count.Should().Be(1);
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.AnomalousPermissionDetected,
+            nameof(GoogleResource),
+            resource.Id,
+            Arg.Is<string>(d =>
+                d.Contains("people/42", StringComparison.Ordinal) &&
+                !d.Contains("first@example.com", StringComparison.Ordinal) &&
+                !d.Contains("second@example.com", StringComparison.Ordinal)),
             JobName);
     }
 
@@ -295,6 +375,35 @@ public class DriveActivityMonitorServiceTests
         name,
         GoogleResourceType.DriveFolder,
         Url: null);
+
+    private UserInfo BuildUserInfo(string email, params UserExternalLoginInfo[] externalLogins) =>
+        new(
+            Guid.NewGuid(),
+            BurnerName: email,
+            IsGdprAnonymized: false,
+            PreferredLanguage: "en",
+            FallbackPictureUrl: null,
+            CreatedAt: _clock.GetCurrentInstant(),
+            LastLoginAt: null,
+            LastConsentReminderSentAt: null,
+            DeletionRequestedAt: null,
+            DeletionScheduledFor: null,
+            DeletionEligibleAfter: null,
+            UnsubscribedFromCampaigns: false,
+            ICalToken: null,
+            SuppressScheduleChangeEmails: false,
+            MagicLinkSentAt: null,
+            GoogleEmailStatus: GoogleEmailStatus.Unknown,
+            ContactSource: null,
+            ExternalSourceId: null,
+            MergedToUserId: null,
+            MergedAt: null,
+            IdentityEmailColumn: email,
+            UserEmails: [],
+            EventParticipations: [],
+            ExternalLogins: externalLogins,
+            Profile: null,
+            CommunicationPreferences: []);
 
     private static DriveActivityEvent BuildPermissionChangeEvent(
         string actorPersonName, string addedRole, string targetUser) =>

--- a/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
@@ -162,6 +162,65 @@ public class DriveActivityMonitorServiceTests
     }
 
     [HumansFact]
+    public async Task CheckForAnomalousActivityAsync_DoesNotLoadUserInfo_WhenAllPeopleIdsResolvedByDirectory()
+    {
+        var resource = BuildResource("MultiActor-Drive");
+        SeedResources(resource);
+
+        var eventA = BuildPermissionChangeEvent(
+            actorPersonName: "people/111",
+            addedRole: "writer",
+            targetUser: "people/111");
+        var eventB = BuildPermissionChangeEvent(
+            actorPersonName: "people/222",
+            addedRole: "reader",
+            targetUser: "people/222");
+        SeedActivity(resource.GoogleId, eventA, eventB);
+
+        _client.TryResolvePersonEmailAsync("people/111", Arg.Any<CancellationToken>())
+            .Returns("actor-a@example.com");
+        _client.TryResolvePersonEmailAsync("people/222", Arg.Any<CancellationToken>())
+            .Returns("actor-b@example.com");
+
+        var count = await _service.CheckForAnomalousActivityAsync();
+
+        count.Should().Be(2);
+        await _userService.DidNotReceive().GetAllUserInfosAsync(Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task CheckForAnomalousActivityAsync_LeavesRawPeopleIdWhenUserInfoHasNullEmail()
+    {
+        var resource = BuildResource("NullEmail-Drive");
+        SeedResources(resource);
+
+        var anomalousEvent = BuildPermissionChangeEvent(
+            actorPersonName: "people/99",
+            addedRole: "writer",
+            targetUser: "people/99");
+        SeedActivity(resource.GoogleId, anomalousEvent);
+
+        _client.TryResolvePersonEmailAsync("people/99", Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                BuildUserInfoWithNullEmail(new UserExternalLoginInfo("Google", "99"))
+            ]);
+
+        var count = await _service.CheckForAnomalousActivityAsync();
+
+        count.Should().Be(1);
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.AnomalousPermissionDetected,
+            nameof(GoogleResource),
+            resource.Id,
+            Arg.Is<string>(d =>
+                d.Contains("people/99", StringComparison.Ordinal) &&
+                !d.Contains("Skipping ambiguous", StringComparison.Ordinal)),
+            JobName);
+    }
+
+    [HumansFact]
     public async Task CheckForAnomalousActivityAsync_FallsBackToUserInfoWhenDirectoryLookupFails()
     {
         var resource = BuildResource("Fallback-Drive");
@@ -399,6 +458,35 @@ public class DriveActivityMonitorServiceTests
             MergedToUserId: null,
             MergedAt: null,
             IdentityEmailColumn: email,
+            UserEmails: [],
+            EventParticipations: [],
+            ExternalLogins: externalLogins,
+            Profile: null,
+            CommunicationPreferences: []);
+
+    private UserInfo BuildUserInfoWithNullEmail(params UserExternalLoginInfo[] externalLogins) =>
+        new(
+            Guid.NewGuid(),
+            BurnerName: "Deleted User",
+            IsGdprAnonymized: true,
+            PreferredLanguage: "en",
+            FallbackPictureUrl: null,
+            CreatedAt: _clock.GetCurrentInstant(),
+            LastLoginAt: null,
+            LastConsentReminderSentAt: null,
+            DeletionRequestedAt: null,
+            DeletionScheduledFor: null,
+            DeletionEligibleAfter: null,
+            UnsubscribedFromCampaigns: false,
+            ICalToken: null,
+            SuppressScheduleChangeEmails: false,
+            MagicLinkSentAt: null,
+            GoogleEmailStatus: GoogleEmailStatus.Unknown,
+            ContactSource: null,
+            ExternalSourceId: null,
+            MergedToUserId: null,
+            MergedAt: null,
+            IdentityEmailColumn: null,
             UserEmails: [],
             EventParticipations: [],
             ExternalLogins: externalLogins,

--- a/tests/Humans.Application.Tests/Repositories/DriveActivityMonitorRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/DriveActivityMonitorRepositoryTests.cs
@@ -1,5 +1,4 @@
 using AwesomeAssertions;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
@@ -11,10 +10,8 @@ using Humans.Infrastructure.Repositories.GoogleIntegration;
 namespace Humans.Application.Tests.Repositories;
 
 /// <summary>
-/// Tests for <see cref="DriveActivityMonitorRepository"/> — the owner of
-/// <c>system_settings["DriveActivityMonitor:LastRunAt"]</c>, anomaly audit
-/// persistence for the Drive activity monitor, and the
-/// Google-OAuth-id → email fallback lookup.
+/// Tests for <see cref="DriveActivityMonitorRepository"/>, the owner of
+/// <c>system_settings["DriveActivityMonitor:LastRunAt"]</c>.
 /// </summary>
 public sealed class DriveActivityMonitorRepositoryTests : IDisposable
 {
@@ -151,58 +148,4 @@ public sealed class DriveActivityMonitorRepositoryTests : IDisposable
         rows[0].Value.Should().Be(NodaTime.Text.InstantPattern.General.Format(next));
     }
 
-    [HumansFact]
-    public async Task TryResolveEmailByGoogleUserIdAsync_ReturnsNull_WhenLoginNotFound()
-    {
-        var result = await _repository.TryResolveEmailByGoogleUserIdAsync("nonexistent");
-        result.Should().BeNull();
-    }
-
-    [HumansFact]
-    public async Task TryResolveEmailByGoogleUserIdAsync_ReturnsEmail_WhenGoogleLoginExists()
-    {
-        var user = new User
-        {
-            Id = Guid.NewGuid(),
-            Email = "known@example.com",
-            UserName = "known@example.com",
-            DisplayName = "Known",
-        };
-        _seedContext.Users.Add(user);
-        _seedContext.Set<IdentityUserLogin<Guid>>().Add(new IdentityUserLogin<Guid>
-        {
-            LoginProvider = "Google",
-            ProviderKey = "google-id-7",
-            ProviderDisplayName = "Google",
-            UserId = user.Id,
-        });
-        await _seedContext.SaveChangesAsync();
-
-        var result = await _repository.TryResolveEmailByGoogleUserIdAsync("google-id-7");
-        result.Should().Be("known@example.com");
-    }
-
-    [HumansFact]
-    public async Task TryResolveEmailByGoogleUserIdAsync_IgnoresNonGoogleLoginsWithSameProviderKey()
-    {
-        var user = new User
-        {
-            Id = Guid.NewGuid(),
-            Email = "someone@example.com",
-            UserName = "someone@example.com",
-            DisplayName = "Someone",
-        };
-        _seedContext.Users.Add(user);
-        _seedContext.Set<IdentityUserLogin<Guid>>().Add(new IdentityUserLogin<Guid>
-        {
-            LoginProvider = "Microsoft",
-            ProviderKey = "shared-id",
-            ProviderDisplayName = "Microsoft",
-            UserId = user.Id,
-        });
-        await _seedContext.SaveChangesAsync();
-
-        var result = await _repository.TryResolveEmailByGoogleUserIdAsync("shared-id");
-        result.Should().BeNull();
-    }
 }


### PR DESCRIPTION
## Summary
- remove the DriveActivity repository fallback that joined `AspNetUserLogins` and `Users`
- inject `IUserServiceRead` into `DriveActivityMonitorService` and lazily load a per-run Google provider-key -> `UserInfo` map only after Directory lookup fails
- use `UserInfo.Email` for unresolved Google `people/{id}` actors after the Directory lookup fails, while logging and continuing with the raw id if the UserInfo fallback is unavailable
- skip ambiguous duplicate Google provider keys rather than attributing an audit entry to the wrong user
- update the active service data-access map for the new boundary

## Verification
- `dotnet build Humans.slnx --disable-build-servers -v minimal`
- `dotnet test tests\Humans.Application.Tests\Humans.Application.Tests.csproj --no-build --disable-build-servers -v minimal --filter "FullyQualifiedName~DriveActivityMonitor"`
- `dotnet test tests\Humans.Application.Tests\Humans.Application.Tests.csproj --no-build --disable-build-servers -v minimal`
- `dotnet ef migrations has-pending-model-changes --project src\Humans.Infrastructure --startup-project src\Humans.Web --context HumansDbContext --no-build`
- `git diff --check`

## HUM0025 Count
- Current `origin/main`: 15
- This branch: 11 (`-4`)