### PR TITLE
Add Reforge surface score config

### DIFF
--- a/.github/workflows/pr-surface-report.yml
+++ b/.github/workflows/pr-surface-report.yml
@@ -29,13 +29,57 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:pr-surface-head"
 
+      - name: Setup .NET
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Generate Reforge score delta inputs
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          set -euo pipefail
+          dotnet tool install --global reforge --version 0.13.*
+          REFORGE="$HOME/.dotnet/tools/reforge"
+
+          BASE_DIR="$(mktemp -d)"
+          HEAD_DIR="$(mktemp -d)"
+          rmdir "$BASE_DIR" "$HEAD_DIR"
+          git worktree add --detach "$BASE_DIR" "${{ github.event.pull_request.base.sha }}"
+          git worktree add --detach "$HEAD_DIR" pr-surface-head
+
+          CONFIG_ARGS=()
+          if [ -f "$HEAD_DIR/reforge.surface-score.json" ]; then
+            CONFIG_ARGS=(--config "$HEAD_DIR/reforge.surface-score.json")
+          elif [ -f "$BASE_DIR/reforge.surface-score.json" ]; then
+            CONFIG_ARGS=(--config "$BASE_DIR/reforge.surface-score.json")
+          fi
+
+          "$REFORGE" stop || true
+          (
+            cd "$BASE_DIR"
+            "$REFORGE" surface-score --solution Humans.slnx "${CONFIG_ARGS[@]}" --format Json --top 200 > "$GITHUB_WORKSPACE/reforge-base.json"
+          )
+          "$REFORGE" stop || true
+          (
+            cd "$HEAD_DIR"
+            "$REFORGE" surface-score --solution Humans.slnx "${CONFIG_ARGS[@]}" --format Json --top 200 > "$GITHUB_WORKSPACE/reforge-head.json"
+          )
+          "$REFORGE" stop || true
+
       - name: Generate surface report
         run: |
+          REFORGE_ARGS=()
+          if [ -f reforge-base.json ] && [ -f reforge-head.json ]; then
+            REFORGE_ARGS=(--reforge-base-json reforge-base.json --reforge-head-json reforge-head.json)
+          fi
+
           python3 scripts/pr-surface-report.py \
             --base "${{ github.event.pull_request.base.sha }}" \
             --head "pr-surface-head" \
             --base-label "${{ github.event.pull_request.base.sha }}" \
             --head-label "${{ github.event.pull_request.head.sha }}" \
+            "${REFORGE_ARGS[@]}" \
             --output pr-surface-report.md \
             --json-output pr-surface-report.json
 

--- a/reforge.surface-score.json
+++ b/reforge.surface-score.json
@@ -1,0 +1,869 @@
+{
+  "sections": {
+    "Admin": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Admin/**",
+        "src/Humans.Application/Services/Admin/**",
+        "src/Humans.Infrastructure/Repositories/Admin/**",
+        "src/Humans.Web/Controllers/Admin*/**"
+      ],
+      "symbols": [
+        "Admin*",
+        "IAdmin*"
+      ]
+    },
+    "Agent": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Agent/**",
+        "src/Humans.Application/Models/Agent*",
+        "src/Humans.Application/Services/Agent/**",
+        "src/Humans.Domain/Entities/Agent*",
+        "src/Humans.Infrastructure/Repositories/Agent*",
+        "src/Humans.Infrastructure/Services/Agent/**",
+        "src/Humans.Web/Controllers/Agent*"
+      ],
+      "symbols": [
+        "Agent*",
+        "IAgent*"
+      ],
+      "repositoryInterfaces": [
+        "IAgentRepository"
+      ],
+      "serviceInterfaces": [
+        "IAgentService"
+      ]
+    },
+    "AuditLog": {
+      "paths": [
+        "src/Humans.Application/Interfaces/AuditLog/**",
+        "src/Humans.Application/Services/AuditLog/**",
+        "src/Humans.Domain/Entities/AuditLog*",
+        "src/Humans.Infrastructure/Repositories/AuditLog/**",
+        "src/Humans.Web/Controllers/AuditLogController.cs"
+      ],
+      "symbols": [
+        "AuditLog*",
+        "IAuditLog*"
+      ],
+      "repositoryInterfaces": [
+        "IAuditLogRepository"
+      ],
+      "serviceInterfaces": [
+        "IAuditLogService"
+      ]
+    },
+    "Auth": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Auth/**",
+        "src/Humans.Application/Services/Auth/**",
+        "src/Humans.Domain/Entities/RoleAssignment*",
+        "src/Humans.Infrastructure/Repositories/Auth/**",
+        "src/Humans.Infrastructure/Services/Auth/**",
+        "src/Humans.Web/Authorization/**"
+      ],
+      "symbols": [
+        "RoleAssignment*",
+        "IRoleAssignment*",
+        "*Authorization*",
+        "*Claims*"
+      ],
+      "repositoryInterfaces": [
+        "IRoleAssignmentRepository"
+      ],
+      "serviceInterfaces": [
+        "IRoleAssignmentService"
+      ]
+    },
+    "Budget": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Budget/**",
+        "src/Humans.Application/Services/Budget/**",
+        "src/Humans.Application/DTOs/Budget*",
+        "src/Humans.Application/DTOs/TicketingBudget*",
+        "src/Humans.Domain/Entities/Budget*",
+        "src/Humans.Infrastructure/Repositories/Budget/**",
+        "src/Humans.Web/Controllers/BudgetController.cs"
+      ],
+      "symbols": [
+        "Budget*",
+        "IBudget*",
+        "TicketingBudget*"
+      ],
+      "repositoryInterfaces": [
+        "IBudgetRepository"
+      ],
+      "serviceInterfaces": [
+        "IBudgetService"
+      ]
+    },
+    "Calendar": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Calendar/**",
+        "src/Humans.Application/Services/Calendar/**",
+        "src/Humans.Domain/Entities/Calendar*",
+        "src/Humans.Infrastructure/Repositories/Calendar/**",
+        "src/Humans.Infrastructure/Services/Calendar/**",
+        "src/Humans.Web/Controllers/CalendarController.cs"
+      ],
+      "symbols": [
+        "Calendar*",
+        "ICalendar*"
+      ],
+      "repositoryInterfaces": [
+        "ICalendarRepository"
+      ],
+      "serviceInterfaces": [
+        "ICalendarService"
+      ],
+      "readServiceInterfaces": [
+        "ICalendarServiceRead"
+      ],
+      "canonicalReadDtos": [
+        "CalendarEventInfo"
+      ]
+    },
+    "Campaigns": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Campaigns/**",
+        "src/Humans.Application/Services/Campaigns/**",
+        "src/Humans.Domain/Entities/Campaign*",
+        "src/Humans.Infrastructure/Repositories/Campaigns/**",
+        "src/Humans.Web/Controllers/CampaignController.cs"
+      ],
+      "symbols": [
+        "Campaign*",
+        "ICampaign*"
+      ],
+      "repositoryInterfaces": [
+        "ICampaignRepository"
+      ],
+      "serviceInterfaces": [
+        "ICampaignService"
+      ]
+    },
+    "Camps": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Camps/**",
+        "src/Humans.Application/Services/Camps/**",
+        "src/Humans.Application/DTOs/Camp*",
+        "src/Humans.Domain/Entities/Camp.cs",
+        "src/Humans.Domain/Entities/CampHistoricalName.cs",
+        "src/Humans.Domain/Entities/CampImage.cs",
+        "src/Humans.Domain/Entities/CampLead.cs",
+        "src/Humans.Domain/Entities/CampMember.cs",
+        "src/Humans.Domain/Entities/CampRoleAssignment.cs",
+        "src/Humans.Domain/Entities/CampRoleDefinition.cs",
+        "src/Humans.Domain/Entities/CampSeason.cs",
+        "src/Humans.Domain/Entities/CampSettings.cs",
+        "src/Humans.Infrastructure/Repositories/Camps/**",
+        "src/Humans.Infrastructure/Services/Camps/**",
+        "src/Humans.Web/Controllers/Camp*",
+        "src/Humans.Web/Models/CampAdmin/**"
+      ],
+      "symbols": [
+        "ICamp*"
+      ],
+      "repositoryInterfaces": [
+        "ICampRepository"
+      ],
+      "serviceInterfaces": [
+        "ICampService",
+        "ICampRoleService"
+      ],
+      "readServiceInterfaces": [
+        "ICampServiceRead"
+      ],
+      "canonicalReadDtos": [
+        "CampInfo",
+        "CampSeasonInfo",
+        "CampSettingsInfo",
+        "CampSearchHit"
+      ]
+    },
+    "CityPlanning": {
+      "paths": [
+        "src/Humans.Application/Interfaces/CityPlanning/**",
+        "src/Humans.Application/Services/CityPlanning/**",
+        "src/Humans.Domain/Entities/CampPolygon*",
+        "src/Humans.Infrastructure/Repositories/CityPlanning/**",
+        "src/Humans.Web/Controllers/CityPlanningController.cs",
+        "src/Humans.Web/Hubs/CityPlanningHub.cs"
+      ],
+      "symbols": [
+        "CityPlanning*",
+        "CampPolygon*",
+        "ICityPlanning*"
+      ],
+      "repositoryInterfaces": [
+        "ICityPlanningRepository"
+      ],
+      "serviceInterfaces": [
+        "ICityPlanningService"
+      ]
+    },
+    "Consent": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Consent/**",
+        "src/Humans.Application/Services/Consent/**",
+        "src/Humans.Application/Services/Legal/**",
+        "src/Humans.Domain/Entities/Consent*",
+        "src/Humans.Domain/Entities/LegalDocument*",
+        "src/Humans.Infrastructure/Repositories/Consent/**",
+        "src/Humans.Infrastructure/Services/GitHubLegalDocumentConnector.cs",
+        "src/Humans.Infrastructure/Services/Legal/**",
+        "src/Humans.Infrastructure/Services/Consent/**",
+        "src/Humans.Web/Controllers/ConsentController.cs",
+        "src/Humans.Web/Controllers/LegalController.cs",
+        "src/Humans.Web/Controllers/AdminLegalDocumentsController.cs"
+      ],
+      "symbols": [
+        "Consent*",
+        "LegalDocument*",
+        "IConsent*",
+        "ILegalDocument*"
+      ],
+      "repositoryInterfaces": [
+        "IConsentRepository",
+        "ILegalDocumentRepository"
+      ],
+      "serviceInterfaces": [
+        "IConsentService",
+        "ILegalDocumentService"
+      ],
+      "readServiceInterfaces": [
+        "IConsentServiceRead"
+      ],
+      "canonicalReadDtos": [
+        "ConsentInfo",
+        "LegalDocumentInfo"
+      ]
+    },
+    "Containers": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Containers/**",
+        "src/Humans.Application/Services/Containers/**",
+        "src/Humans.Domain/Entities/Container*",
+        "src/Humans.Infrastructure/Repositories/Containers/**",
+        "src/Humans.Web/Controllers/ContainerController.cs"
+      ],
+      "symbols": [
+        "Container*",
+        "IContainer*"
+      ],
+      "repositoryInterfaces": [
+        "IContainerRepository"
+      ],
+      "serviceInterfaces": [
+        "IContainerService"
+      ]
+    },
+    "Dashboard": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Dashboard/**",
+        "src/Humans.Application/Services/Dashboard/**",
+        "src/Humans.Application/DTOs/AdminDashboardData.cs",
+        "src/Humans.Application/DTOs/DashboardOverview.cs",
+        "src/Humans.Web/Models/AdminDashboardViewModel.cs",
+        "src/Humans.Web/Models/DashboardViewModel.cs"
+      ],
+      "symbols": [
+        "Dashboard*",
+        "AdminDashboard*",
+        "IDashboard*",
+        "IAdminDashboard*"
+      ],
+      "serviceInterfaces": [
+        "IDashboardService",
+        "IAdminDashboardService"
+      ],
+      "canonicalReadDtos": [
+        "DashboardOverview",
+        "AdminDashboardData"
+      ]
+    },
+    "Email": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Email/**",
+        "src/Humans.Application/Interfaces/Mailer/**",
+        "src/Humans.Application/Services/Email/**",
+        "src/Humans.Application/Services/Mailer/**",
+        "src/Humans.Domain/Entities/Email*",
+        "src/Humans.Infrastructure/Repositories/Email/**",
+        "src/Humans.Infrastructure/Services/BrandedEmailBodyComposer.cs",
+        "src/Humans.Infrastructure/Services/EmailRenderer.cs",
+        "src/Humans.Infrastructure/Services/SmtpEmailService.cs",
+        "src/Humans.Infrastructure/Services/SmtpEmailTransport.cs",
+        "src/Humans.Infrastructure/Services/StubEmailService.cs",
+        "src/Humans.Infrastructure/Services/StubEmailTransport.cs",
+        "src/Humans.Web/Controllers/EmailController.cs",
+        "src/Humans.Web/Controllers/Mailer/**",
+        "src/Humans.Web/Controllers/UnsubscribeController.cs",
+        "src/Humans.Web/Models/Mailer/**"
+      ],
+      "symbols": [
+        "Email*",
+        "Mailer*",
+        "IEmail*",
+        "IMailer*"
+      ],
+      "repositoryInterfaces": [
+        "IEmailOutboxRepository"
+      ],
+      "serviceInterfaces": [
+        "IEmailService",
+        "IMailerAudienceSyncService",
+        "IMailerImportService",
+        "IMailerLiteService"
+      ]
+    },
+    "Events": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Events/**",
+        "src/Humans.Application/Services/Events/**",
+        "src/Humans.Domain/Entities/Event*",
+        "src/Humans.Infrastructure/Repositories/Events/**",
+        "src/Humans.Infrastructure/Services/Events/**",
+        "src/Humans.Web/Controllers/Events*"
+      ],
+      "symbols": [
+        "Event*",
+        "IEvent*"
+      ],
+      "repositoryInterfaces": [
+        "IEventRepository"
+      ],
+      "serviceInterfaces": [
+        "IEventService"
+      ]
+    },
+    "Expenses": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Expenses/**",
+        "src/Humans.Application/Services/Expenses/**",
+        "src/Humans.Domain/Entities/Expense*",
+        "src/Humans.Infrastructure/Repositories/Expenses/**",
+        "src/Humans.Web/Controllers/ExpensesController.cs"
+      ],
+      "symbols": [
+        "Expense*",
+        "IExpense*"
+      ],
+      "repositoryInterfaces": [
+        "IExpenseRepository"
+      ],
+      "serviceInterfaces": [
+        "IExpenseService"
+      ]
+    },
+    "Feedback": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Feedback/**",
+        "src/Humans.Application/Services/Feedback/**",
+        "src/Humans.Domain/Entities/Feedback*",
+        "src/Humans.Infrastructure/Repositories/Feedback/**",
+        "src/Humans.Web/Controllers/FeedbackController.cs"
+      ],
+      "symbols": [
+        "Feedback*",
+        "IFeedback*"
+      ],
+      "repositoryInterfaces": [
+        "IFeedbackRepository"
+      ],
+      "serviceInterfaces": [
+        "IFeedbackService"
+      ]
+    },
+    "Finance": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Finance/**",
+        "src/Humans.Application/Services/Finance/**",
+        "src/Humans.Infrastructure/Repositories/Finance/**",
+        "src/Humans.Web/Controllers/FinanceController.cs"
+      ],
+      "symbols": [
+        "Finance*",
+        "Holded*",
+        "IHolded*"
+      ],
+      "repositoryInterfaces": [
+        "IHoldedRepository"
+      ],
+      "serviceInterfaces": [
+        "IHoldedFinanceService"
+      ]
+    },
+    "Gdpr": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Gdpr/**",
+        "src/Humans.Application/Services/Gdpr/**"
+      ],
+      "symbols": [
+        "Gdpr*",
+        "IGdpr*"
+      ],
+      "serviceInterfaces": [
+        "IGdprExportService"
+      ]
+    },
+    "GoogleIntegration": {
+      "paths": [
+        "src/Humans.Application/Interfaces/GoogleIntegration/**",
+        "src/Humans.Application/Services/GoogleIntegration/**",
+        "src/Humans.Domain/Entities/Google*",
+        "src/Humans.Domain/Entities/SyncServiceSettings.cs",
+        "src/Humans.Infrastructure/GoogleIntegration/**",
+        "src/Humans.Infrastructure/Repositories/GoogleIntegration/**",
+        "src/Humans.Infrastructure/Services/StubGoogleSyncService.cs",
+        "src/Humans.Web/Controllers/GoogleController.cs"
+      ],
+      "symbols": [
+        "Google*",
+        "Drive*",
+        "IGoogle*",
+        "IDrive*"
+      ],
+      "repositoryInterfaces": [
+        "IDriveActivityMonitorRepository",
+        "IGoogleResourceRepository",
+        "IGoogleSyncOutboxRepository",
+        "ISyncSettingsRepository"
+      ],
+      "serviceInterfaces": [
+        "IGoogleSyncService",
+        "IGoogleResourceService",
+        "IDriveActivityMonitorService"
+      ]
+    },
+    "Governance": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Governance/**",
+        "src/Humans.Application/Services/Governance/**",
+        "src/Humans.Domain/Entities/Application*",
+        "src/Humans.Domain/Entities/Board*",
+        "src/Humans.Infrastructure/Repositories/Governance/**",
+        "src/Humans.Web/Controllers/Governance*"
+      ],
+      "symbols": [
+        "Application*",
+        "Board*",
+        "Governance*",
+        "IApplication*"
+      ],
+      "repositoryInterfaces": [
+        "IApplicationRepository"
+      ],
+      "serviceInterfaces": [
+        "IApplicationService"
+      ]
+    },
+    "Users": {
+      "paths": [
+        "src/Humans.Application/UserInfo.cs",
+        "src/Humans.Application/Interfaces/HumanLifecycle/**",
+        "src/Humans.Application/Interfaces/Onboarding/**",
+        "src/Humans.Application/Interfaces/Profiles/**",
+        "src/Humans.Application/Interfaces/Users/**",
+        "src/Humans.Application/Services/HumanLifecycle/**",
+        "src/Humans.Application/Services/Onboarding/**",
+        "src/Humans.Application/Services/Profile/**",
+        "src/Humans.Application/Services/Profiles/**",
+        "src/Humans.Application/Services/Users/**",
+        "src/Humans.Domain/Entities/Profile*",
+        "src/Humans.Domain/Entities/AccountMerge*",
+        "src/Humans.Domain/Entities/CommunicationPreference*",
+        "src/Humans.Domain/Entities/ContactField*",
+        "src/Humans.Domain/Entities/User*",
+        "src/Humans.Infrastructure/Repositories/Users/**",
+        "src/Humans.Infrastructure/Repositories/Profiles/**",
+        "src/Humans.Infrastructure/Services/Users/**",
+        "src/Humans.Web/Controllers/Profile*",
+        "src/Humans.Web/Controllers/User*",
+        "src/Humans.Web/Controllers/AboutController.cs",
+        "src/Humans.Web/Controllers/AccountController.cs",
+        "src/Humans.Web/Controllers/GuestController.cs",
+        "src/Humans.Web/Controllers/HomeController.cs",
+        "src/Humans.Web/Controllers/LanguageController.cs",
+        "src/Humans.Web/Controllers/Onboarding*",
+        "src/Humans.Web/Controllers/AdminDuplicateAccountsController.cs",
+        "src/Humans.Web/Controllers/AdminMergeController.cs"
+      ],
+      "symbols": [
+        "Profile*",
+        "AccountMerge*",
+        "CommunicationPreference*",
+        "ContactField*",
+        "User*",
+        "Human*",
+        "HumanLifecycle*",
+        "Onboarding*",
+        "IProfile*",
+        "IUser*"
+      ],
+      "repositoryInterfaces": [
+        "IAccountMergeRepository",
+        "ICommunicationPreferenceRepository",
+        "IProfileRepository",
+        "IUserRepository"
+      ],
+      "serviceInterfaces": [
+        "IHumanLifecycleService",
+        "IOnboardingService",
+        "IProfileEditorService",
+        "IProfileService",
+        "IUserService"
+      ],
+      "readServiceInterfaces": [
+        "IUserServiceRead"
+      ],
+      "canonicalReadDtos": [
+        "UserInfo",
+        "UserEmailInfo",
+        "ContactFieldInfo",
+        "ProfileLanguageInfo",
+        "VolunteerHistoryInfo",
+        "CommunicationPreferenceInfo",
+        "EventParticipationInfo",
+        "UserExternalLoginInfo",
+        "ProfileInfo",
+        "HumanSearchResult",
+        "OnsiteUserRow"
+      ]
+    },
+    "Issues": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Issues/**",
+        "src/Humans.Application/Services/Issues/**",
+        "src/Humans.Domain/Entities/Issue*",
+        "src/Humans.Infrastructure/Repositories/Issues/**",
+        "src/Humans.Web/Controllers/Issues*"
+      ],
+      "symbols": [
+        "Issue*",
+        "IIssues*"
+      ],
+      "repositoryInterfaces": [
+        "IIssuesRepository"
+      ],
+      "serviceInterfaces": [
+        "IIssuesService"
+      ]
+    },
+    "Notifications": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Notifications/**",
+        "src/Humans.Application/Services/Notifications/**",
+        "src/Humans.Domain/Entities/Notification*",
+        "src/Humans.Infrastructure/Repositories/Notifications/**",
+        "src/Humans.Web/Controllers/NotificationsController.cs"
+      ],
+      "symbols": [
+        "Notification*",
+        "INotification*"
+      ],
+      "repositoryInterfaces": [
+        "INotificationRepository"
+      ],
+      "serviceInterfaces": [
+        "INotificationService"
+      ]
+    },
+    "Search": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Search/**",
+        "src/Humans.Application/Services/Search/**",
+        "src/Humans.Application/DTOs/GlobalSearchResults.cs",
+        "src/Humans.Web/Controllers/SearchController.cs",
+        "src/Humans.Web/Models/SearchViewModels.cs"
+      ],
+      "symbols": [
+        "Search*",
+        "GlobalSearch*",
+        "ISearch*"
+      ],
+      "serviceInterfaces": [
+        "ISearchService"
+      ],
+      "canonicalReadDtos": [
+        "GlobalSearchResult",
+        "GlobalSearchResults"
+      ]
+    },
+    "Shifts": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Shifts/**",
+        "src/Humans.Application/Interfaces/EarlyEntry/**",
+        "src/Humans.Application/Services/Shifts/**",
+        "src/Humans.Application/Services/EarlyEntry/**",
+        "src/Humans.Domain/Entities/EventSettings.cs",
+        "src/Humans.Domain/Entities/GeneralAvailability.cs",
+        "src/Humans.Domain/Entities/Rota*",
+        "src/Humans.Domain/Entities/Shift*",
+        "src/Humans.Domain/Entities/Volunteer*",
+        "src/Humans.Infrastructure/Repositories/Shifts/**",
+        "src/Humans.Infrastructure/Services/Shifts/**",
+        "src/Humans.Infrastructure/Services/EarlyEntry/**",
+        "src/Humans.Infrastructure/Stores/EarlyEntry/**",
+        "src/Humans.Web/Controllers/Shift*",
+        "src/Humans.Web/Controllers/VolunteerTrackingController.cs",
+        "src/Humans.Web/Controllers/EarlyEntryRosterController.cs",
+        "src/Humans.Web/Models/Shifts/**"
+      ],
+      "symbols": [
+        "EventSettings*",
+        "GeneralAvailability*",
+        "Shift*",
+        "Volunteer*",
+        "IShift*",
+        "IVolunteer*",
+        "IGeneralAvailability*"
+      ],
+      "repositoryInterfaces": [
+        "IShiftManagementRepository",
+        "IShiftSignupRepository",
+        "IVolunteerTrackingRepository"
+      ],
+      "serviceInterfaces": [
+        "IGeneralAvailabilityService",
+        "IShiftManagementService",
+        "IShiftSignupService",
+        "IVolunteerTrackingService"
+      ],
+      "readServiceInterfaces": [
+        "IVolunteerTrackingServiceRead"
+      ],
+      "canonicalReadDtos": [
+        "ShiftInfo",
+        "ShiftSignupInfo",
+        "VolunteerBuildStrip",
+        "VolunteerTrackingData",
+        "VolunteerCell"
+      ]
+    },
+    "Store": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Store/**",
+        "src/Humans.Application/Services/Store/**",
+        "src/Humans.Domain/Entities/Store*",
+        "src/Humans.Infrastructure/Repositories/Store/**",
+        "src/Humans.Web/Controllers/Store*"
+      ],
+      "symbols": [
+        "Store*",
+        "IStore*"
+      ],
+      "repositoryInterfaces": [
+        "IStoreRepository"
+      ],
+      "serviceInterfaces": [
+        "IStoreService"
+      ]
+    },
+    "Teams": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Teams/**",
+        "src/Humans.Application/Services/Teams/**",
+        "src/Humans.Domain/Entities/Team*",
+        "src/Humans.Infrastructure/Repositories/Teams/**",
+        "src/Humans.Infrastructure/Services/Teams/**",
+        "src/Humans.Web/Controllers/Team*"
+      ],
+      "symbols": [
+        "Team*",
+        "ITeam*"
+      ],
+      "repositoryInterfaces": [
+        "ITeamRepository"
+      ],
+      "serviceInterfaces": [
+        "ITeamService",
+        "ITeamResourceService"
+      ],
+      "readServiceInterfaces": [
+        "ITeamServiceRead"
+      ],
+      "canonicalReadDtos": [
+        "TeamInfo",
+        "TeamMemberInfo",
+        "TeamJoinRequestInfo",
+        "TeamSearchHit"
+      ]
+    },
+    "Tickets": {
+      "paths": [
+        "src/Humans.Application/TicketOrderInfo.cs",
+        "src/Humans.Application/Interfaces/Tickets/**",
+        "src/Humans.Application/Services/Tickets/**",
+        "src/Humans.Domain/Entities/Ticket*",
+        "src/Humans.Infrastructure/Repositories/Tickets/**",
+        "src/Humans.Infrastructure/Services/Tickets/**",
+        "src/Humans.Web/Controllers/Ticket*",
+        "src/Humans.Web/Controllers/Tickets*"
+      ],
+      "symbols": [
+        "Ticket*",
+        "ITicket*"
+      ],
+      "repositoryInterfaces": [
+        "ITicketRepository",
+        "ITicketTransferRepository"
+      ],
+      "serviceInterfaces": [
+        "ITicketService",
+        "ITicketingBudgetService",
+        "ITicketTransferService"
+      ],
+      "readServiceInterfaces": [
+        "ITicketServiceRead"
+      ],
+      "canonicalReadDtos": [
+        "TicketOrderInfo",
+        "TicketAttendeeInfo",
+        "TicketDashboardTotals",
+        "TicketTransferRowDto",
+        "TicketTransferDetailDto",
+        "MyAttendeeRowDto"
+      ]
+    },
+    "Cantina": {
+      "paths": [
+        "src/Humans.Application/Interfaces/Cantina/**",
+        "src/Humans.Application/Services/Cantina/**",
+        "src/Humans.Web/Cantina/**",
+        "src/Humans.Web/Controllers/CantinaController.cs"
+      ],
+      "symbols": [
+        "Cantina*",
+        "ICantina*"
+      ],
+      "serviceInterfaces": [
+        "ICantinaRosterService"
+      ]
+    },
+    "Platform": {
+      "paths": [
+        "src/Humans.Application/Configuration/**",
+        "src/Humans.Application/Extensions/**",
+        "src/Humans.Application/Helpers/**",
+        "src/Humans.Application/Interfaces/Caching/**",
+        "src/Humans.Application/Interfaces/IApplicationService.cs",
+        "src/Humans.Application/Interfaces/ICacheStatsProvider.cs",
+        "src/Humans.Application/Interfaces/IClientStatsTracker.cs",
+        "src/Humans.Application/Interfaces/IFileStorage.cs",
+        "src/Humans.Application/Interfaces/IGuideContentService.cs",
+        "src/Humans.Application/Interfaces/IGuideContentSource.cs",
+        "src/Humans.Application/Interfaces/IGuideRenderer.cs",
+        "src/Humans.Application/Interfaces/IGuideRoleResolver.cs",
+        "src/Humans.Application/Interfaces/IHttpStatusTracker.cs",
+        "src/Humans.Application/Interfaces/IHumansMetrics.cs",
+        "src/Humans.Application/Interfaces/IOrchestrator.cs",
+        "src/Humans.Application/Interfaces/IRecurringJob.cs",
+        "src/Humans.Application/Interfaces/Repositories/IRepository.cs",
+        "src/Humans.Application/Models/Anthropic*",
+        "src/Humans.Application/Models/Api*",
+        "src/Humans.Application/Models/Claude*",
+        "src/Humans.Application/Models/Mistral*",
+        "src/Humans.Application/Models/OpenRouter*",
+        "src/Humans.Application/Models/Platform*",
+        "src/Humans.Domain/Attributes/**",
+        "src/Humans.Domain/Constants/**",
+        "src/Humans.Domain/Helpers/**",
+        "src/Humans.Infrastructure/Caching/**",
+        "src/Humans.Infrastructure/Data/**",
+        "src/Humans.Infrastructure/Services/AdminDatabaseDiagnosticsService.cs",
+        "src/Humans.Infrastructure/Services/ClientStatsTracker.cs",
+        "src/Humans.Infrastructure/Services/FileSystemFileStorage.cs",
+        "src/Humans.Infrastructure/Services/GitHubGuideContentSource.cs",
+        "src/Humans.Infrastructure/Services/GuideContentService.cs",
+        "src/Humans.Infrastructure/Services/GuideHtmlPostprocessor.cs",
+        "src/Humans.Infrastructure/Services/GuideMarkdownPreprocessor.cs",
+        "src/Humans.Infrastructure/Services/GuideRenderer.cs",
+        "src/Humans.Infrastructure/Services/GuideRoleResolver.cs",
+        "src/Humans.Infrastructure/Helpers/**",
+        "src/Humans.Infrastructure/Hosting/**",
+        "src/Humans.Infrastructure/Jobs/**",
+        "src/Humans.Infrastructure/Services/HttpStatusTracker.cs",
+        "src/Humans.Infrastructure/Services/StripeStartupSmokeService.cs",
+        "src/Humans.Infrastructure/Stores/**",
+        "src/Humans.Web/Controllers/ColorPaletteController.cs",
+        "src/Humans.Web/Controllers/DebugController.cs",
+        "src/Humans.Web/Controllers/DevLoginController.cs",
+        "src/Humans.Web/Controllers/DevSeedController.cs",
+        "src/Humans.Web/Controllers/GuideController.cs",
+        "src/Humans.Web/Controllers/LogApiController.cs",
+        "src/Humans.Web/Controllers/ScannerController.cs",
+        "src/Humans.Web/Controllers/TimezoneApiController.cs",
+        "src/Humans.Web/Controllers/WidgetGalleryController.cs",
+        "src/Humans.Web/Extensions/**",
+        "src/Humans.Web/Filters/**",
+        "src/Humans.Web/Helpers/**",
+        "src/Humans.Web/Infrastructure/**",
+        "src/Humans.Web/Middleware/**"
+      ],
+      "symbols": [
+        "*Cache*",
+        "*Invalidator",
+        "*Job",
+        "*HostedService",
+        "*Interceptor",
+        "*Middleware",
+        "*Filter",
+        "*Helper",
+        "*Options",
+        "*Configuration",
+        "*Settings",
+        "TrackedCache",
+        "IApplicationService",
+        "IOrchestrator",
+        "IRepository"
+      ]
+    }
+  },
+  "classifications": {
+    "entity": {
+      "paths": [
+        "src/Humans.Domain/Entities/**"
+      ],
+      "namespaces": [
+        "Humans.Domain.Entities"
+      ]
+    },
+    "dto": {
+      "namePatterns": [
+        "*Dto",
+        "*Info",
+        "*Row",
+        "*Rows",
+        "*Result",
+        "*Results",
+        "*Snapshot",
+        "*View",
+        "*ViewModel"
+      ],
+      "paths": [
+        "src/Humans.Application/DTOs/**",
+        "src/Humans.Application/Models/**",
+        "src/Humans.Web/Models/**"
+      ]
+    },
+    "readServiceInterface": {
+      "namePatterns": [
+        "I*ServiceRead",
+        "I*ReadService"
+      ]
+    },
+    "fullServiceInterface": {
+      "namePatterns": [
+        "I*Service"
+      ]
+    },
+    "repositoryInterface": {
+      "namePatterns": [
+        "I*Repository"
+      ],
+      "inherits": [
+        "IRepository"
+      ]
+    }
+  }
+}

--- a/scripts/pr-surface-report.py
+++ b/scripts/pr-surface-report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a PR surface report from a git diff."""
+"""Generate a PR surface report from git and Reforge deltas."""
 
 from __future__ import annotations
 
@@ -11,12 +11,19 @@ from collections import defaultdict
 from pathlib import Path
 
 
-COMMENT_PREFIXES = ("//", "/*", "*", "*/", "#", "@*", "<!--", "--")
+INTERFACES_PREFIX = "src/Humans.Application/Interfaces/"
 MIGRATIONS_PREFIX = "src/Humans.Infrastructure/Migrations/"
 
 
 def run_git(args: list[str]) -> str:
     return subprocess.check_output(["git", *args], text=True, encoding="utf-8")
+
+
+def try_run_git(args: list[str]) -> str:
+    try:
+        return run_git(args)
+    except subprocess.CalledProcessError:
+        return ""
 
 
 def normalize(path: str) -> str:
@@ -31,19 +38,8 @@ def classify_path(path: str) -> str:
         return "tests"
     if path.startswith(("docs/", "memory/")) or path.endswith(".md"):
         return "docs"
-    return "code"
-
-
-def classify_line(path: str, line: str) -> str:
-    path_bucket = classify_path(path)
-    if path_bucket in {"migrations", "tests", "docs"}:
-        return path_bucket
-
-    stripped = line.strip()
-    if stripped == "":
-        return "blank"
-    if stripped.startswith(COMMENT_PREFIXES):
-        return "comments"
+    if path.startswith((".github/", ".config/")) or not path.endswith((".cs", ".cshtml", ".razor", ".csproj", ".props", ".targets", ".json")):
+        return "other"
     return "code"
 
 
@@ -79,78 +75,21 @@ def parse_name_status(base: str, head: str) -> tuple[list[str], list[str], list[
     return added_files, changed_files, migration_files
 
 
-def parse_diff(base: str, head: str) -> tuple[dict[str, dict[str, int]], dict[str, list[str]]]:
-    raw = run_git(["diff", "--find-renames", "--find-copies", "--unified=0", f"{base}...{head}"])
+def parse_numstat(base: str, head: str) -> dict[str, dict[str, int]]:
+    raw = run_git(["diff", "--numstat", "--find-renames", "--find-copies", f"{base}...{head}"])
     counts: dict[str, dict[str, int]] = defaultdict(lambda: {"added": 0, "deleted": 0})
-    inventory: dict[str, list[str]] = defaultdict(list)
-
-    old_path = ""
-    new_path = ""
-    old_line = 0
-    new_line = 0
-
-    public_type_re = re.compile(r"^\s*public\s+(?:sealed\s+|abstract\s+|static\s+|partial\s+)*(?:class|record|interface|enum|struct)\s+\w+")
-    interface_method_re = re.compile(r"^\s*(?:Task|ValueTask|IReadOnly|IAsync|bool|int|string|Guid|void|[A-Z]\w+)\S*\s+\w+\s*\([^;]*\)\s*;")
-    service_method_re = re.compile(r"^\s*(?:public|internal)\s+(?:async\s+)?[\w<>,\[\]\?]+\s+\w+\s*\(")
-    route_re = re.compile(r"^\s*\[(?:Route|HttpGet|HttpPost|HttpPut|HttpDelete|HttpPatch)\b")
-    action_re = re.compile(r"^\s*public\s+(?:async\s+)?(?:Task<)?IActionResult\b")
-    di_re = re.compile(r"\bservices\.Add(?:Keyed)?(?:Scoped|Singleton|Transient)\b")
-    package_re = re.compile(r"<PackageReference\b")
-
     for line in raw.splitlines():
-        if line.startswith("diff --git "):
-            old_path = ""
-            new_path = ""
+        parts = line.split("\t")
+        if len(parts) < 3:
             continue
-        if line.startswith("--- "):
-            path = line[4:].strip()
-            old_path = "" if path == "/dev/null" else normalize(path.removeprefix("a/"))
+        added_raw, deleted_raw, path_raw = parts[0], parts[1], parts[-1]
+        if added_raw == "-" or deleted_raw == "-":
             continue
-        if line.startswith("+++ "):
-            path = line[4:].strip()
-            new_path = "" if path == "/dev/null" else normalize(path.removeprefix("b/"))
-            continue
-        if line.startswith("@@ "):
-            match = re.search(r"@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@", line)
-            if match:
-                old_line = int(match.group(1))
-                new_line = int(match.group(2))
-            continue
-        if line.startswith("+") and not line.startswith("+++"):
-            content = line[1:]
-            path = new_path or old_path
-            bucket = classify_line(path, content)
-            counts[bucket]["added"] += 1
-
-            stripped = content.strip()
-            location = f"{path}:{new_line}: {stripped}"
-            if stripped and not stripped.startswith(COMMENT_PREFIXES):
-                if public_type_re.match(content):
-                    inventory["public_types"].append(location)
-                if "/Interfaces/" in path and interface_method_re.match(content):
-                    inventory["interface_methods"].append(location)
-                if ("/Services/" in path or "/Repositories/" in path) and service_method_re.match(content):
-                    inventory["service_repository_methods"].append(location)
-                if route_re.match(content) or ("/Controllers/" in path and action_re.match(content)):
-                    inventory["routes_actions"].append(location)
-                if di_re.search(content):
-                    inventory["di_registrations"].append(location)
-                if path.endswith((".csproj", ".props", ".targets")) and package_re.search(content):
-                    inventory["package_references"].append(location)
-            new_line += 1
-            continue
-        if line.startswith("-") and not line.startswith("---"):
-            content = line[1:]
-            path = old_path or new_path
-            bucket = classify_line(path, content)
-            counts[bucket]["deleted"] += 1
-            old_line += 1
-            continue
-        if old_path or new_path:
-            old_line += 1
-            new_line += 1
-
-    return counts, inventory
+        path = normalize(path_raw)
+        bucket = classify_path(path)
+        counts[bucket]["added"] += int(added_raw)
+        counts[bucket]["deleted"] += int(deleted_raw)
+    return counts
 
 
 def limited(items: list[str], limit: int = 25) -> list[str]:
@@ -164,7 +103,169 @@ def bullet_list(items: list[str]) -> str:
 
 
 def short_ref(ref: str) -> str:
-    return ref[:8] if re.fullmatch(r"[0-9a-fA-F]{40}", ref) else ref
+    return ref[:8] if len(ref) == 40 and all(c in "0123456789abcdefABCDEF" for c in ref) else ref
+
+
+def load_json(path: str | None) -> dict | None:
+    if not path:
+        return None
+    data = Path(path).read_bytes()
+    for encoding in ("utf-8", "utf-8-sig", "utf-16"):
+        try:
+            return json.loads(data.decode(encoding))
+        except UnicodeError:
+            continue
+    return json.loads(data.decode("utf-8"))
+
+
+def format_delta(delta: int) -> str:
+    return f"+{delta}" if delta > 0 else str(delta)
+
+
+def compare_number_maps(base: dict[str, int], head: dict[str, int]) -> list[tuple[str, int, int, int]]:
+    rows: list[tuple[str, int, int, int]] = []
+    for key in sorted(set(base) | set(head)):
+        base_value = int(base.get(key) or 0)
+        head_value = int(head.get(key) or 0)
+        delta = head_value - base_value
+        if delta != 0:
+            rows.append((key, base_value, head_value, delta))
+    return sorted(rows, key=lambda row: (-abs(row[3]), row[0]))
+
+
+def groups_by_name(score: dict) -> dict[str, int]:
+    return {
+        str(group["name"]): int(group.get("total") or 0)
+        for group in score.get("groups", [])
+    }
+
+
+def git_files(ref: str, prefix: str) -> list[str]:
+    raw = run_git(["ls-tree", "-r", "--name-only", ref, "--", prefix])
+    return [normalize(line) for line in raw.splitlines() if line.endswith(".cs")]
+
+
+def normalize_signature(signature: str) -> str:
+    return " ".join(signature.replace("\t", " ").split()).rstrip(";")
+
+
+def extract_interface_symbols(ref: str) -> dict[str, dict[str, object]]:
+    interfaces: dict[str, dict[str, object]] = {}
+    interface_re = re.compile(r"\binterface\s+(I[A-Za-z0-9_]*)\b")
+
+    for path in git_files(ref, INTERFACES_PREFIX):
+        content = try_run_git(["show", f"{ref}:{path}"])
+        current: str | None = None
+        depth = 0
+        pending_signature: list[str] = []
+
+        for raw_line in content.splitlines():
+            line = raw_line.split("//", 1)[0].strip()
+            if not line or line.startswith("["):
+                continue
+
+            if current is None:
+                match = interface_re.search(line)
+                if not match:
+                    continue
+                current = match.group(1)
+                interfaces.setdefault(current, {"path": path, "methods": set()})
+                depth = line.count("{") - line.count("}")
+                continue
+
+            depth += line.count("{") - line.count("}")
+            if "(" in line or pending_signature:
+                pending_signature.append(line)
+                if ";" in line:
+                    signature = normalize_signature(" ".join(pending_signature))
+                    pending_signature.clear()
+                    if "(" in signature and ")" in signature:
+                        interfaces[current]["methods"].add(signature)
+
+            if depth <= 0:
+                current = None
+                depth = 0
+                pending_signature.clear()
+
+    return interfaces
+
+
+def interface_delta(base: str, head: str) -> dict[str, object]:
+    base_interfaces = extract_interface_symbols(base)
+    head_interfaces = extract_interface_symbols(head)
+    new_interfaces = [
+        f"{name} ({head_interfaces[name]['path']})"
+        for name in sorted(set(head_interfaces) - set(base_interfaces))
+    ]
+
+    added_methods: dict[str, list[str]] = {}
+    for name in sorted(set(base_interfaces) & set(head_interfaces)):
+        base_methods = base_interfaces[name]["methods"]
+        head_methods = head_interfaces[name]["methods"]
+        added = sorted(head_methods - base_methods)
+        if added:
+            added_methods[name] = added
+
+    return {
+        "new_interfaces": new_interfaces,
+        "added_interface_methods": added_methods,
+    }
+
+
+def interface_delta_markdown(delta: dict[str, object]) -> str:
+    new_interfaces = list(delta.get("new_interfaces", []))
+    added_methods = dict(delta.get("added_interface_methods", {}))
+    if not new_interfaces and not added_methods:
+        return "### Interface Surface\n\nNo new interfaces or interface methods."
+
+    sections = ["### Interface Surface"]
+    if new_interfaces:
+        sections.extend(["", "**New interfaces**", "", bullet_list(new_interfaces)])
+    if added_methods:
+        sections.extend(["", "**Added interface methods**"])
+        for name, methods in added_methods.items():
+            sections.extend(["", f"`{name}`", "", bullet_list(list(methods))])
+    return "\n".join(sections)
+
+
+def reforge_delta_markdown(base_score: dict | None, head_score: dict | None) -> str:
+    if not base_score or not head_score:
+        return "### Reforge Surface Score\n\nNot available for this run.\n"
+
+    sections: list[str] = ["### Reforge Surface Score", ""]
+    total_delta = int(head_score.get("total") or 0) - int(base_score.get("total") or 0)
+    sections.extend(
+        [
+            "| metric | base | head | delta |",
+            "|---|---:|---:|---:|",
+            f"| total | {int(base_score.get('total') or 0)} | {int(head_score.get('total') or 0)} | {format_delta(total_delta)} |",
+            "",
+        ]
+    )
+
+    section_rows = compare_number_maps(groups_by_name(base_score), groups_by_name(head_score))
+    if section_rows:
+        sections.extend(["#### Section Deltas", "", "| section | base | head | delta |", "|---|---:|---:|---:|"])
+        sections.extend(
+            f"| {name} | {base} | {head} | {format_delta(delta)} |"
+            for name, base, head, delta in section_rows
+        )
+        sections.append("")
+    else:
+        sections.extend(["#### Section Deltas", "", "No section score changes.", ""])
+
+    rule_rows = compare_number_maps(base_score.get("byRule", {}), head_score.get("byRule", {}))
+    if rule_rows:
+        sections.extend(["#### Rule Deltas", "", "| rule | base | head | delta |", "|---|---:|---:|---:|"])
+        sections.extend(
+            f"| `{name}` | {base} | {head} | {format_delta(delta)} |"
+            for name, base, head, delta in rule_rows
+        )
+        sections.append("")
+    else:
+        sections.extend(["#### Rule Deltas", "", "No rule score changes.", ""])
+
+    return "\n".join(sections)
 
 
 def build_markdown(
@@ -174,20 +275,22 @@ def build_markdown(
     added_files: list[str],
     changed_files: list[str],
     migration_files: list[str],
-    inventory: dict[str, list[str]],
+    base_score: dict | None,
+    head_score: dict | None,
+    interfaces: dict[str, object],
     base_label: str,
     head_label: str,
 ) -> str:
-    categories = ["code", "comments", "tests", "migrations", "docs", "blank"]
+    categories = ["code", "migrations", "tests", "docs", "other"]
     rows = [
         f"| {category} | {counts.get(category, {}).get('added', 0)} | {counts.get(category, {}).get('deleted', 0)} |"
         for category in categories
         if counts.get(category, {}).get("added", 0) or counts.get(category, {}).get("deleted", 0)
     ]
     loc_section = (
-        "### LOC\n\n| bucket | added | deleted |\n|---|---:|---:|\n" + "\n".join(rows)
+        "### Diff Size\n\n| bucket | added | deleted |\n|---|---:|---:|\n" + "\n".join(rows)
         if rows
-        else "### LOC\n\nNo line changes detected."
+        else "### Diff Size\n\nNo line changes detected."
     )
     migration_status = "OK" if len(migration_files) <= 1 else "BLOCK"
     summary = f"{len(changed_files)} changed file(s) | EF migrations: {len(migration_files)}/1"
@@ -199,6 +302,10 @@ def build_markdown(
         f"Compared `{short_ref(base_label)}`...`{short_ref(head_label)}`.",
         "",
         f"**Summary:** {summary}",
+        "",
+        reforge_delta_markdown(base_score, head_score).rstrip(),
+        "",
+        interface_delta_markdown(interfaces).rstrip(),
         "",
         loc_section,
     ]
@@ -216,20 +323,6 @@ def build_markdown(
             ]
         )
 
-    inventory_sections = [
-        ("Public types", inventory.get("public_types", [])),
-        ("Interface methods", inventory.get("interface_methods", [])),
-        ("Service/repository methods", inventory.get("service_repository_methods", [])),
-        ("Routes/actions", inventory.get("routes_actions", [])),
-        ("DI registrations", inventory.get("di_registrations", [])),
-        ("Package references", inventory.get("package_references", [])),
-    ]
-    non_empty_inventory = [(title, items) for title, items in inventory_sections if items]
-    if non_empty_inventory:
-        sections.extend(["", "### Surface Inventory"])
-        for title, items in non_empty_inventory:
-            sections.extend(["", f"**{title}**", "", bullet_list(items)])
-
     return "\n".join(sections) + "\n"
 
 
@@ -239,12 +332,17 @@ def main() -> int:
     parser.add_argument("--head", required=True)
     parser.add_argument("--base-label")
     parser.add_argument("--head-label")
+    parser.add_argument("--reforge-base-json")
+    parser.add_argument("--reforge-head-json")
     parser.add_argument("--output", default="pr-surface-report.md")
     parser.add_argument("--json-output", default="pr-surface-report.json")
     args = parser.parse_args()
 
     added_files, changed_files, migration_files = parse_name_status(args.base, args.head)
-    counts, inventory = parse_diff(args.base, args.head)
+    counts = parse_numstat(args.base, args.head)
+    base_score = load_json(args.reforge_base_json)
+    head_score = load_json(args.reforge_head_json)
+    interfaces = interface_delta(args.base, args.head)
     base_label = args.base_label or args.base
     head_label = args.head_label or args.head
     markdown = build_markdown(
@@ -254,7 +352,9 @@ def main() -> int:
         added_files,
         changed_files,
         migration_files,
-        inventory,
+        base_score,
+        head_score,
+        interfaces,
         base_label,
         head_label,
     )
@@ -272,7 +372,11 @@ def main() -> int:
                 "changed_files": changed_files,
                 "migration_files": migration_files,
                 "migration_count": len(migration_files),
-                "inventory": inventory,
+                "reforge": {
+                    "base": base_score,
+                    "head": head_score,
+                },
+                "interfaces": interfaces,
             },
             indent=2,
         ),

--- a/src/Humans.Application/Services/Issues/IssuesService.cs
+++ b/src/Humans.Application/Services/Issues/IssuesService.cs
@@ -26,7 +26,7 @@ namespace Humans.Application.Services.Issues;
 /// </summary>
 public sealed class IssuesService(
     IIssuesRepository repo,
-    IUserService users,
+    IUserServiceRead users,
     IUserEmailService userEmails,
     IRoleAssignmentService roles,
     IEmailService email,

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -23,7 +23,7 @@ namespace Humans.Application.Services.Tickets;
 public sealed class TicketTransferService(
     ITicketTransferRepository transferRepo,
     ITicketRepository ticketRepo,
-    IUserService userService,
+    IUserServiceRead userService,
     IUserEmailService userEmailService,
     IEmailService emailService,
     IAuditLogService auditLog,

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -24,7 +24,7 @@ public class TeamAdminController(
     ITeamService teamService,
     ITeamResourceService teamResourceService,
     IGoogleSyncService googleSyncService,
-    IUserService userService,
+    IUserServiceRead userService,
     IEmailProvisioningService emailProvisioningService,
     INotificationService notificationService,
     IAuthorizationService authorizationService,
@@ -34,7 +34,7 @@ public class TeamAdminController(
     : HumansTeamControllerBase(userService, teamService, authorizationService)
 {
     private readonly ITeamService _teamService = teamService;
-    private readonly IUserService _userService = userService;
+    private readonly IUserServiceRead _userService = userService;
     private readonly INotificationService _notificationService = notificationService;
 
     [HttpPost("Requests/{requestId}/Approve")]

--- a/src/Humans.Web/Models/CampAdmin/CampCsvExportBuilder.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampCsvExportBuilder.cs
@@ -8,7 +8,7 @@ namespace Humans.Web.Models.CampAdmin;
 public sealed record CampCsvExport(byte[] Content, string ContentType, string FileName);
 
 public sealed class CampCsvExportBuilder(
-    ICampService campService, ICampRoleService campRoleService, IUserServiceRead userService)
+    ICampServiceRead campService, ICampRoleService campRoleService, IUserServiceRead userService)
 {
     public async Task<CampCsvExport> BuildAsync()
     {

--- a/tests/Humans.Application.Tests/Architecture/IssuesArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/IssuesArchitectureTests.cs
@@ -44,8 +44,8 @@ public class IssuesArchitectureTests
         var ctor = typeof(IssuesService).GetConstructors().Single();
         var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
 
-        paramTypes.Should().Contain(typeof(IUserService),
-            because: "Issues resolves reporter / assignee / resolver / comment-sender display names via IUserService instead of cross-domain .Include() chains");
+        paramTypes.Should().Contain(typeof(IUserServiceRead),
+            because: "Issues resolves reporter / assignee / resolver / comment-sender display names via IUserServiceRead instead of taking the write-capable user service or using cross-domain .Include() chains");
         paramTypes.Should().Contain(typeof(IUserEmailService),
             because: "Issues resolves the reporter's effective notification email via IUserEmailService.GetNotificationTargetEmailsAsync — no User.UserEmails navigation");
         paramTypes.Should().Contain(typeof(IRoleAssignmentService),


### PR DESCRIPTION
## Summary
- adds `reforge.surface-score.json` with configured section ownership, canonical read DTOs, and narrowed entity/DTO classification
- renames the user-owned section to `Users` and maps every `src/Humans.Application/Services/*` folder to an owning section
- swaps four read-only consumers from write-capable services to read interfaces: `IUserServiceRead` / `ICampServiceRead`
- updates the Issues architecture test to enforce the read-service dependency
- upgrades the PR surface report to compare Reforge base/head JSON and show only non-zero total, section, and rule deltas
- replaces the old regex surface inventory with a scoped interface-surface comparison for new interfaces and added interface methods
- addresses review comments by removing broad/duplicate section ownership and not classifying executable ViewComponents as DTOs

## Verification
- `dotnet build Humans.slnx --disable-build-servers -v minimal` (passes; existing analyzer warnings remain)
- `dotnet test tests\Humans.Application.Tests\Humans.Application.Tests.csproj --disable-build-servers -v minimal --filter "FullyQualifiedName~IssuesService"`
- `dotnet test tests\Humans.Web.Tests\Humans.Web.Tests.csproj --no-build --disable-build-servers -v minimal --filter "FullyQualifiedName~TeamAdminController|FullyQualifiedName~CampCsvExportBuilder"` (no matching tests)
- `dotnet ef migrations has-pending-model-changes --project src\Humans.Infrastructure --startup-project src\Humans.Web --context HumansDbContext --no-build`
- `git diff --check`
- `python -m py_compile scripts/pr-surface-report.py`
- exact duplicate ownership check for config paths and service interfaces
- local PR report render with Reforge base/head JSON
- `reforge stop; reforge surface-score --solution Humans.slnx --format Json --top 20; reforge stop`

## Reforge Result
- total: `55841`
- configured sections: `30`
- `writeCapableInterfaceUsedReadOnly`: no findings
- duplicate exact path owners: no findings
- duplicate service-interface owners: no findings
- top sections: `Users 7555`, `Shifts 5263`, `Camps 3884`, `Teams 3602`, `(ungrouped) 3399`