### PR TITLE
Admin nav: realign sidebar groups to sections + fix admin-shell layout on ~15 pages

### DIFF
--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -61,7 +61,7 @@ public static class AdminNavTree
         new("Google", [
             new("Overview",              "Google", "Index",        null, null, "fa-brands fa-google",           PolicyNames.AdminOnly),
             new("Sync settings",         "Google", "SyncSettings", null, null, "fa-solid fa-sliders",           PolicyNames.AdminOnly),
-            new("Resource sync",         "Google", "Sync",         null, null, "fa-solid fa-arrows-rotate",     PolicyNames.AdminOnly),
+            new("Resource sync",         "Google", "Sync",         null, null, "fa-solid fa-arrows-rotate",     PolicyNames.TeamsAdminBoardOrAdmin),
             new("All domain groups",     "Google", "AllGroups",    null, null, "fa-solid fa-globe",             PolicyNames.AdminOnly),
             new("Workspace accounts",    "Google", "Accounts",     null, null, "fa-solid fa-at",                PolicyNames.AdminOnly),
             new("Sync outbox",           "Google", "SyncOutbox",   null, null, "fa-solid fa-clock-rotate-left", PolicyNames.AdminOnly),

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -12,7 +12,7 @@ public static class AdminNavTree
 {
     public static IReadOnlyList<AdminNavGroup> Groups { get; } =
     [
-        new("Operations", [
+        new("Tickets", [
             new("Tickets",            "Ticket",         "Index", null, null, "fa-solid fa-ticket",      PolicyNames.TicketAdminBoardOrAdmin),
             new("Transfer requests",  "TicketTransferAdmin", "Index", null, null, "fa-solid fa-right-left",  PolicyNames.TicketAdminOrAdmin,
                  PillCount: PillCounts.TransferQueue),
@@ -22,27 +22,33 @@ public static class AdminNavTree
             new("Humans", "Profile", "AdminList",       null, null, "fa-solid fa-users",            PolicyNames.HumanAdminBoardOrAdmin),
             new("Roles",  "Profile", "Roles",           null, null, "fa-solid fa-id-badge",         PolicyNames.HumanAdminBoardOrAdmin),
             new("Review", "OnboardingReview", "Index",   null, null, "fa-solid fa-clipboard-check",  PolicyNames.ReviewQueueAccess,
-                 PillCount: PillCounts.ReviewQueue)
+                 PillCount: PillCounts.ReviewQueue),
+            new("Merge requests",      "AdminMerge", "Index",             null, null, "fa-solid fa-code-merge", PolicyNames.AdminOnly),
+            new("Duplicate detection", "AdminDuplicateAccounts", "Index", null, null, "fa-solid fa-clone",      PolicyNames.AdminOnly),
+            new("Email problems",      "ProfileAdmin", "EmailProblems",   null, null, "fa-solid fa-envelope-circle-check", PolicyNames.AdminOnly)
         ]),
         new("Shifts", [
             new("Dashboard", "ShiftDashboard", "Index",  null, null, "fa-solid fa-gauge",            PolicyNames.ShiftDepartmentManager),
             new("Workload",  "ShiftWorkloadAdmin", "Index",   null, null, "fa-solid fa-scale-unbalanced", PolicyNames.ShiftDashboardAccess),
-            new("Early entry", "EarlyEntryRoster", "Index", null, null, "fa-solid fa-door-open",       PolicyNames.ShiftDashboardAccess)
+            new("Early entry", "EarlyEntryRoster", "Index", null, null, "fa-solid fa-door-open",       PolicyNames.ShiftDashboardAccess),
+            new("Orphan signups",  "Shifts", "OrphanSignups", null, null, "fa-solid fa-user-secret",  PolicyNames.AdminOnly)
         ]),
         new("Cantina", [
             new("Roster", "Cantina", "Roster", null, null, "fa-solid fa-utensils", PolicyNames.CantinaAdminOrAdmin)
-        ]),
-        new("Money", [
-            new("Finance",        "Finance",      "Index",   null, null, "fa-solid fa-coins",        PolicyNames.FinanceAdminOrAdmin),
-            new("Store catalog",  "StoreAdmin",   "Catalog", null, null, "fa-solid fa-tags",         PolicyNames.StoreCatalogAdmin),
-            new("Store summary",  "StoreAdmin",   "Summary", null, null, "fa-solid fa-chart-column", PolicyNames.StoreCatalogAdmin)
         ]),
         new("Expenses", [
             new("Expenses",          "Expenses", "Index",       null, null, "fa-solid fa-receipt",        PolicyNames.IsActiveMember),
             new("Coordinator Queue", "Expenses", "Coordinator", null, null, "fa-solid fa-list-check",     PolicyNames.IsActiveMember),
             new("Expense Review",    "Expenses", "Review",      null, null, "fa-solid fa-magnifying-glass-dollar", PolicyNames.FinanceAdminOrAdmin)
         ]),
-        new("Events", [
+        new("Finance", [
+            new("Finance",        "Finance",      "Index",   null, null, "fa-solid fa-coins",        PolicyNames.FinanceAdminOrAdmin)
+        ]),
+        new("Store", [
+            new("Store catalog",  "StoreAdmin",   "Catalog", null, null, "fa-solid fa-tags",         PolicyNames.StoreCatalogAdmin),
+            new("Store summary",  "StoreAdmin",   "Summary", null, null, "fa-solid fa-chart-column", PolicyNames.StoreCatalogAdmin)
+        ]),
+        new("Event Guide", [
             new("Guide settings", "EventsAdmin", "Settings", null, null, "fa-solid fa-calendar-days", PolicyNames.EventsAdminOrAdmin),
             new("Guide categories", "EventsAdmin", "Categories", null, null, "fa-solid fa-tags", PolicyNames.EventsAdminOrAdmin),
             new("Guide venues", "EventsAdmin", "Venues", null, null, "fa-solid fa-location-dot", PolicyNames.EventsAdminOrAdmin)
@@ -50,31 +56,37 @@ public static class AdminNavTree
         new("Governance", [
             new("Voting", "GovernanceBoardVoting", "BoardVoting", null, null, "fa-solid fa-check-to-slot", PolicyNames.BoardOrAdmin,
                  PillCount: PillCounts.VotingQueue),
-            new("Applications", "GovernanceApplications", "Admin", null, null, "fa-solid fa-file-signature", PolicyNames.BoardOrAdmin),
-            new("Audit log",    "AuditLog",    "Index",            null, null, "fa-solid fa-book-open",      PolicyNames.BoardOrAdmin)
+            new("Applications", "GovernanceApplications", "Admin", null, null, "fa-solid fa-file-signature", PolicyNames.BoardOrAdmin)
         ]),
-        new("Integrations", [
-            new("Google",             "Google", "Index",        null, null, "fa-brands fa-google",   PolicyNames.AdminOnly),
+        new("Google", [
+            new("Overview",              "Google", "Index",        null, null, "fa-brands fa-google",           PolicyNames.AdminOnly),
+            new("Sync settings",         "Google", "SyncSettings", null, null, "fa-solid fa-sliders",           PolicyNames.AdminOnly),
+            new("Resource sync",         "Google", "Sync",         null, null, "fa-solid fa-arrows-rotate",     PolicyNames.AdminOnly),
+            new("All domain groups",     "Google", "AllGroups",    null, null, "fa-solid fa-globe",             PolicyNames.AdminOnly),
+            new("Workspace accounts",    "Google", "Accounts",     null, null, "fa-solid fa-at",                PolicyNames.AdminOnly),
+            new("Sync outbox",           "Google", "SyncOutbox",   null, null, "fa-solid fa-clock-rotate-left", PolicyNames.AdminOnly),
+            new("Sync results",          "Google", "SyncResults",  null, null, "fa-solid fa-list-check",        PolicyNames.AdminOnly),
+            new("Group settings",        "Google", "GroupSettingsResults", null, null, "fa-solid fa-gears",     PolicyNames.AdminOnly),
+            new("Email renames",         "Google", "EmailRenames", null, null, "fa-solid fa-right-left",        PolicyNames.AdminOnly),
+            new("Email flag violations", "Google", "EmailFlagViolations", null, null, "fa-solid fa-triangle-exclamation", PolicyNames.AdminOnly)
+        ]),
+        new("Messaging", [
             new("Email preview",      "Email",  "EmailPreview", null, null, "fa-solid fa-envelope",  PolicyNames.AdminOnly),
             new("Email outbox",       "Email",  "EmailOutbox",  null, null, "fa-solid fa-inbox",     PolicyNames.AdminOnly),
             new("Campaigns",          "Campaign", "Index",      null, null, "fa-solid fa-bullhorn",  PolicyNames.AdminOnly),
-            new("Workspace accounts", "Google",  "Accounts",    null, null, "fa-solid fa-at",        PolicyNames.AdminOnly),
-            new("Email flag violations", "Google", "EmailFlagViolations", null, null, "fa-solid fa-triangle-exclamation", PolicyNames.AdminOnly),
-            new("Mailer",                "MailerAdmin", "Index",           null, null, "fa-solid fa-paper-plane",          PolicyNames.AdminOnly)
+            new("Mailer",             "MailerAdmin", "Index",   null, null, "fa-solid fa-paper-plane", PolicyNames.AdminOnly),
+            new("Audience segmentation", "Admin", "AudienceSegmentation", null, null, "fa-solid fa-chart-pie", PolicyNames.AdminOnly)
         ]),
         new("Agent", [
             new("Agent Status",  "AdminAgent", "Status",        null, null, "fa-solid fa-gauge-high", PolicyNames.AdminOnly),
             new("Agent Config",  "AdminAgent", "Settings",      null, null, "fa-solid fa-robot",      PolicyNames.AdminOnly),
             new("Agent History", "Agent",      "Conversations", null, null, "fa-solid fa-comments",   PolicyNames.AdminOnly)
         ]),
-        new("People data", [
-            new("Merge requests",        "AdminMerge", "Index",            null, null, "fa-solid fa-code-merge", PolicyNames.AdminOnly),
-            new("Duplicate detection",   "AdminDuplicateAccounts", "Index", null, null, "fa-solid fa-clone",      PolicyNames.AdminOnly),
-            new("Email problems",        "ProfileAdmin", "EmailProblems", null, null, "fa-solid fa-envelope-circle-check", PolicyNames.AdminOnly),
-            new("Audience segmentation", "Admin", "AudienceSegmentation",   null, null, "fa-solid fa-chart-pie",  PolicyNames.AdminOnly),
-            new("Legal documents",       "AdminLegalDocuments", "LegalDocuments", null, null, "fa-solid fa-scale-balanced", PolicyNames.AdminOnly),
-            new("Backfill Provider/IsGoogle", "Admin", "BackfillUserEmailProviders", null, null, "fa-solid fa-key", PolicyNames.AdminOnly),
-            new("Stub Profile Backfill",      "ProfileBackfillAdmin", "Index",       null, null, "fa-solid fa-user-plus", PolicyNames.AdminOnly)
+        new("Legal", [
+            new("Legal documents", "AdminLegalDocuments", "LegalDocuments", null, null, "fa-solid fa-scale-balanced", PolicyNames.AdminOnly)
+        ]),
+        new("Audit", [
+            new("Audit log", "AuditLog", "Index", null, null, "fa-solid fa-book-open", PolicyNames.BoardOrAdmin)
         ]),
         new("Diagnostics", [
             new("Logs",            "Admin", "Logs",          null, null, "fa-solid fa-triangle-exclamation", PolicyNames.AdminOnly),
@@ -84,8 +96,6 @@ public static class AdminNavTree
             new("All users (debug)", "UsersAdminDebug", "Index", null, null, "fa-solid fa-bug-slash", PolicyNames.AdminOnly),
             new("Configuration",   "Admin", "Configuration", null, null, "fa-solid fa-gear",                PolicyNames.AdminOnly),
             new("Maintenance",     "Admin", "Maintenance",   null, null, "fa-solid fa-screwdriver-wrench",  PolicyNames.AdminOnly),
-            new("Orphan signups",  "Shifts", "OrphanSignups", null, null, "fa-solid fa-user-secret",        PolicyNames.AdminOnly),
-            new("Picture migration", "ProfilePictureMigrationAdmin", "Index", null, null, "fa-solid fa-image", PolicyNames.AdminOnly),
             new("Hangfire",        null, null, null, "/hangfire",      "fa-solid fa-clock-rotate-left", PolicyNames.AdminOnly),
             new("Health",          null, null, null, "/health/ready",  "fa-solid fa-heart-pulse",       PolicyNames.AdminOnly)
         ]),
@@ -98,6 +108,11 @@ public static class AdminNavTree
         new("Design", [
             new("Color palette", "ColorPalette",  "Index", null, null, "fa-solid fa-palette", PolicyNames.AdminOnly),
             new("Components",    "WidgetGallery", "Index", null, null, "fa-solid fa-shapes",  PolicyNames.AdminOnly)
+        ]),
+        new("Temp", [
+            new("Picture migration",          "ProfilePictureMigrationAdmin", "Index", null, null, "fa-solid fa-image",     PolicyNames.AdminOnly),
+            new("Backfill Provider/IsGoogle", "Admin", "BackfillUserEmailProviders",    null, null, "fa-solid fa-key",       PolicyNames.AdminOnly),
+            new("Stub Profile Backfill",      "ProfileBackfillAdmin", "Index",          null, null, "fa-solid fa-user-plus", PolicyNames.AdminOnly)
         ])
     ];
 }

--- a/src/Humans.Web/Views/Cantina/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/Cantina/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/Debug/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/Debug/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/EarlyEntryRoster/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/EarlyEntryRoster/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/EventsAdmin/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/EventsAdmin/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/Expenses/Review.cshtml
+++ b/src/Humans.Web/Views/Expenses/Review.cshtml
@@ -1,6 +1,7 @@
 @model Humans.Web.Models.ExpenseReviewViewModel
 @{
     ViewData["Title"] = "Expense Reports — Finance Review";
+    Layout = "_AdminLayout";
     var badgeClass = (ExpenseReportStatus s) => s switch
     {
         ExpenseReportStatus.Draft => "bg-secondary",

--- a/src/Humans.Web/Views/Google/Index.cshtml
+++ b/src/Humans.Web/Views/Google/Index.cshtml
@@ -9,29 +9,13 @@
 
 <vc:temp-data-alerts />
 
-<div class="row">
-    <div class="col-md-6">
-        <div class="card mb-4">
-            <div class="card-header">Google Tools</div>
-            <div class="list-group list-group-flush">
-                <a asp-action="SyncSettings" class="list-group-item list-group-item-action">
-                    <i class="fa-solid fa-sliders me-2"></i>Sync Settings
-                </a>
-                <a asp-action="Sync" class="list-group-item list-group-item-action">
-                    <i class="fa-solid fa-arrows-rotate me-2"></i>Resource Sync Status
-                </a>
-                <a asp-action="AllGroups" class="list-group-item list-group-item-action">
-                    <i class="fa-solid fa-globe me-2"></i>All Domain Groups
-                </a>
-                <a asp-action="Accounts" class="list-group-item list-group-item-action">
-                    <i class="fa-solid fa-at me-2"></i>@@nobodies.team Accounts
-                </a>
-                <a asp-action="SyncOutbox" class="list-group-item list-group-item-action">
-                    <i class="fa-solid fa-clock-rotate-left me-2"></i>Sync Outbox
-                </a>
-            </div>
-        </div>
+<p class="text-muted">
+    Sync settings, accounts, domain groups, outbox, and detection results now live in the
+    <strong>Google</strong> section of the admin sidebar. The cards below trigger on-demand checks.
+</p>
 
+<div class="row">
+    <div class="col-md-4">
         <div class="card mb-4">
             <div class="card-header">System Team Sync</div>
             <div class="card-body">
@@ -47,7 +31,9 @@
                 </a>
             </div>
         </div>
+    </div>
 
+    <div class="col-md-4">
         <div class="card mb-4">
             <div class="card-header">Google Group Settings</div>
             <div class="card-body">
@@ -63,7 +49,9 @@
                 </a>
             </div>
         </div>
+    </div>
 
+    <div class="col-md-4">
         <div class="card mb-4">
             <div class="card-header">Email Rename Detection</div>
             <div class="card-body">
@@ -76,20 +64,6 @@
                 </form>
                 <a asp-action="EmailRenames" class="btn btn-outline-secondary btn-sm mt-3">
                     <i class="fa-solid fa-list-check me-1"></i>View Last Results
-                </a>
-            </div>
-        </div>
-    </div>
-
-    <div class="col-md-6">
-        <div class="card mb-4">
-            <div class="card-header">Quick Links</div>
-            <div class="list-group list-group-flush">
-                <a asp-controller="Admin" asp-action="Index" class="list-group-item list-group-item-action">
-                    <i class="fa-solid fa-gear me-2"></i>Admin Tools
-                </a>
-                <a asp-controller="AuditLog" asp-action="Index" class="list-group-item list-group-item-action">
-                    <i class="fa-solid fa-clipboard-list me-2"></i>Audit Log
                 </a>
             </div>
         </div>

--- a/src/Humans.Web/Views/Governance/Applications/Admin.cshtml
+++ b/src/Humans.Web/Views/Governance/Applications/Admin.cshtml
@@ -1,6 +1,7 @@
 @model Humans.Web.Models.AdminApplicationListViewModel
 @{
     ViewData["Title"] = Localizer["AdminApplications_Title"].Value;
+    Layout = "_AdminLayout";
 }
 
 <partial name="~/Views/Shared/_ApplicationsListContent.cshtml" model="Model" />

--- a/src/Humans.Web/Views/Governance/Applications/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Governance/Applications/AdminDetail.cshtml
@@ -1,6 +1,7 @@
 @model Humans.Web.Models.AdminApplicationDetailViewModel
 @{
     ViewData["Title"] = Localizer["AdminApplicationDetail_Title"].Value;
+    Layout = "_AdminLayout";
 }
 
 <nav aria-label="breadcrumb">

--- a/src/Humans.Web/Views/Governance/BoardVoting/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/Governance/BoardVoting/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/ProfileAdmin/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/Shared/Roles.cshtml
+++ b/src/Humans.Web/Views/Shared/Roles.cshtml
@@ -1,6 +1,7 @@
 @model Humans.Web.Models.AdminRoleAssignmentListViewModel
 @{
     ViewData["Title"] = Localizer["AdminRoles_Title"].Value;
+    Layout = "_AdminLayout";
 }
 
 <partial name="~/Views/Shared/_RolesListContent.cshtml" model="Model" />

--- a/src/Humans.Web/Views/ShiftDashboard/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/ShiftWorkloadAdmin/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/ShiftWorkloadAdmin/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/Shifts/OrphanSignups.cshtml
+++ b/src/Humans.Web/Views/Shifts/OrphanSignups.cshtml
@@ -2,7 +2,7 @@
 
 @{
     ViewData["Title"] = "Orphan shift signups";
-    Layout = "~/Views/Shared/_Layout.cshtml";
+    Layout = "_AdminLayout";
 }
 
 <div class="container-fluid py-3">

--- a/src/Humans.Web/Views/TicketTransferAdmin/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/TicketTransferAdmin/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/src/Humans.Web/Views/UsersAdminDebug/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/UsersAdminDebug/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_AdminLayout";
+}

--- a/tests/Humans.Application.Tests/ViewComponents/AdminBreadcrumbViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/AdminBreadcrumbViewComponentTests.cs
@@ -23,7 +23,7 @@ public class AdminBreadcrumbViewComponentTests
         sut.ViewComponentContext = ctx;
         var result = sut.Invoke() as ViewViewComponentResult;
         var model = result!.ViewData!.Model as AdminBreadcrumbViewModel;
-        model!.GroupLabel.Should().Be("Operations");
+        model!.GroupLabel.Should().Be("Tickets");
         model.ItemLabel.Should().Be("Tickets");
     }
 

--- a/tests/Humans.Application.Tests/ViewComponents/AdminSidebarViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/AdminSidebarViewComponentTests.cs
@@ -31,7 +31,7 @@ public class AdminSidebarViewComponentTests
     public async Task Hides_Empty_Groups()
     {
         var auth = Substitute.For<IAuthorizationService>();
-        // Allow only items in the Operations group
+        // Allow only items in the Tickets group
         auth.AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object?>(),
                 Arg.Is<string>(p => p == PolicyNames.TicketAdminBoardOrAdmin))
             .Returns(AuthorizationResult.Success());
@@ -42,7 +42,7 @@ public class AdminSidebarViewComponentTests
         var result = await sut.InvokeAsync() as ViewViewComponentResult;
         var model = result!.ViewData!.Model as AdminSidebarViewModel;
         model!.Groups.Should().HaveCount(1);
-        model.Groups.Single().Label.Should().Be("Operations");
+        model.Groups.Single().Label.Should().Be("Tickets");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Part 1 — Nav reorganization (`AdminNavTree.cs`)

Realigns the admin sidebar groups to the app's actual sections:

| Change | Detail |
|--------|--------|
| Rename | **Operations → Tickets**; **Events → Event Guide** |
| Split | **Money → Finance + Store** (separate sections) |
| Split | **Integrations → Google + Messaging** |
| Promote | The `/Google` page's buried tools (Sync settings, Resource sync, All domain groups, Sync outbox, Sync results, Group settings, Email renames) become first-class items in the new **Google** group |
| Move | **Audit log** out of Governance → its own **Audit** group (it's a horizontal/cross-cutting section) |
| Dissolve | **People data** → Merge/Duplicate/Email problems to **Members**; Audience segmentation to **Messaging**; Legal documents to new **Legal**; backfills + Picture migration to new **Temp** (bottom) |
| Move | **Orphan signups** Diagnostics → **Shifts** |
| Slim | `/Google` landing page reduced to its three on-demand action triggers |

## Part 2 — Admin-shell layout fixes

~15 admin nav targets were rendering in the **member shell** (silently fell back to `_Layout`), not just the two originally spotted (`/Profile/Admin/Roles`, `/Shifts/Dashboard`).

- **Folder `_ViewStart` (`_AdminLayout`)** for pure-admin folders: `TicketTransferAdmin`, `ShiftDashboard`, `ShiftWorkloadAdmin`, `EarlyEntryRoster`, `EventsAdmin`, `ProfileAdmin`, `UsersAdminDebug`, `Cantina`, `Debug`, `Governance/BoardVoting`.
- **In-file layout** for shared/mixed-folder views: `Shared/Roles`, `Shifts/OrphanSignups`, `Governance/Applications/{Admin,AdminDetail}`, `Expenses/Review`.

**Left as member shell intentionally** (member-facing pages surfaced in admin nav, or design playground): Expenses `Index`/`Coordinator` (gated `IsActiveMember`), Agent History (`[Authorize]` only), Color palette, Components.

## Verification
- `dotnet build src/Humans.Web` — 0 errors (only pre-existing HUM00xx baseline warnings).
- AdminSidebar/AdminBreadcrumb ViewComponent tests pass (22/22); updated two assertions for the Operations→Tickets rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)