### PR TITLE
test(e2e): reuse persona auth state to kill the per-test login herd

### DIFF
--- a/docs/superpowers/plans/2026-06-05-e2e-auth-state-reuse.md
+++ b/docs/superpowers/plans/2026-06-05-e2e-auth-state-reuse.md
@@ -1,0 +1,318 @@
+# e2e Auth-State Reuse + Persona Completeness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the e2e per-test login herd by reusing a once-captured `storageState` cookie per persona, and close the persona-coverage gap in `nav-visibility`.
+
+**Architecture:** A Playwright `setup` project logs in + seeds each persona once (serially, in one looping test) and saves `storageState` to `playwright/.auth/{slug}.json`. `loginAsX(page)` helpers keep their signatures but, instead of hitting `/dev/login`, attach the saved cookies via `addCookies`. The chromium project depends on `setup` and caps `workers`.
+
+**Tech Stack:** Playwright `@playwright/test` ^1.60, TypeScript (CommonJS — `__dirname` available), targets the shared deploy (`BASE_URL`, default `https://humans.n.burn.camp`).
+
+**Spec:** `docs/superpowers/specs/2026-06-05-e2e-auth-state-reuse-design.md`
+
+**Working dir:** `H:/source/humans/.worktrees/e2e-auth-reuse` (branch `test/e2e-auth-state-reuse`). All paths below are under `tests/e2e/`.
+
+---
+
+## File Structure
+
+- `tests/e2e/helpers/auth.ts` — **modify.** Add `PERSONAS` (source of truth), `authFile()`, `liveLoginAndSave()` (live login + capture, used only by setup), rewrite `loginAs()` to reuse saved cookies, add 5 new persona helpers. Keep `getAntiForgeryToken`/`postWithCsrf`/`expectBlocked` unchanged.
+- `tests/e2e/auth.setup.ts` — **create.** Setup project: loop `PERSONAS`, capture state serially.
+- `tests/e2e/playwright.config.ts` — **modify.** Add `setup` project (own `testDir: '.'`), `dependencies: ['setup']` on chromium, `workers` cap.
+- `tests/e2e/tests/nav-visibility.spec.ts` — **modify.** Add 5 matrix rows.
+- `tests/e2e/.gitignore` — **modify.** Ignore `playwright/.auth/`.
+
+No `src/` changes. 18 other spec files unchanged.
+
+---
+
+## Task 1: SPIKE — prove `addCookies` re-authenticates (de-risk before rollout)
+
+The load-bearing assumption: re-adding a saved Identity cookie via `addCookies` to a fresh context yields an authenticated request. If false, the fallback is `test.use({ storageState })`, which forces splitting multi-persona spec files — a much bigger change. Prove it on one persona first.
+
+**Files:**
+- Modify: `tests/e2e/helpers/auth.ts`
+- Create: `tests/e2e/auth.setup.ts`
+- Modify: `tests/e2e/playwright.config.ts`
+
+- [ ] **Step 1: Add persona list + path helper + capture/reuse functions to `auth.ts`**
+
+Add near the top of `tests/e2e/helpers/auth.ts` (after the existing `NAV_SELECTOR` const), and add `import fs from 'fs'; import path from 'path';` to the import block, plus `type BrowserContext` to the `@playwright/test` import:
+
+```ts
+// Single source of truth: every reusable persona slug (= /dev/login/{slug} segment).
+export const PERSONAS = [
+  'volunteer', 'admin', 'board', 'consent-coordinator', 'teams-admin',
+  'camp-admin', 'ticket-admin', 'no-info-admin', 'volunteer-coordinator',
+  'human-admin', 'finance-admin', 'feedback-admin', 'city-planning',
+  'coordinator', 'events-admin', 'store-admin', 'cantina-admin',
+  'e-e-team-admin', 'barrio-1-lead',
+] as const;
+
+// Resolve relative to THIS file (not cwd): tests run via --config from a different cwd.
+const AUTH_DIR = path.join(__dirname, '..', 'playwright', '.auth');
+export const authFile = (slug: string): string => path.join(AUTH_DIR, `${slug}.json`);
+
+function baseUrl(): string {
+  return process.env.BASE_URL || 'https://humans.n.burn.camp';
+}
+
+// Live /dev/login + seed, then capture storageState. Used ONLY by auth.setup.ts.
+export async function liveLoginAndSave(context: BrowserContext, slug: string): Promise<void> {
+  await context.addCookies([
+    { name: 'cookieConsent', value: 'accepted', url: baseUrl(), sameSite: 'Lax' },
+  ]);
+  const page = await context.newPage();
+  await page.goto(`/dev/login/${slug}`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector(NAV_SELECTOR, { timeout: 60_000 });
+  await context.storageState({ path: authFile(slug) });
+  await page.close();
+}
+```
+
+Then replace the existing `loginAs` function body (currently the `/dev/login` + `waitForSelector` version) with the reuse version:
+
+```ts
+// Reuse: attach the persona's once-captured cookies to this test's context.
+// No /dev/login, no seeding, no SeedLock contention.
+async function loginAs(page: Page, slug: string): Promise<void> {
+  const state = JSON.parse(fs.readFileSync(authFile(slug), 'utf-8'));
+  await page.context().addCookies(state.cookies);
+}
+```
+
+Leave all existing `export const loginAsX = (page) => loginAs(page, '...')` lines and `seedCookieConsent`/`getAntiForgeryToken`/`postWithCsrf`/`expectBlocked` as-is.
+
+- [ ] **Step 2: Create the setup project `tests/e2e/auth.setup.ts`**
+
+```ts
+import { test as setup, expect } from '@playwright/test';
+import { PERSONAS, liveLoginAndSave } from './helpers/auth';
+
+// One serial test: seed + log in every persona once, capturing storageState.
+// Single test = single worker = no login herd during seeding.
+setup('authenticate all personas', async ({ browser }) => {
+  setup.setTimeout(PERSONAS.length * 60_000);
+  const failures: string[] = [];
+  for (const slug of PERSONAS) {
+    const context = await browser.newContext();
+    try {
+      await liveLoginAndSave(context, slug);
+    } catch (e) {
+      failures.push(`${slug}: ${(e as Error).message.split('\n')[0]}`);
+    } finally {
+      await context.close();
+    }
+  }
+  expect(failures, `personas failed to seed/login:\n${failures.join('\n')}`).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Wire the setup project in `tests/e2e/playwright.config.ts`**
+
+Replace the `projects` array with:
+
+```ts
+  projects: [
+    { name: 'setup', testDir: '.', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+      dependencies: ['setup'],
+    },
+  ],
+```
+
+(`testDir: '.'` lets the setup project find `auth.setup.ts` at the e2e root; the chromium project keeps the top-level `testDir: './tests'` and the default `*.spec.ts` match, so it ignores the setup file.)
+
+- [ ] **Step 4: Run the spike — one persona, reuse path**
+
+Run (from anywhere; absolute config path):
+
+```bash
+BASE_URL=https://humans.n.burn.camp \
+H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/node_modules/.bin/playwright test nav-visibility \
+  --config H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/playwright.config.ts \
+  --grep "volunteer: sees correct top-nav" --reporter=line
+```
+
+Expected: setup runs (captures all personas once), then the `volunteer` row passes via cookie reuse. **Decision gate:** if it passes → `addCookies` re-auth works, continue to Task 2. If the volunteer row fails at a nav/`expectBlocked` assertion (not a setup failure) → the mechanism does NOT re-auth; STOP and switch to the `test.use({ storageState })` fallback (re-plan with per-persona spec splits).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C H:/source/humans/.worktrees/e2e-auth-reuse add tests/e2e/helpers/auth.ts tests/e2e/auth.setup.ts tests/e2e/playwright.config.ts
+git -C H:/source/humans/.worktrees/e2e-auth-reuse commit -m "test(e2e): storageState reuse mechanism + setup project (spike)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Verify all 14 existing personas pass via reuse
+
+The reuse `loginAs` + the full `PERSONAS` list already cover the 14 existing helpers (their `loginAsX` exports are unchanged and now route through reuse). Confirm the existing matrix is green before adding new rows.
+
+**Files:** none (verification + commit only).
+
+- [ ] **Step 1: Run the full existing `nav-visibility` (13 rows) via reuse**
+
+```bash
+BASE_URL=https://humans.n.burn.camp \
+H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/node_modules/.bin/playwright test nav-visibility \
+  --config H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/playwright.config.ts --reporter=line
+```
+
+Expected: setup + 13 passed, 0 failed. (Pre-change baseline was 13/13 in 9.6s with live login; reuse should match and be faster.)
+
+- [ ] **Step 2: Spot-check a boundary spec actually executes its assertion (not just login)**
+
+```bash
+BASE_URL=https://humans.n.burn.camp \
+H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/node_modules/.bin/playwright test tickets \
+  --config H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/playwright.config.ts --reporter=line
+```
+
+Expected: 3 passed — including `boundary: volunteer cannot access /Tickets` reaching `expectBlocked` (the assertion that previously never ran because login timed out).
+
+No commit (no file changes).
+
+---
+
+## Task 3: Add the 5 missing personas + nav-visibility rows
+
+**Files:**
+- Modify: `tests/e2e/helpers/auth.ts`
+- Modify: `tests/e2e/tests/nav-visibility.spec.ts`
+
+- [ ] **Step 1: Add 5 persona helpers to `auth.ts`**
+
+After the existing `loginAsCityPlanning`/`loginAsCoordinator` exports, add:
+
+```ts
+export const loginAsEventsAdmin = (page: Page) => loginAs(page, 'events-admin');
+export const loginAsStoreAdmin = (page: Page) => loginAs(page, 'store-admin');
+export const loginAsCantinaAdmin = (page: Page) => loginAs(page, 'cantina-admin');
+export const loginAsEETeamAdmin = (page: Page) => loginAs(page, 'e-e-team-admin');
+export const loginAsBarrioLead = (page: Page) => loginAs(page, 'barrio-1-lead');
+```
+
+(The slugs already exist as dev-login personas — `RoleNames` auto-generate one each; `barrio-1-lead` is hardcoded. `e-e-team-admin` is the kebab of `EETeamAdmin`. All are already in `PERSONAS`, so setup already captures them.)
+
+- [ ] **Step 2: Add the 5 rows to `nav-visibility.spec.ts`**
+
+Add these imports to the existing `import { ... } from '../helpers/auth';` block: `loginAsEventsAdmin, loginAsStoreAdmin, loginAsCantinaAdmin, loginAsEETeamAdmin, loginAsBarrioLead`.
+
+Append to the `roles: RoleTest[]` array (before the closing `]`):
+
+```ts
+  { name: 'eventsAdmin', login: loginAsEventsAdmin, visible: ['volunteer', 'admin'] },
+  { name: 'storeAdmin', login: loginAsStoreAdmin, visible: ['volunteer', 'admin'] },
+  { name: 'cantinaAdmin', login: loginAsCantinaAdmin, visible: ['volunteer', 'admin'] },
+  // EETeamAdmin holds a role (passes AppAccess via HasAnyRole) but is NOT in the
+  // AnyAdminRole composite, so it does NOT see the Admin top-nav.
+  { name: 'eeTeamAdmin', login: loginAsEETeamAdmin, visible: ['volunteer'] },
+  // Camp lead: no governance role; access via UserState.Active. Sees Volunteer, not Admin.
+  { name: 'barrioLead', login: loginAsBarrioLead, visible: ['volunteer'] },
+```
+
+- [ ] **Step 3: Run the expanded matrix (18 rows)**
+
+```bash
+BASE_URL=https://humans.n.burn.camp \
+H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/node_modules/.bin/playwright test nav-visibility \
+  --config H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/playwright.config.ts --reporter=line
+```
+
+Expected: 18 passed, 0 failed. Specifically `eeTeamAdmin` and `barrioLead` see Volunteer but NOT Admin; `eventsAdmin`/`storeAdmin`/`cantinaAdmin` see both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C H:/source/humans/.worktrees/e2e-auth-reuse add tests/e2e/helpers/auth.ts tests/e2e/tests/nav-visibility.spec.ts
+git -C H:/source/humans/.worktrees/e2e-auth-reuse commit -m "test(e2e): cover EventsAdmin/StoreAdmin/CantinaAdmin/EETeamAdmin + camp lead in nav matrix
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Cap workers, ignore generated state, full-suite verification
+
+**Files:**
+- Modify: `tests/e2e/playwright.config.ts`
+- Modify: `tests/e2e/.gitignore`
+
+- [ ] **Step 1: Add a workers cap in `playwright.config.ts`**
+
+Add `workers: 4,` to the top-level `defineConfig({...})` object (next to `retries: 2`). Feature tests no longer log in (cookie reuse), so 4 concurrent workers is gentle on the single shared deploy while staying fast.
+
+- [ ] **Step 2: Ignore the generated auth state**
+
+Append to `tests/e2e/.gitignore`:
+
+```
+playwright/.auth/
+```
+
+- [ ] **Step 3: Verify `.auth/` is not tracked**
+
+Run:
+
+```bash
+git -C H:/source/humans/.worktrees/e2e-auth-reuse status --porcelain tests/e2e/playwright/.auth
+```
+
+Expected: empty output (ignored, untracked).
+
+- [ ] **Step 4: Full-suite run — the real test of the fix**
+
+```bash
+BASE_URL=https://humans.n.burn.camp \
+H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/node_modules/.bin/playwright test \
+  --config H:/source/humans/.worktrees/e2e-auth-reuse/tests/e2e/playwright.config.ts --reporter=line \
+  2>&1 | tee C:/Users/PeterDrier/AppData/Local/Temp/e2e-reuse-full.log | tail -8
+```
+
+Expected: dramatically fewer/zero failures vs the pre-change baseline (66 pass / 32 flaky / 17 fail). Critically: **zero `auth.ts` login-wait timeouts.** Any remaining failure must be a real assertion (investigate per systematic-debugging) — confirm by grepping the log:
+
+```bash
+grep -c "waiting for locator('\[data-testid=\"user-nav\"\]" C:/Users/PeterDrier/AppData/Local/Temp/e2e-reuse-full.log
+```
+
+Expected: `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C H:/source/humans/.worktrees/e2e-auth-reuse add tests/e2e/playwright.config.ts tests/e2e/.gitignore
+git -C H:/source/humans/.worktrees/e2e-auth-reuse commit -m "test(e2e): cap workers at 4, gitignore generated .auth state
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Push and open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git -C H:/source/humans/.worktrees/e2e-auth-reuse push
+```
+
+- [ ] **Step 2: Open PR to `origin/main`**
+
+```bash
+gh pr create -R peterdrier/Humans --base main --head test/e2e-auth-state-reuse \
+  --title "test(e2e): reuse persona auth state; cover missing role personas" \
+  --body "See docs/superpowers/specs/2026-06-05-e2e-auth-state-reuse-design.md. Removes the per-test /dev/login herd (capture storageState once in a setup project, reuse the cookie in loginAsX), and adds nav-visibility rows for EventsAdmin/StoreAdmin/CantinaAdmin/EETeamAdmin + camp lead. Test-only; no src changes. Follow-up: nobodies-collective/Humans#832."
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** A (setup project + reuse + config + .gitignore) → Tasks 1,4. Specs-unchanged invariant → only `nav-visibility` edited (Task 3), helper signatures preserved (Task 1 keeps `loginAsX` exports). Live-login coverage retained → setup project (Task 1). b (5 personas + rows) → Task 3. Risk-verify-first → Task 1 decision gate. All covered.
+- **Placeholder scan:** none — every code/command step is concrete.
+- **Type consistency:** `PERSONAS`, `authFile`, `liveLoginAndSave`, `loginAs`, the 5 `loginAsX` names, and the `RoleTest` row shape (`name`/`login`/`visible`) match the existing `nav-visibility.spec.ts` interface and across tasks.

--- a/docs/superpowers/specs/2026-06-05-e2e-auth-state-reuse-design.md
+++ b/docs/superpowers/specs/2026-06-05-e2e-auth-state-reuse-design.md
@@ -1,0 +1,107 @@
+# e2e auth-state reuse + persona completeness
+
+- **Date:** 2026-06-05
+- **Status:** Approved (design), pending implementation
+- **Branch:** `test/e2e-auth-state-reuse`
+- **Related:** predecessor PR peterdrier#881 (name-only access via stored `UserState`); follow-up nobodies-collective/Humans#832 (authorization matrix + section-admin convention)
+
+## Problem
+
+The Playwright e2e suite is fragile under its own load. Every test calls `loginAsX(page)`,
+which hits `/dev/login/{slug}` → triggers heavy first-touch persona seeding in
+`DevPersonaSeeder` (profile, consent, teams, roles; camp+season for barrio leads) behind a
+single global `SemaphoreSlim SeedLock`, against one small shared preview deploy. Run with
+default multi-worker parallelism, ~120 tests stampede that lock and the deploy, so the login
+helper's `waitForSelector` for the nav dropdown blows its 60s budget.
+
+Evidence (PR #881 preview, `https://881.n.burn.camp`): full suite = 66 passed / 32 flaky /
+17 failed; **every** failure was `auth.ts:27` (the login nav-wait), none were access
+assertions. The same `nav-visibility` tests passed 13/13 in 9.6s when run alone with 1 worker.
+So the assertions are sound; the per-test login-under-concurrency is the fragility.
+
+A second gap surfaced: the suite only has helpers for 14 personas, but the app defines 15
+`RoleNames` + a camp-lead class. Missing e2e coverage: `EventsAdmin`, `StoreAdmin`,
+`CantinaAdmin` (all in `AnyAdminRole` → should see Admin nav), `EETeamAdmin` (role but NOT in
+`AnyAdminRole` → should NOT see Admin nav), and `barrio-N-lead` (camp lead — access via
+`camp.IsLead`, no governance role). For a PR that rewrote `AnyAdminRole`, those rows are
+exactly the access surface left untested.
+
+## Goals
+
+- Eliminate the per-test login herd so failures reflect real behavior, not login latency.
+- Keep the 19 spec files unchanged (helper signatures stay identical).
+- Retain coverage of the live login + seeding path (exercise it once, explicitly).
+- Close the persona-coverage gap in the `nav-visibility` access matrix.
+
+## Non-goals
+
+- The role × route authorization matrix and section-admin route convention → tracked in #832.
+- Resource-scoped authz tests (camp-lead-of-*this*-camp) → #832.
+- Changing the e2e target away from the shared preview deploy.
+
+## Design
+
+### A. Auth-state reuse (robustness)
+
+**Single source of truth.** `helpers/auth.ts` exports a `PERSONAS` array (slug per persona).
+The named helpers (`loginAsVolunteer`, …) each reference a slug from it. Adding a persona =
+one array entry + one named export.
+
+**New setup project — `tests/e2e/auth.setup.ts`.** For each persona slug, once:
+1. `seedCookieConsent`, then `goto('/dev/login/{slug}')` (real login → seeds + authenticates),
+   `waitForSelector(NAV_SELECTOR)`.
+2. `context.storageState({ path: 'playwright/.auth/{slug}.json' })`.
+
+Runs serially, before the test projects. This is the **sole, explicit coverage of the live
+login + seeding path** — if seeding or the onboarding redirect breaks, setup fails fast and
+loudly, before any feature test.
+
+**`helpers/auth.ts` change.** `loginAsX(page)` keeps its exact signature but no longer hits
+`/dev/login`. It seeds the consent cookie and applies the persona's saved cookies via
+`page.context().addCookies(...)` read from `playwright/.auth/{slug}.json`. Instant, no network
+login, no nav-wait, no `SeedLock` contention. All ~175 call sites are untouched.
+
+**`playwright.config.ts` change.** Add a `setup` project (`testMatch: /auth\.setup\.ts/`);
+make `chromium` depend on it (`dependencies: ['setup']`); add a moderate `workers` cap (gentle
+on the single shared deploy); keep `retries: 2` for residual network flake.
+
+**`.gitignore`.** Add `tests/e2e/playwright/.auth/` — generated live session cookies; never
+committed.
+
+**Technical risk (verify first).** Confirm that re-adding a saved ASP.NET Identity cookie via
+`addCookies` re-authenticates a request. Prove with one persona (apply saved cookie → GET a
+protected page → expect 200) before converting all helpers. Fallback if it fails:
+`test.use({ storageState })` at the spec level (more idiomatic, but touches spec files).
+
+### B. Persona completeness (`nav-visibility`)
+
+Add 5 helpers + `PERSONAS` entries and 5 matrix rows in `nav-visibility.spec.ts` with the
+correct expected nav (per `AnyAdminRole` in `AuthorizationPolicyExtensions.cs`):
+
+| Persona | slug | Expected top-nav |
+|---|---|---|
+| `eventsAdmin` | `events-admin` | Volunteer + Admin |
+| `storeAdmin` | `store-admin` | Volunteer + Admin |
+| `cantinaAdmin` | `cantina-admin` | Volunteer + Admin |
+| `eeTeamAdmin` | `e-e-team-admin` | Volunteer only (role-holder, not in `AnyAdminRole`) |
+| `barrioLead` | `barrio-1-lead` | Volunteer only (camp lead, no governance role) |
+
+All five already exist as dev-login personas (the controller auto-generates one per
+`RoleNames` constant; barrio leads are hardcoded), so they seed today with no app change.
+
+## Files touched
+
+- `tests/e2e/helpers/auth.ts` — `PERSONAS` source of truth; cookie-reuse login; 5 new helpers.
+- `tests/e2e/auth.setup.ts` — **new** setup project.
+- `tests/e2e/playwright.config.ts` — setup project, `dependencies`, `workers`, retries.
+- `tests/e2e/tests/nav-visibility.spec.ts` — 5 new matrix rows.
+- `.gitignore` — ignore `tests/e2e/playwright/.auth/`.
+
+No `src/` changes. The 18 other spec files are unchanged.
+
+## Verification
+
+- Run `nav-visibility` (now 18 rows) against the QA/preview deploy → all green.
+- Run the full suite multi-worker → no `auth.ts` login-wait timeouts; failures (if any) are
+  real assertions, not login latency.
+- Confirm setup fails loudly if a persona can't reach `Active`/its role (negative check).

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 test-results/
 playwright-report/
 dist/
+playwright/.auth/

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -4,11 +4,13 @@ import { PERSONAS, liveLoginAndSave } from './helpers/auth';
 // One serial test: seed + log in every persona once, capturing storageState.
 // Single test = single worker = no login herd during seeding. Failures are
 // collected so one broken persona doesn't hide the others.
-setup('authenticate all personas', async ({ browser }) => {
+setup('authenticate all personas', async ({ browser, baseURL }) => {
   setup.setTimeout(PERSONAS.length * 60_000);
   const failures: string[] = [];
   for (const slug of PERSONAS) {
-    const context = await browser.newContext();
+    // baseURL isn't applied to ad-hoc contexts (only test page/context fixtures
+    // get use.* options), so pass it through for liveLoginAndSave's relative goto.
+    const context = await browser.newContext({ baseURL });
     try {
       await liveLoginAndSave(context, slug);
     } catch (e) {

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,0 +1,21 @@
+import { test as setup, expect } from '@playwright/test';
+import { PERSONAS, liveLoginAndSave } from './helpers/auth';
+
+// One serial test: seed + log in every persona once, capturing storageState.
+// Single test = single worker = no login herd during seeding. Failures are
+// collected so one broken persona doesn't hide the others.
+setup('authenticate all personas', async ({ browser }) => {
+  setup.setTimeout(PERSONAS.length * 60_000);
+  const failures: string[] = [];
+  for (const slug of PERSONAS) {
+    const context = await browser.newContext();
+    try {
+      await liveLoginAndSave(context, slug);
+    } catch (e) {
+      failures.push(`${slug}: ${(e as Error).message.split('\n')[0]}`);
+    } finally {
+      await context.close();
+    }
+  }
+  expect(failures, `personas failed to seed/login:\n${failures.join('\n')}`).toEqual([]);
+});

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,6 +1,21 @@
-import { type Page, type APIResponse, expect } from '@playwright/test';
+import { type Page, type APIResponse, type BrowserContext, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
 
 const NAV_SELECTOR = '[data-testid="user-nav"], .navbar .dropdown:has(.profile-dropdown-menu)';
+
+// Single source of truth: every reusable persona slug (= /dev/login/{slug} segment).
+export const PERSONAS = [
+  'volunteer', 'admin', 'board', 'consent-coordinator', 'teams-admin',
+  'camp-admin', 'ticket-admin', 'no-info-admin', 'volunteer-coordinator',
+  'human-admin', 'finance-admin', 'feedback-admin', 'city-planning',
+  'coordinator', 'events-admin', 'store-admin', 'cantina-admin',
+  'e-e-team-admin', 'barrio-1-lead',
+] as const;
+
+// Resolve relative to THIS file (not cwd): tests run via --config from a different cwd.
+const AUTH_DIR = path.join(__dirname, '..', 'playwright', '.auth');
+export const authFile = (slug: string): string => path.join(AUTH_DIR, `${slug}.json`);
 
 /**
  * Pre-seed the cookie-consent cookie so the banner never renders during tests.
@@ -21,10 +36,28 @@ async function seedCookieConsent(page: Page): Promise<void> {
   ]);
 }
 
-async function loginAs(page: Page, slug: string): Promise<void> {
+/**
+ * Live /dev/login + persona seed, then capture storageState to disk.
+ * Used ONLY by auth.setup.ts to mint the per-persona cookie once per run —
+ * this is the suite's sole coverage of the real login + seeding path.
+ */
+export async function liveLoginAndSave(context: BrowserContext, slug: string): Promise<void> {
+  const page = await context.newPage();
   await seedCookieConsent(page);
   await page.goto(`/dev/login/${slug}`, { waitUntil: 'domcontentloaded' });
-  await page.waitForSelector(NAV_SELECTOR);
+  await page.waitForSelector(NAV_SELECTOR, { timeout: 60_000 });
+  await context.storageState({ path: authFile(slug) });
+  await page.close();
+}
+
+/**
+ * Attach the persona's once-captured cookies to this test's context — no
+ * /dev/login, no seeding, no SeedLock contention. The saved state includes the
+ * cookie-consent cookie (seeded before capture), so the banner stays suppressed.
+ */
+async function loginAs(page: Page, slug: string): Promise<void> {
+  const state = JSON.parse(fs.readFileSync(authFile(slug), 'utf-8'));
+  await page.context().addCookies(state.cookies);
 }
 
 export const loginAsVolunteer = (page: Page) => loginAs(page, 'volunteer');

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -58,6 +58,9 @@ export async function liveLoginAndSave(context: BrowserContext, slug: string): P
 async function loginAs(page: Page, slug: string): Promise<void> {
   const state = JSON.parse(fs.readFileSync(authFile(slug), 'utf-8'));
   await page.context().addCookies(state.cookies);
+  // Land on the authenticated home, matching the old /dev/login flow's redirect,
+  // so callers that don't navigate themselves (e.g. login.spec) still see the nav.
+  await page.goto('/');
 }
 
 export const loginAsVolunteer = (page: Page) => loginAs(page, 'volunteer');

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -10,9 +10,11 @@ export default defineConfig({
     trace: 'retain-on-first-failure',
   },
   projects: [
+    { name: 'setup', testDir: '.', testMatch: /auth\.setup\.ts/ },
     {
       name: 'chromium',
       use: { browserName: 'chromium' },
+      dependencies: ['setup'],
     },
   ],
   reporter: [['html', { open: 'never' }]],

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   testDir: './tests',
   timeout: 60_000,
   retries: 2,
+  // Feature tests reuse a captured cookie (no per-test login), so there's no
+  // login herd — but the target is one small shared deploy, so cap concurrency.
+  workers: 4,
   use: {
     baseURL: process.env.BASE_URL || 'https://humans.n.burn.camp',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
## Problem

The Playwright e2e suite was fragile under its own load. Every test called `loginAsX(page)`, which hit `/dev/login/{slug}` → triggered heavy first-touch persona seeding in `DevPersonaSeeder` (profile, consent, teams, roles; camp+season for barrio leads) behind a single global `SeedLock`, against one small shared deploy. Run multi-worker, ~120 tests stampeded that lock and the deploy, so the login helper's `waitForSelector` for the nav blew its 60s budget. A full run was **66 pass / 32 flaky / 17 fail — and every failure was the login wait** (`auth.ts:27`), not an actual assertion. The negative-access boundary tests never even reached their assertions.

## Fix

Capture each persona's auth cookie **once** and reuse it:

- **`auth.setup.ts`** (new Playwright `setup` project) — logs in + seeds every persona once, serially in one looping test, saving `storageState` to `playwright/.auth/{slug}.json`. This becomes the suite's single, explicit coverage of the live login + seeding path (fails fast and loud if seeding breaks).
- **`helpers/auth.ts`** — `loginAsX(page)` keeps its exact signature but now attaches the saved cookie via `addCookies` and lands on `/`, instead of hitting `/dev/login`. No login, no seeding, no `SeedLock` contention. All ~175 call sites unchanged.
- **`playwright.config.ts`** — `setup` project + `dependencies: ['setup']`; `workers: 4` (gentle on the shared deploy); retries kept.
- **`.gitignore`** — ignore the generated `playwright/.auth/`.

The 18 other spec files are untouched.

## Results (full suite vs QA)

| | Before | After |
|---|---|---|
| Login-wait timeouts | 17 hard + 32 flaky | **0** |
| Wall time | ~11.8m (serial) / 7.1m (parallel, flaky) | **1.6m** |
| Result | 66 pass / 32 flaky / 17 fail | 100 pass / 16 fail / 0 flaky |

The 16 residual failures are **pre-existing** stale/feature tests — e.g. the admin-shell sidebar-label tests fail identically on `origin/main`; the City-Planning POST boundary tests assert `[302,403]` and reject the (correct) `404`. The harness now *surfaces* them instead of masking them behind login timeouts. They're out of scope here; good candidates for a follow-up test-cleanup.

## Notes

- Design + plan: `docs/superpowers/specs/2026-06-05-e2e-auth-state-reuse-design.md`, `docs/superpowers/plans/2026-06-05-e2e-auth-state-reuse.md`.
- Test-only; no `src/` changes; model-agnostic (pre-existing fragility, not tied to any access change).
- Related follow-up: nobodies-collective/Humans#832 (discovery-gated authorization matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
