### PR TITLE
refactor(roleassignment): cross-section read-split (IRoleAssignmentServiceRead)

### DIFF
--- a/src/Humans.Application/Interfaces/Auth/IRoleAssignmentService.cs
+++ b/src/Humans.Application/Interfaces/Auth/IRoleAssignmentService.cs
@@ -3,23 +3,8 @@ using NodaTime;
 
 namespace Humans.Application.Interfaces.Auth;
 
-public interface IRoleAssignmentService : IApplicationService
+public interface IRoleAssignmentService : IRoleAssignmentServiceRead, IApplicationService
 {
-    Task<bool> HasOverlappingAssignmentAsync(
-        Guid userId,
-        string roleName,
-        Instant validFrom,
-        Instant? validTo = null,
-        CancellationToken cancellationToken = default);
-
-    Task<(IReadOnlyList<RoleAssignmentSummarySnapshot> Items, int TotalCount)> GetFilteredAsync(
-        string? roleFilter, bool activeOnly, int page, int pageSize, Instant now,
-        CancellationToken ct = default);
-
-    Task<RoleAssignmentDetailSnapshot?> GetByIdAsync(Guid assignmentId, CancellationToken ct = default);
-
-    Task<IReadOnlyList<RoleAssignmentSummarySnapshot>> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
-
     Task<OnboardingResult> AssignRoleAsync(
         Guid userId, string roleName, Guid assignerId,
         string? notes,
@@ -31,58 +16,11 @@ public interface IRoleAssignmentService : IApplicationService
         CancellationToken ct = default);
 
     /// <summary>
-    /// Checks if a user has an active Admin role assignment.
-    /// </summary>
-    Task<bool> IsUserAdminAsync(Guid userId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Checks if a user has an active Board role assignment.
-    /// </summary>
-    Task<bool> IsUserBoardMemberAsync(Guid userId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Checks if a user has an active TeamsAdmin role assignment.
-    /// </summary>
-    Task<bool> IsUserTeamsAdminAsync(Guid userId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Checks if a user has an active assignment for the specified role.
-    /// Generic version — prefer the specific Is*Async methods when available.
-    /// </summary>
-    Task<bool> HasActiveRoleAsync(Guid userId, string roleName, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns true if the user has any active role assignment (regardless of role name).
-    /// Used by the membership calculator to distinguish governance members from
-    /// plain volunteers.
-    /// </summary>
-    Task<bool> HasAnyActiveAssignmentAsync(Guid userId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns the distinct set of user IDs that have at least one active
-    /// role assignment at the current instant. Used by batch jobs
-    /// (e.g., membership status reconciliation) that need to enumerate every
-    /// governance-active user without reading the role assignments table
-    /// themselves.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetUserIdsWithActiveAssignmentsAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Ends all active governance role assignments for a user by setting
     /// <c>ValidTo</c> to now. Returns the count of ended assignments.
     /// Used during account deletion.
     /// </summary>
     Task<int> RevokeAllActiveAsync(Guid userId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the user ids of every human with an active assignment for the
-    /// given role. Read-only. Used by cross-section composers that need to
-    /// enumerate Board members, Coordinators, etc. without touching the
-    /// <c>role_assignments</c> table directly — including notification
-    /// dispatch for role-targeted sends.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetActiveUserIdsInRoleAsync(
-        string roleName, CancellationToken ct = default);
 
     /// <summary>
     /// Evicts the cached claims for <paramref name="userId"/> so the next
@@ -101,7 +39,7 @@ public interface IRoleAssignmentService : IApplicationService
 
     /// <summary>
     /// Evicts the singleton role-assignment row cache (the one backing
-    /// <see cref="GetActiveCountsByRoleAsync"/>). Called post-commit by
+    /// <see cref="IRoleAssignmentServiceRead.GetActiveCountsByRoleAsync"/>). Called post-commit by
     /// <c>AccountMergeService.AcceptAsync</c> after a fold, since the fold's
     /// bulk re-FK happens through <c>IRoleAssignmentRepository.ReassignToUserAsync</c>
     /// without flowing through one of this service's standalone write
@@ -110,21 +48,6 @@ public interface IRoleAssignmentService : IApplicationService
     /// invalidate themselves and do not require the caller to do so.
     /// </summary>
     void InvalidateRoleAssignmentCache();
-
-    /// <summary>
-    /// Returns all currently active role assignments for the user
-    /// (ValidFrom &lt;= now and ValidTo is null or in the future).
-    /// Used by the agent snapshot provider.
-    /// </summary>
-    Task<IReadOnlyList<RoleAssignmentSnapshot>> GetActiveForUserAsync(Guid userId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the count of currently active role assignments grouped by role
-    /// name. Used by the metrics snapshot refresh so the metrics service does
-    /// not need to read <c>role_assignments</c> directly.
-    /// </summary>
-    Task<IReadOnlyDictionary<string, int>> GetActiveCountsByRoleAsync(CancellationToken ct = default);
-
 }
 
 public sealed record RoleAssignmentSnapshot(

--- a/src/Humans.Application/Interfaces/Auth/IRoleAssignmentServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Auth/IRoleAssignmentServiceRead.cs
@@ -1,0 +1,89 @@
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Auth;
+
+/// <summary>
+/// Cross-section read surface for the RoleAssignment (Auth) section. External
+/// sections inject this interface for read-only governance-role facts; only the
+/// canonical <see cref="RoleAssignmentSnapshot"/> / <see cref="RoleAssignmentSummarySnapshot"/>
+/// / <see cref="RoleAssignmentDetailSnapshot"/> projections, no EF entities. See
+/// <c>memory/architecture/section-read-write-split.md</c>.
+/// </summary>
+public interface IRoleAssignmentServiceRead
+{
+    Task<bool> HasOverlappingAssignmentAsync(
+        Guid userId,
+        string roleName,
+        Instant validFrom,
+        Instant? validTo = null,
+        CancellationToken cancellationToken = default);
+
+    Task<(IReadOnlyList<RoleAssignmentSummarySnapshot> Items, int TotalCount)> GetFilteredAsync(
+        string? roleFilter, bool activeOnly, int page, int pageSize, Instant now,
+        CancellationToken ct = default);
+
+    Task<RoleAssignmentDetailSnapshot?> GetByIdAsync(Guid assignmentId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<RoleAssignmentSummarySnapshot>> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks if a user has an active Admin role assignment.
+    /// </summary>
+    Task<bool> IsUserAdminAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a user has an active Board role assignment.
+    /// </summary>
+    Task<bool> IsUserBoardMemberAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a user has an active TeamsAdmin role assignment.
+    /// </summary>
+    Task<bool> IsUserTeamsAdminAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a user has an active assignment for the specified role.
+    /// Generic version — prefer the specific Is*Async methods when available.
+    /// </summary>
+    Task<bool> HasActiveRoleAsync(Guid userId, string roleName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns true if the user has any active role assignment (regardless of role name).
+    /// Used by the membership calculator to distinguish governance members from
+    /// plain volunteers.
+    /// </summary>
+    Task<bool> HasAnyActiveAssignmentAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the distinct set of user IDs that have at least one active
+    /// role assignment at the current instant. Used by batch jobs
+    /// (e.g., membership status reconciliation) that need to enumerate every
+    /// governance-active user without reading the role assignments table
+    /// themselves.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetUserIdsWithActiveAssignmentsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the user ids of every human with an active assignment for the
+    /// given role. Read-only. Used by cross-section composers that need to
+    /// enumerate Board members, Coordinators, etc. without touching the
+    /// <c>role_assignments</c> table directly — including notification
+    /// dispatch for role-targeted sends.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveUserIdsInRoleAsync(
+        string roleName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all currently active role assignments for the user
+    /// (ValidFrom &lt;= now and ValidTo is null or in the future).
+    /// Used by the agent snapshot provider.
+    /// </summary>
+    Task<IReadOnlyList<RoleAssignmentSnapshot>> GetActiveForUserAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of currently active role assignments grouped by role
+    /// name. Used by the metrics snapshot refresh so the metrics service does
+    /// not need to read <c>role_assignments</c> directly.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, int>> GetActiveCountsByRoleAsync(CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -25,7 +25,7 @@ namespace Humans.Application.Services.Governance;
 public sealed class ApplicationDecisionService(
     IApplicationRepository repository,
     IUserService userService,
-    IRoleAssignmentService roleAssignmentService,
+    IRoleAssignmentServiceRead roleAssignmentService,
     IAuditLogService auditLogService,
     IEmailService emailService,
     IEmailMessageFactory emailMessages,

--- a/src/Humans.Application/Services/Governance/MembershipQuery.cs
+++ b/src/Humans.Application/Services/Governance/MembershipQuery.cs
@@ -4,9 +4,9 @@ using Humans.Application.Interfaces.Teams;
 
 namespace Humans.Application.Services.Governance;
 
-// Pass-through to ITeamServiceRead + IRoleAssignmentService. Exists to break the DI cycle
+// Pass-through to ITeamServiceRead + IRoleAssignmentServiceRead. Exists to break the DI cycle
 // MembershipCalculator → ITeamService → ISystemTeamSync → IMembershipCalculator.
-public sealed class MembershipQuery(ITeamServiceRead teamService, IRoleAssignmentService roleAssignmentService)
+public sealed class MembershipQuery(ITeamServiceRead teamService, IRoleAssignmentServiceRead roleAssignmentService)
     : IMembershipQuery
 {
     public async Task<IReadOnlyList<MembershipTeamSnapshot>> GetUserTeamsAsync(

--- a/src/Humans.Application/Services/Issues/IssuesService.cs
+++ b/src/Humans.Application/Services/Issues/IssuesService.cs
@@ -28,7 +28,7 @@ public sealed class IssuesService(
     IIssuesRepository repo,
     IUserServiceRead users,
     IUserEmailService userEmails,
-    IRoleAssignmentService roles,
+    IRoleAssignmentServiceRead roles,
     IEmailService email,
     IEmailMessageFactory emailMessages,
     INotificationService notifications,

--- a/src/Humans.Application/Services/Notifications/NotificationRecipientResolver.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationRecipientResolver.cs
@@ -6,13 +6,13 @@ namespace Humans.Application.Services.Notifications;
 
 /// <summary>
 /// Pass-through adapter delegating to <see cref="ITeamServiceRead"/> and
-/// <see cref="IRoleAssignmentService"/>. Exists so <see cref="INotificationService"/>
+/// <see cref="IRoleAssignmentServiceRead"/>. Exists so <see cref="INotificationService"/>
 /// doesn't depend on those services directly (they inject INotificationService,
 /// which would close a DI cycle).
 /// </summary>
 public sealed class NotificationRecipientResolver(
     ITeamServiceRead teamService,
-    IRoleAssignmentService roleAssignmentService) : INotificationRecipientResolver
+    IRoleAssignmentServiceRead roleAssignmentService) : INotificationRecipientResolver
 {
     public async Task<TeamNotificationInfo?> GetTeamNotificationInfoAsync(
         Guid teamId,

--- a/src/Humans.Application/Services/Profiles/ContactFieldService.cs
+++ b/src/Humans.Application/Services/Profiles/ContactFieldService.cs
@@ -18,7 +18,7 @@ public sealed class ContactFieldService(
     IUserRepository userRepository,
     IUserServiceRead userService,
     ITeamServiceRead teamService,
-    IRoleAssignmentService roleAssignmentService,
+    IRoleAssignmentServiceRead roleAssignmentService,
     IUserInfoInvalidator userInfoInvalidator,
     IClock clock,
     ILogger<ContactFieldService> logger) : IContactFieldService, IUserMerge

--- a/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
+++ b/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
@@ -21,14 +21,14 @@ public sealed class OnsiteRosterService : IOnsiteRosterService, IApplicationServ
     private readonly IShiftManagementService _shifts;
     private readonly ICampServiceRead _camps;
     private readonly ITeamServiceRead _teams;
-    private readonly IRoleAssignmentService _roles;
+    private readonly IRoleAssignmentServiceRead _roles;
 
     public OnsiteRosterService(
         IUserServiceRead users,
         IShiftManagementService shifts,
         ICampServiceRead camps,
         ITeamServiceRead teams,
-        IRoleAssignmentService roles)
+        IRoleAssignmentServiceRead roles)
     {
         _users = users;
         _shifts = shifts;

--- a/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
@@ -15,7 +15,7 @@ namespace Humans.Infrastructure.Services.Agent;
 
 public sealed class AgentUserSnapshotProvider(
     IUserServiceRead users,
-    IRoleAssignmentService roles,
+    IRoleAssignmentServiceRead roles,
     ITeamServiceRead teams,
     IConsentServiceRead consents,
     IFeedbackService feedback,

--- a/src/Humans.Web/Controllers/AboutController.cs
+++ b/src/Humans.Web/Controllers/AboutController.cs
@@ -13,7 +13,7 @@ namespace Humans.Web.Controllers;
 [Route("[controller]")]
 public class AboutController(
     IUserServiceRead userService,
-    IRoleAssignmentService roleAssignmentService,
+    IRoleAssignmentServiceRead roleAssignmentService,
     IClock clock,
     ILogger<AboutController> logger) : HumansControllerBase(userService)
 {

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -24,7 +24,7 @@ public class ProfileAdminController(
     IAuditLogService audit,
     ILogger<ProfileAdminController> logger,
     ITeamServiceRead teamService,
-    IRoleAssignmentService roleAssignmentService) : HumansControllerBase(userService)
+    IRoleAssignmentServiceRead roleAssignmentService) : HumansControllerBase(userService)
 {
     [HttpGet("EmailProblems")]
     public async Task<IActionResult> EmailProblems(CancellationToken ct)

--- a/src/Humans.Web/Extensions/Sections/AuthSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/AuthSectionExtensions.cs
@@ -44,6 +44,8 @@ internal static class AuthSectionExtensions
         services.AddSingleton<CachingRoleAssignmentService>();
         services.AddSingleton<IRoleAssignmentService>(sp =>
             sp.GetRequiredService<CachingRoleAssignmentService>());
+        services.AddSingleton<IRoleAssignmentServiceRead>(sp =>
+            sp.GetRequiredService<CachingRoleAssignmentService>());
         services.AddSingleton<IRoleAssignmentCacheInvalidator>(sp =>
             sp.GetRequiredService<CachingRoleAssignmentService>());
         services.AddSingleton<ICacheStats>(sp =>

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -24,7 +24,7 @@ public class ProfileCardViewComponent(
     IContactFieldService contactFieldService,
     IUserEmailService userEmailService,
     ITeamServiceRead teamService,
-    IRoleAssignmentService roleAssignmentService,
+    IRoleAssignmentServiceRead roleAssignmentService,
     IMembershipCalculator membershipCalculator,
     ICommunicationPreferenceService commPrefService) : ViewComponent
 {

--- a/tests/Humans.Application.Tests/Architecture/IssuesArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/IssuesArchitectureTests.cs
@@ -48,8 +48,8 @@ public class IssuesArchitectureTests
             because: "Issues resolves reporter / assignee / resolver / comment-sender display names via IUserServiceRead instead of taking the write-capable user service or using cross-domain .Include() chains");
         paramTypes.Should().Contain(typeof(IUserEmailService),
             because: "Issues resolves the reporter's effective notification email via IUserEmailService.GetNotificationTargetEmailsAsync — no User.UserEmails navigation");
-        paramTypes.Should().Contain(typeof(IRoleAssignmentService),
-            because: "Issues fans out comment notifications to section role-holders via IRoleAssignmentService.GetActiveUserIdsInRoleAsync — no direct query on the role_assignments table");
+        paramTypes.Should().Contain(typeof(IRoleAssignmentServiceRead),
+            because: "Issues fans out comment notifications to section role-holders via IRoleAssignmentServiceRead.GetActiveUserIdsInRoleAsync — read-only cross-section access through the read interface, no direct query on the role_assignments table");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Thesis — RoleAssignment (Auth) cross-section read-split

Auth's `IRoleAssignmentService` was a single fat interface bundling read facts, writes, and cache-control. Every cross-section consumer — including the ~10 that only ever *read* role facts — took a constructor dependency on the **full** service, scoring `crossSectionFullService` coupling and leaving Auth with a `missingReadSurface` deficiency.

This refactor applies the canonical **section read-write-split** (the Teams / `ITeamServiceRead` pattern, documented at `memory/architecture/section-read-write-split.md`):

- Carve the 13 read methods out into a new `IRoleAssignmentServiceRead` (verbatim relocation — identical signatures and XML docs, no bespoke predicate/scalar/bool method invented, no new DTO).
- Re-parent the full interface: `IRoleAssignmentService : IRoleAssignmentServiceRead, IApplicationService`, so it now declares only the 3 writes (`AssignRoleAsync` / `EndRoleAsync` / `RevokeAllActiveAsync`) plus the 3 `Invalidate*` cache-control methods.
- Both implementing classes (`RoleAssignmentService`, `CachingRoleAssignmentService`) satisfy the read interface **for free via inheritance** — zero body changes.
- DI-register `IRoleAssignmentServiceRead` as a singleton delegating to the **same** `CachingRoleAssignmentService` instance (mirrors `ITeamServiceRead`), so cross-section reads still hit the warmed `RoleAssignmentRow` cache.
- Migrate the 10 read-only consumers onto the read sub-interface; leave the 5 genuine write/cache-control consumers on the full interface.

The structural win is at the **consumer edges**: 10 cross-section consumers shed their full read+write+cache-control dependency and now depend only on the lighter read sub-interface. Auth remains horizontal — it gained no reference to any vertical section, only exposes read facts returning canonical DTOs/primitives.

## Accepted commits

### Wave 1 / 1b — `9d41c61` · RoleAssignment (Auth) cross-section read-split

- **Concept deleted:** the Tickets / Governance / Agent / Notifications / Issues / Profiles → Auth **full-service constructor dependency** for 10 read-only consumers (`crossSectionFullService` coupling), plus Auth's `missingReadSurface` deficiency.
- **Reforge group (Auth section):** `1066 → 1061` (**-5**); surface -5, internal +0.
- **Per-rule breakdown** (the architecturally-honest signal, computed directly from the two stage JSONs):
  - `crossSectionFullService`: `2248 → 2168` (**-80**) — consumers shed full-service deps
  - `fullServiceInterfaceMethod`: `6328 → 6224` (**-104**) — 13 read methods left the full interface
  - `readServiceInterfaceMethod`: `240 → 318` (**+78**) — they now live on the lighter read interface
  - `crossSectionReadInterface`: `378 → 398` (**+20**) — consumers gained the lighter read dep
  - **Net of the read-split's four rules: -86 (weighted value).**
- **Where the coupling dropped:** `crossSectionFullService` fell EXACTLY on the 6 migrated consumer sections and nowhere else — Tickets 192→184, Governance 72→56, Agent 40→32, Notifications 40→32, Issues 40→32, Users 376→344.
- **Panel verdict: accept (unanimous across all three active lenses).**
  - **Lens A — accept:** Genuine cross-section read-write-split, not relocation-gaming. The 13 read methods were moved to `IRoleAssignmentServiceRead` and the full interface re-parented (canonical Teams pattern). Verified call-site by call-site that every migrated consumer invokes only read methods (the `Invalidate` hits in those files were on unrelated badge/meter services). The 5 write consumers (AccountMergeService, DuplicateAccountService, AccountDeletionService, ProfileController, DevPersonaSeeder) correctly retained the full interface. No accessibility narrowing, no signature weakening, no callers deleted to dodge a count. Both impls implement the read interface for free via inheritance with zero body changes. DI mirrors the `ITeamServiceRead` singleton-delegation pattern. `TeamDirectoryBuilder` (static class, service-as-method-parameter) doesn't score `crossSectionFullService` and is legitimately out of scope. Independent build: 0 errors.
  - **Lens B — accept:** Verified against origin/main that `IRoleAssignmentServiceRead` contains exactly the 13 read methods VERBATIM-relocated — identical signatures and XML docs, no bespoke method, no new DTO. Full interface re-parented; impls satisfy the read interface for free via inheritance, zero body changes. Read interface DI-registered as a singleton delegating to the same `CachingRoleAssignmentService`, so cross-section reads still hit the warmed cache. All 10 migrated consumers (OnsiteRosterService, AgentUserSnapshotProvider, NotificationRecipientResolver, IssuesService, ApplicationDecisionService, MembershipQuery, ContactFieldService, ProfileCardViewComponent, AboutController, ProfileAdminController) call ONLY read methods. Auth remains horizontal. `IssuesArchitectureTests` ctor-type assertion flipped in the same diff; all other consumer tests use `Substitute.For<IRoleAssignmentService>()` which is assignable to the read base and compile unchanged.
  - **Lens C — accept:** Clean, genuine read-write split following the canonical Teams pattern. Verified independently: (1) build 0 errors / 125 warnings, all pre-existing HUM0025/HUM0014 unrelated; (2) `DiResolutionSmoke` passes — `IRoleAssignmentServiceRead` is registered in `AuthSectionExtensions.cs:47-48` as a singleton delegating to the same `CachingRoleAssignmentService`, so it actually resolves in the Web container with `ValidateOnBuild=true`; (3) all Architecture + migrated-consumer tests pass (418 Application + 5 Web + 1 Integration). Migrated data is byte-identical — no method bodies changed, reads still hit the warmed `RoleAssignmentRow` cache via the same singleton; cache/audit/transaction semantics untouched. No public read surface was deleted — relocated, so full-service callers retain everything transitively. Auth remains horizontal (new interface lives in `Interfaces/Auth`, exposes only read facts).

## Cumulative Auth movement

| Stage | Auth Reforge group | Δ |
|-------|-------------------:|---:|
| origin/main | 1066 | — |
| after `9d41c61` | 1061 | **-5** |
| **Cumulative** | **1061** | **-5** |

Architecturally-honest weighted value across both waves: **-86** (net of the read-split's four rules).

> **On the +331 overall delta:** this is degraded-compilation NOISE, not regression. `missingReadSurface` (0→150), `missingPrimaryInfoDto` (0→180), and `readSurfaceProjectionMethod` (0→76) suddenly fired on 15–18 UNRELATED sections (Events, Budget, Store, Finance, CityPlanning, Containers…). Both runs are `build.degraded` with identical 6 errors / 4 unresolved refs; the partial Roslyn compile resolved rule families differently between runs (+406 of cross-section noise). A 13-method RoleAssignment migration cannot create "missing read surface" in Events/Budget. Notably `missingReadSurface` does NOT fire on Auth in the after-run — correct, since this change ADDED Auth's read surface. The delta script also crashed on an unrelated pre-existing bug (line 105 `improvement = baseline.get(...)` shadows the module-level `improvement` function → UnboundLocalError); the two authoritative section/overall delta lines printed before the crash.

## Rejected candidates

None this wave.

## Remaining work

- **`TeamDirectoryBuilder`** — a static helper that takes the role service as a **method parameter** (not a ctor dependency), so it does not score `crossSectionFullService` and was legitimately out of scope. It is a read-only consumer; routing it onto `IRoleAssignmentServiceRead` is a minor follow-up, not a defect in this work.
- **Lazy `GetRequiredService` consumers** are likewise out of scope for the ctor-dependency-driven migration.
- The 5 genuine write/cache-control consumers (AccountMergeService, DuplicateAccountService, AccountDeletionService, ProfileController, DevPersonaSeeder) correctly remain on the full `IRoleAssignmentService` — no work needed.

## Verification

- **Build:** succeeded — 0 errors, 125 warnings (all pre-existing HUM0025 table-ownership / HUM0014 web-injects-repository, unrelated to this change).
- **Tests:** Humans.Application.Tests 436 passed / 1 skipped, Humans.Web.Tests 5 passed, Humans.Integration.Tests `DiResolutionSmoke` 1 passed (Web container `ValidateOnBuild=true` resolves `IRoleAssignmentServiceRead` cleanly), Humans.Domain.Tests 6 passed. 0 failures.
- **Scope:** interface / service / controller / DI / test edits only — no EF migrations, no DbContext/model/schema changes, no entity persistence-shape or JSON serialization changes. Repository-layer-and-above only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
