### PR TITLE
feat(camps): fall back to barrio leads in role email lists when role is unassigned

### DIFF
--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -633,6 +633,18 @@ public sealed class CampRoleService(
                 g => g.Key,
                 g => g.Select(a => a.CampMember.UserId).Distinct().ToArray());
 
+        // Per-camp lookup used for the lead-fallback: which camps have a given
+        // (slug, year) filled, and which leads exist per (camp, year).
+        var assignmentsByCampSlugYear = assignments
+            .Where(a => !string.IsNullOrWhiteSpace(a.Definition.Slug))
+            .GroupBy(a => (CampId: a.CampSeason.CampId, Slug: a.Definition.Slug, Year: a.CampSeason.Year))
+            .ToDictionary(g => g.Key, g => g.Select(a => a.CampMember.UserId).Distinct().ToArray());
+
+        var leadsByCampAndYear = assignments
+            .Where(a => a.Definition.SpecialRole == CampSpecialRole.Lead)
+            .GroupBy(a => (CampId: a.CampSeason.CampId, Year: a.CampSeason.Year))
+            .ToDictionary(g => g.Key, g => g.Select(a => a.CampMember.UserId).Distinct().ToArray());
+
         var result = new Dictionary<string, Guid[]>(StringComparer.OrdinalIgnoreCase);
         foreach (var def in activeDefs)
         {
@@ -644,10 +656,24 @@ public sealed class CampRoleService(
                 {
                     continue;
                 }
-                var userIds = assignmentsBySlugAndYear.TryGetValue((def.Slug, year), out var ids)
+                var directIds = assignmentsBySlugAndYear.TryGetValue((def.Slug, year), out var ids)
                     ? ids
                     : [];
-                result[key] = userIds;
+
+                // For non-Lead roles: any camp that has a lead but no direct
+                // assignee for this role contributes its lead(s) as a stand-in.
+                Guid[] fallbackIds = [];
+                if (def.SpecialRole != CampSpecialRole.Lead)
+                {
+                    fallbackIds = leadsByCampAndYear.Keys
+                        .Where(k => k.Year == year
+                            && !assignmentsByCampSlugYear.ContainsKey((k.CampId, def.Slug, year)))
+                        .SelectMany(k => leadsByCampAndYear[k])
+                        .Distinct()
+                        .ToArray();
+                }
+
+                result[key] = directIds.Concat(fallbackIds).Distinct().ToArray();
             }
         }
 


### PR DESCRIPTION
## What changed

When a camp has no one assigned to a non-Lead role for a given year, its lead(s) are now included in that role's Google Group (`barrios-{year}-{slug}@domain`) as a stand-in. Once someone is properly assigned to the role for that camp, the lead falls out of the group naturally on the next sync.

## Why

Role email lists were silently empty for camps that hadn't yet staffed a given role, meaning emails to the group would miss those camps entirely. The barrio lead is the natural fallback contact until an assignee is in place.

## Behaviour

- **Camps with the role filled** — unaffected; their direct assignees remain the only members from that camp.
- **Camps with no assignee for this role** — their lead(s) are added as stand-ins.
- **The Lead role's own group** — unchanged; no recursive fallback (leads don't fall back to themselves).
- **Camps with no lead** — nothing added (no lead to fall back to).

## Implementation

All logic is inside `CampRoleService.GetExpectedAsync()`. Two additional in-memory LINQ groupings are built from the already-fetched `assignments` collection — no extra database queries.

## Reviewer notes

- No new types, interfaces, queries, or DI registrations.
- The fallback is per-barrio: a camp that has the role filled does not contribute its lead to the group.
- Fully undone automatically once an assignee is added to a camp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)