### PR TITLE
Make budget amounts explicitly VAT/IVA-inclusive in the UI

### DIFF
--- a/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
@@ -60,11 +60,20 @@
 
 <vc:temp-data-alerts />
 
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+    <i class="fa-solid fa-triangle-exclamation fa-lg me-2"></i>
+    <div>
+        <strong>All amounts on this page include VAT / IVA.</strong>
+        Enter the gross figure you will actually pay or receive — the full amount including IVA. <strong>Do not subtract VAT.</strong>
+        The "VAT %" field only records the rate so the IVA portion can be broken out for projections; it does <em>not</em> add VAT on top of the amount you enter.
+    </div>
+</div>
+
 <div class="row mb-4">
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Allocated</h6>
+                <h6 class="card-subtitle mb-2 text-muted">Allocated <span class="text-muted">(incl. VAT/IVA)</span></h6>
                 <h3 class="card-title mb-0">&euro;@category.AllocatedAmount.ToString("N2")</h3>
             </div>
         </div>
@@ -116,7 +125,7 @@
                 <thead>
                     <tr>
                         <th>Description</th>
-                        <th class="text-end">Amount</th>
+                        <th class="text-end">Amount <small class="text-muted fw-normal">(incl. VAT/IVA)</small></th>
                         <th>VAT</th>
                         <th>Responsible Team</th>
                         <th>Notes</th>
@@ -186,7 +195,7 @@
                                             <input type="text" name="description" class="form-control form-control-sm" value="@item.Description" required />
                                         </div>
                                         <div class="col-md-2">
-                                            <label class="form-label form-label-sm">Amount (&euro;)</label>
+                                            <label class="form-label form-label-sm">Amount (&euro;, incl. VAT/IVA)</label>
                                             <input type="number" name="amount" class="form-control form-control-sm" step="0.01" value="@item.Amount" required />
                                         </div>
                                         <div class="col-md-1">
@@ -267,7 +276,7 @@
                     <input type="text" name="description" class="form-control form-control-sm" required />
                 </div>
                 <div class="col-md-2">
-                    <label class="form-label form-label-sm">Amount (&euro;)</label>
+                    <label class="form-label form-label-sm">Amount (&euro;, incl. VAT/IVA)</label>
                     <input type="number" name="amount" class="form-control form-control-sm" step="0.01" value="0" required />
                 </div>
                 <div class="col-md-1">

--- a/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
@@ -55,11 +55,20 @@
 
 <vc:temp-data-alerts />
 
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+    <i class="fa-solid fa-triangle-exclamation fa-lg me-2"></i>
+    <div>
+        <strong>All amounts on this page include VAT / IVA.</strong>
+        Enter the gross figure you will actually pay or receive — the full amount including IVA. <strong>Do not subtract VAT.</strong>
+        The "VAT %" field only records the rate so the IVA portion can be broken out for projections; it does <em>not</em> add VAT on top of the amount you enter.
+    </div>
+</div>
+
 <div class="row mb-4">
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Allocated</h6>
+                <h6 class="card-subtitle mb-2 text-muted">Allocated <span class="text-muted">(incl. VAT/IVA)</span></h6>
                 <h3 class="card-title mb-0">&euro;@Model.AllocatedAmount.ToString("N2")</h3>
             </div>
         </div>
@@ -97,7 +106,7 @@
                     <input type="text" name="name" class="form-control" value="@Model.Name" required />
                 </div>
                 <div class="col-md-3">
-                    <label class="form-label">Allocated Amount (&euro;)</label>
+                    <label class="form-label">Allocated Amount (&euro;, incl. VAT/IVA)</label>
                     <input type="number" name="allocatedAmount" class="form-control" step="0.01" value="@Model.AllocatedAmount" required />
                 </div>
                 <div class="col-md-3">
@@ -146,7 +155,7 @@
                 <thead>
                     <tr>
                         <th>Description</th>
-                        <th class="text-end">Amount</th>
+                        <th class="text-end">Amount <small class="text-muted fw-normal">(incl. VAT/IVA)</small></th>
                         <th>VAT</th>
                         <th>Responsible Team</th>
                         <th>Notes</th>
@@ -208,7 +217,7 @@
                                         <input type="text" name="description" class="form-control form-control-sm" value="@item.Description" required />
                                     </div>
                                     <div class="col-md-2">
-                                        <label class="form-label form-label-sm">Amount (&euro;)</label>
+                                        <label class="form-label form-label-sm">Amount (&euro;, incl. VAT/IVA)</label>
                                         <input type="number" name="amount" class="form-control form-control-sm" step="0.01" value="@item.Amount" required />
                                     </div>
                                     <div class="col-md-1">
@@ -281,7 +290,7 @@
                 <input type="text" name="description" class="form-control form-control-sm" required />
             </div>
             <div class="col-md-2">
-                <label class="form-label form-label-sm">Amount (&euro;)</label>
+                <label class="form-label form-label-sm">Amount (&euro;, incl. VAT/IVA)</label>
                 <input type="number" name="amount" class="form-control form-control-sm" step="0.01" value="0" required />
             </div>
             <div class="col-md-1">

--- a/src/Humans.Web/Views/Finance/YearDetail.cshtml
+++ b/src/Humans.Web/Views/Finance/YearDetail.cshtml
@@ -477,7 +477,7 @@
                                 <input type="text" name="name" class="form-control form-control-sm" required />
                             </div>
                             <div class="col-md-3">
-                                <label class="form-label form-label-sm">Allocated Amount (&euro;)</label>
+                                <label class="form-label form-label-sm">Allocated Amount (&euro;, incl. VAT/IVA)</label>
                                 <input type="number" name="allocatedAmount" class="form-control form-control-sm" step="0.01" value="0" required />
                             </div>
                             <div class="col-md-3">


### PR DESCRIPTION
## Summary
- Budgets were drifting ~21% in some departments because people entered **net (ex-VAT)** figures into amount fields that are actually **gross / VAT-inclusive**.
- Added a prominent warning banner at the top of both budget category pages stating all amounts include VAT/IVA and not to subtract VAT.
- Suffixed every money label and the "Amount" column header with `(incl. VAT/IVA)` across:
  - `/Finance/Categories/{id}` (Finance/CategoryDetail) — allocated card, edit form, add/edit line-item labels, column header
  - `/Budget/Category/{id}` (coordinator Budget/CategoryDetail) — same surfaces (this is where coordinators enter most line items)
  - `/Finance/Years/{id}` create-category form allocated-amount label

No logic changes — the data was always stored gross (VAT projection extracts VAT *out of* the amount); this only makes that explicit to users.

## Test plan
- [ ] Open `/Finance/Categories/{id}` — banner shows; "Allocated", column header, and both Amount inputs read "incl. VAT/IVA"
- [ ] Open `/Budget/Category/{id}` as a coordinator — same labels + banner
- [ ] Open `/Finance/Years/{id}` — create-category "Allocated Amount" label reads "incl. VAT/IVA"

🤖 Generated with [Claude Code](https://claude.com/claude-code)