### PR TITLE
feat(store): show VAT-inclusive prices as primary; add incl/excl VAT toggle in admin

### DIFF
--- a/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
@@ -17,5 +17,11 @@ public record OrderLineDto(
     decimal DepositEur,
     decimal TotalEur)
 {
-    public decimal UnitPriceSnapshotInclVat => Math.Round(UnitPriceSnapshot * (1 + VatRateSnapshot / 100m), 2);
+    /// <summary>
+    /// Per-unit price including VAT, for display only. Rounded to 2 dp away-from-zero to match the
+    /// authoritative VAT rounding used by BalanceCalculator. Note: for <c>Qty &gt; 1</c>,
+    /// <c>Qty * UnitPriceSnapshotInclVat</c> is not guaranteed to equal <c>TotalEur</c>, because the
+    /// authoritative line VAT is rounded once over the whole line subtotal rather than per unit.
+    /// </summary>
+    public decimal UnitPriceSnapshotInclVat => Math.Round(UnitPriceSnapshot * (1 + VatRateSnapshot / 100m), 2, MidpointRounding.AwayFromZero);
 }

--- a/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
@@ -15,4 +15,7 @@ public record OrderLineDto(
     decimal SubtotalEur,
     decimal VatEur,
     decimal DepositEur,
-    decimal TotalEur);
+    decimal TotalEur)
+{
+    public decimal UnitPriceSnapshotInclVat => Math.Round(UnitPriceSnapshot * (1 + VatRateSnapshot / 100m), 2);
+}

--- a/src/Humans.Application/Services/Store/Dtos/ProductDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/ProductDto.cs
@@ -13,5 +13,9 @@ public record ProductDto(
     LocalDate OrderableUntil,
     bool IsActive)
 {
-    public decimal UnitPriceInclVatEur => Math.Round(UnitPriceEur * (1 + VatRatePercent / 100m), 2);
+    /// <summary>
+    /// Unit price including VAT, for display. Rounded to 2 dp away-from-zero to match the
+    /// authoritative VAT rounding used by BalanceCalculator.
+    /// </summary>
+    public decimal UnitPriceInclVatEur => Math.Round(UnitPriceEur * (1 + VatRatePercent / 100m), 2, MidpointRounding.AwayFromZero);
 }

--- a/src/Humans.Application/Services/Store/Dtos/ProductDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/ProductDto.cs
@@ -11,4 +11,7 @@ public record ProductDto(
     decimal VatRatePercent,
     decimal? DepositAmountEur,
     LocalDate OrderableUntil,
-    bool IsActive);
+    bool IsActive)
+{
+    public decimal UnitPriceInclVatEur => Math.Round(UnitPriceEur * (1 + VatRatePercent / 100m), 2);
+}

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -126,8 +126,7 @@ else
             <tr>
                 <th>Name</th>
                 <th>Description</th>
-                <th class="text-end">Unit price</th>
-                <th class="text-end">VAT</th>
+                <th class="text-end">Unit price (incl. VAT)</th>
                 <th class="text-end">Deposit</th>
                 <th>Order by</th>
             </tr>
@@ -138,8 +137,10 @@ else
                 <tr>
                     <td>@product.Name</td>
                     <td>@Html.SanitizedMarkdown(product.Description)</td>
-                    <td class="text-end">&euro;@product.UnitPriceEur.ToString("N2")</td>
-                    <td class="text-end">@product.VatRatePercent.ToString("0.##")%</td>
+                    <td class="text-end">
+                        &euro;@product.UnitPriceInclVatEur.ToString("N2")
+                        <div class="text-muted small">(&euro;@product.UnitPriceEur.ToString("N2") + @product.VatRatePercent.ToString("0.##")% VAT)</div>
+                    </td>
                     <td class="text-end">@(product.DepositAmountEur.HasValue ? $"€{product.DepositAmountEur.Value:N2}" : "—")</td>
                     <td>@product.OrderableUntil.ToDisplayDate()</td>
                 </tr>

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -82,8 +82,7 @@
                 <th class="text-end">Qty</th>
                 @if (!isTeamOrder)
                 {
-                    <th class="text-end">Unit price</th>
-                    <th class="text-end">VAT %</th>
+                    <th class="text-end">Unit price (incl. VAT)</th>
                     <th class="text-end">Deposit</th>
                     <th class="text-end">Line total (incl. VAT &amp; deposit)</th>
                 }
@@ -98,8 +97,10 @@
                     <td class="text-end">@line.Qty</td>
                     @if (!isTeamOrder)
                     {
-                        <td class="text-end">&euro;@line.UnitPriceSnapshot.ToString("N2")</td>
-                        <td class="text-end">@line.VatRateSnapshot.ToString("0.##")%</td>
+                        <td class="text-end">
+                            &euro;@line.UnitPriceSnapshotInclVat.ToString("N2")
+                            <div class="text-muted small">(&euro;@line.UnitPriceSnapshot.ToString("N2") + @line.VatRateSnapshot.ToString("0.##")% VAT)</div>
+                        </td>
                         <td class="text-end">@(line.DepositAmountSnapshot.HasValue ? $"€{line.DepositEur:N2}" : "—")</td>
                         <td class="text-end">&euro;@line.TotalEur.ToString("N2")</td>
                     }
@@ -134,7 +135,7 @@ else
                 <option value="">Choose a product…</option>
                 @foreach (var product in Model.Catalog)
                 {
-                    <option value="@product.Id">@product.Name — &euro;@product.UnitPriceEur.ToString("N2") (deadline @product.OrderableUntil.ToDisplayDate())</option>
+                    <option value="@product.Id">@product.Name — &euro;@product.UnitPriceInclVatEur.ToString("N2") incl. VAT (deadline @product.OrderableUntil.ToDisplayDate())</option>
                 }
             </select>
         </div>

--- a/src/Humans.Web/Views/StoreAdmin/CatalogEdit.cshtml
+++ b/src/Humans.Web/Views/StoreAdmin/CatalogEdit.cshtml
@@ -38,14 +38,19 @@
                     <span asp-validation-for="Description" class="text-danger small"></span>
                 </div>
                 <div class="col-md-3">
-                    <label asp-for="UnitPriceEur" class="form-label">Unit price (€)</label>
-                    <input asp-for="UnitPriceEur" type="number" step="0.01" min="0" class="form-control" />
+                    <label asp-for="UnitPriceEur" class="form-label">Unit price ex. VAT (€)</label>
+                    <input asp-for="UnitPriceEur" id="priceExVat" type="number" step="0.01" min="0" class="form-control" />
                     <span asp-validation-for="UnitPriceEur" class="text-danger small"></span>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="VatRatePercent" class="form-label">VAT %</label>
-                    <input asp-for="VatRatePercent" type="number" step="0.01" min="0" class="form-control" />
+                    <input asp-for="VatRatePercent" id="vatRate" type="number" step="0.01" min="0" class="form-control" />
                     <span asp-validation-for="VatRatePercent" class="text-danger small"></span>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Unit price incl. VAT (€)</label>
+                    <input id="priceInclVat" type="number" step="0.01" min="0" class="form-control" />
+                    <div class="form-text">Enter either price — the other updates automatically.</div>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="DepositAmountEur" class="form-label">Deposit (€, optional)</label>
@@ -77,4 +82,35 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script nonce="@Context.Items["CspNonce"]">
+        (function () {
+            var exInput = document.getElementById('priceExVat');
+            var inclInput = document.getElementById('priceInclVat');
+            var vatInput = document.getElementById('vatRate');
+
+            function multiplier() {
+                var rate = parseFloat(vatInput.value);
+                return isNaN(rate) ? 1 : 1 + rate / 100;
+            }
+
+            function round2(v) { return Math.round(v * 100) / 100; }
+
+            function syncInclFromEx() {
+                var ex = parseFloat(exInput.value);
+                inclInput.value = isNaN(ex) ? '' : round2(ex * multiplier()).toFixed(2);
+            }
+
+            function syncExFromIncl() {
+                var incl = parseFloat(inclInput.value);
+                exInput.value = isNaN(incl) ? '' : round2(incl / multiplier()).toFixed(2);
+            }
+
+            exInput.addEventListener('input', syncInclFromEx);
+            inclInput.addEventListener('input', syncExFromIncl);
+            vatInput.addEventListener('input', syncInclFromEx);
+
+            // Initialise incl. field from the server-rendered ex-VAT value
+            syncInclFromEx();
+        })();
+    </script>
 }

--- a/tests/Humans.Application.Tests/Services/Store/VatInclusivePriceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/VatInclusivePriceTests.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using AwesomeAssertions;
+using Humans.Application.Services.Store;
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Entities;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Store;
+
+public class VatInclusivePriceTests
+{
+    // ex, vatPercent, expectedIncl — passed as strings because decimal is not a valid InlineData literal.
+    [HumansTheory]
+    [InlineData("9.99", "21", "12.09")]   // standard rate, rounds up from 12.0879
+    [InlineData("50", "21", "60.50")]
+    [InlineData("10", "10", "11.00")]     // reduced rate
+    [InlineData("10", "4", "10.40")]      // super-reduced rate
+    [InlineData("12.34", "0", "12.34")]   // 0% VAT is a no-op, must not regress
+    [InlineData("0.50", "21", "0.61")]    // 0.605 midpoint: away-from-zero rounds to 0.61 (banker's would give 0.60)
+    public void ProductDto_unit_price_incl_vat(string ex, string vat, string expected)
+    {
+        Product(D(ex), D(vat)).UnitPriceInclVatEur.Should().Be(D(expected));
+    }
+
+    [HumansTheory]
+    [InlineData("9.99", "21", "12.09")]
+    [InlineData("50", "21", "60.50")]
+    [InlineData("10", "10", "11.00")]
+    [InlineData("10", "4", "10.40")]
+    [InlineData("12.34", "0", "12.34")]
+    [InlineData("0.50", "21", "0.61")]
+    public void OrderLineDto_unit_price_incl_vat(string ex, string vat, string expected)
+    {
+        Line(qty: 1, unitEx: D(ex), vat: D(vat)).UnitPriceSnapshotInclVat.Should().Be(D(expected));
+    }
+
+    [HumansFact]
+    public void Per_unit_incl_vat_is_display_only_and_not_additive_for_multi_qty()
+    {
+        // qty 3 × €9.99 @ 21%: per-unit incl VAT is rounded per unit (€12.09), but the
+        // authoritative line VAT is rounded once on the whole subtotal. The two intentionally
+        // diverge by a cent for multi-quantity lines; this locks that documented behavior.
+        var line = Line(qty: 3, unitEx: 9.99m, vat: 21m);
+        line.UnitPriceSnapshotInclVat.Should().Be(12.09m);
+
+        var order = new StoreOrder
+        {
+            Lines = new List<StoreOrderLine>
+            {
+                new() { Qty = 3, UnitPriceSnapshot = 9.99m, VatRateSnapshot = 21m }
+            }
+        };
+        var authoritativeLineTotal = BalanceCalculator.Compute(order).Lines.Single().TotalEur;
+
+        authoritativeLineTotal.Should().Be(36.26m);
+        (3 * line.UnitPriceSnapshotInclVat).Should().Be(36.27m);
+        (3 * line.UnitPriceSnapshotInclVat).Should().NotBe(authoritativeLineTotal,
+            "per-unit incl VAT is display-only; the authoritative line total rounds VAT once on the subtotal");
+    }
+
+    private static decimal D(string value) => decimal.Parse(value, CultureInfo.InvariantCulture);
+
+    private static ProductDto Product(decimal unitEx, decimal vat) =>
+        new(Guid.NewGuid(), 2026, "P", "", unitEx, vat, null, default, true);
+
+    private static OrderLineDto Line(int qty, decimal unitEx, decimal vat) =>
+        new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "P", qty, unitEx, vat, null,
+            default, 0m, 0m, 0m, 0m);
+}


### PR DESCRIPTION
## Summary

- **Catalog & order views:** headline unit price now shows incl. VAT (Spanish consumer law requirement); ex-VAT + rate shown as small secondary text
- **Add line dropdown:** product options now show incl. VAT price
- **Admin edit form:** added a synced "Price incl. VAT" input — typing in either field (ex or incl.) auto-updates the other via JS; server still stores ex-VAT only

No schema changes. `UnitPriceInclVatEur` and `UnitPriceSnapshotInclVat` are pure computed properties on the DTOs (`ex × (1 + vat/100)`, rounded to 2dp).

## Test plan

- [ ] `/Store` catalog — headline price is incl. VAT; ex-VAT + rate visible as secondary text
- [ ] `/Store/Order/{id}` — unit price column shows incl. VAT; summary breakdown (subtotal / VAT / deposits / balance) unchanged
- [ ] Add-line dropdown shows incl. VAT price for each product
- [ ] `/StoreAdmin/Catalog/Edit/{id}` — entering ex-VAT price updates incl. field and vice versa; saving and reopening preserves the correct ex-VAT value

🤖 Generated with [Claude Code](https://claude.com/claude-code)