### PR TITLE
fix(teams): preserve Team.IsSensitive when a non-Admin saves Edit Team (#824)

### DIFF
--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Humans.Application.Configuration;
-using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
@@ -733,7 +732,8 @@ public class TeamController(
             // The IsSensitive checkbox is suppressed (authorize-policy="AdminOnly") for non-Admin
             // editors, so it posts nothing and binds to false. Pass null (leave-unchanged) unless
             // the editor is a global Admin, mirroring the EarlyEntryEnabled leave-unchanged guard.
-            bool? isSensitive = User.IsInRole(RoleNames.Admin) ? model.IsSensitive : null;
+            var isAdmin = (await authorizationService.AuthorizeAsync(User, PolicyNames.AdminOnly)).Succeeded;
+            bool? isSensitive = isAdmin ? model.IsSensitive : null;
             await teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden, isSensitive, model.IsPromotedToDirectory, earlyEntryEnabled: model.EarlyEntryEnabled);
             var currentUser = await GetCurrentUserInfoAsync();
             logger.LogInformation("Admin {AdminId} updated team {TeamId}", currentUser?.Id, id);

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Humans.Application.Configuration;
+using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
@@ -729,7 +730,11 @@ public class TeamController(
 
         try
         {
-            await teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden, model.IsSensitive, model.IsPromotedToDirectory, earlyEntryEnabled: model.EarlyEntryEnabled);
+            // The IsSensitive checkbox is suppressed (authorize-policy="AdminOnly") for non-Admin
+            // editors, so it posts nothing and binds to false. Pass null (leave-unchanged) unless
+            // the editor is a global Admin, mirroring the EarlyEntryEnabled leave-unchanged guard.
+            bool? isSensitive = User.IsInRole(RoleNames.Admin) ? model.IsSensitive : null;
+            await teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden, isSensitive, model.IsPromotedToDirectory, earlyEntryEnabled: model.EarlyEntryEnabled);
             var currentUser = await GetCurrentUserInfoAsync();
             logger.LogInformation("Admin {AdminId} updated team {TeamId}", currentUser?.Id, id);
 


### PR DESCRIPTION
## Summary

On the **Edit Team** form, the `IsSensitive` checkbox is wrapped in `authorize-policy="AdminOnly"`. The `AuthorizeViewTagHelper` removes from the DOM any element whose policy the user fails, so a non-`Admin` editor never renders the checkbox. But the Edit Team POST is gated by the broader `TeamsAdminBoardOrAdmin` policy, so `TeamsAdmin`/`Board` members (not the global `Admin` role) can submit. The suppressed checkbox posts nothing → `model.IsSensitive` binds to `false` → `TeamController.EditTeam` passed it unconditionally to `UpdateTeamAsync` → the flag was **silently cleared**, removing the add/approve confirmation-modal protection on a privacy-sensitive team with no warning.

## Fix

In `TeamController.EditTeam` (POST), pass `model.IsSensitive` only when the editor is a global Admin, else `null` (leave-unchanged):

```csharp
bool? isSensitive = User.IsInRole(RoleNames.Admin) ? model.IsSensitive : null;
```

`ITeamService.UpdateTeamAsync` already accepts `bool? isSensitive` and `TeamService` already applies it with leave-unchanged semantics (`if (isSensitive.HasValue) team.IsSensitive = isSensitive.Value;`), so no service/interface signature change was needed — this is purely the missing controller-side guard, mirroring the `EarlyEntryEnabled` leave-unchanged precedent.

## Acceptance criteria

1. ✅ A non-Admin (Board/TeamsAdmin) saving Edit Team no longer clears `IsSensitive` — when not Admin, `null` is passed and the service leaves the existing value untouched.
2. ✅ A global Admin can still set/unset `IsSensitive` — `User.IsInRole(RoleNames.Admin)` passes `model.IsSensitive` through unchanged.
3. ✅ Guard mirrors the `EarlyEntryEnabled` precedent (`null` = leave-unchanged when not Admin); reuses the already-nullable `UpdateTeamAsync` parameter.
4. ✅ Solution builds (0 errors); 214 Teams application tests pass.

## Secondary audit (no scope change)

Grepped all `authorize-policy`-wrapped controls in `src/Humans.Web/Views`. The **only** policy-suppressed *form input that contributes to a broadly-gated POST* is the `IsSensitive` checkbox fixed here. Other `authorize-policy` usages are nav links, cards, table headers/cells, danger-zone panels, and standalone forms wrapped in their entirety (e.g. `Ticket/Index.cshtml` Sync/FullResync, `_GuideLayout.cshtml` Refresh) — suppression removes the whole form, not a binding input, so they post nothing and pose no silent-clear hazard. The `EarlyEntryEnabled` checkbox in `EditTeam.cshtml` is **not** `authorize-policy`-gated (renders for all editors), so it is not affected. No follow-up candidates found.

Closes nobodies-collective/Humans#824

🤖 Generated with [Claude Code](https://claude.com/claude-code)