### PR TITLE
feat(store): surface recorded payments on order page + admin-nav Payments link

### DIFF
--- a/docs/sections/Store.md
+++ b/docs/sections/Store.md
@@ -168,7 +168,7 @@ Stored as int via `HasConversion<int>()`.
 ## Routing
 
 - `/Store` — Camp Lead and department-coordinator order browse + create + line edit. Each counterparty (camp-you-lead or department-you-coordinate) is rendered as its own card. A privileged reader (StoreAdmin/FinanceAdmin/Admin **or** TeamsAdmin) sees every camp season and department for the year, not just the ones they lead/coordinate; per-row Create/Delete affordances are resolved against `StoreOrderAuthorizationHandler` rather than a blanket admin flag.
-- `/Store/Order/{id}` — Order detail. Camp orders show balance + Pay button. Team orders show only lines + add-line form + a "non-billable" footer (no counterparty form, no Pay, no payments list).
+- `/Store/Order/{id}` — Order detail. Camp orders show summary cards (lines subtotal, VAT, deposits, total payments, balance owed), the recorded-payments list (date, method, Stripe/external reference, amount), the Pay button, and a collapsed-by-default counterparty section. Team orders show only lines + add-line form + a "non-billable" footer (no counterparty form, no Pay, no payments list).
 - `/Store/Team/{teamId}/Create` — POST: department coordinator creates their team's order for the active event year.
 - `/Store/Admin/Catalog` — StoreAdmin catalog CRUD (`StoreAdminController`, policy `StoreCatalogAdmin`).
 - `/Store/Admin/Catalog/Edit[/{id}]` — Create / edit product.
@@ -176,7 +176,7 @@ Stored as int via `HasConversion<int>()`.
 - `/Store/Admin/Catalog/Deactivate/{id}` — POST soft-deactivate product.
 - `/Store/Admin/Orders` — FinanceAdmin order ledger + payment entry + Issue Invoice. **Not yet implemented (Phase 5 stub).**
 - `/Store/Admin/Summary` — FinanceAdmin/StoreAdmin/Admin aggregate report: by-counterparty (with Type column distinguishing Camp / Team), by-item (sums lines from both camp and team orders for supplier aggregation), counterparties × products cross-tab for a given year. Reuses `PolicyNames.StoreCatalogAdmin`.
-- `/Store/Admin/Payments` — FinanceAdmin/StoreAdmin/Admin Stripe payment reconciliation screen: webhook/checkout health banner, every Store Checkout Session matched to its order with a status (Recorded / Missing / Unmatched / Unpaid), and orphan recorded payments. Reuses `PolicyNames.StoreCatalogAdmin`. Linked from the Store-admin button group on `/Store`.
+- `/Store/Admin/Payments` — FinanceAdmin/StoreAdmin/Admin Stripe payment reconciliation screen: webhook/checkout health banner, every Store Checkout Session matched to its order with a status (Recorded / Missing / Unmatched / Unpaid), and orphan recorded payments. Reuses `PolicyNames.StoreCatalogAdmin`. Linked from the Store-admin button group on `/Store` and the admin sidebar (**Store → Store payments**).
 - `/Store/Admin/Payments/RecordMissing` — POST: records every paid, order-matched, not-yet-recorded session via the idempotent `RecordStripePaymentAsync` path.
 - `/Store/StripeWebhook` — anonymous endpoint for Stripe checkout-session events (`StoreStripeWebhookController`).
 

--- a/src/Humans.Application/Services/Store/Dtos/OrderDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderDto.cs
@@ -19,9 +19,19 @@ public record OrderDto(
     string? CounterpartyEmail,
     Guid? IssuedInvoiceId,
     IReadOnlyList<OrderLineDto> Lines,
+    IReadOnlyList<OrderPaymentDto> Payments,
     decimal LinesSubtotalEur,
     decimal VatTotalEur,
     decimal DepositTotalEur,
     decimal PaymentsTotalEur,
     decimal BalanceEur,
     Instant CreatedAt);
+
+/// <summary>One recorded payment against a camp order (a row in <c>store_payments</c>).</summary>
+public record OrderPaymentDto(
+    decimal AmountEur,
+    StorePaymentMethod Method,
+    string? StripePaymentIntentId,
+    string? ExternalRef,
+    Instant ReceivedAt,
+    string? Notes);

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -1022,7 +1022,6 @@ public class StoreService(
         }).ToList();
 
         var payments = o.Payments
-            .OrderBy(p => p.ReceivedAt)
             .Select(p => new OrderPaymentDto(
                 p.AmountEur, p.Method, p.StripePaymentIntentId, p.ExternalRef, p.ReceivedAt, p.Notes))
             .ToList();

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -1021,6 +1021,12 @@ public class StoreService(
                 t.SubtotalEur, t.VatEur, t.DepositEur, t.TotalEur);
         }).ToList();
 
+        var payments = o.Payments
+            .OrderBy(p => p.ReceivedAt)
+            .Select(p => new OrderPaymentDto(
+                p.AmountEur, p.Method, p.StripePaymentIntentId, p.ExternalRef, p.ReceivedAt, p.Notes))
+            .ToList();
+
         var counterpartyType = o.TeamId is not null
             ? StoreOrderCounterpartyType.Team
             : StoreOrderCounterpartyType.Camp;
@@ -1039,6 +1045,7 @@ public class StoreService(
             o.CounterpartyName, o.CounterpartyVatId, o.CounterpartyAddress, o.CounterpartyCountryCode, o.CounterpartyEmail,
             o.IssuedInvoiceId,
             lines,
+            payments,
             balance.LinesSubtotalEur, balance.VatTotalEur, balance.DepositTotalEur,
             balance.PaymentsTotalEur, balance.BalanceEur,
             o.CreatedAt);

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -45,8 +45,9 @@ public static class AdminNavTree
             new("Finance",        "Finance",      "Index",   null, null, "fa-solid fa-coins",        PolicyNames.FinanceAdminOrAdmin)
         ]),
         new("Store", [
-            new("Store catalog",  "StoreAdmin",   "Catalog", null, null, "fa-solid fa-tags",         PolicyNames.StoreCatalogAdmin),
-            new("Store summary",  "StoreAdmin",   "Summary", null, null, "fa-solid fa-chart-column", PolicyNames.StoreCatalogAdmin)
+            new("Store catalog",  "StoreAdmin",   "Catalog",  null, null, "fa-solid fa-tags",         PolicyNames.StoreCatalogAdmin),
+            new("Store summary",  "StoreAdmin",   "Summary",   null, null, "fa-solid fa-chart-column", PolicyNames.StoreCatalogAdmin),
+            new("Store payments", "StoreAdmin",   "Payments",  null, null, "fa-solid fa-credit-card",  PolicyNames.StoreCatalogAdmin)
         ]),
         new("Event Guide", [
             new("Guide settings", "EventsAdmin", "Settings", null, null, "fa-solid fa-calendar-days", PolicyNames.EventsAdminOrAdmin),

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -195,10 +195,10 @@ else
                 </tr>
             </thead>
             <tbody>
-                @foreach (var payment in order.Payments)
+                @foreach (var payment in order.Payments.OrderBy(p => p.ReceivedAt))
                 {
                     <tr>
-                        <td>@payment.ReceivedAt.ToDateTimeUtc().ToString("yyyy-MM-dd HH:mm") UTC</td>
+                        <td>@payment.ReceivedAt.ToAuditMinuteTimestamp() UTC</td>
                         <td><span class="badge bg-secondary">@payment.Method</span></td>
                         <td>
                             @if (!string.IsNullOrEmpty(payment.StripePaymentIntentId ?? payment.ExternalRef))

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -36,33 +36,41 @@
 
 @if (!isTeamOrder)
 {
-    <div class="row mb-4">
-        <div class="col-md-3">
-            <div class="card text-center">
+    <div class="row g-3 mb-4">
+        <div class="col-6 col-md">
+            <div class="card text-center h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">Lines subtotal</h6>
                     <h4 class="card-title mb-0">&euro;@order.LinesSubtotalEur.ToString("N2")</h4>
                 </div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="card text-center">
+        <div class="col-6 col-md">
+            <div class="card text-center h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">VAT</h6>
                     <h4 class="card-title mb-0">&euro;@order.VatTotalEur.ToString("N2")</h4>
                 </div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="card text-center">
+        <div class="col-6 col-md">
+            <div class="card text-center h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">Deposits</h6>
                     <h4 class="card-title mb-0">&euro;@order.DepositTotalEur.ToString("N2")</h4>
                 </div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="card text-center bg-light">
+        <div class="col-6 col-md">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <h6 class="card-subtitle mb-2 text-muted">Total payments</h6>
+                    <h4 class="card-title mb-0 text-success">&euro;@order.PaymentsTotalEur.ToString("N2")</h4>
+                </div>
+            </div>
+        </div>
+        <div class="col-6 col-md">
+            <div class="card text-center bg-light h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">Balance owed</h6>
                     <h4 class="card-title mb-0 fw-bold">&euro;@order.BalanceEur.ToString("N2")</h4>
@@ -174,48 +182,51 @@ else
 
 @if (!isTeamOrder)
 {
-    <h2 class="h4 mb-3">Counterparty (for invoice)</h2>
-    @if (Model.CanEdit)
+    <h2 class="h4 mb-3">Payments</h2>
+    @if (order.Payments.Any())
     {
-        <form asp-action="UpdateCounterparty" asp-route-id="@order.Id" method="post" class="row g-3 mb-4">
-            @Html.AntiForgeryToken()
-            <div class="col-md-6">
-                <label class="form-label">Name</label>
-                <input type="text" name="Name" class="form-control" value="@order.CounterpartyName" />
-            </div>
-            <div class="col-md-6">
-                <label class="form-label">VAT / NIF / CIF</label>
-                <input type="text" name="VatId" class="form-control" value="@order.CounterpartyVatId" />
-            </div>
-            <div class="col-md-12">
-                <label class="form-label">Address</label>
-                <input type="text" name="Address" class="form-control" value="@order.CounterpartyAddress" />
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Country</label>
-                <input type="text" name="CountryCode" class="form-control" maxlength="2" value="@order.CounterpartyCountryCode" />
-            </div>
-            <div class="col-md-6">
-                <label class="form-label">Email</label>
-                <input type="email" name="Email" class="form-control" value="@order.CounterpartyEmail" />
-            </div>
-            <div class="col-md-12">
-                <button type="submit" class="btn btn-primary">Save counterparty</button>
-            </div>
-        </form>
+        <table class="table table-sm mb-3">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Method</th>
+                    <th>Reference</th>
+                    <th class="text-end">Amount</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var payment in order.Payments)
+                {
+                    <tr>
+                        <td>@payment.ReceivedAt.ToDateTimeUtc().ToString("yyyy-MM-dd HH:mm") UTC</td>
+                        <td><span class="badge bg-secondary">@payment.Method</span></td>
+                        <td>
+                            @if (!string.IsNullOrEmpty(payment.StripePaymentIntentId ?? payment.ExternalRef))
+                            {
+                                <code>@(payment.StripePaymentIntentId ?? payment.ExternalRef)</code>
+                            }
+                            else
+                            {
+                                <span class="text-muted">&mdash;</span>
+                            }
+                        </td>
+                        <td class="text-end @(payment.AmountEur < 0 ? "text-danger" : "")">&euro;@payment.AmountEur.ToString("N2")</td>
+                    </tr>
+                }
+            </tbody>
+            <tfoot>
+                <tr class="fw-bold">
+                    <td colspan="3" class="text-end">Total payments</td>
+                    <td class="text-end">&euro;@order.PaymentsTotalEur.ToString("N2")</td>
+                </tr>
+            </tfoot>
+        </table>
     }
     else
     {
-        <dl class="row">
-            <dt class="col-sm-3">Name</dt><dd class="col-sm-9">@order.CounterpartyName</dd>
-            <dt class="col-sm-3">VAT / NIF / CIF</dt><dd class="col-sm-9">@order.CounterpartyVatId</dd>
-            <dt class="col-sm-3">Address</dt><dd class="col-sm-9">@order.CounterpartyAddress</dd>
-            <dt class="col-sm-3">Country</dt><dd class="col-sm-9">@order.CounterpartyCountryCode</dd>
-            <dt class="col-sm-3">Email</dt><dd class="col-sm-9">@order.CounterpartyEmail</dd>
-        </dl>
+        <p class="text-muted">No payments recorded yet.</p>
     }
 
-    <h2 class="h4 mb-3">Payments</h2>
     @if (order.BalanceEur > 0 && Model.CanPay)
     {
         if (Model.IsStripeConfigured)
@@ -248,6 +259,55 @@ else
     {
         <p class="text-muted">Payments are recorded by the finance team.</p>
     }
+
+    <h2 class="h4 mb-3 mt-4">
+        <button class="btn btn-link p-0 text-reset text-decoration-none" type="button"
+                data-bs-toggle="collapse" data-bs-target="#counterpartyCollapse"
+                aria-expanded="false" aria-controls="counterpartyCollapse">
+            <i class="fa-solid fa-chevron-down me-1 small"></i> Counterparty (for invoice)
+        </button>
+    </h2>
+    <div class="collapse" id="counterpartyCollapse">
+        @if (Model.CanEdit)
+        {
+            <form asp-action="UpdateCounterparty" asp-route-id="@order.Id" method="post" class="row g-3 mb-4">
+                @Html.AntiForgeryToken()
+                <div class="col-md-6">
+                    <label class="form-label">Name</label>
+                    <input type="text" name="Name" class="form-control" value="@order.CounterpartyName" />
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">VAT / NIF / CIF</label>
+                    <input type="text" name="VatId" class="form-control" value="@order.CounterpartyVatId" />
+                </div>
+                <div class="col-md-12">
+                    <label class="form-label">Address</label>
+                    <input type="text" name="Address" class="form-control" value="@order.CounterpartyAddress" />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">Country</label>
+                    <input type="text" name="CountryCode" class="form-control" maxlength="2" value="@order.CounterpartyCountryCode" />
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">Email</label>
+                    <input type="email" name="Email" class="form-control" value="@order.CounterpartyEmail" />
+                </div>
+                <div class="col-md-12">
+                    <button type="submit" class="btn btn-primary">Save counterparty</button>
+                </div>
+            </form>
+        }
+        else
+        {
+            <dl class="row">
+                <dt class="col-sm-3">Name</dt><dd class="col-sm-9">@order.CounterpartyName</dd>
+                <dt class="col-sm-3">VAT / NIF / CIF</dt><dd class="col-sm-9">@order.CounterpartyVatId</dd>
+                <dt class="col-sm-3">Address</dt><dd class="col-sm-9">@order.CounterpartyAddress</dd>
+                <dt class="col-sm-3">Country</dt><dd class="col-sm-9">@order.CounterpartyCountryCode</dd>
+                <dt class="col-sm-3">Email</dt><dd class="col-sm-9">@order.CounterpartyEmail</dd>
+            </dl>
+        }
+    </div>
 }
 else
 {

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
@@ -435,6 +435,7 @@ public class StoreServiceTeamOrdersTests
             CounterpartyEmail: null,
             IssuedInvoiceId: null,
             Lines: [],
+            Payments: [],
             LinesSubtotalEur: balanceEur,
             VatTotalEur: 0m,
             DepositTotalEur: 0m,

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
@@ -109,6 +109,7 @@ public class StoreServiceTests
             CounterpartyEmail: null,
             IssuedInvoiceId: null,
             Lines: [],
+            Payments: [],
             LinesSubtotalEur: 25m,
             VatTotalEur: 0m,
             DepositTotalEur: 0m,
@@ -144,7 +145,7 @@ public class StoreServiceTests
             Year: 2026, Label: null, State: StoreOrderState.Open,
             CounterpartyName: null, CounterpartyVatId: null, CounterpartyAddress: null,
             CounterpartyCountryCode: null, CounterpartyEmail: null, IssuedInvoiceId: null,
-            Lines: [line], LinesSubtotalEur: 2.34m, VatTotalEur: 0.49m, DepositTotalEur: 0m,
+            Lines: [line], Payments: [], LinesSubtotalEur: 2.34m, VatTotalEur: 0.49m, DepositTotalEur: 0m,
             PaymentsTotalEur: 0m, BalanceEur: 2.83m, CreatedAt: orderStart);
 
         _audit.GetFilteredEntriesAsync(nameof(StoreProduct), productId, null,
@@ -1198,6 +1199,7 @@ public class StoreServiceTests
             CounterpartyEmail: email,
             IssuedInvoiceId: null,
             Lines: [],
+            Payments: [],
             LinesSubtotalEur: balanceEur,
             VatTotalEur: 0m,
             DepositTotalEur: 0m,

--- a/tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/StoreOrderAuthorizationHandlerTests.cs
@@ -88,6 +88,7 @@ public class StoreOrderAuthorizationHandlerTests
             CounterpartyEmail: null,
             IssuedInvoiceId: null,
             Lines: [],
+            Payments: [],
             LinesSubtotalEur: 0m,
             VatTotalEur: 0m,
             DepositTotalEur: 0m,


### PR DESCRIPTION
## What & why

The camp store order page (`/Store/Order/{id}`) had a **Payments** heading but never listed the payments that had actually been recorded against the order. This surfaces them and tidies the layout.

### Order detail page
- **Total payments** summary card added alongside the existing Lines subtotal / VAT / Deposits / Balance owed cards (cards restructured to responsive equal-width so five fit cleanly).
- **Recorded-payments table** (date · method · Stripe/external reference · amount, with a total row) rendered above the counterparty section. Refunds (negative amounts) show in red.
- **Counterparty (for invoice)** section is now **collapsed by default** — it's rarely used and was eating a lot of vertical space.

### Admin nav
- Added the missing **Store payments** item to the admin sidebar's *Store* group (it previously had only Catalog + Summary, even though the `/Store/Admin/Payments` screen — the Stripe reconciliation view from #883 — already existed and was linked from the `/Store` button group). Reuses `PolicyNames.StoreCatalogAdmin`.

## Implementation notes
- **Read model only:** enriched the canonical `OrderDto` with a `Payments` list (new `OrderPaymentDto`), mapped from the already-loaded `StoreOrder.Payments` aggregate nav. No new interface, repository, or service surface — `GetOrderAsync` already returns `OrderDto`.
- "Reference" column shows `StripePaymentIntentId` (Stripe) falling back to `ExternalRef` (Holded bank-transfer), else `—`.
- Counterparty collapse uses Bootstrap's declarative `data-bs-toggle="collapse"` (no inline script, CSP-safe).

## Testing
- `dotnet build Humans.slnx` — clean (0 errors; Razor views compile at build).
- `dotnet test` Store + AdminSidebar unit tests — **Application.Tests 153/153, Web.Tests 8/8 pass**. (Integration tests require Docker/Testcontainers, unavailable in this environment.)
- Updated the five `OrderDto` test fixtures for the new `Payments` parameter.

Docs: updated the `/Store/Order/{id}` and `/Store/Admin/Payments` routing bullets in `docs/sections/Store.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)