### PR TITLE
refactor(agent): drop dead conversationId parameter from tool-dispatch contract

### DIFF
--- a/src/Humans.Application/Interfaces/IAgentToolDispatcher.cs
+++ b/src/Humans.Application/Interfaces/IAgentToolDispatcher.cs
@@ -7,6 +7,5 @@ public interface IAgentToolDispatcher
     Task<AnthropicToolResult> DispatchAsync(
         AnthropicToolCall call,
         Guid userId,
-        Guid conversationId,
         CancellationToken cancellationToken);
 }

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -193,7 +193,7 @@ public sealed class AgentService : IAgentService, IUserDataContributor
                     break;
                 }
 
-                var result = await _tools.DispatchAsync(call, request.UserId, conversation.Id, cancellationToken);
+                var result = await _tools.DispatchAsync(call, request.UserId, cancellationToken);
                 results.Add(result);
                 // Normalize slug so admin "Top fetched docs" groups by document, not tool-name+args.
                 fetchedDocs.Add(NormalizeFetchedDocSlug(call.Name, call.JsonArguments, _logger));

--- a/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
@@ -26,7 +26,7 @@ public sealed class AgentToolDispatcher(
     internal const int MaxAuditHistoryLimit = 50;
 
     public async Task<AnthropicToolResult> DispatchAsync(
-        AnthropicToolCall call, Guid userId, Guid conversationId, CancellationToken cancellationToken)
+        AnthropicToolCall call, Guid userId, CancellationToken cancellationToken)
     {
         if (!AgentToolNames.All.Contains(call.Name))
         {

--- a/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
@@ -14,7 +14,6 @@ public class AgentToolDispatcherTests
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", "delete_users", "{}"),
             userId: Guid.NewGuid(),
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
 
         result.IsError.Should().BeTrue();
@@ -40,7 +39,6 @@ public class AgentToolDispatcherTests
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetAuditHistory, """{"limit":5}"""),
             userId: viewer,
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
 
         result.IsError.Should().BeFalse();
@@ -59,7 +57,6 @@ public class AgentToolDispatcherTests
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetAuditHistory, "{}"),
             userId: Guid.NewGuid(),
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
 
         result.IsError.Should().BeFalse();
@@ -77,19 +74,19 @@ public class AgentToolDispatcherTests
         // Request 999 → clamps to 50.
         await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetAuditHistory, """{"limit":999}"""),
-            userId: Guid.NewGuid(), conversationId: Guid.NewGuid(), CancellationToken.None);
+            userId: Guid.NewGuid(), CancellationToken.None);
         stub.LastLimit.Should().Be(50);
 
         // Omit limit → defaults to 20.
         await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetAuditHistory, "{}"),
-            userId: Guid.NewGuid(), conversationId: Guid.NewGuid(), CancellationToken.None);
+            userId: Guid.NewGuid(), CancellationToken.None);
         stub.LastLimit.Should().Be(20);
 
         // Request 0 → clamps to 1 (minimum).
         await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetAuditHistory, """{"limit":0}"""),
-            userId: Guid.NewGuid(), conversationId: Guid.NewGuid(), CancellationToken.None);
+            userId: Guid.NewGuid(), CancellationToken.None);
         stub.LastLimit.Should().Be(1);
     }
 
@@ -171,7 +168,6 @@ public class AgentToolDispatcherTests
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
                 $$"""{"shiftId":"{{blockId}}"}"""),
             userId: viewer,
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
 
         result.IsError.Should().BeFalse();
@@ -203,7 +199,6 @@ public class AgentToolDispatcherTests
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
                 $$"""{"shiftId":"{{signup.Id}}"}"""),
             userId: viewer,
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
 
         result.IsError.Should().BeFalse();
@@ -229,7 +224,6 @@ public class AgentToolDispatcherTests
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
                 $$"""{"shiftId":"{{Guid.NewGuid()}}"}"""),
             userId: viewer,
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
 
         result.IsError.Should().BeTrue();
@@ -258,7 +252,6 @@ public class AgentToolDispatcherTests
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
                 $$"""{"shiftId":"{{foreignBlockId}}"}"""),
             userId: viewer,
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
 
         result.IsError.Should().BeTrue();
@@ -272,7 +265,6 @@ public class AgentToolDispatcherTests
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails, """{"shiftId":"not-a-guid"}"""),
             userId: Guid.NewGuid(),
-            conversationId: Guid.NewGuid(),
             CancellationToken.None);
         result.IsError.Should().BeTrue();
         result.Content.Should().Contain("must be a valid GUID");
@@ -328,7 +320,6 @@ public class AgentToolDispatcherTests
             new AnthropicToolCall("t1", AgentToolNames.RouteToIssue,
                 """{"title":"Calendar feature","category":"Feature","description":"User asked about calendar; not implemented yet."}"""),
             userId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
-            conversationId: Guid.Parse("33333333-3333-3333-3333-333333333333"),
             CancellationToken.None);
 
         result.IsError.Should().BeFalse();


### PR DESCRIPTION
## Section thesis

Agent is a repo-backed vertical section with one repository (`IAgentRepository` owning `agent_settings` / `agent_conversations` / `agent_messages`) and an orchestrator-heavy service (`AgentService` streams an LLM turn via `AskAsync` plus several repo-backed read methods).

**Critical finding:** `IAgentService` has **zero** cross-section consumers — every caller is Agent's own controllers (`AgentController`, `AgentApiController`, `AdminAgentController`) plus DI and the `IUserDataContributor` contract. So the canonical "carve `IAgentServiceRead` and route cross-section callers onto it" move has no caller to route and would be pure relocation (forbidden by the charter).

The section's read DTOs (`AgentConversationListSnapshot`, `AgentConversationTranscriptSnapshot` / `AgentMessageSnapshot`, `AgentStatusMessageRow`, `AgentUserSnapshot`, `AgentPromptPreview`) are cohesive materialized read shapes for distinct consumers — not projection/predicate bags — so there is nothing to inline as LINQ over a canonical DTO.

The genuine architectural debt is cross-section dependence on full/write services in `AgentUserSnapshotProvider` and `AgentToolDispatcher` (`IFeedbackService`, `IRoleAssignmentService`, `IShiftManagementService` — Reforge `crossSectionFullService`, 40 pts), but fixing any of them requires **creating or growing a read interface in another section** (Feedback / Auth / Shifts have no read variant for those methods). That is out of scope for this single-section lane and is deferred.

The only clean in-scope deletion is the dead `conversationId` parameter on `IAgentToolDispatcher.DispatchAsync`; the only in-scope internal-complexity reduction (decomposing `AskAsync`) was rejected by the panel as relocation. No DB / schema / serialization changes are in play; `HandedOffToFeedbackId` and the `handoffsOnly` API filter are legacy-but-live, not dead.

## Accepted commits

### 1. Drop unused `conversationId` parameter from `IAgentToolDispatcher.DispatchAsync`

- **Commit:** `87f1222fba139c71a9da62b42eaa649cdabd39ae`
- **Concept deleted:** the unused conversation-identity dependency in the tool-dispatch contract.
- **Reforge target (Agent):** 1300 → 1298 (−2); surface −2, internal +0. Outside target unchanged (55380 → 55380, +0).
- **Weighted value:** +2 (target +2 + 2× outside +0).
- **Panel verdict:** **accept** — unanimous across all three active lenses.
  - **Lens A (accept):** Genuine deletion, not relocation. The entire `AgentToolDispatcher` implementation including all private helpers never references `conversationId` — dispatch keys solely on `call`, `userId`, and the parsed JSON args. `conversation.Id` was simply dropped at the single production call site (`AgentService.cs:196`); it was NOT threaded into a new field, helper, options/parameter bag, partial, extension, or another type. No accessibility was narrowed. All four touched files are Agent-owned and in-scope. `IAgentToolDispatcher` has zero cross-section consumers, so no other section's interface was grown. Behavior is identical (the argument was inert). Also removes a real `methodParameterOverflow` contributor (3-arg+ct → 2-arg+ct).
  - **Lens B (accept):** Pure deletion of a genuinely-dead parameter from an Agent-owned, single-implementation contract. `conversationId` has zero references in the dispatcher body; `DispatchAsync` has exactly one production caller, and dropping the arg does not orphan the `conversation` local. No file outside Agent, no other section's interface grown, no `I*ServiceRead` touched. Read-model-purist lens has no objection.
  - **Lens C (accept):** Genuine in-scope deletion of dead public surface, not relocation. Verified the parameter was unused, the single caller correctly updated with no orphaned variable, all four files Agent-owned, test coverage preserved (same 12 dispatch sites exercising the same branches), and no authorization / audit / cache / notification / transaction / DB / schema / serialization boundary touched.

## Cumulative Agent score movement

| | Agent total | Surface | Internal |
|---|---|---|---|
| `origin/main` baseline | 1300 | — | — |
| Final (`87f1222fb`) | 1298 | −2 | +0 |

Net Agent movement: **1300 → 1298 (−2)**, entirely surface, achieved by a true parameter deletion. Outside-target score is unchanged (55380 → 55380), so the improvement is purely in-section with no debt pushed elsewhere.

## Candidates rejected and why

### Decompose `AskAsync` streaming turn into private members (no new type) — **rejected**

**Lens A reject:** Nothing is genuinely deleted; the change's main effect is intra-class relocation. The diff touches exactly one in-scope Agent file (`src/Humans.Application/Services/Agent/AgentService.cs`, +147/−75, net +72 lines) and respects charter scope, but it deletes no public/durable surface — no interface member, DTO, public type, or parameter is removed. The "monolithic god-method" `AskAsync` was NOT deleted: its body was carved into three new *private* sibling members (`PrepareTurnAsync`, `DispatchPendingToolsAsync`, `FinalizeTurnAsync`) plus two new private readonly record structs (`PreparedTurn`, `ToolDispatchResult`), all within the same class. The only reason the Reforge symbol-complexity count drops is that the long-method / cognitive-complexity symbol vanished by moving code, not by removing a concept. The thesis's one genuinely-deletable item (the dead `conversationId` parameter) is not in this diff. Behavior is faithfully preserved, making this a clean readability refactor — but the lens rejects when relocation is the main effect and no concept is genuinely deleted.

## Remaining high-value work not done

- **Cross-section full-service dependence (Reforge `crossSectionFullService`, 40 pts each):** `AgentUserSnapshotProvider` and `AgentToolDispatcher` depend on `IFeedbackService`, `IRoleAssignmentService`, and `IShiftManagementService`. Routing these onto read interfaces is the highest-value remaining move, but Feedback / Auth / Shifts have no read variant for the consumed methods — fixing it requires creating or growing a read interface in **another** section, which is out of scope for this single-section lane. Deferred to a Feedback / Auth / Shifts lane or a dedicated cross-section read-split.
- **`AskAsync` internal complexity:** the orchestrator turn method remains long. A decomposition was attempted and rejected as relocation; a genuine simplification would require deleting a concept (e.g. collapsing redundant state threading), not just carving private helpers — left for a future pass with a sharper deletion target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
