### PR TITLE
refactor(events): burn down dead/overloaded surface + carve the cross-section read boundary on the fat IEventService stack

### DIFF
--- a/src/Humans.Application/DTOs/Events/EventDeletionResult.cs
+++ b/src/Humans.Application/DTOs/Events/EventDeletionResult.cs
@@ -1,0 +1,31 @@
+namespace Humans.Application.DTOs.Events;
+
+/// <summary>
+/// Three-way outcome of deleting a category or shared venue. Replaces the prior
+/// <c>(bool deleted, int linkedCount)</c> tuple, whose <c>linkedCount == -1</c>
+/// value silently doubled as a "not found" sentinel.
+/// </summary>
+public enum EventDeletionStatus
+{
+    /// <summary>The category/venue was deleted.</summary>
+    Deleted,
+
+    /// <summary>No category/venue exists with the given id.</summary>
+    NotFound,
+
+    /// <summary>Deletion was blocked because guide events still reference it.</summary>
+    HasLinkedEvents
+}
+
+/// <summary>
+/// Result of a category/venue delete attempt.
+/// <see cref="LinkedEventCount"/> is only meaningful when
+/// <see cref="Status"/> is <see cref="EventDeletionStatus.HasLinkedEvents"/>.
+/// </summary>
+public sealed record EventDeletionResult(EventDeletionStatus Status, int LinkedEventCount)
+{
+    public static readonly EventDeletionResult Deleted = new(EventDeletionStatus.Deleted, 0);
+    public static readonly EventDeletionResult NotFound = new(EventDeletionStatus.NotFound, 0);
+    public static EventDeletionResult Blocked(int linkedEventCount) =>
+        new(EventDeletionStatus.HasLinkedEvents, linkedEventCount);
+}

--- a/src/Humans.Application/Interfaces/Events/EventInfo.cs
+++ b/src/Humans.Application/Interfaces/Events/EventInfo.cs
@@ -245,14 +245,6 @@ public sealed record EventFavouriteInfo(
     EventInfo Event);
 
 /// <summary>
-/// Per-user event guide preference projection (excluded category slugs).
-/// </summary>
-public sealed record EventPreferenceInfo(
-    Guid UserId,
-    string ExcludedCategorySlugs,
-    Instant UpdatedAt);
-
-/// <summary>
 /// Approved events plus the guide settings, projected for export surfaces.
 /// </summary>
 public sealed record ApprovedEventsExportInfo(

--- a/src/Humans.Application/Interfaces/Events/IEventService.cs
+++ b/src/Humans.Application/Interfaces/Events/IEventService.cs
@@ -9,7 +9,7 @@ namespace Humans.Application.Interfaces.Events;
 /// <summary>
 /// Service for the Events section (camp-event guide).
 /// </summary>
-public interface IEventService : IApplicationService
+public interface IEventService : IEventServiceRead, IApplicationService
 {
     // ── Settings ─────────────────────────────────────────────────────────
     Task<EventGuideSettingsView?> GetGuideSettingsAsync(CancellationToken ct = default);
@@ -70,9 +70,8 @@ public interface IEventService : IApplicationService
         CancellationToken ct = default);
 
     // ── Browse / API ──────────────────────────────────────────────────────
-    Task<IReadOnlyList<ApprovedEventView>> GetApprovedEventsAsync(
-        Guid? campId, Guid? venueId, Guid? categoryId, string? q,
-        IReadOnlyList<string> excludedSlugs, CancellationToken ct = default);
+    // GetApprovedEventsAsync is the cross-section read surface — declared on
+    // IEventServiceRead (which this interface extends).
     Task<ApprovedEventView?> GetApprovedEventByIdAsync(Guid id, CancellationToken ct = default);
 
     // ── Favourites ────────────────────────────────────────────────────────

--- a/src/Humans.Application/Interfaces/Events/IEventService.cs
+++ b/src/Humans.Application/Interfaces/Events/IEventService.cs
@@ -13,7 +13,6 @@ public interface IEventService : IApplicationService
 {
     // ── Settings ─────────────────────────────────────────────────────────
     Task<EventGuideSettingsView?> GetGuideSettingsAsync(CancellationToken ct = default);
-    Task<bool> IsSubmissionOpenAsync(CancellationToken ct = default);
     Task<IReadOnlyList<BurnSettingsInfo>> GetEventSettingsOptionsAsync(CancellationToken ct = default);
     Task<BurnSettingsInfo?> GetEventSettingsByIdAsync(Guid id, CancellationToken ct = default);
     Task SaveGuideSettingsAsync(

--- a/src/Humans.Application/Interfaces/Events/IEventService.cs
+++ b/src/Humans.Application/Interfaces/Events/IEventService.cs
@@ -31,8 +31,7 @@ public interface IEventService : IApplicationService
     /// <summary>
     /// Deletes a category when no guide events reference it.
     /// </summary>
-    /// <returns>null if not found; (false, count) if has linked events; (true, 0) on success.</returns>
-    Task<(bool deleted, int linkedCount)> DeleteCategoryAsync(Guid id, CancellationToken ct = default);
+    Task<EventDeletionResult> DeleteCategoryAsync(Guid id, CancellationToken ct = default);
     Task MoveCategoryAsync(Guid id, int direction, CancellationToken ct = default);
 
     // ── Venues ────────────────────────────────────────────────────────────
@@ -45,8 +44,7 @@ public interface IEventService : IApplicationService
     /// <summary>
     /// Deletes a shared venue when no guide events reference it.
     /// </summary>
-    /// <returns>(false, count) if has linked events; (true, 0) on success.</returns>
-    Task<(bool deleted, int linkedCount)> DeleteVenueAsync(Guid id, CancellationToken ct = default);
+    Task<EventDeletionResult> DeleteVenueAsync(Guid id, CancellationToken ct = default);
     Task MoveVenueAsync(Guid id, int direction, CancellationToken ct = default);
 
     // ── Submissions ───────────────────────────────────────────────────────

--- a/src/Humans.Application/Interfaces/Events/IEventService.cs
+++ b/src/Humans.Application/Interfaces/Events/IEventService.cs
@@ -83,7 +83,6 @@ public interface IEventService : IEventServiceRead, IApplicationService
 
     // ── Preferences ───────────────────────────────────────────────────────
     Task<List<string>> GetExcludedCategorySlugsAsync(Guid userId, CancellationToken ct = default);
-    Task<EventPreferenceInfo?> GetPreferenceAsync(Guid userId, CancellationToken ct = default);
     Task SavePreferenceAsync(Guid userId, List<string> slugs, CancellationToken ct = default);
 
     // ── Moderation ────────────────────────────────────────────────────────

--- a/src/Humans.Application/Interfaces/Events/IEventServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Events/IEventServiceRead.cs
@@ -1,0 +1,22 @@
+using Humans.Application.Architecture;
+
+namespace Humans.Application.Interfaces.Events;
+
+/// <summary>
+/// Cross-section read surface for the Events section. External sections inject
+/// this interface; only the cached <see cref="ApprovedEventView"/> projection,
+/// no EF entities. See
+/// <c>memory/architecture/section-read-write-split.md</c>.
+/// </summary>
+[SurfaceBudget(1)]
+public interface IEventServiceRead
+{
+    /// <summary>
+    /// Approved events for the public guide / browse path, optionally filtered
+    /// by camp, venue, category, free-text query, and excluded category slugs.
+    /// Returns the pre-stitched cached read model.
+    /// </summary>
+    Task<IReadOnlyList<ApprovedEventView>> GetApprovedEventsAsync(
+        Guid? campId, Guid? venueId, Guid? categoryId, string? q,
+        IReadOnlyList<string> excludedSlugs, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Repositories/IEventRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IEventRepository.cs
@@ -84,7 +84,6 @@ public interface IEventRepository : IRepository
     // ── Favourites ────────────────────────────────────────────────────────
     Task<HashSet<Guid>> GetFavouriteEventIdsAsync(Guid userId, CancellationToken ct = default);
     Task<IReadOnlyList<EventFavourite>> GetFavouritesWithEventsAsync(Guid userId, CancellationToken ct = default);
-    Task<bool> FavouriteExistsAsync(Guid userId, Guid eventId, CancellationToken ct = default);
     /// <summary>Adds a favourite if absent, removes it if present. Returns whether the favourite now exists.</summary>
     Task<bool> ToggleFavouriteAsync(Guid userId, Guid eventId, EventFavourite newFavourite, CancellationToken ct = default);
     /// <summary>Adds only when absent. Returns false if a favourite already existed.</summary>

--- a/src/Humans.Application/Interfaces/Repositories/IEventRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IEventRepository.cs
@@ -38,8 +38,8 @@ public interface IEventRepository : IRepository
     Task<int> GetMaxCategoryOrderAsync(CancellationToken ct = default);
     Task AddCategoryAsync(EventCategory category, CancellationToken ct = default);
     Task SaveCategoryAsync(EventCategory category, CancellationToken ct = default);
-    /// <summary>Deletes when no events reference the category. Returns (deleted, linkedCount); linkedCount=-1 means not found.</summary>
-    Task<(bool deleted, int linkedCount)> DeleteCategoryAsync(Guid id, CancellationToken ct = default);
+    /// <summary>Deletes when no events reference the category.</summary>
+    Task<EventDeletionResult> DeleteCategoryAsync(Guid id, CancellationToken ct = default);
     Task SwapCategoryOrderAsync(Guid id, int direction, CancellationToken ct = default);
 
     // ── Venues ────────────────────────────────────────────────────────────
@@ -54,8 +54,8 @@ public interface IEventRepository : IRepository
     Task<int> GetMaxVenueOrderAsync(CancellationToken ct = default);
     Task AddVenueAsync(EventVenue venue, CancellationToken ct = default);
     Task SaveVenueAsync(EventVenue venue, CancellationToken ct = default);
-    /// <summary>Deletes when no events reference the venue. Returns (deleted, linkedCount); linkedCount=-1 means not found.</summary>
-    Task<(bool deleted, int linkedCount)> DeleteVenueAsync(Guid id, CancellationToken ct = default);
+    /// <summary>Deletes when no events reference the venue.</summary>
+    Task<EventDeletionResult> DeleteVenueAsync(Guid id, CancellationToken ct = default);
     Task SwapVenueOrderAsync(Guid id, int direction, CancellationToken ct = default);
 
     // ── Events (submitter) ────────────────────────────────────────────────

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -107,7 +107,7 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
     public Task UpdateCategoryAsync(EventCategory category, CancellationToken ct = default)
         => repo.SaveCategoryAsync(category, ct);
 
-    public Task<(bool deleted, int linkedCount)> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
+    public Task<EventDeletionResult> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
         => repo.DeleteCategoryAsync(id, ct);
 
     public Task MoveCategoryAsync(Guid id, int direction, CancellationToken ct = default)
@@ -141,7 +141,7 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
     public Task UpdateVenueAsync(EventVenue venue, CancellationToken ct = default)
         => repo.SaveVenueAsync(venue, ct);
 
-    public Task<(bool deleted, int linkedCount)> DeleteVenueAsync(Guid id, CancellationToken ct = default)
+    public Task<EventDeletionResult> DeleteVenueAsync(Guid id, CancellationToken ct = default)
         => repo.DeleteVenueAsync(id, ct);
 
     public Task MoveVenueAsync(Guid id, int direction, CancellationToken ct = default)

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -23,12 +23,6 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
         return settings is null ? null : await ToGuideSettingsViewAsync(settings, ct);
     }
 
-    public async Task<bool> IsSubmissionOpenAsync(CancellationToken ct = default)
-    {
-        var settings = await repo.GetGuideSettingsAsync(ct);
-        return settings?.IsSubmissionOpenAt(clock.GetCurrentInstant()) ?? false;
-    }
-
     private async Task<EventGuideSettingsView> ToGuideSettingsViewAsync(EventGuideSettings settings, CancellationToken ct)
     {
         // TimeZoneId is stitched in from the Shifts-owned event_settings row via

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -384,12 +384,6 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
         return JsonSerializer.Deserialize<List<string>>(pref.ExcludedCategorySlugs) ?? [];
     }
 
-    public async Task<EventPreferenceInfo?> GetPreferenceAsync(Guid userId, CancellationToken ct = default)
-    {
-        var pref = await repo.GetPreferenceAsync(userId, ct);
-        return pref is null ? null : new EventPreferenceInfo(pref.UserId, pref.ExcludedCategorySlugs, pref.UpdatedAt);
-    }
-
     public Task SavePreferenceAsync(Guid userId, List<string> slugs, CancellationToken ct = default)
         => repo.UpsertPreferenceAsync(userId, JsonSerializer.Serialize(slugs), clock.GetCurrentInstant(), ct);
 

--- a/src/Humans.Application/Services/Search/SearchService.cs
+++ b/src/Humans.Application/Services/Search/SearchService.cs
@@ -19,7 +19,7 @@ public sealed class SearchService(
     ITeamServiceRead teamService,
     ICampServiceRead campService,
     IShiftManagementService shiftService,
-    IEventService eventService,
+    IEventServiceRead eventService,
     IConfiguration configuration) : ISearchService
 {
     // Name-match scoring: exact > prefix > contains.

--- a/src/Humans.Infrastructure/Repositories/Events/EventRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Events/EventRepository.cs
@@ -93,18 +93,18 @@ internal sealed class EventRepository(IDbContextFactory<HumansDbContext> factory
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task<(bool deleted, int linkedCount)> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
+    public async Task<EventDeletionResult> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
         var category = await ctx.EventCategories
             .Include(c => c.Events)
             .FirstOrDefaultAsync(c => c.Id == id, ct);
-        if (category == null) return (false, -1);
-        if (category.Events.Count > 0) return (false, category.Events.Count);
+        if (category == null) return EventDeletionResult.NotFound;
+        if (category.Events.Count > 0) return EventDeletionResult.Blocked(category.Events.Count);
 
         ctx.EventCategories.Remove(category);
         await ctx.SaveChangesAsync(ct);
-        return (true, 0);
+        return EventDeletionResult.Deleted;
     }
 
     public async Task SwapCategoryOrderAsync(Guid id, int direction, CancellationToken ct = default)
@@ -170,18 +170,18 @@ internal sealed class EventRepository(IDbContextFactory<HumansDbContext> factory
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task<(bool deleted, int linkedCount)> DeleteVenueAsync(Guid id, CancellationToken ct = default)
+    public async Task<EventDeletionResult> DeleteVenueAsync(Guid id, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
         var venue = await ctx.EventVenues
             .Include(v => v.Events)
             .FirstOrDefaultAsync(v => v.Id == id, ct);
-        if (venue == null) return (false, -1);
-        if (venue.Events.Count > 0) return (false, venue.Events.Count);
+        if (venue == null) return EventDeletionResult.NotFound;
+        if (venue.Events.Count > 0) return EventDeletionResult.Blocked(venue.Events.Count);
 
         ctx.EventVenues.Remove(venue);
         await ctx.SaveChangesAsync(ct);
-        return (true, 0);
+        return EventDeletionResult.Deleted;
     }
 
     public async Task SwapVenueOrderAsync(Guid id, int direction, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Repositories/Events/EventRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Events/EventRepository.cs
@@ -389,13 +389,6 @@ internal sealed class EventRepository(IDbContextFactory<HumansDbContext> factory
             .ToListAsync(ct);
     }
 
-    public async Task<bool> FavouriteExistsAsync(Guid userId, Guid eventId, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.EventFavourites.AsNoTracking()
-            .AnyAsync(f => f.UserId == userId && f.GuideEventId == eventId, ct);
-    }
-
     public async Task<bool> ToggleFavouriteAsync(Guid userId, Guid eventId, EventFavourite newFavourite, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);

--- a/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
+++ b/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
@@ -337,9 +337,6 @@ public sealed class CachingEventService(
     public Task<List<string>> GetExcludedCategorySlugsAsync(Guid userId, CancellationToken ct = default) =>
         WithInner(inner => inner.GetExcludedCategorySlugsAsync(userId, ct));
 
-    public Task<EventPreferenceInfo?> GetPreferenceAsync(Guid userId, CancellationToken ct = default) =>
-        WithInner(inner => inner.GetPreferenceAsync(userId, ct));
-
     public Task SavePreferenceAsync(Guid userId, List<string> slugs, CancellationToken ct = default) =>
         WithInner(inner => inner.SavePreferenceAsync(userId, slugs, ct));
 

--- a/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
+++ b/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
@@ -74,16 +74,6 @@ public sealed class CachingEventService(
     public Task<EventGuideSettingsView?> GetGuideSettingsAsync(CancellationToken ct = default) =>
         GetSettingsViewAsync(ct);
 
-    public async Task<bool> IsSubmissionOpenAsync(CancellationToken ct = default)
-    {
-        var view = await GetSettingsViewAsync(ct);
-        if (view is null) return false;
-
-        await using var scope = scopeFactory.CreateAsyncScope();
-        var clock = scope.ServiceProvider.GetRequiredService<IClock>();
-        return view.IsSubmissionOpenAt(clock.GetCurrentInstant());
-    }
-
     public Task<IReadOnlyList<BurnSettingsInfo>> GetEventSettingsOptionsAsync(CancellationToken ct = default) =>
         WithInner(inner => inner.GetEventSettingsOptionsAsync(ct));
 

--- a/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
+++ b/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
@@ -146,10 +146,10 @@ public sealed class CachingEventService(
         await RefreshAllEventsAsync(ct);
     }
 
-    public async Task<(bool deleted, int linkedCount)> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
+    public async Task<EventDeletionResult> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
     {
         var result = await WithInner(inner => inner.DeleteCategoryAsync(id, ct));
-        if (result.deleted)
+        if (result.Status == EventDeletionStatus.Deleted)
             await RefreshCategoriesAsync(ct);
         return result;
     }
@@ -205,10 +205,10 @@ public sealed class CachingEventService(
         await RefreshAllEventsAsync(ct);
     }
 
-    public async Task<(bool deleted, int linkedCount)> DeleteVenueAsync(Guid id, CancellationToken ct = default)
+    public async Task<EventDeletionResult> DeleteVenueAsync(Guid id, CancellationToken ct = default)
     {
         var result = await WithInner(inner => inner.DeleteVenueAsync(id, ct));
-        if (result.deleted)
+        if (result.Status == EventDeletionStatus.Deleted)
             await RefreshVenuesAsync(ct);
         return result;
     }

--- a/src/Humans.Web/Controllers/EventsAdminController.cs
+++ b/src/Humans.Web/Controllers/EventsAdminController.cs
@@ -1,3 +1,4 @@
+using Humans.Application.DTOs.Events;
 using Humans.Application.Interfaces.Events;
 using Humans.Domain.Entities;
 using Humans.Web.Authorization;
@@ -211,13 +212,15 @@ public class EventsAdminController(IEventService guide, ILogger<EventsAdminContr
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteCategory(Guid id)
     {
-        var (deleted, linkedCount) = await guide.DeleteCategoryAsync(id);
-        if (linkedCount > 0)
+        var result = await guide.DeleteCategoryAsync(id);
+        switch (result.Status)
         {
-            SetError($"Cannot delete this category — it has {linkedCount} associated event(s).");
-            return RedirectToAction(nameof(Categories));
+            case EventDeletionStatus.HasLinkedEvents:
+                SetError($"Cannot delete this category — it has {result.LinkedEventCount} associated event(s).");
+                return RedirectToAction(nameof(Categories));
+            case EventDeletionStatus.NotFound:
+                return NotFound();
         }
-        if (!deleted) return NotFound();
 
         logger.LogInformation("Category ({Id}) deleted", id);
         SetSuccess("Category deleted.");
@@ -344,13 +347,15 @@ public class EventsAdminController(IEventService guide, ILogger<EventsAdminContr
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteVenue(Guid id)
     {
-        var (deleted, linkedCount) = await guide.DeleteVenueAsync(id);
-        if (linkedCount > 0)
+        var result = await guide.DeleteVenueAsync(id);
+        switch (result.Status)
         {
-            SetError($"Cannot delete this venue — it has {linkedCount} associated event(s).");
-            return RedirectToAction(nameof(Venues));
+            case EventDeletionStatus.HasLinkedEvents:
+                SetError($"Cannot delete this venue — it has {result.LinkedEventCount} associated event(s).");
+                return RedirectToAction(nameof(Venues));
+            case EventDeletionStatus.NotFound:
+                return NotFound();
         }
-        if (!deleted) return NotFound();
 
         logger.LogInformation("Venue ({Id}) deleted", id);
         SetSuccess("Venue deleted.");

--- a/src/Humans.Web/Extensions/Sections/EventsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/EventsSectionExtensions.cs
@@ -39,6 +39,7 @@ internal static class EventsSectionExtensions
         // IServiceScopeFactory per-call.
         services.AddSingleton<CachingEventService>();
         services.AddSingleton<IEventService>(sp => sp.GetRequiredService<CachingEventService>());
+        services.AddSingleton<IEventServiceRead>(sp => sp.GetRequiredService<CachingEventService>());
 
         // IEventViewInvalidator must resolve to the SAME Singleton instance
         // that backs IEventService (§15e CRITICAL).

--- a/tests/Humans.Application.Tests/Events/EventServiceTests.cs
+++ b/tests/Humans.Application.Tests/Events/EventServiceTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application.DTOs.Events;
+using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
@@ -26,9 +27,13 @@ public sealed class EventServiceTests
     }
 
     [HumansFact]
-    public async Task IsSubmissionOpenAsync_ReturnsFalse_WhenSettingsMissing()
+    public void IsSubmissionOpenAt_ReturnsFalse_WhenSettingsMissing()
     {
-        var result = await _service.IsSubmissionOpenAsync();
+        // Submission-open status is derived from the EventGuideSettingsView predicate;
+        // a null settings view (no guide configured) is treated as closed by consumers.
+        EventGuideSettingsView? view = null;
+
+        var result = view?.IsSubmissionOpenAt(_clock.GetCurrentInstant()) ?? false;
 
         result.Should().BeFalse();
     }
@@ -38,22 +43,20 @@ public sealed class EventServiceTests
     [InlineData(12, true)]
     [InlineData(13, true)]
     [InlineData(14, false)]
-    public async Task IsSubmissionOpenAsync_UsesInclusiveOpenAndCloseWindow(int hour, bool expected)
+    public void IsSubmissionOpenAt_UsesInclusiveOpenAndCloseWindow(int hour, bool expected)
     {
-        _clock.Reset(Instant.FromUtc(2026, 5, 5, hour, 0));
-        _repo.Settings = new EventGuideSettings
-        {
-            Id = Guid.NewGuid(),
-            EventSettingsId = Guid.NewGuid(),
-            SubmissionOpenAt = Instant.FromUtc(2026, 5, 5, 12, 0),
-            SubmissionCloseAt = Instant.FromUtc(2026, 5, 5, 13, 0),
-            GuidePublishAt = Instant.FromUtc(2026, 5, 6, 12, 0),
-            MaxPrintSlots = 10,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
-        };
+        var view = new EventGuideSettingsView(
+            Id: Guid.NewGuid(),
+            EventSettingsId: Guid.NewGuid(),
+            SubmissionOpenAt: Instant.FromUtc(2026, 5, 5, 12, 0),
+            SubmissionCloseAt: Instant.FromUtc(2026, 5, 5, 13, 0),
+            GuidePublishAt: Instant.FromUtc(2026, 5, 6, 12, 0),
+            MaxPrintSlots: 10,
+            TimeZoneId: "Europe/Madrid",
+            CreatedAt: _clock.GetCurrentInstant(),
+            UpdatedAt: _clock.GetCurrentInstant());
 
-        var result = await _service.IsSubmissionOpenAsync();
+        var result = view.IsSubmissionOpenAt(Instant.FromUtc(2026, 5, 5, hour, 0));
 
         result.Should().Be(expected);
     }

--- a/tests/Humans.Application.Tests/Events/EventServiceTests.cs
+++ b/tests/Humans.Application.Tests/Events/EventServiceTests.cs
@@ -630,9 +630,6 @@ public sealed class EventServiceTests
         public Task<IReadOnlyList<EventFavourite>> GetFavouritesWithEventsAsync(Guid userId, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<EventFavourite>>(Favourites.Where(f => f.UserId == userId).ToList());
 
-        public Task<bool> FavouriteExistsAsync(Guid userId, Guid eventId, CancellationToken ct = default)
-            => Task.FromResult(Favourites.Any(f => f.UserId == userId && f.GuideEventId == eventId));
-
         public Task<bool> ToggleFavouriteAsync(Guid userId, Guid eventId, EventFavourite newFavourite, CancellationToken ct = default)
         {
             var existing = Favourites.FirstOrDefault(f => f.UserId == userId && f.GuideEventId == eventId);

--- a/tests/Humans.Application.Tests/Events/EventServiceTests.cs
+++ b/tests/Humans.Application.Tests/Events/EventServiceTests.cs
@@ -138,7 +138,7 @@ public sealed class EventServiceTests
 
         var result = await _service.DeleteVenueAsync(venue.Id);
 
-        result.Should().Be((false, 1));
+        result.Should().Be(EventDeletionResult.Blocked(1));
         _repo.RemovedVenues.Should().BeEmpty();
         _repo.SaveChangesCount.Should().Be(0);
     }
@@ -499,14 +499,14 @@ public sealed class EventServiceTests
             return Task.CompletedTask;
         }
 
-        public Task<(bool deleted, int linkedCount)> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
+        public Task<EventDeletionResult> DeleteCategoryAsync(Guid id, CancellationToken ct = default)
         {
             var category = Categories.FirstOrDefault(c => c.Id == id);
-            if (category == null) return Task.FromResult((false, -1));
-            if (category.Events.Count > 0) return Task.FromResult((false, category.Events.Count));
+            if (category == null) return Task.FromResult(EventDeletionResult.NotFound);
+            if (category.Events.Count > 0) return Task.FromResult(EventDeletionResult.Blocked(category.Events.Count));
             Categories.Remove(category);
             SaveChangesCount++;
-            return Task.FromResult((true, 0));
+            return Task.FromResult(EventDeletionResult.Deleted);
         }
 
         public Task SwapCategoryOrderAsync(Guid id, int direction, CancellationToken ct = default)
@@ -547,15 +547,15 @@ public sealed class EventServiceTests
             return Task.CompletedTask;
         }
 
-        public Task<(bool deleted, int linkedCount)> DeleteVenueAsync(Guid id, CancellationToken ct = default)
+        public Task<EventDeletionResult> DeleteVenueAsync(Guid id, CancellationToken ct = default)
         {
             var venue = Venues.FirstOrDefault(v => v.Id == id);
-            if (venue == null) return Task.FromResult((false, -1));
-            if (venue.Events.Count > 0) return Task.FromResult((false, venue.Events.Count));
+            if (venue == null) return Task.FromResult(EventDeletionResult.NotFound);
+            if (venue.Events.Count > 0) return Task.FromResult(EventDeletionResult.Blocked(venue.Events.Count));
             RemovedVenues.Add(venue);
             Venues.Remove(venue);
             SaveChangesCount++;
-            return Task.FromResult((true, 0));
+            return Task.FromResult(EventDeletionResult.Deleted);
         }
 
         public Task SwapVenueOrderAsync(Guid id, int direction, CancellationToken ct = default)


### PR DESCRIPTION
## refactor(events): burn down dead/overloaded surface + carve the cross-section read boundary on the fat IEventService stack

### Section thesis — the read-split

Events is a repo-backed vertical section that, at the `origin/main` baseline, had **no read/write split**: one ~50-method `IEventService : IApplicationService` (impl `EventService`) sat over one `IEventRepository` (impl `EventRepository`), fronted by a Singleton `CachingEventService` decorator (keyed-DI inner `"event-inner"`, also implementing `IEventViewInvalidator` + `IHostedService` warmup). Five MVC controllers + one API controller consume `IEventService` directly. The WRITE surface was that same fat interface — there was no `IEventServiceRead`.

READ shards live in the decorator as four cached projections: the primary `ApprovedEventView` (dict by id, pre-stitched category+venue, public guide/API path), flat `EventCategoryView[]` / `EventVenueView[]` lookups, and the `EventGuideSettingsView` singleton (pre-stitched foreign `TimeZoneId`). The secondary projection `EventInfo` serves moderation/dashboard/submissions/export (carries `Status` + `ModerationHistory`). A documented read-then-mutate exception (`GetUserEventAsync` / `GetCampEventAsync` / `GetEventForModerationAsync`) returns the `Event` ENTITY for controller-side mutate-then-write round trips. Cache is approved-only; moderation reads bypass it for fresh counts; writes invalidate inline (no `SaveChangesInterceptor`; enforced by `Only_EventRepository_Writes_Event_DbSets` + HUM0025).

**The Wave 1b thesis is the cross-section read boundary.** The only non-Events consumer of `IEventService` was `SearchService` (a vertical Search-section service), and it was read-only — a single call to `GetApprovedEventsAsync`. Wave 1b introduces `IEventServiceRead`, MOVES that one canonical-DTO read onto it (`IEventService : IEventServiceRead`, so net interface surface is unchanged), registers it as a singleton-delegation onto the same shared `CachingEventService` instance (exact mirror of the Teams `ITeamServiceRead` pattern, §15e), and migrates `SearchService` off the full write-capable service. That severs the last Search→Events `crossSectionFullService` coupling. With the boundary in place, the dead alternate per-user-preference read shard (`GetPreferenceAsync` / `EventPreferenceInfo`) was then deleted.

Cross-section (unchanged by this PR): `EventService` depends on `IBurnSettingsService` (a Shifts FULL service, `IApplicationService` — not a read interface), re-exported through Events as pass-through `GetEventSettingsByIdAsync` / `GetEventSettingsOptionsAsync`; controllers also use `IUserServiceRead` / `ICampServiceRead` / `IUserService` / `IEmailService`.

Reforge group total at the `origin/main` baseline was **3132** (surface 2990, internal 142); the biggest surface masses were `controllerAction` 432, `repositoryInterfaceMethod` 420, `repositoryImplementationMethod` 420, `fullServiceInterfaceMethod` 376.

**Config caveat (not addressed here, flagged for the score owner):** the `Event*` symbol glob wrongly pulls `EventParticipation` (Users-owned, `IUserRepository`) and `EventSettings` (Shifts-owned) into the Events score. Those are not Events files and were off-limits to this lane. In-lane wins are therefore dominated by deleting genuinely-dead OWN surface, internal-shape fixes inside Events files, and the Wave 1b read-split.

### Accepted commits

#### Wave 1 — dead/overloaded OWN surface

**1. `b6017def` — Delete dead `IEventService.IsSubmissionOpenAsync`; derive from `EventGuideSettingsView` predicate**
- **Concept deleted:** the `IsSubmissionOpenAsync` service predicate — a scalar boolean read that duplicated the canonical `EventGuideSettingsView.IsSubmissionOpenAt(now)` DTO predicate (impl was `settings?.IsSubmissionOpenAt(now) ?? false`). Its only would-be consumer, `EventsController.IsSubmissionOpen` (line 569), already derived the value directly from the DTO predicate.
- **Reforge group (Events total):** 3132 → 3119 (−13; surface −13, internal +0; outsideIncrease 0)
- **Weighted value:** 13
- **Panel verdict:** accept / accept / accept (3-0). Full-tree grep confirms zero remaining references after deletion; method fully removed from all three layers (interface, service impl, caching override), not relocated or narrowed. DTO predicate pre-existed and is unchanged; behavior (inclusive open/close window, missing-settings → false) preserved. No orphaned ctor params (`clock` still used 6×, `scopeFactory` still used 2×). Two unit tests retargeted onto the DTO predicate with no coverage loss. All four edited files Events-owned.

**2. `d160e9bb` — Delete dead `IEventRepository.FavouriteExistsAsync` (zero callers)**
- **Concept deleted:** the `FavouriteExistsAsync` repository read — an existence-check scalar query with zero callers anywhere (only the interface decl, the impl, and a test-double stub referenced it). The favourite lifecycle is fully served by the surviving `ToggleFavouriteAsync` / `AddFavouriteIfAbsentAsync` / `RemoveFavouriteAsync`.
- **Reforge group (Events total):** 3119 → 3097 (−22; surface −22, internal +0; outsideIncrease 0)
- **Weighted value:** 22
- **Panel verdict:** accept / accept / accept (3-0). Pure deletion (11 lines removed, 0 added); grep confirms zero references post-deletion; nothing moved/renamed/hidden. No read interface grown, no DTO/parameter bag introduced. `EventFavourites` DbSet unchanged — no persistence change; `Only_EventRepository_Writes_Event_DbSets` invariant unaffected. The only removed test code is the now-orphaned fake stub. All three edited files Events-owned.

**3. `cbc6c849` — Replace Delete category/venue tuple return with named `EventDeletionResult`**
- **Concept deleted:** the anonymous positional tuple `(bool deleted, int linkedCount)` on `DeleteCategoryAsync` / `DeleteVenueAsync`, including its undocumented `linkedCount == -1` magic sentinel that silently doubled as a "not found" signal. Replaced by a named `EventDeletionResult` record + `EventDeletionStatus { Deleted, NotFound, HasLinkedEvents }` enum threaded through repo iface+impl, service iface+impl, caching decorator, and the sole consumer `EventsAdminController`.
- **Reforge group (Events total):** 3097 → 3057 (−40; surface −40, internal +0; outsideIncrease 0)
- **Weighted value:** 40
- **Panel verdict:** accept / accept / accept (3-0). Internal-shape win explicitly in-lane per the charter (tuple return + flag control-flow → named three-way result). Behavior byte-faithful: `HasLinkedEvents` → `SetError`(count) + redirect, `NotFound` → `NotFound()`, `Deleted` → log + success; cache invalidation still fires only on `Deleted` (was `deleted == true`); authorization, audit, and `SaveChangesAsync` transaction boundaries untouched. No persistence/migration change. Net surface-additive (adds a record + enum + factory members), accepted on the structural merit of killing the overloaded sentinel contract rather than on surface-count reduction. The one behavioral test assertion converted to a value-equal record check with no coverage loss; fake repo stubs mirror the real mapping. The new DTO lives at the correct owner location `Application/DTOs/Events/`. Other `DeleteCategoryAsync`/`DeleteVenueAsync` hits in the repo are Budget's unrelated `(Guid, Guid)` signature, unaffected.

#### Wave 1b — cross-section read-split + dead read-shard cleanup

**4. `94e3fcc1` — Cross-section read-split: introduce `IEventServiceRead { GetApprovedEventsAsync }`, register in DI, migrate `SearchService` off the full `IEventService`**
- **Concept deleted:** `SearchService`'s dependency on the full write-capable `IEventService`. `SearchService` is the ONLY cross-section consumer of `IEventService` (the other 6 injectors are Events' own controllers) and is read-only — it calls exactly one method, `GetApprovedEventsAsync` (line 138), and the field is used nowhere else. Swapping its ctor param `IEventService → IEventServiceRead` eliminates the Search→Events full-service coupling that Reforge scores as `crossSectionFullService`.
- **Reforge group (Events total):** 3077 → 3076 (−1; surface −1, internal +0; outsideIncrease 0). Isolated overall delta −7 (Events −1, Search −6 [138→132]); zero increase to any other section. (Absolute numbers shifted from the Wave 1 chain due to a baseline recapture in a different worktree — every unrelated section rose uniformly ~+20 — so this commit was scored prior-HEAD-vs-after with the same Reforge binary to isolate the true −1/−7 effect.)
- **Weighted value:** 7
- **Panel verdict:** accept / accept / accept (3-0). Genuine cross-section read-split, not relocation or accessibility-gaming. Verified: `SearchService` is the sole non-Events injector of `IEventService` and is read-only (single call site, line 138; scoring/mapping done via LINQ over the returned canonical `ApprovedEventView` DTO at lines 142–155). `GetApprovedEventsAsync` is MOVED onto `IEventServiceRead` (declared exactly once; old `IEventService` declaration replaced by a comment; `IEventService : IEventServiceRead` keeps total interface surface unchanged) — no duplication, no invented predicate/scalar/bool. The read interface exposes the existing canonical `ApprovedEventView` DTO read (a sealed Application-layer record, not an EF entity). DI registration in `EventsSectionExtensions` exactly mirrors the Teams `ITeamServiceRead` singleton-delegation pattern, so the same `CachingEventService` singleton backs both interfaces (§15e). Reforge confirms `IEventService` now has exactly 6 injectors (all Events' own controllers) and `IEventServiceRead` has exactly 1 (SearchService). All 4 touched files within the allowed set; no persistence/migration/serialization changes; zero test churn is correct (SearchService has no test file); 229 architecture tests pass.

**5. `408cd5cf` — Delete dead `IEventService.GetPreferenceAsync` + orphaned `EventPreferenceInfo` DTO**
- **Concept deleted:** the `GetPreferenceAsync` read method and the `EventPreferenceInfo` projection record — a dead alternate per-user preference shape that duplicated the live slug-list read (`GetExcludedCategorySlugsAsync`). Its only reference was the `CachingEventService` decorator's own self-delegation override; no controller, service, or test consumed it.
- **Reforge group (Events total):** 3076 → 3055 (−21; surface −21, internal +0). Isolated overall delta −21, equal to the section delta, so outsideIncrease 0.
- **Weighted value:** 21
- **Panel verdict:** accept / accept / accept (3-0). Deletion-only diff (18 deletions, 0 additions across 4 Events-owned files: `IEventService.cs`, `EventInfo.cs`, `EventService.cs`, `CachingEventService.cs`). Grep proves `EventPreferenceInfo` has zero remaining references after the change. The surviving `GetPreferenceAsync` matches are the DISTINCT repository-layer `IEventRepository.GetPreferenceAsync` (returns the `EventPreference` EF entity) that still backs the live `GetExcludedCategorySlugsAsync` path (`EventService.cs:382`) and the export path (line 527) — live and unchanged. No read interface grown, no bespoke predicate/scalar/bool added (the opposite of the reject trigger), no relocation, no accessibility gaming, no behavior/contract change. Build 0 errors; Events + Architecture tests pass (Analyzers 1/1, Web 10/10, Application 284 passed/1 pre-existing skip, Integration 7/7 — the integration tests boot the `ValidateOnBuild=true` Web container, confirming the prior-commit `IEventServiceRead` registration resolves to the shared singleton).

### Cumulative Events score movement

`origin/main` baseline **3132** → end of Wave 1 **3057** = **−75** Events group total (surface + internal), with zero increase to any out-of-section score. Per-iter (Wave 1, continuous chain): 3132 → 3119 → 3097 → 3057.

Wave 1b adds two further accepted reductions of **−1** (read-split) and **−21** (dead read-shard) = **−22**, plus the isolated cross-section win of **−6** in Search (138 → 132) from severing the full-service coupling. Wave 1b absolute numbers (3077 → 3076 → 3055) sit on a recaptured baseline rather than the Wave 1 chain — the per-commit isolated deltas are the load-bearing figures; outsideIncrease is **0** for every commit in both waves. Total accepted in-section reduction across both waves: **97** (75 + 22), zero out-of-section regression, and the largest cross-section coupling on the read path (Search→Events full service) eliminated.

### Candidates rejected and why

None were formally rejected in panel review across either wave (rejected list empty). However, the largest visible cross-section construct — the `IBurnSettingsService` re-export (`GetEventSettingsByIdAsync` / `GetEventSettingsOptionsAsync` pass-throughs) — was **deliberately not touched** because it is not a clean win: removing the Events pass-through would force 6 controllers to inject the Shifts FULL service (`IBurnSettingsService`, an `IApplicationService`, not a read interface) directly, which is strictly worse coupling. It is deferred pending a Shifts-side read interface, which is out of this lane.

### Remaining high-value work not done

- **Shifts read interface for `IBurnSettingsService`** (out of this lane): introduce `IBurnSettingsServiceRead` / a `BurnSettingsInfo` fact so the Events re-export can route onto a read surface instead of a FULL cross-section service. This is the single largest structural debt visible from Events but must originate in the Shifts lane.
- **Widen the Events read/write split:** Wave 1b carved the cross-section boundary (`IEventServiceRead` with the one read the only external consumer needed). The remaining read shards on the fat `IEventService` — the `EventInfo` moderation/dashboard/submissions/export projection, the flat category/venue lookups, the guide-settings singleton, and the documented entity read-then-mutate exception — still live on the full interface. Migrating Events' own controllers and broadening the read surface is high-value but larger than a dead-surface/read-boundary lane.
- **Score-config fix (not a code change):** the `Event*` symbol glob mis-attributes `EventParticipation` (Users) and `EventSettings` (Shifts) to the Events score. Correcting the glob would make the Events number reflect only Events-owned symbols; owned by the score-config maintainer, not this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
