### PR TITLE
refactor(issues): collapse two forwarding convenience overloads on IIssuesService

### DIFF
--- a/src/Humans.Application/Interfaces/Issues/IIssuesService.cs
+++ b/src/Humans.Application/Interfaces/Issues/IIssuesService.cs
@@ -18,20 +18,7 @@ public interface IIssuesService : IApplicationService
         string? additionalContext,
         IFormFile? screenshot,
         LocalDate? dueDate = null,
-        CancellationToken ct = default);
-
-    Task<Issue> SubmitIssueAsync(
-        Guid reporterUserId,
-        IssueCategory category,
-        string title,
-        string description,
-        string? section,
-        string? pageUrl,
-        string? userAgent,
-        string? additionalContext,
-        IFormFile? screenshot,
-        LocalDate? dueDate,
-        IReadOnlyList<string>? reporterRoles,
+        IReadOnlyList<string>? reporterRoles = null,
         CancellationToken ct = default);
 
     Task<IssueDetail?> GetIssueByIdAsync(Guid id, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/Issues/IIssuesService.cs
+++ b/src/Humans.Application/Interfaces/Issues/IIssuesService.cs
@@ -47,11 +47,7 @@ public interface IIssuesService : IApplicationService
 
     Task<IssueComment> PostCommentAsync(
         Guid issueId, Guid? senderUserId, string content,
-        bool senderIsReporter, CancellationToken ct = default);
-
-    Task<IssueComment> PostCommentAsync(
-        Guid issueId, Guid? senderUserId, string content,
-        bool senderIsReporter, bool resolveOnPost, CancellationToken ct = default);
+        bool senderIsReporter, bool resolveOnPost = false, CancellationToken ct = default);
 
     Task UpdateStatusAsync(
         Guid issueId, IssueStatus newStatus, Guid? actorUserId, CancellationToken ct = default);

--- a/src/Humans.Application/Services/Issues/IssuesService.cs
+++ b/src/Humans.Application/Services/Issues/IssuesService.cs
@@ -70,33 +70,7 @@ public sealed class IssuesService(
         string? additionalContext,
         IFormFile? screenshot,
         LocalDate? dueDate = null,
-        CancellationToken ct = default) =>
-        await SubmitIssueAsync(
-            reporterUserId,
-            category,
-            title,
-            description,
-            section,
-            pageUrl,
-            userAgent,
-            additionalContext,
-            screenshot,
-            dueDate,
-            reporterRoles: null,
-            ct);
-
-    public async Task<Issue> SubmitIssueAsync(
-        Guid reporterUserId,
-        IssueCategory category,
-        string title,
-        string description,
-        string? section,
-        string? pageUrl,
-        string? userAgent,
-        string? additionalContext,
-        IFormFile? screenshot,
-        LocalDate? dueDate,
-        IReadOnlyList<string>? reporterRoles,
+        IReadOnlyList<string>? reporterRoles = null,
         CancellationToken ct = default)
     {
         var now = clock.GetCurrentInstant();

--- a/src/Humans.Application/Services/Issues/IssuesService.cs
+++ b/src/Humans.Application/Services/Issues/IssuesService.cs
@@ -332,15 +332,7 @@ public sealed class IssuesService(
         Guid? senderUserId,
         string content,
         bool senderIsReporter,
-        CancellationToken ct = default) =>
-        await PostCommentAsync(issueId, senderUserId, content, senderIsReporter, resolveOnPost: false, ct);
-
-    public async Task<IssueComment> PostCommentAsync(
-        Guid issueId,
-        Guid? senderUserId,
-        string content,
-        bool senderIsReporter,
-        bool resolveOnPost,
+        bool resolveOnPost = false,
         CancellationToken ct = default)
     {
         var issue = await repo.FindForMutationAsync(issueId, ct)

--- a/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
@@ -357,7 +357,7 @@ public class IssuesApiControllerTests
 
         _issues.SubmitIssueAsync(
                 reporterId, IssueCategory.Bug, "T", "D",
-                "Tickets", null, null, null, null, null,
+                "Tickets", null, null, null, null, null, null,
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(created));
 
@@ -375,7 +375,7 @@ public class IssuesApiControllerTests
 
         await _issues.Received(1).SubmitIssueAsync(
             reporterId, IssueCategory.Bug, "T", "D",
-            "Tickets", null, null, null, null, null,
+            "Tickets", null, null, null, null, null, null,
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
@@ -394,7 +394,7 @@ public class IssuesApiControllerTests
             Content = "From admin agent",
             CreatedAt = Instant.FromUtc(2026, 4, 29, 12, 0)
         };
-        _issues.PostCommentAsync(issueId, null, "From admin agent", false, Arg.Any<CancellationToken>())
+        _issues.PostCommentAsync(issueId, null, "From admin agent", false, false, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(comment));
 
         var result = await _sut.PostComment(issueId, new PostIssueCommentModel { Content = "From admin agent" });
@@ -405,6 +405,7 @@ public class IssuesApiControllerTests
             senderUserId: null,
             content: "From admin agent",
             senderIsReporter: false,
+            resolveOnPost: false,
             ct: Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## refactor(issues): collapse two forwarding convenience overloads on `IIssuesService`

### Section thesis

Issues is a repo-backed, post-§15, fully-migrated vertical section: an in-app issue tracker (bug/feature/question) with role-routed triage queues and a reporter↔handler thread.

- **Shape:** a single full interface `IIssuesService` (18 methods, no read/write split, no caching decorator by design). Repository `IIssuesRepository` (Singleton + `IDbContextFactory`) is the only DbContext path for `issues`/`issue_comments` (11 distinct methods). The service stitches cross-domain display names in-memory via `IUserServiceRead` (cross-domain navs `[Obsolete]`-marked, never `Include`d).
- **Read surface:** `GetIssueByIdAsync→IssueDetail`; `GetIssueListAsync→IssueListSnapshot`; `GetThreadAsync→IssueThreadEvent` (Comment|Audit); `GetActionableCountForViewerAsync→int` (2-min per-viewer badge cache); `GetDistinctReportersAsync`.
- **Write surface:** `SubmitIssueAsync` (×2 overloads), `PostCommentAsync` (×2 overloads), `Update{Status,Assignee,Section}Async` + `SetGitHubIssueNumberAsync` each paired with a `*WithResultAsync` try/catch wrapper, `PurgeExpiredAsync` (retention), `ContributeForUserAsync` (GDPR).
- **Primary DTOs:** `IssueListSnapshot` (list/API-list; `ReporterEmail` + `ReporterPreferredLanguage` ARE consumed by API `MapList` — not dead) and `IssueDetail` (detail + API-get + the resource for resource-based auth `IssuesAuthorizationHandler`). No `IssueInfo`/`IssueSettingsInfo`; Issues exposes no settings and is not read cross-section as a cached canonical DTO.
- **Cache:** one short-TTL per-viewer count cache, evicted via `IIssuesBadgeCacheInvalidator` + `INavBadgeCacheInvalidator` on every count-shifting mutation.
- **Cross-section:** outbound deps (`IUserServiceRead`, `IUserEmailService`, `IRoleAssignmentService`, `IEmailService`, `IEmailMessageFactory`, `INotificationService`, `IAuditLogService`) are legitimate read/factory interfaces.

**Point pressure** concentrates on `fullServiceInterfaceMethod` (144) and `methodParameterOverflow` (111). The only genuinely-deletable in-scope concepts are the two forwarding convenience overloads (bare `SubmitIssueAsync`, bare `PostCommentAsync`), each existing solely to let one caller omit a trailing default. Everything else (repo methods, controller actions, ViewModels, DTOs, intrinsic boolean/multi-param submit methods) is durable, distinct, and consumed.

### Accepted commits

#### 1. Collapse `PostCommentAsync` overloads into one method on `IIssuesService`
`943a87e69e60c35441fd86341b558b644237ed44`

- **Concept deleted:** the bare 4-arg `PostCommentAsync(issueId, senderUserId, content, senderIsReporter, ct)` overload — a pure forwarding convenience method whose body was `=> PostCommentAsync(..., resolveOnPost: false, ct)`. Collapsed into the surviving 5-arg method via a `bool resolveOnPost = false` default.
- **Reforge target (`fullServiceInterfaceMethod`):** Issues section score 1055 → 1030 (Δ −25); outside-section increase 0.
- **Weighted value:** 25.
- **Panel verdict:** accept / accept / accept (3-0). Genuine deletion of one interface method, not a relocation/rename/hide; the surviving method's body is unchanged and merely gained a defaulted parameter. Both production callers bind unchanged (`IssuesController` passes `resolveOnPost` explicitly; `IssuesApiController` omits it → default `false`, identical runtime behavior). The lone test edit is a mechanical NSubstitute disambiguation (positional `CancellationToken` vs the new `bool` slot) asserting identical behavior; no coverage weakened. All three changed files are Issues-owned. Build succeeded; 345 Issues+Architecture tests pass.

#### 2. Collapse `SubmitIssueAsync` overloads into one method on `IIssuesService`
`4f4a8a8fe0bdeb31301491e10a469117d7f4aae1`

- **Concept deleted:** the bare 10-parameter `SubmitIssueAsync` overload — a pure forwarding convenience method whose entire body delegated to the unified overload with `reporterRoles: null`. Collapsed into the surviving 11-param method via optional defaults.
- **Reforge target (`fullServiceInterfaceMethod`):** Issues section score 1030 → 999 (Δ −31); outside-section increase 0.
- **Weighted value:** 31.
- **Panel verdict:** accept / accept / accept (3-0). Genuine surface reduction: the bare forwarder is removed from both interface and implementation; the surviving 11-param overload absorbs its sole behavior (`reporterRoles` defaults to null). Both production callers compile unchanged (`IssuesController` passes `reporterRoles` explicitly; `IssuesApiController.Create` omits it → default null). No DTO/projection/read-interface growth, no accessibility narrowing, no DbContext/migration/entity change. The lone test edit inserts one `null` positional arg to match the unified shape, preserving coverage. Build clean; 345 Issues/Architecture tests pass.

### Cumulative score movement

`fullServiceInterfaceMethod` (Issues section): **1055 (origin/main baseline) → 999 (final)** — net **−56**, with **zero** outside-section increase across both commits. Two redundant interface methods removed, with their duplicate `methodParameterOverflow`/boolean-parameter tallies removed alongside.

### Candidates rejected and why

None rejected — both audited candidates were accepted 3-0 by the panel.

### Remaining high-value work not done

- **C1 (deferred, out of scope for this internal-only lane):** the inbound consumer `NavBadgesViewComponent` (Web) depends on the full `IIssuesService` but only calls the read method `GetActionableCountForViewerAsync`. The correct fix — introduce `IIssuesServiceRead` and route the consumer onto it — edits files outside the Issues section, so it falls outside this lane's single-section charter. This is the largest remaining `fullServiceInterfaceMethod` reduction available for Issues.
- **The `*WithResultAsync` quartet** (`Update{Status,Assignee,Section}Async` + `SetGitHubIssueNumberAsync` try/catch wrappers) is the largest soft block but is an established codebase-wide convention; collapsing it would relocate `try/catch` into the Web controller and risk panel rejection. Left as-is.
- The intrinsic boolean/multi-param submit methods, repo methods, controller actions, ViewModels, and DTOs are durable, distinct, and consumed — no further in-scope deletions identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
