### PR TITLE
refactor(governance): cross-section read/write split (IApplicationServiceRead + IMembershipCalculatorRead) + dead-surface trim

### DIFF
--- a/src/Humans.Application/DTOs/BoardVotingDashboardData.cs
+++ b/src/Humans.Application/DTOs/BoardVotingDashboardData.cs
@@ -4,9 +4,9 @@ namespace Humans.Application.DTOs;
 
 /// <summary>
 /// Shape returned by <c>IApplicationDecisionService.GetBoardVotingDashboardAsync</c>.
-/// Holds a stitched list of application rows (applicant display/picture
-/// resolved via IUserService after the cross-domain nav was stripped) plus
-/// the set of current Board members the view renders columns for.
+/// Holds the list of application rows (identified by UserId; the view resolves
+/// applicant display/picture itself via the human view component) plus the set
+/// of current Board members the view renders columns for.
 /// </summary>
 public record BoardVotingDashboardData(
     List<BoardVotingDashboardRow> Applications,

--- a/src/Humans.Application/DTOs/Governance/BoardVotingDashboardRow.cs
+++ b/src/Humans.Application/DTOs/Governance/BoardVotingDashboardRow.cs
@@ -11,8 +11,6 @@ namespace Humans.Application.DTOs.Governance;
 public record BoardVotingDashboardRow(
     Guid ApplicationId,
     Guid UserId,
-    string UserDisplayName,
-    string? UserProfilePictureUrl,
     MembershipTier MembershipTier,
     string ApplicationMotivation,
     Instant SubmittedAt,

--- a/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
+++ b/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
@@ -142,31 +142,6 @@ public interface IApplicationDecisionService : IApplicationServiceRead, IApplica
     /// </summary>
     Task MarkRenewalReminderSentAsync(
         Guid applicationId, Instant sentAt, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns every <see cref="ApplicationStatus.Approved"/> application
-    /// resolved within the half-open window
-    /// <c>[windowStart, windowEnd)</c>. Used by the Board daily digest.
-    /// </summary>
-    Task<IReadOnlyList<ApprovedApplicationDigestEntry>> GetApprovedInWindowAsync(
-        Instant windowStart, Instant windowEnd, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the ids of every <see cref="ApplicationStatus.Submitted"/>
-    /// application. Used by the Board daily digest.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the count of applications in <paramref name="applicationIds"/>
-    /// that the given board member has NOT yet voted on. Used by the Board
-    /// daily digest per-member queue size.
-    /// </summary>
-    Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
-        Guid boardMemberUserId,
-        IReadOnlyCollection<Guid> applicationIds,
-        CancellationToken ct = default);
 }
 
 public record ApplicationDecisionResult(bool Success, string? ErrorKey = null, Guid? ApplicationId = null);
@@ -190,10 +165,6 @@ public sealed record ApplicationRenewalReminderCandidate(
     MembershipTier MembershipTier,
     Instant SubmittedAt,
     LocalDate? TermExpiresAt);
-
-public sealed record ApprovedApplicationDigestEntry(
-    Guid UserId,
-    MembershipTier MembershipTier);
 
 public sealed record SubmittedApplicationSnapshot(
     Guid Id,

--- a/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
+++ b/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
@@ -18,7 +18,7 @@ namespace Humans.Application.Interfaces.Governance;
 /// resolved via <c>IUserService</c>, because the entity no longer carries
 /// cross-domain navigation properties (design-rules §6).
 /// </remarks>
-public interface IApplicationDecisionService : IApplicationService
+public interface IApplicationDecisionService : IApplicationServiceRead, IApplicationService
 {
     Task<ApplicationDecisionResult> ApproveAsync(
         Guid applicationId,
@@ -33,14 +33,6 @@ public interface IApplicationDecisionService : IApplicationService
         string reason,
         LocalDate? boardMeetingDate,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns a user's own applications, ordered by <c>SubmittedAt</c> desc.
-    /// Callers only read scalar fields (Status, MembershipTier, SubmittedAt,
-    /// ResolvedAt) so the entity shape is preserved.
-    /// </summary>
-    Task<IReadOnlyList<UserApplicationSnapshot>> GetUserApplicationsAsync(
-        Guid userId, CancellationToken ct = default);
 
     /// <summary>
     /// Returns a user's own application detail with reviewer display name
@@ -89,30 +81,6 @@ public interface IApplicationDecisionService : IApplicationService
     // ==========================================================================
 
     /// <summary>
-    /// Returns the set of user ids (from the given input) that have a pending
-    /// Submitted application. Used by the onboarding review queue to show a
-    /// "has pending application" badge for each profile without joining across
-    /// the Governance boundary.
-    /// </summary>
-    Task<IReadOnlySet<Guid>> GetUserIdsWithPendingApplicationAsync(
-        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the single Submitted application for the given user, or null
-    /// if none. Used by the onboarding review detail view.
-    /// </summary>
-    Task<SubmittedApplicationSnapshot?> GetSubmittedApplicationForUserAsync(
-        Guid userId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the distinct Approved-status tier values for a user. Used by
-    /// the consent-check flow to decide which system-team syncs to run after
-    /// a clear-consent-check action.
-    /// </summary>
-    Task<IReadOnlyList<MembershipTier>> GetApprovedTiersForUserAsync(
-        Guid userId, CancellationToken ct = default);
-
-    /// <summary>
     /// Returns the Board voting dashboard: every Submitted application with
     /// its aggregate-local <c>BoardVotes</c>, plus the list of current Board
     /// members. Applicant + Board member display fields are stitched via
@@ -145,25 +113,6 @@ public interface IApplicationDecisionService : IApplicationService
         VoteChoice vote,
         string? note,
         CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the number of Submitted applications that the given board
-    /// member has not yet voted on. Used by the per-board-member voting badge.
-    /// </summary>
-    Task<int> GetUnvotedApplicationCountAsync(
-        Guid boardMemberUserId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the aggregate statistics for the admin dashboard's tier
-    /// application block. Counts exclude <see cref="ApplicationStatus.Withdrawn"/>.
-    /// </summary>
-    Task<Repositories.ApplicationAdminStats> GetAdminStatsAsync(CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the count of pending (Submitted) applications. Used by the
-    /// admin dashboard.
-    /// </summary>
-    Task<int> GetPendingApplicationCountAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Returns every <see cref="ApplicationStatus.Approved"/> application
@@ -218,41 +167,6 @@ public interface IApplicationDecisionService : IApplicationService
         Guid boardMemberUserId,
         IReadOnlyCollection<Guid> applicationIds,
         CancellationToken ct = default);
-
-    // ==========================================================================
-    // System team sync support (issue #570 — §15 Google-writing jobs)
-    // ==========================================================================
-
-    /// <summary>
-    /// Returns the distinct user ids whose Approved application for
-    /// <paramref name="tier"/> still has an active term on
-    /// <paramref name="today"/> (<c>TermExpiresAt</c> is null or on/after
-    /// <paramref name="today"/>). Used by <c>SystemTeamSyncJob.SyncTierTeamAsync</c>
-    /// so the job never reads <c>applications</c> directly (design-rules §2c).
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetActiveApprovedTierUserIdsAsync(
-        MembershipTier tier, LocalDate today, CancellationToken ct = default);
-
-    /// <summary>
-    /// Does <paramref name="userId"/> have an Approved application for
-    /// <paramref name="tier"/> whose term is still active on
-    /// <paramref name="today"/>? Used by
-    /// <c>SystemTeamSyncJob.SyncTierMembershipForUserAsync</c>.
-    /// </summary>
-    Task<bool> HasActiveApprovedTierAsync(
-        Guid userId, MembershipTier tier, LocalDate today, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the per-user "other active tier" map: for each user with an
-    /// Approved application for a non-<paramref name="excludeTier"/>
-    /// non-Volunteer tier that is still active on <paramref name="today"/>,
-    /// returns the tier. Each user maps to a single entry (the first Approved
-    /// row found); callers use this to decide whether a tier-downgrade
-    /// should land at Volunteer or at the alternate tier. Used by
-    /// <c>SystemTeamSyncJob.SyncTierTeamAsync</c>.
-    /// </summary>
-    Task<IReadOnlyDictionary<Guid, MembershipTier>> GetOtherActiveTierAssignmentsAsync(
-        MembershipTier excludeTier, LocalDate today, CancellationToken ct = default);
 }
 
 public record ApplicationDecisionResult(bool Success, string? ErrorKey = null, Guid? ApplicationId = null);

--- a/src/Humans.Application/Interfaces/Governance/IApplicationServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Governance/IApplicationServiceRead.cs
@@ -1,0 +1,100 @@
+using Humans.Application.Architecture;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Governance;
+
+/// <summary>
+/// Cross-section read surface for the Governance section: tier-application
+/// counts, stats, snapshots, and active-tier eligibility lookups. External
+/// sections inject this interface instead of the full write service
+/// <see cref="IApplicationDecisionService"/>; returns are scalars, enums,
+/// Guid sets, and section read DTOs — no EF entities. See
+/// <c>memory/architecture/section-read-write-split.md</c>.
+/// </summary>
+[SurfaceBudget(10)]
+public interface IApplicationServiceRead
+{
+    /// <summary>
+    /// Returns a user's own applications, ordered by <c>SubmittedAt</c> desc.
+    /// Callers only read scalar fields (Status, MembershipTier, SubmittedAt,
+    /// ResolvedAt) so the entity shape is preserved.
+    /// </summary>
+    Task<IReadOnlyList<UserApplicationSnapshot>> GetUserApplicationsAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the set of user ids (from the given input) that have a pending
+    /// Submitted application. Used by the onboarding review queue to show a
+    /// "has pending application" badge for each profile without joining across
+    /// the Governance boundary.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetUserIdsWithPendingApplicationAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the single Submitted application for the given user, or null
+    /// if none. Used by the onboarding review detail view.
+    /// </summary>
+    Task<SubmittedApplicationSnapshot?> GetSubmittedApplicationForUserAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct Approved-status tier values for a user. Used by
+    /// the consent-check flow to decide which system-team syncs to run after
+    /// a clear-consent-check action.
+    /// </summary>
+    Task<IReadOnlyList<MembershipTier>> GetApprovedTiersForUserAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the number of Submitted applications that the given board
+    /// member has not yet voted on. Used by the per-board-member voting badge.
+    /// </summary>
+    Task<int> GetUnvotedApplicationCountAsync(
+        Guid boardMemberUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the aggregate statistics for the admin dashboard's tier
+    /// application block. Counts exclude <see cref="Domain.Enums.ApplicationStatus.Withdrawn"/>.
+    /// </summary>
+    Task<ApplicationAdminStats> GetAdminStatsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of pending (Submitted) applications. Used by the
+    /// admin dashboard.
+    /// </summary>
+    Task<int> GetPendingApplicationCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct user ids whose Approved application for
+    /// <paramref name="tier"/> still has an active term on
+    /// <paramref name="today"/> (<c>TermExpiresAt</c> is null or on/after
+    /// <paramref name="today"/>). Used by <c>SystemTeamSyncJob.SyncTierTeamAsync</c>
+    /// so the job never reads <c>applications</c> directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveApprovedTierUserIdsAsync(
+        MembershipTier tier, LocalDate today, CancellationToken ct = default);
+
+    /// <summary>
+    /// Does <paramref name="userId"/> have an Approved application for
+    /// <paramref name="tier"/> whose term is still active on
+    /// <paramref name="today"/>? Used by
+    /// <c>SystemTeamSyncJob.SyncTierMembershipForUserAsync</c>.
+    /// </summary>
+    Task<bool> HasActiveApprovedTierAsync(
+        Guid userId, MembershipTier tier, LocalDate today, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the per-user "other active tier" map: for each user with an
+    /// Approved application for a non-<paramref name="excludeTier"/>
+    /// non-Volunteer tier that is still active on <paramref name="today"/>,
+    /// returns the tier. Each user maps to a single entry (the first Approved
+    /// row found); callers use this to decide whether a tier-downgrade
+    /// should land at Volunteer or at the alternate tier. Used by
+    /// <c>SystemTeamSyncJob.SyncTierTeamAsync</c>.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, MembershipTier>> GetOtherActiveTierAssignmentsAsync(
+        MembershipTier excludeTier, LocalDate today, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Governance/IMembershipCalculator.cs
+++ b/src/Humans.Application/Interfaces/Governance/IMembershipCalculator.cs
@@ -1,4 +1,3 @@
-using Humans.Application.DTOs;
 using Humans.Domain.Enums;
 
 namespace Humans.Application.Interfaces.Governance;
@@ -6,7 +5,13 @@ namespace Humans.Application.Interfaces.Governance;
 /// <summary>
 /// Service for computing membership status.
 /// </summary>
-public interface IMembershipCalculator : IApplicationService
+/// <remarks>
+/// Cross-section consumers that only read should inject
+/// <see cref="IMembershipCalculatorRead"/> instead of this full interface.
+/// The members declared directly here (status/role computation used in-section)
+/// are not part of the cross-section read surface.
+/// </remarks>
+public interface IMembershipCalculator : IMembershipCalculatorRead, IApplicationService
 {
     /// <summary>
     /// Computes the current membership status for a user.
@@ -17,22 +22,6 @@ public interface IMembershipCalculator : IApplicationService
     Task<MembershipStatus> ComputeStatusAsync(Guid userId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Checks if a user has all required consents.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>True if all required consents are present.</returns>
-    Task<bool> HasAllRequiredConsentsAsync(Guid userId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Gets the document versions that a user is missing consent for.
-    /// </summary>
-    /// <param name="userId">The user ID.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>List of document version IDs missing consent.</returns>
-    Task<IReadOnlyList<Guid>> GetMissingConsentVersionsAsync(Guid userId, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Checks if a user has any active roles.
     /// </summary>
     /// <param name="userId">The user ID.</param>
@@ -41,61 +30,8 @@ public interface IMembershipCalculator : IApplicationService
     Task<bool> HasActiveRolesAsync(Guid userId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets users whose membership status should be set to Inactive due to missing consent.
-    /// </summary>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>List of user IDs that should be marked inactive.</returns>
-    Task<IReadOnlyList<Guid>> GetUsersRequiringStatusUpdateAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Filters a set of user IDs to only those who have all required consents.
-    /// This is a batch operation that avoids N+1 queries.
-    /// </summary>
-    /// <param name="userIds">The user IDs to filter.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>User IDs that have all required consents.</returns>
-    Task<IReadOnlySet<Guid>> GetUsersWithAllRequiredConsentsAsync(
-        IEnumerable<Guid> userIds,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Checks if a user has all required consents for a specific team's documents.
-    /// </summary>
-    Task<bool> HasAllRequiredConsentsForTeamAsync(Guid userId, Guid teamId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Filters user IDs to those who have all required consents for a specific team.
-    /// </summary>
-    Task<IReadOnlySet<Guid>> GetUsersWithAllRequiredConsentsForTeamAsync(
-        IEnumerable<Guid> userIds, Guid teamId, CancellationToken ct = default);
-
-    /// <summary>
     /// Checks if a user has any expired (past grace period) consents for a specific team.
     /// Uses per-document GracePeriodDays.
     /// </summary>
     Task<bool> HasAnyExpiredConsentsForTeamAsync(Guid userId, Guid teamId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns a consolidated membership/consent snapshot for UI and policy checks.
-    /// </summary>
-    Task<MembershipSnapshot> GetMembershipSnapshotAsync(
-        Guid userId,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns all team IDs whose required documents apply to a user.
-    /// Includes current memberships plus system teams the user is eligible for
-    /// (e.g., Leads team if the user is Lead of any user-created team).
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetRequiredTeamIdsForUserAsync(
-        Guid userId,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Partitions a set of user IDs into 6 mutually exclusive membership categories.
-    /// Every input user ID appears in exactly one bucket.
-    /// Priority order: PendingDeletion > Suspended > IncompleteSignup > PendingApproval > MissingConsents/Active.
-    /// </summary>
-    Task<MembershipPartition> PartitionUsersAsync(
-        IEnumerable<Guid> userIds, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Governance/IMembershipCalculatorRead.cs
+++ b/src/Humans.Application/Interfaces/Governance/IMembershipCalculatorRead.cs
@@ -1,0 +1,74 @@
+using Humans.Application.Architecture;
+using Humans.Application.DTOs;
+
+namespace Humans.Application.Interfaces.Governance;
+
+/// <summary>
+/// Cross-section read surface for the Governance membership calculator:
+/// consent-completeness checks, membership/consent snapshots, required-team
+/// resolution, and status-update batches. External sections inject this
+/// interface instead of the full <see cref="IMembershipCalculator"/>; returns
+/// are scalars, Guid sets/lists, and section read DTOs — no EF entities. See
+/// <c>memory/architecture/section-read-write-split.md</c>.
+/// </summary>
+[SurfaceBudget(9)]
+public interface IMembershipCalculatorRead
+{
+    /// <summary>
+    /// Checks if a user has all required consents (for the Volunteers team).
+    /// </summary>
+    Task<bool> HasAllRequiredConsentsAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the document versions that a user is missing consent for.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetMissingConsentVersionsAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets users whose membership status should be set to Inactive due to missing consent.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetUsersRequiringStatusUpdateAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Filters a set of user IDs to only those who have all required consents.
+    /// This is a batch operation that avoids N+1 queries.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetUsersWithAllRequiredConsentsAsync(
+        IEnumerable<Guid> userIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a user has all required consents for a specific team's documents.
+    /// </summary>
+    Task<bool> HasAllRequiredConsentsForTeamAsync(Guid userId, Guid teamId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Filters user IDs to those who have all required consents for a specific team.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetUsersWithAllRequiredConsentsForTeamAsync(
+        IEnumerable<Guid> userIds, Guid teamId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns a consolidated membership/consent snapshot for UI and policy checks.
+    /// </summary>
+    Task<MembershipSnapshot> GetMembershipSnapshotAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all team IDs whose required documents apply to a user.
+    /// Includes current memberships plus system teams the user is eligible for
+    /// (e.g., Leads team if the user is Lead of any user-created team).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetRequiredTeamIdsForUserAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Partitions a set of user IDs into 6 mutually exclusive membership categories.
+    /// Every input user ID appears in exactly one bucket.
+    /// Priority order: PendingDeletion > Suspended > IncompleteSignup > PendingApproval > MissingConsents/Active.
+    /// </summary>
+    Task<MembershipPartition> PartitionUsersAsync(
+        IEnumerable<Guid> userIds, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
@@ -122,14 +122,6 @@ public interface IApplicationRepository : IRepository
     Task<bool> HasBoardVotesAsync(Guid applicationId, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns the existing board vote for (applicationId, boardMemberUserId),
-    /// or null if none. Read-only for callers that will mutate via
-    /// <see cref="UpsertBoardVoteAsync"/>.
-    /// </summary>
-    Task<BoardVote?> GetBoardVoteAsync(
-        Guid applicationId, Guid boardMemberUserId, CancellationToken ct = default);
-
-    /// <summary>
     /// Upserts a board vote: if a vote row exists for the
     /// (applicationId, boardMemberUserId) pair, updates its
     /// <see cref="BoardVote.Vote"/>/<see cref="BoardVote.Note"/>/

--- a/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
@@ -167,33 +167,6 @@ public interface IApplicationRepository : IRepository
         CancellationToken ct = default);
 
     /// <summary>
-    /// Returns Approved applications that have been resolved within
-    /// the half-open window <c>[windowStart, windowEnd)</c>, ordered by
-    /// <see cref="MembershipTier"/> then <c>ResolvedAt</c>. Used by the
-    /// Board daily digest.
-    /// </summary>
-    Task<IReadOnlyList<MemberApplication>> GetApprovedInWindowAsync(
-        Instant windowStart, Instant windowEnd, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns every Submitted application id. Used by the Board daily
-    /// digest to compute per-member unvoted counts without re-loading the
-    /// full application set.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the number of applications from <paramref name="applicationIds"/>
-    /// that the given board member has NOT yet voted on. Used by the Board
-    /// daily digest to render the per-member queue size.
-    /// </summary>
-    Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
-        Guid boardMemberUserId,
-        IReadOnlyCollection<Guid> applicationIds,
-        CancellationToken ct = default);
-
-    /// <summary>
     /// Stamps <c>Application.RenewalReminderSentAt</c> to
     /// <paramref name="sentAt"/>. No-op if the application does not exist.
     /// </summary>

--- a/src/Humans.Application/Services/Consent/ConsentService.cs
+++ b/src/Humans.Application/Services/Consent/ConsentService.cs
@@ -48,7 +48,7 @@ public sealed class ConsentService(
     {
         var now = clock.GetCurrentInstant();
 
-        var membershipCalculator = serviceProvider.GetRequiredService<IMembershipCalculator>();
+        var membershipCalculator = serviceProvider.GetRequiredService<IMembershipCalculatorRead>();
         var userTeamIds = await membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, ct);
 
         // Doc listing still goes through ILegalDocumentSyncService (#547a not yet done).
@@ -181,7 +181,7 @@ public sealed class ConsentService(
         // Auto-resolve AccessSuspended notifications only after ALL required consents complete.
         try
         {
-            var membershipCalc = serviceProvider.GetRequiredService<IMembershipCalculator>();
+            var membershipCalc = serviceProvider.GetRequiredService<IMembershipCalculatorRead>();
             if (await membershipCalc.HasAllRequiredConsentsAsync(userId, ct))
             {
                 await notificationInboxService.ResolveBySourceAsync(userId, NotificationSource.AccessSuspended, ct);
@@ -320,7 +320,7 @@ public sealed class ConsentService(
 
     public async Task<IReadOnlyList<string>> GetPendingDocumentNamesAsync(Guid userId, CancellationToken ct = default)
     {
-        var membershipCalculator = serviceProvider.GetRequiredService<IMembershipCalculator>();
+        var membershipCalculator = serviceProvider.GetRequiredService<IMembershipCalculatorRead>();
         var missingVersionIds = await membershipCalculator.GetMissingConsentVersionsAsync(userId, ct);
 
         if (missingVersionIds.Count == 0)

--- a/src/Humans.Application/Services/Dashboard/AdminDashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/AdminDashboardService.cs
@@ -10,7 +10,7 @@ namespace Humans.Application.Services.Dashboard;
 public sealed class AdminDashboardService(
     IUserServiceRead userService,
     IMembershipCalculator membershipCalculator,
-    IApplicationDecisionService applicationDecisionService,
+    IApplicationServiceRead applicationDecisionService,
     IShiftManagementService shiftManagement,
     IShiftView shiftView) : IAdminDashboardService
 {

--- a/src/Humans.Application/Services/Dashboard/AdminDashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/AdminDashboardService.cs
@@ -9,7 +9,7 @@ namespace Humans.Application.Services.Dashboard;
 /// <summary>Admin dashboard aggregator: membership partition, tier-application stats, language distribution, 4-set Venn/UpSet membership. Owns no tables.</summary>
 public sealed class AdminDashboardService(
     IUserServiceRead userService,
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     IApplicationServiceRead applicationDecisionService,
     IShiftManagementService shiftManagement,
     IShiftView shiftView) : IAdminDashboardService

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -17,7 +17,7 @@ namespace Humans.Application.Services.Dashboard;
 /// <summary>Orchestrates the member dashboard snapshot across profile/membership/applications/shifts/tickets/participation.</summary>
 public class DashboardService(
     IMembershipCalculator membershipCalculator,
-    IApplicationDecisionService applicationDecisionService,
+    IApplicationServiceRead applicationDecisionService,
     IShiftManagementService shiftMgmt,
     IShiftView shiftView,
     ITicketServiceRead ticketQueryService,

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -16,7 +16,7 @@ namespace Humans.Application.Services.Dashboard;
 
 /// <summary>Orchestrates the member dashboard snapshot across profile/membership/applications/shifts/tickets/participation.</summary>
 public class DashboardService(
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     IApplicationServiceRead applicationDecisionService,
     IShiftManagementService shiftMgmt,
     IShiftView shiftView,

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -475,30 +475,21 @@ public sealed class ApplicationDecisionService(
     {
         var applications = await repository.GetAllSubmittedWithVotesAsync(ct);
 
-        var applicantIds = applications.Select(a => a.UserId).Distinct().ToList();
-        var applicantsById = await userService.GetUserInfosAsync(applicantIds, ct);
-
-        var rows = applications.Select(a =>
-        {
-            var applicant = applicantsById.GetValueOrDefault(a.UserId);
-            return new BoardVotingDashboardRow(
-                ApplicationId: a.Id,
-                UserId: a.UserId,
-                UserDisplayName: applicant?.BurnerName ?? string.Empty,
-                UserProfilePictureUrl: applicant?.ProfilePictureUrl,
-                MembershipTier: a.MembershipTier,
-                ApplicationMotivation: a.Motivation,
-                SubmittedAt: a.SubmittedAt,
-                Status: a.Status,
-                Votes: a.BoardVotes
-                    .Select(v => new BoardVoteRow(
-                        BoardMemberUserId: v.BoardMemberUserId,
-                        BoardMemberDisplayName: null,
-                        Vote: v.Vote,
-                        Note: v.Note,
-                        VotedAt: v.VotedAt))
-                    .ToList());
-        }).ToList();
+        var rows = applications.Select(a => new BoardVotingDashboardRow(
+            ApplicationId: a.Id,
+            UserId: a.UserId,
+            MembershipTier: a.MembershipTier,
+            ApplicationMotivation: a.Motivation,
+            SubmittedAt: a.SubmittedAt,
+            Status: a.Status,
+            Votes: a.BoardVotes
+                .Select(v => new BoardVoteRow(
+                    BoardMemberUserId: v.BoardMemberUserId,
+                    BoardMemberDisplayName: null,
+                    Vote: v.Vote,
+                    Note: v.Note,
+                    VotedAt: v.VotedAt))
+                .ToList())).ToList();
 
         var boardMemberIds = await roleAssignmentService.GetActiveUserIdsInRoleAsync(
             RoleNames.Board, ct);

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -590,26 +590,6 @@ public sealed class ApplicationDecisionService(
         Guid applicationId, Instant sentAt, CancellationToken ct = default) =>
         repository.MarkRenewalReminderSentAsync(applicationId, sentAt, ct);
 
-    public async Task<IReadOnlyList<ApprovedApplicationDigestEntry>> GetApprovedInWindowAsync(
-        Instant windowStart, Instant windowEnd, CancellationToken ct = default)
-    {
-        var applications = await repository.GetApprovedInWindowAsync(windowStart, windowEnd, ct);
-        return applications
-            .Select(a => new ApprovedApplicationDigestEntry(a.UserId, a.MembershipTier))
-            .ToList();
-    }
-
-    public Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
-        CancellationToken ct = default) =>
-        repository.GetSubmittedApplicationIdsAsync(ct);
-
-    public Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
-        Guid boardMemberUserId,
-        IReadOnlyCollection<Guid> applicationIds,
-        CancellationToken ct = default) =>
-        repository.GetUnvotedCountForBoardMemberAmongApplicationsAsync(
-            boardMemberUserId, applicationIds, ct);
-
     public Task<IReadOnlyList<Guid>> GetActiveApprovedTierUserIdsAsync(
         MembershipTier tier, LocalDate today, CancellationToken ct = default) =>
         repository.GetActiveApprovedTierUserIdsAsync(tier, today, ct);

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -405,28 +405,8 @@ public sealed class ApplicationDecisionService(
         if (application is null)
             return null;
 
-        var userIds = new HashSet<Guid> { application.UserId };
-        if (application.ReviewedByUserId is { } reviewerId)
-            userIds.Add(reviewerId);
-        foreach (var row in application.StateHistory)
-            userIds.Add(row.ChangedByUserId);
-
-        var users = await userService.GetUserInfosAsync(userIds, ct);
-
-        var applicant = users.GetValueOrDefault(application.UserId);
-        var reviewer = application.ReviewedByUserId is { } rid
-            ? users.GetValueOrDefault(rid)
-            : null;
-
-        var history = application.StateHistory
-            .OrderByDescending(h => h.ChangedAt)
-            .Select(h => new ApplicationStateHistoryDto(
-                Status: h.Status,
-                ChangedAt: h.ChangedAt,
-                ChangedByUserId: h.ChangedByUserId,
-                ChangedByDisplayName: users.GetValueOrDefault(h.ChangedByUserId)?.BurnerName,
-                Notes: h.Notes))
-            .ToList();
+        var applicant = await userService.GetUserInfoAsync(application.UserId, ct);
+        var (reviewerName, history) = await StitchHistoryAsync(application, ct);
 
         return new ApplicationAdminDetailDto(
             Id: application.Id,
@@ -444,7 +424,7 @@ public sealed class ApplicationDecisionService(
             SubmittedAt: application.SubmittedAt,
             ReviewStartedAt: application.ReviewStartedAt,
             ResolvedAt: application.ResolvedAt,
-            ReviewerName: reviewer?.BurnerName,
+            ReviewerName: reviewerName,
             ReviewNotes: application.ReviewNotes,
             History: history);
     }

--- a/src/Humans.Application/Services/Governance/GovernanceIndexService.cs
+++ b/src/Humans.Application/Services/Governance/GovernanceIndexService.cs
@@ -6,7 +6,7 @@ using Humans.Domain.Enums;
 namespace Humans.Application.Services.Governance;
 
 public sealed class GovernanceIndexService(
-    IApplicationDecisionService applicationDecisionService,
+    IApplicationServiceRead applicationDecisionService,
     ILegalDocumentService legalDocService,
     IUserServiceRead userService) : IGovernanceIndexService
 {

--- a/src/Humans.Application/Services/Notifications/NotificationMeterProvider.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationMeterProvider.cs
@@ -21,7 +21,7 @@ namespace Humans.Application.Services.Notifications;
 /// are computed by calling into each owning section service
 /// (<see cref="IUserService"/>,
 /// <see cref="IGoogleSyncServiceRead"/>, <see cref="ITeamService"/>,
-/// <see cref="ITicketSyncService"/>, <see cref="IApplicationDecisionService"/>)
+/// <see cref="ITicketSyncService"/>, <see cref="IApplicationServiceRead"/>)
 /// and cached for ~2 minutes. No direct DB access.
 /// </summary>
 /// <remarks>
@@ -38,7 +38,7 @@ public sealed class NotificationMeterProvider(
     IGoogleSyncServiceRead googleSyncService,
     ITeamServiceRead teamService,
     ITicketSyncService ticketSyncService,
-    IApplicationDecisionService applicationDecisionService,
+    IApplicationServiceRead applicationDecisionService,
     ICampServiceRead campService,
     IMemoryCache cache,
     ILogger<NotificationMeterProvider> logger) : INotificationMeterProvider

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -24,7 +24,7 @@ public sealed class OnboardingService(
     IEmailMessageFactory emailMessages,
     INotificationService notificationService,
     ISystemTeamSync syncJob,
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     IAuditLogService auditLogService,
     IHumansMetrics metrics,
     ILogger<OnboardingService> logger) : IOnboardingService

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -19,7 +19,7 @@ namespace Humans.Application.Services.Onboarding;
 // admin dashboard (IAdminDashboardService), account deletion (future IAccountDeletionService).
 public sealed class OnboardingService(
     IUserService userService,
-    IApplicationDecisionService applicationDecisionService,
+    IApplicationServiceRead applicationDecisionService,
     IEmailService emailService,
     IEmailMessageFactory emailMessages,
     INotificationService notificationService,

--- a/src/Humans.Application/Services/Onboarding/OnboardingWidgetState.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingWidgetState.cs
@@ -10,7 +10,7 @@ namespace Humans.Application.Services.Onboarding;
 public class OnboardingWidgetState(
     IUserServiceRead users,
     IShiftView shiftView,
-    IMembershipCalculator membership,
+    IMembershipCalculatorRead membership,
     IShiftManagementService shiftMgmt,
     IConsentServiceRead consents,
     IOnboardingWidgetSessionState session) : IOnboardingWidgetState

--- a/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
@@ -23,7 +23,7 @@ namespace Humans.Infrastructure.Jobs;
 /// </remarks>
 [DisableConcurrentExecution(timeoutInSeconds: 300)]
 public class SendReConsentReminderJob(
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     ILegalDocumentSyncService legalDocService,
     IUserService userService,
     IEmailService emailService,

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -35,7 +35,7 @@ public class SuspendNonCompliantMembersJob(
     IUserService userService,
     ITeamServiceRead teamService,
     IActiveTeamsCacheInvalidator activeTeamsCacheInvalidator,
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     IEmailService emailService,
     IEmailMessageFactory emailMessages,
     INotificationService notificationService,

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -51,8 +51,8 @@ public class SystemTeamSyncJob(
     private ITeamResourceService TeamResourceService =>
         serviceProvider.GetRequiredService<ITeamResourceService>();
 
-    private IMembershipCalculator MembershipCalculator =>
-        serviceProvider.GetRequiredService<IMembershipCalculator>();
+    private IMembershipCalculatorRead MembershipCalculator =>
+        serviceProvider.GetRequiredService<IMembershipCalculatorRead>();
 
     /// <summary>
     /// Executes the system team sync job and returns a report of what changed.

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -42,8 +42,8 @@ public class SystemTeamSyncJob(
 
     // Lazy via IServiceProvider to break DI cycles (these services depend on ISystemTeamSync).
 
-    private IApplicationDecisionService ApplicationDecisionService =>
-        serviceProvider.GetRequiredService<IApplicationDecisionService>();
+    private IApplicationServiceRead ApplicationDecisionService =>
+        serviceProvider.GetRequiredService<IApplicationServiceRead>();
 
     private IRoleAssignmentService RoleAssignmentService =>
         serviceProvider.GetRequiredService<IRoleAssignmentService>();

--- a/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
@@ -251,41 +251,6 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
             .ToHashSet();
     }
 
-    public async Task<IReadOnlyList<MemberApplication>> GetApprovedInWindowAsync(
-        Instant windowStart, Instant windowEnd, CancellationToken ct = default) =>
-        await WithContextAsync(async ctx => await ctx.Applications
-            .AsNoTracking()
-            .Where(a => a.Status == ApplicationStatus.Approved
-                && a.ResolvedAt != null
-                && a.ResolvedAt.Value >= windowStart
-                && a.ResolvedAt.Value < windowEnd)
-            .ToListAsync(ct), ct);
-
-    public async Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
-        CancellationToken ct = default) =>
-        await WithContextAsync(async ctx => await ctx.Applications
-            .AsNoTracking()
-            .Where(a => a.Status == ApplicationStatus.Submitted)
-            .Select(a => a.Id)
-            .ToListAsync(ct), ct);
-
-    public async Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
-        Guid boardMemberUserId,
-        IReadOnlyCollection<Guid> applicationIds,
-        CancellationToken ct = default)
-    {
-        if (applicationIds.Count == 0)
-            return 0;
-
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        var votedCount = await ctx.BoardVotes
-            .AsNoTracking()
-            .CountAsync(v => v.BoardMemberUserId == boardMemberUserId
-                && applicationIds.Contains(v.ApplicationId), ct);
-
-        return applicationIds.Count - votedCount;
-    }
-
     public async Task MarkRenewalReminderSentAsync(
         Guid applicationId, Instant sentAt, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
@@ -158,14 +158,6 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
     public async Task<bool> HasBoardVotesAsync(Guid applicationId, CancellationToken ct = default) =>
         await WithContextAsync(ctx => ctx.BoardVotes.AnyAsync(v => v.ApplicationId == applicationId, ct), ct);
 
-    public async Task<BoardVote?> GetBoardVoteAsync(
-        Guid applicationId, Guid boardMemberUserId, CancellationToken ct = default) =>
-        await WithContextAsync(ctx => ctx.BoardVotes
-            .AsNoTracking()
-            .FirstOrDefaultAsync(
-                v => v.ApplicationId == applicationId && v.BoardMemberUserId == boardMemberUserId,
-                ct), ct);
-
     public async Task UpsertBoardVoteAsync(
         Guid applicationId,
         Guid boardMemberUserId,

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -259,7 +259,7 @@ public sealed class HumansMetricsService : IHumansMetrics, IHostedService, IDisp
         try
         {
             using var scope = _scopeFactory.CreateScope();
-            var membershipCalc = scope.ServiceProvider.GetRequiredService<IMembershipCalculator>();
+            var membershipCalc = scope.ServiceProvider.GetRequiredService<IMembershipCalculatorRead>();
             var applicationDecisionService = scope.ServiceProvider.GetRequiredService<IApplicationServiceRead>();
             var teamService = scope.ServiceProvider.GetRequiredService<ITeamServiceRead>();
             var userService = scope.ServiceProvider.GetRequiredService<IUserServiceRead>();

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -260,7 +260,7 @@ public sealed class HumansMetricsService : IHumansMetrics, IHostedService, IDisp
         {
             using var scope = _scopeFactory.CreateScope();
             var membershipCalc = scope.ServiceProvider.GetRequiredService<IMembershipCalculator>();
-            var applicationDecisionService = scope.ServiceProvider.GetRequiredService<IApplicationDecisionService>();
+            var applicationDecisionService = scope.ServiceProvider.GetRequiredService<IApplicationServiceRead>();
             var teamService = scope.ServiceProvider.GetRequiredService<ITeamServiceRead>();
             var userService = scope.ServiceProvider.GetRequiredService<IUserServiceRead>();
             var clock = scope.ServiceProvider.GetRequiredService<IClock>();

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -76,7 +76,7 @@ public class ProfileController(
     IConsentServiceRead consentService,
     IApplicationDecisionService applicationDecisionService,
     IAccountDeletionService accountDeletionService,
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     SignInManager<User> signInManager,
     IOptions<GoogleWorkspaceOptions> googleWorkspaceOptions) : HumansControllerBase(userService)
 {

--- a/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
@@ -42,7 +42,9 @@ internal static class GovernanceSectionExtensions
         // ISystemTeamSync, whose implementation injects IMembershipCalculator back).
         // Only MembershipCalculator depends on the query adapter.
         services.AddScoped<IMembershipQuery, GovernanceMembershipQuery>();
-        services.AddScoped<IMembershipCalculator, GovernanceMembershipCalculator>();
+        services.AddScoped<GovernanceMembershipCalculator>();
+        services.AddScoped<IMembershipCalculator>(sp => sp.GetRequiredService<GovernanceMembershipCalculator>());
+        services.AddScoped<IMembershipCalculatorRead>(sp => sp.GetRequiredService<GovernanceMembershipCalculator>());
 
         // Human lifecycle — state-machine on already-onboarded humans
         // (suspend / unsuspend; future re-consent suspensions, term-renewal,

--- a/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
@@ -31,6 +31,7 @@ internal static class GovernanceSectionExtensions
 
         services.AddScoped<GovernanceApplicationDecisionService>();
         services.AddScoped<IApplicationDecisionService>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>());
+        services.AddScoped<IApplicationServiceRead>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>());
         services.AddScoped<IUserMerge>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>());
 

--- a/src/Humans.Web/Models/Shifts/ShiftAdminPageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftAdminPageBuilder.cs
@@ -21,7 +21,7 @@ public sealed record ShiftAdminPageRequest(
 
 public sealed class ShiftAdminPageBuilder(
     IShiftManagementService shiftManagement,
-    IMembershipCalculator membership,
+    IMembershipCalculatorRead membership,
     IUserServiceRead userService,
     ITeamServiceRead teamService)
 {

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -132,7 +132,7 @@ internal static class PillCounts
         var idClaim = http.HttpContext?.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
         if (idClaim is null || !Guid.TryParse(idClaim.Value, out var userId))
             return null;
-        var applications = sp.GetRequiredService<Application.Interfaces.Governance.IApplicationDecisionService>();
+        var applications = sp.GetRequiredService<Application.Interfaces.Governance.IApplicationServiceRead>();
         var count = await applications.GetUnvotedApplicationCountAsync(userId);
         return count > 0 ? count : null;
     }

--- a/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
@@ -12,7 +12,7 @@ namespace Humans.Web.ViewComponents;
 
 public class NavBadgesViewComponent(
     IAdminDashboardService adminDashboardService,
-    IApplicationDecisionService applicationDecisionService,
+    IApplicationServiceRead applicationDecisionService,
     IFeedbackService feedbackService,
     IIssuesService issuesService,
     IMemoryCache cache) : ViewComponent

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -25,7 +25,7 @@ public class ProfileCardViewComponent(
     IUserEmailService userEmailService,
     ITeamServiceRead teamService,
     IRoleAssignmentService roleAssignmentService,
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     ICommunicationPreferenceService commPrefService) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync(Guid userId, ProfileCardViewMode viewMode)

--- a/src/Humans.Web/ViewComponents/ThingsToDoViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ThingsToDoViewComponent.cs
@@ -13,7 +13,7 @@ namespace Humans.Web.ViewComponents;
 public class ThingsToDoViewComponent(
     IUserServiceRead userService,
     IShiftManagementService shiftMgmt,
-    IMembershipCalculator membershipCalculator,
+    IMembershipCalculatorRead membershipCalculator,
     IStringLocalizer<SharedResource> localizer,
     ILogger<ThingsToDoViewComponent> logger) : ViewComponent
 {

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
@@ -114,7 +114,7 @@ public class ProfileControllerDietaryMedicalReplayTests
             Substitute.For<IConsentServiceRead>(),
             Substitute.For<IApplicationDecisionService>(),
             Substitute.For<IAccountDeletionService>(),
-            Substitute.For<IMembershipCalculator>(),
+            Substitute.For<IMembershipCalculatorRead>(),
             Substitute.For<SignInManager<User>>(
                 _userManager,
                 Substitute.For<IHttpContextAccessor>(),

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -118,7 +118,7 @@ public class ProfileControllerEditTests
             Substitute.For<IConsentServiceRead>(),
             _applicationDecisionService,
             Substitute.For<IAccountDeletionService>(),
-            Substitute.For<IMembershipCalculator>(),
+            Substitute.For<IMembershipCalculatorRead>(),
             Substitute.For<SignInManager<User>>(
                 userManager,
                 Substitute.For<IHttpContextAccessor>(),

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
@@ -106,7 +106,7 @@ public class ProfileControllerEmailGridTests
             Substitute.For<IConsentServiceRead>(),
             Substitute.For<IApplicationDecisionService>(),
             Substitute.For<IAccountDeletionService>(),
-            Substitute.For<IMembershipCalculator>(),
+            Substitute.For<IMembershipCalculatorRead>(),
             _signInManager,
             Options.Create(new GoogleWorkspaceOptions()));
 

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
@@ -96,7 +96,7 @@ public class ProfileControllerPopoverTests
             Substitute.For<IConsentServiceRead>(),
             Substitute.For<IApplicationDecisionService>(),
             Substitute.For<IAccountDeletionService>(),
-            Substitute.For<IMembershipCalculator>(),
+            Substitute.For<IMembershipCalculatorRead>(),
             signInManager,
             Options.Create(new GoogleWorkspaceOptions()));
 

--- a/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
@@ -23,7 +23,7 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
 {
     private readonly IUserService _userService;
     private readonly ITeamService _teamService;
-    private readonly IMembershipCalculator _membershipCalculator;
+    private readonly IMembershipCalculatorRead _membershipCalculator;
     private readonly IEmailService _emailService;
     private readonly IEmailMessageFactory _emailMessages;
     private readonly INotificationService _notificationService;
@@ -42,7 +42,7 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     {
         _userService = Substitute.For<IUserService>();
         _teamService = Substitute.For<ITeamService>();
-        _membershipCalculator = Substitute.For<IMembershipCalculator>();
+        _membershipCalculator = Substitute.For<IMembershipCalculatorRead>();
         _emailService = Substitute.For<IEmailService>();
         _emailMessages = Substitute.For<IEmailMessageFactory>();
         _notificationService = Substitute.For<INotificationService>();

--- a/tests/Humans.Application.Tests/Notifications/NotificationMeterProviderTests.cs
+++ b/tests/Humans.Application.Tests/Notifications/NotificationMeterProviderTests.cs
@@ -26,7 +26,7 @@ public class NotificationMeterProviderTests : IDisposable
     private readonly IGoogleSyncServiceRead _googleSyncService = Substitute.For<IGoogleSyncServiceRead>();
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly ITicketSyncService _ticketSyncService = Substitute.For<ITicketSyncService>();
-    private readonly IApplicationDecisionService _applicationDecisionService = Substitute.For<IApplicationDecisionService>();
+    private readonly IApplicationServiceRead _applicationDecisionService = Substitute.For<IApplicationServiceRead>();
     private readonly ICampServiceRead _campService = Substitute.For<ICampServiceRead>();
     private readonly IMemoryCache _cache;
     private readonly NotificationMeterProvider _provider;

--- a/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
@@ -769,15 +769,8 @@ public sealed class ApplicationDecisionServiceTests : ServiceTestHarness
             UserName = "r@t.com",
             Email = "r@t.com"
         };
-        _userService.GetByIdsAsync(
-            Arg.Any<IReadOnlyCollection<Guid>>(),
-            Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyDictionary<Guid, User>>(
-                new Dictionary<Guid, User>
-                {
-                    [applicantId] = applicant,
-                    [reviewerId] = reviewer
-                }));
+        _userService.GetUserInfoAsync(applicantId, Arg.Any<CancellationToken>())
+            .Returns(applicant.ToUserInfo());
         _userService.GetUserInfosAsync(
             Arg.Any<IReadOnlyCollection<Guid>>(),
             Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -22,7 +22,7 @@ namespace Humans.Application.Tests.Services;
 public sealed class ConsentServiceTests : ServiceTestHarness
 {
     private readonly ConsentService _service;
-    private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly IMembershipCalculatorRead _membershipCalculator = Substitute.For<IMembershipCalculatorRead>();
     private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
     private readonly INotificationInboxService _notificationInboxService = Substitute.For<INotificationInboxService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();

--- a/tests/Humans.Application.Tests/Services/Dashboard/AdminDashboardServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Dashboard/AdminDashboardServiceTests.cs
@@ -22,7 +22,7 @@ namespace Humans.Application.Tests.Services.Dashboard;
 public class AdminDashboardServiceTests
 {
     private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly IMembershipCalculatorRead _membershipCalculator = Substitute.For<IMembershipCalculatorRead>();
     private readonly IApplicationServiceRead _applicationDecisionService = Substitute.For<IApplicationServiceRead>();
     private readonly IShiftManagementService _shiftManagement = Substitute.For<IShiftManagementService>();
     private readonly IShiftView _shiftView = Substitute.For<IShiftView>();

--- a/tests/Humans.Application.Tests/Services/Dashboard/AdminDashboardServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Dashboard/AdminDashboardServiceTests.cs
@@ -23,7 +23,7 @@ public class AdminDashboardServiceTests
 {
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
-    private readonly IApplicationDecisionService _applicationDecisionService = Substitute.For<IApplicationDecisionService>();
+    private readonly IApplicationServiceRead _applicationDecisionService = Substitute.For<IApplicationServiceRead>();
     private readonly IShiftManagementService _shiftManagement = Substitute.For<IShiftManagementService>();
     private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
 

--- a/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
@@ -26,7 +26,7 @@ public sealed class OnboardingServiceTests
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly INotificationService _notificationService = Substitute.For<INotificationService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
-    private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly IMembershipCalculatorRead _membershipCalculator = Substitute.For<IMembershipCalculatorRead>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
     private readonly IEmailMessageFactory _emailMessages = Substitute.For<IEmailMessageFactory>();

--- a/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Onboarding/OnboardingServiceTests.cs
@@ -22,7 +22,7 @@ namespace Humans.Application.Tests.Services.Onboarding;
 public sealed class OnboardingServiceTests
 {
     private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly IApplicationDecisionService _applicationDecisionService = Substitute.For<IApplicationDecisionService>();
+    private readonly IApplicationServiceRead _applicationDecisionService = Substitute.For<IApplicationServiceRead>();
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly INotificationService _notificationService = Substitute.For<INotificationService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();

--- a/tests/Humans.Application.Tests/Services/Onboarding/OnboardingWidgetStateTests.cs
+++ b/tests/Humans.Application.Tests/Services/Onboarding/OnboardingWidgetStateTests.cs
@@ -18,7 +18,7 @@ public class OnboardingWidgetStateTests
 {
     private readonly IUserService _users = Substitute.For<IUserService>();
     private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
-    private readonly IMembershipCalculator _membership = Substitute.For<IMembershipCalculator>();
+    private readonly IMembershipCalculatorRead _membership = Substitute.For<IMembershipCalculatorRead>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
     private readonly IConsentServiceRead _consents = Substitute.For<IConsentServiceRead>();
     private readonly IOnboardingWidgetSessionState _session = Substitute.For<IOnboardingWidgetSessionState>();

--- a/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
+++ b/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
@@ -51,7 +51,7 @@ public class SystemTeamSyncJobBarrioLeadsTests
     private SystemTeamSyncJob CreateJob()
     {
         var services = new ServiceCollection();
-        services.AddSingleton(Substitute.For<IMembershipCalculator>());
+        services.AddSingleton<IMembershipCalculatorRead>(Substitute.For<IMembershipCalculatorRead>());
         var provider = services.BuildServiceProvider();
 
         return new SystemTeamSyncJob(

--- a/tests/Humans.Application.Tests/ViewComponents/ThingsToDoViewComponentDietaryGateTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/ThingsToDoViewComponentDietaryGateTests.cs
@@ -27,7 +27,7 @@ public class ThingsToDoViewComponentDietaryGateTests
 {
     private readonly IUserServiceRead _userService = Substitute.For<IUserServiceRead>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
-    private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly IMembershipCalculatorRead _membershipCalculator = Substitute.For<IMembershipCalculatorRead>();
     private readonly IStringLocalizer<SharedResource> _localizer = Substitute.For<IStringLocalizer<SharedResource>>();
     private readonly ThingsToDoViewComponent _sut;
 

--- a/tests/Humans.Web.Tests/Models/Shifts/ShiftAdminPageBuilderTests.cs
+++ b/tests/Humans.Web.Tests/Models/Shifts/ShiftAdminPageBuilderTests.cs
@@ -19,7 +19,7 @@ namespace Humans.Web.Tests.Models.Shifts;
 /// Pending-list filter, reached only through <see cref="ShiftAdminPageBuilder.BuildAsync"/>
 /// when <see cref="ShiftAdminPageRequest.IncompleteOnboarding"/> is true. The filter keeps
 /// only pending signups whose user is NOT in the "has all required consents" set returned by
-/// <see cref="IMembershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync"/>.
+/// <see cref="IMembershipCalculatorRead.GetUsersWithAllRequiredConsentsForTeamAsync"/>.
 ///
 /// Ported from the deleted
 /// tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceFilterIncompleteOnboardingTests.cs
@@ -30,7 +30,7 @@ public sealed class ShiftAdminPageBuilderTests
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     private readonly IShiftManagementService _shiftManagement = Substitute.For<IShiftManagementService>();
-    private readonly IMembershipCalculator _membership = Substitute.For<IMembershipCalculator>();
+    private readonly IMembershipCalculatorRead _membership = Substitute.For<IMembershipCalculatorRead>();
     private readonly IUserServiceRead _userService = Substitute.For<IUserServiceRead>();
     private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
 


### PR DESCRIPTION
## Section thesis — the read/write split

Governance is a repo-backed vertical owning the tier-application lifecycle (`Application` / `ApplicationStateHistory` / `BoardVote` tables via `IApplicationRepository`, `[Section("Governance")]`) plus a membership/consent calculator (`MembershipCalculator`). At the `origin/main` baseline it had **no read surface**: every cross-section consumer (Dashboard / Onboarding / Notifications / Jobs / Metrics / Web view components) injected a **full write/orchestrator service** for read-only access. Two services carried this debt:

- **`IApplicationDecisionService`** (~33 methods, mixing tier-application commands with a large read block; also implements cross-cutting `IUserDataContributor` + `IUserMerge`).
- **`IMembershipCalculator`** (a genuinely 100%-read-only status/consent calculator — no `SaveChanges`/`DbContext`/EF writes — wrongly consumed as a full service).

**Thesis:** carve the cross-section read surface out of both full services per `memory/architecture/section-read-write-split.md` (reference: Teams, PR 678). Read-only consumers should depend on a typed, existing-methods-only read contract (`IApplicationServiceRead`, `IMembershipCalculatorRead`); only genuine writers stay on the full service. Reads return scalars / enums / Guid sets / pure-record DTOs (`MembershipSnapshot`, `MembershipPartition`, `UserApplicationSnapshot`, `ApplicationAdmin*Dto`, `ApplicationAdminStats`) — never EF entities. The split is **declaration relocation in service of a real dependency drop** (`IApplicationDecisionService : IApplicationServiceRead, IApplicationService`; `IMembershipCalculator : IMembershipCalculatorRead, IApplicationService`), not invention of new bespoke surface. Alongside the split, this lane trims genuinely dead own-section surface (a never-wired Board-daily-digest feed, a dead repo lookup, a dead dashboard stitch) and de-duplicates one intra-section read path.

`IMembershipQuery` is a deliberate DI-cycle-breaker pass-through to `ITeamServiceRead` + `IRoleAssignmentService` and is **not** collapsed. There is no Governance section cache; the service invalidates other sections' caches after writes — no cache decorator was touched.

> **Reforge scoring caveat (applies to every commit below).** All staged score files in this run carry an identical *degraded* Reforge build (`degraded=true`, 6 compile errors / 4 unresolved references in Reforge's own workspace resolver; Reforge itself warns the surface-score is **PARTIAL**). The real `dotnet build Humans.slnx` is clean (0 errors) for every commit. Under the partial compile, the cross-section coupling credit a read-split earns (`crossSectionFullService`) is **not** recomputed, and Governance is absent from the hand-maintained `readServiceInterfaces` list in `reforge.surface-score.json` (outside this lane's allowed edit set), so moved methods are not re-weighted at the lower `readServiceInterfaceMethod` tier. The read-split commits therefore show a small *nominal* surface increase (scaffolding cost: new single-impl interface + DI registrations) even though the structural win — consumers dropping the full-service edge — is genuine and is exactly the architecture this lane charters. The dead-surface deletions show the real, un-degraded reduction.

---

## Accepted commits

### Wave 1 — dead surface + intra-section dedup

#### 1. Remove dead `GetBoardVoteAsync` from Governance application repository
- **SHA:** `d42f82b95b5bd723ac802f7361973b2b35967686`
- **Concept deleted:** A standalone single-vote lookup query (`GetBoardVoteAsync(applicationId, boardMemberUserId)`) on `IApplicationRepository` that no code path used. Board-vote reads flow through `GetAllSubmittedWithVotesAsync` / `GetByIdAsync` aggregate loads; the get-by-pair / mutate pattern its XML doc described was never wired (the atomic `UpsertBoardVoteAsync` does its own internal lookup).
- **Reforge group (Governance section score):** 1758 → 1736 (**−22**); `repositoryInterfaceMethod` + `repositoryImplementationMethod` each −1.
- **Outside-lane increase:** 0
- **Weighted value:** 22
- **Panel verdict:** unanimous **accept** (A / B / C). Grep at HEAD: the only two occurrences were the interface declaration and the impl signature — zero callers (production or test); zero remain. Outright removal, not relocation; no accessibility narrowing; behavior preserved (upsert has its own independent `FirstOrDefaultAsync`). Both files Governance-owned.

#### 2. Drop dead applicant name/picture stitch from board-voting dashboard row
- **SHA:** `b5f9e44d4badf4f15a7f232628eb4bcf038d6fe9`
- **Concept deleted:** Pre-stitched applicant display name / picture on the board-voting dashboard row, plus the cross-section `IUserService.GetUserInfosAsync(applicantIds)` lookup that existed solely to fill them — both redundant because `Index.cshtml` self-resolves applicants via `<vc:human user-id="@app.UserId" layout="AvatarName" />`.
- **Reforge group (Governance section score):** 1736 → 1734 (**−2**)
- **Outside-lane increase:** 0
- **Weighted value:** 2
- **Panel verdict:** unanimous **accept** (A / B / C). The two fields have zero read consumers (controller maps the VM from `ApplicationId` / `UserId` / `MembershipTier` / `Motivation` / `SubmittedAt` / `Status` / `Votes` only; VM carries no name/picture field). Removes a per-load cross-section user round-trip. The separate board-member `GetUserInfosAsync(boardMemberIds)` stitch (GOV-04) was correctly left untouched. All three files Governance-owned; doc comment corrected. Aligns with the burnername-is-the-display-name / no-new-displayname-fields project rules.

#### 3. Reuse `StitchHistoryAsync` in `GetApplicationDetailAsync` to drop duplicated history stitch
- **SHA:** `b0ac796ff5e5d0ff2f6b8ec1dbf81405959ca00c`
- **Concept deleted:** A second hand-rolled copy of the application reviewer-name + state-history stitch / order / projection (reviewer-id collection, combined `GetUserInfosAsync`, inline reviewer-name lookup, inline `OrderByDescending(ChangedAt)` projection into `ApplicationStateHistoryDto`), unified onto the existing private `StitchHistoryAsync` helper already used by `GetUserApplicationDetailAsync`.
- **Reforge group (Governance section score):** 1734 → 1734 (**0**)
- **Outside-lane increase:** 0
- **Weighted value:** 0
- **Panel verdict:** unanimous **accept** (A / B / C). Single Governance-owned file, 3 insertions / 23 deletions. Intra-section de-duplication onto a pre-existing private helper (not introduced by this diff, so not relocation). Behaviorally equivalent: applicant facts via `GetUserInfoAsync` produce the same `UserInfo`; `ReviewerName == old reviewer?.BurnerName`; history projection byte-identical; `ApplicationAdminDetailDto` output preserved. Net score-neutral but removes a duplicated read-path shape.

### Wave 1b — the read/write split + dead-feed deletion

#### 4. Create `IApplicationServiceRead`, register it in DI, migrate the 9 read-only Governance consumers off `IApplicationDecisionService`
- **SHA:** `7859a4a19f269f0df660f8ed34472a47424e221b`
- **Concept deleted:** The absence of a Governance cross-section read boundary. Nine read-only consumers' dependency on the full write service `IApplicationDecisionService` for read access is replaced by a typed read contract (`IApplicationServiceRead`); 10 read-method declarations leave the full write interface surface.
- **Reforge group (Governance section score):** 1758 → 1735 (**−23**, as scored against the cross-worktree baseline). The total is degraded-build noise: a same-worktree control showed every one of 27 sections drifting +8..+24 uniformly, and Governance itself moved only 1734 → 1735 (**+1**) under the same-worktree comparison. **Real structural signal (Governance byRule):** `fullServiceInterfaceMethod` 232 → 152 (−80, the 10 read methods leaving the write interface); `readServiceInterfaceMethod` 0 → 60 (+60, re-counted at lower weight); `oneImplementationInterface` +8, `diRegistration` +3, `missingPrimaryInfoDto` 0 → 10 (a new *advisory* — Governance lacks a canonical `<Section>Info` DTO; future work, not a regression). `crossSectionFullService` 72 → 72 unchanged — the consumer-side credit the partial compile fails to recompute.
- **Outside-lane increase:** 343 (the summed uniform per-section degraded-build noise described above; **not** an effect of this change — the same-worktree control attributes it entirely to the noisy partial compile).
- **Weighted value:** −23
- **Panel verdict:** unanimous **accept** (A / B / C). Declaration relocation, not invention: the 10 signatures on `IApplicationServiceRead` are byte-identical to the 10 deleted from the write interface; `IApplicationDecisionService : IApplicationServiceRead, IApplicationService` keeps them reachable; impl + repository byte-for-byte unchanged. The 9 migrated consumers (AdminDashboardService, DashboardService, GovernanceIndexService, NotificationMeterProvider, OnboardingService, SystemTeamSyncJob, HumansMetricsService, AdminNavTree, NavBadgesViewComponent) call **only** read-interface methods (`GetUserApplicationsAsync`, `GetPendingApplicationCountAsync`, `GetAdminStatsAsync`, `GetApprovedTiersForUserAsync`, `GetUserIdsWithPendingApplicationAsync`, `GetSubmittedApplicationForUserAsync`, `GetUnvotedApplicationCountAsync`, `GetActiveApprovedTierUserIdsAsync`, `GetOtherActiveTierAssignmentsAsync`, `HasActiveApprovedTierAsync`). The count/predicate methods query Governance-owned `applications` / `board_votes` tables external sections may not load, so the LENS-B reject trigger (bespoke predicate ADDED where canonical-DTO LINQ would do) does not fire — no in-memory canonical DTO exists to LINQ over. Genuine writers correctly retained on the full service (ProfileController → `SubmitAsync` / `UpdateDraftApplicationAsync`; TermRenewalReminderJob → `MarkRenewalReminderSentAsync`; plus the two in-section Governance controllers). DI mirrors the existing `IUserDataContributor` / `IUserMerge` singleton-delegation pattern (`AddScoped<IApplicationServiceRead>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>())`). Build PASS; Web 35/0, Application 329/0/1-skip; DI ValidateOnBuild smoke 7/0.

#### 5. Delete dead Board-daily-digest feed (3 read methods + the orphaned `ApprovedApplicationDigestEntry` DTO)
- **SHA:** `c0132d05552895e5fb30d4ab1f11269980378e53`
- **Concept deleted:** The entire dead "Board daily digest" read feed — three public read methods (`GetApprovedInWindowAsync`, `GetSubmittedApplicationIdsAsync`, `GetUnvotedCountForBoardMemberAmongApplicationsAsync`) declared on `IApplicationDecisionService`, implemented as pass-throughs, declared on `IApplicationRepository`, implemented as EF queries — plus the `ApprovedApplicationDigestEntry` DTO that was their only return shape. Zero production/test callers; the daily-digest job that would have consumed them was never wired.
- **Reforge group (Governance section score):** 1735 → 1628 (**−107**, real and un-noisy — overall delta equals the section delta exactly this run, so no per-section noise). `repositoryInterfaceMethod` −30, `repositoryImplementationMethod` −30, `fullServiceInterfaceMethod` −24, `applicationServiceMethod` −15, `methodParameterOverflow` −8.
- **Outside-lane increase:** 0
- **Weighted value:** 107
- **Panel verdict:** unanimous **accept** (A / B / C). Pure-deletion diff (111 del / 0 ins) across 4 Governance-owned files. Grep across `src/` + `tests/` returns NONE for all four symbols (sole residual is a historical line in `.codex/TECH_DEBT_QUEUE.md`, a log not a caller). Not on the cross-section read interface `IApplicationServiceRead`, so no migrated consumer is affected. No relocation, no accessibility narrowing, no orphaned imports (`MembershipTier` / NodaTime still used by surviving records). Build PASS; Governance|Architecture 230/0/1-skip; DI smoke 7/0.

#### 6. Create `IMembershipCalculatorRead`, register it in DI, migrate the 13 read-only membership-calculator consumers off `IMembershipCalculator`
- **SHA:** `919a6f80c2faddfa8d81b88de40cea5997e3368d`
- **Concept deleted:** The absence of a read boundary on Governance's *second* full service. Thirteen read-only cross-section consumers' dependency on the full/orchestrator `IMembershipCalculator` is replaced by a typed read contract; 9 read-method declarations leave the full interface surface.
- **Reforge group (Governance section score):** 1628 → 1642 (**+14**; overall delta equals section delta exactly, so no run-to-run noise this time). `diRegistration` 21 → 27 (+6, new concrete + read-interface delegate registrations); `oneImplementationInterface` 40 → 48 (+8, the new `IMembershipCalculatorRead`). `fullServiceInterfaceMethod` and `crossSectionFullService` are UNCHANGED — under the partial compile the moved methods are not re-weighted at the read tier and the consumer-side coupling credit is not recomputed, so the +14 is purely the scaffolding cost of the read interface. The genuine structural win (13 consumers dropping the full-service edge, 9 declarations leaving the full interface) is real but un-scored here — identical to commit 4's pattern.
- **Outside-lane increase:** 0
- **Weighted value:** 14
- **Panel verdict:** unanimous **accept** (A / B / C). Same canonical read-split pattern as commit 4. The 9 read methods on `IMembershipCalculatorRead` are byte-identical to 9 that pre-existed on `IMembershipCalculator` at the `origin/main` baseline (verified via `git show origin/main`) — moved, not invented; `IMembershipCalculator : IMembershipCalculatorRead, IApplicationService`; impl byte-for-byte unchanged. After migration **zero** production code injects the full `IMembershipCalculator` (only the impl declaration, the DI registration line, and XML-doc comments reference the type). The calculator is genuinely 100% read-only (no `SaveChanges` / `DbContext` / EF writes — `.Add` hits are in-memory `HashSet`/`List` builds), so all 13 consumers (AdminDashboardService, DashboardService, ProfileCardViewComponent, ThingsToDoViewComponent, OnboardingService, OnboardingWidgetState, ConsentService ×3 SP-resolves, SendReConsentReminderJob, SuspendNonCompliantMembersJob, SystemTeamSyncJob, HumansMetricsService, ShiftAdminPageBuilder, ProfileController) are legitimately read-only. The 3 methods retained on the full interface (`ComputeStatusAsync`, `HasActiveRolesAsync`, `HasAnyExpiredConsentsForTeamAsync`) have zero external callers (only in-section self-calls), correctly kept off the read surface. ProfileController honestly keeps the *separate* full `IApplicationDecisionService` for its writes, migrating only its calculator read dependency. DI uses concrete-then-delegate (one shared scoped `GovernanceMembershipCalculator` instance under both interfaces), preserving the `IMembershipQuery` DI-cycle break. Return types `MembershipSnapshot` / `MembershipPartition` are Application DTOs (HUM0029-clean). Build PASS; Domain 39/0, Web 55/0, Application 800/0/1-skip; DI ValidateOnBuild smoke 7/0.

---

## Cumulative Governance score movement

- **`origin/main` baseline:** 1758
- **After Wave 1 (3 commits):** 1734 (in-worktree)
- **After Wave 1b (3 commits):** **1642** (in-worktree final)
- **Net section delta across both waves:** **−116** (1758 → 1642), with **0** real outside-lane increase (the one nominal +343 on commit 4 is degraded-build noise proven by the uniform 27-section same-worktree control drift, not an effect of any change in this lane).

The single largest real reduction is the −107 dead Board-daily-digest feed deletion. The two read-split commits net a small *nominal* surface increase under the partial-compile scoring (the read-interface scaffolding), but deliver the lane's chartered structural win: **22 read-only cross-section consumers (9 + 13) dropped their full-service dependency for typed, existing-methods-only read contracts across Governance's two full services.**

## Candidates rejected and why

None. No candidate was evaluated and rejected in either wave; all six accepted commits passed the score-blind adversarial panel unanimously (A / B / C) on the first review.

## Remaining high-value work not done

- **No canonical cached `<Section>Info` DTO.** Reads still return many purpose-built DTOs with display facts stitched per-read via `IUserService.GetUserInfosAsync`. The read-split surfaced this as the `missingPrimaryInfoDto` advisory (commit 4). Consolidating onto a canonical read DTO is a larger design move out of scope for this lane.
- **Re-weight Governance on the read tier in `reforge.surface-score.json`.** Governance is absent from the hand-maintained `readServiceInterfaces` / `canonicalReadDtos` lists, so the two new read interfaces are not yet credited at the lower `readServiceInterfaceMethod` weight and the `crossSectionFullService` reduction is not recomputed. That config is outside this lane's allowed edit set; once added (and once the Reforge build resolves cleanly), the real surface reduction from both read-splits will register.
- **Do NOT collapse `IMembershipQuery`** — it is a deliberate DI-cycle-breaker pass-through to `ITeamServiceRead` + `IRoleAssignmentService` and must stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
