### PR TITLE
feat(events): allow moderators to directly edit submitted events

### DIFF
--- a/docs/features/26-events.md
+++ b/docs/features/26-events.md
@@ -62,6 +62,18 @@ Both kinds of submission are managed from a single page — **My Event Submissio
 - On Approve: submitter receives confirmation email
 - All decisions logged as append-only ModerationAction records
 
+### US-26.4b: Moderator Edits a Submitted Event
+**As a** GuideModerator
+**I want to** edit a submitted event directly
+**So that** I can fix minor issues without asking the submitter to resubmit
+
+**Acceptance Criteria:**
+- Edit action available from the moderation queue on any non-Withdrawn event
+- Moderator can change all event fields (title, description, category, date/time, duration, location note, host, recurrence, priority rank, venue for individual events)
+- Event status is preserved — the event is not re-queued for moderation
+- Edit is recorded as a `ModerationAction` with type `Edited` (visible in moderation history)
+- No email sent to the submitter on a moderator edit
+
 ### US-26.4b: Withdrawing an Approved Event
 
 **As a** moderator or the original submitter

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.300",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Humans.Application/Interfaces/Events/IEventService.cs
+++ b/src/Humans.Application/Interfaces/Events/IEventService.cs
@@ -95,6 +95,7 @@ public interface IEventService : IApplicationService, IEventServiceRead
     Task<Event?> GetEventForModerationAsync(Guid eventId, CancellationToken ct = default);
     Task<IReadOnlyList<CampEventOverlap>> GetCampEventsForOverlapAsync(CancellationToken ct = default);
     Task ApplyModerationAsync(Guid eventId, Guid actorUserId, EventModerationActionType actionType, string? reason, CancellationToken ct = default);
+    Task ModeratorEditEventAsync(Event guideEvent, Guid actorUserId, CancellationToken ct = default);
 
     // ── Dashboard / Export ────────────────────────────────────────────────
     Task<IReadOnlyList<EventInfo>> GetAllEventsForDashboardAsync(CancellationToken ct = default);

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -414,6 +414,24 @@ public sealed class EventService(IEventRepository repo, IBurnSettingsService bur
     public Task<IReadOnlyList<CampEventOverlap>> GetCampEventsForOverlapAsync(CancellationToken ct = default)
         => repo.GetActiveCampEventsAsync(ct);
 
+    public async Task ModeratorEditEventAsync(Event guideEvent, Guid actorUserId, CancellationToken ct = default)
+    {
+        var now = clock.GetCurrentInstant();
+        guideEvent.LastUpdatedAt = now;
+
+        var action = new EventModerationAction
+        {
+            Id = Guid.NewGuid(),
+            GuideEventId = guideEvent.Id,
+            ActorUserId = actorUserId,
+            Action = EventModerationActionType.Edited,
+            Reason = null,
+            CreatedAt = now
+        };
+
+        await repo.SaveEventAndModerationActionAsync(guideEvent, action, ct);
+    }
+
     public async Task ApplyModerationAsync(
         Guid eventId, Guid actorUserId, EventModerationActionType actionType, string? reason, CancellationToken ct = default)
     {

--- a/src/Humans.Domain/Enums/EventModerationActionType.cs
+++ b/src/Humans.Domain/Enums/EventModerationActionType.cs
@@ -12,5 +12,8 @@ public enum EventModerationActionType
     Rejected = 1,
 
     /// <summary>Moderator requested edits — reason required.</summary>
-    ResubmitRequested = 2
+    ResubmitRequested = 2,
+
+    /// <summary>Moderator edited the event directly without changing its status.</summary>
+    Edited = 3
 }

--- a/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
+++ b/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
@@ -381,6 +381,13 @@ public sealed class CachingEventService(
         await RefreshEventEntryAsync(eventId, ct);
     }
 
+    public async Task ModeratorEditEventAsync(Event guideEvent, Guid actorUserId, CancellationToken ct = default)
+    {
+        await WithInner(inner => inner.ModeratorEditEventAsync(guideEvent, actorUserId, ct));
+        // Field edits on an Approved event must be visible to the public API immediately.
+        await RefreshEventEntryAsync(guideEvent.Id, ct);
+    }
+
     // ==========================================================================
     // Dashboard / Export — moderator-only, must show fresh pending count
     // ==========================================================================

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -881,8 +881,8 @@ public class EventsController(
         {
             ModelState.AddModelError(string.Empty, ex.Message);
             model.Id = eventId;
-            model.CampId = camp.Id;
-            model.CampName = ResolveCampDisplayName(camp);
+            model.CampId = camp2.Id;
+            model.CampName = ResolveCampDisplayName(camp2);
             model.CampSlug = slug;
             await PopulateBarrioDropdownsAsync(model, eventSettings);
             return View("BarrioEventForm", model);

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -206,17 +206,19 @@ public class EventsController(
     }
 
     [HttpGet("Submit/{eventId:guid}/Edit")]
-    public async Task<IActionResult> Edit(Guid eventId)
+    public async Task<IActionResult> Edit(Guid eventId, bool isModerationEdit = false)
     {
         var user = await GetCurrentUserInfoAsync();
         if (user == null) return Challenge();
 
+        var isMod = isModerationEdit && RoleChecks.IsEventsAdmin(User);
+
         var guideEvent = await guide.GetEventForModerationAsync(eventId);
         if (guideEvent is null || guideEvent.CampId != null) return NotFound();
-        if (guideEvent.SubmitterUserId != user.Id && !RoleChecks.IsEventsAdmin(User))
+        if (!isMod && guideEvent.SubmitterUserId != user.Id && !RoleChecks.IsEventsAdmin(User))
             return Forbid();
 
-        if (guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
+        if (!isMod && guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
         {
             SetError("This event cannot be edited in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -248,7 +250,13 @@ public class EventsController(
         model.Host = guideEvent.Host;
         model.IsRecurring = guideEvent.IsRecurring;
         model.RecurrenceDays = guideEvent.RecurrenceDays;
-        model.IsResubmit = guideEvent.Status is EventStatus.Rejected or EventStatus.ResubmitRequested;
+        model.IsResubmit = !isMod && guideEvent.Status is (EventStatus.Rejected or EventStatus.ResubmitRequested);
+
+        if (isMod)
+        {
+            model.IsModerationEdit = true;
+            model.PostUrl = Url.Action(nameof(Update), new { eventId })!;
+        }
 
         return View("IndividualEventForm", model);
     }
@@ -262,10 +270,12 @@ public class EventsController(
 
         var guideEvent = await guide.GetEventForModerationAsync(eventId);
         if (guideEvent is null || guideEvent.CampId != null) return NotFound();
-        if (guideEvent.SubmitterUserId != user.Id && !RoleChecks.IsEventsAdmin(User))
+
+        var isModerationEdit = model.IsModerationEdit && RoleChecks.IsEventsAdmin(User);
+        if (!isModerationEdit && guideEvent.SubmitterUserId != user.Id && !RoleChecks.IsEventsAdmin(User))
             return Forbid();
 
-        if (guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
+        if (!isModerationEdit && guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
         {
             SetError("This event cannot be edited in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -284,6 +294,8 @@ public class EventsController(
         if (!ModelState.IsValid)
         {
             model.Id = eventId;
+            if (isModerationEdit)
+                model.PostUrl = Url.Action(nameof(Update), new { eventId })!;
             await PopulateDropdownsAsync(model, eventSettings);
             return View("IndividualEventForm", model);
         }
@@ -302,6 +314,14 @@ public class EventsController(
         guideEvent.Host = model.Host;
         guideEvent.IsRecurring = model.IsRecurring;
         guideEvent.RecurrenceDays = model.IsRecurring ? model.RecurrenceDays : null;
+
+        if (isModerationEdit)
+        {
+            await guide.ModeratorEditEventAsync(guideEvent, user.Id);
+            logger.LogInformation("Moderator {UserId} edited event '{Title}' ({EventId})", user.Id, model.Title, eventId);
+            SetSuccess($"Event \"{model.Title}\" updated.");
+            return RedirectToAction(nameof(Index), "EventsModeration", new { tab = guideEvent.Status });
+        }
 
         try
         {
@@ -705,15 +725,28 @@ public class EventsController(
     }
 
     [HttpGet("Barrio/{slug}/{eventId:guid}/Edit")]
-    public async Task<IActionResult> BarrioEdit(string slug, Guid eventId)
+    public async Task<IActionResult> BarrioEdit(string slug, Guid eventId, bool isModerationEdit = false)
     {
-        var (error, _, camp) = await ResolveCampEventManagementAsync(slug);
-        if (error != null) return error;
+        var isMod = isModerationEdit && RoleChecks.IsEventsAdmin(User);
+
+        CampInfo camp;
+        if (isMod)
+        {
+            var found = await GetCampBySlugAsync(slug);
+            if (found == null) return NotFound();
+            camp = found;
+        }
+        else
+        {
+            var (error, _, resolved) = await ResolveCampEventManagementAsync(slug);
+            if (error != null) return error;
+            camp = resolved;
+        }
 
         var guideEvent = await guide.GetCampEventAsync(eventId, camp.Id);
         if (guideEvent == null) return NotFound();
 
-        if (guideEvent.Status is not (EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
+        if (!isMod && guideEvent.Status is not (EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
         {
             SetError("This event cannot be edited in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -739,7 +772,13 @@ public class EventsController(
         model.IsRecurring = guideEvent.IsRecurring;
         model.RecurrenceDays = guideEvent.RecurrenceDays;
         model.PriorityRank = guideEvent.PriorityRank;
-        model.IsResubmit = guideEvent.Status is EventStatus.Rejected or EventStatus.ResubmitRequested;
+        model.IsResubmit = !isMod && guideEvent.Status is (EventStatus.Rejected or EventStatus.ResubmitRequested);
+
+        if (isMod)
+        {
+            model.IsModerationEdit = true;
+            model.PostUrl = Url.Action(nameof(BarrioUpdate), new { slug, eventId })!;
+        }
 
         return View("BarrioEventForm", model);
     }
@@ -748,10 +787,57 @@ public class EventsController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> BarrioUpdate(string slug, Guid eventId, CampEventFormViewModel model)
     {
-        var (error, user, camp) = await ResolveCampEventManagementAsync(slug);
+        // Moderation edit: moderator bypasses camp-lead auth check
+        if (model.IsModerationEdit && RoleChecks.IsEventsAdmin(User))
+        {
+            var moderator = await GetCurrentUserInfoAsync();
+            if (moderator == null) return Challenge();
+
+            var camp = await GetCampBySlugAsync(slug);
+            if (camp == null) return NotFound();
+
+            var guideEventForMod = await guide.GetCampEventAsync(eventId, camp.Id);
+            if (guideEventForMod == null) return NotFound();
+
+            var guideSettingsForMod = await guide.GetGuideSettingsAsync()
+                ?? throw new InvalidOperationException("Guide settings not configured.");
+            var eventSettingsForMod = await LoadBurnSettingsAsync(guideSettingsForMod)
+                ?? throw new InvalidOperationException("Event settings not configured.");
+
+            if (!ModelState.IsValid)
+            {
+                model.Id = eventId;
+                model.CampId = camp.Id;
+                model.CampName = ResolveCampDisplayName(camp);
+                model.CampSlug = slug;
+                model.IsModerationEdit = true;
+                model.PostUrl = Url.Action(nameof(BarrioUpdate), new { slug, eventId })!;
+                await PopulateBarrioDropdownsAsync(model, eventSettingsForMod);
+                return View("BarrioEventForm", model);
+            }
+
+            var tzForMod = GetTimeZone(eventSettingsForMod);
+            guideEventForMod.Title = model.Title;
+            guideEventForMod.Description = model.Description;
+            guideEventForMod.CategoryId = model.CategoryId;
+            guideEventForMod.StartAt = ToInstant(model.StartDate.Add(model.StartTime), tzForMod);
+            guideEventForMod.DurationMinutes = model.DurationMinutes;
+            guideEventForMod.LocationNote = model.LocationNote;
+            guideEventForMod.Host = model.Host;
+            guideEventForMod.IsRecurring = model.IsRecurring;
+            guideEventForMod.RecurrenceDays = model.IsRecurring ? model.RecurrenceDays : null;
+            guideEventForMod.PriorityRank = model.PriorityRank;
+
+            await guide.ModeratorEditEventAsync(guideEventForMod, moderator.Id);
+            logger.LogInformation("Moderator {UserId} edited barrio event '{Title}' ({EventId})", moderator.Id, model.Title, eventId);
+            SetSuccess($"Event \"{model.Title}\" updated.");
+            return RedirectToAction(nameof(Index), "EventsModeration", new { tab = guideEventForMod.Status });
+        }
+
+        var (error, user, camp2) = await ResolveCampEventManagementAsync(slug);
         if (error != null) return error;
 
-        var guideEvent = await guide.GetCampEventAsync(eventId, camp.Id);
+        var guideEvent = await guide.GetCampEventAsync(eventId, camp2.Id);
         if (guideEvent == null) return NotFound();
 
         if (guideEvent.Status is not (EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
@@ -768,8 +854,8 @@ public class EventsController(
         if (!ModelState.IsValid)
         {
             model.Id = eventId;
-            model.CampId = camp.Id;
-            model.CampName = ResolveCampDisplayName(camp);
+            model.CampId = camp2.Id;
+            model.CampName = ResolveCampDisplayName(camp2);
             model.CampSlug = slug;
             await PopulateBarrioDropdownsAsync(model, eventSettings);
             return View("BarrioEventForm", model);

--- a/src/Humans.Web/Controllers/EventsModerationController.cs
+++ b/src/Humans.Web/Controllers/EventsModerationController.cs
@@ -117,6 +117,12 @@ public class EventsModerationController(
         var guideEvent = await guide.GetEventForModerationAsync(eventId);
         if (guideEvent == null) return NotFound();
 
+        if (guideEvent.Status == EventStatus.Withdrawn)
+        {
+            SetError("Withdrawn events cannot be edited.");
+            return RedirectToAction(nameof(Index));
+        }
+
         if (guideEvent.CampId.HasValue)
         {
             var guideSettings = await guide.GetGuideSettingsAsync();

--- a/src/Humans.Web/Controllers/EventsModerationController.cs
+++ b/src/Humans.Web/Controllers/EventsModerationController.cs
@@ -111,6 +111,34 @@ public class EventsModerationController(
         return await ProcessActionAsync(model.EventId, EventModerationActionType.Rejected, model.Reason);
     }
 
+    [HttpGet("{eventId:guid}/Edit")]
+    public async Task<IActionResult> Edit(Guid eventId)
+    {
+        var guideEvent = await guide.GetEventForModerationAsync(eventId);
+        if (guideEvent == null) return NotFound();
+
+        if (guideEvent.CampId.HasValue)
+        {
+            var guideSettings = await guide.GetGuideSettingsAsync();
+            var eventSettings = guideSettings != null ? await guide.GetEventSettingsByIdAsync(guideSettings.EventSettingsId) : null;
+            if (eventSettings == null)
+            {
+                SetError("Event settings not configured.");
+                return RedirectToAction(nameof(Index));
+            }
+            var campsById = await LoadCampsByIdAsync(camps, eventSettings.GateOpeningDate.Year);
+            var slug = campsById.GetValueOrDefault(guideEvent.CampId.Value)?.Slug;
+            if (slug == null)
+            {
+                SetError("Camp not found.");
+                return RedirectToAction(nameof(Index));
+            }
+            return RedirectToAction("BarrioEdit", "Events", new { slug, eventId, isModerationEdit = true });
+        }
+
+        return RedirectToAction("Edit", "Events", new { eventId, isModerationEdit = true });
+    }
+
     [HttpPost("Withdraw")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Withdraw(ModerationActionFormModel model)
@@ -152,7 +180,7 @@ public class EventsModerationController(
         return await ProcessActionAsync(model.EventId, EventModerationActionType.ResubmitRequested, model.Reason);
     }
 
-    // ─── Helpers ──────────────────────────────────────────────────
+    // ─── Moderation action helpers ────────────────────────────────
 
     private async Task<IActionResult> ProcessActionAsync(Guid eventId, EventModerationActionType actionType, string? reason)
     {

--- a/src/Humans.Web/Models/Events/BarrioEventViewModels.cs
+++ b/src/Humans.Web/Models/Events/BarrioEventViewModels.cs
@@ -105,6 +105,12 @@ public class CampEventFormViewModel
     /// Whether this is a resubmission of a rejected/resubmit-requested event.
     /// </summary>
     public bool IsResubmit { get; set; }
+
+    /// <summary>When set, the form posts to this URL instead of the default Events controller action.</summary>
+    public string? PostUrl { get; set; }
+
+    /// <summary>When true, the post is a moderator direct edit — status is preserved instead of re-queuing.</summary>
+    public bool IsModerationEdit { get; set; }
 }
 
 public class CategoryOptionViewModel

--- a/src/Humans.Web/Models/Events/EventsModerationViewModels.cs
+++ b/src/Humans.Web/Models/Events/EventsModerationViewModels.cs
@@ -3,6 +3,7 @@ using Humans.Domain.Enums;
 
 namespace Humans.Web.Models.Events;
 
+
 public class ModerationQueueViewModel
 {
     public EventStatus ActiveTab { get; set; } = EventStatus.Pending;
@@ -61,6 +62,7 @@ public class ModerationHistoryItemViewModel
         EventModerationActionType.Approved => "bg-success",
         EventModerationActionType.Rejected => "bg-danger",
         EventModerationActionType.ResubmitRequested => "bg-info",
+        EventModerationActionType.Edited => "bg-primary",
         _ => "bg-secondary"
     };
 }

--- a/src/Humans.Web/Models/Events/IndividualEventViewModels.cs
+++ b/src/Humans.Web/Models/Events/IndividualEventViewModels.cs
@@ -122,6 +122,12 @@ public class IndividualEventFormViewModel
     public string? TimeZoneId { get; set; }
 
     public bool IsResubmit { get; set; }
+
+    /// <summary>When set, the form posts to this URL instead of the default Events controller action.</summary>
+    public string? PostUrl { get; set; }
+
+    /// <summary>When true, the post is a moderator direct edit — status is preserved instead of re-queuing.</summary>
+    public bool IsModerationEdit { get; set; }
 }
 
 public class ScheduleViewModel

--- a/src/Humans.Web/Views/Events/BarrioEventForm.cshtml
+++ b/src/Humans.Web/Views/Events/BarrioEventForm.cshtml
@@ -32,11 +32,10 @@
 <div class="card" style="max-width: 700px;">
     <div class="card-body">
         <form method="post"
-              asp-controller="Events"
-              asp-action="@(isEdit ? "BarrioUpdate" : "BarrioCreate")"
-              asp-route-slug="@Model.CampSlug"
-              asp-route-eventId="@Model.Id">
+              action="@(Model.PostUrl ?? Url.Action(isEdit ? "BarrioUpdate" : "BarrioCreate", "Events", new { slug = Model.CampSlug, eventId = Model.Id }))"
+              >
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="IsModerationEdit" />
 
             <div class="mb-3">
                 <label asp-for="Title" class="form-label"></label>

--- a/src/Humans.Web/Views/Events/BarrioEventForm.cshtml
+++ b/src/Humans.Web/Views/Events/BarrioEventForm.cshtml
@@ -33,6 +33,7 @@
     <div class="card-body">
         <form method="post"
               action="@(Model.PostUrl ?? Url.Action(isEdit ? "BarrioUpdate" : "BarrioCreate", "Events", new { slug = Model.CampSlug, eventId = Model.Id }))"
+              asp-antiforgery="true"
               >
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="IsModerationEdit" />

--- a/src/Humans.Web/Views/Events/IndividualEventForm.cshtml
+++ b/src/Humans.Web/Views/Events/IndividualEventForm.cshtml
@@ -31,6 +31,7 @@
     <div class="card-body">
         <form method="post"
               action="@(Model.PostUrl ?? Url.Action(isEdit ? "Update" : "Create", "Events", new { eventId = Model.Id }))"
+              asp-antiforgery="true"
               >
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="IsModerationEdit" />

--- a/src/Humans.Web/Views/Events/IndividualEventForm.cshtml
+++ b/src/Humans.Web/Views/Events/IndividualEventForm.cshtml
@@ -30,10 +30,10 @@
 <div class="card" style="max-width: 700px;">
     <div class="card-body">
         <form method="post"
-              asp-controller="Events"
-              asp-action="@(isEdit ? "Update" : "Create")"
-              asp-route-eventId="@Model.Id">
+              action="@(Model.PostUrl ?? Url.Action(isEdit ? "Update" : "Create", "Events", new { eventId = Model.Id }))"
+              >
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="IsModerationEdit" />
 
             <div class="mb-3">
                 <label asp-for="Title" class="form-label"></label>

--- a/src/Humans.Web/Views/EventsModeration/Index.cshtml
+++ b/src/Humans.Web/Views/EventsModeration/Index.cshtml
@@ -173,30 +173,13 @@ else
                                 }
                             </div>
 
-                            @if (evt.Status == EventStatus.Approved)
-                            {
-                                <div class="col-md-4">
-                                    <div class="card">
-                                        <div class="card-body">
-                                            <h6 class="card-title">Actions</h6>
-                                            <form method="post" asp-action="Withdraw">
-                                                @Html.AntiForgeryToken()
-                                                <input type="hidden" name="EventId" value="@evt.Id" />
-                                                <button type="submit" class="btn btn-outline-secondary w-100" data-confirm="Withdraw this event? It will be hidden from the guide.">
-                                                    <i class="fa-solid fa-eye-slash me-1"></i>Withdraw
-                                                </button>
-                                            </form>
-                                        </div>
-                                    </div>
-                                </div>
-                            }
-                            @if (evt.Status == EventStatus.Pending)
-                            {
-                                <div class="col-md-4">
-                                    <div class="card">
-                                        <div class="card-body">
-                                            <h6 class="card-title">Actions</h6>
+                            <div class="col-md-4">
+                                <div class="card">
+                                    <div class="card-body">
+                                        <h6 class="card-title">Actions</h6>
 
+                                        @if (evt.Status == EventStatus.Pending)
+                                        {
                                             <form method="post" asp-action="Approve" class="mb-2">
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="EventId" value="@evt.Id" />
@@ -216,7 +199,7 @@ else
                                                 </button>
                                             </form>
 
-                                            <form method="post" asp-action="RequestEdit">
+                                            <form method="post" asp-action="RequestEdit" class="mb-2">
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="EventId" value="@evt.Id" />
                                                 <div class="mb-2">
@@ -226,10 +209,28 @@ else
                                                     <i class="fa-solid fa-pen-to-square me-1"></i>Request Edit
                                                 </button>
                                             </form>
-                                        </div>
+                                        }
+
+                                        @if (evt.Status == EventStatus.Approved)
+                                        {
+                                            <form method="post" asp-action="Withdraw" class="mb-2">
+                                                @Html.AntiForgeryToken()
+                                                <input type="hidden" name="EventId" value="@evt.Id" />
+                                                <button type="submit" class="btn btn-outline-secondary w-100" data-confirm="Withdraw this event? It will be hidden from the guide.">
+                                                    <i class="fa-solid fa-eye-slash me-1"></i>Withdraw
+                                                </button>
+                                            </form>
+                                        }
+
+                                        @if (evt.Status != EventStatus.Withdrawn)
+                                        {
+                                            <a asp-action="Edit" asp-route-eventId="@evt.Id" class="btn btn-outline-primary w-100">
+                                                <i class="fa-solid fa-pencil me-1"></i>Edit
+                                            </a>
+                                        }
                                     </div>
                                 </div>
-                            }
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- Adds an **Edit** button to the moderation queue for all non-Withdrawn events (Pending, Approved, Rejected, ResubmitRequested)
- Moderators can change all event fields directly; event status is preserved (no re-queue)
- Edit is recorded as a new `ModerationAction` with type `Edited`, visible in the moderation history panel
- No email sent to the submitter on a moderator edit

## Implementation notes

- New `EventModerationActionType.Edited = 3` enum value
- New `ModeratorEditEventAsync` on `IEventService` / `EventService` / `CachingEventService` — saves fields + logs action atomically via the existing `SaveEventAndModerationActionAsync` repo method; cache refresh covers Approved events
- Reuses existing `BarrioEventForm` / `IndividualEventForm` views via `PostUrl` + `IsModerationEdit` flags on the view models — no form HTML duplication
- `EventsModerationController.Edit` resolves the camp slug then redirects to the existing `EventsController.BarrioEdit` / `Edit` GET with `isModerationEdit=true`; those actions bypass the status restriction and camp-lead auth check for events admins
- `BarrioUpdate` / `Update` POST actions detect `IsModerationEdit && IsEventsAdmin` and call `ModeratorEditEventAsync` instead of `UpdateAndResubmitAsync`, then redirect back to the moderation queue

## Test plan

- [ ] Build passes (`dotnet build Humans.slnx -v quiet`)
- [ ] All tests pass (`dotnet test Humans.slnx -v quiet`)
- [ ] Moderation queue shows Edit button on Pending, Approved, Rejected, ResubmitRequested events; not on Withdrawn
- [ ] Editing a Pending event saves fields, status stays Pending, ModerationAction(Edited) appears in history
- [ ] Editing an Approved event saves fields, status stays Approved, public API reflects the change immediately
- [ ] Camp event edit and individual event edit both work (different form/auth path)
- [ ] Non-moderator cannot trigger the moderation edit path (IsModerationEdit=true on form is ignored without IsEventsAdmin)
- [ ] Editing a camp event as moderator (who is not a camp lead) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)