### PR TITLE
feat(shifts): double trends chart height on dashboard

### DIFF
--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div class="card-body">
-        <canvas id="dashboardTrendsChart" height="90" role="img" aria-label="@Localizer["ShiftDash_Trends_Title"]"></canvas>
+        <canvas id="dashboardTrendsChart" height="180" role="img" aria-label="@Localizer["ShiftDash_Trends_Title"]"></canvas>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Bump `<canvas>` height from 90 to 180 on the Shift Dashboard trends card so the chart renders 2× as tall (Chart.js uses the canvas attributes for its aspect ratio under `responsive: true`).

## Test plan
- [ ] Visit `/Shifts/Dashboard` and confirm the trends card is roughly twice as tall as before.
- [ ] Switch window buttons (7d / 30d / 90d / All) and confirm the chart re-renders at the new height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)