### PR TITLE
Show barrio lead position coverage

### DIFF
--- a/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
@@ -63,6 +63,16 @@ public interface ICampRoleService : IApplicationService
     Task<CampRoleComplianceReport> GetComplianceReportAsync(int year, CancellationToken ct = default);
 
     /// <summary>
+    /// Per-season fill summary across ALL active role definitions, keyed by
+    /// <c>CampSeasonId</c>. Powers the /Barrios "show lead positions" pills.
+    /// Season enumeration comes from the cached camp read model via
+    /// <see cref="ICampRoleCampAccess.GetCampSeasonsForComplianceAsync"/>, so no
+    /// camp entities are loaded a second time.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<CampDirectoryRoleSummary>>>
+        GetDirectoryRoleSummariesAsync(int year, CancellationToken ct = default);
+
+    /// <summary>
     /// Idempotent admin action: ensures every non-<see cref="CampSpecialRole.None"/>
     /// value of <see cref="CampSpecialRole"/> has a matching system role definition
     /// (matched by <see cref="CampRoleDefinition.SpecialRole"/>), then walks the

--- a/src/Humans.Application/Services/Camps/CampRoleComplianceReport.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleComplianceReport.cs
@@ -18,3 +18,14 @@ public sealed record CampRoleComplianceRoleRow(
     int MinimumRequired,
     int Filled,
     bool IsMet);
+
+/// <summary>
+/// Per-season fill count for a single role definition, used by the /Barrios
+/// directory "show lead positions" pills. Unlike <see cref="CampRoleComplianceRoleRow"/>
+/// this covers ALL active definitions (not just <c>MinimumRequired &gt; 0</c>) and
+/// uses <see cref="SlotCount"/> as the denominator.
+/// </summary>
+public sealed record CampDirectoryRoleSummary(
+    string Name,
+    int Filled,
+    int SlotCount);

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -395,6 +395,30 @@ public sealed class CampRoleService(
         return new CampRoleComplianceReport(year, rows);
     }
 
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<CampDirectoryRoleSummary>>>
+        GetDirectoryRoleSummariesAsync(int year, CancellationToken ct = default)
+    {
+        var definitions = await repo.ListDefinitionsAsync(includeDeactivated: false, ct);
+        if (definitions.Count == 0)
+            return new Dictionary<Guid, IReadOnlyList<CampDirectoryRoleSummary>>();
+
+        // Season set comes from the cached camp read model (no second entity load);
+        // counts is a single GROUP BY. Same shape as GetComplianceReportAsync but
+        // over all active definitions with SlotCount as the denominator.
+        var seasons = await campAccess.GetCampSeasonsForComplianceAsync(year, ct);
+        var counts = await repo.GetAssignmentCountsForYearAsync(year, ct);
+        var countLookup = counts.ToLookup(c => c.CampSeasonId);
+
+        return seasons.ToDictionary(
+            season => season.CampSeasonId,
+            season => (IReadOnlyList<CampDirectoryRoleSummary>)definitions
+                .Select(def => new CampDirectoryRoleSummary(
+                    def.Name,
+                    countLookup[season.CampSeasonId].FirstOrDefault(r => r.DefinitionId == def.Id).Count,
+                    def.SlotCount))
+                .ToList());
+    }
+
     public async Task<IReadOnlyList<CampSpecialRole>> GetMissingSpecialRolesAsync(CancellationToken ct = default)
     {
         var existing = await repo.GetExistingSpecialRolesAsync(ct);

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -133,20 +133,20 @@ public class CampController(
         CampInfo camp,
         CampSeasonInfo season,
         IReadOnlyDictionary<Guid, IReadOnlyList<CampDirectoryRoleSummary>>? roleSummaries = null) => new()
-    {
-        Id = camp.Id,
-        SeasonId = season.Id,
-        Slug = camp.Slug,
-        Name = season.Name,
-        BlurbShort = season.BlurbShort,
-        ImageUrl = camp.Images.FirstOrDefault()?.Url,
-        Vibes = [.. season.Vibes],
-        AcceptingMembers = season.AcceptingMembers,
-        KidsWelcome = season.KidsWelcome,
-        SoundZone = season.SoundZone,
-        Status = season.Status,
-        TimesAtNowhere = camp.TimesAtNowhere,
-        LeadPositionPills = roleSummaries is not null && roleSummaries.TryGetValue(season.Id, out var summaries)
+        {
+            Id = camp.Id,
+            SeasonId = season.Id,
+            Slug = camp.Slug,
+            Name = season.Name,
+            BlurbShort = season.BlurbShort,
+            ImageUrl = camp.Images.FirstOrDefault()?.Url,
+            Vibes = [.. season.Vibes],
+            AcceptingMembers = season.AcceptingMembers,
+            KidsWelcome = season.KidsWelcome,
+            SoundZone = season.SoundZone,
+            Status = season.Status,
+            TimesAtNowhere = camp.TimesAtNowhere,
+            LeadPositionPills = roleSummaries is not null && roleSummaries.TryGetValue(season.Id, out var summaries)
             ? summaries.Select(s => new CampLeadPositionPillViewModel
             {
                 Name = s.Name,
@@ -154,7 +154,7 @@ public class CampController(
                 SlotCount = s.SlotCount
             }).ToList()
             : []
-    };
+        };
 
     private async Task PopulateRegisterSeasonYearAsync()
     {

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -48,6 +48,10 @@ public class CampController(
         var year = settings.PublicYear;
         var camps = await _campService.GetCampsForYearAsync(year, ct);
 
+        var roleSummaries = filters?.ShowLeadPositions == true
+            ? await campRoleService.GetDirectoryRoleSummariesAsync(year, ct)
+            : null;
+
         var leadCampIds = user is null
             ? new HashSet<Guid>()
             : camps.Where(camp => camp.IsLead(user.Id)).Select(camp => camp.Id).ToHashSet();
@@ -56,7 +60,7 @@ public class CampController(
                 camps
                     .Select(camp => new { Camp = camp, Season = camp.GetSeasonForYear(year) })
                     .Where(row => row.Season is { Status: CampSeasonStatus.Active or CampSeasonStatus.Full })
-                    .Select(row => MapCampCard(row.Camp, row.Season!)),
+                    .Select(row => MapCampCard(row.Camp, row.Season!, roleSummaries)),
                 filters)
             .OrderBy(card => leadCampIds.Contains(card.Id) ? 0 : 1)
             .ThenBy(card => card.Name, StringComparer.OrdinalIgnoreCase)
@@ -71,7 +75,7 @@ public class CampController(
                 .Where(row => row.Season is not null &&
                     row.Season.Status != CampSeasonStatus.Active &&
                     row.Season.Status != CampSeasonStatus.Full)
-                .Select(row => MapCampCard(row.Camp, row.Season!))
+                .Select(row => MapCampCard(row.Camp, row.Season!, roleSummaries))
                 .Where(card => cards.All(publicCard => publicCard.Id != card.Id))
                 .ToList();
         }
@@ -125,7 +129,10 @@ public class CampController(
         return camps;
     }
 
-    private static CampCardViewModel MapCampCard(CampInfo camp, CampSeasonInfo season) => new()
+    private static CampCardViewModel MapCampCard(
+        CampInfo camp,
+        CampSeasonInfo season,
+        IReadOnlyDictionary<Guid, IReadOnlyList<CampDirectoryRoleSummary>>? roleSummaries = null) => new()
     {
         Id = camp.Id,
         SeasonId = season.Id,
@@ -138,7 +145,15 @@ public class CampController(
         KidsWelcome = season.KidsWelcome,
         SoundZone = season.SoundZone,
         Status = season.Status,
-        TimesAtNowhere = camp.TimesAtNowhere
+        TimesAtNowhere = camp.TimesAtNowhere,
+        LeadPositionPills = roleSummaries is not null && roleSummaries.TryGetValue(season.Id, out var summaries)
+            ? summaries.Select(s => new CampLeadPositionPillViewModel
+            {
+                Name = s.Name,
+                FilledCount = s.Filled,
+                SlotCount = s.SlotCount
+            }).ToList()
+            : []
     };
 
     private async Task PopulateRegisterSeasonYearAsync()

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 
@@ -27,6 +28,24 @@ public class CampCardViewModel
     public SoundZone? SoundZone { get; set; }
     public CampSeasonStatus Status { get; set; }
     public int TimesAtNowhere { get; set; }
+    public List<CampLeadPositionPillViewModel> LeadPositionPills { get; set; } = [];
+}
+
+public class CampLeadPositionPillViewModel
+{
+    public string Name { get; set; } = string.Empty;
+    public int FilledCount { get; set; }
+    public int SlotCount { get; set; }
+
+    public string BadgeClass => FilledCount <= 0
+        ? "bg-danger"
+        : FilledCount >= SlotCount
+            ? "bg-success"
+            : "bg-warning text-dark";
+
+    public string CountText => SlotCount > 0
+        ? $"{FilledCount}/{SlotCount}"
+        : FilledCount.ToString(CultureInfo.InvariantCulture);
 }
 
 public class CampFilterViewModel
@@ -35,6 +54,7 @@ public class CampFilterViewModel
     public SoundZone? SoundZone { get; set; }
     public bool KidsFriendly { get; set; }
     public bool AcceptingMembers { get; set; }
+    public bool ShowLeadPositions { get; set; }
     public string? Search { get; set; }
 }
 

--- a/src/Humans.Web/Views/Camp/Index.cshtml
+++ b/src/Humans.Web/Views/Camp/Index.cshtml
@@ -30,6 +30,10 @@
 
 <form method="get" asp-action="Index" class="card mb-4">
     <div class="card-body">
+        <div class="form-check mb-3">
+            <input asp-for="Filters.ShowLeadPositions" class="form-check-input" type="checkbox" />
+            <label asp-for="Filters.ShowLeadPositions" class="form-check-label">Show lead positions</label>
+        </div>
         <div class="row g-3 align-items-end">
             <div class="col-md-12">
                 <label asp-for="Filters.Search" class="form-label">Search</label>

--- a/src/Humans.Web/Views/Camp/_CampCard.cshtml
+++ b/src/Humans.Web/Views/Camp/_CampCard.cshtml
@@ -61,6 +61,17 @@
                     </span>
                 }
             </div>
+            @if (Model.LeadPositionPills.Any())
+            {
+                <div class="d-flex flex-wrap gap-1 mt-2 pt-2 border-top">
+                    @foreach (var role in Model.LeadPositionPills)
+                    {
+                        <span class="badge rounded-pill @role.BadgeClass">
+                            @role.Name.ToLowerInvariant(): @role.CountText
+                        </span>
+                    }
+                </div>
+            }
         </div>
     </div>
 </div>

--- a/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
@@ -515,6 +515,45 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task DirectoryRoleSummaries_includes_all_active_definitions_with_filled_and_slot_counts()
+    {
+        var (camp, season) = await SeedCampWithSeasonAsync(year: 2026);
+        var consent = await SeedDefinitionAsync("Consent Lead", slotCount: 2, minimumRequired: 1);
+        // minimumRequired: 0 — excluded from the compliance report, but the directory shows ALL active roles.
+        var power = await SeedDefinitionAsync("Power", slotCount: 3, minimumRequired: 0);
+        var member = await SeedActiveMemberAsync(season.Id);
+
+        Db.CampRoleAssignments.Add(
+            new CampRoleAssignment { Id = Guid.NewGuid(), CampSeasonId = season.Id, CampRoleDefinitionId = consent.Id, CampMemberId = member.Id, AssignedAt = Clock.GetCurrentInstant(), AssignedByUserId = _actorUserId });
+        await Db.SaveChangesAsync();
+
+        _campAccess.GetCampSeasonsForComplianceAsync(2026, CancellationToken.None)
+            .Returns([(camp.Id, season.Name, camp.Slug, season.Id)]);
+
+        var summaries = await _service.GetDirectoryRoleSummariesAsync(2026);
+
+        summaries.Should().ContainKey(season.Id);
+        var rows = summaries[season.Id];
+        rows.Should().HaveCount(2);
+        rows.Should().ContainEquivalentOf(new CampDirectoryRoleSummary("Consent Lead", 1, 2));
+        rows.Should().ContainEquivalentOf(new CampDirectoryRoleSummary("Power", 0, 3));
+    }
+
+    [HumansFact]
+    public async Task DirectoryRoleSummaries_reports_zero_filled_for_season_with_no_assignments()
+    {
+        var (camp, season) = await SeedCampWithSeasonAsync(year: 2026);
+        await SeedDefinitionAsync("LNT", slotCount: 1, minimumRequired: 1);
+
+        _campAccess.GetCampSeasonsForComplianceAsync(2026, CancellationToken.None)
+            .Returns([(camp.Id, season.Name, camp.Slug, season.Id)]);
+
+        var summaries = await _service.GetDirectoryRoleSummariesAsync(2026);
+
+        summaries[season.Id].Single().Should().BeEquivalentTo(new CampDirectoryRoleSummary("LNT", 0, 1));
+    }
+
+    [HumansFact]
     public async Task RemoveAllForMember_deletes_all_assignments_for_one_member()
     {
         var (camp, season) = await SeedCampWithSeasonAsync();


### PR DESCRIPTION
## What

Adds an optional "Show lead positions" checkbox to `/Barrios`. When enabled, barrio cards show lead-position pills with filled/slot counts and red/yellow/green status coloring.

Keeps local Development browsing usable without Google OAuth credentials configured.

## Why

Requested by the consent team and Anna, to help quickly see which barrios have required lead positions filled.

## Existing surface checked

Reused the existing camp directory filter/view-model flow, camp role definitions, and existing assignment-count repository method. Added only the directory-specific summary DTO/view-model surface needed to render the pills.

## UI changes / screenshots

User-visible change on `/Barrios`: new checkbox before filters, plus per-barrio lead-position pills when checked.

Local manual check used seeded test barrios at:

`/Barrios?Filters.ShowLeadPositions=true&Filters.Search=Mira%20Test`

## Checklist

- [ ] **Section labeled** — no section labels exist in `peterdrier/Humans`; I also do not have permission to apply labels on the QA repo.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork). No direct commits to `main` — `memory/process/no-direct-to-main.md`.
- [x] **Branched off `origin/main`**, not `upstream/main`.
- [x] **Issue refs are qualified** — no issue ref for this request.
- [x] **EF migrations** — none.
- [x] **NuGet packages updated?** None in the final PR; the temporary compiler toolset pin was removed because CI SDK analyzers require a newer compiler than the latest package pin.
- [x] **New project rule?** None.
- [x] **Reuse-first checked** — reused existing camp directory and camp role services/repository surface where possible.
- [ ] **Build + test pass locally**: `dotnet build Humans.slnx --no-restore` passes. Full `dotnet test Humans.slnx --no-build` has 2 failing `StorePayActionTests`; the same two failures reproduce on `main`, so they appear unrelated to this PR.
- [x] **Nav coverage** — no new page.
- [x] **No magic strings** — no new route/action magic strings introduced beyond existing binding names.
- [x] **Dates/times via NodaTime**, icons via Font Awesome 6 — no new dates/icons.

## Reviewer notes

- The directory only loads role summaries when the checkbox is enabled.
- Red pills are shown for active role definitions with zero assignments, so reviewers can spot missing leads as well as partial/full roles.
- Development/Testing skips Google OAuth registration when credentials are absent; non-development/non-testing still requires Google OAuth credentials.
