### PR TITLE
fix(events): keep scroll position when toggling an event favourite

### DIFF
--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -551,7 +551,7 @@ public class EventsController(
         if (user == null) return Challenge();
 
         await guide.ToggleFavouriteAsync(user.Id, eventId);
-        return RedirectToAction(nameof(Browse), new { days, categoryId, venueId, q, favouritesOnly });
+        return RedirectToAction(nameof(Browse), null, new { days, categoryId, venueId, q, favouritesOnly }, $"event-{eventId}");
     }
 
     [HttpPost("Schedule/Unfavourite/{eventId:guid}")]

--- a/src/Humans.Web/Views/Events/Browse.cshtml
+++ b/src/Humans.Web/Views/Events/Browse.cshtml
@@ -107,7 +107,7 @@ else
         <div class="list-group mb-3">
             @foreach (var item in dayGroup.Items)
             {
-                <div class="list-group-item">
+                <div class="list-group-item" id="event-@item.EventId">
                     <div class="d-flex justify-content-between align-items-start">
                         <div>
                             <strong>@item.Title</strong>


### PR DESCRIPTION
## Summary

Toggling a favourite on the Events Browse page POSTed to `ToggleFavourite` and redirected back to `Browse` with no fragment, so the full-page reload always landed the user at the **top** of the page rather than the event they just clicked.

That kinda annoyed me when I was selecting events from top to bottom of the planning!

This tags each event row with `id="event-{EventId}"` and redirects to that fragment, so the post-toggle reload returns to the row that was clicked.

I hope this makes the planning process easier for everyone ^^

## Changes

- `Browse.cshtml` — each event row now carries `id="event-@item.EventId"`.
- `EventsController.cs` — `ToggleFavourite` redirects with the `#event-{eventId}` fragment.

## Known limitation

In the default Browse view this works cleanly. Under the `favouritesOnly` filter, unfavouriting removes the row from the list, so the fragment has no target and the browser stays near the top. A full no-reload fix (AJAX toggle) is the clean upgrade if that case starts to matter.

## Verification

- `dotnet build Humans.slnx -v quiet` → 0 errors (pre-existing `HUM0024` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)