### PR TITLE
feat(store): team orders as non-billable counterparty

### DIFF
--- a/docs/sections/Store.md
+++ b/docs/sections/Store.md
@@ -21,11 +21,11 @@ Per-camp catalog ordering, multi-method payments, and consolidated Holded factur
 
 ## Concepts
 
-- A **Store Product** is a catalog item available to Camp Leads in a given event year (price, VAT rate, optional deposit, ordering deadline). Products are created and edited by StoreAdmin.
-- A **Store Order** is a Camp Lead's order against a `CampSeason`. Lifecycle: **Open** → **InvoiceIssued**. Multiple orders per `CampSeason` are allowed, distinguished by an optional `Label`.
+- A **Store Product** is a catalog item available to Camp Leads and department coordinators in a given event year (price, VAT rate, optional deposit, ordering deadline). Products are created and edited by StoreAdmin.
+- A **Store Order** is owned by exactly one counterparty — either a `CampSeason` (billable, full lifecycle Open → InvoiceIssued, multiple orders per season allowed) **or** a `Team` (non-billable, department-level only, stays `Open` indefinitely, one order per team per year). The "exactly one" invariant is service-enforced, not DB-enforced. Both kinds reuse the same `StoreProduct` catalog and the `OrderableUntil` deadline gate.
 - A **Store Order Line** is a line on an order that snapshots the product's price, VAT, and deposit at the time the line was added — later catalog edits never mutate existing lines.
-- A **Store Payment** is a payment against an order, recorded with one of three methods (`Stripe`, `BankTransfer`, `Manual`). Negative amounts represent refunds.
-- A **Store Invoice** is the consolidated Holded factura issued for an order. One invoice per order, written once at issuance.
+- A **Store Payment** is a payment against a camp order, recorded with one of three methods (`Stripe`, `BankTransfer`, `Manual`). Negative amounts represent refunds. Team orders never have payments.
+- A **Store Invoice** is the consolidated Holded factura issued for a camp order. One invoice per order, written once at issuance. Team orders never receive invoices.
 - A **Store Treasury Sync State** is the singleton cursor row that the treasury-sync job uses to track its last successful Holded poll.
 
 ## Data Model
@@ -61,16 +61,20 @@ A camp's order against a season.
 | Property | Type | Notes |
 |----------|------|-------|
 | Id | Guid | PK |
-| CampSeasonId | Guid | FK only — no nav |
-| Label | string(100)? | Optional disambiguator within a season |
-| State | StoreOrderState (int) | Open or InvoiceIssued |
-| CounterpartyName / CounterpartyVatId / CounterpartyAddress / CounterpartyCountryCode / CounterpartyEmail | string? | Editable by Camp Lead while Open; FinanceAdmin always |
-| IssuedInvoiceId | Guid? | Set when invoice is issued |
+| CampSeasonId | Guid? | FK only — no nav. Set for camp orders; null for team orders. |
+| TeamId | Guid? | FK only — no nav. Set for team orders; null for camp orders. |
+| Year | int | Event year the catalog draws from. Always set on write; lazy-backfilled from `CampSeason.Year` for legacy camp rows. |
+| Label | string(100)? | Optional disambiguator within a season (camp orders only) |
+| State | StoreOrderState (int) | Open or InvoiceIssued; team orders stay Open |
+| CounterpartyName / CounterpartyVatId / CounterpartyAddress / CounterpartyCountryCode / CounterpartyEmail | string? | Editable by Camp Lead while Open; FinanceAdmin always. Never populated on team orders. |
+| IssuedInvoiceId | Guid? | Set when invoice is issued (camp orders only) |
 | CreatedAt / UpdatedAt | Instant | |
 
-**Indexes:** `CampSeasonId`, `State`.
+**Indexes:** `CampSeasonId`, `TeamId`, `State`.
 
-**Cross-section linkage:** `CampSeasonId` is a bare `Guid` column — no FK constraint, no navigation property (per `memory/architecture/no-cross-section-ef-joins.md`). Resolved at the service layer via `ICampService.GetCampSeasonByIdAsync`.
+**Cross-section linkage:** `CampSeasonId` and `TeamId` are bare `Guid?` columns — no FK constraint, no navigation property (per `memory/architecture/no-cross-section-ef-joins.md`). Resolved at the service layer via `ICampService.GetCampSeasonByIdAsync` / `ITeamServiceRead.GetTeamAsync`.
+
+**Year backfill rule:** new writes always populate `Year`. Pre-existing camp rows may carry `Year = 0` until they're next saved through the service, at which point the column is backfilled from `CampSeason.Year`.
 
 **Aggregate-local navs:** `StoreOrder.Lines`, `StoreOrder.Payments`.
 
@@ -163,14 +167,15 @@ Stored as int via `HasConversion<int>()`.
 
 ## Routing
 
-- `/Store` — Camp Lead order browse + create + line edit.
-- `/Store/Order/{id}` — Camp Lead order detail (balance + Pay button).
+- `/Store` — Camp Lead and department-coordinator order browse + create + line edit. Each counterparty (camp-you-lead or department-you-coordinate) is rendered as its own card.
+- `/Store/Order/{id}` — Order detail. Camp orders show balance + Pay button. Team orders show only lines + add-line form + a "non-billable" footer (no counterparty form, no Pay, no payments list).
+- `/Store/Team/{teamId}/Create` — POST: department coordinator creates their team's order for the active event year.
 - `/Store/Admin/Catalog` — StoreAdmin catalog CRUD (`StoreAdminController`, policy `StoreCatalogAdmin`).
 - `/Store/Admin/Catalog/Edit[/{id}]` — Create / edit product.
 - `/Store/Admin/Catalog/Save` — POST save product.
 - `/Store/Admin/Catalog/Deactivate/{id}` — POST soft-deactivate product.
 - `/Store/Admin/Orders` — FinanceAdmin order ledger + payment entry + Issue Invoice. **Not yet implemented (Phase 5 stub).**
-- `/Store/Admin/Summary` — FinanceAdmin/StoreAdmin/Admin aggregate report: by-camp, by-item, camps × products cross-tab for a given year. Reuses `PolicyNames.StoreCatalogAdmin`.
+- `/Store/Admin/Summary` — FinanceAdmin/StoreAdmin/Admin aggregate report: by-counterparty (with Type column distinguishing Camp / Team), by-item (sums lines from both camp and team orders for supplier aggregation), counterparties × products cross-tab for a given year. Reuses `PolicyNames.StoreCatalogAdmin`.
 - `/Store/StripeWebhook` — anonymous endpoint for Stripe checkout-session events (`StoreStripeWebhookController`).
 
 ## Actors & Roles
@@ -178,13 +183,19 @@ Stored as int via `HasConversion<int>()`.
 | Actor | Capabilities |
 |-------|--------------|
 | Camp Lead | View / create orders for camp-seasons they lead. Add and remove lines while order is Open and the product's `OrderableUntil` has not passed. Edit counterparty fields while Open. Initiate Stripe checkout to pay. |
-| StoreAdmin | **Store-domain superset** (per `memory/code/admin-role-superset.md`): catalog CRUD, view all orders, record manual payments, issue invoices, run treasury sync. Equivalent to FinanceAdmin within the Store section. |
-| FinanceAdmin, Admin | All Camp Lead and StoreAdmin capabilities. Record manual payments (incl. refunds via negative amounts) regardless of order state. Issue invoice (single + Issue All). View `/Store/Summary`. Run treasury sync on demand. |
+| Coordinator (department) | View / create the single team order for departments (top-level teams) they coordinate, scoped to the active event year. Add and remove lines while the product's `OrderableUntil` has not passed. No pay, no counterparty edit, no invoice — team orders are non-billable. |
+| StoreAdmin | **Store-domain superset** (per `memory/code/admin-role-superset.md`): catalog CRUD, view all orders, record manual payments, issue invoices, run treasury sync. Equivalent to FinanceAdmin within the Store section. EditCounterparty/Pay remain denied on team orders even for admins. |
+| FinanceAdmin, Admin | All Camp Lead and StoreAdmin capabilities. Record manual payments (incl. refunds via negative amounts) regardless of order state. Issue invoice (single + Issue All). View `/Store/Admin/Summary`. Run treasury sync on demand. EditCounterparty/Pay remain denied on team orders. |
 
 ## Invariants
 
-- An order follows the lifecycle: **Open → InvoiceIssued**. There is no return-to-Open transition.
-- Lines may only be added or removed while the order is `Open` AND `today <= Product.OrderableUntil` (enforced in `StoreService.AddLineAsync` / `RemoveLineAsync`).
+- An order has **exactly one counterparty** — `CampSeasonId` xor `TeamId` is non-null. The invariant is service-enforced (in `StoreService.CreateOrderAsync` / `CreateTeamOrderAsync`), not DB-enforced.
+- **Team orders are non-billable.** `UpdateCounterpartyAsync`, `RecordManualPaymentAsync`, `RecordStripePaymentAsync`, `CreateStripeCheckoutSessionAsync`, and `IssueInvoiceAsync` reject any order whose `TeamId is not null` with `InvalidOperationException`. The auth handler also permanently denies the `EditCounterparty` and `Pay` operations on team orders regardless of role.
+- A team order is restricted to a **department** (top-level team — `ParentTeamId is null`). Sub-team orders are not supported.
+- At most **one team order per team per year** — enforced by `CreateTeamOrderAsync` via a repo lookup before insert.
+- Camp orders follow the lifecycle: **Open → InvoiceIssued**. There is no return-to-Open transition.
+- Team orders stay in **Open** indefinitely. The implicit close-out signal is per-product `OrderableUntil` — once every catalog product has passed its deadline, the order is effectively read-only.
+- Lines may only be added or removed while the order is `Open` AND `today <= Product.OrderableUntil` (enforced in `StoreService.AddLineAsync` / `RemoveLineAsync`). The deadline gate is per-product and identical for camp and team orders.
 - Counterparty fields (`CounterpartyName`, `CounterpartyVatId`, `CounterpartyAddress`, `CounterpartyCountryCode`, `CounterpartyEmail`) are editable only while the order is `Open` (Camp Lead) or by FinanceAdmin/Admin always.
 - Line snapshots (`UnitPriceSnapshot`, `VatRateSnapshot`, `DepositAmountSnapshot`) are written at add-time and never recomputed — later catalog edits to `StoreProduct` do not propagate to existing lines.
 - Payments may be recorded regardless of order state — payments do not freeze on issuance.
@@ -217,7 +228,8 @@ Stored as int via `HasConversion<int>()`.
 ## Cross-Section Dependencies
 
 - **Camps:** `ICampService` for `CampSeason` lookups (camp name, lead resolution for resource-based auth).
-- **Shifts:** `IShiftManagementService.GetActiveAsync()` for the active event's `Year` and `TimeZoneId` — used to (a) resolve the active catalog year on `/Store` and `/Store/Admin/Catalog` and (b) compute "today in event time zone" for the `OrderableUntil` deadline gate.
+- **Teams:** `ITeamServiceRead` for department lookups (team name, department check via `ParentTeamId is null`, coordinator check via `ManagementRoleHolderUserIds`). Existing methods only — no new surface added to its `[SurfaceBudget(4)]`.
+- **Shifts:** `IShiftManagementService.GetActiveAsync()` for the active event's `Year` and `TimeZoneId` — used to (a) resolve the active catalog year on `/Store` and `/Store/Admin/Catalog`, (b) populate `Year` on new team orders, and (c) compute "today in event time zone" for the `OrderableUntil` deadline gate.
 - **Auth/Roles:** `RoleNames.StoreAdmin` (this section), `RoleNames.FinanceAdmin`, `RoleNames.Admin`.
 - **Holded connector** (Infrastructure): `IHoldedClient` extended with `UpsertContactAsync`, `CreateInvoiceAsync`, `ListTreasuryEntriesAsync` in Phase 4.
 - **Stripe connector** (Infrastructure): `IStripeService.CreateCheckoutSessionAsync` for camp-lead payments; `StoreStripeWebhookController` for `checkout.session.completed` ingestion.

--- a/docs/superpowers/plans/2026-05-27-store-team-orders.md
+++ b/docs/superpowers/plans/2026-05-27-store-team-orders.md
@@ -1,0 +1,936 @@
+# Store Team Orders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let department coordinators place non-billable orders against the existing Store catalog so supplier-aggregation totals reflect their demand.
+
+**Architecture:** Make `StoreOrder` polymorphic — either `CampSeasonId` (billable, today's flow, unchanged) or `TeamId` (non-billable, no payment/invoice path, stays `Open` forever). Service layer enforces "exactly one counterparty"; DB does not. Catalog and `OrderableUntil` gate are reused as-is. `Year` is added to the row, populated lazily.
+
+**Tech Stack:** ASP.NET Core MVC, EF Core (PostgreSQL), NodaTime, NSubstitute + xUnit, resource-based authorization. Existing Store section conventions: `IRepository` + `IApplicationService` + `IDbContextFactory` (§15b Singleton). Cross-section reads go through `ITeamServiceRead` (existing methods only — its `[SurfaceBudget(4)]` is full).
+
+**Branch:** `feat/store-team-orders` (worktree at `H:\source\Humans\.worktrees\store-team-orders`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-27-store-team-orders-design.md`](../specs/2026-05-27-store-team-orders-design.md).
+
+---
+
+## Task 1: Domain entity + EF config + migration
+
+**Files:**
+- Modify: `src/Humans.Domain/Entities/StoreOrder.cs`
+- Modify: `src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderConfiguration.cs`
+- Generate: `src/Humans.Infrastructure/Data/Migrations/*_StoreOrderTeamCounterpartyAndYear.cs`
+
+- [ ] **Step 1: Make `CampSeasonId` nullable, add `TeamId` and `Year` on `StoreOrder`**
+
+In `src/Humans.Domain/Entities/StoreOrder.cs` change:
+
+```csharp
+public Guid? CampSeasonId { get; set; }
+
+/// <summary>
+/// Cross-section linkage to <c>Team</c> — bare Guid, no EF navigation, no FK constraint
+/// (per <c>memory/architecture/no-cross-section-ef-joins.md</c>). Resolved at the service
+/// layer via <c>ITeamServiceRead.GetTeamAsync</c>. Exactly one of <see cref="CampSeasonId"/>
+/// and <see cref="TeamId"/> is non-null; the invariant is service-enforced, not DB-enforced.
+/// </summary>
+public Guid? TeamId { get; set; }
+
+/// <summary>
+/// Event year the order's catalog draws from. Always set on write. For camp orders this
+/// mirrors <c>CampSeason.Year</c>; for team orders it is the active event year at create time.
+/// </summary>
+public int Year { get; set; }
+```
+
+- [ ] **Step 2: Update `StoreOrderConfiguration`**
+
+In `src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderConfiguration.cs`:
+
+- `CampSeasonId`: drop `.IsRequired()` if present; keep its existing index.
+- Add `builder.Property(o => o.TeamId);` (nullable).
+- Add `builder.HasIndex(o => o.TeamId);`
+- Add `builder.Property(o => o.Year).IsRequired();`
+
+No new FK constraints (cross-section linkage stays bare-Guid).
+
+- [ ] **Step 3: Build to confirm config compiles**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 4: Generate migration**
+
+Run from repo root: `dotnet ef migrations add StoreOrderTeamCounterpartyAndYear --project src/Humans.Infrastructure --startup-project src/Humans.Web`
+Expected: three new files under `src/Humans.Infrastructure/Data/Migrations/` (`*_StoreOrderTeamCounterpartyAndYear.cs`, `.Designer.cs`, snapshot update). Do not hand-edit any of them.
+
+- [ ] **Step 5: Re-run build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Domain/Entities/StoreOrder.cs \
+        src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderConfiguration.cs \
+        src/Humans.Infrastructure/Data/Migrations/
+git commit -m "feat(store): StoreOrder gains nullable TeamId/CampSeasonId + Year"
+```
+
+---
+
+## Task 2: DTOs — polymorphic `OrderDto` + counterparty enum
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Store/Dtos/OrderDto.cs`
+- Modify: `src/Humans.Application/Services/Store/Dtos/StoreIndexData.cs`
+- Create: `src/Humans.Domain/Enums/StoreOrderCounterpartyType.cs`
+
+- [ ] **Step 1: Add `StoreOrderCounterpartyType` enum**
+
+Create `src/Humans.Domain/Enums/StoreOrderCounterpartyType.cs`:
+
+```csharp
+namespace Humans.Domain.Enums;
+
+public enum StoreOrderCounterpartyType
+{
+    Camp = 0,
+    Team = 1,
+}
+```
+
+- [ ] **Step 2: Extend `OrderDto`**
+
+Rewrite `src/Humans.Application/Services/Store/Dtos/OrderDto.cs`:
+
+```csharp
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Store.Dtos;
+
+public record OrderDto(
+    Guid Id,
+    Guid? CampSeasonId,
+    Guid? TeamId,
+    StoreOrderCounterpartyType CounterpartyType,
+    string CounterpartyDisplayName,
+    int Year,
+    string? Label,
+    StoreOrderState State,
+    string? CounterpartyName,
+    string? CounterpartyVatId,
+    string? CounterpartyAddress,
+    string? CounterpartyCountryCode,
+    string? CounterpartyEmail,
+    Guid? IssuedInvoiceId,
+    IReadOnlyList<OrderLineDto> Lines,
+    decimal LinesSubtotalEur,
+    decimal VatTotalEur,
+    decimal DepositTotalEur,
+    decimal PaymentsTotalEur,
+    decimal BalanceEur);
+```
+
+- [ ] **Step 3: Extend `StoreIndexData` with unified counterparty list**
+
+Rewrite `src/Humans.Application/Services/Store/Dtos/StoreIndexData.cs`:
+
+```csharp
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Store.Dtos;
+
+public sealed record StoreIndexData(
+    int Year,
+    IReadOnlyList<ProductDto> Catalog,
+    IReadOnlyList<StoreCounterpartyOrders> Counterparties,
+    bool ShowNoOrdersMessage);
+
+public sealed record StoreCounterpartyOrders(
+    StoreOrderCounterpartyType CounterpartyType,
+    Guid CounterpartyId,
+    string DisplayName,
+    int Year,
+    IReadOnlyList<OrderDto> Orders);
+
+public sealed record StoreOrderPageData(
+    OrderDto Order,
+    IReadOnlyList<ProductDto> Catalog,
+    string CounterpartyDisplayName,
+    bool CanEdit,
+    bool CanPay,
+    bool IsStripeConfigured);
+```
+
+The old `StoreCampSeasonOrders` record is replaced. The old `StoreOrderPageData.CampName` becomes `CounterpartyDisplayName`.
+
+- [ ] **Step 4: Build (will fail at callers — expected)**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build fails — `StoreService`, `StoreController`, view models, and tests still reference the old shapes. Those fixes happen in subsequent tasks.
+
+- [ ] **Step 5: Commit (DTO shape only)**
+
+```bash
+git add src/Humans.Application/Services/Store/Dtos/OrderDto.cs \
+        src/Humans.Application/Services/Store/Dtos/StoreIndexData.cs \
+        src/Humans.Domain/Enums/StoreOrderCounterpartyType.cs
+git commit -m "feat(store): OrderDto + StoreIndexData go polymorphic"
+```
+
+---
+
+## Task 3: Repository — team-scoped queries
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs`
+- Modify: `tests/Humans.Application.Tests/Architecture/Baselines/*` (only if architecture baseline lists the surface — check after build)
+
+- [ ] **Step 1: Add team-order methods to `IStoreRepository`**
+
+In `src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs`, after `GetOrdersForCampSeasonsWithLinesAndPaymentsAsync`:
+
+```csharp
+/// <summary>
+/// Returns the single open team order for <paramref name="teamId"/>, or null. The
+/// "one order per team per year" invariant is service-enforced; this method returns
+/// the first match if more exist.
+/// </summary>
+Task<StoreOrder?> GetOrderForTeamAsync(Guid teamId, int year, CancellationToken ct = default);
+
+/// <summary>
+/// Returns every <see cref="StoreOrder"/> whose <c>TeamId</c> is in
+/// <paramref name="teamIds"/>, with <c>Lines</c> eager-loaded. Empty input returns an
+/// empty list without a round-trip. Used by the admin summary cross-tab.
+/// </summary>
+Task<IReadOnlyList<StoreOrder>> GetOrdersForTeamsWithLinesAsync(
+    IReadOnlyCollection<Guid> teamIds,
+    int year,
+    CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement in `StoreRepository`**
+
+In `src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs`, follow the existing camp-scoped method shape (open `IDbContextFactory` context, `.AsNoTracking()` for reads, eager-load `Lines` where indicated). Example:
+
+```csharp
+public async Task<StoreOrder?> GetOrderForTeamAsync(Guid teamId, int year, CancellationToken ct = default)
+{
+    await using var db = await contextFactory.CreateDbContextAsync(ct);
+    return await db.Set<StoreOrder>()
+        .AsNoTracking()
+        .Include(o => o.Lines)
+        .Where(o => o.TeamId == teamId && o.Year == year)
+        .FirstOrDefaultAsync(ct);
+}
+
+public async Task<IReadOnlyList<StoreOrder>> GetOrdersForTeamsWithLinesAsync(
+    IReadOnlyCollection<Guid> teamIds,
+    int year,
+    CancellationToken ct = default)
+{
+    if (teamIds.Count == 0) return [];
+    await using var db = await contextFactory.CreateDbContextAsync(ct);
+    return await db.Set<StoreOrder>()
+        .AsNoTracking()
+        .Include(o => o.Lines)
+        .Where(o => o.TeamId.HasValue && teamIds.Contains(o.TeamId.Value) && o.Year == year)
+        .ToListAsync(ct);
+}
+```
+
+- [ ] **Step 3: Build (other callers still broken — expected)**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: same DTO-related caller errors from Task 2, plus the new repo methods compile. No new errors out of the repo files themselves.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs \
+        src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+git commit -m "feat(store): repo gains team-scoped order queries"
+```
+
+---
+
+## Task 4: Service — `IStoreService` shape + team write methods
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Store/IStoreService.cs`
+- Modify: `src/Humans.Application/Services/Store/StoreService.cs`
+- Test: `tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs` (new)
+
+- [ ] **Step 1: Add team-order methods to `IStoreService`**
+
+In `src/Humans.Application/Interfaces/Store/IStoreService.cs` under the camp-lead Orders section:
+
+```csharp
+// Orders (team coordinator)
+Task<Guid> CreateTeamOrderAsync(Guid teamId, Guid actorUserId, CancellationToken ct = default);
+Task<OrderDto?> GetOrderForTeamAsync(Guid teamId, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Write failing test for `CreateTeamOrderAsync`**
+
+Create `tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs`. Mirror the existing `StoreServiceTests.cs` SUT setup (NSubstitute for `IStoreRepository`, `IAuditLogService`, `ICampService`, `IClock`, `IShiftManagementService`, `IStripeService`, `ITeamServiceRead`, `ILogger<StoreService>`). Add:
+
+```csharp
+[Fact]
+public async Task CreateTeamOrderAsync_writes_order_with_team_id_and_active_year()
+{
+    var teamId = Guid.NewGuid();
+    var userId = Guid.NewGuid();
+    _shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026, TimeZoneId = "Europe/Madrid" });
+    _teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+        .Returns(new TeamInfo(teamId, "Kitchen", null, "kitchen", true, false,
+            SystemTeamType.None, false, true, false, false, Instant.FromUtc(2026,1,1,0,0),
+            new List<TeamMemberInfo>(), ParentTeamId: null,
+            ManagementRoleHolderUserIds: new HashSet<Guid> { userId }));
+    _repo.GetOrderForTeamAsync(teamId, 2026, Arg.Any<CancellationToken>()).Returns((StoreOrder?)null);
+
+    var id = await _service.CreateTeamOrderAsync(teamId, userId);
+
+    await _repo.Received(1).AddOrderAsync(Arg.Is<StoreOrder>(o =>
+        o.TeamId == teamId &&
+        o.CampSeasonId == null &&
+        o.Year == 2026 &&
+        o.State == StoreOrderState.Open));
+    Assert.NotEqual(Guid.Empty, id);
+}
+
+[Fact]
+public async Task CreateTeamOrderAsync_throws_when_team_already_has_order_this_year()
+{
+    var teamId = Guid.NewGuid();
+    var userId = Guid.NewGuid();
+    _shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026, TimeZoneId = "Europe/Madrid" });
+    _teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+        .Returns(new TeamInfo(teamId, "Kitchen", null, "kitchen", true, false,
+            SystemTeamType.None, false, true, false, false, Instant.FromUtc(2026,1,1,0,0),
+            new List<TeamMemberInfo>(), ParentTeamId: null,
+            ManagementRoleHolderUserIds: new HashSet<Guid> { userId }));
+    _repo.GetOrderForTeamAsync(teamId, 2026, Arg.Any<CancellationToken>())
+        .Returns(new StoreOrder { Id = Guid.NewGuid(), TeamId = teamId, Year = 2026 });
+
+    await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _service.CreateTeamOrderAsync(teamId, userId));
+}
+
+[Fact]
+public async Task CreateTeamOrderAsync_throws_when_team_is_a_subteam()
+{
+    var teamId = Guid.NewGuid();
+    var userId = Guid.NewGuid();
+    _shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026, TimeZoneId = "Europe/Madrid" });
+    _teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+        .Returns(new TeamInfo(teamId, "Sub", null, "sub", true, false,
+            SystemTeamType.None, false, true, false, false, Instant.FromUtc(2026,1,1,0,0),
+            new List<TeamMemberInfo>(), ParentTeamId: Guid.NewGuid()));
+
+    await Assert.ThrowsAsync<InvalidOperationException>(
+        () => _service.CreateTeamOrderAsync(teamId, userId));
+}
+```
+
+(Adjust constructor positional args of `TeamInfo` to match the actual record — see `ITeamService.cs` for current order.)
+
+Run: `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj -v quiet --filter "FullyQualifiedName~StoreServiceTeamOrdersTests"`
+Expected: tests fail to compile (no `_teams` field, no `CreateTeamOrderAsync`).
+
+- [ ] **Step 3: Add `ITeamServiceRead` dependency to `StoreService` ctor**
+
+In `src/Humans.Application/Services/Store/StoreService.cs`:
+
+```csharp
+public class StoreService(
+    IStoreRepository repo,
+    IAuditLogService audit,
+    ICampService campService,
+    ITeamServiceRead teamService,
+    IClock clock,
+    IShiftManagementService shifts,
+    IStripeService stripeService,
+    ILogger<StoreService> logger) : IStoreService
+```
+
+Update DI registration in `src/Humans.Web/Program.cs` (or wherever Store services register) — `ITeamServiceRead` should already be registered by the Teams section; no new registration needed, just a constructor signature change.
+
+- [ ] **Step 4: Implement `CreateTeamOrderAsync` and `GetOrderForTeamAsync`**
+
+Add to `StoreService`:
+
+```csharp
+public async Task<Guid> CreateTeamOrderAsync(Guid teamId, Guid actorUserId, CancellationToken ct = default)
+{
+    var team = await teamService.GetTeamAsync(teamId, ct)
+        ?? throw new InvalidOperationException($"Team {teamId} not found.");
+    if (team.ParentTeamId is not null)
+        throw new InvalidOperationException("Team orders are restricted to departments (top-level teams).");
+
+    var activeEvent = await shifts.GetActiveAsync();
+    var year = activeEvent?.Year > 0 ? activeEvent.Year : clock.GetCurrentInstant().InUtc().Year;
+
+    var existing = await repo.GetOrderForTeamAsync(teamId, year, ct);
+    if (existing is not null)
+        throw new InvalidOperationException($"Team {teamId} already has a Store order for {year}.");
+
+    var now = clock.GetCurrentInstant();
+    var order = new StoreOrder
+    {
+        Id = Guid.NewGuid(),
+        TeamId = teamId,
+        CampSeasonId = null,
+        Year = year,
+        State = StoreOrderState.Open,
+        CreatedAt = now,
+        UpdatedAt = now,
+    };
+    await repo.AddOrderAsync(order, ct);
+    await audit.LogAsync(AuditEvent.StoreOrderCreated, actorUserId, order.Id.ToString(),
+        $"Team: {team.Name}", ct);
+    return order.Id;
+}
+
+public async Task<OrderDto?> GetOrderForTeamAsync(Guid teamId, CancellationToken ct = default)
+{
+    var activeEvent = await shifts.GetActiveAsync();
+    var year = activeEvent?.Year > 0 ? activeEvent.Year : clock.GetCurrentInstant().InUtc().Year;
+    var order = await repo.GetOrderForTeamAsync(teamId, year, ct);
+    if (order is null) return null;
+    return await MapOrderToDtoAsync(order, ct);
+}
+```
+
+`MapOrderToDtoAsync` is the existing private mapper — Step 5 updates it to fill `CounterpartyDisplayName`.
+
+- [ ] **Step 5: Update `MapOrderToDtoAsync` (or equivalent) to fill the new DTO fields**
+
+Find the existing order-to-DTO mapper inside `StoreService`. Update it to:
+- Pass through `CampSeasonId`, `TeamId`, `Year`.
+- Set `CounterpartyType = order.TeamId.HasValue ? Team : Camp`.
+- Resolve `CounterpartyDisplayName`:
+  - Camp: existing `campService.GetCampSeasonByIdAsync(...).Name` lookup.
+  - Team: `teamService.GetTeamAsync(...).Name` lookup.
+  - Fallback to `"(unknown)"` if either lookup returns null.
+
+- [ ] **Step 6: Run team-order tests, expect green**
+
+Run: `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj -v quiet --filter "FullyQualifiedName~StoreServiceTeamOrdersTests"`
+Expected: 3 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Store/IStoreService.cs \
+        src/Humans.Application/Services/Store/StoreService.cs \
+        tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+git commit -m "feat(store): CreateTeamOrderAsync + GetOrderForTeamAsync"
+```
+
+---
+
+## Task 5: Service — guard rails on billable-only methods
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Store/StoreService.cs`
+- Test: `tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs`
+
+- [ ] **Step 1: Write failing guard-rail tests**
+
+Append to `StoreServiceTeamOrdersTests.cs`:
+
+```csharp
+[Theory]
+[MemberData(nameof(BillableOnlyMethods))]
+public async Task Billable_only_methods_throw_on_team_orders(string methodName, Func<StoreService, Guid, Task> invoke)
+{
+    var orderId = Guid.NewGuid();
+    var teamOrder = new StoreOrder { Id = orderId, TeamId = Guid.NewGuid(), CampSeasonId = null, Year = 2026 };
+    _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>()).Returns(teamOrder);
+    _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>()).Returns(teamOrder);
+
+    await Assert.ThrowsAsync<InvalidOperationException>(() => invoke(_service, orderId));
+}
+
+public static IEnumerable<object[]> BillableOnlyMethods()
+{
+    yield return new object[] { "UpdateCounterpartyAsync",
+        (Func<StoreService, Guid, Task>)((s, id) =>
+            s.UpdateCounterpartyAsync(id, new OrderCounterpartyInput("N", null, null, null, null), Guid.NewGuid())) };
+    yield return new object[] { "RecordManualPaymentAsync",
+        (Func<StoreService, Guid, Task>)((s, id) =>
+            s.RecordManualPaymentAsync(id, 1m, StorePaymentMethod.Manual, null, null, Guid.NewGuid())) };
+    yield return new object[] { "CreateStripeCheckoutSessionAsync",
+        (Func<StoreService, Guid, Task>)((s, id) => Task.Run(async () =>
+        {
+            var dto = await s.GetOrderAsync(id);
+            await s.CreateStripeCheckoutSessionAsync(dto!, 1m, "https://x");
+        })) };
+    yield return new object[] { "IssueInvoiceAsync",
+        (Func<StoreService, Guid, Task>)((s, id) => s.IssueInvoiceAsync(id, Guid.NewGuid())) };
+}
+```
+
+Run: `dotnet test ... --filter "Billable_only_methods_throw_on_team_orders"`
+Expected: fails (current code doesn't guard).
+
+- [ ] **Step 2: Add guard at the top of each method**
+
+In `StoreService.cs`, the first action of each of the following methods is to load the order (most already do) and throw if `order.TeamId is not null`. Helper:
+
+```csharp
+private static void EnsureBillable(StoreOrder order)
+{
+    if (order.TeamId is not null)
+        throw new InvalidOperationException("Team orders are non-billable.");
+}
+```
+
+Apply at the top of these (after the existing `repo.GetOrder…` load):
+
+- `UpdateCounterpartyAsync` / `UpdateCounterpartyWithResultAsync`
+- `RecordManualPaymentAsync`
+- `CreateStripeCheckoutSessionAsync` — for this one, branch on `OrderDto.CounterpartyType`.
+- `RecordStripePaymentAsync` — load by `orderId` and guard.
+- `HandleStripeCheckoutWebhookEventAsync` — guard at the order-lookup branch.
+- `IssueInvoiceAsync`.
+
+- [ ] **Step 3: Re-run tests**
+
+Run: `dotnet test ... --filter "Billable_only_methods_throw_on_team_orders"`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Services/Store/StoreService.cs \
+        tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+git commit -m "feat(store): guard rails — billable-only methods reject team orders"
+```
+
+---
+
+## Task 6: Service — lazy `Year` backfill on camp order saves
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Store/StoreService.cs`
+- Test: `tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```csharp
+[Fact]
+public async Task Add_line_to_camp_order_with_zero_year_backfills_year_from_season()
+{
+    var orderId = Guid.NewGuid();
+    var seasonId = Guid.NewGuid();
+    var productId = Guid.NewGuid();
+    var order = new StoreOrder
+    {
+        Id = orderId,
+        CampSeasonId = seasonId,
+        TeamId = null,
+        Year = 0, // legacy row, never re-saved since column added
+        State = StoreOrderState.Open,
+    };
+    _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
+    _campService.GetCampSeasonByIdAsync(seasonId, Arg.Any<CancellationToken>())
+        .Returns(new CampSeasonInfo(seasonId, Guid.NewGuid(), "Camp X", Year: 2025));
+    _repo.GetProductByIdAsync(productId, Arg.Any<CancellationToken>())
+        .Returns(new StoreProduct
+        {
+            Id = productId, Year = 2025, IsActive = true,
+            OrderableUntil = LocalDate.MaxIsoValue,
+            UnitPriceEur = 10m, VatRatePercent = 21m,
+        });
+
+    await _service.AddLineAsync(orderId, productId, 1, Guid.NewGuid());
+
+    await _repo.Received(1).UpdateOrderAsync(Arg.Is<StoreOrder>(o => o.Year == 2025));
+}
+```
+
+Run: fails (no backfill yet).
+
+- [ ] **Step 2: Add backfill to camp-touching mutators**
+
+In `StoreService.cs`, factor out:
+
+```csharp
+private async Task EnsureYearPopulatedAsync(StoreOrder order, CancellationToken ct)
+{
+    if (order.Year != 0) return;
+    if (order.CampSeasonId is { } seasonId)
+    {
+        var season = await campService.GetCampSeasonByIdAsync(seasonId, ct);
+        if (season is not null) order.Year = season.Year;
+    }
+}
+```
+
+Call it in: `AddLineAsync`, `RemoveLineAsync`, `UpdateCounterpartyAsync`, `RecordManualPaymentAsync`, `RecordStripePaymentAsync` — anywhere a camp order is loaded and saved. Persist the change in the same `UpdateOrderAsync` call the method already makes (or add an explicit one when the method does not currently mutate the order row).
+
+- [ ] **Step 3: Re-run test**
+
+Run: same filter.
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Services/Store/StoreService.cs \
+        tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+git commit -m "feat(store): lazy Year backfill on camp order writes"
+```
+
+---
+
+## Task 7: Service — `GetIndexDataAsync` includes coordinated teams
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Store/StoreService.cs`
+- Test: `tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+[Fact]
+public async Task Index_data_lists_coordinated_departments_alongside_led_camps()
+{
+    var userId = Guid.NewGuid();
+    var deptId = Guid.NewGuid();
+    _shifts.GetActiveAsync().Returns(new ActiveEventInfo(2026, "Europe/Madrid"));
+    _campService.GetCampLeadSeasonIdForYearAsync(userId, 2026, Arg.Any<CancellationToken>()).Returns((Guid?)null);
+    _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+        .Returns(new Dictionary<Guid, TeamInfo>
+        {
+            [deptId] = new TeamInfo(deptId, "Build", null, "build", true, false,
+                SystemTeamType.None, false, true, false, false, Instant.FromUtc(2026,1,1,0,0),
+                new List<TeamMemberInfo>(), ParentTeamId: null,
+                ManagementRoleHolderUserIds: new HashSet<Guid> { userId }),
+        });
+    _repo.GetOrderForTeamAsync(deptId, 2026, Arg.Any<CancellationToken>()).Returns((StoreOrder?)null);
+    _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
+        .Returns(new List<StoreProduct>());
+
+    var data = await _service.GetIndexDataAsync(userId, isPrivilegedReader: false);
+
+    Assert.Single(data.Counterparties);
+    Assert.Equal(StoreOrderCounterpartyType.Team, data.Counterparties[0].CounterpartyType);
+    Assert.Equal(deptId, data.Counterparties[0].CounterpartyId);
+    Assert.False(data.ShowNoOrdersMessage);
+}
+```
+
+- [ ] **Step 2: Update `GetIndexDataAsync`**
+
+In `StoreService.cs`, rewrite the index data builder so the loop builds `StoreCounterpartyOrders` for both:
+- The user's lead camp-season (existing logic, mapped to `CounterpartyType.Camp`).
+- Every department (`ParentTeamId is null`) in `teamService.GetTeamsAsync()` where `ManagementRoleHolderUserIds.Contains(userId)`. Use `repo.GetOrderForTeamAsync(teamId, year)` to load the existing order (may be null — coordinator sees "Create order" CTA).
+
+`ShowNoOrdersMessage` = `Counterparties.Count == 0 && !isPrivilegedReader`.
+
+- [ ] **Step 3: Run test, expect green**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Services/Store/StoreService.cs \
+        tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+git commit -m "feat(store): index lists coordinated departments + their orders"
+```
+
+---
+
+## Task 8: Service — `GetOrderPageDataAsync` resolves team counterparty
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Store/StoreService.cs`
+
+- [ ] **Step 1: Branch on `OrderDto.CounterpartyType`**
+
+In `GetOrderPageDataAsync`, replace the `campService.GetCampSeasonByIdAsync(order.CampSeasonId, ct)` call with branching:
+
+```csharp
+string counterpartyName = order.CounterpartyType switch
+{
+    StoreOrderCounterpartyType.Camp when order.CampSeasonId is { } sid =>
+        (await campService.GetCampSeasonByIdAsync(sid, ct))?.Name ?? "(unknown camp)",
+    StoreOrderCounterpartyType.Team when order.TeamId is { } tid =>
+        (await teamService.GetTeamAsync(tid, ct))?.Name ?? "(unknown team)",
+    _ => "(unknown)",
+};
+return new StoreOrderPageData(
+    order, catalog, counterpartyName, canEdit,
+    canPayAuthorized && order.BalanceEur > 0 && order.CounterpartyType == StoreOrderCounterpartyType.Camp,
+    stripeService.IsStoreCheckoutConfigured);
+```
+
+The `CanPay` flag is forced false for team orders so the Pay button never renders even if auth somehow granted it.
+
+- [ ] **Step 2: Build + run existing Store tests**
+
+Run: `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj -v quiet --filter "FullyQualifiedName~Store"`
+Expected: all green. (Old `StoreServiceTests` may still expect `CampName` on `StoreOrderPageData` — update the assertions to `CounterpartyDisplayName` if any fail.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Services/Store/StoreService.cs \
+        tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+git commit -m "feat(store): order page data resolves team counterparty name"
+```
+
+---
+
+## Task 9: Auth handler — branch on counterparty type
+
+**Files:**
+- Modify: `src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs`
+- Modify: `src/Humans.Web/Authorization/Requirements/StoreOrderCreateContext.cs` (if exists — extend to carry teamId too)
+- Test: `tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs` (new or existing)
+
+- [ ] **Step 1: Find or define `StoreOrderCreateContext`**
+
+Run: `grep -rn "StoreOrderCreateContext" src/`. If it exists, extend:
+
+```csharp
+public record StoreOrderCreateContext(Guid? CampSeasonId, Guid? TeamId);
+```
+
+Update existing call sites that construct it.
+
+- [ ] **Step 2: Write failing auth-handler tests**
+
+Add tests:
+- Coordinator of a team can `View` / `AddLine` / `RemoveLine` on a team order.
+- Non-coordinator denied on the same operations.
+- `EditCounterparty` and `Pay` denied for any team order (defense-in-depth).
+
+Use the existing tests file's NSubstitute pattern; inject `ITeamServiceRead` mock alongside the `ICampService` mock.
+
+- [ ] **Step 3: Extend the handler**
+
+In `StoreOrderAuthorizationHandler.cs`, rewrite the switch and lookup:
+
+```csharp
+public class StoreOrderAuthorizationHandler(
+    ICampService campService,
+    ITeamServiceRead teamService) : IAuthorizationHandler
+{
+    public async Task HandleAsync(AuthorizationHandlerContext context)
+    {
+        var pending = context.PendingRequirements.OfType<StoreOrderOperationRequirement>().ToList();
+        if (pending.Count == 0) return;
+
+        Guid? campSeasonId; Guid? teamId; StoreOrderState? orderState;
+        switch (context.Resource)
+        {
+            case OrderDto order:
+                campSeasonId = order.CampSeasonId; teamId = order.TeamId; orderState = order.State; break;
+            case StoreOrderCreateContext create:
+                campSeasonId = create.CampSeasonId; teamId = create.TeamId; orderState = null; break;
+            default: return;
+        }
+
+        if (RoleChecks.CanAdministerStore(context.User))
+        {
+            foreach (var req in pending) context.Succeed(req);
+            return;
+        }
+
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId)) return;
+
+        bool authorized = false;
+        if (campSeasonId is { } sid)
+        {
+            var season = await campService.GetCampSeasonByIdAsync(sid);
+            if (season is not null && await campService.IsUserCampLeadAsync(userId, season.CampId))
+                authorized = true;
+        }
+        else if (teamId is { } tid)
+        {
+            var team = await teamService.GetTeamAsync(tid);
+            if (team?.ManagementRoleHolderUserIds?.Contains(userId) == true && team.ParentTeamId is null)
+                authorized = true;
+        }
+        if (!authorized) return;
+
+        foreach (var req in pending)
+        {
+            // Team orders never allow EditCounterparty or Pay regardless of coordinator status.
+            if (teamId is not null &&
+                (req == StoreOrderOperationRequirement.EditCounterparty ||
+                 req == StoreOrderOperationRequirement.Pay))
+                continue;
+
+            var isMutating = req == StoreOrderOperationRequirement.AddLine
+                || req == StoreOrderOperationRequirement.RemoveLine
+                || req == StoreOrderOperationRequirement.EditCounterparty;
+            if (isMutating && orderState is not null and not StoreOrderState.Open) continue;
+            context.Succeed(req);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run handler tests, expect green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs \
+        src/Humans.Web/Authorization/Requirements/StoreOrderCreateContext.cs \
+        tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs
+git commit -m "feat(store): auth handler branches on team coordinator"
+```
+
+---
+
+## Task 10: Controller — create-team-order route + Index/Order view branching
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/StoreController.cs`
+- Modify: `src/Humans.Web/Models/Store/StoreIndexViewModel.cs`
+- Modify: `src/Humans.Web/Models/Store/StoreOrderViewModel.cs`
+- Modify: `src/Humans.Web/Views/Store/Index.cshtml`
+- Modify: `src/Humans.Web/Views/Store/Order.cshtml`
+
+- [ ] **Step 1: Add `CreateTeamOrder` POST**
+
+In `StoreController.cs`:
+
+```csharp
+[HttpPost("Team/{teamId:guid}/Create")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> CreateTeamOrder(Guid teamId, CancellationToken ct)
+{
+    var (errorResult, user) = await RequireCurrentUserAsync();
+    if (errorResult is not null) return errorResult;
+
+    var createContext = new StoreOrderCreateContext(CampSeasonId: null, TeamId: teamId);
+    var auth = await authService.AuthorizeAsync(User, createContext, StoreOrderOperationRequirement.Create);
+    if (!auth.Succeeded) return Forbid();
+
+    var orderId = await storeService.CreateTeamOrderAsync(teamId, user.Id, ct);
+    return RedirectToAction(nameof(Order), new { id = orderId });
+}
+```
+
+- [ ] **Step 2: Update `StoreIndexViewModel`** to carry `Counterparties` (renamed from `CampSeasons`).
+
+- [ ] **Step 3: Update `Index.cshtml`** to iterate `Counterparties` and render an action per row:
+- If `Orders.Count > 0`: link to the existing order.
+- Else if `CounterpartyType == Team`: render a "Create order" POST form to `/Store/Team/{id}/Create`.
+- Else if `CounterpartyType == Camp` and no orders: existing camp-create flow (unchanged).
+
+- [ ] **Step 4: Update `Order.cshtml`** to skip the counterparty form, payments list, Pay button, and Issue Invoice section when `Order.CounterpartyType == Team`. Add a small footer: "Non-billable — counts toward supplier totals only."
+
+- [ ] **Step 5: Build + run web tests**
+
+Run: `dotnet build Humans.slnx -v quiet && dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Store"`
+Expected: green.
+
+- [ ] **Step 6: Manual smoke**
+
+Run: `dotnet run --project src/Humans.Web`
+Verify:
+- Sign in as a department coordinator with no camp-lead role → `/Store` shows their department with a "Create order" button.
+- Click it → redirects to `/Store/Order/{id}` showing an empty team order.
+- Add a line → it persists.
+- The Pay button and counterparty form are not rendered.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/StoreController.cs \
+        src/Humans.Web/Models/Store/ \
+        src/Humans.Web/Views/Store/
+git commit -m "feat(store): team coordinator UI — create + order page"
+```
+
+---
+
+## Task 11: Summary — merge team orders into the cross-tab
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Store/StoreService.cs` (`GetStoreSummaryAsync`)
+- Modify: `src/Humans.Application/Services/Store/Dtos/StoreSummaryDto.cs`
+- Modify: `src/Humans.Web/Views/Store/Summary.cshtml`
+- Test: `tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs` (extend)
+
+- [ ] **Step 1: Extend `StoreSummaryDto`** with a counterparty-type column on each row of the by-counterparty list. The cross-tab columns become "counterparties" (camps + teams) instead of "camps".
+
+- [ ] **Step 2: Write failing test**
+
+A summary call against a year with one camp order (qty 3) and one team order (qty 5) for the same product produces a row total of 8 on the by-product roll-up and two distinct rows in the by-counterparty list.
+
+- [ ] **Step 3: Update `GetStoreSummaryAsync`**
+
+Load both camp-scoped orders (existing call) and team-scoped orders (new `repo.GetOrdersForTeamsWithLinesAsync` — pass every dept teamId from `teamService.GetTeamsAsync()` filtered by `ParentTeamId == null`). Merge into the same by-counterparty / cross-tab structures.
+
+- [ ] **Step 4: Update `Summary.cshtml`** to render a "Type" column on the by-counterparty table.
+
+- [ ] **Step 5: Run summary tests, expect green**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Application/Services/Store/StoreService.cs \
+        src/Humans.Application/Services/Store/Dtos/StoreSummaryDto.cs \
+        src/Humans.Web/Views/Store/Summary.cshtml \
+        tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+git commit -m "feat(store): summary merges team orders into cross-tab"
+```
+
+---
+
+## Task 12: Docs — update `docs/sections/Store.md`
+
+**Files:**
+- Modify: `docs/sections/Store.md`
+
+- [ ] **Step 1: Update the invariants doc**
+
+In the "Concepts" section, add: "A **Store Order** may be owned by a `CampSeason` (billable, full lifecycle) or by a `Team` (non-billable, stays Open, department-level only)."
+
+In "Data Model → StoreOrder", reflect the nullable `CampSeasonId`, the new `TeamId`, and the new `Year` column. Note the lazy-fill rule for `Year`.
+
+In "Actors & Roles", add a Coordinator row: "Coordinator (department): view / create / add-line / remove-line on their department's team order. No pay, no counterparty edit."
+
+In "Invariants", add: "An order has exactly one counterparty — `CampSeasonId` xor `TeamId`. Invariant is service-enforced, not DB-enforced." And: "Team orders never transition out of `Open`. Payment / invoice / Stripe paths reject team orders."
+
+In "Cross-Section Dependencies", add `ITeamServiceRead` (existing methods).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/sections/Store.md
+git commit -m "docs(store): document team-orders counterparty"
+```
+
+---
+
+## Task 13: Final verification + push
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all green.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push
+```
+
+- [ ] **Step 3: Open PR**
+
+Use `gh pr create` per the repo workflow. Target `peterdrier/Humans:main`. Title: `feat(store): team orders as non-billable counterparty`.

--- a/docs/superpowers/specs/2026-05-27-store-team-orders-design.md
+++ b/docs/superpowers/specs/2026-05-27-store-team-orders-design.md
@@ -62,7 +62,7 @@ No backfill script. New writes populate `Year` lazily:
 
 ```csharp
 Task<Guid> CreateTeamOrderAsync(Guid teamId, Guid actorUserId, CancellationToken ct = default);
-Task<IReadOnlyList<OrderDto>> GetOrdersForTeamAsync(Guid teamId, CancellationToken ct = default);
+Task<OrderDto?> GetOrderForTeamAsync(Guid teamId, CancellationToken ct = default);
 ```
 
 ### `IStoreService` modifications (guard rails)

--- a/docs/superpowers/specs/2026-05-27-store-team-orders-design.md
+++ b/docs/superpowers/specs/2026-05-27-store-team-orders-design.md
@@ -1,0 +1,160 @@
+# Store — Team Orders (Non-Billable Counterparty)
+
+**Status:** Design approved, pending implementation.
+**Section:** Store.
+**Date:** 2026-05-27.
+
+## Problem
+
+`StoreOrder` currently has one counterparty type: a `CampSeason`. The Store's value to the org isn't just camp billing — it's also the consolidated demand signal used to size supplier purchases. Departments consume from the same suppliers (kitchen, build, first-aid, etc.) but the org covers their cost, so they have no invoice path. Today their demand is invisible to `/Store/Admin/Summary` and to suppliers.
+
+## Goal
+
+Let department coordinators place orders against the existing catalog so the supplier-aggregation totals reflect the full need. Teams never get invoiced, never pay, and stay in `Open` indefinitely.
+
+## Non-goals
+
+- Sub-team orders. Only departments (top-level teams), placed by their coordinator.
+- A lifecycle for team orders beyond `Open`. Manual close-out post-event is out of scope.
+- Cost allocation memos / chargeback. Not in this change.
+- Touching the camp-side ordering flow beyond the lazy `Year` backfill described below.
+
+## Conceptual model
+
+A `StoreOrder` has exactly one counterparty: either a `CampSeasonId` (billable, full lifecycle) or a `TeamId` (non-billable, never leaves `Open`). The DB does not enforce the "exactly one" invariant — `StoreService` does, at write time.
+
+A team order:
+- Is scoped to one `Year` (the active event year at create time).
+- Reuses `StoreProduct` catalog and the per-product `OrderableUntil` deadline gate.
+- Has no counterparty fields (`CounterpartyName`/`VatId`/`Address`/`CountryCode`/`Email`), no payments, no invoice.
+- Is authored by the team's coordinator. StoreAdmin / FinanceAdmin / Admin retain the superset view.
+- Stays in `Open` forever. Implicit close-out is "no product has an open `OrderableUntil` anymore".
+
+One order per team per year. Multiple orders per team per year are not supported.
+
+## Data model
+
+### `StoreOrder` (modified)
+
+| Change | Detail |
+|---|---|
+| `CampSeasonId` | `Guid` → `Guid?` (nullable). |
+| `TeamId` | New `Guid?`. FK-only, no navigation, no DB FK constraint (per `memory/architecture/no-cross-section-ef-joins.md`). |
+| `Year` | New `int`. Always set on write. |
+
+Existing columns unchanged. No new tables. No FKs across sections.
+
+**Invariant (service-enforced, not DB-enforced):** exactly one of `CampSeasonId` / `TeamId` is non-null on any `StoreOrder`.
+
+**Indexes:** add `TeamId` (non-filtered is fine at ~500 users). Keep existing `CampSeasonId` index.
+
+### `Year` backfill
+
+No backfill script. New writes populate `Year` lazily:
+
+- **Team orders** — set at creation time to the active event year (resolved via `IShiftManagementService.GetActiveAsync()`).
+- **Camp orders** — existing rows keep `Year = 0` (or whatever EF defaults to) until they're next saved through the service, at which point the service writes `CampSeason.Year` into the column.
+- **The summary report** must tolerate `Year = 0` rows until they're touched — they're old orders that haven't been re-saved since the column existed. Filtering is `(Year == requestedYear) OR (CampSeasonId in seasons-for-requestedYear AND Year == 0)`. (This fallback can be removed once all rows have been touched.)
+
+## Service surface
+
+### `IStoreService` additions
+
+```csharp
+Task<Guid> CreateTeamOrderAsync(Guid teamId, Guid actorUserId, CancellationToken ct = default);
+Task<IReadOnlyList<OrderDto>> GetOrdersForTeamAsync(Guid teamId, CancellationToken ct = default);
+```
+
+### `IStoreService` modifications (guard rails)
+
+The following methods reject team-owned orders at the top of the method with `InvalidOperationException("Team orders are non-billable")`:
+
+- `UpdateCounterpartyAsync` / `UpdateCounterpartyWithResultAsync`
+- `RecordManualPaymentAsync`
+- `CreateStripeCheckoutSessionAsync`
+- `RecordStripePaymentAsync`
+- `HandleStripeCheckoutWebhookEventAsync` (only matters if a malformed event references a team order id — defense-in-depth)
+- `IssueInvoiceAsync`
+
+`AddLineAsync` / `RemoveLineAsync` / `AddLineWithResultAsync` / `RemoveLineWithResultAsync` — unchanged. The `OrderableUntil` gate is per-product and is independent of counterparty type.
+
+### `GetIndexDataAsync` (modified)
+
+`/Store` index lists the user's orderable counterparties. Today: camps-you-lead. Becomes: camps-you-lead + teams-you-coordinate. Service merges the two collections and resolves each into a unified item with display name, type (Camp / Team), and either the existing order or "Create order" affordance.
+
+### DTO changes
+
+`OrderDto`:
+- Add `Guid? TeamId`.
+- `CampSeasonId` becomes `Guid?` (already exposed as Guid; change to nullable).
+- Add `string CounterpartyDisplayName` — resolved by the service (camp name OR team name).
+- Add `StoreOrderCounterpartyType` enum (`Camp` / `Team`) for view-side branching.
+
+`StoreIndexData` — gains the team list (or extends the existing camp list with a typed item; structure decided during impl).
+
+## Authorization
+
+`StoreOrderAuthorizationHandler` extends its current camp-lead check:
+
+```
+if (order.CampSeasonId is not null)   → existing camp-lead check
+if (order.TeamId is not null)          → ITeamServiceRead.IsCoordinatorAsync(userId, teamId)
+```
+
+Operation gating for team orders:
+- `View`, `Create`, `AddLine`, `RemoveLine` — allowed for the coordinator.
+- `EditCounterparty`, `Pay` — denied for team orders. UI does not surface them; handler denies as defense-in-depth.
+
+StoreAdmin / FinanceAdmin / Admin — unchanged. They retain full access (`memory/code/admin-role-superset.md`).
+
+`StoreCatalogAdmin` policy on `/Store/Admin/*` — unchanged.
+
+## Cross-section dependencies
+
+Adds `ITeamServiceRead` to Store's dependency set. Methods required (audit during impl, add only what's missing):
+
+- `GetTeamByIdAsync(Guid teamId)` — name + parent-team check (must be a department, not a sub-team).
+- `GetCoordinatedTeamsAsync(Guid userId)` — populates the `/Store` index list.
+- `IsCoordinatorAsync(Guid userId, Guid teamId)` — used by `StoreOrderAuthorizationHandler`.
+
+If any of these don't exist on `ITeamServiceRead` today, they're added there (not on Store's side) per the section-read-write-split rule. Implementation reuses existing methods where possible.
+
+`ICampService` and `IShiftManagementService` — unchanged.
+
+## Routing / UI
+
+| Route | Change |
+|---|---|
+| `/Store` | Lists camps-you-lead and teams-you-coordinate together. Each entry deep-links to its single order (or a "Create order" affordance if none exists). |
+| `/Store/Order/{id}` | Branches on counterparty type. Camp orders unchanged. Team orders render: header (team name, year), lines table, add/remove-line form, "Non-billable — supplier aggregation only" footer. No counterparty form, no Pay button, no payments list, no Issue Invoice. |
+| `/Store/Admin/Summary` | Merges team rows into the by-counterparty table and the cross-tab. A "Type" column distinguishes Camp / Team rows. Suppliers totals are unambiguous because the column makes the counterparty type explicit. |
+| `/Store/Admin/Catalog` | Unchanged. |
+| `/Store/Admin/Orders` | Unchanged (still the Phase-5 stub). |
+
+## Audit
+
+Reuse existing event types: `StoreOrderCreated`, `StoreLineAdded`, `StoreLineRemoved`. The audit row's counterparty descriptor is "Camp: {name}" or "Team: {name}" — picked by the service. No new event vocabulary.
+
+## Lifecycle
+
+Team orders stay in `Open` indefinitely. There is no `Submitted` / `Closed` / `Fulfilled` state. The implicit "this order is done" signal is supplier-side: once every product on the catalog has passed its `OrderableUntil`, the order is effectively read-only by the deadline gate alone.
+
+## Out of scope / explicit non-features
+
+- DB check constraint on the "exactly one counterparty" invariant. Service-layer only.
+- Migration backfill of `Year` for existing camp orders. Lazy fill on next save.
+- Sub-team orders. Coordinators only, departments only.
+- Cost allocation memos / chargeback to the parent org. Future work, not this change.
+- A separate `store_team_orders` table. Polymorphic `StoreOrder` is the cheaper variant of the same thing.
+
+## Testing
+
+- `StoreService.CreateTeamOrderAsync` — sets `TeamId`, `Year`, `State = Open`; rejects sub-teams; rejects when actor isn't a coordinator (defense-in-depth — auth handler is the primary gate).
+- Guard-rail tests on `RecordManualPaymentAsync` / `IssueInvoiceAsync` / `CreateStripeCheckoutSessionAsync` / `UpdateCounterpartyAsync` — throw on team-owned orders.
+- `Year` backfill on next camp order save (mutating the row writes `CampSeason.Year` into the column).
+- `StoreOrderAuthorizationHandler` — coordinator can `AddLine` on their team's order; non-coordinator denied; `EditCounterparty` and `Pay` denied for team orders regardless of role (except FinanceAdmin/Admin where applicable — though those ops are no-ops for team orders anyway).
+- Summary cross-tab — camp + team rows aggregate per product; per-counterparty type distinction is preserved in the by-counterparty list.
+
+## Architecture impact
+
+No layer rule changes. Repository surface grows by one or two methods (team-scoped order lookup). All cross-section access goes through `ITeamServiceRead` per the section-read-write-split rule. No new tables, no new connectors.

--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -83,6 +83,11 @@ public interface IStoreRepository : IRepository
 
     Task AddOrderAsync(StoreOrder order, CancellationToken ct = default);
     Task UpdateOrderAsync(StoreOrder order, CancellationToken ct = default);
+    /// <summary>
+    /// Hard-deletes the order. Cascade FKs remove its lines and payments. The
+    /// service is responsible for enforcing balance/state preconditions.
+    /// </summary>
+    Task DeleteOrderAsync(Guid orderId, CancellationToken ct = default);
 
     // Lines
     Task AddLineAsync(StoreOrderLine line, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -13,7 +13,7 @@ namespace Humans.Application.Interfaces.Repositories;
 public record StoreLineContext(
     Guid LineId,
     Guid OrderId,
-    Guid CampSeasonId,
+    Guid? CampSeasonId,
     StoreOrderState OrderState,
     LocalDate ProductOrderableUntil);
 
@@ -61,6 +61,26 @@ public interface IStoreRepository : IRepository
     Task<IReadOnlyList<StoreOrder>> GetOrdersForCampSeasonsWithLinesAndPaymentsAsync(
         IReadOnlyCollection<Guid> campSeasonIds,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the single open team order for <paramref name="teamId"/> in
+    /// <paramref name="year"/>, or null. The "one order per team per year"
+    /// invariant is service-enforced; this method returns the first match if
+    /// more exist. <c>Lines</c> are eager-loaded.
+    /// </summary>
+    Task<StoreOrder?> GetOrderForTeamAsync(Guid teamId, int year, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every <see cref="StoreOrder"/> whose <c>TeamId</c> is in
+    /// <paramref name="teamIds"/> for the given <paramref name="year"/>, with
+    /// <c>Lines</c> eager-loaded. Empty input returns an empty list without a
+    /// round-trip. Used by the admin summary cross-tab.
+    /// </summary>
+    Task<IReadOnlyList<StoreOrder>> GetOrdersForTeamsWithLinesAsync(
+        IReadOnlyCollection<Guid> teamIds,
+        int year,
+        CancellationToken ct = default);
+
     Task AddOrderAsync(StoreOrder order, CancellationToken ct = default);
     Task UpdateOrderAsync(StoreOrder order, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Store/IStoreService.cs
+++ b/src/Humans.Application/Interfaces/Store/IStoreService.cs
@@ -26,6 +26,19 @@ public interface IStoreService : IApplicationService
         bool canPayAuthorized,
         CancellationToken ct = default);
     Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default);
+
+    // Orders (team coordinator — non-billable)
+    /// <summary>
+    /// Creates a non-billable team order for <paramref name="teamId"/> in the
+    /// active event year. The team must be a department (no <c>ParentTeamId</c>);
+    /// only one open team order per team per year is permitted.
+    /// </summary>
+    Task<Guid> CreateTeamOrderAsync(Guid teamId, Guid actorUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the team's order for the active event year, or null if none exists.
+    /// </summary>
+    Task<OrderDto?> GetOrderForTeamAsync(Guid teamId, CancellationToken ct = default);
     Task AddLineAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default);
     Task<StoreMutationResult> AddLineWithResultAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default);
     Task RemoveLineAsync(Guid orderId, Guid lineId, Guid actorUserId, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/Store/IStoreService.cs
+++ b/src/Humans.Application/Interfaces/Store/IStoreService.cs
@@ -27,6 +27,14 @@ public interface IStoreService : IApplicationService
         CancellationToken ct = default);
     Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Hard-deletes the order. Permitted only when the order's balance is zero
+    /// (no outstanding charges, no payments needing reversal). Authorization is
+    /// enforced at the controller via <c>StoreOrderOperationRequirement.Delete</c>;
+    /// the service rejects non-zero balances as a defense-in-depth invariant.
+    /// </summary>
+    Task DeleteOrderAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default);
+
     // Orders (team coordinator — non-billable)
     /// <summary>
     /// Creates a non-billable team order for <paramref name="teamId"/> in the

--- a/src/Humans.Application/Services/Store/Dtos/OrderDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderDto.cs
@@ -4,7 +4,11 @@ namespace Humans.Application.Services.Store.Dtos;
 
 public record OrderDto(
     Guid Id,
-    Guid CampSeasonId,
+    Guid? CampSeasonId,
+    Guid? TeamId,
+    StoreOrderCounterpartyType CounterpartyType,
+    string CounterpartyDisplayName,
+    int Year,
     string? Label,
     StoreOrderState State,
     string? CounterpartyName,

--- a/src/Humans.Application/Services/Store/Dtos/OrderSummaryDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderSummaryDto.cs
@@ -4,8 +4,9 @@ namespace Humans.Application.Services.Store.Dtos;
 
 public record OrderSummaryDto(
     Guid OrderId,
-    Guid CampSeasonId,
-    string CampName,
+    StoreOrderCounterpartyType CounterpartyType,
+    Guid CounterpartyId,
+    string CounterpartyName,
     string? Label,
     StoreOrderState State,
     decimal TotalDueEur,

--- a/src/Humans.Application/Services/Store/Dtos/StoreIndexData.cs
+++ b/src/Humans.Application/Services/Store/Dtos/StoreIndexData.cs
@@ -1,21 +1,24 @@
+using Humans.Domain.Enums;
+
 namespace Humans.Application.Services.Store.Dtos;
 
 public sealed record StoreIndexData(
     int Year,
     IReadOnlyList<ProductDto> Catalog,
-    IReadOnlyList<StoreCampSeasonOrders> CampSeasons,
-    bool ShowNoCampOrdersMessage);
+    IReadOnlyList<StoreCounterpartyOrders> Counterparties,
+    bool ShowNoOrdersMessage);
 
-public sealed record StoreCampSeasonOrders(
-    Guid CampSeasonId,
-    string CampName,
+public sealed record StoreCounterpartyOrders(
+    StoreOrderCounterpartyType CounterpartyType,
+    Guid CounterpartyId,
+    string DisplayName,
     int Year,
     IReadOnlyList<OrderDto> Orders);
 
 public sealed record StoreOrderPageData(
     OrderDto Order,
     IReadOnlyList<ProductDto> Catalog,
-    string CampName,
+    string CounterpartyDisplayName,
     bool CanEdit,
     bool CanPay,
     bool IsStripeConfigured);

--- a/src/Humans.Application/Services/Store/Dtos/StoreSummaryDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/StoreSummaryDto.cs
@@ -1,8 +1,10 @@
+using Humans.Domain.Enums;
+
 namespace Humans.Application.Services.Store.Dtos;
 
 public sealed record StoreSummaryDto(
     int Year,
-    IReadOnlyList<OrderSummaryDto> ByCamp,
+    IReadOnlyList<OrderSummaryDto> ByCounterparty,
     IReadOnlyList<ProductAggregateDto> ByItem,
     StoreCrossTabDto CrossTab);
 
@@ -14,7 +16,7 @@ public sealed record ProductAggregateDto(
 
 public sealed record StoreCrossTabDto(
     IReadOnlyList<StoreCrossTabColumn> Products,
-    IReadOnlyList<StoreCrossTabRow> Camps);
+    IReadOnlyList<StoreCrossTabRow> Counterparties);
 
 public sealed record StoreCrossTabColumn(
     Guid ProductId,
@@ -22,7 +24,8 @@ public sealed record StoreCrossTabColumn(
     int TotalQty);
 
 public sealed record StoreCrossTabRow(
-    Guid CampSeasonId,
-    string CampName,
+    StoreOrderCounterpartyType CounterpartyType,
+    Guid CounterpartyId,
+    string CounterpartyName,
     int TotalQty,
     IReadOnlyDictionary<Guid, int> QtyByProduct);

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -44,7 +44,13 @@ public class StoreService(
             var season = await campService.GetCampSeasonByIdAsync(seasonId, ct);
             if (season is not null)
             {
-                var orders = await GetOrdersForCampSeasonAsync(season.Id, ct);
+                // One order per camp-season; if legacy data has multiple, surface
+                // only the highest-balance one and let the admin delete the rest.
+                var allOrders = await GetOrdersForCampSeasonAsync(season.Id, ct);
+                var primary = allOrders
+                    .OrderByDescending(o => o.BalanceEur)
+                    .FirstOrDefault();
+                IReadOnlyList<OrderDto> orders = primary is null ? [] : [primary];
                 counterparties.Add(new StoreCounterpartyOrders(
                     StoreOrderCounterpartyType.Camp,
                     season.Id,
@@ -282,6 +288,10 @@ public class StoreService(
         var season = await campService.GetCampSeasonByIdAsync(campSeasonId, ct)
             ?? throw new InvalidOperationException($"Camp season {campSeasonId} not found.");
 
+        var existing = await repo.GetOrdersForCampSeasonAsync(campSeasonId, ct);
+        if (existing.Any(o => o.Year == season.Year))
+            throw new InvalidOperationException($"Camp season {campSeasonId} already has a Store order for {season.Year}.");
+
         var now = clock.GetCurrentInstant();
         var order = new StoreOrder
         {
@@ -301,6 +311,23 @@ public class StoreService(
             (string.IsNullOrWhiteSpace(label) ? string.Empty : $" — '{label}'"),
             actorUserId);
         return order.Id;
+    }
+
+    public async Task DeleteOrderAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default)
+    {
+        var order = await repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct)
+            ?? throw new InvalidOperationException($"Order {orderId} not found.");
+
+        var balance = BalanceCalculator.Compute(order).BalanceEur;
+        if (balance != 0m)
+            throw new InvalidOperationException(
+                $"Order {orderId} has a non-zero balance (EUR {balance:0.00}); only zero-balance orders may be deleted.");
+
+        await repo.DeleteOrderAsync(orderId, ct);
+        await audit.LogAsync(
+            AuditAction.StoreOrderDeleted, nameof(StoreOrder), orderId,
+            $"Deleted store order {orderId}",
+            actorUserId);
     }
 
     public async Task<Guid> CreateTeamOrderAsync(Guid teamId, Guid actorUserId, CancellationToken ct = default)

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Store;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Services.Store.Dtos;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -17,6 +18,7 @@ public class StoreService(
     IStoreRepository repo,
     IAuditLogService audit,
     ICampService campService,
+    ITeamServiceRead teamService,
     IClock clock,
     IShiftManagementService shifts,
     IStripeService stripeService,
@@ -33,7 +35,9 @@ public class StoreService(
             .OrderBy(p => p.Name, StringComparer.Ordinal)
             .ToList();
 
-        var sections = new List<StoreCampSeasonOrders>();
+        var counterparties = new List<StoreCounterpartyOrders>();
+
+        // Camp-lead counterparty
         var leadSeasonId = await campService.GetCampLeadSeasonIdForYearAsync(userId, year, ct);
         if (leadSeasonId is { } seasonId)
         {
@@ -41,15 +45,48 @@ public class StoreService(
             if (season is not null)
             {
                 var orders = await GetOrdersForCampSeasonAsync(season.Id, ct);
-                sections.Add(new StoreCampSeasonOrders(season.Id, season.Name, year, orders));
+                counterparties.Add(new StoreCounterpartyOrders(
+                    StoreOrderCounterpartyType.Camp,
+                    season.Id,
+                    season.Name,
+                    year,
+                    orders));
             }
+        }
+
+        // Team-coordinator counterparties — departments only
+        var teams = await teamService.GetTeamsAsync(ct);
+        foreach (var team in teams.Values
+            .Where(t => t.ParentTeamId is null
+                        && t.ManagementRoleHolderUserIds is not null
+                        && t.ManagementRoleHolderUserIds.Contains(userId))
+            .OrderBy(t => t.Name, StringComparer.Ordinal))
+        {
+            var existing = await repo.GetOrderForTeamAsync(team.Id, year, ct);
+            IReadOnlyList<OrderDto> orders;
+            if (existing is null)
+            {
+                orders = [];
+            }
+            else
+            {
+                var productIds = existing.Lines.Select(l => l.ProductId).Distinct().ToList();
+                var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
+                orders = [await MapOrderAsync(existing, productNames, ct)];
+            }
+            counterparties.Add(new StoreCounterpartyOrders(
+                StoreOrderCounterpartyType.Team,
+                team.Id,
+                team.Name,
+                year,
+                orders));
         }
 
         return new StoreIndexData(
             year,
             catalog,
-            sections,
-            sections.Count == 0 && !isPrivilegedReader);
+            counterparties,
+            counterparties.Count == 0 && !isPrivilegedReader);
     }
 
     public async Task<IReadOnlyList<ProductDto>> GetActiveCatalogAsync(int year, CancellationToken ct = default)
@@ -76,14 +113,12 @@ public class StoreService(
                 .ToList();
         }
 
-        var season = await campService.GetCampSeasonByIdAsync(order.CampSeasonId, ct);
-
         return new StoreOrderPageData(
             order,
             catalog,
-            season?.Name ?? "(unknown camp)",
+            order.CounterpartyDisplayName,
             canEdit,
-            canPayAuthorized && order.BalanceEur > 0,
+            canPayAuthorized && order.BalanceEur > 0 && order.CounterpartyType == StoreOrderCounterpartyType.Camp,
             stripeService.IsStoreCheckoutConfigured);
     }
 
@@ -227,7 +262,10 @@ public class StoreService(
         var orders = await repo.GetOrdersForCampSeasonAsync(campSeasonId, ct);
         var productIds = orders.SelectMany(o => o.Lines).Select(l => l.ProductId).Distinct().ToList();
         var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
-        return orders.Select(o => MapOrder(o, productNames)).ToList();
+        var result = new List<OrderDto>(orders.Count);
+        foreach (var o in orders)
+            result.Add(await MapOrderAsync(o, productNames, ct));
+        return result;
     }
 
     public async Task<OrderDto?> GetOrderAsync(Guid orderId, CancellationToken ct = default)
@@ -236,16 +274,21 @@ public class StoreService(
         if (o is null) return null;
         var productIds = o.Lines.Select(l => l.ProductId).Distinct().ToList();
         var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
-        return MapOrder(o, productNames);
+        return await MapOrderAsync(o, productNames, ct);
     }
 
     public async Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default)
     {
+        var season = await campService.GetCampSeasonByIdAsync(campSeasonId, ct);
+        var year = season?.Year ?? 0;
+
         var now = clock.GetCurrentInstant();
         var order = new StoreOrder
         {
             Id = Guid.NewGuid(),
             CampSeasonId = campSeasonId,
+            TeamId = null,
+            Year = year,
             Label = label,
             State = StoreOrderState.Open,
             CreatedAt = now,
@@ -258,6 +301,50 @@ public class StoreService(
             (string.IsNullOrWhiteSpace(label) ? string.Empty : $" — '{label}'"),
             actorUserId);
         return order.Id;
+    }
+
+    public async Task<Guid> CreateTeamOrderAsync(Guid teamId, Guid actorUserId, CancellationToken ct = default)
+    {
+        var team = await teamService.GetTeamAsync(teamId, ct)
+            ?? throw new InvalidOperationException($"Team {teamId} not found.");
+        if (team.ParentTeamId is not null)
+            throw new InvalidOperationException("Team orders are restricted to departments (top-level teams).");
+
+        var activeEvent = await shifts.GetActiveAsync();
+        var year = activeEvent?.Year > 0 ? activeEvent.Year : clock.GetCurrentInstant().InUtc().Year;
+
+        var existing = await repo.GetOrderForTeamAsync(teamId, year, ct);
+        if (existing is not null)
+            throw new InvalidOperationException($"Team {teamId} already has a Store order for {year}.");
+
+        var now = clock.GetCurrentInstant();
+        var order = new StoreOrder
+        {
+            Id = Guid.NewGuid(),
+            CampSeasonId = null,
+            TeamId = teamId,
+            Year = year,
+            State = StoreOrderState.Open,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        await repo.AddOrderAsync(order, ct);
+        await audit.LogAsync(
+            AuditAction.StoreOrderCreated, nameof(StoreOrder), order.Id,
+            $"Created store order for team '{team.Name}' ({year})",
+            actorUserId);
+        return order.Id;
+    }
+
+    public async Task<OrderDto?> GetOrderForTeamAsync(Guid teamId, CancellationToken ct = default)
+    {
+        var activeEvent = await shifts.GetActiveAsync();
+        var year = activeEvent?.Year > 0 ? activeEvent.Year : clock.GetCurrentInstant().InUtc().Year;
+        var order = await repo.GetOrderForTeamAsync(teamId, year, ct);
+        if (order is null) return null;
+        var productIds = order.Lines.Select(l => l.ProductId).Distinct().ToList();
+        var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
+        return await MapOrderAsync(order, productNames, ct);
     }
 
     public async Task AddLineAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default)
@@ -296,6 +383,19 @@ public class StoreService(
             AddedByUserId = actorUserId
         };
         await repo.AddLineAsync(line, ct);
+
+        // Lazy backfill of Year on legacy camp orders that pre-date the Year column.
+        if (order.Year == 0 && order.CampSeasonId is { } seasonIdForBackfill)
+        {
+            var season = await campService.GetCampSeasonByIdAsync(seasonIdForBackfill, ct);
+            if (season is not null)
+            {
+                order.Year = season.Year;
+                order.UpdatedAt = clock.GetCurrentInstant();
+                await repo.UpdateOrderAsync(order, ct);
+            }
+        }
+
         await audit.LogAsync(
             AuditAction.StoreLineAdded, nameof(StoreOrderLine), line.Id,
             $"Added {qty} × '{product.Name}' to order {order.Id}",
@@ -372,6 +472,8 @@ public class StoreService(
         var order = await repo.GetOrderByIdAsync(orderId, ct)
             ?? throw new InvalidOperationException($"Order {orderId} not found");
 
+        EnsureBillable(order);
+
         order.CounterpartyName = input.Name;
         order.CounterpartyVatId = input.VatId;
         order.CounterpartyAddress = input.Address;
@@ -422,6 +524,9 @@ public class StoreService(
         string returnUrl,
         CancellationToken ct = default)
     {
+        if (order.CounterpartyType == StoreOrderCounterpartyType.Team)
+            throw new InvalidOperationException("Team orders are non-billable.");
+
         if (!stripeService.IsStoreCheckoutConfigured)
             throw new InvalidOperationException("Stripe is not configured for this environment. Contact an admin.");
 
@@ -453,6 +558,11 @@ public class StoreService(
 
         if (await repo.StripePaymentIntentExistsAsync(paymentIntentId, ct))
             return; // idempotent: duplicate Stripe webhook delivery
+
+        // Defense-in-depth: never record a payment on a team-owned order.
+        var order = await repo.GetOrderByIdAsync(orderId, ct);
+        if (order is not null && order.TeamId is not null)
+            throw new InvalidOperationException("Team orders are non-billable.");
 
         var payment = new StorePayment
         {
@@ -549,37 +659,71 @@ public class StoreService(
         var seasonsForYear = await campService.GetCampSeasonDisplayDataForYearAsync(year, ct);
         var products = await repo.GetAllProductsForYearAsync(year, ct);
 
-        var orders = seasonsForYear.Count == 0
+        var campOrders = seasonsForYear.Count == 0
             ? (IReadOnlyList<StoreOrder>)Array.Empty<StoreOrder>()
             : await repo.GetOrdersForCampSeasonsWithLinesAndPaymentsAsync(
                 seasonsForYear.Keys.ToList(), ct);
 
-        var ordersInYear = orders
-            .Where(o => seasonsForYear.ContainsKey(o.CampSeasonId))
+        var campOrdersInYear = campOrders
+            .Where(o => o.CampSeasonId is { } sid && seasonsForYear.ContainsKey(sid))
             .ToList();
+
+        // Team orders — load departments the user *exists on the platform* (no user filter here:
+        // admin summary reflects all departments). Filter to ParentTeamId is null.
+        var allTeams = await teamService.GetTeamsAsync(ct);
+        var departmentIds = allTeams.Values
+            .Where(t => t.ParentTeamId is null)
+            .Select(t => t.Id)
+            .ToList();
+        var teamOrders = await repo.GetOrdersForTeamsWithLinesAsync(departmentIds, year, ct);
+        var teamNames = allTeams.Values.ToDictionary(t => t.Id, t => t.Name);
 
         var productNames = products.ToDictionary(p => p.Id, p => p.Name);
 
-        var byCamp = ordersInYear
-            .Select(o =>
-            {
-                var totals = BalanceCalculator.Compute(o);
-                var totalDue = totals.LinesSubtotalEur + totals.VatTotalEur + totals.DepositTotalEur;
-                var campName = seasonsForYear[o.CampSeasonId].Name;
-                return new OrderSummaryDto(
-                    o.Id,
-                    o.CampSeasonId,
-                    campName,
-                    o.Label,
-                    o.State,
-                    totalDue,
-                    totals.PaymentsTotalEur,
-                    totals.BalanceEur);
-            })
-            .OrderBy(s => s.CampName, StringComparer.Ordinal)
+        var byCounterparty = new List<OrderSummaryDto>();
+
+        foreach (var o in campOrdersInYear)
+        {
+            var totals = BalanceCalculator.Compute(o);
+            var totalDue = totals.LinesSubtotalEur + totals.VatTotalEur + totals.DepositTotalEur;
+            var sid = o.CampSeasonId!.Value;
+            var campName = seasonsForYear[sid].Name;
+            byCounterparty.Add(new OrderSummaryDto(
+                o.Id,
+                StoreOrderCounterpartyType.Camp,
+                sid,
+                campName,
+                o.Label,
+                o.State,
+                totalDue,
+                totals.PaymentsTotalEur,
+                totals.BalanceEur));
+        }
+        foreach (var o in teamOrders)
+        {
+            var totals = BalanceCalculator.Compute(o);
+            var tid = o.TeamId!.Value;
+            var teamName = teamNames.TryGetValue(tid, out var n) ? n : "(unknown team)";
+            byCounterparty.Add(new OrderSummaryDto(
+                o.Id,
+                StoreOrderCounterpartyType.Team,
+                tid,
+                teamName,
+                o.Label,
+                o.State,
+                totals.LinesSubtotalEur + totals.VatTotalEur + totals.DepositTotalEur,
+                0m, // team orders never have payments
+                0m));
+        }
+
+        var byCounterpartySorted = byCounterparty
+            .OrderBy(s => s.CounterpartyType)
+            .ThenBy(s => s.CounterpartyName, StringComparer.Ordinal)
             .ToList();
 
-        var byItem = ordersInYear
+        // by-item aggregates lines from BOTH camp and team orders so suppliers see the full demand.
+        var allLineProjections = campOrdersInYear
+            .Concat(teamOrders)
             .SelectMany(o => o.Lines.Select(l => new
             {
                 l.ProductId,
@@ -588,6 +732,9 @@ public class StoreService(
                 Vat = Math.Round(l.Qty * l.UnitPriceSnapshot * l.VatRateSnapshot / 100m, 2, MidpointRounding.AwayFromZero),
                 Deposit = l.DepositAmountSnapshot is { } d ? l.Qty * d : 0m
             }))
+            .ToList();
+
+        var byItem = allLineProjections
             .GroupBy(x => x.ProductId)
             .Select(g => new ProductAggregateDto(
                 g.Key,
@@ -603,36 +750,55 @@ public class StoreService(
             .OrderBy(c => c.ProductName, StringComparer.Ordinal)
             .ToList();
 
-        var campRows = ordersInYear
-            .GroupBy(o => o.CampSeasonId)
-            .Select(g =>
-            {
-                var perProduct = g
-                    .SelectMany(o => o.Lines)
-                    .GroupBy(l => l.ProductId)
-                    .ToDictionary(lg => lg.Key, lg => lg.Sum(l => l.Qty));
-                var total = perProduct.Values.Sum();
-                return new StoreCrossTabRow(
-                    g.Key,
-                    seasonsForYear[g.Key].Name,
-                    total,
-                    perProduct);
-            })
-            .OrderBy(r => r.CampName, StringComparer.Ordinal)
+        var counterpartyRows = new List<StoreCrossTabRow>();
+        foreach (var g in campOrdersInYear.GroupBy(o => o.CampSeasonId!.Value))
+        {
+            var perProduct = g
+                .SelectMany(o => o.Lines)
+                .GroupBy(l => l.ProductId)
+                .ToDictionary(lg => lg.Key, lg => lg.Sum(l => l.Qty));
+            var total = perProduct.Values.Sum();
+            counterpartyRows.Add(new StoreCrossTabRow(
+                StoreOrderCounterpartyType.Camp,
+                g.Key,
+                seasonsForYear[g.Key].Name,
+                total,
+                perProduct));
+        }
+        foreach (var g in teamOrders.GroupBy(o => o.TeamId!.Value))
+        {
+            var perProduct = g
+                .SelectMany(o => o.Lines)
+                .GroupBy(l => l.ProductId)
+                .ToDictionary(lg => lg.Key, lg => lg.Sum(l => l.Qty));
+            var total = perProduct.Values.Sum();
+            counterpartyRows.Add(new StoreCrossTabRow(
+                StoreOrderCounterpartyType.Team,
+                g.Key,
+                teamNames.TryGetValue(g.Key, out var n) ? n : "(unknown team)",
+                total,
+                perProduct));
+        }
+        var counterpartyRowsSorted = counterpartyRows
+            .OrderBy(r => r.CounterpartyType)
+            .ThenBy(r => r.CounterpartyName, StringComparer.Ordinal)
             .ToList();
 
         return new StoreSummaryDto(
             year,
-            byCamp,
+            byCounterpartySorted,
             byItem,
-            new StoreCrossTabDto(productColumns, campRows));
+            new StoreCrossTabDto(productColumns, counterpartyRowsSorted));
     }
 
     private static ProductDto MapProduct(StoreProduct p) =>
         new(p.Id, p.Year, p.Name, p.Description, p.UnitPriceEur, p.VatRatePercent,
             p.DepositAmountEur, p.OrderableUntil, p.IsActive);
 
-    private static OrderDto MapOrder(StoreOrder o, IReadOnlyDictionary<Guid, string> productNames)
+    private async Task<OrderDto> MapOrderAsync(
+        StoreOrder o,
+        IReadOnlyDictionary<Guid, string> productNames,
+        CancellationToken ct)
     {
         var balance = BalanceCalculator.Compute(o);
         var totalsByLine = balance.Lines.ToDictionary(t => t.LineId);
@@ -646,12 +812,46 @@ public class StoreService(
                 t.SubtotalEur, t.VatEur, t.DepositEur, t.TotalEur);
         }).ToList();
 
+        var counterpartyType = o.TeamId is not null
+            ? StoreOrderCounterpartyType.Team
+            : StoreOrderCounterpartyType.Camp;
+
+        var displayName = await ResolveCounterpartyDisplayNameAsync(o, ct);
+
         return new OrderDto(
-            o.Id, o.CampSeasonId, o.Label, o.State,
+            o.Id,
+            o.CampSeasonId,
+            o.TeamId,
+            counterpartyType,
+            displayName,
+            o.Year,
+            o.Label,
+            o.State,
             o.CounterpartyName, o.CounterpartyVatId, o.CounterpartyAddress, o.CounterpartyCountryCode, o.CounterpartyEmail,
             o.IssuedInvoiceId,
             lines,
             balance.LinesSubtotalEur, balance.VatTotalEur, balance.DepositTotalEur,
             balance.PaymentsTotalEur, balance.BalanceEur);
+    }
+
+    private async Task<string> ResolveCounterpartyDisplayNameAsync(StoreOrder o, CancellationToken ct)
+    {
+        if (o.TeamId is { } tid)
+        {
+            var team = await teamService.GetTeamAsync(tid, ct);
+            return team?.Name ?? "(unknown team)";
+        }
+        if (o.CampSeasonId is { } sid)
+        {
+            var season = await campService.GetCampSeasonByIdAsync(sid, ct);
+            return season?.Name ?? "(unknown camp)";
+        }
+        return "(unknown)";
+    }
+
+    private static void EnsureBillable(StoreOrder order)
+    {
+        if (order.TeamId is not null)
+            throw new InvalidOperationException("Team orders are non-billable.");
     }
 }

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -54,13 +54,13 @@ public class StoreService(
             }
         }
 
-        // Team-coordinator counterparties — departments only
+        // Team-coordinator counterparties — departments only.
+        // Order is the controller / view's concern (memory/architecture/display-sort-in-controllers.md).
         var teams = await teamService.GetTeamsAsync(ct);
         foreach (var team in teams.Values
             .Where(t => t.ParentTeamId is null
                         && t.ManagementRoleHolderUserIds is not null
-                        && t.ManagementRoleHolderUserIds.Contains(userId))
-            .OrderBy(t => t.Name, StringComparer.Ordinal))
+                        && t.ManagementRoleHolderUserIds.Contains(userId)))
         {
             var existing = await repo.GetOrderForTeamAsync(team.Id, year, ct);
             IReadOnlyList<OrderDto> orders;
@@ -279,8 +279,8 @@ public class StoreService(
 
     public async Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default)
     {
-        var season = await campService.GetCampSeasonByIdAsync(campSeasonId, ct);
-        var year = season?.Year ?? 0;
+        var season = await campService.GetCampSeasonByIdAsync(campSeasonId, ct)
+            ?? throw new InvalidOperationException($"Camp season {campSeasonId} not found.");
 
         var now = clock.GetCurrentInstant();
         var order = new StoreOrder
@@ -288,7 +288,7 @@ public class StoreService(
             Id = Guid.NewGuid(),
             CampSeasonId = campSeasonId,
             TeamId = null,
-            Year = year,
+            Year = season.Year,
             Label = label,
             State = StoreOrderState.Open,
             CreatedAt = now,
@@ -716,11 +716,8 @@ public class StoreService(
                 0m));
         }
 
-        var byCounterpartySorted = byCounterparty
-            .OrderBy(s => s.CounterpartyType)
-            .ThenBy(s => s.CounterpartyName, StringComparer.Ordinal)
-            .ToList();
-
+        // Counterparty row ordering is the view's concern
+        // (memory/architecture/display-sort-in-controllers.md).
         // by-item aggregates lines from BOTH camp and team orders so suppliers see the full demand.
         var allLineProjections = campOrdersInYear
             .Concat(teamOrders)
@@ -779,16 +776,11 @@ public class StoreService(
                 total,
                 perProduct));
         }
-        var counterpartyRowsSorted = counterpartyRows
-            .OrderBy(r => r.CounterpartyType)
-            .ThenBy(r => r.CounterpartyName, StringComparer.Ordinal)
-            .ToList();
-
         return new StoreSummaryDto(
             year,
-            byCounterpartySorted,
+            byCounterparty,
             byItem,
-            new StoreCrossTabDto(productColumns, counterpartyRowsSorted));
+            new StoreCrossTabDto(productColumns, counterpartyRows));
     }
 
     private static ProductDto MapProduct(StoreProduct p) =>

--- a/src/Humans.Domain/Entities/StoreOrder.cs
+++ b/src/Humans.Domain/Entities/StoreOrder.cs
@@ -10,9 +10,29 @@ public class StoreOrder
     /// <summary>
     /// Cross-section linkage to <c>CampSeason</c> — bare Guid, no EF navigation, no FK
     /// constraint (per <c>memory/architecture/no-cross-section-ef-joins.md</c>). Resolved
-    /// at the service layer via <c>ICampService.GetCampSeasonByIdAsync</c>.
+    /// at the service layer via <c>ICampService.GetCampSeasonByIdAsync</c>. Exactly one of
+    /// <see cref="CampSeasonId"/> and <see cref="TeamId"/> is non-null; the invariant is
+    /// service-enforced, not DB-enforced.
     /// </summary>
-    public Guid CampSeasonId { get; set; }
+    public Guid? CampSeasonId { get; set; }
+
+    /// <summary>
+    /// Cross-section linkage to <c>Team</c> for non-billable department orders — bare
+    /// Guid, no EF navigation, no FK constraint. Resolved at the service layer via
+    /// <c>ITeamServiceRead.GetTeamAsync</c>. Exactly one of <see cref="CampSeasonId"/>
+    /// and <see cref="TeamId"/> is non-null; the invariant is service-enforced, not
+    /// DB-enforced.
+    /// </summary>
+    public Guid? TeamId { get; set; }
+
+    /// <summary>
+    /// Event year the order's catalog draws from. Always set on write. For camp orders
+    /// this mirrors <c>CampSeason.Year</c>; for team orders it is the active event year
+    /// at create time. Legacy rows may carry <c>0</c> until they're next saved through
+    /// the service, at which point the camp-side year is backfilled.
+    /// </summary>
+    public int Year { get; set; }
+
     public string? Label { get; set; }
     public StoreOrderState State { get; set; } = StoreOrderState.Open;
 

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -117,6 +117,7 @@ public enum AuditAction
     ShiftSignupCreated,
     ShiftSignupReassigned,
     StoreOrderCreated,
+    StoreOrderDeleted,
     StoreLineAdded,
     StoreLineRemoved,
     StoreCounterpartyEdited,

--- a/src/Humans.Domain/Enums/StoreOrderCounterpartyType.cs
+++ b/src/Humans.Domain/Enums/StoreOrderCounterpartyType.cs
@@ -1,0 +1,7 @@
+namespace Humans.Domain.Enums;
+
+public enum StoreOrderCounterpartyType
+{
+    Camp = 0,
+    Team = 1,
+}

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderConfiguration.cs
@@ -17,8 +17,10 @@ public class StoreOrderConfiguration : IEntityTypeConfiguration<StoreOrder>
         b.Property(x => x.CounterpartyCountryCode).HasMaxLength(2);
         b.Property(x => x.CounterpartyEmail).HasMaxLength(320);
         b.Property(x => x.State).HasConversion<int>();
+        b.Property(x => x.Year).IsRequired();
         b.HasIndex(x => x.State);
         b.HasIndex(x => x.CampSeasonId);
+        b.HasIndex(x => x.TeamId);
         b.HasMany(x => x.Lines).WithOne(l => l.Order!).HasForeignKey(l => l.OrderId).OnDelete(DeleteBehavior.Cascade);
         b.HasMany(x => x.Payments).WithOne(p => p.Order!).HasForeignKey(p => p.OrderId).OnDelete(DeleteBehavior.Cascade);
     }

--- a/src/Humans.Infrastructure/Migrations/20260527214625_StoreOrderTeamCounterpartyAndYear.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260527214625_StoreOrderTeamCounterpartyAndYear.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527214625_StoreOrderTeamCounterpartyAndYear")]
+    partial class StoreOrderTeamCounterpartyAndYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260527214625_StoreOrderTeamCounterpartyAndYear.cs
+++ b/src/Humans.Infrastructure/Migrations/20260527214625_StoreOrderTeamCounterpartyAndYear.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class StoreOrderTeamCounterpartyAndYear : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CampSeasonId",
+                table: "store_orders",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "TeamId",
+                table: "store_orders",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Year",
+                table: "store_orders",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_orders_TeamId",
+                table: "store_orders",
+                column: "TeamId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_store_orders_TeamId",
+                table: "store_orders");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "store_orders");
+
+            migrationBuilder.DropColumn(
+                name: "Year",
+                table: "store_orders");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CampSeasonId",
+                table: "store_orders",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -117,9 +117,33 @@ internal sealed class StoreRepository(IDbContextFactory<HumansDbContext> factory
 
         await using var ctx = await factory.CreateDbContextAsync(ct);
         return await ctx.StoreOrders.AsNoTracking()
-            .Where(o => campSeasonIds.Contains(o.CampSeasonId))
+            .Where(o => o.CampSeasonId.HasValue && campSeasonIds.Contains(o.CampSeasonId.Value))
             .Include(o => o.Lines)
             .Include(o => o.Payments)
+            .ToListAsync(ct);
+    }
+
+    public async Task<StoreOrder?> GetOrderForTeamAsync(Guid teamId, int year, CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.StoreOrders.AsNoTracking()
+            .Include(o => o.Lines)
+            .Where(o => o.TeamId == teamId && o.Year == year)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<StoreOrder>> GetOrdersForTeamsWithLinesAsync(
+        IReadOnlyCollection<Guid> teamIds,
+        int year,
+        CancellationToken ct = default)
+    {
+        if (teamIds.Count == 0)
+            return Array.Empty<StoreOrder>();
+
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.StoreOrders.AsNoTracking()
+            .Where(o => o.TeamId.HasValue && teamIds.Contains(o.TeamId.Value) && o.Year == year)
+            .Include(o => o.Lines)
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -161,6 +161,15 @@ internal sealed class StoreRepository(IDbContextFactory<HumansDbContext> factory
         await ctx.SaveChangesAsync(ct);
     }
 
+    public async Task DeleteOrderAsync(Guid orderId, CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        var order = await ctx.StoreOrders.FirstOrDefaultAsync(o => o.Id == orderId, ct);
+        if (order is null) return;
+        ctx.StoreOrders.Remove(order);
+        await ctx.SaveChangesAsync(ct);
+    }
+
     // ==========================================================================
     // Lines
     // ==========================================================================

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
@@ -97,6 +97,9 @@ public class StoreOrderAuthorizationHandler(
                  req == StoreOrderOperationRequirement.Pay))
                 continue;
 
+            // Delete is admin-only; camp leads and team coordinators never delete their own orders.
+            if (req == StoreOrderOperationRequirement.Delete) continue;
+
             var isMutating = req == StoreOrderOperationRequirement.AddLine
                 || req == StoreOrderOperationRequirement.RemoveLine
                 || req == StoreOrderOperationRequirement.EditCounterparty;

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Services.Store.Dtos;
 using Humans.Domain.Enums;
 using Microsoft.AspNetCore.Authorization;
@@ -13,14 +14,18 @@ namespace Humans.Web.Authorization.Requirements;
 /// View/AddLine/RemoveLine/EditCounterparty and <see cref="StoreOrderCreateContext"/>
 /// resources for Create):
 /// - Admin or FinanceAdmin: allow any operation regardless of order state.
-/// - Camp lead/co-lead of the camp owning the resource's CampSeason: allow.
+/// - Camp lead/co-lead of the camp owning the resource's CampSeason: allow camp orders.
+/// - Coordinator (department-level management role holder) of the resource's Team:
+///   allow team orders for View/AddLine/RemoveLine; EditCounterparty and Pay are
+///   permanently denied on team orders regardless of role (team orders are non-billable).
 ///   Mutating operations (AddLine, RemoveLine, EditCounterparty) are gated on
 ///   order being Open (per Store invariant: "A Camp Lead cannot edit lines or
-///   counterparty on an order in InvoiceIssued state"). View and Pay carry no
-///   state gate — payments continue after invoice issuance.
+///   counterparty on an order in InvoiceIssued state").
 /// - Everyone else: deny.
 /// </summary>
-public class StoreOrderAuthorizationHandler(ICampService campService) : IAuthorizationHandler
+public class StoreOrderAuthorizationHandler(
+    ICampService campService,
+    ITeamServiceRead teamService) : IAuthorizationHandler
 {
     public async Task HandleAsync(AuthorizationHandlerContext context)
     {
@@ -29,16 +34,19 @@ public class StoreOrderAuthorizationHandler(ICampService campService) : IAuthori
             .ToList();
         if (pending.Count == 0) return;
 
-        Guid campSeasonId;
+        Guid? campSeasonId;
+        Guid? teamId;
         StoreOrderState? orderState;
         switch (context.Resource)
         {
             case OrderDto order:
                 campSeasonId = order.CampSeasonId;
+                teamId = order.TeamId;
                 orderState = order.State;
                 break;
             case StoreOrderCreateContext create:
                 campSeasonId = create.CampSeasonId;
+                teamId = create.TeamId;
                 orderState = null;
                 break;
             default:
@@ -47,7 +55,15 @@ public class StoreOrderAuthorizationHandler(ICampService campService) : IAuthori
 
         if (RoleChecks.CanAdministerStore(context.User))
         {
-            foreach (var req in pending) context.Succeed(req);
+            foreach (var req in pending)
+            {
+                // Even admins can't Pay/EditCounterparty a team order — it has no billing.
+                if (teamId is not null &&
+                    (req == StoreOrderOperationRequirement.EditCounterparty ||
+                     req == StoreOrderOperationRequirement.Pay))
+                    continue;
+                context.Succeed(req);
+            }
             return;
         }
 
@@ -55,14 +71,32 @@ public class StoreOrderAuthorizationHandler(ICampService campService) : IAuthori
         if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
             return;
 
-        var season = await campService.GetCampSeasonByIdAsync(campSeasonId);
-        if (season is null) return;
-
-        if (!await campService.IsUserCampLeadAsync(userId, season.CampId))
-            return;
+        bool authorized = false;
+        if (campSeasonId is { } sid)
+        {
+            var season = await campService.GetCampSeasonByIdAsync(sid);
+            if (season is not null && await campService.IsUserCampLeadAsync(userId, season.CampId))
+                authorized = true;
+        }
+        else if (teamId is { } tid)
+        {
+            var team = await teamService.GetTeamAsync(tid);
+            if (team is not null
+                && team.ParentTeamId is null
+                && team.ManagementRoleHolderUserIds is not null
+                && team.ManagementRoleHolderUserIds.Contains(userId))
+                authorized = true;
+        }
+        if (!authorized) return;
 
         foreach (var req in pending)
         {
+            // Team orders never allow EditCounterparty or Pay regardless of role.
+            if (teamId is not null &&
+                (req == StoreOrderOperationRequirement.EditCounterparty ||
+                 req == StoreOrderOperationRequirement.Pay))
+                continue;
+
             var isMutating = req == StoreOrderOperationRequirement.AddLine
                 || req == StoreOrderOperationRequirement.RemoveLine
                 || req == StoreOrderOperationRequirement.EditCounterparty;

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
@@ -16,6 +16,8 @@ public sealed class StoreOrderOperationRequirement : IAuthorizationRequirement
     public static readonly StoreOrderOperationRequirement EditCounterparty = new(nameof(EditCounterparty));
     /// <summary>Initiate Stripe Checkout to pay against the order. Allowed regardless of order state — payments continue after invoice issuance.</summary>
     public static readonly StoreOrderOperationRequirement Pay = new(nameof(Pay));
+    /// <summary>Delete a zero-balance order. Admin-only — camp leads and team coordinators cannot delete their own orders.</summary>
+    public static readonly StoreOrderOperationRequirement Delete = new(nameof(Delete));
 
     public string OperationName { get; }
 

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
@@ -28,6 +28,7 @@ public sealed class StoreOrderOperationRequirement : IAuthorizationRequirement
 /// <summary>
 /// Resource passed to <see cref="StoreOrderAuthorizationHandler"/> when
 /// authorizing a Create-order operation. There is no <c>StoreOrder</c> yet, so
-/// the camp-lead check is rooted at the target <c>CampSeason</c>.
+/// the camp-lead or team-coordinator check is rooted at the target
+/// <c>CampSeason</c> or <c>Team</c>. Exactly one of the two ids is non-null.
 /// </summary>
-public sealed record StoreOrderCreateContext(Guid CampSeasonId);
+public sealed record StoreOrderCreateContext(Guid? CampSeasonId, Guid? TeamId = null);

--- a/src/Humans.Web/Controllers/StoreController.cs
+++ b/src/Humans.Web/Controllers/StoreController.cs
@@ -28,16 +28,16 @@ public class StoreController(
 
         var isPrivilegedReader = RoleChecks.CanAdministerStore(User);
         var pageData = await storeService.GetIndexDataAsync(user.Id, isPrivilegedReader, ct);
-        if (pageData.ShowNoCampOrdersMessage)
+        if (pageData.ShowNoOrdersMessage)
         {
-            SetInfo("You don't lead any camps this year, so there are no Store orders to manage.");
+            SetInfo("You don't lead any camps or coordinate any departments this year, so there are no Store orders to manage.");
         }
 
         var model = new StoreIndexViewModel
         {
             Year = pageData.Year,
             Catalog = pageData.Catalog,
-            CampSeasons = pageData.CampSeasons
+            Counterparties = pageData.Counterparties
         };
         return View(model);
     }
@@ -106,13 +106,39 @@ public class StoreController(
 
         var auth = await authService.AuthorizeAsync(
             User,
-            new StoreOrderCreateContext(campSeasonId),
+            new StoreOrderCreateContext(CampSeasonId: campSeasonId),
             StoreOrderOperationRequirement.Create);
         if (!auth.Succeeded) return Forbid();
 
         var newId = await storeService.CreateOrderAsync(campSeasonId, label, user.Id, ct);
         SetSuccess("Order created.");
         return RedirectToAction(nameof(Order), new { id = newId });
+    }
+
+    [HttpPost("Team/{teamId:guid}/Create")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CreateTeamOrder(Guid teamId, CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var auth = await authService.AuthorizeAsync(
+            User,
+            new StoreOrderCreateContext(CampSeasonId: null, TeamId: teamId),
+            StoreOrderOperationRequirement.Create);
+        if (!auth.Succeeded) return Forbid();
+
+        try
+        {
+            var newId = await storeService.CreateTeamOrderAsync(teamId, user.Id, ct);
+            SetSuccess("Team order created.");
+            return RedirectToAction(nameof(Order), new { id = newId });
+        }
+        catch (InvalidOperationException ex)
+        {
+            SetError(ex.Message);
+            return RedirectToAction(nameof(Index));
+        }
     }
 
     [HttpPost("Order/{id:guid}/AddLine")]

--- a/src/Humans.Web/Controllers/StoreController.cs
+++ b/src/Humans.Web/Controllers/StoreController.cs
@@ -56,8 +56,9 @@ public class StoreController(
 
         var canEdit = (await authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.AddLine)).Succeeded;
         var canPay = (await authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.Pay)).Succeeded;
+        var canDeleteAuth = (await authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.Delete)).Succeeded;
         var pageData = await storeService.GetOrderPageDataAsync(order, canEdit, canPay, ct);
-        return View(StoreOrderViewModel.FromPageData(pageData));
+        return View(StoreOrderViewModel.FromPageData(pageData, canDeleteAuth && order.BalanceEur == 0m));
     }
 
     [HttpPost("Order/{id:guid}/Pay")]
@@ -139,6 +140,32 @@ public class StoreController(
             SetError(ex.Message);
             return RedirectToAction(nameof(Index));
         }
+    }
+
+    [HttpPost("Order/{id:guid}/Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var order = await storeService.GetOrderAsync(id, ct);
+        if (order is null) return NotFound();
+
+        var auth = await authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.Delete);
+        if (!auth.Succeeded) return Forbid();
+
+        try
+        {
+            await storeService.DeleteOrderAsync(id, user.Id, ct);
+            SetSuccess("Order deleted.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            SetError(ex.Message);
+            return RedirectToAction(nameof(Order), new { id });
+        }
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpPost("Order/{id:guid}/AddLine")]

--- a/src/Humans.Web/Controllers/StoreController.cs
+++ b/src/Humans.Web/Controllers/StoreController.cs
@@ -37,7 +37,8 @@ public class StoreController(
         {
             Year = pageData.Year,
             Catalog = pageData.Catalog,
-            Counterparties = pageData.Counterparties
+            Counterparties = pageData.Counterparties,
+            IsAdmin = isPrivilegedReader
         };
         return View(model);
     }

--- a/src/Humans.Web/Models/StoreIndexViewModel.cs
+++ b/src/Humans.Web/Models/StoreIndexViewModel.cs
@@ -6,14 +6,14 @@ public sealed class StoreIndexViewModel
 {
     public int Year { get; init; }
     public IReadOnlyList<ProductDto> Catalog { get; init; } = [];
-    public IReadOnlyList<StoreCampSeasonOrders> CampSeasons { get; init; } = [];
+    public IReadOnlyList<StoreCounterpartyOrders> Counterparties { get; init; } = [];
 }
 
 public sealed class StoreOrderViewModel
 {
     public OrderDto Order { get; init; } = null!;
     public IReadOnlyList<ProductDto> Catalog { get; init; } = [];
-    public string CampName { get; init; } = string.Empty;
+    public string CounterpartyDisplayName { get; init; } = string.Empty;
     public bool CanEdit { get; init; }
     /// <summary>True when the camp lead may initiate Stripe Checkout against this order (auth + balance > 0 + Stripe configured).</summary>
     public bool CanPay { get; init; }
@@ -24,7 +24,7 @@ public sealed class StoreOrderViewModel
     {
         Order = pageData.Order,
         Catalog = pageData.Catalog,
-        CampName = pageData.CampName,
+        CounterpartyDisplayName = pageData.CounterpartyDisplayName,
         CanEdit = pageData.CanEdit,
         CanPay = pageData.CanPay,
         IsStripeConfigured = pageData.IsStripeConfigured

--- a/src/Humans.Web/Models/StoreIndexViewModel.cs
+++ b/src/Humans.Web/Models/StoreIndexViewModel.cs
@@ -7,6 +7,8 @@ public sealed class StoreIndexViewModel
     public int Year { get; init; }
     public IReadOnlyList<ProductDto> Catalog { get; init; } = [];
     public IReadOnlyList<StoreCounterpartyOrders> Counterparties { get; init; } = [];
+    /// <summary>True when the viewer can administer the Store (StoreAdmin / FinanceAdmin / Admin). Surfaces per-row admin affordances such as Delete.</summary>
+    public bool IsAdmin { get; init; }
 }
 
 public sealed class StoreOrderViewModel

--- a/src/Humans.Web/Models/StoreIndexViewModel.cs
+++ b/src/Humans.Web/Models/StoreIndexViewModel.cs
@@ -19,14 +19,17 @@ public sealed class StoreOrderViewModel
     public bool CanPay { get; init; }
     /// <summary>False when STRIPE_STORE_KEY is unset; suppresses the Pay button + shows a disabled tooltip.</summary>
     public bool IsStripeConfigured { get; init; }
+    /// <summary>True when the current user is a Store admin AND the order's balance is zero. Surfaces the Delete button.</summary>
+    public bool CanDelete { get; init; }
 
-    public static StoreOrderViewModel FromPageData(StoreOrderPageData pageData) => new()
+    public static StoreOrderViewModel FromPageData(StoreOrderPageData pageData, bool canDelete) => new()
     {
         Order = pageData.Order,
         Catalog = pageData.Catalog,
         CounterpartyDisplayName = pageData.CounterpartyDisplayName,
         CanEdit = pageData.CanEdit,
         CanPay = pageData.CanPay,
-        IsStripeConfigured = pageData.IsStripeConfigured
+        IsStripeConfigured = pageData.IsStripeConfigured,
+        CanDelete = canDelete
     };
 }

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -20,7 +20,7 @@
 }
 else
 {
-    @foreach (var cp in Model.Counterparties)
+    @foreach (var cp in Model.Counterparties.OrderBy(c => c.CounterpartyType).ThenBy(c => c.DisplayName, StringComparer.Ordinal))
     {
         <div class="card mb-4">
             <div class="card-header d-flex justify-content-between align-items-center">

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -28,7 +28,7 @@ else
                     @cp.DisplayName
                     <span class="badge bg-light text-dark ms-2">@cp.CounterpartyType</span>
                 </h2>
-                @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp)
+                @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp && cp.Orders.Count == 0)
                 {
                     <form asp-action="Create" asp-route-campSeasonId="@cp.CounterpartyId"
                           method="post" class="d-flex gap-2 align-items-center mb-0">
@@ -38,7 +38,7 @@ else
                         <button type="submit" class="btn btn-sm btn-primary">Start order</button>
                     </form>
                 }
-                else if (cp.Orders.Count == 0)
+                else if (cp.CounterpartyType == StoreOrderCounterpartyType.Team && cp.Orders.Count == 0)
                 {
                     <form asp-action="CreateTeamOrder" asp-route-teamId="@cp.CounterpartyId"
                           method="post" class="mb-0">

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -1,3 +1,4 @@
+@using Humans.Domain.Enums
 @model Humans.Web.Models.StoreIndexViewModel
 @{
     ViewData["Title"] = "Store";
@@ -10,51 +11,79 @@
 
 <vc:temp-data-alerts />
 
-@if (!Model.CampSeasons.Any())
+@if (!Model.Counterparties.Any())
 {
     <div class="alert alert-info">
-        You don't lead any camps with an active season this year. The catalog
-        below is read-only.
+        You don't lead any camps or coordinate any departments with an active
+        season this year. The catalog below is read-only.
     </div>
 }
 else
 {
-    @foreach (var campSection in Model.CampSeasons)
+    @foreach (var cp in Model.Counterparties)
     {
         <div class="card mb-4">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <h2 class="h5 mb-0">@campSection.CampName</h2>
-                <form asp-action="Create" asp-route-campSeasonId="@campSection.CampSeasonId"
-                      method="post" class="d-flex gap-2 align-items-center mb-0">
-                    @Html.AntiForgeryToken()
-                    <input type="text" name="label" class="form-control form-control-sm"
-                           placeholder="Label (optional)" maxlength="100" />
-                    <button type="submit" class="btn btn-sm btn-primary">Start order</button>
-                </form>
+                <h2 class="h5 mb-0">
+                    @cp.DisplayName
+                    <span class="badge bg-light text-dark ms-2">@cp.CounterpartyType</span>
+                </h2>
+                @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp)
+                {
+                    <form asp-action="Create" asp-route-campSeasonId="@cp.CounterpartyId"
+                          method="post" class="d-flex gap-2 align-items-center mb-0">
+                        @Html.AntiForgeryToken()
+                        <input type="text" name="label" class="form-control form-control-sm"
+                               placeholder="Label (optional)" maxlength="100" />
+                        <button type="submit" class="btn btn-sm btn-primary">Start order</button>
+                    </form>
+                }
+                else if (cp.Orders.Count == 0)
+                {
+                    <form asp-action="CreateTeamOrder" asp-route-teamId="@cp.CounterpartyId"
+                          method="post" class="mb-0">
+                        @Html.AntiForgeryToken()
+                        <button type="submit" class="btn btn-sm btn-primary">Create order</button>
+                    </form>
+                }
             </div>
             <div class="card-body p-0">
-                @if (campSection.Orders.Any())
+                @if (cp.Orders.Any())
                 {
                     <table class="table table-sm mb-0">
                         <thead>
                             <tr>
                                 <th>Label</th>
                                 <th>State</th>
-                                <th class="text-end">Lines + VAT</th>
-                                <th class="text-end">Deposits</th>
-                                <th class="text-end">Balance</th>
+                                @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp)
+                                {
+                                    <th class="text-end">Lines + VAT</th>
+                                    <th class="text-end">Deposits</th>
+                                    <th class="text-end">Balance</th>
+                                }
+                                else
+                                {
+                                    <th class="text-end">Lines</th>
+                                }
                                 <th></th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var order in campSection.Orders)
+                            @foreach (var order in cp.Orders)
                             {
                                 <tr>
                                     <td>@(string.IsNullOrWhiteSpace(order.Label) ? "(no label)" : order.Label)</td>
                                     <td><span class="badge bg-secondary">@order.State</span></td>
-                                    <td class="text-end">&euro;@((order.LinesSubtotalEur + order.VatTotalEur).ToString("N2"))</td>
-                                    <td class="text-end">&euro;@order.DepositTotalEur.ToString("N2")</td>
-                                    <td class="text-end fw-bold">&euro;@order.BalanceEur.ToString("N2")</td>
+                                    @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp)
+                                    {
+                                        <td class="text-end">&euro;@((order.LinesSubtotalEur + order.VatTotalEur).ToString("N2"))</td>
+                                        <td class="text-end">&euro;@order.DepositTotalEur.ToString("N2")</td>
+                                        <td class="text-end fw-bold">&euro;@order.BalanceEur.ToString("N2")</td>
+                                    }
+                                    else
+                                    {
+                                        <td class="text-end">@order.Lines.Count</td>
+                                    }
                                     <td class="text-end">
                                         <a asp-action="Order" asp-route-id="@order.Id" class="btn btn-sm btn-outline-primary">Open</a>
                                     </td>

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -85,7 +85,20 @@ else
                                         <td class="text-end">@order.Lines.Count</td>
                                     }
                                     <td class="text-end">
-                                        <a asp-action="Order" asp-route-id="@order.Id" class="btn btn-sm btn-outline-primary">Open</a>
+                                        <div class="d-inline-flex gap-1">
+                                            @if (Model.IsAdmin && order.BalanceEur == 0m)
+                                            {
+                                                <form asp-action="Delete" asp-route-id="@order.Id" method="post" class="mb-0">
+                                                    @Html.AntiForgeryToken()
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger"
+                                                            title="Delete (zero balance)"
+                                                            data-confirm="Delete this zero-balance order? This cannot be undone.">
+                                                        <i class="fa-solid fa-trash"></i>
+                                                    </button>
+                                                </form>
+                                            }
+                                            <a asp-action="Order" asp-route-id="@order.Id" class="btn btn-sm btn-outline-primary">Open</a>
+                                        </div>
                                     </td>
                                 </tr>
                             }

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -1,58 +1,66 @@
+@using Humans.Domain.Enums
 @model Humans.Web.Models.StoreOrderViewModel
 @{
-    ViewData["Title"] = $"Store order — {Model.CampName}";
+    ViewData["Title"] = $"Store order — {Model.CounterpartyDisplayName}";
     var order = Model.Order;
+    var isTeamOrder = order.CounterpartyType == StoreOrderCounterpartyType.Team;
 }
 
 <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a asp-action="Index">Store</a></li>
-        <li class="breadcrumb-item">@Model.CampName</li>
+        <li class="breadcrumb-item">@Model.CounterpartyDisplayName</li>
         <li class="breadcrumb-item active">@(string.IsNullOrWhiteSpace(order.Label) ? "Order" : order.Label)</li>
     </ol>
 </nav>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="mb-0">@(string.IsNullOrWhiteSpace(order.Label) ? "Store order" : order.Label)</h1>
-    <span class="badge bg-secondary fs-6">@order.State</span>
+    <div>
+        <span class="badge bg-info text-dark fs-6 me-2">@order.CounterpartyType</span>
+        <span class="badge bg-secondary fs-6">@order.State</span>
+    </div>
 </div>
 
 <vc:temp-data-alerts />
 
-<div class="row mb-4">
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Lines subtotal</h6>
-                <h4 class="card-title mb-0">&euro;@order.LinesSubtotalEur.ToString("N2")</h4>
+@if (!isTeamOrder)
+{
+    <div class="row mb-4">
+        <div class="col-md-3">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-subtitle mb-2 text-muted">Lines subtotal</h6>
+                    <h4 class="card-title mb-0">&euro;@order.LinesSubtotalEur.ToString("N2")</h4>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-subtitle mb-2 text-muted">VAT</h6>
+                    <h4 class="card-title mb-0">&euro;@order.VatTotalEur.ToString("N2")</h4>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-subtitle mb-2 text-muted">Deposits</h6>
+                    <h4 class="card-title mb-0">&euro;@order.DepositTotalEur.ToString("N2")</h4>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card text-center bg-light">
+                <div class="card-body">
+                    <h6 class="card-subtitle mb-2 text-muted">Balance owed</h6>
+                    <h4 class="card-title mb-0 fw-bold">&euro;@order.BalanceEur.ToString("N2")</h4>
+                </div>
             </div>
         </div>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">VAT</h6>
-                <h4 class="card-title mb-0">&euro;@order.VatTotalEur.ToString("N2")</h4>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Deposits</h6>
-                <h4 class="card-title mb-0">&euro;@order.DepositTotalEur.ToString("N2")</h4>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3">
-        <div class="card text-center bg-light">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Balance owed</h6>
-                <h4 class="card-title mb-0 fw-bold">&euro;@order.BalanceEur.ToString("N2")</h4>
-            </div>
-        </div>
-    </div>
-</div>
+}
 
 <h2 class="h4 mb-3">Lines</h2>
 @if (order.Lines.Any())
@@ -62,10 +70,13 @@
             <tr>
                 <th>Product</th>
                 <th class="text-end">Qty</th>
-                <th class="text-end">Unit price</th>
-                <th class="text-end">VAT %</th>
-                <th class="text-end">Deposit</th>
-                <th class="text-end">Line total (incl. VAT &amp; deposit)</th>
+                @if (!isTeamOrder)
+                {
+                    <th class="text-end">Unit price</th>
+                    <th class="text-end">VAT %</th>
+                    <th class="text-end">Deposit</th>
+                    <th class="text-end">Line total (incl. VAT &amp; deposit)</th>
+                }
                 <th></th>
             </tr>
         </thead>
@@ -75,10 +86,13 @@
                 <tr>
                     <td>@line.ProductName</td>
                     <td class="text-end">@line.Qty</td>
-                    <td class="text-end">&euro;@line.UnitPriceSnapshot.ToString("N2")</td>
-                    <td class="text-end">@line.VatRateSnapshot.ToString("0.##")%</td>
-                    <td class="text-end">@(line.DepositAmountSnapshot.HasValue ? $"€{line.DepositEur:N2}" : "—")</td>
-                    <td class="text-end">&euro;@line.TotalEur.ToString("N2")</td>
+                    @if (!isTeamOrder)
+                    {
+                        <td class="text-end">&euro;@line.UnitPriceSnapshot.ToString("N2")</td>
+                        <td class="text-end">@line.VatRateSnapshot.ToString("0.##")%</td>
+                        <td class="text-end">@(line.DepositAmountSnapshot.HasValue ? $"€{line.DepositEur:N2}" : "—")</td>
+                        <td class="text-end">&euro;@line.TotalEur.ToString("N2")</td>
+                    }
                     <td class="text-end">
                         @if (Model.CanEdit)
                         {
@@ -123,79 +137,88 @@ else
     </form>
 }
 
-<h2 class="h4 mb-3">Counterparty (for invoice)</h2>
-@if (Model.CanEdit)
+@if (!isTeamOrder)
 {
-    <form asp-action="UpdateCounterparty" asp-route-id="@order.Id" method="post" class="row g-3 mb-4">
-        @Html.AntiForgeryToken()
-        <div class="col-md-6">
-            <label class="form-label">Name</label>
-            <input type="text" name="Name" class="form-control" value="@order.CounterpartyName" />
-        </div>
-        <div class="col-md-6">
-            <label class="form-label">VAT / NIF / CIF</label>
-            <input type="text" name="VatId" class="form-control" value="@order.CounterpartyVatId" />
-        </div>
-        <div class="col-md-12">
-            <label class="form-label">Address</label>
-            <input type="text" name="Address" class="form-control" value="@order.CounterpartyAddress" />
-        </div>
-        <div class="col-md-2">
-            <label class="form-label">Country</label>
-            <input type="text" name="CountryCode" class="form-control" maxlength="2" value="@order.CounterpartyCountryCode" />
-        </div>
-        <div class="col-md-6">
-            <label class="form-label">Email</label>
-            <input type="email" name="Email" class="form-control" value="@order.CounterpartyEmail" />
-        </div>
-        <div class="col-md-12">
-            <button type="submit" class="btn btn-primary">Save counterparty</button>
-        </div>
-    </form>
-}
-else
-{
-    <dl class="row">
-        <dt class="col-sm-3">Name</dt><dd class="col-sm-9">@order.CounterpartyName</dd>
-        <dt class="col-sm-3">VAT / NIF / CIF</dt><dd class="col-sm-9">@order.CounterpartyVatId</dd>
-        <dt class="col-sm-3">Address</dt><dd class="col-sm-9">@order.CounterpartyAddress</dd>
-        <dt class="col-sm-3">Country</dt><dd class="col-sm-9">@order.CounterpartyCountryCode</dd>
-        <dt class="col-sm-3">Email</dt><dd class="col-sm-9">@order.CounterpartyEmail</dd>
-    </dl>
-}
-
-<h2 class="h4 mb-3">Payments</h2>
-@if (order.BalanceEur > 0 && Model.CanPay)
-{
-    if (Model.IsStripeConfigured)
+    <h2 class="h4 mb-3">Counterparty (for invoice)</h2>
+    @if (Model.CanEdit)
     {
-        <form asp-action="Pay" asp-route-id="@order.Id" method="post" class="row g-2 mb-3 align-items-end">
+        <form asp-action="UpdateCounterparty" asp-route-id="@order.Id" method="post" class="row g-3 mb-4">
             @Html.AntiForgeryToken()
-            <div class="col-md-4">
-                <label class="form-label">Amount to pay (EUR)</label>
-                <input type="number" name="amountEur" class="form-control"
-                       min="0.01" max="@order.BalanceEur.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)"
-                       step="0.01"
-                       value="@order.BalanceEur.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)" required />
+            <div class="col-md-6">
+                <label class="form-label">Name</label>
+                <input type="text" name="Name" class="form-control" value="@order.CounterpartyName" />
             </div>
-            <div class="col-md-4">
-                <button type="submit" class="btn btn-primary">Pay with Stripe</button>
-                <small class="form-text text-muted d-block">You'll be redirected to Stripe Checkout.</small>
+            <div class="col-md-6">
+                <label class="form-label">VAT / NIF / CIF</label>
+                <input type="text" name="VatId" class="form-control" value="@order.CounterpartyVatId" />
+            </div>
+            <div class="col-md-12">
+                <label class="form-label">Address</label>
+                <input type="text" name="Address" class="form-control" value="@order.CounterpartyAddress" />
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Country</label>
+                <input type="text" name="CountryCode" class="form-control" maxlength="2" value="@order.CounterpartyCountryCode" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Email</label>
+                <input type="email" name="Email" class="form-control" value="@order.CounterpartyEmail" />
+            </div>
+            <div class="col-md-12">
+                <button type="submit" class="btn btn-primary">Save counterparty</button>
             </div>
         </form>
     }
     else
     {
-        <div class="alert alert-warning">Stripe checkout is not configured for this environment.</div>
+        <dl class="row">
+            <dt class="col-sm-3">Name</dt><dd class="col-sm-9">@order.CounterpartyName</dd>
+            <dt class="col-sm-3">VAT / NIF / CIF</dt><dd class="col-sm-9">@order.CounterpartyVatId</dd>
+            <dt class="col-sm-3">Address</dt><dd class="col-sm-9">@order.CounterpartyAddress</dd>
+            <dt class="col-sm-3">Country</dt><dd class="col-sm-9">@order.CounterpartyCountryCode</dd>
+            <dt class="col-sm-3">Email</dt><dd class="col-sm-9">@order.CounterpartyEmail</dd>
+        </dl>
     }
-}
-else if (order.BalanceEur <= 0)
-{
-    <p class="text-muted">No outstanding balance.</p>
+
+    <h2 class="h4 mb-3">Payments</h2>
+    @if (order.BalanceEur > 0 && Model.CanPay)
+    {
+        if (Model.IsStripeConfigured)
+        {
+            <form asp-action="Pay" asp-route-id="@order.Id" method="post" class="row g-2 mb-3 align-items-end">
+                @Html.AntiForgeryToken()
+                <div class="col-md-4">
+                    <label class="form-label">Amount to pay (EUR)</label>
+                    <input type="number" name="amountEur" class="form-control"
+                           min="0.01" max="@order.BalanceEur.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)"
+                           step="0.01"
+                           value="@order.BalanceEur.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)" required />
+                </div>
+                <div class="col-md-4">
+                    <button type="submit" class="btn btn-primary">Pay with Stripe</button>
+                    <small class="form-text text-muted d-block">You'll be redirected to Stripe Checkout.</small>
+                </div>
+            </form>
+        }
+        else
+        {
+            <div class="alert alert-warning">Stripe checkout is not configured for this environment.</div>
+        }
+    }
+    else if (order.BalanceEur <= 0)
+    {
+        <p class="text-muted">No outstanding balance.</p>
+    }
+    else
+    {
+        <p class="text-muted">Payments are recorded by the finance team.</p>
+    }
 }
 else
 {
-    <p class="text-muted">Payments are recorded by the finance team.</p>
+    <div class="alert alert-info mt-4">
+        <strong>Non-billable.</strong> Team orders count toward supplier totals only — no invoice, no payment.
+    </div>
 }
 
 @section Scripts {

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -16,9 +16,19 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="mb-0">@(string.IsNullOrWhiteSpace(order.Label) ? "Store order" : order.Label)</h1>
-    <div>
-        <span class="badge bg-info text-dark fs-6 me-2">@order.CounterpartyType</span>
+    <div class="d-flex align-items-center gap-2">
+        <span class="badge bg-info text-dark fs-6">@order.CounterpartyType</span>
         <span class="badge bg-secondary fs-6">@order.State</span>
+        @if (Model.CanDelete)
+        {
+            <form asp-action="Delete" asp-route-id="@order.Id" method="post" class="mb-0">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-sm btn-outline-danger"
+                        data-confirm="Delete this zero-balance order? This cannot be undone.">
+                    <i class="fa-solid fa-trash me-1"></i> Delete
+                </button>
+            </form>
+        }
     </div>
 </div>
 

--- a/src/Humans.Web/Views/StoreAdmin/Summary.cshtml
+++ b/src/Humans.Web/Views/StoreAdmin/Summary.cshtml
@@ -50,7 +50,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                @foreach (var row in s.ByCounterparty)
+                @foreach (var row in s.ByCounterparty.OrderBy(r => r.CounterpartyType).ThenBy(r => r.CounterpartyName, StringComparer.Ordinal))
                 {
                     string paidClass =
                         row.CounterpartyType == Humans.Domain.Enums.StoreOrderCounterpartyType.Team ? "paid" :
@@ -139,7 +139,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                @foreach (var cp in s.CrossTab.Counterparties)
+                @foreach (var cp in s.CrossTab.Counterparties.OrderBy(c => c.CounterpartyType).ThenBy(c => c.CounterpartyName, StringComparer.Ordinal))
                 {
                     <tr>
                         <td>@cp.CounterpartyType</td>

--- a/src/Humans.Web/Views/StoreAdmin/Summary.cshtml
+++ b/src/Humans.Web/Views/StoreAdmin/Summary.cshtml
@@ -16,10 +16,10 @@
 
 <vc:temp-data-alerts />
 
-@* =====================  By camp  ===================== *@
+@* =====================  By counterparty  ===================== *@
 <section class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <h2 class="h5 mb-0">By camp</h2>
+        <h2 class="h5 mb-0">By counterparty</h2>
         <div class="d-flex gap-2 align-items-center">
             <label for="paid-filter" class="form-label mb-0 small">Show</label>
             <select id="paid-filter" class="form-select form-select-sm" style="width: 9rem;">
@@ -31,7 +31,7 @@
         </div>
     </div>
     <div class="card-body p-0">
-        @if (s.ByCamp.Count == 0)
+        @if (s.ByCounterparty.Count == 0)
         {
             <p class="text-muted m-3 mb-3">No orders for @s.Year.</p>
         }
@@ -40,7 +40,8 @@
             <table class="table table-sm mb-0" id="by-camp-table">
                 <thead>
                     <tr>
-                        <th class="sortable" data-sort-key="camp" data-sort-type="text" role="button">Camp <span class="sort-indicator" aria-hidden="true"></span></th>
+                        <th class="sortable" data-sort-key="type" data-sort-type="text" role="button">Type <span class="sort-indicator" aria-hidden="true"></span></th>
+                        <th class="sortable" data-sort-key="camp" data-sort-type="text" role="button">Counterparty <span class="sort-indicator" aria-hidden="true"></span></th>
                         <th class="sortable" data-sort-key="label" data-sort-type="text" role="button">Label <span class="sort-indicator" aria-hidden="true"></span></th>
                         <th class="sortable" data-sort-key="state" data-sort-type="text" role="button">State <span class="sort-indicator" aria-hidden="true"></span></th>
                         <th class="sortable text-end" data-sort-key="due" data-sort-type="number" role="button">Total due (€) <span class="sort-indicator" aria-hidden="true"></span></th>
@@ -49,28 +50,31 @@
                     </tr>
                 </thead>
                 <tbody>
-                @foreach (var row in s.ByCamp)
+                @foreach (var row in s.ByCounterparty)
                 {
                     string paidClass =
+                        row.CounterpartyType == Humans.Domain.Enums.StoreOrderCounterpartyType.Team ? "paid" :
                         row.BalanceEur <= 0m ? "paid" :
                         row.PaymentsTotalEur > 0m ? "partial" : "unpaid";
                     <tr data-paid-status="@paidClass"
-                        data-camp="@row.CampName"
+                        data-type="@row.CounterpartyType"
+                        data-camp="@row.CounterpartyName"
                         data-label="@row.Label"
                         data-state="@row.State"
                         data-due="@row.TotalDueEur.ToString(System.Globalization.CultureInfo.InvariantCulture)"
                         data-paid="@row.PaymentsTotalEur.ToString(System.Globalization.CultureInfo.InvariantCulture)"
                         data-balance="@row.BalanceEur.ToString(System.Globalization.CultureInfo.InvariantCulture)">
+                        <td>@row.CounterpartyType</td>
                         <td>
                             <a asp-controller="Store" asp-action="Order" asp-route-id="@row.OrderId">
-                                @row.CampName
+                                @row.CounterpartyName
                             </a>
                         </td>
                         <td>@row.Label</td>
                         <td>@row.State</td>
                         <td class="text-end">@row.TotalDueEur.ToString("F2")</td>
-                        <td class="text-end">@row.PaymentsTotalEur.ToString("F2")</td>
-                        <td class="text-end">@row.BalanceEur.ToString("F2")</td>
+                        <td class="text-end">@(row.CounterpartyType == Humans.Domain.Enums.StoreOrderCounterpartyType.Team ? "—" : row.PaymentsTotalEur.ToString("F2"))</td>
+                        <td class="text-end">@(row.CounterpartyType == Humans.Domain.Enums.StoreOrderCounterpartyType.Team ? "—" : row.BalanceEur.ToString("F2"))</td>
                     </tr>
                 }
                 </tbody>
@@ -114,9 +118,9 @@
 
 @* =====================  Cross-tab  ===================== *@
 <section class="card mb-4">
-    <div class="card-header"><h2 class="h5 mb-0">Camps × products (qty)</h2></div>
+    <div class="card-header"><h2 class="h5 mb-0">Counterparties × products (qty)</h2></div>
     <div class="card-body p-0 table-responsive">
-        @if (s.CrossTab.Camps.Count == 0 || s.CrossTab.Products.Count == 0)
+        @if (s.CrossTab.Counterparties.Count == 0 || s.CrossTab.Products.Count == 0)
         {
             <p class="text-muted m-3 mb-3">Nothing to plot for @s.Year.</p>
         }
@@ -125,7 +129,8 @@
             <table class="table table-sm table-bordered mb-0">
                 <thead>
                     <tr>
-                        <th>Camp</th>
+                        <th>Type</th>
+                        <th>Counterparty</th>
                         @foreach (var col in s.CrossTab.Products)
                         {
                             <th class="text-end">@col.ProductName</th>
@@ -134,22 +139,23 @@
                     </tr>
                 </thead>
                 <tbody>
-                @foreach (var camp in s.CrossTab.Camps)
+                @foreach (var cp in s.CrossTab.Counterparties)
                 {
                     <tr>
-                        <td>@camp.CampName</td>
+                        <td>@cp.CounterpartyType</td>
+                        <td>@cp.CounterpartyName</td>
                         @foreach (var col in s.CrossTab.Products)
                         {
-                            var qty = camp.QtyByProduct.TryGetValue(col.ProductId, out var q) ? q : 0;
+                            var qty = cp.QtyByProduct.TryGetValue(col.ProductId, out var q) ? q : 0;
                             <td class="text-end">@(qty == 0 ? "" : qty.ToString())</td>
                         }
-                        <td class="text-end fw-semibold">@camp.TotalQty</td>
+                        <td class="text-end fw-semibold">@cp.TotalQty</td>
                     </tr>
                 }
                 </tbody>
                 <tfoot>
                     <tr class="fw-semibold">
-                        <td>Total</td>
+                        <td colspan="2">Total</td>
                         @foreach (var col in s.CrossTab.Products)
                         {
                             <td class="text-end">@col.TotalQty</td>

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -304,6 +304,13 @@
                     <a asp-controller="Calendar" asp-action="Team" asp-route-teamId="@Model.Id" class="btn btn-outline-secondary w-100 mt-2">
                         Team calendar
                     </a>
+
+                    @if (Model.IsCurrentUserCoordinator && Model.ParentTeam is null && Model.IsActive)
+                    {
+                        <a asp-controller="Store" asp-action="Index" class="btn btn-outline-primary w-100 mt-2">
+                            <i class="fa-solid fa-cart-shopping me-1"></i> Open store
+                        </a>
+                    }
                 </div>
             </div>
         }

--- a/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
@@ -36,6 +36,7 @@ public class AuthorizationPolicyTests : IDisposable
         services.AddScoped(_ => Substitute.For<ICampService>());
         services.AddScoped(_ => Substitute.For<ICityPlanningService>());
         services.AddScoped(_ => Substitute.For<ITeamService>());
+        services.AddScoped(_ => Substitute.For<ITeamServiceRead>());
         services.AddScoped(_ => Substitute.For<IAgentRateLimitStore>());
         services.AddScoped(_ => Substitute.For<IAgentSettingsService>());
         // Expense resource-based handlers

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
@@ -320,6 +320,83 @@ public class StoreServiceTeamOrdersTests
             ManagementRoleHolderUserIds: new HashSet<Guid> { coordinatorUserId });
     }
 
+    // ==========================================================================
+    // DeleteOrderAsync
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task DeleteOrderAsync_removes_zero_balance_order_and_audits()
+    {
+        var orderId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>())
+            .Returns(new StoreOrder { Id = orderId, CampSeasonId = Guid.NewGuid(), Year = 2026 });
+
+        await _service.DeleteOrderAsync(orderId, actor);
+
+        await _repo.Received(1).DeleteOrderAsync(orderId, Arg.Any<CancellationToken>());
+        await _audit.Received(1).LogAsync(
+            AuditAction.StoreOrderDeleted, nameof(StoreOrder), orderId,
+            Arg.Any<string>(), actor,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task DeleteOrderAsync_rejects_non_zero_balance_camp_order()
+    {
+        var orderId = Guid.NewGuid();
+        var order = new StoreOrder
+        {
+            Id = orderId,
+            CampSeasonId = Guid.NewGuid(),
+            Year = 2026,
+            Lines = new List<StoreOrderLine>
+            {
+                new() { Id = Guid.NewGuid(), OrderId = orderId, ProductId = Guid.NewGuid(),
+                        Qty = 1, UnitPriceSnapshot = 10m, VatRateSnapshot = 0m }
+            }
+        };
+        _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.DeleteOrderAsync(orderId, Guid.NewGuid()));
+
+        await _repo.DidNotReceive().DeleteOrderAsync(orderId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task DeleteOrderAsync_throws_when_order_not_found()
+    {
+        var orderId = Guid.NewGuid();
+        _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>())
+            .Returns((StoreOrder?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.DeleteOrderAsync(orderId, Guid.NewGuid()));
+    }
+
+    // ==========================================================================
+    // CreateOrderAsync uniqueness (camp side — one order per camp-season-year)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task CreateOrderAsync_throws_when_camp_season_already_has_order_for_year()
+    {
+        var seasonId = Guid.NewGuid();
+        _campService.GetCampSeasonByIdAsync(seasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeasonInfo(seasonId, Guid.NewGuid(), "alpha", 2026, null,
+                "Camp X", string.Empty, string.Empty, [], CampSeasonStatus.Pending,
+                YesNoMaybe.No, YesNoMaybe.No, AdultPlayspacePolicy.No, 0, null, null, null, 0, null, null));
+        _repo.GetOrdersForCampSeasonAsync(seasonId, Arg.Any<CancellationToken>())
+            .Returns(new List<StoreOrder>
+            {
+                new() { Id = Guid.NewGuid(), CampSeasonId = seasonId, Year = 2026 }
+            });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.CreateOrderAsync(seasonId, null, Guid.NewGuid()));
+    }
+
     private static OrderDto MakeOrderDto(
         StoreOrderCounterpartyType counterpartyType,
         decimal balanceEur)

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
@@ -1,0 +1,349 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Store;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Services.Store;
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Store;
+
+/// <summary>
+/// Focused coverage for the polymorphic team-coordinator order path.
+/// See <c>docs/superpowers/specs/2026-05-27-store-team-orders-design.md</c>.
+/// </summary>
+public class StoreServiceTeamOrdersTests
+{
+    private readonly IStoreRepository _repo = Substitute.For<IStoreRepository>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+    private readonly ICampService _campService = Substitute.For<ICampService>();
+    private readonly ITeamServiceRead _teams = Substitute.For<ITeamServiceRead>();
+    private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
+    private readonly IStripeService _stripe = Substitute.For<IStripeService>();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 14, 12, 0));
+    private readonly StoreService _service;
+
+    public StoreServiceTeamOrdersTests()
+    {
+        _shifts.GetActiveAsync().Returns(new EventSettings
+        {
+            Year = 2026,
+            TimeZoneId = "Europe/Madrid"
+        });
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+        _service = new StoreService(_repo, _audit, _campService, _teams, _clock, _shifts, _stripe, NullLogger<StoreService>.Instance);
+    }
+
+    // ==========================================================================
+    // CreateTeamOrderAsync
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task CreateTeamOrderAsync_writes_order_with_team_id_and_active_year()
+    {
+        var teamId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        _teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(MakeDepartment(teamId, "Kitchen", userId));
+        _repo.GetOrderForTeamAsync(teamId, 2026, Arg.Any<CancellationToken>())
+            .Returns((StoreOrder?)null);
+
+        StoreOrder? captured = null;
+        await _repo.AddOrderAsync(Arg.Do<StoreOrder>(o => captured = o), Arg.Any<CancellationToken>());
+
+        var id = await _service.CreateTeamOrderAsync(teamId, userId);
+
+        captured.Should().NotBeNull();
+        captured!.Id.Should().Be(id);
+        captured.TeamId.Should().Be(teamId);
+        captured.CampSeasonId.Should().BeNull();
+        captured.Year.Should().Be(2026);
+        captured.State.Should().Be(StoreOrderState.Open);
+    }
+
+    [HumansFact]
+    public async Task CreateTeamOrderAsync_throws_when_team_already_has_order_this_year()
+    {
+        var teamId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        _teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(MakeDepartment(teamId, "Kitchen", userId));
+        _repo.GetOrderForTeamAsync(teamId, 2026, Arg.Any<CancellationToken>())
+            .Returns(new StoreOrder { Id = Guid.NewGuid(), TeamId = teamId, Year = 2026 });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.CreateTeamOrderAsync(teamId, userId));
+    }
+
+    [HumansFact]
+    public async Task CreateTeamOrderAsync_throws_when_team_is_a_subteam()
+    {
+        var teamId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var parentId = Guid.NewGuid();
+        _teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(MakeDepartment(teamId, "Sub", userId, parentTeamId: parentId));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.CreateTeamOrderAsync(teamId, userId));
+    }
+
+    [HumansFact]
+    public async Task CreateTeamOrderAsync_throws_when_team_not_found()
+    {
+        var teamId = Guid.NewGuid();
+        _teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>()).Returns((TeamInfo?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.CreateTeamOrderAsync(teamId, Guid.NewGuid()));
+    }
+
+    // ==========================================================================
+    // Guard rails on billable-only methods
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task UpdateCounterpartyAsync_throws_on_team_order()
+    {
+        var orderId = Guid.NewGuid();
+        var teamOrder = new StoreOrder { Id = orderId, TeamId = Guid.NewGuid(), CampSeasonId = null, Year = 2026 };
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>()).Returns(teamOrder);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.UpdateCounterpartyAsync(
+                orderId,
+                new OrderCounterpartyInput("N", null, null, null, null),
+                Guid.NewGuid()));
+    }
+
+    [HumansFact]
+    public async Task CreateStripeCheckoutSessionAsync_throws_on_team_order()
+    {
+        var teamOrder = MakeOrderDto(
+            counterpartyType: StoreOrderCounterpartyType.Team,
+            balanceEur: 0m);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreateStripeCheckoutSessionAsync(teamOrder, 10m, "https://x"));
+    }
+
+    [HumansFact]
+    public async Task RecordStripePaymentAsync_throws_on_team_order()
+    {
+        var orderId = Guid.NewGuid();
+        var teamOrder = new StoreOrder { Id = orderId, TeamId = Guid.NewGuid(), CampSeasonId = null, Year = 2026 };
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>()).Returns(teamOrder);
+        _repo.StripePaymentIntentExistsAsync("pi_x", Arg.Any<CancellationToken>()).Returns(false);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.RecordStripePaymentAsync(orderId, "pi_x", 10m));
+    }
+
+    // ==========================================================================
+    // Year backfill on legacy camp orders
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task AddLineAsync_backfills_Year_from_camp_season_when_order_year_is_zero()
+    {
+        var orderId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var product = new StoreProduct
+        {
+            Id = Guid.NewGuid(),
+            Year = 2025,
+            IsActive = true,
+            OrderableUntil = new LocalDate(2026, 12, 31),
+            UnitPriceEur = 10m,
+            VatRatePercent = 21m,
+        };
+        var order = new StoreOrder
+        {
+            Id = orderId,
+            CampSeasonId = seasonId,
+            TeamId = null,
+            Year = 0,
+            State = StoreOrderState.Open,
+        };
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
+        _repo.GetProductByIdAsync(product.Id, Arg.Any<CancellationToken>()).Returns(product);
+        _campService.GetCampSeasonByIdAsync(seasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeasonInfo(seasonId, Guid.NewGuid(), "alpha", 2025, null,
+                "Camp X", string.Empty, string.Empty, [], CampSeasonStatus.Pending,
+                YesNoMaybe.No, YesNoMaybe.No, AdultPlayspacePolicy.No, 0, null, null, null, 0, null, null));
+
+        await _service.AddLineAsync(orderId, product.Id, 1, Guid.NewGuid());
+
+        await _repo.Received(1).UpdateOrderAsync(
+            Arg.Is<StoreOrder>(o => o.Year == 2025),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // Index data — team coordinators see their departments
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetIndexDataAsync_lists_coordinated_departments_alongside_led_camps()
+    {
+        var userId = Guid.NewGuid();
+        var deptId = Guid.NewGuid();
+        var subteamId = Guid.NewGuid();
+        _campService.GetCampLeadSeasonIdForYearAsync(userId, 2026, Arg.Any<CancellationToken>())
+            .Returns((Guid?)null);
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>
+            {
+                [deptId] = MakeDepartment(deptId, "Build", userId),
+                // sub-team the user coordinates — must NOT appear in the index
+                [subteamId] = MakeDepartment(subteamId, "Build Sub", userId, parentTeamId: deptId),
+            });
+        _repo.GetOrderForTeamAsync(deptId, 2026, Arg.Any<CancellationToken>()).Returns((StoreOrder?)null);
+        _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<StoreProduct>());
+
+        var data = await _service.GetIndexDataAsync(userId, isPrivilegedReader: false);
+
+        data.Counterparties.Should().HaveCount(1);
+        data.Counterparties[0].CounterpartyType.Should().Be(StoreOrderCounterpartyType.Team);
+        data.Counterparties[0].CounterpartyId.Should().Be(deptId);
+        data.Counterparties[0].Orders.Should().BeEmpty();
+        data.ShowNoOrdersMessage.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task GetIndexDataAsync_ignores_departments_user_does_not_coordinate()
+    {
+        var userId = Guid.NewGuid();
+        var otherDeptId = Guid.NewGuid();
+        _campService.GetCampLeadSeasonIdForYearAsync(userId, 2026, Arg.Any<CancellationToken>())
+            .Returns((Guid?)null);
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>
+            {
+                [otherDeptId] = MakeDepartment(otherDeptId, "Other", coordinatorUserId: Guid.NewGuid()),
+            });
+        _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<StoreProduct>());
+
+        var data = await _service.GetIndexDataAsync(userId, isPrivilegedReader: false);
+
+        data.Counterparties.Should().BeEmpty();
+        data.ShowNoOrdersMessage.Should().BeTrue();
+    }
+
+    // ==========================================================================
+    // Summary — team orders merge into cross-tab
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetStoreSummaryAsync_merges_team_orders_into_by_counterparty_and_cross_tab()
+    {
+        var deptId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+
+        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, CampSeasonDisplayData>());
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>
+            {
+                [deptId] = MakeDepartment(deptId, "Kitchen", Guid.NewGuid()),
+            });
+        _repo.GetAllProductsForYearAsync(2026, Arg.Any<CancellationToken>()).Returns([
+            new StoreProduct {
+                Id = productId, Year = 2026, Name = "Tent", Description = "x",
+                UnitPriceEur = 10m, VatRatePercent = 0m,
+                OrderableUntil = new LocalDate(2026,12,31), IsActive = true }
+        ]);
+        _repo.GetOrdersForTeamsWithLinesAsync(
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(deptId)),
+                2026, Arg.Any<CancellationToken>())
+            .Returns([new StoreOrder {
+                Id = orderId, TeamId = deptId, Year = 2026, State = StoreOrderState.Open,
+                Lines = { new StoreOrderLine {
+                    Id = Guid.NewGuid(), OrderId = orderId, ProductId = productId,
+                    Qty = 7, UnitPriceSnapshot = 10m, VatRateSnapshot = 0m }} }]);
+
+        var result = await _service.GetStoreSummaryAsync(2026);
+
+        result.ByCounterparty.Should().ContainSingle(r =>
+            r.CounterpartyType == StoreOrderCounterpartyType.Team
+            && r.OrderId == orderId
+            && r.CounterpartyName == "Kitchen"
+            && r.PaymentsTotalEur == 0m
+            && r.BalanceEur == 0m);
+        result.ByItem.Single(i => i.ProductId == productId).TotalQty.Should().Be(7);
+        result.CrossTab.Counterparties.Should().ContainSingle(r =>
+            r.CounterpartyType == StoreOrderCounterpartyType.Team
+            && r.CounterpartyName == "Kitchen"
+            && r.TotalQty == 7);
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private static TeamInfo MakeDepartment(
+        Guid teamId,
+        string name,
+        Guid coordinatorUserId,
+        Guid? parentTeamId = null)
+    {
+        return new TeamInfo(
+            Id: teamId,
+            Name: name,
+            Description: null,
+            Slug: name.ToLowerInvariant(),
+            IsActive: true,
+            IsSystemTeam: false,
+            SystemTeamType: SystemTeamType.None,
+            RequiresApproval: false,
+            IsPublicPage: true,
+            IsHidden: false,
+            IsPromotedToDirectory: false,
+            CreatedAt: Instant.FromUtc(2026, 1, 1, 0, 0),
+            Members: new List<TeamMemberInfo>(),
+            ParentTeamId: parentTeamId,
+            ManagementRoleHolderUserIds: new HashSet<Guid> { coordinatorUserId });
+    }
+
+    private static OrderDto MakeOrderDto(
+        StoreOrderCounterpartyType counterpartyType,
+        decimal balanceEur)
+    {
+        return new OrderDto(
+            Id: Guid.NewGuid(),
+            CampSeasonId: counterpartyType == StoreOrderCounterpartyType.Camp ? Guid.NewGuid() : null,
+            TeamId: counterpartyType == StoreOrderCounterpartyType.Team ? Guid.NewGuid() : null,
+            CounterpartyType: counterpartyType,
+            CounterpartyDisplayName: counterpartyType.ToString(),
+            Year: 2026,
+            Label: null,
+            State: StoreOrderState.Open,
+            CounterpartyName: null,
+            CounterpartyVatId: null,
+            CounterpartyAddress: null,
+            CounterpartyCountryCode: null,
+            CounterpartyEmail: null,
+            IssuedInvoiceId: null,
+            Lines: [],
+            LinesSubtotalEur: balanceEur,
+            VatTotalEur: 0m,
+            DepositTotalEur: 0m,
+            PaymentsTotalEur: 0m,
+            BalanceEur: balanceEur);
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
@@ -244,6 +244,10 @@ public class StoreServiceTests
         var actor = Guid.NewGuid();
         StoreOrder? captured = null;
         await _repo.AddOrderAsync(Arg.Do<StoreOrder>(o => captured = o), Arg.Any<CancellationToken>());
+        _campService.GetCampSeasonByIdAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeasonInfo(campSeasonId, Guid.NewGuid(), "alpha", 2026, null,
+                "Camp X", string.Empty, string.Empty, [], CampSeasonStatus.Pending,
+                YesNoMaybe.No, YesNoMaybe.No, AdultPlayspacePolicy.No, 0, null, null, null, 0, null, null));
 
         var orderId = await _service.CreateOrderAsync(campSeasonId, "First order", actor);
 

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
@@ -1,10 +1,12 @@
 using AwesomeAssertions;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Store;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Services.Store;
 using Humans.Application.Services.Store.Dtos;
 using Humans.Domain.Entities;
@@ -22,6 +24,7 @@ public class StoreServiceTests
     private readonly IStoreRepository _repo = Substitute.For<IStoreRepository>();
     private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
     private readonly ICampService _campService = Substitute.For<ICampService>();
+    private readonly ITeamServiceRead _teams = Substitute.For<ITeamServiceRead>();
     private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
     private readonly IStripeService _stripeService = Substitute.For<IStripeService>();
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 14, 12, 0));
@@ -34,7 +37,9 @@ public class StoreServiceTests
             Year = 2026,
             TimeZoneId = "Europe/Madrid"
         });
-        _service = new StoreService(_repo, _audit, _campService, _clock, _shifts, _stripeService, NullLogger<StoreService>.Instance);
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+        _service = new StoreService(_repo, _audit, _campService, _teams, _clock, _shifts, _stripeService, NullLogger<StoreService>.Instance);
     }
 
     // ==========================================================================
@@ -54,16 +59,21 @@ public class StoreServiceTests
 
         result.Year.Should().Be(2026);
         result.Catalog.Select(p => p.Name).Should().Equal("Blanket", "Tent");
-        result.CampSeasons.Should().BeEmpty();
-        result.ShowNoCampOrdersMessage.Should().BeTrue();
+        result.Counterparties.Should().BeEmpty();
+        result.ShowNoOrdersMessage.Should().BeTrue();
     }
 
     [HumansFact]
     public async Task GetOrderPageDataAsync_loads_edit_catalog_and_computes_payment_state()
     {
+        var campSeasonId = Guid.NewGuid();
         var order = new OrderDto(
             Id: Guid.NewGuid(),
-            CampSeasonId: Guid.NewGuid(),
+            CampSeasonId: campSeasonId,
+            TeamId: null,
+            CounterpartyType: StoreOrderCounterpartyType.Camp,
+            CounterpartyDisplayName: "Camp Test",
+            Year: 2026,
             Label: "Kitchen",
             State: StoreOrderState.Open,
             CounterpartyName: null,
@@ -83,15 +93,11 @@ public class StoreServiceTests
                 MakeProduct(name: "Tent"),
                 MakeProduct(name: "Blanket")
             ]);
-        _campService.GetCampSeasonByIdAsync(order.CampSeasonId, Arg.Any<CancellationToken>())
-            .Returns(new CampSeasonInfo(order.CampSeasonId, Guid.NewGuid(), string.Empty, 2026, null,
-                "Camp Test", string.Empty, string.Empty, [], CampSeasonStatus.Pending,
-                YesNoMaybe.No, YesNoMaybe.No, AdultPlayspacePolicy.No, 0, null, null, null, 0, null, null));
         _stripeService.IsStoreCheckoutConfigured.Returns(true);
 
         var result = await _service.GetOrderPageDataAsync(order, canEdit: true, canPayAuthorized: true);
 
-        result.CampName.Should().Be("Camp Test");
+        result.CounterpartyDisplayName.Should().Be("Camp Test");
         result.Catalog.Select(p => p.Name).Should().Equal("Blanket", "Tent");
         result.CanEdit.Should().BeTrue();
         result.CanPay.Should().BeTrue();
@@ -970,15 +976,19 @@ public class StoreServiceTests
         string? email = null)
     {
         return new OrderDto(
-            Guid.NewGuid(),
-            Guid.NewGuid(),
-            label,
-            StoreOrderState.Open,
-            counterpartyName,
+            Id: Guid.NewGuid(),
+            CampSeasonId: Guid.NewGuid(),
+            TeamId: null,
+            CounterpartyType: StoreOrderCounterpartyType.Camp,
+            CounterpartyDisplayName: counterpartyName ?? "Camp",
+            Year: 2026,
+            Label: label,
+            State: StoreOrderState.Open,
+            CounterpartyName: counterpartyName,
             CounterpartyVatId: null,
             CounterpartyAddress: null,
             CounterpartyCountryCode: null,
-            email,
+            CounterpartyEmail: email,
             IssuedInvoiceId: null,
             Lines: [],
             LinesSubtotalEur: balanceEur,

--- a/tests/Humans.Application.Tests/Services/Store/StoreSummaryAggregateTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreSummaryAggregateTests.cs
@@ -1,9 +1,11 @@
 using AwesomeAssertions;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Services.Store;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -19,6 +21,7 @@ public class StoreSummaryAggregateTests
     private readonly IStoreRepository _repo = Substitute.For<IStoreRepository>();
     private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
     private readonly ICampService _camps = Substitute.For<ICampService>();
+    private readonly ITeamServiceRead _teams = Substitute.For<ITeamServiceRead>();
     private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
     private readonly IStripeService _stripe = Substitute.For<IStripeService>();
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 14, 12, 0));
@@ -26,7 +29,9 @@ public class StoreSummaryAggregateTests
 
     public StoreSummaryAggregateTests()
     {
-        _service = new StoreService(_repo, _audit, _camps, _clock, _shifts, _stripe, NullLogger<StoreService>.Instance);
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+        _service = new StoreService(_repo, _audit, _camps, _teams, _clock, _shifts, _stripe, NullLogger<StoreService>.Instance);
     }
 
     [HumansFact]
@@ -40,10 +45,10 @@ public class StoreSummaryAggregateTests
         var result = await _service.GetStoreSummaryAsync(2026);
 
         result.Year.Should().Be(2026);
-        result.ByCamp.Should().BeEmpty();
+        result.ByCounterparty.Should().BeEmpty();
         result.ByItem.Should().BeEmpty();
         result.CrossTab.Products.Should().BeEmpty();
-        result.CrossTab.Camps.Should().BeEmpty();
+        result.CrossTab.Counterparties.Should().BeEmpty();
     }
 
     [HumansFact]
@@ -111,11 +116,12 @@ public class StoreSummaryAggregateTests
 
         var result = await _service.GetStoreSummaryAsync(2026);
 
-        // By-camp
-        result.ByCamp.Should().HaveCount(1);
-        var camp = result.ByCamp[0];
+        // By-counterparty
+        result.ByCounterparty.Should().HaveCount(1);
+        var camp = result.ByCounterparty[0];
         camp.OrderId.Should().Be(orderId);
-        camp.CampName.Should().Be("Camp Alpha");
+        camp.CounterpartyName.Should().Be("Camp Alpha");
+        camp.CounterpartyType.Should().Be(StoreOrderCounterpartyType.Camp);
         camp.TotalDueEur.Should().Be(36.30m); // 3 * 10 + VAT 6.30
         camp.PaymentsTotalEur.Should().Be(20m);
         camp.BalanceEur.Should().Be(16.30m);
@@ -129,10 +135,10 @@ public class StoreSummaryAggregateTests
         // Cross-tab
         result.CrossTab.Products.Should().HaveCount(1);
         result.CrossTab.Products[0].TotalQty.Should().Be(3);
-        result.CrossTab.Camps.Should().HaveCount(1);
-        result.CrossTab.Camps[0].CampName.Should().Be("Camp Alpha");
-        result.CrossTab.Camps[0].TotalQty.Should().Be(3);
-        result.CrossTab.Camps[0].QtyByProduct[productId].Should().Be(3);
+        result.CrossTab.Counterparties.Should().HaveCount(1);
+        result.CrossTab.Counterparties[0].CounterpartyName.Should().Be("Camp Alpha");
+        result.CrossTab.Counterparties[0].TotalQty.Should().Be(3);
+        result.CrossTab.Counterparties[0].QtyByProduct[productId].Should().Be(3);
     }
 
     [HumansFact]
@@ -193,13 +199,13 @@ public class StoreSummaryAggregateTests
         colY.TotalQty.Should().Be(1);
 
         // Cross-tab row totals
-        result.CrossTab.Camps.Single(r => string.Equals(r.CampName, "Camp Alpha", StringComparison.Ordinal)).TotalQty.Should().Be(3);
-        result.CrossTab.Camps.Single(r => string.Equals(r.CampName, "Camp Bravo", StringComparison.Ordinal)).TotalQty.Should().Be(4);
+        result.CrossTab.Counterparties.Single(r => string.Equals(r.CounterpartyName, "Camp Alpha", StringComparison.Ordinal)).TotalQty.Should().Be(3);
+        result.CrossTab.Counterparties.Single(r => string.Equals(r.CounterpartyName, "Camp Bravo", StringComparison.Ordinal)).TotalQty.Should().Be(4);
 
         // Sum of all cells == sum of column totals == sum of row totals
-        var cellSum = result.CrossTab.Camps.Sum(r => r.QtyByProduct.Values.Sum());
+        var cellSum = result.CrossTab.Counterparties.Sum(r => r.QtyByProduct.Values.Sum());
         cellSum.Should().Be(result.CrossTab.Products.Sum(c => c.TotalQty));
-        cellSum.Should().Be(result.CrossTab.Camps.Sum(r => r.TotalQty));
+        cellSum.Should().Be(result.CrossTab.Counterparties.Sum(r => r.TotalQty));
     }
 
     [HumansFact]
@@ -294,17 +300,17 @@ public class StoreSummaryAggregateTests
 
         var result = await _service.GetStoreSummaryAsync(2026);
 
-        var paidRow = result.ByCamp.Single(r => r.OrderId == orderPaid);
+        var paidRow = result.ByCounterparty.Single(r => r.OrderId == orderPaid);
         paidRow.TotalDueEur.Should().Be(20m);
         paidRow.PaymentsTotalEur.Should().Be(20m);
         paidRow.BalanceEur.Should().Be(0m);
 
-        var partialRow = result.ByCamp.Single(r => r.OrderId == orderPartial);
+        var partialRow = result.ByCounterparty.Single(r => r.OrderId == orderPartial);
         partialRow.TotalDueEur.Should().Be(30m);
         partialRow.PaymentsTotalEur.Should().Be(10m);
         partialRow.BalanceEur.Should().Be(20m);
 
-        var unpaidRow = result.ByCamp.Single(r => r.OrderId == orderUnpaid);
+        var unpaidRow = result.ByCounterparty.Single(r => r.OrderId == orderUnpaid);
         unpaidRow.TotalDueEur.Should().Be(10m);
         unpaidRow.PaymentsTotalEur.Should().Be(0m);
         unpaidRow.BalanceEur.Should().Be(10m);
@@ -332,7 +338,7 @@ public class StoreSummaryAggregateTests
 
         var result = await _service.GetStoreSummaryAsync(2026);
 
-        result.ByCamp.Should().BeEmpty();
-        result.CrossTab.Camps.Should().BeEmpty();
+        result.ByCounterparty.Should().BeEmpty();
+        result.CrossTab.Counterparties.Should().BeEmpty();
     }
 }

--- a/tests/Humans.Integration.Tests/Controllers/StoreSummaryControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/StoreSummaryControllerTests.cs
@@ -29,8 +29,8 @@ public class StoreSummaryControllerTests(HumansWebApplicationFactory factory)
 
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await resp.Content.ReadAsStringAsync();
-        body.Should().Contain("By camp");
+        body.Should().Contain("By counterparty");
         body.Should().Contain("By item");
-        body.Should().Contain("Camps × products");
+        body.Should().Contain("Counterparties × products");
     }
 }


### PR DESCRIPTION
## Summary

- `StoreOrder` becomes polymorphic — either `CampSeasonId` (billable, today's flow, unchanged) or `TeamId` (non-billable, stays `Open` forever, never invoiced).
- Department coordinators can create + manage a single per-year order against the existing Store catalog. Lines roll into supplier totals on `/Store/Admin/Summary` alongside camp rows.
- Service-layer enforces "exactly one counterparty"; DB does not. Year column added to `store_orders`; lazy-filled for existing camp orders on next save.

## Spec + Plan

- Spec: `docs/superpowers/specs/2026-05-27-store-team-orders-design.md`
- Plan: `docs/superpowers/plans/2026-05-27-store-team-orders.md`

## Test plan

- [ ] Sign in as a department coordinator (no camp-lead role) → `/Store` lists the department with a Create-order CTA
- [ ] Create order → redirects to `/Store/Order/{id}` showing an empty team order with no Pay button, no counterparty form, no payments list
- [ ] Add a line → persists; remove a line → persists; deadline gate behaves as on camp orders
- [ ] `/Store/Admin/Summary` for the active year shows team rows alongside camp rows with a Type column
- [ ] StoreAdmin/FinanceAdmin/Admin retain full visibility; non-coordinator users cannot view/edit a team's order
- [ ] Trying to invoke Pay or counterparty edit on a team order is blocked at the auth handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)