### PR TITLE
feat: link Barrio Guide 2026 from the Barrios page header

### DIFF
--- a/src/Humans.Web/Views/Camp/Index.cshtml
+++ b/src/Humans.Web/Views/Camp/Index.cshtml
@@ -16,6 +16,11 @@
             }
             <i class="fa-solid fa-lock auth-lock-icon"></i>
         </a>
+        <a href="https://drive.google.com/file/d/1orfoEDH6uFz3Hn6ioaqVo-EG_Iuv1Dji/view"
+           class="btn btn-outline-secondary" target="_blank" rel="noopener noreferrer">
+            <i class="fa-solid fa-book me-1"></i> Barrio Guide 2026
+            <i class="fa-solid fa-arrow-up-right-from-square ms-1"></i>
+        </a>
         @if (User.HasClaim(Humans.Web.Authorization.RoleAssignmentClaimsTransformation.HasProfileClaimType,
                            Humans.Web.Authorization.RoleAssignmentClaimsTransformation.ActiveClaimValue))
         {


### PR DESCRIPTION
## What

Adds a **"Barrio Guide 2026"** button to the action row at the top of the `/Barrios` (Camp Index) page, next to **Register Your Barrio**. It links to the Drive guide, opens in a new tab, and matches the existing top-row button styling (`btn-outline-secondary` + external-link icon).

Visible to everyone — unlike the Register button, which is gated behind an active-profile claim.

## Why

Camp leads need the Barrio Guide discoverable straight from the Barrios directory, not only from the Camp Leads team page.

## Notes

- Single-file view change (`src/Humans.Web/Views/Camp/Index.cshtml`), no logic/data changes.
- The camp-leads team-page guide link (URL + label) is updated separately via the in-app Edit Page UI.
- Rebased onto current `main`; builds clean (`0 errors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
