### PR TITLE
fix(docs): stop NoTargets docs project emitting phantom-compiled obj files

### DIFF
--- a/docs/docs.csproj
+++ b/docs/docs.csproj
@@ -10,6 +10,16 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <IsPackable>false</IsPackable>
+    <!--
+      NoTargets has no CoreCompile, but the SDK still emits GlobalUsings.g.cs
+      (ImplicitUsings) and the TFM AssemblyAttributes.cs into obj/. dotnet build
+      never compiles them, but Roslyn MSBuildWorkspace loaders (e.g. reforge
+      surface-score) open this as a C# project, compile those generated files
+      with no framework references, and report phantom CS0234/CS0518 errors.
+      Suppress both so the project carries zero compilable source.
+    -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/docs.csproj
+++ b/docs/docs.csproj
@@ -12,13 +12,16 @@
     <IsPackable>false</IsPackable>
     <!--
       NoTargets has no CoreCompile, but the SDK still emits GlobalUsings.g.cs
-      (ImplicitUsings) and the TFM AssemblyAttributes.cs into obj/. dotnet build
-      never compiles them, but Roslyn MSBuildWorkspace loaders (e.g. reforge
-      surface-score) open this as a C# project, compile those generated files
-      with no framework references, and report phantom CS0234/CS0518 errors.
-      Suppress both so the project carries zero compilable source.
+      (ImplicitUsings) and the TFM .NETCoreApp,Version=vX.AssemblyAttributes.cs
+      (GenerateTargetFrameworkAttribute) into obj/. dotnet build never compiles
+      them, but Roslyn MSBuildWorkspace loaders (e.g. reforge surface-score) open
+      this as a C# project, compile those generated files with no framework
+      references, and report phantom CS0234/CS0518 errors. Suppress all three so
+      the project carries zero compilable source. GenerateTargetFrameworkAttribute
+      is a separate gate from GenerateAssemblyInfo and must be set explicitly.
     -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
## Problem

The PR Surface Report CI job runs `reforge surface-score`, which loads the solution via Roslyn **MSBuildWorkspace**. On every PR it reported:

> Solution did not compile cleanly (6 compile error(s), 4 unresolved reference(s)). Surface-score is PARTIAL: cross-section/DI/entity rules may under-count.

`dotnet build` is clean (0 errors), so this looked alarming but was never a real build break. All 6 errors trace to the **`docs` NoTargets project**:

- `docs/obj/Debug/net10.0/.NETCoreApp,Version=v10.0.AssemblyAttributes.cs` → CS0234 / CS0518 (`TargetFrameworkAttribute`, `System.String` undefined)
- `docs/obj/Debug/net10.0/docs.GlobalUsings.g.cs` → CS0234 (`System.Linq`, `System.Net` undefined)

## Root cause

`docs.csproj` uses `Microsoft.Build.NoTargets` (no `CoreCompile`) but inherits `ImplicitUsings=enable` and the default `GenerateAssemblyInfo=true` from the root `Directory.Build.props`. The SDK therefore emits `GlobalUsings.g.cs` and the TFM `AssemblyAttributes.cs` into `docs/obj`. `dotnet build` never compiles them, but MSBuildWorkspace opens `docs` as a C# project and compiles those generated files **with no framework references** → every `System.*` type is "undefined." That trips reforge's degraded-build path and downgrades the whole surface score to PARTIAL.

## Fix

Opt the docs-only project out of both codegen features so it carries zero compilable source:

```xml
<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
<ImplicitUsings>disable</ImplicitUsings>
```

The `<None Include="**/*">` glob is untouched, so `docs/` still surfaces in Solution Explorer — the project's only purpose.

## Verification

- `reforge surface-score` → `degraded=false`, **0** compile errors, **0** unresolved references (was 6 / 4).
- Rebuild regenerates no `.cs` under `docs/obj`.
- `dotnet build Humans.slnx` → 0 errors.

## Test plan

- [ ] PR Surface Report job no longer prints the "did not compile cleanly / PARTIAL" warning
- [ ] CI green