### PR TITLE
feat(debug): break ClientStats bots down by crawler name

### DIFF
--- a/src/Humans.Application/Interfaces/IClientStatsTracker.cs
+++ b/src/Humans.Application/Interfaces/IClientStatsTracker.cs
@@ -31,6 +31,7 @@ public sealed record ClientStatsSnapshot(
     IReadOnlyList<ClientStatCount> OperatingSystems,
     IReadOnlyList<ClientStatCount> Browsers,
     IReadOnlyList<ClientStatCount> DeviceTypes,
+    IReadOnlyList<ClientStatCount> Bots,
     long TotalResolutionSamples,
     IReadOnlyList<ClientStatCount> Resolutions);
 

--- a/src/Humans.Infrastructure/Services/ClientStatsTracker.cs
+++ b/src/Humans.Infrastructure/Services/ClientStatsTracker.cs
@@ -6,11 +6,13 @@ namespace Humans.Infrastructure.Services;
 /// <inheritdoc cref="IClientStatsTracker"/>
 public sealed class ClientStatsTracker : IClientStatsTracker
 {
-    // OS / browser / device labels come from UserAgentClassifier's bounded
-    // vocabulary, so these dictionaries cannot grow without limit.
+    // OS / browser / device / bot labels come from UserAgentClassifier's bounded
+    // vocabulary, so these dictionaries cannot grow without limit. _bots breaks the
+    // collapsed "Bot" bucket down by the specific crawler name.
     private readonly ConcurrentDictionary<string, long> _operatingSystems = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, long> _browsers = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, long> _deviceTypes = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, long> _bots = new(StringComparer.Ordinal);
 
     // Resolution is fed by an anonymous beacon, so distinct buckets are soft-capped
     // to bound memory; once the cap is reached new keys fold into an "Other" bucket.
@@ -27,6 +29,8 @@ public sealed class ClientStatsTracker : IClientStatsTracker
         Bump(_operatingSystems, c.Os);
         Bump(_browsers, c.Browser);
         Bump(_deviceTypes, c.Device);
+        if (c.BotName is { } bot)
+            Bump(_bots, bot);
     }
 
     public void RecordResolution(int screenWidth, int screenHeight)
@@ -54,6 +58,7 @@ public sealed class ClientStatsTracker : IClientStatsTracker
         OperatingSystems: Rank(_operatingSystems),
         Browsers: Rank(_browsers),
         DeviceTypes: Rank(_deviceTypes),
+        Bots: Rank(_bots),
         TotalResolutionSamples: Interlocked.Read(ref _totalResolutionSamples),
         Resolutions: Rank(_resolutions));
 

--- a/src/Humans.Infrastructure/Services/UserAgentClassifier.cs
+++ b/src/Humans.Infrastructure/Services/UserAgentClassifier.cs
@@ -23,9 +23,14 @@ public static class UserAgentClassifier
         var info = HttpUserAgentInformation.Parse(userAgent);
 
         // Bots collapse to a single bucket across all three dimensions so crawler
-        // traffic is visible without inflating cardinality with bot names.
+        // traffic is visible without inflating cardinality. The specific bot name
+        // (from the parser's bounded known-bot list) is carried separately so the
+        // ClientStats screen can break the "Bot" bucket down by crawler.
         if (info.IsRobot())
-            return new ClientClassification("Bot", "Bot", "Bot");
+        {
+            var botName = string.IsNullOrEmpty(info.Name) ? "Other bot" : info.Name!;
+            return new ClientClassification("Bot", "Bot", "Bot", botName);
+        }
 
         var os = MapOs(info.Platform?.PlatformType);
         var browser = string.IsNullOrEmpty(info.Name) ? "Unknown" : info.Name!;
@@ -49,5 +54,10 @@ public static class UserAgentClassifier
     };
 }
 
-/// <summary>Coarse family-level classification of one client.</summary>
-public sealed record ClientClassification(string Os, string Browser, string Device);
+/// <summary>
+/// Coarse family-level classification of one client. <paramref name="BotName"/> is
+/// non-null only when the client is a recognised crawler (<see cref="UserAgentClassifier"/>
+/// still collapses <paramref name="Os"/>/<paramref name="Browser"/>/<paramref name="Device"/>
+/// to <c>"Bot"</c>); it names the specific crawler for the ClientStats breakdown.
+/// </summary>
+public sealed record ClientClassification(string Os, string Browser, string Device, string? BotName = null);

--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -262,11 +262,15 @@ public class DebugController(
                 statusTotal > 0 ? Math.Round(kv.Value * 100.0 / statusTotal, 1) : 0))
             .ToList();
 
+        var totalBotPageViews = snapshot.Bots.Sum(b => b.Count);
+
         var vm = new ClientStatsViewModel(
             TotalPageViews: snapshot.TotalPageViews,
             OperatingSystems: ToRows(snapshot.OperatingSystems, snapshot.TotalPageViews),
             Browsers: ToRows(snapshot.Browsers, snapshot.TotalPageViews),
             DeviceTypes: ToRows(snapshot.DeviceTypes, snapshot.TotalPageViews),
+            TotalBotPageViews: totalBotPageViews,
+            Bots: ToRows(snapshot.Bots, totalBotPageViews),
             TotalResolutionSamples: snapshot.TotalResolutionSamples,
             Resolutions: ToRows(snapshot.Resolutions, snapshot.TotalResolutionSamples),
             TotalResponses: statusTotal,

--- a/src/Humans.Web/Models/ClientStatsViewModel.cs
+++ b/src/Humans.Web/Models/ClientStatsViewModel.cs
@@ -9,6 +9,8 @@ public sealed record ClientStatsViewModel(
     IReadOnlyList<ClientStatRow> OperatingSystems,
     IReadOnlyList<ClientStatRow> Browsers,
     IReadOnlyList<ClientStatRow> DeviceTypes,
+    long TotalBotPageViews,
+    IReadOnlyList<ClientStatRow> Bots,
     long TotalResolutionSamples,
     IReadOnlyList<ClientStatRow> Resolutions,
     long TotalResponses,

--- a/src/Humans.Web/Views/Debug/ClientStats.cshtml
+++ b/src/Humans.Web/Views/Debug/ClientStats.cshtml
@@ -32,6 +32,10 @@
     </div>
     <div class="col-lg-6">
         <partial name="_ClientStatTable"
+                 model="@(new Humans.Web.Models.ClientStatTableModel("Bots / crawlers", "fa-solid fa-robot", Model.TotalBotPageViews, Model.Bots))" />
+    </div>
+    <div class="col-lg-6">
+        <partial name="_ClientStatTable"
                  model="@(new Humans.Web.Models.ClientStatTableModel("Screen resolution", "fa-solid fa-ruler-combined", Model.TotalResolutionSamples, Model.Resolutions))" />
     </div>
 </div>

--- a/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
@@ -8,6 +8,23 @@ public class ClientStatsTrackerTests
 {
     private const string WinChrome = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
     private const string IPhone = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1";
+    private const string Googlebot = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+
+    [HumansFact]
+    public void RecordPageView_TalliesBotsByName()
+    {
+        var tracker = new ClientStatsTracker();
+
+        tracker.RecordPageView(Googlebot);
+        tracker.RecordPageView(Googlebot);
+        tracker.RecordPageView(WinChrome);
+
+        var snap = tracker.GetSnapshot();
+        // Only the crawler is broken out by name; human traffic stays out of the bot tally.
+        snap.Bots.Should().ContainSingle().Which.Count.Should().Be(2);
+        snap.Bots[0].Label.Should().NotBe("Bot");
+        snap.Bots.Should().NotContain(b => b.Label == "Windows" || b.Label == "Chrome");
+    }
 
     [HumansFact]
     public void RecordPageView_TalliesOsAndDevice()

--- a/tests/Humans.Web.Tests/Services/UserAgentClassifierTests.cs
+++ b/tests/Humans.Web.Tests/Services/UserAgentClassifierTests.cs
@@ -46,6 +46,23 @@ public class UserAgentClassifierTests
         result.Device.Should().Be("Bot");
     }
 
+    [HumansFact]
+    public void Classify_Googlebot_SurfacesSpecificBotName()
+    {
+        const string ua = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+
+        var result = UserAgentClassifier.Classify(ua);
+
+        // A recognised crawler carries its specific name (not the "Other bot" fallback)
+        // so the ClientStats screen can break the collapsed "Bot" bucket down.
+        result.BotName.Should().NotBeNullOrEmpty();
+        result.BotName.Should().NotBe("Other bot");
+    }
+
+    [HumansFact]
+    public void Classify_NormalBrowser_HasNoBotName()
+        => UserAgentClassifier.Classify(WinChrome).BotName.Should().BeNull();
+
     [HumansTheory]
     [InlineData(null)]
     [InlineData("")]


### PR DESCRIPTION
## What

`/Debug/ClientStats` collapsed every crawler into a single **Bot** bucket across the OS / Browser / Device tables — you could see *how many* page views were bots, but not *which* bots.

The User-Agent parser (`MyCSharp.HttpUserAgentParser`) already identifies the specific crawler. This surfaces that name on a new **Bots / crawlers** card listing each bot by name + count + %, the same `_ClientStatTable` partial used by the other tables and mirroring the HTTP status-code list.

## How

- `UserAgentClassifier` — keeps the `"Bot"` collapse on OS/Browser/Device, but now also carries the parser's bot name on a new optional `ClientClassification.BotName` (`"Other bot"` fallback if unnamed). Bounded by the parser's known-bot vocabulary, so cardinality stays limited like the other dimensions.
- `ClientStatsTracker` — new `_bots` tally + `Bots` on the snapshot.
- View model / controller — mapped through; bot-traffic total = sum of bot views (denominator for the card's %).
- `ClientStats.cshtml` — new "Bots / crawlers" card between Device type and Screen resolution.

No new interfaces — existing DTOs enriched. In-memory only, resets on redeploy like the rest of the screen.

## Tests

- `UserAgentClassifier`: Googlebot surfaces a specific name (not the `"Other bot"` fallback); a normal browser has `BotName == null`.
- `ClientStatsTracker`: crawlers are tallied by name and human traffic stays out of the bot breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)