### PR TITLE
refactor(Tickets): Reforge-guided section surface reduction

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
@@ -177,9 +177,6 @@ public interface ITicketRepository : IRepository
     Task<IReadOnlyList<TicketAttendee>> GetUnmatchedActiveAttendeesAsync(
         string vendorEventId, CancellationToken ct = default);
 
-    /// <summary>Insert or update a single TicketAttendee row. Used when the Tickets section creates an attendee outside the sync loop (e.g. on approved transfer reissue).</summary>
-    Task UpsertAttendeeAsync(TicketAttendee attendee, CancellationToken ct = default);
-
     /// <summary>
     /// Persists <c>VatAmount</c> updates for the given orders in a single
     /// <c>SaveChanges</c>. Only the VAT column is written — other mutations
@@ -223,57 +220,13 @@ public interface ITicketRepository : IRepository
 
     Task<IReadOnlyList<Guid>> GetAllMatchedOrderUserIdsAsync(CancellationToken ct = default);
 
-    /// <summary>
-    /// Returns distinct <c>MatchedUserId</c> values for orders whose
-    /// <c>PurchasedAt</c> falls within <c>[fromInclusive, toExclusive)</c>. Used
-    /// by the admin audience-segmentation diagnostic to compute year-scoped
-    /// ticket buckets without reading the orders table directly.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetMatchedOrderUserIdsInWindowAsync(
-        Instant fromInclusive, Instant toExclusive, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns distinct <c>MatchedUserId</c> values for attendees whose owning
-    /// order's <c>PurchasedAt</c> falls within <c>[fromInclusive, toExclusive)</c>.
-    /// Mirrors <see cref="GetMatchedOrderUserIdsInWindowAsync"/> for the attendee
-    /// side of the audience-segmentation diagnostic.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetMatchedAttendeeUserIdsInWindowAsync(
-        Instant fromInclusive, Instant toExclusive, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the distinct calendar years (UTC) of <c>PurchasedAt</c> for
-    /// every order with <c>MatchedUserId</c> set. Used by the admin
-    /// audience-segmentation diagnostic to populate the year picker.
-    /// </summary>
-    Task<IReadOnlyList<int>> GetMatchedOrderYearsAsync(CancellationToken ct = default);
-
-    Task<IReadOnlyList<Guid>> GetMatchedUserIdsForPaidOrdersAsync(CancellationToken ct = default);
-
-    Task<bool> HasAnyTicketMatchAsync(Guid userId, CancellationToken ct = default);
-
     Task<bool> HasEventTicketAsync(Guid userId, string vendorEventId, CancellationToken ct = default);
 
     Task<IReadOnlyList<string>> GetDistinctTicketTypesAsync(CancellationToken ct = default);
 
-    Task<int> CountSoldAttendeesAsync(CancellationToken ct = default);
-
     Task<IReadOnlyList<TicketOrder>> GetOrdersMatchedToUserAsync(Guid userId, CancellationToken ct = default);
 
-    /// <summary>
-    /// Returns the ids of every order matched to <paramref name="userId"/> whose
-    /// <c>PaymentStatus</c> is <see cref="TicketPaymentStatus.Paid"/> or
-    /// <see cref="TicketPaymentStatus.Pending"/>. Refunded and Cancelled rows are
-    /// excluded so the agent snapshot only surfaces actionable tickets.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetOpenOrderIdsMatchedToUserAsync(Guid userId, CancellationToken ct = default);
-
     Task<IReadOnlyList<TicketAttendee>> GetAttendeesMatchedToUserAsync(Guid userId, CancellationToken ct = default);
-
-    Task<IReadOnlyList<Instant>> GetPaidOrderDatesInWindowAsync(
-        Instant fromInclusive,
-        Instant toExclusive,
-        CancellationToken ct = default);
 
     Task<TicketDashboardTotals> GetDashboardTotalsAsync(CancellationToken ct = default);
 
@@ -282,8 +235,6 @@ public interface ITicketRepository : IRepository
     Task<IReadOnlyList<OrderDateAndCount>> GetOrderDateAttendeeCountsAsync(CancellationToken ct = default);
 
     Task<IReadOnlyList<RecentOrder>> GetRecentOrdersAsync(int count, CancellationToken ct = default);
-
-    Task<decimal> GetGrossPaidRevenueAsync(CancellationToken ct = default);
 
     Task<IReadOnlyList<PaidOrderSalesRow>> GetPaidOrderSalesRowsAsync(CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Tickets/ITicketService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketService.cs
@@ -102,11 +102,6 @@ public interface ITicketService : ITicketServiceRead, IApplicationService
     Task<List<OrderExportRow>> GetOrderExportDataAsync();
 
     /// <summary>
-    /// Returns ticket data for a user's GDPR data export.
-    /// </summary>
-    Task<UserTicketExportData> GetUserTicketExportDataAsync(Guid userId, CancellationToken ct = default);
-
-    /// <summary>
     /// Returns paid orders where the number of valid+checked-in attendees is
     /// less than the total number of attendees on the order.
     /// </summary>

--- a/src/Humans.Application/Interfaces/Tickets/ITicketingBudgetService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketingBudgetService.cs
@@ -1,5 +1,4 @@
 using Humans.Application.DTOs;
-using Humans.Domain.Entities;
 using NodaTime;
 
 namespace Humans.Application.Interfaces.Tickets;
@@ -30,13 +29,6 @@ public interface ITicketingBudgetService : IOrchestrator
     /// and the latest actuals. Returns virtual (non-persisted) entries for display.
     /// </summary>
     Task<IReadOnlyList<TicketingWeekProjection>> GetProjectionsAsync(Guid budgetGroupId);
-
-    /// <summary>
-    /// Returns the total number of tickets sold through completed weeks, derived from synced
-    /// revenue line item notes (e.g. "187 tickets"). Consistent with existing sync logic
-    /// that only includes completed ISO weeks.
-    /// </summary>
-    int GetActualTicketsSold(BudgetGroup ticketingGroup);
 }
 
 public sealed record TicketingProjectionUpdateCommand(

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -719,7 +719,7 @@ public sealed class TicketQueryService(
         return postEventInstant > now ? postEventInstant : null;
     }
 
-    public async Task<UserTicketExportData> GetUserTicketExportDataAsync(
+    private async Task<UserTicketExportData> GetUserTicketExportDataAsync(
         Guid userId, CancellationToken ct = default)
     {
         var orders = await ticketRepository.GetOrdersMatchedToUserAsync(userId, ct);

--- a/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
@@ -1,7 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Budget;
 using Humans.Application.Interfaces.Tickets;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using NodaTime;
@@ -94,11 +93,6 @@ public sealed class TicketingBudgetService(
     public Task<IReadOnlyList<TicketingWeekProjection>> GetProjectionsAsync(Guid budgetGroupId)
     {
         return budgetService.GetTicketingProjectionEntriesAsync(budgetGroupId);
-    }
-
-    public int GetActualTicketsSold(BudgetGroup ticketingGroup)
-    {
-        return budgetService.GetActualTicketsSold(ticketingGroup);
     }
 
     // NodaTime IsoDayOfWeek: Monday=1, Sunday=7.

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -270,18 +270,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
             .ToListAsync(ct);
     }
 
-    public async Task UpsertAttendeeAsync(TicketAttendee attendee, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        var existing = await ctx.TicketAttendees
-            .FirstOrDefaultAsync(a => a.VendorTicketId == attendee.VendorTicketId, ct);
-        if (existing is null)
-            ctx.TicketAttendees.Add(attendee);
-        else
-            ctx.Entry(existing).CurrentValues.SetValues(attendee);
-        await ctx.SaveChangesAsync(ct);
-    }
-
     public async Task UpdateOrderVatAmountsAsync(
         IReadOnlyList<(Guid OrderId, decimal VatAmount)> updates,
         CancellationToken ct = default)
@@ -393,70 +381,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
             .ToListAsync(ct);
     }
 
-    public async Task<IReadOnlyList<Guid>> GetMatchedOrderUserIdsInWindowAsync(
-        Instant fromInclusive, Instant toExclusive, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.TicketOrders
-            .AsNoTracking()
-            .Where(o => o.MatchedUserId != null &&
-                        o.PurchasedAt >= fromInclusive &&
-                        o.PurchasedAt < toExclusive)
-            .Select(o => o.MatchedUserId!.Value)
-            .Distinct()
-            .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<Guid>> GetMatchedAttendeeUserIdsInWindowAsync(
-        Instant fromInclusive, Instant toExclusive, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.TicketAttendees
-            .AsNoTracking()
-            .Where(a => a.MatchedUserId != null &&
-                        a.TicketOrder.PurchasedAt >= fromInclusive &&
-                        a.TicketOrder.PurchasedAt < toExclusive)
-            .Select(a => a.MatchedUserId!.Value)
-            .Distinct()
-            .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<int>> GetMatchedOrderYearsAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        var purchasedAt = await ctx.TicketOrders
-            .AsNoTracking()
-            .Where(o => o.MatchedUserId != null)
-            .Select(o => o.PurchasedAt)
-            .ToListAsync(ct);
-
-        return purchasedAt
-            .Select(i => i.ToDateTimeUtc().Year)
-            .Distinct()
-            .OrderDescending()
-            .ToList();
-    }
-
-    public async Task<IReadOnlyList<Guid>> GetMatchedUserIdsForPaidOrdersAsync(
-        CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.TicketOrders
-            .AsNoTracking()
-            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid && o.MatchedUserId != null)
-            .Select(o => o.MatchedUserId!.Value)
-            .Distinct()
-            .ToListAsync(ct);
-    }
-
-    public async Task<bool> HasAnyTicketMatchAsync(Guid userId, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        if (await ctx.TicketAttendees.AsNoTracking().AnyAsync(a => a.MatchedUserId == userId, ct))
-            return true;
-        return await ctx.TicketOrders.AsNoTracking().AnyAsync(o => o.MatchedUserId == userId, ct);
-    }
-
     public async Task<bool> HasEventTicketAsync(
         Guid userId, string vendorEventId, CancellationToken ct = default)
     {
@@ -489,15 +413,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
             .ToListAsync(ct);
     }
 
-    public async Task<int> CountSoldAttendeesAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.TicketAttendees
-            .AsNoTracking()
-            .CountAsync(a =>
-                a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn, ct);
-    }
-
     // ==========================================================================
     // Reads — TicketOrders
     // ==========================================================================
@@ -512,19 +427,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
             .Where(o => o.MatchedUserId == userId)
             // arch:db-sort-ok user ticket history chronology over unbounded orders
             .OrderByDescending(o => o.PurchasedAt)
-            .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<Guid>> GetOpenOrderIdsMatchedToUserAsync(
-        Guid userId, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.TicketOrders
-            .AsNoTracking()
-            .Where(o => o.MatchedUserId == userId
-                && (o.PaymentStatus == TicketPaymentStatus.Paid
-                    || o.PaymentStatus == TicketPaymentStatus.Pending))
-            .Select(o => o.Id)
             .ToListAsync(ct);
     }
 
@@ -546,21 +448,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
             .AsNoTracking()
             .Include(a => a.TicketOrder)
             .Where(a => a.TicketOrder.MatchedUserId == userId || a.MatchedUserId == userId)
-            .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<Instant>> GetPaidOrderDatesInWindowAsync(
-        Instant fromInclusive,
-        Instant toExclusive,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.TicketOrders
-            .AsNoTracking()
-            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid
-                        && o.PurchasedAt >= fromInclusive
-                        && o.PurchasedAt < toExclusive)
-            .Select(o => o.PurchasedAt)
             .ToListAsync(ct);
     }
 
@@ -648,15 +535,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
                 PaymentStatus = o.PaymentStatus,
             })
             .ToListAsync(ct);
-    }
-
-    public async Task<decimal> GetGrossPaidRevenueAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.TicketOrders
-            .AsNoTracking()
-            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
-            .SumAsync(o => o.TotalAmount, ct);
     }
 
     public async Task<IReadOnlyList<PaidOrderSalesRow>> GetPaidOrderSalesRowsAsync(

--- a/src/Humans.Infrastructure/Services/Tickets/CachingTicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/Tickets/CachingTicketQueryService.cs
@@ -102,10 +102,6 @@ public sealed class CachingTicketQueryService : ITicketService, ITicketCacheInva
     public Task<List<OrderExportRow>> GetOrderExportDataAsync() =>
         WithInner(inner => inner.GetOrderExportDataAsync());
 
-    public Task<UserTicketExportData> GetUserTicketExportDataAsync(
-        Guid userId, CancellationToken ct = default) =>
-        WithInner(inner => inner.GetUserTicketExportDataAsync(userId, ct));
-
     public Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default) =>
         WithInner(inner => inner.GetOrderDriftAsync(ct));
 

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -975,7 +975,6 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task<WhoHasntBoughtResult> GetWhoHasntBoughtAsync(string? search, string? filterTeam, string? filterTier, string? filterTicketStatus, int page, int pageSize) => throw new NotSupportedException();
         public Task<List<AttendeeExportRow>> GetAttendeeExportDataAsync() => throw new NotSupportedException();
         public Task<List<OrderExportRow>> GetOrderExportDataAsync() => throw new NotSupportedException();
-        public Task<UserTicketExportData> GetUserTicketExportDataAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<UserTicketHoldings> GetUserTicketHoldingsAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default) => throw new NotSupportedException();
     }

--- a/tests/Humans.Application.Tests/Services/TicketingBudgetServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketingBudgetServiceTests.cs
@@ -3,7 +3,6 @@ using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Budget;
 using Humans.Application.Interfaces.Tickets;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
@@ -250,17 +249,6 @@ public class TicketingBudgetServiceTests
         var result = await sut.GetProjectionsAsync(groupId);
 
         result.Should().BeSameAs(expected);
-    }
-
-    [HumansFact]
-    public void GetActualTicketsSold_DelegatesToBudgetService()
-    {
-        var group = new BudgetGroup { Id = Guid.NewGuid(), Name = "Ticketing" };
-        _budgetService.GetActualTicketsSold(group).Returns(187);
-
-        var sut = CreateSut();
-
-        sut.GetActualTicketsSold(group).Should().Be(187);
     }
 
     private static TicketOrderInfo BuildOrder(


### PR DESCRIPTION
## Tickets — Reforge-guided section surface reduction

### Section thesis

Tickets is a clean repo-backed vertical section. Its read surface `ITicketServiceRead` (`[SurfaceBudget(2)]`) exposes exactly `GetTicketOrdersAsync` (canonical `TicketOrderInfo`) and `GetUserTicketHoldingsAsync`; **all** cross-section consumers (Dashboard, Profile, Finance, Guest, Mailer audiences, AccountDeletion, Agent, AdminDiagnostics, ShiftManagement, UserEmail) correctly go through the read interface — the read boundary is already clean. The write/full surface `ITicketService : ITicketServiceRead, IApplicationService` (12 extra methods) is consumed only in-section (`TicketController`, `TicketTransferAdminController`, `TicketDashboardPageBuilder`). The primary DTO is `TicketOrderInfo` (+ embedded `TicketAttendeeInfo`), cached by `CachingTicketQueryService` (Singleton, two `TrackedCache` slices + one `IMemoryCache` event summary, inner cache-free, §15-compliant). Two repositories: `ITicketRepository` (`ticket_orders` / `ticket_attendees` / `ticket_sync_states`, ~52 methods) and `ITicketTransferRepository`.

The real, in-section, no-out-of-section-surface wins here are **deletions of dead surface**: 10 fully-dead `ITicketRepository` methods (zero callers including tests, several stranded by a removed audience-segmentation diagnostic), the dead-interface `GetUserTicketExportDataAsync` (only consumed internally by the GDPR contributor), and the dead cross-section-leaking `ITicketingBudgetService.GetActualTicketsSold(BudgetGroup)` pass-through.

The large `crossSectionFullService` pressure (152) is **blocked** — every fix needs read interfaces that do not exist on Budget / Campaigns / Shifts / Roles, or new methods on another section's read surface (out of scope for a surgical, in-section pass).

**Reforge baseline:** Tickets 3456 (surface 3303, internal 153).

This PR is repository-layer-and-above only: no EF migrations, no DbContext/model/schema changes, no entity persistence-shape or JSON serialization changes. No new durable surface is added — every change is a deletion.

### Accepted commits

#### 1. Delete 10 fully-dead `ITicketRepository` methods (interface + impl)

- **Subject:** `Delete 10 fully-dead ITicketRepository methods`
- **SHA:** `35ae072fd78c31dc18ce5b2c7604c011c02d5769`
- **Concept deleted:** Ten unused `ITicketRepository` query/write operations — the audience-segmentation window/year readers (`GetMatchedOrderUserIdsInWindowAsync`, `GetMatchedAttendeeUserIdsInWindowAsync`, `GetMatchedOrderYearsAsync`), scalar aggregates (`GetGrossPaidRevenueAsync`, `CountSoldAttendeesAsync`), the match probe (`HasAnyTicketMatchAsync`), `GetMatchedUserIdsForPaidOrdersAsync`, `GetOpenOrderIdsMatchedToUserAsync`, `GetPaidOrderDatesInWindowAsync`, and the single-row write helper `UpsertAttendeeAsync`.
- **Reforge target:** section 3562 → 3356 (Δ **−206**); outside increase 0.
- **Weighted value:** 206
- **Panel verdict: ACCEPT (A / B / C unanimous).**
  - **A:** Pure subtractive deletion — 171 lines removed, 0 added, confined to two Tickets-section files (`ITicketRepository` interface + `TicketRepository` impl). Independently verified zero callers: a grep for all 10 method names across every `.cs` file in the worktree (src + tests) returns no matches; the only textual hits are historical planning markdown under `docs/superpowers/plans/`, which are not callers. Glob confirms each of `TicketRepository`/`ITicketRepository` is a single file, so nothing was relocated to a partial/extension/static companion. No surviving member was narrowed `public`→`internal` or hidden. Return types were primitives/entities, so no DTO orphaned; behavior preserved (two aggregates superseded by `GetDashboardTotalsAsync`; the audience-segmentation readers stranded by a removed admin feature). Genuine reduction of real dead durable surface in a single section, with no cross-section, persistence, migration, or test changes.
  - **B:** Pure deletion of 171 lines, 0 added, confined to the Tickets section. Independently grep-verified the 10 method names across all `.cs` files: zero references in src or tests; only textual matches are three historical planning docs under `docs/superpowers/plans/`. Exactly the win this lens rewards — bespoke projection/predicate/scalar read methods (and one dead write helper) removed from a repository interface with nothing added. No new interface surface, no parameter/result bag DTOs, no relocation/rename/hide. No DTO orphaned (all returned primitives or existing entities). Dashboard scalars superseded by surviving `GetDashboardTotalsAsync`; audience-segmentation readers orphaned when that admin feature was removed. Contract preserved — no live consumers to migrate.
  - **C:** Pure deletion confined to the repository layer (171 removed, 0 added; only `ITicketRepository.cs` + `TicketRepository.cs` touched). Verified all 10 names have ZERO references in any `.cs` file across src and tests; only matches are historical `docs/superpowers/plans/` markdown. Build: 0 errors, 140 warnings all pre-existing HUM0025/HUM0014 in Shifts/Google/Email/Web/Teams — none in Tickets, none introduced. Tests: `Humans.Application.Tests` 332 passed / 1 skipped / 0 failed; `Humans.Web.Tests` 6 passed / 0 failed; diff contains zero test changes. Behavior/contract intact across service, controller, authorization, caching, audit, notification, transaction, DbContext, migration. Superseding `GetDashboardTotalsAsync` remains and is consumed by `TicketQueryService`. `Instant` (NodaTime) using correctly retained (still used by `ResetStaleRunningStateAsync`/`ReassignToUserAsync`); no orphaned imports or DTOs.

#### 2. Delete dead cross-section-leaking `ITicketingBudgetService.GetActualTicketsSold(BudgetGroup)`

- **Subject:** `Delete dead ITicketingBudgetService.GetActualTicketsSold cross-section pass-through`
- **SHA:** `38b7a590128ca9ba43762ea67761a4fa9575f235`
- **Concept deleted:** A redundant Tickets-side `GetActualTicketsSold` pass-through that duplicated `IBudgetService` and leaked the Budget-section domain entity `BudgetGroup` into the Tickets service surface (interface, impl, and the `using Humans.Domain.Entities;` import in all three touched files).
- **Reforge target:** section 3356 → 3340 (Δ **−16**); outside increase −13 (outside surface also shrank).
- **Weighted value:** 42
- **Panel verdict: ACCEPT (A / B / C unanimous).**
  - **A:** Genuine deletion, not relocation or hiding. The only references to the Tickets-side method were its interface declaration, one-line delegating impl body, and a single self-referential test — all three removed. The canonical owner `IBudgetService.GetActualTicketsSold` (both `BudgetGroup` and `BudgetGroupDetail` overloads) still exists in the Budget section, so the concept is not deleted from the app, only the redundant duplicate. The sole production consumer (`FinanceController.cs:605`) calls `budgetService.GetActualTicketsSold(ticketingGroup)` directly on `IBudgetService` against the `BudgetGroupDetail` overload — it never went through `ITicketingBudgetService`, so no production path changes behavior; contract preserved. Nothing moved to a helper/extension/partial/other section. No accessibility narrowing. The removed `using Humans.Domain.Entities;` is a real consequence — `BudgetGroup` was the only Domain.Entities type referenced, so its removal eliminates a genuine cross-section domain-entity leak from the Tickets surface (`Humans.Domain.Enums` correctly retained).
  - **B:** Verified the deletion is genuine, not a relocation or score game. After the diff, `GetActualTicketsSold` exists only on the Budget section. The sole production caller (`FinanceController.cs:605`) calls it directly on `IBudgetService`; `ticketingGroup` is a `BudgetGroupDetail` (`year.Groups.FirstOrDefault`), binding the `BudgetGroupDetail` overload, and never touched the deleted Tickets-side `BudgetGroup` method. `BudgetGroup` is confirmed a Domain entity (`src/Humans.Domain/Entities/BudgetGroup.cs`), so accepting it on the Tickets surface was a real cross-section domain-entity leak; the `using Humans.Domain.Entities;` import is now genuinely unreferenced in both touched Tickets source files. The only removed test was a self-referential delegation-only unit test. Nothing added. Named structural win: the Budget-section domain entity `BudgetGroup` is removed from the Tickets service surface by deleting a dead pass-through.
  - **C:** Genuine deletion, not relocation/rename/hide. Zero production callers: surviving `GetActualTicketsSold` references are `IBudgetService`'s two overloads, `BudgetService`'s two impls, and `FinanceController.cs:605` which calls it directly with a `BudgetGroupDetail` (from `BudgetYearDetail.Groups: IReadOnlyList<BudgetGroupDetail>`), binding the surviving overload. No production path changes behavior. No authorization, caching, audit, notification, or transaction boundary touches this synchronous arithmetic pass-through. The removed test was delegation-only coverage for the deleted method. The `using Humans.Domain.Entities;` removal in all three files is real (`BudgetGroup` was the only Domain.Entities type each referenced; Domain.Enums retained). Build: 0 errors, 140 warnings all pre-existing HUM0025/HUM0014 baseline outside Tickets.

#### 3. Drop dead-interface `GetUserTicketExportDataAsync` from `ITicketService`; make it private

- **Subject:** `Remove dead ITicketService.GetUserTicketExportDataAsync interface surface`
- **SHA:** `f1e1ac0f1dd62123ed12c95d3ef6ed1a28320d19`
- **Concept deleted:** Public `ITicketService` GDPR-export read method that nothing external consumes — the interface method, its caching-decorator forwarder, and the throw-stub in the Shifts test fake. The GDPR export feature itself is unchanged; it still runs via an internal private call.
- **Reforge target:** section 3340 → 3327 (Δ **−13**); outside increase 0.
- **Weighted value:** 13
- **Panel verdict: ACCEPT (A / B / C unanimous).**
  - **A:** Genuine durable-surface deletion, not relocation or gaming. The method was removed from the `ITicketService` interface entirely; the `CachingTicketQueryService` forwarder and `ShiftDashboardMetricsTests` fake stub were deleted outright (not moved). Grep over the worktree confirms `GetUserTicketExportDataAsync` now has exactly two references: the private declaration (`TicketQueryService.cs:722`) and a single internal self-call from `ContributeForUserAsync` (line 779). Zero external production or test callers, so the public→private demotion did not hide a real external caller — it corrected an interface member whose only consumer was the implementation's own GDPR self-call (the textbook interface-surface-dead case; the correct shape is private). Behavior preserved: GDPR export still runs unchanged through `ContributeForUserAsync` → private method; no DB/serialization touched. `UserTicketExportData` and its row records legitimately remain (still used by the private method). Net −11 lines; build succeeds; architecture + GDPR-adjacent tests pass.
  - **B:** Pure deletion of dead read-interface surface, nothing added. The only remaining references are the now-private impl at `TicketQueryService.cs:722` and its single internal self-call at line 779 inside `ContributeForUserAsync` (the GDPR `IUserDataContributor` path). The method was demoted public→private — the interface CONTRACT is genuinely gone; the surviving body is correctly an internal helper, not a renamed/relocated public surface. The `UserTicketExportData` record is retained because the private method still returns it (correct, not an orphan). No new DTO, predicate, scalar, or parameter-bag added. Behavior preserved. The single hand-written fake (`FakeTicketQueryService`, `ShiftDashboardMetricsTests:946`) had its stub removed to match; all other test usages are NSubstitute auto-fakes that self-conform. Build succeeds; Tickets/Architecture/Shift tests pass.
  - **C:** Verified by full grep + diff inspection. After the change, `GetUserTicketExportDataAsync` is referenced only at its private definition (`TicketQueryService.cs:722`) and the internal self-call from `ContributeForUserAsync` (line 779), the `IUserDataContributor` GDPR path. The implementation was demoted public→private (a legitimate hide — now purely the GDPR contributor's helper), while the interface declaration, the decorator forwarder, and the test stub are genuinely deleted. Behavior/contract preserved: the deleted decorator forwarder was a plain `WithInner` pass-through that performed NO caching (cold-key/invalidation behavior unchanged); GDPR export runs the identical query (`GetOrdersMatchedToUserAsync`/`GetAttendeesMatchedToUserAsync`) and identical projection through the private helper; authorization, audit, notification, transaction boundaries untouched; no DB/serialization change. The removed test throw-stub is mechanically forced by the interface narrowing, not a coverage weakening; the GDPR path remains exercised via `ContributeForUserAsync`.

### Cumulative score movement

- **Reforge Tickets baseline (origin/main):** 3456 (surface 3303, internal 153).
- Note: the per-commit `sectionBefore`/`sectionAfter` series above is measured on the section-deletion scale used during the run (3562 → 3356 → 3340 → 3327); the three accepted deletions are strictly subtractive and reduce the section surface monotonically.
- **Net section delta across the three accepted commits:** −206, −16, −13 = **−235**, all from deletion, with outside surface also shrinking by 13 (commit 2). No durable surface was added in any commit.

### Candidates rejected and why

None. The dominant `crossSectionFullService` pressure (152) was identified as the highest-magnitude opportunity but is **blocked / out of scope**: every viable fix requires read interfaces that do not yet exist on Budget / Campaigns / Shifts / Roles, or new methods on another section's read surface — both of which would add out-of-section surface and violate the surgical, in-section constraint of this pass. It is recorded below as remaining work rather than attempted.

### Remaining high-value work not done

- **Reduce `crossSectionFullService` pressure (Reforge ~152).** Tickets depends on the full write/orchestration surfaces of other sections where a read interface would suffice. Resolving it requires introducing `I<Section>ServiceRead` boundaries (or adding read-surface methods) on **Budget, Campaigns, Shifts, and Roles** — work that lands in *those* sections, not Tickets, and is therefore out of scope for this in-section pass. This is the single largest remaining lever and should be sequenced as per-section read-split work (cf. the `section-read-split` pattern) before Tickets can shed the dependency.
- The remaining `ITicketService` write/full surface (12 methods beyond the read interface) is consumed only in-section and is not dead, so no further deletion is available there without behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
