### PR TITLE
refactor(campaigns): carve ICampaignServiceRead; route TicketQueryService off the full service

### DIFF
--- a/src/Humans.Application/Interfaces/Campaigns/ICampaignService.cs
+++ b/src/Humans.Application/Interfaces/Campaigns/ICampaignService.cs
@@ -30,7 +30,7 @@ public sealed record CampaignGrantSummary(
     Instant? LatestEmailAt,
     Instant? RedeemedAt);
 
-public interface ICampaignService : IApplicationService
+public interface ICampaignService : ICampaignServiceRead, IApplicationService
 {
     Task<CampaignCreateResult> CreateAsync(string title, string? description,
         string emailSubject, string emailBodyTemplate, string? replyToAddress,
@@ -81,16 +81,6 @@ public interface ICampaignService : IApplicationService
     Task<int> MarkGrantsRedeemedAsync(
         IReadOnlyCollection<DiscountCodeRedemption> redemptions,
         CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns code tracking data — campaign summaries and individual grant
-    /// details for campaigns that are Active or Completed — for the Tickets
-    /// admin dashboard. The returned <see cref="CampaignCodeTrackingData"/>
-    /// carries recipient user IDs and display names sourced from the Campaigns
-    /// section; the caller correlates discount-code redemptions against
-    /// ticket orders separately.
-    /// </summary>
-    Task<CampaignCodeTrackingData> GetCodeTrackingAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Updates a campaign grant's denormalized email delivery status

--- a/src/Humans.Application/Interfaces/Campaigns/ICampaignServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Campaigns/ICampaignServiceRead.cs
@@ -1,0 +1,23 @@
+using Humans.Application.Architecture;
+using Humans.Application.DTOs;
+
+namespace Humans.Application.Interfaces.Campaigns;
+
+/// <summary>
+/// Cross-section read surface for the Campaigns section. External sections
+/// inject this interface; only DTO projections (no EF entities). See
+/// <c>memory/architecture/section-read-write-split.md</c>.
+/// </summary>
+[SurfaceBudget(1)]
+public interface ICampaignServiceRead
+{
+    /// <summary>
+    /// Returns code tracking data — campaign summaries and individual grant
+    /// details for campaigns that are Active or Completed — for the Tickets
+    /// admin dashboard. The returned <see cref="CampaignCodeTrackingData"/>
+    /// carries recipient user IDs and display names sourced from the Campaigns
+    /// section; the caller correlates discount-code redemptions against
+    /// ticket orders separately.
+    /// </summary>
+    Task<CampaignCodeTrackingData> GetCodeTrackingAsync(CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -24,7 +24,7 @@ namespace Humans.Application.Services.Tickets;
 public sealed class TicketQueryService(
     ITicketRepository ticketRepository,
     IBudgetService budgetService,
-    ICampaignService campaignService,
+    ICampaignServiceRead campaignService,
     IUserService userService,
     IUserEmailService userEmailService,
     ITeamServiceRead teamService,

--- a/src/Humans.Web/Extensions/Sections/CampaignsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/CampaignsSectionExtensions.cs
@@ -16,6 +16,7 @@ internal static class CampaignsSectionExtensions
         services.AddSingleton<ICampaignRepository, CampaignRepository>();
         services.AddScoped<CampaignsCampaignService>();
         services.AddScoped<ICampaignService>(sp => sp.GetRequiredService<CampaignsCampaignService>());
+        services.AddScoped<ICampaignServiceRead>(sp => sp.GetRequiredService<CampaignsCampaignService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<CampaignsCampaignService>());
         services.AddScoped<IUserMerge>(sp => sp.GetRequiredService<CampaignsCampaignService>());
 

--- a/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class TicketQueryServiceTests : ServiceTestHarness
 {
     private readonly TicketRepository _repo;
     private readonly IBudgetService _budgetService = Substitute.For<IBudgetService>();
-    private readonly ICampaignService _campaignService = Substitute.For<ICampaignService>();
+    private readonly ICampaignServiceRead _campaignService = Substitute.For<ICampaignServiceRead>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();


### PR DESCRIPTION
## Section thesis

Campaigns is a repo-backed §15 section (`ICampaignRepository`/`CampaignRepository`, owning `campaigns` / `campaign_codes` / `campaign_grants`) with a single fat full-service interface `ICampaignService` and **no** existing read-split (unlike Teams' `ITeamServiceRead`). There is no caching decorator: `ICampaignService` is registered directly against the concrete `CampaignService`, so the read interface only needs DI registration against the same scoped instance (the Teams pattern) — no §15c caching seam to thread. There is no cached `CampaignInfo` and no `docs/sections/` Campaigns doc.

The cross-section read surface is already clean per-purpose, entity-free DTOs in `CampaignAdminPageDtos.cs` (`CampaignCodeTrackingData` for Tickets, `CampaignGrantSummary` for Profiles), so this lane needs **no new canonical DTO** — the deliverable is pure interface-routing.

Reforge (degraded/PARTIAL build) charges `CampaignService` 40 pts `crossSectionFullService`, scored per constructor dependency on a full-service interface owned by another section, spread across 4 consumers:

- `TicketQueryService` — read (`GetCodeTrackingAsync`) — **in scope, migrated**
- `TicketSyncService` — write (`MarkGrantsRedeemedAsync`) — deferred (write, see below)
- `ProfileController` — read — out of scope (controller lane)
- `ProcessEmailOutboxJob` — write — out of scope (job lane)

**Central tension:** only `TicketQueryService` is a genuine read consumer and is a textbook rule-compliant read-split. `TicketSyncService`'s only Campaigns call, `MarkGrantsRedeemedAsync`, is a **mutation**; `section-read-write-split.md` says writes stay on the full interface, and the charter itself says a cross-section write dependency is legitimate when orchestrating a mutation. There is therefore **no rule-compliant way** to move `TicketSyncService` onto a read interface (it doesn't read): putting a write on `ICampaignServiceRead` would violate the rule and mislead the future analyzer, and a bespoke narrow write interface would be new/hostile surface. Honest end state: ship the `TicketQueryService` read-split (a real win — it deletes a write-surface dependency held purely for a read) and **defer** the `TicketSyncService` "migration" with rationale recorded. That write edge is the correct end state unless the owner explicitly approves a separate write-interface carve.

## Accepted commits

### 1. Carve `ICampaignServiceRead`; route `TicketQueryService` off the full `ICampaignService`

- **SHA:** `af7500cd6068e9cb9b77824b3b5ae6b78637b57b`
- **Concept deleted:** `TicketQueryService`'s constructor dependency on the full write-capable `ICampaignService` when it only ever reads (`GetCodeTrackingAsync`).
- **Reforge target:** Campaigns section score `1222 → 1231` (Δ **+9**); outside/cross-section pressure `−6` (the full-service edge removed from the Tickets consumer).
- **Weighted value:** 3
- **Panel verdict:** accept / accept / accept (3 of 3)

The `GetCodeTrackingAsync` declaration moved from `ICampaignService` into a new public `ICampaignServiceRead`, with `ICampaignService : ICampaignServiceRead` (the canonical `IServiceRead` pattern, mirroring `ITeamService : ITeamServiceRead`) — one declaration, one unchanged implementation in `CampaignService`. `TicketQueryService` now depends on `ICampaignServiceRead`; it calls Campaigns exactly once (`GetCodeTrackingAsync`, line 243) and consumes the returned `CampaignCodeTrackingData` (Guids/strings/ints, no EF entities) — a pre-existing entity-free cross-section read DTO, not a bespoke predicate/scalar/parameter-bag, and a real read-model projection the Tickets caller cannot derive by LINQ (no access to those tables). DI registers `ICampaignServiceRead` against the same scoped `CampaignService` instance. `CampaignService` body, `TicketSyncService`, `ProfileController`, and `ProcessEmailOutboxJob` are all untouched; no DB/persistence changes. `[SurfaceBudget(1)]` on the new one-method interface matches every sibling `I*ServiceRead`; the test substitute was narrowed to `ICampaignServiceRead` with no coverage weakened. Build green; targeted Campaigns + Architecture + `TicketQueryService` tests pass.

## Cumulative Campaigns score movement

- `origin/main` baseline: **1222**
- Final (this branch): **1231**
- Net movement: **+9**

## Candidates rejected

None. The single in-scope read consumer was migrated; the remaining edges were deferred on architectural grounds rather than rejected (see below).

## Remaining high-value work not done (deferred)

- **`TicketSyncService` → Campaigns (`MarkGrantsRedeemedAsync`)** — a mutation, not a read. Per `section-read-write-split.md`, writes stay on the full interface, and a cross-section write dependency is the legitimate, correct end state when orchestrating a mutation. Migrating it onto `ICampaignServiceRead` would violate the rule and mislead the analyzer; a bespoke narrow write interface would be new/hostile surface. Left on `ICampaignService` deliberately. Revisit only if the section owner explicitly approves a separate write-interface carve.
- **`ProfileController` → Campaigns (read)** — out of this lane's charter (controller lane). A candidate future read-split onto `ICampaignServiceRead`.
- **`ProcessEmailOutboxJob` → Campaigns (write)** — out of this lane's charter (job lane); a write edge, same write-stays-on-full reasoning as `TicketSyncService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
