### PR TITLE
refactor(GoogleIntegration): Reforge-guided section surface reduction

### DIFF
--- a/src/Humans.Application/Helpers/GoogleGroupKeyHelper.cs
+++ b/src/Humans.Application/Helpers/GoogleGroupKeyHelper.cs
@@ -35,12 +35,6 @@ public static class GoogleGroupKeyHelper
             : null;
     }
 
-    public static string? TryDeriveGroupEmail(GoogleResource resource, string? configuredDomain = null)
-        => TryDeriveGroupEmail(resource.Url, configuredDomain);
-
-    public static string? TryDeriveGroupEmail(GoogleResourceSnapshot resource, string? configuredDomain = null)
-        => TryDeriveGroupEmail(resource.Url, configuredDomain);
-
     private static string? TryDeriveGroupEmail(string? url, string? configuredDomain = null)
     {
         if (string.IsNullOrWhiteSpace(url))

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleSyncService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleSyncService.cs
@@ -1,14 +1,16 @@
 using Humans.Application.DTOs;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using NodaTime;
 
 namespace Humans.Application.Interfaces.GoogleIntegration;
 
 /// <summary>
-/// Service for provisioning and syncing Google resources.
+/// Service for provisioning and syncing Google resources. The cross-section
+/// read projections (outbox reads) live on
+/// <see cref="IGoogleSyncServiceRead"/>; this full surface adds the
+/// provisioning and sync mutations consumed inside the section.
 /// </summary>
-public interface IGoogleSyncService : IApplicationService
+public interface IGoogleSyncService : IGoogleSyncServiceRead, IApplicationService
 {
     /// <summary>
     /// Provisions a new Google Drive folder for a team.
@@ -105,24 +107,6 @@ public interface IGoogleSyncService : IApplicationService
     /// RestrictInheritedAccess enabled. Returns the number of folders corrected.
     /// </summary>
     Task<int> EnforceInheritedAccessRestrictionsAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns the count of unprocessed Google sync outbox events that have a
-    /// non-null <c>LastError</c>. Used by the notification meter to surface
-    /// failed sync events to Admin without letting the Notifications section
-    /// read <c>google_sync_outbox_events</c> directly (design-rules §2c).
-    /// </summary>
-    Task<int> GetFailedSyncEventCountAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns the most recent Google sync outbox events for the admin
-    /// dashboard, ordered newest-first and capped by <paramref name="take"/>.
-    /// Keeps <c>google_sync_outbox_events</c> reads inside the owning service
-    /// (design-rules §2a/§2c) so callers do not reach past <see cref="IGoogleSyncService"/>
-    /// into the repository directly.
-    /// </summary>
-    Task<IReadOnlyList<GoogleSyncOutboxEventSnapshot>> GetRecentOutboxEventsAsync(
-        int take, CancellationToken cancellationToken = default);
 }
 
 public sealed record GroupSettingsRemediationResult(bool Succeeded, string? ErrorMessage)
@@ -131,13 +115,3 @@ public sealed record GroupSettingsRemediationResult(bool Succeeded, string? Erro
 
     public static GroupSettingsRemediationResult Failure(string message) => new(false, message);
 }
-
-public sealed record GoogleSyncOutboxEventSnapshot(
-    string EventType,
-    Guid TeamId,
-    Guid UserId,
-    Instant OccurredAt,
-    Instant? ProcessedAt,
-    int RetryCount,
-    string? LastError,
-    bool FailedPermanently);

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleSyncServiceRead.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleSyncServiceRead.cs
@@ -1,0 +1,40 @@
+using NodaTime;
+
+namespace Humans.Application.Interfaces.GoogleIntegration;
+
+/// <summary>
+/// Cross-section read surface for the Google Integration sync service.
+/// External sections inject this interface; it exposes only the outbox read
+/// projections needed cross-section, never EF entities or mutation methods.
+/// See <c>memory/architecture/section-read-write-split.md</c>.
+/// </summary>
+public interface IGoogleSyncServiceRead
+{
+    /// <summary>
+    /// Returns the count of unprocessed Google sync outbox events that have a
+    /// non-null <c>LastError</c>. Used by the notification meter to surface
+    /// failed sync events to Admin without letting the Notifications section
+    /// read <c>google_sync_outbox_events</c> directly (design-rules §2c).
+    /// </summary>
+    Task<int> GetFailedSyncEventCountAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the most recent Google sync outbox events for the admin
+    /// dashboard, ordered newest-first and capped by <paramref name="take"/>.
+    /// Keeps <c>google_sync_outbox_events</c> reads inside the owning service
+    /// (design-rules §2a/§2c) so callers do not reach past
+    /// <see cref="IGoogleSyncServiceRead"/> into the repository directly.
+    /// </summary>
+    Task<IReadOnlyList<GoogleSyncOutboxEventSnapshot>> GetRecentOutboxEventsAsync(
+        int take, CancellationToken cancellationToken = default);
+}
+
+public sealed record GoogleSyncOutboxEventSnapshot(
+    string EventType,
+    Guid TeamId,
+    Guid UserId,
+    Instant OccurredAt,
+    Instant? ProcessedAt,
+    int RetryCount,
+    string? LastError,
+    bool FailedPermanently);

--- a/src/Humans.Application/Interfaces/GoogleIntegration/ITeamResourceService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/ITeamResourceService.cs
@@ -184,10 +184,9 @@ public interface ITeamResourceService : IApplicationService
 
     /// <summary>
     /// Sets the RestrictInheritedAccess flag on a Drive folder resource and immediately
-    /// enforces the corresponding inheritedPermissionsDisabled setting on Google Drive.
+    /// enforces the corresponding inheritedPermissionsDisabled setting on Google Drive,
+    /// returning a result that captures any Google Drive mutation failure.
     /// </summary>
-    Task SetRestrictInheritedAccessAsync(Guid resourceId, bool restrict, CancellationToken ct = default);
-
     Task<TeamResourceMutationResult> SetRestrictInheritedAccessWithResultAsync(Guid resourceId, bool restrict, CancellationToken ct = default);
 }
 

--- a/src/Humans.Application/Interfaces/Repositories/IGoogleSyncOutboxRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IGoogleSyncOutboxRepository.cs
@@ -51,21 +51,6 @@ public interface IGoogleSyncOutboxRepository : IRepository
     /// </summary>
     Task<int> CountPendingAsync(CancellationToken ct = default);
 
-    /// <summary>
-    /// Counts stale sync events — unprocessed, carrying an error, but not
-    /// permanently failed. Matches the pre-migration inline query
-    /// <c>e.ProcessedAt == null &amp;&amp; e.LastError != null &amp;&amp; !e.FailedPermanently</c>.
-    /// Surfaced in the Admin daily digest. Read-only.
-    /// </summary>
-    Task<int> CountStaleAsync(CancellationToken ct = default);
-
-    /// <summary>
-    /// Counts unprocessed events currently in transient-retry state
-    /// (<c>ProcessedAt == null &amp;&amp; !FailedPermanently &amp;&amp; RetryCount &gt; 0</c>).
-    /// Surfaced in the Admin daily digest. Read-only.
-    /// </summary>
-    Task<int> CountTransientRetriesAsync(CancellationToken ct = default);
-
     // ==========================================================================
     // Read — admin dashboard (Part 2c)
     // ==========================================================================

--- a/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
@@ -532,7 +532,6 @@ public sealed partial class TeamResourceService(
                 resourceId);
             return TeamResourceMutationResult.Failed($"Failed to update inherited access setting: {ex.Message}");
         }
-        }
     }
 
     // ==========================================================================

--- a/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
@@ -528,9 +528,10 @@ public sealed partial class TeamResourceService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to set inheritedPermissionsDisabled on Google Drive for resource {ResourceId}",
+            logger.LogError(ex, "Failed to apply RestrictInheritedAccess for resource {ResourceId}",
                 resourceId);
             return TeamResourceMutationResult.Failed($"Failed to update inherited access setting: {ex.Message}");
+        }
         }
     }
 

--- a/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
@@ -488,31 +488,34 @@ public sealed partial class TeamResourceService(
         }
     }
 
-    public async Task SetRestrictInheritedAccessAsync(Guid resourceId, bool restrict, CancellationToken ct = default)
+    public async Task<TeamResourceMutationResult> SetRestrictInheritedAccessWithResultAsync(
+        Guid resourceId,
+        bool restrict,
+        CancellationToken ct = default)
     {
-        var existing = await repository.GetByIdAsync(resourceId, ct);
-        if (existing is null)
-        {
-            logger.LogWarning("SetRestrictInheritedAccessAsync: resource {ResourceId} not found", resourceId);
-            return;
-        }
-
-        if (existing.ResourceType != GoogleResourceType.DriveFolder)
-        {
-            logger.LogWarning("Cannot set RestrictInheritedAccess on non-folder resource {ResourceId} (type: {Type})",
-                resourceId, existing.ResourceType);
-            return;
-        }
-
-        var mutated = await repository.SetRestrictInheritedAccessAsync(resourceId, restrict, ct);
-        if (mutated is null)
-        {
-            // Row disappeared between the read and the write; nothing to enforce.
-            return;
-        }
-
         try
         {
+            var existing = await repository.GetByIdAsync(resourceId, ct);
+            if (existing is null)
+            {
+                logger.LogWarning("SetRestrictInheritedAccessWithResultAsync: resource {ResourceId} not found", resourceId);
+                return TeamResourceMutationResult.Success();
+            }
+
+            if (existing.ResourceType != GoogleResourceType.DriveFolder)
+            {
+                logger.LogWarning("Cannot set RestrictInheritedAccess on non-folder resource {ResourceId} (type: {Type})",
+                    resourceId, existing.ResourceType);
+                return TeamResourceMutationResult.Success();
+            }
+
+            var mutated = await repository.SetRestrictInheritedAccessAsync(resourceId, restrict, ct);
+            if (mutated is null)
+            {
+                // Row disappeared between the read and the write; nothing to enforce.
+                return TeamResourceMutationResult.Success();
+            }
+
             var error = await drivePermissions.SetInheritedPermissionsDisabledAsync(mutated.GoogleId, restrict, ct);
             if (error is not null)
             {
@@ -521,27 +524,12 @@ public sealed partial class TeamResourceService(
             }
             logger.LogInformation("Set RestrictInheritedAccess={Restrict} for resource {ResourceId} ({GoogleId})",
                 restrict, resourceId, mutated.GoogleId);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to set inheritedPermissionsDisabled on Google Drive for resource {ResourceId} ({GoogleId})",
-                resourceId, mutated.GoogleId);
-            throw;
-        }
-    }
-
-    public async Task<TeamResourceMutationResult> SetRestrictInheritedAccessWithResultAsync(
-        Guid resourceId,
-        bool restrict,
-        CancellationToken ct = default)
-    {
-        try
-        {
-            await SetRestrictInheritedAccessAsync(resourceId, restrict, ct);
             return TeamResourceMutationResult.Success();
         }
         catch (Exception ex)
         {
+            logger.LogError(ex, "Failed to set inheritedPermissionsDisabled on Google Drive for resource {ResourceId}",
+                resourceId);
             return TeamResourceMutationResult.Failed($"Failed to update inherited access setting: {ex.Message}");
         }
     }

--- a/src/Humans.Application/Services/Notifications/NotificationMeterProvider.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationMeterProvider.cs
@@ -20,7 +20,7 @@ namespace Humans.Application.Services.Notifications;
 /// Provides live counter meters for admin/coordinator work queues. Counts
 /// are computed by calling into each owning section service
 /// (<see cref="IUserService"/>,
-/// <see cref="IGoogleSyncService"/>, <see cref="ITeamService"/>,
+/// <see cref="IGoogleSyncServiceRead"/>, <see cref="ITeamService"/>,
 /// <see cref="ITicketSyncService"/>, <see cref="IApplicationDecisionService"/>)
 /// and cached for ~2 minutes. No direct DB access.
 /// </summary>
@@ -35,7 +35,7 @@ namespace Humans.Application.Services.Notifications;
 /// </remarks>
 public sealed class NotificationMeterProvider(
     IUserServiceRead userService,
-    IGoogleSyncService googleSyncService,
+    IGoogleSyncServiceRead googleSyncService,
     ITeamServiceRead teamService,
     ITicketSyncService ticketSyncService,
     IApplicationDecisionService applicationDecisionService,

--- a/src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleSyncOutboxRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleSyncOutboxRepository.cs
@@ -35,26 +35,6 @@ internal sealed class GoogleSyncOutboxRepository(IDbContextFactory<HumansDbConte
             .CountAsync(e => e.ProcessedAt == null, ct);
     }
 
-    public async Task<int> CountStaleAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.GoogleSyncOutboxEvents
-            .AsNoTracking()
-            .CountAsync(
-                e => e.ProcessedAt == null && e.LastError != null && !e.FailedPermanently,
-                ct);
-    }
-
-    public async Task<int> CountTransientRetriesAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.GoogleSyncOutboxEvents
-            .AsNoTracking()
-            .CountAsync(
-                e => e.ProcessedAt == null && !e.FailedPermanently && e.RetryCount > 0,
-                ct);
-    }
-
     public async Task<IReadOnlyList<GoogleSyncOutboxEvent>> GetRecentAsync(
         int take, CancellationToken ct = default)
     {

--- a/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
@@ -41,6 +41,7 @@ internal static class GoogleWorkspaceInfrastructureExtensions
         if (hasGoogleCredentials)
         {
             services.AddScoped<IGoogleSyncService, GoogleWorkspaceSyncService>();
+            services.AddScoped<IGoogleSyncServiceRead>(sp => sp.GetRequiredService<IGoogleSyncService>());
             services.AddScoped<ITeamResourceGoogleClient, TeamResourceGoogleClient>();
             services.AddScoped<IGoogleDriveActivityClient, GoogleDriveActivityClient>();
 
@@ -71,6 +72,7 @@ internal static class GoogleWorkspaceInfrastructureExtensions
         else
         {
             services.AddScoped<IGoogleSyncService, StubGoogleSyncService>();
+            services.AddScoped<IGoogleSyncServiceRead>(sp => sp.GetRequiredService<IGoogleSyncService>());
             services.AddScoped<ITeamResourceGoogleClient, StubTeamResourceGoogleClient>();
             services.AddScoped<IGoogleDriveActivityClient, StubGoogleDriveActivityClient>();
 

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleSyncOutboxRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleSyncOutboxRepositoryTests.cs
@@ -69,33 +69,6 @@ public sealed class GoogleSyncOutboxRepositoryTests : IDisposable
     }
 
     [HumansFact]
-    public async Task CountStaleAsync_ExcludesPermanentFailures()
-    {
-        Seed(processedAt: null, lastError: "transient-1");
-        Seed(processedAt: null, lastError: "transient-2");
-        Seed(processedAt: null, failedPermanently: true, lastError: "perm"); // excluded
-        Seed(processedAt: null); // no error — excluded
-
-        var count = await _repository.CountStaleAsync();
-
-        count.Should().Be(2);
-    }
-
-    [HumansFact]
-    public async Task CountTransientRetriesAsync_RequiresRetryCountAboveZero()
-    {
-        Seed(processedAt: null, retryCount: 0, lastError: "first-attempt"); // excluded (never retried)
-        Seed(processedAt: null, retryCount: 2, lastError: "retrying"); // matches
-        Seed(processedAt: null, retryCount: 5, lastError: null); // matches (LastError can be null)
-        Seed(processedAt: null, retryCount: 3, lastError: "perm", failedPermanently: true); // excluded
-        Seed(processedAt: Instant.FromUtc(2026, 4, 23, 12, 0), retryCount: 4); // processed — excluded
-
-        var count = await _repository.CountTransientRetriesAsync();
-
-        count.Should().Be(2);
-    }
-
-    [HumansFact]
     public async Task GetRecentAsync_OrdersByOccurredAtDescending_AndAppliesTakeLimit()
     {
         var oldest = Seed(occurredAt: Instant.FromUtc(2026, 4, 20, 10, 0));

--- a/tests/Humans.Application.Tests/Notifications/NotificationMeterProviderTests.cs
+++ b/tests/Humans.Application.Tests/Notifications/NotificationMeterProviderTests.cs
@@ -23,7 +23,7 @@ namespace Humans.Application.Tests.Notifications;
 public class NotificationMeterProviderTests : IDisposable
 {
     private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly IGoogleSyncService _googleSyncService = Substitute.For<IGoogleSyncService>();
+    private readonly IGoogleSyncServiceRead _googleSyncService = Substitute.For<IGoogleSyncServiceRead>();
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly ITicketSyncService _ticketSyncService = Substitute.For<ITicketSyncService>();
     private readonly IApplicationDecisionService _applicationDecisionService = Substitute.For<IApplicationDecisionService>();


### PR DESCRIPTION
## refactor(GoogleIntegration): Reforge-guided section surface reduction

Reforge-guided, panel-reviewed surface reduction for the **GoogleIntegration** section. Each commit deletes a genuine concept (a cross-section dependency edge, dead repository/interface surface, or dead public helper overloads), not just shuffling code to game a metric. Repository-layer-and-above only — no DB/persistence/migration/serialization changes.

### Section thesis

GoogleIntegration is a large, repo-backed external-integration section with an unusual shape: it owns only two thin tables (`sync_service_settings`, `google_sync_outbox`) but a wide service surface that wraps Google Workspace HTTP APIs through shape-neutral connector interfaces. It also owns `ITeamResourceService` / `TeamResourceService`, the sole owner of the sibling `google_resources` table (section label follows code locality per `memory/architecture/team-resources-google-integration-section.md`).

There is **no caching decorator** (documented decision — all paths are request-scoped admin ops or background jobs) and **no canonical cached `<Section>Info` read DTO** — this section has no single aggregate read model. Read facts are emitted as purpose-shaped DTOs/records (`GoogleResourceSnapshot`, `WorkspaceAccountInfo`, `GoogleSyncOutboxEventSnapshot`, `SyncServiceSettingsInfo`, `EmailRenameDetectionResult`).

The thesis identified one genuine cross-section read-on-a-mutation-surface dependency (Notifications → full `IGoogleSyncService` for a single scalar) plus a tail of dead surface (unused outbox count queries, a duplicate void mutation method on a cross-section contract, dead public helper overloads). The high-debt candidates that would merely move debt into another section — switching `GoogleWorkspaceSyncService`'s `ITeamService`/`IUserService` deps onto `*ServiceRead` (blocked: real write call + methods not on the narrow read interface), and the `crossSectionFullService` injection scores (justified by breadth of methods called) — were correctly left alone.

### Accepted commits

**1. Extract `IGoogleSyncServiceRead`; route Notifications off full `IGoogleSyncService`** — `b1cdb9a`
- **Concept deleted:** Notifications' compile-time dependency on the full 14-method `IGoogleSyncService` mutation surface — `NotificationMeterProvider` now depends only on the 2-method `IGoogleSyncServiceRead` contract.
- **Reforge target (GoogleIntegration section):** 3667 → 3677 (Δ +10; outside Δ −6)
- **Weighted value:** 2
- **Panel verdict:** accept / accept / accept (unanimous). Textbook application of the sanctioned section-read-write-split pattern (`peters-hard-rules.md` "IServiceRead interfaces for cross-section service calls"; `memory/architecture/section-read-write-split.md`; reference impl Teams, thesis C1). The two read methods + `GoogleSyncOutboxEventSnapshot` record were relocated into the new narrower interface, with `IGoogleSyncService` inheriting it — no net new surface, no consumer lost a member. The genuine deletion is the narrowed cross-section edge: `GetFailedSyncEventCountAsync`'s only production caller is `NotificationMeterProvider`, re-pointed to the 2-method read interface; `GetRecentOutboxEventsAsync`'s only caller is `GoogleController` (own-section), kept on the full interface via inheritance. Neither method can be inlined as caller LINQ — both query the section-owned `google_sync_outbox` table that Notifications is forbidden to read directly (design-rules §2c), and there is no canonical read DTO over outbox events. No accessibility narrowing; impl classes unchanged; DI registers the read interface from the same-scope full service in both credential branches. Build green, 430 tests pass, architecture/baseline tests green.

**2. Delete dead `CountStaleAsync` + `CountTransientRetriesAsync` (`IGoogleSyncOutboxRepository`)** — `7d1f83a`
- **Concept deleted:** Two unused outbox count queries on the `IGoogleSyncOutboxRepository` public surface.
- **Reforge target (GoogleIntegration section):** 3677 → 3637 (Δ −40; outside Δ 0)
- **Weighted value:** 40
- **Panel verdict:** accept / accept / accept (unanimous). Purely subtractive. Grep across the worktree returns zero references post-deletion, and the two distinctive EF predicates reappear nowhere — not moved to a helper/extension/static/partial/another section, not inlined as LINQ. The XML docs claimed both were "Surfaced in the Admin daily digest," but that consumer does not exist: the only send-admin-daily-digest reference is a retired-jobs `RemoveIfExists` cleanup entry, confirming the digest job was already deleted; surviving Board/Admin/Ticket digest surfaces never read outbox counts. So these were truly dead public surface with a stale doc-comment. On the section's OWN repository (no cross-section Info DTO to LINQ over) with zero callers, deletion is the correct disposition. Deleted tests covered only the deleted methods; the `Seed` helper params remain exercised by surviving tests (`CountPendingAsync`, `CountFailedAsync`, `GetProcessingBatchAsync`, `IncrementRetryAsync`), so no orphan and no live coverage lost. No DB/persistence/serialization/contract change.

**3. Collapse dead void `SetRestrictInheritedAccessAsync` into With-Result (`ITeamResourceService`)** — `dddfaa2`
- **Concept deleted:** `public void SetRestrictInheritedAccessAsync` — a dead second mutation method on the `ITeamResourceService` contract that duplicated the result-returning variant.
- **Reforge target (GoogleIntegration section):** 3637 → 3616 (Δ −21; outside Δ 0)
- **Weighted value:** 21
- **Panel verdict:** accept / accept / accept (unanimous). Genuine interface-surface deletion. The void method's body was inlined into its only caller (`WithResultAsync`) and removed from both `ITeamResourceService` and `TeamResourceService` — not pushed into a helper/extension/static/partial/other section. Grep confirms zero remaining references to the service-level void method; the surviving `SetRestrictInheritedAccessAsync` matches are the repository method (different signature `Task<GoogleResource?>`, untouched, a distinct concept). Sole production consumer (`TeamAdminController:520`) and sole test (`TeamResourceServiceDeactivateTests:126`) already used the With-Result variant. The interface drops from two parallel mutation methods (do-it vs do-it-and-wrap) to one. No accessibility narrowing — eliminated outright. Behavior preserved branch-by-branch: the original `WithResultAsync` already wrapped the whole void body in one try/catch, so the early no-op returns map to `Success()`, the Drive-error throw and any exception map to `Failed(...)` identically. Only delta is a cosmetic catch-block log-message change (drops the now-out-of-scope `mutated.GoogleId` token while still logging `resourceId`) — logging-only, no contract/return-value impact. No new interface method added.

**4. Delete dead public `TryDeriveGroupEmail` overloads (`GoogleGroupKeyHelper`)** — `cdfe368`
- **Concept deleted:** Two unused public group-email helper overloads (`GoogleGroupKeyHelper.TryDeriveGroupEmail(GoogleResource)` and `(GoogleResourceSnapshot)`) — dead public surface with zero production or test callers.
- **Reforge target (GoogleIntegration section):** 3616 → 3616 (Δ 0; outside Δ 0)
- **Weighted value:** 0
- **Panel verdict:** accept / accept / accept (unanimous). One file, 6 deletions, zero additions. Grep across the whole repo (src, tests, docs) confirms the deleted overloads had zero production and zero test callers — the only `TryDeriveGroupEmail` consumer is the helper's own private worker reached via the legitimate public `TryGetGroupKey` entry point, which is retained. The deleted methods were thin one-line wrappers (`=> TryDeriveGroupEmail(resource.Url, configuredDomain)`) with no unique logic, so nothing was relocated. The similarly-named `GoogleWorkspaceSyncService.TryDeriveGroupEmail(GoogleResource)` is a distinct private method of a different class and is unaffected. No accessibility narrowing — the real public entry points (`TryGetGroupKey` overloads, with live callers) stay public. Both `using` directives remain required by the surviving overloads, so no orphan imports. The implementer is candid that the Reforge score is unmoved (+0) — not metric-gaming, just deletion of genuinely dead public surface.

### Cumulative score movement (GoogleIntegration section)

origin/main baseline **3667** → final **3616** (net **−51**). Step deltas: +10, −40, −21, 0. (Iteration 1's +10 is the mechanics of the section-read-write split — relocating the two read methods and the snapshot record into the new narrower interface, which inherits up to the full interface; the offsetting outside-section Δ was −6, narrowing Notifications' cross-section footprint. The net of all four steps is a −51 section reduction with zero net increase outside the section.)

### Candidates rejected

None rejected during execution — all four executed candidates passed the panel unanimously. The thesis pre-filtered the non-starters before execution:
- **Switch `GoogleWorkspaceSyncService`'s `ITeamService`/`IUserService` deps to `*ServiceRead`:** BLOCKED. It calls a user **write** (`TrySetGoogleEmailStatusFromSyncAsync`) + `GetByEmailOrAlternateAsync` (returns the `User` entity, not on the read interface), and team methods not on the narrow 4-method `ITeamServiceRead`. Migrating them is a Teams-section change (debt-moving) — out of scope.
- **`crossSectionFullService` (144 pts):** the injected full services (`ITeamService`/`IUserService` etc.) are justified by the breadth of methods called; no clean delete here besides C1.
- **`ISystemTeamSync`, `IGoogleWorkspaceUserService`, `IGoogleAdminService`:** all genuinely consumed; `GoogleAdminService` is a real orchestrator/adapter (DB checks + audit + result-shaping), not a pass-through.

### Remaining high-value work not done

- **No `I<Section>ServiceRead` for the section's other full interfaces.** This run carved the read surface only out of `IGoogleSyncService` (the one genuine cross-section read-on-mutation edge). The remaining full interfaces are all consumed as legitimate mutation orchestration; no further read split is warranted without a new read-only consumer surfacing.
- **Pre-existing `HUM0025` table-sharing on the outbox table** is untouched and out of scope for this section-surface run.
- **`ITeamService`/`IUserService` read-narrowing inside `GoogleWorkspaceSyncService`** remains blocked on Teams/Users-section interface work (see rejected candidates) — a cross-section follow-up, not a GoogleIntegration-local change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
