### PR TITLE
fix(store): include Payments on GetOrderForTeamAsync repo query

### DIFF
--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -128,6 +128,7 @@ internal sealed class StoreRepository(IDbContextFactory<HumansDbContext> factory
         await using var ctx = await factory.CreateDbContextAsync(ct);
         return await ctx.StoreOrders.AsNoTracking()
             .Include(o => o.Lines)
+            .Include(o => o.Payments)
             .Where(o => o.TeamId == teamId && o.Year == year)
             .FirstOrDefaultAsync(ct);
     }


### PR DESCRIPTION
## What & why

Follow-up to peterdrier/Humans#885. A review flagged:

> WARN — missing `.Include(o => o.Payments)` on `GetOrderForTeamAsync` repo method

`GetOrderForTeamAsync` feeds the shared `MapOrderAsync`, which since #885 reads `o.Payments` into `OrderDto.Payments`. The query only eager-loaded `Lines`, so on the team-order path the mapper relied on the implicit empty-list nav default instead of an explicit load. Added `.Include(o => o.Payments)` to match the camp-order query paths.

## Severity

Latent / consistency, not a live crash:
- `StoreOrder.Payments` is initialized to an empty list, so there's no `NullReferenceException`.
- Team orders never have payments (section invariant), so the result is correct today.
- The fix makes the mapper's data contract explicit on every feeding query, so it stays correct if the entity's nav initialization or the team-order invariant ever changes.

## Scope

Only `GetOrderForTeamAsync` needed it — it's the one team-order query that flows into `MapOrderAsync`. The sibling `GetOrdersForTeamsWithLinesAsync` deliberately does **not** load payments: it feeds `/Store/Admin/Summary`, which hardcodes team payments to `0m`, and is named "WithLines" by design.

## Testing

- `dotnet build Humans.slnx` — clean.
- Store unit tests: Application 148/148, Web 8/8 pass. (Integration tests require Docker/Testcontainers, unavailable in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)