### PR TITLE
feat(store): TeamsAdmin access to team orders; show all orders to privileged readers

### DIFF
--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -37,40 +37,51 @@ public class StoreService(
 
         var counterparties = new List<StoreCounterpartyOrders>();
 
-        // Camp-lead counterparty
-        CampSeasonInfo? leadSeason = null;
+        // Camp counterparties: the one camp the viewer leads, or every camp's
+        // season for the year when the viewer is a privileged reader.
+        var campSeasons = new List<CampSeasonInfo>();
         foreach (var camp in await campService.GetCampsForYearAsync(year, ct))
         {
-            var leadSeasonId = camp.GetLeadSeasonIdForYear(userId, year);
-            if (leadSeasonId is null) continue;
-            leadSeason = camp.Seasons.First(season => season.Id == leadSeasonId.Value);
-            break;
+            if (isPrivilegedReader)
+            {
+                var season = camp.GetSeasonForYear(year);
+                if (season is not null) campSeasons.Add(season);
+            }
+            else
+            {
+                var leadSeasonId = camp.GetLeadSeasonIdForYear(userId, year);
+                if (leadSeasonId is null) continue;
+                campSeasons.Add(camp.Seasons.First(season => season.Id == leadSeasonId.Value));
+                break; // a user leads at most one camp
+            }
         }
 
-        if (leadSeason is not null)
+        foreach (var season in campSeasons)
         {
             // One order per camp-season; if legacy data has multiple, surface
             // only the highest-balance one and let the admin delete the rest.
-            var allOrders = await GetOrdersForCampSeasonAsync(leadSeason.Id, ct);
+            var allOrders = await GetOrdersForCampSeasonAsync(season.Id, ct);
             var primary = allOrders
                 .OrderByDescending(o => o.BalanceEur)
                 .FirstOrDefault();
             IReadOnlyList<OrderDto> orders = primary is null ? [] : [primary];
             counterparties.Add(new StoreCounterpartyOrders(
                 StoreOrderCounterpartyType.Camp,
-                leadSeason.Id,
-                leadSeason.Name,
+                season.Id,
+                season.Name,
                 year,
                 orders));
         }
 
-        // Team-coordinator counterparties — departments only.
+        // Team counterparties — top-level departments only. The viewer's own
+        // coordinated departments, or every department when a privileged reader.
         // Order is the controller / view's concern (memory/architecture/display-sort-in-controllers.md).
         var teams = await teamService.GetTeamsAsync(ct);
         foreach (var team in teams.Values
             .Where(t => t.ParentTeamId is null
-                        && t.ManagementRoleHolderUserIds is not null
-                        && t.ManagementRoleHolderUserIds.Contains(userId)))
+                        && (isPrivilegedReader
+                            || (t.ManagementRoleHolderUserIds is not null
+                                && t.ManagementRoleHolderUserIds.Contains(userId)))))
         {
             var existing = await repo.GetOrderForTeamAsync(team.Id, year, ct);
             IReadOnlyList<OrderDto> orders;

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
@@ -14,6 +14,9 @@ namespace Humans.Web.Authorization.Requirements;
 /// View/AddLine/RemoveLine/EditCounterparty and <see cref="StoreOrderCreateContext"/>
 /// resources for Create):
 /// - Admin or FinanceAdmin: allow any operation regardless of order state.
+/// - TeamsAdmin: View any order (camp or team); manage (AddLine/RemoveLine/Delete)
+///   team orders only. Camp orders are view-only. Additive — a TeamsAdmin who is also
+///   a camp lead still gets camp-edit rights through the lead path below.
 /// - Camp lead/co-lead of the camp owning the resource's CampSeason: allow camp orders.
 /// - Coordinator (department-level management role holder) of the resource's Team:
 ///   allow team orders for View/AddLine/RemoveLine; EditCounterparty and Pay are
@@ -65,6 +68,27 @@ public class StoreOrderAuthorizationHandler(
                 context.Succeed(req);
             }
             return;
+        }
+
+        // TeamsAdmin: read any order; manage team orders only (camp orders stay
+        // view-only). Additive — fall through so a TeamsAdmin who is also a camp
+        // lead still picks up camp-edit rights in the lead/coordinator block below.
+        if (RoleChecks.IsTeamsAdmin(context.User))
+        {
+            foreach (var req in pending)
+            {
+                if (req == StoreOrderOperationRequirement.View)
+                {
+                    context.Succeed(req);
+                    continue;
+                }
+                if (teamId is null) continue; // camp orders are view-only for TeamsAdmin
+                // Team orders are non-billable — never Pay/EditCounterparty.
+                if (req == StoreOrderOperationRequirement.EditCounterparty ||
+                    req == StoreOrderOperationRequirement.Pay)
+                    continue;
+                context.Succeed(req);
+            }
         }
 
         var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
@@ -87,6 +87,12 @@ public class StoreOrderAuthorizationHandler(
                 if (req == StoreOrderOperationRequirement.EditCounterparty ||
                     req == StoreOrderOperationRequirement.Pay)
                     continue;
+                // Line edits require an Open order, matching the coordinator path and the
+                // StoreService guard ("Cannot add/remove lines from an issued order").
+                var isLineEdit = req == StoreOrderOperationRequirement.AddLine
+                    || req == StoreOrderOperationRequirement.RemoveLine;
+                if (isLineEdit && orderState is not null and not StoreOrderState.Open)
+                    continue;
                 context.Succeed(req);
             }
         }

--- a/src/Humans.Web/Controllers/StoreController.cs
+++ b/src/Humans.Web/Controllers/StoreController.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Store;
 using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
 using Humans.Web.Models;
@@ -26,11 +27,28 @@ public class StoreController(
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var isPrivilegedReader = RoleChecks.CanAdministerStore(User);
+        // Full store admins and TeamsAdmins read every counterparty; TeamsAdmins
+        // can edit team orders but only view camp orders, so per-row affordances
+        // are resolved against the order authorization handler below.
+        var isPrivilegedReader = RoleChecks.CanAdministerStore(User) || RoleChecks.IsTeamsAdmin(User);
         var pageData = await storeService.GetIndexDataAsync(user.Id, isPrivilegedReader, ct);
         if (pageData.ShowNoOrdersMessage)
         {
             SetInfo("You don't lead any camps or coordinate any departments this year, so there are no Store orders to manage.");
+        }
+
+        var canManage = new Dictionary<Guid, bool>(pageData.Counterparties.Count);
+        foreach (var cp in pageData.Counterparties)
+        {
+            // The order's one actionable affordance on this page: Delete when it
+            // exists, Create when it doesn't.
+            var (resource, requirement) = cp.Orders.Count > 0
+                ? ((object)cp.Orders[0], StoreOrderOperationRequirement.Delete)
+                : (new StoreOrderCreateContext(
+                       CampSeasonId: cp.CounterpartyType == StoreOrderCounterpartyType.Camp ? cp.CounterpartyId : null,
+                       TeamId: cp.CounterpartyType == StoreOrderCounterpartyType.Team ? cp.CounterpartyId : null),
+                   StoreOrderOperationRequirement.Create);
+            canManage[cp.CounterpartyId] = (await authService.AuthorizeAsync(User, resource, requirement)).Succeeded;
         }
 
         var model = new StoreIndexViewModel
@@ -38,7 +56,7 @@ public class StoreController(
             Year = pageData.Year,
             Catalog = pageData.Catalog,
             Counterparties = pageData.Counterparties,
-            IsAdmin = isPrivilegedReader
+            CanManageByCounterparty = canManage
         };
         return View(model);
     }

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -158,7 +158,10 @@ public class TeamController(
             CanCurrentUserEditTeam = teamPage.CanCurrentUserEditTeam,
             CurrentUserPendingRequestId = teamPage.CurrentUserPendingRequestId,
             PendingRequestCount = teamPage.PendingRequestCount,
-            ShiftsSummary = MapShiftsSummary(teamPage.ShiftsSummary, slug)
+            ShiftsSummary = MapShiftsSummary(teamPage.ShiftsSummary, slug),
+            CanOpenStore = (teamPage.IsCurrentUserCoordinator && team.ParentTeam is null && team.IsActive)
+                || RoleChecks.IsAdmin(User)
+                || RoleChecks.IsTeamsAdmin(User)
         };
 
         // Subteam member rollup: for departments, show child team members not already direct members

--- a/src/Humans.Web/Models/StoreIndexViewModel.cs
+++ b/src/Humans.Web/Models/StoreIndexViewModel.cs
@@ -7,8 +7,14 @@ public sealed class StoreIndexViewModel
     public int Year { get; init; }
     public IReadOnlyList<ProductDto> Catalog { get; init; } = [];
     public IReadOnlyList<StoreCounterpartyOrders> Counterparties { get; init; } = [];
-    /// <summary>True when the viewer can administer the Store (StoreAdmin / FinanceAdmin / Admin). Surfaces per-row admin affordances such as Delete.</summary>
-    public bool IsAdmin { get; init; }
+    /// <summary>
+    /// Keyed by <see cref="StoreCounterpartyOrders.CounterpartyId"/>: whether the viewer may act on that
+    /// counterparty's order (Create when it has none, Delete when it does). Privileged readers see
+    /// counterparties they cannot manage (e.g. a TeamsAdmin sees camp orders read-only), so per-row gating
+    /// is resolved against the order authorization handler in the controller rather than a blanket admin flag.
+    /// </summary>
+    public IReadOnlyDictionary<Guid, bool> CanManageByCounterparty { get; init; } =
+        new Dictionary<Guid, bool>();
 }
 
 public sealed class StoreOrderViewModel

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -87,6 +87,12 @@ public class TeamDetailViewModel
     public ShiftsSummaryCardViewModel? ShiftsSummary { get; set; }
 
     /// <summary>
+    /// Whether to surface the "Open store" link: a coordinator of this active top-level department,
+    /// or an Admin / TeamsAdmin (who reach the Store regardless of coordinator status).
+    /// </summary>
+    public bool CanOpenStore { get; set; }
+
+    /// <summary>
     /// Coordinators/leads from child teams. Only populated for departments with child team coordinators.
     /// </summary>
     public List<ChildTeamMemberViewModel> SubteamLeads { get; set; } = [];

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -28,7 +28,7 @@ else
                     @cp.DisplayName
                     <span class="badge bg-light text-dark ms-2">@cp.CounterpartyType</span>
                 </h2>
-                @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp && cp.Orders.Count == 0)
+                @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp && cp.Orders.Count == 0 && Model.CanManageByCounterparty[cp.CounterpartyId])
                 {
                     <form asp-action="Create" asp-route-campSeasonId="@cp.CounterpartyId"
                           method="post" class="d-flex gap-2 align-items-center mb-0">
@@ -38,7 +38,7 @@ else
                         <button type="submit" class="btn btn-sm btn-primary">Start order</button>
                     </form>
                 }
-                else if (cp.CounterpartyType == StoreOrderCounterpartyType.Team && cp.Orders.Count == 0)
+                else if (cp.CounterpartyType == StoreOrderCounterpartyType.Team && cp.Orders.Count == 0 && Model.CanManageByCounterparty[cp.CounterpartyId])
                 {
                     <form asp-action="CreateTeamOrder" asp-route-teamId="@cp.CounterpartyId"
                           method="post" class="mb-0">
@@ -86,7 +86,7 @@ else
                                     }
                                     <td class="text-end">
                                         <div class="d-inline-flex gap-1">
-                                            @if (Model.IsAdmin && order.BalanceEur == 0m)
+                                            @if (Model.CanManageByCounterparty[cp.CounterpartyId] && order.BalanceEur == 0m)
                                             {
                                                 <form asp-action="Delete" asp-route-id="@order.Id" method="post" class="mb-0">
                                                     @Html.AntiForgeryToken()

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -306,7 +306,7 @@
                         Team calendar
                     </a>
 
-                    @if (Model.IsCurrentUserCoordinator && Model.ParentTeam is null && Model.IsActive)
+                    @if (Model.CanOpenStore)
                     {
                         <a asp-controller="Store" asp-action="Index" class="btn btn-outline-primary w-100 mt-2">
                             <i class="fa-solid fa-cart-shopping me-1"></i> Open store

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
@@ -242,6 +242,26 @@ public class StoreServiceTeamOrdersTests
         data.ShowNoOrdersMessage.Should().BeTrue();
     }
 
+    [HumansFact]
+    public async Task GetIndexDataAsync_privileged_reader_lists_departments_it_does_not_coordinate()
+    {
+        var viewerId = Guid.NewGuid();
+        var otherDeptId = Guid.NewGuid();
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>
+            {
+                [otherDeptId] = MakeDepartment(otherDeptId, "Other", coordinatorUserId: Guid.NewGuid()),
+            });
+        _repo.GetOrderForTeamAsync(otherDeptId, 2026, Arg.Any<CancellationToken>()).Returns((StoreOrder?)null);
+        _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<StoreProduct>());
+
+        var data = await _service.GetIndexDataAsync(viewerId, isPrivilegedReader: true);
+
+        data.Counterparties.Should().ContainSingle(c =>
+            c.CounterpartyType == StoreOrderCounterpartyType.Team && c.CounterpartyId == otherDeptId);
+    }
+
     // ==========================================================================
     // Summary — team orders merge into cross-tab
     // ==========================================================================

--- a/tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs
@@ -1,0 +1,92 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
+using Humans.Web.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Authorization;
+
+/// <summary>
+/// Covers the TeamsAdmin branch of <see cref="StoreOrderAuthorizationHandler"/>:
+/// read any order, manage (edit/delete) team orders only, camp orders view-only.
+/// </summary>
+public class StoreOrderAuthorizationHandlerTests
+{
+    private readonly ICampServiceRead _campService = Substitute.For<ICampServiceRead>();
+    private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
+    private readonly StoreOrderAuthorizationHandler _handler;
+
+    public StoreOrderAuthorizationHandlerTests()
+    {
+        _handler = new StoreOrderAuthorizationHandler(_campService, _teamService);
+    }
+
+    [HumansFact]
+    public Task TeamsAdmin_can_view_camp_order() =>
+        AssertOutcome(RoleNames.TeamsAdmin, MakeOrder(team: false), StoreOrderOperationRequirement.View, expectAllowed: true);
+
+    [HumansFact]
+    public Task TeamsAdmin_cannot_edit_camp_order() =>
+        AssertOutcome(RoleNames.TeamsAdmin, MakeOrder(team: false), StoreOrderOperationRequirement.AddLine, expectAllowed: false);
+
+    [HumansFact]
+    public Task TeamsAdmin_can_edit_team_order() =>
+        AssertOutcome(RoleNames.TeamsAdmin, MakeOrder(team: true), StoreOrderOperationRequirement.AddLine, expectAllowed: true);
+
+    [HumansFact]
+    public Task TeamsAdmin_can_delete_team_order() =>
+        AssertOutcome(RoleNames.TeamsAdmin, MakeOrder(team: true), StoreOrderOperationRequirement.Delete, expectAllowed: true);
+
+    [HumansFact]
+    public Task TeamsAdmin_cannot_pay_team_order() =>
+        AssertOutcome(RoleNames.TeamsAdmin, MakeOrder(team: true), StoreOrderOperationRequirement.Pay, expectAllowed: false);
+
+    private async Task AssertOutcome(
+        string role,
+        OrderDto order,
+        StoreOrderOperationRequirement requirement,
+        bool expectAllowed)
+    {
+        var context = new AuthorizationHandlerContext([requirement], Principal(role), order);
+
+        await _handler.HandleAsync(context);
+
+        Assert.Equal(expectAllowed, context.HasSucceeded);
+    }
+
+    private static ClaimsPrincipal Principal(string role) =>
+        new(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+                new Claim(ClaimTypes.Role, role),
+            ],
+            authenticationType: "test"));
+
+    private static OrderDto MakeOrder(bool team) =>
+        new(
+            Id: Guid.NewGuid(),
+            CampSeasonId: team ? null : Guid.NewGuid(),
+            TeamId: team ? Guid.NewGuid() : null,
+            CounterpartyType: team ? StoreOrderCounterpartyType.Team : StoreOrderCounterpartyType.Camp,
+            CounterpartyDisplayName: "x",
+            Year: 2026,
+            Label: null,
+            State: StoreOrderState.Open,
+            CounterpartyName: null,
+            CounterpartyVatId: null,
+            CounterpartyAddress: null,
+            CounterpartyCountryCode: null,
+            CounterpartyEmail: null,
+            IssuedInvoiceId: null,
+            Lines: [],
+            LinesSubtotalEur: 0m,
+            VatTotalEur: 0m,
+            DepositTotalEur: 0m,
+            PaymentsTotalEur: 0m,
+            BalanceEur: 0m);
+}

--- a/tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs
@@ -46,6 +46,10 @@ public class StoreOrderAuthorizationHandlerTests
     public Task TeamsAdmin_cannot_pay_team_order() =>
         AssertOutcome(RoleNames.TeamsAdmin, MakeOrder(team: true), StoreOrderOperationRequirement.Pay, expectAllowed: false);
 
+    [HumansFact]
+    public Task TeamsAdmin_cannot_edit_issued_team_order() =>
+        AssertOutcome(RoleNames.TeamsAdmin, MakeOrder(team: true, StoreOrderState.InvoiceIssued), StoreOrderOperationRequirement.AddLine, expectAllowed: false);
+
     private async Task AssertOutcome(
         string role,
         OrderDto order,
@@ -67,7 +71,7 @@ public class StoreOrderAuthorizationHandlerTests
             ],
             authenticationType: "test"));
 
-    private static OrderDto MakeOrder(bool team) =>
+    private static OrderDto MakeOrder(bool team, StoreOrderState state = StoreOrderState.Open) =>
         new(
             Id: Guid.NewGuid(),
             CampSeasonId: team ? null : Guid.NewGuid(),
@@ -76,7 +80,7 @@ public class StoreOrderAuthorizationHandlerTests
             CounterpartyDisplayName: "x",
             Year: 2026,
             Label: null,
-            State: StoreOrderState.Open,
+            State: state,
             CounterpartyName: null,
             CounterpartyVatId: null,
             CounterpartyAddress: null,


### PR DESCRIPTION
## What

Started from: *"where's the button for departments to get into the store?"* → that button (Team Details → **Open store**) only showed to a department's coordinator. This extends Store access per the rule **"TeamsAdmin can admin team store orders; full site admin can do all; they can see other camp orders, just not edit."**

## Permission model

| Role | See | Edit |
|---|---|---|
| Admin / StoreAdmin / FinanceAdmin | all orders | all orders |
| **TeamsAdmin** | all orders (camp + team) | **team orders only** — camp orders view-only |
| Camp lead / team coordinator | own counterparty | own counterparty (unchanged) |

## Changes

- **`StoreOrderAuthorizationHandler`** — additive TeamsAdmin branch: `View` any order; `AddLine`/`RemoveLine`/`Delete` on **team** orders only; never `Pay`/`EditCounterparty` (team orders are non-billable). Falls through, so a TeamsAdmin who is also a camp lead keeps camp-edit rights via the lead path.
- **`StoreService.GetIndexDataAsync`** — privileged readers now enumerate **every** camp-season + top-level department, not just their own. (The `isPrivilegedReader` flag previously only suppressed the empty-state message — now it drives visibility, as its name implies.)
- **`StoreController.Index`** — privileged set is `CanAdministerStore || IsTeamsAdmin`; per-counterparty Create/Delete affordances resolved against the auth handler (`CanManageByCounterparty`) instead of a blanket `IsAdmin` flag, so a TeamsAdmin sees camp orders read-only.
- **`Store/Index.cshtml`** — Start order / Create order / Delete buttons gated per counterparty.
- **Team Details** — `CanOpenStore`: the **Open store** button now shows to coordinators (as before) **or** Admin **or** TeamsAdmin.

## Tests

- `StoreOrderAuthorizationHandlerTests` (new): TeamsAdmin can view a camp order, cannot edit it, can edit + delete a team order, cannot pay a team order.
- `StoreServiceTeamOrdersTests`: privileged reader lists departments it does not coordinate.
- Full Web (207) + Application (3258) unit suites green.

## Notes

- The **Open store** button is shown to Admin/TeamsAdmin on any team page (the Store is global, not scoped to the viewed team). StoreAdmin/FinanceAdmin reach `/Store` directly but were intentionally not added to the team-page button per the role list given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)