### PR TITLE
Tighten tech debt score-gaming guardrails

### DIFF
--- a/.codex/skills/humans-refactor/SKILL.md
+++ b/.codex/skills/humans-refactor/SKILL.md
@@ -80,8 +80,11 @@ Two failed patches in a row are a signal that the search strategy is too shallow
 - Do not move debt across sections to win points. Regressions outside the target section count against the change.
 - Public members may be removed when they are internal application surface and the call graph is updated. Preserve reflection/external contracts, Razor action routes, serialized DTO contracts, and public APIs that are intentionally consumed outside the repo.
 - Prefer the best end-state architecture over the smallest diff. Large cohesive refactors are allowed when the call graph and tests support them.
+- Do not satisfy Reforge by adding thin behavior to DTO/request/command/options/input records. Methods such as `ApplyTo`, `ToDto`, `RenderWith`, `BuildSummary`, `SaveAsync`, or service-delegating wrappers are score-gaming unless they enforce real invariants, validation, state transitions, or domain policy already owned by that type.
 
 ## Scoring
+
+Reforge is a candidate-selection and checkpoint tool, not the definition of success. A lower score is useful only after the score-blind architecture review accepts the diff.
 
 Capture baseline scores before editing:
 
@@ -106,6 +109,8 @@ Measure value as:
 - adding facts to an existing canonical `<Section>Info`/read DTO is not the same
   as creating a new DTO; it is often the preferred move when it lets callers
   derive projections/predicates without DB or service-specific reads
+
+Never keep a patch only to hit a percentage target. If the remaining ledger is only reducible through score-gaming, stop and report that safe score reduction is exhausted.
 
 ## Work Loop
 
@@ -154,11 +159,12 @@ Then repeat until stasis:
 1. Inspect Reforge top symbols/rules for the target section.
 2. Read the surrounding code and call graph before editing.
 3. Pick the highest-leverage cohesive improvement, not just the highest scoring rule.
-4. Make the change.
-5. Run targeted tests and `dotnet build Humans.slnx --disable-build-servers -v q`.
-6. Run Reforge after the change.
-7. Run the score-blind architecture-review gate.
-8. If accepted, commit and push. If rework/reject, improve or abandon before committing.
+4. Write a candidate thesis in the run notes: what concept will be deleted, which responsibility moves to its rightful owner, or which duplicated/cross-section path disappears. If the thesis is just "the score drops", reject the candidate before editing.
+5. Make the change.
+6. Run targeted tests and `dotnet build Humans.slnx --disable-build-servers -v q`.
+7. Run Reforge after the change.
+8. Run the score-blind architecture-review gate.
+9. If accepted, commit and push. If rework/reject, improve or abandon before committing.
 
 Stasis means the autonomy floor has been met and the remaining ledger is exhausted, blocked by hard limits, score-negative without architectural upside, or too speculative to change without user/product input. A run may stop early only when the user explicitly asks, the repo cannot build for reasons outside the branch, or continuing risks data/schema/contract changes the user did not authorize.
 
@@ -189,6 +195,12 @@ helper/static class, replacing parameters with a DTO bag, or reducing a score
 without deleting a concept. Acceptable read-model growth should usually add
 facts to the existing `<Section>Info`/read shard, not create another projection
 service.
+
+The reviewer must also reject request/command/DTO "behavior" whose body only
+assigns fields, formats current fields, creates a DTO from the same fields, or
+delegates to a service. Accept only when the type owns a real invariant,
+validation rule, state transition, normalization rule, or domain policy that
+callers should not duplicate.
 
 After the reviewer returns `accept`, attach the Reforge deltas and weighted value
 to the commit message. If the reviewer returns `rework` or `reject`, do not use
@@ -235,6 +247,7 @@ Push after each accepted commit. If a PR does not exist by the time the user ask
   grandfathered, not silently normalized.
 - Keep controllers thin, but allow UI-specific finite sorting/filtering/paging at the controller/view boundary.
 - Reject parameter-object refactors whose primary effect is hiding a long method signature. Accept a new input/command object only when it has cohesive domain meaning, public readable semantics appropriate to its boundary, validation/invariants, reuse across related flows, or a materially simpler call site.
+- Reject adding thin methods to existing parameter objects when the only deleted code is field assignment, string formatting, DTO construction, or direct service delegation. This is score-gaming even if Reforge reports a large improvement.
 - Treat `public` input types with mostly `internal` state as a smell on service interfaces; decorators and cross-assembly callers should not need result objects or side channels to recover data the input already contained.
 - For read-surface pruning, ask: "Could the caller express this as a LINQ query
   over `<Section>Info` or a known read shard?" If yes, add missing facts to the

--- a/.codex/skills/humans-refactor/references/architecture-reviewer.md
+++ b/.codex/skills/humans-refactor/references/architecture-reviewer.md
@@ -19,6 +19,7 @@ Judge whether the change is architecturally worth keeping. Do not infer or rewar
 Look for:
 - score gaming through generic action/mode dispatchers
 - score gaming through parameter DTOs, input bags, options bags, or command wrappers that only hide a long signature
+- score gaming through thin methods added to DTO/request/command records, such as `ApplyTo`, `ToDto`, `RenderWith`, `BuildSummary`, `SaveAsync`, or service-delegating wrappers, when they only assign fields, format existing fields, construct another DTO, or forward calls
 - score gaming through new helper/static classes that only move methods out of a service without deleting a concept
 - one method doing several unrelated jobs
 - hidden complexity moved from public methods into large private methods
@@ -48,6 +49,7 @@ State-engine distinction:
 Parameter-object distinction:
 - Reject or rework changes whose primary benefit is replacing many method parameters with `new Input(...)`/`new Options(...)` at each call site.
 - Accept a new input/command object only when it carries cohesive domain meaning, validation/invariants, reuse across related flows, or materially improves call-site clarity.
+- Accept behavior on an existing request/command only when the type owns a real invariant, validation rule, state transition, normalization rule, or domain policy. Reject behavior that merely moves field assignment, string formatting, DTO construction, or service delegation out of another class.
 - Treat public service-interface input types with mostly internal/private state as a smell; boundary objects should have readable semantics appropriate to their consumers.
 
 Read-model consolidation checks:
@@ -61,6 +63,7 @@ Read-model consolidation checks:
 Before verdict, answer these internally:
 - What concept was deleted?
 - What new concept was added?
+- Would this patch still be worth keeping if Reforge showed no improvement?
 - Could the removed behavior have been derived from the canonical read model instead?
 - Did the patch reduce DB/repository/full-service read paths?
 - Did it preserve cache invalidation and cold-key behavior?

--- a/.codex/skills/humans-tech-debt/SKILL.md
+++ b/.codex/skills/humans-tech-debt/SKILL.md
@@ -20,17 +20,28 @@ Run recurring autonomous tech-debt reduction passes in this repository.
 - Do not modify entity shapes, migration files, or JSON serialization attributes.
 - Do not delete files, remove controller actions, or remove public members as part of the cleanup.
 - Prefer structural simplification and consolidation over broad rewrites.
+- Treat Reforge or any score as a detector, not an objective. A score decrease alone never justifies a commit.
+- Do not add thin behavior to DTO/request/command/options/input records just to escape a parameter-bag or long-signature rule. Methods such as `ApplyTo`, `ToDto`, `RenderWith`, `BuildSummary`, `SaveAsync`, or service-delegating wrappers are acceptable only when they enforce real invariants, validation, state transitions, or domain policy that the type already owns.
 
 ## Working Loop
 
 1. Read [humans-tech-debt-rules.md](./references/humans-tech-debt-rules.md).
 2. Pick one high-value debt item at a time.
-3. Make the smallest coherent improvement that reduces divergence, duplication, or misplaced responsibility.
-4. Add or extend tests when practical.
-5. Run targeted verification, plus `dotnet build Humans.slnx --disable-build-servers -v q`.
-6. Periodically run `dotnet test Humans.slnx --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Application"`.
-7. Commit each improvement separately and push the branch after verified progress.
-8. Continue until remaining ideas are low-value, speculative, or blocked by forbidden areas.
+3. Before editing, write a one-sentence architecture thesis: what concept will be deleted, what responsibility will move to its rightful owner, or what duplication/coupling will disappear. If the thesis is "the score drops", abandon the candidate.
+4. Make the smallest coherent improvement that reduces divergence, duplication, misplaced responsibility, or durable public surface.
+5. Add or extend tests when practical.
+6. Run targeted verification, plus `dotnet build Humans.slnx --disable-build-servers -v q`.
+7. Run a score-blind second pass before commit. Review only the diff, the architecture thesis, and verification. Reject the change if it would not be worth keeping without metric movement.
+8. Periodically run `dotnet test Humans.slnx --no-build --disable-build-servers -v q --filter "FullyQualifiedName~Application"`.
+9. Commit each accepted improvement separately and push the branch after verified progress.
+10. Continue until remaining ideas are low-value, speculative, blocked by forbidden areas, or only reducible through metric-gaming changes.
+
+## Metric Integrity
+
+- Use Reforge to find suspicious surfaces and compare checkpoints, not to decide that a weak patch is good.
+- Prefer changes that remove a real concept, collapse duplicated behavior, narrow cross-section dependencies, or move a rule to its owning section.
+- Reject refactors whose main effect is moving assignments, formatting strings, or service calls from one class into a request/command object without reducing coupling or clarifying ownership.
+- Do not keep working toward a percentage target after the remaining candidates fail the architecture thesis or score-blind review. Report that the safe score reduction is exhausted instead.
 
 ## Parallel Work
 

--- a/.codex/skills/humans-tech-debt/references/humans-tech-debt-rules.md
+++ b/.codex/skills/humans-tech-debt/references/humans-tech-debt-rules.md
@@ -6,6 +6,8 @@ Use this reference to guide autonomous tech-debt reduction passes in the Humans 
 
 Reduce impactful tech debt. Favor consolidation, clearer ownership, shared patterns, and simpler code paths. Do not add features or chase style-only cleanup.
 
+Reforge and similar scores are triage signals only. A lower score is not proof of improvement and must never be the primary reason to keep a change. Every committed change needs an architecture reason that is valid without score context: a concept deleted, duplicated behavior collapsed, ownership clarified, coupling reduced, or durable surface removed.
+
 Good candidates usually look like:
 
 - duplicated logic that should be shared
@@ -53,6 +55,7 @@ Deprioritize:
 - large rewrites with weak behavioral payoff
 - breaking interface churn unless the call graph is fully understood
 - file splitting done only to reduce line count
+- moving assignments, string formatting, or service calls into DTO/request/command records only to make a metric stop flagging them
 
 ## Layer-Separation Rules
 
@@ -138,6 +141,32 @@ Bad pattern:
 
 New durable surfaces are justified when the data is unbounded, permission-specific, expensive to materialize through the read model, transactional, sensitive, not a stable fact of the aggregate, or when adding the fields would pollute the canonical DTO with screen-only concerns. Otherwise, a few scalar DTO properties are lower weight than another interface, implementation, DI registration, test fixture, cache path, and HUM0025 ownership surface.
 
+## Parameter-Bag And Command Rules
+
+Treat parameter-bag warnings as prompts to inspect ownership, not as instructions to add methods.
+
+Bad fixes:
+
+- add `ApplyTo`, `ToDto`, `RenderWith`, `BuildSummary`, `SaveAsync`, or similar thin methods whose body only assigns fields, formats existing fields, or delegates to a service
+- move a long call's arguments into an input record and immediately unpack them elsewhere
+- add behavior to a public request/command only so Reforge no longer classifies it as a bag
+- convert explicit domain verbs into generic action/mode dispatchers
+
+Good fixes:
+
+- replace a long signature with a command that has cohesive domain meaning and is reused across related flows
+- put validation, invariants, state-transition rules, authorization-neutral domain policy, or normalization on the object that owns those rules
+- delete duplicated call structures or public overload families because callers can use one clear command/query
+- add facts to an existing canonical read DTO when doing so removes DB reads, service predicates, or projection methods
+
+Before committing a parameter-object change, answer:
+
+- What responsibility is now in the correct owner?
+- What concept, overload, method family, or duplicate call structure was deleted?
+- Would this diff still be worth keeping if Reforge showed no score movement?
+
+If the answer is weak, abandon the patch even if the score improves.
+
 ## Section Read-Service Rules
 
 When a section exposes both a full service interface and a `*ServiceRead` interface, code outside the owning section should depend on the read interface unless it truly writes, invalidates caches, performs an owning-section workflow, or needs an entity-only method that has no read-model equivalent yet.
@@ -164,3 +193,4 @@ Migration strategy:
 - When touching authorization, preserve the exact access level.
 - Keep controllers thin and services cohesive, but do not move code across boundaries unless the ownership problem is obvious and local.
 - Stop if the next step drifts into database, migration, or entity-shape changes.
+- Stop when remaining candidates only satisfy metric movement, not architecture value. Report the exhausted safe opportunities instead of forcing a target.


### PR DESCRIPTION
## Summary

Updates the Humans tech-debt and refactor skills to prevent Reforge score-gaming from being treated as progress.

Key additions:

- Reforge is a detector/checkpoint, not the definition of success.
- Each candidate needs an architecture thesis before editing.
- Score-blind review must reject changes that are not worth keeping without metric movement.
- Thin DTO/request/command methods such as `ApplyTo`, `ToDto`, `RenderWith`, `BuildSummary`, `SaveAsync`, or service-delegating wrappers are explicitly rejected unless they enforce real invariants, validation, state transitions, normalization, or domain policy.
- Runs must stop and report exhausted safe opportunities when remaining candidates only satisfy score movement.

## Validation

- `python C:\Users\PeterDrier\.codex\skills\.system\skill-creator\scripts\quick_validate.py H:\source\humans\.codex\skills\humans-tech-debt`
- `python C:\Users\PeterDrier\.codex\skills\.system\skill-creator\scripts\quick_validate.py H:\source\humans\.codex\skills\humans-refactor`