### PR TITLE
ci: restore pull-requests:write so surface report comment posts

### DIFF
--- a/.github/workflows/pr-surface-report-comment.yml
+++ b/.github/workflows/pr-surface-report-comment.yml
@@ -18,6 +18,10 @@ on:
 
 permissions:
   contents: read
+  # createComment targets a pull request, so the GITHUB_TOKEN needs
+  # pull-requests: write — issues: write alone only authorizes comments on
+  # plain issues and yields "Resource not accessible by integration" on a PR.
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Problem

PR #841 ("score fork PRs in surface report") split the surface report into two workflows and **dropped `pull-requests: write`** from the privileged comment half, on the reasoning that the comment is posted through the issues API and so only needs `issues: write`.

That reasoning is wrong. Every run of **PR Surface Report Comment** since #841 has failed at the actual write:

```
RequestError [HttpError]: Resource not accessible by integration
  - .../rest/issues/comments#create-an-issue-comment
##[error]Unhandled error: HttpError: Resource not accessible by integration
```

The PR-resolution logic works (the script reaches `issues.createComment`). The failure is the write itself, on a **same-repo** PR with the repo default token already set to `write` — so it is not a fork/token-downgrade issue. The cause: `POST /repos/.../issues/{n}/comments` where `{n}` is a **pull request** requires the `GITHUB_TOKEN` to hold `pull-requests: write`; `issues: write` only authorizes comments on plain issues. The pre-#841 workflow had **both**, which is why commenting worked before.

## Fix

Restore `pull-requests: write` on the comment workflow (`pr-surface-report-comment.yml`) only.

This does **not** weaken #841's isolation: that workflow never checks out or builds PR code — it only downloads the report artifact and comments — so granting it `pull-requests: write` is exactly what the GitHub-recommended `pull_request` + `workflow_run` pattern intends. The build half (`pr-surface-report.yml`) stays `contents: read`.

## Verification

Note: `workflow_run` workflows always run the copy of the workflow file on the **default branch**, so this fix only takes effect once merged — #843's own comment run will still use main's buggy copy and won't post. After merge, the next PR's **PR Surface Report Comment** run posting a comment is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)