### PR TITLE
fix(events): profile events card shows only personal events, not camp submissions

### DIFF
--- a/src/Humans.Web/ViewComponents/EventsCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/EventsCardViewComponent.cs
@@ -10,7 +10,8 @@ namespace Humans.Web.ViewComponents;
 /// <summary>
 /// Renders a compact card of approved events with the Browse-style per-row
 /// favourite toggle. Scoped to exactly one of: a camp (the camp detail page's
-/// events card) or a user's submitted events (their profile page). Invoked with
+/// events card) or a user's personal (non-camp) submitted events — their
+/// profile page; camp events they submitted live on the camp's page. Invoked with
 /// ids only — no Event types cross into the host section's views. The favourite
 /// toggle bounces back to the current request's URL. Auth-gated at the call
 /// site (logged-in Humans users); returns empty content when the Events feature
@@ -41,7 +42,7 @@ public class EventsCardViewComponent(
 
             var approved = await events.GetApprovedEventsAsync(campId, null, null, null, []);
             if (userId is not null)
-                approved = approved.Where(e => e.SubmitterUserId == userId).ToList();
+                approved = approved.Where(e => e.SubmitterUserId == userId && e.CampId is null).ToList();
             if (approved.Count == 0)
                 return Content(string.Empty);
 

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -80,7 +80,7 @@
             <vc:my-camps />
         }
 
-        @* Approved events this human submitted this edition (auto-hidden when empty) *@
+        @* Approved personal (non-camp) events this human submitted this edition (auto-hidden when empty); camp events show on the camp's page *@
         <vc:events-card user-id="@Model.UserId" />
 
         @if (!Model.IsOwnProfile && Model.CanViewShiftSignups)

--- a/tests/Humans.Application.Tests/ViewComponents/EventsCardViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/EventsCardViewComponentTests.cs
@@ -15,9 +15,9 @@ namespace Humans.Application.Tests.ViewComponents;
 
 /// <summary>
 /// Covers <see cref="EventsCardViewComponent"/>: it renders the approved events
-/// for exactly one scope — a camp, or a user's submissions — ordered by start
-/// time with the viewer's favourites marked, and renders nothing when the scope
-/// has no approved events or the viewer is unauthenticated.
+/// for exactly one scope — a camp, or a user's personal (non-camp) submissions —
+/// ordered by start time with the viewer's favourites marked, and renders nothing
+/// when the scope has no approved events or the viewer is unauthenticated.
 /// </summary>
 public class EventsCardViewComponentTests
 {
@@ -44,8 +44,8 @@ public class EventsCardViewComponentTests
         };
     }
 
-    private static ApprovedEventView Approved(Guid id, string title, Instant startAt, string description = "", Guid? submitterUserId = null) => new(
-        Id: id, CampId: Guid.NewGuid(), GuideSharedVenueId: null, SubmitterUserId: submitterUserId ?? Guid.NewGuid(),
+    private static ApprovedEventView Approved(Guid id, string title, Instant startAt, string description = "", Guid? submitterUserId = null, bool isPersonal = false) => new(
+        Id: id, CampId: isPersonal ? null : Guid.NewGuid(), GuideSharedVenueId: isPersonal ? Guid.NewGuid() : null, SubmitterUserId: submitterUserId ?? Guid.NewGuid(),
         CategoryId: Guid.NewGuid(), CategorySlug: "music", CategoryName: "Music", CategoryIsSensitive: false,
         VenueName: null, Title: title, Description: description, LocationNote: null, Host: null,
         StartAt: startAt, DurationMinutes: 60, IsRecurring: false, RecurrenceDays: null,
@@ -85,15 +85,16 @@ public class EventsCardViewComponentTests
     }
 
     [HumansFact]
-    public async Task UserScope_FiltersToSubmittersEvents()
+    public async Task UserScope_FiltersToSubmittersPersonalEvents()
     {
         var viewerId = Guid.NewGuid();
         var susieId = Guid.NewGuid();
-        var susies = Approved(Guid.NewGuid(), "Susie's Salon", Instant.FromUtc(2026, 8, 1, 10, 0), submitterUserId: susieId);
-        var other = Approved(Guid.NewGuid(), "Someone Else's", Instant.FromUtc(2026, 8, 1, 12, 0));
+        var susies = Approved(Guid.NewGuid(), "Susie's Salon", Instant.FromUtc(2026, 8, 1, 10, 0), submitterUserId: susieId, isPersonal: true);
+        var susiesCampEvent = Approved(Guid.NewGuid(), "Susie's Camp Bash", Instant.FromUtc(2026, 8, 1, 11, 0), submitterUserId: susieId);
+        var other = Approved(Guid.NewGuid(), "Someone Else's", Instant.FromUtc(2026, 8, 1, 12, 0), isPersonal: true);
         _events.GetApprovedEventsAsync(null, null, null, null,
                 Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
-            .Returns([susies, other]);
+            .Returns([susies, susiesCampEvent, other]);
         StubSettings();
         _events.GetFavouriteEventIdsAsync(viewerId, Arg.Any<CancellationToken>())
             .Returns([]);


### PR DESCRIPTION
## Problem

The events card recently added to the user profile page showed **all** approved events the user submitted — including camp events. Camp events belong on the camp's detail page; the profile card should only show the user's personal events.

## Fix

`EventsCardViewComponent`'s user scope now filters by `SubmitterUserId == userId && CampId is null`. An `Event` has exactly one of `CampId` or `GuideSharedVenueId`, so `CampId is null` ⇔ personal event at a shared venue.

- Updated `UserScope_FiltersToSubmittersPersonalEvents` test to cover the leak (camp event submitted by the same user must be excluded) — red before the fix, green after.
- Doc comments on the component, test class, and `Profile/Index.cshtml` updated to state the personal-only scope.

## Verification

Full suite green: 222 + 295 + 3575 + 110 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)