### PR TITLE
Refactor Expenses service surfaces

### DIFF
--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportBackgroundProcessor.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportBackgroundProcessor.cs
@@ -1,0 +1,16 @@
+namespace Humans.Application.Interfaces.Expenses;
+
+public interface IExpenseReportBackgroundProcessor
+{
+    /// <summary>
+    /// Drains the Holded expense outbox: creates or updates purchase documents in Holded
+    /// for each approved expense report.
+    /// </summary>
+    Task DrainHoldedOutboxAsync(int batchSize, CancellationToken ct = default);
+
+    /// <summary>
+    /// Reconciles payment status on SepaSent expense reports against the member's Holded creditor
+    /// balance and marks them Paid when that balance is settled.
+    /// </summary>
+    Task PollHoldedPaidStatusAsync(int batchSize, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
@@ -1,6 +1,6 @@
 namespace Humans.Application.Interfaces.Expenses;
 
-public interface IExpenseReportService : IApplicationService
+public interface IExpenseReportService : IExpenseReportServiceRead, IApplicationService
 {
     Task<Guid> CreateDraftAsync(
         Guid submitterUserId, Guid budgetCategoryId, string? note,

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
@@ -67,19 +67,6 @@ public interface IExpenseReportService : IApplicationService
         IReadOnlyCollection<Guid> reportIds, Guid actorUserId,
         CancellationToken ct = default);
 
-    /// <summary>
-    /// Drains the Holded expense outbox: creates or updates purchase documents in Holded
-    /// for each approved expense report. Called by the recurring job.
-    /// </summary>
-    Task DrainHoldedOutboxAsync(int batchSize, CancellationToken ct = default);
-
-    /// <summary>
-    /// Reconciles payment status on SepaSent expense reports against the member's Holded creditor
-    /// balance and marks them Paid when that balance is settled (≥ 0) — treasury pays the creditor
-    /// account in aggregate, not per-document. Missing supplier-account numbers are backfilled here.
-    /// Called by the recurring job.
-    /// </summary>
-    Task PollHoldedPaidStatusAsync(int batchSize, CancellationToken ct = default);
 }
 
 public sealed record ExpenseAttachmentDownload(

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
@@ -1,42 +1,9 @@
-using Humans.Application.Services.Expenses.Dtos;
-
 namespace Humans.Application.Interfaces.Expenses;
 
 public interface IExpenseReportService : IApplicationService
 {
-    Task<ExpenseReportDto?> GetAsync(Guid id, CancellationToken ct = default);
-
-    Task<ExpenseDetailViewData> GetDetailViewDataAsync(
-        Guid viewerUserId, ExpenseReportDto report, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the report that owns the given attachment (via its line), with
-    /// Lines populated. Returns null if the attachment doesn't belong to any
-    /// line or the report is gone. Used by the attachment-streaming endpoint
-    /// so visibility is decided by the View authorization handler against the
-    /// real owning report, rather than by scanning curated queues that may
-    /// drift from the handler's grant scope.
-    /// </summary>
-    Task<ExpenseReportDto?> GetReportOwningAttachmentAsync(
-        Guid attachmentId, CancellationToken ct = default);
-
-    Task<ExpenseAttachmentDownload?> TryReadAttachmentAsync(
-        ExpenseReportDto owningReport,
-        Guid attachmentId,
-        CancellationToken ct = default);
-    Task<IReadOnlyList<ExpenseReportDto>> GetForSubmitterAsync(
-        Guid submitterUserId, CancellationToken ct = default);
-    Task<IReadOnlyList<ExpenseReportDto>> GetCoordinatorQueueAsync(
-        Guid coordinatorUserId, CancellationToken ct = default);
-    Task<IReadOnlyList<ExpenseReportDto>> GetReviewQueueAsync(CancellationToken ct = default);
-
     Task<Guid> CreateDraftAsync(
         Guid submitterUserId, Guid budgetCategoryId, string? note,
-        CancellationToken ct = default);
-
-    Task UpdateDraftAsync(
-        Guid reportId, Guid submitterUserId,
-        Guid budgetCategoryId, string? note,
         CancellationToken ct = default);
 
     Task<ExpenseMutationResult> UpdateDraftWithResultAsync(
@@ -44,19 +11,9 @@ public interface IExpenseReportService : IApplicationService
         Guid budgetCategoryId, string? note,
         CancellationToken ct = default);
 
-    Task<Guid> AddLineAsync(
-        Guid reportId, Guid submitterUserId,
-        string description, decimal amount,
-        CancellationToken ct = default);
-
     Task<ExpenseMutationResult> AddLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
-        CancellationToken ct = default);
-
-    Task UpdateLineAsync(
-        Guid reportId, Guid submitterUserId,
-        Guid lineId, string description, decimal amount,
         CancellationToken ct = default);
 
     Task<ExpenseMutationResult> UpdateLineWithResultAsync(
@@ -64,23 +21,9 @@ public interface IExpenseReportService : IApplicationService
         Guid lineId, string description, decimal amount,
         CancellationToken ct = default);
 
-    Task RemoveLineAsync(
-        Guid reportId, Guid submitterUserId, Guid lineId,
-        CancellationToken ct = default);
-
     Task<ExpenseMutationResult> RemoveLineWithResultAsync(
         Guid reportId, Guid submitterUserId, Guid lineId,
         CancellationToken ct = default);
-
-    /// <summary>
-    /// Stores the file bytes, creates the attachment row, and links it to the line.
-    /// Authorizes: submitter ownership + editable status + line belongs to report.
-    /// Returns the new attachment id.
-    /// </summary>
-    Task<Guid> AttachFileToLineAsync(
-        Guid reportId, Guid submitterUserId,
-        Guid lineId, string originalFileName, string contentType,
-        Stream content, CancellationToken ct = default);
 
     Task<ExpenseMutationResult> AttachFileToLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
@@ -96,15 +39,8 @@ public interface IExpenseReportService : IApplicationService
         Guid reportId, Guid submitterUserId,
         Guid lineId, CancellationToken ct = default);
 
-    Task<bool> SubmitAsync(
-        Guid reportId, Guid submitterUserId, CancellationToken ct = default);
-
     Task<ExpenseMutationResult> SubmitWithResultAsync(
         Guid reportId, Guid submitterUserId, CancellationToken ct = default);
-
-    Task<bool> WithdrawAsync(
-        Guid reportId, Guid submitterUserId, CancellationToken ct = default);
-
 
     Task<ExpenseMutationResult> WithdrawWithResultAsync(
         Guid reportId, Guid submitterUserId, CancellationToken ct = default);
@@ -112,33 +48,15 @@ public interface IExpenseReportService : IApplicationService
     Task<ExpenseIbanSaveResult> SaveSubmitterIbanWithResultAsync(
         Guid submitterUserId, string? iban, CancellationToken ct = default);
 
-    Task<ExpenseIbanViewData> GetSubmitterIbanViewAsync(
-        Guid submitterUserId, CancellationToken ct = default);
-
-    Task<bool> CoordinatorEndorseAsync(
-        Guid reportId, Guid coordinatorUserId, CancellationToken ct = default);
-
     Task<ExpenseMutationResult> CoordinatorEndorseWithResultAsync(
         Guid reportId, Guid coordinatorUserId, CancellationToken ct = default);
-
-    Task<bool> CoordinatorRejectAsync(
-        Guid reportId, Guid coordinatorUserId, string reason,
-        CancellationToken ct = default);
 
     Task<ExpenseMutationResult> CoordinatorRejectWithResultAsync(
         Guid reportId, Guid coordinatorUserId, string reason,
         CancellationToken ct = default);
 
-    Task<bool> ApproveAsync(
-        Guid reportId, Guid actorUserId, Guid? overrideCategoryId,
-        CancellationToken ct = default);
-
     Task<ExpenseMutationResult> ApproveWithResultAsync(
         Guid reportId, Guid actorUserId, Guid? overrideCategoryId,
-        CancellationToken ct = default);
-
-    Task<bool> FinanceRejectAsync(
-        Guid reportId, Guid actorUserId, string reason,
         CancellationToken ct = default);
 
     Task<ExpenseMutationResult> FinanceRejectWithResultAsync(
@@ -148,14 +66,6 @@ public interface IExpenseReportService : IApplicationService
     Task<IReadOnlyList<Guid>> MarkSepaSentAsync(
         IReadOnlyCollection<Guid> reportIds, Guid actorUserId,
         CancellationToken ct = default);
-
-    Task<bool> MarkPaidAsync(
-        Guid reportId, NodaTime.Instant paidAt, CancellationToken ct = default);
-
-    /// <summary>True iff the category has at least one budget coordinator
-    /// (so the Submitted -> CoordinatorEndorsed step is required).</summary>
-    Task<bool> CategoryRequiresCoordinatorEndorsementAsync(
-        Guid categoryId, CancellationToken ct = default);
 
     /// <summary>
     /// Drains the Holded expense outbox: creates or updates purchase documents in Holded

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
@@ -101,7 +101,7 @@ public sealed record ExpenseIbanSaveResult(
     bool HasIban,
     string? MaskedIban);
 
-public sealed record ExpenseIbanViewData(bool HasIban, string? MaskedIban);
+internal sealed record ExpenseIbanViewData(bool HasIban, string? MaskedIban);
 
 public sealed record ExpenseDetailViewData(
     string CategoryDisplayName,

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
@@ -103,15 +103,6 @@ public sealed record ExpenseIbanSaveResult(
 
 internal sealed record ExpenseIbanViewData(bool HasIban, string? MaskedIban);
 
-public sealed record ExpenseDetailViewData(
-    string CategoryDisplayName,
-    bool CanEdit,
-    bool CanSubmit,
-    bool CanWithdraw,
-    bool HasIban,
-    string? MaskedIban,
-    ExpenseHoldedTimeline? HoldedTimeline);
-
 /// <summary>Round-trip timeline for the submitter, sourced from the Holded creditor balance.</summary>
 public sealed record ExpenseHoldedTimeline(
     bool RegisteredInHolded,

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
@@ -84,11 +84,7 @@ public sealed record ExpenseMutationResult(bool Succeeded, string? ErrorMessage)
 public sealed record ExpenseIbanSaveResult(
     bool Succeeded,
     bool IsValidationError,
-    string Message,
-    bool HasIban,
-    string? MaskedIban);
-
-internal sealed record ExpenseIbanViewData(bool HasIban, string? MaskedIban);
+    string Message);
 
 /// <summary>Round-trip timeline for the submitter, sourced from the Holded creditor balance.</summary>
 public sealed record ExpenseHoldedTimeline(

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportServiceRead.cs
@@ -12,8 +12,8 @@ public interface IExpenseReportServiceRead
 {
     Task<ExpenseReportDto?> GetAsync(Guid id, CancellationToken ct = default);
 
-    Task<ExpenseDetailViewData> GetDetailViewDataAsync(
-        Guid viewerUserId, ExpenseReportDto report, CancellationToken ct = default);
+    Task<ExpenseHoldedTimeline?> GetHoldedTimelineAsync(
+        ExpenseReportDto report, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the report that owns the given attachment (via its line), with

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportServiceRead.cs
@@ -7,7 +7,7 @@ namespace Humans.Application.Interfaces.Expenses;
 /// Cross-section read surface for expense reports. External readers should use
 /// this interface instead of the mutation service.
 /// </summary>
-[SurfaceBudget(8)]
+[SurfaceBudget(7)]
 public interface IExpenseReportServiceRead
 {
     Task<ExpenseReportDto?> GetAsync(Guid id, CancellationToken ct = default);
@@ -35,7 +35,4 @@ public interface IExpenseReportServiceRead
         Guid coordinatorUserId, CancellationToken ct = default);
 
     Task<IReadOnlyList<ExpenseReportDto>> GetReviewQueueAsync(CancellationToken ct = default);
-
-    Task<ExpenseIbanViewData> GetSubmitterIbanViewAsync(
-        Guid submitterUserId, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportServiceRead.cs
@@ -1,0 +1,41 @@
+using Humans.Application.Architecture;
+using Humans.Application.Services.Expenses.Dtos;
+
+namespace Humans.Application.Interfaces.Expenses;
+
+/// <summary>
+/// Cross-section read surface for expense reports. External readers should use
+/// this interface instead of the mutation service.
+/// </summary>
+[SurfaceBudget(8)]
+public interface IExpenseReportServiceRead
+{
+    Task<ExpenseReportDto?> GetAsync(Guid id, CancellationToken ct = default);
+
+    Task<ExpenseDetailViewData> GetDetailViewDataAsync(
+        Guid viewerUserId, ExpenseReportDto report, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the report that owns the given attachment (via its line), with
+    /// Lines populated. Returns null if the attachment doesn't belong to any
+    /// line or the report is gone.
+    /// </summary>
+    Task<ExpenseReportDto?> GetReportOwningAttachmentAsync(
+        Guid attachmentId, CancellationToken ct = default);
+
+    Task<ExpenseAttachmentDownload?> TryReadAttachmentAsync(
+        ExpenseReportDto owningReport,
+        Guid attachmentId,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<ExpenseReportDto>> GetForSubmitterAsync(
+        Guid submitterUserId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<ExpenseReportDto>> GetCoordinatorQueueAsync(
+        Guid coordinatorUserId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<ExpenseReportDto>> GetReviewQueueAsync(CancellationToken ct = default);
+
+    Task<ExpenseIbanViewData> GetSubmitterIbanViewAsync(
+        Guid submitterUserId, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -51,41 +51,13 @@ public sealed class ExpenseReportService(
     public Task<ExpenseReportDto?> GetAsync(Guid id, CancellationToken ct = default)
         => repo.GetByIdAsync(id, ct);
 
-    public async Task<ExpenseDetailViewData> GetDetailViewDataAsync(
-        Guid viewerUserId, ExpenseReportDto report, CancellationToken ct = default)
-    {
-        var category = await budgetService.GetCategoryByIdAsync(report.BudgetCategoryId);
-        var categoryName = category is not null
-            ? $"{category.BudgetGroup?.Name} / {category.Name}"
-            : "(unknown category)";
-
-        var isSubmitter = report.SubmitterUserId == viewerUserId;
-        var canWithdraw = report.Status is ExpenseReportStatus.Submitted
-            or ExpenseReportStatus.CoordinatorEndorsed
-            or ExpenseReportStatus.Approved;
-        var iban = await GetSubmitterIbanViewAsync(viewerUserId, ct);
-
-        var timeline = isSubmitter
-            ? await BuildHoldedTimelineAsync(report, ct)
-            : null;
-
-        return new ExpenseDetailViewData(
-            CategoryDisplayName: categoryName,
-            CanEdit: isSubmitter && report.Status == ExpenseReportStatus.Draft,
-            CanSubmit: isSubmitter && report.Status == ExpenseReportStatus.Draft,
-            CanWithdraw: isSubmitter && canWithdraw,
-            HasIban: iban.HasIban,
-            MaskedIban: iban.MaskedIban,
-            HoldedTimeline: timeline);
-    }
-
     /// <summary>
     /// Aggregates the submitter's owed/paid round-trip from the cached Holded creditor balance.
     /// The balance already sums all of a member's outstanding docs; when it exceeds the member's
     /// own registered-unpaid ER totals, the remainder is shown as fronted/adjustments (spec §3).
     /// </summary>
-    private async Task<ExpenseHoldedTimeline?> BuildHoldedTimelineAsync(
-        ExpenseReportDto report, CancellationToken ct)
+    public async Task<ExpenseHoldedTimeline?> GetHoldedTimelineAsync(
+        ExpenseReportDto report, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(report.HoldedContactId))
             return new ExpenseHoldedTimeline(

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -545,17 +545,16 @@ public sealed class ExpenseReportService(
         Guid submitterUserId, string? iban, CancellationToken ct = default)
     {
         var ibanValue = string.IsNullOrWhiteSpace(iban) ? null : iban.Trim();
-        var existingIban = (await userService.GetUserInfoAsync(submitterUserId, ct))?.Profile?.Iban;
 
         if (ibanValue is not null && !IbanValidator.IsValid(ibanValue))
-            return IbanFailure("Invalid IBAN format.", isValidationError: true, existingIban);
+            return IbanFailure("Invalid IBAN format.", isValidationError: true);
 
         var normalized = ibanValue is null ? null : IbanValidator.Normalize(ibanValue);
         try
         {
             var saved = await userService.SetProfileIbanAsync(submitterUserId, normalized, ct);
             if (!saved)
-                return IbanFailure("Failed to save IBAN.", isValidationError: false, existingIban);
+                return IbanFailure("Failed to save IBAN.", isValidationError: false);
 
             var isClearing = normalized is null;
             await auditLogService.LogAsync(
@@ -573,37 +572,17 @@ public sealed class ExpenseReportService(
             return new ExpenseIbanSaveResult(
                 Succeeded: true,
                 IsValidationError: false,
-                Message: normalized is null ? "IBAN removed." : "IBAN saved.",
-                HasIban: normalized is not null,
-                MaskedIban: normalized is null ? null : IbanFormatter.Mask(normalized));
+                Message: normalized is null ? "IBAN removed." : "IBAN saved.");
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error setting IBAN for user {UserId}", submitterUserId);
-            return IbanFailure("Failed to save IBAN.", isValidationError: false, existingIban);
+            return IbanFailure("Failed to save IBAN.", isValidationError: false);
         }
     }
 
-    internal async Task<ExpenseIbanViewData> GetSubmitterIbanViewAsync(
-        Guid submitterUserId, CancellationToken ct = default)
-    {
-        var iban = (await userService.GetUserInfoAsync(submitterUserId, ct))?.Profile?.Iban;
-        var hasIban = !string.IsNullOrEmpty(iban);
-        return new ExpenseIbanViewData(
-            HasIban: hasIban,
-            MaskedIban: hasIban ? IbanFormatter.Mask(iban!) : null);
-    }
-
-    private static ExpenseIbanSaveResult IbanFailure(string message, bool isValidationError, string? existingIban)
-    {
-        var hasIban = !string.IsNullOrEmpty(existingIban);
-        return new ExpenseIbanSaveResult(
-            Succeeded: false,
-            IsValidationError: isValidationError,
-            Message: message,
-            HasIban: hasIban,
-            MaskedIban: hasIban ? IbanFormatter.Mask(existingIban!) : null);
-    }
+    private static ExpenseIbanSaveResult IbanFailure(string message, bool isValidationError) =>
+        new(Succeeded: false, IsValidationError: isValidationError, Message: message);
 
     internal async Task<bool> CoordinatorEndorseAsync(
         Guid reportId, Guid coordinatorUserId, CancellationToken ct = default)

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -34,7 +34,7 @@ public sealed class ExpenseReportService(
     IHoldedClient holdedClient,
     IHoldedFinanceService holdedFinance,
     IClock clock,
-    ILogger<ExpenseReportService> logger) : IExpenseReportServiceRead, IExpenseReportService,
+    ILogger<ExpenseReportService> logger) : IExpenseReportService,
         IExpenseReportBackgroundProcessor, IUserDataContributor
 {
     // Stored for future Holded Finance integration tasks (creditor status polling etc.).

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -34,7 +34,8 @@ public sealed class ExpenseReportService(
     IHoldedClient holdedClient,
     IHoldedFinanceService holdedFinance,
     IClock clock,
-    ILogger<ExpenseReportService> logger) : IExpenseReportServiceRead, IExpenseReportService, IUserDataContributor
+    ILogger<ExpenseReportService> logger) : IExpenseReportServiceRead, IExpenseReportService,
+        IExpenseReportBackgroundProcessor, IUserDataContributor
 {
     // Stored for future Holded Finance integration tasks (creditor status polling etc.).
     private readonly IHoldedFinanceService _holdedFinance = holdedFinance;
@@ -821,8 +822,15 @@ public sealed class ExpenseReportService(
         return team.Members.Any(m => m.Role == TeamMemberRole.Coordinator);
     }
 
-    /// <inheritdoc/>
-    public async Task DrainHoldedOutboxAsync(int batchSize, CancellationToken ct = default)
+    Task IExpenseReportBackgroundProcessor.DrainHoldedOutboxAsync(
+        int batchSize, CancellationToken ct)
+        => DrainHoldedOutboxAsync(batchSize, ct);
+
+    Task IExpenseReportBackgroundProcessor.PollHoldedPaidStatusAsync(
+        int batchSize, CancellationToken ct)
+        => PollHoldedPaidStatusAsync(batchSize, ct);
+
+    internal async Task DrainHoldedOutboxAsync(int batchSize, CancellationToken ct = default)
     {
         var events = await repo
             .GetUnprocessedOutboxAsync(batchSize, ct);
@@ -899,8 +907,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    /// <inheritdoc/>
-    public async Task PollHoldedPaidStatusAsync(int batchSize, CancellationToken ct = default)
+    internal async Task PollHoldedPaidStatusAsync(int batchSize, CancellationToken ct = default)
     {
         var reports = await repo.GetByStatusAsync(ExpenseReportStatus.SepaSent, ct);
 

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -40,7 +40,7 @@ public sealed class ExpenseReportService(
     // Stored for future Holded Finance integration tasks (creditor status polling etc.).
     private readonly IHoldedFinanceService _holdedFinance = holdedFinance;
 
-    public static string AttachmentKey(Guid id, string extension) =>
+    internal static string AttachmentKey(Guid id, string extension) =>
         $"uploads/expense-attachments/{id}{extension}";
 
     private static readonly HashSet<string> AllowedExtensions =

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -34,7 +34,7 @@ public sealed class ExpenseReportService(
     IHoldedClient holdedClient,
     IHoldedFinanceService holdedFinance,
     IClock clock,
-    ILogger<ExpenseReportService> logger) : IExpenseReportService, IUserDataContributor
+    ILogger<ExpenseReportService> logger) : IExpenseReportServiceRead, IExpenseReportService, IUserDataContributor
 {
     // Stored for future Holded Finance integration tasks (creditor status polling etc.).
     private readonly IHoldedFinanceService _holdedFinance = holdedFinance;
@@ -208,7 +208,7 @@ public sealed class ExpenseReportService(
         return report.Id;
     }
 
-    public async Task UpdateDraftAsync(
+    internal async Task UpdateDraftAsync(
         Guid reportId, Guid submitterUserId,
         Guid budgetCategoryId, string? note,
         CancellationToken ct = default)
@@ -254,7 +254,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task<Guid> AddLineAsync(
+    internal async Task<Guid> AddLineAsync(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
         CancellationToken ct = default)
@@ -290,7 +290,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task UpdateLineAsync(
+    internal async Task UpdateLineAsync(
         Guid reportId, Guid submitterUserId,
         Guid lineId, string description, decimal amount,
         CancellationToken ct = default)
@@ -325,7 +325,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task RemoveLineAsync(
+    internal async Task RemoveLineAsync(
         Guid reportId, Guid submitterUserId, Guid lineId,
         CancellationToken ct = default)
     {
@@ -378,7 +378,7 @@ public sealed class ExpenseReportService(
         "application/pdf", "image/jpeg", "image/jpg", "image/png", "image/heic"
     };
 
-    public async Task<Guid> AttachFileToLineAsync(
+    internal async Task<Guid> AttachFileToLineAsync(
         Guid reportId, Guid submitterUserId,
         Guid lineId, string originalFileName, string contentType,
         Stream content, CancellationToken ct = default)
@@ -473,7 +473,7 @@ public sealed class ExpenseReportService(
             submitterUserId);
     }
 
-    public async Task<bool> SubmitAsync(
+    internal async Task<bool> SubmitAsync(
         Guid reportId, Guid submitterUserId, CancellationToken ct = default)
     {
         var report = await repo.GetByIdAsync(reportId, ct);
@@ -531,7 +531,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task<bool> WithdrawAsync(
+    internal async Task<bool> WithdrawAsync(
         Guid reportId, Guid submitterUserId, CancellationToken ct = default)
     {
         var report = await repo.GetByIdAsync(reportId, ct);
@@ -632,7 +632,7 @@ public sealed class ExpenseReportService(
             MaskedIban: hasIban ? IbanFormatter.Mask(existingIban!) : null);
     }
 
-    public async Task<bool> CoordinatorEndorseAsync(
+    internal async Task<bool> CoordinatorEndorseAsync(
         Guid reportId, Guid coordinatorUserId, CancellationToken ct = default)
     {
         var report = await repo.GetByIdAsync(reportId, ct);
@@ -670,7 +670,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task<bool> CoordinatorRejectAsync(
+    internal async Task<bool> CoordinatorRejectAsync(
         Guid reportId, Guid coordinatorUserId, string reason,
         CancellationToken ct = default)
     {
@@ -710,7 +710,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task<bool> ApproveAsync(
+    internal async Task<bool> ApproveAsync(
         Guid reportId, Guid actorUserId, Guid? overrideCategoryId,
         CancellationToken ct = default)
     {
@@ -758,7 +758,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task<bool> FinanceRejectAsync(
+    internal async Task<bool> FinanceRejectAsync(
         Guid reportId, Guid actorUserId, string reason,
         CancellationToken ct = default)
     {
@@ -818,7 +818,7 @@ public sealed class ExpenseReportService(
         return flippedIds;
     }
 
-    public async Task<bool> MarkPaidAsync(
+    internal async Task<bool> MarkPaidAsync(
         Guid reportId, Instant paidAt, CancellationToken ct = default)
     {
         var ok = await repo.MarkPaidAsync(reportId, paidAt, ct);
@@ -833,8 +833,8 @@ public sealed class ExpenseReportService(
         return true;
     }
 
-    /// <inheritdoc/>
-    public async Task<bool> CategoryRequiresCoordinatorEndorsementAsync(
+    /// <summary>True iff the category has at least one budget coordinator.</summary>
+    internal async Task<bool> CategoryRequiresCoordinatorEndorsementAsync(
         Guid categoryId, CancellationToken ct = default)
     {
         // True iff category's team has ≥1 active Coordinator (cache hit, no DB).

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -611,7 +611,7 @@ public sealed class ExpenseReportService(
         }
     }
 
-    public async Task<ExpenseIbanViewData> GetSubmitterIbanViewAsync(
+    internal async Task<ExpenseIbanViewData> GetSubmitterIbanViewAsync(
         Guid submitterUserId, CancellationToken ct = default)
     {
         var iban = (await userService.GetUserInfoAsync(submitterUserId, ct))?.Profile?.Iban;

--- a/src/Humans.Infrastructure/Jobs/ExpensePaidPollingJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ExpensePaidPollingJob.cs
@@ -10,10 +10,10 @@ namespace Humans.Infrastructure.Jobs;
 /// member's creditor account balance is settled (≥ 0) — treasury pays the account in aggregate.
 /// </summary>
 [DisableConcurrentExecution(timeoutInSeconds: 120)]
-public class ExpensePaidPollingJob(IExpenseReportService expenseService) : IRecurringJob
+public class ExpensePaidPollingJob(IExpenseReportBackgroundProcessor expenses) : IRecurringJob
 {
     private const int BatchSize = 50;
 
     public Task ExecuteAsync(CancellationToken cancellationToken = default) =>
-        expenseService.PollHoldedPaidStatusAsync(BatchSize, cancellationToken);
+        expenses.PollHoldedPaidStatusAsync(BatchSize, cancellationToken);
 }

--- a/src/Humans.Infrastructure/Jobs/HoldedExpenseOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/HoldedExpenseOutboxJob.cs
@@ -9,10 +9,10 @@ namespace Humans.Infrastructure.Jobs;
 /// for each approved expense report.
 /// </summary>
 [DisableConcurrentExecution(timeoutInSeconds: 300)]
-public class HoldedExpenseOutboxJob(IExpenseReportService expenseService) : IRecurringJob
+public class HoldedExpenseOutboxJob(IExpenseReportBackgroundProcessor expenses) : IRecurringJob
 {
     private const int BatchSize = 100;
 
     public Task ExecuteAsync(CancellationToken cancellationToken = default) =>
-        expenseService.DrainHoldedOutboxAsync(BatchSize, cancellationToken);
+        expenses.DrainHoldedOutboxAsync(BatchSize, cancellationToken);
 }

--- a/src/Humans.Web/Authorization/Requirements/IbanAccessHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/IbanAccessHandler.cs
@@ -14,7 +14,7 @@ namespace Humans.Web.Authorization.Requirements;
 ///   <item><description>Admin on admin page: <see cref="IbanAccessRequirement.IsAdminPageContext"/> is true.</description></item>
 /// </list>
 /// </summary>
-public sealed class IbanAccessHandler(IExpenseReportService expenseService)
+public sealed class IbanAccessHandler(IExpenseReportServiceRead expenseReports)
     : AuthorizationHandler<IbanAccessRequirement>
 {
     protected override async Task HandleRequirementAsync(
@@ -43,7 +43,7 @@ public sealed class IbanAccessHandler(IExpenseReportService expenseService)
         // and is neither Draft nor Withdrawn
         if (requirement.ReportId.HasValue && RoleChecks.IsFinanceAdmin(context.User))
         {
-            var report = await expenseService.GetAsync(requirement.ReportId.Value);
+            var report = await expenseReports.GetAsync(requirement.ReportId.Value);
             if (report is not null &&
                 report.Status is not ExpenseReportStatus.Draft and not ExpenseReportStatus.Withdrawn)
             {

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -18,6 +18,7 @@ namespace Humans.Web.Controllers;
 [Route("Expenses")]
 public sealed class ExpensesController(
     IUserServiceRead userService,
+    IExpenseReportServiceRead expenseReadService,
     IExpenseReportService service,
     IBudgetService budgetService,
     IClock clock,
@@ -36,7 +37,7 @@ public sealed class ExpensesController(
             var (errorResult, user) = await RequireCurrentUserAsync();
             if (errorResult is not null) return errorResult;
 
-            var reports = await service.GetForSubmitterAsync(user.Id);
+            var reports = await expenseReadService.GetForSubmitterAsync(user.Id);
             var activeYear = await budgetService.GetActiveYearAsync();
             var info = await _userService.GetUserInfoAsync(user.Id);
 
@@ -128,14 +129,14 @@ public sealed class ExpensesController(
             var (errorResult, user) = await RequireCurrentUserAsync();
             if (errorResult is not null) return errorResult;
 
-            var report = await service.GetAsync(id);
+            var report = await expenseReadService.GetAsync(id);
             if (report is null) return NotFound();
 
             var authResult = await authService.AuthorizeAsync(User, report,
                 new ExpenseReportOperationRequirement(ExpenseReportOperation.View));
             if (!authResult.Succeeded) return Forbid();
 
-            var detail = await service.GetDetailViewDataAsync(user.Id, report);
+            var detail = await expenseReadService.GetDetailViewDataAsync(user.Id, report);
             var model = new ExpenseDetailViewModel
             {
                 Report = report,
@@ -165,7 +166,7 @@ public sealed class ExpensesController(
             var (errorResult, user) = await RequireCurrentUserAsync();
             if (errorResult is not null) return errorResult;
 
-            var report = await service.GetAsync(id);
+            var report = await expenseReadService.GetAsync(id);
             if (report is null) return NotFound();
             if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -199,7 +200,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -228,7 +229,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -254,7 +255,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -280,7 +281,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -301,7 +302,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -330,7 +331,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -354,7 +355,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -374,7 +375,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid(); var result = await service.WithdrawWithResultAsync(id, user.Id);
         if (result.Succeeded)
@@ -392,11 +393,11 @@ public sealed class ExpensesController(
             var (errorResult, user) = await RequireCurrentUserAsync();
             if (errorResult is not null) return errorResult;
 
-            var report = await service.GetAsync(id);
+            var report = await expenseReadService.GetAsync(id);
             if (report is null) return NotFound();
             if (report.SubmitterUserId != user.Id) return Forbid();
 
-            var iban = await service.GetSubmitterIbanViewAsync(user.Id);
+            var iban = await expenseReadService.GetSubmitterIbanViewAsync(user.Id);
             var model = new ExpenseIbanViewModel
             {
                 ReportId = id,
@@ -420,7 +421,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
@@ -451,14 +452,14 @@ public sealed class ExpensesController(
             if (errorResult is not null) return errorResult;
 
             // Visibility = report's View handler grant. NotFound on both miss + denial (no leak).
-            var owningReport = await service.GetReportOwningAttachmentAsync(attachmentId);
+            var owningReport = await expenseReadService.GetReportOwningAttachmentAsync(attachmentId);
             if (owningReport is null) return NotFound();
 
             var authResult = await authService.AuthorizeAsync(User, owningReport,
                 new ExpenseReportOperationRequirement(ExpenseReportOperation.View));
             if (!authResult.Succeeded) return NotFound();
 
-            var attachment = await service.TryReadAttachmentAsync(owningReport, attachmentId);
+            var attachment = await expenseReadService.TryReadAttachmentAsync(owningReport, attachmentId);
             if (attachment is null) return NotFound();
 
             return File(attachment.Bytes, attachment.ContentType, attachment.OriginalFileName);
@@ -478,7 +479,7 @@ public sealed class ExpensesController(
             var (errorResult, user) = await RequireCurrentUserAsync();
             if (errorResult is not null) return errorResult;
 
-            var reports = await service.GetCoordinatorQueueAsync(user.Id);
+            var reports = await expenseReadService.GetCoordinatorQueueAsync(user.Id);
             var submitterNames = await ResolveSubmitterNamesAsync(reports);
             return View(new ExpenseCoordinatorViewModel { Reports = reports, SubmitterNames = submitterNames });
         }
@@ -497,7 +498,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
 
         var authResult = await authService.AuthorizeAsync(User, report,
@@ -520,7 +521,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
 
         var authResult = await authService.AuthorizeAsync(User, report,
@@ -548,7 +549,7 @@ public sealed class ExpensesController(
     {
         try
         {
-            var reports = await service.GetReviewQueueAsync();
+            var reports = await expenseReadService.GetReviewQueueAsync();
             var submitterNames = await ResolveSubmitterNamesAsync(reports);
             return View(new ExpenseReviewViewModel { Reports = reports, SubmitterNames = submitterNames });
         }
@@ -568,7 +569,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
 
         var authResult = await authService.AuthorizeAsync(User, report,
@@ -592,7 +593,7 @@ public sealed class ExpensesController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var report = await service.GetAsync(id);
+        var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
 
         var authResult = await authService.AuthorizeAsync(User, report,
@@ -679,7 +680,7 @@ public sealed class ExpensesController(
         var result = new List<ExpenseReportDto>();
         foreach (var id in ids)
         {
-            var report = await service.GetAsync(id, ct);
+            var report = await expenseReadService.GetAsync(id, ct);
             if (report is null || report.Status != ExpenseReportStatus.Approved) continue;
 
             var authResult = await authService.AuthorizeAsync(User, report,

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -450,9 +450,10 @@ public sealed class ExpensesController(
         else
             SetError(result.Message);
 
+        var iban = await GetIbanViewAsync(user.Id);
         model.ReportId = id;
-        model.HasIban = result.HasIban;
-        model.MaskedIban = result.MaskedIban;
+        model.HasIban = iban.HasIban;
+        model.MaskedIban = iban.MaskedIban;
         return View(model);
     }
 

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Expenses;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Expenses.Dtos;
 using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
 using Humans.Web.Models;
@@ -397,12 +398,13 @@ public sealed class ExpensesController(
             if (report is null) return NotFound();
             if (report.SubmitterUserId != user.Id) return Forbid();
 
-            var iban = await expenseReadService.GetSubmitterIbanViewAsync(user.Id);
+            var iban = (await _userService.GetUserInfoAsync(user.Id))?.Profile?.Iban;
+            var hasIban = !string.IsNullOrEmpty(iban);
             var model = new ExpenseIbanViewModel
             {
                 ReportId = id,
-                HasIban = iban.HasIban,
-                MaskedIban = iban.MaskedIban
+                HasIban = hasIban,
+                MaskedIban = hasIban ? IbanFormatter.Mask(iban!) : null
             };
             return View(model);
         }

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -137,17 +137,29 @@ public sealed class ExpensesController(
                 new ExpenseReportOperationRequirement(ExpenseReportOperation.View));
             if (!authResult.Succeeded) return Forbid();
 
-            var detail = await expenseReadService.GetDetailViewDataAsync(user.Id, report);
+            var category = await budgetService.GetCategoryByIdAsync(report.BudgetCategoryId);
+            var categoryName = category is not null
+                ? $"{category.BudgetGroup?.Name} / {category.Name}"
+                : "(unknown category)";
+            var isSubmitter = report.SubmitterUserId == user.Id;
+            var canWithdraw = report.Status is ExpenseReportStatus.Submitted
+                or ExpenseReportStatus.CoordinatorEndorsed
+                or ExpenseReportStatus.Approved;
+            var iban = await GetIbanViewAsync(user.Id);
+            var timeline = isSubmitter
+                ? await expenseReadService.GetHoldedTimelineAsync(report)
+                : null;
+
             var model = new ExpenseDetailViewModel
             {
                 Report = report,
-                CategoryDisplayName = detail.CategoryDisplayName,
-                CanEdit = detail.CanEdit,
-                CanSubmit = detail.CanSubmit,
-                CanWithdraw = detail.CanWithdraw,
-                HasIban = detail.HasIban,
-                MaskedIban = detail.MaskedIban,
-                HoldedTimeline = detail.HoldedTimeline
+                CategoryDisplayName = categoryName,
+                CanEdit = isSubmitter && report.Status == ExpenseReportStatus.Draft,
+                CanSubmit = isSubmitter && report.Status == ExpenseReportStatus.Draft,
+                CanWithdraw = isSubmitter && canWithdraw,
+                HasIban = iban.HasIban,
+                MaskedIban = iban.MaskedIban,
+                HoldedTimeline = timeline
             };
             return View(model);
         }
@@ -398,13 +410,12 @@ public sealed class ExpensesController(
             if (report is null) return NotFound();
             if (report.SubmitterUserId != user.Id) return Forbid();
 
-            var iban = (await _userService.GetUserInfoAsync(user.Id))?.Profile?.Iban;
-            var hasIban = !string.IsNullOrEmpty(iban);
+            var iban = await GetIbanViewAsync(user.Id);
             var model = new ExpenseIbanViewModel
             {
                 ReportId = id,
-                HasIban = hasIban,
-                MaskedIban = hasIban ? IbanFormatter.Mask(iban!) : null
+                HasIban = iban.HasIban,
+                MaskedIban = iban.MaskedIban
             };
             return View(model);
         }
@@ -725,6 +736,13 @@ public sealed class ExpensesController(
                 .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
                 .Select(c => new BudgetCategoryOption(c.Id, g.Name, c.Name)))
             .ToList();
+    }
+
+    private async Task<(bool HasIban, string? MaskedIban)> GetIbanViewAsync(Guid userId)
+    {
+        var iban = (await _userService.GetUserInfoAsync(userId))?.Profile?.Iban;
+        var hasIban = !string.IsNullOrEmpty(iban);
+        return (hasIban, hasIban ? IbanFormatter.Mask(iban!) : null);
     }
 
 }

--- a/src/Humans.Web/Extensions/Sections/ExpensesSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ExpensesSectionExtensions.cs
@@ -17,6 +17,7 @@ internal static class ExpensesSectionExtensions
         services.AddSingleton<IExpenseRepository, ExpenseRepository>();
         // Dual-register: IExpenseReportService and IUserDataContributor resolve to the same instance.
         services.AddScoped<ExpensesExpenseReportService>();
+        services.AddScoped<IExpenseReportServiceRead>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
         services.AddScoped<IExpenseReportService>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
         services.AddScoped<HoldedExpenseOutboxJob>();

--- a/src/Humans.Web/Extensions/Sections/ExpensesSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ExpensesSectionExtensions.cs
@@ -15,10 +15,11 @@ internal static class ExpensesSectionExtensions
         this IServiceCollection services, IConfiguration config)
     {
         services.AddSingleton<IExpenseRepository, ExpenseRepository>();
-        // Dual-register: IExpenseReportService and IUserDataContributor resolve to the same instance.
+        // Register each Expenses surface against the same scoped orchestrator instance.
         services.AddScoped<ExpensesExpenseReportService>();
         services.AddScoped<IExpenseReportServiceRead>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
         services.AddScoped<IExpenseReportService>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
+        services.AddScoped<IExpenseReportBackgroundProcessor>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
         services.AddScoped<HoldedExpenseOutboxJob>();
         services.AddScoped<ExpensePaidPollingJob>();

--- a/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
@@ -41,6 +41,7 @@ public class AuthorizationPolicyTests : IDisposable
         services.AddScoped(_ => Substitute.For<IAgentRateLimitStore>());
         services.AddScoped(_ => Substitute.For<IAgentSettingsService>());
         // Expense resource-based handlers
+        services.AddScoped(_ => Substitute.For<IExpenseReportServiceRead>());
         services.AddScoped(_ => Substitute.For<IExpenseReportService>());
         // IsAnyTeamManagerOrCoordinatorHandler reads team-coord ids through this service
         // (cached path); register a single shared substitute so per-test setups stick.

--- a/tests/Humans.Application.Tests/Authorization/IbanAccessHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/IbanAccessHandlerTests.cs
@@ -19,7 +19,7 @@ namespace Humans.Application.Tests.Authorization;
 /// </summary>
 public sealed class IbanAccessHandlerTests
 {
-    private readonly IExpenseReportService _expenseService = Substitute.For<IExpenseReportService>();
+    private readonly IExpenseReportServiceRead _expenseReports = Substitute.For<IExpenseReportServiceRead>();
     private readonly IbanAccessHandler _handler;
 
     private static readonly Guid TargetUserId = Guid.NewGuid();
@@ -27,10 +27,10 @@ public sealed class IbanAccessHandlerTests
 
     public IbanAccessHandlerTests()
     {
-        _handler = new IbanAccessHandler(_expenseService);
+        _handler = new IbanAccessHandler(_expenseReports);
 
         // Default: report exists in Submitted status (non-Draft, non-Withdrawn)
-        _expenseService.GetAsync(ReportId, Arg.Any<CancellationToken>())
+        _expenseReports.GetAsync(ReportId, Arg.Any<CancellationToken>())
             .Returns(MakeReport(ReportId, ExpenseReportStatus.Submitted));
     }
 
@@ -74,7 +74,7 @@ public sealed class IbanAccessHandlerTests
     [HumansFact]
     public async Task FinanceAdmin_CanAccess_Iban_WhenReportIsCoordinatorEndorsed()
     {
-        _expenseService.GetAsync(ReportId, Arg.Any<CancellationToken>())
+        _expenseReports.GetAsync(ReportId, Arg.Any<CancellationToken>())
             .Returns(MakeReport(ReportId, ExpenseReportStatus.CoordinatorEndorsed));
         var user = CreateUserWithRole(RoleNames.FinanceAdmin);
         var requirement = new IbanAccessRequirement(TargetUserId, reportId: ReportId);
@@ -87,7 +87,7 @@ public sealed class IbanAccessHandlerTests
     [HumansFact]
     public async Task FinanceAdmin_CanAccess_Iban_WhenReportIsApproved()
     {
-        _expenseService.GetAsync(ReportId, Arg.Any<CancellationToken>())
+        _expenseReports.GetAsync(ReportId, Arg.Any<CancellationToken>())
             .Returns(MakeReport(ReportId, ExpenseReportStatus.Approved));
         var user = CreateUserWithRole(RoleNames.FinanceAdmin);
         var requirement = new IbanAccessRequirement(TargetUserId, reportId: ReportId);
@@ -102,7 +102,7 @@ public sealed class IbanAccessHandlerTests
     [HumansFact]
     public async Task FinanceAdmin_CannotAccess_Iban_WhenReportIsDraft()
     {
-        _expenseService.GetAsync(ReportId, Arg.Any<CancellationToken>())
+        _expenseReports.GetAsync(ReportId, Arg.Any<CancellationToken>())
             .Returns(MakeReport(ReportId, ExpenseReportStatus.Draft));
         var user = CreateUserWithRole(RoleNames.FinanceAdmin);
         var requirement = new IbanAccessRequirement(TargetUserId, reportId: ReportId);
@@ -115,7 +115,7 @@ public sealed class IbanAccessHandlerTests
     [HumansFact]
     public async Task FinanceAdmin_CannotAccess_Iban_WhenReportIsWithdrawn()
     {
-        _expenseService.GetAsync(ReportId, Arg.Any<CancellationToken>())
+        _expenseReports.GetAsync(ReportId, Arg.Any<CancellationToken>())
             .Returns(MakeReport(ReportId, ExpenseReportStatus.Withdrawn));
         var user = CreateUserWithRole(RoleNames.FinanceAdmin);
         var requirement = new IbanAccessRequirement(TargetUserId, reportId: ReportId);

--- a/tests/Humans.Application.Tests/Jobs/ExpensePaidPollingJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ExpensePaidPollingJobTests.cs
@@ -6,7 +6,7 @@ namespace Humans.Application.Tests.Jobs;
 
 /// <summary>
 /// Smoke tests: the job is a thin wrapper that delegates to
-/// <see cref="IExpenseReportService.PollHoldedPaidStatusAsync"/> with the right batch size.
+/// <see cref="IExpenseReportBackgroundProcessor.PollHoldedPaidStatusAsync"/> with the right batch size.
 /// Business logic is covered by <c>ExpenseReportServiceHoldedPollingTests</c>.
 /// </summary>
 public class ExpensePaidPollingJobTests
@@ -14,23 +14,23 @@ public class ExpensePaidPollingJobTests
     [HumansFact]
     public async Task ExecuteAsync_DelegatesToService_WithBatchSize50()
     {
-        var service = Substitute.For<IExpenseReportService>();
-        var job = new ExpensePaidPollingJob(service);
+        var expenses = Substitute.For<IExpenseReportBackgroundProcessor>();
+        var job = new ExpensePaidPollingJob(expenses);
 
         await job.ExecuteAsync();
 
-        await service.Received(1).PollHoldedPaidStatusAsync(50, Arg.Any<CancellationToken>());
+        await expenses.Received(1).PollHoldedPaidStatusAsync(50, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
     public async Task ExecuteAsync_PassesCancellationTokenThrough()
     {
-        var service = Substitute.For<IExpenseReportService>();
-        var job = new ExpensePaidPollingJob(service);
+        var expenses = Substitute.For<IExpenseReportBackgroundProcessor>();
+        var job = new ExpensePaidPollingJob(expenses);
         using var cts = new CancellationTokenSource();
 
         await job.ExecuteAsync(cts.Token);
 
-        await service.Received(1).PollHoldedPaidStatusAsync(50, cts.Token);
+        await expenses.Received(1).PollHoldedPaidStatusAsync(50, cts.Token);
     }
 }

--- a/tests/Humans.Application.Tests/Jobs/HoldedExpenseOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/HoldedExpenseOutboxJobTests.cs
@@ -6,7 +6,7 @@ namespace Humans.Application.Tests.Jobs;
 
 /// <summary>
 /// Smoke tests: the job is a thin wrapper that delegates to
-/// <see cref="IExpenseReportService.DrainHoldedOutboxAsync"/> with the right batch size.
+/// <see cref="IExpenseReportBackgroundProcessor.DrainHoldedOutboxAsync"/> with the right batch size.
 /// Business logic is covered by <c>ExpenseReportServiceHoldedOutboxTests</c>.
 /// </summary>
 public class HoldedExpenseOutboxJobTests
@@ -14,23 +14,23 @@ public class HoldedExpenseOutboxJobTests
     [HumansFact]
     public async Task ExecuteAsync_DelegatesToService_WithBatchSize100()
     {
-        var service = Substitute.For<IExpenseReportService>();
-        var job = new HoldedExpenseOutboxJob(service);
+        var expenses = Substitute.For<IExpenseReportBackgroundProcessor>();
+        var job = new HoldedExpenseOutboxJob(expenses);
 
         await job.ExecuteAsync();
 
-        await service.Received(1).DrainHoldedOutboxAsync(100, Arg.Any<CancellationToken>());
+        await expenses.Received(1).DrainHoldedOutboxAsync(100, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
     public async Task ExecuteAsync_PassesCancellationTokenThrough()
     {
-        var service = Substitute.For<IExpenseReportService>();
-        var job = new HoldedExpenseOutboxJob(service);
+        var expenses = Substitute.For<IExpenseReportBackgroundProcessor>();
+        var job = new HoldedExpenseOutboxJob(expenses);
         using var cts = new CancellationTokenSource();
 
         await job.ExecuteAsync(cts.Token);
 
-        await service.Received(1).DrainHoldedOutboxAsync(100, cts.Token);
+        await expenses.Received(1).DrainHoldedOutboxAsync(100, cts.Token);
     }
 }

--- a/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
@@ -179,39 +179,6 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
     // ─────────────────────────────── 4.3 ─────────────────────────────────────
 
     [HumansFact]
-    public async Task GetDetailViewDataAsync_ReturnsDraftSubmitterFlagsAndIban()
-    {
-        var (_, category) = SetupActiveYear();
-        var submitter = Guid.NewGuid();
-        var id = await _sut.CreateDraftAsync(submitter, category.Id, null);
-        var report = await _sut.GetAsync(id);
-        _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" }));
-
-        var result = await _sut.GetDetailViewDataAsync(submitter, report!);
-
-        result.CanEdit.Should().BeTrue();
-        result.CanSubmit.Should().BeTrue();
-        result.CanWithdraw.Should().BeFalse();
-        result.HasIban.Should().BeTrue();
-    }
-
-    [HumansFact]
-    public async Task GetDetailViewDataAsync_DeniesSubmitterActionsForOtherViewer()
-    {
-        var (_, category) = SetupActiveYear();
-        var submitter = Guid.NewGuid();
-        var id = await _sut.CreateDraftAsync(submitter, category.Id, null);
-        var report = await _sut.GetAsync(id);
-
-        var result = await _sut.GetDetailViewDataAsync(Guid.NewGuid(), report!);
-
-        result.CanEdit.Should().BeFalse();
-        result.CanSubmit.Should().BeFalse();
-        result.CanWithdraw.Should().BeFalse();
-    }
-
-    [HumansFact]
     public async Task AddLineAsync_AddsLine_AndUpdatesTotal()
     {
         var (_, category) = SetupActiveYear();
@@ -1253,7 +1220,7 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
     // ─────────────────────── Holded timeline (submitter view) ───────────────────
 
     [HumansFact]
-    public async Task GetDetailViewData_builds_timeline_with_owed_and_other()
+    public async Task GetHoldedTimelineAsync_builds_timeline_with_owed_and_other()
     {
         var userId = Guid.NewGuid();
         var (_, category) = SetupActiveYear();
@@ -1267,12 +1234,12 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
                 LastPaymentDate: null, TotalPaid: 0m));
 
         var report = await _sut.GetAsync(reportId);
-        var detail = await _sut.GetDetailViewDataAsync(userId, report!);
+        var timeline = await _sut.GetHoldedTimelineAsync(report!);
 
-        detail.HoldedTimeline.Should().NotBeNull();
-        detail.HoldedTimeline!.RegisteredInHolded.Should().BeTrue();
-        detail.HoldedTimeline.OwedToMember.Should().Be(200m);
-        detail.HoldedTimeline.OtherAmount.Should().Be(200m - report!.Total);
+        timeline.Should().NotBeNull();
+        timeline!.RegisteredInHolded.Should().BeTrue();
+        timeline.OwedToMember.Should().Be(200m);
+        timeline.OtherAmount.Should().Be(200m - report!.Total);
     }
 
     // ─────────────────────── PollHoldedPaidStatus (creditor balance) ──────────

--- a/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
@@ -697,8 +697,6 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
 
         result.Succeeded.Should().BeTrue();
         result.Message.Should().Be("IBAN saved.");
-        result.HasIban.Should().BeTrue();
-        result.MaskedIban.Should().NotBeNullOrWhiteSpace();
         await AuditLog.Received(1).LogAsync(
             AuditAction.IbanSet,
             nameof(Profile),
@@ -711,37 +709,12 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
     public async Task SaveSubmitterIbanWithResultAsync_ReturnsValidationFailure_WhenIbanInvalid()
     {
         var submitter = Guid.NewGuid();
-        _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" }));
 
         var result = await _sut.SaveSubmitterIbanWithResultAsync(submitter, "not-an-iban");
 
         result.Succeeded.Should().BeFalse();
         result.IsValidationError.Should().BeTrue();
         result.Message.Should().Be("Invalid IBAN format.");
-        result.HasIban.Should().BeTrue();
-    }
-
-    [HumansFact]
-    public async Task GetSubmitterIbanViewAsync_ReturnsMaskedIban_WhenProfileHasIban()
-    {
-        var submitter = Guid.NewGuid();
-        _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" }));
-
-        var result = await _sut.GetSubmitterIbanViewAsync(submitter);
-
-        result.HasIban.Should().BeTrue();
-        result.MaskedIban.Should().NotBeNullOrWhiteSpace();
-    }
-
-    [HumansFact]
-    public async Task GetSubmitterIbanViewAsync_ReturnsEmptyState_WhenProfileMissing()
-    {
-        var result = await _sut.GetSubmitterIbanViewAsync(Guid.NewGuid());
-
-        result.HasIban.Should().BeFalse();
-        result.MaskedIban.Should().BeNull();
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

Refactor pass for the Expenses section using the Reforge-guided workflow.

Changes:
- Split Expenses reads from the write service via `IExpenseReportServiceRead`.
- Moved IBAN display projections to the web boundary using `UserInfo.Profile.Iban`.
- Removed the UI-shaped expense detail service DTO/builder and kept only the Holded timeline read.
- Split recurring Holded maintenance work onto `IExpenseReportBackgroundProcessor`.
- Internalized the attachment storage key helper.
- Slimmed the IBAN save result to mutation outcome only.

## Reforge

- Expenses: 1740 -> 1470 (-270); surface -269, internal -1
- Overall: 57177 -> 56899 (-278); surface -277, internal -1

Accepted stages:
- `feb825c40` Split Expenses read surface
- `bdeddc66f` Derive expense IBAN view from UserInfo
- `01dd639f0` Narrow Expenses detail read surface
- `1614d726d` Split Expenses background processor surface
- `a51612a9a` Internalize Expenses attachment key helper
- `3e2bb3202` Slim Expenses IBAN save result

## Verification

Each accepted stage ran:
- `dotnet build Humans.slnx --disable-build-servers -v q` passed with existing analyzer warnings.
- Focused test slice passed after each stage: `dotnet test tests\Humans.Application.Tests\Humans.Application.Tests.csproj --no-build --filter "FullyQualifiedName~Services.Expenses|FullyQualifiedName~Authorization.IbanAccessHandlerTests|FullyQualifiedName~Authorization.AuthorizationPolicyTests|FullyQualifiedName~Jobs.ExpensePaidPollingJobTests|FullyQualifiedName~Jobs.HoldedExpenseOutboxJobTests" -v q`.

Final focused count: 322 tests passed.

## Stasis Notes

Remaining Reforge pressure is mostly broad repository surface, command parameter counts, controller action count, and cross-section full-service dependencies. I stopped here because the next likely changes would need either Budget/Team read-surface work outside the Expenses section, risky repository reshaping, or parameter objects that would be score gaming without a stronger domain command design.