### PR TITLE
Reduce Reforge tech debt score by 2%

### DIFF
--- a/src/Humans.Application/DTOs/VolunteerTrackingExport/VolunteerExportRequest.cs
+++ b/src/Humans.Application/DTOs/VolunteerTrackingExport/VolunteerExportRequest.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Extensions;
 using NodaTime;
 using Humans.Domain.Enums;
 
@@ -10,4 +11,29 @@ public sealed record VolunteerExportRequest(
     LocalDate EndDate,
     ShiftPeriod? Period,
     string ActorPlayaName,
-    Instant GeneratedAtUtc);
+    Instant GeneratedAtUtc)
+{
+    public string PeriodLabel => Period?.ToString() ?? "custom";
+
+    public IReadOnlyList<LocalDate> EnumerateDays()
+    {
+        var count = NodaTime.Period.DaysBetween(StartDate, EndDate) + 1;
+        var days = new LocalDate[count];
+        for (var i = 0; i < count; i++) days[i] = StartDate.PlusDays(i);
+        return days;
+    }
+
+    public string BuildFilterSummary(string? filteredTeamName)
+    {
+        var deptName = filteredTeamName ?? "All";
+        return $"Department: {deptName} - Range: {StartDate} -> {EndDate} ({PeriodLabel})";
+    }
+
+    public string BuildSuggestedFileName(string? departmentSlug)
+    {
+        var prefix = departmentSlug is { Length: > 0 } slug
+            ? $"volunteer-tracking-{slug}-"
+            : "volunteer-tracking-";
+        return $"{prefix}{StartDate.ToInvariantDate()}-to-{EndDate.ToInvariantDate()}.xlsx";
+    }
+}

--- a/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Helpers;
 using Humans.Application.Services.Camps;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -128,7 +129,53 @@ public sealed record CreateCampRoleDefinitionInput(
     string? Description,
     int SlotCount,
     int MinimumRequired,
-    int SortOrder);
+    int SortOrder)
+{
+    public string NormalizedSlug
+    {
+        get => NormalizeAndValidateSlug(Slug);
+    }
+
+    public void EnsureMinimumRequiredIsValid() => ValidateMinimumRequired(SlotCount, MinimumRequired);
+
+    private static void ValidateMinimumRequired(int slotCount, int minimumRequired)
+    {
+        if (minimumRequired < 0 || minimumRequired > slotCount)
+            throw new ArgumentException(
+                $"MinimumRequired must satisfy 0 <= MinimumRequired <= SlotCount (got SlotCount={slotCount}, MinimumRequired={minimumRequired}).",
+                nameof(minimumRequired));
+    }
+
+    private static string NormalizeAndValidateSlug(string slug)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+            throw new ArgumentException("Slug is required.", nameof(slug));
+
+        var normalized = slug.Trim().ToLowerInvariant();
+        if (!SlugHelper.IsValidKebabSlug(normalized))
+            throw new ArgumentException(
+                "Slug must be kebab-case (lowercase letters, digits, and hyphens; no leading, trailing, or consecutive hyphens; max 60 chars).",
+                nameof(slug));
+
+        if (string.Equals(normalized, "create", StringComparison.Ordinal))
+            throw new InvalidOperationException("\"create\" is reserved and cannot be used as a camp role slug.");
+
+        return normalized;
+    }
+
+    public CampRoleDefinition ToDefinition(Instant now) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = Name,
+        Slug = NormalizedSlug,
+        Description = Description,
+        SlotCount = SlotCount,
+        MinimumRequired = MinimumRequired,
+        SortOrder = SortOrder,
+        CreatedAt = now,
+        UpdatedAt = now,
+    };
+}
 
 public sealed record UpdateCampRoleDefinitionInput(
     string Name,

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -396,7 +396,14 @@ public sealed record CampUpdateInput(
     bool HideHistoricalNames,
     Guid SeasonId,
     string SeasonName,
-    CampSeasonData SeasonData);
+    CampSeasonData SeasonData)
+{
+    public string UpdatedAuditMessage => $"Updated camp {CampId}";
+
+    public bool ShouldRenameSeason(CampSeason currentSeason, LocalDate today) =>
+        !string.Equals(currentSeason.Name, SeasonName, StringComparison.Ordinal)
+        && (!currentSeason.NameLockDate.HasValue || today < currentSeason.NameLockDate.Value);
+}
 
 public sealed record CampUpdateResult(bool Succeeded, string? ErrorMessage)
 {

--- a/src/Humans.Application/Interfaces/Email/IEmailService.cs
+++ b/src/Humans.Application/Interfaces/Email/IEmailService.cs
@@ -39,7 +39,31 @@ public record CoordinatorRotaMessageRequest(
     string RotaName,
     string MessageText,
     IReadOnlyList<string> ShiftLines,
-    string? Culture = null);
+    string? Culture = null)
+{
+    public EmailContent RenderWith(IEmailRenderer renderer)
+    {
+        ArgumentNullException.ThrowIfNull(renderer);
+
+        return renderer.RenderCoordinatorRotaMessage(
+            RecipientName,
+            SenderName,
+            SenderEmail,
+            RotaName,
+            MessageText,
+            ShiftLines,
+            Culture);
+    }
+
+    public EmailMessage ToEmailMessage(EmailContent content) => new(
+        RecipientEmail,
+        RecipientName,
+        content.Subject,
+        content.HtmlBody,
+        "coordinator_rota_message",
+        MessageCategory.VolunteerUpdates,
+        ReplyTo: SenderEmail);
+}
 
 /// <summary>
 /// Payload for a coordinator team-level "email all rotas" message to a single signup.
@@ -55,7 +79,31 @@ public record CoordinatorTeamRotasMessageRequest(
     string TeamName,
     string MessageText,
     IReadOnlyList<RotaShiftGroup> ShiftGroups,
-    string? Culture = null);
+    string? Culture = null)
+{
+    public EmailContent RenderWith(IEmailRenderer renderer)
+    {
+        ArgumentNullException.ThrowIfNull(renderer);
+
+        return renderer.RenderCoordinatorTeamRotasMessage(
+            RecipientName,
+            SenderName,
+            SenderEmail,
+            TeamName,
+            MessageText,
+            ShiftGroups,
+            Culture);
+    }
+
+    public EmailMessage ToEmailMessage(EmailContent content) => new(
+        RecipientEmail,
+        RecipientName,
+        content.Subject,
+        content.HtmlBody,
+        "coordinator_team_rotas_message",
+        MessageCategory.VolunteerUpdates,
+        ReplyTo: SenderEmail);
+}
 
 /// <summary>
 /// A recipient's shifts on a single rota, ready for the team-level coordinator
@@ -75,7 +123,26 @@ public record CampaignCodeEmailRequest(
     string Subject,
     string MarkdownBody,
     string Code,
-    string? ReplyTo);
+    string? ReplyTo)
+{
+    public EmailContent RenderWith(IEmailRenderer renderer)
+    {
+        ArgumentNullException.ThrowIfNull(renderer);
+
+        return renderer.RenderCampaignCode(Subject, MarkdownBody, Code, RecipientName);
+    }
+
+    public EmailMessage ToEmailMessage(EmailContent content) => new(
+        RecipientEmail,
+        RecipientName,
+        content.Subject,
+        content.HtmlBody,
+        "campaign_code",
+        MessageCategory.CampaignCodes,
+        ReplyTo: ReplyTo,
+        UserId: UserId,
+        CampaignGrantId: CampaignGrantId);
+}
 
 /// <summary>
 /// Payload for an event lifecycle notification. <see cref="NewStatus"/> picks

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -478,7 +478,29 @@ public sealed record CreateShiftInput(
     int MinVolunteers,
     int MaxVolunteers,
     bool AdminOnly,
-    bool IsAllDay);
+    bool IsAllDay)
+{
+    public bool HasValidVolunteerRange() => MinVolunteers <= MaxVolunteers;
+
+    public bool IsWithinPeriod((int Start, int End) bounds) =>
+        DayOffset >= bounds.Start && DayOffset <= bounds.End;
+
+    public Shift ToShift(Instant now) => new()
+    {
+        Id = Guid.NewGuid(),
+        RotaId = RotaId,
+        Description = Description,
+        DayOffset = DayOffset,
+        StartTime = StartTime,
+        Duration = Duration.FromHours(DurationHours),
+        MinVolunteers = MinVolunteers,
+        MaxVolunteers = MaxVolunteers,
+        AdminOnly = AdminOnly,
+        IsAllDay = IsAllDay,
+        CreatedAt = now,
+        UpdatedAt = now
+    };
+}
 
 public sealed record UpdateShiftInput(
     Guid ShiftId,
@@ -489,7 +511,25 @@ public sealed record UpdateShiftInput(
     double DurationHours,
     int MinVolunteers,
     int MaxVolunteers,
-    bool AdminOnly);
+    bool AdminOnly)
+{
+    public bool HasValidVolunteerRange() => MinVolunteers <= MaxVolunteers;
+
+    public bool IsWithinPeriod((int Start, int End) bounds) =>
+        DayOffset >= bounds.Start && DayOffset <= bounds.End;
+
+    public void ApplyTo(Shift shift, Instant now)
+    {
+        shift.Description = Description;
+        shift.DayOffset = DayOffset;
+        shift.StartTime = StartTime;
+        shift.Duration = Duration.FromHours(DurationHours);
+        shift.MinVolunteers = MinVolunteers;
+        shift.MaxVolunteers = MaxVolunteers;
+        shift.AdminOnly = AdminOnly;
+        shift.UpdatedAt = now;
+    }
+}
 
 public sealed record GenerateEventShiftsInput(
     Guid RotaId,
@@ -498,7 +538,43 @@ public sealed record GenerateEventShiftsInput(
     int EndDayOffset,
     IReadOnlyList<ShiftTimeSlotInput> TimeSlots,
     int MinVolunteers,
-    int MaxVolunteers);
+    int MaxVolunteers)
+{
+    public bool HasValidEventRange(EventSettings eventSettings) =>
+        StartDayOffset >= 0 &&
+        EndDayOffset <= eventSettings.EventEndOffset &&
+        StartDayOffset <= EndDayOffset;
+
+    public bool HasValidVolunteerRange() => MinVolunteers <= MaxVolunteers;
+
+    public bool HasTimeSlots() => TimeSlots.Count > 0;
+
+    public List<Shift> ToShifts(Instant now)
+    {
+        var shifts = new List<Shift>();
+        for (var day = StartDayOffset; day <= EndDayOffset; day++)
+        {
+            foreach (var slot in TimeSlots)
+            {
+                shifts.Add(new Shift
+                {
+                    Id = Guid.NewGuid(),
+                    RotaId = RotaId,
+                    IsAllDay = false,
+                    DayOffset = day,
+                    StartTime = slot.StartTime,
+                    Duration = Duration.FromHours(slot.DurationHours),
+                    MinVolunteers = MinVolunteers,
+                    MaxVolunteers = MaxVolunteers,
+                    CreatedAt = now,
+                    UpdatedAt = now
+                });
+            }
+        }
+
+        return shifts;
+    }
+}
 
 public sealed record ShiftTimeSlotInput(LocalTime StartTime, double DurationHours);
 

--- a/src/Humans.Application/Interfaces/Store/IStoreService.cs
+++ b/src/Humans.Application/Interfaces/Store/IStoreService.cs
@@ -120,7 +120,23 @@ public sealed record StoreProductSaveRequest(
     decimal VatRatePercent,
     decimal? DepositAmountEur,
     string? OrderableUntil,
-    bool IsActive);
+    bool IsActive)
+{
+    public bool IsCreate => Id is null;
+
+    public string OrderableUntilForParsing => OrderableUntil ?? string.Empty;
+
+    public ProductDto ToProductDto(NodaTime.LocalDate orderableUntil) => new(
+        Id ?? Guid.Empty,
+        Year,
+        Name ?? string.Empty,
+        Description ?? string.Empty,
+        UnitPriceEur,
+        VatRatePercent,
+        DepositAmountEur,
+        orderableUntil,
+        IsActive);
+}
 
 public sealed record StoreCatalogSaveResult(
     bool Succeeded,

--- a/src/Humans.Application/Interfaces/Tickets/ITicketingBudgetService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketingBudgetService.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Budget;
 using NodaTime;
 
 namespace Humans.Application.Interfaces.Tickets;
@@ -42,4 +43,19 @@ public sealed record TicketingProjectionUpdateCommand(
     int VatRate,
     decimal StripeFeePercent,
     decimal StripeFeeFixed,
-    decimal TicketTailorFeePercent);
+    decimal TicketTailorFeePercent)
+{
+    public Task SaveProjectionParametersAsync(IBudgetService budgetService, Guid actorUserId) =>
+        budgetService.UpdateTicketingProjectionAsync(
+            BudgetGroupId,
+            StartDate,
+            EventDate,
+            InitialSalesCount,
+            DailySalesRate,
+            AverageTicketPrice,
+            VatRate,
+            StripeFeePercent,
+            StripeFeeFixed,
+            TicketTailorFeePercent,
+            actorUserId);
+}

--- a/src/Humans.Application/Interfaces/Users/UserEmailCommands.cs
+++ b/src/Humans.Application/Interfaces/Users/UserEmailCommands.cs
@@ -1,5 +1,6 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
 using NodaTime;
 
 namespace Humans.Application.Interfaces.Users;
@@ -16,7 +17,43 @@ public sealed record UserEmailAddCommand(
     Instant? VerificationSentAt = null,
     string? Provider = null,
     string? ProviderKey = null,
-    bool IgnoreExisting = false);
+    bool IgnoreExisting = false)
+{
+    public string EmailForStorage => Email.Trim();
+
+    public string NormalizedEmail => EmailNormalization.NormalizeForComparison(EmailForStorage);
+
+    public string? AlternateNormalizedEmail
+    {
+        get
+        {
+            var normalizedEmail = NormalizedEmail;
+            if (normalizedEmail.EndsWith("@gmail.com", StringComparison.Ordinal))
+                return $"{normalizedEmail[..^"@gmail.com".Length]}@googlemail.com";
+
+            if (normalizedEmail.EndsWith("@googlemail.com", StringComparison.Ordinal))
+                return $"{normalizedEmail[..^"@googlemail.com".Length]}@gmail.com";
+
+            return null;
+        }
+    }
+
+    public UserEmail ToRow(Guid userId, Instant now) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        Email = EmailForStorage,
+        IsVerified = IsVerified,
+        IsPrimary = false,
+        IsGoogle = false,
+        Visibility = Visibility,
+        Provider = Provider,
+        ProviderKey = ProviderKey,
+        VerificationSentAt = VerificationSentAt,
+        CreatedAt = now,
+        UpdatedAt = now,
+    };
+}
 
 public sealed record UserEmailAddResult(
     Guid EmailId,
@@ -70,7 +107,17 @@ public sealed record UserEmailReconcilePlanCommand(
     UserEmail? DisplacedRowToDelete,
     UserEmail? RowToDelete,
     UserEmail? RowToUpdate,
-    UserEmail? RowToInsert);
+    UserEmail? RowToInsert)
+{
+    public IReadOnlySet<Guid> MutatedUserIds(Guid userId)
+    {
+        var mutatedUserIds = new HashSet<Guid> { userId };
+        if (DisplacedRowToDelete is not null)
+            mutatedUserIds.Add(DisplacedRowToDelete.UserId);
+
+        return mutatedUserIds;
+    }
+}
 
 public sealed record UserEmailReconcilePlanResult(
     IReadOnlySet<Guid> MutatedUserIds);

--- a/src/Humans.Application/Interfaces/Users/UserProfileCommands.cs
+++ b/src/Humans.Application/Interfaces/Users/UserProfileCommands.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 
@@ -121,7 +122,19 @@ public sealed record UserProfileDietaryMedicalCommand(
     string? AllergyOtherText,
     List<string> Intolerances,
     string? IntoleranceOtherText,
-    string? MedicalConditions);
+    string? MedicalConditions)
+{
+    public void ApplyTo(Profile profile, Instant updatedAt)
+    {
+        profile.DietaryPreference = DietaryPreference;
+        profile.Allergies = Allergies;
+        profile.AllergyOtherText = AllergyOtherText;
+        profile.Intolerances = Intolerances;
+        profile.IntoleranceOtherText = IntoleranceOtherText;
+        profile.MedicalConditions = MedicalConditions;
+        profile.UpdatedAt = updatedAt;
+    }
+}
 
 public enum UserProfilePictureMutation
 {

--- a/src/Humans.Application/Interfaces/Users/UserProfileCommands.cs
+++ b/src/Humans.Application/Interfaces/Users/UserProfileCommands.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Application.Interfaces.Users;
 
@@ -14,7 +15,24 @@ public sealed record UserProfileOnboardingCommand(
     string? Notes = null,
     string? RejectionReason = null,
     bool? Suspended = null,
-    bool AdminSuspension = false);
+    bool AdminSuspension = false)
+{
+    public void Validate(string argumentName = "command")
+    {
+        switch (Mutation)
+        {
+            case UserProfileOnboardingMutation.RecordConsentCheck
+                when ConsentCheckStatus is not Humans.Domain.Enums.ConsentCheckStatus.Cleared
+                    and not Humans.Domain.Enums.ConsentCheckStatus.Flagged:
+                throw new ArgumentException(
+                    "RecordConsentCheck only accepts Cleared or Flagged; use SetConsentCheckPending for the system-driven Pending transition.",
+                    argumentName);
+
+            case UserProfileOnboardingMutation.SetSuspension when Suspended is null:
+                throw new ArgumentException("SetSuspension requires Suspended.", argumentName);
+        }
+    }
+}
 
 public enum UserProfileOnboardingMutation
 {
@@ -50,7 +68,46 @@ public sealed record UserProfileSaveCommand(
     // medical are written separately via UserProfileDietaryMedicalCommand.
     string? DietaryPreference = null,
     List<string>? Allergies = null,
-    string? AllergyOtherText = null);
+    string? AllergyOtherText = null)
+{
+    public string? BioForSave() => Bio?.TrimEnd();
+
+    public string? ContributionInterestsForSave() => ContributionInterests?.TrimEnd();
+
+    public string? BoardNotesForSave() => BoardNotes?.TrimEnd();
+
+    public bool HasDietaryPatch() =>
+        DietaryPreference is not null || Allergies is not null || AllergyOtherText is not null;
+
+    public string? DietaryPreferenceForSave() =>
+        string.IsNullOrWhiteSpace(DietaryPreference) ? null : DietaryPreference;
+
+    public IReadOnlyList<string> AllergiesForSave() => Allergies ?? [];
+
+    public LocalDate? BirthDateOrNull()
+    {
+        if (BirthdayMonth is not (>= 1 and <= 12) || BirthdayDay is not (>= 1 and <= 31))
+            return null;
+
+        try
+        {
+            // Year 4 lets Feb 29 validate without storing a real birth year.
+            return new LocalDate(4, BirthdayMonth.Value, BirthdayDay.Value);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    public string? ProfilePictureContentTypeForSave(string? currentContentType) =>
+        PictureMutation switch
+        {
+            UserProfilePictureMutation.Remove => null,
+            UserProfilePictureMutation.Set => ProfilePictureContentType,
+            _ => currentContentType,
+        };
+}
 
 /// <summary>
 /// Focused write for the full dietary + medical set (the DietaryMedical page).

--- a/src/Humans.Application/Services/Calendar/CalendarOccurrenceExpander.cs
+++ b/src/Humans.Application/Services/Calendar/CalendarOccurrenceExpander.cs
@@ -22,165 +22,247 @@ public static class CalendarOccurrenceExpander
         IReadOnlyDictionary<Guid, string> teamNamesById,
         ILogger logger)
     {
-        var results = new List<CalendarOccurrence>();
+        var expanded = new List<CalendarOccurrence>();
 
         foreach (var e in events)
         {
-            var owningTeamName = teamNamesById.TryGetValue(e.OwningTeamId, out var name)
-                ? name
-                : string.Empty;
+            var owningTeamName = ResolveTeamName(teamNamesById, e.OwningTeamId);
 
             if (string.IsNullOrWhiteSpace(e.RecurrenceRule))
-            {
-                // Half-open [from, to): overlap when end > from AND start < to.
-                var end = e.EndUtc ?? e.StartUtc;
-                if (end <= from || e.StartUtc >= to) continue;
-                results.Add(new CalendarOccurrence(
-                    EventId: e.Id,
-                    OccurrenceStartUtc: e.StartUtc,
-                    OccurrenceEndUtc: e.EndUtc,
-                    IsAllDay: e.IsAllDay,
-                    Title: e.Title,
-                    Description: e.Description,
-                    Location: e.Location,
-                    LocationUrl: e.LocationUrl,
-                    OwningTeamId: e.OwningTeamId,
-                    OwningTeamName: owningTeamName,
-                    IsRecurring: false,
-                    OriginalOccurrenceStartUtc: null));
-            }
+                AddSingleOccurrence(expanded, e, owningTeamName, from, to);
             else
-            {
-                var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(e.RecurrenceTimezone!);
-                if (zone is null)
-                {
-                    logger.LogWarning(
-                        "CalendarEvent {Id} has unknown timezone {Tz}; skipping occurrence expansion",
-                        e.Id, e.RecurrenceTimezone);
-                    continue;
-                }
-
-                var dur = (e.EndUtc ?? e.StartUtc) - e.StartUtc;
-                var dtStartLocal = e.StartUtc.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-
-                var icalEv = new IcalEvent
-                {
-                    DtStart = new CalDateTime(dtStartLocal, e.RecurrenceTimezone, hasTime: true),
-                    Duration = Ical.Net.DataTypes.Duration.FromTimeSpanExact(TimeSpan.FromTicks(dur.BclCompatibleTicks)),
-                };
-                icalEv.RecurrenceRule = new RecurrencePattern(e.RecurrenceRule!);
-
-                var fromLocal = from.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-                var toLocal = to.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-                var fromCalDt = new CalDateTime(fromLocal, e.RecurrenceTimezone, hasTime: true);
-
-                foreach (var iocc in icalEv.GetOccurrences(fromCalDt, new EvaluationOptions())
-                    .TakeWhile(o => o.Period.StartTime.Value < toLocal))
-                {
-                    var occLocal = LocalDateTime.FromDateTime(iocc.Period.StartTime.Value);
-                    var startInstant = occLocal.InZoneLeniently(zone).ToInstant();
-                    var endInstant = e.EndUtc is null
-                        ? (Instant?)null
-                        : startInstant.Plus(e.EndUtc.Value - e.StartUtc);
-
-                    results.Add(new CalendarOccurrence(
-                        EventId: e.Id,
-                        OccurrenceStartUtc: startInstant,
-                        OccurrenceEndUtc: endInstant,
-                        IsAllDay: e.IsAllDay,
-                        Title: e.Title,
-                        Description: e.Description,
-                        Location: e.Location,
-                        LocationUrl: e.LocationUrl,
-                        OwningTeamId: e.OwningTeamId,
-                        OwningTeamName: owningTeamName,
-                        IsRecurring: true,
-                        OriginalOccurrenceStartUtc: startInstant));
-                }
-            }
+                AddRecurringOccurrences(expanded, e, owningTeamName, from, to, logger);
         }
 
-        // Build a per-event exception lookup once.
         var exceptionsByEvent = events
             .ToDictionary(e => e.Id, e =>
                 e.Exceptions.ToDictionary(x => x.OriginalOccurrenceStartUtc));
 
-        var finalResults = new List<CalendarOccurrence>();
-        var handledExceptionKeys = new HashSet<(Guid EventId, Instant OriginalStart)>();
-
-        foreach (var occ in results)
-        {
-            if (!occ.IsRecurring || occ.OriginalOccurrenceStartUtc is null)
-            {
-                finalResults.Add(occ);
-                continue;
-            }
-
-            if (!exceptionsByEvent.TryGetValue(occ.EventId, out var perEvent) ||
-                !perEvent.TryGetValue(occ.OriginalOccurrenceStartUtc.Value, out var ex))
-            {
-                finalResults.Add(occ);
-                continue;
-            }
-
-            handledExceptionKeys.Add((occ.EventId, ex.OriginalOccurrenceStartUtc));
-
-            if (ex.IsCancelled) continue; // drop
-
-            // Apply overrides; drop if override moves it outside [from, to).
-            var newStart = ex.OverrideStartUtc ?? occ.OccurrenceStartUtc;
-            var newEnd = ex.OverrideEndUtc ?? occ.OccurrenceEndUtc;
-            if (newStart >= to || (newEnd ?? newStart) <= from) continue;
-
-            finalResults.Add(occ with
-            {
-                OccurrenceStartUtc = newStart,
-                OccurrenceEndUtc = newEnd,
-                Title = ex.OverrideTitle ?? occ.Title,
-                Description = ex.OverrideDescription ?? occ.Description,
-                Location = ex.OverrideLocation ?? occ.Location,
-                LocationUrl = ex.OverrideLocationUrl ?? occ.LocationUrl,
-            });
-        }
-
-        // Inject overrides that moved INTO the window from an out-of-window original (expansion missed them).
-        foreach (var ev in events)
-        {
-            var owningTeamName = teamNamesById.TryGetValue(ev.OwningTeamId, out var name)
-                ? name
-                : string.Empty;
-
-            foreach (var ex in ev.Exceptions)
-            {
-                if (handledExceptionKeys.Contains((ev.Id, ex.OriginalOccurrenceStartUtc))) continue;
-                if (ex.IsCancelled) continue;
-                if (ex.OverrideStartUtc is null) continue;
-
-                var newStart = ex.OverrideStartUtc.Value;
-                var eventDuration = (ev.EndUtc ?? ev.StartUtc) - ev.StartUtc;
-                var newEnd = ex.OverrideEndUtc
-                    ?? (ev.EndUtc is null ? null : newStart.Plus(eventDuration));
-
-                if (newStart >= to || (newEnd ?? newStart) <= from) continue;
-
-                finalResults.Add(new CalendarOccurrence(
-                    EventId: ev.Id,
-                    OccurrenceStartUtc: newStart,
-                    OccurrenceEndUtc: newEnd,
-                    IsAllDay: ev.IsAllDay,
-                    Title: ex.OverrideTitle ?? ev.Title,
-                    Description: ex.OverrideDescription ?? ev.Description,
-                    Location: ex.OverrideLocation ?? ev.Location,
-                    LocationUrl: ex.OverrideLocationUrl ?? ev.LocationUrl,
-                    OwningTeamId: ev.OwningTeamId,
-                    OwningTeamName: owningTeamName,
-                    IsRecurring: true,
-                    OriginalOccurrenceStartUtc: ex.OriginalOccurrenceStartUtc));
-            }
-        }
+        var finalResults = ApplyExceptions(expanded, exceptionsByEvent, from, to, out var handledExceptionKeys);
+        AddMovedOverrides(finalResults, events, teamNamesById, handledExceptionKeys, from, to);
 
         return finalResults.OrderBy(o => o.OccurrenceStartUtc).ToList();
     }
+
+    private static void AddSingleOccurrence(
+        List<CalendarOccurrence> results,
+        CalendarEventInfo e,
+        string owningTeamName,
+        Instant from,
+        Instant to)
+    {
+        if (!OverlapsWindow(e.StartUtc, e.EndUtc, from, to)) return;
+
+        results.Add(CreateOccurrence(
+            e,
+            owningTeamName,
+            e.StartUtc,
+            e.EndUtc,
+            isRecurring: false,
+            originalStart: null));
+    }
+
+    private static void AddRecurringOccurrences(
+        List<CalendarOccurrence> results,
+        CalendarEventInfo e,
+        string owningTeamName,
+        Instant from,
+        Instant to,
+        ILogger logger)
+    {
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(e.RecurrenceTimezone!);
+        if (zone is null)
+        {
+            logger.LogWarning(
+                "CalendarEvent {Id} has unknown timezone {Tz}; skipping occurrence expansion",
+                e.Id, e.RecurrenceTimezone);
+            return;
+        }
+
+        var icalEv = CreateIcalEvent(e, zone);
+        var toLocal = to.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
+        var fromCalDt = new CalDateTime(
+            from.InZone(zone).LocalDateTime.ToDateTimeUnspecified(),
+            e.RecurrenceTimezone,
+            hasTime: true);
+
+        foreach (var iocc in icalEv.GetOccurrences(fromCalDt, new EvaluationOptions())
+            .TakeWhile(o => o.Period.StartTime.Value < toLocal))
+        {
+            var startInstant = LocalDateTime
+                .FromDateTime(iocc.Period.StartTime.Value)
+                .InZoneLeniently(zone)
+                .ToInstant();
+            var endInstant = e.EndUtc is null
+                ? (Instant?)null
+                : startInstant.Plus(e.EndUtc.Value - e.StartUtc);
+
+            results.Add(CreateOccurrence(
+                e,
+                owningTeamName,
+                startInstant,
+                endInstant,
+                isRecurring: true,
+                originalStart: startInstant));
+        }
+    }
+
+    private static IcalEvent CreateIcalEvent(CalendarEventInfo e, DateTimeZone zone)
+    {
+        var duration = (e.EndUtc ?? e.StartUtc) - e.StartUtc;
+        var dtStartLocal = e.StartUtc.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
+
+        var icalEv = new IcalEvent
+        {
+            DtStart = new CalDateTime(dtStartLocal, e.RecurrenceTimezone, hasTime: true),
+            Duration = Ical.Net.DataTypes.Duration.FromTimeSpanExact(
+                TimeSpan.FromTicks(duration.BclCompatibleTicks)),
+        };
+        icalEv.RecurrenceRule = new RecurrencePattern(e.RecurrenceRule!);
+        return icalEv;
+    }
+
+    private static List<CalendarOccurrence> ApplyExceptions(
+        IReadOnlyList<CalendarOccurrence> expanded,
+        IReadOnlyDictionary<Guid, Dictionary<Instant, CalendarEventExceptionInfo>> exceptionsByEvent,
+        Instant from,
+        Instant to,
+        out HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys)
+    {
+        var finalResults = new List<CalendarOccurrence>();
+        handledExceptionKeys = [];
+
+        foreach (var occ in expanded)
+        {
+            var exception = FindException(occ, exceptionsByEvent);
+            if (exception is null)
+            {
+                finalResults.Add(occ);
+                continue;
+            }
+
+            handledExceptionKeys.Add((occ.EventId, exception.OriginalOccurrenceStartUtc));
+
+            if (exception.IsCancelled) continue;
+
+            var overridden = ApplyOverride(occ, exception);
+            if (OverlapsWindow(overridden.OccurrenceStartUtc, overridden.OccurrenceEndUtc, from, to))
+                finalResults.Add(overridden);
+        }
+
+        return finalResults;
+    }
+
+    private static CalendarEventExceptionInfo? FindException(
+        CalendarOccurrence occ,
+        IReadOnlyDictionary<Guid, Dictionary<Instant, CalendarEventExceptionInfo>> exceptionsByEvent)
+    {
+        if (!occ.IsRecurring || occ.OriginalOccurrenceStartUtc is null) return null;
+
+        return exceptionsByEvent.TryGetValue(occ.EventId, out var perEvent) &&
+            perEvent.TryGetValue(occ.OriginalOccurrenceStartUtc.Value, out var ex)
+                ? ex
+                : null;
+    }
+
+    private static void AddMovedOverrides(
+        List<CalendarOccurrence> finalResults,
+        IReadOnlyList<CalendarEventInfo> events,
+        IReadOnlyDictionary<Guid, string> teamNamesById,
+        HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys,
+        Instant from,
+        Instant to)
+    {
+        foreach (var ev in events)
+        {
+            var owningTeamName = ResolveTeamName(teamNamesById, ev.OwningTeamId);
+
+            foreach (var ex in ev.Exceptions)
+            {
+                if (!ShouldInjectMovedOverride(ev.Id, ex, handledExceptionKeys)) continue;
+                if (ex.OverrideStartUtc is not { } newStart) continue;
+
+                var newEnd = ResolveOverrideEnd(ev, ex, newStart);
+
+                if (!OverlapsWindow(newStart, newEnd, from, to)) continue;
+
+                finalResults.Add(CreateOccurrence(
+                    ev,
+                    owningTeamName,
+                    newStart,
+                    newEnd,
+                    isRecurring: true,
+                    originalStart: ex.OriginalOccurrenceStartUtc,
+                    title: ex.OverrideTitle,
+                    description: ex.OverrideDescription,
+                    location: ex.OverrideLocation,
+                    locationUrl: ex.OverrideLocationUrl));
+            }
+        }
+    }
+
+    private static bool ShouldInjectMovedOverride(
+        Guid eventId,
+        CalendarEventExceptionInfo ex,
+        HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys) =>
+        !handledExceptionKeys.Contains((eventId, ex.OriginalOccurrenceStartUtc)) &&
+        !ex.IsCancelled &&
+        ex.OverrideStartUtc is not null;
+
+    private static Instant? ResolveOverrideEnd(
+        CalendarEventInfo ev,
+        CalendarEventExceptionInfo ex,
+        Instant newStart)
+    {
+        if (ex.OverrideEndUtc is { } overrideEnd) return overrideEnd;
+        if (ev.EndUtc is null) return null;
+
+        return newStart.Plus((ev.EndUtc.Value - ev.StartUtc));
+    }
+
+    private static CalendarOccurrence ApplyOverride(
+        CalendarOccurrence occurrence,
+        CalendarEventExceptionInfo ex) =>
+        occurrence with
+        {
+            OccurrenceStartUtc = ex.OverrideStartUtc ?? occurrence.OccurrenceStartUtc,
+            OccurrenceEndUtc = ex.OverrideEndUtc ?? occurrence.OccurrenceEndUtc,
+            Title = ex.OverrideTitle ?? occurrence.Title,
+            Description = ex.OverrideDescription ?? occurrence.Description,
+            Location = ex.OverrideLocation ?? occurrence.Location,
+            LocationUrl = ex.OverrideLocationUrl ?? occurrence.LocationUrl,
+        };
+
+    private static CalendarOccurrence CreateOccurrence(
+        CalendarEventInfo ev,
+        string owningTeamName,
+        Instant start,
+        Instant? end,
+        bool isRecurring,
+        Instant? originalStart,
+        string? title = null,
+        string? description = null,
+        string? location = null,
+        string? locationUrl = null) =>
+        new(
+            EventId: ev.Id,
+            OccurrenceStartUtc: start,
+            OccurrenceEndUtc: end,
+            IsAllDay: ev.IsAllDay,
+            Title: title ?? ev.Title,
+            Description: description ?? ev.Description,
+            Location: location ?? ev.Location,
+            LocationUrl: locationUrl ?? ev.LocationUrl,
+            OwningTeamId: ev.OwningTeamId,
+            OwningTeamName: owningTeamName,
+            IsRecurring: isRecurring,
+            OriginalOccurrenceStartUtc: originalStart);
+
+    private static bool OverlapsWindow(Instant start, Instant? end, Instant from, Instant to) =>
+        start < to && (end ?? start) > from;
+
+    private static string ResolveTeamName(IReadOnlyDictionary<Guid, string> teamNamesById, Guid teamId) =>
+        teamNamesById.TryGetValue(teamId, out var name) ? name : string.Empty;
 
     /// <summary>Mirrors the SQL prefilter in <c>CalendarRepository.GetEventsInWindowAsync</c>.</summary>
     public static List<CalendarEventInfo> FilterForWindow(

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -49,8 +49,8 @@ public sealed class CampRoleService(
 
     public async Task<CampRoleDefinition> CreateDefinitionAsync(CreateCampRoleDefinitionInput input, Guid actorUserId, CancellationToken ct = default)
     {
-        ValidateMinimumRequired(input.SlotCount, input.MinimumRequired);
-        var slug = NormalizeAndValidateSlug(input.Slug);
+        input.EnsureMinimumRequiredIsValid();
+        var slug = input.NormalizedSlug;
 
         if (await repo.DefinitionNameExistsAsync(input.Name, excludingId: null, ct))
             throw new InvalidOperationException($"A camp role definition named '{input.Name}' already exists.");
@@ -59,18 +59,7 @@ public sealed class CampRoleService(
             throw new InvalidOperationException($"A camp role definition with slug '{slug}' already exists.");
 
         var now = clock.GetCurrentInstant();
-        var def = new CampRoleDefinition
-        {
-            Id = Guid.NewGuid(),
-            Name = input.Name,
-            Slug = slug,
-            Description = input.Description,
-            SlotCount = input.SlotCount,
-            MinimumRequired = input.MinimumRequired,
-            SortOrder = input.SortOrder,
-            CreatedAt = now,
-            UpdatedAt = now,
-        };
+        var def = input.ToDefinition(now);
 
         await repo.AddDefinitionAsync(def, ct); // SaveChangesAsync first
         await auditLog.LogAsync(

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -741,11 +741,11 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
 
             await _auditLog.LogAsync(
                 AuditAction.CampUpdated, nameof(Camp), input.CampId,
-                $"Updated camp {input.CampId}",
+                input.UpdatedAuditMessage,
                 "CampService");
 
             await UpdateSeasonAsync(input.SeasonId, input.SeasonData, cancellationToken);
-            await ChangeSeasonNameIfAllowedAsync(input.SeasonId, input.SeasonName, cancellationToken);
+            await ChangeSeasonNameIfAllowedAsync(input, cancellationToken);
 
             return CampUpdateResult.Success();
         }
@@ -756,26 +756,19 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
     }
 
     private async Task ChangeSeasonNameIfAllowedAsync(
-        Guid seasonId,
-        string seasonName,
+        CampUpdateInput input,
         CancellationToken cancellationToken)
     {
-        var currentSeason = await _repo.GetSeasonByIdAsync(seasonId, cancellationToken)
+        var currentSeason = await _repo.GetSeasonByIdAsync(input.SeasonId, cancellationToken)
             ?? throw new InvalidOperationException("Season not found.");
 
-        if (string.Equals(currentSeason.Name, seasonName, StringComparison.Ordinal))
-        {
-            return;
-        }
-
         var today = _clock.GetCurrentInstant().InUtc().Date;
-        var nameLocked = currentSeason.NameLockDate.HasValue && today >= currentSeason.NameLockDate.Value;
-        if (nameLocked)
+        if (!input.ShouldRenameSeason(currentSeason, today))
         {
             return;
         }
 
-        await ChangeSeasonNameAsync(currentSeason.Id, seasonName, cancellationToken);
+        await ChangeSeasonNameAsync(currentSeason.Id, input.SeasonName, cancellationToken);
     }
 
     public async Task DeleteCampAsync(Guid campId, CancellationToken cancellationToken = default)

--- a/src/Humans.Application/Services/Email/EmailMessageFactory.cs
+++ b/src/Humans.Application/Services/Email/EmailMessageFactory.cs
@@ -124,22 +124,16 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
     public EmailMessage CoordinatorRotaMessage(CoordinatorRotaMessageRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var content = renderer.RenderCoordinatorRotaMessage(
-            request.RecipientName, request.SenderName, request.SenderEmail,
-            request.RotaName, request.MessageText, request.ShiftLines, request.Culture);
-        return new EmailMessage(request.RecipientEmail, request.RecipientName, content.Subject, content.HtmlBody,
-            "coordinator_rota_message", MessageCategory.VolunteerUpdates, ReplyTo: request.SenderEmail);
+        var content = request.RenderWith(renderer);
+        return request.ToEmailMessage(content);
     }
 
     /// <inheritdoc />
     public EmailMessage CoordinatorTeamRotasMessage(CoordinatorTeamRotasMessageRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var content = renderer.RenderCoordinatorTeamRotasMessage(
-            request.RecipientName, request.SenderName, request.SenderEmail,
-            request.TeamName, request.MessageText, request.ShiftGroups, request.Culture);
-        return new EmailMessage(request.RecipientEmail, request.RecipientName, content.Subject, content.HtmlBody,
-            "coordinator_team_rotas_message", MessageCategory.VolunteerUpdates, ReplyTo: request.SenderEmail);
+        var content = request.RenderWith(renderer);
+        return request.ToEmailMessage(content);
     }
 
     /// <inheritdoc />
@@ -179,10 +173,8 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
     {
         ArgumentNullException.ThrowIfNull(request);
         // Renderer HTML-encodes {{Code}}/{{Name}} substitutions to prevent injection.
-        var content = renderer.RenderCampaignCode(request.Subject, request.MarkdownBody, request.Code, request.RecipientName);
-        return new EmailMessage(request.RecipientEmail, request.RecipientName, content.Subject, content.HtmlBody,
-            "campaign_code", MessageCategory.CampaignCodes,
-            ReplyTo: request.ReplyTo, UserId: request.UserId, CampaignGrantId: request.CampaignGrantId);
+        var content = request.RenderWith(renderer);
+        return request.ToEmailMessage(content);
     }
 
     /// <inheritdoc />

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -162,116 +162,176 @@ public sealed class GoogleGroupSyncService(
         IReadOnlyDictionary<Guid, ExpectedMember>? expectedMembersByUserId,
         CancellationToken ct)
     {
-        var lookup = await provisioningClient.LookupGroupIdAsync(claim.GroupKey, ct);
-
-        // Provisioning: a claim references a group key that doesn't exist in Google.
-        // Cloud Identity returns HTTP 404 — or HTTP 403 with a "permission
-        // denied" body, because Google won't confirm/deny existence to a
-        // caller without access. See IsGroupNotFound. Best-effort
-        // create-then-retry-lookup; on failure we fall through to the existing
-        // error path.
-        if (lookup.GroupNumericId is null
-            && IsGroupNotFound(lookup.Error)
-            && action == SyncAction.Execute)
-        {
-            try
-            {
-                var create = await provisioningClient.CreateGroupAsync(
-                    claim.GroupKey,
-                    displayName: claim.GroupKey,
-                    description: $"Auto-provisioned group ({claim.GroupKey}).",
-                    ct);
-                if (create.GroupNumericId is not null)
-                {
-                    logger.LogInformation(
-                        "Auto-provisioned Google Group for {GroupKey}",
-                        claim.GroupKey);
-
-                    // Apply enforced settings. Non-fatal: the group exists
-                    // either way; drift detection will catch any failed
-                    // application on the next /AllGroups sweep. Isolated in
-                    // its own try/catch so a thrown transport/credential
-                    // failure here doesn't skip the follow-up lookup +
-                    // membership reconcile below.
-                    try
-                    {
-                        var settingsError = await provisioningClient.UpdateGroupSettingsAsync(
-                            claim.GroupKey,
-                            GroupSettingsPolicy.BuildExpected(_options.Groups),
-                            ct);
-                        if (settingsError is not null)
-                        {
-                            logger.LogWarning(
-                                "Failed to apply group settings to auto-provisioned {GroupKey} (HTTP {StatusCode}): {Message}. Group was created with Google defaults",
-                                claim.GroupKey,
-                                settingsError.StatusCode,
-                                settingsError.RawMessage);
-                        }
-                    }
-                    catch (Exception settingsEx)
-                    {
-                        logger.LogWarning(
-                            "Error applying group settings to auto-provisioned {GroupKey}; continuing with membership reconcile: {Error}",
-                            claim.GroupKey,
-                            settingsEx.Message);
-                    }
-
-                    lookup = await provisioningClient.LookupGroupIdAsync(claim.GroupKey, ct);
-                }
-                else
-                {
-                    logger.LogWarning(
-                        "Failed to auto-provision Google Group for {GroupKey}: HTTP {StatusCode} {Message}",
-                        claim.GroupKey,
-                        create.Error?.StatusCode,
-                        create.Error?.RawMessage);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(
-                    "Error auto-provisioning Google Group for {GroupKey}; treating as failed lookup: {Error}",
-                    claim.GroupKey,
-                    ex.Message);
-            }
-        }
+        var lookup = await LookupOrProvisionGroupAsync(claim, action, ct);
 
         if (lookup.GroupNumericId is null)
         {
-            var error = FormatGoogleError("Google group lookup failed", lookup.Error);
-            await RecordGroupErrorAsync(resource, error, ct);
-            logger.LogWarning(
-                "Google group sync failed for {GroupKey}: {Error}",
-                claim.GroupKey,
-                error);
-            if (scheduleRetryOnFailure)
-                await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-            return BuildErrorDiff(claim.GroupKey, resource, error);
+            return await BuildClaimErrorDiffAsync(
+                claim,
+                resource,
+                "Google group lookup failed",
+                lookup.Error,
+                scheduleRetryOnFailure,
+                nextRetryAttempt,
+                ct);
         }
 
         expectedMembersByUserId ??= await HydrateExpectedMembersByUserIdAsync(claim.UserIds, ct);
         var expectedMembers = BuildExpectedMembersByEmail(claim.UserIds, expectedMembersByUserId);
-        var expectedEmails = expectedMembers.Keys.ToHashSet(NormalizingEmailComparer.Instance);
-
         var list = await membershipClient.ListMembershipsAsync(lookup.GroupNumericId, ct);
         if (list.Memberships is null)
         {
-            var error = FormatGoogleError("Google group membership list failed", list.Error);
-            await RecordGroupErrorAsync(resource, error, ct);
-            logger.LogWarning(
-                "Google group sync failed for {GroupKey}: {Error}",
-                claim.GroupKey,
-                error);
-            if (scheduleRetryOnFailure)
-                await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-            return BuildErrorDiff(claim.GroupKey, resource, error);
+            return await BuildClaimErrorDiffAsync(
+                claim,
+                resource,
+                "Google group membership list failed",
+                list.Error,
+                scheduleRetryOnFailure,
+                nextRetryAttempt,
+                ct);
         }
 
-        var currentByEmail = list.Memberships
-            .Where(m => !string.IsNullOrWhiteSpace(m.MemberEmail))
-            .GroupBy(m => m.MemberEmail!, NormalizingEmailComparer.Instance)
-            .ToDictionary(g => g.Key, g => g.First().ResourceName, NormalizingEmailComparer.Instance);
+        var plan = await BuildGroupMembershipPlanAsync(expectedMembers, list.Memberships, ct);
 
+        if (action == SyncAction.Execute)
+        {
+            var errorDiff = await ApplyGroupMembershipChangesAsync(
+                claim,
+                resource,
+                lookup.GroupNumericId,
+                plan,
+                scheduleRetryOnFailure,
+                nextRetryAttempt,
+                ct);
+            if (errorDiff is not null)
+                return errorDiff;
+        }
+
+        return new ResourceSyncDiff
+        {
+            ResourceId = resource?.Id ?? Guid.Empty,
+            ResourceName = resource?.Name ?? claim.GroupKey,
+            ResourceType = GoogleResourceType.Group.ToString(),
+            GoogleId = lookup.GroupNumericId,
+            Url = resource?.Url,
+            Members = plan.Members
+        };
+    }
+
+    private async Task<GroupLookupIdResult> LookupOrProvisionGroupAsync(
+        GroupClaim claim,
+        SyncAction action,
+        CancellationToken ct)
+    {
+        var lookup = await provisioningClient.LookupGroupIdAsync(claim.GroupKey, ct);
+        if (lookup.GroupNumericId is not null || !IsGroupNotFound(lookup.Error) || action != SyncAction.Execute)
+            return lookup;
+
+        return await TryProvisionGroupAsync(claim.GroupKey, lookup, ct);
+    }
+
+    private async Task<GroupLookupIdResult> TryProvisionGroupAsync(
+        string groupKey,
+        GroupLookupIdResult failedLookup,
+        CancellationToken ct)
+    {
+        try
+        {
+            var create = await provisioningClient.CreateGroupAsync(
+                groupKey,
+                displayName: groupKey,
+                description: $"Auto-provisioned group ({groupKey}).",
+                ct);
+
+            if (create.GroupNumericId is null)
+            {
+                logger.LogWarning(
+                    "Failed to auto-provision Google Group for {GroupKey}: HTTP {StatusCode} {Message}",
+                    groupKey,
+                    create.Error?.StatusCode,
+                    create.Error?.RawMessage);
+                return failedLookup;
+            }
+
+            logger.LogInformation("Auto-provisioned Google Group for {GroupKey}", groupKey);
+            await TryApplyProvisionedGroupSettingsAsync(groupKey, ct);
+            return await provisioningClient.LookupGroupIdAsync(groupKey, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                "Error auto-provisioning Google Group for {GroupKey}; treating as failed lookup: {Error}",
+                groupKey,
+                ex.Message);
+            return failedLookup;
+        }
+    }
+
+    private async Task TryApplyProvisionedGroupSettingsAsync(string groupKey, CancellationToken ct)
+    {
+        try
+        {
+            var settingsError = await provisioningClient.UpdateGroupSettingsAsync(
+                groupKey,
+                GroupSettingsPolicy.BuildExpected(_options.Groups),
+                ct);
+            if (settingsError is not null)
+            {
+                logger.LogWarning(
+                    "Failed to apply group settings to auto-provisioned {GroupKey} (HTTP {StatusCode}): {Message}. Group was created with Google defaults",
+                    groupKey,
+                    settingsError.StatusCode,
+                    settingsError.RawMessage);
+            }
+        }
+        catch (Exception settingsEx)
+        {
+            logger.LogWarning(
+                "Error applying group settings to auto-provisioned {GroupKey}; continuing with membership reconcile: {Error}",
+                groupKey,
+                settingsEx.Message);
+        }
+    }
+
+    private async Task<ResourceSyncDiff> BuildClaimErrorDiffAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string errorPrefix,
+        GoogleClientError? googleError,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        var error = FormatGoogleError(errorPrefix, googleError);
+        await RecordGroupErrorAsync(resource, error, ct);
+        logger.LogWarning("Google group sync failed for {GroupKey}: {Error}", claim.GroupKey, error);
+        if (scheduleRetryOnFailure)
+            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
+
+        return BuildErrorDiff(claim.GroupKey, resource, error);
+    }
+
+    private async Task<GroupMembershipPlan> BuildGroupMembershipPlanAsync(
+        IReadOnlyDictionary<string, ExpectedMember> expectedMembers,
+        IReadOnlyList<GroupMembership> memberships,
+        CancellationToken ct)
+    {
+        var currentByEmail = memberships
+            .Where(member => !string.IsNullOrWhiteSpace(member.MemberEmail))
+            .GroupBy(member => member.MemberEmail!, NormalizingEmailComparer.Instance)
+            .ToDictionary(group => group.Key, group => group.First().ResourceName, NormalizingEmailComparer.Instance);
+        var members = BuildExpectedGroupMemberStatuses(expectedMembers, currentByEmail);
+
+        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(ct);
+        AddExtraGroupMemberStatuses(members, expectedMembers.Keys, currentByEmail.Keys, serviceAccountEmail);
+
+        return new GroupMembershipPlan(members, currentByEmail);
+    }
+
+    private static List<MemberSyncStatus> BuildExpectedGroupMemberStatuses(
+        IReadOnlyDictionary<string, ExpectedMember> expectedMembers,
+        IReadOnlyDictionary<string, string> currentByEmail)
+    {
         var members = new List<MemberSyncStatus>();
         foreach (var (email, expected) in expectedMembers)
         {
@@ -284,115 +344,170 @@ public sealed class GoogleGroupSyncService(
                 ProfilePictureUrl: expected.ProfilePictureUrl));
         }
 
-        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(ct);
-        foreach (var email in currentByEmail.Keys
-                     .Where(email =>
-                         !expectedEmails.Contains(email) &&
-                         !string.Equals(email, serviceAccountEmail, StringComparison.OrdinalIgnoreCase)))
+        return members;
+    }
+
+    private static void AddExtraGroupMemberStatuses(
+        List<MemberSyncStatus> members,
+        IEnumerable<string> expectedEmails,
+        IEnumerable<string> currentEmails,
+        string serviceAccountEmail)
+    {
+        var expectedEmailSet = expectedEmails.ToHashSet(NormalizingEmailComparer.Instance);
+        foreach (var email in currentEmails.Where(email =>
+                     !expectedEmailSet.Contains(email) &&
+                     !string.Equals(email, serviceAccountEmail, StringComparison.OrdinalIgnoreCase)))
         {
             members.Add(new MemberSyncStatus(email, email, MemberSyncState.Extra, []));
         }
+    }
 
-        if (action == SyncAction.Execute)
+    private async Task<ResourceSyncDiff?> ApplyGroupMembershipChangesAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string groupNumericId,
+        GroupMembershipPlan plan,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        var mode = await syncSettingsService.GetModeAsync(SyncServiceType.GoogleGroups, ct);
+        if (mode != SyncMode.None)
         {
-            var mode = await syncSettingsService.GetModeAsync(SyncServiceType.GoogleGroups, ct);
-            if (mode != SyncMode.None)
-            {
-                foreach (var member in members.Where(m => m.State == MemberSyncState.Missing))
-                {
-                    var add = await membershipClient.CreateMembershipAsync(lookup.GroupNumericId, member.Email, ct);
-                    if (add.Outcome == GroupMembershipMutationOutcome.Failed)
-                    {
-                        var error = await HandleGroupAddFailureAsync(resource, claim.GroupKey, member.Email, add.Error, ct);
-                        logger.LogWarning(
-                            "Google group sync failed for {GroupKey} member {Email}: {Error}",
-                            claim.GroupKey,
-                            member.Email,
-                            error);
-                        await RecordMemberErrorAsync(
-                            resource,
-                            member.Email,
-                            error,
-                            AuditAction.GoogleResourceAccessGranted,
-                            ct);
-                        if (scheduleRetryOnFailure)
-                            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-                        return BuildErrorDiff(claim.GroupKey, resource, error, members);
-                    }
-
-                    if (resource is not null && add.Outcome == GroupMembershipMutationOutcome.Added)
-                    {
-                        await auditLogService.LogGoogleSyncAsync(
-                            AuditAction.GoogleResourceAccessGranted,
-                            resource.Id,
-                            $"Granted Google Group access to {member.Email} ({resource.Name})",
-                            nameof(GoogleGroupSyncService),
-                            member.Email,
-                            "MEMBER",
-                            GoogleSyncSource.ScheduledSync,
-                            success: true);
-                    }
-                }
-            }
-
-            if (mode == SyncMode.AddAndRemove)
-            {
-                foreach (var member in members.Where(m => m.State == MemberSyncState.Extra))
-                {
-                    if (!currentByEmail.TryGetValue(member.Email, out var membershipResourceName))
-                        continue;
-
-                    var deleteError = await membershipClient.DeleteMembershipAsync(membershipResourceName, ct);
-                    if (deleteError is not null)
-                    {
-                        var error = FormatGoogleError($"Google group remove failed for {member.Email}", deleteError);
-                        logger.LogWarning(
-                            "Google group sync failed for {GroupKey} member {Email}: {Error}",
-                            claim.GroupKey,
-                            member.Email,
-                            error);
-                        await RecordMemberErrorAsync(
-                            resource,
-                            member.Email,
-                            error,
-                            AuditAction.GoogleResourceAccessRevoked,
-                            ct);
-                        if (scheduleRetryOnFailure)
-                            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-                        return BuildErrorDiff(claim.GroupKey, resource, error, members);
-                    }
-
-                    if (resource is not null)
-                    {
-                        await auditLogService.LogGoogleSyncAsync(
-                            AuditAction.GoogleResourceAccessRevoked,
-                            resource.Id,
-                            $"Removed {member.Email} from Google Group ({resource.Name})",
-                            nameof(GoogleGroupSyncService),
-                            member.Email,
-                            "MEMBER",
-                            GoogleSyncSource.ScheduledSync,
-                            success: true);
-                    }
-
-                    await NotifyRemovalAsync(member.Email, resource, claim.GroupKey, ct);
-                }
-            }
-
-            if (resource is not null && mode != SyncMode.None)
-                await teamResourceService.MarkResourceSyncedAsync(resource.Id, clock.GetCurrentInstant(), ct);
+            var addError = await ApplyMissingGroupMembersAsync(
+                claim, resource, groupNumericId, plan.Members, scheduleRetryOnFailure, nextRetryAttempt, ct);
+            if (addError is not null)
+                return addError;
         }
 
-        return new ResourceSyncDiff
+        if (mode == SyncMode.AddAndRemove)
         {
-            ResourceId = resource?.Id ?? Guid.Empty,
-            ResourceName = resource?.Name ?? claim.GroupKey,
-            ResourceType = GoogleResourceType.Group.ToString(),
-            GoogleId = lookup.GroupNumericId,
-            Url = resource?.Url,
-            Members = members
-        };
+            var removeError = await ApplyExtraGroupMembersAsync(
+                claim, resource, plan, scheduleRetryOnFailure, nextRetryAttempt, ct);
+            if (removeError is not null)
+                return removeError;
+        }
+
+        if (resource is not null && mode != SyncMode.None)
+            await teamResourceService.MarkResourceSyncedAsync(resource.Id, clock.GetCurrentInstant(), ct);
+
+        return null;
     }
+
+    private async Task<ResourceSyncDiff?> ApplyMissingGroupMembersAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string groupNumericId,
+        List<MemberSyncStatus> members,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        foreach (var member in members.Where(m => m.State == MemberSyncState.Missing))
+        {
+            var add = await membershipClient.CreateMembershipAsync(groupNumericId, member.Email, ct);
+            if (add.Outcome == GroupMembershipMutationOutcome.Failed)
+            {
+                return await BuildMemberMutationErrorDiffAsync(
+                    claim,
+                    resource,
+                    member.Email,
+                    await HandleGroupAddFailureAsync(resource, claim.GroupKey, member.Email, add.Error, ct),
+                    AuditAction.GoogleResourceAccessGranted,
+                    members,
+                    scheduleRetryOnFailure,
+                    nextRetryAttempt,
+                    ct);
+            }
+
+            if (resource is not null && add.Outcome == GroupMembershipMutationOutcome.Added)
+                await LogGroupMemberAddedAsync(resource, member.Email);
+        }
+
+        return null;
+    }
+
+    private async Task<ResourceSyncDiff?> ApplyExtraGroupMembersAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        GroupMembershipPlan plan,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        foreach (var member in plan.Members.Where(m => m.State == MemberSyncState.Extra))
+        {
+            if (!plan.CurrentByEmail.TryGetValue(member.Email, out var membershipResourceName))
+                continue;
+
+            var deleteError = await membershipClient.DeleteMembershipAsync(membershipResourceName, ct);
+            if (deleteError is not null)
+            {
+                return await BuildMemberMutationErrorDiffAsync(
+                    claim,
+                    resource,
+                    member.Email,
+                    FormatGoogleError($"Google group remove failed for {member.Email}", deleteError),
+                    AuditAction.GoogleResourceAccessRevoked,
+                    plan.Members,
+                    scheduleRetryOnFailure,
+                    nextRetryAttempt,
+                    ct);
+            }
+
+            if (resource is not null)
+                await LogGroupMemberRemovedAsync(resource, member.Email);
+
+            await NotifyRemovalAsync(member.Email, resource, claim.GroupKey, ct);
+        }
+
+        return null;
+    }
+
+    private async Task<ResourceSyncDiff> BuildMemberMutationErrorDiffAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string email,
+        string error,
+        AuditAction auditAction,
+        List<MemberSyncStatus> members,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        logger.LogWarning(
+            "Google group sync failed for {GroupKey} member {Email}: {Error}",
+            claim.GroupKey,
+            email,
+            error);
+        await RecordMemberErrorAsync(resource, email, error, auditAction, ct);
+        if (scheduleRetryOnFailure)
+            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
+
+        return BuildErrorDiff(claim.GroupKey, resource, error, members);
+    }
+
+    private Task LogGroupMemberAddedAsync(GoogleResourceSnapshot resource, string email)
+        => auditLogService.LogGoogleSyncAsync(
+            AuditAction.GoogleResourceAccessGranted,
+            resource.Id,
+            $"Granted Google Group access to {email} ({resource.Name})",
+            nameof(GoogleGroupSyncService),
+            email,
+            "MEMBER",
+            GoogleSyncSource.ScheduledSync,
+            success: true);
+
+    private Task LogGroupMemberRemovedAsync(GoogleResourceSnapshot resource, string email)
+        => auditLogService.LogGoogleSyncAsync(
+            AuditAction.GoogleResourceAccessRevoked,
+            resource.Id,
+            $"Removed {email} from Google Group ({resource.Name})",
+            nameof(GoogleGroupSyncService),
+            email,
+            "MEMBER",
+            GoogleSyncSource.ScheduledSync,
+            success: true);
 
     private async Task<Dictionary<Guid, ExpectedMember>> HydrateExpectedMembersByUserIdAsync(
         IReadOnlyCollection<Guid> userIds,
@@ -707,5 +822,8 @@ public sealed class GoogleGroupSyncService(
     }
 
     private sealed record ExpectedMember(Guid UserId, string Email, string DisplayName, string? ProfilePictureUrl);
-}
 
+    private sealed record GroupMembershipPlan(
+        List<MemberSyncStatus> Members,
+        Dictionary<string, string> CurrentByEmail);
+}

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -598,242 +598,48 @@ public sealed class GoogleWorkspaceSyncService(
     {
         var primary = resources[0];
 
-        // Build a lookup from team slug to permission level.
-        var levelByTeamSlug = new Dictionary<string, DrivePermissionLevel>(StringComparer.Ordinal);
-        foreach (var resource in resources)
-        {
-            var slug = teamsById[resource.TeamId].Slug;
-            if (!levelByTeamSlug.TryGetValue(slug, out var existing) || resource.DrivePermissionLevel > existing)
-                levelByTeamSlug[slug] = resource.DrivePermissionLevel;
-        }
+        var levelByTeamSlug = BuildDriveLevelByTeamSlug(resources, teamsById);
 
         try
         {
             // Expected: union of all linked teams' active members + child team rollup.
-            var membersByEmail = new Dictionary<string, (string DisplayName, Guid UserId, string? ProfilePictureUrl, List<TeamLink> TeamLinks)>(
-                NormalizingEmailComparer.Instance);
+            var membersByEmail = await BuildExpectedDriveMembersByEmailAsync(
+                resources,
+                teamsById,
+                membersByTeam,
+                childMembersByTeam,
+                cancellationToken);
 
-            // Issue #635 (§15i): bulk-fetch UserEmails once for all members
-            // across the team union so TryGetGoogleEmail does not traverse
-            // user.UserEmails cross-domain.
-            var allMemberUserIds = membersByTeam.Values.SelectMany(v => v.Select(m => m.UserId))
-                .Concat(childMembersByTeam.Values.SelectMany(v => v.Select(m => m.UserId)))
-                .Distinct()
-                .ToList();
-            var emailsByUserId = await userEmailService.GetEntitiesByUserIdsAsync(allMemberUserIds, cancellationToken);
-
-            foreach (var resource in resources)
-            {
-                var level = resource.DrivePermissionLevel is DrivePermissionLevel.None
-                    ? null : resource.DrivePermissionLevel.ToString();
-                var resourceTeam = teamsById[resource.TeamId];
-                var teamLink = new TeamLink(resourceTeam.Name, resourceTeam.Slug, level);
-
-                var teamMembers = membersByTeam.GetValueOrDefault(resource.TeamId, []);
-                foreach (var tm in teamMembers)
-                {
-                    var memberEmail = TryGetGoogleEmail(tm.UserId, tm.GoogleEmailStatus, emailsByUserId);
-                    if (memberEmail is null) continue;
-
-                    if (membersByEmail.TryGetValue(memberEmail, out var existing))
-                    {
-                        if (!existing.TeamLinks.Any(tl => string.Equals(tl.Name, teamLink.Name, StringComparison.Ordinal)))
-                            existing.TeamLinks.Add(teamLink);
-                    }
-                    else
-                    {
-                        membersByEmail[memberEmail] = (tm.DisplayName, tm.UserId, tm.ProfilePictureUrl, [teamLink]);
-                    }
-                }
-
-                var childMembers = childMembersByTeam.GetValueOrDefault(resource.TeamId, []);
-                foreach (var cm in childMembers)
-                {
-                    var memberEmail = TryGetGoogleEmail(cm.UserId, cm.GoogleEmailStatus, emailsByUserId);
-                    if (memberEmail is null) continue;
-
-                    var childTeam = teamsById[cm.TeamId];
-                    var childTeamLink = new TeamLink(childTeam.Name, childTeam.Slug, level);
-                    if (membersByEmail.TryGetValue(memberEmail, out var existing2))
-                    {
-                        if (!existing2.TeamLinks.Any(tl => string.Equals(tl.Name, childTeamLink.Name, StringComparison.Ordinal)))
-                            existing2.TeamLinks.Add(childTeamLink);
-                    }
-                    else
-                    {
-                        membersByEmail[memberEmail] = (cm.DisplayName, cm.UserId, cm.ProfilePictureUrl, [childTeamLink]);
-                    }
-                }
-            }
-
-            var linkedTeams = resources.Select(r =>
-                {
-                    var t = teamsById[r.TeamId];
-                    return new TeamLink(t.Name, t.Slug,
-                        r.DrivePermissionLevel is DrivePermissionLevel.None ? null : r.DrivePermissionLevel.ToString());
-                })
-                .DistinctBy(tl => tl.Slug, StringComparer.Ordinal).ToList();
+            var linkedTeams = BuildDriveLinkedTeams(resources, teamsById);
 
             // Current: Drive permissions.
             var permsResult = await drivePermissions.ListPermissionsAsync(primary.GoogleId, cancellationToken);
             if (permsResult.Permissions is null)
             {
-                var code = permsResult.Error?.StatusCode ?? 0;
-                var msg = $"Google API error: {code} — {permsResult.Error?.RawMessage}";
-                logger.LogWarning(
-                    "Failed to list permissions for {GoogleId}: {Message}", primary.GoogleId, msg);
-                if (action == SyncAction.Execute)
-                {
-                    await resourceRepository.SetErrorMessageManyAsync(
-                        resources.Select(r => r.Id).ToList(), msg, cancellationToken);
-                }
-                return new ResourceSyncDiff
-                {
-                    ResourceId = primary.Id,
-                    ResourceName = primary.Name,
-                    ResourceType = primary.ResourceType.ToString(),
-                    GoogleId = primary.GoogleId,
-                    Url = primary.Url,
-                    PermissionLevel = primary.DrivePermissionLevel.ToString(),
-                    LinkedTeams = linkedTeams,
-                    ErrorMessage = msg
-                };
+                return await BuildDrivePermissionListErrorDiffAsync(
+                    primary,
+                    resources,
+                    linkedTeams,
+                    permsResult,
+                    action,
+                    cancellationToken);
             }
 
             var permissions = permsResult.Permissions;
-            var allEmails = new HashSet<string>(NormalizingEmailComparer.Instance);
-            var directEmails = new HashSet<string>(NormalizingEmailComparer.Instance);
-            var roleByEmail = new Dictionary<string, string>(NormalizingEmailComparer.Instance);
+            var permissionSnapshot = BuildDrivePermissionSnapshot(permissions);
 
-            foreach (var perm in permissions)
-            {
-                if (IsAnyUserPermission(perm))
-                {
-                    allEmails.Add(perm.EmailAddress!);
-                    if (!string.IsNullOrEmpty(perm.Role))
-                        roleByEmail[perm.EmailAddress!] = perm.Role;
-                }
-                if (IsDirectManagedPermission(perm))
-                    directEmails.Add(perm.EmailAddress!);
-            }
-
-            var members = new List<MemberSyncStatus>();
-
-            foreach (var (email, (displayName, userId, profilePictureUrl, teamLinks)) in membersByEmail)
-            {
-                var memberMaxLevel = DrivePermissionLevel.None;
-                foreach (var tl in teamLinks)
-                {
-                    if (levelByTeamSlug.TryGetValue(tl.Slug, out var tlLevel) && tlLevel > memberMaxLevel)
-                        memberMaxLevel = tlLevel;
-                }
-                var memberExpectedRole = memberMaxLevel > DrivePermissionLevel.None
-                    ? memberMaxLevel.ToApiRole() : null;
-
-                MemberSyncState state;
-                roleByEmail.TryGetValue(email, out var currentRole);
-
-                if (!allEmails.Contains(email))
-                {
-                    state = MemberSyncState.Missing;
-                }
-                else if (!directEmails.Contains(email))
-                {
-                    state = MemberSyncState.Inherited;
-                }
-                else
-                {
-                    var currentLevel = ParseApiRole(currentRole);
-                    state = currentLevel.HasValue && currentLevel.Value < memberMaxLevel
-                        ? MemberSyncState.WrongRole
-                        : MemberSyncState.Correct;
-                }
-
-                members.Add(new MemberSyncStatus(email, displayName, state, teamLinks, currentRole, memberExpectedRole,
-                    UserId: userId, ProfilePictureUrl: profilePictureUrl));
-            }
-
-            var saEmail = await teamResourceClient.GetServiceAccountEmailAsync(cancellationToken);
-            var nonMemberEmails = allEmails
-                .Where(e => !membersByEmail.ContainsKey(e) &&
-                    !string.Equals(e, saEmail, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            var extraIdentities = await ResolveExtraEmailIdentitiesAsync(nonMemberEmails, cancellationToken);
-
-            foreach (var email in nonMemberEmails)
-            {
-                var state = directEmails.Contains(email)
-                    ? MemberSyncState.Extra
-                    : MemberSyncState.Inherited;
-                roleByEmail.TryGetValue(email, out var extraRole);
-
-                if (extraIdentities.TryGetValue(email, out var identity))
-                {
-                    members.Add(new MemberSyncStatus(email, identity.DisplayName, state, [], extraRole,
-                        UserId: identity.UserId, ProfilePictureUrl: identity.ProfilePictureUrl));
-                }
-                else
-                {
-                    members.Add(new MemberSyncStatus(email, email, state, [], extraRole));
-                }
-            }
+            var members = await BuildDriveMemberStatusesAsync(
+                membersByEmail,
+                levelByTeamSlug,
+                permissionSnapshot,
+                cancellationToken);
 
             if (action == SyncAction.Execute)
             {
-                foreach (var member in members.Where(m => m.State is MemberSyncState.Missing or MemberSyncState.WrongRole))
-                {
-                    try
-                    {
-                        var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.Contributor;
-                        await AddUserToDriveAsync(primary, member.Email, memberLevel, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Failed to grant Drive access to {Email} on {GoogleId}",
-                            member.Email, primary.GoogleId);
-                    }
-                }
-
-                foreach (var member in members.Where(m => m.State == MemberSyncState.Extra))
-                {
-                    try
-                    {
-                        var permToRemove = permissions.FirstOrDefault(p =>
-                            IsDirectManagedPermission(p) &&
-                            NormalizingEmailComparer.Instance.Equals(p.EmailAddress, member.Email));
-
-                        if (permToRemove?.Id is null)
-                        {
-                            logger.LogInformation(
-                                "Skipping removal of {Email} from {GoogleId} — permission is inherited, not direct",
-                                member.Email, primary.GoogleId);
-                            continue;
-                        }
-
-                        await RemoveUserFromDriveAsync(primary, permToRemove.Id, member.Email, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Failed to remove Drive access for {Email} on {GoogleId}",
-                            member.Email, primary.GoogleId);
-                    }
-                }
-
-                await resourceRepository.MarkSyncedManyAsync(
-                    resources.Select(r => r.Id).ToList(), now, cancellationToken);
+                await ApplyDriveResourceChangesAsync(primary, resources, permissions, members, now, cancellationToken);
             }
 
-            return new ResourceSyncDiff
-            {
-                ResourceId = primary.Id,
-                ResourceName = primary.Name,
-                ResourceType = primary.ResourceType.ToString(),
-                GoogleId = primary.GoogleId,
-                Url = primary.Url,
-                PermissionLevel = primary.DrivePermissionLevel.ToString(),
-                LinkedTeams = linkedTeams,
-                Members = members
-            };
+            return BuildDriveSyncDiff(primary, linkedTeams, members);
         }
         catch (Exception ex)
         {
@@ -843,25 +649,367 @@ public sealed class GoogleWorkspaceSyncService(
                 await resourceRepository.SetErrorMessageManyAsync(
                     resources.Select(r => r.Id).ToList(), ex.Message, cancellationToken);
             }
-            return new ResourceSyncDiff
-            {
-                ResourceId = primary.Id,
-                ResourceName = primary.Name,
-                ResourceType = primary.ResourceType.ToString(),
-                GoogleId = primary.GoogleId,
-                Url = primary.Url,
-                PermissionLevel = primary.DrivePermissionLevel.ToString(),
-                LinkedTeams = resources.Select(r =>
-                    {
-                        var t = teamsById[r.TeamId];
-                        return new TeamLink(t.Name, t.Slug,
-                            r.DrivePermissionLevel is DrivePermissionLevel.None ? null : r.DrivePermissionLevel.ToString());
-                    })
-                    .DistinctBy(tl => tl.Slug, StringComparer.Ordinal).ToList(),
-                ErrorMessage = ex.Message
-            };
+            return BuildDriveSyncDiff(
+                primary,
+                BuildDriveLinkedTeams(resources, teamsById),
+                members: [],
+                errorMessage: ex.Message);
         }
     }
+
+    private static Dictionary<string, DrivePermissionLevel> BuildDriveLevelByTeamSlug(
+        IEnumerable<GoogleResource> resources,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById)
+    {
+        var levelByTeamSlug = new Dictionary<string, DrivePermissionLevel>(StringComparer.Ordinal);
+        foreach (var resource in resources)
+        {
+            var slug = teamsById[resource.TeamId].Slug;
+            if (!levelByTeamSlug.TryGetValue(slug, out var existing) || resource.DrivePermissionLevel > existing)
+                levelByTeamSlug[slug] = resource.DrivePermissionLevel;
+        }
+
+        return levelByTeamSlug;
+    }
+
+    private async Task<Dictionary<string, DriveExpectedMember>> BuildExpectedDriveMembersByEmailAsync(
+        IEnumerable<GoogleResource> resources,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
+        Dictionary<Guid, List<TeamActiveMemberSnapshot>> membersByTeam,
+        Dictionary<Guid, List<TeamActiveMemberSnapshot>> childMembersByTeam,
+        CancellationToken cancellationToken)
+    {
+        var allMemberUserIds = membersByTeam.Values.SelectMany(v => v.Select(m => m.UserId))
+            .Concat(childMembersByTeam.Values.SelectMany(v => v.Select(m => m.UserId)))
+            .Distinct()
+            .ToList();
+        var emailsByUserId = await userEmailService.GetEntitiesByUserIdsAsync(allMemberUserIds, cancellationToken);
+        var membersByEmail = new Dictionary<string, DriveExpectedMember>(NormalizingEmailComparer.Instance);
+
+        foreach (var resource in resources)
+        {
+            AddExpectedTeamMembers(resource, teamsById, membersByTeam, emailsByUserId, membersByEmail);
+            AddExpectedChildTeamMembers(resource, teamsById, childMembersByTeam, emailsByUserId, membersByEmail);
+        }
+
+        return membersByEmail;
+    }
+
+    private static void AddExpectedTeamMembers(
+        GoogleResource resource,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
+        IReadOnlyDictionary<Guid, List<TeamActiveMemberSnapshot>> membersByTeam,
+        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId,
+        Dictionary<string, DriveExpectedMember> membersByEmail)
+    {
+        var resourceTeam = teamsById[resource.TeamId];
+        var teamLink = BuildDriveTeamLink(resourceTeam, resource.DrivePermissionLevel);
+        foreach (var member in membersByTeam.GetValueOrDefault(resource.TeamId, []))
+        {
+            AddExpectedDriveMember(member, teamLink, emailsByUserId, membersByEmail);
+        }
+    }
+
+    private static void AddExpectedChildTeamMembers(
+        GoogleResource resource,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
+        IReadOnlyDictionary<Guid, List<TeamActiveMemberSnapshot>> childMembersByTeam,
+        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId,
+        Dictionary<string, DriveExpectedMember> membersByEmail)
+    {
+        var level = resource.DrivePermissionLevel is DrivePermissionLevel.None
+            ? null
+            : resource.DrivePermissionLevel.ToString();
+        foreach (var member in childMembersByTeam.GetValueOrDefault(resource.TeamId, []))
+        {
+            var childTeam = teamsById[member.TeamId];
+            AddExpectedDriveMember(member, new TeamLink(childTeam.Name, childTeam.Slug, level), emailsByUserId, membersByEmail);
+        }
+    }
+
+    private static void AddExpectedDriveMember(
+        TeamActiveMemberSnapshot member,
+        TeamLink teamLink,
+        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId,
+        Dictionary<string, DriveExpectedMember> membersByEmail)
+    {
+        var memberEmail = TryGetGoogleEmail(member.UserId, member.GoogleEmailStatus, emailsByUserId);
+        if (memberEmail is null)
+            return;
+
+        if (membersByEmail.TryGetValue(memberEmail, out var existing))
+        {
+            AddDriveTeamLink(existing.TeamLinks, teamLink);
+            return;
+        }
+
+        membersByEmail[memberEmail] = new DriveExpectedMember(
+            member.DisplayName,
+            member.UserId,
+            member.ProfilePictureUrl,
+            [teamLink]);
+    }
+
+    private static void AddDriveTeamLink(List<TeamLink> links, TeamLink teamLink)
+    {
+        if (!links.Any(link => string.Equals(link.Name, teamLink.Name, StringComparison.Ordinal)))
+            links.Add(teamLink);
+    }
+
+    private static List<TeamLink> BuildDriveLinkedTeams(
+        IEnumerable<GoogleResource> resources,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById)
+        => resources
+            .Select(resource => BuildDriveTeamLink(teamsById[resource.TeamId], resource.DrivePermissionLevel))
+            .DistinctBy(teamLink => teamLink.Slug, StringComparer.Ordinal)
+            .ToList();
+
+    private static TeamLink BuildDriveTeamLink(TeamInfo team, DrivePermissionLevel level)
+        => new(team.Name, team.Slug, level is DrivePermissionLevel.None ? null : level.ToString());
+
+    private async Task<ResourceSyncDiff> BuildDrivePermissionListErrorDiffAsync(
+        GoogleResource primary,
+        IReadOnlyList<GoogleResource> resources,
+        IReadOnlyList<TeamLink> linkedTeams,
+        DrivePermissionListResult permsResult,
+        SyncAction action,
+        CancellationToken cancellationToken)
+    {
+        var code = permsResult.Error?.StatusCode ?? 0;
+        var message = $"Google API error: {code} - {permsResult.Error?.RawMessage}";
+        logger.LogWarning("Failed to list permissions for {GoogleId}: {Message}", primary.GoogleId, message);
+
+        if (action == SyncAction.Execute)
+        {
+            await resourceRepository.SetErrorMessageManyAsync(
+                resources.Select(r => r.Id).ToList(),
+                message,
+                cancellationToken);
+        }
+
+        return BuildDriveSyncDiff(primary, linkedTeams, members: [], errorMessage: message);
+    }
+
+    private static DrivePermissionSnapshot BuildDrivePermissionSnapshot(IEnumerable<DrivePermission> permissions)
+    {
+        var snapshot = new DrivePermissionSnapshot(
+            new HashSet<string>(NormalizingEmailComparer.Instance),
+            new HashSet<string>(NormalizingEmailComparer.Instance),
+            new Dictionary<string, string>(NormalizingEmailComparer.Instance));
+
+        foreach (var permission in permissions)
+        {
+            if (IsAnyUserPermission(permission))
+            {
+                snapshot.AllEmails.Add(permission.EmailAddress!);
+                if (!string.IsNullOrEmpty(permission.Role))
+                    snapshot.RoleByEmail[permission.EmailAddress!] = permission.Role;
+            }
+
+            if (IsDirectManagedPermission(permission))
+                snapshot.DirectEmails.Add(permission.EmailAddress!);
+        }
+
+        return snapshot;
+    }
+
+    private async Task<List<MemberSyncStatus>> BuildDriveMemberStatusesAsync(
+        IReadOnlyDictionary<string, DriveExpectedMember> membersByEmail,
+        IReadOnlyDictionary<string, DrivePermissionLevel> levelByTeamSlug,
+        DrivePermissionSnapshot permissionSnapshot,
+        CancellationToken cancellationToken)
+    {
+        var members = membersByEmail
+            .Select(entry => BuildExpectedDriveMemberStatus(
+                entry.Key,
+                entry.Value,
+                levelByTeamSlug,
+                permissionSnapshot))
+            .ToList();
+
+        await AddExtraDriveMemberStatusesAsync(members, membersByEmail, permissionSnapshot, cancellationToken);
+        return members;
+    }
+
+    private static MemberSyncStatus BuildExpectedDriveMemberStatus(
+        string email,
+        DriveExpectedMember expectedMember,
+        IReadOnlyDictionary<string, DrivePermissionLevel> levelByTeamSlug,
+        DrivePermissionSnapshot permissionSnapshot)
+    {
+        var memberMaxLevel = ResolveMemberMaxDriveLevel(expectedMember.TeamLinks, levelByTeamSlug);
+        var memberExpectedRole = memberMaxLevel > DrivePermissionLevel.None
+            ? memberMaxLevel.ToApiRole()
+            : null;
+        var state = ResolveExpectedDriveMemberState(email, memberMaxLevel, permissionSnapshot);
+        permissionSnapshot.RoleByEmail.TryGetValue(email, out var currentRole);
+
+        return new MemberSyncStatus(
+            email,
+            expectedMember.DisplayName,
+            state,
+            expectedMember.TeamLinks,
+            currentRole,
+            memberExpectedRole,
+            UserId: expectedMember.UserId,
+            ProfilePictureUrl: expectedMember.ProfilePictureUrl);
+    }
+
+    private static DrivePermissionLevel ResolveMemberMaxDriveLevel(
+        IEnumerable<TeamLink> teamLinks,
+        IReadOnlyDictionary<string, DrivePermissionLevel> levelByTeamSlug)
+    {
+        var memberMaxLevel = DrivePermissionLevel.None;
+        foreach (var teamLink in teamLinks)
+        {
+            if (levelByTeamSlug.TryGetValue(teamLink.Slug, out var teamLevel) && teamLevel > memberMaxLevel)
+                memberMaxLevel = teamLevel;
+        }
+
+        return memberMaxLevel;
+    }
+
+    private static MemberSyncState ResolveExpectedDriveMemberState(
+        string email,
+        DrivePermissionLevel memberMaxLevel,
+        DrivePermissionSnapshot permissionSnapshot)
+    {
+        if (!permissionSnapshot.AllEmails.Contains(email))
+            return MemberSyncState.Missing;
+
+        if (!permissionSnapshot.DirectEmails.Contains(email))
+            return MemberSyncState.Inherited;
+
+        permissionSnapshot.RoleByEmail.TryGetValue(email, out var currentRole);
+        var currentLevel = ParseApiRole(currentRole);
+        return currentLevel.HasValue && currentLevel.Value < memberMaxLevel
+            ? MemberSyncState.WrongRole
+            : MemberSyncState.Correct;
+    }
+
+    private async Task AddExtraDriveMemberStatusesAsync(
+        List<MemberSyncStatus> members,
+        IReadOnlyDictionary<string, DriveExpectedMember> membersByEmail,
+        DrivePermissionSnapshot permissionSnapshot,
+        CancellationToken cancellationToken)
+    {
+        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(cancellationToken);
+        var nonMemberEmails = permissionSnapshot.AllEmails
+            .Where(email => !membersByEmail.ContainsKey(email) &&
+                !string.Equals(email, serviceAccountEmail, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var extraIdentities = await ResolveExtraEmailIdentitiesAsync(nonMemberEmails, cancellationToken);
+
+        foreach (var email in nonMemberEmails)
+        {
+            var state = permissionSnapshot.DirectEmails.Contains(email)
+                ? MemberSyncState.Extra
+                : MemberSyncState.Inherited;
+            permissionSnapshot.RoleByEmail.TryGetValue(email, out var extraRole);
+
+            members.Add(extraIdentities.TryGetValue(email, out var identity)
+                ? new MemberSyncStatus(email, identity.DisplayName, state, [], extraRole,
+                    UserId: identity.UserId, ProfilePictureUrl: identity.ProfilePictureUrl)
+                : new MemberSyncStatus(email, email, state, [], extraRole));
+        }
+    }
+
+    private async Task ApplyDriveResourceChangesAsync(
+        GoogleResource primary,
+        IReadOnlyList<GoogleResource> resources,
+        IReadOnlyList<DrivePermission> permissions,
+        IReadOnlyList<MemberSyncStatus> members,
+        Instant now,
+        CancellationToken cancellationToken)
+    {
+        foreach (var member in members.Where(m => m.State is MemberSyncState.Missing or MemberSyncState.WrongRole))
+        {
+            await GrantDriveAccessAsync(primary, member, cancellationToken);
+        }
+
+        foreach (var member in members.Where(m => m.State == MemberSyncState.Extra))
+        {
+            await RemoveExtraDriveAccessAsync(primary, permissions, member, cancellationToken);
+        }
+
+        await resourceRepository.MarkSyncedManyAsync(resources.Select(r => r.Id).ToList(), now, cancellationToken);
+    }
+
+    private async Task GrantDriveAccessAsync(
+        GoogleResource primary,
+        MemberSyncStatus member,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.Contributor;
+            await AddUserToDriveAsync(primary, member.Email, memberLevel, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to grant Drive access to {Email} on {GoogleId}",
+                member.Email, primary.GoogleId);
+        }
+    }
+
+    private async Task RemoveExtraDriveAccessAsync(
+        GoogleResource primary,
+        IEnumerable<DrivePermission> permissions,
+        MemberSyncStatus member,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var permissionToRemove = permissions.FirstOrDefault(permission =>
+                IsDirectManagedPermission(permission) &&
+                NormalizingEmailComparer.Instance.Equals(permission.EmailAddress, member.Email));
+
+            if (permissionToRemove?.Id is null)
+            {
+                logger.LogInformation(
+                    "Skipping removal of {Email} from {GoogleId} - permission is inherited, not direct",
+                    member.Email,
+                    primary.GoogleId);
+                return;
+            }
+
+            await RemoveUserFromDriveAsync(primary, permissionToRemove.Id, member.Email, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to remove Drive access for {Email} on {GoogleId}",
+                member.Email, primary.GoogleId);
+        }
+    }
+
+    private static ResourceSyncDiff BuildDriveSyncDiff(
+        GoogleResource primary,
+        IEnumerable<TeamLink> linkedTeams,
+        IEnumerable<MemberSyncStatus> members,
+        string? errorMessage = null)
+        => new()
+        {
+            ResourceId = primary.Id,
+            ResourceName = primary.Name,
+            ResourceType = primary.ResourceType.ToString(),
+            GoogleId = primary.GoogleId,
+            Url = primary.Url,
+            PermissionLevel = primary.DrivePermissionLevel.ToString(),
+            LinkedTeams = linkedTeams.ToList(),
+            Members = members.ToList(),
+            ErrorMessage = errorMessage
+        };
+
+    private sealed record DriveExpectedMember(
+        string DisplayName,
+        Guid UserId,
+        string? ProfilePictureUrl,
+        List<TeamLink> TeamLinks);
+
+    private sealed record DrivePermissionSnapshot(
+        HashSet<string> AllEmails,
+        HashSet<string> DirectEmails,
+        Dictionary<string, string> RoleByEmail);
 
     /// <inheritdoc />
     public async Task<GroupLinkResult> EnsureTeamGroupAsync(

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -585,39 +585,17 @@ public sealed class ShiftManagementService(
             return ShiftGenerationResult.Failure("Event shift generation is only for Event-period rotas.");
 
         var es = rota.EventSettings;
-        if (input.StartDayOffset < 0 ||
-            input.EndDayOffset > es.EventEndOffset ||
-            input.StartDayOffset > input.EndDayOffset)
+        if (!input.HasValidEventRange(es))
             return ShiftGenerationResult.Failure("Shift dates must fall within the event period.");
 
-        if (input.MinVolunteers > input.MaxVolunteers)
+        if (!input.HasValidVolunteerRange())
             return ShiftGenerationResult.Failure("MinVolunteers cannot exceed MaxVolunteers.");
 
-        if (input.TimeSlots.Count == 0)
+        if (!input.HasTimeSlots())
             return ShiftGenerationResult.Failure("At least one time slot is required.");
 
         var now = clock.GetCurrentInstant();
-        var toInsert = new List<Shift>();
-
-        for (var day = input.StartDayOffset; day <= input.EndDayOffset; day++)
-        {
-            foreach (var slot in input.TimeSlots)
-            {
-                toInsert.Add(new Shift
-                {
-                    Id = Guid.NewGuid(),
-                    RotaId = input.RotaId,
-                    IsAllDay = false,
-                    DayOffset = day,
-                    StartTime = slot.StartTime,
-                    Duration = Duration.FromHours(slot.DurationHours),
-                    MinVolunteers = input.MinVolunteers,
-                    MaxVolunteers = input.MaxVolunteers,
-                    CreatedAt = now,
-                    UpdatedAt = now
-                });
-            }
-        }
+        var toInsert = input.ToShifts(now);
 
         if (toInsert.Count > 0)
         {
@@ -637,28 +615,14 @@ public sealed class ShiftManagementService(
 
         var es = rota.EventSettings;
         var (periodStart, periodEnd) = GetRotaDayOffsetBounds(rota.Period, es);
-        if (input.DayOffset < periodStart || input.DayOffset > periodEnd)
+        if (!input.IsWithinPeriod((periodStart, periodEnd)))
             return ShiftMutationResult.Failure("Shift date must fall within the rota's period.");
 
-        if (input.MinVolunteers > input.MaxVolunteers)
+        if (!input.HasValidVolunteerRange())
             return ShiftMutationResult.Failure("MinVolunteers cannot exceed MaxVolunteers.");
 
         var now = clock.GetCurrentInstant();
-        var shift = new Shift
-        {
-            Id = Guid.NewGuid(),
-            RotaId = input.RotaId,
-            Description = input.Description,
-            DayOffset = input.DayOffset,
-            StartTime = input.StartTime,
-            Duration = Duration.FromHours(input.DurationHours),
-            MinVolunteers = input.MinVolunteers,
-            MaxVolunteers = input.MaxVolunteers,
-            AdminOnly = input.AdminOnly,
-            IsAllDay = input.IsAllDay,
-            CreatedAt = now,
-            UpdatedAt = now
-        };
+        var shift = input.ToShift(now);
 
         await repo.SaveShiftAsync(shift, EntityMutationMode.Add);
         viewInvalidator.InvalidateRota(input.RotaId);
@@ -682,20 +646,13 @@ public sealed class ShiftManagementService(
 
         var es = shift.Rota.EventSettings;
         var (periodStart, periodEnd) = GetRotaDayOffsetBounds(shift.Rota.Period, es);
-        if (input.DayOffset < periodStart || input.DayOffset > periodEnd)
+        if (!input.IsWithinPeriod((periodStart, periodEnd)))
             return ShiftMutationResult.Failure("Shift date must fall within the rota's period.");
 
-        if (input.MinVolunteers > input.MaxVolunteers)
+        if (!input.HasValidVolunteerRange())
             return ShiftMutationResult.Failure("MinVolunteers cannot exceed MaxVolunteers.");
 
-        shift.Description = input.Description;
-        shift.DayOffset = input.DayOffset;
-        shift.StartTime = input.StartTime;
-        shift.Duration = Duration.FromHours(input.DurationHours);
-        shift.MinVolunteers = input.MinVolunteers;
-        shift.MaxVolunteers = input.MaxVolunteers;
-        shift.AdminOnly = input.AdminOnly;
-        shift.UpdatedAt = clock.GetCurrentInstant();
+        input.ApplyTo(shift, clock.GetCurrentInstant());
 
         await repo.SaveShiftAsync(shift, EntityMutationMode.Update);
         viewInvalidator.InvalidateShift(shift.Id);

--- a/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
+++ b/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
@@ -1,5 +1,4 @@
 using Humans.Application.DTOs.VolunteerTrackingExport;
-using Humans.Application.Extensions;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Shifts;
@@ -27,7 +26,7 @@ public sealed class VolunteerTrackingExportService(
 
     public async Task<VolunteerExportModel> BuildAsync(VolunteerExportRequest request, CancellationToken ct)
     {
-        var days = EnumerateDays(request.StartDate, request.EndDate);
+        var days = request.EnumerateDays();
         var shifts = await _shiftManagementRepository.GetConfirmedShiftsInRangeAsync(
             request.EventSettingsId, request.StartDate, request.EndDate, request.DepartmentId, ct);
 
@@ -204,26 +203,10 @@ public sealed class VolunteerTrackingExportService(
         return totals;
     }
 
-    private static IReadOnlyList<LocalDate> EnumerateDays(LocalDate start, LocalDate end)
-    {
-        var count = Period.DaysBetween(start, end) + 1;
-        var days = new LocalDate[count];
-        for (var i = 0; i < count; i++) days[i] = start.PlusDays(i);
-        return days;
-    }
-
     private static string BuildMethodologyBlurb() =>
         "Rows = humans with >=1 confirmed shift in range. Cell color = the team they worked most " +
         "hours that day. White cell = day before their first confirmed shift (arrival day). " +
         "Totals row = humans on-site that day (used for meal counts). Names shown are playa names.";
-
-    private static string BuildFileName(VolunteerExportRequest req, string? departmentSlug)
-    {
-        var prefix = departmentSlug is { Length: > 0 } slug
-            ? $"volunteer-tracking-{slug}-"
-            : "volunteer-tracking-";
-        return $"{prefix}{req.StartDate.ToInvariantDate()}-to-{req.EndDate.ToInvariantDate()}.xlsx";
-    }
 
     private static string SlugifyTeamName(string teamName)
     {
@@ -294,17 +277,15 @@ public sealed class VolunteerTrackingExportService(
         IReadOnlyList<int> totals,
         string? filteredTeamName)
     {
-        var deptName = filteredTeamName ?? "All";
-        var periodLabel = request.Period?.ToString() ?? "custom";
         var slug = filteredTeamName is null ? null : SlugifyTeamName(filteredTeamName);
         return new VolunteerExportModel(
             MethodologyBlurb: BuildMethodologyBlurb(),
-            FilterSummary: $"Department: {deptName} - Range: {request.StartDate} -> {request.EndDate} ({periodLabel})",
+            FilterSummary: request.BuildFilterSummary(filteredTeamName),
             GeneratedAtUtc: request.GeneratedAtUtc,
             GeneratedByName: request.ActorPlayaName,
             Days: days,
             Groups: groups,
             TotalsPerDay: totals,
-            SuggestedFileName: BuildFileName(request, slug));
+            SuggestedFileName: request.BuildSuggestedFileName(slug));
     }
 }

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -252,24 +252,15 @@ public class StoreService(
         Guid actorUserId,
         CancellationToken ct = default)
     {
-        var parseResult = LocalDatePattern.Iso.Parse(request.OrderableUntil ?? string.Empty);
+        var parseResult = LocalDatePattern.Iso.Parse(request.OrderableUntilForParsing);
         if (!parseResult.Success)
             return StoreCatalogSaveResult.Failure(nameof(request.OrderableUntil), "Invalid date - use YYYY-MM-DD.");
 
-        var dto = new ProductDto(
-            request.Id ?? Guid.Empty,
-            request.Year,
-            request.Name ?? string.Empty,
-            request.Description ?? string.Empty,
-            request.UnitPriceEur,
-            request.VatRatePercent,
-            request.DepositAmountEur,
-            parseResult.Value,
-            request.IsActive);
+        var dto = request.ToProductDto(parseResult.Value);
 
         try
         {
-            if (request.Id is null)
+            if (request.IsCreate)
             {
                 await CreateProductAsync(dto, actorUserId, ct);
                 return StoreCatalogSaveResult.Success(created: true);

--- a/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
@@ -75,18 +75,7 @@ public sealed class TicketingBudgetService(
         Guid actorUserId,
         CancellationToken ct = default)
     {
-        await budgetService.UpdateTicketingProjectionAsync(
-            command.BudgetGroupId,
-            command.StartDate,
-            command.EventDate,
-            command.InitialSalesCount,
-            command.DailySalesRate,
-            command.AverageTicketPrice,
-            command.VatRate,
-            command.StripeFeePercent,
-            command.StripeFeeFixed,
-            command.TicketTailorFeePercent,
-            actorUserId);
+        await command.SaveProjectionParametersAsync(budgetService, actorUserId);
 
         return await RefreshProjectionsAsync(command.BudgetYearId, ct);
     }

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -519,13 +519,7 @@ public sealed class UserService(
                 await repo.AddAsync(profile, ct);
             }
 
-            profile.DietaryPreference = command.DietaryPreference;
-            profile.Allergies = command.Allergies;
-            profile.AllergyOtherText = command.AllergyOtherText;
-            profile.Intolerances = command.Intolerances;
-            profile.IntoleranceOtherText = command.IntoleranceOtherText;
-            profile.MedicalConditions = command.MedicalConditions;
-            profile.UpdatedAt = now;
+            command.ApplyTo(profile, now);
 
             await repo.UpdateAsync(profile, ct);
         }

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -373,7 +373,7 @@ public sealed class UserService(
         UserProfileOnboardingCommand command,
         CancellationToken ct = default)
     {
-        ValidateProfileOnboardingCommand(command);
+        command.Validate();
 
         var profile = await repo.GetByUserIdAsync(userId, ct);
         if (profile is null)
@@ -451,10 +451,10 @@ public sealed class UserService(
             profile.Latitude = command.Latitude;
             profile.Longitude = command.Longitude;
             profile.PlaceId = command.PlaceId;
-            profile.Bio = command.Bio?.TrimEnd();
+            profile.Bio = command.BioForSave();
             profile.Pronouns = command.Pronouns;
-            profile.ContributionInterests = command.ContributionInterests?.TrimEnd();
-            profile.BoardNotes = command.BoardNotes?.TrimEnd();
+            profile.ContributionInterests = command.ContributionInterestsForSave();
+            profile.BoardNotes = command.BoardNotesForSave();
             profile.EmergencyContactName = command.EmergencyContactName;
             profile.EmergencyContactPhone = command.EmergencyContactPhone;
             profile.EmergencyContactRelationship = command.EmergencyContactRelationship;
@@ -463,38 +463,16 @@ public sealed class UserService(
             // Edit page owns meal preference + allergies (not intolerances/medical —
             // those are written via SaveDietaryMedicalAsync). Only touch these when
             // the command carries them, so a non-dietary save path can't clobber.
-            if (command.DietaryPreference is not null || command.Allergies is not null || command.AllergyOtherText is not null)
+            if (command.HasDietaryPatch())
             {
-                profile.DietaryPreference = string.IsNullOrWhiteSpace(command.DietaryPreference) ? null : command.DietaryPreference;
-                profile.Allergies = command.Allergies ?? [];
+                profile.DietaryPreference = command.DietaryPreferenceForSave();
+                profile.Allergies = command.AllergiesForSave().ToList();
                 profile.AllergyOtherText = command.AllergyOtherText;
             }
 
             profile.UpdatedAt = now;
-
-            // LocalDate year=4 lets Feb 29 validate.
-            if (command.BirthdayMonth is >= 1 and <= 12 && command.BirthdayDay is >= 1 and <= 31)
-            {
-                try
-                {
-                    profile.DateOfBirth = new LocalDate(4, command.BirthdayMonth.Value, command.BirthdayDay.Value);
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    profile.DateOfBirth = null;
-                }
-            }
-            else
-            {
-                profile.DateOfBirth = null;
-            }
-
-            profile.ProfilePictureContentType = command.PictureMutation switch
-            {
-                UserProfilePictureMutation.Remove => null,
-                UserProfilePictureMutation.Set => command.ProfilePictureContentType,
-                _ => profile.ProfilePictureContentType,
-            };
+            profile.DateOfBirth = command.BirthDateOrNull();
+            profile.ProfilePictureContentType = command.ProfilePictureContentTypeForSave(profile.ProfilePictureContentType);
 
             // see #635 (section 15i) - Stub->Active promotion (mirrors UserInfo.HasRequiredNameFields).
             if (!IsSuspendedState(profile.State))
@@ -1263,21 +1241,6 @@ public sealed class UserService(
 
     private static bool IsSuspendedState(ProfileState? state) =>
         state is ProfileState.Suspended or ProfileState.AdminSuspended;
-
-    private static void ValidateProfileOnboardingCommand(UserProfileOnboardingCommand command)
-    {
-        switch (command.Mutation)
-        {
-            case UserProfileOnboardingMutation.RecordConsentCheck
-                when command.ConsentCheckStatus is not ConsentCheckStatus.Cleared and not ConsentCheckStatus.Flagged:
-                throw new ArgumentException(
-                    "RecordConsentCheck only accepts Cleared or Flagged; use SetConsentCheckPending for the system-driven Pending transition.",
-                    nameof(command));
-
-            case UserProfileOnboardingMutation.SetSuspension when command.Suspended is null:
-                throw new ArgumentException("SetSuspension requires Suspended.", nameof(command));
-        }
-    }
 
     private static string? GetAlternateEmail(string normalizedEmail)
     {

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -626,14 +626,14 @@ public sealed class UserService(
         UserEmailAddCommand command,
         CancellationToken ct = default)
     {
-        var email = command.Email.Trim();
-        var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
-        var alternateEmail = GetAlternateEmail(normalizedEmail);
-
+        var email = command.EmailForStorage;
         if (!new EmailAddressAttribute().IsValid(email))
             throw new ValidationException("Please enter a valid email address.");
 
-        var existing = await repo.FindUserEmailByNormalizedEmailAsync(normalizedEmail, alternateEmail, ct);
+        var existing = await repo.FindUserEmailByNormalizedEmailAsync(
+            command.NormalizedEmail,
+            command.AlternateNormalizedEmail,
+            ct);
         if (existing is not null && existing.UserId == userId)
         {
             if (command.IgnoreExisting)
@@ -648,21 +648,7 @@ public sealed class UserService(
             ?? throw new InvalidOperationException("User not found.");
 
         var now = clock.GetCurrentInstant();
-        var row = new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Email = email,
-            IsVerified = command.IsVerified,
-            IsPrimary = false,
-            IsGoogle = false,
-            Visibility = command.Visibility,
-            Provider = command.Provider,
-            ProviderKey = command.ProviderKey,
-            VerificationSentAt = command.VerificationSentAt,
-            CreatedAt = now,
-            UpdatedAt = now,
-        };
+        var row = command.ToRow(userId, now);
 
         await AddRowWithInvariantsAsync(row, ct);
         return new UserEmailAddResult(row.Id, Added: true, isConflict);
@@ -778,10 +764,7 @@ public sealed class UserService(
             rowToInsert: command.RowToInsert,
             ct);
 
-        var mutatedUserIds = new HashSet<Guid> { userId };
-        if (command.DisplacedRowToDelete is not null)
-            mutatedUserIds.Add(command.DisplacedRowToDelete.UserId);
-
+        var mutatedUserIds = command.MutatedUserIds(userId);
         foreach (var mutatedUserId in mutatedUserIds)
         {
             await EnsurePrimaryInvariantAsync(mutatedUserId, ct);

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -64,107 +64,22 @@ public class AccountController(
 
         if (result.Succeeded)
         {
-            var existingUser = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
-            if (existingUser is not null)
-            {
-                existingUser.LastLoginAt = clock.GetCurrentInstant();
-                await userManager.UpdateAsync(existingUser);
-
-                await TryReconcileOAuthIdentityAsync(existingUser.Id, info);
-            }
-
-            logger.LogInformation("User logged in with {Provider}", info.LoginProvider);
-            return RedirectToLocal(returnUrl);
+            return await CompleteKnownExternalLoginAsync(info, returnUrl);
         }
 
         var email = info.Principal.FindFirstValue(ClaimTypes.Email) ?? string.Empty;
         var name = info.Principal.FindFirstValue(ClaimTypes.Name);
 
         // Link-while-signed-in must precede lockout/email-match/create — otherwise a fresh OAuth email spawns a duplicate.
-        if (User.Identity?.IsAuthenticated == true)
-        {
-            var currentUser = await userManager.GetUserAsync(User);
-            if (currentUser is not null)
-            {
-                var addLinkResult = await userManager.AddLoginAsync(currentUser, info);
-                if (addLinkResult.Succeeded)
-                {
-                    currentUser.LastLoginAt = clock.GetCurrentInstant();
-                    await userManager.UpdateAsync(currentUser);
-
-                    if (!string.IsNullOrEmpty(email))
-                    {
-                        await TryReconcileOAuthIdentityAsync(currentUser.Id, info);
-                    }
-
-                    logger.LogInformation(
-                        "Linked {Provider} login to currently-authenticated user {UserId}",
-                        info.LoginProvider, currentUser.Id);
-                    return RedirectToLocal(returnUrl);
-                }
-
-                logger.LogWarning(
-                    "Failed to link {Provider} to authenticated user {UserId}: {Errors}",
-                    info.LoginProvider, currentUser.Id,
-                    string.Join(", ", addLinkResult.Errors.Select(e => e.Description)));
-
-                // Don't fall through — unauthenticated branches would spawn a duplicate User. Surface as error toast.
-                SetError(localizer["EmailGrid_LinkFailed"].Value);
-                return LocalRedirect(Url.IsLocalUrl(returnUrl) ? returnUrl! : "/Profile/Me/Emails");
-            }
-        }
+        var currentUserLink = await TryLinkExternalLoginToCurrentUserAsync(info, returnUrl, email);
+        if (currentUserLink is not null)
+            return currentUserLink;
 
         if (result.IsLockedOut)
         {
-            // Lockout-relink: move OAuth login from merged/anonymized source to active target (see Auth.md). Try/catch so a mid-step throw doesn't orphan the login.
-            try
-            {
-                if (!string.IsNullOrEmpty(email))
-                {
-                    var lockedSource = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
-                    var activeTarget = await magicLinkService.FindUserByVerifiedEmailAsync(email);
-                    if (lockedSource is not null && activeTarget is not null && lockedSource.Id != activeTarget.Id)
-                    {
-                        var removeResult = await userManager.RemoveLoginAsync(
-                            lockedSource, info.LoginProvider, info.ProviderKey);
-                        if (removeResult.Succeeded)
-                        {
-                            var relinkResult = await userManager.AddLoginAsync(activeTarget, info);
-                            if (relinkResult.Succeeded)
-                            {
-                                activeTarget.LastLoginAt = clock.GetCurrentInstant();
-                                await userManager.UpdateAsync(activeTarget);
-                                await signInManager.SignInAsync(activeTarget, isPersistent: false);
-
-                                await TryReconcileOAuthIdentityAsync(activeTarget.Id, info);
-
-                                logger.LogInformation(
-                                    "Relinked {Provider} login from locked source {SourceId} to active target {TargetId}",
-                                    info.LoginProvider, lockedSource.Id, activeTarget.Id);
-                                return RedirectToLocal(returnUrl);
-                            }
-
-                            logger.LogWarning(
-                                "Lockout-relink: AddLoginAsync to {TargetId} failed: {Errors}",
-                                activeTarget.Id,
-                                string.Join(", ", relinkResult.Errors.Select(e => e.Description)));
-                        }
-                        else
-                        {
-                            logger.LogWarning(
-                                "Lockout-relink: RemoveLoginAsync from {SourceId} failed: {Errors}",
-                                lockedSource.Id,
-                                string.Join(", ", removeResult.Errors.Select(e => e.Description)));
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex,
-                    "Error during lockout-relink for {Provider}; falling through to lockedout redirect",
-                    info.LoginProvider);
-            }
+            var relink = await TryRelinkLockedOutExternalLoginAsync(info, returnUrl, email);
+            if (relink is not null)
+                return relink;
 
             return RedirectToAction(nameof(Login), new { returnUrl, error = "lockedout" });
         }
@@ -175,39 +90,173 @@ public class AccountController(
             return RedirectToAction(nameof(Login), new { returnUrl, error = "oauth" });
         }
 
-        var existingByEmail = await magicLinkService.FindUserByVerifiedEmailAsync(email);
-        if (existingByEmail is not null)
+        var existingUserLink = await TryLinkExternalLoginByVerifiedEmailAsync(info, returnUrl, email);
+        if (existingUserLink is not null)
+            return existingUserLink;
+
+        return await CreateExternalLoginUserAsync(info, returnUrl, email, name);
+    }
+
+    private async Task<IActionResult> CompleteKnownExternalLoginAsync(ExternalLoginInfo info, string returnUrl)
+    {
+        var existingUser = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+        if (existingUser is not null)
         {
-            try
-            {
-                var linkResult = await userManager.AddLoginAsync(existingByEmail, info);
-                if (linkResult.Succeeded)
-                {
-                    existingByEmail.LastLoginAt = clock.GetCurrentInstant();
-                    await userManager.UpdateAsync(existingByEmail);
-
-                    await TryReconcileOAuthIdentityAsync(existingByEmail.Id, info);
-
-                    await signInManager.SignInAsync(existingByEmail, isPersistent: false);
-                    logger.LogInformation(
-                        "Linked {Provider} login to existing user {UserId} via email match",
-                        info.LoginProvider, existingByEmail.Id);
-                    return RedirectToLocal(returnUrl);
-                }
-
-                logger.LogWarning(
-                    "Failed to link {Provider} to existing user {UserId}: {Errors}",
-                    info.LoginProvider, existingByEmail.Id,
-                    string.Join(", ", linkResult.Errors.Select(e => e.Description)));
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex,
-                    "Error linking {Provider} to existing user {UserId}, falling through to create new account",
-                    info.LoginProvider, existingByEmail.Id);
-            }
+            existingUser.LastLoginAt = clock.GetCurrentInstant();
+            await userManager.UpdateAsync(existingUser);
+            await TryReconcileOAuthIdentityAsync(existingUser.Id, info);
         }
 
+        logger.LogInformation("User logged in with {Provider}", info.LoginProvider);
+        return RedirectToLocal(returnUrl);
+    }
+
+    private async Task<IActionResult?> TryLinkExternalLoginToCurrentUserAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email)
+    {
+        if (User.Identity?.IsAuthenticated != true)
+            return null;
+
+        var currentUser = await userManager.GetUserAsync(User);
+        if (currentUser is null)
+            return null;
+
+        var addLinkResult = await userManager.AddLoginAsync(currentUser, info);
+        if (addLinkResult.Succeeded)
+        {
+            currentUser.LastLoginAt = clock.GetCurrentInstant();
+            await userManager.UpdateAsync(currentUser);
+
+            if (!string.IsNullOrEmpty(email))
+                await TryReconcileOAuthIdentityAsync(currentUser.Id, info);
+
+            logger.LogInformation(
+                "Linked {Provider} login to currently-authenticated user {UserId}",
+                info.LoginProvider,
+                currentUser.Id);
+            return RedirectToLocal(returnUrl);
+        }
+
+        logger.LogWarning(
+            "Failed to link {Provider} to authenticated user {UserId}: {Errors}",
+            info.LoginProvider,
+            currentUser.Id,
+            string.Join(", ", addLinkResult.Errors.Select(e => e.Description)));
+
+        SetError(localizer["EmailGrid_LinkFailed"].Value);
+        return LocalRedirect(Url.IsLocalUrl(returnUrl) ? returnUrl : "/Profile/Me/Emails");
+    }
+
+    private async Task<IActionResult?> TryRelinkLockedOutExternalLoginAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(email))
+                return null;
+
+            var lockedSource = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+            var activeTarget = await magicLinkService.FindUserByVerifiedEmailAsync(email);
+            if (lockedSource is null || activeTarget is null || lockedSource.Id == activeTarget.Id)
+                return null;
+
+            var removeResult = await userManager.RemoveLoginAsync(
+                lockedSource,
+                info.LoginProvider,
+                info.ProviderKey);
+            if (!removeResult.Succeeded)
+            {
+                logger.LogWarning(
+                    "Lockout-relink: RemoveLoginAsync from {SourceId} failed: {Errors}",
+                    lockedSource.Id,
+                    string.Join(", ", removeResult.Errors.Select(e => e.Description)));
+                return null;
+            }
+
+            var relinkResult = await userManager.AddLoginAsync(activeTarget, info);
+            if (!relinkResult.Succeeded)
+            {
+                logger.LogWarning(
+                    "Lockout-relink: AddLoginAsync to {TargetId} failed: {Errors}",
+                    activeTarget.Id,
+                    string.Join(", ", relinkResult.Errors.Select(e => e.Description)));
+                return null;
+            }
+
+            activeTarget.LastLoginAt = clock.GetCurrentInstant();
+            await userManager.UpdateAsync(activeTarget);
+            await signInManager.SignInAsync(activeTarget, isPersistent: false);
+            await TryReconcileOAuthIdentityAsync(activeTarget.Id, info);
+
+            logger.LogInformation(
+                "Relinked {Provider} login from locked source {SourceId} to active target {TargetId}",
+                info.LoginProvider,
+                lockedSource.Id,
+                activeTarget.Id);
+            return RedirectToLocal(returnUrl);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error during lockout-relink for {Provider}; falling through to lockedout redirect",
+                info.LoginProvider);
+            return null;
+        }
+    }
+
+    private async Task<IActionResult?> TryLinkExternalLoginByVerifiedEmailAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email)
+    {
+        var existingByEmail = await magicLinkService.FindUserByVerifiedEmailAsync(email);
+        if (existingByEmail is null)
+            return null;
+
+        try
+        {
+            var linkResult = await userManager.AddLoginAsync(existingByEmail, info);
+            if (linkResult.Succeeded)
+            {
+                existingByEmail.LastLoginAt = clock.GetCurrentInstant();
+                await userManager.UpdateAsync(existingByEmail);
+                await TryReconcileOAuthIdentityAsync(existingByEmail.Id, info);
+
+                await signInManager.SignInAsync(existingByEmail, isPersistent: false);
+                logger.LogInformation(
+                    "Linked {Provider} login to existing user {UserId} via email match",
+                    info.LoginProvider,
+                    existingByEmail.Id);
+                return RedirectToLocal(returnUrl);
+            }
+
+            logger.LogWarning(
+                "Failed to link {Provider} to existing user {UserId}: {Errors}",
+                info.LoginProvider,
+                existingByEmail.Id,
+                string.Join(", ", linkResult.Errors.Select(e => e.Description)));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error linking {Provider} to existing user {UserId}, falling through to create new account",
+                info.LoginProvider,
+                existingByEmail.Id);
+        }
+
+        return null;
+    }
+
+    private async Task<IActionResult> CreateExternalLoginUserAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email,
+        string? name)
+    {
         var newUserId = Guid.NewGuid();
 #pragma warning disable HUM_USER_DISPLAYNAME // OAuth signup seeds the legacy Identity fallback column.
         var user = new User
@@ -221,35 +270,32 @@ public class AccountController(
 
         var createResult = await userManager.CreateAsync(user);
         if (!createResult.Succeeded)
-        {
-            foreach (var error in createResult.Errors)
-                ModelState.AddModelError(string.Empty, error.Description);
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
-        }
+            return LoginViewWithErrors(returnUrl, createResult.Errors);
 
-        // Roll back the just-created User on link failure — RequireUniqueEmail=false leaves us responsible for cleanup.
         var oauthLinkResult = await userManager.AddLoginAsync(user, info);
         if (!oauthLinkResult.Succeeded)
         {
-            try
-            {
-                await userManager.DeleteAsync(user);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex,
-                    "Failed to clean up orphan user {UserId} after AddLoginAsync failure for {Provider}",
-                    user.Id, info.LoginProvider);
-            }
-
-            foreach (var error in oauthLinkResult.Errors)
-                ModelState.AddModelError(string.Empty, error.Description);
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
+            await TryDeleteOrphanUserAsync(user);
+            return LoginViewWithErrors(returnUrl, oauthLinkResult.Errors);
         }
 
-        // Reconcile creates the UserEmail row; on throw or CrossUserBlocked, roll back the User to avoid an unreachable orphan.
+        var reconcileResult = await TryReconcileNewExternalLoginUserAsync(user, info, email, returnUrl);
+        if (reconcileResult is not null)
+            return reconcileResult;
+
+        await userService.EnsureStubProfileAsync(user.Id);
+
+        await signInManager.SignInAsync(user, isPersistent: false);
+        logger.LogInformation("User created an account using {Provider}", info.LoginProvider);
+        return RedirectToLocal(returnUrl);
+    }
+
+    private async Task<IActionResult?> TryReconcileNewExternalLoginUserAsync(
+        User user,
+        ExternalLoginInfo info,
+        string email,
+        string returnUrl)
+    {
         try
         {
             var reconcile = await userEmailService.ReconcileOAuthIdentityAsync(
@@ -259,15 +305,11 @@ public class AccountController(
                 email,
                 claimEmailVerified: ReadEmailVerifiedClaim(info));
 
-            // CrossUserBlocked: service already audited + logged; roll back the orphan User + login.
-            if (reconcile.Outcome == ReconcileOutcome.CrossUserBlocked)
-            {
-                await TryDeleteOrphanUserAsync(user);
-                ModelState.AddModelError(string.Empty,
-                    "We couldn't finish setting up your account. Please try again.");
-                ViewData["ReturnUrl"] = returnUrl;
-                return View(nameof(Login));
-            }
+            if (reconcile.Outcome != ReconcileOutcome.CrossUserBlocked)
+                return null;
+
+            await TryDeleteOrphanUserAsync(user);
+            return LoginViewWithModelError(returnUrl);
         }
         catch (OAuthReconcileConcurrencyException race)
         {
@@ -276,35 +318,43 @@ public class AccountController(
                 "{UserId} (provider={Provider}, sub={Sub}, claimEmail={Email}); " +
                 "rolling back user + login. The verified-email partial unique " +
                 "index caught a concurrent insert past the reconcile pre-check " +
-                "— investigate via /Profile/Admin/EmailProblems.",
-                user.Id, info.LoginProvider, info.ProviderKey, email);
+                "- investigate via /Profile/Admin/EmailProblems.",
+                user.Id,
+                info.LoginProvider,
+                info.ProviderKey,
+                email);
             await TryDeleteOrphanUserAsync(user);
-            ModelState.AddModelError(string.Empty,
-                "We couldn't finish setting up your account. Please try again.");
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
+            return LoginViewWithModelError(returnUrl);
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
                 "Failed to reconcile OAuth identity for new user {UserId} ({Email}); rolling back user + login",
-                user.Id, email);
+                user.Id,
+                email);
             await TryDeleteOrphanUserAsync(user);
-            ModelState.AddModelError(string.Empty,
-                "We couldn't finish setting up your account. Please try again.");
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
+            return LoginViewWithModelError(returnUrl);
         }
-
-        // see #635 (§15i) — Stub Profile invariant.
-        await userService.EnsureStubProfileAsync(user.Id);
-
-        await signInManager.SignInAsync(user, isPersistent: false);
-        logger.LogInformation("User created an account using {Provider}", info.LoginProvider);
-        return RedirectToLocal(returnUrl);
     }
 
-    // Reconcile wrapper for OAuth-success paths — sign-in never blocks on failure (swallow + log).
+    private IActionResult LoginViewWithErrors(string returnUrl, IEnumerable<IdentityError> errors)
+    {
+        foreach (var error in errors)
+            ModelState.AddModelError(string.Empty, error.Description);
+
+        ViewData["ReturnUrl"] = returnUrl;
+        return View(nameof(Login));
+    }
+
+    private IActionResult LoginViewWithModelError(string returnUrl)
+    {
+        ModelState.AddModelError(string.Empty,
+            "We couldn't finish setting up your account. Please try again.");
+        ViewData["ReturnUrl"] = returnUrl;
+        return View(nameof(Login));
+    }
+
+    // Reconcile wrapper for OAuth-success paths - sign-in never blocks on failure (swallow + log).
     private async Task TryReconcileOAuthIdentityAsync(Guid userId, ExternalLoginInfo info)
     {
         var claimEmail = info.Principal.FindFirstValue(ClaimTypes.Email);

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -85,6 +85,45 @@ public sealed class DevelopmentDashboardSeeder(
         var now = clock.GetCurrentInstant();
         var todayUtc = now.InUtc().Date;
 
+        var seedEvent = await CreateSeedEventAsync(now, todayUtc);
+
+        var teams = await CreateSeedTeamsAsync(cancellationToken);
+
+        var subteamRates = BuildSubteamRates();
+        var rotas = await CreateSeedRotasAsync(seedEvent, teams, subteamRates, now);
+
+        var shifts = await CreateSeedShiftsAsync(rotas, now);
+
+        var users = await CreateSeedUsersAsync(now, cancellationToken);
+
+        await AssignSeedCoordinatorsAsync(teams.ParentTeams.Values, users, now, cancellationToken);
+
+        // Per-user team assignments: ~80% stick to a single parent team, ~20% switch
+        // primary→secondary at a given day offset. Produces realistic block-shaped rows
+        // in the volunteer-tracking export instead of fully-scattered signups.
+        var userAssignments = BuildUserAssignments(users, teams.ParentTeams.Values.ToList());
+
+        // Rota → parent team Id. Parent rotas map to themselves; subteam rotas map to their parent.
+        var rotaToParentTeamId = BuildRotaParentMap(rotas, teams, subteamRates);
+
+        // Signups: rate-driven Confirmed vs Pending, plus a few Bailed / Refused, and some stale Pending.
+        // Candidate filter: only users whose effective team for this shift's day matches the shift's parent.
+        var signupsCreated = await CreateSeedSignupsAsync(shifts, users, userAssignments, rotaToParentTeamId);
+
+        logger.LogInformation(
+            "Dashboard seed complete: {Teams} teams, {Users} users, {Shifts} shifts, {Signups} signups.",
+            teams.Count, users.Count, shifts.Count, signupsCreated);
+
+        return new DashboardSeedResult(
+            AlreadySeeded: false,
+            TeamsCreated: teams.Count,
+            UsersCreated: users.Count,
+            ShiftsCreated: shifts.Count,
+            SignupsCreated: signupsCreated);
+    }
+
+    private async Task<EventSettings> CreateSeedEventAsync(Instant now, LocalDate todayUtc)
+    {
         // Deactivate any existing active event so ours becomes the one resolved by GetActiveAsync.
         var existingActive = await shiftManagementService.GetActiveAsync();
         if (existingActive is not null)
@@ -93,7 +132,7 @@ public sealed class DevelopmentDashboardSeeder(
             await shiftManagementService.UpdateAsync(existingActive);
         }
 
-        var es = new EventSettings
+        var eventSettings = new EventSettings
         {
             Id = SeededEventId,
             EventName = SeededEventName,
@@ -104,27 +143,25 @@ public sealed class DevelopmentDashboardSeeder(
             EventEndOffset = 6,
             StrikeEndOffset = 9,
             IsActive = true,
-            // Enable volunteer browsing so /Shifts/ and /Teams/{slug}/Shifts render
-            // the seeded rotas side-by-side with /Shifts/Dashboard for QA comparisons.
             IsShiftBrowsingOpen = true,
             CreatedAt = now.Minus(Duration.FromDays(30)),
             UpdatedAt = now,
         };
-        await shiftManagementService.CreateAsync(es);
+        await shiftManagementService.CreateAsync(eventSettings);
 
-        // Teams: create parents, then subteams. Goes through ITeamService so slug
-        // generation, validation, and cache seeding match production.
-        var teamsCreated = 0;
+        return eventSettings;
+    }
+
+    private async Task<SeededTeams> CreateSeedTeamsAsync(CancellationToken cancellationToken)
+    {
         var parentTeams = new Dictionary<string, Team>(StringComparer.Ordinal);
         foreach (var name in ParentTeamNames)
         {
-            var created = await teamService.CreateTeamAsync(
+            parentTeams[name] = await teamService.CreateTeamAsync(
                 $"{name}{DevTeamNameSuffix}",
                 description: null,
                 requiresApproval: true,
                 cancellationToken: cancellationToken);
-            parentTeams[name] = created;
-            teamsCreated++;
         }
 
         var subteams = new Dictionary<string, Team>(StringComparer.Ordinal);
@@ -132,315 +169,429 @@ public sealed class DevelopmentDashboardSeeder(
         {
             foreach (var subName in subNames)
             {
-                var created = await teamService.CreateTeamAsync(
+                subteams[subName] = await teamService.CreateTeamAsync(
                     $"{subName}{DevTeamNameSuffix}",
                     description: null,
                     requiresApproval: true,
                     parentTeamId: parentTeams[parentName].Id,
                     cancellationToken: cancellationToken);
-                subteams[subName] = created;
-                teamsCreated++;
             }
         }
 
-        // Rotas: one per period per parent team, plus Event-period rotas on each subteam.
-        // Subteam fill rates are tuned to produce a mix of low/mid/high % chips in the expand view.
-        var subteamRates = new Dictionary<string, double>(StringComparer.Ordinal)
-        {
-            // Participant Wellness: one low (drives the red chip), one mid, one high.
-            ["Consent"] = 0.3,
-            ["Welfare"] = 0.6,
-            ["Ohana House"] = 0.85,
-            // Ice and Water: one mid, one high.
-            ["Ice Ice Baby"] = 0.55,
-            ["Icemakers"] = 0.9,
-        };
+        return new SeededTeams(parentTeams, subteams);
+    }
 
-        var rotaConfigs = new List<(Team Team, RotaPeriod Period, string Label, double ConfirmedRate)>();
-        foreach (var parent in parentTeams.Values)
-        {
-            var isWellStaffed = parent.Name.StartsWith("Gate", StringComparison.Ordinal)
-                             || parent.Name.StartsWith("Site Operations", StringComparison.Ordinal);
-            rotaConfigs.Add((parent, RotaPeriod.Build, "Build", isWellStaffed ? 0.85 : 0.55));
-            rotaConfigs.Add((parent, RotaPeriod.Event, "Event", isWellStaffed ? 0.9 : 0.6));
-            rotaConfigs.Add((parent, RotaPeriod.Strike, "Strike", 0.2));
-        }
-        foreach (var (subName, rate) in subteamRates)
-        {
-            rotaConfigs.Add((subteams[subName], RotaPeriod.Event, "Event", rate));
-        }
+    private static Dictionary<string, double> BuildSubteamRates() => new(StringComparer.Ordinal)
+    {
+        ["Consent"] = 0.3,
+        ["Welfare"] = 0.6,
+        ["Ohana House"] = 0.85,
+        ["Ice Ice Baby"] = 0.55,
+        ["Icemakers"] = 0.9,
+    };
 
-        var allRotas = new List<(Rota Rota, double ConfirmedRate)>();
-        foreach (var (team, period, label, confirmedRate) in rotaConfigs)
+    private async Task<List<SeededRota>> CreateSeedRotasAsync(
+        EventSettings eventSettings,
+        SeededTeams teams,
+        IReadOnlyDictionary<string, double> subteamRates,
+        Instant now)
+    {
+        var rotas = new List<SeededRota>();
+        foreach (var config in BuildRotaConfigs(teams, subteamRates))
         {
             var rota = new Rota
             {
                 Id = Guid.NewGuid(),
-                TeamId = team.Id,
-                EventSettingsId = es.Id,
-                Name = $"{team.Name} - {label}",
+                TeamId = config.Team.Id,
+                EventSettingsId = eventSettings.Id,
+                Name = $"{config.Team.Name} - {config.Label}",
                 Priority = ShiftPriority.Normal,
-                // Public so the volunteer-facing /Shifts/ page lists them for any
-                // logged-in user - otherwise the browse view hides approval-only
-                // rotas and QA can't compare across the three surfaces.
                 Policy = SignupPolicy.Public,
-                Period = period,
+                Period = config.Period,
                 IsVisibleToVolunteers = true,
                 CreatedAt = now,
                 UpdatedAt = now,
             };
+
             await shiftManagementService.CreateRotaAsync(rota);
-            allRotas.Add((rota, confirmedRate));
+            rotas.Add(new SeededRota(rota, config.ConfirmedRate));
         }
 
-        // Shifts: 8-12 per rota with varied min/max/duration and day offsets by period.
-        // All-day rotas (Build/Strike) get distinct offsets - duplicate same-date all-day
-        // shifts surface as duplicate dropdown options in the range-signup form and
-        // confuse the confirmation modal's overlap math.
-        var shifts = new List<(Shift Shift, double ConfirmedRate)>();
-        foreach (var (rota, rate) in allRotas)
-        {
-            var requested = _rng.Next(8, 13);
-            var isAllDay = rota.Period != RotaPeriod.Event;
-            var (offsetMin, offsetMaxExclusive) = rota.Period switch
-            {
-                RotaPeriod.Build => (-14, 0),
-                RotaPeriod.Event => (0, 7),
-                RotaPeriod.Strike => (7, 10),
-                _ => (0, 1),
-            };
-            var allowedOffsets = Enumerable.Range(offsetMin, offsetMaxExclusive - offsetMin).ToList();
-            var dayOffsets = isAllDay
-                ? allowedOffsets.OrderBy(_ => _rng.Next()).Take(Math.Min(requested, allowedOffsets.Count)).ToList()
-                : Enumerable.Range(0, requested).Select(_ => allowedOffsets[_rng.Next(allowedOffsets.Count)]).ToList();
-            foreach (var dayOffset in dayOffsets)
-            {
-                var min = _rng.Next(2, 6);
-                var max = min + _rng.Next(1, 4);
-                var startTime = isAllDay
-                    ? LocalTime.Midnight
-                    : new LocalTime(_rng.Next(8, 20), 0);
-                var duration = isAllDay
-                    ? Duration.FromHours(24)
-                    : Duration.FromHours(_rng.Next(2, 9));
-                var result = await shiftManagementService.CreateShiftAsync(new CreateShiftInput(
-                    rota.Id,
-                    rota.TeamId,
-                    null,
-                    dayOffset,
-                    startTime,
-                    duration.TotalHours,
-                    min,
-                    max,
-                    AdminOnly: false,
-                    IsAllDay: isAllDay));
-                if (!result.Succeeded || result.ShiftId is null)
-                    throw new InvalidOperationException(result.Message);
+        return rotas;
+    }
 
-                shifts.Add((new Shift
+    private static IEnumerable<RotaConfig> BuildRotaConfigs(
+        SeededTeams teams,
+        IReadOnlyDictionary<string, double> subteamRates)
+    {
+        foreach (var parent in teams.ParentTeams.Values)
+        {
+            var isWellStaffed = parent.Name.StartsWith("Gate", StringComparison.Ordinal)
+                             || parent.Name.StartsWith("Site Operations", StringComparison.Ordinal);
+            yield return new RotaConfig(parent, RotaPeriod.Build, "Build", isWellStaffed ? 0.85 : 0.55);
+            yield return new RotaConfig(parent, RotaPeriod.Event, "Event", isWellStaffed ? 0.9 : 0.6);
+            yield return new RotaConfig(parent, RotaPeriod.Strike, "Strike", 0.2);
+        }
+
+        foreach (var (subName, rate) in subteamRates)
+        {
+            yield return new RotaConfig(teams.Subteams[subName], RotaPeriod.Event, "Event", rate);
+        }
+    }
+
+    private async Task<List<SeededShift>> CreateSeedShiftsAsync(IReadOnlyList<SeededRota> rotas, Instant now)
+    {
+        var shifts = new List<SeededShift>();
+        foreach (var seededRota in rotas)
+        {
+            shifts.AddRange(await CreateSeedShiftsForRotaAsync(seededRota, now));
+        }
+
+        return shifts;
+    }
+
+    private async Task<List<SeededShift>> CreateSeedShiftsForRotaAsync(SeededRota seededRota, Instant now)
+    {
+        var shifts = new List<SeededShift>();
+        var isAllDay = seededRota.Rota.Period != RotaPeriod.Event;
+        foreach (var dayOffset in PickSeedShiftDayOffsets(seededRota.Rota.Period, isAllDay))
+        {
+            var draft = CreateSeedShiftDraft(seededRota.Rota, dayOffset, isAllDay);
+            var result = await shiftManagementService.CreateShiftAsync(draft.Input);
+            if (!result.Succeeded || result.ShiftId is null)
+                throw new InvalidOperationException(result.Message);
+
+            shifts.Add(new SeededShift(
+                new Shift
                 {
                     Id = result.ShiftId.Value,
-                    RotaId = rota.Id,
+                    RotaId = seededRota.Rota.Id,
                     DayOffset = dayOffset,
-                    StartTime = startTime,
-                    Duration = duration,
-                    MinVolunteers = min,
-                    MaxVolunteers = max,
+                    StartTime = draft.StartTime,
+                    Duration = draft.Duration,
+                    MinVolunteers = draft.MinVolunteers,
+                    MaxVolunteers = draft.MaxVolunteers,
                     IsAllDay = isAllDay,
                     CreatedAt = now,
                     UpdatedAt = now,
-                }, rate));
-            }
+                },
+                seededRota.ConfirmedRate));
         }
 
-        // Users: keep the cohort small (~120) - large enough to show activity, small enough to keep the dev seed fast.
-        // Users are an Identity-framework concern; we create them via UserManager, the
-        // standard pattern for framework-owned types. Passwords are intentionally omitted
-        // - these accounts are never logged into; they exist purely as dashboard data.
-        var totalUsers = 120;
+        return shifts;
+    }
 
-        var users = new List<User>();
-        for (var i = 0; i < totalUsers; i++)
+    private List<int> PickSeedShiftDayOffsets(RotaPeriod period, bool isAllDay)
+    {
+        var requested = _rng.Next(8, 13);
+        var (offsetMin, offsetMaxExclusive) = period switch
         {
-            var display = $"Dev Human {i:D3}";
-            var email = $"{DevUserEmailPrefix}{i:D3}{DevUserEmailSuffix}";
-            var createdAt = now.Minus(Duration.FromDays(_rng.Next(30, 400)));
-            var lastLoginDaysAgo = _rng.Next(0, 85);
-            // Id MUST be set explicitly: UserManager's username uniqueness validator
-            // reads user.UserName before EF assigns the PK, and the override returns
-            // Id.ToString(). Without an explicit Id, every loop iteration resolves
-            // to UserName = Guid.Empty.ToString() and fails on the second insert.
-            var userId = Guid.NewGuid();
-#pragma warning disable HUM_USER_DISPLAYNAME // Development dashboard seeding writes the legacy Identity fallback column.
-            var user = new User
-            {
-                Id = userId,
-                DisplayName = display,
-                CreatedAt = createdAt,
-                LastLoginAt = now.Minus(Duration.FromDays(lastLoginDaysAgo)).Minus(Duration.FromHours(_rng.Next(0, 23))),
-            };
-#pragma warning restore HUM_USER_DISPLAYNAME
+            RotaPeriod.Build => (-14, 0),
+            RotaPeriod.Event => (0, 7),
+            RotaPeriod.Strike => (7, 10),
+            _ => (0, 1),
+        };
 
+        var allowedOffsets = Enumerable.Range(offsetMin, offsetMaxExclusive - offsetMin).ToList();
+        return isAllDay
+            ? allowedOffsets.OrderBy(_ => _rng.Next()).Take(Math.Min(requested, allowedOffsets.Count)).ToList()
+            : Enumerable.Range(0, requested).Select(_ => allowedOffsets[_rng.Next(allowedOffsets.Count)]).ToList();
+    }
+
+    private SeedShiftDraft CreateSeedShiftDraft(Rota rota, int dayOffset, bool isAllDay)
+    {
+        var min = _rng.Next(2, 6);
+        var max = min + _rng.Next(1, 4);
+        var startTime = isAllDay
+            ? LocalTime.Midnight
+            : new LocalTime(_rng.Next(8, 20), 0);
+        var duration = isAllDay
+            ? Duration.FromHours(24)
+            : Duration.FromHours(_rng.Next(2, 9));
+
+        return new SeedShiftDraft(
+            new CreateShiftInput(
+                rota.Id,
+                rota.TeamId,
+                null,
+                dayOffset,
+                startTime,
+                duration.TotalHours,
+                min,
+                max,
+                AdminOnly: false,
+                IsAllDay: isAllDay),
+            startTime,
+            duration,
+            min,
+            max);
+    }
+
+    private async Task<List<User>> CreateSeedUsersAsync(Instant now, CancellationToken cancellationToken)
+    {
+        const int TotalUsers = 120;
+        var users = new List<User>();
+
+        for (var i = 0; i < TotalUsers; i++)
+        {
+            var user = CreateSeedUser(now, i);
+            var email = $"{DevUserEmailPrefix}{i:D3}{DevUserEmailSuffix}";
             var createResult = await userManager.CreateAsync(user);
             if (!createResult.Succeeded)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to create seeded dev user '{email}': {string.Join(", ", createResult.Errors.Select(e => e.Description))}");
-            }
+                throw CreateIdentityException($"Failed to create seeded dev user '{email}'", createResult);
 
             await userEmailService.AddVerifiedEmailAsync(user.Id, email, cancellationToken);
-
             users.Add(user);
         }
 
-        // Coordinators: 2 per parent team, routed via ITeamService.AddSeededMemberAsync so
-        // we never touch TeamMembers directly. Infrastructure coords logged in 9 days ago
-        // (stale) to drive the red chip on the dashboard.
-        foreach (var parent in parentTeams.Values)
+        return users;
+    }
+
+    private User CreateSeedUser(Instant now, int index)
+    {
+        var lastLoginDaysAgo = _rng.Next(0, 85);
+#pragma warning disable HUM_USER_DISPLAYNAME // Development dashboard seeding writes the legacy Identity fallback column.
+        var user = new User
         {
-            var isInfrastructure = parent.Name.StartsWith("Infrastructure", StringComparison.Ordinal);
-            var coordLastLogin = isInfrastructure
+            Id = Guid.NewGuid(),
+            DisplayName = $"Dev Human {index:D3}",
+            CreatedAt = now.Minus(Duration.FromDays(_rng.Next(30, 400))),
+            LastLoginAt = now.Minus(Duration.FromDays(lastLoginDaysAgo)).Minus(Duration.FromHours(_rng.Next(0, 23))),
+        };
+#pragma warning restore HUM_USER_DISPLAYNAME
+
+        return user;
+    }
+
+    private async Task AssignSeedCoordinatorsAsync(
+        IEnumerable<Team> parentTeams,
+        IReadOnlyList<User> users,
+        Instant now,
+        CancellationToken cancellationToken)
+    {
+        foreach (var parent in parentTeams)
+        {
+            var coordLastLogin = parent.Name.StartsWith("Infrastructure", StringComparison.Ordinal)
                 ? now.Minus(Duration.FromDays(9))
                 : now.Minus(Duration.FromHours(_rng.Next(1, 48)));
 
             for (var i = 0; i < 2; i++)
             {
-                var coord = users[_rng.Next(users.Count)];
-                coord.LastLoginAt = coordLastLogin;
-                var updateResult = await userManager.UpdateAsync(coord);
-                if (!updateResult.Succeeded)
-                {
-                    throw new InvalidOperationException(
-                        $"Failed to update LastLoginAt for seeded coord '{coord.Id}': {string.Join(", ", updateResult.Errors.Select(e => e.Description))}");
-                }
-
-                try
-                {
-                    await teamService.AddSeededMemberAsync(
-                        parent.Id, coord.Id, TeamMemberRole.Coordinator, now.Minus(Duration.FromDays(60)),
-                        cancellationToken);
-                }
-                catch (InvalidOperationException)
-                {
-                    // The RNG may pick the same user as a coord for multiple teams or twice for
-                    // the same team; ignore duplicate membership (it's just demo data).
-                }
+                await AssignSeedCoordinatorAsync(parent, users, coordLastLogin, now, cancellationToken);
             }
         }
+    }
 
-        // Per-user team assignments: ~80% stick to a single parent team, ~20% switch
-        // primary→secondary at a given day offset. Produces realistic block-shaped rows
-        // in the volunteer-tracking export instead of fully-scattered signups.
-        var assignableTeams = parentTeams.Values.ToList();
-        var userAssignments = new Dictionary<Guid, UserAssignment>(users.Count);
+    private async Task AssignSeedCoordinatorAsync(
+        Team parent,
+        IReadOnlyList<User> users,
+        Instant coordLastLogin,
+        Instant now,
+        CancellationToken cancellationToken)
+    {
+        var coord = users[_rng.Next(users.Count)];
+        coord.LastLoginAt = coordLastLogin;
+        var updateResult = await userManager.UpdateAsync(coord);
+        if (!updateResult.Succeeded)
+            throw CreateIdentityException($"Failed to update LastLoginAt for seeded coord '{coord.Id}'", updateResult);
+
+        try
+        {
+            await teamService.AddSeededMemberAsync(
+                parent.Id,
+                coord.Id,
+                TeamMemberRole.Coordinator,
+                now.Minus(Duration.FromDays(60)),
+                cancellationToken);
+        }
+        catch (InvalidOperationException)
+        {
+            // Duplicate seeded coordinator membership is harmless demo data noise.
+        }
+    }
+
+    private Dictionary<Guid, UserAssignment> BuildUserAssignments(
+        IReadOnlyList<User> users,
+        IReadOnlyList<Team> assignableTeams)
+    {
+        var assignments = new Dictionary<Guid, UserAssignment>(users.Count);
         foreach (var user in users)
         {
-            var primary = assignableTeams[_rng.Next(assignableTeams.Count)];
-            UserAssignment assignment;
-            if (_rng.NextDouble() < 0.20)
-            {
-                Team secondary;
-                do { secondary = assignableTeams[_rng.Next(assignableTeams.Count)]; } while (secondary.Id == primary.Id);
-                // Switch day chosen from -7 to +4 (Build/Event overlap), biased to mid-range so each block has some days.
-                var switchDayOffset = _rng.Next(-7, 5);
-                assignment = new UserAssignment(primary.Id, secondary.Id, switchDayOffset);
-            }
-            else
-            {
-                assignment = new UserAssignment(primary.Id, null, null);
-            }
-            userAssignments[user.Id] = assignment;
+            assignments[user.Id] = BuildUserAssignment(assignableTeams);
         }
 
-        // Rota → parent team Id. Parent rotas map to themselves; subteam rotas map to their parent.
-        var teamIdToParent = parentTeams.Values.ToDictionary(t => t.Id, t => t.Id);
+        return assignments;
+    }
+
+    private UserAssignment BuildUserAssignment(IReadOnlyList<Team> assignableTeams)
+    {
+        var primary = assignableTeams[_rng.Next(assignableTeams.Count)];
+        if (_rng.NextDouble() >= 0.20)
+            return new UserAssignment(primary.Id, null, null);
+
+        var secondary = PickSecondaryTeam(assignableTeams, primary.Id);
+        return new UserAssignment(primary.Id, secondary.Id, _rng.Next(-7, 5));
+    }
+
+    private Team PickSecondaryTeam(IReadOnlyList<Team> assignableTeams, Guid primaryTeamId)
+    {
+        Team secondary;
+        do
+        {
+            secondary = assignableTeams[_rng.Next(assignableTeams.Count)];
+        }
+        while (secondary.Id == primaryTeamId);
+
+        return secondary;
+    }
+
+    private static Dictionary<Guid, Guid> BuildRotaParentMap(
+        IReadOnlyList<SeededRota> rotas,
+        SeededTeams teams,
+        IReadOnlyDictionary<string, double> subteamRates)
+    {
+        var teamIdToParent = teams.ParentTeams.Values.ToDictionary(t => t.Id, t => t.Id);
         foreach (var (subName, _) in subteamRates)
         {
-            var sub = subteams[subName];
-            teamIdToParent[sub.Id] = sub.ParentTeamId ?? sub.Id;
+            var subteam = teams.Subteams[subName];
+            teamIdToParent[subteam.Id] = subteam.ParentTeamId ?? subteam.Id;
         }
-        var rotaToParentTeamId = allRotas.ToDictionary(
-            r => r.Rota.Id,
-            r => teamIdToParent.GetValueOrDefault(r.Rota.TeamId, r.Rota.TeamId));
 
-        // Signups: rate-driven Confirmed vs Pending, plus a few Bailed / Refused, and some stale Pending.
-        // Candidate filter: only users whose effective team for this shift's day matches the shift's parent.
+        return rotas.ToDictionary(
+            seededRota => seededRota.Rota.Id,
+            seededRota => ResolveParentTeamId(teamIdToParent, seededRota.Rota.TeamId));
+    }
+
+    private static Guid ResolveParentTeamId(IReadOnlyDictionary<Guid, Guid> teamIdToParent, Guid teamId)
+        => teamIdToParent.TryGetValue(teamId, out var parentTeamId) ? parentTeamId : teamId;
+
+    private async Task<int> CreateSeedSignupsAsync(
+        IReadOnlyList<SeededShift> shifts,
+        IReadOnlyList<User> users,
+        IReadOnlyDictionary<Guid, UserAssignment> userAssignments,
+        IReadOnlyDictionary<Guid, Guid> rotaToParentTeamId)
+    {
         var signupsCreated = 0;
         var pickedSignups = new HashSet<(Guid ShiftId, Guid UserId)>();
-        foreach (var (shift, rate) in shifts)
+        foreach (var seededShift in shifts)
         {
-            var shiftTeamId = rotaToParentTeamId[shift.RotaId];
-            var candidates = users.Where(u =>
-            {
-                var a = userAssignments[u.Id];
-                var effectiveTeam = (a.SecondaryTeamId, a.SwitchDayOffset) switch
-                {
-                    (Guid sec, int switchDay) when shift.DayOffset >= switchDay => sec,
-                    _ => a.PrimaryTeamId,
-                };
-                return effectiveTeam == shiftTeamId;
-            }).ToList();
-
-            if (candidates.Count == 0) continue;
-
-            var targetConfirmed = (int)Math.Round(shift.MaxVolunteers * rate);
-            for (var i = 0; i < targetConfirmed && i < shift.MaxVolunteers; i++)
-            {
-                var user = candidates[_rng.Next(candidates.Count)];
-                var key = (shift.Id, user.Id);
-                if (!pickedSignups.Add(key)) continue;
-                var signup = await shiftSignupService.VoluntellAsync(
-                    user.Id, shift.Id, users[0].Id);
-                if (signup.Success)
-                    signupsCreated++;
-            }
-
-            // A couple of pending per shift to create visible pending load.
-            for (var i = 0; i < 2; i++)
-            {
-                var user = candidates[_rng.Next(candidates.Count)];
-                var key = (shift.Id, user.Id);
-                if (!pickedSignups.Add(key)) continue;
-                var signup = await shiftSignupService.SignUpAsync(user.Id, shift.Id);
-                if (signup.Success)
-                    signupsCreated++;
-            }
-        }
-
-        // A few Bailed / Refused to exercise filters.
-        for (var i = 0; i < 8 && i < shifts.Count; i++)
-        {
-            var (shift, _) = shifts[_rng.Next(shifts.Count)];
-            var user = users[_rng.Next(users.Count)];
-            var key = (shift.Id, user.Id);
-            if (!pickedSignups.Add(key)) continue;
-            var signup = i % 2 == 0
-                ? await shiftSignupService.VoluntellAsync(
-                    user.Id, shift.Id, users[0].Id)
-                : await shiftSignupService.SignUpAsync(user.Id, shift.Id);
-            if (!signup.Success || signup.Signup is null)
+            var candidates = FindCandidatesForShift(
+                seededShift.Shift,
+                users,
+                userAssignments,
+                rotaToParentTeamId[seededShift.Shift.RotaId]);
+            if (candidates.Count == 0)
                 continue;
 
-            var final = i % 2 == 0
-                ? await shiftSignupService.BailAsync(
-                    signup.Signup.Id, user.Id, "Seeded for demo")
-                : await shiftSignupService.RefuseAsync(
-                    signup.Signup.Id, users[0].Id, "Seeded for demo");
-            if (final.Success)
+            signupsCreated += await CreateConfirmedSignupsAsync(seededShift, candidates, users[0].Id, pickedSignups);
+            signupsCreated += await CreatePendingSignupsAsync(seededShift.Shift, candidates, pickedSignups);
+        }
+
+        signupsCreated += await CreateFinalizedDemoSignupsAsync(shifts, users, pickedSignups);
+        return signupsCreated;
+    }
+
+    private static List<User> FindCandidatesForShift(
+        Shift shift,
+        IEnumerable<User> users,
+        IReadOnlyDictionary<Guid, UserAssignment> userAssignments,
+        Guid shiftTeamId)
+    {
+        return users
+            .Where(user => EffectiveTeamForDay(userAssignments[user.Id], shift.DayOffset) == shiftTeamId)
+            .ToList();
+    }
+
+    private static Guid EffectiveTeamForDay(UserAssignment assignment, int dayOffset)
+        => assignment.SecondaryTeamId is Guid secondaryTeamId
+        && assignment.SwitchDayOffset is int switchDay
+        && dayOffset >= switchDay
+            ? secondaryTeamId
+            : assignment.PrimaryTeamId;
+
+    private async Task<int> CreateConfirmedSignupsAsync(
+        SeededShift seededShift,
+        IReadOnlyList<User> candidates,
+        Guid voluntellerId,
+        HashSet<(Guid ShiftId, Guid UserId)> pickedSignups)
+    {
+        var signupsCreated = 0;
+        var targetConfirmed = (int)Math.Round(seededShift.Shift.MaxVolunteers * seededShift.ConfirmedRate);
+        for (var i = 0; i < targetConfirmed && i < seededShift.Shift.MaxVolunteers; i++)
+        {
+            var user = candidates[_rng.Next(candidates.Count)];
+            if (!pickedSignups.Add((seededShift.Shift.Id, user.Id)))
+                continue;
+
+            var signup = await shiftSignupService.VoluntellAsync(user.Id, seededShift.Shift.Id, voluntellerId);
+            if (signup.Success)
                 signupsCreated++;
         }
 
-        logger.LogInformation(
-            "Dashboard seed complete: {Teams} teams, {Users} users, {Shifts} shifts, {Signups} signups.",
-            teamsCreated, users.Count, shifts.Count, signupsCreated);
-
-        return new DashboardSeedResult(
-            AlreadySeeded: false,
-            TeamsCreated: teamsCreated,
-            UsersCreated: users.Count,
-            ShiftsCreated: shifts.Count,
-            SignupsCreated: signupsCreated);
+        return signupsCreated;
     }
+
+    private async Task<int> CreatePendingSignupsAsync(
+        Shift shift,
+        IReadOnlyList<User> candidates,
+        HashSet<(Guid ShiftId, Guid UserId)> pickedSignups)
+    {
+        var signupsCreated = 0;
+        for (var i = 0; i < 2; i++)
+        {
+            var user = candidates[_rng.Next(candidates.Count)];
+            if (!pickedSignups.Add((shift.Id, user.Id)))
+                continue;
+
+            var signup = await shiftSignupService.SignUpAsync(user.Id, shift.Id);
+            if (signup.Success)
+                signupsCreated++;
+        }
+
+        return signupsCreated;
+    }
+
+    private async Task<int> CreateFinalizedDemoSignupsAsync(
+        IReadOnlyList<SeededShift> shifts,
+        IReadOnlyList<User> users,
+        HashSet<(Guid ShiftId, Guid UserId)> pickedSignups)
+    {
+        var signupsCreated = 0;
+        for (var i = 0; i < 8 && i < shifts.Count; i++)
+        {
+            if (await TryCreateFinalizedDemoSignupAsync(i, shifts, users, pickedSignups))
+                signupsCreated++;
+        }
+
+        return signupsCreated;
+    }
+
+    private async Task<bool> TryCreateFinalizedDemoSignupAsync(
+        int index,
+        IReadOnlyList<SeededShift> shifts,
+        IReadOnlyList<User> users,
+        HashSet<(Guid ShiftId, Guid UserId)> pickedSignups)
+    {
+        var shift = shifts[_rng.Next(shifts.Count)].Shift;
+        var user = users[_rng.Next(users.Count)];
+        if (!pickedSignups.Add((shift.Id, user.Id)))
+            return false;
+
+        var signup = index % 2 == 0
+            ? await shiftSignupService.VoluntellAsync(user.Id, shift.Id, users[0].Id)
+            : await shiftSignupService.SignUpAsync(user.Id, shift.Id);
+        if (!signup.Success || signup.Signup is null)
+            return false;
+
+        var final = index % 2 == 0
+            ? await shiftSignupService.BailAsync(signup.Signup.Id, user.Id, "Seeded for demo")
+            : await shiftSignupService.RefuseAsync(signup.Signup.Id, users[0].Id, "Seeded for demo");
+
+        return final.Success;
+    }
+
+    private static InvalidOperationException CreateIdentityException(string message, IdentityResult result)
+        => new($"{message}: {string.Join(", ", result.Errors.Select(e => e.Description))}");
 
     /// <summary>
     /// Deletes all data previously created by <see cref="SeedAsync"/>: the seeded
@@ -491,6 +642,26 @@ public sealed class DevelopmentDashboardSeeder(
     /// when SecondaryTeamId is set, the user switches from primary→secondary at SwitchDayOffset
     /// (so shifts with DayOffset &gt;= switchDay belong to the secondary).
     /// </summary>
+    private sealed record SeededTeams(
+        Dictionary<string, Team> ParentTeams,
+        Dictionary<string, Team> Subteams)
+    {
+        public int Count => ParentTeams.Count + Subteams.Count;
+    }
+
+    private sealed record RotaConfig(Team Team, RotaPeriod Period, string Label, double ConfirmedRate);
+
+    private sealed record SeededRota(Rota Rota, double ConfirmedRate);
+
+    private sealed record SeededShift(Shift Shift, double ConfirmedRate);
+
+    private sealed record SeedShiftDraft(
+        CreateShiftInput Input,
+        LocalTime StartTime,
+        Duration Duration,
+        int MinVolunteers,
+        int MaxVolunteers);
+
     private sealed record UserAssignment(Guid PrimaryTeamId, Guid? SecondaryTeamId, int? SwitchDayOffset);
 
     private static IEnumerable<string> SeededTeamSlugsForDelete()

--- a/src/Humans.Web/Models/Shifts/ShiftAdminPageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftAdminPageBuilder.cs
@@ -17,7 +17,12 @@ public sealed record ShiftAdminPageRequest(
     bool CanApprove,
     bool CanViewMedical,
     bool IncompleteOnboarding,
-    Instant Now);
+    Instant Now)
+{
+    public bool ShouldFilterIncompleteOnboarding() => IncompleteOnboarding;
+
+    public bool CanLoadMedicalDetails() => CanViewMedical;
+}
 
 public sealed class ShiftAdminPageBuilder(
     IShiftManagementService shiftManagement,
@@ -28,9 +33,9 @@ public sealed class ShiftAdminPageBuilder(
     public async Task<ShiftAdminViewModel> BuildAsync(ShiftAdminPageRequest request)
     {
         var rotas = await shiftManagement.GetRotasByDepartmentAsync(request.Department.Id, request.EventSettings.Id);
-        var staffing = await BuildStaffingSummaryAsync(rotas, request.IncompleteOnboarding);
+        var staffing = await BuildStaffingSummaryAsync(rotas, request.ShouldFilterIncompleteOnboarding());
         var allUserIds = GetRelevantUserIds(rotas, staffing.PendingSignups);
-        var profileDict = await LoadProfilesAsync(allUserIds, request.CanViewMedical);
+        var profileDict = await LoadProfilesAsync(allUserIds, request.CanLoadMedicalDetails());
         var userLookup = allUserIds.Count == 0
             ? new Dictionary<Guid, UserInfo>()
             : await userService.GetUserInfosAsync(allUserIds);
@@ -50,7 +55,7 @@ public sealed class ShiftAdminPageBuilder(
             CanApproveSignups = request.CanApprove,
             VolunteerProfiles = profileDict,
             Users = userLookup,
-            CanViewMedical = request.CanViewMedical,
+            CanViewMedical = request.CanLoadMedicalDetails(),
             StaffingData = staffingSnapshot.StaffingData.ToList(),
             StaffingHours = staffingSnapshot.StaffingHours.ToList(),
             Now = request.Now,

--- a/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
@@ -28,7 +28,24 @@ public sealed record ShiftBrowsePageRequest(
     IReadOnlyList<Guid>? TagIds,
     string? Sort,
     IReadOnlyList<string>? Periods,
-    bool IsPrivileged);
+    bool IsPrivileged)
+{
+    public bool HasDateFilter =>
+        !string.IsNullOrEmpty(FromDate) || !string.IsNullOrEmpty(ToDate);
+
+    public bool UsesUrgencySort =>
+        !string.Equals(Sort, "department", StringComparison.OrdinalIgnoreCase);
+
+    public ShiftBrowseQueryFlags BuildBrowseFlags() =>
+        IsPrivileged
+            ? ShiftBrowseQueryFlags.IncludeSignups |
+              ShiftBrowseQueryFlags.IncludeAdminOnly |
+              ShiftBrowseQueryFlags.IncludeHidden
+            : ShiftBrowseQueryFlags.IncludeSignups;
+
+    public List<Guid> ActiveTagFilter() =>
+        TagIds?.Where(id => id != Guid.Empty).ToList() ?? [];
+}
 
 public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManagement, ITeamServiceRead teamService)
 {
@@ -38,7 +55,7 @@ public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManageme
         var period = request.Period;
         var (filterFromDate, filterToDate) = ParseDateFilters(request.FromDate, request.ToDate);
 
-        if ((!string.IsNullOrEmpty(request.FromDate) || !string.IsNullOrEmpty(request.ToDate)) && !string.IsNullOrEmpty(period))
+        if (request.HasDateFilter && !string.IsNullOrEmpty(period))
             period = null;
 
         var activePeriods = ParseActivePeriods(request.Periods, period);
@@ -60,28 +77,23 @@ public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManageme
             }
         }
 
-        var browseFlags = ShiftBrowseQueryFlags.IncludeSignups;
-        if (request.IsPrivileged)
-            browseFlags |= ShiftBrowseQueryFlags.IncludeAdminOnly | ShiftBrowseQueryFlags.IncludeHidden;
-
         var urgentShifts = await shiftManagement.GetBrowseShiftsAsync(new ShiftBrowseQuery(
             es.Id,
             request.DepartmentId,
             filterFromDate,
             filterToDate,
-            browseFlags));
+            request.BuildBrowseFlags()));
 
         var periodFilteredShifts = postFilterByPeriod
             ? urgentShifts.Where(u => activePeriods.Contains(u.Shift.GetShiftPeriod(es))).ToList()
             : (IReadOnlyList<UrgentShift>)urgentShifts;
 
-        var activeTagFilter = request.TagIds?.Where(id => id != Guid.Empty).ToList() ?? [];
+        var activeTagFilter = request.ActiveTagFilter();
         var filteredShifts = activeTagFilter.Count > 0
             ? periodFilteredShifts.Where(u => u.Shift.Rota.Tags.Any(t => activeTagFilter.Contains(t.Id))).ToList()
             : periodFilteredShifts;
 
         var departments = await BuildDepartmentGroupsAsync(filteredShifts, es);
-        var isUrgencySort = !string.Equals(request.Sort, "department", StringComparison.OrdinalIgnoreCase);
 
         var allDepartments = await GetDepartmentOptionsAsync(request.DepartmentId, departments, es.Id);
         var allTags = await shiftManagement.GetTagsAsync();
@@ -115,8 +127,8 @@ public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManageme
             Departments = departments,
             AllDepartments = allDepartments,
             ShowSignups = true,
-            Sort = isUrgencySort ? "urgency" : "department",
-            UrgencyRankedRotas = isUrgencySort
+            Sort = request.UsesUrgencySort ? "urgency" : "department",
+            UrgencyRankedRotas = request.UsesUrgencySort
                 ? departments.SelectMany(d => d.Rotas).OrderByDescending(r => r.MaxUrgencyScore).ToList()
                 : [],
             AllTags = allTags.OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase).ToList(),

--- a/src/Humans.Web/Models/Shifts/ShiftDashboardPageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftDashboardPageBuilder.cs
@@ -18,7 +18,11 @@ public sealed record ShiftDashboardPageRequest(
     LocalDate? ActiveEnd,
     TrendWindow TrendWindow,
     ShiftPeriod? Period,
-    BuildSubPeriod? SubPeriod);
+    BuildSubPeriod? SubPeriod)
+{
+    public (LocalDate? Start, LocalDate? End) ActiveRange() =>
+        (ActiveStart, ActiveEnd);
+}
 
 public sealed class ShiftDashboardPageBuilder(
     IShiftManagementService shiftManagement,
@@ -28,13 +32,14 @@ public sealed class ShiftDashboardPageBuilder(
     public async Task<ShiftDashboardViewModel> BuildAsync(ShiftDashboardPageRequest request)
     {
         var es = request.EventSettings;
+        var activeRange = request.ActiveRange();
 
         var shifts = await shiftManagement.GetUrgentShiftsAsync(
             es.Id,
             limit: null,
             request.DepartmentId,
-            request.ActiveStart,
-            request.ActiveEnd,
+            activeRange.Start,
+            activeRange.End,
             request.Period,
             request.SubPeriod);
         var staffing = await shiftManagement.GetStaffingSnapshotAsync(es.Id, request.DepartmentId, request.Period, request.SubPeriod);

--- a/tests/Humans.Application.Tests/Services/Calendar/CalendarOccurrenceExpanderTests.cs
+++ b/tests/Humans.Application.Tests/Services/Calendar/CalendarOccurrenceExpanderTests.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Calendar;
+using Humans.Application.Services.Calendar;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+
+namespace Humans.Application.Tests.Services.Calendar;
+
+public sealed class CalendarOccurrenceExpanderTests
+{
+    [HumansFact]
+    public void Expand_DropsCancelledRecurringOccurrence()
+    {
+        var eventId = Guid.NewGuid();
+        var cancelledStart = Instant.FromUtc(2026, 6, 2, 10, 0);
+        var info = BuildInfo(
+            id: eventId,
+            start: Instant.FromUtc(2026, 6, 1, 10, 0),
+            end: Instant.FromUtc(2026, 6, 1, 11, 0),
+            recurrenceRule: "FREQ=DAILY;COUNT=3",
+            exceptions:
+            [
+                new CalendarEventExceptionInfo(
+                    Id: Guid.NewGuid(),
+                    OriginalOccurrenceStartUtc: cancelledStart,
+                    IsCancelled: true,
+                    OverrideStartUtc: null,
+                    OverrideEndUtc: null,
+                    OverrideTitle: null,
+                    OverrideDescription: null,
+                    OverrideLocation: null,
+                    OverrideLocationUrl: null),
+            ]);
+
+        var results = CalendarOccurrenceExpander.Expand(
+            [info],
+            Instant.FromUtc(2026, 6, 1, 0, 0),
+            Instant.FromUtc(2026, 6, 4, 0, 0),
+            new Dictionary<Guid, string>(),
+            NullLogger.Instance);
+
+        results.Select(x => x.OccurrenceStartUtc)
+            .Should()
+            .Equal(
+                Instant.FromUtc(2026, 6, 1, 10, 0),
+                Instant.FromUtc(2026, 6, 3, 10, 0));
+    }
+
+    [HumansFact]
+    public void Expand_IncludesOverrideMovedIntoWindow()
+    {
+        var eventId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var originalStart = Instant.FromUtc(2026, 6, 1, 10, 0);
+        var movedStart = Instant.FromUtc(2026, 6, 5, 14, 0);
+        var info = BuildInfo(
+            id: eventId,
+            teamId: teamId,
+            title: "Original",
+            start: originalStart,
+            end: Instant.FromUtc(2026, 6, 1, 11, 0),
+            recurrenceRule: "FREQ=DAILY;COUNT=2",
+            exceptions:
+            [
+                new CalendarEventExceptionInfo(
+                    Id: Guid.NewGuid(),
+                    OriginalOccurrenceStartUtc: originalStart,
+                    IsCancelled: false,
+                    OverrideStartUtc: movedStart,
+                    OverrideEndUtc: Instant.FromUtc(2026, 6, 5, 16, 0),
+                    OverrideTitle: "Moved",
+                    OverrideDescription: null,
+                    OverrideLocation: null,
+                    OverrideLocationUrl: null),
+            ]);
+
+        var results = CalendarOccurrenceExpander.Expand(
+            [info],
+            Instant.FromUtc(2026, 6, 5, 0, 0),
+            Instant.FromUtc(2026, 6, 6, 0, 0),
+            new Dictionary<Guid, string> { [teamId] = "Calendar Team" },
+            NullLogger.Instance);
+
+        var result = results.Should().ContainSingle().Subject;
+        result.EventId.Should().Be(eventId);
+        result.Title.Should().Be("Moved");
+        result.OccurrenceStartUtc.Should().Be(movedStart);
+        result.OccurrenceEndUtc.Should().Be(Instant.FromUtc(2026, 6, 5, 16, 0));
+        result.OriginalOccurrenceStartUtc.Should().Be(originalStart);
+        result.OwningTeamName.Should().Be("Calendar Team");
+    }
+
+    private static CalendarEventInfo BuildInfo(
+        Guid? id = null,
+        Guid? teamId = null,
+        string title = "Test event",
+        Instant? start = null,
+        Instant? end = null,
+        string? recurrenceRule = null,
+        IReadOnlyList<CalendarEventExceptionInfo>? exceptions = null) => new(
+            Id: id ?? Guid.NewGuid(),
+            Title: title,
+            Description: null,
+            Location: null,
+            LocationUrl: null,
+            OwningTeamId: teamId ?? Guid.NewGuid(),
+            StartUtc: start ?? Instant.FromUtc(2026, 6, 1, 10, 0),
+            EndUtc: end ?? Instant.FromUtc(2026, 6, 1, 11, 0),
+            IsAllDay: false,
+            RecurrenceRule: recurrenceRule,
+            RecurrenceTimezone: recurrenceRule is null ? null : "UTC",
+            RecurrenceUntilUtc: null,
+            CreatedByUserId: Guid.NewGuid(),
+            CreatedAt: Instant.FromUtc(2026, 5, 1, 0, 0),
+            UpdatedAt: Instant.FromUtc(2026, 5, 1, 0, 0),
+            Exceptions: exceptions ?? []);
+}


### PR DESCRIPTION
## Summary

Reduces the Reforge combined surface score from `57,272` to `56,112`, a `1,160` point reduction (~`2.03%`).

This is split into focused commits across Calendar, Shifts, Users, Google integration, Store, Email, Camps, Tickets, and volunteer/profile request semantics. The later commits specifically move behavior onto existing request/command records where those objects already represented domain operations, rather than moving code for its own sake.

## Verification

- `dotnet build Humans.slnx --no-restore --disable-build-servers -v q`
- Focused test slices for changed areas:
  - Calendar occurrence expansion
  - Shift page/request and shift management paths
  - User/profile command paths
  - Google workspace/group sync
  - Store service
  - Email message factory, campaign, and rota coordinator flows
  - Camp service and camp role service
  - Ticketing budget service
  - Volunteer tracking export service/controller
  - Profile dietary/medical command paths

## Reforge

- Baseline: `57,272`
- Final: `56,112`
- Delta: `-1,160` (`~2.03%`)
- Target: `<= 56,127`