### PR TITLE
feat(events): show event description on the camp events card

### DIFF
--- a/src/Humans.Web/Models/Events/CampEventsCardViewModel.cs
+++ b/src/Humans.Web/Models/Events/CampEventsCardViewModel.cs
@@ -17,6 +17,7 @@ public class CampEventsCardRow
     public Guid EventId { get; set; }
     public string Title { get; set; } = string.Empty;
     public string CategoryName { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
 
     /// <summary>Start time already converted to the guide's local zone.</summary>
     public DateTime StartAt { get; set; }

--- a/src/Humans.Web/ViewComponents/CampEventsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/CampEventsViewComponent.cs
@@ -50,6 +50,7 @@ public class CampEventsViewComponent(
                     EventId = e.Id,
                     Title = e.Title,
                     CategoryName = e.CategoryName,
+                    Description = e.Description,
                     StartAt = EventsTimeHelpers.ToLocalDateTime(e.StartAt, tz),
                     DurationMinutes = e.DurationMinutes,
                     VenueName = e.VenueName,

--- a/src/Humans.Web/Views/Shared/Components/CampEvents/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/CampEvents/Default.cshtml
@@ -55,6 +55,10 @@
                         <text> &middot; <i class="fa-solid fa-user me-1"></i>@row.Host</text>
                     }
                 </div>
+                @if (!string.IsNullOrEmpty(row.Description))
+                {
+                    <p class="mt-2 mb-0 small">@row.Description</p>
+                }
             </div>
         }
     </div>

--- a/tests/Humans.Application.Tests/ViewComponents/CampEventsViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/CampEventsViewComponentTests.cs
@@ -41,10 +41,10 @@ public class CampEventsViewComponentTests
         };
     }
 
-    private static ApprovedEventView Approved(Guid id, string title, Instant startAt) => new(
+    private static ApprovedEventView Approved(Guid id, string title, Instant startAt, string description = "") => new(
         Id: id, CampId: Guid.NewGuid(), GuideSharedVenueId: null, SubmitterUserId: Guid.NewGuid(),
         CategoryId: Guid.NewGuid(), CategorySlug: "music", CategoryName: "Music", CategoryIsSensitive: false,
-        VenueName: null, Title: title, Description: "", LocationNote: null, Host: null,
+        VenueName: null, Title: title, Description: description, LocationNote: null, Host: null,
         StartAt: startAt, DurationMinutes: 60, IsRecurring: false, RecurrenceDays: null,
         PriorityRank: 0, SubmittedAt: startAt, LastUpdatedAt: startAt);
 
@@ -61,7 +61,7 @@ public class CampEventsViewComponentTests
     {
         var userId = Guid.NewGuid();
         var campId = Guid.NewGuid();
-        var early = Approved(Guid.NewGuid(), "Early", Instant.FromUtc(2026, 8, 1, 10, 0));
+        var early = Approved(Guid.NewGuid(), "Early", Instant.FromUtc(2026, 8, 1, 10, 0), description: "Morning yoga by the temple.");
         var late = Approved(Guid.NewGuid(), "Late", Instant.FromUtc(2026, 8, 1, 22, 0));
         _events.GetApprovedEventsAsync(campId, null, null, null,
                 Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
@@ -78,6 +78,7 @@ public class CampEventsViewComponentTests
         vm.Rows.Select(r => r.Title).Should().ContainInOrder("Early", "Late");
         vm.Rows[0].IsFavourited.Should().BeTrue();   // Early — favourited
         vm.Rows[1].IsFavourited.Should().BeFalse();  // Late — not favourited
+        vm.Rows[0].Description.Should().Be("Morning yoga by the temple.");
     }
 
     [HumansFact]


### PR DESCRIPTION
## What

Yesterday's camp events card (#915) rendered each event's title and the time/venue/host meta line but dropped the **description**. This adds it, matching the format used in the Events section's own Browse view.

## Changes

- `CampEventsCardRow` — carry `Description` (sourced from `ApprovedEventView.Description`, already on the read interface; no new surface).
- `CampEventsViewComponent` — map it through.
- `CampEvents/Default.cshtml` — render the description below the meta line using the same markup as `Events/Browse.cshtml`: `<p class="mt-2 mb-0 small">`, gated on a non-empty description.
- Test — extend the ordered-rows ViewComponent test to assert the description flows through to the row VM.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors.
- `dotnet test … --filter CampEventsViewComponentTests` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)