### PR TITLE
docs(specs): codes must work as direct redemption links

### DIFF
--- a/docs/specs/ticketing-vendor-requirements.md
+++ b/docs/specs/ticketing-vendor-requirements.md
@@ -12,6 +12,7 @@ We run a single annual general-admission event for a Spanish nonprofit. Everyone
 ## Codes & Special Programs
 
 - Nearly every special price is a code: **1 code = 1 ticket at a set price**, with an optional **"valid until" (purchase-by) date**.
+- **Direct-link redemption**: each code should also work as a single clickable redemption link (e.g. `https://<vendor>/customer/<eventName>/<code>`), so we can hand someone one URL rather than a code to enter manually.
 - Staff set up programs via the website. Each program defines: price, purchase-by date, **refundable-until date** (independent of purchase-by), and transferable yes/no. Examples:
   - Low Income — €100, non-transferable, refundable until 1 July
   - Supporter — €250, transferable, valid until 1 May


### PR DESCRIPTION
Adds one requirement to the Codes & Special Programs section of `docs/specs/ticketing-vendor-requirements.md`: each code should also work as a single clickable redemption link (e.g. `https://<vendor>/customer/<eventName>/<code>`), so we can hand someone one URL rather than a code to enter manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)