### PR TITLE
test(localization): localization-coverage sweep (pseudo-localizer page crawl)

### DIFF
--- a/.github/workflows/localization-sweep.yml
+++ b/.github/workflows/localization-sweep.yml
@@ -1,0 +1,95 @@
+name: Localization coverage sweep
+
+# Renders the app through the pseudo-localizer and reports hard-coded strings on
+# public pages + localized strings on admin pages. Report-only — a maintenance
+# signal, never a gate. The sweep itself is gated out of normal CI (the build
+# job excludes ~Integration and this test SkipUnless RUN_LOCALIZATION_SWEEP=1),
+# so it only runs here, on this schedule or on demand.
+#
+# Runs on GitHub-hosted ubuntu-latest: Docker is present there, so Testcontainers
+# (the seeded Postgres the integration host spins up) works without the
+# container-in-container networking the self-hosted devbox runners need.
+#
+# NOTE: scheduled triggers only fire once this file is on the default branch
+# (main). Until then, run it from the Actions tab via "Run workflow".
+
+on:
+  schedule:
+    # cron has no true "every two weeks"; 1st & 15th at 06:00 UTC is the standard
+    # twice-monthly approximation.
+    - cron: '0 6 1,15 * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DOTNET_VERSION: '10.0.x'
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Run localization sweep
+        env:
+          RUN_LOCALIZATION_SWEEP: '1'
+        run: |
+          dotnet test tests/Humans.Integration.Tests/Humans.Integration.Tests.csproj \
+            --configuration Release \
+            --filter "FullyQualifiedName~LocalizationCoverageSweep" \
+            --logger "console;verbosity=minimal"
+
+      - name: Publish report to job summary
+        if: always()
+        run: |
+          if [ -f localization-sweep-report.md ]; then
+            cat localization-sweep-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No report produced — the sweep did not complete (see the test step)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: localization-sweep-report
+          path: localization-sweep-report.md
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Update tracking issue
+        if: always() && hashFiles('localization-sweep-report.md') != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            sed -n '/^## Summary/,/^## Public pages/p' localization-sweep-report.md | sed '$d'
+            echo ""
+            echo "_Updated $(date -u +'%Y-%m-%d %H:%M UTC') by the scheduled sweep ([run]($RUN_URL))._"
+            echo ""
+            echo "Full report: the **localization-sweep-report** artifact on that run, and the run's job summary."
+            echo ""
+            echo "Report-only — a maintenance signal, not a gate."
+          } > issue-body.md
+
+          NUM="$(gh issue list --repo "$REPO" --state open --search 'Localization coverage sweep in:title' \
+            --json number,title --jq 'first(.[] | select(.title | startswith("Localization coverage sweep")) | .number) // empty')"
+          if [ -n "$NUM" ]; then
+            gh issue edit "$NUM" --repo "$REPO" --body-file issue-body.md
+          else
+            gh issue create --repo "$REPO" \
+              --title "Localization coverage sweep — latest report" \
+              --body-file issue-body.md
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ insp*.xml
 /.claude/skills/stripe-projects
 /.claude/skills/upgrade-stripe
 /skills-lock.json
+
+# Generated artifact of the localization-coverage sweep (tests/.../Localization). Re-created on each run.
+/localization-sweep-report.md

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,6 +86,8 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Stripe.net" Version="51.1.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <!-- HTML parsing for the localization-coverage sweep; pinned to the version HtmlSanitizer already resolves so the solution-wide graph is unchanged. -->
+    <PackageVersion Include="AngleSharp" Version="0.17.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />

--- a/tests/Humans.Integration.Tests/Humans.Integration.Tests.csproj
+++ b/tests/Humans.Integration.Tests/Humans.Integration.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="AngleSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
+++ b/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
@@ -81,7 +81,7 @@ public sealed class LocalizationCoverageSweep(
         }
         catch (Exception ex)
         {
-            return RouteScanResult.Error(route, ex.GetType().Name);
+            return RouteScanResult.Error(route, $"{ex.GetType().Name}: {ex.Message}");
         }
 
         var status = (int)response.StatusCode;

--- a/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
+++ b/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
@@ -1,0 +1,270 @@
+using System.Net;
+using System.Text;
+using AwesomeAssertions;
+using Humans.Integration.Tests.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Humans.Integration.Tests.Localization;
+
+/// <summary>
+/// Localization-coverage sweep. Renders the whole app through the pseudo-localizer
+/// (<see cref="PseudoLocalizationWebApplicationFactory"/>) so every localized string is
+/// bracketed, then crawls every GET page and checks the rendered text:
+/// <list type="bullet">
+///   <item>Public pages (anonymous / <c>AppAccess</c>): unbracketed prose = hard-coded string that should be localized.</item>
+///   <item>Admin/role-gated pages: bracketed text = a string that should have stayed English-only.</item>
+/// </list>
+/// The first run is report-only (it never fails on findings) — it writes
+/// <c>localization-sweep-report.md</c> at the repo root and echoes it to test output. How
+/// aggressively (if at all) it should gate is decided after we read that first report; the
+/// intended cadence is a bi-weekly maintenance sweep, not a per-build blocker.
+/// </summary>
+public sealed class LocalizationCoverageSweep(
+    PseudoLocalizationWebApplicationFactory factory,
+    ITestOutputHelper output) : IClassFixture<PseudoLocalizationWebApplicationFactory>
+{
+    /// <summary>
+    /// Gates the sweep out of normal CI runs (it boots a Postgres container and crawls every
+    /// page, ~20s). Set <c>RUN_LOCALIZATION_SWEEP=1</c> to run it — e.g. from the bi-weekly
+    /// maintenance job. How (and whether) it should gate on findings is decided separately.
+    /// </summary>
+    public static bool SweepEnabled =>
+        string.Equals(Environment.GetEnvironmentVariable("RUN_LOCALIZATION_SWEEP"), "1", StringComparison.Ordinal);
+
+    [HumansFact(
+        Timeout = 600_000,
+        Skip = "Set RUN_LOCALIZATION_SWEEP=1 to run the localization-coverage sweep (bi-weekly maintenance job).",
+        SkipUnless = nameof(SweepEnabled))]
+    public async Task Public_pages_are_localized_and_admin_pages_are_not()
+    {
+        var catalog = SweepRouteCatalog.Build(factory.Services);
+
+        var publicClient = CreateClient();
+        await factory.SignInAsFullyOnboardedAsync(publicClient, DevPersona.Volunteer);
+
+        var adminClient = CreateClient();
+        await factory.SignInAsFullyOnboardedAsync(adminClient, DevPersona.Admin);
+
+        var results = new List<RouteScanResult>(catalog.Crawlable.Count);
+        foreach (var route in catalog.Crawlable)
+        {
+            var client = route.Audience == Audience.Public ? publicClient : adminClient;
+            results.Add(await ScanRoute(client, route));
+        }
+
+        var report = SweepReport.Build(results, catalog.SkippedParamRoutes);
+        var path = SweepReport.Write(report);
+
+        output.WriteLine(report);
+        output.WriteLine($"{Environment.NewLine}Full report written to: {path}");
+
+        results.Should().NotBeEmpty("the sweep must crawl at least one page");
+    }
+
+    private HttpClient CreateClient() =>
+        factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+    private static string? LocationOf(HttpResponseMessage response)
+    {
+        if (response.Headers.Location is not { } location)
+            return null;
+        return location.IsAbsoluteUri ? location.PathAndQuery : location.OriginalString;
+    }
+
+    private static async Task<RouteScanResult> ScanRoute(HttpClient client, RouteCandidate route)
+    {
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.GetAsync(route.Url, TestContext.Current.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return RouteScanResult.Error(route, ex.GetType().Name);
+        }
+
+        var status = (int)response.StatusCode;
+        if (response.StatusCode != HttpStatusCode.OK)
+            return RouteScanResult.NonOk(route, status, LocationOf(response));
+
+        var contentType = response.Content.Headers.ContentType?.MediaType;
+        if (!string.Equals(contentType, "text/html", StringComparison.OrdinalIgnoreCase))
+            return RouteScanResult.NonHtml(route, status, contentType);
+
+        var html = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var runs = RenderedTextScanner.ExtractTextRuns(html);
+
+        var findings = route.Audience == Audience.Public
+            ? runs.Where(r => !RenderedTextScanner.HasMarker(r)).Distinct(StringComparer.Ordinal).ToList()
+            : runs.Where(RenderedTextScanner.HasMarker).Distinct(StringComparer.Ordinal).ToList();
+
+        return RouteScanResult.Scanned(route, status, findings);
+    }
+}
+
+internal enum ScanOutcome
+{
+    Scanned,
+    NonOk,
+    NonHtml,
+    Error,
+}
+
+internal sealed record RouteScanResult(
+    RouteCandidate Route,
+    ScanOutcome Outcome,
+    int StatusCode,
+    string? Detail,
+    IReadOnlyList<string> Findings)
+{
+    public static RouteScanResult Scanned(RouteCandidate route, int status, IReadOnlyList<string> findings) =>
+        new(route, ScanOutcome.Scanned, status, null, findings);
+
+    public static RouteScanResult NonOk(RouteCandidate route, int status, string? location) =>
+        new(route, ScanOutcome.NonOk, status, location, []);
+
+    public static RouteScanResult NonHtml(RouteCandidate route, int status, string? contentType) =>
+        new(route, ScanOutcome.NonHtml, status, contentType, []);
+
+    public static RouteScanResult Error(RouteCandidate route, string error) =>
+        new(route, ScanOutcome.Error, 0, error, []);
+}
+
+internal static class SweepReport
+{
+    private const int MaxRunLength = 160;
+
+    public static string Build(IReadOnlyList<RouteScanResult> results, IReadOnlyList<string> skippedParamRoutes)
+    {
+        var scanned = results.Where(r => r.Outcome == ScanOutcome.Scanned).ToList();
+        var publicWithBare = scanned
+            .Where(r => r.Route.Audience == Audience.Public && r.Findings.Count > 0)
+            .OrderBy(r => r.Route.Url, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var adminWithLocalized = scanned
+            .Where(r => r.Route.Audience == Audience.Restricted && r.Findings.Count > 0)
+            .OrderBy(r => r.Route.Url, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var nonOk = results.Where(r => r.Outcome == ScanOutcome.NonOk).ToList();
+        var nonHtml = results.Where(r => r.Outcome == ScanOutcome.NonHtml).ToList();
+        var errors = results.Where(r => r.Outcome == ScanOutcome.Error).ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Localization coverage sweep");
+        sb.AppendLine();
+        sb.AppendLine("Rendered through the pseudo-localizer (every localized string is bracketed `⟦…⟧`).");
+        sb.AppendLine("Unbracketed prose on a public page = not localized; bracketed text on an admin page = should be English-only.");
+        sb.AppendLine();
+
+        sb.AppendLine("## Summary");
+        sb.AppendLineInv($"- Crawlable GET pages: {results.Count}");
+        sb.AppendLineInv($"- Scanned (200 text/html): {scanned.Count}");
+        sb.AppendLineInv($"- Public pages with hard-coded text: {publicWithBare.Count}");
+        sb.AppendLineInv($"- Admin pages with localized text: {adminWithLocalized.Count}");
+        sb.AppendLineInv($"- Coverage gaps — non-200 responses: {nonOk.Count}");
+        sb.AppendLineInv($"- Non-HTML responses (skipped): {nonHtml.Count}");
+        sb.AppendLineInv($"- Request errors: {errors.Count}");
+        sb.AppendLineInv($"- Coverage gaps — parameterized routes (need seed data): {skippedParamRoutes.Count}");
+        sb.AppendLine();
+
+        sb.AppendLine("## Public pages — hard-coded strings that should be localized");
+        if (publicWithBare.Count == 0)
+        {
+            sb.AppendLine("_None._");
+        }
+        foreach (var result in publicWithBare)
+        {
+            sb.AppendLine();
+            sb.AppendLineInv($"### {result.Route.Url}  ({result.Route.Controller}/{result.Route.Action})");
+            var likelyStatic = result.Findings.Where(f => !IsLikelyDynamic(f)).ToList();
+            var likelyDynamic = result.Findings.Where(IsLikelyDynamic).ToList();
+            foreach (var finding in likelyStatic)
+                sb.AppendLineInv($"- {Display(finding)}");
+            foreach (var finding in likelyDynamic)
+                sb.AppendLineInv($"- _(likely dynamic data)_ {Display(finding)}");
+        }
+        sb.AppendLine();
+
+        sb.AppendLine("## Admin pages — localized strings that should be English-only");
+        if (adminWithLocalized.Count == 0)
+        {
+            sb.AppendLine("_None._");
+        }
+        foreach (var result in adminWithLocalized)
+        {
+            sb.AppendLine();
+            sb.AppendLineInv($"### {result.Route.Url}  ({result.Route.Controller}/{result.Route.Action})");
+            foreach (var finding in result.Findings)
+                sb.AppendLineInv($"- {Display(finding)}");
+        }
+        sb.AppendLine();
+
+        AppendList(sb, "## Coverage gaps — non-200 responses", nonOk
+            .OrderBy(r => r.Route.Url, StringComparer.OrdinalIgnoreCase)
+            .Select(r => FormattableString.Invariant(
+                $"{r.Route.Url} ({r.Route.Controller}/{r.Route.Action}) → {r.StatusCode}{(r.Detail is null ? "" : $" {r.Detail}")} [{r.Route.Audience}]")));
+
+        AppendList(sb, "## Non-HTML responses (skipped)", nonHtml
+            .OrderBy(r => r.Route.Url, StringComparer.OrdinalIgnoreCase)
+            .Select(r => $"{r.Route.Url} ({r.Route.Controller}/{r.Route.Action}) → {r.Detail ?? "?"}"));
+
+        AppendList(sb, "## Request errors", errors
+            .Select(r => $"{r.Route.Url} ({r.Route.Controller}/{r.Route.Action}) → {r.Detail}"));
+
+        AppendList(sb, "## Coverage gaps — parameterized routes (need seed data)", skippedParamRoutes);
+
+        return sb.ToString();
+    }
+
+    private static void AppendLineInv(this StringBuilder sb, FormattableString line) =>
+        sb.AppendLine(FormattableString.Invariant(line));
+
+    public static string Write(string report)
+    {
+        var path = Path.Combine(FindRepoRoot(), "localization-sweep-report.md");
+        File.WriteAllText(path, report);
+        return path;
+    }
+
+    // Cheap first-pass classifier so the public-page findings separate obvious dynamic data
+    // (emails, seeded persona tokens) from real hard-coded literals; refined after the first run.
+    private static bool IsLikelyDynamic(string run)
+    {
+        var value = run.Trim();
+        return value.Contains('@', StringComparison.Ordinal)
+            || value.StartsWith("dev-", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Display(string run)
+    {
+        var trimmed = run.Trim();
+        if (trimmed.Length > MaxRunLength)
+            trimmed = trimmed[..MaxRunLength] + "…";
+        return "`" + trimmed.Replace("`", "'", StringComparison.Ordinal) + "`";
+    }
+
+    private static void AppendList(StringBuilder sb, string heading, IEnumerable<string> items)
+    {
+        var list = items.ToList();
+        sb.AppendLine(heading);
+        if (list.Count == 0)
+        {
+            sb.AppendLine("_None._");
+        }
+        else
+        {
+            foreach (var item in list)
+                sb.AppendLineInv($"- {item}");
+        }
+        sb.AppendLine();
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Humans.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName ?? AppContext.BaseDirectory;
+    }
+}

--- a/tests/Humans.Integration.Tests/Localization/PseudoLocalization.cs
+++ b/tests/Humans.Integration.Tests/Localization/PseudoLocalization.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using Humans.Integration.Tests.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Localization;
+
+namespace Humans.Integration.Tests.Localization;
+
+/// <summary>
+/// Test-only <see cref="IStringLocalizerFactory"/> that wraps every localized lookup in
+/// sentinel brackets (<see cref="PseudoStringLocalizer.Open"/> / <see cref="PseudoStringLocalizer.Close"/>).
+/// When the app renders through this factory, any user-visible text that came from the
+/// localizer is bracketed; therefore any <em>unbracketed</em> prose in the rendered HTML is a
+/// hard-coded (non-localized) literal. This is the engine of the localization-coverage sweep.
+/// </summary>
+internal sealed class PseudoStringLocalizerFactory : IStringLocalizerFactory
+{
+    public IStringLocalizer Create(Type resourceSource) => PseudoStringLocalizer.Instance;
+
+    public IStringLocalizer Create(string baseName, string location) => PseudoStringLocalizer.Instance;
+}
+
+/// <summary>
+/// Returns every requested key wrapped in marker brackets. The sweep only cares whether a
+/// rendered run is marked, so the real resource values are irrelevant — keying off the name
+/// keeps this independent of which .resx entries happen to exist.
+/// </summary>
+internal sealed class PseudoStringLocalizer : IStringLocalizer
+{
+    /// <summary>U+27E6 MATHEMATICAL LEFT WHITE SQUARE BRACKET — does not occur in app content.</summary>
+    public const char Open = '⟦';
+
+    /// <summary>U+27E7 MATHEMATICAL RIGHT WHITE SQUARE BRACKET.</summary>
+    public const char Close = '⟧';
+
+    public static readonly PseudoStringLocalizer Instance = new();
+
+    public LocalizedString this[string name] => Mark(name, name);
+
+    public LocalizedString this[string name, params object[] arguments] =>
+        Mark(name, SafeFormat(name, arguments));
+
+    // The sweep never enumerates resources; it only inspects rendered output for markers.
+    public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+
+    private static string SafeFormat(string name, object[] arguments)
+    {
+        if (arguments is not { Length: > 0 })
+            return name;
+        try
+        {
+            return string.Format(CultureInfo.CurrentCulture, name, arguments);
+        }
+        catch (FormatException)
+        {
+            // Key is a plain resource name (not a composite format string) — leave it as-is.
+            return name;
+        }
+    }
+
+    private static LocalizedString Mark(string name, string value) =>
+        new(name, $"{Open}{value}{Close}", resourceNotFound: false);
+}
+
+/// <summary>
+/// <see cref="HumansWebApplicationFactory"/> with the real <see cref="IStringLocalizerFactory"/>
+/// swapped for <see cref="PseudoStringLocalizerFactory"/>, so every localized string renders
+/// bracketed. The swap also reaches <c>IViewLocalizer</c> and <c>IHtmlLocalizer&lt;T&gt;</c>,
+/// which the framework builds on top of <see cref="IStringLocalizerFactory"/>. Isolated to the
+/// sweep fixture — all other integration tests keep the real localizer.
+/// </summary>
+public sealed class PseudoLocalizationWebApplicationFactory : HumansWebApplicationFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<IStringLocalizerFactory>();
+            services.AddSingleton<IStringLocalizerFactory, PseudoStringLocalizerFactory>();
+        });
+    }
+}

--- a/tests/Humans.Integration.Tests/Localization/RenderedTextScanner.cs
+++ b/tests/Humans.Integration.Tests/Localization/RenderedTextScanner.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+
+namespace Humans.Integration.Tests.Localization;
+
+/// <summary>
+/// Extracts user-visible text runs from rendered HTML and tests them for the pseudo-localizer
+/// marker. Script/style/etc. containers are skipped, whitespace is collapsed, and runs with no
+/// letters (pure digits/punctuation) are dropped — they are never localizable prose.
+/// </summary>
+internal static class RenderedTextScanner
+{
+    private static readonly HtmlParser Parser = new();
+
+    private static readonly HashSet<string> SkipContainers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE", "HEAD", "SVG",
+    };
+
+    /// <summary>
+    /// One run per visible text node — enough granularity to test each for the marker. Scanning
+    /// is scoped to the page's <c>&lt;main&gt;</c> content region so the shared layout shell
+    /// (nav, sidebar, language switcher, footer, feedback modal) — which is identical on every
+    /// page and is its own concern — does not drown the per-page signal. Falls back to the whole
+    /// body if a page has no <c>&lt;main&gt;</c>.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractTextRuns(string html)
+    {
+        var document = Parser.ParseDocument(html);
+        var root = document.QuerySelector("main") ?? (IElement?)document.Body;
+        if (root is null)
+            return [];
+
+        var runs = new List<string>();
+        var stack = new Stack<INode>();
+        PushChildren(stack, root);
+
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            switch (node)
+            {
+                case IText text:
+                    var run = CollapseWhitespace(text.Data);
+                    if (run.Length > 0 && ContainsLetter(run))
+                        runs.Add(run);
+                    break;
+
+                case IElement element when SkipContainers.Contains(element.TagName):
+                    break; // don't descend into script/style/etc.
+
+                default:
+                    PushChildren(stack, node);
+                    break;
+            }
+        }
+
+        return runs;
+    }
+
+    private static void PushChildren(Stack<INode> stack, INode node)
+    {
+        foreach (var child in node.ChildNodes)
+            stack.Push(child);
+    }
+
+    public static bool HasMarker(string run) =>
+        run.Contains(PseudoStringLocalizer.Open) || run.Contains(PseudoStringLocalizer.Close);
+
+    public static string StripMarkers(string run) =>
+        run.Replace(PseudoStringLocalizer.Open.ToString(), string.Empty)
+           .Replace(PseudoStringLocalizer.Close.ToString(), string.Empty);
+
+    private static bool ContainsLetter(string value)
+    {
+        foreach (var c in value)
+        {
+            if (char.IsLetter(c))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string CollapseWhitespace(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        var pendingSpace = false;
+        foreach (var c in value)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                pendingSpace = sb.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+                sb.Append(' ');
+            pendingSpace = false;
+            sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/Humans.Integration.Tests/Localization/RenderedTextScanner.cs
+++ b/tests/Humans.Integration.Tests/Localization/RenderedTextScanner.cs
@@ -5,7 +5,8 @@ using AngleSharp.Html.Parser;
 namespace Humans.Integration.Tests.Localization;
 
 /// <summary>
-/// Extracts user-visible text runs from rendered HTML and tests them for the pseudo-localizer
+/// Extracts user-visible text runs from rendered HTML — both text nodes and a whitelist of
+/// visible attributes (placeholder/title/alt/aria-label) — and tests them for the pseudo-localizer
 /// marker. Script/style/etc. containers are skipped, whitespace is collapsed, and runs with no
 /// letters (pure digits/punctuation) are dropped — they are never localizable prose.
 /// </summary>
@@ -17,6 +18,9 @@ internal static class RenderedTextScanner
     {
         "SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE", "HEAD", "SVG",
     };
+
+    // User-visible attribute text (labels/hints) that should be localized just like body text.
+    private static readonly string[] VisibleTextAttributes = ["placeholder", "title", "alt", "aria-label"];
 
     /// <summary>
     /// One run per visible text node — enough granularity to test each for the marker. Scanning
@@ -42,13 +46,17 @@ internal static class RenderedTextScanner
             switch (node)
             {
                 case IText text:
-                    var run = CollapseWhitespace(text.Data);
-                    if (run.Length > 0 && ContainsLetter(run))
-                        runs.Add(run);
+                    AddRun(runs, text.Data);
                     break;
 
                 case IElement element when SkipContainers.Contains(element.TagName):
                     break; // don't descend into script/style/etc.
+
+                case IElement element:
+                    foreach (var attribute in VisibleTextAttributes)
+                        AddRun(runs, element.GetAttribute(attribute));
+                    PushChildren(stack, element);
+                    break;
 
                 default:
                     PushChildren(stack, node);
@@ -59,6 +67,15 @@ internal static class RenderedTextScanner
         return runs;
     }
 
+    private static void AddRun(List<string> runs, string? value)
+    {
+        if (value is null)
+            return;
+        var run = CollapseWhitespace(value);
+        if (run.Length > 0 && ContainsLetter(run))
+            runs.Add(run);
+    }
+
     private static void PushChildren(Stack<INode> stack, INode node)
     {
         foreach (var child in node.ChildNodes)
@@ -67,10 +84,6 @@ internal static class RenderedTextScanner
 
     public static bool HasMarker(string run) =>
         run.Contains(PseudoStringLocalizer.Open) || run.Contains(PseudoStringLocalizer.Close);
-
-    public static string StripMarkers(string run) =>
-        run.Replace(PseudoStringLocalizer.Open.ToString(), string.Empty)
-           .Replace(PseudoStringLocalizer.Close.ToString(), string.Empty);
 
     private static bool ContainsLetter(string value)
     {

--- a/tests/Humans.Integration.Tests/Localization/SweepRouteCatalog.cs
+++ b/tests/Humans.Integration.Tests/Localization/SweepRouteCatalog.cs
@@ -1,0 +1,139 @@
+using Humans.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Integration.Tests.Localization;
+
+/// <summary>
+/// Whether a page is expected to be localized (member/anonymous facing) or English-only
+/// (role/admin gated). Derived from each endpoint's real authorization metadata.
+/// </summary>
+internal enum Audience
+{
+    /// <summary>Anonymous, or gated only by <see cref="PolicyNames.AppAccess"/> — should be localized.</summary>
+    Public,
+
+    /// <summary>Role- or admin-policy gated — should stay English-only.</summary>
+    Restricted,
+}
+
+internal sealed record RouteCandidate(string Url, Audience Audience, string Controller, string Action);
+
+/// <summary>
+/// Builds the list of crawlable GET pages straight from the MVC action descriptors, so the page
+/// inventory and the public/admin split are both authoritative (no hand-maintained list, no view
+/// markers). Parameterized routes that can't be satisfied without seed data are reported as gaps.
+/// </summary>
+internal static class SweepRouteCatalog
+{
+    // Dev/operational tooling that is not a localizable member page; GET to these is noise (and a
+    // GET to a seeder could mutate state), so they are excluded up front.
+    private static readonly HashSet<string> ExcludedControllers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "DevLogin", "DevSeed",
+    };
+
+    public static SweepCatalog Build(IServiceProvider services)
+    {
+        var provider = services.GetRequiredService<IActionDescriptorCollectionProvider>();
+        var crawlable = new Dictionary<string, RouteCandidate>(StringComparer.OrdinalIgnoreCase);
+        var skipped = new List<string>();
+
+        foreach (var descriptor in provider.ActionDescriptors.Items)
+        {
+            if (descriptor is not ControllerActionDescriptor action)
+                continue;
+            if (ExcludedControllers.Contains(action.ControllerName))
+                continue;
+            if (IsApi(action) || !IsGettable(action))
+                continue;
+
+            if (!TryBuildUrl(action, out var url, out var reason))
+            {
+                skipped.Add($"{action.ControllerName}/{action.ActionName} — {reason}");
+                continue;
+            }
+
+            var candidate = new RouteCandidate(url, Classify(action.EndpointMetadata), action.ControllerName, action.ActionName);
+            crawlable.TryAdd(url, candidate); // first action wins when several map to the same URL
+        }
+
+        var ordered = crawlable.Values
+            .OrderBy(c => c.Audience)
+            .ThenBy(c => c.Url, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new SweepCatalog(ordered, skipped);
+    }
+
+    private static bool IsApi(ControllerActionDescriptor action) =>
+        action.EndpointMetadata.OfType<ApiControllerAttribute>().Any();
+
+    private static bool IsGettable(ControllerActionDescriptor action)
+    {
+        var methods = action.ActionConstraints?
+            .OfType<HttpMethodActionConstraint>()
+            .SelectMany(c => c.HttpMethods)
+            .ToList();
+
+        // No method constraint ⇒ responds to any verb (including GET).
+        return methods is null
+            || methods.Count == 0
+            || methods.Contains("GET", StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static Audience Classify(IEnumerable<object> metadata)
+    {
+        if (metadata.OfType<IAllowAnonymous>().Any())
+            return Audience.Public;
+
+        var authorizeData = metadata.OfType<IAuthorizeData>().ToList();
+        if (authorizeData.Count == 0)
+            return Audience.Public; // no auth, or only the global "must be signed in" fallback — member facing
+
+        foreach (var data in authorizeData)
+        {
+            if (!string.IsNullOrEmpty(data.Roles))
+                return Audience.Restricted;
+            if (!string.IsNullOrEmpty(data.Policy) && !string.Equals(data.Policy, PolicyNames.AppAccess, StringComparison.Ordinal))
+                return Audience.Restricted;
+        }
+
+        return Audience.Public; // gated only by AppAccess (basic active-member gate)
+    }
+
+    private static bool TryBuildUrl(ControllerActionDescriptor action, out string url, out string reason)
+    {
+        url = string.Empty;
+        reason = string.Empty;
+
+        var template = action.AttributeRouteInfo?.Template;
+        if (!string.IsNullOrEmpty(template))
+        {
+            var resolved = template
+                .Replace("[controller]", action.ControllerName, StringComparison.OrdinalIgnoreCase)
+                .Replace("[action]", action.ActionName, StringComparison.OrdinalIgnoreCase);
+
+            if (resolved.Contains('{'))
+            {
+                reason = $"param route: {template}";
+                return false;
+            }
+
+            url = "/" + resolved.TrimStart('/');
+            return true;
+        }
+
+        // Conventional route: {controller=Home}/{action=Index}/{id?}.
+        url = string.Equals(action.ActionName, "Index", StringComparison.OrdinalIgnoreCase)
+            ? $"/{action.ControllerName}"
+            : $"/{action.ControllerName}/{action.ActionName}";
+        return true;
+    }
+}
+
+internal sealed record SweepCatalog(IReadOnlyList<RouteCandidate> Crawlable, IReadOnlyList<string> SkippedParamRoutes);

--- a/tests/Humans.Integration.Tests/Localization/SweepRouteCatalog.cs
+++ b/tests/Humans.Integration.Tests/Localization/SweepRouteCatalog.cs
@@ -118,13 +118,28 @@ internal static class SweepRouteCatalog
                 .Replace("[controller]", action.ControllerName, StringComparison.OrdinalIgnoreCase)
                 .Replace("[action]", action.ActionName, StringComparison.OrdinalIgnoreCase);
 
-            if (resolved.Contains('{'))
+            // Optional ({x?}) and defaulted ({x=…}) segments can be omitted to form a valid URL;
+            // only a required {param} genuinely needs seed data. Drop the omittable ones and skip
+            // only if something required is left (e.g. /Legal from [HttpGet("{slug?}")] is scannable).
+            var kept = new List<string>();
+            foreach (var segment in resolved.Split('/', StringSplitOptions.RemoveEmptyEntries))
             {
-                reason = $"param route: {template}";
-                return false;
+                if (!segment.Contains('{'))
+                {
+                    kept.Add(segment);
+                    continue;
+                }
+
+                var omittable = segment.Contains("?}", StringComparison.Ordinal)
+                    || segment.Contains('=', StringComparison.Ordinal);
+                if (!omittable)
+                {
+                    reason = $"param route: {template}";
+                    return false;
+                }
             }
 
-            url = "/" + resolved.TrimStart('/');
+            url = "/" + string.Join('/', kept);
             return true;
         }
 


### PR DESCRIPTION
## What

An integration sweep that **finds non-localized strings on public pages and localized strings on admin pages** — the pseudo-localizer ("funny localizer") approach.

It renders the whole app through a **pseudo-localizer** that wraps every localized string in marker brackets (`⟦…⟧`), crawls every GET page, and inspects the rendered `<main>`:

- **Public pages** (anonymous / `AppAccess`): unbracketed prose = a hard-coded string that should be localized.
- **Admin / role-gated pages**: bracketed text = a string that should be English-only.

The page inventory **and** the public/admin split come straight from MVC endpoint metadata (`IActionDescriptorCollectionProvider` + each endpoint's authorization policy) — no hand-maintained route list, no view markers. Scanning is scoped to `<main>` so the shared layout shell (nav, sidebar, language switcher, footer, feedback modal) doesn't drown the per-page signal. Visible attribute text (`placeholder`/`title`/`alt`/`aria-label`) is scanned alongside text nodes.

Reuses the existing `HumansWebApplicationFactory` (seeded Postgres + dev-login personas); only `IStringLocalizerFactory` is swapped, isolated to this fixture so other integration tests keep the real localizer.

## How it runs

**Report-only — never gates.** It writes `localization-sweep-report.md` (gitignored) and echoes it to test output.

- **Local, on demand:**
  ```
  RUN_LOCALIZATION_SWEEP=1 dotnet test tests/Humans.Integration.Tests \
    --filter "FullyQualifiedName~LocalizationCoverageSweep"
  ```
  Without the env var it **skips** (2 ms, no container), so it never burdens per-build CI.
- **Scheduled / cloud:** `.github/workflows/localization-sweep.yml` runs it twice-monthly (1st & 15th) and on manual `workflow_dispatch`, on GitHub-hosted `ubuntu-latest` (Docker present → Testcontainers works). Publishes the report to the job summary, uploads it as an artifact, and find-or-updates a tracking issue with the summary. Scheduled triggers activate once this file is on `main`.

## First-run results (77 pages scanned of 187 enumerated)

- **Public pages with hard-coded text: 51** — real gaps (camp/city-planning glossaries, enum values like `Workshop`/`Sqm2800`, form labels, placeholders), plus inherently non-localizable pages (the `/About` listing is package + license names) and dev/demo surfaces (`ColorPalette`, `WidgetGallery`).
- **Admin pages with localized text: 9** — genuine inverse findings (`CampAdmin`, `CampCompliance`, fully-localized `Cantina/Roster`). Whether those are *intended* is a judgment call the sweep surfaces.
- **Coverage gaps**: 104 non-200 (mostly redirects / pages needing query data), 83 parameterized routes skipped (need seed data), 6 non-HTML — reported, not silently dropped.

## Known follow-ups (the "how aggressive" decision)

1. **False-positive buckets to tune**: brand/library names, the language switcher (intentionally each language in its own name), and dev/demo pages (`ColorPalette`/`WidgetGallery`).
2. **Shared-layout chrome** is excluded from per-page scanning; the hard-coded sidebar/language-switcher there is a real but *separate* gap — could be reported once.
3. **Parameterized-route coverage** via a small seed fixture (optional-param routes like `/Legal` are already scanned).
4. **Gating model** — baseline vs report-only vs fail-on-new. _(The bi-weekly job is already wired and report-only; this is just the question of whether it should ever fail.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
