### PR TITLE
fix(dev-seed): seed system camp roles so barrio-lead personas hold Camp Lead

### DIFF
--- a/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
@@ -453,9 +453,16 @@ public sealed class DevPersonaSeeder(
         var leadDef = await campRoleService.GetDefinitionBySlugAsync(CampSystemRoles.CampLeadSlug);
         if (leadDef is null)
         {
-            logger.LogInformation(
-                "DEV: Camp Lead role definition missing — skipping lead seed for {CampId}. Run 'Seed system roles'.",
-                camp.Id);
+            // Fresh database: the system camp role definitions only exist after an
+            // admin runs "Seed system roles". Seed them here (idempotent) so dev
+            // personas can hold the Camp Lead role in new dev/test environments.
+            await campRoleService.SeedSystemRolesAndMigrateLeadsAsync(leadUserId);
+            leadDef = await campRoleService.GetDefinitionBySlugAsync(CampSystemRoles.CampLeadSlug);
+            logger.LogInformation("DEV: seeded system camp role definitions for {CampId}", camp.Id);
+        }
+        if (leadDef is null)
+        {
+            logger.LogError("DEV: Camp Lead role definition still missing after seed — skipping lead seed for {CampId}.", camp.Id);
             return false;
         }
 


### PR DESCRIPTION
## Problem

`StorePayActionTests.Pay_with_valid_amount_redirects_to_Stripe_session_url` and `Pay_with_amount_over_balance_redirects_back_to_order_without_calling_Stripe` fail on main: `GET /Store/Order/{id}` returns 302 (→ `/Account/AccessDenied`) where the antiforgery harvest expects 200.

## Root cause

Not a recent regression — broken since the camp-lead decouple (#703), and invisible because `build.yml` excludes `~Integration` tests from CI.

Since #703, lead-ness lives in `CampRoleAssignment` rows against **system camp role definitions** that are only created when an admin runs "Seed system roles" (`POST /CampAdmin/SeedSystemRoles`). In any fresh database — the integration-test Postgres container, a new dev DB — `CampRoleDefinitions` is empty, so `DevPersonaSeeder.EnsureCampLeadAsync` hit its `leadDef is null` branch and **silently skipped** the Camp Lead assignment ("Run 'Seed system roles'"). The `barrio-1-lead` persona was therefore never an actual lead, `StoreOrderAuthorizationHandler` denied `View` on the order page, and `Forbid()` became the 302.

Verified by instrumentation inside the failing test: season/camp/year all resolved correctly, but `roleAssignments=[]` and `roleDefs=[]`.

## Fix

When the `camp-lead` definition is missing, the dev seeder now runs the existing idempotent `SeedSystemRolesAndMigrateLeadsAsync` itself and proceeds with the lead assignment — fixing fresh dev/test environments at the source instead of patching the tests.

## Verification

- The two failing tests now pass.
- Full integration suite: 108 passed, 1 skipped.
- Full solution: 4,255 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
