### PR TITLE
feat(auth): collect burner + legal name at signup instead of DisplayName

### DIFF
--- a/src/Humans.Application/Interfaces/Users/IAccountProvisioningService.cs
+++ b/src/Humans.Application/Interfaces/Users/IAccountProvisioningService.cs
@@ -26,12 +26,15 @@ public interface IAccountProvisioningService : IApplicationService
     /// <summary>
     /// Completes a magic-link signup after the Auth section has verified the
     /// signup token. Idempotently signs in the existing verified-email owner
-    /// on double submit, otherwise creates User + verified UserEmail + stub
-    /// Profile and rolls back the User if the email row cannot be created.
+    /// on double submit, otherwise creates User + verified UserEmail + a stub
+    /// Profile seeded with the member's burner and legal names, rolling back
+    /// the User if the email row cannot be created.
     /// </summary>
     Task<MagicLinkSignupCompletionResult> CompleteMagicLinkSignupAsync(
         string email,
-        string? displayName,
+        string burnerName,
+        string firstName,
+        string lastName,
         CancellationToken ct = default);
 }
 

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -175,9 +175,16 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
 
     /// <summary>
     /// Idempotently materializes a stub profile for a live user. Returns true
-    /// only when a profile row was created.
+    /// only when a profile row was created. When provided, seeds the stub with
+    /// the member's burner and legal names (the magic-link signup path); import
+    /// callers omit them and create an empty stub.
     /// </summary>
-    Task<bool> EnsureStubProfileAsync(Guid userId, CancellationToken ct = default);
+    Task<bool> EnsureStubProfileAsync(
+        Guid userId,
+        string? burnerName = null,
+        string? firstName = null,
+        string? lastName = null,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Updates <see cref="Profile.MembershipTier"/> on the user's profile.

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -137,11 +137,6 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
         Guid userId, GoogleEmailStatus status, CancellationToken ct = default);
 
     /// <summary>
-    /// Updates <c>User.DisplayName</c>. No-op if the user does not exist.
-    /// </summary>
-    Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default);
-
-    /// <summary>
     /// Sets <c>User.PreferredLanguage</c>. Invalidates the UserInfo cache on
     /// success. No-op if the user does not exist.
     /// </summary>

--- a/src/Humans.Application/Services/Users/AccountProvisioningService.cs
+++ b/src/Humans.Application/Services/Users/AccountProvisioningService.cs
@@ -84,7 +84,8 @@ public sealed class AccountProvisioningService(
         await userEmailService.AddProvisionedEmailAsync(newUser.Id, email, ct);
 
         // see #635 (§15i) — Stub Profile invariant; UserService owns UserInfo storage/cache.
-        await userService.EnsureStubProfileAsync(newUser.Id, ct);
+        // Import path seeds no names; the empty stub is filled in during onboarding.
+        await userService.EnsureStubProfileAsync(newUser.Id, ct: ct);
 
         await auditLogService.LogAsync(
             AuditAction.ContactCreated,
@@ -101,10 +102,15 @@ public sealed class AccountProvisioningService(
 
     public async Task<MagicLinkSignupCompletionResult> CompleteMagicLinkSignupAsync(
         string email,
-        string? displayName,
+        string burnerName,
+        string firstName,
+        string lastName,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(burnerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(firstName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(lastName);
 
         var existingEmail = await userEmailService.FindVerifiedEmailWithUserAsync(email, ct);
         if (existingEmail is not null)
@@ -128,11 +134,11 @@ public sealed class AccountProvisioningService(
         }
 
         var now = clock.GetCurrentInstant();
-#pragma warning disable HUM_USER_DISPLAYNAME // Magic-link signup seeds the legacy Identity fallback column.
+#pragma warning disable HUM_USER_DISPLAYNAME // Sanctioned creation-time BurnerName fallback (memory/architecture/burnername-is-the-display-name.md).
         var user = new User
         {
             Id = Guid.NewGuid(),
-            DisplayName = string.IsNullOrWhiteSpace(displayName) ? email : displayName.Trim(),
+            DisplayName = burnerName.Trim(),
             CreatedAt = now,
             LastLoginAt = now
         };
@@ -165,7 +171,8 @@ public sealed class AccountProvisioningService(
                 User: null);
         }
 
-        await userService.EnsureStubProfileAsync(user.Id, ct);
+        await userService.EnsureStubProfileAsync(
+            user.Id, burnerName.Trim(), firstName.Trim(), lastName.Trim(), ct);
 
         logger.LogInformation(
             "Magic link signup: user {UserId} created account for {Email}",

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -315,7 +315,12 @@ public sealed class UserService(
         return await repo.ClearDeletionAsync(userId, ct);
     }
 
-    public async Task<bool> EnsureStubProfileAsync(Guid userId, CancellationToken ct = default)
+    public async Task<bool> EnsureStubProfileAsync(
+        Guid userId,
+        string? burnerName = null,
+        string? firstName = null,
+        string? lastName = null,
+        CancellationToken ct = default)
     {
         var gate = ProfileStubLockFor(userId);
         await gate.WaitAsync(ct).ConfigureAwait(false);
@@ -344,6 +349,9 @@ public sealed class UserService(
                 CreatedAt = now,
                 UpdatedAt = now,
                 State = ProfileState.Stub,
+                BurnerName = (burnerName ?? string.Empty).Trim(),
+                FirstName = (firstName ?? string.Empty).Trim(),
+                LastName = (lastName ?? string.Empty).Trim(),
             };
 
             await repo.AddAsync(profile, ct);

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -286,11 +286,6 @@ public sealed class UserService(
         return await repo.SetGoogleEmailStatusAsync(userId, status, ct);
     }
 
-    public async Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default)
-    {
-        await repo.UpdateDisplayNameAsync(userId, displayName, ct);
-    }
-
     public async Task SetPreferredLanguageAsync(Guid userId, string preferredLanguage, CancellationToken ct = default)
     {
         await repo.SetPreferredLanguageAsync(userId, preferredLanguage, ct);

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -343,11 +343,14 @@ public sealed class UserService(
                 UserId = userId,
                 CreatedAt = now,
                 UpdatedAt = now,
-                State = ProfileState.Stub,
                 BurnerName = (burnerName ?? string.Empty).Trim(),
                 FirstName = (firstName ?? string.Empty).Trim(),
                 LastName = (lastName ?? string.Empty).Trim(),
             };
+
+            // Seeded names (magic-link signup) promote straight to Active, mirroring
+            // SaveProfileAsync; import/OAuth paths pass no names and stay Stub. see #635 / #812.
+            profile.State = HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
 
             await repo.AddAsync(profile, ct);
             return true;

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -686,12 +686,6 @@ public sealed class CachingUserService(
         return result;
     }
 
-    public async Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default)
-    {
-        await WithInnerAsync(inner => inner.UpdateDisplayNameAsync(userId, displayName, ct));
-        await RefreshEntryAsync(userId, ct);
-    }
-
     public async Task SetPreferredLanguageAsync(Guid userId, string preferredLanguage, CancellationToken ct = default)
     {
         await WithInnerAsync(inner => inner.SetPreferredLanguageAsync(userId, preferredLanguage, ct));

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -721,9 +721,15 @@ public sealed class CachingUserService(
         return updated;
     }
 
-    public async Task<bool> EnsureStubProfileAsync(Guid userId, CancellationToken ct = default)
+    public async Task<bool> EnsureStubProfileAsync(
+        Guid userId,
+        string? burnerName = null,
+        string? firstName = null,
+        string? lastName = null,
+        CancellationToken ct = default)
     {
-        var created = await WithInnerAsync(inner => inner.EnsureStubProfileAsync(userId, ct));
+        var created = await WithInnerAsync(inner =>
+            inner.EnsureStubProfileAsync(userId, burnerName, firstName, lastName, ct));
         if (created) await RefreshEntryAsync(userId, ct);
         return created;
     }

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -463,6 +463,9 @@ public class AccountController(
             ViewData["ReturnUrl"] = returnUrl;
             ViewData["Email"] = verifiedEmail;
             ViewData["Token"] = token;
+            ViewData["BurnerName"] = burnerName;
+            ViewData["FirstName"] = firstName;
+            ViewData["LastName"] = lastName;
             ModelState.AddModelError(string.Empty, localizer["CompleteSignup_AllFieldsRequired"]);
             return View("CompleteSignup");
         }

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -441,7 +441,9 @@ public class AccountController(
 
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> CompleteSignup(string token, string displayName, string? email = null, string? returnUrl = null)
+    public async Task<IActionResult> CompleteSignup(
+        string token, string burnerName, string firstName, string lastName,
+        string? email = null, string? returnUrl = null)
     {
         if (string.IsNullOrEmpty(token))
             return View("MagicLinkError");
@@ -454,9 +456,22 @@ public class AccountController(
             return View("MagicLinkError");
         }
 
+        if (string.IsNullOrWhiteSpace(burnerName) ||
+            string.IsNullOrWhiteSpace(firstName) ||
+            string.IsNullOrWhiteSpace(lastName))
+        {
+            ViewData["ReturnUrl"] = returnUrl;
+            ViewData["Email"] = verifiedEmail;
+            ViewData["Token"] = token;
+            ModelState.AddModelError(string.Empty, localizer["CompleteSignup_AllFieldsRequired"]);
+            return View("CompleteSignup");
+        }
+
         var result = await accountProvisioningService.CompleteMagicLinkSignupAsync(
             verifiedEmail,
-            displayName,
+            burnerName,
+            firstName,
+            lastName,
             HttpContext.RequestAborted);
 
 #pragma warning disable CS0618 // result.User is a record field on MagicLinkSignupCompletionResult, not a cross-domain nav read; arch test pattern-matches the literal `.User`.

--- a/src/Humans.Web/Controllers/ProfileBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileBackfillAdminController.cs
@@ -35,7 +35,7 @@ public sealed class ProfileBackfillAdminController(
         foreach (var row in missing)
         {
             // Idempotent — UserService takes a per-userId lock around the get/add pair.
-            await userService.EnsureStubProfileAsync(row.UserId, ct);
+            await userService.EnsureStubProfileAsync(row.UserId, ct: ct);
         }
 
         logger.LogInformation(

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -3250,8 +3250,26 @@
   <data name="CompleteSignup_Title" xml:space="preserve">
     <value>Completa el teu registre</value>
   </data>
-  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve">
-    <value>Nom per mostra</value>
+  <data name="CompleteSignup_BurnerNameLabel" xml:space="preserve">
+    <value>Nom burner</value>
+  </data>
+  <data name="CompleteSignup_BurnerNameHelp" xml:space="preserve">
+    <value>És el nom que tothom veurà a Humans. Fes servir el que utilitzis a la comunitat.</value>
+  </data>
+  <data name="CompleteSignup_FirstNameLabel" xml:space="preserve">
+    <value>Nom legal</value>
+  </data>
+  <data name="CompleteSignup_LastNameLabel" xml:space="preserve">
+    <value>Cognoms legals</value>
+  </data>
+  <data name="CompleteSignup_LegalNameNote" xml:space="preserve">
+    <value>Et demanem el teu nom legal per saber qui és qui darrere dels noms burner, i perquè puguis signar l'acord de voluntariat més endavant. Només és visible per als administradors dins de Humans, mai es comparteix fora de l'aplicació, i a la resta de llocs sempre se't mostrarà amb el teu nom burner.</value>
+  </data>
+  <data name="CompleteSignup_PrivacyLink" xml:space="preserve">
+    <value>Llegeix la nostra política de privacitat</value>
+  </data>
+  <data name="CompleteSignup_AllFieldsRequired" xml:space="preserve">
+    <value>Si us plau, omple el teu nom burner i el teu nom i cognoms legals.</value>
   </data>
   <data name="CompleteSignup_Submit" xml:space="preserve">
     <value>Crea un compte</value>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -3250,8 +3250,26 @@
   <data name="CompleteSignup_Title" xml:space="preserve">
     <value>Registrierung abschließen</value>
   </data>
-  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve">
-    <value>Anzeigename</value>
+  <data name="CompleteSignup_BurnerNameLabel" xml:space="preserve">
+    <value>Burner-Name</value>
+  </data>
+  <data name="CompleteSignup_BurnerNameHelp" xml:space="preserve">
+    <value>Das ist der Name, den alle in Humans sehen. Verwende den Namen, unter dem du in der Community bekannt bist.</value>
+  </data>
+  <data name="CompleteSignup_FirstNameLabel" xml:space="preserve">
+    <value>Rechtlicher Vorname</value>
+  </data>
+  <data name="CompleteSignup_LastNameLabel" xml:space="preserve">
+    <value>Rechtlicher Nachname</value>
+  </data>
+  <data name="CompleteSignup_LegalNameNote" xml:space="preserve">
+    <value>Wir fragen nach deinem rechtlichen Namen, damit wir wissen, wer hinter den Burner-Namen steht, und damit du später die Freiwilligenvereinbarung unterschreiben kannst. Er ist nur für Administratoren innerhalb von Humans sichtbar, wird niemals außerhalb der App geteilt, und überall sonst wirst du nur mit deinem Burner-Namen angezeigt.</value>
+  </data>
+  <data name="CompleteSignup_PrivacyLink" xml:space="preserve">
+    <value>Datenschutzerklärung lesen</value>
+  </data>
+  <data name="CompleteSignup_AllFieldsRequired" xml:space="preserve">
+    <value>Bitte gib deinen Burner-Namen sowie deinen rechtlichen Vor- und Nachnamen ein.</value>
   </data>
   <data name="CompleteSignup_Submit" xml:space="preserve">
     <value>Konto erstellen</value>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -3250,8 +3250,26 @@
   <data name="CompleteSignup_Title" xml:space="preserve">
     <value>Completa tu registro</value>
   </data>
-  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve">
-    <value>Nombre para mostrar</value>
+  <data name="CompleteSignup_BurnerNameLabel" xml:space="preserve">
+    <value>Nombre burner</value>
+  </data>
+  <data name="CompleteSignup_BurnerNameHelp" xml:space="preserve">
+    <value>Es el nombre que todos verán en Humans. Usa el que utilices en la comunidad.</value>
+  </data>
+  <data name="CompleteSignup_FirstNameLabel" xml:space="preserve">
+    <value>Nombre legal</value>
+  </data>
+  <data name="CompleteSignup_LastNameLabel" xml:space="preserve">
+    <value>Apellidos legales</value>
+  </data>
+  <data name="CompleteSignup_LegalNameNote" xml:space="preserve">
+    <value>Te pedimos tu nombre legal para saber quién es quién detrás de los nombres burner, y para que puedas firmar el acuerdo de voluntariado más adelante. Solo es visible para los administradores dentro de Humans, nunca se comparte fuera de la aplicación, y en el resto de sitios siempre se te mostrará con tu nombre burner.</value>
+  </data>
+  <data name="CompleteSignup_PrivacyLink" xml:space="preserve">
+    <value>Lee nuestra política de privacidad</value>
+  </data>
+  <data name="CompleteSignup_AllFieldsRequired" xml:space="preserve">
+    <value>Por favor, rellena tu nombre burner y tu nombre y apellidos legales.</value>
   </data>
   <data name="CompleteSignup_Submit" xml:space="preserve">
     <value>Crear cuenta</value>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -3250,8 +3250,26 @@
   <data name="CompleteSignup_Title" xml:space="preserve">
     <value>Finaliser votre inscription</value>
   </data>
-  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve">
-    <value>Nom d'affichage</value>
+  <data name="CompleteSignup_BurnerNameLabel" xml:space="preserve">
+    <value>Nom burner</value>
+  </data>
+  <data name="CompleteSignup_BurnerNameHelp" xml:space="preserve">
+    <value>C'est le nom que tout le monde verra dans Humans. Utilisez celui que vous portez dans la communauté.</value>
+  </data>
+  <data name="CompleteSignup_FirstNameLabel" xml:space="preserve">
+    <value>Prénom légal</value>
+  </data>
+  <data name="CompleteSignup_LastNameLabel" xml:space="preserve">
+    <value>Nom légal</value>
+  </data>
+  <data name="CompleteSignup_LegalNameNote" xml:space="preserve">
+    <value>Nous demandons votre nom légal afin de savoir qui est qui derrière les noms burner, et pour que vous puissiez signer l'accord de bénévolat plus tard. Il n'est visible que par les administrateurs au sein de Humans, n'est jamais partagé en dehors de l'application, et partout ailleurs vous ne serez désigné que par votre nom burner.</value>
+  </data>
+  <data name="CompleteSignup_PrivacyLink" xml:space="preserve">
+    <value>Lire notre politique de confidentialité</value>
+  </data>
+  <data name="CompleteSignup_AllFieldsRequired" xml:space="preserve">
+    <value>Veuillez renseigner votre nom burner ainsi que vos prénom et nom légaux.</value>
   </data>
   <data name="CompleteSignup_Submit" xml:space="preserve">
     <value>Créer un compte</value>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -3250,8 +3250,26 @@
   <data name="CompleteSignup_Title" xml:space="preserve">
     <value>Completa la registrazione</value>
   </data>
-  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve">
-    <value>Nome visualizzato</value>
+  <data name="CompleteSignup_BurnerNameLabel" xml:space="preserve">
+    <value>Nome burner</value>
+  </data>
+  <data name="CompleteSignup_BurnerNameHelp" xml:space="preserve">
+    <value>È il nome che tutti vedranno in Humans. Usa quello con cui ti conoscono nella comunità.</value>
+  </data>
+  <data name="CompleteSignup_FirstNameLabel" xml:space="preserve">
+    <value>Nome legale</value>
+  </data>
+  <data name="CompleteSignup_LastNameLabel" xml:space="preserve">
+    <value>Cognome legale</value>
+  </data>
+  <data name="CompleteSignup_LegalNameNote" xml:space="preserve">
+    <value>Ti chiediamo il tuo nome legale per sapere chi è chi dietro i nomi burner e per permetterti di firmare l'accordo di volontariato in seguito. È visibile solo agli amministratori all'interno di Humans, non viene mai condiviso al di fuori dell'app e ovunque altro verrai mostrato solo con il tuo nome burner.</value>
+  </data>
+  <data name="CompleteSignup_PrivacyLink" xml:space="preserve">
+    <value>Leggi la nostra informativa sulla privacy</value>
+  </data>
+  <data name="CompleteSignup_AllFieldsRequired" xml:space="preserve">
+    <value>Inserisci il tuo nome burner e il tuo nome e cognome legali.</value>
   </data>
   <data name="CompleteSignup_Submit" xml:space="preserve">
     <value>Crea account</value>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1391,7 +1391,13 @@
   <data name="MagicLinkError_Message" xml:space="preserve"><value>This login link has expired or has already been used.</value></data>
   <data name="MagicLinkError_RequestNew" xml:space="preserve"><value>Request a new link</value></data>
   <data name="CompleteSignup_Title" xml:space="preserve"><value>Complete your signup</value></data>
-  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve"><value>Display name</value></data>
+  <data name="CompleteSignup_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
+  <data name="CompleteSignup_BurnerNameHelp" xml:space="preserve"><value>This is the name everyone in Humans sees. Use whatever you go by in the community.</value></data>
+  <data name="CompleteSignup_FirstNameLabel" xml:space="preserve"><value>Legal first name</value></data>
+  <data name="CompleteSignup_LastNameLabel" xml:space="preserve"><value>Legal last name</value></data>
+  <data name="CompleteSignup_LegalNameNote" xml:space="preserve"><value>We ask for your legal name so we can tell who's who behind everyone's burner names, and so you can sign the volunteer agreement later. It is visible only to admins inside Humans, is never shared outside the app, and everywhere else you'll only ever be shown by your burner name.</value></data>
+  <data name="CompleteSignup_PrivacyLink" xml:space="preserve"><value>Read our privacy policy</value></data>
+  <data name="CompleteSignup_AllFieldsRequired" xml:space="preserve"><value>Please fill in your burner name and your legal first and last name.</value></data>
   <data name="CompleteSignup_Submit" xml:space="preserve"><value>Create account</value></data>
   <data name="MagicLinkSent_BackToLogin" xml:space="preserve"><value>Back to login</value></data>
   <data name="MagicLinkSent_Expiry" xml:space="preserve"><value>Your link expires at {0}.</value></data>

--- a/src/Humans.Web/Views/Account/CompleteSignup.cshtml
+++ b/src/Humans.Web/Views/Account/CompleteSignup.cshtml
@@ -13,18 +13,44 @@
                     <input type="hidden" name="token" value="@token" />
                     <input type="hidden" name="email" value="@email" />
                     <input type="hidden" name="returnUrl" value="@ViewData["ReturnUrl"]" />
+
+                    <div asp-validation-summary="All" class="text-danger mb-3"></div>
+
                     <div class="mb-3">
                         <label class="form-label">Email</label>
                         <input type="email" class="form-control" value="@email" disabled />
                     </div>
+
                     <div class="mb-3">
-                        <label for="displayName" class="form-label">@Localizer["CompleteSignup_DisplayNameLabel"]</label>
-                        <input type="text" name="displayName" class="form-control"
-                               placeholder="@email" required autofocus />
+                        <label for="burnerName" class="form-label">@Localizer["CompleteSignup_BurnerNameLabel"]</label>
+                        <input type="text" id="burnerName" name="burnerName" class="form-control" required autofocus />
+                        <div class="form-text">@Localizer["CompleteSignup_BurnerNameHelp"]</div>
                     </div>
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="firstName" class="form-label">@Localizer["CompleteSignup_FirstNameLabel"]</label>
+                            <input type="text" id="firstName" name="firstName" class="form-control" required />
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="lastName" class="form-label">@Localizer["CompleteSignup_LastNameLabel"]</label>
+                            <input type="text" id="lastName" name="lastName" class="form-control" required />
+                        </div>
+                    </div>
+
+                    <div class="alert alert-light border small mb-3">
+                        @Localizer["CompleteSignup_LegalNameNote"]
+                    </div>
+
                     <button type="submit" class="btn btn-primary w-100">
                         @Localizer["CompleteSignup_Submit"]
                     </button>
+
+                    <p class="text-center mt-3 mb-0 small">
+                        <a asp-controller="Home" asp-action="Privacy" target="_blank" rel="noopener">
+                            @Localizer["CompleteSignup_PrivacyLink"]
+                        </a>
+                    </p>
                 </form>
             </div>
         </div>

--- a/src/Humans.Web/Views/Account/CompleteSignup.cshtml
+++ b/src/Humans.Web/Views/Account/CompleteSignup.cshtml
@@ -23,18 +23,18 @@
 
                     <div class="mb-3">
                         <label for="burnerName" class="form-label">@Localizer["CompleteSignup_BurnerNameLabel"]</label>
-                        <input type="text" id="burnerName" name="burnerName" class="form-control" required autofocus />
+                        <input type="text" id="burnerName" name="burnerName" class="form-control" required autofocus value="@ViewData["BurnerName"]" />
                         <div class="form-text">@Localizer["CompleteSignup_BurnerNameHelp"]</div>
                     </div>
 
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="firstName" class="form-label">@Localizer["CompleteSignup_FirstNameLabel"]</label>
-                            <input type="text" id="firstName" name="firstName" class="form-control" required />
+                            <input type="text" id="firstName" name="firstName" class="form-control" required value="@ViewData["FirstName"]" />
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="lastName" class="form-label">@Localizer["CompleteSignup_LastNameLabel"]</label>
-                            <input type="text" id="lastName" name="lastName" class="form-control" required />
+                            <input type="text" id="lastName" name="lastName" class="form-control" required value="@ViewData["LastName"]" />
                         </div>
                     </div>
 

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -836,7 +836,7 @@ public class AccountProvisioningServiceTests
     public async Task CompleteMagicLinkSignupAsync_CreatesUserEmailAndStubProfile()
     {
         var result = await _service.CompleteMagicLinkSignupAsync(
-            "magic@example.com", " Magic Human ");
+            "magic@example.com", " Magic Human ", " Legal ", " Surname ");
 
         result.Outcome.Should().Be(MagicLinkSignupCompletionOutcome.Created);
         result.User.Should().NotBeNull();
@@ -848,7 +848,7 @@ public class AccountProvisioningServiceTests
             && ue.IsVerified
             && ue.IsPrimary);
         await _userService.Received(1)
-            .EnsureStubProfileAsync(result.User.Id, Arg.Any<CancellationToken>());
+            .EnsureStubProfileAsync(result.User.Id, "Magic Human", "Legal", "Surname", Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -873,7 +873,7 @@ public class AccountProvisioningServiceTests
         });
 
         var result = await _service.CompleteMagicLinkSignupAsync(
-            "existing@example.com", "Ignored");
+            "existing@example.com", "Ignored", "Ignored", "Ignored");
 
         result.Outcome.Should().Be(MagicLinkSignupCompletionOutcome.ExistingUser);
         result.User.Should().BeSameAs(user);
@@ -888,7 +888,7 @@ public class AccountProvisioningServiceTests
         _userEmailFake.ThrowOnAddVerified = true;
 
         var result = await _service.CompleteMagicLinkSignupAsync(
-            "rollback@example.com", "Rollback");
+            "rollback@example.com", "Rollback", "First", "Last");
 
         result.Outcome.Should().Be(MagicLinkSignupCompletionOutcome.Failed);
         result.User.Should().BeNull();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1050,7 +1050,6 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task<bool> TrySetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> TrySetGoogleEmailStatusFromSyncAsync(Guid userId, GoogleEmailStatus status, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default) => throw new NotSupportedException();
         public Task SetPreferredLanguageAsync(Guid userId, string preferredLanguage, CancellationToken ct = default) => throw new NotSupportedException();
         public Task SetICalTokenAsync(Guid userId, Guid token, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetDeletionPendingAsync(Guid userId, Instant requestedAt, Instant scheduledFor, Instant? eligibleAfter, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1055,7 +1055,7 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task SetICalTokenAsync(Guid userId, Guid token, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetDeletionPendingAsync(Guid userId, Instant requestedAt, Instant scheduledFor, Instant? eligibleAfter, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> ClearDeletionAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<bool> EnsureStubProfileAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> EnsureStubProfileAsync(Guid userId, string? burnerName = null, string? firstName = null, string? lastName = null, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetMembershipTierAsync(Guid userId, MembershipTier tier, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<OnboardingResult> ApplyProfileOnboardingMutationAsync(Guid userId, UserProfileOnboardingCommand command, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<UserProfileSaveResult> SaveProfileAsync(Guid userId, UserProfileSaveCommand command, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -133,30 +133,6 @@ public class CachingUserServiceTests
     }
 
     [HumansFact]
-    public async Task UpdateDisplayNameAsync_RefreshesDictEntry()
-    {
-        var userId = Guid.NewGuid();
-        var stale = SampleUserInfo(userId, "Before");
-        var freshInfo = SampleUserInfo(userId, "After");
-
-        // Prime cache with the stale entry.
-        _inner.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<UserInfo?>(stale), new ValueTask<UserInfo?>(freshInfo));
-
-        var sut = CreateSut();
-        await sut.GetUserInfoAsync(userId); // prime
-
-        await sut.UpdateDisplayNameAsync(userId, "After");
-
-        var fresh = await sut.GetUserInfoAsync(userId);
-        fresh.Should().NotBeNull();
-        fresh.BurnerName.Should().Be("After");
-
-        await _inner.Received(2).GetUserInfoAsync(userId, Arg.Any<CancellationToken>());
-        await _inner.Received(1).UpdateDisplayNameAsync(userId, "After", Arg.Any<CancellationToken>());
-    }
-
-    [HumansFact]
     public async Task InvalidateAsync_UserDeleted_RemovesEntry()
     {
         var userId = Guid.NewGuid();

--- a/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
@@ -403,6 +403,36 @@ public sealed class UserServiceProfileOnboardingMutationTests : ServiceTestHarne
     }
 
     [HumansFact]
+    public async Task EnsureStubProfileAsync_WithSeededNames_CreatesActiveProfileWithTrimmedNames()
+    {
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        await Db.SaveChangesAsync();
+
+        await _service.EnsureStubProfileAsync(userId, " Sparkle ", " Ada ", " Lovelace ");
+
+        var profile = await Db.Profiles.SingleAsync(p => p.UserId == userId);
+        profile.BurnerName.Should().Be("Sparkle");
+        profile.FirstName.Should().Be("Ada");
+        profile.LastName.Should().Be("Lovelace");
+        profile.State.Should().Be(ProfileState.Active);
+    }
+
+    [HumansFact]
+    public async Task EnsureStubProfileAsync_WithoutNames_CreatesStubProfile()
+    {
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        await Db.SaveChangesAsync();
+
+        await _service.EnsureStubProfileAsync(userId);
+
+        var profile = await Db.Profiles.SingleAsync(p => p.UserId == userId);
+        profile.BurnerName.Should().BeEmpty();
+        profile.State.Should().Be(ProfileState.Stub);
+    }
+
+    [HumansFact]
     public async Task EnsureStubProfileAsync_MergedTombstone_NoOps()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
## Why

The magic-link signup page (`/Account/MagicLinkSignup` → `CompleteSignup`) collected a single **Display name** and wrote it only to the legacy, `[Obsolete]` `User.DisplayName` column (`HUM_USER_DISPLAYNAME`, #691), while `EnsureStubProfileAsync` created an **empty** stub `Profile`.

Per `memory/architecture/burnername-is-the-display-name.md`, when a Profile exists **`BurnerName` is the only name we render**. So every new member's `BurnerName` started blank and the UI fell back to the legacy column / email — the root cause of widespread "name is wrong" behaviour.

`DisplayName` is **not** an ASP.NET Identity concept (`IdentityUser` has no such property) — it's a custom, already-obsolete column. Nothing requires it.

## What changed

- **`CompleteSignup`** now collects three **required** fields: **Burner name**, **Legal first name**, **Legal last name**.
- These are seeded onto the `Profile` at creation (`BurnerName` / `FirstName` / `LastName`) instead of the legacy column. We still set `User.DisplayName = burnerName` as the sanctioned *creation-time fallback*.
- The legal-name fields carry the explanatory note: we need it to know who's who behind burner names and to sign the volunteer agreement later; it's **admin-only within Humans, never shared outside the app**, and everywhere else only the burner name is shown.
- A **privacy-policy link** opens in a new tab (`target="_blank" rel="noopener"` → `Home/Privacy`).
- Server-side guard re-renders the form with a validation message if any field is blank.

## Architecture

The name write goes through **`IUserService.EnsureStubProfileAsync`** (extended with optional seed names) — `AccountProvisioningService` stays on the orchestrator path with **no new repository coupling**, per the direction that new work routes through `IUserService`. `CachingUserService` decorator and all call sites updated; the import path passes no names (empty stub, unchanged).

## i18n

New `CompleteSignup_*` resource keys added across all 6 cultures; the orphaned `CompleteSignup_DisplayNameLabel` key was removed. **Spanish + English are authored; ca / de / fr / it are best-effort and want a native review.**

## Testing

- `dotnet build` — 0 errors.
- Full suite green **except** 2 pre-existing `StorePayActionTests` (Stripe) integration failures that fail identically on clean `origin/main` (verified via stash) — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)