### PR TITLE
refactor(domain): strip 12 dead cross-section User nav properties

### DIFF
--- a/src/Humans.Domain/Entities/AuditLogEntry.cs
+++ b/src/Humans.Domain/Entities/AuditLogEntry.cs
@@ -45,12 +45,6 @@ public class AuditLogEntry
     public Guid? ActorUserId { get; init; }
 
     /// <summary>
-    /// Navigation property to the actor user.
-    /// Uses set (not init) as required by EF Core for navigation properties.
-    /// </summary>
-    public User? ActorUser { get; set; }
-
-    /// <summary>
     /// ID of a secondary related entity (e.g. UserId when EntityType=Team).
     /// Enables per-user views across both direct and related entries.
     /// </summary>

--- a/src/Humans.Domain/Entities/Camp.cs
+++ b/src/Humans.Domain/Entities/Camp.cs
@@ -17,7 +17,6 @@ public class Camp
     public int TimesAtNowhere { get; set; }
 
     public Guid CreatedByUserId { get; init; }
-    public User CreatedByUser { get; set; } = null!;
 
     public Instant CreatedAt { get; init; }
     public Instant UpdatedAt { get; set; }

--- a/src/Humans.Domain/Entities/CampPolygon.cs
+++ b/src/Humans.Domain/Entities/CampPolygon.cs
@@ -13,7 +13,6 @@ public class CampPolygon
     public double AreaSqm { get; set; }
 
     public Guid LastModifiedByUserId { get; set; }
-    public User LastModifiedByUser { get; set; } = null!;
 
     public Instant LastModifiedAt { get; set; }
 }

--- a/src/Humans.Domain/Entities/CampPolygonHistory.cs
+++ b/src/Humans.Domain/Entities/CampPolygonHistory.cs
@@ -13,7 +13,6 @@ public class CampPolygonHistory
     public double AreaSqm { get; init; }
 
     public Guid ModifiedByUserId { get; init; }
-    public User ModifiedByUser { get; set; } = null!;
 
     public Instant ModifiedAt { get; init; }
 

--- a/src/Humans.Domain/Entities/CampSeason.cs
+++ b/src/Humans.Domain/Entities/CampSeason.cs
@@ -44,7 +44,6 @@ public class CampSeason
 
     // Review
     public Guid? ReviewedByUserId { get; set; }
-    public User? ReviewedByUser { get; set; }
     public string? ReviewNotes { get; set; }
     public Instant? ResolvedAt { get; set; }
 

--- a/src/Humans.Domain/Entities/ConsentRecord.cs
+++ b/src/Humans.Domain/Entities/ConsentRecord.cs
@@ -19,11 +19,6 @@ public class ConsentRecord
     public Guid UserId { get; init; }
 
     /// <summary>
-    /// Navigation property to the user.
-    /// </summary>
-    public User User { get; set; } = null!;
-
-    /// <summary>
     /// Foreign key to the document version being consented to.
     /// </summary>
     public Guid DocumentVersionId { get; init; }

--- a/src/Humans.Domain/Entities/EventParticipation.cs
+++ b/src/Humans.Domain/Entities/EventParticipation.cs
@@ -47,9 +47,4 @@ public class EventParticipation
     /// How the status was set.
     /// </summary>
     public ParticipationSource Source { get; set; }
-
-    /// <summary>
-    /// Navigation property to the user.
-    /// </summary>
-    public User User { get; set; } = null!;
 }

--- a/src/Humans.Domain/Entities/Notification.cs
+++ b/src/Humans.Domain/Entities/Notification.cs
@@ -70,11 +70,6 @@ public class Notification
     public Guid? ResolvedByUserId { get; set; }
 
     /// <summary>
-    /// Navigation to the user who resolved this notification.
-    /// </summary>
-    public User? ResolvedByUser { get; set; }
-
-    /// <summary>
     /// Recipients who can see this notification.
     /// </summary>
     public ICollection<NotificationRecipient> Recipients { get; init; } = new List<NotificationRecipient>();

--- a/src/Humans.Domain/Entities/NotificationRecipient.cs
+++ b/src/Humans.Domain/Entities/NotificationRecipient.cs
@@ -27,9 +27,4 @@ public class NotificationRecipient
     /// Navigation to the notification.
     /// </summary>
     public Notification Notification { get; init; } = null!;
-
-    /// <summary>
-    /// Navigation to the recipient user.
-    /// </summary>
-    public User User { get; init; } = null!;
 }

--- a/src/Humans.Domain/Entities/SyncServiceSettings.cs
+++ b/src/Humans.Domain/Entities/SyncServiceSettings.cs
@@ -21,7 +21,4 @@ public class SyncServiceSettings
 
     /// <summary>Who last changed the mode. Null for seed data.</summary>
     public Guid? UpdatedByUserId { get; set; }
-
-    /// <summary>Navigation property to the user who last changed the setting.</summary>
-    public User? UpdatedByUser { get; set; }
 }

--- a/src/Humans.Domain/Entities/TicketAttendee.cs
+++ b/src/Humans.Domain/Entities/TicketAttendee.cs
@@ -34,9 +34,6 @@ public class TicketAttendee
     /// <summary>Auto-matched user by email. Null if no match or no email.</summary>
     public Guid? MatchedUserId { get; set; }
 
-    /// <summary>Navigation to matched user.</summary>
-    public User? MatchedUser { get; set; }
-
     /// <summary>Ticket type name (e.g. "Full Week", "Weekend Pass").</summary>
     public string TicketTypeName { get; set; } = string.Empty;
 

--- a/src/Humans.Domain/Entities/TicketOrder.cs
+++ b/src/Humans.Domain/Entities/TicketOrder.cs
@@ -23,9 +23,6 @@ public class TicketOrder
     /// <summary>Auto-matched user by email. Null if no match found.</summary>
     public Guid? MatchedUserId { get; set; }
 
-    /// <summary>Navigation to matched user.</summary>
-    public User? MatchedUser { get; set; }
-
     /// <summary>Order total amount.</summary>
     public decimal TotalAmount { get; set; }
 

--- a/src/Humans.Infrastructure/Data/Configurations/AuditLog/AuditLogEntryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/AuditLog/AuditLogEntryConfiguration.cs
@@ -46,7 +46,7 @@ public class AuditLogEntryConfiguration : IEntityTypeConfiguration<AuditLogEntry
             .HasMaxLength(100);
 
         // FK to User with SetNull on delete (null ActorUserId = system action or deleted user)
-        builder.HasOne(e => e.ActorUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(e => e.ActorUserId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Data/Configurations/Camps/CampConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Camps/CampConfiguration.cs
@@ -37,7 +37,7 @@ public class CampConfiguration : IEntityTypeConfiguration<Camp>
 
         builder.HasIndex(b => b.Slug).IsUnique();
 
-        builder.HasOne(b => b.CreatedByUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(b => b.CreatedByUserId)
             .OnDelete(DeleteBehavior.Restrict);

--- a/src/Humans.Infrastructure/Data/Configurations/Camps/CampSeasonConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Camps/CampSeasonConfiguration.cs
@@ -59,7 +59,7 @@ public class CampSeasonConfiguration : IEntityTypeConfiguration<CampSeason>
         builder.HasIndex(s => new { s.CampId, s.Year }).IsUnique();
         builder.HasIndex(s => s.Status);
 
-        builder.HasOne(s => s.ReviewedByUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(s => s.ReviewedByUserId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonConfiguration.cs
@@ -26,7 +26,7 @@ public class CampPolygonConfiguration : IEntityTypeConfiguration<CampPolygon>
             .HasForeignKey(p => p.CampSeasonId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        builder.HasOne(p => p.LastModifiedByUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(p => p.LastModifiedByUserId)
             .OnDelete(DeleteBehavior.Restrict);

--- a/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonHistoryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonHistoryConfiguration.cs
@@ -26,7 +26,7 @@ public class CampPolygonHistoryConfiguration : IEntityTypeConfiguration<CampPoly
             .HasForeignKey(h => h.CampSeasonId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        builder.HasOne(h => h.ModifiedByUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(h => h.ModifiedByUserId)
             .OnDelete(DeleteBehavior.Restrict);

--- a/src/Humans.Infrastructure/Data/Configurations/Legal/ConsentRecordConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Legal/ConsentRecordConfiguration.cs
@@ -46,12 +46,10 @@ public class ConsentRecordConfiguration : IEntityTypeConfiguration<ConsentRecord
         // nav (User.ConsentRecords) was stripped. OnDelete(Restrict) preserves
         // append-only history when a User is deleted via the orchestrated
         // anonymization path.
-#pragma warning disable CS0618 // ConsentRecord.User is Obsolete; kept for EF FK + inverse nav.
-        builder.HasOne(cr => cr.User)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(cr => cr.UserId)
             .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
 
         builder.HasIndex(cr => new { cr.UserId, cr.DocumentVersionId })
             .IsUnique();

--- a/src/Humans.Infrastructure/Data/Configurations/Notifications/NotificationConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Notifications/NotificationConfiguration.cs
@@ -52,7 +52,7 @@ public class NotificationConfiguration : IEntityTypeConfiguration<Notification>
         builder.Property(n => n.CreatedAt)
             .IsRequired();
 
-        builder.HasOne(n => n.ResolvedByUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(n => n.ResolvedByUserId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Data/Configurations/Notifications/NotificationRecipientConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Notifications/NotificationRecipientConfiguration.cs
@@ -18,7 +18,7 @@ public class NotificationRecipientConfiguration : IEntityTypeConfiguration<Notif
 
         builder.HasKey(r => new { r.NotificationId, r.UserId });
 
-        builder.HasOne(r => r.User)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(r => r.UserId)
             .OnDelete(DeleteBehavior.Cascade);

--- a/src/Humans.Infrastructure/Data/Configurations/Shifts/EventParticipationConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Shifts/EventParticipationConfiguration.cs
@@ -38,7 +38,7 @@ public class EventParticipationConfiguration : IEntityTypeConfiguration<EventPar
         builder.HasIndex(ep => new { ep.UserId, ep.Year })
             .IsUnique();
 
-        builder.HasOne(ep => ep.User)
+        builder.HasOne<User>()
             .WithMany(u => u.EventParticipations)
             .HasForeignKey(ep => ep.UserId)
             .OnDelete(DeleteBehavior.Cascade);

--- a/src/Humans.Infrastructure/Data/Configurations/SyncServiceSettingsConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/SyncServiceSettingsConfiguration.cs
@@ -32,7 +32,7 @@ public class SyncServiceSettingsConfiguration : IEntityTypeConfiguration<SyncSer
         builder.HasIndex(s => s.ServiceType)
             .IsUnique();
 
-        builder.HasOne(s => s.UpdatedByUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(s => s.UpdatedByUserId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Data/Configurations/Tickets/TicketAttendeeConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Tickets/TicketAttendeeConfiguration.cs
@@ -56,7 +56,7 @@ public class TicketAttendeeConfiguration : IEntityTypeConfiguration<TicketAttend
         builder.Property(a => a.SyncedAt)
             .IsRequired();
 
-        builder.HasOne(a => a.MatchedUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(a => a.MatchedUserId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Data/Configurations/Tickets/TicketOrderConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Tickets/TicketOrderConfiguration.cs
@@ -61,7 +61,7 @@ public class TicketOrderConfiguration : IEntityTypeConfiguration<TicketOrder>
         builder.Property(o => o.SyncedAt)
             .IsRequired();
 
-        builder.HasOne(o => o.MatchedUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(o => o.MatchedUserId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs
@@ -16,9 +16,9 @@ namespace Humans.Infrastructure.Repositories.Notifications;
 /// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
 /// </summary>
 /// <remarks>
-/// Read methods deliberately do not <c>.Include</c> cross-domain navigations
-/// (recipient <see cref="NotificationRecipient.User"/>,
-/// resolver <see cref="Notification.ResolvedByUser"/>). Callers resolve
+/// Read methods deliberately do not <c>.Include</c> cross-domain user data
+/// (recipient <see cref="NotificationRecipient.UserId"/>,
+/// resolver <see cref="Notification.ResolvedByUserId"/>). Callers resolve
 /// display names through <c>IUserService</c> and stitch results in memory,
 /// preserving table ownership (§2c) and eliminating cross-domain joins (§6).
 /// </remarks>


### PR DESCRIPTION
## What

Removes 12 cross-section `→ User` navigation properties that had **zero production read sites**, and converts their EF mappings to the typed-FK form already used by `CampLead`, `Rota`, `ShiftSignup`, etc.

Follow-up to the cross-domain-nav audit: these were the User-targeting navs that had never been `[Obsolete]`-marked. Rather than mark-and-defer, they're deleted outright since nothing reads them — every section already resolves users via `IUserService` / `IUserServiceRead` → `UserInfo`.

| Entity | Nav removed | Section → |
|---|---|---|
| `AuditLogEntry` | `ActorUser` | AuditLog → Users |
| `Camp` | `CreatedByUser` | Camps → Users |
| `CampSeason` | `ReviewedByUser` | Camps → Users |
| `CampPolygon` | `LastModifiedByUser` | CityPlanning → Users |
| `CampPolygonHistory` | `ModifiedByUser` | CityPlanning → Users |
| `ConsentRecord` | `User` | Legal → Users |
| `EventParticipation` | `User` | Shifts → Users |
| `Notification` | `ResolvedByUser` | Notifications → Users |
| `NotificationRecipient` | `User` | Notifications → Users |
| `TicketOrder` | `MatchedUser` | Tickets → Users |
| `TicketAttendee` | `MatchedUser` | Tickets → Users |
| `SyncServiceSettings` | `UpdatedByUser` | (root) → Users |

Each EF config goes from `HasOne(x => x.User)` to `HasOne<User>()` — same FK column, same `OnDelete`. `EventParticipation` keeps its inverse `User.EventParticipations` (used to build `UserInfo`).

Also:
- Drops a dead `#pragma warning disable CS0618` in `ConsentRecordConfiguration` — the comment claimed `ConsentRecord.User` was `[Obsolete]`, but it never was.
- Repoints two `<see cref>` doc comments in `NotificationRepository` to the FK columns.

## Scope boundary

This is the **code-side** cleanup only. The cross-section FK columns, FK constraints, and `[Grandfathered("HUM0024")]` markers are intentionally retained — dropping those is the separate database-level cleanup (needs an EF migration).

## Verification

- ✅ `dotnet build Humans.slnx` — 0 errors (HUM0024 warnings unchanged: the grandfathered cross-section joins still exist)
- ✅ `dotnet ef migrations has-pending-model-changes` — **"No changes have been made to the model since the last migration"** (no migration needed)
- ✅ Full test suite green except 2 `StorePayActionTests` (Stripe) that fail identically on `origin/main` — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)