### PR TITLE
fix(ci): build worktrees before reforge surface-score

### DIFF
--- a/.github/workflows/pr-surface-report.yml
+++ b/.github/workflows/pr-surface-report.yml
@@ -2,8 +2,9 @@ name: PR Surface Report
 
 # Build/analysis half of the surface report. Runs on `pull_request` (NOT
 # pull_request_target) so that for fork PRs it carries only a read-only token
-# and no secrets. This job restores/builds PR-head code via reforge, which can
-# execute fork-authored MSBuild targets — that is acceptable ONLY because this
+# and no secrets. This job restores+builds PR-head code (`dotnet build`) and
+# scores it with reforge; both execute fork-authored MSBuild targets — that is
+# acceptable ONLY because this
 # job has nothing privileged to steal and no privileged follow-up step to
 # poison (no commenting here). The privileged comment is posted by the separate
 # pr-surface-report-comment.yml workflow, triggered via workflow_run, which
@@ -71,11 +72,19 @@ jobs:
           "$REFORGE" stop || true
           (
             cd "$BASE_DIR"
+            # Restore+build before scoring: reforge opens the solution via
+            # MSBuildWorkspace, which needs each project's obj/project.assets.json
+            # to resolve package/project references. An unbuilt worktree yields
+            # tens of thousands of unresolved-reference errors and a PARTIAL
+            # surface-score (cross-section/DI/entity rules under-count). reforge
+            # is a query tool, not a build tool, so the caller must build.
+            dotnet build Humans.slnx --disable-build-servers -v quiet
             "$REFORGE" surface-score --solution Humans.slnx "${CONFIG_ARGS[@]}" --format Json --top 200 > "$GITHUB_WORKSPACE/reforge-base.json"
           )
           "$REFORGE" stop || true
           (
             cd "$HEAD_DIR"
+            dotnet build Humans.slnx --disable-build-servers -v quiet
             "$REFORGE" surface-score --solution Humans.slnx "${CONFIG_ARGS[@]}" --format Json --top 200 > "$GITHUB_WORKSPACE/reforge-head.json"
           )
           "$REFORGE" stop || true


### PR DESCRIPTION
## Problem
`pr-surface-report.yml` ran `reforge surface-score` against freshly-created `git worktree` checkouts that were **never restored or built**. reforge opens the solution via MSBuildWorkspace, which needs each project's `obj/project.assets.json` (produced by restore) to resolve package/project references. Without it, the recent reforge 0.20 run reported **47,165 compile errors / 22,208 unresolved references** and flagged the score as `PARTIAL` — meaning cross-section/DI/entity rules silently under-count.

reforge 0.20 didn't introduce this — it added the degraded-build *detector* that finally surfaced it. Every prior surface report scored the same unbuilt worktrees and produced equally partial numbers, silently. (The smoking gun: base and head both sat at ~47k errors, i.e. the same noise floor, with only a 2-error real delta on top.)

## Fix
Run `dotnet build Humans.slnx --disable-build-servers -v quiet` in each (base + head) worktree before scoring. reforge is a query tool, not a build tool, so the caller must build. `set -euo pipefail` is already in effect, so a genuinely uncompilable PR now **fails this step loudly** instead of emitting a garbage score.

Also corrected the header comment: the job now explicitly builds fork code via `dotnet build` (not "via reforge"). Fork-PR threat model is unchanged — `pull_request` trigger, read-only token, no secrets; `dotnet build` runs the same fork-authored MSBuild that reforge already executed.

## Verification
Built a fresh worktree off `origin/main` with the exact CI command: **0 errors**, exit 0, ~56s cold — so ~2 min added per PR for the two builds.

## Follow-up (separate, not in this PR)
The local `.codex/skills/humans-refactor` harness has the same gap: its stage00 baseline scores an unbuilt worktree, then builds mid-loop, so it compares a partial baseline against fully-resolved candidate scores. Higher stakes — it gates real commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)