### PR TITLE
refactor(Users): Reforge-guided section surface reduction

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,11 +43,6 @@
           service entry point per issue #691. Kept visible as warnings (not
           hidden via NoWarn in production projects) so new render-path
           violations stay surfaced.
-        - HUM_USER_GetById: [Obsolete] marker on IUserService.GetByIdAsync.
-          Callers are being migrated to GetUserInfoAsync; remaining sites
-          (e.g. CampaignService.cs:550 private-helper overload) ride the
-          warning until the migration finishes. Kept visible as a warning
-          so new callers stay surfaced.
         - HUM0019: read of Identity-derived User column from Application or
           Web (issue nobodies-collective/Humans#506). Stays a warning while
           legacy reads (computed-override projections of UserEmails) are
@@ -73,7 +68,7 @@
           remove this entry once the last [Grandfathered("HUM0028", ...)] is
           gone (i.e., every cross-section invalidator has been absorbed).
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009;HUM0010;HUM0011;HUM0014;HUM0017;HUM0018;HUM0019;HUM0024;HUM0025;HUM0028;HUM_USER_DISPLAYNAME;HUM_USER_GetById</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009;HUM0010;HUM0011;HUM0014;HUM0017;HUM0018;HUM0019;HUM0024;HUM0025;HUM0028;HUM_USER_DISPLAYNAME</WarningsNotAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/src/Humans.Application/Interfaces/Repositories/ISyncSettingsRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ISyncSettingsRepository.cs
@@ -22,7 +22,7 @@ public interface ISyncSettingsRepository : IRepository
     /// Returns every sync service settings row, ordered by <see cref="SyncServiceType"/>.
     /// Read-only (<c>AsNoTracking</c>). The <c>UpdatedByUser</c> navigation is
     /// <b>not</b> loaded — callers resolve the display name via
-    /// <c>IUserService.GetByIdAsync(UpdatedByUserId)</c>.
+    /// <c>IUserService.GetUserInfoAsync(UpdatedByUserId)</c>.
     /// </summary>
     Task<IReadOnlyList<SyncServiceSettings>> GetAllAsync(CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
@@ -522,7 +522,7 @@ public interface ITeamRepository : IRepository
     /// cross-section read routed through <see cref="Users.IUserService"/> in
     /// the application service, not here.
     /// </summary>
-    // (no method on this interface — see IUserService.GetByIdAsync)
+    // (no method on this interface — see IUserService.GetUserInfoAsync)
 
     // ==========================================================================
     // Outbox (Google sync) — accessed from Teams writes

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -58,15 +58,6 @@ public partial interface IUserRepository : IRepository
         string normalizedEmail, string? alternateEmail, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns the id of any user, other than <paramref name="excludeUserId"/>,
-    /// whose legacy <c>GoogleEmail</c> shadow column matches the given address
-    /// (case-insensitive), or null if no such user exists.
-    /// </summary>
-    [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. Use IUserRepository.GetOtherUserIdHavingUserEmailAsync (matches the user_emails table — the canonical location for Google identity once UserEmail.IsGoogle is sole source of truth).")]
-    Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
-        string email, Guid excludeUserId, CancellationToken ct = default);
-
-    /// <summary>
     /// Returns the legacy <c>GoogleEmail</c> shadow-column value for the given
     /// users (only entries where the column is non-null are present in the
     /// result). The CLR property is gone — this is the only way to observe the

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -339,17 +339,6 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns the id of any user, other than <paramref name="excludeUserId"/>,
-    /// whose legacy <c>User.GoogleEmail</c> shadow column matches <paramref name="email"/>
-    /// (case-insensitive), or null if no such user exists.
-    /// </summary>
-    [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. Use IUserEmailService.GetOtherUserIdHavingEmailAsync — once UserEmail.IsGoogle is sole source of truth a Google identity always has a matching user_emails row, so any other user already owning the address is detected by the user_emails check.")]
-    Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
-        string email,
-        Guid excludeUserId,
-        CancellationToken ct = default);
-
-    /// <summary>
     /// Sets <c>User.LastConsentReminderSentAt</c> to <paramref name="sentAt"/>.
     /// No-op if the user does not exist. Used by the re-consent reminder job
     /// so it does not write to the Users table directly (design-rules §2c).

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -41,9 +41,12 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
         CancellationToken ct = default);
 
     /// <summary>
-    /// Get all participation records for a given year.
+    /// Get all participation records for a given year, projected to the slim
+    /// <see cref="UserParticipationRow"/> shape (no EF entity leaves the
+    /// section). Served from the caching decorator's <see cref="UserInfo"/>
+    /// snapshot.
     /// </summary>
-    Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default);
+    Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default);
 
     /// <summary>
     /// Declare that the user is not attending this year's event.
@@ -451,4 +454,16 @@ public record AnonymizedAccountSummary(
 public sealed record OnsiteUserRow(
     Guid UserId,
     string DisplayName,
+    Instant? CheckedInAt);
+
+/// <summary>
+/// Slim cross-section projection of an <see cref="EventParticipation"/> row for
+/// a given year, returned by <see cref="IUserService.GetAllParticipationsForYearAsync"/>.
+/// Carries only the facts consumers diff against (status, source, check-in
+/// instant) keyed by user — no EF entity crosses the section boundary.
+/// </summary>
+public sealed record UserParticipationRow(
+    Guid UserId,
+    ParticipationStatus Status,
+    ParticipationSource Source,
     Instant? CheckedInAt);

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -329,11 +329,14 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     // ---- Methods added for ContactService migration ----
 
     /// <summary>
-    /// Finds a user whose <c>Email</c> or <c>GoogleEmail</c> matches the given
-    /// address (case-insensitive). Also checks the gmail/googlemail alternate
-    /// when applicable. Returns null if no match.
+    /// Finds the user whose <c>Email</c> or <c>GoogleEmail</c> matches the given
+    /// address (case-insensitive) and returns the cached <see cref="UserInfo"/>
+    /// read-model for them. Also checks the gmail/googlemail alternate when
+    /// applicable, and falls back to the legacy <c>User.GoogleEmail</c> shadow
+    /// column for pre-issue-687 users whose <c>UserEmail.IsGoogle</c> rows are
+    /// unset. Returns null if no match.
     /// </summary>
-    Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default);
+    Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the id of any user, other than <paramref name="excludeUserId"/>,

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -49,9 +49,11 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default);
 
     /// <summary>
-    /// Declare that the user is not attending this year's event.
+    /// Declare that the user is not attending this year's event. Upserts a
+    /// UserDeclared NotAttending row unless the user is already Attended (in
+    /// which case the declaration is logged and ignored).
     /// </summary>
-    Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default);
+    Task DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default);
 
     /// <summary>
     /// Undo a "not attending" declaration. Removes the record.

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -92,12 +92,6 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns all users, read-only. At ~500 users this is cheap to load in full.
-    /// Used by admin list views that must include profileless users.
-    /// </summary>
-    Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default);
-
-    /// <summary>
     /// Purges a human at the User aggregate — removes all UserEmail rows
     /// through <c>IUserRepository</c>, anonymizes the display name, and
     /// permanently locks out the account. Returns the prior display name on

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -19,16 +19,6 @@ namespace Humans.Application.Interfaces.Users;
 public interface IUserService : IUserServiceRead, IApplicationService, IUserMerge
 {
     /// <summary>
-    /// Fetches a single user by id with the <see cref="User.UserEmails"/>
-    /// collection populated. Returns null if the user does not exist. Served
-    /// from the caching decorator's <see cref="UserInfo"/> dict for warm-cache
-    /// callers — the cache holds the full user payload, so there is no
-    /// "without emails" variant.
-    /// </summary>
-    [Obsolete("Callers must migrate to IUserService.GetUserInfoAsync()", false, DiagnosticId = "HUM_USER_GetById")]
-    Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default);
-
-    /// <summary>
     /// Fetches a batched set of users keyed by id with each user's
     /// <see cref="User.UserEmails"/> collection populated. Missing users are
     /// absent from the returned dictionary. Used for in-memory stitching

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -169,13 +169,6 @@ public sealed class UserService(
         return users;
     }
 
-    public async Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default)
-    {
-        var users = await repo.GetAllAsync(ct);
-        await HydrateUserEmailsAsync(users, ct);
-        return users;
-    }
-
     public async Task<string?> PurgeOwnDataAsync(Guid userId, CancellationToken ct = default)
     {
         if (await repo.GetByIdAsync(userId, ct) is null)

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -211,11 +211,6 @@ public sealed class UserService(
         return await GetUserInfoAsync(legacyUser.Id, ct);
     }
 
-    [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. Use IUserEmailService.GetOtherUserIdHavingEmailAsync.")]
-    public Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
-        string email, Guid excludeUserId, CancellationToken ct = default) =>
-        repo.GetOtherUserIdHavingGoogleEmailAsync(email, excludeUserId, ct);
-
     private async Task HydrateUserEmailsAsync(User user, CancellationToken ct)
     {
         var emails = await repo.GetUserEmailsByUserIdReadOnlyAsync(user.Id, ct);

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -195,21 +195,20 @@ public sealed class UserService(
         return await repo.ApplyExpiredDeletionAnonymizationAsync(userId, ct);
     }
 
-    public async Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default)
+    public async Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default)
     {
         var normalized = EmailNormalization.NormalizeForComparison(email);
         var alternate = GetAlternateEmail(normalized);
 
         var matchingUserIds = await repo.GetDistinctVerifiedUserEmailUserIdsAsync(normalized, alternate, ct);
         if (matchingUserIds.Count > 0)
-            return await GetByIdAsync(matchingUserIds[0], ct);
+            return await GetUserInfoAsync(matchingUserIds[0], ct);
 
         var legacyUser = await repo.GetByEmailOrAlternateAsync(normalized, alternate, ct);
         if (legacyUser is null)
             return null;
 
-        await HydrateUserEmailsAsync(legacyUser, ct);
-        return legacyUser;
+        return await GetUserInfoAsync(legacyUser.Id, ct);
     }
 
     [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. Use IUserEmailService.GetOtherUserIdHavingEmailAsync.")]

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -835,7 +835,7 @@ public sealed class UserService(
 
     // --- EventParticipation writes ---
 
-    public async Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default)
+    public async Task DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default)
     {
         var now = clock.GetCurrentInstant();
         var persisted = await repo.UpsertParticipationAsync(
@@ -848,14 +848,12 @@ public sealed class UserService(
             logger.LogWarning(
                 "Cannot declare NotAttending for user {UserId} year {Year} — already Attended",
                 userId, year);
-            // Re-read because upsert returned null.
-            return (await repo.GetParticipationAsync(userId, year, ct))!;
+            return;
         }
 
         logger.LogInformation(
             "User {UserId} declared NotAttending for year {Year}",
             userId, year);
-        return persisted;
     }
 
     public async Task<bool> UndoNotAttendingAsync(Guid userId, int year, CancellationToken ct = default)

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -834,7 +834,7 @@ public sealed class UserService(
 
     // --- EventParticipation reads ---
 
-    public Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default) =>
+    public Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default) =>
         throw new NotSupportedException(
             "GetAllParticipationsForYearAsync is only meaningful through CachingUserService — " +
             "projects the year's participations from the cached UserInfo snapshot. If this is " +

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -148,16 +148,6 @@ public sealed class UserService(
             "it indicates a DI registration mistake — IUserService should resolve " +
             "to CachingUserService.");
 
-    public async Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default)
-    {
-        var user = await repo.GetByIdAsync(userId, ct);
-        if (user is null)
-            return null;
-
-        await HydrateUserEmailsAsync(user, ct);
-        return user;
-    }
-
     public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(
         IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
     {
@@ -209,12 +199,6 @@ public sealed class UserService(
             return null;
 
         return await GetUserInfoAsync(legacyUser.Id, ct);
-    }
-
-    private async Task HydrateUserEmailsAsync(User user, CancellationToken ct)
-    {
-        var emails = await repo.GetUserEmailsByUserIdReadOnlyAsync(user.Id, ct);
-        AttachUserEmails(user, emails);
     }
 
     private async Task HydrateUserEmailsAsync(IEnumerable<User> users, CancellationToken ct)

--- a/src/Humans.Domain/Entities/Application.cs
+++ b/src/Humans.Domain/Entities/Application.cs
@@ -20,7 +20,7 @@ public class Application
     public Guid Id { get; init; }
 
     /// <summary>
-    /// Foreign key to the applicant user. Use <c>IUserService.GetByIdAsync</c>
+    /// Foreign key to the applicant user. Use <c>IUserService.GetUserInfoAsync</c>
     /// or <c>IUserService.GetByIdsAsync</c> to hydrate user info — cross-domain
     /// navigation properties are forbidden on this entity (design-rules §6).
     /// </summary>

--- a/src/Humans.Domain/Entities/EmailOutboxMessage.cs
+++ b/src/Humans.Domain/Entities/EmailOutboxMessage.cs
@@ -32,7 +32,7 @@ public class EmailOutboxMessage
     // Navigation
     // Note: no User nav (FK-only per design-rules §6c — cross-domain nav
     // into the Users section would defeat table ownership). Callers resolve
-    // the user via IUserService.GetByIdAsync(message.UserId.Value) when needed.
+    // the user via IUserService.GetUserInfoAsync(message.UserId.Value) when needed.
     public CampaignGrant? CampaignGrant { get; set; }
     public ShiftSignup? ShiftSignup { get; set; }
 }

--- a/src/Humans.Domain/Entities/TeamJoinRequest.cs
+++ b/src/Humans.Domain/Entities/TeamJoinRequest.cs
@@ -18,9 +18,9 @@ public class TeamJoinRequest
     /// <remarks>
     /// Cross-domain nav into the Users section — will be removed per
     /// design-rules §6c once the User-entity nav strip follow-up lands.
-    /// New callers resolve user data via <c>IUserService.GetByIdAsync</c>.
+    /// New callers resolve user data via <c>IUserService.GetUserInfoAsync</c>.
     /// </remarks>
-    [Obsolete("Cross-domain nav; resolve via IUserService.GetByIdAsync(UserId) instead. See design-rules §6c.")]
+    [Obsolete("Cross-domain nav; resolve via IUserService.GetUserInfoAsync(UserId) instead. See design-rules §6c.")]
     public User User { get; set; } = null!;
     public TeamJoinRequestStatus Status { get; set; } = TeamJoinRequestStatus.Pending;
     public string? Message { get; set; }
@@ -33,7 +33,7 @@ public class TeamJoinRequest
     /// <remarks>
     /// Cross-domain nav into the Users section — see <see cref="User"/>.
     /// </remarks>
-    [Obsolete("Cross-domain nav; resolve via IUserService.GetByIdAsync(ReviewedByUserId) instead. See design-rules §6c.")]
+    [Obsolete("Cross-domain nav; resolve via IUserService.GetUserInfoAsync(ReviewedByUserId) instead. See design-rules §6c.")]
     public User? ReviewedByUser { get; set; }
     public string? ReviewNotes { get; set; }
     public ICollection<TeamJoinRequestStateHistory> StateHistory { get; } = new List<TeamJoinRequestStateHistory>();

--- a/src/Humans.Domain/Entities/TeamJoinRequestStateHistory.cs
+++ b/src/Humans.Domain/Entities/TeamJoinRequestStateHistory.cs
@@ -44,10 +44,10 @@ public class TeamJoinRequestStateHistory
     /// <remarks>
     /// Cross-domain nav into the Users section — will be removed per
     /// design-rules §6c once the User-entity nav strip follow-up lands.
-    /// New callers resolve user data via <c>IUserService.GetByIdAsync</c>
+    /// New callers resolve user data via <c>IUserService.GetUserInfoAsync</c>
     /// keyed on <see cref="ChangedByUserId"/>.
     /// </remarks>
-    [Obsolete("Cross-domain nav; resolve via IUserService.GetByIdAsync(ChangedByUserId) instead. See design-rules §6c.")]
+    [Obsolete("Cross-domain nav; resolve via IUserService.GetUserInfoAsync(ChangedByUserId) instead. See design-rules §6c.")]
     public User ChangedByUser { get; set; } = null!;
 
     /// <summary>

--- a/src/Humans.Domain/Entities/TeamMember.cs
+++ b/src/Humans.Domain/Entities/TeamMember.cs
@@ -35,12 +35,12 @@ public class TeamMember
     /// Cross-domain nav into the Users section — will be removed per
     /// design-rules §6c once the User-entity nav strip follow-up lands.
     /// New callers must resolve user data via
-    /// <c>IUserService.GetByIdAsync</c> keyed on <see cref="UserId"/>;
+    /// <c>IUserService.GetUserInfoAsync</c> keyed on <see cref="UserId"/>;
     /// existing callers are migrated opportunistically. The Application-layer
     /// <c>TeamService</c> already populates this nav in-memory (§6b) for the
     /// readers that still reach through it.
     /// </remarks>
-    [Obsolete("Cross-domain nav; resolve via IUserService.GetByIdAsync(UserId) instead. See design-rules §6c.")]
+    [Obsolete("Cross-domain nav; resolve via IUserService.GetUserInfoAsync(UserId) instead. See design-rules §6c.")]
     public User User { get; set; } = null!;
 
     /// <summary>

--- a/src/Humans.Domain/Entities/TeamRoleAssignment.cs
+++ b/src/Humans.Domain/Entities/TeamRoleAssignment.cs
@@ -53,9 +53,9 @@ public class TeamRoleAssignment
     /// <remarks>
     /// Cross-domain nav into the Users section — will be removed per
     /// design-rules §6c once the User-entity nav strip follow-up lands.
-    /// New callers resolve user data via <c>IUserService.GetByIdAsync</c>
+    /// New callers resolve user data via <c>IUserService.GetUserInfoAsync</c>
     /// keyed on <see cref="AssignedByUserId"/>.
     /// </remarks>
-    [Obsolete("Cross-domain nav; resolve via IUserService.GetByIdAsync(AssignedByUserId) instead. See design-rules §6c.")]
+    [Obsolete("Cross-domain nav; resolve via IUserService.GetUserInfoAsync(AssignedByUserId) instead. See design-rules §6c.")]
     public User AssignedByUser { get; set; } = null!;
 }

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -96,19 +96,6 @@ internal sealed partial class UserRepository : IUserRepository
             .Replace("%", "\\%")
             .Replace("_", "\\_");
 
-    public async Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
-        string email, Guid excludeUserId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.Users
-            .AsNoTracking()
-            .Where(u => EF.Property<string?>(u, "GoogleEmail") != null
-                        && EF.Functions.ILike(EF.Property<string?>(u, "GoogleEmail")!, email)
-                        && u.Id != excludeUserId)
-            .Select(u => (Guid?)u.Id)
-            .FirstOrDefaultAsync(ct);
-    }
-
     public async Task<IReadOnlyDictionary<Guid, string>> GetLegacyGoogleEmailsAsync(
         IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -599,26 +599,17 @@ public sealed class CachingUserService(
         return user;
     }
 
-    public async Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default)
+    public async Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default)
     {
         await EnsureWarmedAsync(ct).ConfigureAwait(false);
         var snapshot = Values;
-        var result = new List<EventParticipation>();
+        var result = new List<UserParticipationRow>();
         foreach (var u in snapshot)
         {
             foreach (var p in u.EventParticipations)
             {
                 if (p.Year != year) continue;
-                result.Add(new EventParticipation
-                {
-                    Id = p.Id,
-                    UserId = u.Id,
-                    Year = p.Year,
-                    Status = p.Status,
-                    Source = p.Source,
-                    DeclaredAt = p.DeclaredAt,
-                    CheckedInAt = p.CheckedInAt,
-                });
+                result.Add(new UserParticipationRow(u.Id, p.Status, p.Source, p.CheckedInAt));
             }
         }
         return result;

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -632,12 +632,6 @@ public sealed class CachingUserService(
     public Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) =>
         WithInnerAsync(inner => inner.GetByEmailOrAlternateAsync(email, ct));
 
-#pragma warning disable CS0618
-    public Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
-        string email, Guid excludeUserId, CancellationToken ct = default) =>
-        WithInnerAsync(inner => inner.GetOtherUserIdHavingGoogleEmailAsync(email, excludeUserId, ct));
-#pragma warning restore CS0618
-
     public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
         Instant now, CancellationToken ct = default) =>
         WithInnerAsync(inner => inner.GetAccountsDueForAnonymizationAsync(now, ct));

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -891,12 +891,11 @@ public sealed class CachingUserService(
             await RefreshEntryAsync(userId, ct);
         });
 
-    public async Task<EventParticipation> DeclareNotAttendingAsync(
+    public async Task DeclareNotAttendingAsync(
         Guid userId, int year, CancellationToken ct = default)
     {
-        var result = await WithInnerAsync(inner => inner.DeclareNotAttendingAsync(userId, year, ct));
+        await WithInnerAsync(inner => inner.DeclareNotAttendingAsync(userId, year, ct));
         await RefreshEntryAsync(userId, ct);
-        return result;
     }
 
     public async Task<bool> UndoNotAttendingAsync(Guid userId, int year, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -495,24 +495,13 @@ public sealed class CachingUserService(
         await work(inner);
     }
 
-    // GetByIdAsync / GetByIdsAsync — issue #744: serve from the in-memory
-    // UserInfo dict for cache hits, falling back to the inner UserService only
-    // for ids missing from the cache. The cached payload already carries every
-    // User-side column AND the UserEmails collection, so rehydration is
-    // mechanical and zero-DB for warm-cache callers. There is no
-    // "without emails" variant because there is nothing else the cache could
-    // serve — UserInfo is the whole person.
+    // GetByIdsAsync — issue #744: serve from the in-memory UserInfo dict for
+    // cache hits, falling back to the inner UserService only for ids missing
+    // from the cache. The cached payload already carries every User-side column
+    // AND the UserEmails collection, so rehydration is mechanical and zero-DB
+    // for warm-cache callers.
     // Callers consume the returned User as read-only (the repo emits the
     // entity AsNoTracking) so rehydrated instances are safe to share.
-
-    public async Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default)
-    {
-        if (TryGet(userId, out var info))
-            return RehydrateUser(info);
-
-        var users = await WithInnerAsync(inner => inner.GetByIdsAsync([userId], ct));
-        return users.TryGetValue(userId, out var user) ? user : null;
-    }
 
     public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(
         IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -629,9 +629,6 @@ public sealed class CachingUserService(
         return result;
     }
 
-    public Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default) =>
-        WithInnerAsync(inner => inner.GetAllUsersAsync(ct));
-
     public Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) =>
         WithInnerAsync(inner => inner.GetByEmailOrAlternateAsync(email, ct));
 

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -629,7 +629,7 @@ public sealed class CachingUserService(
         return result;
     }
 
-    public Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) =>
+    public Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) =>
         WithInnerAsync(inner => inner.GetByEmailOrAlternateAsync(email, ct));
 
 #pragma warning disable CS0618

--- a/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
@@ -29,7 +29,6 @@ Humans.Application.Interfaces.Teams.ITeamService.GetTeamByIdAsync:Humans.Domain.
 Humans.Application.Interfaces.Teams.ITeamService.GetTeamEntityBySlugAsync:Humans.Domain.Entities.Team
 Humans.Application.Interfaces.Teams.ITeamService.GetUserTeamsAsync:Humans.Domain.Entities.TeamMember
 Humans.Application.Interfaces.Users.IAccountProvisioningService.FindOrCreateUserByEmailAsync:Humans.Domain.Entities.User
-Humans.Application.Interfaces.Users.IUserService.GetAllUsersAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByEmailOrAlternateAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByIdAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByIdsAsync:Humans.Domain.Entities.User

--- a/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
@@ -29,6 +29,5 @@ Humans.Application.Interfaces.Teams.ITeamService.GetTeamByIdAsync:Humans.Domain.
 Humans.Application.Interfaces.Teams.ITeamService.GetTeamEntityBySlugAsync:Humans.Domain.Entities.Team
 Humans.Application.Interfaces.Teams.ITeamService.GetUserTeamsAsync:Humans.Domain.Entities.TeamMember
 Humans.Application.Interfaces.Users.IAccountProvisioningService.FindOrCreateUserByEmailAsync:Humans.Domain.Entities.User
-Humans.Application.Interfaces.Users.IUserService.GetByEmailOrAlternateAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByIdAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByIdsAsync:Humans.Domain.Entities.User

--- a/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
@@ -29,5 +29,4 @@ Humans.Application.Interfaces.Teams.ITeamService.GetTeamByIdAsync:Humans.Domain.
 Humans.Application.Interfaces.Teams.ITeamService.GetTeamEntityBySlugAsync:Humans.Domain.Entities.Team
 Humans.Application.Interfaces.Teams.ITeamService.GetUserTeamsAsync:Humans.Domain.Entities.TeamMember
 Humans.Application.Interfaces.Users.IAccountProvisioningService.FindOrCreateUserByEmailAsync:Humans.Domain.Entities.User
-Humans.Application.Interfaces.Users.IUserService.GetByIdAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByIdsAsync:Humans.Domain.Entities.User

--- a/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
@@ -29,7 +29,6 @@ Humans.Application.Interfaces.Teams.ITeamService.GetTeamByIdAsync:Humans.Domain.
 Humans.Application.Interfaces.Teams.ITeamService.GetTeamEntityBySlugAsync:Humans.Domain.Entities.Team
 Humans.Application.Interfaces.Teams.ITeamService.GetUserTeamsAsync:Humans.Domain.Entities.TeamMember
 Humans.Application.Interfaces.Users.IAccountProvisioningService.FindOrCreateUserByEmailAsync:Humans.Domain.Entities.User
-Humans.Application.Interfaces.Users.IUserService.GetAllParticipationsForYearAsync:Humans.Domain.Entities.EventParticipation
 Humans.Application.Interfaces.Users.IUserService.GetAllUsersAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByEmailOrAlternateAsync:Humans.Domain.Entities.User
 Humans.Application.Interfaces.Users.IUserService.GetByIdAsync:Humans.Domain.Entities.User

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleAdminServiceTests.cs
@@ -304,7 +304,7 @@ public class GoogleAdminServiceTests
                 Id = ownerId,
                 Email = "x@example.com",
                 DisplayName = "X",
-            });
+            }.ToUserInfo());
 
         var result = await _service.ProvisionStandaloneAccountAsync(
             "test", "Test", "User", _actorUserId);
@@ -327,7 +327,7 @@ public class GoogleAdminServiceTests
             .Returns(false);
         _userService.GetByEmailOrAlternateAsync(
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns((User?)null);
+            .Returns((UserInfo?)null);
         var commsTeamId = Guid.NewGuid();
         var commsTeam = new TeamInfo(
             commsTeamId, "Communications", null, "communications",

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceTests.cs
@@ -261,14 +261,7 @@ public sealed class GoogleWorkspaceSyncServiceTests
         var user = MakeUser(TestUserId, TestUserEmail);
         _userService.GetUserInfoAsync(TestUserId, Arg.Any<CancellationToken>()).Returns(user);
         _userService.GetByEmailOrAlternateAsync(TestUserEmail, Arg.Any<CancellationToken>())
-            .Returns(new User
-            {
-                Id = TestUserId,
-                UserName = $"user-{TestUserId:N}",
-                DisplayName = "Alice Test",
-                Email = TestUserEmail,
-                GoogleEmailStatus = GoogleEmailStatus.Unknown
-            });
+            .Returns(MakeUser(TestUserId, TestUserEmail));
 
         _userEmailService
             .GetEntitiesByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
@@ -363,7 +363,7 @@ public sealed class GoogleGroupSyncServiceTests
                 DisplayName = "Alice",
                 GoogleEmailStatus = GoogleEmailStatus.Unknown,
                 CreatedAt = _clock.GetCurrentInstant()
-            });
+            }.ToUserInfo());
 
         var diff = await service.ReconcileOneAsync("team@nobodies.team", SyncAction.Execute);
 
@@ -401,7 +401,7 @@ public sealed class GoogleGroupSyncServiceTests
                 DisplayName = "Alice",
                 GoogleEmailStatus = GoogleEmailStatus.Unknown,
                 CreatedAt = _clock.GetCurrentInstant()
-            });
+            }.ToUserInfo());
 
         var diff = await service.ReconcileOneAsync("team@nobodies.team", SyncAction.Execute);
 

--- a/tests/Humans.Application.Tests/Notifications/NotificationMeterProviderTests.cs
+++ b/tests/Humans.Application.Tests/Notifications/NotificationMeterProviderTests.cs
@@ -56,8 +56,6 @@ public class NotificationMeterProviderTests : IDisposable
     {
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(MakeNeedsConsentReview(1)));
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<User>)[]);
         _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);
@@ -76,8 +74,6 @@ public class NotificationMeterProviderTests : IDisposable
     {
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(MakeNeedsConsentReview(1)));
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<User>)[]);
         _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);
@@ -94,8 +90,6 @@ public class NotificationMeterProviderTests : IDisposable
     {
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(MakeNeedsConsentReview(3)));
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<User>)[]);
         _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);
@@ -117,8 +111,6 @@ public class NotificationMeterProviderTests : IDisposable
         };
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>(usersForDeletion.Select(u => u.ToUserInfo()).ToList()));
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns(usersForDeletion);
         _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(5);
         var pendingTeamId = Guid.NewGuid();
         _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
@@ -148,8 +140,6 @@ public class NotificationMeterProviderTests : IDisposable
 
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>([]));
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<User>)[]);
         _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
         _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -190,9 +190,6 @@ public class AccountProvisioningServiceTests
         public Task<int> ReassignEventParticipationToUserAsync(
             Guid sourceUserId, Guid targetUserId, CancellationToken ct = default) =>
             throw new NotSupportedException();
-        public Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(
-            string email, Guid excludeUserId, CancellationToken ct = default) =>
-            throw new NotSupportedException();
         public Task<bool> SetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<bool> SetGoogleEmailStatusAsync(Guid userId, GoogleEmailStatus status, CancellationToken ct = default) =>

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1071,7 +1071,6 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task<UserEmailReconcilePlanResult> ApplyUserEmailReconcilePlanAsync(Guid userId, UserEmailReconcilePlanCommand command, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<User>> GetContactUsersAsync(string? search, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(string email, Guid excludeUserId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<string?> PurgeOwnDataAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<ExpiredDeletionAnonymizationResult?> ApplyExpiredDeletionAnonymizationAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task SetLastConsentReminderSentAsync(Guid userId, Instant sentAt, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1040,7 +1040,7 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         // Members below are unused by the dashboard compute paths under test.
         public Task<EventParticipation?> GetParticipationAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> UndoNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status, Instant? checkedInAt, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<OnsiteUserRow>> GetOnsiteUsersAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1008,9 +1008,6 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
             string query, Humans.Application.Services.Profiles.PersonSearchFields fields,
             int limit = 10, CancellationToken ct = default) => throw new NotSupportedException();
 
-        public async Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default)
-            => await db.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
-
         public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
         {
             if (userIds.Count == 0) return new Dictionary<Guid, User>();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1069,7 +1069,7 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task<bool> UpdateUserEmailAsync(Guid userId, Guid emailId, UserEmailUpdateCommand command, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> RemoveUserEmailAsync(Guid userId, Guid emailId, UserEmailRemoveCommand command, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<UserEmailReconcilePlanResult> ApplyUserEmailReconcilePlanAsync(Guid userId, UserEmailReconcilePlanCommand command, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<User>> GetContactUsersAsync(string? search, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<Guid?> GetOtherUserIdHavingGoogleEmailAsync(string email, Guid excludeUserId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<string?> PurgeOwnDataAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1046,7 +1046,6 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task<IReadOnlyList<OnsiteUserRow>> GetOnsiteUsersAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task RemoveTicketSyncParticipationAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> TrySetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> TrySetGoogleEmailStatusFromSyncAsync(Guid userId, GoogleEmailStatus status, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1039,7 +1039,7 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
 
         // Members below are unused by the dashboard compute paths under test.
         public Task<EventParticipation?> GetParticipationAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> UndoNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status, Instant? checkedInAt, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Shifts/VolunteerTrackingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/VolunteerTrackingServiceTests.cs
@@ -727,9 +727,11 @@ public class VolunteerTrackingServiceTests
             .Returns(call =>
             {
                 var year = call.Arg<int>();
-                return Task.FromResult(
+                return Task.FromResult<IReadOnlyList<UserParticipationRow>>(
                     (participations ?? [])
-                    .Where(p => p.Year == year).ToList());
+                    .Where(p => p.Year == year)
+                    .Select(p => new UserParticipationRow(p.UserId, p.Status, p.Source, p.CheckedInAt))
+                    .ToList());
             });
 
         trackingRepo ??= new FakeVolunteerTrackingRepository(

--- a/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
@@ -45,9 +45,6 @@ public sealed class TicketQueryServiceTests : ServiceTestHarness
         _teamService.GetTeamAsync(SystemTeamIds.Volunteers, Arg.Any<CancellationToken>())
             .Returns(VolunteersTeam([]));
 
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns([]);
-
         _userService.GetAllParticipationsForYearAsync(
                 Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([]);
@@ -480,8 +477,6 @@ public sealed class TicketQueryServiceTests : ServiceTestHarness
         var allUsers = users.ToList();
         var userIds = users.Select(u => u.Id).ToList();
 
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns(allUsers);
         _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyCollection<UserInfo>>(
                 allUsers.Select(u => u.ToUserInfo(profile: new Profile

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -554,15 +554,9 @@ public sealed class TicketSyncServiceTests : ServiceTestHarness
             .Returns(new EventSettings { Year = 2026 });
 
         _userService.GetAllParticipationsForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new List<EventParticipation>
+            .Returns(new List<UserParticipationRow>
             {
-                new()
-                {
-                    UserId = userId,
-                    Year = 2026,
-                    Status = ParticipationStatus.Ticketed,
-                    Source = ParticipationSource.TicketSync
-                }
+                new(userId, ParticipationStatus.Ticketed, ParticipationSource.TicketSync, null)
             });
 
         _vendorService.GetOrdersAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -596,15 +590,9 @@ public sealed class TicketSyncServiceTests : ServiceTestHarness
             .Returns(new EventSettings { Year = 2026 });
 
         _userService.GetAllParticipationsForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new List<EventParticipation>
+            .Returns(new List<UserParticipationRow>
             {
-                new()
-                {
-                    UserId = userId,
-                    Year = 2026,
-                    Status = ParticipationStatus.Ticketed,
-                    Source = ParticipationSource.TicketSync
-                }
+                new(userId, ParticipationStatus.Ticketed, ParticipationSource.TicketSync, null)
             });
 
         var checkInInstant = Instant.FromUtc(2026, 7, 8, 14, 30);

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -24,12 +24,6 @@ public class CachingUserServiceTests
         typeof(User).GetProperty("DisplayName")
         ?? throw new InvalidOperationException("User.DisplayName property missing.");
 
-    private static readonly System.Reflection.MethodInfo GetByIdAsyncMethod =
-        typeof(CachingUserService).GetMethod(
-            "GetByIdAsync",
-            [typeof(Guid), typeof(CancellationToken)])
-        ?? throw new InvalidOperationException("CachingUserService.GetByIdAsync method missing.");
-
     private readonly IUserService _inner = Substitute.For<IUserService>();
 
     private CachingUserService CreateSut()
@@ -82,20 +76,6 @@ public class CachingUserServiceTests
 
     private static string LegacyDisplayName(User user) =>
         (string?)LegacyDisplayNameProperty.GetValue(user) ?? string.Empty;
-
-    private static async Task<User?> InvokeGetByIdAsync(CachingUserService sut, Guid userId)
-    {
-        var task = (Task<User?>)GetByIdAsyncMethod.Invoke(
-            sut,
-            [userId, CancellationToken.None])!;
-        return await task;
-    }
-
-    private void InnerShouldNotHaveReceivedGetById()
-    {
-        _inner.ReceivedCalls().Should().NotContain(call =>
-            string.Equals(call.GetMethodInfo().Name, "GetByIdAsync", StringComparison.Ordinal));
-    }
 
     [HumansFact]
     public async Task GetUserInfoAsync_DictMiss_DelegatesToInnerAndCaches()
@@ -516,47 +496,6 @@ public class CachingUserServiceTests
         await _inner.Received(1).GetByIdsAsync(
             Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1 && ids.Contains(missId)),
             Arg.Any<CancellationToken>());
-    }
-
-    [HumansFact]
-    public async Task GetByIdAsync_ColdCache_UsesBatchFallback()
-    {
-        var userId = Guid.NewGuid();
-        var user = WithLegacyDisplayName(SampleUser(userId), "Fresh");
-        _inner.GetByIdsAsync(
-            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1 && ids.Contains(userId)),
-            Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, User> { [userId] = user });
-
-        var sut = CreateSut();
-
-        var result = await InvokeGetByIdAsync(sut, userId);
-
-        result.Should().BeSameAs(user);
-        InnerShouldNotHaveReceivedGetById();
-        await _inner.Received(1).GetByIdsAsync(
-            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1 && ids.Contains(userId)),
-            Arg.Any<CancellationToken>());
-    }
-
-    [HumansFact]
-    public async Task GetByIdAsync_WarmCache_ServesFromDict_NoInnerCall()
-    {
-        var userId = Guid.NewGuid();
-        var info = SampleUserInfo(userId, "Cached");
-        _inner.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<UserInfo?>(info));
-
-        var sut = CreateSut();
-        await sut.GetUserInfoAsync(userId); // prime
-
-        var user = await InvokeGetByIdAsync(sut, userId);
-
-        user.Should().NotBeNull();
-        LegacyDisplayName(user).Should().Be("Cached");
-
-        // GetByIdAsync should not have been delegated.
-        InnerShouldNotHaveReceivedGetById();
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/UserServiceProfileOnboardingMutationTests.cs
@@ -80,29 +80,6 @@ public sealed class UserServiceProfileOnboardingMutationTests : ServiceTestHarne
     }
 
     [HumansFact]
-    public async Task GetByIdAsync_HydratesUserEmailsThroughUserRepository()
-    {
-        var userId = Guid.NewGuid();
-        SeedUser(userId, "Hydrated User");
-        var email = new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Email = "hydrated@example.com",
-            IsVerified = true,
-            IsPrimary = true,
-        };
-        Db.UserEmails.Add(email);
-        await Db.SaveChangesAsync();
-
-        var user = await _service.GetByIdAsync(userId);
-
-        user.Should().NotBeNull();
-        user!.UserEmails.Should().ContainSingle(e =>
-            e.Id == email.Id && e.Email == "hydrated@example.com");
-    }
-
-    [HumansFact]
     public async Task GetUsersWithLoginsButNoEmailsAsync_ComposesLoginAndUserEmailRepositories()
     {
         var userWithEmail = SeedUser(Guid.NewGuid(), "Has Email");


### PR DESCRIPTION
## refactor(Users): Reforge-guided section surface reduction

### Section thesis

Users is the broad Humans ownership super-section (Users/Identity + Profiles + UserEmail are **one** section per `memory/architecture/users-profiles-one-section.md`) plus its orchestrators (Onboarding, AccountDeletion, AccountMerge, HumanLifecycle).

`IUserService` is mid-flight **absorbing** `IProfileService` methods (`SurfaceBudget` intentionally removed during the merge), so the repository surface (~90-method `IUserRepository` spanning users / event_participations / profiles / contact_fields / user_emails) and the parameter-bag command objects are deliberately in flux and **off-limits** to this pass.

Shape:
- **repo-backed**; primaryDto `UserInfo` (8-table cached read-model with a rich derived-predicate surface)
- **readSurface** `IUserServiceRead` `[SurfaceBudget(6)]` (already broadly adopted by ~40 cross-section consumers)
- **writeSurface** the large `IUserService : IUserServiceRead, IApplicationService, IUserMerge`
- `CachingUserService` Singleton dict + `IUserInfoInvalidator` + `UserInfoSaveChangesInterceptor`; no settings DTO.

The genuine, concept-deleting value is concentrated in the 6 entity-returning Application read methods tracked as tech debt in `tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt` — several are **dead** or trivially re-projectable, so fixing them **deletes** a baselined violation (the file header mandates removing the line when fixed).

Score baseline for `group:Users`: total **8143** (surface 7509, internal 634); `methodReturnsEntityAcrossSection` 30, `crossSectionFullService` 224, `canonicalReadDtoReturn` -27 credit. Cross-section read-split is already mature, so the marginal value is in **retiring dead / entity-leaking surface**, not introducing new read interfaces.

**No DB / persistence changes anywhere** (no migrations, no DbContext/model/schema/serialization edits) — repository-layer-and-above only.

---

### Accepted commits

#### 1. Project Users participation read to a slim DTO instead of leaking the EventParticipation entity
- **SHA:** `ceda63e71c0cce8977e7c65f1fbaaa8e7993b600`
- **Concept deleted:** the cross-section `EventParticipation` entity leaking out of the Users read path (`IUserService.GetAllParticipationsForYearAsync`), plus the entity-fabrication step in `CachingUserService` that synthesized fake `EventParticipation` entities from the cached `UserInfo` snapshot. Retired its line from the `ApplicationServiceEntityReadReturns` baseline.
- **Reforge target (group:Users):** 8521 → 8500 (**-21**), outside increase 0
- **Weighted value:** 21
- **Panel verdict:** accept / accept / accept (3-0)
  - *A:* Return narrowed from `Task<List<EventParticipation>>` to `Task<IReadOnlyList<UserParticipationRow>>` (strict 4-field projection dropping Id/Year/DeclaredAt — not a renamed/relocated entity). Within-section repo methods returning `EventParticipation` left untouched and legitimate; nothing pushed into a helper/partial/static/extension; no accessibility narrowing, no SurfaceBudget dodge (implementer declined to relocate onto `IUserServiceRead`, correctly left USR-06 blocked). All three production consumers (TicketSyncService, TicketQueryService, VolunteerTrackingService) read only UserId/Status/Source/CheckedInAt; 520 tests pass incl. Architecture baseline.
  - *B:* Slim value record carrying only facts consumers read (Status/Source are domain enums, value types). Baselined violation line removed per file-header mandate; Architecture test validates the line is genuinely gone. Did NOT move the method to `IUserServiceRead` and did NOT raise off-limits `[SurfaceBudget(6)]` — net deletion of cross-section coupling, not new query surface.
  - *C:* Bidirectional ratchet (RatchetTestRunner) live-scans source and hard-fails if a removed baseline line still maps to a violation — passing test proves the boundary no longer carries a Domain entity. Inner `UserService` method still throws `NotSupportedException` (pre-existing; only return type changed), so cache warm-gating unchanged. No cache key / invalidation / audit / notification / auth / transaction altered. No tests removed/weakened; build 0 errors / 140 pre-existing warnings; 393 targeted tests pass.

#### 2. Delete dead IUserService.GetAllUsersAsync entity-returning read
- **SHA:** `21f97be3e3e92f4c8d96da2cc1db642cb53ad0b4`
- **Concept deleted:** the `IUserService.GetAllUsersAsync` entity-returning cross-section read method (`Task<IReadOnlyList<User>>`) and its baselined `methodReturnsEntityAcrossSection` violation.
- **Reforge target (group:Users):** 8500 → 8487 (**-13**), outside increase 0
- **Weighted value:** 13
- **Panel verdict:** accept / accept / accept (3-0)
  - *A:* Zero references remain in src/ or tests/ (net 33 deletions, 0 additions); not moved to helper/extension/static/partial/other-section, no new file/type/method/DI. No accessibility narrowed. Both flagged consumers read via canonical `IUserServiceRead.GetAllUserInfosAsync` (NotificationMeterProvider:242, TicketQueryService:484) — the deleted method was dead in production. `repo.GetAllAsync`/`HydrateUserEmailsAsync` stay used by `GetAllUserInfosAsync`, no orphans. Baseline line removed per header; 6 architecture tests pass.
  - *B:* Pure deletion (-13 surface, 0 internal). Sole real consumer (NotificationMeterProvider) already derives PendingDeletions via LINQ over the canonical `UserInfo` read-model. Nothing moved/renamed/hidden; no replacement method/DTO/interface. Baseline edit removes (not adds) a line per header; entity-read tests pass. Minor non-blocking nit: `docs/sections/Notifications.md:119` already-stale reference (not introduced here).
  - *C:* Zero production callers; all 40+ consumers read canonical cached `GetAllUserInfosAsync`. Pending-deletions meter already derives from the `UserInfo` snapshot (DeletionRequestedAt != null) — section-doc claim is stale. No auth/cache/audit/notification/transaction/DB boundary touched; nothing orphaned. Re-ran EntityRead/Baseline + affected suites: 91 passed, 0 failed.

#### 3. Drop dead EventParticipation entity return from DeclareNotAttendingAsync
- **SHA:** `da3fca2e7408812806785e91bb838085f6202141`
- **Concept deleted:** the cross-section `EventParticipation` entity return from `IUserService.DeclareNotAttendingAsync` (an Events-owned entity leaking out of the Users write path), plus the now-pointless re-read of the entity on the Attended-blocked branch.
- **Reforge target (group:Users):** 8487 → 8457 (**-30**), outside increase 0
- **Weighted value:** 30
- **Panel verdict:** accept / accept / accept (3-0)
  - *A:* Method stays public on `IUserService` at the same location; only its return narrows from an Events/Shifts-owned entity to plain `Task`. Nothing moved into a helper/extension/static/partial/other section; no accessibility narrowed. Sole production caller `HomeController.cs:132` already awaited without capturing the result, so the entity was dead; dropped re-read materialized a never-inspected value. Warning log, null-check, and decorator `RefreshEntryAsync` cache invalidation all kept. No read-interface method added.
  - *B:* Caller awaits-and-discards; decorator only captured `result` to pass back while refreshing cache independently — entity return entirely dead. Deleted re-read sat on the null branch (blocked-by-Attended) and flowed only to the discarding caller — pure dead DB read. Nothing added (no interface/repo/DTO/DI/read-projection). Behavior preserved; all three implementers (UserService, CachingUserService, the one hand-written fake) migrated; build clean, tests pass. Honest caveat: write method, never on the read-baseline — no baseline line to delete.
  - *C:* `EventParticipation` is EF-configured under Configurations/Shifts — genuine cross-section leak now deleted. `await Task` vs `await Task<T>` behaviorally identical at the caller; try/catch+redirect unchanged. UpsertParticipationAsync call/args, Attended-blocked guard, both logs preserved; only the side-effect-free re-read removed. Decorator still calls inner + unconditional `RefreshEntryAsync`. No auth/audit/notification/transaction/DB change. `EventParticipation` still referenced 8x in UserService — no orphaned using. Baseline grep confirms it was never in the read-baseline.

#### 4. Return UserInfo from IUserService.GetByEmailOrAlternateAsync instead of User entity
- **SHA:** `9437cb49a6e9c475292ad8cf15d1e3054b95f842`
- **Concept deleted:** the `User` entity leaking out of the email-lookup read across the section boundary, and its baselined `methodReturnsEntityAcrossSection` violation (`ApplicationServiceEntityReadReturns.baseline.txt` line for `IUserService.GetByEmailOrAlternateAsync`).
- **Reforge target (group:Users):** 8457 → 8451 (**-6**), outside increase 0
- **Weighted value:** 6
- **Panel verdict:** accept / accept / accept (3-0)
  - *A:* Matching logic (verified-user-email lookup + legacy `User.GoogleEmail` shadow-column fallback) stays in the service; both branches resolve a user id and return the canonical cached `UserInfo` via the **existing** `GetUserInfoAsync`. No helper/partial/extension/static created; dropped `HydrateUserEmailsAsync` helper still live (UserService.cs:157,168). No accessibility narrowing; no new read-interface method (LINQ-over-DTO moot). Three consumers (GoogleWorkspaceSyncService, GoogleAdminService, GoogleGroupSyncService) read only `.Id`/`.GoogleEmailStatus`/null — stable `UserInfo` facts; no body edits. Baseline line removed per header; Architecture test validates.
  - *B:* Return changed `Task<User?>` → `Task<UserInfo?>` (canonical cross-section read DTO). `UserInfo.Id`/`GoogleEmailStatus` pre-existing canonical facts. NO read-interface surface added. Correctly stays a keeper (not inlined as LINQ) because the lookup needs repo queries against `user_emails` and the legacy `User.GoogleEmail` shadow column, deliberately not projected onto `UserInfo` (deprecated per #687). Exactly one baseline line removed; arch test passes. Net -6 lines, no SurfaceBudget touched, no DB changes, no orphaned helpers.
  - *C:* Genuine entity-leak deletion, not relocation/hiding. Repo's intra-section `GetByEmailOrAlternateAsync` still returns `User` (off-limits per thesis). `HydrateUserEmailsAsync` still used by GetByIdAsync/GetByIdsAsync — not orphaned. Caching passthrough is a one-line type change, still `WithInnerAsync` — no cache-key/invalidation change. No auth/audit/notification/transaction/DB touched. Baseline removal validated by passing ratchet/architecture test. Test mocks converted via existing helpers — coverage preserved. Only behavioral delta: one extra repo round-trip on the rare legacy-fallback arm, returning the identical canonical DTO.

#### 5. Delete dead obsolete GetOtherUserIdHavingGoogleEmailAsync from Users service and repository
- **SHA:** `db6315573cb57abbeba4bdcad38fdc8e0d35752f`
- **Concept deleted:** the obsolete (issue #687) Google-email shadow-column lookup method, removed end-to-end across the Users service interface, implementation, caching decorator, AND the now-orphaned `IUserRepository` interface + impl. Zero production callers existed.
- **Reforge target (group:Users):** 8451 → 8413 (**-38**), outside increase 0
- **Weighted value:** 38
- **Panel verdict:** accept / accept / accept (3-0)
  - *A:* Pure deletion: 48 deletions, 0 non-blank additions. Method gone from all production code (only an explanatory test comment remains); nothing absorbed it — no helper/extension/static/partial, no accessibility narrowing. Documented replacement `IUserEmailService.GetOtherUserIdHavingEmailAsync` is pre-existing (#745/#811), not a move target created here. Fully dead; build 0 errors / 140 pre-existing warnings. `GoogleEmail` column stays mapped and read by the separate `GetLegacyGoogleEmailsAsync` — only the dead query method deleted, no persistence change.
  - *B:* 48 deletions, 0 additions, 7 files; zero remaining callers. No read-interface method/predicate/scalar added (nothing to reroute to LINQ). Successor path (`IUserEmailService.GetOtherUserIdHavingEmailAsync` over canonical `user_emails`) pre-existed and is untouched. Deleted method fully dead; shadow column stays live via `GetLegacyGoogleEmailsAsync`. Baseline-retirement claim correctly withdrawn (returns `Guid?`, never in the read-baseline).
  - *C:* Zero remaining references except one explanatory test comment; live conflict-check routes through `IUserEmailService.GetOtherUserIdHavingEmailAsync` → `repo.GetOtherUserIdHavingUserEmailAsync` (#687 replacement). Auth/cache invalidation/audit/notification/transaction untouched. No coverage weakened (two interface-fake stub lines removed; surviving behavioral test exercises the replacement). Shadow column stays fully mapped/live (reader, ILIKE query, Set/TrySet writers all remain). No DbContext/migration/snapshot change.

#### 6. Delete dead obsolete IUserService.GetByIdAsync and redirect stale references
- **SHA:** `bd698c2d8a14e1db3b31b7b2c593f4a75c9d4b22`
- **Concept deleted:** the obsolete `IUserService.GetByIdAsync` single-id entity read (and its baselined cross-section-entity-return violation), plus the now-dead `HUM_USER_GetById` diagnostic and every stale reference that pointed callers at the deleted method.
- **Reforge target (group:Users):** 8413 → 8400 (**-13**), outside increase 0
- **Weighted value:** 13
- **Panel verdict:** accept / accept / accept (3-0)
  - *A:* Numstat proves impl/interface/test files are pure deletions (0 insertions); single-`User` `HydrateUserEmailsAsync` overload is gone (batch overload survives, serving `GetByIdsAsync`). Zero live references to `IUserService.GetByIdAsync` or `HUM_USER_GetById`; build succeeds — compile-time proof of deadness. No accessibility narrowing. Sibling `GetByIdsAsync` correctly retained in interface and baseline. Zero new surface. Comment edits across Team* entities / Application.cs / EmailOutboxMessage.cs / ISyncSettingsRepository.cs / ITeamRepository.cs / Directory.Build.props are 1-for-1 doc repointers to live `GetUserInfoAsync`/`GetByIdsAsync` — no contract change.
  - *B:* Pure deletion of a baselined entity-leaking read with the canonical `UserInfo` read path already in place. Zero live callers in src/tests (other `GetByIdAsync` hits are unrelated repo methods). No analyzer emits `HUM_USER_GetById` and nothing references it — dead-config cleanup of `WarningsNotAsErrors`. Baseline header mandates removing the fixed line; live sibling `GetByIdsAsync` retained. NO interface surface added. Remaining doc-comment/Obsolete-message edits merely repoint stale text. Deleted tests covered only the deleted method.
  - *C:* Zero production callers (src-scoped grep clean; remaining hits are `repo.GetByIdAsync`/other sections). `HUM_USER_GetById` no longer in source — no live emitter; build SUCCESS confirms no compiling callers. Capability removed, not moved/renamed/hidden — surviving `GetUserInfoAsync` (IUserServiceRead:25) and batch `GetByIdsAsync` cover all needs. Cache cold-key/warm-hit preserved for the surviving batch method. No auth/audit/notification/transaction/invalidation/interceptor/DB change. Coverage not weakened. Baseline line removed per header. Non-gating gap: stale references remain in `docs/sections/{Tickets,Mailer,Expenses,Campaigns}.md` and `memory/architecture/iuserservice-onestop-userinfo.md` — deliberately left per the worktree's no-docs/memory-edit constraint (descriptive docs, not code contracts).

---

### Cumulative Users score movement

| | total |
|---|---|
| origin/main baseline (`group:Users`) | 8521 |
| final | 8400 |
| **net delta** | **-121** |

Sum of weighted value across the 6 accepted commits: **121** (21 + 13 + 30 + 6 + 38 + 13). Outside-section increase across all commits: **0** — no debt pushed into other sections or shared/helper code.

The score baseline cited in the section thesis (total 8143) reflects a different snapshot than the `origin/main` Reforge measurement (8521) used as the live baseline for this pass; the movement reported here is measured consistently against the `origin/main` (8521) anchor through each iteration.

---

### Candidates rejected and why

None. Every candidate evaluated this pass cleared the 3-0 panel and was accepted.

---

### Remaining high-value work not done

- **Repository surface and command-bag command objects are off-limits this pass.** `IUserService` is mid-flight absorbing `IProfileService` (SurfaceBudget intentionally removed during the merge), so the ~90-method `IUserRepository` and the parameter-bag command objects are deliberately in flux and were not touched. Revisit once the Profile absorption settles.
- **USR-06 (relocate the participation read onto `IUserServiceRead`) left blocked** — correctly declined this pass because the `[SurfaceBudget(6)]` on `IUserServiceRead` is off-limits and a relocation would have been budget-gaming rather than a genuine deletion.
- **Stale documentation references to deleted methods** remain by design (the worktree's no-docs/memory-edit constraint): `docs/sections/Notifications.md:119` (`GetAllUsersAsync`), `docs/sections/{Tickets,Mailer,Expenses,Campaigns}.md` and `memory/architecture/iuserservice-onestop-userinfo.md` (`GetByIdAsync`). These are descriptive docs, not code contracts; a follow-up freshness sweep should repoint them.
- **Any remaining entity-returning Application read methods** on the `ApplicationServiceEntityReadReturns` baseline that are neither dead nor trivially re-projectable would require deeper consumer migration and were not in scope for this surface-reduction pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
