### PR TITLE
Add running-count column to Early Entry roster

### DIFF
--- a/src/Humans.Web/Views/EarlyEntryRoster/Index.cshtml
+++ b/src/Humans.Web/Views/EarlyEntryRoster/Index.cshtml
@@ -15,12 +15,15 @@ else
 {
     <table class="table table-sm">
         <thead>
-            <tr><th>Human</th><th>Enters</th><th>Source(s)</th><th></th></tr>
+            <tr><th class="text-end">#</th><th>Human</th><th>Enters</th><th>Source(s)</th><th></th></tr>
         </thead>
         <tbody>
+        @{ var count = 0; }
         @foreach (var row in Model.Rows)
         {
+            count++;
             <tr class="@(row.HasMultiple ? "table-warning" : "")">
+                <td class="text-end text-muted">@count</td>
                 <td><vc:human user-id="@row.UserId" layout="AvatarName" size="32" /></td>
                 <td>@row.EarliestEntryDate.ToString("ddd d MMM", null)</td>
                 <td>@string.Join(", ", row.Sources)</td>


### PR DESCRIPTION
## Summary
- Adds a leftmost `#` column to the Early Entry roster table (`/Shifts/Admin/EarlyEntry`).
- The number is a running per-row count. Because the roster is already ordered by earliest-entry date, it doubles as the cumulative head count of everyone entering up to and including that row — an easy "how many people by this point" read.
- View-only change (`Index.cshtml`); ordering and data untouched.

## Test plan
- [x] `dotnet build src/Humans.Web` — 0 errors
- [ ] After preview deploy: open `/Shifts/Admin/EarlyEntry`, confirm the `#` column counts 1..N down the rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)