### PR TITLE
feat(ci): surface reforge version in PR surface report

### DIFF
--- a/.github/workflows/pr-surface-report.yml
+++ b/.github/workflows/pr-surface-report.yml
@@ -44,8 +44,14 @@ jobs:
       - name: Generate Reforge score delta inputs
         run: |
           set -euo pipefail
-          dotnet tool install --global reforge --version 0.13.*
+          dotnet tool install --global reforge
           REFORGE="$HOME/.dotnet/tools/reforge"
+
+          # Record the resolved version so the report can name which reforge
+          # scored it — rules/weightings change between releases, so the version
+          # is what makes one run's score comparable to another's.
+          REFORGE_VERSION="$(dotnet tool list --global | awk 'tolower($1)=="reforge"{print $2}')"
+          echo "REFORGE_VERSION=$REFORGE_VERSION" >> "$GITHUB_ENV"
 
           BASE_DIR="$(mktemp -d)"
           HEAD_DIR="$(mktemp -d)"
@@ -79,6 +85,9 @@ jobs:
           REFORGE_ARGS=()
           if [ -f reforge-base.json ] && [ -f reforge-head.json ]; then
             REFORGE_ARGS=(--reforge-base-json reforge-base.json --reforge-head-json reforge-head.json)
+          fi
+          if [ -n "${REFORGE_VERSION:-}" ]; then
+            REFORGE_ARGS+=(--reforge-version "$REFORGE_VERSION")
           fi
 
           python3 scripts/pr-surface-report.py \

--- a/scripts/pr-surface-report.py
+++ b/scripts/pr-surface-report.py
@@ -289,6 +289,7 @@ def build_markdown(
     interfaces: dict[str, object],
     base_label: str,
     head_label: str,
+    reforge_version: str | None,
 ) -> str:
     categories = ["code", "migrations", "tests", "docs", "other"]
     rows = [
@@ -304,11 +305,15 @@ def build_markdown(
     migration_status = "OK" if len(migration_files) <= 1 else "BLOCK"
     summary = f"{len(changed_files)} changed file(s) | EF migrations: {len(migration_files)}/1"
 
+    compared_line = f"Compared `{short_ref(base_label)}`...`{short_ref(head_label)}`."
+    if reforge_version:
+        compared_line += f" Scored with reforge `{md_safe(reforge_version)}`."
+
     sections = [
         "<!-- pr-surface-report -->",
         "## PR Surface Report",
         "",
-        f"Compared `{short_ref(base_label)}`...`{short_ref(head_label)}`.",
+        compared_line,
         "",
         f"**Summary:** {summary}",
         "",
@@ -343,6 +348,7 @@ def main() -> int:
     parser.add_argument("--head-label")
     parser.add_argument("--reforge-base-json")
     parser.add_argument("--reforge-head-json")
+    parser.add_argument("--reforge-version")
     parser.add_argument("--output", default="pr-surface-report.md")
     parser.add_argument("--json-output", default="pr-surface-report.json")
     args = parser.parse_args()
@@ -366,6 +372,7 @@ def main() -> int:
         interfaces,
         base_label,
         head_label,
+        args.reforge_version,
     )
 
     Path(args.output).write_text(markdown, encoding="utf-8")
@@ -382,6 +389,7 @@ def main() -> int:
                 "migration_files": migration_files,
                 "migration_count": len(migration_files),
                 "reforge": {
+                    "version": args.reforge_version,
                     "base": base_score,
                     "head": head_score,
                 },


### PR DESCRIPTION
## What

Surface the reforge version in the PR Surface Report so the score is interpretable across runs — rules and weightings change between releases, so a delta is only meaningful if you know which reforge produced it.

- The `Compared X...Y` line now appends `Scored with reforge \`<version>\`.` when the version is known.
- The version is also recorded in the JSON artifact under `reforge.version`.
- Runs without a version (e.g. local invocations) render the plain `Compared` line unchanged.

## How

- `pr-surface-report.yml`: capture the resolved version from `dotnet tool list --global` after install and thread it into the script via a new `--reforge-version` arg.
- `pr-surface-report.py`: new optional `--reforge-version` arg, appended to the Compared line (via `md_safe`) and added to the JSON `reforge` block.

## Also

Unpinned reforge in CI (was `0.13.*`) so it scores with the latest release — matching what we refactor against locally (currently `0.17.0`), closing a ~4-minor drift between CI scoring and local scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
