### PR TITLE
feat(camps): ICampServiceRead.GetCampUserInfoAsync — active-year camp + roles

### DIFF
--- a/src/Humans.Application/Interfaces/Camps/ICampInfoInvalidator.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampInfoInvalidator.cs
@@ -51,4 +51,13 @@ public interface ICampInfoInvalidator : IInvalidator
     /// rebuilds from <c>ICampRepository</c>.
     /// </summary>
     Task InvalidateSettingsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Drop the entire cached <c>CampInfo</c> projection; the next read rebuilds it
+    /// from <c>ICampRepository</c>. Use when a change spans an unbounded set of camps —
+    /// e.g. a camp-role <i>definition</i> rename/reorder/(de)activation, which can shift
+    /// the cached role names/ordering of members in any camp and so has no single
+    /// camp/season id to target.
+    /// </summary>
+    Task InvalidateAllAsync(CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -322,7 +322,52 @@ public sealed record CampSeasonMemberInfo(
     CampMemberStatus Status,
     Instant RequestedAt,
     Instant? ConfirmedAt,
-    bool HasEarlyEntry);
+    bool HasEarlyEntry)
+{
+    /// <summary>
+    /// Names of the camp roles this member holds in the season (e.g. "Camp Lead",
+    /// "Greeter"), ordered by role sort order. Empty when the member holds none.
+    /// Projected from the same active-assignment fetch that feeds
+    /// <see cref="CampSeasonInfo.LeadUserIds"/>/<see cref="CampSeasonInfo.WorkshopLeadUserIds"/>.
+    /// </summary>
+    public IReadOnlyList<string> Roles { get; init; } = [];
+}
+
+/// <summary>
+/// A user's camp membership for the active (<c>PublicYear</c>) season: the attached
+/// <see cref="Season"/> and the named camp roles the user holds in it. <see cref="Season"/>
+/// is null (and <see cref="Roles"/> empty) when the user is not an Active member of any
+/// camp this year. Derived from the cached <see cref="CampInfo"/> projection — no DB hit.
+/// </summary>
+public sealed record CampUserInfo(
+    CampSeasonInfo? Season,
+    IReadOnlyList<string> Roles)
+{
+    /// <summary>The "not in any camp this year" result.</summary>
+    public static readonly CampUserInfo None = new(null, []);
+
+    /// <summary>
+    /// Resolves a user's membership for <paramref name="activeYear"/> from a set of camp
+    /// projections. Considers only the season whose <see cref="CampSeasonInfo.Year"/> equals
+    /// <paramref name="activeYear"/> (never a camp's latest season) and only Active membership;
+    /// takes the first match if the user is somehow active in more than one camp.
+    /// </summary>
+    public static CampUserInfo Resolve(IEnumerable<CampInfo> camps, int activeYear, Guid userId)
+    {
+        foreach (var camp in camps)
+        {
+            var season = camp.Seasons.FirstOrDefault(s => s.Year == activeYear);
+            var member = season?.Members.FirstOrDefault(
+                m => m.UserId == userId && m.Status == CampMemberStatus.Active);
+            if (member is not null)
+            {
+                return new CampUserInfo(season, member.Roles);
+            }
+        }
+
+        return None;
+    }
+}
 
 /// <summary>
 /// Result of a camp membership request action.

--- a/src/Humans.Application/Interfaces/Camps/ICampServiceRead.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampServiceRead.cs
@@ -14,4 +14,13 @@ public interface ICampServiceRead
     Task<CampSeasonInfo?> GetCampSeasonByIdAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
     Task<CampSettingsInfo> GetSettingsAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampSearchHit>> SearchAsync(string query, int max, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The user's camp membership for the <b>active (<c>PublicYear</c>) season only</b> —
+    /// never a stale prior-year season a camp last ran. <see cref="CampUserInfo.Season"/>
+    /// is null (and <see cref="CampUserInfo.Roles"/> empty) when the user is not an
+    /// Active member of any camp this year. Served from the cached projection; no DB hit.
+    /// Feeds the admin human card and the Shifts coordinator view.
+    /// </summary>
+    Task<CampUserInfo> GetCampUserInfoAsync(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -176,6 +176,10 @@ public sealed class CampRoleService(
             $"Updated camp role definition '{input.Name}'.",
             actorUserId);
 
+        // Name/SortOrder are baked into the cached CampInfo role projection across
+        // every camp that assigns this definition — flush the whole projection.
+        await campInfoInvalidator.InvalidateAllAsync(ct);
+
         return UpdateCampRoleDefinitionResult.Updated(input.Name);
     }
 
@@ -202,6 +206,10 @@ public sealed class CampRoleService(
             AuditAction.CampRoleDefinitionDeactivated,
             nameof(CampRoleDefinition), id,
             "Deactivated camp role definition.", actorUserId);
+
+        // Deactivated definitions drop from the cached role projection (the fetch
+        // filters DeactivatedAt == null) — flush so the role disappears now.
+        await campInfoInvalidator.InvalidateAllAsync(ct);
         return true;
     }
 
@@ -219,6 +227,10 @@ public sealed class CampRoleService(
             AuditAction.CampRoleDefinitionReactivated,
             nameof(CampRoleDefinition), id,
             "Reactivated camp role definition.", actorUserId);
+
+        // Reactivated definitions re-enter the cached role projection — flush so the
+        // role reappears now rather than at the next unrelated camp invalidation.
+        await campInfoInvalidator.InvalidateAllAsync(ct);
         return true;
     }
 

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -171,10 +171,10 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         // GetBySlugAsync does not load Seasons.Members, so EE/member counts are
         // unknown here — emit null rather than a misleading 0.
         if (camp is null) return null;
-        var specialRoleUserIds = await GetSpecialRoleUserIdsBySeasonAsync(
+        var roles = await GetRoleProjectionForYearsAsync(
             camp.Seasons.Select(season => season.Year).Distinct().ToList(),
             cancellationToken);
-        return CreateCampInfo(camp, includeEarlyEntryGrantCount: false, specialRoleUserIds);
+        return CreateCampInfo(camp, includeEarlyEntryGrantCount: false, roles);
     }
 
     public async Task<CampEditData?> GetCampEditDataAsync(
@@ -219,8 +219,15 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
     {
         var camps = await _repo.GetCampsWithLeadsForYearAsync(
             year, statusFilter: null, cancellationToken);
-        var specialRoleUserIds = await GetSpecialRoleUserIdsBySeasonAsync([year], cancellationToken);
-        return camps.Select(c => CreateCampInfo(c, specialRoleUserIds: specialRoleUserIds)).ToList();
+        var roles = await GetRoleProjectionForYearsAsync([year], cancellationToken);
+        return camps.Select(c => CreateCampInfo(c, roles: roles)).ToList();
+    }
+
+    public async Task<CampUserInfo> GetCampUserInfoAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var settings = await GetSettingsAsync(cancellationToken);
+        var camps = await GetCampsForYearAsync(settings.PublicYear, cancellationToken);
+        return CampUserInfo.Resolve(camps, settings.PublicYear, userId);
     }
 
     private async Task<List<Camp>> GetCampEntitiesForYearAsync(
@@ -283,13 +290,28 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         return hits;
     }
 
-    private async Task<IReadOnlyDictionary<(Guid CampSeasonId, CampSpecialRole Role), IReadOnlyList<Guid>>>
-        GetSpecialRoleUserIdsBySeasonAsync(IReadOnlyCollection<int> years, CancellationToken cancellationToken)
+    /// <summary>
+    /// Special-role user-id lists (Lead/Workshop) keyed by season+role, plus the full
+    /// named-role list per camp member — both projected from a single active-assignment
+    /// fetch (active definitions, active members).
+    /// </summary>
+    private sealed record CampRoleProjection(
+        IReadOnlyDictionary<(Guid CampSeasonId, CampSpecialRole Role), IReadOnlyList<Guid>> SpecialRoleUserIds,
+        IReadOnlyDictionary<Guid, IReadOnlyList<string>> MemberRoleNames)
     {
-        if (years.Count == 0) return new Dictionary<(Guid CampSeasonId, CampSpecialRole Role), IReadOnlyList<Guid>>();
+        public static readonly CampRoleProjection Empty = new(
+            new Dictionary<(Guid, CampSpecialRole), IReadOnlyList<Guid>>(),
+            new Dictionary<Guid, IReadOnlyList<string>>());
+    }
+
+    private async Task<CampRoleProjection> GetRoleProjectionForYearsAsync(
+        IReadOnlyCollection<int> years, CancellationToken cancellationToken)
+    {
+        if (years.Count == 0) return CampRoleProjection.Empty;
 
         var assignments = await _repo.GetActiveAssignmentsForYearsAsync(years, cancellationToken);
-        return assignments
+
+        var specialRoleUserIds = assignments
             .Where(a => a.Definition.SpecialRole is CampSpecialRole.Lead or CampSpecialRole.Workshop)
             .GroupBy(a => (a.CampSeasonId, a.Definition.SpecialRole))
             .ToDictionary(
@@ -298,12 +320,24 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
                     .Select(a => a.CampMember.UserId)
                     .Distinct()
                     .ToList());
+
+        var memberRoleNames = assignments
+            .GroupBy(a => a.CampMemberId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<string>)group
+                    .OrderBy(a => a.Definition.SortOrder)
+                    .ThenBy(a => a.Definition.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(a => a.Definition.Name)
+                    .ToList());
+
+        return new CampRoleProjection(specialRoleUserIds, memberRoleNames);
     }
 
     private static CampInfo CreateCampInfo(
         Camp camp,
         bool includeEarlyEntryGrantCount = true,
-        IReadOnlyDictionary<(Guid CampSeasonId, CampSpecialRole Role), IReadOnlyList<Guid>>? specialRoleUserIds = null)
+        CampRoleProjection? roles = null)
     {
         return new CampInfo(
             camp.Id,
@@ -313,7 +347,7 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
             camp.IsSwissCamp,
             camp.TimesAtNowhere,
             camp.Seasons
-                .Select(s => CreateCampSeasonInfo(s, camp.Slug, includeEarlyEntryGrantCount, specialRoleUserIds))
+                .Select(s => CreateCampSeasonInfo(s, camp.Slug, includeEarlyEntryGrantCount, roles))
                 .ToList())
         {
             WebOrSocialUrl = camp.WebOrSocialUrl,
@@ -333,7 +367,7 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         CampSeason season,
         string campSlug,
         bool includeEarlyEntryGrantCount = false,
-        IReadOnlyDictionary<(Guid CampSeasonId, CampSpecialRole Role), IReadOnlyList<Guid>>? specialRoleUserIds = null)
+        CampRoleProjection? roles = null)
     {
         return new CampSeasonInfo(
             season.Id,
@@ -369,10 +403,10 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
             Members = season.Members
                 .Where(m => m.Status != CampMemberStatus.Removed)
                 .OrderBy(m => m.RequestedAt)
-                .Select(CreateCampSeasonMemberInfo)
+                .Select(m => CreateCampSeasonMemberInfo(m, roles?.MemberRoleNames))
                 .ToList(),
-            LeadUserIds = GetSpecialRoleUserIds(season.Id, CampSpecialRole.Lead, specialRoleUserIds),
-            WorkshopLeadUserIds = GetSpecialRoleUserIds(season.Id, CampSpecialRole.Workshop, specialRoleUserIds)
+            LeadUserIds = GetSpecialRoleUserIds(season.Id, CampSpecialRole.Lead, roles?.SpecialRoleUserIds),
+            WorkshopLeadUserIds = GetSpecialRoleUserIds(season.Id, CampSpecialRole.Workshop, roles?.SpecialRoleUserIds)
         };
     }
 
@@ -393,14 +427,21 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
             settings.OpenSeasons.ToList(),
             settings.EeStartDate);
 
-    private static CampSeasonMemberInfo CreateCampSeasonMemberInfo(CampMember member) =>
+    private static CampSeasonMemberInfo CreateCampSeasonMemberInfo(
+        CampMember member,
+        IReadOnlyDictionary<Guid, IReadOnlyList<string>>? memberRoleNames = null) =>
         new(
             member.Id,
             member.UserId,
             member.Status,
             member.RequestedAt,
             member.ConfirmedAt,
-            member.HasEarlyEntry);
+            member.HasEarlyEntry)
+        {
+            Roles = memberRoleNames is not null && memberRoleNames.TryGetValue(member.Id, out var names)
+                ? names
+                : []
+        };
 
     private static CampEditData CreateCampEditData(Camp camp, CampSeason season, LocalDate today)
     {
@@ -800,11 +841,11 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
     {
         var season = await _repo.GetSeasonByIdAsync(campSeasonId, cancellationToken);
         if (season is null) return null;
-        var specialRoleUserIds = await GetSpecialRoleUserIdsBySeasonAsync([season.Year], cancellationToken);
+        var roles = await GetRoleProjectionForYearsAsync([season.Year], cancellationToken);
         return CreateCampSeasonInfo(
             season,
             season.Camp?.Slug ?? string.Empty,
-            specialRoleUserIds: specialRoleUserIds);
+            roles: roles);
     }
 
     public async Task<CampMemberLookup?> GetCampMemberStatusAsync(Guid campMemberId, CancellationToken cancellationToken = default)

--- a/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
+++ b/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
@@ -100,6 +100,15 @@ public sealed class CachingCampService(
             .ToList();
     }
 
+    public async Task<CampUserInfo> GetCampUserInfoAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        // PublicYear is always a warm year (warmup seeds it), so both calls below
+        // are served from the dict — no DB round-trip for the human card / Shifts view.
+        var settings = await GetSettingsAsync(cancellationToken);
+        var camps = await GetCampsForYearAsync(settings.PublicYear, cancellationToken);
+        return CampUserInfo.Resolve(camps, settings.PublicYear, userId);
+    }
+
     // Pass-through reads
 
     public Task<CampEditData?> GetCampEditDataAsync(

--- a/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
+++ b/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
@@ -426,6 +426,13 @@ public sealed class CachingCampService(
     public Task InvalidateSeasonAsync(Guid campSeasonId, CancellationToken ct = default) =>
         InvalidateBySeasonAsync(campSeasonId, ct);
 
+    /// <inheritdoc cref="ICampInfoInvalidator.InvalidateAllAsync" />
+    public Task InvalidateAllAsync(CancellationToken ct = default)
+    {
+        RefreshAll();
+        return Task.CompletedTask;
+    }
+
     private Task InvalidateCampAsync(
         Guid campId,
         CancellationToken ct,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Campaigns;
+using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Shifts;
@@ -70,6 +71,7 @@ public class ProfileController(
     ITicketServiceRead ticketQueryService,
     ITeamServiceRead teamService,
     ICampaignService campaignService,
+    ICampServiceRead campService,
     IEmailOutboxServiceRead emailOutboxService,
     IClock clock,
     IAuthorizationService authorizationService,
@@ -1931,7 +1933,9 @@ public class ProfileController(
             .Where(x => x.Membership is not null)
             .Select(x => new TeamMembership(x.TeamInfo.Name, x.Membership!.Role) { IsHidden = x.TeamInfo.IsHidden })
             .ToList();
-        var vm = ProfileSummaryViewModelBuilder.BuildWithProfile(info, memberships);
+        // Camp + roles for the active season; rendered admin-only in the view.
+        var camp = await campService.GetCampUserInfoAsync(id, ct);
+        var vm = ProfileSummaryViewModelBuilder.BuildWithProfile(info, memberships, camp);
 
         return PartialView("_HumanPopover", vm);
     }

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -248,6 +248,20 @@ public class ProfileSummaryViewModel
     public IReadOnlyList<ProfileLanguageDisplayViewModel> Languages { get; set; } = [];
 
     /// <summary>
+    /// The subject's camp for the active season, if they're an active member of one.
+    /// Only rendered in the popover when the viewer holds an admin-shaped role
+    /// (<see cref="Humans.Web.Authorization.PolicyNames.AnyAdminRole"/>). Null when not in a camp this year.
+    /// </summary>
+    public string? CampName { get; set; }
+
+    /// <summary>
+    /// Named camp roles the subject holds in <see cref="CampName"/> (e.g. "Camp Lead",
+    /// "Greeter"), ordered by role sort order. Empty when none. Same admin-only gate as
+    /// <see cref="CampName"/>.
+    /// </summary>
+    public IReadOnlyList<string> CampRoles { get; set; } = [];
+
+    /// <summary>
     /// False when the user exists (AspNetUsers row) but has no Profile row —
     /// e.g. mailing-list / ticketing imports. The popover renders a sparse
     /// "imported account" card in that case instead of 404'ing.

--- a/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
@@ -1,4 +1,5 @@
 using Humans.Application;
+using Humans.Application.Interfaces.Camps;
 using Humans.Application.Models;
 
 namespace Humans.Web.Models;
@@ -24,7 +25,8 @@ public static class ProfileSummaryViewModelBuilder
 
     public static ProfileSummaryViewModel BuildWithProfile(
         UserInfo info,
-        IReadOnlyList<TeamMembership> memberships)
+        IReadOnlyList<TeamMembership> memberships,
+        CampUserInfo? camp = null)
     {
         ArgumentNullException.ThrowIfNull(info);
         ArgumentNullException.ThrowIfNull(memberships);
@@ -56,7 +58,9 @@ public static class ProfileSummaryViewModelBuilder
                 LanguageCode = pl.LanguageCode,
                 LanguageName = Helpers.LanguageCatalog.GetDisplayName(pl.LanguageCode),
                 Proficiency = pl.Proficiency
-            }).ToList()
+            }).ToList(),
+            CampName = camp?.Season?.Name,
+            CampRoles = camp?.Roles ?? []
         };
     }
 }

--- a/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
@@ -7,6 +7,8 @@
         (await AuthService.AuthorizeAsync(User, PolicyNames.TeamsAdminBoardOrAdmin)).Succeeded;
     IReadOnlyList<string> visibleHiddenTeams =
         canSeeHiddenTeams ? Model.HiddenTeams : [];
+    var canSeeCamp =
+        (await AuthService.AuthorizeAsync(User, PolicyNames.AnyAdminRole)).Succeeded;
 }
 
 <div class="d-flex align-items-center" style="min-width: 200px;">
@@ -66,6 +68,19 @@
                 @lang.LanguageName
                 <small class="opacity-75">(@lang.Proficiency)</small>
             </span>
+        }
+    </div>
+}
+@if (canSeeCamp && !string.IsNullOrEmpty(Model.CampName))
+{
+    <div class="mt-2 pt-2 border-top">
+        <span class="badge bg-light text-dark border me-1 mb-1" style="font-size: 0.7rem;"
+              title="Camp — current season (admin-only)">
+            <i class="fa-solid fa-campground me-1 opacity-75"></i>@Model.CampName
+        </span>
+        @foreach (var role in Model.CampRoles)
+        {
+            <span class="badge bg-info-subtle text-dark border me-1 mb-1" style="font-size: 0.7rem;">@role</span>
         }
     </div>
 }

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
@@ -5,6 +5,7 @@ using Humans.Application.Configuration;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Campaigns;
+using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Gdpr;
@@ -108,6 +109,7 @@ public class ProfileControllerDietaryMedicalReplayTests
             Substitute.For<ITicketService>(),
             Substitute.For<ITeamService>(),
             Substitute.For<ICampaignService>(),
+            Substitute.For<ICampServiceRead>(),
             Substitute.For<IEmailOutboxService>(),
             new FakeClock(Instant.FromUtc(2026, 5, 25, 12, 0)),
             authorizationService,

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -6,6 +6,7 @@ using Humans.Application.DTOs.Shifts;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Campaigns;
+using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Gdpr;
@@ -112,6 +113,7 @@ public class ProfileControllerEditTests
             Substitute.For<ITicketService>(),
             Substitute.For<ITeamService>(),
             Substitute.For<ICampaignService>(),
+            Substitute.For<ICampServiceRead>(),
             Substitute.For<IEmailOutboxService>(),
             new FakeClock(Instant.FromUtc(2026, 5, 9, 12, 0)),
             authorizationService,

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
@@ -5,6 +5,7 @@ using Humans.Domain.Enums;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Campaigns;
+using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Gdpr;
@@ -100,6 +101,7 @@ public class ProfileControllerEmailGridTests
             Substitute.For<ITicketService>(),
             Substitute.For<ITeamService>(),
             Substitute.For<ICampaignService>(),
+            Substitute.For<ICampServiceRead>(),
             Substitute.For<IEmailOutboxService>(),
             new FakeClock(Instant.FromUtc(2026, 4, 30, 12, 0)),
             _authorizationService,

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
@@ -4,6 +4,7 @@ using Humans.Application.Configuration;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Campaigns;
+using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Gdpr;
@@ -43,6 +44,7 @@ public class ProfileControllerPopoverTests
     private readonly IProfilePictureService _profilePictureService = Substitute.For<IProfilePictureService>();
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly IAuthorizationService _authorizationService = Substitute.For<IAuthorizationService>();
+    private readonly ICampServiceRead _campService = Substitute.For<ICampServiceRead>();
     private readonly ProfileController _controller;
     private readonly Guid _viewerId = Guid.NewGuid();
 
@@ -90,6 +92,7 @@ public class ProfileControllerPopoverTests
             Substitute.For<ITicketService>(),
             _teamService,
             Substitute.For<ICampaignService>(),
+            _campService,
             Substitute.For<IEmailOutboxService>(),
             new FakeClock(Instant.FromUtc(2026, 5, 9, 12, 0)),
             _authorizationService,
@@ -201,6 +204,47 @@ public class ProfileControllerPopoverTests
         vm.MembershipStatus.Should().Be("Active");
         vm.City.Should().Be("Madrid");
         vm.CountryCode.Should().Be("ES");
+    }
+
+    [HumansFact]
+    public async Task Popover_UserInCampWithRoles_PopulatesCampNameAndRoles()
+    {
+        var id = Guid.NewGuid();
+        var user = new User
+        {
+            Id = id,
+            DisplayName = "Camp Human",
+            Email = "camp@example.com",
+            PreferredLanguage = "en",
+        };
+        var profile = new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = id,
+            MembershipTier = MembershipTier.Volunteer,
+            IsApproved = true,
+            IsSuspended = false,
+            State = ProfileState.Active,
+        };
+        _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
+            .Returns(BuildUserInfo(user, profile, userEmails: null));
+        _teamService.GetActiveTeamMembershipsForUserAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new List<Models.TeamMembership>());
+
+        var season = new CampSeasonInfo(
+            Guid.NewGuid(), Guid.NewGuid(), "camp-funhouse", 2026, null,
+            "Camp Funhouse", "", "", [],
+            CampSeasonStatus.Active, YesNoMaybe.Yes, YesNoMaybe.No,
+            AdultPlayspacePolicy.No, 0, null, null, null, 0, null, null);
+        _campService.GetCampUserInfoAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new CampUserInfo(season, ["Camp Lead", "Greeter"]));
+
+        var result = await _controller.Popover(id, CancellationToken.None);
+
+        var vm = result.Should().BeOfType<PartialViewResult>().Subject
+            .Model.Should().BeOfType<ProfileSummaryViewModel>().Subject;
+        vm.CampName.Should().Be("Camp Funhouse");
+        vm.CampRoles.Should().Equal("Camp Lead", "Greeter");
     }
 
     private static UserInfo BuildUserInfo(User user, Profile? profile, IReadOnlyList<UserEmail>? userEmails) =>

--- a/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
@@ -164,6 +164,9 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
             Arg.Any<string>(),
             _actorUserId,
             null, null);
+
+        // Name/SortOrder are cached in the CampInfo role projection across all camps.
+        await _campInfoInvalidator.Received(1).InvalidateAllAsync(Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -208,6 +211,8 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
         await AuditLog.Received(1).LogAsync(
             AuditAction.CampRoleDefinitionDeactivated,
             nameof(CampRoleDefinition), def.Id, Arg.Any<string>(), _actorUserId, null, null);
+
+        await _campInfoInvalidator.Received(1).InvalidateAllAsync(Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -231,6 +236,8 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
         await AuditLog.Received(1).LogAsync(
             AuditAction.CampRoleDefinitionReactivated,
             nameof(CampRoleDefinition), def.Id, Arg.Any<string>(), _actorUserId, null, null);
+
+        await _campInfoInvalidator.Received(1).InvalidateAllAsync(Arg.Any<CancellationToken>());
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -1388,6 +1388,73 @@ public sealed class CampServiceTests : ServiceTestHarness
     }
 
     // ==========================================================================
+    // GetCampUserInfoAsync / CampUserInfo.Resolve
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetCampUserInfoAsync_ActiveMemberWithRole_ReturnsActiveSeasonAndNamedRole()
+    {
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        var season = await Db.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id);
+        var regularDef = await SeedRegularDefinitionAsync();
+        var userId = Guid.NewGuid();
+        await SeedRoleAssignmentAsync(season.Id, regularDef.Id, userId);
+
+        var info = await _service.GetCampUserInfoAsync(userId);
+
+        info.Season.Should().NotBeNull();
+        info.Season!.CampId.Should().Be(camp.Id);
+        info.Season.Year.Should().Be(2026);
+        info.Roles.Should().ContainSingle().Which.Should().Be(regularDef.Name);
+    }
+
+    [HumansFact]
+    public async Task GetCampUserInfoAsync_NonMember_ReturnsNone()
+    {
+        await SeedSettingsAsync();
+        await CreateTestCamp();
+
+        var info = await _service.GetCampUserInfoAsync(Guid.NewGuid());
+
+        info.Season.Should().BeNull();
+        info.Roles.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void Resolve_ActiveMemberInActiveYear_ReturnsSeasonAndRolesInOrder()
+    {
+        var userId = Guid.NewGuid();
+        var camps = new[] { MakeCampWithMember(2026, userId, CampMemberStatus.Active, ["Camp Lead", "Greeter"]) };
+
+        var info = CampUserInfo.Resolve(camps, activeYear: 2026, userId);
+
+        info.Season.Should().NotBeNull();
+        info.Season!.Year.Should().Be(2026);
+        info.Roles.Should().Equal("Camp Lead", "Greeter");
+    }
+
+    [HumansFact]
+    public void Resolve_MemberOnlyInPriorYearSeason_ReturnsNone()
+    {
+        // The user's camp last ran in 2025; active year is 2026. Must NOT surface
+        // the stale prior-year season just because it's the camp's latest.
+        var userId = Guid.NewGuid();
+        var camps = new[] { MakeCampWithMember(2025, userId, CampMemberStatus.Active, ["Camp Lead"]) };
+
+        CampUserInfo.Resolve(camps, activeYear: 2026, userId).Should().BeSameAs(CampUserInfo.None);
+    }
+
+    [HumansFact]
+    public void Resolve_PendingMemberInActiveYear_ReturnsNone()
+    {
+        var userId = Guid.NewGuid();
+        var camps = new[] { MakeCampWithMember(2026, userId, CampMemberStatus.Pending, []) };
+
+        CampUserInfo.Resolve(camps, activeYear: 2026, userId).Should().BeSameAs(CampUserInfo.None);
+    }
+
+    // ==========================================================================
     // Helpers
     // ==========================================================================
 
@@ -1430,6 +1497,27 @@ public sealed class CampServiceTests : ServiceTestHarness
             EeSlotCount: 0,
             EeGrantedCount: 0,
             JoinedMemberCount: 0);
+
+    private static CampInfo MakeCampWithMember(
+        int year, Guid userId, CampMemberStatus status, IReadOnlyList<string> roles)
+    {
+        var campId = Guid.NewGuid();
+        var requestedAt = Instant.FromUtc(year, 3, 1, 0, 0);
+        var season = MakeCampSeasonInfo(campId, year, CampSeasonStatus.Active) with
+        {
+            Members =
+            [
+                new CampSeasonMemberInfo(
+                    Guid.NewGuid(), userId, status, requestedAt, requestedAt, HasEarlyEntry: false)
+                {
+                    Roles = roles
+                }
+            ]
+        };
+        return new CampInfo(
+            campId, "resolve-camp", "camp@example.com", "+34600000010",
+            IsSwissCamp: false, TimesAtNowhere: 1, [season]);
+    }
 
     private async Task<Camp> CreateTestCamp()
     {


### PR DESCRIPTION
## What

Adds `ICampServiceRead.GetCampUserInfoAsync(userId, ct)` → `CampUserInfo`, the cross-section read for *"what camp is this user in this year, and what roles do they hold there"* — and wires it into the human-card popover as its consumer.

```csharp
Task<CampUserInfo> GetCampUserInfoAsync(Guid userId, CancellationToken ct = default);

public sealed record CampUserInfo(CampSeasonInfo? Season, IReadOnlyList<string> Roles);
```

- **Active year only.** Resolves against the `PublicYear` season *specifically* — never a camp's latest/stale prior-year season. `Season` is null (and `Roles` empty) when the user isn't an **Active** member of any camp this year.
- **Full named roles**: includes "Camp Lead"/"Workshop Lead" (now `CampRoleAssignment`s) and admin-defined custom roles, ordered by sort order.

## How (read model)

No new query, no new repo method. The cache warmup's existing `GetActiveAssignmentsForYearsAsync` fetch already loads every active assignment (definition name + member) — previously only the Lead/Workshop user-id lists were kept. That same set now also projects **per-member role names** onto `CampSeasonMemberInfo.Roles`. `CampService` resolves over `GetCampsForYearAsync(PublicYear)`; `CachingCampService` over its own cached settings + per-year read → pure in-memory. `HUM0029` (read-interface DTO-only) satisfied.

## Consumer — human popover

`ProfileController.Popover` fetches the subject's camp + roles (cache-served) and passes them to `ProfileSummaryViewModel`; `_HumanPopover` renders a camp badge + role badges, **gated to admin-shaped viewers** (`PolicyNames.AnyAdminRole`) alongside the existing hidden-teams / language-flag admin sections.

## Tests

- `CampUserInfo.Resolve`: active-year-only (rejects stale prior-year season), Active-only (rejects Pending), role-name order, none-on-miss; end-to-end `GetCampUserInfoAsync` projection test.
- Popover test proving camp name + roles reach the view model.
- Build 0 errors. Application.Tests 3282 passed / 1 skipped. Web.Tests 213 passed. Analyzers 12 passed.
- Integration.Tests not run locally (Docker/Testcontainers unavailable) — unaffected.

## Remaining follow-up

- **Shifts coordinator view** — show what camp a shift person is from. Not wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)