### PR TITLE
fix(store): admin summary reprices Open orders to the live catalog like the order page

### DIFF
--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -874,11 +874,19 @@ public class StoreService(
 
         var productNames = products.ToDictionary(p => p.Id, p => p.Name);
 
+        // Reprice Open orders to the live catalog, exactly like the order page
+        // (MapOrderAsync) — summing raw snapshots here made summary totals drift
+        // from order totals whenever a catalog price changed after lines were added.
+        var currentPrices = await LoadCurrentPricesAsync(ct);
+        var totalsByOrder = campOrdersInYear
+            .Concat(teamOrders)
+            .ToDictionary(o => o.Id, o => BalanceCalculator.Compute(o, currentPrices));
+
         var byCounterparty = new List<OrderSummaryDto>();
 
         foreach (var o in campOrdersInYear)
         {
-            var totals = BalanceCalculator.Compute(o);
+            var totals = totalsByOrder[o.Id];
             var totalDue = totals.LinesSubtotalEur + totals.VatTotalEur + totals.DepositTotalEur;
             var sid = o.CampSeasonId!.Value;
             var campName = seasonsForYear[sid].Name;
@@ -895,7 +903,7 @@ public class StoreService(
         }
         foreach (var o in teamOrders)
         {
-            var totals = BalanceCalculator.Compute(o);
+            var totals = totalsByOrder[o.Id];
             var tid = o.TeamId!.Value;
             var teamName = teamNames.TryGetValue(tid, out var n) ? n : "(unknown team)";
             byCounterparty.Add(new OrderSummaryDto(
@@ -915,14 +923,11 @@ public class StoreService(
         // by-item aggregates lines from BOTH camp and team orders so suppliers see the full demand.
         var allLineProjections = campOrdersInYear
             .Concat(teamOrders)
-            .SelectMany(o => o.Lines.Select(l => new
+            .SelectMany(o =>
             {
-                l.ProductId,
-                l.Qty,
-                Subtotal = l.Qty * l.UnitPriceSnapshot,
-                Vat = Math.Round(l.Qty * l.UnitPriceSnapshot * l.VatRateSnapshot / 100m, 2, MidpointRounding.AwayFromZero),
-                Deposit = l.DepositAmountSnapshot is { } d ? l.Qty * d : 0m
-            }))
+                var lineTotals = totalsByOrder[o.Id].Lines.ToDictionary(t => t.LineId);
+                return o.Lines.Select(l => new { l.ProductId, l.Qty, lineTotals[l.Id].TotalEur });
+            })
             .ToList();
 
         var byItem = allLineProjections
@@ -931,7 +936,7 @@ public class StoreService(
                 g.Key,
                 productNames.TryGetValue(g.Key, out var n) ? n : "(unknown)",
                 g.Sum(x => x.Qty),
-                g.Sum(x => x.Subtotal + x.Vat + x.Deposit)))
+                g.Sum(x => x.TotalEur)))
             .OrderByDescending(p => p.TotalQty)
             .ThenBy(p => p.ProductName, StringComparer.Ordinal)
             .ToList();

--- a/tests/Humans.Application.Tests/Services/Store/StoreSummaryAggregateTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreSummaryAggregateTests.cs
@@ -308,6 +308,50 @@ public class StoreSummaryAggregateTests
     }
 
     [HumansFact]
+    public async Task Open_order_reprices_to_current_catalog_like_the_order_page()
+    {
+        var seasonId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+
+        _camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns([MakeCampInfo(seasonId, "Camp Alpha", "alpha")]);
+
+        // Catalog price dropped to 8 after the line was added at 10.
+        _repo.GetAllProductsForYearAsync(2026, Arg.Any<CancellationToken>()).Returns([
+            new StoreProduct { Id = productId, Year = 2026, Name = "Tent", Description = "x",
+                UnitPriceEur = 8m, VatRatePercent = 21m, OrderableUntil = new LocalDate(2026,12,31), IsActive = true }
+        ]);
+
+        var order = new StoreOrder
+        {
+            Id = orderId,
+            CampSeasonId = seasonId,
+            State = StoreOrderState.Open,
+            Lines =
+            {
+                new StoreOrderLine
+                {
+                    Id = Guid.NewGuid(), OrderId = orderId, ProductId = productId,
+                    Qty = 3, UnitPriceSnapshot = 10m, VatRateSnapshot = 21m
+                }
+            }
+        };
+        _repo.GetOrdersForCampSeasonsWithLinesAndPaymentsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns([order]);
+
+        var result = await _service.GetStoreSummaryAsync(2026);
+
+        // 3 × 8 = 24.00 + 21% VAT 5.04 = 29.04 — the live total the order page
+        // shows for an Open order, not the 36.30 the add-time snapshot would give.
+        var row = result.ByCounterparty.Single();
+        row.TotalDueEur.Should().Be(29.04m);
+        row.BalanceEur.Should().Be(29.04m);
+        result.ByItem.Single().TotalRevenueEur.Should().Be(29.04m);
+    }
+
+    [HumansFact]
     public async Task Order_for_camp_season_not_in_year_is_excluded()
     {
         // Camp service returns ONE season for 2026; the repo gets that season's id.


### PR DESCRIPTION
## Problem

`/Store/Admin/Summary` showed most camps with a small phantom remaining balance even though their orders were fully paid. Example: summary said total due 1882.57 / paid 1835.42 / remaining 47.15, while the order page showed subtotal 1492.75 + VAT 269.47 + deposits 73.20 = 1835.42, paid 1835.42, balance 0.00.

## Root cause

The order page (`MapOrderAsync`) reprices `Open` orders to the **current catalog** via `BalanceCalculator.Compute(order, currentPrices)` — the running-tab semantics from nobodies-collective/Humans#816. The admin summary (`GetStoreSummaryAsync`) called the no-prices overload, which sums each line's **add-time snapshot**. Every catalog price/VAT/deposit change after lines were added made the two pages diverge by qty × delta.

## Fix

In `GetStoreSummaryAsync`, load the current catalog prices once (`LoadCurrentPricesAsync`, same helper the order page path uses) and compute every order's totals with them. The by-item revenue aggregate had the same inline snapshot math; it now reuses the same repriced per-line totals. The cross-tab is quantity-only and unaffected.

## Tests

- New: `Open_order_reprices_to_current_catalog_like_the_order_page` — fails on the old snapshot math (36.30), passes with live repricing (29.04).
- Full suite green: 4,203 passed, 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)