### PR TITLE
Reduce tech debt score by clarifying bounded workflows

### DIFF
--- a/src/Humans.Application/Interfaces/Teams/TeamCoordinatorAccess.cs
+++ b/src/Humans.Application/Interfaces/Teams/TeamCoordinatorAccess.cs
@@ -1,0 +1,31 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces.Teams;
+
+/// <summary>
+/// Shared coordinator-access rule over the Teams read model.
+/// </summary>
+public static class TeamCoordinatorAccess
+{
+    /// <summary>
+    /// Returns true when the user can coordinate the active team through direct
+    /// coordinator membership, a management role, or parent-team coordinator inheritance.
+    /// </summary>
+    public static bool IsCoordinatorOfActiveTeam(
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
+        Guid teamId,
+        Guid userId)
+    {
+        if (!teamsById.TryGetValue(teamId, out var team) || !team.IsActive)
+            return false;
+
+        if (team.Members.Any(member => member.UserId == userId && member.Role == TeamMemberRole.Coordinator))
+            return true;
+
+        if (!team.IsSystemTeam && team.ManagementRoleHolderUserIds?.Contains(userId) == true)
+            return true;
+
+        return team.ParentTeamId is Guid parentTeamId
+            && IsCoordinatorOfActiveTeam(teamsById, parentTeamId, userId);
+    }
+}

--- a/src/Humans.Application/Services/Calendar/CalendarOccurrenceExpander.cs
+++ b/src/Humans.Application/Services/Calendar/CalendarOccurrenceExpander.cs
@@ -22,165 +22,247 @@ public static class CalendarOccurrenceExpander
         IReadOnlyDictionary<Guid, string> teamNamesById,
         ILogger logger)
     {
-        var results = new List<CalendarOccurrence>();
+        var expanded = new List<CalendarOccurrence>();
 
         foreach (var e in events)
         {
-            var owningTeamName = teamNamesById.TryGetValue(e.OwningTeamId, out var name)
-                ? name
-                : string.Empty;
+            var owningTeamName = ResolveTeamName(teamNamesById, e.OwningTeamId);
 
             if (string.IsNullOrWhiteSpace(e.RecurrenceRule))
-            {
-                // Half-open [from, to): overlap when end > from AND start < to.
-                var end = e.EndUtc ?? e.StartUtc;
-                if (end <= from || e.StartUtc >= to) continue;
-                results.Add(new CalendarOccurrence(
-                    EventId: e.Id,
-                    OccurrenceStartUtc: e.StartUtc,
-                    OccurrenceEndUtc: e.EndUtc,
-                    IsAllDay: e.IsAllDay,
-                    Title: e.Title,
-                    Description: e.Description,
-                    Location: e.Location,
-                    LocationUrl: e.LocationUrl,
-                    OwningTeamId: e.OwningTeamId,
-                    OwningTeamName: owningTeamName,
-                    IsRecurring: false,
-                    OriginalOccurrenceStartUtc: null));
-            }
+                AddSingleOccurrence(expanded, e, owningTeamName, from, to);
             else
-            {
-                var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(e.RecurrenceTimezone!);
-                if (zone is null)
-                {
-                    logger.LogWarning(
-                        "CalendarEvent {Id} has unknown timezone {Tz}; skipping occurrence expansion",
-                        e.Id, e.RecurrenceTimezone);
-                    continue;
-                }
-
-                var dur = (e.EndUtc ?? e.StartUtc) - e.StartUtc;
-                var dtStartLocal = e.StartUtc.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-
-                var icalEv = new IcalEvent
-                {
-                    DtStart = new CalDateTime(dtStartLocal, e.RecurrenceTimezone, hasTime: true),
-                    Duration = Ical.Net.DataTypes.Duration.FromTimeSpanExact(TimeSpan.FromTicks(dur.BclCompatibleTicks)),
-                };
-                icalEv.RecurrenceRule = new RecurrencePattern(e.RecurrenceRule!);
-
-                var fromLocal = from.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-                var toLocal = to.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-                var fromCalDt = new CalDateTime(fromLocal, e.RecurrenceTimezone, hasTime: true);
-
-                foreach (var iocc in icalEv.GetOccurrences(fromCalDt, new EvaluationOptions())
-                    .TakeWhile(o => o.Period.StartTime.Value < toLocal))
-                {
-                    var occLocal = LocalDateTime.FromDateTime(iocc.Period.StartTime.Value);
-                    var startInstant = occLocal.InZoneLeniently(zone).ToInstant();
-                    var endInstant = e.EndUtc is null
-                        ? (Instant?)null
-                        : startInstant.Plus(e.EndUtc.Value - e.StartUtc);
-
-                    results.Add(new CalendarOccurrence(
-                        EventId: e.Id,
-                        OccurrenceStartUtc: startInstant,
-                        OccurrenceEndUtc: endInstant,
-                        IsAllDay: e.IsAllDay,
-                        Title: e.Title,
-                        Description: e.Description,
-                        Location: e.Location,
-                        LocationUrl: e.LocationUrl,
-                        OwningTeamId: e.OwningTeamId,
-                        OwningTeamName: owningTeamName,
-                        IsRecurring: true,
-                        OriginalOccurrenceStartUtc: startInstant));
-                }
-            }
+                AddRecurringOccurrences(expanded, e, owningTeamName, from, to, logger);
         }
 
-        // Build a per-event exception lookup once.
         var exceptionsByEvent = events
             .ToDictionary(e => e.Id, e =>
                 e.Exceptions.ToDictionary(x => x.OriginalOccurrenceStartUtc));
 
-        var finalResults = new List<CalendarOccurrence>();
-        var handledExceptionKeys = new HashSet<(Guid EventId, Instant OriginalStart)>();
-
-        foreach (var occ in results)
-        {
-            if (!occ.IsRecurring || occ.OriginalOccurrenceStartUtc is null)
-            {
-                finalResults.Add(occ);
-                continue;
-            }
-
-            if (!exceptionsByEvent.TryGetValue(occ.EventId, out var perEvent) ||
-                !perEvent.TryGetValue(occ.OriginalOccurrenceStartUtc.Value, out var ex))
-            {
-                finalResults.Add(occ);
-                continue;
-            }
-
-            handledExceptionKeys.Add((occ.EventId, ex.OriginalOccurrenceStartUtc));
-
-            if (ex.IsCancelled) continue; // drop
-
-            // Apply overrides; drop if override moves it outside [from, to).
-            var newStart = ex.OverrideStartUtc ?? occ.OccurrenceStartUtc;
-            var newEnd = ex.OverrideEndUtc ?? occ.OccurrenceEndUtc;
-            if (newStart >= to || (newEnd ?? newStart) <= from) continue;
-
-            finalResults.Add(occ with
-            {
-                OccurrenceStartUtc = newStart,
-                OccurrenceEndUtc = newEnd,
-                Title = ex.OverrideTitle ?? occ.Title,
-                Description = ex.OverrideDescription ?? occ.Description,
-                Location = ex.OverrideLocation ?? occ.Location,
-                LocationUrl = ex.OverrideLocationUrl ?? occ.LocationUrl,
-            });
-        }
-
-        // Inject overrides that moved INTO the window from an out-of-window original (expansion missed them).
-        foreach (var ev in events)
-        {
-            var owningTeamName = teamNamesById.TryGetValue(ev.OwningTeamId, out var name)
-                ? name
-                : string.Empty;
-
-            foreach (var ex in ev.Exceptions)
-            {
-                if (handledExceptionKeys.Contains((ev.Id, ex.OriginalOccurrenceStartUtc))) continue;
-                if (ex.IsCancelled) continue;
-                if (ex.OverrideStartUtc is null) continue;
-
-                var newStart = ex.OverrideStartUtc.Value;
-                var eventDuration = (ev.EndUtc ?? ev.StartUtc) - ev.StartUtc;
-                var newEnd = ex.OverrideEndUtc
-                    ?? (ev.EndUtc is null ? null : newStart.Plus(eventDuration));
-
-                if (newStart >= to || (newEnd ?? newStart) <= from) continue;
-
-                finalResults.Add(new CalendarOccurrence(
-                    EventId: ev.Id,
-                    OccurrenceStartUtc: newStart,
-                    OccurrenceEndUtc: newEnd,
-                    IsAllDay: ev.IsAllDay,
-                    Title: ex.OverrideTitle ?? ev.Title,
-                    Description: ex.OverrideDescription ?? ev.Description,
-                    Location: ex.OverrideLocation ?? ev.Location,
-                    LocationUrl: ex.OverrideLocationUrl ?? ev.LocationUrl,
-                    OwningTeamId: ev.OwningTeamId,
-                    OwningTeamName: owningTeamName,
-                    IsRecurring: true,
-                    OriginalOccurrenceStartUtc: ex.OriginalOccurrenceStartUtc));
-            }
-        }
+        var finalResults = ApplyExceptions(expanded, exceptionsByEvent, from, to, out var handledExceptionKeys);
+        AddMovedOverrides(finalResults, events, teamNamesById, handledExceptionKeys, from, to);
 
         return finalResults.OrderBy(o => o.OccurrenceStartUtc).ToList();
     }
+
+    private static void AddSingleOccurrence(
+        List<CalendarOccurrence> results,
+        CalendarEventInfo e,
+        string owningTeamName,
+        Instant from,
+        Instant to)
+    {
+        if (!OverlapsWindow(e.StartUtc, e.EndUtc, from, to)) return;
+
+        results.Add(CreateOccurrence(
+            e,
+            owningTeamName,
+            e.StartUtc,
+            e.EndUtc,
+            isRecurring: false,
+            originalStart: null));
+    }
+
+    private static void AddRecurringOccurrences(
+        List<CalendarOccurrence> results,
+        CalendarEventInfo e,
+        string owningTeamName,
+        Instant from,
+        Instant to,
+        ILogger logger)
+    {
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(e.RecurrenceTimezone!);
+        if (zone is null)
+        {
+            logger.LogWarning(
+                "CalendarEvent {Id} has unknown timezone {Tz}; skipping occurrence expansion",
+                e.Id, e.RecurrenceTimezone);
+            return;
+        }
+
+        var icalEv = CreateIcalEvent(e, zone);
+        var toLocal = to.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
+        var fromCalDt = new CalDateTime(
+            from.InZone(zone).LocalDateTime.ToDateTimeUnspecified(),
+            e.RecurrenceTimezone,
+            hasTime: true);
+
+        foreach (var iocc in icalEv.GetOccurrences(fromCalDt, new EvaluationOptions())
+            .TakeWhile(o => o.Period.StartTime.Value < toLocal))
+        {
+            var startInstant = LocalDateTime
+                .FromDateTime(iocc.Period.StartTime.Value)
+                .InZoneLeniently(zone)
+                .ToInstant();
+            var endInstant = e.EndUtc is null
+                ? (Instant?)null
+                : startInstant.Plus(e.EndUtc.Value - e.StartUtc);
+
+            results.Add(CreateOccurrence(
+                e,
+                owningTeamName,
+                startInstant,
+                endInstant,
+                isRecurring: true,
+                originalStart: startInstant));
+        }
+    }
+
+    private static IcalEvent CreateIcalEvent(CalendarEventInfo e, DateTimeZone zone)
+    {
+        var duration = (e.EndUtc ?? e.StartUtc) - e.StartUtc;
+        var dtStartLocal = e.StartUtc.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
+
+        var icalEv = new IcalEvent
+        {
+            DtStart = new CalDateTime(dtStartLocal, e.RecurrenceTimezone, hasTime: true),
+            Duration = Ical.Net.DataTypes.Duration.FromTimeSpanExact(
+                TimeSpan.FromTicks(duration.BclCompatibleTicks)),
+        };
+        icalEv.RecurrenceRule = new RecurrencePattern(e.RecurrenceRule!);
+        return icalEv;
+    }
+
+    private static List<CalendarOccurrence> ApplyExceptions(
+        IReadOnlyList<CalendarOccurrence> expanded,
+        IReadOnlyDictionary<Guid, Dictionary<Instant, CalendarEventExceptionInfo>> exceptionsByEvent,
+        Instant from,
+        Instant to,
+        out HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys)
+    {
+        var finalResults = new List<CalendarOccurrence>();
+        handledExceptionKeys = [];
+
+        foreach (var occ in expanded)
+        {
+            var exception = FindException(occ, exceptionsByEvent);
+            if (exception is null)
+            {
+                finalResults.Add(occ);
+                continue;
+            }
+
+            handledExceptionKeys.Add((occ.EventId, exception.OriginalOccurrenceStartUtc));
+
+            if (exception.IsCancelled) continue;
+
+            var overridden = ApplyOverride(occ, exception);
+            if (OverlapsWindow(overridden.OccurrenceStartUtc, overridden.OccurrenceEndUtc, from, to))
+                finalResults.Add(overridden);
+        }
+
+        return finalResults;
+    }
+
+    private static CalendarEventExceptionInfo? FindException(
+        CalendarOccurrence occ,
+        IReadOnlyDictionary<Guid, Dictionary<Instant, CalendarEventExceptionInfo>> exceptionsByEvent)
+    {
+        if (!occ.IsRecurring || occ.OriginalOccurrenceStartUtc is null) return null;
+
+        return exceptionsByEvent.TryGetValue(occ.EventId, out var perEvent) &&
+            perEvent.TryGetValue(occ.OriginalOccurrenceStartUtc.Value, out var ex)
+                ? ex
+                : null;
+    }
+
+    private static void AddMovedOverrides(
+        List<CalendarOccurrence> finalResults,
+        IReadOnlyList<CalendarEventInfo> events,
+        IReadOnlyDictionary<Guid, string> teamNamesById,
+        HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys,
+        Instant from,
+        Instant to)
+    {
+        foreach (var ev in events)
+        {
+            var owningTeamName = ResolveTeamName(teamNamesById, ev.OwningTeamId);
+
+            foreach (var ex in ev.Exceptions)
+            {
+                if (!ShouldInjectMovedOverride(ev.Id, ex, handledExceptionKeys)) continue;
+                if (ex.OverrideStartUtc is not { } newStart) continue;
+
+                var newEnd = ResolveOverrideEnd(ev, ex, newStart);
+
+                if (!OverlapsWindow(newStart, newEnd, from, to)) continue;
+
+                finalResults.Add(CreateOccurrence(
+                    ev,
+                    owningTeamName,
+                    newStart,
+                    newEnd,
+                    isRecurring: true,
+                    originalStart: ex.OriginalOccurrenceStartUtc,
+                    title: ex.OverrideTitle,
+                    description: ex.OverrideDescription,
+                    location: ex.OverrideLocation,
+                    locationUrl: ex.OverrideLocationUrl));
+            }
+        }
+    }
+
+    private static bool ShouldInjectMovedOverride(
+        Guid eventId,
+        CalendarEventExceptionInfo ex,
+        HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys) =>
+        !handledExceptionKeys.Contains((eventId, ex.OriginalOccurrenceStartUtc)) &&
+        !ex.IsCancelled &&
+        ex.OverrideStartUtc is not null;
+
+    private static Instant? ResolveOverrideEnd(
+        CalendarEventInfo ev,
+        CalendarEventExceptionInfo ex,
+        Instant newStart)
+    {
+        if (ex.OverrideEndUtc is { } overrideEnd) return overrideEnd;
+        if (ev.EndUtc is null) return null;
+
+        return newStart.Plus((ev.EndUtc.Value - ev.StartUtc));
+    }
+
+    private static CalendarOccurrence ApplyOverride(
+        CalendarOccurrence occurrence,
+        CalendarEventExceptionInfo ex) =>
+        occurrence with
+        {
+            OccurrenceStartUtc = ex.OverrideStartUtc ?? occurrence.OccurrenceStartUtc,
+            OccurrenceEndUtc = ex.OverrideEndUtc ?? occurrence.OccurrenceEndUtc,
+            Title = ex.OverrideTitle ?? occurrence.Title,
+            Description = ex.OverrideDescription ?? occurrence.Description,
+            Location = ex.OverrideLocation ?? occurrence.Location,
+            LocationUrl = ex.OverrideLocationUrl ?? occurrence.LocationUrl,
+        };
+
+    private static CalendarOccurrence CreateOccurrence(
+        CalendarEventInfo ev,
+        string owningTeamName,
+        Instant start,
+        Instant? end,
+        bool isRecurring,
+        Instant? originalStart,
+        string? title = null,
+        string? description = null,
+        string? location = null,
+        string? locationUrl = null) =>
+        new(
+            EventId: ev.Id,
+            OccurrenceStartUtc: start,
+            OccurrenceEndUtc: end,
+            IsAllDay: ev.IsAllDay,
+            Title: title ?? ev.Title,
+            Description: description ?? ev.Description,
+            Location: location ?? ev.Location,
+            LocationUrl: locationUrl ?? ev.LocationUrl,
+            OwningTeamId: ev.OwningTeamId,
+            OwningTeamName: owningTeamName,
+            IsRecurring: isRecurring,
+            OriginalOccurrenceStartUtc: originalStart);
+
+    private static bool OverlapsWindow(Instant start, Instant? end, Instant from, Instant to) =>
+        start < to && (end ?? start) > from;
+
+    private static string ResolveTeamName(IReadOnlyDictionary<Guid, string> teamNamesById, Guid teamId) =>
+        teamNamesById.TryGetValue(teamId, out var name) ? name : string.Empty;
 
     /// <summary>Mirrors the SQL prefilter in <c>CalendarRepository.GetEventsInWindowAsync</c>.</summary>
     public static List<CalendarEventInfo> FilterForWindow(

--- a/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
+++ b/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
@@ -53,43 +53,15 @@ public sealed class CantinaRosterService : ICantinaRosterService
         // to highlight the current row in the per-day mini-table. Falling back
         // to view-side DateTime.UtcNow caused a Madrid coordinator to see
         // tomorrow highlighted late in the evening (CET is ahead of UTC).
-        LocalDate? eventTodayDate = null;
-        if (eventSettings is not null)
-        {
-            var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId)
-                ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
-            eventTodayDate = _clock.GetCurrentInstant().InZone(zone).Date;
-        }
+        var eventTodayDate = GetEventTodayDate(eventSettings);
 
         // Per-day cohort: 7 sequential queries for the on-site user ids. At ~500
         // users this is fine (see CLAUDE.md scale notes).
-        var perDay = new List<(int DayOffset, IReadOnlyList<Guid> UserIds)>(DaysPerWeek);
-        for (var i = 0; i < DaysPerWeek; i++)
-        {
-            var dayOffset = weekStartOffset + i;
-            var userIds = eventSettings is null
-                ? Array.Empty<Guid>()
-                : await _shiftMgmt.GetOnSiteUserIdsForDayAsync(eventSettings.Id, dayOffset, ct).ConfigureAwait(false);
-            perDay.Add((dayOffset, userIds));
-        }
+        var perDay = await LoadWeeklyOnSiteUsersAsync(eventSettings, weekStartOffset, ct).ConfigureAwait(false);
 
         // Build the union of unique on-site user IDs across the week, and
         // map each user id to the set of calendar dates they were on-site.
-        var daysOnSiteByUserId = new Dictionary<Guid, List<LocalDate>>();
-        foreach (var (dayOffset, userIds) in perDay)
-        {
-            var calendarDate = weekStartDate?.PlusDays(dayOffset - weekStartOffset);
-            foreach (var id in userIds)
-            {
-                if (!daysOnSiteByUserId.TryGetValue(id, out var list))
-                {
-                    list = new List<LocalDate>(capacity: DaysPerWeek);
-                    daysOnSiteByUserId[id] = list;
-                }
-                if (calendarDate is not null)
-                    list.Add(calendarDate.Value);
-            }
-        }
+        var daysOnSiteByUserId = BuildDaysOnSiteByUserId(perDay, weekStartOffset, weekStartDate);
 
         var uniqueUserIds = daysOnSiteByUserId.Keys.ToList();
 
@@ -102,22 +74,7 @@ public sealed class CantinaRosterService : ICantinaRosterService
 
         // Build per-day summaries (counts only). Dietary is per-user, so a day's
         // "unanswered" count is over that day's user ids.
-        var days = new List<DayRosterSummaryDto>(DaysPerWeek);
-        for (var i = 0; i < DaysPerWeek; i++)
-        {
-            var (dayOffset, userIds) = perDay[i];
-            var unanswered = 0;
-            foreach (var id in userIds)
-            {
-                if (!profileByUserId.TryGetValue(id, out var p) || string.IsNullOrEmpty(p.DietaryPreference))
-                    unanswered++;
-            }
-            days.Add(new DayRosterSummaryDto(
-                DayOffset: dayOffset,
-                CalendarDate: weekStartDate?.PlusDays(i),
-                TotalOnSite: userIds.Count,
-                UnansweredOnDay: unanswered));
-        }
+        var days = BuildDaySummaries(perDay, weekStartDate, profileByUserId);
 
         if (uniqueUserIds.Count == 0)
         {
@@ -140,68 +97,18 @@ public sealed class CantinaRosterService : ICantinaRosterService
 
         // Unique-humans dietary cohort — every aggregate below is computed over
         // this list so a person on-site multiple days contributes exactly once.
-        var uniqueProfiles = new List<ProfileInfo>(uniqueUserIds.Count);
-        foreach (var id in uniqueUserIds)
-        {
-            if (profileByUserId.TryGetValue(id, out var p))
-                uniqueProfiles.Add(p);
-        }
+        var uniqueProfiles = BuildUniqueProfiles(uniqueUserIds, profileByUserId);
 
         // The 7 calendar dates of the week, used to compute NoShift as the
         // complement of each person's on-site days. Empty when the week
         // has no anchor date (no active event) — in that branch we don't
         // reach this code path anyway since uniqueUserIds.Count == 0.
-        var weekDays = weekStartDate is null
-            ? Array.Empty<LocalDate>()
-            : Enumerable.Range(0, DaysPerWeek)
-                .Select(i => weekStartDate.Value.PlusDays(i))
-                .ToArray();
+        var weekDays = BuildWeekDays(weekStartDate);
 
         // People are returned in unspecified order. Display sort happens at
         // the Web layer in CantinaRosterAssembler (see
         // memory/architecture/display-sort-in-controllers.md).
-        var people = new List<RosterPersonDto>(uniqueUserIds.Count);
-        foreach (var id in uniqueUserIds)
-        {
-            profileByUserId.TryGetValue(id, out var profile);
-            var daysList = daysOnSiteByUserId[id];
-            daysList.Sort();
-
-            // ArrivesOn is non-nullable by cohort invariant: every user
-            // in daysOnSiteByUserId got there by appearing on at least
-            // one day. If weekStartDate is null we never enter this
-            // branch (early-return above), so daysList is non-empty.
-            var arrivesOn = daysList[0];
-
-            // NoShift = weekDays \ on-site days. HashSet for O(1) lookup.
-            IReadOnlyList<LocalDate> noShift;
-            if (weekDays.Length == 0)
-            {
-                noShift = Array.Empty<LocalDate>();
-            }
-            else
-            {
-                var onSiteSet = new HashSet<LocalDate>(daysList);
-                var offList = new List<LocalDate>(DaysPerWeek);
-                foreach (var day in weekDays)
-                {
-                    if (!onSiteSet.Contains(day))
-                        offList.Add(day);
-                }
-                noShift = offList;
-            }
-
-            people.Add(new RosterPersonDto(
-                UserId: id,
-                BurnerName: ResolveBurnerName(profile),
-                ArrivesOn: arrivesOn,
-                NoShift: noShift,
-                DietaryPreference: profile?.DietaryPreference,
-                Allergies: profile?.Allergies is { Count: > 0 } a ? a.ToArray() : Array.Empty<string>(),
-                AllergyOtherText: profile?.AllergyOtherText,
-                Intolerances: profile?.Intolerances is { Count: > 0 } i ? i.ToArray() : Array.Empty<string>(),
-                IntoleranceOtherText: profile?.IntoleranceOtherText));
-        }
+        var people = BuildWeeklyPeople(uniqueUserIds, profileByUserId, daysOnSiteByUserId, weekDays);
 
         var dietaryBreakdown = BuildDietaryBreakdown(uniqueProfiles, uniqueUserIds.Count);
         var (allergyRollup, allergyOther) = BuildRollup(
@@ -268,13 +175,7 @@ public sealed class CantinaRosterService : ICantinaRosterService
 
         // "Today" must be in event timezone (same rationale as the weekly view —
         // a Madrid coordinator late in the evening must not see tomorrow flagged).
-        LocalDate? eventTodayDate = null;
-        if (eventSettings is not null)
-        {
-            var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId)
-                ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
-            eventTodayDate = _clock.GetCurrentInstant().InZone(zone).Date;
-        }
+        var eventTodayDate = GetEventTodayDate(eventSettings);
 
         // Monday-of-week containing this day. With active event use NodaTime
         // day-of-week so the result respects ISO Monday=1. Fallback when no
@@ -383,6 +284,154 @@ public sealed class CantinaRosterService : ICantinaRosterService
             IntoleranceRollup: intoleranceRollup,
             IntoleranceOtherEntries: intoleranceOther,
             People: people);
+    }
+
+    private async Task<List<(int DayOffset, IReadOnlyList<Guid> UserIds)>> LoadWeeklyOnSiteUsersAsync(
+        EventSettings? eventSettings,
+        int weekStartOffset,
+        CancellationToken ct)
+    {
+        var perDay = new List<(int DayOffset, IReadOnlyList<Guid> UserIds)>(DaysPerWeek);
+        for (var i = 0; i < DaysPerWeek; i++)
+        {
+            var dayOffset = weekStartOffset + i;
+            var userIds = eventSettings is null
+                ? Array.Empty<Guid>()
+                : await _shiftMgmt.GetOnSiteUserIdsForDayAsync(eventSettings.Id, dayOffset, ct)
+                    .ConfigureAwait(false);
+            perDay.Add((dayOffset, userIds));
+        }
+
+        return perDay;
+    }
+
+    private static Dictionary<Guid, List<LocalDate>> BuildDaysOnSiteByUserId(
+        IReadOnlyList<(int DayOffset, IReadOnlyList<Guid> UserIds)> perDay,
+        int weekStartOffset,
+        LocalDate? weekStartDate)
+    {
+        var daysOnSiteByUserId = new Dictionary<Guid, List<LocalDate>>();
+        foreach (var (dayOffset, userIds) in perDay)
+        {
+            var calendarDate = weekStartDate?.PlusDays(dayOffset - weekStartOffset);
+            foreach (var id in userIds)
+            {
+                if (!daysOnSiteByUserId.TryGetValue(id, out var list))
+                {
+                    list = new List<LocalDate>(capacity: DaysPerWeek);
+                    daysOnSiteByUserId[id] = list;
+                }
+
+                if (calendarDate is not null)
+                    list.Add(calendarDate.Value);
+            }
+        }
+
+        return daysOnSiteByUserId;
+    }
+
+    private static List<DayRosterSummaryDto> BuildDaySummaries(
+        IReadOnlyList<(int DayOffset, IReadOnlyList<Guid> UserIds)> perDay,
+        LocalDate? weekStartDate,
+        IReadOnlyDictionary<Guid, ProfileInfo> profileByUserId)
+    {
+        var days = new List<DayRosterSummaryDto>(DaysPerWeek);
+        for (var i = 0; i < DaysPerWeek; i++)
+        {
+            var (dayOffset, userIds) = perDay[i];
+            var unanswered = 0;
+            foreach (var id in userIds)
+            {
+                if (!profileByUserId.TryGetValue(id, out var profile)
+                    || string.IsNullOrEmpty(profile.DietaryPreference))
+                    unanswered++;
+            }
+
+            days.Add(new DayRosterSummaryDto(
+                DayOffset: dayOffset,
+                CalendarDate: weekStartDate?.PlusDays(i),
+                TotalOnSite: userIds.Count,
+                UnansweredOnDay: unanswered));
+        }
+
+        return days;
+    }
+
+    private static List<ProfileInfo> BuildUniqueProfiles(
+        IReadOnlyList<Guid> uniqueUserIds,
+        IReadOnlyDictionary<Guid, ProfileInfo> profileByUserId)
+    {
+        var uniqueProfiles = new List<ProfileInfo>(uniqueUserIds.Count);
+        foreach (var id in uniqueUserIds)
+        {
+            if (profileByUserId.TryGetValue(id, out var profile))
+                uniqueProfiles.Add(profile);
+        }
+
+        return uniqueProfiles;
+    }
+
+    private static LocalDate[] BuildWeekDays(LocalDate? weekStartDate)
+        => weekStartDate is null
+            ? Array.Empty<LocalDate>()
+            : Enumerable.Range(0, DaysPerWeek)
+                .Select(i => weekStartDate.Value.PlusDays(i))
+                .ToArray();
+
+    private static List<RosterPersonDto> BuildWeeklyPeople(
+        IReadOnlyList<Guid> uniqueUserIds,
+        IReadOnlyDictionary<Guid, ProfileInfo> profileByUserId,
+        IReadOnlyDictionary<Guid, List<LocalDate>> daysOnSiteByUserId,
+        IReadOnlyList<LocalDate> weekDays)
+    {
+        var people = new List<RosterPersonDto>(uniqueUserIds.Count);
+        foreach (var id in uniqueUserIds)
+        {
+            profileByUserId.TryGetValue(id, out var profile);
+            var daysList = daysOnSiteByUserId[id];
+            daysList.Sort();
+
+            people.Add(new RosterPersonDto(
+                UserId: id,
+                BurnerName: ResolveBurnerName(profile),
+                ArrivesOn: daysList[0],
+                NoShift: BuildNoShiftDays(daysList, weekDays),
+                DietaryPreference: profile?.DietaryPreference,
+                Allergies: profile?.Allergies is { Count: > 0 } a ? a.ToArray() : Array.Empty<string>(),
+                AllergyOtherText: profile?.AllergyOtherText,
+                Intolerances: profile?.Intolerances is { Count: > 0 } i ? i.ToArray() : Array.Empty<string>(),
+                IntoleranceOtherText: profile?.IntoleranceOtherText));
+        }
+
+        return people;
+    }
+
+    private static IReadOnlyList<LocalDate> BuildNoShiftDays(
+        IReadOnlyCollection<LocalDate> daysOnSite,
+        IReadOnlyCollection<LocalDate> weekDays)
+    {
+        if (weekDays.Count == 0)
+            return Array.Empty<LocalDate>();
+
+        var onSiteSet = new HashSet<LocalDate>(daysOnSite);
+        var noShift = new List<LocalDate>(DaysPerWeek);
+        foreach (var day in weekDays)
+        {
+            if (!onSiteSet.Contains(day))
+                noShift.Add(day);
+        }
+
+        return noShift;
+    }
+
+    private LocalDate? GetEventTodayDate(EventSettings? eventSettings)
+    {
+        if (eventSettings is null)
+            return null;
+
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId)
+            ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+        return _clock.GetCurrentInstant().InZone(zone).Date;
     }
 
     private static Dictionary<Guid, ProfileInfo> BuildProfileMap(IReadOnlyDictionary<Guid, UserInfo> userInfos)

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -162,116 +162,176 @@ public sealed class GoogleGroupSyncService(
         IReadOnlyDictionary<Guid, ExpectedMember>? expectedMembersByUserId,
         CancellationToken ct)
     {
-        var lookup = await provisioningClient.LookupGroupIdAsync(claim.GroupKey, ct);
-
-        // Provisioning: a claim references a group key that doesn't exist in Google.
-        // Cloud Identity returns HTTP 404 — or HTTP 403 with a "permission
-        // denied" body, because Google won't confirm/deny existence to a
-        // caller without access. See IsGroupNotFound. Best-effort
-        // create-then-retry-lookup; on failure we fall through to the existing
-        // error path.
-        if (lookup.GroupNumericId is null
-            && IsGroupNotFound(lookup.Error)
-            && action == SyncAction.Execute)
-        {
-            try
-            {
-                var create = await provisioningClient.CreateGroupAsync(
-                    claim.GroupKey,
-                    displayName: claim.GroupKey,
-                    description: $"Auto-provisioned group ({claim.GroupKey}).",
-                    ct);
-                if (create.GroupNumericId is not null)
-                {
-                    logger.LogInformation(
-                        "Auto-provisioned Google Group for {GroupKey}",
-                        claim.GroupKey);
-
-                    // Apply enforced settings. Non-fatal: the group exists
-                    // either way; drift detection will catch any failed
-                    // application on the next /AllGroups sweep. Isolated in
-                    // its own try/catch so a thrown transport/credential
-                    // failure here doesn't skip the follow-up lookup +
-                    // membership reconcile below.
-                    try
-                    {
-                        var settingsError = await provisioningClient.UpdateGroupSettingsAsync(
-                            claim.GroupKey,
-                            GroupSettingsPolicy.BuildExpected(_options.Groups),
-                            ct);
-                        if (settingsError is not null)
-                        {
-                            logger.LogWarning(
-                                "Failed to apply group settings to auto-provisioned {GroupKey} (HTTP {StatusCode}): {Message}. Group was created with Google defaults",
-                                claim.GroupKey,
-                                settingsError.StatusCode,
-                                settingsError.RawMessage);
-                        }
-                    }
-                    catch (Exception settingsEx)
-                    {
-                        logger.LogWarning(
-                            "Error applying group settings to auto-provisioned {GroupKey}; continuing with membership reconcile: {Error}",
-                            claim.GroupKey,
-                            settingsEx.Message);
-                    }
-
-                    lookup = await provisioningClient.LookupGroupIdAsync(claim.GroupKey, ct);
-                }
-                else
-                {
-                    logger.LogWarning(
-                        "Failed to auto-provision Google Group for {GroupKey}: HTTP {StatusCode} {Message}",
-                        claim.GroupKey,
-                        create.Error?.StatusCode,
-                        create.Error?.RawMessage);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(
-                    "Error auto-provisioning Google Group for {GroupKey}; treating as failed lookup: {Error}",
-                    claim.GroupKey,
-                    ex.Message);
-            }
-        }
+        var lookup = await LookupOrProvisionGroupAsync(claim, action, ct);
 
         if (lookup.GroupNumericId is null)
         {
-            var error = FormatGoogleError("Google group lookup failed", lookup.Error);
-            await RecordGroupErrorAsync(resource, error, ct);
-            logger.LogWarning(
-                "Google group sync failed for {GroupKey}: {Error}",
-                claim.GroupKey,
-                error);
-            if (scheduleRetryOnFailure)
-                await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-            return BuildErrorDiff(claim.GroupKey, resource, error);
+            return await BuildClaimErrorDiffAsync(
+                claim,
+                resource,
+                "Google group lookup failed",
+                lookup.Error,
+                scheduleRetryOnFailure,
+                nextRetryAttempt,
+                ct);
         }
 
         expectedMembersByUserId ??= await HydrateExpectedMembersByUserIdAsync(claim.UserIds, ct);
         var expectedMembers = BuildExpectedMembersByEmail(claim.UserIds, expectedMembersByUserId);
-        var expectedEmails = expectedMembers.Keys.ToHashSet(NormalizingEmailComparer.Instance);
-
         var list = await membershipClient.ListMembershipsAsync(lookup.GroupNumericId, ct);
         if (list.Memberships is null)
         {
-            var error = FormatGoogleError("Google group membership list failed", list.Error);
-            await RecordGroupErrorAsync(resource, error, ct);
-            logger.LogWarning(
-                "Google group sync failed for {GroupKey}: {Error}",
-                claim.GroupKey,
-                error);
-            if (scheduleRetryOnFailure)
-                await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-            return BuildErrorDiff(claim.GroupKey, resource, error);
+            return await BuildClaimErrorDiffAsync(
+                claim,
+                resource,
+                "Google group membership list failed",
+                list.Error,
+                scheduleRetryOnFailure,
+                nextRetryAttempt,
+                ct);
         }
 
-        var currentByEmail = list.Memberships
-            .Where(m => !string.IsNullOrWhiteSpace(m.MemberEmail))
-            .GroupBy(m => m.MemberEmail!, NormalizingEmailComparer.Instance)
-            .ToDictionary(g => g.Key, g => g.First().ResourceName, NormalizingEmailComparer.Instance);
+        var plan = await BuildGroupMembershipPlanAsync(expectedMembers, list.Memberships, ct);
 
+        if (action == SyncAction.Execute)
+        {
+            var errorDiff = await ApplyGroupMembershipChangesAsync(
+                claim,
+                resource,
+                lookup.GroupNumericId,
+                plan,
+                scheduleRetryOnFailure,
+                nextRetryAttempt,
+                ct);
+            if (errorDiff is not null)
+                return errorDiff;
+        }
+
+        return new ResourceSyncDiff
+        {
+            ResourceId = resource?.Id ?? Guid.Empty,
+            ResourceName = resource?.Name ?? claim.GroupKey,
+            ResourceType = GoogleResourceType.Group.ToString(),
+            GoogleId = lookup.GroupNumericId,
+            Url = resource?.Url,
+            Members = plan.Members
+        };
+    }
+
+    private async Task<GroupLookupIdResult> LookupOrProvisionGroupAsync(
+        GroupClaim claim,
+        SyncAction action,
+        CancellationToken ct)
+    {
+        var lookup = await provisioningClient.LookupGroupIdAsync(claim.GroupKey, ct);
+        if (lookup.GroupNumericId is not null || !IsGroupNotFound(lookup.Error) || action != SyncAction.Execute)
+            return lookup;
+
+        return await TryProvisionGroupAsync(claim.GroupKey, lookup, ct);
+    }
+
+    private async Task<GroupLookupIdResult> TryProvisionGroupAsync(
+        string groupKey,
+        GroupLookupIdResult failedLookup,
+        CancellationToken ct)
+    {
+        try
+        {
+            var create = await provisioningClient.CreateGroupAsync(
+                groupKey,
+                displayName: groupKey,
+                description: $"Auto-provisioned group ({groupKey}).",
+                ct);
+
+            if (create.GroupNumericId is null)
+            {
+                logger.LogWarning(
+                    "Failed to auto-provision Google Group for {GroupKey}: HTTP {StatusCode} {Message}",
+                    groupKey,
+                    create.Error?.StatusCode,
+                    create.Error?.RawMessage);
+                return failedLookup;
+            }
+
+            logger.LogInformation("Auto-provisioned Google Group for {GroupKey}", groupKey);
+            await TryApplyProvisionedGroupSettingsAsync(groupKey, ct);
+            return await provisioningClient.LookupGroupIdAsync(groupKey, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                "Error auto-provisioning Google Group for {GroupKey}; treating as failed lookup: {Error}",
+                groupKey,
+                ex.Message);
+            return failedLookup;
+        }
+    }
+
+    private async Task TryApplyProvisionedGroupSettingsAsync(string groupKey, CancellationToken ct)
+    {
+        try
+        {
+            var settingsError = await provisioningClient.UpdateGroupSettingsAsync(
+                groupKey,
+                GroupSettingsPolicy.BuildExpected(_options.Groups),
+                ct);
+            if (settingsError is not null)
+            {
+                logger.LogWarning(
+                    "Failed to apply group settings to auto-provisioned {GroupKey} (HTTP {StatusCode}): {Message}. Group was created with Google defaults",
+                    groupKey,
+                    settingsError.StatusCode,
+                    settingsError.RawMessage);
+            }
+        }
+        catch (Exception settingsEx)
+        {
+            logger.LogWarning(
+                "Error applying group settings to auto-provisioned {GroupKey}; continuing with membership reconcile: {Error}",
+                groupKey,
+                settingsEx.Message);
+        }
+    }
+
+    private async Task<ResourceSyncDiff> BuildClaimErrorDiffAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string errorPrefix,
+        GoogleClientError? googleError,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        var error = FormatGoogleError(errorPrefix, googleError);
+        await RecordGroupErrorAsync(resource, error, ct);
+        logger.LogWarning("Google group sync failed for {GroupKey}: {Error}", claim.GroupKey, error);
+        if (scheduleRetryOnFailure)
+            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
+
+        return BuildErrorDiff(claim.GroupKey, resource, error);
+    }
+
+    private async Task<GroupMembershipPlan> BuildGroupMembershipPlanAsync(
+        IReadOnlyDictionary<string, ExpectedMember> expectedMembers,
+        IReadOnlyList<GroupMembership> memberships,
+        CancellationToken ct)
+    {
+        var currentByEmail = memberships
+            .Where(member => !string.IsNullOrWhiteSpace(member.MemberEmail))
+            .GroupBy(member => member.MemberEmail!, NormalizingEmailComparer.Instance)
+            .ToDictionary(group => group.Key, group => group.First().ResourceName, NormalizingEmailComparer.Instance);
+        var members = BuildExpectedGroupMemberStatuses(expectedMembers, currentByEmail);
+
+        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(ct);
+        AddExtraGroupMemberStatuses(members, expectedMembers.Keys, currentByEmail.Keys, serviceAccountEmail);
+
+        return new GroupMembershipPlan(members, currentByEmail);
+    }
+
+    private static List<MemberSyncStatus> BuildExpectedGroupMemberStatuses(
+        IReadOnlyDictionary<string, ExpectedMember> expectedMembers,
+        IReadOnlyDictionary<string, string> currentByEmail)
+    {
         var members = new List<MemberSyncStatus>();
         foreach (var (email, expected) in expectedMembers)
         {
@@ -284,115 +344,170 @@ public sealed class GoogleGroupSyncService(
                 ProfilePictureUrl: expected.ProfilePictureUrl));
         }
 
-        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(ct);
-        foreach (var email in currentByEmail.Keys
-                     .Where(email =>
-                         !expectedEmails.Contains(email) &&
-                         !string.Equals(email, serviceAccountEmail, StringComparison.OrdinalIgnoreCase)))
+        return members;
+    }
+
+    private static void AddExtraGroupMemberStatuses(
+        List<MemberSyncStatus> members,
+        IEnumerable<string> expectedEmails,
+        IEnumerable<string> currentEmails,
+        string serviceAccountEmail)
+    {
+        var expectedEmailSet = expectedEmails.ToHashSet(NormalizingEmailComparer.Instance);
+        foreach (var email in currentEmails.Where(email =>
+                     !expectedEmailSet.Contains(email) &&
+                     !string.Equals(email, serviceAccountEmail, StringComparison.OrdinalIgnoreCase)))
         {
             members.Add(new MemberSyncStatus(email, email, MemberSyncState.Extra, []));
         }
+    }
 
-        if (action == SyncAction.Execute)
+    private async Task<ResourceSyncDiff?> ApplyGroupMembershipChangesAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string groupNumericId,
+        GroupMembershipPlan plan,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        var mode = await syncSettingsService.GetModeAsync(SyncServiceType.GoogleGroups, ct);
+        if (mode != SyncMode.None)
         {
-            var mode = await syncSettingsService.GetModeAsync(SyncServiceType.GoogleGroups, ct);
-            if (mode != SyncMode.None)
-            {
-                foreach (var member in members.Where(m => m.State == MemberSyncState.Missing))
-                {
-                    var add = await membershipClient.CreateMembershipAsync(lookup.GroupNumericId, member.Email, ct);
-                    if (add.Outcome == GroupMembershipMutationOutcome.Failed)
-                    {
-                        var error = await HandleGroupAddFailureAsync(resource, claim.GroupKey, member.Email, add.Error, ct);
-                        logger.LogWarning(
-                            "Google group sync failed for {GroupKey} member {Email}: {Error}",
-                            claim.GroupKey,
-                            member.Email,
-                            error);
-                        await RecordMemberErrorAsync(
-                            resource,
-                            member.Email,
-                            error,
-                            AuditAction.GoogleResourceAccessGranted,
-                            ct);
-                        if (scheduleRetryOnFailure)
-                            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-                        return BuildErrorDiff(claim.GroupKey, resource, error, members);
-                    }
-
-                    if (resource is not null && add.Outcome == GroupMembershipMutationOutcome.Added)
-                    {
-                        await auditLogService.LogGoogleSyncAsync(
-                            AuditAction.GoogleResourceAccessGranted,
-                            resource.Id,
-                            $"Granted Google Group access to {member.Email} ({resource.Name})",
-                            nameof(GoogleGroupSyncService),
-                            member.Email,
-                            "MEMBER",
-                            GoogleSyncSource.ScheduledSync,
-                            success: true);
-                    }
-                }
-            }
-
-            if (mode == SyncMode.AddAndRemove)
-            {
-                foreach (var member in members.Where(m => m.State == MemberSyncState.Extra))
-                {
-                    if (!currentByEmail.TryGetValue(member.Email, out var membershipResourceName))
-                        continue;
-
-                    var deleteError = await membershipClient.DeleteMembershipAsync(membershipResourceName, ct);
-                    if (deleteError is not null)
-                    {
-                        var error = FormatGoogleError($"Google group remove failed for {member.Email}", deleteError);
-                        logger.LogWarning(
-                            "Google group sync failed for {GroupKey} member {Email}: {Error}",
-                            claim.GroupKey,
-                            member.Email,
-                            error);
-                        await RecordMemberErrorAsync(
-                            resource,
-                            member.Email,
-                            error,
-                            AuditAction.GoogleResourceAccessRevoked,
-                            ct);
-                        if (scheduleRetryOnFailure)
-                            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
-                        return BuildErrorDiff(claim.GroupKey, resource, error, members);
-                    }
-
-                    if (resource is not null)
-                    {
-                        await auditLogService.LogGoogleSyncAsync(
-                            AuditAction.GoogleResourceAccessRevoked,
-                            resource.Id,
-                            $"Removed {member.Email} from Google Group ({resource.Name})",
-                            nameof(GoogleGroupSyncService),
-                            member.Email,
-                            "MEMBER",
-                            GoogleSyncSource.ScheduledSync,
-                            success: true);
-                    }
-
-                    await NotifyRemovalAsync(member.Email, resource, claim.GroupKey, ct);
-                }
-            }
-
-            if (resource is not null && mode != SyncMode.None)
-                await teamResourceService.MarkResourceSyncedAsync(resource.Id, clock.GetCurrentInstant(), ct);
+            var addError = await ApplyMissingGroupMembersAsync(
+                claim, resource, groupNumericId, plan.Members, scheduleRetryOnFailure, nextRetryAttempt, ct);
+            if (addError is not null)
+                return addError;
         }
 
-        return new ResourceSyncDiff
+        if (mode == SyncMode.AddAndRemove)
         {
-            ResourceId = resource?.Id ?? Guid.Empty,
-            ResourceName = resource?.Name ?? claim.GroupKey,
-            ResourceType = GoogleResourceType.Group.ToString(),
-            GoogleId = lookup.GroupNumericId,
-            Url = resource?.Url,
-            Members = members
-        };
+            var removeError = await ApplyExtraGroupMembersAsync(
+                claim, resource, plan, scheduleRetryOnFailure, nextRetryAttempt, ct);
+            if (removeError is not null)
+                return removeError;
+        }
+
+        if (resource is not null && mode != SyncMode.None)
+            await teamResourceService.MarkResourceSyncedAsync(resource.Id, clock.GetCurrentInstant(), ct);
+
+        return null;
     }
+
+    private async Task<ResourceSyncDiff?> ApplyMissingGroupMembersAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string groupNumericId,
+        List<MemberSyncStatus> members,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        foreach (var member in members.Where(m => m.State == MemberSyncState.Missing))
+        {
+            var add = await membershipClient.CreateMembershipAsync(groupNumericId, member.Email, ct);
+            if (add.Outcome == GroupMembershipMutationOutcome.Failed)
+            {
+                return await BuildMemberMutationErrorDiffAsync(
+                    claim,
+                    resource,
+                    member.Email,
+                    await HandleGroupAddFailureAsync(resource, claim.GroupKey, member.Email, add.Error, ct),
+                    AuditAction.GoogleResourceAccessGranted,
+                    members,
+                    scheduleRetryOnFailure,
+                    nextRetryAttempt,
+                    ct);
+            }
+
+            if (resource is not null && add.Outcome == GroupMembershipMutationOutcome.Added)
+                await LogGroupMemberAddedAsync(resource, member.Email);
+        }
+
+        return null;
+    }
+
+    private async Task<ResourceSyncDiff?> ApplyExtraGroupMembersAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        GroupMembershipPlan plan,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        foreach (var member in plan.Members.Where(m => m.State == MemberSyncState.Extra))
+        {
+            if (!plan.CurrentByEmail.TryGetValue(member.Email, out var membershipResourceName))
+                continue;
+
+            var deleteError = await membershipClient.DeleteMembershipAsync(membershipResourceName, ct);
+            if (deleteError is not null)
+            {
+                return await BuildMemberMutationErrorDiffAsync(
+                    claim,
+                    resource,
+                    member.Email,
+                    FormatGoogleError($"Google group remove failed for {member.Email}", deleteError),
+                    AuditAction.GoogleResourceAccessRevoked,
+                    plan.Members,
+                    scheduleRetryOnFailure,
+                    nextRetryAttempt,
+                    ct);
+            }
+
+            if (resource is not null)
+                await LogGroupMemberRemovedAsync(resource, member.Email);
+
+            await NotifyRemovalAsync(member.Email, resource, claim.GroupKey, ct);
+        }
+
+        return null;
+    }
+
+    private async Task<ResourceSyncDiff> BuildMemberMutationErrorDiffAsync(
+        GroupClaim claim,
+        GoogleResourceSnapshot? resource,
+        string email,
+        string error,
+        AuditAction auditAction,
+        List<MemberSyncStatus> members,
+        bool scheduleRetryOnFailure,
+        int nextRetryAttempt,
+        CancellationToken ct)
+    {
+        logger.LogWarning(
+            "Google group sync failed for {GroupKey} member {Email}: {Error}",
+            claim.GroupKey,
+            email,
+            error);
+        await RecordMemberErrorAsync(resource, email, error, auditAction, ct);
+        if (scheduleRetryOnFailure)
+            await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
+
+        return BuildErrorDiff(claim.GroupKey, resource, error, members);
+    }
+
+    private Task LogGroupMemberAddedAsync(GoogleResourceSnapshot resource, string email)
+        => auditLogService.LogGoogleSyncAsync(
+            AuditAction.GoogleResourceAccessGranted,
+            resource.Id,
+            $"Granted Google Group access to {email} ({resource.Name})",
+            nameof(GoogleGroupSyncService),
+            email,
+            "MEMBER",
+            GoogleSyncSource.ScheduledSync,
+            success: true);
+
+    private Task LogGroupMemberRemovedAsync(GoogleResourceSnapshot resource, string email)
+        => auditLogService.LogGoogleSyncAsync(
+            AuditAction.GoogleResourceAccessRevoked,
+            resource.Id,
+            $"Removed {email} from Google Group ({resource.Name})",
+            nameof(GoogleGroupSyncService),
+            email,
+            "MEMBER",
+            GoogleSyncSource.ScheduledSync,
+            success: true);
 
     private async Task<Dictionary<Guid, ExpectedMember>> HydrateExpectedMembersByUserIdAsync(
         IReadOnlyCollection<Guid> userIds,
@@ -707,5 +822,8 @@ public sealed class GoogleGroupSyncService(
     }
 
     private sealed record ExpectedMember(Guid UserId, string Email, string DisplayName, string? ProfilePictureUrl);
-}
 
+    private sealed record GroupMembershipPlan(
+        List<MemberSyncStatus> Members,
+        Dictionary<string, string> CurrentByEmail);
+}

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -598,242 +598,48 @@ public sealed class GoogleWorkspaceSyncService(
     {
         var primary = resources[0];
 
-        // Build a lookup from team slug to permission level.
-        var levelByTeamSlug = new Dictionary<string, DrivePermissionLevel>(StringComparer.Ordinal);
-        foreach (var resource in resources)
-        {
-            var slug = teamsById[resource.TeamId].Slug;
-            if (!levelByTeamSlug.TryGetValue(slug, out var existing) || resource.DrivePermissionLevel > existing)
-                levelByTeamSlug[slug] = resource.DrivePermissionLevel;
-        }
+        var levelByTeamSlug = BuildDriveLevelByTeamSlug(resources, teamsById);
 
         try
         {
             // Expected: union of all linked teams' active members + child team rollup.
-            var membersByEmail = new Dictionary<string, (string DisplayName, Guid UserId, string? ProfilePictureUrl, List<TeamLink> TeamLinks)>(
-                NormalizingEmailComparer.Instance);
+            var membersByEmail = await BuildExpectedDriveMembersByEmailAsync(
+                resources,
+                teamsById,
+                membersByTeam,
+                childMembersByTeam,
+                cancellationToken);
 
-            // Issue #635 (§15i): bulk-fetch UserEmails once for all members
-            // across the team union so TryGetGoogleEmail does not traverse
-            // user.UserEmails cross-domain.
-            var allMemberUserIds = membersByTeam.Values.SelectMany(v => v.Select(m => m.UserId))
-                .Concat(childMembersByTeam.Values.SelectMany(v => v.Select(m => m.UserId)))
-                .Distinct()
-                .ToList();
-            var emailsByUserId = await userEmailService.GetEntitiesByUserIdsAsync(allMemberUserIds, cancellationToken);
-
-            foreach (var resource in resources)
-            {
-                var level = resource.DrivePermissionLevel is DrivePermissionLevel.None
-                    ? null : resource.DrivePermissionLevel.ToString();
-                var resourceTeam = teamsById[resource.TeamId];
-                var teamLink = new TeamLink(resourceTeam.Name, resourceTeam.Slug, level);
-
-                var teamMembers = membersByTeam.GetValueOrDefault(resource.TeamId, []);
-                foreach (var tm in teamMembers)
-                {
-                    var memberEmail = TryGetGoogleEmail(tm.UserId, tm.GoogleEmailStatus, emailsByUserId);
-                    if (memberEmail is null) continue;
-
-                    if (membersByEmail.TryGetValue(memberEmail, out var existing))
-                    {
-                        if (!existing.TeamLinks.Any(tl => string.Equals(tl.Name, teamLink.Name, StringComparison.Ordinal)))
-                            existing.TeamLinks.Add(teamLink);
-                    }
-                    else
-                    {
-                        membersByEmail[memberEmail] = (tm.DisplayName, tm.UserId, tm.ProfilePictureUrl, [teamLink]);
-                    }
-                }
-
-                var childMembers = childMembersByTeam.GetValueOrDefault(resource.TeamId, []);
-                foreach (var cm in childMembers)
-                {
-                    var memberEmail = TryGetGoogleEmail(cm.UserId, cm.GoogleEmailStatus, emailsByUserId);
-                    if (memberEmail is null) continue;
-
-                    var childTeam = teamsById[cm.TeamId];
-                    var childTeamLink = new TeamLink(childTeam.Name, childTeam.Slug, level);
-                    if (membersByEmail.TryGetValue(memberEmail, out var existing2))
-                    {
-                        if (!existing2.TeamLinks.Any(tl => string.Equals(tl.Name, childTeamLink.Name, StringComparison.Ordinal)))
-                            existing2.TeamLinks.Add(childTeamLink);
-                    }
-                    else
-                    {
-                        membersByEmail[memberEmail] = (cm.DisplayName, cm.UserId, cm.ProfilePictureUrl, [childTeamLink]);
-                    }
-                }
-            }
-
-            var linkedTeams = resources.Select(r =>
-                {
-                    var t = teamsById[r.TeamId];
-                    return new TeamLink(t.Name, t.Slug,
-                        r.DrivePermissionLevel is DrivePermissionLevel.None ? null : r.DrivePermissionLevel.ToString());
-                })
-                .DistinctBy(tl => tl.Slug, StringComparer.Ordinal).ToList();
+            var linkedTeams = BuildDriveLinkedTeams(resources, teamsById);
 
             // Current: Drive permissions.
             var permsResult = await drivePermissions.ListPermissionsAsync(primary.GoogleId, cancellationToken);
             if (permsResult.Permissions is null)
             {
-                var code = permsResult.Error?.StatusCode ?? 0;
-                var msg = $"Google API error: {code} — {permsResult.Error?.RawMessage}";
-                logger.LogWarning(
-                    "Failed to list permissions for {GoogleId}: {Message}", primary.GoogleId, msg);
-                if (action == SyncAction.Execute)
-                {
-                    await resourceRepository.SetErrorMessageManyAsync(
-                        resources.Select(r => r.Id).ToList(), msg, cancellationToken);
-                }
-                return new ResourceSyncDiff
-                {
-                    ResourceId = primary.Id,
-                    ResourceName = primary.Name,
-                    ResourceType = primary.ResourceType.ToString(),
-                    GoogleId = primary.GoogleId,
-                    Url = primary.Url,
-                    PermissionLevel = primary.DrivePermissionLevel.ToString(),
-                    LinkedTeams = linkedTeams,
-                    ErrorMessage = msg
-                };
+                return await BuildDrivePermissionListErrorDiffAsync(
+                    primary,
+                    resources,
+                    linkedTeams,
+                    permsResult,
+                    action,
+                    cancellationToken);
             }
 
             var permissions = permsResult.Permissions;
-            var allEmails = new HashSet<string>(NormalizingEmailComparer.Instance);
-            var directEmails = new HashSet<string>(NormalizingEmailComparer.Instance);
-            var roleByEmail = new Dictionary<string, string>(NormalizingEmailComparer.Instance);
+            var permissionSnapshot = BuildDrivePermissionSnapshot(permissions);
 
-            foreach (var perm in permissions)
-            {
-                if (IsAnyUserPermission(perm))
-                {
-                    allEmails.Add(perm.EmailAddress!);
-                    if (!string.IsNullOrEmpty(perm.Role))
-                        roleByEmail[perm.EmailAddress!] = perm.Role;
-                }
-                if (IsDirectManagedPermission(perm))
-                    directEmails.Add(perm.EmailAddress!);
-            }
-
-            var members = new List<MemberSyncStatus>();
-
-            foreach (var (email, (displayName, userId, profilePictureUrl, teamLinks)) in membersByEmail)
-            {
-                var memberMaxLevel = DrivePermissionLevel.None;
-                foreach (var tl in teamLinks)
-                {
-                    if (levelByTeamSlug.TryGetValue(tl.Slug, out var tlLevel) && tlLevel > memberMaxLevel)
-                        memberMaxLevel = tlLevel;
-                }
-                var memberExpectedRole = memberMaxLevel > DrivePermissionLevel.None
-                    ? memberMaxLevel.ToApiRole() : null;
-
-                MemberSyncState state;
-                roleByEmail.TryGetValue(email, out var currentRole);
-
-                if (!allEmails.Contains(email))
-                {
-                    state = MemberSyncState.Missing;
-                }
-                else if (!directEmails.Contains(email))
-                {
-                    state = MemberSyncState.Inherited;
-                }
-                else
-                {
-                    var currentLevel = ParseApiRole(currentRole);
-                    state = currentLevel.HasValue && currentLevel.Value < memberMaxLevel
-                        ? MemberSyncState.WrongRole
-                        : MemberSyncState.Correct;
-                }
-
-                members.Add(new MemberSyncStatus(email, displayName, state, teamLinks, currentRole, memberExpectedRole,
-                    UserId: userId, ProfilePictureUrl: profilePictureUrl));
-            }
-
-            var saEmail = await teamResourceClient.GetServiceAccountEmailAsync(cancellationToken);
-            var nonMemberEmails = allEmails
-                .Where(e => !membersByEmail.ContainsKey(e) &&
-                    !string.Equals(e, saEmail, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            var extraIdentities = await ResolveExtraEmailIdentitiesAsync(nonMemberEmails, cancellationToken);
-
-            foreach (var email in nonMemberEmails)
-            {
-                var state = directEmails.Contains(email)
-                    ? MemberSyncState.Extra
-                    : MemberSyncState.Inherited;
-                roleByEmail.TryGetValue(email, out var extraRole);
-
-                if (extraIdentities.TryGetValue(email, out var identity))
-                {
-                    members.Add(new MemberSyncStatus(email, identity.DisplayName, state, [], extraRole,
-                        UserId: identity.UserId, ProfilePictureUrl: identity.ProfilePictureUrl));
-                }
-                else
-                {
-                    members.Add(new MemberSyncStatus(email, email, state, [], extraRole));
-                }
-            }
+            var members = await BuildDriveMemberStatusesAsync(
+                membersByEmail,
+                levelByTeamSlug,
+                permissionSnapshot,
+                cancellationToken);
 
             if (action == SyncAction.Execute)
             {
-                foreach (var member in members.Where(m => m.State is MemberSyncState.Missing or MemberSyncState.WrongRole))
-                {
-                    try
-                    {
-                        var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.Contributor;
-                        await AddUserToDriveAsync(primary, member.Email, memberLevel, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Failed to grant Drive access to {Email} on {GoogleId}",
-                            member.Email, primary.GoogleId);
-                    }
-                }
-
-                foreach (var member in members.Where(m => m.State == MemberSyncState.Extra))
-                {
-                    try
-                    {
-                        var permToRemove = permissions.FirstOrDefault(p =>
-                            IsDirectManagedPermission(p) &&
-                            NormalizingEmailComparer.Instance.Equals(p.EmailAddress, member.Email));
-
-                        if (permToRemove?.Id is null)
-                        {
-                            logger.LogInformation(
-                                "Skipping removal of {Email} from {GoogleId} — permission is inherited, not direct",
-                                member.Email, primary.GoogleId);
-                            continue;
-                        }
-
-                        await RemoveUserFromDriveAsync(primary, permToRemove.Id, member.Email, cancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Failed to remove Drive access for {Email} on {GoogleId}",
-                            member.Email, primary.GoogleId);
-                    }
-                }
-
-                await resourceRepository.MarkSyncedManyAsync(
-                    resources.Select(r => r.Id).ToList(), now, cancellationToken);
+                await ApplyDriveResourceChangesAsync(primary, resources, permissions, members, now, cancellationToken);
             }
 
-            return new ResourceSyncDiff
-            {
-                ResourceId = primary.Id,
-                ResourceName = primary.Name,
-                ResourceType = primary.ResourceType.ToString(),
-                GoogleId = primary.GoogleId,
-                Url = primary.Url,
-                PermissionLevel = primary.DrivePermissionLevel.ToString(),
-                LinkedTeams = linkedTeams,
-                Members = members
-            };
+            return BuildDriveSyncDiff(primary, linkedTeams, members);
         }
         catch (Exception ex)
         {
@@ -843,25 +649,367 @@ public sealed class GoogleWorkspaceSyncService(
                 await resourceRepository.SetErrorMessageManyAsync(
                     resources.Select(r => r.Id).ToList(), ex.Message, cancellationToken);
             }
-            return new ResourceSyncDiff
-            {
-                ResourceId = primary.Id,
-                ResourceName = primary.Name,
-                ResourceType = primary.ResourceType.ToString(),
-                GoogleId = primary.GoogleId,
-                Url = primary.Url,
-                PermissionLevel = primary.DrivePermissionLevel.ToString(),
-                LinkedTeams = resources.Select(r =>
-                    {
-                        var t = teamsById[r.TeamId];
-                        return new TeamLink(t.Name, t.Slug,
-                            r.DrivePermissionLevel is DrivePermissionLevel.None ? null : r.DrivePermissionLevel.ToString());
-                    })
-                    .DistinctBy(tl => tl.Slug, StringComparer.Ordinal).ToList(),
-                ErrorMessage = ex.Message
-            };
+            return BuildDriveSyncDiff(
+                primary,
+                BuildDriveLinkedTeams(resources, teamsById),
+                members: [],
+                errorMessage: ex.Message);
         }
     }
+
+    private static Dictionary<string, DrivePermissionLevel> BuildDriveLevelByTeamSlug(
+        IEnumerable<GoogleResource> resources,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById)
+    {
+        var levelByTeamSlug = new Dictionary<string, DrivePermissionLevel>(StringComparer.Ordinal);
+        foreach (var resource in resources)
+        {
+            var slug = teamsById[resource.TeamId].Slug;
+            if (!levelByTeamSlug.TryGetValue(slug, out var existing) || resource.DrivePermissionLevel > existing)
+                levelByTeamSlug[slug] = resource.DrivePermissionLevel;
+        }
+
+        return levelByTeamSlug;
+    }
+
+    private async Task<Dictionary<string, DriveExpectedMember>> BuildExpectedDriveMembersByEmailAsync(
+        IEnumerable<GoogleResource> resources,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
+        Dictionary<Guid, List<TeamActiveMemberSnapshot>> membersByTeam,
+        Dictionary<Guid, List<TeamActiveMemberSnapshot>> childMembersByTeam,
+        CancellationToken cancellationToken)
+    {
+        var allMemberUserIds = membersByTeam.Values.SelectMany(v => v.Select(m => m.UserId))
+            .Concat(childMembersByTeam.Values.SelectMany(v => v.Select(m => m.UserId)))
+            .Distinct()
+            .ToList();
+        var emailsByUserId = await userEmailService.GetEntitiesByUserIdsAsync(allMemberUserIds, cancellationToken);
+        var membersByEmail = new Dictionary<string, DriveExpectedMember>(NormalizingEmailComparer.Instance);
+
+        foreach (var resource in resources)
+        {
+            AddExpectedTeamMembers(resource, teamsById, membersByTeam, emailsByUserId, membersByEmail);
+            AddExpectedChildTeamMembers(resource, teamsById, childMembersByTeam, emailsByUserId, membersByEmail);
+        }
+
+        return membersByEmail;
+    }
+
+    private static void AddExpectedTeamMembers(
+        GoogleResource resource,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
+        IReadOnlyDictionary<Guid, List<TeamActiveMemberSnapshot>> membersByTeam,
+        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId,
+        Dictionary<string, DriveExpectedMember> membersByEmail)
+    {
+        var resourceTeam = teamsById[resource.TeamId];
+        var teamLink = BuildDriveTeamLink(resourceTeam, resource.DrivePermissionLevel);
+        foreach (var member in membersByTeam.GetValueOrDefault(resource.TeamId, []))
+        {
+            AddExpectedDriveMember(member, teamLink, emailsByUserId, membersByEmail);
+        }
+    }
+
+    private static void AddExpectedChildTeamMembers(
+        GoogleResource resource,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
+        IReadOnlyDictionary<Guid, List<TeamActiveMemberSnapshot>> childMembersByTeam,
+        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId,
+        Dictionary<string, DriveExpectedMember> membersByEmail)
+    {
+        var level = resource.DrivePermissionLevel is DrivePermissionLevel.None
+            ? null
+            : resource.DrivePermissionLevel.ToString();
+        foreach (var member in childMembersByTeam.GetValueOrDefault(resource.TeamId, []))
+        {
+            var childTeam = teamsById[member.TeamId];
+            AddExpectedDriveMember(member, new TeamLink(childTeam.Name, childTeam.Slug, level), emailsByUserId, membersByEmail);
+        }
+    }
+
+    private static void AddExpectedDriveMember(
+        TeamActiveMemberSnapshot member,
+        TeamLink teamLink,
+        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId,
+        Dictionary<string, DriveExpectedMember> membersByEmail)
+    {
+        var memberEmail = TryGetGoogleEmail(member.UserId, member.GoogleEmailStatus, emailsByUserId);
+        if (memberEmail is null)
+            return;
+
+        if (membersByEmail.TryGetValue(memberEmail, out var existing))
+        {
+            AddDriveTeamLink(existing.TeamLinks, teamLink);
+            return;
+        }
+
+        membersByEmail[memberEmail] = new DriveExpectedMember(
+            member.DisplayName,
+            member.UserId,
+            member.ProfilePictureUrl,
+            [teamLink]);
+    }
+
+    private static void AddDriveTeamLink(List<TeamLink> links, TeamLink teamLink)
+    {
+        if (!links.Any(link => string.Equals(link.Name, teamLink.Name, StringComparison.Ordinal)))
+            links.Add(teamLink);
+    }
+
+    private static List<TeamLink> BuildDriveLinkedTeams(
+        IEnumerable<GoogleResource> resources,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById)
+        => resources
+            .Select(resource => BuildDriveTeamLink(teamsById[resource.TeamId], resource.DrivePermissionLevel))
+            .DistinctBy(teamLink => teamLink.Slug, StringComparer.Ordinal)
+            .ToList();
+
+    private static TeamLink BuildDriveTeamLink(TeamInfo team, DrivePermissionLevel level)
+        => new(team.Name, team.Slug, level is DrivePermissionLevel.None ? null : level.ToString());
+
+    private async Task<ResourceSyncDiff> BuildDrivePermissionListErrorDiffAsync(
+        GoogleResource primary,
+        IReadOnlyList<GoogleResource> resources,
+        IReadOnlyList<TeamLink> linkedTeams,
+        DrivePermissionListResult permsResult,
+        SyncAction action,
+        CancellationToken cancellationToken)
+    {
+        var code = permsResult.Error?.StatusCode ?? 0;
+        var message = $"Google API error: {code} - {permsResult.Error?.RawMessage}";
+        logger.LogWarning("Failed to list permissions for {GoogleId}: {Message}", primary.GoogleId, message);
+
+        if (action == SyncAction.Execute)
+        {
+            await resourceRepository.SetErrorMessageManyAsync(
+                resources.Select(r => r.Id).ToList(),
+                message,
+                cancellationToken);
+        }
+
+        return BuildDriveSyncDiff(primary, linkedTeams, members: [], errorMessage: message);
+    }
+
+    private static DrivePermissionSnapshot BuildDrivePermissionSnapshot(IEnumerable<DrivePermission> permissions)
+    {
+        var snapshot = new DrivePermissionSnapshot(
+            new HashSet<string>(NormalizingEmailComparer.Instance),
+            new HashSet<string>(NormalizingEmailComparer.Instance),
+            new Dictionary<string, string>(NormalizingEmailComparer.Instance));
+
+        foreach (var permission in permissions)
+        {
+            if (IsAnyUserPermission(permission))
+            {
+                snapshot.AllEmails.Add(permission.EmailAddress!);
+                if (!string.IsNullOrEmpty(permission.Role))
+                    snapshot.RoleByEmail[permission.EmailAddress!] = permission.Role;
+            }
+
+            if (IsDirectManagedPermission(permission))
+                snapshot.DirectEmails.Add(permission.EmailAddress!);
+        }
+
+        return snapshot;
+    }
+
+    private async Task<List<MemberSyncStatus>> BuildDriveMemberStatusesAsync(
+        IReadOnlyDictionary<string, DriveExpectedMember> membersByEmail,
+        IReadOnlyDictionary<string, DrivePermissionLevel> levelByTeamSlug,
+        DrivePermissionSnapshot permissionSnapshot,
+        CancellationToken cancellationToken)
+    {
+        var members = membersByEmail
+            .Select(entry => BuildExpectedDriveMemberStatus(
+                entry.Key,
+                entry.Value,
+                levelByTeamSlug,
+                permissionSnapshot))
+            .ToList();
+
+        await AddExtraDriveMemberStatusesAsync(members, membersByEmail, permissionSnapshot, cancellationToken);
+        return members;
+    }
+
+    private static MemberSyncStatus BuildExpectedDriveMemberStatus(
+        string email,
+        DriveExpectedMember expectedMember,
+        IReadOnlyDictionary<string, DrivePermissionLevel> levelByTeamSlug,
+        DrivePermissionSnapshot permissionSnapshot)
+    {
+        var memberMaxLevel = ResolveMemberMaxDriveLevel(expectedMember.TeamLinks, levelByTeamSlug);
+        var memberExpectedRole = memberMaxLevel > DrivePermissionLevel.None
+            ? memberMaxLevel.ToApiRole()
+            : null;
+        var state = ResolveExpectedDriveMemberState(email, memberMaxLevel, permissionSnapshot);
+        permissionSnapshot.RoleByEmail.TryGetValue(email, out var currentRole);
+
+        return new MemberSyncStatus(
+            email,
+            expectedMember.DisplayName,
+            state,
+            expectedMember.TeamLinks,
+            currentRole,
+            memberExpectedRole,
+            UserId: expectedMember.UserId,
+            ProfilePictureUrl: expectedMember.ProfilePictureUrl);
+    }
+
+    private static DrivePermissionLevel ResolveMemberMaxDriveLevel(
+        IEnumerable<TeamLink> teamLinks,
+        IReadOnlyDictionary<string, DrivePermissionLevel> levelByTeamSlug)
+    {
+        var memberMaxLevel = DrivePermissionLevel.None;
+        foreach (var teamLink in teamLinks)
+        {
+            if (levelByTeamSlug.TryGetValue(teamLink.Slug, out var teamLevel) && teamLevel > memberMaxLevel)
+                memberMaxLevel = teamLevel;
+        }
+
+        return memberMaxLevel;
+    }
+
+    private static MemberSyncState ResolveExpectedDriveMemberState(
+        string email,
+        DrivePermissionLevel memberMaxLevel,
+        DrivePermissionSnapshot permissionSnapshot)
+    {
+        if (!permissionSnapshot.AllEmails.Contains(email))
+            return MemberSyncState.Missing;
+
+        if (!permissionSnapshot.DirectEmails.Contains(email))
+            return MemberSyncState.Inherited;
+
+        permissionSnapshot.RoleByEmail.TryGetValue(email, out var currentRole);
+        var currentLevel = ParseApiRole(currentRole);
+        return currentLevel.HasValue && currentLevel.Value < memberMaxLevel
+            ? MemberSyncState.WrongRole
+            : MemberSyncState.Correct;
+    }
+
+    private async Task AddExtraDriveMemberStatusesAsync(
+        List<MemberSyncStatus> members,
+        IReadOnlyDictionary<string, DriveExpectedMember> membersByEmail,
+        DrivePermissionSnapshot permissionSnapshot,
+        CancellationToken cancellationToken)
+    {
+        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(cancellationToken);
+        var nonMemberEmails = permissionSnapshot.AllEmails
+            .Where(email => !membersByEmail.ContainsKey(email) &&
+                !string.Equals(email, serviceAccountEmail, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var extraIdentities = await ResolveExtraEmailIdentitiesAsync(nonMemberEmails, cancellationToken);
+
+        foreach (var email in nonMemberEmails)
+        {
+            var state = permissionSnapshot.DirectEmails.Contains(email)
+                ? MemberSyncState.Extra
+                : MemberSyncState.Inherited;
+            permissionSnapshot.RoleByEmail.TryGetValue(email, out var extraRole);
+
+            members.Add(extraIdentities.TryGetValue(email, out var identity)
+                ? new MemberSyncStatus(email, identity.DisplayName, state, [], extraRole,
+                    UserId: identity.UserId, ProfilePictureUrl: identity.ProfilePictureUrl)
+                : new MemberSyncStatus(email, email, state, [], extraRole));
+        }
+    }
+
+    private async Task ApplyDriveResourceChangesAsync(
+        GoogleResource primary,
+        IReadOnlyList<GoogleResource> resources,
+        IReadOnlyList<DrivePermission> permissions,
+        IReadOnlyList<MemberSyncStatus> members,
+        Instant now,
+        CancellationToken cancellationToken)
+    {
+        foreach (var member in members.Where(m => m.State is MemberSyncState.Missing or MemberSyncState.WrongRole))
+        {
+            await GrantDriveAccessAsync(primary, member, cancellationToken);
+        }
+
+        foreach (var member in members.Where(m => m.State == MemberSyncState.Extra))
+        {
+            await RemoveExtraDriveAccessAsync(primary, permissions, member, cancellationToken);
+        }
+
+        await resourceRepository.MarkSyncedManyAsync(resources.Select(r => r.Id).ToList(), now, cancellationToken);
+    }
+
+    private async Task GrantDriveAccessAsync(
+        GoogleResource primary,
+        MemberSyncStatus member,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.Contributor;
+            await AddUserToDriveAsync(primary, member.Email, memberLevel, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to grant Drive access to {Email} on {GoogleId}",
+                member.Email, primary.GoogleId);
+        }
+    }
+
+    private async Task RemoveExtraDriveAccessAsync(
+        GoogleResource primary,
+        IEnumerable<DrivePermission> permissions,
+        MemberSyncStatus member,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var permissionToRemove = permissions.FirstOrDefault(permission =>
+                IsDirectManagedPermission(permission) &&
+                NormalizingEmailComparer.Instance.Equals(permission.EmailAddress, member.Email));
+
+            if (permissionToRemove?.Id is null)
+            {
+                logger.LogInformation(
+                    "Skipping removal of {Email} from {GoogleId} - permission is inherited, not direct",
+                    member.Email,
+                    primary.GoogleId);
+                return;
+            }
+
+            await RemoveUserFromDriveAsync(primary, permissionToRemove.Id, member.Email, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to remove Drive access for {Email} on {GoogleId}",
+                member.Email, primary.GoogleId);
+        }
+    }
+
+    private static ResourceSyncDiff BuildDriveSyncDiff(
+        GoogleResource primary,
+        IEnumerable<TeamLink> linkedTeams,
+        IEnumerable<MemberSyncStatus> members,
+        string? errorMessage = null)
+        => new()
+        {
+            ResourceId = primary.Id,
+            ResourceName = primary.Name,
+            ResourceType = primary.ResourceType.ToString(),
+            GoogleId = primary.GoogleId,
+            Url = primary.Url,
+            PermissionLevel = primary.DrivePermissionLevel.ToString(),
+            LinkedTeams = linkedTeams.ToList(),
+            Members = members.ToList(),
+            ErrorMessage = errorMessage
+        };
+
+    private sealed record DriveExpectedMember(
+        string DisplayName,
+        Guid UserId,
+        string? ProfilePictureUrl,
+        List<TeamLink> TeamLinks);
+
+    private sealed record DrivePermissionSnapshot(
+        HashSet<string> AllEmails,
+        HashSet<string> DirectEmails,
+        Dictionary<string, string> RoleByEmail);
 
     /// <inheritdoc />
     public async Task<GroupLinkResult> EnsureTeamGroupAsync(

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -517,47 +517,161 @@ public sealed class ShiftSignupService(
         var now = clock.GetCurrentInstant();
         isPrivileged = isPrivileged || await IsPrivilegedAsync(userId, rota.TeamId);
 
-        if (!es.IsShiftBrowsingOpen && !isPrivileged)
-            return SignupResult.Fail("Shift browsing is not currently open.");
-
-        if (rota.Period == RotaPeriod.Build && es.EarlyEntryClose.HasValue && now >= es.EarlyEntryClose.Value && !isPrivileged)
-            return SignupResult.Fail("Early entry signups are closed.");
+        var gateFailure = ValidateRangeSignupGate(rota, es, now, isPrivileged);
+        if (gateFailure is not null)
+            return gateFailure;
 
         var shiftsInRange = SelectAllDayRangeShifts(rota, startDayOffset, endDayOffset);
 
         if (!isPrivileged && shiftsInRange.Any(s => s.AdminOnly))
             return SignupResult.Fail("One or more shifts in this range are restricted to coordinators and admins.");
 
-        // Fetched upfront — used for both duplicate-check and time-overlap check.
-        var shiftIdsInRange = shiftsInRange.Select(s => s.Id).ToHashSet();
         var existingSignups = await GetActiveUserSignupsAsync(userId);
+
+        var duplicateSelection = PruneDuplicateRangeShifts(shiftsInRange, existingSignups, es, skipConflicts);
+        if (duplicateSelection.Failure is not null)
+            return duplicateSelection.Failure;
+
+        var conflictSelection = PruneConflictingRangeShifts(
+            duplicateSelection.Shifts,
+            existingSignups,
+            es,
+            duplicateSelection.Warnings,
+            skipConflicts);
+        if (conflictSelection.Failure is not null)
+            return conflictSelection.Failure;
+
+        shiftsInRange = conflictSelection.Shifts;
+        if (shiftsInRange.Count == 0)
+            return BuildEmptyRangeSignupResult(conflictSelection.Warnings);
+
+        var capacitySelection = await SelectCapacityAvailableRangeShiftsAsync(shiftsInRange);
+        if (capacitySelection.AvailableShifts.Count == 0)
+            return SignupResult.Fail("All shifts in this range are at capacity.");
+
+        string? warning = CombineRangeWarnings(conflictSelection.Warnings);
+        warning = AppendFullDayRangeWarning(warning, capacitySelection.FullDayOffsets, es);
+
+        var availableShifts = capacitySelection.AvailableShifts;
+
+        if (rota.Period == RotaPeriod.Build)
+            warning = await AppendEarlyEntryRangeWarningAsync(warning, availableShifts, es);
+
+        var blockId = Guid.NewGuid();
+
+        // Public rotas auto-confirm at signup regardless of the volunteer's admission/consent
+        // status; only RequireApproval rotas park signups as Pending for coordinator review.
+        var autoConfirm = rota.Policy == SignupPolicy.Public ||
+                           await shiftMgmt.CanApproveSignupsAsync(userId, rota.TeamId);
+        var createdSignups = StageRangeSignups(userId, actorUserId, blockId, now, availableShifts, autoConfirm);
+
+        await repo.SaveChangesAsync();
+        viewInvalidator.InvalidateUser(userId);
+        viewInvalidator.InvalidateRota(rotaId);
+        if (autoConfirm && availableShifts.Any(s => s.IsEarlyEntry))
+            earlyEntryInvalidator.InvalidateUser(userId);
+
+        await AuditRangeSignupsAsync(userId, rota, es, createdSignups.SignupsForAudit, autoConfirm);
+
+        if (autoConfirm)
+        {
+            await DispatchSignupChangeNotificationAsync(createdSignups.LastSignup, availableShifts[^1], rota,
+                $"Range signup for '{rota.Name}' ({shiftsInRange.Count} shifts, confirmed).");
+        }
+
+        return SignupResult.Ok(createdSignups.LastSignup, warning);
+    }
+
+    private static SignupResult? ValidateRangeSignupGate(
+        Rota rota,
+        EventSettings eventSettings,
+        Instant now,
+        bool isPrivileged)
+    {
+        if (!eventSettings.IsShiftBrowsingOpen && !isPrivileged)
+            return SignupResult.Fail("Shift browsing is not currently open.");
+
+        if (rota.Period == RotaPeriod.Build
+            && eventSettings.EarlyEntryClose.HasValue
+            && now >= eventSettings.EarlyEntryClose.Value
+            && !isPrivileged)
+        {
+            return SignupResult.Fail("Early entry signups are closed.");
+        }
+
+        return null;
+    }
+
+    private static RangeSignupCandidateSelection PruneDuplicateRangeShifts(
+        List<Shift> shiftsInRange,
+        IReadOnlyCollection<ShiftSignup> existingSignups,
+        EventSettings eventSettings,
+        bool skipConflicts)
+    {
+        var shiftIdsInRange = shiftsInRange.Select(s => s.Id).ToHashSet();
         var activeShiftIds = existingSignups
             .Where(s => shiftIdsInRange.Contains(s.ShiftId))
             .Select(s => s.ShiftId)
             .ToHashSet();
 
-        var skipMessages = new List<string>();
-        if (activeShiftIds.Count > 0)
-        {
-            if (!skipConflicts)
-                return SignupResult.Fail("Already signed up for one or more shifts in this range.");
+        if (activeShiftIds.Count == 0)
+            return new RangeSignupCandidateSelection(shiftsInRange, [], null);
 
-            var alreadySignedUpDays = shiftsInRange
-                .Where(s => activeShiftIds.Contains(s.Id))
-                .Select(s => s.DayOffset)
-                .ToList();
-            var dayList = string.Join(", ", alreadySignedUpDays.Select(offset =>
-                es.GateOpeningDate.PlusDays(offset).ToWeekdayDayMonth()));
-            skipMessages.Add($"Already signed up for day(s): {dayList}.");
+        if (!skipConflicts)
+            return new RangeSignupCandidateSelection(
+                shiftsInRange,
+                [],
+                SignupResult.Fail("Already signed up for one or more shifts in this range."));
 
-            shiftsInRange = shiftsInRange.Where(s => !activeShiftIds.Contains(s.Id)).ToList();
-        }
+        var alreadySignedUpDays = shiftsInRange
+            .Where(s => activeShiftIds.Contains(s.Id))
+            .Select(s => s.DayOffset)
+            .ToList();
+        var dayList = FormatRangeDayList(eventSettings, alreadySignedUpDays);
+        var warnings = new List<string> { $"Already signed up for day(s): {dayList}." };
+        var remainingShifts = shiftsInRange
+            .Where(s => !activeShiftIds.Contains(s.Id))
+            .ToList();
 
+        return new RangeSignupCandidateSelection(remainingShifts, warnings, null);
+    }
+
+    private static RangeSignupCandidateSelection PruneConflictingRangeShifts(
+        List<Shift> shiftsInRange,
+        IReadOnlyCollection<ShiftSignup> existingSignups,
+        EventSettings eventSettings,
+        IReadOnlyList<string> existingWarnings,
+        bool skipConflicts)
+    {
+        var conflictingDays = GetConflictingRangeDays(shiftsInRange, existingSignups, eventSettings);
+        if (conflictingDays.Count == 0)
+            return new RangeSignupCandidateSelection(shiftsInRange, existingWarnings.ToList(), null);
+
+        var dayList = FormatRangeDayList(eventSettings, conflictingDays);
+        if (!skipConflicts)
+            return new RangeSignupCandidateSelection(
+                shiftsInRange,
+                existingWarnings.ToList(),
+                SignupResult.Fail($"Time conflict on day(s): {dayList}."));
+
+        var warnings = existingWarnings.Append($"Time conflict on day(s): {dayList}.").ToList();
+        var remainingShifts = shiftsInRange
+            .Where(s => !conflictingDays.Contains(s.DayOffset))
+            .ToList();
+
+        return new RangeSignupCandidateSelection(remainingShifts, warnings, null);
+    }
+
+    private static List<int> GetConflictingRangeDays(
+        IReadOnlyList<Shift> shiftsInRange,
+        IEnumerable<ShiftSignup> existingSignups,
+        EventSettings eventSettings)
+    {
         var conflictingDays = new List<int>();
         foreach (var shift in shiftsInRange)
         {
-            var shiftStart = shift.GetAbsoluteStart(es);
-            var shiftEnd = shift.GetAbsoluteEnd(es);
+            var shiftStart = shift.GetAbsoluteStart(eventSettings);
+            var shiftEnd = shift.GetAbsoluteEnd(eventSettings);
 
             foreach (var existing in existingSignups)
             {
@@ -573,28 +687,17 @@ public sealed class ShiftSignupService(
             }
         }
 
-        if (conflictingDays.Count > 0)
-        {
-            var dayList = string.Join(", ", conflictingDays.Select(offset =>
-                es.GateOpeningDate.PlusDays(offset).ToWeekdayDayMonth()));
+        return conflictingDays;
+    }
 
-            if (!skipConflicts)
-                return SignupResult.Fail($"Time conflict on day(s): {dayList}.");
+    private static SignupResult BuildEmptyRangeSignupResult(IReadOnlyList<string> warnings)
+        => warnings.Count > 0
+            ? SignupResult.Fail(string.Join(" ", warnings) + " Nothing to add.")
+            : SignupResult.Fail("No shifts found in the specified date range.");
 
-            skipMessages.Add($"Time conflict on day(s): {dayList}.");
-            shiftsInRange = shiftsInRange.Where(s => !conflictingDays.Contains(s.DayOffset)).ToList();
-        }
-
-        if (shiftsInRange.Count == 0)
-        {
-            return skipMessages.Count > 0
-                ? SignupResult.Fail(string.Join(" ", skipMessages) + " Nothing to add.")
-                : SignupResult.Fail("No shifts found in the specified date range.");
-        }
-
-        shiftIdsInRange = shiftsInRange.Select(s => s.Id).ToHashSet();
-
-        string? warning = skipMessages.Count > 0 ? string.Join(" ", skipMessages) : null;
+    private async Task<RangeCapacitySelection> SelectCapacityAvailableRangeShiftsAsync(List<Shift> shiftsInRange)
+    {
+        var shiftIdsInRange = shiftsInRange.Select(s => s.Id).ToHashSet();
         var signupCounts = await repo.GetConfirmedSignupCountsByShiftAsync(shiftIdsInRange);
         var fullDays = shiftsInRange
             .Where(s => signupCounts.GetValueOrDefault(s.Id) >= s.MaxVolunteers)
@@ -605,48 +708,64 @@ public sealed class ShiftSignupService(
             .Where(s => signupCounts.GetValueOrDefault(s.Id) < s.MaxVolunteers)
             .ToList();
 
-        if (availableShifts.Count == 0)
-            return SignupResult.Fail("All shifts in this range are at capacity.");
+        return new RangeCapacitySelection(availableShifts, fullDays);
+    }
 
-        if (fullDays.Count > 0)
+    private static string? CombineRangeWarnings(IReadOnlyList<string> warnings)
+        => warnings.Count > 0 ? string.Join(" ", warnings) : null;
+
+    private static string? AppendFullDayRangeWarning(
+        string? warning,
+        IReadOnlyCollection<int> fullDays,
+        EventSettings eventSettings)
+    {
+        if (fullDays.Count == 0)
+            return warning;
+
+        var dayList = FormatRangeDayList(eventSettings, fullDays);
+        return AppendRangeWarning(warning, $"Day(s) {dayList} are at capacity.");
+    }
+
+    private async Task<string?> AppendEarlyEntryRangeWarningAsync(
+        string? warning,
+        IReadOnlyList<Shift> availableShifts,
+        EventSettings eventSettings)
+    {
+        var fullEeDays = new List<int>();
+        foreach (var dayOffset in availableShifts
+                     .Where(shift => shift.IsEarlyEntry)
+                     .Select(shift => shift.DayOffset)
+                     .Distinct()
+                     .OrderBy(day => day))
         {
-            var dayList = string.Join(", ", fullDays.Select(offset =>
-                es.GateOpeningDate.PlusDays(offset).ToWeekdayDayMonth()));
-            var capacityWarning = $"Day(s) {dayList} are at capacity.";
-            warning = warning is null ? capacityWarning : $"{warning} {capacityWarning}";
+            var eeWarning = await CheckEeCapAsync(eventSettings, dayOffset);
+            if (eeWarning is not null)
+                fullEeDays.Add(dayOffset);
         }
 
-        if (rota.Period == RotaPeriod.Build)
-        {
-            var fullEeDays = new List<int>();
-            foreach (var dayOffset in availableShifts
-                         .Where(shift => shift.IsEarlyEntry)
-                         .Select(shift => shift.DayOffset)
-                         .Distinct()
-                         .OrderBy(day => day))
-            {
-                var eeWarning = await CheckEeCapAsync(es, dayOffset);
-                if (eeWarning is not null)
-                    fullEeDays.Add(dayOffset);
-            }
+        if (fullEeDays.Count == 0)
+            return warning;
 
-            if (fullEeDays.Count > 0)
-            {
-                var eeDayList = string.Join(", ", fullEeDays.Select(offset =>
-                    es.GateOpeningDate.PlusDays(offset).ToWeekdayDayMonth()));
-                var eeWarning = $"Early entry capacity reached for day(s): {eeDayList}.";
-                warning = warning is null ? eeWarning : $"{warning} {eeWarning}";
-            }
-        }
+        var eeDayList = FormatRangeDayList(eventSettings, fullEeDays);
+        return AppendRangeWarning(warning, $"Early entry capacity reached for day(s): {eeDayList}.");
+    }
 
-        var blockId = Guid.NewGuid();
+    private static string AppendRangeWarning(string? warning, string nextWarning)
+        => warning is null ? nextWarning : $"{warning} {nextWarning}";
 
-        // Public rotas auto-confirm at signup regardless of the volunteer's admission/consent
-        // status; only RequireApproval rotas park signups as Pending for coordinator review.
-        var autoConfirm = rota.Policy == SignupPolicy.Public ||
-                          await shiftMgmt.CanApproveSignupsAsync(userId, rota.TeamId);
+    private static string FormatRangeDayList(EventSettings eventSettings, IEnumerable<int> dayOffsets)
+        => string.Join(", ", dayOffsets.Select(offset =>
+            eventSettings.GateOpeningDate.PlusDays(offset).ToWeekdayDayMonth()));
+
+    private RangeSignupCreation StageRangeSignups(
+        Guid userId,
+        Guid? actorUserId,
+        Guid blockId,
+        Instant now,
+        IReadOnlyList<Shift> availableShifts,
+        bool autoConfirm)
+    {
         ShiftSignup? lastSignup = null;
-
         var rangeSignupsForAudit = new List<(ShiftSignup Signup, int DayOffset)>();
         foreach (var shift in availableShifts)
         {
@@ -672,30 +791,26 @@ public sealed class ShiftSignupService(
             rangeSignupsForAudit.Add((signup, shift.DayOffset));
         }
 
-        await repo.SaveChangesAsync();
-        viewInvalidator.InvalidateUser(userId);
-        viewInvalidator.InvalidateRota(rotaId);
-        if (autoConfirm && availableShifts.Any(s => s.IsEarlyEntry))
-            earlyEntryInvalidator.InvalidateUser(userId);
+        return new RangeSignupCreation(lastSignup!, rangeSignupsForAudit);
+    }
 
+    private async Task AuditRangeSignupsAsync(
+        Guid userId,
+        Rota rota,
+        EventSettings eventSettings,
+        IEnumerable<(ShiftSignup Signup, int DayOffset)> rangeSignupsForAudit,
+        bool autoConfirm)
+    {
         var statusSuffix = autoConfirm ? "confirmed" : "pending";
         foreach (var (auditedSignup, dayOffset) in rangeSignupsForAudit)
         {
             await auditLogService.LogAsync(
                 AuditAction.ShiftSignupCreated,
                 nameof(ShiftSignup), auditedSignup.Id,
-                $"'{rota.Name}' on {es.GateOpeningDate.PlusDays(dayOffset).ToWeekdayDayMonth()} (range, {statusSuffix})",
+                $"'{rota.Name}' on {eventSettings.GateOpeningDate.PlusDays(dayOffset).ToWeekdayDayMonth()} (range, {statusSuffix})",
                 userId,
                 userId, nameof(User));
         }
-
-        if (autoConfirm)
-        {
-            await DispatchSignupChangeNotificationAsync(lastSignup!, availableShifts[^1], rota,
-                $"Range signup for '{rota.Name}' ({shiftsInRange.Count} shifts, confirmed).");
-        }
-
-        return SignupResult.Ok(lastSignup!, warning);
     }
 
     public async Task<SignupResult> ApproveRangeAsync(Guid signupBlockId, Guid reviewerUserId)
@@ -1217,4 +1332,17 @@ public sealed class ShiftSignupService(
                 targetUserId, nameof(User));
         }
     }
+
+    private sealed record RangeSignupCandidateSelection(
+        List<Shift> Shifts,
+        List<string> Warnings,
+        SignupResult? Failure);
+
+    private sealed record RangeCapacitySelection(
+        List<Shift> AvailableShifts,
+        List<int> FullDayOffsets);
+
+    private sealed record RangeSignupCreation(
+        ShiftSignup LastSignup,
+        List<(ShiftSignup Signup, int DayOffset)> SignupsForAudit);
 }

--- a/src/Humans.Application/Services/Shifts/VolunteerTrackingService.cs
+++ b/src/Humans.Application/Services/Shifts/VolunteerTrackingService.cs
@@ -67,15 +67,7 @@ public sealed class VolunteerTrackingService(
     {
         var es = await shiftManagement.GetActiveEventSettingsAsync(ct).ConfigureAwait(false);
         if (es is null)
-        {
-            return new VolunteerTrackingViewModel(
-                false,
-                0,
-                default,
-                default,
-                [],
-                []);
-        }
+            return EmptyTrackingViewModel();
 
         var zone = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
         var today = clock.GetCurrentInstant().InZone(zone).Date;
@@ -83,103 +75,160 @@ public sealed class VolunteerTrackingService(
 
         var signups = await shiftManagement.GetEligibleBuildSignupsAsync(es.Id, ct).ConfigureAwait(false);
         var users = await userService.GetAllUserInfosAsync(ct).ConfigureAwait(false);
-        var statusMap = users
+        var statusMap = BuildParticipationStatusMap(users, es.Year);
+        var perUserSignups = BuildPerUserSignupMap(signups);
+
+        var bsRows = await trackingRepo.GetBuildStatusesForEventAsync(es.Id, ct: ct).ConfigureAwait(false);
+        var bsByUser = bsRows.ToDictionary(r => r.UserId);
+        var mainRows = BuildMainCohortRows(es, perUserSignups, statusMap, bsByUser);
+
+        var availabilityRows = await trackingRepo.GetAvailabilityForEventAsync(es.Id, ct: ct).ConfigureAwait(false);
+        var availabilityByUser = availabilityRows
+            .ToDictionary(g => g.UserId, g => g.AvailableDayOffsets.ToHashSet());
+        var unbookedRows = BuildUnbookedCohortRows(
+            es,
+            todayOffset,
+            statusMap,
+            perUserSignups,
+            availabilityByUser,
+            bsByUser);
+
+        return new VolunteerTrackingViewModel(
+            true,
+            es.BuildStartOffset,
+            es.GateOpeningDate,
+            today,
+            mainRows,
+            unbookedRows);
+    }
+
+    private static VolunteerTrackingViewModel EmptyTrackingViewModel() =>
+        new(
+            false,
+            0,
+            default,
+            default,
+            [],
+            []);
+
+    private static Dictionary<Guid, ParticipationStatus> BuildParticipationStatusMap(
+        IEnumerable<UserInfo> users,
+        int eventYear)
+        => users
             .SelectMany(
-                user => user.EventParticipations.Where(p => p.Year == es.Year),
+                user => user.EventParticipations.Where(p => p.Year == eventYear),
                 (user, participation) => (UserId: user.Id, participation.Status))
             .Where(p => p.Status == ParticipationStatus.NotAttending
                      || p.Status == ParticipationStatus.Ticketed
                      || p.Status == ParticipationStatus.Attended)
             .ToDictionary(p => p.UserId, p => p.Status);
 
-        // Per-user, per-day: best status (Confirmed > Pending) + distinct rota names.
-        var perUserSignups = signups
+    private static Dictionary<Guid, Dictionary<int, VolunteerDaySignup>> BuildPerUserSignupMap(
+        IEnumerable<EligibleBuildSignup> signups)
+        => signups
             .GroupBy(s => s.UserId)
             .ToDictionary(g => g.Key, g => g
                 .GroupBy(x => x.DayOffset)
                 .ToDictionary(
                     dg => dg.Key,
-                    dg => (
-                        Status: dg.Any(x => x.Status == SignupStatus.Confirmed)
+                    dg => new VolunteerDaySignup(
+                        dg.Any(x => x.Status == SignupStatus.Confirmed)
                             ? SignupStatus.Confirmed : SignupStatus.Pending,
-                        RotaNames: (IReadOnlyList<string>)dg
+                        dg
                             .Select(x => x.RotaName)
                             .Distinct(StringComparer.Ordinal)
                             .ToList())));
 
-        var bsRows = await trackingRepo.GetBuildStatusesForEventAsync(es.Id, ct: ct).ConfigureAwait(false);
-        var bsByUser = bsRows.ToDictionary(r => r.UserId);
-
+    private static List<VolunteerHeatmapRow> BuildMainCohortRows(
+        EventSettings es,
+        IReadOnlyDictionary<Guid, Dictionary<int, VolunteerDaySignup>> perUserSignups,
+        IReadOnlyDictionary<Guid, ParticipationStatus> statusMap,
+        IReadOnlyDictionary<Guid, VolunteerBuildStatus> bsByUser)
+    {
         var mainRows = new List<VolunteerHeatmapRow>();
         foreach (var (userId, daySignups) in perUserSignups)
         {
             if (statusMap.TryGetValue(userId, out var st) && st == ParticipationStatus.NotAttending)
-            {
                 continue;
-            }
 
-            var firstSignupDay = daySignups.Keys.Min();
-            var lastEligibleSignupOffset = daySignups.Keys.Max();
             bsByUser.TryGetValue(userId, out var bs);
-            int? setupOffset = bs?.BarrioSetupStartDate is { } d
-                ? OffsetOf(es, d)
-                : null;
+            var firstSignupDay = daySignups.Keys.Min();
+            var setupOffset = GetSetupOffset(es, bs);
             var lastExpectedDay = Math.Min(setupOffset ?? int.MaxValue, 0);
-            var dayOffSet = bs?.DayOffs.Select(x => x.DayOffset).ToHashSet() ?? [];
-
-            var cells = new List<VolunteerCell>(-es.BuildStartOffset);
-            int gapCount = 0;
-            for (int d2 = es.BuildStartOffset; d2 < 0; d2++)
-            {
-                VolunteerCellState s;
-                IReadOnlyList<string> rotaNames = [];
-                if (setupOffset.HasValue && d2 >= setupOffset.Value)
-                {
-                    s = VolunteerCellState.CampSetup;
-                }
-                else if (d2 < firstSignupDay || d2 >= lastExpectedDay)
-                {
-                    s = VolunteerCellState.Outside;
-                }
-                else if (daySignups.TryGetValue(d2, out var info))
-                {
-                    s = info.Status == SignupStatus.Confirmed
-                        ? VolunteerCellState.Confirmed
-                        : VolunteerCellState.Pending;
-                    rotaNames = info.RotaNames;
-                }
-                else if (dayOffSet.Contains(d2))
-                {
-                    s = VolunteerCellState.DayOff;
-                }
-                else
-                {
-                    s = VolunteerCellState.Gap;
-                    gapCount++;
-                }
-
-                cells.Add(new VolunteerCell(d2, s, rotaNames));
-            }
-
-            // Repo persists DayOffs sorted by DayOffset; no resort needed.
-            var dayOffSummaries = (bs?.DayOffs ?? [])
-                .Select(x => new DayOffSummary(x.DayOffset, x.Reason))
-                .ToList();
+            var buildRow = BuildMainCohortCells(es, daySignups, bs, firstSignupDay, lastExpectedDay, setupOffset);
 
             mainRows.Add(new VolunteerHeatmapRow(
                 userId,
                 firstSignupDay,
-                lastEligibleSignupOffset,
+                daySignups.Keys.Max(),
                 bs?.BarrioSetupStartDate,
-                gapCount,
-                cells,
-                dayOffSummaries));
+                buildRow.GapCount,
+                buildRow.Cells,
+                BuildDayOffSummaries(bs)));
         }
 
-        var availabilityRows = await trackingRepo.GetAvailabilityForEventAsync(es.Id, ct: ct).ConfigureAwait(false);
-        var availabilityByUser = availabilityRows
-            .ToDictionary(g => g.UserId, g => g.AvailableDayOffsets.ToHashSet());
+        return mainRows;
+    }
 
+    private static MainCohortCells BuildMainCohortCells(
+        EventSettings es,
+        IReadOnlyDictionary<int, VolunteerDaySignup> daySignups,
+        VolunteerBuildStatus? bs,
+        int firstSignupDay,
+        int lastExpectedDay,
+        int? setupOffset)
+    {
+        var dayOffSet = bs?.DayOffs.Select(x => x.DayOffset).ToHashSet() ?? [];
+        var cells = new List<VolunteerCell>(-es.BuildStartOffset);
+        int gapCount = 0;
+        for (int day = es.BuildStartOffset; day < 0; day++)
+        {
+            var cell = BuildMainCohortCell(day, daySignups, dayOffSet, firstSignupDay, lastExpectedDay, setupOffset);
+            if (cell.State == VolunteerCellState.Gap)
+                gapCount++;
+
+            cells.Add(cell);
+        }
+
+        return new MainCohortCells(cells, gapCount);
+    }
+
+    private static VolunteerCell BuildMainCohortCell(
+        int dayOffset,
+        IReadOnlyDictionary<int, VolunteerDaySignup> daySignups,
+        IReadOnlySet<int> dayOffSet,
+        int firstSignupDay,
+        int lastExpectedDay,
+        int? setupOffset)
+    {
+        if (setupOffset.HasValue && dayOffset >= setupOffset.Value)
+            return new VolunteerCell(dayOffset, VolunteerCellState.CampSetup, []);
+
+        if (dayOffset < firstSignupDay || dayOffset >= lastExpectedDay)
+            return new VolunteerCell(dayOffset, VolunteerCellState.Outside, []);
+
+        if (daySignups.TryGetValue(dayOffset, out var info))
+        {
+            var state = info.Status == SignupStatus.Confirmed
+                ? VolunteerCellState.Confirmed
+                : VolunteerCellState.Pending;
+            return new VolunteerCell(dayOffset, state, info.RotaNames);
+        }
+
+        if (dayOffSet.Contains(dayOffset))
+            return new VolunteerCell(dayOffset, VolunteerCellState.DayOff, []);
+
+        return new VolunteerCell(dayOffset, VolunteerCellState.Gap, []);
+    }
+
+    private static List<VolunteerCohortRow> BuildUnbookedCohortRows(
+        EventSettings es,
+        int todayOffset,
+        IReadOnlyDictionary<Guid, ParticipationStatus> statusMap,
+        IReadOnlyDictionary<Guid, Dictionary<int, VolunteerDaySignup>> perUserSignups,
+        IReadOnlyDictionary<Guid, HashSet<int>> availabilityByUser,
+        IReadOnlyDictionary<Guid, VolunteerBuildStatus> bsByUser)
+    {
         var unbookedRows = new List<VolunteerCohortRow>();
         foreach (var participation in statusMap)
         {
@@ -191,69 +240,76 @@ public sealed class VolunteerTrackingService(
 
             var userId = participation.Key;
             if (perUserSignups.ContainsKey(userId))
-            {
                 continue; // already in main cohort
-            }
 
             if (!availabilityByUser.TryGetValue(userId, out var avail))
-            {
                 continue;
-            }
 
             var inBuild = avail.Where(d => d >= es.BuildStartOffset && d < 0).ToHashSet();
             if (inBuild.Count == 0)
-            {
                 continue;
-            }
 
             var firstAvailableDay = inBuild.Min();
             bsByUser.TryGetValue(userId, out var bs);
-            int? setupOffset = bs?.BarrioSetupStartDate is { } d2
-                ? OffsetOf(es, d2)
-                : null;
-
-            var cells = new List<VolunteerCell>(-es.BuildStartOffset);
-            int unbookedCount = 0;
-            for (int d3 = es.BuildStartOffset; d3 < 0; d3++)
-            {
-                VolunteerCellState s;
-                if (setupOffset.HasValue && d3 >= setupOffset.Value)
-                {
-                    s = VolunteerCellState.CampSetup;
-                }
-                else if (inBuild.Contains(d3) && d3 < todayOffset)
-                {
-                    s = VolunteerCellState.AvailableUnbooked;
-                    unbookedCount++;
-                }
-                else if (inBuild.Contains(d3))
-                {
-                    s = VolunteerCellState.AvailableExpected;
-                }
-                else
-                {
-                    s = VolunteerCellState.NotAvailable;
-                }
-
-                cells.Add(new VolunteerCell(d3, s, []));
-            }
+            var buildRow = BuildUnbookedCohortCells(es, inBuild, todayOffset, GetSetupOffset(es, bs));
 
             unbookedRows.Add(new VolunteerCohortRow(
                 userId,
                 firstAvailableDay,
                 bs?.BarrioSetupStartDate,
-                unbookedCount,
-                cells));
+                buildRow.UnbookedCount,
+                buildRow.Cells));
         }
 
-        return new VolunteerTrackingViewModel(
-            true,
-            es.BuildStartOffset,
-            es.GateOpeningDate,
-            today,
-            mainRows,
-            unbookedRows);
+        return unbookedRows;
     }
+
+    private static UnbookedCohortCells BuildUnbookedCohortCells(
+        EventSettings es,
+        IReadOnlySet<int> inBuild,
+        int todayOffset,
+        int? setupOffset)
+    {
+        var cells = new List<VolunteerCell>(-es.BuildStartOffset);
+        int unbookedCount = 0;
+        for (int day = es.BuildStartOffset; day < 0; day++)
+        {
+            var state = GetUnbookedCohortCellState(day, inBuild, todayOffset, setupOffset);
+            if (state == VolunteerCellState.AvailableUnbooked)
+                unbookedCount++;
+
+            cells.Add(new VolunteerCell(day, state, []));
+        }
+
+        return new UnbookedCohortCells(cells, unbookedCount);
+    }
+
+    private static VolunteerCellState GetUnbookedCohortCellState(
+        int dayOffset,
+        IReadOnlySet<int> inBuild,
+        int todayOffset,
+        int? setupOffset)
+    {
+        if (setupOffset.HasValue && dayOffset >= setupOffset.Value)
+            return VolunteerCellState.CampSetup;
+
+        if (inBuild.Contains(dayOffset) && dayOffset < todayOffset)
+            return VolunteerCellState.AvailableUnbooked;
+
+        return inBuild.Contains(dayOffset)
+            ? VolunteerCellState.AvailableExpected
+            : VolunteerCellState.NotAvailable;
+    }
+
+    private static int? GetSetupOffset(EventSettings es, VolunteerBuildStatus? buildStatus) =>
+        buildStatus?.BarrioSetupStartDate is { } date
+            ? OffsetOf(es, date)
+            : null;
+
+    private static List<DayOffSummary> BuildDayOffSummaries(VolunteerBuildStatus? buildStatus) =>
+        (buildStatus?.DayOffs ?? [])
+            .Select(dayOff => new DayOffSummary(dayOff.DayOffset, dayOff.Reason))
+            .ToList();
 
     public async Task<SetCampSetupResult> SetCampSetupAsync(
         Guid targetUserId, LocalDate barrioSetupStartDate, string? notes,
@@ -453,4 +509,16 @@ public sealed class VolunteerTrackingService(
 
     private static int OffsetOf(EventSettings es, LocalDate date) =>
         Period.Between(es.GateOpeningDate, date, PeriodUnits.Days).Days;
+
+    private sealed record VolunteerDaySignup(
+        SignupStatus Status,
+        IReadOnlyList<string> RotaNames);
+
+    private sealed record MainCohortCells(
+        List<VolunteerCell> Cells,
+        int GapCount);
+
+    private sealed record UnbookedCohortCells(
+        List<VolunteerCell> Cells,
+        int UnbookedCount);
 }

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -1118,46 +1118,7 @@ public sealed class TeamService(
         CancellationToken cancellationToken = default)
     {
         var teamsById = await LoadTeamsByIdAsync(cancellationToken);
-        var coordinatorTeamIds = await repo.GetUserCoordinatorTeamIdsAsync(userId, cancellationToken);
-        return IsUserCoordinatorOfActiveTeam(teamsById, coordinatorTeamIds, teamId, userId);
-    }
-
-    private bool IsUserCoordinatorOfActiveTeam(
-        IReadOnlyDictionary<Guid, TeamInfo> teamsById,
-        IReadOnlyCollection<Guid> coordinatorTeamIds,
-        Guid teamId,
-        Guid userId)
-    {
-        if (!teamsById.TryGetValue(teamId, out var team) || !team.IsActive)
-        {
-            logger.LogDebug("Coordinator check: team {TeamId} not found in cache for user {UserId}", teamId, userId);
-            return false;
-        }
-
-        if (team.Members.Any(m => m.UserId == userId && m.Role == TeamMemberRole.Coordinator))
-        {
-            logger.LogDebug("Coordinator check: user {UserId} is direct coordinator of team {TeamName} ({TeamId})",
-                userId, team.Name, teamId);
-            return true;
-        }
-
-        if (coordinatorTeamIds.Contains(teamId))
-        {
-            logger.LogDebug("Coordinator check: user {UserId} has IsManagement role on team {TeamName} ({TeamId})",
-                userId, team.Name, teamId);
-            return true;
-        }
-
-        if (team.ParentTeamId.HasValue)
-        {
-            logger.LogDebug("Coordinator check: checking parent team {ParentTeamId} for user {UserId} on team {TeamName} ({TeamId})",
-                team.ParentTeamId.Value, userId, team.Name, teamId);
-            return IsUserCoordinatorOfActiveTeam(teamsById, coordinatorTeamIds, team.ParentTeamId.Value, userId);
-        }
-
-        logger.LogDebug("Coordinator check: user {UserId} is NOT coordinator of team {TeamName} ({TeamId})",
-            userId, team.Name, teamId);
-        return false;
+        return TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, teamId, userId);
     }
 
     public async Task<bool> RemoveMemberAsync(

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -25,10 +25,7 @@ public sealed class AttendeeContactImportService(
 {
     public async Task<AttendeeImportPlan> BuildPlanAsync(CancellationToken ct = default)
     {
-        var state = await ticketRepository.GetSyncStateAsync(ct);
-        var eventId = state?.VendorEventId;
-        if (string.IsNullOrEmpty(eventId))
-            throw new InvalidOperationException("No active vendor event id — sync has not run.");
+        var eventId = await RequireActiveVendorEventIdAsync(ct);
 
         var unmatched = await ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
         var decisions = new List<AttendeeImportDecision>();
@@ -76,154 +73,53 @@ public sealed class AttendeeContactImportService(
             throw new InvalidOperationException("No active vendor event id — sync has not run.");
 
         // Re-query so plan/apply are stateless (a sync between plan and apply is tolerated).
-        var freshUnmatched = await ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
-        var freshById = freshUnmatched.ToDictionary(a => a.Id);
-
-        var toUpsert = new List<TicketAttendee>();
-        var newlyMatchedUserIds = new HashSet<Guid>();
-        int attempted = 0, created = 0, attached = 0, replaced = 0,
-            ambiguous = 0, noEmail = 0, vanished = 0, errors = 0;
+        var freshById = await LoadFreshUnmatchedAttendeesByIdAsync(eventId, ct);
+        var importState = new AttendeeImportApplyState();
 
         foreach (var d in plan.Decisions.Where(d => selectedAttendeeIds.Contains(d.AttendeeId)))
         {
-            attempted++;
+            importState.Attempted++;
 
-            var groupIds = new List<Guid>(1 + (d.AdditionalAttendeeIds?.Count ?? 0))
-                { d.AttendeeId };
-            if (d.AdditionalAttendeeIds is { Count: > 0 } more) groupIds.AddRange(more);
-
-            // Tolerate per-attendee drift between plan and apply (lead must remain).
-            var resolved = new List<TicketAttendee>();
-            foreach (var gid in groupIds)
-            {
-                if (!freshById.TryGetValue(gid, out var ga))
-                {
-                    logger.LogWarning(
-                        "Attendee {AttendeeId} ({Email}) vanished between plan and apply",
-                        gid, d.Email);
-                    continue;
-                }
-                // Trim+OrdinalIgnoreCase to match plan-time grouping.
-                if (!string.Equals(ga.AttendeeEmail?.Trim(), d.Email?.Trim(), StringComparison.OrdinalIgnoreCase))
-                {
-                    logger.LogWarning(
-                        "Attendee {AttendeeId} email drifted between plan ({PlanEmail}) and apply ({FreshEmail}); skipping",
-                        gid, d.Email, ga.AttendeeEmail);
-                    continue;
-                }
-                resolved.Add(ga);
-            }
+            var resolved = ResolveFreshAttendeeGroup(d, freshById);
 
             if (resolved.Count == 0)
             {
-                vanished++;
+                importState.Vanished++;
                 continue;
             }
 
             try
             {
-                switch (d.Outcome)
-                {
-                    case AttendeeImportOutcome.SkipNoEmail:
-                        noEmail++;
-                        break;
-
-                    case AttendeeImportOutcome.SkipVoided:
-                        break;
-
-                    case AttendeeImportOutcome.AmbiguousMultipleVerified:
-                        ambiguous++;
-                        logger.LogWarning(
-                            "Attendee {AttendeeId} email {Email} verified by multiple users {UserIds}",
-                            d.AttendeeId, d.Email, d.AmbiguousUserIds);
-                        break;
-
-                    case AttendeeImportOutcome.AttachVerified:
-                        {
-                            var targetUserId = d.TargetUserId!.Value;
-                            foreach (var ga in resolved)
-                            {
-                                ga.MatchedUserId = targetUserId;
-                                toUpsert.Add(ga);
-                            }
-                            newlyMatchedUserIds.Add(targetUserId);
-                            attached++;
-                            break;
-                        }
-
-                    case AttendeeImportOutcome.DeleteUnverifiedThenCreate:
-                        {
-                            if (d.UnverifiedRowUserId is Guid uid &&
-                                d.UnverifiedEmailIdToDelete is Guid eid)
-                            {
-                                await userEmails.DeleteEmailAsync(uid, eid, ct);
-                            }
-                            var (newUser, wasCreated) = await provisioning.FindOrCreateUserByEmailAsync(
-                                d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
-                            foreach (var ga in resolved)
-                            {
-                                ga.MatchedUserId = newUser.Id;
-                                toUpsert.Add(ga);
-                            }
-                            newlyMatchedUserIds.Add(newUser.Id);
-                            if (wasCreated) created++;
-                            replaced++;
-                            break;
-                        }
-
-                    case AttendeeImportOutcome.CreateNewUser:
-                        {
-                            var (newUser, wasCreated) = await provisioning.FindOrCreateUserByEmailAsync(
-                                d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
-                            foreach (var ga in resolved)
-                            {
-                                ga.MatchedUserId = newUser.Id;
-                                toUpsert.Add(ga);
-                            }
-                            newlyMatchedUserIds.Add(newUser.Id);
-                            if (wasCreated) created++;
-                            break;
-                        }
-                }
+                await ApplyResolvedImportDecisionAsync(d, resolved, importState, ct);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                errors++;
+                importState.Errors++;
                 logger.LogError(ex,
                     "Attendee contact import failed for {AttendeeId} ({Email})",
                     d.AttendeeId, d.Email);
             }
         }
 
-        if (toUpsert.Count > 0)
+        if (importState.ToUpsert.Count > 0)
         {
-            await ticketRepository.UpsertAttendeesAsync(toUpsert, ct);
+            await ticketRepository.UpsertAttendeesAsync(importState.ToUpsert, ct);
         }
 
         // Evict before participation loop so attendee mutation always invalidates caches.
         ticketCacheInvalidator.InvalidateAfterContactImport();
 
         var active = await shifts.GetActiveAsync();
-        if (active is not null && newlyMatchedUserIds.Count > 0)
+        if (active is not null && importState.NewlyMatchedUserIds.Count > 0)
         {
-            foreach (var userId in newlyMatchedUserIds)
+            foreach (var userId in importState.NewlyMatchedUserIds)
             {
                 await users.SetParticipationFromTicketSyncAsync(
                     userId, active.Year, ParticipationStatus.Ticketed, checkedInAt: null, ct);
             }
         }
 
-        var elapsed = clock.GetCurrentInstant() - start;
-        var result = new AttendeeImportResult(
-            TotalAttempted: attempted,
-            UsersCreated: created,
-            AttachedToExistingVerified: attached,
-            UnverifiedRowsDeletedAndUserCreated: replaced,
-            AmbiguousSkipped: ambiguous,
-            NoEmailSkipped: noEmail,
-            VanishedBetweenPlanAndApply: vanished,
-            Errors: errors,
-            Elapsed: elapsed);
+        var result = BuildImportResult(importState, start);
 
         await audit.LogAsync(
             AuditAction.TicketContactsImported,
@@ -233,6 +129,135 @@ public sealed class AttendeeContactImportService(
 
         return result;
     }
+
+    private async Task<string> RequireActiveVendorEventIdAsync(CancellationToken ct)
+    {
+        var state = await ticketRepository.GetSyncStateAsync(ct);
+        return string.IsNullOrEmpty(state?.VendorEventId)
+            ? throw new InvalidOperationException("No active vendor event id — sync has not run.")
+            : state.VendorEventId;
+    }
+
+    private async Task<Dictionary<Guid, TicketAttendee>> LoadFreshUnmatchedAttendeesByIdAsync(
+        string eventId,
+        CancellationToken ct)
+    {
+        var freshUnmatched = await ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
+        return freshUnmatched.ToDictionary(a => a.Id);
+    }
+
+    private List<TicketAttendee> ResolveFreshAttendeeGroup(
+        AttendeeImportDecision decision,
+        IReadOnlyDictionary<Guid, TicketAttendee> freshById)
+    {
+        var groupIds = new List<Guid>(1 + (decision.AdditionalAttendeeIds?.Count ?? 0))
+            { decision.AttendeeId };
+        if (decision.AdditionalAttendeeIds is { Count: > 0 } more)
+            groupIds.AddRange(more);
+
+        var resolved = new List<TicketAttendee>();
+        foreach (var groupId in groupIds)
+        {
+            if (!freshById.TryGetValue(groupId, out var attendee))
+            {
+                logger.LogWarning(
+                    "Attendee {AttendeeId} ({Email}) vanished between plan and apply",
+                    groupId, decision.Email);
+                continue;
+            }
+
+            if (!string.Equals(
+                    attendee.AttendeeEmail?.Trim(),
+                    decision.Email?.Trim(),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogWarning(
+                    "Attendee {AttendeeId} email drifted between plan ({PlanEmail}) and apply ({FreshEmail}); skipping",
+                    groupId, decision.Email, attendee.AttendeeEmail);
+                continue;
+            }
+
+            resolved.Add(attendee);
+        }
+
+        return resolved;
+    }
+
+    private async Task ApplyResolvedImportDecisionAsync(
+        AttendeeImportDecision decision,
+        IReadOnlyList<TicketAttendee> resolved,
+        AttendeeImportApplyState state,
+        CancellationToken ct)
+    {
+        switch (decision.Outcome)
+        {
+            case AttendeeImportOutcome.SkipNoEmail:
+                state.NoEmail++;
+                return;
+
+            case AttendeeImportOutcome.SkipVoided:
+                return;
+
+            case AttendeeImportOutcome.AmbiguousMultipleVerified:
+                state.Ambiguous++;
+                logger.LogWarning(
+                    "Attendee {AttendeeId} email {Email} verified by multiple users {UserIds}",
+                    decision.AttendeeId, decision.Email, decision.AmbiguousUserIds);
+                return;
+
+            case AttendeeImportOutcome.AttachVerified:
+                AttachResolvedAttendees(resolved, decision.TargetUserId!.Value, state);
+                state.Attached++;
+                return;
+
+            case AttendeeImportOutcome.DeleteUnverifiedThenCreate:
+                if (decision.UnverifiedRowUserId is Guid uid &&
+                    decision.UnverifiedEmailIdToDelete is Guid eid)
+                {
+                    await userEmails.DeleteEmailAsync(uid, eid, ct);
+                }
+
+                var replacement = await provisioning.FindOrCreateUserByEmailAsync(
+                    decision.Email!, decision.AttendeeName, ContactSource.TicketTailor, ct);
+                AttachResolvedAttendees(resolved, replacement.User.Id, state);
+                if (replacement.Created) state.Created++;
+                state.Replaced++;
+                return;
+
+            case AttendeeImportOutcome.CreateNewUser:
+                var createdUser = await provisioning.FindOrCreateUserByEmailAsync(
+                    decision.Email!, decision.AttendeeName, ContactSource.TicketTailor, ct);
+                AttachResolvedAttendees(resolved, createdUser.User.Id, state);
+                if (createdUser.Created) state.Created++;
+                return;
+        }
+    }
+
+    private static void AttachResolvedAttendees(
+        IEnumerable<TicketAttendee> resolved,
+        Guid userId,
+        AttendeeImportApplyState state)
+    {
+        foreach (var attendee in resolved)
+        {
+            attendee.MatchedUserId = userId;
+            state.ToUpsert.Add(attendee);
+        }
+
+        state.NewlyMatchedUserIds.Add(userId);
+    }
+
+    private AttendeeImportResult BuildImportResult(AttendeeImportApplyState state, Instant start)
+        => new(
+            TotalAttempted: state.Attempted,
+            UsersCreated: state.Created,
+            AttachedToExistingVerified: state.Attached,
+            UnverifiedRowsDeletedAndUserCreated: state.Replaced,
+            AmbiguousSkipped: state.Ambiguous,
+            NoEmailSkipped: state.NoEmail,
+            VanishedBetweenPlanAndApply: state.Vanished,
+            Errors: state.Errors,
+            Elapsed: clock.GetCurrentInstant() - start);
 
     private async Task<AttendeeImportDecision> ClassifyAsync(
         TicketAttendee a,
@@ -326,4 +351,18 @@ public sealed class AttendeeContactImportService(
 
     private static string? ResolveDisplayName(TicketAttendee a) =>
         string.IsNullOrWhiteSpace(a.AttendeeName) ? null : a.AttendeeName.Trim();
+
+    private sealed class AttendeeImportApplyState
+    {
+        public List<TicketAttendee> ToUpsert { get; } = [];
+        public HashSet<Guid> NewlyMatchedUserIds { get; } = [];
+        public int Attempted { get; set; }
+        public int Created { get; set; }
+        public int Attached { get; set; }
+        public int Replaced { get; set; }
+        public int Ambiguous { get; set; }
+        public int NoEmail { get; set; }
+        public int Vanished { get; set; }
+        public int Errors { get; set; }
+    }
 }

--- a/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
+++ b/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
@@ -180,7 +180,7 @@ public sealed class CachingTeamService(
 
         var currentUserId = userId.Value;
         var isCurrentUserMember = team.Members.Any(m => m.UserId == currentUserId);
-        var isCurrentUserCoordinator = IsUserCoordinatorOfActiveTeam(teamsById, team.Id, currentUserId);
+        var isCurrentUserCoordinator = TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, team.Id, currentUserId);
 
         await using var scope = scopeFactory.CreateAsyncScope();
         var roleAssignmentService = scope.ServiceProvider.GetRequiredService<IRoleAssignmentService>();
@@ -395,7 +395,7 @@ public sealed class CachingTeamService(
             // team (matches CanUserApproveRequestsForTeamAsync's recursive
             // parent walk via IsUserCoordinatorOfActiveTeam).
             var canManage =
-                (isBoardMember || IsUserCoordinatorOfActiveTeam(teamsById, team.Id, userId))
+                (isBoardMember || TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, team.Id, userId))
                 && !team.IsSystemTeam;
 
             var pendingCount = 0;
@@ -565,7 +565,7 @@ public sealed class CachingTeamService(
         CancellationToken cancellationToken = default)
     {
         var teamsById = await GetTeamsByIdAsync(cancellationToken);
-        return IsUserCoordinatorOfActiveTeam(teamsById, teamId, userId);
+        return TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, teamId, userId);
     }
 
     public async Task<bool> RemoveMemberAsync(
@@ -992,29 +992,6 @@ public sealed class CachingTeamService(
                 set.Add(team.Id);
             }
         }
-    }
-
-    private bool IsUserCoordinatorOfActiveTeam(
-        IReadOnlyDictionary<Guid, TeamInfo> teams,
-        Guid teamId,
-        Guid userId)
-    {
-        if (!teams.TryGetValue(teamId, out var team) || !team.IsActive)
-        {
-            logger.LogDebug("Coordinator check: team {TeamId} not found in team cache for user {UserId}", teamId, userId);
-            return false;
-        }
-
-        if (team.Members.Any(m => m.UserId == userId && m.Role == TeamMemberRole.Coordinator))
-            return true;
-
-        // Mirror GetUserCoordinatorTeamIdsAsync: the "by management role assignment"
-        // path was filtered to non-system teams.
-        if (!team.IsSystemTeam && team.ManagementRoleHolderUserIds?.Contains(userId) == true)
-            return true;
-
-        return team.ParentTeamId.HasValue
-            && IsUserCoordinatorOfActiveTeam(teams, team.ParentTeamId.Value, userId);
     }
 
     private static TeamInfo BuildTeamInfo(

--- a/src/Humans.Web/Authorization/Requirements/ExpenseReportAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/ExpenseReportAuthorizationHandler.cs
@@ -13,7 +13,7 @@ namespace Humans.Web.Authorization.Requirements;
 /// submitter / coordinator-of-the-report's-category / FinanceAdmin / Admin × operation.
 /// Deny-by-default: only explicit Succeed paths grant access.
 /// </summary>
-public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetService, ITeamService teamService)
+public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetService, ITeamServiceRead teamService)
     : AuthorizationHandler<ExpenseReportOperationRequirement, ExpenseReportDto>
 {
     protected override async Task HandleRequirementAsync(
@@ -128,7 +128,8 @@ public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetServi
         if (category?.TeamId is null)
             return false;
 
-        return await teamService.IsUserCoordinatorOfTeamAsync(category.TeamId.Value, userId);
+        var teamsById = await teamService.GetTeamsAsync();
+        return TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, category.TeamId.Value, userId);
     }
 
     private static Guid? GetUserId(ClaimsPrincipal user)

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
@@ -37,33 +37,15 @@ public class StoreOrderAuthorizationHandler(
             .ToList();
         if (pending.Count == 0) return;
 
-        Guid? campSeasonId;
-        Guid? teamId;
-        StoreOrderState? orderState;
-        switch (context.Resource)
-        {
-            case OrderDto order:
-                campSeasonId = order.CampSeasonId;
-                teamId = order.TeamId;
-                orderState = order.State;
-                break;
-            case StoreOrderCreateContext create:
-                campSeasonId = create.CampSeasonId;
-                teamId = create.TeamId;
-                orderState = null;
-                break;
-            default:
-                return;
-        }
+        if (!TryResolveResource(context.Resource, out var resource))
+            return;
 
         if (RoleChecks.CanAdministerStore(context.User))
         {
             foreach (var req in pending)
             {
                 // Even admins can't Pay/EditCounterparty a team order — it has no billing.
-                if (teamId is not null &&
-                    (req == StoreOrderOperationRequirement.EditCounterparty ||
-                     req == StoreOrderOperationRequirement.Pay))
+                if (resource.IsTeamOrder && IsTeamBillingBlocked(req))
                     continue;
                 context.Succeed(req);
             }
@@ -82,16 +64,13 @@ public class StoreOrderAuthorizationHandler(
                     context.Succeed(req);
                     continue;
                 }
-                if (teamId is null) continue; // camp orders are view-only for TeamsAdmin
+                if (!resource.IsTeamOrder) continue; // camp orders are view-only for TeamsAdmin
                 // Team orders are non-billable — never Pay/EditCounterparty.
-                if (req == StoreOrderOperationRequirement.EditCounterparty ||
-                    req == StoreOrderOperationRequirement.Pay)
+                if (IsTeamBillingBlocked(req))
                     continue;
                 // Line edits require an Open order, matching the coordinator path and the
                 // StoreService guard ("Cannot add/remove lines from an issued order").
-                var isLineEdit = req == StoreOrderOperationRequirement.AddLine
-                    || req == StoreOrderOperationRequirement.RemoveLine;
-                if (isLineEdit && orderState is not null and not StoreOrderState.Open)
+                if (IsLineEdit(req) && !IsOpenOrCreate(resource))
                     continue;
                 context.Succeed(req);
             }
@@ -102,7 +81,7 @@ public class StoreOrderAuthorizationHandler(
             return;
 
         bool authorized = false;
-        if (campSeasonId is { } sid)
+        if (resource.CampSeasonId is { } sid)
         {
             var season = await campService.GetCampSeasonByIdAsync(sid);
             if (season is not null)
@@ -115,7 +94,7 @@ public class StoreOrderAuthorizationHandler(
                 }
             }
         }
-        else if (teamId is { } tid)
+        else if (resource.TeamId is { } tid)
         {
             var team = await teamService.GetTeamAsync(tid);
             if (team is not null
@@ -129,22 +108,64 @@ public class StoreOrderAuthorizationHandler(
         foreach (var req in pending)
         {
             // Team orders never allow EditCounterparty or Pay regardless of role.
-            if (teamId is not null &&
-                (req == StoreOrderOperationRequirement.EditCounterparty ||
-                 req == StoreOrderOperationRequirement.Pay))
+            if (resource.IsTeamOrder && IsTeamBillingBlocked(req))
                 continue;
 
             // Delete is admin-only; camp leads and team coordinators never delete their own orders.
             if (req == StoreOrderOperationRequirement.Delete) continue;
 
-            var isMutating = req == StoreOrderOperationRequirement.AddLine
-                || req == StoreOrderOperationRequirement.RemoveLine
-                || req == StoreOrderOperationRequirement.EditCounterparty;
-            if (isMutating && orderState is not null and not StoreOrderState.Open)
+            if (IsMutating(req) && !IsOpenOrCreate(resource))
             {
                 continue;
             }
             context.Succeed(req);
         }
+    }
+
+    private static bool TryResolveResource(
+        object? candidate,
+        out StoreOrderAuthorizationResource resource)
+    {
+        switch (candidate)
+        {
+            case OrderDto order:
+                resource = new StoreOrderAuthorizationResource(
+                    order.CampSeasonId,
+                    order.TeamId,
+                    order.State);
+                return true;
+            case StoreOrderCreateContext create:
+                resource = new StoreOrderAuthorizationResource(
+                    create.CampSeasonId,
+                    create.TeamId,
+                    State: null);
+                return true;
+            default:
+                resource = new StoreOrderAuthorizationResource(null, null, null);
+                return false;
+        }
+    }
+
+    private static bool IsTeamBillingBlocked(StoreOrderOperationRequirement requirement)
+        => requirement == StoreOrderOperationRequirement.EditCounterparty
+            || requirement == StoreOrderOperationRequirement.Pay;
+
+    private static bool IsLineEdit(StoreOrderOperationRequirement requirement)
+        => requirement == StoreOrderOperationRequirement.AddLine
+            || requirement == StoreOrderOperationRequirement.RemoveLine;
+
+    private static bool IsMutating(StoreOrderOperationRequirement requirement)
+        => IsLineEdit(requirement)
+            || requirement == StoreOrderOperationRequirement.EditCounterparty;
+
+    private static bool IsOpenOrCreate(StoreOrderAuthorizationResource resource)
+        => resource.State is null or StoreOrderState.Open;
+
+    private sealed record StoreOrderAuthorizationResource(
+        Guid? CampSeasonId,
+        Guid? TeamId,
+        StoreOrderState? State)
+    {
+        public bool IsTeamOrder => TeamId is not null;
     }
 }

--- a/src/Humans.Web/Authorization/Requirements/TeamAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/TeamAuthorizationHandler.cs
@@ -14,7 +14,7 @@ namespace Humans.Web.Authorization.Requirements;
 ///   own team's early entry de facto)
 /// - Everyone else: deny
 /// </summary>
-public class TeamAuthorizationHandler(ITeamService teamService)
+public class TeamAuthorizationHandler(ITeamServiceRead teamService)
     : AuthorizationHandler<TeamOperationRequirement, TeamInfo>
 {
     protected override async Task HandleRequirementAsync(
@@ -39,7 +39,8 @@ public class TeamAuthorizationHandler(ITeamService teamService)
         if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
             return;
 
-        if (await teamService.IsUserCoordinatorOfTeamAsync(resource.Id, userId))
+        var teamsById = await teamService.GetTeamsAsync();
+        if (TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, resource.Id, userId))
         {
             context.Succeed(requirement);
         }

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -64,107 +64,22 @@ public class AccountController(
 
         if (result.Succeeded)
         {
-            var existingUser = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
-            if (existingUser is not null)
-            {
-                existingUser.LastLoginAt = clock.GetCurrentInstant();
-                await userManager.UpdateAsync(existingUser);
-
-                await TryReconcileOAuthIdentityAsync(existingUser.Id, info);
-            }
-
-            logger.LogInformation("User logged in with {Provider}", info.LoginProvider);
-            return RedirectToLocal(returnUrl);
+            return await CompleteKnownExternalLoginAsync(info, returnUrl);
         }
 
         var email = info.Principal.FindFirstValue(ClaimTypes.Email) ?? string.Empty;
         var name = info.Principal.FindFirstValue(ClaimTypes.Name);
 
         // Link-while-signed-in must precede lockout/email-match/create — otherwise a fresh OAuth email spawns a duplicate.
-        if (User.Identity?.IsAuthenticated == true)
-        {
-            var currentUser = await userManager.GetUserAsync(User);
-            if (currentUser is not null)
-            {
-                var addLinkResult = await userManager.AddLoginAsync(currentUser, info);
-                if (addLinkResult.Succeeded)
-                {
-                    currentUser.LastLoginAt = clock.GetCurrentInstant();
-                    await userManager.UpdateAsync(currentUser);
-
-                    if (!string.IsNullOrEmpty(email))
-                    {
-                        await TryReconcileOAuthIdentityAsync(currentUser.Id, info);
-                    }
-
-                    logger.LogInformation(
-                        "Linked {Provider} login to currently-authenticated user {UserId}",
-                        info.LoginProvider, currentUser.Id);
-                    return RedirectToLocal(returnUrl);
-                }
-
-                logger.LogWarning(
-                    "Failed to link {Provider} to authenticated user {UserId}: {Errors}",
-                    info.LoginProvider, currentUser.Id,
-                    string.Join(", ", addLinkResult.Errors.Select(e => e.Description)));
-
-                // Don't fall through — unauthenticated branches would spawn a duplicate User. Surface as error toast.
-                SetError(localizer["EmailGrid_LinkFailed"].Value);
-                return LocalRedirect(Url.IsLocalUrl(returnUrl) ? returnUrl! : "/Profile/Me/Emails");
-            }
-        }
+        var currentUserLink = await TryLinkExternalLoginToCurrentUserAsync(info, returnUrl, email);
+        if (currentUserLink is not null)
+            return currentUserLink;
 
         if (result.IsLockedOut)
         {
-            // Lockout-relink: move OAuth login from merged/anonymized source to active target (see Auth.md). Try/catch so a mid-step throw doesn't orphan the login.
-            try
-            {
-                if (!string.IsNullOrEmpty(email))
-                {
-                    var lockedSource = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
-                    var activeTarget = await magicLinkService.FindUserByVerifiedEmailAsync(email);
-                    if (lockedSource is not null && activeTarget is not null && lockedSource.Id != activeTarget.Id)
-                    {
-                        var removeResult = await userManager.RemoveLoginAsync(
-                            lockedSource, info.LoginProvider, info.ProviderKey);
-                        if (removeResult.Succeeded)
-                        {
-                            var relinkResult = await userManager.AddLoginAsync(activeTarget, info);
-                            if (relinkResult.Succeeded)
-                            {
-                                activeTarget.LastLoginAt = clock.GetCurrentInstant();
-                                await userManager.UpdateAsync(activeTarget);
-                                await signInManager.SignInAsync(activeTarget, isPersistent: false);
-
-                                await TryReconcileOAuthIdentityAsync(activeTarget.Id, info);
-
-                                logger.LogInformation(
-                                    "Relinked {Provider} login from locked source {SourceId} to active target {TargetId}",
-                                    info.LoginProvider, lockedSource.Id, activeTarget.Id);
-                                return RedirectToLocal(returnUrl);
-                            }
-
-                            logger.LogWarning(
-                                "Lockout-relink: AddLoginAsync to {TargetId} failed: {Errors}",
-                                activeTarget.Id,
-                                string.Join(", ", relinkResult.Errors.Select(e => e.Description)));
-                        }
-                        else
-                        {
-                            logger.LogWarning(
-                                "Lockout-relink: RemoveLoginAsync from {SourceId} failed: {Errors}",
-                                lockedSource.Id,
-                                string.Join(", ", removeResult.Errors.Select(e => e.Description)));
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex,
-                    "Error during lockout-relink for {Provider}; falling through to lockedout redirect",
-                    info.LoginProvider);
-            }
+            var relink = await TryRelinkLockedOutExternalLoginAsync(info, returnUrl, email);
+            if (relink is not null)
+                return relink;
 
             return RedirectToAction(nameof(Login), new { returnUrl, error = "lockedout" });
         }
@@ -175,39 +90,173 @@ public class AccountController(
             return RedirectToAction(nameof(Login), new { returnUrl, error = "oauth" });
         }
 
-        var existingByEmail = await magicLinkService.FindUserByVerifiedEmailAsync(email);
-        if (existingByEmail is not null)
+        var existingUserLink = await TryLinkExternalLoginByVerifiedEmailAsync(info, returnUrl, email);
+        if (existingUserLink is not null)
+            return existingUserLink;
+
+        return await CreateExternalLoginUserAsync(info, returnUrl, email, name);
+    }
+
+    private async Task<IActionResult> CompleteKnownExternalLoginAsync(ExternalLoginInfo info, string returnUrl)
+    {
+        var existingUser = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+        if (existingUser is not null)
         {
-            try
-            {
-                var linkResult = await userManager.AddLoginAsync(existingByEmail, info);
-                if (linkResult.Succeeded)
-                {
-                    existingByEmail.LastLoginAt = clock.GetCurrentInstant();
-                    await userManager.UpdateAsync(existingByEmail);
-
-                    await TryReconcileOAuthIdentityAsync(existingByEmail.Id, info);
-
-                    await signInManager.SignInAsync(existingByEmail, isPersistent: false);
-                    logger.LogInformation(
-                        "Linked {Provider} login to existing user {UserId} via email match",
-                        info.LoginProvider, existingByEmail.Id);
-                    return RedirectToLocal(returnUrl);
-                }
-
-                logger.LogWarning(
-                    "Failed to link {Provider} to existing user {UserId}: {Errors}",
-                    info.LoginProvider, existingByEmail.Id,
-                    string.Join(", ", linkResult.Errors.Select(e => e.Description)));
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex,
-                    "Error linking {Provider} to existing user {UserId}, falling through to create new account",
-                    info.LoginProvider, existingByEmail.Id);
-            }
+            existingUser.LastLoginAt = clock.GetCurrentInstant();
+            await userManager.UpdateAsync(existingUser);
+            await TryReconcileOAuthIdentityAsync(existingUser.Id, info);
         }
 
+        logger.LogInformation("User logged in with {Provider}", info.LoginProvider);
+        return RedirectToLocal(returnUrl);
+    }
+
+    private async Task<IActionResult?> TryLinkExternalLoginToCurrentUserAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email)
+    {
+        if (User.Identity?.IsAuthenticated != true)
+            return null;
+
+        var currentUser = await userManager.GetUserAsync(User);
+        if (currentUser is null)
+            return null;
+
+        var addLinkResult = await userManager.AddLoginAsync(currentUser, info);
+        if (addLinkResult.Succeeded)
+        {
+            currentUser.LastLoginAt = clock.GetCurrentInstant();
+            await userManager.UpdateAsync(currentUser);
+
+            if (!string.IsNullOrEmpty(email))
+                await TryReconcileOAuthIdentityAsync(currentUser.Id, info);
+
+            logger.LogInformation(
+                "Linked {Provider} login to currently-authenticated user {UserId}",
+                info.LoginProvider,
+                currentUser.Id);
+            return RedirectToLocal(returnUrl);
+        }
+
+        logger.LogWarning(
+            "Failed to link {Provider} to authenticated user {UserId}: {Errors}",
+            info.LoginProvider,
+            currentUser.Id,
+            string.Join(", ", addLinkResult.Errors.Select(e => e.Description)));
+
+        SetError(localizer["EmailGrid_LinkFailed"].Value);
+        return LocalRedirect(Url.IsLocalUrl(returnUrl) ? returnUrl : "/Profile/Me/Emails");
+    }
+
+    private async Task<IActionResult?> TryRelinkLockedOutExternalLoginAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(email))
+                return null;
+
+            var lockedSource = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+            var activeTarget = await magicLinkService.FindUserByVerifiedEmailAsync(email);
+            if (lockedSource is null || activeTarget is null || lockedSource.Id == activeTarget.Id)
+                return null;
+
+            var removeResult = await userManager.RemoveLoginAsync(
+                lockedSource,
+                info.LoginProvider,
+                info.ProviderKey);
+            if (!removeResult.Succeeded)
+            {
+                logger.LogWarning(
+                    "Lockout-relink: RemoveLoginAsync from {SourceId} failed: {Errors}",
+                    lockedSource.Id,
+                    string.Join(", ", removeResult.Errors.Select(e => e.Description)));
+                return null;
+            }
+
+            var relinkResult = await userManager.AddLoginAsync(activeTarget, info);
+            if (!relinkResult.Succeeded)
+            {
+                logger.LogWarning(
+                    "Lockout-relink: AddLoginAsync to {TargetId} failed: {Errors}",
+                    activeTarget.Id,
+                    string.Join(", ", relinkResult.Errors.Select(e => e.Description)));
+                return null;
+            }
+
+            activeTarget.LastLoginAt = clock.GetCurrentInstant();
+            await userManager.UpdateAsync(activeTarget);
+            await signInManager.SignInAsync(activeTarget, isPersistent: false);
+            await TryReconcileOAuthIdentityAsync(activeTarget.Id, info);
+
+            logger.LogInformation(
+                "Relinked {Provider} login from locked source {SourceId} to active target {TargetId}",
+                info.LoginProvider,
+                lockedSource.Id,
+                activeTarget.Id);
+            return RedirectToLocal(returnUrl);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error during lockout-relink for {Provider}; falling through to lockedout redirect",
+                info.LoginProvider);
+            return null;
+        }
+    }
+
+    private async Task<IActionResult?> TryLinkExternalLoginByVerifiedEmailAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email)
+    {
+        var existingByEmail = await magicLinkService.FindUserByVerifiedEmailAsync(email);
+        if (existingByEmail is null)
+            return null;
+
+        try
+        {
+            var linkResult = await userManager.AddLoginAsync(existingByEmail, info);
+            if (linkResult.Succeeded)
+            {
+                existingByEmail.LastLoginAt = clock.GetCurrentInstant();
+                await userManager.UpdateAsync(existingByEmail);
+                await TryReconcileOAuthIdentityAsync(existingByEmail.Id, info);
+
+                await signInManager.SignInAsync(existingByEmail, isPersistent: false);
+                logger.LogInformation(
+                    "Linked {Provider} login to existing user {UserId} via email match",
+                    info.LoginProvider,
+                    existingByEmail.Id);
+                return RedirectToLocal(returnUrl);
+            }
+
+            logger.LogWarning(
+                "Failed to link {Provider} to existing user {UserId}: {Errors}",
+                info.LoginProvider,
+                existingByEmail.Id,
+                string.Join(", ", linkResult.Errors.Select(e => e.Description)));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Error linking {Provider} to existing user {UserId}, falling through to create new account",
+                info.LoginProvider,
+                existingByEmail.Id);
+        }
+
+        return null;
+    }
+
+    private async Task<IActionResult> CreateExternalLoginUserAsync(
+        ExternalLoginInfo info,
+        string returnUrl,
+        string email,
+        string? name)
+    {
         var newUserId = Guid.NewGuid();
 #pragma warning disable HUM_USER_DISPLAYNAME // OAuth signup seeds the legacy Identity fallback column.
         var user = new User
@@ -221,35 +270,32 @@ public class AccountController(
 
         var createResult = await userManager.CreateAsync(user);
         if (!createResult.Succeeded)
-        {
-            foreach (var error in createResult.Errors)
-                ModelState.AddModelError(string.Empty, error.Description);
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
-        }
+            return LoginViewWithErrors(returnUrl, createResult.Errors);
 
-        // Roll back the just-created User on link failure — RequireUniqueEmail=false leaves us responsible for cleanup.
         var oauthLinkResult = await userManager.AddLoginAsync(user, info);
         if (!oauthLinkResult.Succeeded)
         {
-            try
-            {
-                await userManager.DeleteAsync(user);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex,
-                    "Failed to clean up orphan user {UserId} after AddLoginAsync failure for {Provider}",
-                    user.Id, info.LoginProvider);
-            }
-
-            foreach (var error in oauthLinkResult.Errors)
-                ModelState.AddModelError(string.Empty, error.Description);
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
+            await TryDeleteOrphanUserAsync(user);
+            return LoginViewWithErrors(returnUrl, oauthLinkResult.Errors);
         }
 
-        // Reconcile creates the UserEmail row; on throw or CrossUserBlocked, roll back the User to avoid an unreachable orphan.
+        var reconcileResult = await TryReconcileNewExternalLoginUserAsync(user, info, email, returnUrl);
+        if (reconcileResult is not null)
+            return reconcileResult;
+
+        await userService.EnsureStubProfileAsync(user.Id);
+
+        await signInManager.SignInAsync(user, isPersistent: false);
+        logger.LogInformation("User created an account using {Provider}", info.LoginProvider);
+        return RedirectToLocal(returnUrl);
+    }
+
+    private async Task<IActionResult?> TryReconcileNewExternalLoginUserAsync(
+        User user,
+        ExternalLoginInfo info,
+        string email,
+        string returnUrl)
+    {
         try
         {
             var reconcile = await userEmailService.ReconcileOAuthIdentityAsync(
@@ -259,15 +305,11 @@ public class AccountController(
                 email,
                 claimEmailVerified: ReadEmailVerifiedClaim(info));
 
-            // CrossUserBlocked: service already audited + logged; roll back the orphan User + login.
-            if (reconcile.Outcome == ReconcileOutcome.CrossUserBlocked)
-            {
-                await TryDeleteOrphanUserAsync(user);
-                ModelState.AddModelError(string.Empty,
-                    "We couldn't finish setting up your account. Please try again.");
-                ViewData["ReturnUrl"] = returnUrl;
-                return View(nameof(Login));
-            }
+            if (reconcile.Outcome != ReconcileOutcome.CrossUserBlocked)
+                return null;
+
+            await TryDeleteOrphanUserAsync(user);
+            return LoginViewWithModelError(returnUrl);
         }
         catch (OAuthReconcileConcurrencyException race)
         {
@@ -276,35 +318,43 @@ public class AccountController(
                 "{UserId} (provider={Provider}, sub={Sub}, claimEmail={Email}); " +
                 "rolling back user + login. The verified-email partial unique " +
                 "index caught a concurrent insert past the reconcile pre-check " +
-                "— investigate via /Profile/Admin/EmailProblems.",
-                user.Id, info.LoginProvider, info.ProviderKey, email);
+                "- investigate via /Profile/Admin/EmailProblems.",
+                user.Id,
+                info.LoginProvider,
+                info.ProviderKey,
+                email);
             await TryDeleteOrphanUserAsync(user);
-            ModelState.AddModelError(string.Empty,
-                "We couldn't finish setting up your account. Please try again.");
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
+            return LoginViewWithModelError(returnUrl);
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
                 "Failed to reconcile OAuth identity for new user {UserId} ({Email}); rolling back user + login",
-                user.Id, email);
+                user.Id,
+                email);
             await TryDeleteOrphanUserAsync(user);
-            ModelState.AddModelError(string.Empty,
-                "We couldn't finish setting up your account. Please try again.");
-            ViewData["ReturnUrl"] = returnUrl;
-            return View(nameof(Login));
+            return LoginViewWithModelError(returnUrl);
         }
-
-        // see #635 (§15i) — Stub Profile invariant.
-        await userService.EnsureStubProfileAsync(user.Id);
-
-        await signInManager.SignInAsync(user, isPersistent: false);
-        logger.LogInformation("User created an account using {Provider}", info.LoginProvider);
-        return RedirectToLocal(returnUrl);
     }
 
-    // Reconcile wrapper for OAuth-success paths — sign-in never blocks on failure (swallow + log).
+    private IActionResult LoginViewWithErrors(string returnUrl, IEnumerable<IdentityError> errors)
+    {
+        foreach (var error in errors)
+            ModelState.AddModelError(string.Empty, error.Description);
+
+        ViewData["ReturnUrl"] = returnUrl;
+        return View(nameof(Login));
+    }
+
+    private IActionResult LoginViewWithModelError(string returnUrl)
+    {
+        ModelState.AddModelError(string.Empty,
+            "We couldn't finish setting up your account. Please try again.");
+        ViewData["ReturnUrl"] = returnUrl;
+        return View(nameof(Login));
+    }
+
+    // Reconcile wrapper for OAuth-success paths - sign-in never blocks on failure (swallow + log).
     private async Task TryReconcileOAuthIdentityAsync(Guid userId, ExternalLoginInfo info)
     {
         var claimEmail = info.Principal.FindFirstValue(ClaimTypes.Email);

--- a/tests/Humans.Application.Tests/Authorization/ExpenseReportAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/ExpenseReportAuthorizationHandlerTests.cs
@@ -20,7 +20,7 @@ namespace Humans.Application.Tests.Authorization;
 public sealed class ExpenseReportAuthorizationHandlerTests
 {
     private readonly IBudgetService _budgetService = Substitute.For<IBudgetService>();
-    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
     private readonly ExpenseReportAuthorizationHandler _handler;
 
     private static readonly Guid SubmitterId = Guid.NewGuid();
@@ -39,15 +39,7 @@ public sealed class ExpenseReportAuthorizationHandlerTests
         _budgetService.GetCategoryByIdAsync(CategoryId)
             .Returns(CreateCategorySnapshot(CategoryId, TeamId));
 
-        // CoordinatorId is a coordinator of TeamId; OtherCoordinatorId is not
-        _teamService.IsUserCoordinatorOfTeamAsync(TeamId, CoordinatorId)
-            .Returns(true);
-        _teamService.IsUserCoordinatorOfTeamAsync(TeamId, OtherCoordinatorId)
-            .Returns(false);
-        _teamService.IsUserCoordinatorOfTeamAsync(Arg.Any<Guid>(), RandomUserId)
-            .Returns(false);
-        _teamService.IsUserCoordinatorOfTeamAsync(Arg.Any<Guid>(), SubmitterId)
-            .Returns(false);
+        _teamService.GetTeamsAsync().Returns(CreateTeamMap());
     }
 
     // ─── Submitter × View ────────────────────────────────────────────────────
@@ -380,6 +372,36 @@ public sealed class ExpenseReportAuthorizationHandlerTests
             0,
             null,
             []);
+
+    private static IReadOnlyDictionary<Guid, TeamInfo> CreateTeamMap()
+    {
+        var teams = new[]
+        {
+            CreateTeamInfo(TeamId, CoordinatorId),
+            CreateTeamInfo(OtherTeamId, OtherCoordinatorId),
+        };
+
+        return teams.ToDictionary(team => team.Id);
+    }
+
+    private static TeamInfo CreateTeamInfo(Guid teamId, Guid coordinatorId) =>
+        new(
+            Id: teamId,
+            Name: "Team",
+            Description: null,
+            Slug: "team",
+            IsActive: true,
+            IsSystemTeam: false,
+            SystemTeamType: SystemTeamType.None,
+            RequiresApproval: false,
+            IsPublicPage: false,
+            IsHidden: false,
+            IsPromotedToDirectory: false,
+            CreatedAt: Instant.MinValue,
+            Members:
+            [
+                new TeamMemberInfo(Guid.NewGuid(), coordinatorId, "Coordinator", null, null, TeamMemberRole.Coordinator, Instant.MinValue)
+            ]);
 
     private static ClaimsPrincipal CreateUser(Guid userId)
     {

--- a/tests/Humans.Application.Tests/Authorization/TeamAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/TeamAuthorizationHandlerTests.cs
@@ -13,9 +13,11 @@ namespace Humans.Application.Tests.Authorization;
 
 public sealed class TeamAuthorizationHandlerTests
 {
-    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
     private readonly TeamAuthorizationHandler _handler;
 
+    private static readonly Guid ParentTeamId = Guid.NewGuid();
+    private static readonly Guid ChildTeamId = Guid.NewGuid();
     private static readonly Guid CoordinatorTeamId = Guid.NewGuid();
     private static readonly Guid OtherTeamId = Guid.NewGuid();
     private static readonly Guid UserId = Guid.NewGuid();
@@ -23,8 +25,7 @@ public sealed class TeamAuthorizationHandlerTests
     public TeamAuthorizationHandlerTests()
     {
         _handler = new TeamAuthorizationHandler(_teamService);
-        _teamService.IsUserCoordinatorOfTeamAsync(CoordinatorTeamId, UserId).Returns(true);
-        _teamService.IsUserCoordinatorOfTeamAsync(OtherTeamId, UserId).Returns(false);
+        _teamService.GetTeamsAsync().Returns(CreateTeamMap());
     }
 
     public static TheoryData<string, string, bool> TeamAuthorizationCases => new()
@@ -47,8 +48,6 @@ public sealed class TeamAuthorizationHandlerTests
         bool expected)
     {
         var regularUserId = Guid.NewGuid();
-        _teamService.IsUserCoordinatorOfTeamAsync(CoordinatorTeamId, regularUserId).Returns(false);
-
         var user = CreateUser(userKind, regularUserId);
         var team = CreateTeam(teamKind);
 
@@ -81,6 +80,17 @@ public sealed class TeamAuthorizationHandlerTests
         result.Should().BeTrue();
     }
 
+    [HumansFact]
+    public async Task Parent_coordinator_can_manage_child_team()
+    {
+        var user = CreateUserWithId(UserId);
+        var team = CreateTeam("child");
+
+        var result = await EvaluateAsync(user, team, TeamOperationRequirement.ManageCoordinators);
+
+        result.Should().BeTrue();
+    }
+
     private async Task<bool> EvaluateAsync(ClaimsPrincipal user, TeamInfo resource, TeamOperationRequirement requirement)
     {
         var context = new AuthorizationHandlerContext([requirement], user, resource);
@@ -93,6 +103,8 @@ public sealed class TeamAuthorizationHandlerTests
         new(
             Id: kind switch
             {
+                "parent" => ParentTeamId,
+                "child" => ChildTeamId,
                 "coordinator" => CoordinatorTeamId,
                 "other" => OtherTeamId,
                 _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
@@ -108,7 +120,17 @@ public sealed class TeamAuthorizationHandlerTests
             IsHidden: false,
             IsPromotedToDirectory: false,
             CreatedAt: Instant.MinValue,
-            Members: []);
+            Members: string.Equals(kind, "coordinator", StringComparison.Ordinal)
+                || string.Equals(kind, "parent", StringComparison.Ordinal)
+                ? [new TeamMemberInfo(Guid.NewGuid(), UserId, "Coordinator", null, null, TeamMemberRole.Coordinator, Instant.MinValue)]
+                : [],
+            ParentTeamId: string.Equals(kind, "child", StringComparison.Ordinal) ? ParentTeamId : null);
+
+    private static IReadOnlyDictionary<Guid, TeamInfo> CreateTeamMap()
+    {
+        var teams = new[] { CreateTeam("parent"), CreateTeam("child"), CreateTeam("coordinator"), CreateTeam("other") };
+        return teams.ToDictionary(team => team.Id);
+    }
 
     private static ClaimsPrincipal CreateUser(string kind, Guid regularUserId) =>
         kind switch

--- a/tests/Humans.Application.Tests/Services/Calendar/CalendarOccurrenceExpanderTests.cs
+++ b/tests/Humans.Application.Tests/Services/Calendar/CalendarOccurrenceExpanderTests.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Calendar;
+using Humans.Application.Services.Calendar;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+
+namespace Humans.Application.Tests.Services.Calendar;
+
+public sealed class CalendarOccurrenceExpanderTests
+{
+    [HumansFact]
+    public void Expand_DropsCancelledRecurringOccurrence()
+    {
+        var eventId = Guid.NewGuid();
+        var cancelledStart = Instant.FromUtc(2026, 6, 2, 10, 0);
+        var info = BuildInfo(
+            id: eventId,
+            start: Instant.FromUtc(2026, 6, 1, 10, 0),
+            end: Instant.FromUtc(2026, 6, 1, 11, 0),
+            recurrenceRule: "FREQ=DAILY;COUNT=3",
+            exceptions:
+            [
+                new CalendarEventExceptionInfo(
+                    Id: Guid.NewGuid(),
+                    OriginalOccurrenceStartUtc: cancelledStart,
+                    IsCancelled: true,
+                    OverrideStartUtc: null,
+                    OverrideEndUtc: null,
+                    OverrideTitle: null,
+                    OverrideDescription: null,
+                    OverrideLocation: null,
+                    OverrideLocationUrl: null),
+            ]);
+
+        var results = CalendarOccurrenceExpander.Expand(
+            [info],
+            Instant.FromUtc(2026, 6, 1, 0, 0),
+            Instant.FromUtc(2026, 6, 4, 0, 0),
+            new Dictionary<Guid, string>(),
+            NullLogger.Instance);
+
+        results.Select(x => x.OccurrenceStartUtc)
+            .Should()
+            .Equal(
+                Instant.FromUtc(2026, 6, 1, 10, 0),
+                Instant.FromUtc(2026, 6, 3, 10, 0));
+    }
+
+    [HumansFact]
+    public void Expand_IncludesOverrideMovedIntoWindow()
+    {
+        var eventId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var originalStart = Instant.FromUtc(2026, 6, 1, 10, 0);
+        var movedStart = Instant.FromUtc(2026, 6, 5, 14, 0);
+        var info = BuildInfo(
+            id: eventId,
+            teamId: teamId,
+            title: "Original",
+            start: originalStart,
+            end: Instant.FromUtc(2026, 6, 1, 11, 0),
+            recurrenceRule: "FREQ=DAILY;COUNT=2",
+            exceptions:
+            [
+                new CalendarEventExceptionInfo(
+                    Id: Guid.NewGuid(),
+                    OriginalOccurrenceStartUtc: originalStart,
+                    IsCancelled: false,
+                    OverrideStartUtc: movedStart,
+                    OverrideEndUtc: Instant.FromUtc(2026, 6, 5, 16, 0),
+                    OverrideTitle: "Moved",
+                    OverrideDescription: null,
+                    OverrideLocation: null,
+                    OverrideLocationUrl: null),
+            ]);
+
+        var results = CalendarOccurrenceExpander.Expand(
+            [info],
+            Instant.FromUtc(2026, 6, 5, 0, 0),
+            Instant.FromUtc(2026, 6, 6, 0, 0),
+            new Dictionary<Guid, string> { [teamId] = "Calendar Team" },
+            NullLogger.Instance);
+
+        var result = results.Should().ContainSingle().Subject;
+        result.EventId.Should().Be(eventId);
+        result.Title.Should().Be("Moved");
+        result.OccurrenceStartUtc.Should().Be(movedStart);
+        result.OccurrenceEndUtc.Should().Be(Instant.FromUtc(2026, 6, 5, 16, 0));
+        result.OriginalOccurrenceStartUtc.Should().Be(originalStart);
+        result.OwningTeamName.Should().Be("Calendar Team");
+    }
+
+    private static CalendarEventInfo BuildInfo(
+        Guid? id = null,
+        Guid? teamId = null,
+        string title = "Test event",
+        Instant? start = null,
+        Instant? end = null,
+        string? recurrenceRule = null,
+        IReadOnlyList<CalendarEventExceptionInfo>? exceptions = null) => new(
+            Id: id ?? Guid.NewGuid(),
+            Title: title,
+            Description: null,
+            Location: null,
+            LocationUrl: null,
+            OwningTeamId: teamId ?? Guid.NewGuid(),
+            StartUtc: start ?? Instant.FromUtc(2026, 6, 1, 10, 0),
+            EndUtc: end ?? Instant.FromUtc(2026, 6, 1, 11, 0),
+            IsAllDay: false,
+            RecurrenceRule: recurrenceRule,
+            RecurrenceTimezone: recurrenceRule is null ? null : "UTC",
+            RecurrenceUntilUtc: null,
+            CreatedByUserId: Guid.NewGuid(),
+            CreatedAt: Instant.FromUtc(2026, 5, 1, 0, 0),
+            UpdatedAt: Instant.FromUtc(2026, 5, 1, 0, 0),
+            Exceptions: exceptions ?? []);
+}


### PR DESCRIPTION
## Summary

This tech-debt pass applies score-independent improvements across bounded workflows instead of chasing detector movement alone:

- consolidated team coordinator authorization reads through the Teams read surface
- clarified calendar occurrence expansion and Google group/Drive reconciliation phases
- clarified OAuth callback, shift range signup, volunteer tracking, ticket attendee import, store-order authorization, and Cantina roster assembly workflows

## Reforge

- Baseline: `57,272`
- Final: `56,681`
- Delta: `-591` points (`~1.03%` reduction)
- Build degraded: `false`
- Compile errors: `0`

Checkpoint file: `local/tech-debt-runs/2026-06-07-codex-2/stage10-after-cantina-roster.json`

## Verification

Targeted tests run during the pass:

- `TeamAuthorizationHandlerTests`, `TeamServiceTests`, `CachingTeamServiceTests`
- `CalendarOccurrenceExpanderTests`
- `GoogleGroupSyncServiceTests`, removal notification tests
- `GoogleWorkspaceSyncServiceTests`, Google integration architecture tests
- `AccountControllerOAuthReconcileTests`, user architecture and endpoint authorization tests
- `ShiftSignupService` focused tests
- `VolunteerTrackingServiceTests`, volunteer tracking web controller tests
- `AttendeeContactImportServiceApplyTests`, `AttendeeContactImportServicePlanTests`, `AttendeeContactImportServiceSquatterTests`, `TicketsContactsAdminControllerTests`
- `StoreOrderAuthorizationHandlerTests`
- `CantinaRosterServiceTests`

Final verification:

- `dotnet build Humans.slnx --disable-build-servers -v q`
- `reforge surface-score --solution Humans.slnx --format Json --all --top-symbols 250`