### PR TITLE
chore(hooks): hard-block authoring EF data migrations

### DIFF
--- a/.claude/block-data-migration-hook.sh
+++ b/.claude/block-data-migration-hook.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-# block-data-migration-hook.sh — PreToolUse hook (Write|Edit|MultiEdit).
+# block-data-migration-hook.sh — PreToolUse hook.
 #
-# Hard-blocks authoring an EF *data* migration: a migrationBuilder.Sql(...) call
-# carrying UPDATE/INSERT/DELETE in a *.cs file under a Migrations/ directory.
+# Hard-blocks authoring an EF *data* migration — a migrationBuilder.Sql(...) call
+# carrying UPDATE/INSERT/DELETE in a *.cs file under a Migrations/ directory — at
+# two enforcement points:
+#   * Write|Edit|MultiEdit : the text this tool call would land in the file.
+#   * Bash `git commit`    : the staged/committed Migrations/*.cs content. This is
+#                            the backstop that also catches files produced by
+#                            cat/tee/sed/python/etc., which never touch the
+#                            Write/Edit tools.
+#
 # Schema migrations are left alone — CreateTable/AddColumn and even raw DDL via
-# migrationBuilder.Sql (e.g. CREATE INDEX) pass untouched; only data-mutating SQL
+# migrationBuilder.Sql (e.g. CREATE INDEX) pass through; only data-mutating SQL
 # (UPDATE/INSERT/DELETE) trips the block.
 #
 # Rationale: HARD RULE — an LLM must never author data migrations. Backfilling or
@@ -17,36 +24,93 @@
 set -euo pipefail
 
 INPUT=$(cat)
-
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
+
+GUIDANCE='An LLM must NEVER author data migrations: backfilling or transforming user data guesses prior state and yields audit-indefensible rows. Schema changes (including raw DDL such as CREATE INDEX) are fine — data-mutating SQL is not. Do this instead: (1) lazy-seed / transform on first interaction in application code, or (2) if a genuine backfill is truly required, STOP and ask Peter — do not write it yourself.'
+
+# True when a blob carries a data-mutating raw-SQL migration call: a
+# migrationBuilder.Sql( call AND a word-bounded UPDATE/INSERT/DELETE somewhere in
+# the blob. Conservative by design (any DML keyword + any Sql() call trips it),
+# which errs toward blocking — the intended bias for this guard.
+is_data_migration() {
+  printf '%s' "$1" | grep -qE 'migrationBuilder\.Sql\s*\(' \
+    && printf '%s' "$1" | grep -qiE '\b(UPDATE|INSERT|DELETE)\b'
+}
+
+deny() {
+  jq -nc --arg r "$1" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+  exit 0
+}
+
 case "$TOOL" in
-  Write|Edit|MultiEdit) ;;
-  *) exit 0 ;;
+  Write|Edit|MultiEdit)
+    FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+    # Only C# files inside a Migrations/ directory (handles / and \ separators).
+    echo "$FILE" | grep -qE '([/\\])Migrations[/\\].*\.cs$' || exit 0
+
+    # New text this call would introduce: Write -> content; Edit -> new_string;
+    # MultiEdit -> edits[].new_string.
+    NEW=$(echo "$INPUT" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join("\n")')
+
+    # Edit/MultiEdit carry only a fragment, so the Sql( call and the DML keyword
+    # can be split across the existing file and the edit — e.g. add an empty
+    # Sql("") in one edit, then fill it with UPDATE in a second whose new_string
+    # no longer mentions Sql(. Fold in the on-disk file so that split cannot slip
+    # through. The pre-edit file over-approximates the post-edit result (an edit
+    # only adds tokens to this scan, never hides one), so there are no false
+    # negatives. Write replaces the whole file, so its content is self-complete.
+    EXISTING=""
+    if [ "$TOOL" != "Write" ]; then
+      FILE_FS=$(printf '%s' "$FILE" | tr '\\' '/')
+      if [ -f "$FILE_FS" ]; then
+        EXISTING=$(cat "$FILE_FS")
+      fi
+    fi
+    CONTENT=$(printf '%s\n%s' "$EXISTING" "$NEW")
+
+    is_data_migration "$CONTENT" || exit 0
+    deny "BLOCKED (hard rule, no bypass): this writes an EF *data* migration — a migrationBuilder.Sql(...) containing UPDATE/INSERT/DELETE in a Migrations/*.cs file. $GUIDANCE"
+    ;;
+
+  Bash)
+    CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+    # Backstop for non-Write authoring paths: gate the commit, where the content
+    # to be shipped is final regardless of how it was produced. (Optional `-C
+    # <path>` is honoured because the permission allowlist permits `git -C`.)
+    echo "$CMD" | grep -qE '\bgit([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+commit\b' || exit 0
+
+    # -a/-am/--all commits tracked working-tree edits → diff HEAD + read worktree;
+    # a plain commit ships only the index → diff --cached + read the staged blob.
+    # (Mirrors .claude/razor-lint-hook.sh's mode selection.)
+    if echo "$CMD" | grep -qE '(\s-[a-zA-Z]*a[a-zA-Z]*(\s|$|"))|(\s--all(\s|=|$|"))'; then
+      files=$(git diff HEAD --name-only 2>/dev/null | grep -E '(^|/)Migrations/.*\.cs$' || true)
+      staged=0
+    else
+      files=$(git diff --cached --name-only 2>/dev/null | grep -E '(^|/)Migrations/.*\.cs$' || true)
+      staged=1
+    fi
+    [ -n "$files" ] || exit 0
+
+    hits=""
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      if [ "$staged" -eq 1 ]; then
+        body=$(git show ":$f" 2>/dev/null || true)
+      else
+        body=$(cat "$f" 2>/dev/null || true)
+      fi
+      if is_data_migration "$body"; then
+        hits="$hits $f"
+      fi
+    done <<< "$files"
+    [ -n "$hits" ] || exit 0
+
+    deny "BLOCKED (hard rule, no bypass): this commit would ship an EF *data* migration —$hits contains a migrationBuilder.Sql(...) with UPDATE/INSERT/DELETE. $GUIDANCE"
+    ;;
+
+  *)
+    exit 0
+    ;;
 esac
-
-FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
-
-# Only C# files inside a Migrations/ directory (handles both / and \ separators).
-echo "$FILE" | grep -qE '([/\\])Migrations[/\\].*\.cs$' || exit 0
-
-# New text this call would introduce, across the Write/Edit/MultiEdit shapes:
-#   Write     -> .tool_input.content
-#   Edit      -> .tool_input.new_string
-#   MultiEdit -> .tool_input.edits[].new_string
-CONTENT=$(echo "$INPUT" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join("\n")')
-
-# Must add a raw-SQL call ...
-echo "$CONTENT" | grep -qE 'migrationBuilder\.Sql\s*\(' || exit 0
-# ... carrying a data-mutation keyword (case-insensitive, word-bounded).
-echo "$CONTENT" | grep -qiE '\b(UPDATE|INSERT|DELETE)\b' || exit 0
-
-REASON='BLOCKED (hard rule, no bypass): this writes an EF *data* migration — a migrationBuilder.Sql(...) containing UPDATE/INSERT/DELETE in a Migrations/*.cs file. An LLM must NEVER author data migrations: backfilling or transforming user data guesses prior state and yields audit-indefensible rows. Schema changes (including raw DDL such as CREATE INDEX) are fine — data-mutating SQL is not. Do this instead: (1) lazy-seed / transform on first interaction in application code, or (2) if a genuine backfill is truly required, STOP and ask Peter — do not write it yourself.'
-
-jq -nc --arg r "$REASON" '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "deny",
-    permissionDecisionReason: $r
-  }
-}'
-exit 0

--- a/.claude/block-data-migration-hook.sh
+++ b/.claude/block-data-migration-hook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# block-data-migration-hook.sh — PreToolUse hook (Write|Edit|MultiEdit).
+#
+# Hard-blocks authoring an EF *data* migration: a migrationBuilder.Sql(...) call
+# carrying UPDATE/INSERT/DELETE in a *.cs file under a Migrations/ directory.
+# Schema migrations are left alone — CreateTable/AddColumn and even raw DDL via
+# migrationBuilder.Sql (e.g. CREATE INDEX) pass untouched; only data-mutating SQL
+# (UPDATE/INSERT/DELETE) trips the block.
+#
+# Rationale: HARD RULE — an LLM must never author data migrations. Backfilling or
+# transforming user data requires guessing prior state and produces
+# audit-indefensible rows (UpdateSource="DataMigration"). Lazy-seed on first
+# interaction instead; if a genuine backfill is truly required, stop and ask Peter.
+#
+# This is structural enforcement, not a reminder. There is no bypass.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // ""')
+case "$TOOL" in
+  Write|Edit|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+# Only C# files inside a Migrations/ directory (handles both / and \ separators).
+echo "$FILE" | grep -qE '([/\\])Migrations[/\\].*\.cs$' || exit 0
+
+# New text this call would introduce, across the Write/Edit/MultiEdit shapes:
+#   Write     -> .tool_input.content
+#   Edit      -> .tool_input.new_string
+#   MultiEdit -> .tool_input.edits[].new_string
+CONTENT=$(echo "$INPUT" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join("\n")')
+
+# Must add a raw-SQL call ...
+echo "$CONTENT" | grep -qE 'migrationBuilder\.Sql\s*\(' || exit 0
+# ... carrying a data-mutation keyword (case-insensitive, word-bounded).
+echo "$CONTENT" | grep -qiE '\b(UPDATE|INSERT|DELETE)\b' || exit 0
+
+REASON='BLOCKED (hard rule, no bypass): this writes an EF *data* migration — a migrationBuilder.Sql(...) containing UPDATE/INSERT/DELETE in a Migrations/*.cs file. An LLM must NEVER author data migrations: backfilling or transforming user data guesses prior state and yields audit-indefensible rows. Schema changes (including raw DDL such as CREATE INDEX) are fine — data-mutating SQL is not. Do this instead: (1) lazy-seed / transform on first interaction in application code, or (2) if a genuine backfill is truly required, STOP and ask Peter — do not write it yourself.'
+
+jq -nc --arg r "$REASON" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
+  }
+}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,12 @@
             "command": "bash .claude/razor-lint-hook.sh || true",
             "timeout": 15,
             "statusMessage": "Linting Razor views..."
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/block-data-migration-hook.sh",
+            "timeout": 10,
+            "statusMessage": "Checking for data migration commit..."
           }
         ]
       },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,17 @@
             "statusMessage": "Linting Razor views..."
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/block-data-migration-hook.sh",
+            "timeout": 10,
+            "statusMessage": "Checking for data migration..."
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## What

Adds a project-level **PreToolUse hook** (`Write|Edit|MultiEdit`) that **denies the tool call** whenever it would write a `migrationBuilder.Sql(...)` containing **UPDATE/INSERT/DELETE** into a `*.cs` file under a `Migrations/` directory.

This is the "structurally impossible" version of the standing rule *an LLM must never author data migrations* — instead of trusting memory for the 51st time, the write physically fails.

## Files

- `.claude/block-data-migration-hook.sh` — the hook. Reads the tool-call JSON on stdin, checks tool ∈ {Write, Edit, MultiEdit}, path matches `…/Migrations/….cs` (handles `/` and `\`), and the new text contains both `migrationBuilder.Sql(` and a word-bounded `UPDATE|INSERT|DELETE`. On match it emits a `permissionDecision: deny` with an actionable reason; otherwise exits 0.
- `.claude/settings.json` — new `Write|Edit|MultiEdit` matcher group invoking the hook (mirrors the existing `bash .claude/razor-lint-hook.sh` wiring).

## What it does NOT block (verified)

- Schema migrations — `CreateTable` / `AddColumn`, columns named `DeletedAtUtc` / `InsertedBy`.
- Raw **DDL** via `migrationBuilder.Sql("CREATE INDEX …")`.
- Read-only `migrationBuilder.Sql("SELECT …")`.
- `migrationBuilder.Sql(...)` DML in files **outside** `Migrations/`, or in non-`.cs` files (so docs that quote the pattern aren't blocked).

## Testing

11-case matrix run against the script directly (Write/Edit/MultiEdit, both path separators, block + allow): all pass. The deny only fires on `Sql(` + DML keyword in a `Migrations/*.cs` file.

## Notes

- Granularity is **deny this one tool call**, not halt the session — the agent reads the reason and pivots to lazy-seed-on-first-interaction, or stops to ask.
- Scope is exactly the requested `UPDATE/INSERT/DELETE`. `MERGE`/`TRUNCATE` are not covered — say the word and I'll add them.
- Takes effect for sessions that load this `settings.json` (after merge to `main` + pull).

🤖 Generated with [Claude Code](https://claude.com/claude-code)