### PR TITLE
Show camp EE allocation total on Members card

### DIFF
--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -163,8 +163,11 @@
                     </ul>
                 }
 
-                <div class="px-3 pt-3 pb-2">
+                <div class="px-3 pt-3 pb-2 d-flex justify-content-between align-items-center gap-2">
                     <strong class="text-muted small">Active humans (@Model.ActiveMembers.Count)</strong>
+                    <span class="badge bg-light text-dark border" title="Early Entry slots granted / allocated to this camp for @Model.Year">
+                        EE: @Model.EeGrantedCount/@Model.EeSlotCount
+                    </span>
                 </div>
                 @if (Model.ActiveMembers.Count == 0)
                 {


### PR DESCRIPTION
## What

On the Barrios **Edit → Members** card (`/Barrios/{slug}/Edit/Members`), nothing showed the camp's total Early Entry allocation — only the per-member grant/revoke buttons. This adds a compact badge next to the **Active humans** header:

> **EE: 3/10**  (granted / allocated, full meaning in the hover tooltip)

## Notes

- View-only change — `EeSlotCount` (allocation) and `EeGrantedCount` (used) were already on `CampEditViewModel`; the view just never displayed them.
- Zero-allocation seasons render naturally as `EE: 0/0`.
- Not built locally: the installed SDK feature band (10.0.100, Roslyn 5.0) is older than the repo's pinned `Microsoft.CodeAnalysis.CSharp` 5.3, so the solution can't compile on this machine (pre-existing, unrelated to this diff). Preview deploy will confirm the render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)