### PR TITLE
Add per-period Has Shift mailer audiences (Setup/Event/Strike)

### DIFF
--- a/docs/architecture/service-data-access-map.md
+++ b/docs/architecture/service-data-access-map.md
@@ -1423,8 +1423,10 @@ cache.
 ### Audience definitions (`IMailerAudience`)
 
 Audience-membership computation classes under `Mailer/Audiences/`:
-`HasShiftAudience`, `HasTicketAudience`, `MarketingAudience`,
-`MarketingNoTicketAudience`, `TicketNoShiftsAudience`, `MailerAudienceBase`.
+`HasShiftAudience`, `HasShiftSetupAudience`, `HasShiftEventAudience`,
+`HasShiftStrikeAudience`, `HasTicketAudience`, `MarketingAudience`,
+`MarketingNoTicketAudience`, `TicketNoShiftsAudience`, `MailerAudienceBase`,
+`HasShiftInPeriodAudienceBase`.
 No repository; compute over read-split / section service interfaces
 (`ITicketServiceRead`, `IShiftSignupService`, `IShiftManagementService`,
 etc.). No direct DB access, no cache.

--- a/docs/sections/Mailer.md
+++ b/docs/sections/Mailer.md
@@ -66,7 +66,7 @@ All routes are `AdminOnly`.
 - **Profiles**: reads `IUserEmailService.FindVerifiedEmailWithUserAsync`, `FindAnyUserIdByEmailAsync`, `DeleteEmailAsync`, `GetPrimaryEmailsByUserIdsAsync`; reads/writes `ICommunicationPreferenceService.GetAsync` / `UpdatePreferenceAsync` / `GetCountByCategoryAndStateAsync`.
 - **Users**: writes via `IAccountProvisioningService.FindOrCreateUserByEmailAsync`; reads `IUserService.GetByIdAsync` (tombstone follow), `IUserService.GetCountByContactSourceAsync`.
 - **Tickets**: `ITicketServiceRead.GetTicketOrdersAsync` — audience-side ticket-holder enumeration for `TicketNoShiftsAudience`, `HasTicketAudience`, and `MarketingNoTicketAudience` is derived from the current-event `TicketOrderInfo` projection.
-- **Shifts**: `IShiftView.GetUsersAsync` + `IUserService.GetAllUserInfosAsync` — cached per-user shift signups, used by `TicketNoShiftsAudience` and `HasShiftAudience` (encode Pending/Confirmed-on-active-event via `ShiftUserView.HasShift`).
+- **Shifts**: `IShiftView.GetUsersAsync` + `IUserService.GetAllUserInfosAsync` — cached per-user shift signups, used by `TicketNoShiftsAudience` and `HasShiftAudience` (encode Pending/Confirmed-on-active-event via `ShiftUserView.HasShift`). The per-period `HasShiftSetupAudience` / `HasShiftEventAudience` / `HasShiftStrikeAudience` add the shift's `DayOffset`-derived period via `ShiftUserView.HasShiftInPeriod` (Setup = Build).
 - **Users**: `IUserService.GetAllUserInfosAsync` — read by `MailerAudienceBase` to drop explicit Marketing opt-outs from *every* audience, and by `MarketingAudience` / `MarketingNoTicketAudience` to enumerate explicit opt-ins (`UserInfo.MarketingOptedOut == false`).
 - **AuditLog**: writes via `IAuditLogService.LogAsync` (job overload).
 

--- a/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
+++ b/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
@@ -35,6 +35,17 @@ public sealed record ShiftUserView(
         s.Status is SignupStatus.Pending or SignupStatus.Confirmed);
 
     /// <summary>
+    /// True when the user has at least one active signup (Pending/Confirmed) on
+    /// a shift classified into the given <paramref name="period"/>. Each shift's
+    /// period is derived from its <see cref="Shift.DayOffset"/> against the
+    /// loaded <c>Rota.EventSettings</c> (Build = before gates open, Event =
+    /// during, Strike = after) via <see cref="Shift.GetShiftPeriod"/>.
+    /// </summary>
+    public bool HasShiftInPeriod(ShiftPeriod period) => Signups.Any(s =>
+        s.Status is SignupStatus.Pending or SignupStatus.Confirmed
+        && s.Shift.GetShiftPeriod(s.Shift.Rota.EventSettings) == period);
+
+    /// <summary>
     /// Empty view returned for unknown ids / no active event.
     /// </summary>
     public static ShiftUserView Empty(Guid userId) => new(

--- a/src/Humans.Application/Services/Mailer/Audiences/HasShiftEventAudience.cs
+++ b/src/Humans.Application/Services/Mailer/Audiences/HasShiftEventAudience.cs
@@ -1,0 +1,20 @@
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Mailer.Audiences;
+
+/// <summary>
+/// "Humans - Has Shift - Event" — humans with at least one Pending/Confirmed
+/// signup on an Event-period shift (during the event) in the active event.
+/// </summary>
+public sealed class HasShiftEventAudience(
+    IShiftView shiftView,
+    IUserServiceRead users) : HasShiftInPeriodAudienceBase(shiftView, users)
+{
+    public override string Key => "has-shift-event";
+    public override string DisplayName => "Volunteers with an event shift";
+    public override string MailerLiteGroupName => "Humans - Has Shift - Event";
+
+    protected override ShiftPeriod Period => ShiftPeriod.Event;
+}

--- a/src/Humans.Application/Services/Mailer/Audiences/HasShiftInPeriodAudienceBase.cs
+++ b/src/Humans.Application/Services/Mailer/Audiences/HasShiftInPeriodAudienceBase.cs
@@ -1,0 +1,31 @@
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Mailer.Audiences;
+
+/// <summary>
+/// Base for the per-period "Has Shift" audiences. Membership is every human
+/// with at least one Pending/Confirmed signup on a shift in <see cref="Period"/>
+/// of the active event, surfaced via the cached <see cref="IShiftView"/>
+/// (<see cref="DTOs.Shifts.ShiftUserView.HasShiftInPeriod"/>). Subclasses supply
+/// the period plus the audience metadata.
+/// </summary>
+public abstract class HasShiftInPeriodAudienceBase(
+    IShiftView shiftView,
+    IUserServiceRead users) : MailerAudienceBase(users)
+{
+    /// <summary>The shift period this audience targets.</summary>
+    protected abstract ShiftPeriod Period { get; }
+
+    protected override async Task<IReadOnlySet<Guid>> ComputeRawMemberUserIdsAsync(CancellationToken ct)
+    {
+        var allUsers = await Users.GetAllUserInfosAsync(ct);
+        var ids = allUsers.Select(u => u.Id).ToList();
+        var views = await shiftView.GetUsersAsync(ids, ct);
+        return views
+            .Where(kv => kv.Value.HasShiftInPeriod(Period))
+            .Select(kv => kv.Key)
+            .ToHashSet();
+    }
+}

--- a/src/Humans.Application/Services/Mailer/Audiences/HasShiftSetupAudience.cs
+++ b/src/Humans.Application/Services/Mailer/Audiences/HasShiftSetupAudience.cs
@@ -1,0 +1,20 @@
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Mailer.Audiences;
+
+/// <summary>
+/// "Humans - Has Shift - Setup" — humans with at least one Pending/Confirmed
+/// signup on a Build-period shift (before gates open) in the active event.
+/// </summary>
+public sealed class HasShiftSetupAudience(
+    IShiftView shiftView,
+    IUserServiceRead users) : HasShiftInPeriodAudienceBase(shiftView, users)
+{
+    public override string Key => "has-shift-setup";
+    public override string DisplayName => "Volunteers with a setup shift";
+    public override string MailerLiteGroupName => "Humans - Has Shift - Setup";
+
+    protected override ShiftPeriod Period => ShiftPeriod.Build;
+}

--- a/src/Humans.Application/Services/Mailer/Audiences/HasShiftStrikeAudience.cs
+++ b/src/Humans.Application/Services/Mailer/Audiences/HasShiftStrikeAudience.cs
@@ -1,0 +1,20 @@
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Mailer.Audiences;
+
+/// <summary>
+/// "Humans - Has Shift - Strike" — humans with at least one Pending/Confirmed
+/// signup on a Strike-period shift (after the event ends) in the active event.
+/// </summary>
+public sealed class HasShiftStrikeAudience(
+    IShiftView shiftView,
+    IUserServiceRead users) : HasShiftInPeriodAudienceBase(shiftView, users)
+{
+    public override string Key => "has-shift-strike";
+    public override string DisplayName => "Volunteers with a strike shift";
+    public override string MailerLiteGroupName => "Humans - Has Shift - Strike";
+
+    protected override ShiftPeriod Period => ShiftPeriod.Strike;
+}

--- a/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
@@ -50,6 +50,9 @@ internal static class MailerSectionExtensions
         services.AddScoped<IMailerAudienceSyncService, MailerAudienceSyncService>();
         services.AddScoped<IMailerAudience, TicketNoShiftsAudience>();
         services.AddScoped<IMailerAudience, HasShiftAudience>();
+        services.AddScoped<IMailerAudience, HasShiftSetupAudience>();
+        services.AddScoped<IMailerAudience, HasShiftEventAudience>();
+        services.AddScoped<IMailerAudience, HasShiftStrikeAudience>();
         services.AddScoped<IMailerAudience, HasTicketAudience>();
         services.AddScoped<IMailerAudience, MarketingAudience>();
         services.AddScoped<IMailerAudience, MarketingNoTicketAudience>();

--- a/tests/Humans.Application.Tests/Services/Mailer/Audiences/HasShiftInPeriodAudienceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/Audiences/HasShiftInPeriodAudienceTests.cs
@@ -1,0 +1,137 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs.Shifts;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Mailer.Audiences;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Mailer.Audiences;
+
+public class HasShiftInPeriodAudienceTests
+{
+    private const int EventEndOffset = 5;
+
+    [HumansFact]
+    public async Task SetupAudience_ReturnsOnlyUsersWithActiveBuildPeriodShift()
+    {
+        var build = Guid.NewGuid();   // DayOffset -3, Confirmed → IN
+        var @event = Guid.NewGuid();  // DayOffset  2, Confirmed → OUT
+        var strike = Guid.NewGuid();  // DayOffset  8, Confirmed → OUT
+        var bailed = Guid.NewGuid();  // DayOffset -3, Bailed    → OUT
+        var none = Guid.NewGuid();    // no signups              → OUT
+
+        var views = new Dictionary<Guid, ShiftUserView>
+        {
+            [build] = ViewWith(build, -3, SignupStatus.Confirmed),
+            [@event] = ViewWith(@event, 2, SignupStatus.Confirmed),
+            [strike] = ViewWith(strike, 8, SignupStatus.Confirmed),
+            [bailed] = ViewWith(bailed, -3, SignupStatus.Bailed),
+            [none] = ShiftUserView.Empty(none),
+        };
+
+        var members = await NewAudience<HasShiftSetupAudience>(views)
+            .ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEquivalentTo([build]);
+    }
+
+    [HumansFact]
+    public async Task EventAudience_ReturnsOnlyUsersWithActiveEventPeriodShift()
+    {
+        var build = Guid.NewGuid();
+        var @event = Guid.NewGuid();
+        var strike = Guid.NewGuid();
+
+        var views = new Dictionary<Guid, ShiftUserView>
+        {
+            [build] = ViewWith(build, -3, SignupStatus.Pending),
+            [@event] = ViewWith(@event, 2, SignupStatus.Pending),
+            [strike] = ViewWith(strike, 8, SignupStatus.Pending),
+        };
+
+        var members = await NewAudience<HasShiftEventAudience>(views)
+            .ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEquivalentTo([@event]);
+    }
+
+    [HumansFact]
+    public async Task StrikeAudience_ReturnsOnlyUsersWithActiveStrikePeriodShift()
+    {
+        var build = Guid.NewGuid();
+        var @event = Guid.NewGuid();
+        var strike = Guid.NewGuid();
+
+        var views = new Dictionary<Guid, ShiftUserView>
+        {
+            [build] = ViewWith(build, -3, SignupStatus.Confirmed),
+            [@event] = ViewWith(@event, 5, SignupStatus.Confirmed),
+            [strike] = ViewWith(strike, 8, SignupStatus.Confirmed),
+        };
+
+        var members = await NewAudience<HasShiftStrikeAudience>(views)
+            .ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEquivalentTo([strike]);
+    }
+
+    [HumansFact]
+    public void Metadata_KeysGroupNamesAndPrefix()
+    {
+        var empty = new Dictionary<Guid, ShiftUserView>();
+
+        var setup = NewAudience<HasShiftSetupAudience>(empty);
+        setup.Key.Should().Be("has-shift-setup");
+        setup.MailerLiteGroupName.Should().Be("Humans - Has Shift - Setup");
+
+        var @event = NewAudience<HasShiftEventAudience>(empty);
+        @event.Key.Should().Be("has-shift-event");
+        @event.MailerLiteGroupName.Should().Be("Humans - Has Shift - Event");
+
+        var strike = NewAudience<HasShiftStrikeAudience>(empty);
+        strike.Key.Should().Be("has-shift-strike");
+        strike.MailerLiteGroupName.Should().Be("Humans - Has Shift - Strike");
+    }
+
+    private static TAudience NewAudience<TAudience>(IReadOnlyDictionary<Guid, ShiftUserView> viewsByUser)
+        where TAudience : HasShiftInPeriodAudienceBase
+    {
+        var users = Substitute.For<IUserService>();
+        users.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(viewsByUser.Keys
+                .Select(id => new User { Id = id }.ToUserInfo())
+                .ToList());
+
+        var shiftView = Substitute.For<IShiftView>();
+        shiftView.GetUsersAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, ShiftUserView>>(viewsByUser));
+
+        return (TAudience)Activator.CreateInstance(typeof(TAudience), shiftView, users)!;
+    }
+
+    private static ShiftUserView ViewWith(Guid userId, int dayOffset, SignupStatus status)
+    {
+        var eventSettings = new EventSettings { Id = Guid.NewGuid(), EventEndOffset = EventEndOffset };
+        return new ShiftUserView(
+            UserId: userId,
+            Profile: null,
+            Availability: null,
+            BuildStatus: null,
+            TagPreferences: [],
+            Signups: [new ShiftSignup
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ShiftId = Guid.NewGuid(),
+                Status = status,
+                Shift = new Shift
+                {
+                    DayOffset = dayOffset,
+                    Rota = new Rota { EventSettings = eventSettings },
+                },
+            }]);
+    }
+}


### PR DESCRIPTION
## Summary
- Splits the existing **Humans - Has Shift** MailerLite audience into three day-based period variants: **Setup**, **Event**, **Strike**, so the org can email volunteers by when they work.
- Period is the **day-based `ShiftPeriod`** (computed from each shift's `DayOffset` vs the loaded `EventSettings`): Setup = Build (before gates), Event = during, Strike = after.
- New `ShiftUserView.HasShiftInPeriod(period)` mirrors the existing `HasShift` (active Pending/Confirmed signups only) and reuses `Shift.GetShiftPeriod`. `EventSettings` is already eager-loaded on each signup's `Shift.Rota`, so nothing new leaks out of the Shifts section — no new cross-section surface.
- Three thin audiences over a shared `HasShiftInPeriodAudienceBase`, registered alongside the others; auto-discovered by the existing arch tests (unique key/group-name, `Humans - ` prefix).

## Group names
- `Humans - Has Shift - Setup`
- `Humans - Has Shift - Event`
- `Humans - Has Shift - Strike`

The original `Humans - Has Shift` (any period) is unchanged.

## Test plan
- [x] `dotnet build Humans.slnx` — 0 errors
- [x] `dotnet test ... --filter ~Mailer` — 85 passed (incl. `AllAudiences_UseHumansPrefix`, `AllAudiences_HaveUniqueGroupNamesAndKeys`)
- [x] New `HasShiftInPeriodAudienceTests` cover Build/Event/Strike partitioning, active-status exclusion (Bailed), and metadata
- [ ] After deploy: sync each new group and spot-check membership against shift sign-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)