### PR TITLE
Default Mailer audience debug tables to 20 rows per page

### DIFF
--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -91,23 +91,23 @@ public sealed class MailerAdminController(
     public async Task<IActionResult> Debug(
         string key,
         [FromQuery(Name = "exp.page")] int expectedPage = 1,
-        [FromQuery(Name = "exp.size")] int expectedSize = 50,
+        [FromQuery(Name = "exp.size")] int expectedSize = 20,
         [FromQuery(Name = "exp.sort")] string expectedSort = "name",
         [FromQuery(Name = "exp.desc")] bool expectedDesc = false,
         [FromQuery(Name = "ml.page")] int mlPage = 1,
-        [FromQuery(Name = "ml.size")] int mlSize = 50,
+        [FromQuery(Name = "ml.size")] int mlSize = 20,
         [FromQuery(Name = "ml.sort")] string mlSort = "name",
         [FromQuery(Name = "ml.desc")] bool mlDesc = false,
         [FromQuery(Name = "add.page")] int addPage = 1,
-        [FromQuery(Name = "add.size")] int addSize = 50,
+        [FromQuery(Name = "add.size")] int addSize = 20,
         [FromQuery(Name = "add.sort")] string addSort = "name",
         [FromQuery(Name = "add.desc")] bool addDesc = false,
         [FromQuery(Name = "rem.page")] int removePage = 1,
-        [FromQuery(Name = "rem.size")] int removeSize = 50,
+        [FromQuery(Name = "rem.size")] int removeSize = 20,
         [FromQuery(Name = "rem.sort")] string removeSort = "name",
         [FromQuery(Name = "rem.desc")] bool removeDesc = false,
         [FromQuery(Name = "np.page")] int nonPrimaryPage = 1,
-        [FromQuery(Name = "np.size")] int nonPrimarySize = 50,
+        [FromQuery(Name = "np.size")] int nonPrimarySize = 20,
         [FromQuery(Name = "np.sort")] string nonPrimarySort = "name",
         [FromQuery(Name = "np.desc")] bool nonPrimaryDesc = false,
         CancellationToken ct = default)
@@ -121,7 +121,7 @@ public sealed class MailerAdminController(
 
         var snapshot = await MailerAudienceDebugSnapshotBuilder.BuildAsync(audience, ml, _users, logger, ct);
 
-        var options = new DebugTableOptions(PageSizes: [50, 100, 200], DefaultPageSize: 50);
+        var options = new DebugTableOptions(PageSizes: [20, 50, 100, 200], DefaultPageSize: 20);
         var vm = new MailerAudienceDebugViewModel(
             SelectedKey: audience.Key,
             SelectedGroupName: audience.DisplayName,

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
@@ -382,7 +382,7 @@ public class MailerAdminControllerTests
         vm.CurrentlyInMl.Total.Should().Be(0);
         vm.NonPrimary.Total.Should().Be(0);
         vm.GroupExists.Should().BeTrue();
-        vm.Options.PageSizes.Should().Equal(50, 100, 200);
+        vm.Options.PageSizes.Should().Equal(20, 50, 100, 200);
     }
 
     [HumansFact]


### PR DESCRIPTION
## What

The five comparison tables on `/Mailer/Admin/Audiences/{key}/Debug` defaulted to **50** rows per page. This changes the default to **20** for all five (Should-be-on-list, Currently-in-ML, To-add, To-remove, Non-primary).

## Changes

- `MailerAdminController.Debug`: the five `*.size` query-param defaults `50 → 20`.
- `DebugTableOptions`: page-size selector now `[20, 50, 100, 200]` with `DefaultPageSize: 20` (20 added so it stays selectable in the pager; 50/100/200 still available).
- Updated the `MailerAdminControllerTests` assertion for the new selector list.

## Verification

- `dotnet build Humans.slnx` — 0 errors.
- `dotnet test --filter MailerAdminControllerTests` — 9/9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)