### PR TITLE
refactor(shifts): converge ShiftSignups + EventSettings onto ShiftRepository (−32 HUM0025 warnings)

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IShiftManagementRepository.Signups.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IShiftManagementRepository.Signups.cs
@@ -1,4 +1,6 @@
+using Humans.Application.DTOs.VolunteerTrackingExport;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Application.Interfaces.Shifts;
 using NodaTime;
 namespace Humans.Application.Interfaces.Repositories;
@@ -156,7 +158,38 @@ public partial interface IShiftManagementRepository
     /// </summary>
     Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
         Guid eventSettingsId, CancellationToken ct = default);
+
+    /// <summary>
+    /// All eligible Build-period signups for the event: rows where
+    /// Shift.DayOffset ∈ [BuildStartOffset, 0), the rota's period
+    /// is Build or All, and Status ∈ {Confirmed, Pending}.
+    /// </summary>
+    Task<IReadOnlyList<EligibleBuildSignup>> GetEligibleBuildSignupsAsync(
+        Guid eventSettingsId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns confirmed shift signups whose [StartsAtUtc, EndsAtUtc) overlaps the date range
+    /// (in event-local time). When <paramref name="departmentId"/> is non-null, restricts to
+    /// shifts whose rota belongs to that team.
+    /// </summary>
+    Task<IReadOnlyList<ConfirmedShiftRow>> GetConfirmedShiftsInRangeAsync(
+        Guid eventSettingsId,
+        LocalDate startDate,
+        LocalDate endDate,
+        Guid? departmentId,
+        CancellationToken ct);
 }
+
+/// <summary>
+/// Projection: just what the gap-detector needs for a single eligible signup.
+/// RotaName is the parent rota's display name, used by the heatmap partial
+/// to populate cell-click popovers.
+/// </summary>
+public sealed record EligibleBuildSignup(
+    Guid UserId,
+    int DayOffset,
+    SignupStatus Status,
+    string RotaName);
 
 public enum ShiftSignupBlockMutationScope
 {

--- a/src/Humans.Application/Interfaces/Repositories/IVolunteerTrackingRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IVolunteerTrackingRepository.cs
@@ -1,15 +1,12 @@
-using Humans.Application.DTOs.VolunteerTrackingExport;
 using Humans.Domain.Attributes;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using NodaTime;
 
 namespace Humans.Application.Interfaces.Repositories;
 
 /// <summary>
 /// Shifts-owned I/O for user-oriented volunteer state:
-/// <c>volunteer_build_statuses</c>, <c>general_availability</c>, and the
-/// scoped Build-period signup read used by the gap detector. All methods
+/// <c>volunteer_build_statuses</c> and <c>general_availability</c>. All methods
 /// return materialized lists / nullable rows - no IQueryable leaks.
 /// </summary>
 [Section("Shifts")]
@@ -104,34 +101,4 @@ public interface IVolunteerTrackingRepository : IRepository
         int dayOffset,
         CancellationToken ct = default);
 
-    /// <summary>
-    /// All eligible Build-period signups for the event: rows where
-    /// Shift.DayOffset ∈ [BuildStartOffset, 0), the rota's period
-    /// is Build or All, and Status ∈ {Confirmed, Pending}.
-    /// </summary>
-    Task<IReadOnlyList<EligibleBuildSignup>> GetEligibleBuildSignupsAsync(
-        Guid eventSettingsId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns confirmed shift signups whose [StartsAtUtc, EndsAtUtc) overlaps the date range
-    /// (in event-local time). When <paramref name="departmentId"/> is non-null, restricts to
-    /// shifts whose rota belongs to that team.
-    /// </summary>
-    Task<IReadOnlyList<ConfirmedShiftRow>> GetConfirmedShiftsInRangeAsync(
-        Guid eventSettingsId,
-        LocalDate startDate,
-        LocalDate endDate,
-        Guid? departmentId,
-        CancellationToken ct);
 }
-
-/// <summary>
-/// Projection: just what the gap-detector needs for a single eligible signup.
-/// RotaName is the parent rota's display name, used by the heatmap partial
-/// to populate cell-click popovers.
-/// </summary>
-public sealed record EligibleBuildSignup(
-    Guid UserId,
-    int DayOffset,
-    SignupStatus Status,
-    string RotaName);

--- a/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
+++ b/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
@@ -15,19 +15,19 @@ namespace Humans.Application.Services.Shifts;
 /// re-check on <see cref="Humans.Domain.Enums.SignupStatus"/>.
 /// </summary>
 public sealed class VolunteerTrackingExportService(
-    IVolunteerTrackingRepository repository,
+    IShiftManagementRepository shiftManagementRepository,
     IShiftManagementService shiftManagementService,
     IUserServiceRead userService)
     : IVolunteerTrackingExportService, IEarlyEntryProvider
 {
-    private readonly IVolunteerTrackingRepository _repository = repository;
+    private readonly IShiftManagementRepository _shiftManagementRepository = shiftManagementRepository;
     private readonly IShiftManagementService _shiftManagementService = shiftManagementService;
     private readonly IUserServiceRead _userService = userService;
 
     public async Task<VolunteerExportModel> BuildAsync(VolunteerExportRequest request, CancellationToken ct)
     {
         var days = EnumerateDays(request.StartDate, request.EndDate);
-        var shifts = await _repository.GetConfirmedShiftsInRangeAsync(
+        var shifts = await _shiftManagementRepository.GetConfirmedShiftsInRangeAsync(
             request.EventSettingsId, request.StartDate, request.EndDate, request.DepartmentId, ct);
 
         // Resolve team names via the Teams-aware service surface (the Shifts repo
@@ -269,7 +269,7 @@ public sealed class VolunteerTrackingExportService(
 
         var start = es.GateOpeningDate.PlusDays(es.BuildStartOffset);
         var end = es.GateOpeningDate.PlusDays(-1);
-        var rows = await _repository.GetConfirmedShiftsInRangeAsync(es.Id, start, end, departmentId: null, ct);
+        var rows = await _shiftManagementRepository.GetConfirmedShiftsInRangeAsync(es.Id, start, end, departmentId: null, ct);
         if (rows.Count == 0) return [];
 
         var depts = await _shiftManagementService.GetDepartmentsWithRotasAsync(es.Id);

--- a/src/Humans.Application/Services/Shifts/VolunteerTrackingService.cs
+++ b/src/Humans.Application/Services/Shifts/VolunteerTrackingService.cs
@@ -81,7 +81,7 @@ public sealed class VolunteerTrackingService(
         var today = clock.GetCurrentInstant().InZone(zone).Date;
         var todayOffset = OffsetOf(es, today);
 
-        var signups = await trackingRepo.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
+        var signups = await shiftManagement.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
         var users = await userService.GetAllUserInfosAsync(ct).ConfigureAwait(false);
         var statusMap = users
             .SelectMany(
@@ -267,7 +267,7 @@ public sealed class VolunteerTrackingService(
             return new SetCampSetupResult(false, "VolTrack_Err_SetupAtOrAfterGateOpen", null);
         }
 
-        var signups = await trackingRepo.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
+        var signups = await shiftManagement.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
         int? firstSignup = signups
             .Where(s => s.UserId == targetUserId)
             .Select(s => (int?)s.DayOffset)
@@ -319,7 +319,7 @@ public sealed class VolunteerTrackingService(
             return new SetDayOffResult(false, "VolTrack_Err_DayOffOutsideBuild");
         }
 
-        var signups = await trackingRepo.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
+        var signups = await shiftManagement.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
         var hasSignupThatDay = signups.Any(s => s.UserId == targetUserId && s.DayOffset == dayOffset);
         if (hasSignupThatDay)
         {
@@ -365,7 +365,7 @@ public sealed class VolunteerTrackingService(
         var zone = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
         var todayOffset = OffsetOf(es, clock.GetCurrentInstant().InZone(zone).Date);
 
-        var signups = await trackingRepo.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
+        var signups = await shiftManagement.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
         var daySignups = signups
             .Where(s => s.UserId == userId)
             .GroupBy(s => s.DayOffset)

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
@@ -1,4 +1,3 @@
-using Humans.Application.Architecture;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -21,8 +20,6 @@ namespace Humans.Infrastructure.Repositories.Shifts;
 /// share one EF change tracker.
 /// </para>
 /// </summary>
-[Grandfathered("HUM0025", justification: "EventSettings is also read by VolunteerTrackingRepository; route VolunteerTracking through a Shifts read surface.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "EventSettings")]
-[Grandfathered("HUM0025", justification: "ShiftSignups is also read by VolunteerTrackingRepository; route VolunteerTracking through a Shifts read surface.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "ShiftSignups")]
 internal sealed partial class ShiftRepository : IShiftManagementRepository
 {
     private readonly IDbContextFactory<HumansDbContext> _factory;

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Signups.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Signups.cs
@@ -1,3 +1,4 @@
+using Humans.Application.DTOs.VolunteerTrackingExport;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Domain.Entities;
@@ -244,5 +245,115 @@ internal sealed partial class ShiftRepository
             .Distinct()
             .ToListAsync(ct);
         return userIds.ToHashSet();
+    }
+
+    public async Task<IReadOnlyList<EligibleBuildSignup>> GetEligibleBuildSignupsAsync(
+        Guid eventSettingsId, CancellationToken ct = default)
+    {
+        var es = await _dbContext.EventSettings
+            .Where(x => x.Id == eventSettingsId)
+            .Select(x => new { x.BuildStartOffset })
+            .FirstOrDefaultAsync(ct);
+
+        if (es is null) return [];
+
+        // SignupStatus and RotaPeriod are stored as strings via
+        // HasConversion<string>(). Per memory/code/no-enum-compare-in-ef.md, we
+        // avoid `>=`/`<=` on those enums and use an explicit `||` chain so the
+        // SQL stays a literal-IN match (no lexicographic comparison).
+        // DayOffset is an int — direct numeric comparison is safe.
+        return await _dbContext.ShiftSignups
+            .Where(s => s.Status == SignupStatus.Confirmed || s.Status == SignupStatus.Pending)
+            .Where(s => s.Shift.DayOffset >= es.BuildStartOffset && s.Shift.DayOffset < 0)
+            .Where(s => s.Shift.Rota.Period == RotaPeriod.Build || s.Shift.Rota.Period == RotaPeriod.All)
+            .Where(s => s.Shift.Rota.EventSettingsId == eventSettingsId)
+            .Select(s => new EligibleBuildSignup(
+                s.UserId, s.Shift.DayOffset, s.Status, s.Shift.Rota.Name))
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<ConfirmedShiftRow>> GetConfirmedShiftsInRangeAsync(
+        Guid eventSettingsId,
+        LocalDate startDate,
+        LocalDate endDate,
+        Guid? departmentId,
+        CancellationToken ct)
+    {
+        // Look up the event so we can resolve absolute shift times in memory.
+        // Shift.StartsAtUtc / EndsAtUtc are NOT stored columns: absolute times are
+        // computed from (GateOpeningDate + DayOffset + StartTime + Duration) via
+        // Shift.GetAbsoluteStart / GetAbsoluteEnd, which involve a NodaTime zone
+        // conversion that cannot be translated to SQL. We narrow in SQL by
+        // DayOffset and finalise the overlap check in memory.
+        var settings = await _dbContext.EventSettings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == eventSettingsId, ct)
+            ?? throw new InvalidOperationException($"EventSettings {eventSettingsId} not found.");
+
+        var zone = DateTimeZoneProviders.Tzdb[settings.TimeZoneId];
+        var rangeStartUtc = startDate.AtStartOfDayInZone(zone).ToInstant();
+        var rangeEndUtcExclusive = endDate.PlusDays(1).AtStartOfDayInZone(zone).ToInstant();
+
+        // DayOffset window matching [startDate, endDate] inclusive, with a one-day
+        // buffer on either side to defend against per-shift wall-time edge cases
+        // and DST. Final filter below clips to the real instant overlap.
+        var startOffset = Period.Between(settings.GateOpeningDate, startDate, PeriodUnits.Days).Days - 1;
+        var endOffset = Period.Between(settings.GateOpeningDate, endDate, PeriodUnits.Days).Days + 1;
+
+        var query = _dbContext.ShiftSignups
+            .AsNoTracking()
+            .Where(s => s.Status == SignupStatus.Confirmed)
+            .Where(s => s.Shift.Rota.EventSettingsId == eventSettingsId)
+            .Where(s => s.Shift.DayOffset >= startOffset && s.Shift.DayOffset <= endOffset);
+
+        if (departmentId.HasValue)
+        {
+            var deptId = departmentId.Value;
+            query = query.Where(s => s.Shift.Rota.TeamId == deptId);
+        }
+
+        var raw = await query
+            .Select(s => new
+            {
+                s.UserId,
+                s.Shift.RotaId,
+                TeamId = s.Shift.Rota.TeamId,
+                s.Shift.DayOffset,
+                s.Shift.StartTime,
+                s.Shift.Duration,
+                s.Shift.IsAllDay,
+            })
+            .ToListAsync(ct);
+
+        if (raw.Count == 0) return [];
+
+        // Team names are NOT resolved here: Teams is another section's table and a
+        // Shifts repo must not query db.Teams (memory/architecture/no-cross-section-ef-joins.md).
+        // The caller (VolunteerTrackingExportService) stitches TeamId → name via
+        // IShiftManagementService.GetDepartmentsWithRotasAsync.
+        var rows = new List<ConfirmedShiftRow>(raw.Count);
+        foreach (var r in raw)
+        {
+            // Reconstruct a minimal Shift so we can reuse the canonical helpers.
+            var shift = new Shift
+            {
+                RotaId = r.RotaId,
+                DayOffset = r.DayOffset,
+                StartTime = r.StartTime,
+                Duration = r.Duration,
+                IsAllDay = r.IsAllDay,
+            };
+            var startsAtUtc = shift.GetAbsoluteStart(settings);
+            var endsAtUtc = shift.GetAbsoluteEnd(settings);
+            if (startsAtUtc < rangeEndUtcExclusive && endsAtUtc > rangeStartUtc)
+            {
+                rows.Add(new ConfirmedShiftRow(
+                    r.UserId,
+                    r.TeamId,
+                    startsAtUtc,
+                    endsAtUtc));
+            }
+        }
+        return rows;
     }
 }

--- a/src/Humans.Infrastructure/Repositories/Shifts/VolunteerTrackingRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/VolunteerTrackingRepository.cs
@@ -1,8 +1,5 @@
-using Humans.Application.DTOs.VolunteerTrackingExport;
-using Humans.Application.Architecture;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
@@ -19,8 +16,6 @@ namespace Humans.Infrastructure.Repositories.Shifts;
 /// <see cref="ShiftRepository"/>) so multi-step mutations on
 /// <see cref="VolunteerBuildStatus"/> share one EF change-tracker.
 /// </remarks>
-[Grandfathered("HUM0025", justification: "Shifts-section table shared across the Shifts repositories; converge them on one owner per table.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "EventSettings")]
-[Grandfathered("HUM0025", justification: "Shifts-section table shared across the Shifts repositories; converge them on one owner per table.", since: "2026-05-25", issueRef: "docs/superpowers/specs/2026-05-25-analyzer-consolidation.md", scope: "ShiftSignups")]
 internal sealed class VolunteerTrackingRepository(HumansDbContext db) : IVolunteerTrackingRepository
 {
     public async Task<IReadOnlyList<VolunteerBuildStatus>> GetBuildStatusesForEventAsync(
@@ -226,113 +221,4 @@ internal sealed class VolunteerTrackingRepository(HumansDbContext db) : IVolunte
         return row;
     }
 
-    public async Task<IReadOnlyList<EligibleBuildSignup>> GetEligibleBuildSignupsAsync(
-        Guid eventSettingsId, CancellationToken ct = default)
-    {
-        var es = await db.EventSettings
-            .Where(x => x.Id == eventSettingsId)
-            .Select(x => new { x.BuildStartOffset })
-            .FirstOrDefaultAsync(ct);
-
-        if (es is null) return [];
-
-        // SignupStatus and RotaPeriod are stored as strings via
-        // HasConversion<string>(). Per memory/code/no-enum-compare-in-ef.md, we
-        // avoid `>=`/`<=` on those enums and use an explicit `||` chain so the
-        // SQL stays a literal-IN match (no lexicographic comparison).
-        // DayOffset is an int — direct numeric comparison is safe.
-        return await db.ShiftSignups
-            .Where(s => s.Status == SignupStatus.Confirmed || s.Status == SignupStatus.Pending)
-            .Where(s => s.Shift.DayOffset >= es.BuildStartOffset && s.Shift.DayOffset < 0)
-            .Where(s => s.Shift.Rota.Period == RotaPeriod.Build || s.Shift.Rota.Period == RotaPeriod.All)
-            .Where(s => s.Shift.Rota.EventSettingsId == eventSettingsId)
-            .Select(s => new EligibleBuildSignup(
-                s.UserId, s.Shift.DayOffset, s.Status, s.Shift.Rota.Name))
-            .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<ConfirmedShiftRow>> GetConfirmedShiftsInRangeAsync(
-        Guid eventSettingsId,
-        LocalDate startDate,
-        LocalDate endDate,
-        Guid? departmentId,
-        CancellationToken ct)
-    {
-        // Look up the event so we can resolve absolute shift times in memory.
-        // Shift.StartsAtUtc / EndsAtUtc are NOT stored columns: absolute times are
-        // computed from (GateOpeningDate + DayOffset + StartTime + Duration) via
-        // Shift.GetAbsoluteStart / GetAbsoluteEnd, which involve a NodaTime zone
-        // conversion that cannot be translated to SQL. We narrow in SQL by
-        // DayOffset and finalise the overlap check in memory.
-        var settings = await db.EventSettings
-            .AsNoTracking()
-            .FirstOrDefaultAsync(e => e.Id == eventSettingsId, ct)
-            ?? throw new InvalidOperationException($"EventSettings {eventSettingsId} not found.");
-
-        var zone = DateTimeZoneProviders.Tzdb[settings.TimeZoneId];
-        var rangeStartUtc = startDate.AtStartOfDayInZone(zone).ToInstant();
-        var rangeEndUtcExclusive = endDate.PlusDays(1).AtStartOfDayInZone(zone).ToInstant();
-
-        // DayOffset window matching [startDate, endDate] inclusive, with a one-day
-        // buffer on either side to defend against per-shift wall-time edge cases
-        // and DST. Final filter below clips to the real instant overlap.
-        var startOffset = Period.Between(settings.GateOpeningDate, startDate, PeriodUnits.Days).Days - 1;
-        var endOffset = Period.Between(settings.GateOpeningDate, endDate, PeriodUnits.Days).Days + 1;
-
-        var query = db.ShiftSignups
-            .AsNoTracking()
-            .Where(s => s.Status == SignupStatus.Confirmed)
-            .Where(s => s.Shift.Rota.EventSettingsId == eventSettingsId)
-            .Where(s => s.Shift.DayOffset >= startOffset && s.Shift.DayOffset <= endOffset);
-
-        if (departmentId.HasValue)
-        {
-            var deptId = departmentId.Value;
-            query = query.Where(s => s.Shift.Rota.TeamId == deptId);
-        }
-
-        var raw = await query
-            .Select(s => new
-            {
-                s.UserId,
-                s.Shift.RotaId,
-                TeamId = s.Shift.Rota.TeamId,
-                s.Shift.DayOffset,
-                s.Shift.StartTime,
-                s.Shift.Duration,
-                s.Shift.IsAllDay,
-            })
-            .ToListAsync(ct);
-
-        if (raw.Count == 0) return [];
-
-        // Team names are NOT resolved here: Teams is another section's table and a
-        // Shifts repo must not query db.Teams (memory/architecture/no-cross-section-ef-joins.md).
-        // The caller (VolunteerTrackingExportService) stitches TeamId → name via
-        // IShiftManagementService.GetDepartmentsWithRotasAsync.
-        var rows = new List<ConfirmedShiftRow>(raw.Count);
-        foreach (var r in raw)
-        {
-            // Reconstruct a minimal Shift so we can reuse the canonical helpers.
-            var shift = new Shift
-            {
-                RotaId = r.RotaId,
-                DayOffset = r.DayOffset,
-                StartTime = r.StartTime,
-                Duration = r.Duration,
-                IsAllDay = r.IsAllDay,
-            };
-            var startsAtUtc = shift.GetAbsoluteStart(settings);
-            var endsAtUtc = shift.GetAbsoluteEnd(settings);
-            if (startsAtUtc < rangeEndUtcExclusive && endsAtUtc > rangeStartUtc)
-            {
-                rows.Add(new ConfirmedShiftRow(
-                    r.UserId,
-                    r.TeamId,
-                    startsAtUtc,
-                    endsAtUtc));
-            }
-        }
-        return rows;
-    }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/VolunteerTrackingExportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/VolunteerTrackingExportServiceTests.cs
@@ -37,13 +37,13 @@ public sealed class VolunteerTrackingExportServiceTests
             ActorPlayaName: "TestActor",
             GeneratedAtUtc: TestNow);
 
-    private static (IVolunteerTrackingRepository repo, IShiftManagementService shiftMgmt, IUserService users)
+    private static (IShiftManagementRepository repo, IShiftManagementService shiftMgmt, IUserService users)
         BuildMocks(
             IReadOnlyList<ConfirmedShiftRow> shifts,
             IReadOnlyList<(Guid TeamId, string TeamName)>? departments = null,
             IReadOnlyDictionary<Guid, string>? playaNames = null)
     {
-        var repo = Substitute.For<IVolunteerTrackingRepository>();
+        var repo = Substitute.For<IShiftManagementRepository>();
         repo.GetConfirmedShiftsInRangeAsync(
             Arg.Any<Guid>(), Arg.Any<LocalDate>(), Arg.Any<LocalDate>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
             .Returns(shifts);
@@ -186,7 +186,7 @@ public sealed class VolunteerTrackingExportServiceTests
         // Bob worked TeamA on Day3, TeamB on Day4. Filtered to TeamA: row appears,
         // Day3 colored, Day4 empty, arrival = Day2 (day before TeamA's first shift).
         var teamAOnly = new[] { ShiftRow(Bob, TeamA, Day1.PlusDays(2), 9, 17) };
-        var repo = Substitute.For<IVolunteerTrackingRepository>();
+        var repo = Substitute.For<IShiftManagementRepository>();
         repo.GetConfirmedShiftsInRangeAsync(EventId, Day1, Day7, TeamA, Arg.Any<CancellationToken>())
             .Returns(teamAOnly);
         var shiftMgmt = Substitute.For<IShiftManagementService>();

--- a/tests/Humans.Application.Tests/Services/Shifts/VolunteerTrackingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/VolunteerTrackingServiceTests.cs
@@ -1,6 +1,5 @@
 using AwesomeAssertions;
 using Humans.Application.DTOs;
-using Humans.Application.DTOs.VolunteerTrackingExport;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;
@@ -301,7 +300,7 @@ public class VolunteerTrackingServiceTests
         {
             new(userId, -5, SignupStatus.Confirmed, "Cleanup"),
         };
-        var trackingRepo = new FakeVolunteerTrackingRepository(signups, [], []);
+        var trackingRepo = new FakeVolunteerTrackingRepository([], []);
         var sut = BuildSut(es, signups: signups, trackingRepo: trackingRepo);
         var setupDate = es.GateOpeningDate.PlusDays(-3);
 
@@ -336,7 +335,7 @@ public class VolunteerTrackingServiceTests
             SetAt = TestNow,
         };
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [bs], []);
+            [bs], []);
         var sut = BuildSut(es, buildStatuses: [bs], trackingRepo: trackingRepo);
 
         await sut.ClearCampSetupAsync(userId, coordinatorId);
@@ -418,7 +417,7 @@ public class VolunteerTrackingServiceTests
         var userId = Guid.NewGuid();
         var coordId = Guid.NewGuid();
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [], []);
+            [], []);
         var sut = BuildSut(es, trackingRepo: trackingRepo);
 
         var result = await sut.SetDayOffAsync(userId, -3, "doctor", coordId);
@@ -439,7 +438,7 @@ public class VolunteerTrackingServiceTests
         var es = MakeEvent(buildStartOffset: -5);
         var userId = Guid.NewGuid();
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [], []);
+            [], []);
         var sut = BuildSut(es, trackingRepo: trackingRepo);
 
         await sut.SetDayOffAsync(userId, -3, "doctor", Guid.NewGuid());
@@ -455,7 +454,7 @@ public class VolunteerTrackingServiceTests
     {
         var es = MakeEvent(buildStartOffset: -5);
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [], []);
+            [], []);
         var sut = BuildSut(es, trackingRepo: trackingRepo);
 
         await sut.SetDayOffAsync(Guid.NewGuid(), -3, "   ", Guid.NewGuid());
@@ -487,7 +486,7 @@ public class VolunteerTrackingServiceTests
             BarrioSetupStartDate = es.GateOpeningDate.PlusDays(-3),  // span = -3..-1
         };
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [bs], []);
+            [bs], []);
         var sut = BuildSut(es, buildStatuses: [bs], trackingRepo: trackingRepo);
 
         // -2 is INSIDE the camp-setup span. The service does NOT reject.
@@ -512,7 +511,7 @@ public class VolunteerTrackingServiceTests
             ],
         };
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [bs], []);
+            [bs], []);
         var sut = BuildSut(es, buildStatuses: [bs], trackingRepo: trackingRepo);
 
         var result = await sut.ClearDayOffAsync(
@@ -527,7 +526,7 @@ public class VolunteerTrackingServiceTests
     {
         var es = MakeEvent(buildStartOffset: -5);
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [], []);
+            [], []);
         var sut = BuildSut(es, trackingRepo: trackingRepo);
 
         var result = await sut.ClearDayOffAsync(
@@ -649,7 +648,7 @@ public class VolunteerTrackingServiceTests
                 new(-6, "soon", Guid.NewGuid(), TestNow) // inside new span
             ],
         };
-        var trackingRepo = new FakeVolunteerTrackingRepository(signups, [bs], []);
+        var trackingRepo = new FakeVolunteerTrackingRepository([bs], []);
         var sut = BuildSut(es, signups: signups, buildStatuses: [bs], trackingRepo: trackingRepo);
 
         // New camp-setup at -7 → span covers -7, -6, -5, ..., -1.
@@ -677,7 +676,7 @@ public class VolunteerTrackingServiceTests
             ],
         };
         var trackingRepo = new FakeVolunteerTrackingRepository(
-            [], [bs], []);
+            [bs], []);
         var sut = BuildSut(es, buildStatuses: [bs], trackingRepo: trackingRepo);
 
         var result = await sut.SetCampSetupAsync(
@@ -727,6 +726,8 @@ public class VolunteerTrackingServiceTests
         var shiftMgmt = Substitute.For<IShiftManagementRepository>();
         shiftMgmt.GetActiveEventSettingsAsync(Arg.Any<CancellationToken>())
             .Returns(activeEvent);
+        shiftMgmt.GetEligibleBuildSignupsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(signups ?? []);
 
         var userService = Substitute.For<IUserServiceRead>();
         userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
@@ -755,7 +756,6 @@ public class VolunteerTrackingServiceTests
             });
 
         trackingRepo ??= new FakeVolunteerTrackingRepository(
-            signups ?? [],
             buildStatuses ?? [],
             availabilities ?? []);
 
@@ -784,7 +784,6 @@ public class VolunteerTrackingServiceTests
     // ----------------------------------------------------------------------
 
     private sealed class FakeVolunteerTrackingRepository(
-        IReadOnlyList<EligibleBuildSignup> signups,
         IReadOnlyList<VolunteerBuildStatus> buildStatuses,
         IReadOnlyList<GeneralAvailability> availabilities) : IVolunteerTrackingRepository
     {
@@ -927,17 +926,5 @@ public class VolunteerTrackingServiceTests
             var removed = existing.DayOffs.RemoveAll(d => d.DayOffset == dayOffset) > 0;
             return Task.FromResult(removed);
         }
-
-        public Task<IReadOnlyList<EligibleBuildSignup>> GetEligibleBuildSignupsAsync(
-            Guid eventSettingsId, CancellationToken ct = default)
-            => Task.FromResult(signups);
-
-        public Task<IReadOnlyList<ConfirmedShiftRow>> GetConfirmedShiftsInRangeAsync(
-            Guid eventSettingsId,
-            LocalDate startDate,
-            LocalDate endDate,
-            Guid? departmentId,
-            CancellationToken ct)
-            => Task.FromResult<IReadOnlyList<ConfirmedShiftRow>>([]);
     }
 }

--- a/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryConfirmedShiftsTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryConfirmedShiftsTests.cs
@@ -13,7 +13,7 @@ namespace Humans.Integration.Tests.Repositories.Shifts;
 
 /// <summary>
 /// Integration tests for
-/// <see cref="IVolunteerTrackingRepository.GetConfirmedShiftsInRangeAsync"/>.
+/// <see cref="IShiftManagementRepository.GetConfirmedShiftsInRangeAsync"/>.
 /// Mirrors the existing <c>VolunteerTrackingRepositoryTests</c> style: container-
 /// backed factory via <see cref="IClassFixture{T}"/>, scope per test, real
 /// PostgreSQL. Seeding helpers are inlined here (rather than shared) because the
@@ -34,7 +34,7 @@ public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
     {
         await using var scope = _factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
-        var repo = scope.ServiceProvider.GetRequiredService<IVolunteerTrackingRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
         var (eventId, _, _, _) = await SeedFixtureAsync(db);
 
@@ -54,7 +54,7 @@ public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
     {
         await using var scope = _factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
-        var repo = scope.ServiceProvider.GetRequiredService<IVolunteerTrackingRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
         var (eventId, _, _, _) = await SeedFixtureAsync(db);
 
@@ -74,7 +74,7 @@ public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
     {
         await using var scope = _factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
-        var repo = scope.ServiceProvider.GetRequiredService<IVolunteerTrackingRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
         var (eventId, teamAId, teamBId, _) = await SeedFixtureAsync(db);
 
@@ -93,7 +93,7 @@ public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
     {
         await using var scope = _factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
-        var repo = scope.ServiceProvider.GetRequiredService<IVolunteerTrackingRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
         var (eventId, _, _, _) = await SeedFixtureAsync(db);
 

--- a/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -94,7 +95,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
         await using var scope = factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);   // BuildStartOffset = -10
-        var sut = new VolunteerTrackingRepository(db);
+        var sut = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
         var teamId = (await SeedTeamAsync(db)).Id;
         var userId = (await SeedUserAsync(db)).Id;


### PR DESCRIPTION
## What

Clears **32 build warnings** (127 → 95, 0 errors) by converging the `ShiftSignups` and `EventSettings` tables onto a single owning repository, per HUM0025 ("a table must belong to exactly one repository").

`VolunteerTrackingRepository` read `DbContext.ShiftSignups` and `DbContext.EventSettings` directly, making both tables shared across two Shifts repositories. Both repos carried `[Grandfathered("HUM0025", …)]` markers citing [`docs/superpowers/specs/2026-05-25-analyzer-consolidation.md`](../blob/main/docs/superpowers/specs/2026-05-25-analyzer-consolidation.md), whose intended resolution is: *"route VolunteerTracking through a Shifts read surface."* This PR executes that convergence.

## How

- **Moved** `GetEligibleBuildSignupsAsync` + `GetConfirmedShiftsInRangeAsync` (both fundamentally `ShiftSignups → Shift → Rota` joins filtered by `EventSettings`) from `VolunteerTrackingRepository` → `ShiftRepository`, the sole owner of all four tables. Declared on `IShiftManagementRepository` (with the `EligibleBuildSignup` projection).
- **Repointed callers** (intra-section, no new surface): `VolunteerTrackingService` already injected `IShiftManagementRepository` — just moved 4 call sites. `VolunteerTrackingExportService` swapped its `IVolunteerTrackingRepository` injection for `IShiftManagementRepository`.
- **Removed** the 4 now-stale `[Grandfathered]` attributes (2 on each repo) and the usings they left dead.

`ShiftRepository` is now the single owner of `ShiftSignups` + `EventSettings`, so all 32 HUM0025 warnings for those tables clear. **No schema change.**

The remaining HUM0025 warnings (`GoogleSyncOutboxEvents`, `SystemSettings`) belong to other sections and are out of scope here.

## Verification

- `dotnet build Humans.slnx`: **127 → 95 warnings, 0 errors** (clean rebuild)
- Unit tests (`~VolunteerTracking`): **48 passed**
- Architecture ratchet tests (`~Architecture`): **229 passed**
- Integration-test changes are mechanical DI-resolution swaps (`GetRequiredService<IVolunteerTrackingRepository>` → `<IShiftManagementRepository>`); not runnable locally (no Docker) — will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)