### PR TITLE
Make people/team/camp search relevance-ranked, uncapped, and cache-only

### DIFF
--- a/src/Humans.Application/DTOs/ProfileSearchResults.cs
+++ b/src/Humans.Application/DTOs/ProfileSearchResults.cs
@@ -26,6 +26,12 @@ namespace Humans.Application.DTOs;
 /// <c>PersonSearchFields.Admin</c> bit. Always <c>null</c> for
 /// non-admin callers — services are auth-free, but never leak admin-bit
 /// content into the basic shape.</param>
+/// <param name="Score">Relevance score (higher = better) from
+/// <c>PersonSearchMatcher</c>: exact name &gt; prefix &gt; token-prefix &gt;
+/// contains &gt; non-name field. The service returns matches unordered
+/// (per <c>memory/architecture/person-search.md</c>); controllers/views sort
+/// by this via <c>OrderByRelevance()</c> so the best name match surfaces first
+/// instead of an alphabetical list.</param>
 public record HumanSearchResult(
     Guid UserId,
     Guid ProfileId,
@@ -33,4 +39,5 @@ public record HumanSearchResult(
     string? ProfilePictureUrl,
     string? MatchField,
     string? MatchSnippet,
-    string? MatchedEmail);
+    string? MatchedEmail,
+    int Score);

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -63,20 +63,6 @@ public partial interface ICampRepository : IRepository
     /// </summary>
     Task<bool> SlugExistsAsync(string slug, CancellationToken ct = default);
 
-    /// <summary>
-    /// Returns camps that have a season for <paramref name="year"/> whose
-    /// <c>CampSeason.Name</c> contains <paramref name="query"/>
-    /// (case-insensitive, Postgres ILike). When
-    /// <paramref name="onlyPublicStatus"/> is true, the year's season must
-    /// also be in <c>CampSeasonStatus.Active</c> or <c>Full</c> — same gate
-    /// the public camp directory uses. Year-filtered seasons are included.
-    /// Capped at <paramref name="max"/>; ordering is unspecified (caller
-    /// ranks). Read-only, no cross-domain navs.
-    /// </summary>
-    Task<IReadOnlyList<Camp>> SearchForYearAsync(
-        string query, int year, bool onlyPublicStatus, int max,
-        CancellationToken ct = default);
-
     // ==========================================================================
     // Writes — Camp / Season / Lead (aggregate)
     // ==========================================================================

--- a/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
@@ -98,16 +98,6 @@ public interface ITeamRepository : IRepository
         int page, int pageSize, CancellationToken ct = default);
 
     /// <summary>
-    /// Active teams whose <c>Name</c> contains <paramref name="query"/>
-    /// (case-insensitive, Postgres ILike). When
-    /// <paramref name="includeHidden"/> is false, hidden teams are
-    /// filtered at the DB layer. Capped at <paramref name="max"/>;
-    /// ordering is unspecified (caller ranks). Read-only, no navs.
-    /// </summary>
-    Task<IReadOnlyList<Team>> SearchAsync(
-        string query, bool includeHidden, int max, CancellationToken ct = default);
-
-    /// <summary>
     /// Load the requested team ids plus any referenced parent teams that
     /// aren't already in the requested set. Used by the shift coordinator
     /// dashboard for department-stitching without cross-domain

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -262,33 +262,16 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         return info with { NameLockDates = nameLockDates.ToDictionary(kv => kv.Key, kv => kv.Value) };
     }
 
-    public async Task<IReadOnlyList<CampSearchHit>> SearchAsync(
+    // Camp search is served from the cached CampInfo snapshot in CachingCampService — it must
+    // never hit the DB. Reaching the inner service means a DI mistake. Mirrors
+    // UserService.SearchUsersAsync (search is cache-only; there is no repository search).
+    public Task<IReadOnlyList<CampSearchHit>> SearchAsync(
         string query, int max,
-        CancellationToken cancellationToken = default)
-    {
-        var settings = await GetSettingsAsync(cancellationToken);
-        var year = settings.PublicYear;
-
-        if (Guid.TryParse(query, out var id))
-        {
-            var camp = await _repo.GetByIdAsync(id, cancellationToken);
-            if (camp is null) return [];
-            var season = camp.Seasons.FirstOrDefault(s => s.Year == year);
-            return [new CampSearchHit(camp.Slug, season?.Name ?? camp.Slug)];
-        }
-
-        var camps = await _repo.SearchForYearAsync(
-            query, year, onlyPublicStatus: true, max, cancellationToken);
-
-        var hits = new List<CampSearchHit>(camps.Count);
-        foreach (var camp in camps)
-        {
-            var season = camp.Seasons.FirstOrDefault(s => s.Year == year);
-            var name = season?.Name ?? camp.Slug;
-            hits.Add(new CampSearchHit(camp.Slug, name));
-        }
-        return hits;
-    }
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException(
+            "Camp search runs against the cached CampInfo snapshot in CachingCampService. " +
+            "If this is being called on the inner CampService it indicates a DI registration " +
+            "mistake — ICampServiceRead must resolve to the caching decorator.");
 
     /// <summary>
     /// Special-role user-id lists (Lead/Workshop) keyed by season+role, plus the full

--- a/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
+++ b/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
@@ -4,8 +4,12 @@ using Humans.Domain.Enums;
 
 namespace Humans.Application.Services.Profiles;
 
-/// <summary>Result of a single person-search match: which field hit, plus optional snippet/email for display.</summary>
-public sealed record PersonSearchMatch(string Field, string? Snippet, string? MatchedEmail);
+/// <summary>
+/// Result of a single person-search match: which field hit, plus optional snippet/email for display
+/// and a relevance <paramref name="Score"/> (higher = better) so controllers can rank results by
+/// match quality instead of alphabetically. See <see cref="PersonSearchMatcher"/> for the tiers.
+/// </summary>
+public sealed record PersonSearchMatch(string Field, string? Snippet, string? MatchedEmail, int Score);
 
 /// <summary>
 /// Pure, scope-confined matcher for person search. Operates on the cached <see cref="UserInfo"/>
@@ -17,6 +21,15 @@ public sealed record PersonSearchMatch(string Field, string? Snippet, string? Ma
 /// </summary>
 public static class PersonSearchMatcher
 {
+    // Relevance tiers (higher = better). Name matches always outrank non-name (bio/city/email)
+    // matches, and within a name the order is exact > whole-string-prefix > token-prefix > contains.
+    // This is what floats the literal "Ian" above "Adrian"/"Brian" instead of alphabetizing them.
+    private const int ScoreExactName = 100;
+    private const int ScorePrefixName = 85;
+    private const int ScoreTokenPrefixName = 80;
+    private const int ScoreContainsName = 60;
+    private const int ScoreOtherField = 40;
+
     /// <summary>Returns the first bucket that matches <paramref name="query"/>, or null if none do.</summary>
     public static PersonSearchMatch? Match(UserInfo user, string query, PersonSearchFields fields)
     {
@@ -47,42 +60,43 @@ public static class PersonSearchMatcher
 
         // ── Exact-name bucket: resolved display name, folded full-string equality (not substring/token). Public. ──
         if (includeExactName && string.Equals(Fold(user.BurnerName), foldedQuery, StringComparison.Ordinal))
-            return new PersonSearchMatch("Exact Name", null, null);
+            return new PersonSearchMatch("Exact Name", null, null, ScoreExactName);
 
         // ── Name bucket: resolved display name (BurnerName → DisplayName fallback). Public. ──
         if (includeName && AllTokensIn(user.BurnerName, tokens))
-            return new PersonSearchMatch("Name", null, null);
+            return new PersonSearchMatch("Name", null, null, ScoreNameTier(Fold(user.BurnerName), foldedQuery));
 
         // ── Legal name: FirstName/LastName. Admin/coordinator only — never public. ──
         if (includeLegal && AllTokensIn($"{p.FirstName} {p.LastName}", tokens))
-            return new PersonSearchMatch("Legal Name", null, null);
+            return new PersonSearchMatch(
+                "Legal Name", null, null, ScoreNameTier(Fold($"{p.FirstName} {p.LastName}"), foldedQuery));
 
         // ── Bio bucket: public long-form + CV + AllActiveProfiles ContactFields + publicly-exposed emails. ──
         if (includeBio)
         {
             if (FoldedContains(p.City, foldedQuery))
-                return new PersonSearchMatch("City", p.City, null);
+                return new PersonSearchMatch("City", p.City, null, ScoreOtherField);
 
             if (FoldedContains(p.ContributionInterests, foldedQuery))
-                return new PersonSearchMatch("Interests", Snippet(p.ContributionInterests, q), null);
+                return new PersonSearchMatch("Interests", Snippet(p.ContributionInterests, q), null, ScoreOtherField);
 
             if (FoldedContains(p.Bio, foldedQuery))
-                return new PersonSearchMatch("Bio", Snippet(p.Bio, q), null);
+                return new PersonSearchMatch("Bio", Snippet(p.Bio, q), null, ScoreOtherField);
 
             if (FoldedContains(p.Pronouns, foldedQuery))
-                return new PersonSearchMatch("Pronouns", p.Pronouns, null);
+                return new PersonSearchMatch("Pronouns", p.Pronouns, null, ScoreOtherField);
 
             foreach (var v in p.VolunteerHistory)
             {
                 if (FoldedContains(v.EventName, foldedQuery) || FoldedContains(v.Description, foldedQuery))
-                    return new PersonSearchMatch("Burner CV", v.EventName, null);
+                    return new PersonSearchMatch("Burner CV", v.EventName, null, ScoreOtherField);
             }
 
             foreach (var cf in p.ContactFields)
             {
                 if (cf.Visibility == ContactFieldVisibility.AllActiveProfiles &&
                     FoldedContains(cf.Value, foldedQuery))
-                    return new PersonSearchMatch(DisplayLabel(cf), cf.Value, null);
+                    return new PersonSearchMatch(DisplayLabel(cf), cf.Value, null, ScoreOtherField);
             }
 
             foreach (var email in user.UserEmails)
@@ -90,7 +104,7 @@ public static class PersonSearchMatcher
                 if (email.IsVerified &&
                     email.Visibility == ContactFieldVisibility.AllActiveProfiles &&
                     FoldedContains(email.Email, foldedQuery))
-                    return new PersonSearchMatch("Email", null, email.Email);
+                    return new PersonSearchMatch("Email", null, email.Email, ScoreOtherField);
             }
         }
 
@@ -100,7 +114,7 @@ public static class PersonSearchMatcher
             foreach (var email in user.AllVerifiedEmails)
             {
                 if (FoldedContains(email, foldedQuery))
-                    return new PersonSearchMatch("Email", null, email);
+                    return new PersonSearchMatch("Email", null, email, ScoreOtherField);
             }
 
             foreach (var cf in p.ContactFields)
@@ -109,7 +123,7 @@ public static class PersonSearchMatcher
                 if (cf.Visibility == ContactFieldVisibility.AllActiveProfiles)
                     continue;
                 if (FoldedContains(cf.Value, foldedQuery))
-                    return new PersonSearchMatch(DisplayLabel(cf), cf.Value, cf.Value);
+                    return new PersonSearchMatch(DisplayLabel(cf), cf.Value, cf.Value, ScoreOtherField);
             }
         }
 
@@ -159,6 +173,26 @@ public static class PersonSearchMatcher
     /// <summary>Folds the query and splits on whitespace into non-empty tokens.</summary>
     private static string[] FoldTokens(string query) =>
         Fold(query).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>
+    /// Ranks an already-matched name: exact &gt; whole-string-prefix &gt; token-prefix &gt; contains.
+    /// Both arguments are pre-folded. The caller has already confirmed a match, so the floor is
+    /// <see cref="ScoreContainsName"/> (covers token-substring/multi-token hits that aren't a prefix).
+    /// </summary>
+    private static int ScoreNameTier(string foldedName, string foldedQuery)
+    {
+        if (string.Equals(foldedName, foldedQuery, StringComparison.Ordinal))
+            return ScoreExactName;
+        if (foldedName.StartsWith(foldedQuery, StringComparison.Ordinal))
+            return ScorePrefixName;
+        foreach (var token in foldedName.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.StartsWith(foldedQuery, StringComparison.Ordinal))
+                return ScoreTokenPrefixName;
+        }
+
+        return ScoreContainsName;
+    }
 
     /// <summary>True when every token is a substring of the folded haystack (order-independent).</summary>
     private static bool AllTokensIn(string? haystack, string[] foldedTokens)

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -175,22 +175,16 @@ public sealed class TeamService(
         return teams.ToList();
     }
 
-    public async Task<IReadOnlyList<TeamSearchHit>> SearchAsync(
+    // Team search is served from the cached TeamInfo snapshot in CachingTeamService — it must
+    // never hit the DB. Reaching the inner service means a DI mistake. Mirrors
+    // UserService.SearchUsersAsync (search is cache-only; there is no repository search).
+    public Task<IReadOnlyList<TeamSearchHit>> SearchAsync(
         string query, int max,
-        CancellationToken cancellationToken = default)
-    {
-        if (Guid.TryParse(query, out var id))
-        {
-            var team = await repo.GetByIdAsync(id, cancellationToken);
-            return team is null ? [] : [new TeamSearchHit(team.Name, team.Slug)];
-        }
-
-        var teams = await repo.SearchAsync(
-            query, includeHidden: false, max, cancellationToken);
-        return teams
-            .Select(t => new TeamSearchHit(t.Name, t.Slug))
-            .ToList();
-    }
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException(
+            "Team search runs against the cached TeamInfo snapshot in CachingTeamService. " +
+            "If this is being called on the inner TeamService it indicates a DI registration " +
+            "mistake — ITeamServiceRead must resolve to the caching decorator.");
 
     public async Task<IReadOnlyCollection<Guid>> GetEffectiveBudgetCoordinatorTeamIdsAsync(
         Guid userId, CancellationToken cancellationToken = default)

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -90,45 +90,6 @@ internal sealed partial class CampRepository : ICampRepository
         return await ctx.Camps.AnyAsync(b => b.Slug == slug, ct);
     }
 
-    // Contains() → IN clause (enum stored as string; see no-enum-compare-in-ef).
-    private static readonly CampSeasonStatus[] PublicCampSeasonStatuses = [CampSeasonStatus.Active, CampSeasonStatus.Full
-    ];
-
-    public async Task<IReadOnlyList<Camp>> SearchForYearAsync(
-        string query, int year, bool onlyPublicStatus, int max,
-        CancellationToken ct = default)
-    {
-        if (string.IsNullOrWhiteSpace(query) || max <= 0)
-            return [];
-
-        var pattern = "%" + EscapeLikePattern(query.Trim()) + "%";
-
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var baseQuery = ctx.Camps
-            .AsNoTracking()
-            .Include(c => c.Seasons.Where(s => s.Year == year));
-
-        // Name-match and public-status MUST bind to the same season row —
-        // splitting across two .Where(.Any(...)) lets different seasons satisfy each.
-        IQueryable<Camp> q = onlyPublicStatus
-            ? baseQuery.Where(c => c.Seasons.Any(s => s.Year == year
-                && EF.Functions.ILike(s.Name, pattern, "\\")
-                && PublicCampSeasonStatuses.Contains(s.Status)))
-            : baseQuery.Where(c => c.Seasons.Any(s => s.Year == year
-                && EF.Functions.ILike(s.Name, pattern, "\\")));
-
-        return await q
-            .OrderBy(c => c.Slug) // arch:db-sort-ok — orchestrator re-ranks by score
-            .Take(max)
-            .ToListAsync(ct);
-    }
-
-    private static string EscapeLikePattern(string value)
-        => value
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
-
     // Writes — Camp (aggregate)
 
     public async Task CreateCampAsync(

--- a/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
@@ -125,36 +125,6 @@ internal sealed class TeamRepository(IDbContextFactory<HumansDbContext> factory)
                 g => (IReadOnlyList<TeamRoleDefinition>)g.ToList());
     }
 
-    private static string EscapeLikePattern(string value)
-        => value
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
-
-    public async Task<IReadOnlyList<Team>> SearchAsync(
-        string query, bool includeHidden, int max, CancellationToken ct = default)
-    {
-        if (string.IsNullOrWhiteSpace(query) || max <= 0)
-            return [];
-
-        var pattern = "%" + EscapeLikePattern(query.Trim()) + "%";
-
-        await using var db = await factory.CreateDbContextAsync(ct);
-        var q = db.Teams
-            .AsNoTracking()
-            .Where(t => t.IsActive);
-
-        if (!includeHidden)
-            q = q.Where(t => !t.IsHidden);
-
-        return await q
-            .Where(t => EF.Functions.ILike(t.Name, pattern, "\\"))
-            // Deterministic Take(max) for global search; controller re-ranks by score before display.
-            .OrderBy(t => t.Name) // arch:db-sort-ok
-            .Take(max)
-            .ToListAsync(ct);
-    }
-
     public async Task<(IReadOnlyList<Team> Items, int TotalCount)> GetAllForAdminAsync(
         int page, int pageSize, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
+++ b/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
@@ -9,6 +9,7 @@ using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Camps;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 
 namespace Humans.Infrastructure.Services.Camps;
@@ -115,9 +116,49 @@ public sealed class CachingCampService(
         Guid campId, int? preferredYear = null, CancellationToken cancellationToken = default) =>
         WithInner(inner => inner.GetCampEditDataAsync(campId, preferredYear, cancellationToken));
 
-    public Task<IReadOnlyList<CampSearchHit>> SearchAsync(
-        string query, int max, CancellationToken cancellationToken = default) =>
-        WithInner(inner => inner.SearchAsync(query, max, cancellationToken));
+    // A camp surfaces in global search only when its public-year season is publicly visible.
+    private static readonly CampSeasonStatus[] PublicCampSeasonStatuses =
+        [CampSeasonStatus.Active, CampSeasonStatus.Full];
+
+    public async Task<IReadOnlyList<CampSearchHit>> SearchAsync(
+        string query, int max, CancellationToken cancellationToken = default)
+    {
+        // Served from the cached CampInfo snapshot — search must never hit the DB. PublicYear is
+        // always a warm year, so both the settings read and GetCampsForYearAsync stay in-cache.
+        if (string.IsNullOrWhiteSpace(query) || max <= 0)
+            return [];
+
+        var settings = await GetSettingsAsync(cancellationToken);
+        var year = settings.PublicYear;
+
+        // GUID paste → jump straight to that camp (any status), mirroring the old by-id path.
+        if (Guid.TryParse(query, out var id))
+        {
+            await EnsureWarmedAsync(cancellationToken);
+            var camp = Values.FirstOrDefault(c => c.Id == id);
+            if (camp is null)
+                return [];
+            var byIdSeason = camp.Seasons.FirstOrDefault(s => s.Year == year);
+            return [new CampSearchHit(camp.Slug, byIdSeason?.Name ?? camp.Slug)];
+        }
+
+        // Name match against the public-year season name, public statuses only (what the DB
+        // ILike + status filter did). Case-insensitive contains.
+        var camps = await GetCampsForYearAsync(year, cancellationToken);
+        var trimmed = query.Trim();
+        var hits = new List<CampSearchHit>();
+        foreach (var camp in camps)
+        {
+            var season = camp.Seasons.FirstOrDefault(s =>
+                s.Year == year
+                && PublicCampSeasonStatuses.Contains(s.Status)
+                && s.Name.Contains(trimmed, StringComparison.OrdinalIgnoreCase));
+            if (season is not null)
+                hits.Add(new CampSearchHit(camp.Slug, season.Name));
+        }
+
+        return hits.Take(max).ToList();
+    }
 
     public async Task<CampSeasonInfo?> GetCampSeasonByIdAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default)

--- a/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
+++ b/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
@@ -101,10 +101,35 @@ public sealed class CachingTeamService(
     public Task<IReadOnlyList<Team>> GetAllTeamsAsync(CancellationToken cancellationToken = default) =>
         WithInner(inner => inner.GetAllTeamsAsync(cancellationToken));
 
-    public Task<IReadOnlyList<TeamSearchHit>> SearchAsync(
+    public async Task<IReadOnlyList<TeamSearchHit>> SearchAsync(
         string query, int max,
-        CancellationToken cancellationToken = default) =>
-        WithInner(inner => inner.SearchAsync(query, max, cancellationToken));
+        CancellationToken cancellationToken = default)
+    {
+        // Served entirely from the cached TeamInfo snapshot — search must never hit the DB
+        // (mirrors CachingUserService.SearchUsersAsync; the inner service + repo search are gone).
+        if (string.IsNullOrWhiteSpace(query) || max <= 0)
+            return [];
+
+        var teamsById = await GetTeamsByIdAsync(cancellationToken);
+
+        // GUID paste → jump straight to that team (any visibility), mirroring the old by-id path.
+        if (Guid.TryParse(query, out var id))
+        {
+            return teamsById.TryGetValue(id, out var byId)
+                ? [new TeamSearchHit(byId.Name, byId.Slug)]
+                : [];
+        }
+
+        // Name match, active + non-hidden (what the DB ILike filtered). Case-insensitive contains.
+        var trimmed = query.Trim();
+        return teamsById.Values
+            .Where(t => t.IsActive && !t.IsHidden
+                && t.Name.Contains(trimmed, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(max)
+            .Select(t => new TeamSearchHit(t.Name, t.Slug))
+            .ToList();
+    }
 
     public async Task<TeamDirectoryResult> GetTeamDirectoryAsync(
         Guid? userId,

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -141,7 +141,8 @@ public sealed class CachingUserService(
                         ProfilePictureUrl: byId.ProfilePictureUrl,
                         MatchField: "User ID",
                         MatchSnippet: null,
-                        MatchedEmail: null)
+                        MatchedEmail: null,
+                        Score: 100) // Exact id hit — top relevance (sole result, so ordering is moot).
                 ];
             }
             return [];
@@ -163,7 +164,8 @@ public sealed class CachingUserService(
                 ProfilePictureUrl: u.ProfilePictureUrl,
                 MatchField: match.Field,
                 MatchSnippet: match.Snippet,
-                MatchedEmail: match.MatchedEmail));
+                MatchedEmail: match.MatchedEmail,
+                Score: match.Score));
 
             if (results.Count >= limit) break;
         }

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -18,7 +18,11 @@ public class ProfileApiController(
     IContactFieldService contactFieldService,
     IUserEmailService userEmailService) : ApiControllerBase(userService)
 {
-    private const int MaxResults = 10;
+    // No result cap: at ~500-user scale a name match returns a handful of rows, and a hard cap
+    // returned an *arbitrary* N in cache-iteration order (so the person being searched for could be
+    // missing entirely), then alphabetized them. We request the full match set, rank by relevance,
+    // and the scrollable dropdown shows the best matches first. Mirrors SearchService's Unlimited.
+    private const int Unlimited = int.MaxValue;
 
     private readonly IUserServiceRead _userService = userService;
 
@@ -64,10 +68,11 @@ public class ProfileApiController(
             });
         }
 
-        var results = await _userService.SearchUsersAsync(q, fields, MaxResults, ct);
+        var results = await _userService.SearchUsersAsync(q, fields, Unlimited, ct);
 
         var response = new List<HumanLookupSearchResult>(results.Count);
-        foreach (var result in results.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase))
+        // Display sort at controller (display-sort-in-controllers): relevance, then name.
+        foreach (var result in results.OrderByRelevance())
         {
             var detail = await GetSharedDetailAsync(
                 result.UserId,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -2023,12 +2023,14 @@ public class ProfileController(
         }
 
         // PublicAll = name + bio + public ContactFields. Admin bit gated by code review.
+        // Uncapped: return the full match set so relevance ranking surfaces the right person
+        // (a hard cap returned an arbitrary subset before sorting). Cheap at ~500 users.
         var results = await _userService.SearchUsersAsync(
-            q!, PersonSearchFields.PublicAll, limit: 50, ct);
+            q!, PersonSearchFields.PublicAll, limit: int.MaxValue, ct);
 
         // Display sort at controller — memory/architecture/display-sort-in-controllers.md.
         viewModel.Results = results
-            .OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase)
+            .OrderByRelevance()
             .Select(r => r.ToHumanSearchViewModel())
             .ToList();
 

--- a/src/Humans.Web/Controllers/SearchController.cs
+++ b/src/Humans.Web/Controllers/SearchController.cs
@@ -58,9 +58,10 @@ public sealed class SearchController(
         {
             Query = results.Query,
             Filter = filter,
-            // Display sort lives in controller (display-sort-in-controllers): humans by BurnerName, others by Score desc + Title asc.
+            // Display sort lives in controller (display-sort-in-controllers): humans by relevance
+            // (exact/prefix/contains, then name), others by Score desc + Title asc.
             HumanResults = results.Humans
-                .OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase)
+                .OrderByRelevance()
                 .Select(r => r.ToHumanSearchViewModel())
                 .ToList(),
             TeamResults = SortByScore(results.Teams),

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -321,8 +321,10 @@ public class TeamAdminController(
         }
 
         // Name-only — team admins are not global admins, so no contact-data search.
+        // Uncapped + relevance-ranked: a hard cap returned an arbitrary subset (the target could be
+        // missing) alphabetized; now the best name match leads the scrollable picker.
         var results = await _userService.SearchUsersAsync(
-            q, PersonSearchFields.Name, limit: 50);
+            q, PersonSearchFields.Name, limit: int.MaxValue);
 
         var teamInfo = await _teamService.GetTeamAsync(team.Id);
         var existingMemberIds = teamInfo?.Members.Select(m => m.UserId).ToHashSet() ?? [];
@@ -330,8 +332,7 @@ public class TeamAdminController(
         // Display sort at controller (memory/architecture/display-sort-in-controllers.md).
         var filtered = results
             .Where(r => !existingMemberIds.Contains(r.UserId))
-            .OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase)
-            .Take(10)
+            .OrderByRelevance()
             .Select(r => new HumanLookupSearchResult(r.UserId, r.BurnerName))
             .ToList();
 
@@ -1138,20 +1139,25 @@ public class TeamAdminController(
             .Select(m => m.UserId)
             .ToHashSet();
 
+        // Name-only for role-picker (no bio/contact data); team admins are not global admins.
+        // Uncapped folded name search over everyone (accent/case-insensitive); relevance-ranked.
+        var allResults = await _userService.SearchUsersAsync(
+            q, PersonSearchFields.Name, limit: int.MaxValue);
+        var nameMatchIds = allResults.Select(r => r.UserId).ToHashSet();
+
+        // Team members first: matched by folded name (via the search above, so "joel" finds "Joël")
+        // OR by email — team admins may know their own members' emails, which the global name-only
+        // search deliberately won't surface for privacy.
         var matchingTeamMembers = teamMembers
-            .Where(m => m.DisplayName.ContainsOrdinalIgnoreCase(q) ||
+            .Where(m => nameMatchIds.Contains(m.UserId) ||
                         (m.Email?.ContainsOrdinalIgnoreCase(q) ?? false))
-            .Take(10)
+            .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
             .Select(m => new RoleAssignmentSearchResult(m.UserId, m.DisplayName, m.Email ?? "", true))
             .ToList();
 
-        // Name-only for role-picker (no bio/contact data); team admins are not global admins.
-        var allResults = await _userService.SearchUsersAsync(
-            q, PersonSearchFields.Name, limit: 50);
         var nonMembers = allResults
             .Where(r => !teamMemberUserIds.Contains(r.UserId))
-            .OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase)
-            .Take(10 - matchingTeamMembers.Count)
+            .OrderByRelevance()
             .Select(r => new RoleAssignmentSearchResult(r.UserId, r.BurnerName, "", false))
             .ToList();
 

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -1145,11 +1145,15 @@ public class TeamAdminController(
             q, PersonSearchFields.Name, limit: int.MaxValue);
         var nameMatchIds = allResults.Select(r => r.UserId).ToHashSet();
 
-        // Team members first: matched by folded name (via the search above, so "joel" finds "Joël")
-        // OR by email — team admins may know their own members' emails, which the global name-only
-        // search deliberately won't surface for privacy.
+        // Team members first, matched by any of:
+        //  - folded name via the search above (so "joel" finds "Joël") — profiled members;
+        //  - direct DisplayName contains — keeps legacy/imported members who appear in team.Members
+        //    but have no searchable Profile findable by name (SearchUsersAsync skips profile-less users);
+        //  - email — team admins may know their own members' emails, which the global name-only
+        //    search deliberately won't surface for privacy.
         var matchingTeamMembers = teamMembers
             .Where(m => nameMatchIds.Contains(m.UserId) ||
+                        m.DisplayName.ContainsOrdinalIgnoreCase(q) ||
                         (m.Email?.ContainsOrdinalIgnoreCase(q) ?? false))
             .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
             .Select(m => new RoleAssignmentSearchResult(m.UserId, m.DisplayName, m.Email ?? "", true))

--- a/src/Humans.Web/Controllers/UsersAdminController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminController.cs
@@ -390,8 +390,10 @@ public sealed class UsersAdminController(
         IReadOnlySet<Guid>? searchUserIds = null;
         if (!string.IsNullOrWhiteSpace(search))
         {
+            // Uncapped: used as a match set to filter the admin list (ordering is the table's own),
+            // so a hard cap would silently drop matching humans. Cheap at ~500 users.
             var searchResults = await _userService.SearchUsersAsync(
-                search, PersonSearchFields.AdminAll, limit: 500, ct);
+                search, PersonSearchFields.AdminAll, limit: int.MaxValue, ct);
 
             var byEmail = allUsers
                 .Where(u =>

--- a/src/Humans.Web/Extensions/SearchResultMappingExtensions.cs
+++ b/src/Humans.Web/Extensions/SearchResultMappingExtensions.cs
@@ -5,6 +5,19 @@ namespace Humans.Web.Extensions;
 
 public static class SearchResultMappingExtensions
 {
+    /// <summary>
+    /// Canonical display order for person-search results: relevance score descending
+    /// (exact-name &gt; prefix &gt; token-prefix &gt; contains &gt; non-name field), then
+    /// BurnerName as a stable alphabetical tiebreak. The service returns matches unordered
+    /// (memory/architecture/person-search.md); every people-search surface orders through here
+    /// so the literal "Ian" lands above "Adrian"/"Brian" instead of one alphabetical list.
+    /// </summary>
+    public static IOrderedEnumerable<HumanSearchResult> OrderByRelevance(
+        this IEnumerable<HumanSearchResult> results) =>
+        results
+            .OrderByDescending(r => r.Score)
+            .ThenBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase);
+
     public static HumanSearchResultViewModel ToHumanSearchViewModel(this HumanSearchResult result) =>
         new()
         {

--- a/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
+++ b/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
@@ -77,15 +77,12 @@ public sealed class ShiftVolunteerSearchBuilder(
         var shiftStart = shift.GetAbsoluteStart(eventSettings);
         var shiftEnd = shift.GetAbsoluteEnd(eventSettings);
 
-        // SearchUsersAsync iterates the in-memory cache and short-circuits at
-        // `limit`, so passing limit: 10 directly returns an arbitrary 10 (cache
-        // order is non-deterministic). Request the full match set and sort
-        // before capping to preserve the prior OrderBy(DisplayName).Take(10)
-        // semantics (Codex P2, PR #638). Cache is ~500 users, so the full sort
-        // is cheap.
+        // Request the full match set (the service short-circuits at `limit`, so a small limit
+        // returns an arbitrary subset in non-deterministic cache order) and rank by relevance so
+        // the closest name match leads. Uncapped — people must be findable (Codex P2, PR #638);
+        // cache is ~500 users so the full sort is cheap.
         var users = (await userService.SearchUsersAsync(query, PersonSearchFields.Name, limit: int.MaxValue))
-            .OrderBy(u => u.BurnerName, StringComparer.OrdinalIgnoreCase)
-            .Take(10)
+            .OrderByRelevance()
             .ToList();
 
         var poolVolunteers = await volunteerTrackingService.GetAvailableForDayAsync(eventSettings.Id, shift.DayOffset);

--- a/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
@@ -350,6 +350,23 @@ public sealed class CachingCampServiceTests : ServiceTestHarness
         }
     }
 
+    [HumansFact]
+    public async Task SearchAsync_ServesFromCache_MatchesPublicYearSeasonName()
+    {
+        await SeedSettingsAsync(publicYear: 2026, openSeasons: [2026]);
+        var (camp, _) = await SeedCampWithSeasonAsync(year: 2026); // season "Test Camp", Active
+
+        var results = await _service.SearchAsync("test camp", int.MaxValue);
+
+        var hit = results.Should().ContainSingle().Subject;
+        hit.Slug.Should().Be(camp.Slug);
+        hit.Name.Should().Be("Test Camp");
+
+        // Search must never reach the inner service's SearchAsync (the DB ILike path is gone).
+        await _innerSubstitute.DidNotReceive().SearchAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
     private async Task<(Camp camp, CampSeason season)> SeedCampWithSeasonAsync(int year)
     {
         var camp = new Camp

--- a/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
@@ -464,6 +464,25 @@ public sealed class CachingTeamServiceTests : ServiceTestHarness
         info.PendingRequestCount.Should().Be(2);
     }
 
+    [HumansFact]
+    public async Task SearchAsync_ServesFromCache_MatchesByName_ExcludesHidden()
+    {
+        SeedTeam("Kitchen");
+        var hidden = SeedTeam("Kitchenette");
+        hidden.IsHidden = true;
+        SeedTeam("Gate");
+        await Db.SaveChangesAsync();
+
+        var results = await _service.SearchAsync("kitchen", int.MaxValue);
+
+        // Cache-served name match: case-insensitive, hidden teams excluded, non-matches dropped.
+        results.Select(r => r.Name).Should().ContainSingle().Which.Should().Be("Kitchen");
+
+        // Search must never reach the inner (DB-backed) service.
+        await _innerTeamService.DidNotReceive().SearchAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
     private TeamJoinRequest SeedJoinRequest(Guid teamId, Guid userId)
     {
         var request = new TeamJoinRequest

--- a/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
@@ -159,6 +159,48 @@ public class PersonSearchMatcherTests
         PersonSearchMatcher.Match(human, query, PersonSearchFields.Name).Should().NotBeNull();
     }
 
+    [HumansTheory]
+    [InlineData("joel", "Joël")]   // unaccented query finds accented name
+    [InlineData("Joël", "joel")]   // accented query finds unaccented name
+    public void Name_match_finds_accented_and_unaccented_joel(string query, string burnerName)
+    {
+        var human = Human(burnerName: burnerName);
+
+        PersonSearchMatcher.Match(human, query, PersonSearchFields.Name).Should().NotBeNull();
+    }
+
+    [HumansTheory]
+    [InlineData("Ian", 100)]         // exact
+    [InlineData("Ian Smith", 85)]    // whole-string prefix
+    [InlineData("Bob Ian", 80)]      // token prefix
+    [InlineData("Brian", 60)]        // substring only
+    public void Name_match_score_reflects_match_quality(string burnerName, int expectedScore)
+    {
+        // This ranking is what floats the literal "Ian" above "Adrian"/"Brian" instead of
+        // alphabetizing them. Controllers sort by Score; the matcher assigns it.
+        var human = Human(burnerName: burnerName);
+
+        var match = PersonSearchMatcher.Match(human, "ian", PersonSearchFields.Name);
+
+        match.Should().NotBeNull();
+        match!.Score.Should().Be(expectedScore);
+    }
+
+    [HumansFact]
+    public void Name_match_outscores_non_name_field_match()
+    {
+        // Someone named "Ian" must rank above someone whose bio merely mentions "Ian".
+        var named = Human(burnerName: "Ian");
+        var bioOnly = Human(burnerName: "Zara", bio: "I volunteered with Ian last year");
+
+        var namedMatch = PersonSearchMatcher.Match(named, "ian", PersonSearchFields.PublicAll);
+        var bioMatch = PersonSearchMatcher.Match(bioOnly, "ian", PersonSearchFields.PublicAll);
+
+        namedMatch.Should().NotBeNull();
+        bioMatch.Should().NotBeNull();
+        namedMatch!.Score.Should().BeGreaterThan(bioMatch!.Score);
+    }
+
     [HumansFact]
     public void Legal_name_matches_under_LegalName_scope_but_not_public()
     {

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -720,6 +720,23 @@ public class CachingUserServiceTests
     }
 
     [HumansFact]
+    public async Task SearchUsersAsync_ScoresExactNameAboveSubstringMatch()
+    {
+        // End-to-end wiring: the matcher's relevance Score must flow through the service onto each
+        // HumanSearchResult so controllers can rank "Ian" (exact) above "Brian" (substring).
+        var sut = CreateSut();
+        await PrimeAsync(sut, BuildSearchableUserInfo(Guid.NewGuid(), burnerName: "Ian"));
+        await PrimeAsync(sut, BuildSearchableUserInfo(Guid.NewGuid(), burnerName: "Brian"));
+
+        var results = await sut.SearchUsersAsync("Ian", PersonSearchFields.PublicAll);
+
+        results.Should().HaveCount(2);
+        results.Single(r => string.Equals(r.BurnerName, "Ian", StringComparison.Ordinal)).Score
+            .Should().BeGreaterThan(
+                results.Single(r => string.Equals(r.BurnerName, "Brian", StringComparison.Ordinal)).Score);
+    }
+
+    [HumansFact]
     public async Task SearchUsersAsync_PublicAll_MatchesByCity()
     {
         var sut = CreateSut();

--- a/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
@@ -97,7 +97,8 @@ public class ProfileApiControllerTests
         return ctrl;
     }
 
-    private static HumanSearchResult MakeSearchResult(Guid userId, Guid profileId, string burnerName) =>
+    private static HumanSearchResult MakeSearchResult(
+        Guid userId, Guid profileId, string burnerName, int score = 0) =>
         new(
             UserId: userId,
             ProfileId: profileId,
@@ -105,7 +106,8 @@ public class ProfileApiControllerTests
             ProfilePictureUrl: null,
             MatchField: "Name",
             MatchSnippet: null,
-            MatchedEmail: null);
+            MatchedEmail: null,
+            Score: score);
 
     private static User MakeUser(Guid id) =>
         new() { Id = id, Email = $"viewer-{id:N}@example.com", DisplayName = "Viewer" };
@@ -312,6 +314,43 @@ public class ProfileApiControllerTests
         var row = result.Should().BeOfType<OkObjectResult>().Subject.Value
             .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.Single();
         row.Detail.Should().Be("Discord user#1234");
+    }
+
+    [HumansFact]
+    public async Task Search_orders_results_by_relevance_score_then_name()
+    {
+        // The reported bug: searching "Ian" buried the literal Ian (exact match) a third of the way
+        // down an alphabetical list of substring hits (Adrian, Brian…). The service returns matches
+        // unordered; the controller must rank by Score desc, then name. Service order here is
+        // deliberately scrambled to prove the controller does the sorting.
+        var viewer = MakeUser(Guid.NewGuid());
+        var brian = Guid.NewGuid();
+        var ian = Guid.NewGuid();
+        var adrian = Guid.NewGuid();
+
+        _userService.SearchUsersAsync(Arg.Any<string>(),
+                Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([
+                MakeSearchResult(brian, Guid.NewGuid(), "Brian", score: 60),
+                MakeSearchResult(ian, Guid.NewGuid(), "Ian", score: 100),
+                MakeSearchResult(adrian, Guid.NewGuid(), "Adrian", score: 60),
+            ]);
+
+        _contactFieldService.GetViewerAccessLevelAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ContactFieldVisibility.AllActiveProfiles);
+        _userEmailService.GetVisibleEmailsAsync(Arg.Any<Guid>(), Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _contactFieldService.GetVisibleContactFieldsAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.Search(q: "Ian");
+
+        var rows = result.Should().BeOfType<OkObjectResult>().Subject.Value
+            .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.ToList();
+        // Ian (100) first; the two 60s follow alphabetically.
+        rows.Select(r => r.DisplayName).Should().Equal("Ian", "Adrian", "Brian");
     }
 
     // ==========================================================================


### PR DESCRIPTION
## Why
Search felt broken: searching **"Ian"** returned 126 results sorted **alphabetically**, burying the real Ian a third of the way down. Root cause — humans were the **only** result type with no relevance ranking (teams/camps/rotas/events are already scored). And the inline picker (`/api/profiles/search`, backing the Barrios "Add Active member" box and every `<vc:human-search>`) capped at an **arbitrary 10** rows in cache order *before* alphabetizing, so the target often wasn't even returned.

## What changed
**Relevance ranking (people)**
- `PersonSearchMatcher` scores each match: exact `100` / name-prefix `85` / token-prefix `80` / contains `60` / non-name field (bio/city/email) `40`. Folded → accent-insensitive (`joel` finds `Joël`).
- `HumanSearchResult` carries `Score` (mirrors `GlobalSearchResult.Score`). One shared `OrderByRelevance()` orders every people-search surface (global `/Search`, the `<vc:human-search>` picker, `/Profile/Search`, TeamAdmin member + role pickers, ShiftVolunteer search).

**Uncapped — people must be findable**
- Removed the artificial caps (`10`/`50`/`500` + `.Take(10)`). At ~500 users the full match set is cheap; ranking puts the target first. The picker dropdown is already scrollable, and per-row enrichment is all in-memory cache work.

**Team/camp search is cache-only (never the DB)**
- `CachingTeamService`/`CachingCampService.SearchAsync` now filter the cached `TeamInfo`/`CampInfo` snapshots (same pattern as `CachingUserService`). Team: active + non-hidden name match. Camp: public-year season-name match, Active/Full only.
- Inner `TeamService`/`CampService.SearchAsync` throw `NotSupportedException`; the dead DB-search repo methods (`TeamRepository.SearchAsync`, `CampRepository.SearchForYearAsync`) and their interface declarations are removed.

## Tests
Scoring tiers; `joel`/`Joël`; "Ian ranks above Brian" end-to-end through the controller; cache-served team/camp search (name match, hidden/non-public excluded, inner `SearchAsync` never called). Full non-integration suite green (the 2 failing Stripe integration tests are pre-existing and unrelated).

## Note / not in scope
Team/camp name matching stays **case-insensitive, accent-sensitive** (matches the prior `ILike` behavior); accent-insensitivity was the explicit ask for *people*. Easy to extend later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)