### PR TITLE
User search: pure matcher — resolved name, accents, tokens, scoped legal/email

### DIFF
--- a/docs/features/user-search-overhaul.md
+++ b/docs/features/user-search-overhaul.md
@@ -1,0 +1,94 @@
+# User search overhaul — match all profile info, exclude board/private
+
+**Status:** in progress. This PR lands the matcher + wiring; the per-window legal-name
+scope flip is the tracked follow-up (see §Follow-up).
+
+## Problem
+
+Search by **name** found nothing in several windows (top-level `/Search`, Volunteers/team
+member pickers, add-to-barrio, add-to-team, early-entry), while searching by **full UserID**
+always worked. Verified by code trace — all human-name matching ran through one method
+(`CachingUserService.TryMatchBuckets`) with four compounding defects:
+
+1. **Resolved-vs-raw name.** Matched **raw** `Profile.BurnerName`, but the UI renders the
+   **resolved** `UserInfo.BurnerName` (falls back to legacy `User.DisplayName` when the burner
+   name is blank). Humans with a blank `Profile.BurnerName` rendered everywhere but were
+   unsearchable by name. *(Intermittent — "I see them but can't find them".)*
+2. **Pseudonym only.** Legal `FirstName`/`LastName` existed but were never searched.
+3. **No accent folding.** `OrdinalIgnoreCase` is case- but not accent-insensitive
+   (`jose` ≠ `José`, `munoz` ≠ `Muñoz`). Heavy impact for Spanish names.
+4. **No token splitting.** The whole query had to be a contiguous substring of one field.
+
+The `Guid.TryParse` fast-path is why full-ID always worked.
+
+## Desired behavior (product decisions)
+
+All **profile information** searchable; **board/admin and private info excluded**.
+
+- Match the **resolved** display name (BurnerName → DisplayName fallback).
+- **Accent- + case-insensitive**, **token-split** matching everywhere.
+- Legal `FirstName`/`LastName` matchable **only in admin/coordinator-gated windows** — never in
+  public `/Search` (prevents real-name → burner deanonymization).
+- Email matchable to everyone **only** when exposed as a public (`AllActiveProfiles`) ContactField
+  or email; verified/login emails and non-public contact fields stay admin/board-only.
+- **Never** searchable: AdminNotes, BoardNotes, ConsentCheckNotes, RejectionReason, Iban,
+  EmergencyContact*, GDPR health fields (DietaryPreference, Allergies, Intolerances,
+  MedicalConditions), and BoardOnly/coordinator-only ContactFields.
+
+## Design
+
+`PersonSearchFields` (scope = authorization model; the matcher never reads a field whose flag is unset):
+
+- `Name` — resolved display name (public).
+- `Bio` — city, bio, pronouns, contribution interests, volunteer CV, `AllActiveProfiles`
+  ContactFields, publicly-exposed emails (public).
+- `LegalName` *(new)* — FirstName/LastName; admin/coordinator only.
+- `Admin` — all verified emails + non-public ContactFields; admin/board only.
+- `PublicAll = Name | Bio`, `ManageAll = Name | Bio | LegalName`, `AdminAll = … | Admin`.
+
+`PersonSearchMatcher` (`src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs`) — a pure,
+unit-tested matcher over the cached `UserInfo` read-model. Accent-/case-fold (`Fold`: lowercase +
+NFD + strip combining marks); name matching token-splits the folded query and requires every token
+(order-independent). `CachingUserService` keeps the cache iteration + Guid fast-path and delegates
+per-record matching to it.
+
+## Done in this PR
+
+- `PersonSearchFields`: `LegalName` + `ManageAll`; `AdminAll` includes `LegalName`.
+- `PersonSearchMatcher` + 23 unit tests (resolved-name fallback, accents, tokens, legal-name
+  gating, bio/CV/public-contact, public-vs-admin email, board/private/health negatives, rejected
+  exclusion).
+- `CachingUserService` delegates to the matcher (Guid fast-path retained).
+- **Net effect now:** resolved-name + accent + token fixes are live in **every** window (defects
+  1, 3, 4). The `LegalName`/email scope infrastructure exists, ready for callers to opt in.
+
+## Follow-up (next PR)
+
+Per-window scope flip so admin/coordinator windows match **legal name** (defect 2):
+
+- `TeamAdminController.SearchUsers` / `SearchMembersForRole` → `ManageAll`; collapse the role-picker
+  hybrid (existing members by DisplayName+Email, candidates by BurnerName) onto the matcher.
+- `Shift{Admin,Dashboard}Controller.SearchVolunteers` → `ManageAll` (confirm each is lead/admin-gated).
+- `ProfileApiController.Search`: add a role-checked `scope=manage` → `ManageAll`; point the
+  add-to-team / add-to-barrio / early-entry views at it.
+- Web controller tests asserting public endpoints never receive legal-name/admin scope.
+
+## Out of scope
+
+Accent-folding for the Postgres `ILIKE` **entity** searches (teams/camps/shifts/events) — needs the
+`unaccent` extension or normalized columns; separate ticket.
+
+## Blast radius (run against QA/prod — local dev DB is unrepresentative)
+
+```sql
+WITH p AS (
+  SELECT pr."BurnerName" AS burner, pr."FirstName" AS fn, pr."LastName" AS ln,
+         u."DisplayName" AS disp, pr."RejectedAt" AS rej
+  FROM profiles pr JOIN users u ON u."Id" = pr."UserId"
+)
+SELECT 'total (not rejected)' AS metric, count(*) FROM p WHERE rej IS NULL
+UNION ALL SELECT 'DEFECT#1 rendered-but-unsearchable (blank BurnerName + has DisplayName)',
+       count(*) FROM p WHERE coalesce(trim(burner),'')='' AND coalesce(trim(disp),'')<>'' AND rej IS NULL
+UNION ALL SELECT 'DEFECT#3 accented chars in name fields',
+       count(*) FROM p WHERE (burner ~ '[^\x20-\x7E]' OR fn ~ '[^\x20-\x7E]' OR ln ~ '[^\x20-\x7E]') AND rej IS NULL;
+```

--- a/memory/architecture/person-search.md
+++ b/memory/architecture/person-search.md
@@ -1,6 +1,6 @@
 ---
 name: Person search uses one bit-flag service method and two canonical UI patterns
-description: HARD RULE. All person-search call sites route through `IProfileService.SearchProfilesAsync(query, PersonSearchFields, limit)`. UI is one of two patterns — `<vc:human-search>` (inline picker) or `_HumanSearchResults` (page-style). Admin-bit fields require admin auth at the controller. Emergency-contact data is never searchable. Shift volunteer search is exempt.
+description: HARD RULE. All person-search call sites route through `IUserServiceRead.SearchUsersAsync(query, PersonSearchFields, limit)`. UI is one of two patterns — `<vc:human-search>` (inline picker) or `_HumanSearchResults` (page-style). Admin-bit fields require admin auth at the controller. Emergency-contact data is never searchable. Shift volunteer search is exempt.
 ---
 
 Person search shows up across the app — Camp role assignment, team-admin member picker, public profile search page, admin humans list, ticket-transfer recipient lookup, etc. Today they all consolidate behind a single service method and two UI partials. Don't fork.
@@ -11,14 +11,16 @@ Person search shows up across the app — Camp role assignment, team-admin membe
 [Flags] public enum PersonSearchFields
 {
     None = 0,
-    Name = 1,    // Profile.BurnerName + User.DisplayName
-    Bio  = 2,    // bio, city, interests, CV, pronouns + AllActiveProfiles ContactFields
-    Admin = 4,   // verified emails + non-public ContactFields (BoardOnly / CoordinatorsAndBoard / MyTeams)
+    Name = 1,        // Profile.BurnerName + User.DisplayName (public)
+    Bio  = 2,        // bio, city, interests, CV, pronouns + AllActiveProfiles ContactFields (public)
+    Admin = 4,       // verified emails + non-public ContactFields (BoardOnly / CoordinatorsAndBoard / MyTeams)
+    LegalName = 8,   // legal FirstName/LastName — admin/coordinator only; deanonymizes burners
     PublicAll = Name | Bio,
-    AdminAll  = Name | Bio | Admin,
+    ManageAll = Name | Bio | LegalName,            // admin/coordinator pickers (real-name find, no private contact data)
+    AdminAll  = Name | Bio | LegalName | Admin,    // admin/board only
 }
 
-Task<IReadOnlyList<HumanSearchResult>> SearchProfilesAsync(
+Task<IReadOnlyList<HumanSearchResult>> SearchUsersAsync(
     string query, PersonSearchFields fields, int limit = 10, CancellationToken ct = default);
 ```
 
@@ -49,6 +51,6 @@ Don't roll a third. If you need a new search surface, route it through one of th
 
 **Rejected design alternatives:**
 
-- `SearchProfilesAsync(predicate)` — too permissive. Audit-by-grep is impossible when every call site can pass arbitrary lambdas.
+- `SearchUsersAsync(predicate)` — too permissive. Audit-by-grep is impossible when every call site can pass arbitrary lambdas.
 - One method per scope (`SearchHumansAsync`, `SearchHumansByNameAsync`, …) — what we replaced. Each method accreted one tiny variant; the service surface grew without anyone deliberately authorizing the expansion.
 - Splitting public vs admin into two interfaces — defeats the budget ratchet. The bit-flag *is* the public/admin split, sitting on a single method.

--- a/src/Humans.Application/Interfaces/Users/IUserServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserServiceRead.cs
@@ -61,8 +61,9 @@ public interface IUserServiceRead
     ///
     /// <para>Auth boundary is the controller per design-rules §6: services
     /// are auth-free, so a non-admin endpoint passing
-    /// <see cref="PersonSearchFields.Admin"/> is a programmer error caught
-    /// in code review, not a runtime check.</para>
+    /// <see cref="PersonSearchFields.Admin"/> or
+    /// <see cref="PersonSearchFields.LegalName"/> (which deanonymizes burners)
+    /// is a programmer error caught in code review, not a runtime check.</para>
     /// </summary>
     Task<IReadOnlyList<HumanSearchResult>> SearchUsersAsync(
         string query,

--- a/src/Humans.Application/Services/Profiles/PersonSearchFields.cs
+++ b/src/Humans.Application/Services/Profiles/PersonSearchFields.cs
@@ -11,18 +11,24 @@ public enum PersonSearchFields
     /// <summary>No fields. Returns no results.</summary>
     None = 0,
 
-    /// <summary>BurnerName only (never legacy User.DisplayName). Narrow picker subset.</summary>
+    /// <summary>Resolved display name (Profile.BurnerName, falling back to legacy User.DisplayName). Public.</summary>
     Name = 1 << 0,
 
-    /// <summary>Bio, city, contribution-interests, CV, pronouns, and AllActiveProfiles-visible ContactFields.</summary>
+    /// <summary>Bio, city, contribution-interests, CV, pronouns, AllActiveProfiles-visible ContactFields, and publicly-exposed emails. Public.</summary>
     Bio = 1 << 1,
 
-    /// <summary>Verified email addresses + non-public ContactFields. Controller MUST gate with Admin auth.</summary>
+    /// <summary>Verified email addresses (any visibility) + non-public ContactFields. Controller MUST gate with Admin/Board auth.</summary>
     Admin = 1 << 2,
+
+    /// <summary>Legal FirstName/LastName. Controller MUST gate with admin/coordinator auth — never on public endpoints (deanonymizes burners).</summary>
+    LegalName = 1 << 3,
 
     /// <summary>Name + Bio — public endpoints.</summary>
     PublicAll = Name | Bio,
 
-    /// <summary>Name + Bio + Admin — admin endpoints only.</summary>
-    AdminAll = Name | Bio | Admin,
+    /// <summary>Name + Bio + LegalName — admin/coordinator picker endpoints (find people by real name; no private contact data).</summary>
+    ManageAll = Name | Bio | LegalName,
+
+    /// <summary>Name + Bio + LegalName + Admin — admin/board endpoints only.</summary>
+    AdminAll = Name | Bio | LegalName | Admin,
 }

--- a/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
+++ b/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
@@ -50,7 +50,7 @@ public static class PersonSearchMatcher
 
         // ── Legal name: FirstName/LastName. Admin/coordinator only — never public. ──
         if (includeLegal && AllTokensIn($"{p.FirstName} {p.LastName}", tokens))
-            return new PersonSearchMatch("Name", null, null);
+            return new PersonSearchMatch("Legal Name", null, null);
 
         // ── Bio bucket: public long-form + CV + AllActiveProfiles ContactFields + publicly-exposed emails. ──
         if (includeBio)
@@ -122,7 +122,7 @@ public static class PersonSearchMatcher
         if (string.IsNullOrEmpty(text))
             return string.Empty;
 
-        var index = text.IndexOf(query, StringComparison.OrdinalIgnoreCase);
+        var index = CultureInfo.InvariantCulture.CompareInfo.IndexOf(text, query, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace);
         if (index < 0)
             return text.Length <= contextChars * 2 ? text : text[..(contextChars * 2)] + "...";
 

--- a/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
+++ b/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
@@ -1,0 +1,173 @@
+using System.Globalization;
+using System.Text;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Profiles;
+
+/// <summary>Result of a single person-search match: which field hit, plus optional snippet/email for display.</summary>
+public sealed record PersonSearchMatch(string Field, string? Snippet, string? MatchedEmail);
+
+/// <summary>
+/// Pure, scope-confined matcher for person search. Operates on the cached <see cref="UserInfo"/>
+/// read-model so callers (CachingUserService) stay a thin iteration + Guid fast-path over it.
+/// Matching is accent- and case-insensitive; name matching is whitespace-token-split.
+/// <paramref name="fields"/> IS the authorization model — the matcher never reads a field its
+/// scope flag is unset. Board/private fields (notes, IBAN, emergency contact, GDPR health) are
+/// never searchable under any flag.
+/// </summary>
+public static class PersonSearchMatcher
+{
+    /// <summary>Returns the first bucket that matches <paramref name="query"/>, or null if none do.</summary>
+    public static PersonSearchMatch? Match(UserInfo user, string query, PersonSearchFields fields)
+    {
+        if (fields == PersonSearchFields.None || user.Profile is null)
+            return null;
+
+        var p = user.Profile;
+
+        // Implicit scope: rejected profiles are never searchable.
+        if (p.RejectedAt is not null)
+            return null;
+
+        var q = query.Trim();
+        if (q.Length == 0)
+            return null;
+
+        var tokens = FoldTokens(q);
+        if (tokens.Length == 0)
+            return null;
+
+        var foldedQuery = Fold(q);
+
+        var includeName = (fields & PersonSearchFields.Name) != PersonSearchFields.None;
+        var includeBio = (fields & PersonSearchFields.Bio) != PersonSearchFields.None;
+        var includeLegal = (fields & PersonSearchFields.LegalName) != PersonSearchFields.None;
+        var includeAdmin = (fields & PersonSearchFields.Admin) != PersonSearchFields.None;
+
+        // ── Name bucket: resolved display name (BurnerName → DisplayName fallback). Public. ──
+        if (includeName && AllTokensIn(user.BurnerName, tokens))
+            return new PersonSearchMatch("Name", null, null);
+
+        // ── Legal name: FirstName/LastName. Admin/coordinator only — never public. ──
+        if (includeLegal && AllTokensIn($"{p.FirstName} {p.LastName}", tokens))
+            return new PersonSearchMatch("Name", null, null);
+
+        // ── Bio bucket: public long-form + CV + AllActiveProfiles ContactFields + publicly-exposed emails. ──
+        if (includeBio)
+        {
+            if (FoldedContains(p.City, foldedQuery))
+                return new PersonSearchMatch("City", p.City, null);
+
+            if (FoldedContains(p.ContributionInterests, foldedQuery))
+                return new PersonSearchMatch("Interests", Snippet(p.ContributionInterests, q), null);
+
+            if (FoldedContains(p.Bio, foldedQuery))
+                return new PersonSearchMatch("Bio", Snippet(p.Bio, q), null);
+
+            if (FoldedContains(p.Pronouns, foldedQuery))
+                return new PersonSearchMatch("Pronouns", p.Pronouns, null);
+
+            foreach (var v in p.VolunteerHistory)
+            {
+                if (FoldedContains(v.EventName, foldedQuery) || FoldedContains(v.Description, foldedQuery))
+                    return new PersonSearchMatch("Burner CV", v.EventName, null);
+            }
+
+            foreach (var cf in p.ContactFields)
+            {
+                if (cf.Visibility == ContactFieldVisibility.AllActiveProfiles &&
+                    FoldedContains(cf.Value, foldedQuery))
+                    return new PersonSearchMatch(DisplayLabel(cf), cf.Value, null);
+            }
+
+            foreach (var email in user.UserEmails)
+            {
+                if (email.IsVerified &&
+                    email.Visibility == ContactFieldVisibility.AllActiveProfiles &&
+                    FoldedContains(email.Email, foldedQuery))
+                    return new PersonSearchMatch("Email", null, email.Email);
+            }
+        }
+
+        // ── Admin bucket: all verified emails + non-public ContactFields. Admin/board only. ──
+        if (includeAdmin)
+        {
+            foreach (var email in user.AllVerifiedEmails)
+            {
+                if (FoldedContains(email, foldedQuery))
+                    return new PersonSearchMatch("Email", null, email);
+            }
+
+            foreach (var cf in p.ContactFields)
+            {
+                // Public ContactFields are handled in the Bio bucket; Admin covers the remainder.
+                if (cf.Visibility == ContactFieldVisibility.AllActiveProfiles)
+                    continue;
+                if (FoldedContains(cf.Value, foldedQuery))
+                    return new PersonSearchMatch(DisplayLabel(cf), cf.Value, cf.Value);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool FoldedContains(string? field, string foldedQuery) =>
+        !string.IsNullOrEmpty(field) && Fold(field).Contains(foldedQuery, StringComparison.Ordinal);
+
+    private static string DisplayLabel(ContactFieldInfo cf) =>
+        !string.IsNullOrWhiteSpace(cf.CustomLabel) ? cf.CustomLabel! : cf.FieldType.ToString();
+
+    private static string Snippet(string? text, string query, int contextChars = 60)
+    {
+        if (string.IsNullOrEmpty(text))
+            return string.Empty;
+
+        var index = text.IndexOf(query, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+            return text.Length <= contextChars * 2 ? text : text[..(contextChars * 2)] + "...";
+
+        var start = Math.Max(0, index - contextChars);
+        var end = Math.Min(text.Length, index + query.Length + contextChars);
+        var snippet = text[start..end];
+        if (start > 0) snippet = "..." + snippet;
+        if (end < text.Length) snippet += "...";
+        return snippet;
+    }
+
+    /// <summary>Folds a string for accent-/case-insensitive comparison: lowercase + NFD + strip combining marks.</summary>
+    internal static string Fold(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+
+        var nfd = value.ToLowerInvariant().Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(nfd.Length);
+        foreach (var ch in nfd)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark)
+                sb.Append(ch);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Folds the query and splits on whitespace into non-empty tokens.</summary>
+    private static string[] FoldTokens(string query) =>
+        Fold(query).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>True when every token is a substring of the folded haystack (order-independent).</summary>
+    private static bool AllTokensIn(string? haystack, string[] foldedTokens)
+    {
+        if (string.IsNullOrEmpty(haystack))
+            return false;
+
+        var folded = Fold(haystack);
+        foreach (var token in foldedTokens)
+        {
+            if (!folded.Contains(token, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -149,7 +149,7 @@ public sealed class CachingUserService(
             if (u.Profile is null) continue;
             if (u.Profile.RejectedAt is not null) continue;
 
-            var match = TryMatchBuckets(u, query, fields);
+            var match = PersonSearchMatcher.Match(u, query, fields);
             if (match is null) continue;
 
             results.Add(new HumanSearchResult(
@@ -157,106 +157,14 @@ public sealed class CachingUserService(
                 ProfileId: u.Profile.Id,
                 BurnerName: u.BurnerName,
                 ProfilePictureUrl: u.ProfilePictureUrl,
-                MatchField: match.Value.Field,
-                MatchSnippet: match.Value.Snippet,
-                MatchedEmail: match.Value.MatchedEmail));
+                MatchField: match.Field,
+                MatchSnippet: match.Snippet,
+                MatchedEmail: match.MatchedEmail));
 
             if (results.Count >= limit) break;
         }
 
         return results;
-    }
-
-    /// <summary>
-    /// Per-record predicate for <see cref="SearchUsersAsync"/>. Returns the
-    /// first bucket that matches <paramref name="query"/>, or null if none do.
-    /// Emergency-contact fields are skipped by every branch regardless of
-    /// which bits are set.
-    /// </summary>
-    private static (string Field, string? Snippet, string? MatchedEmail)?
-        TryMatchBuckets(UserInfo u, string query, PersonSearchFields fields)
-    {
-        // Callers guarantee u.Profile is not null (filtered upstream).
-        var p = u.Profile!;
-        var includeName = (fields & PersonSearchFields.Name) != PersonSearchFields.None;
-        var includeBio = (fields & PersonSearchFields.Bio) != PersonSearchFields.None;
-        var includeAdmin = (fields & PersonSearchFields.Admin) != PersonSearchFields.None;
-
-        // ── Name bucket ─────────────────────────────────────────────
-        if (includeName)
-        {
-            // BurnerName only — see memory/architecture/burnername-is-the-display-name.md.
-            if (!string.IsNullOrEmpty(p.BurnerName) &&
-                p.BurnerName.Contains(query, StringComparison.OrdinalIgnoreCase))
-                return ("Name", null, null);
-        }
-
-        // ── Bio bucket (public long-form + short fields + public ContactFields) ──
-        if (includeBio)
-        {
-            if (p.City?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-                return ("City", p.City, null);
-
-            if (p.ContributionInterests?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-                return ("Interests", GetSnippet(p.ContributionInterests, query), null);
-
-            if (p.Bio?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-                return ("Bio", GetSnippet(p.Bio, query), null);
-
-            if (p.Pronouns?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-                return ("Pronouns", p.Pronouns, null);
-
-            foreach (var v in p.VolunteerHistory)
-            {
-                if (v.EventName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                    v.Description?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-                    return ("Burner CV", v.EventName, null);
-            }
-
-            foreach (var cf in p.ContactFields)
-            {
-                if (cf.Visibility != ContactFieldVisibility.AllActiveProfiles) continue;
-                if (cf.Value.Contains(query, StringComparison.OrdinalIgnoreCase))
-                    return (DisplayLabel(cf), cf.Value, null);
-            }
-        }
-
-        // ── Admin bucket (verified emails + non-public ContactFields) ───────────
-        if (includeAdmin)
-        {
-            foreach (var email in u.AllVerifiedEmails)
-            {
-                if (email.Contains(query, StringComparison.OrdinalIgnoreCase))
-                    return ("Email", null, email);
-            }
-
-            foreach (var cf in p.ContactFields)
-            {
-                // Public ContactFields were already handled above (when
-                // the Bio bit was on). Admin bucket covers the remainder.
-                if (cf.Visibility == ContactFieldVisibility.AllActiveProfiles) continue;
-                if (cf.Value.Contains(query, StringComparison.OrdinalIgnoreCase))
-                    return (DisplayLabel(cf), cf.Value, cf.Value);
-            }
-        }
-
-        return null;
-    }
-
-    private static string DisplayLabel(ContactFieldInfo cf) =>
-        !string.IsNullOrWhiteSpace(cf.CustomLabel) ? cf.CustomLabel! : cf.FieldType.ToString();
-
-    private static string GetSnippet(string text, string query, int contextChars = 60)
-    {
-        var index = text.IndexOf(query, StringComparison.OrdinalIgnoreCase);
-        if (index < 0) return text.Length <= contextChars * 2 ? text : text[..(contextChars * 2)] + "...";
-
-        var start = Math.Max(0, index - contextChars);
-        var end = Math.Min(text.Length, index + query.Length + contextChars);
-        var snippet = text[start..end];
-        if (start > 0) snippet = "..." + snippet;
-        if (end < text.Length) snippet += "...";
-        return snippet;
     }
 
     /// <summary>

--- a/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
@@ -167,7 +167,9 @@ public class PersonSearchMatcherTests
         var human = Human(burnerName: "Sparkle", firstName: "María", lastName: "García",
             displayName: "Sparkle");
 
-        PersonSearchMatcher.Match(human, "garcia maria", PersonSearchFields.ManageAll).Should().NotBeNull();
+        var match = PersonSearchMatcher.Match(human, "garcia maria", PersonSearchFields.ManageAll);
+        match.Should().NotBeNull();
+        match!.Field.Should().Be("Legal Name");
         PersonSearchMatcher.Match(human, "garcia maria", PersonSearchFields.PublicAll).Should().BeNull();
     }
 

--- a/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
@@ -1,0 +1,251 @@
+using AwesomeAssertions;
+using Humans.Application;
+using Humans.Application.Services.Profiles;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Profiles;
+
+public class PersonSearchMatcherTests
+{
+    private static readonly Instant At = Instant.FromUtc(2026, 1, 1, 0, 0);
+
+    /// <summary>
+    /// Builds a real <see cref="UserInfo"/> via <see cref="UserInfo.Create"/> (no mocks) so the
+    /// resolved-name fallback and projections are exercised exactly as in production.
+    /// </summary>
+    private static UserInfo Human(
+        string burnerName = "Sparkle",
+        string firstName = "Test",
+        string lastName = "Human",
+        string displayName = "Test Human",
+        string? city = null,
+        string? bio = null,
+        string? pronouns = null,
+        string? interests = null,
+        string? medicalConditions = null,
+        string? adminNotes = null,
+        string? boardNotes = null,
+        string? iban = null,
+        string? consentCheckNotes = null,
+        string? rejectionReason = null,
+        string? emergencyContactName = null,
+        Instant? rejectedAt = null,
+        IEnumerable<(string Value, ContactFieldVisibility Vis)>? contactFields = null,
+        IEnumerable<(string Email, bool Verified, ContactFieldVisibility? Vis)>? emails = null,
+        IEnumerable<(string EventName, string? Description)>? cv = null)
+    {
+        var userId = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+
+        var profile = new Profile
+        {
+            Id = profileId,
+            UserId = userId,
+            BurnerName = burnerName,
+            FirstName = firstName,
+            LastName = lastName,
+            City = city,
+            Bio = bio,
+            Pronouns = pronouns,
+            ContributionInterests = interests,
+            MedicalConditions = medicalConditions,
+            AdminNotes = adminNotes,
+            BoardNotes = boardNotes,
+            Iban = iban,
+            ConsentCheckNotes = consentCheckNotes,
+            RejectionReason = rejectionReason,
+            EmergencyContactName = emergencyContactName,
+            RejectedAt = rejectedAt,
+            CreatedAt = At,
+            UpdatedAt = At,
+        };
+
+        var user = new User
+        {
+            Id = userId,
+            DisplayName = displayName,
+            PreferredLanguage = "en",
+            CreatedAt = At,
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+        };
+
+        var contactEntities = (contactFields ?? [])
+            .Select((c, i) => new ContactField
+            {
+                Id = Guid.NewGuid(),
+                ProfileId = profileId,
+                FieldType = ContactFieldType.Other,
+                Value = c.Value,
+                Visibility = c.Vis,
+                DisplayOrder = i,
+                CreatedAt = At,
+                UpdatedAt = At,
+            })
+            .ToList();
+
+        var emailEntities = (emails ?? [])
+            .Select(e => new UserEmail
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Email = e.Email,
+                IsVerified = e.Verified,
+                Visibility = e.Vis,
+                CreatedAt = At,
+                UpdatedAt = At,
+            })
+            .ToList();
+
+        var cvEntities = (cv ?? [])
+            .Select(v => new VolunteerHistoryEntry
+            {
+                Id = Guid.NewGuid(),
+                ProfileId = profileId,
+                Date = new LocalDate(2025, 7, 1),
+                EventName = v.EventName,
+                Description = v.Description,
+                CreatedAt = At,
+                UpdatedAt = At,
+            })
+            .ToList();
+
+        return UserInfo.Create(
+            user: user,
+            userEmails: emailEntities,
+            eventParticipations: [],
+            externalLogins: [],
+            profile: profile,
+            contactFields: contactEntities,
+            profileLanguages: [],
+            volunteerHistory: cvEntities,
+            communicationPreferences: []);
+    }
+
+    [HumansFact]
+    public void Matches_resolved_display_name_when_burnername_blank()
+    {
+        // The reported bug: Profile.BurnerName blank, but legacy User.DisplayName populated
+        // (SSO/legacy). The UI renders "Maria Garcia" via the resolver, yet search saw the raw
+        // blank field and found nothing. The matcher must use the resolved name.
+        var human = Human(burnerName: "", displayName: "Maria Garcia");
+
+        var match = PersonSearchMatcher.Match(human, "maria", PersonSearchFields.Name);
+
+        match.Should().NotBeNull();
+    }
+
+    [HumansTheory]
+    [InlineData("jose", "José")]
+    [InlineData("munoz", "Muñoz")]
+    [InlineData("JOSÉ", "josé")]
+    public void Name_match_is_accent_and_case_insensitive(string query, string burnerName)
+    {
+        var human = Human(burnerName: burnerName);
+
+        PersonSearchMatcher.Match(human, query, PersonSearchFields.Name).Should().NotBeNull();
+    }
+
+    [HumansTheory]
+    [InlineData("sparkle pony")]
+    [InlineData("pony sparkle")]
+    [InlineData("PONY")]
+    public void Name_match_splits_query_into_tokens(string query)
+    {
+        var human = Human(burnerName: "Sparkle Pony");
+
+        PersonSearchMatcher.Match(human, query, PersonSearchFields.Name).Should().NotBeNull();
+    }
+
+    [HumansFact]
+    public void Legal_name_matches_under_LegalName_scope_but_not_public()
+    {
+        // Burner "Sparkle" hides legal name "María García". Searching the real name must work in
+        // admin/coordinator windows but NEVER in public search (would deanonymize the burner).
+        var human = Human(burnerName: "Sparkle", firstName: "María", lastName: "García",
+            displayName: "Sparkle");
+
+        PersonSearchMatcher.Match(human, "garcia maria", PersonSearchFields.ManageAll).Should().NotBeNull();
+        PersonSearchMatcher.Match(human, "garcia maria", PersonSearchFields.PublicAll).Should().BeNull();
+    }
+
+    [HumansTheory]
+    [InlineData("welding")]   // Bio
+    [InlineData("berlin")]    // City
+    [InlineData("kitchen")]   // ContributionInterests
+    [InlineData("they")]      // Pronouns
+    public void Bio_fields_match_under_Bio_scope(string query)
+    {
+        var human = Human(burnerName: "Sparkle", bio: "Loves welding", city: "Berlin",
+            interests: "kitchen crew", pronouns: "they/them");
+
+        PersonSearchMatcher.Match(human, query, PersonSearchFields.Bio).Should().NotBeNull();
+    }
+
+    [HumansFact]
+    public void Volunteer_cv_matches_under_Bio_scope()
+    {
+        var human = Human(burnerName: "Sparkle", cv: [("Nowhere 2024", "Gate crew")]);
+
+        PersonSearchMatcher.Match(human, "nowhere", PersonSearchFields.Bio).Should().NotBeNull();
+    }
+
+    [HumansFact]
+    public void Public_contact_field_matches_under_Bio_but_private_one_does_not()
+    {
+        var pub = Human(burnerName: "Sparkle",
+            contactFields: [("publichandle", ContactFieldVisibility.AllActiveProfiles)]);
+        var priv = Human(burnerName: "Sparkle",
+            contactFields: [("privatehandle", ContactFieldVisibility.BoardOnly)]);
+
+        PersonSearchMatcher.Match(pub, "publichandle", PersonSearchFields.Bio).Should().NotBeNull();
+        PersonSearchMatcher.Match(priv, "privatehandle", PersonSearchFields.Bio).Should().BeNull();
+        PersonSearchMatcher.Match(priv, "privatehandle", PersonSearchFields.AdminAll).Should().NotBeNull();
+    }
+
+    [HumansFact]
+    public void Publicly_exposed_email_matches_for_everyone_but_private_email_is_admin_only()
+    {
+        var pub = Human(burnerName: "Sparkle",
+            emails: [("public@example.com", true, ContactFieldVisibility.AllActiveProfiles)]);
+        var priv = Human(burnerName: "Sparkle",
+            emails: [("login@example.com", true, ContactFieldVisibility.BoardOnly)]);
+
+        PersonSearchMatcher.Match(pub, "public@example", PersonSearchFields.Bio).Should().NotBeNull();
+        PersonSearchMatcher.Match(priv, "login@example", PersonSearchFields.Bio).Should().BeNull();
+        PersonSearchMatcher.Match(priv, "login@example", PersonSearchFields.AdminAll).Should().NotBeNull();
+    }
+
+    [HumansTheory]
+    [InlineData("adminnote")]
+    [InlineData("boardnote")]
+    [InlineData("consentnote")]
+    [InlineData("rejectreason")]
+    [InlineData("ES9121")]      // IBAN fragment
+    [InlineData("penicillin")]  // medical
+    [InlineData("janedoe")]     // emergency contact name
+    public void Board_private_and_health_fields_never_match_even_under_AdminAll(string query)
+    {
+        var human = Human(
+            burnerName: "Sparkle",
+            adminNotes: "adminnote",
+            boardNotes: "boardnote",
+            consentCheckNotes: "consentnote",
+            rejectionReason: "rejectreason",
+            iban: "ES9121000418450200051332",
+            medicalConditions: "penicillin allergy",
+            emergencyContactName: "Jane Doe");
+
+        PersonSearchMatcher.Match(human, query, PersonSearchFields.AdminAll).Should().BeNull();
+    }
+
+    [HumansFact]
+    public void Rejected_profile_is_never_matched()
+    {
+        var human = Human(burnerName: "Sparkle", rejectedAt: At);
+
+        PersonSearchMatcher.Match(human, "sparkle", PersonSearchFields.AdminAll).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

User search by **name** found nothing in several windows (top-level `/Search`, Volunteers/team member pickers, add-to-barrio, add-to-team, early-entry), while **full UserID** always worked. Root cause (code-traced): all human-name matching ran through one method with four defects —

1. Matched **raw** `Profile.BurnerName`, not the **resolved** `UserInfo.BurnerName` the UI renders (DisplayName fallback) → humans with a blank burner name were unsearchable but visible everywhere.
2. Searched **only** the burner pseudonym; legal First/Last name never matched.
3. `OrdinalIgnoreCase` is case- but **not accent-insensitive** (`jose` ≠ `José`).
4. No token splitting (`"Maria Garcia"` couldn't match).

`Guid.TryParse` fast-path explains why full-ID always worked.

## What this PR does

Extracts a pure, unit-tested **`PersonSearchMatcher`** over the cached `UserInfo` read-model and wires `CachingUserService` to it (keeping the Guid fast-path):

- **Resolved** display name matching (BurnerName → DisplayName fallback) — fixes the intermittent "see them but can't find them" bug.
- **Accent- + case-insensitive**, **token-split** name matching (José/Muñoz, "Maria Garcia" / "Garcia Maria").
- New `PersonSearchFields.LegalName` / `ManageAll` scope: legal First/Last name matchable **only** in admin/coordinator-gated windows, **never** in public `/Search` (no burner deanonymization).
- Public (`AllActiveProfiles`) contact fields + emails match for everyone; verified login emails + non-public contact fields only under `Admin` scope.
- Board/admin/private + GDPR health fields (notes, IBAN, emergency contact, medical) **never** searchable under any scope.

**Net effect now:** defects #1, #3, #4 are fixed in **every** window. The `LegalName`/email scope infrastructure is in place.

## Tests

- 23 `PersonSearchMatcher` tests (resolved-name fallback, accents, tokens, legal-name gating, bio/CV/public-contact, public-vs-admin email, board/private/health negatives, rejected exclusion).
- Full `Humans.Application.Tests` suite green (3271 passed); `CachingUserService` tests green; full solution builds clean.

## Follow-up (tracked in `docs/features/user-search-overhaul.md`)

Per-window scope flip so admin/coordinator pickers match **legal name** (defect #2): `TeamAdminController` SearchUsers/SearchMembersForRole → `ManageAll` (+ collapse role-picker hybrid), shift pickers → `ManageAll`, `ProfileApiController` role-checked `scope=manage`, and the add-to-team/barrio/early-entry views pointed at it. Plus accent-folding for the Postgres `ILIKE` entity searches (needs `unaccent`).

## Review notes (needs Peter sign-off per reuse-first)

- New enum value `PersonSearchFields.LegalName` (+ `ManageAll`).
- Re-added `PersonSearchMatcher` public type (the memory doc still referenced it; logic moved out of `CachingUserService`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
