### PR TITLE
feat(scanner): door context on the ticket card — EE, check-in, consents, provide list

### DIFF
--- a/src/Humans.Web/Controllers/ScannerController.cs
+++ b/src/Humans.Web/Controllers/ScannerController.cs
@@ -1,5 +1,6 @@
 using Humans.Application;
 using Humans.Application.DTOs;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Events;
@@ -76,7 +77,7 @@ public class ScannerController(
                     .FirstOrDefault(p => p.Year == burn.Year)?.CheckedInAt;
             }
 
-            provideItems = await GetProvideItemsAsync(userId, ct);
+            provideItems = await GetProvideItemsAsync(userId, burn, burnTz, ct);
         }
 
         var stub = new TicketStubInfo(
@@ -101,24 +102,38 @@ public class ScannerController(
     /// are offering, merged and sorted by start. Shifts reuse the iCal feed's
     /// items (its Events half is favourites — the wrong signal at the door, so
     /// those are filtered out); offered events use the same personal filter as
-    /// the profile events card (SubmitterUserId match, non-camp — see #935).
+    /// the profile events card (SubmitterUserId match, non-camp — see #935),
+    /// with recurring events expanded into one item per occurrence the same way
+    /// the Events feed contributor does.
     /// </summary>
-    private async Task<IReadOnlyList<CalendarFeedItem>> GetProvideItemsAsync(Guid userId, CancellationToken ct)
+    private async Task<IReadOnlyList<CalendarFeedItem>> GetProvideItemsAsync(
+        Guid userId, BurnSettingsInfo? burn, DateTimeZone? tz, CancellationToken ct)
     {
         var shiftItems = (await calendarFeed.GetFeedItemsAsync(userId, ct))
             .Where(i => string.Equals(i.Source, "Shifts", StringComparison.Ordinal));
 
         var offered = (await events.GetApprovedEventsAsync(null, null, null, null, [], ct))
             .Where(e => e.SubmitterUserId == userId && e.CampId is null)
-            .Select(e => new CalendarFeedItem(
-                Uid: $"event-{e.Id}@humans.nobodies.team",
-                Source: "Events",
-                Summary: e.IsRecurring ? $"{e.Title} ({e.RecurrenceDays})" : e.Title,
-                Description: null,
-                Start: e.StartAt,
-                End: e.StartAt.Plus(Duration.FromMinutes(e.DurationMinutes)),
-                Location: e.VenueName ?? e.LocationNote,
-                Url: null));
+            .SelectMany(e =>
+            {
+                // tz non-null implies burn non-null (tz is derived from burn in Card).
+                IReadOnlyList<Instant> occurrences = tz is not null
+                    ? e.GetOccurrenceInstants(burn!.GateOpeningDate, tz)
+                    : [e.StartAt];
+                return occurrences.Select(start =>
+                {
+                    var dateKey = DateFormattingExtensions.IcalBasicDatePattern.Format(start.InZone(tz ?? DateTimeZone.Utc).Date);
+                    return new CalendarFeedItem(
+                        Uid: $"event-{e.Id}-{dateKey}@humans.nobodies.team",
+                        Source: "Events",
+                        Summary: e.Title,
+                        Description: null,
+                        Start: start,
+                        End: start.Plus(Duration.FromMinutes(e.DurationMinutes)),
+                        Location: e.VenueName ?? e.LocationNote,
+                        Url: null);
+                });
+            });
 
         return shiftItems.Concat(offered).OrderBy(i => i.Start).ToList();
     }

--- a/src/Humans.Web/Controllers/ScannerController.cs
+++ b/src/Humans.Web/Controllers/ScannerController.cs
@@ -1,16 +1,31 @@
+using Humans.Application;
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.EarlyEntry;
+using Humans.Application.Interfaces.Events;
+using Humans.Application.Interfaces.ICalFeed;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using NodaTime;
 
 namespace Humans.Web.Controllers;
 
 /// <summary>Scanner section — in-browser barcode/QR decoders; no server-side writes. See nobodies-collective/Humans#525.</summary>
 [Authorize(Policy = PolicyNames.ScannerAccess)]
 [Route("Scanner")]
-public class ScannerController(ITicketServiceRead tickets) : Controller
+public class ScannerController(
+    ITicketServiceRead tickets,
+    IUserServiceRead users,
+    IEarlyEntryService earlyEntry,
+    IConsentServiceRead consents,
+    IICalFeedService calendarFeed,
+    IEventServiceRead events,
+    IBurnSettingsService burnSettings) : Controller
 {
     [HttpGet("")]
     public IActionResult Index() => View();
@@ -39,15 +54,72 @@ public class ScannerController(ITicketServiceRead tickets) : Controller
         if (hit is null)
             return PartialView("_TicketCard", new ScannerTicketCardViewModel(false, code, null, null, null, null));
 
+        // Per-person door context (nobodies-collective/Humans#860) — only when the
+        // ticket is matched to a Human; unmatched tickets render the bare card.
+        UserEarlyEntry? ee = null;
+        Instant? checkedInAt = null;
+        IReadOnlyList<string>? pendingConsents = null;
+        IReadOnlyList<CalendarFeedItem>? provideItems = null;
+        DateTimeZone? burnTz = null;
+
+        if (hit.MatchedUserId is { } userId)
+        {
+            ee = await earlyEntry.GetForUserAsync(userId, ct);
+            pendingConsents = await consents.GetPendingDocumentNamesAsync(userId, ct);
+
+            var burn = await burnSettings.GetActiveAsync(ct);
+            burnTz = burn is null ? null : DateTimeZoneProviders.Tzdb.GetZoneOrNull(burn.TimeZoneId);
+            if (burn is not null)
+            {
+                var info = await users.GetUserInfoAsync(userId, ct);
+                checkedInAt = info?.EventParticipations
+                    .FirstOrDefault(p => p.Year == burn.Year)?.CheckedInAt;
+            }
+
+            provideItems = await GetProvideItemsAsync(userId, ct);
+        }
+
         var stub = new TicketStubInfo(
             AttendeeName: hit.AttendeeName ?? "",
             AttendeeEmail: hit.AttendeeEmail,
             Status: hit.Status,
             HasPendingTransfer: false,
             PendingTransferRequestId: null,
-            EarlyEntryDate: null);
+            EarlyEntryDate: ee?.EarliestEntryDate);
 
         return PartialView("_TicketCard", new ScannerTicketCardViewModel(
-            true, code, stub, hit.TicketTypeName, hit.TransferredToName, hit.TransferredAt));
+            true, code, stub, hit.TicketTypeName, hit.TransferredToName, hit.TransferredAt,
+            EarlyEntrySources: ee?.Sources,
+            CheckedInAt: checkedInAt,
+            PendingConsents: pendingConsents,
+            ProvideItems: provideItems,
+            BurnTimeZone: burnTz));
+    }
+
+    /// <summary>
+    /// What this human signed up to provide: shift commitments plus events they
+    /// are offering, merged and sorted by start. Shifts reuse the iCal feed's
+    /// items (its Events half is favourites — the wrong signal at the door, so
+    /// those are filtered out); offered events use the same personal filter as
+    /// the profile events card (SubmitterUserId match, non-camp — see #935).
+    /// </summary>
+    private async Task<IReadOnlyList<CalendarFeedItem>> GetProvideItemsAsync(Guid userId, CancellationToken ct)
+    {
+        var shiftItems = (await calendarFeed.GetFeedItemsAsync(userId, ct))
+            .Where(i => string.Equals(i.Source, "Shifts", StringComparison.Ordinal));
+
+        var offered = (await events.GetApprovedEventsAsync(null, null, null, null, [], ct))
+            .Where(e => e.SubmitterUserId == userId && e.CampId is null)
+            .Select(e => new CalendarFeedItem(
+                Uid: $"event-{e.Id}@humans.nobodies.team",
+                Source: "Events",
+                Summary: e.IsRecurring ? $"{e.Title} ({e.RecurrenceDays})" : e.Title,
+                Description: null,
+                Start: e.StartAt,
+                End: e.StartAt.Plus(Duration.FromMinutes(e.DurationMinutes)),
+                Location: e.VenueName ?? e.LocationNote,
+                Url: null));
+
+        return shiftItems.Concat(offered).OrderBy(i => i.Start).ToList();
     }
 }

--- a/src/Humans.Web/Models/ScannerTicketCardViewModel.cs
+++ b/src/Humans.Web/Models/ScannerTicketCardViewModel.cs
@@ -1,14 +1,23 @@
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces.ICalFeed;
 using NodaTime;
 
 namespace Humans.Web.Models;
 
 /// <summary>Render model for the /Scanner/Tickets result card. Built in the
-/// controller from the cached TicketAttendeeInfo — no new Application surface.</summary>
+/// controller from the cached TicketAttendeeInfo — no new Application surface.
+/// The per-person fields (EE sources, check-in, consents, provide list) are
+/// null when the ticket has no matched Human (nobodies-collective/Humans#860);
+/// <see cref="PendingConsents"/> empty means every required document is signed.</summary>
 public sealed record ScannerTicketCardViewModel(
     bool Found,
     string? ScannedBarcode,
     TicketStubInfo? Stub,
     string? TicketTypeName,
     string? TransferredToName,
-    Instant? TransferredAt);
+    Instant? TransferredAt,
+    IReadOnlyList<string>? EarlyEntrySources = null,
+    Instant? CheckedInAt = null,
+    IReadOnlyList<string>? PendingConsents = null,
+    IReadOnlyList<CalendarFeedItem>? ProvideItems = null,
+    DateTimeZone? BurnTimeZone = null);

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -2946,6 +2946,24 @@
   <data name="Scanner_Tickets_TransferredOn" xml:space="preserve">
     <value>Transferida el</value>
   </data>
+  <data name="Scanner_Tickets_CheckedInAt" xml:space="preserve">
+    <value>Va entrar el</value>
+  </data>
+  <data name="Scanner_Tickets_EarlyEntryVia" xml:space="preserve">
+    <value>Entrada anticipada per</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsOk" xml:space="preserve">
+    <value>Tots els consentiments signats</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsMissing" xml:space="preserve">
+    <value>Consentiments pendents</value>
+  </data>
+  <data name="Scanner_Tickets_Provides" xml:space="preserve">
+    <value>S'ha apuntat a aportar</value>
+  </data>
+  <data name="Scanner_Tickets_ProvidesNone" xml:space="preserve">
+    <value>Sense torns ni activitats</value>
+  </data>
   <data name="TeamAdmin_AddMember" xml:space="preserve">
     <value>Afegeix membre</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -2946,6 +2946,24 @@
   <data name="Scanner_Tickets_TransferredOn" xml:space="preserve">
     <value>Übertragen am</value>
   </data>
+  <data name="Scanner_Tickets_CheckedInAt" xml:space="preserve">
+    <value>Eingecheckt am</value>
+  </data>
+  <data name="Scanner_Tickets_EarlyEntryVia" xml:space="preserve">
+    <value>Früher Einlass über</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsOk" xml:space="preserve">
+    <value>Alle Einwilligungen unterschrieben</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsMissing" xml:space="preserve">
+    <value>Fehlende Einwilligungen</value>
+  </data>
+  <data name="Scanner_Tickets_Provides" xml:space="preserve">
+    <value>Beiträge laut Anmeldung</value>
+  </data>
+  <data name="Scanner_Tickets_ProvidesNone" xml:space="preserve">
+    <value>Keine Schichten oder Veranstaltungen</value>
+  </data>
   <data name="TeamAdmin_AddMember" xml:space="preserve">
     <value>Mitglied hinzufügen</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -2970,6 +2970,24 @@
   <data name="Scanner_Tickets_TransferredOn" xml:space="preserve">
     <value>Transferida el</value>
   </data>
+  <data name="Scanner_Tickets_CheckedInAt" xml:space="preserve">
+    <value>Entró el</value>
+  </data>
+  <data name="Scanner_Tickets_EarlyEntryVia" xml:space="preserve">
+    <value>Entrada anticipada por</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsOk" xml:space="preserve">
+    <value>Todos los consentimientos firmados</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsMissing" xml:space="preserve">
+    <value>Consentimientos pendientes</value>
+  </data>
+  <data name="Scanner_Tickets_Provides" xml:space="preserve">
+    <value>Se ha apuntado a aportar</value>
+  </data>
+  <data name="Scanner_Tickets_ProvidesNone" xml:space="preserve">
+    <value>Sin turnos ni actividades</value>
+  </data>
   <data name="TeamAdmin_AddMember" xml:space="preserve">
     <value>Agregar miembro</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -2946,6 +2946,24 @@
   <data name="Scanner_Tickets_TransferredOn" xml:space="preserve">
     <value>Transféré le</value>
   </data>
+  <data name="Scanner_Tickets_CheckedInAt" xml:space="preserve">
+    <value>Entré le</value>
+  </data>
+  <data name="Scanner_Tickets_EarlyEntryVia" xml:space="preserve">
+    <value>Entrée anticipée via</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsOk" xml:space="preserve">
+    <value>Tous les consentements signés</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsMissing" xml:space="preserve">
+    <value>Consentements manquants</value>
+  </data>
+  <data name="Scanner_Tickets_Provides" xml:space="preserve">
+    <value>S'est engagé·e à fournir</value>
+  </data>
+  <data name="Scanner_Tickets_ProvidesNone" xml:space="preserve">
+    <value>Aucun créneau ni événement</value>
+  </data>
   <data name="TeamAdmin_AddMember" xml:space="preserve">
     <value>Ajouter un membre</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -2946,6 +2946,24 @@
   <data name="Scanner_Tickets_TransferredOn" xml:space="preserve">
     <value>Trasferito il</value>
   </data>
+  <data name="Scanner_Tickets_CheckedInAt" xml:space="preserve">
+    <value>Check-in effettuato il</value>
+  </data>
+  <data name="Scanner_Tickets_EarlyEntryVia" xml:space="preserve">
+    <value>Ingresso anticipato tramite</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsOk" xml:space="preserve">
+    <value>Tutti i consensi firmati</value>
+  </data>
+  <data name="Scanner_Tickets_ConsentsMissing" xml:space="preserve">
+    <value>Consensi mancanti</value>
+  </data>
+  <data name="Scanner_Tickets_Provides" xml:space="preserve">
+    <value>Si è impegnato a fornire</value>
+  </data>
+  <data name="Scanner_Tickets_ProvidesNone" xml:space="preserve">
+    <value>Nessun turno o evento</value>
+  </data>
   <data name="TeamAdmin_AddMember" xml:space="preserve">
     <value>Aggiungi membro</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1266,6 +1266,12 @@
   <data name="Scanner_Tickets_Status" xml:space="preserve"><value>Status</value></data>
   <data name="Scanner_Tickets_TransferredTo" xml:space="preserve"><value>Transferred to</value></data>
   <data name="Scanner_Tickets_TransferredOn" xml:space="preserve"><value>Transferred on</value></data>
+  <data name="Scanner_Tickets_CheckedInAt" xml:space="preserve"><value>Checked in at</value></data>
+  <data name="Scanner_Tickets_EarlyEntryVia" xml:space="preserve"><value>Early entry via</value></data>
+  <data name="Scanner_Tickets_ConsentsOk" xml:space="preserve"><value>All consents signed</value></data>
+  <data name="Scanner_Tickets_ConsentsMissing" xml:space="preserve"><value>Missing consents</value></data>
+  <data name="Scanner_Tickets_Provides" xml:space="preserve"><value>Signed up to provide</value></data>
+  <data name="Scanner_Tickets_ProvidesNone" xml:space="preserve"><value>No shifts or events</value></data>
 
   <!-- Team admin: add member -->
   <data name="TeamAdmin_AddMember" xml:space="preserve"><value>Add Member</value></data>

--- a/src/Humans.Web/Views/Scanner/_TicketCard.cshtml
+++ b/src/Humans.Web/Views/Scanner/_TicketCard.cshtml
@@ -13,6 +13,8 @@
 }
 else
 {
+    var tz = Model.BurnTimeZone ?? DateTimeZone.Utc;
+
     <vc:ticket-stub stub="@Model.Stub" />
 
     <dl class="row mt-3 mb-0 small">
@@ -21,6 +23,18 @@ else
 
         <dt class="col-sm-4">@Localizer["Scanner_Tickets_Status"]</dt>
         <dd class="col-sm-8">@Model.Stub!.Status</dd>
+
+        @if (Model.CheckedInAt is { } checkedInAt)
+        {
+            <dt class="col-sm-4">@Localizer["Scanner_Tickets_CheckedInAt"]</dt>
+            <dd class="col-sm-8">@checkedInAt.ToMonthDayTime(tz)</dd>
+        }
+
+        @if (Model.EarlyEntrySources is { Count: > 0 })
+        {
+            <dt class="col-sm-4">@Localizer["Scanner_Tickets_EarlyEntryVia"]</dt>
+            <dd class="col-sm-8">@string.Join(", ", Model.EarlyEntrySources)</dd>
+        }
 
         @if (Model.Stub.Status == TicketAttendeeStatus.Void && Model.TransferredToName != null)
         {
@@ -34,4 +48,48 @@ else
             }
         }
     </dl>
+
+    @if (Model.PendingConsents is not null)
+    {
+        @if (Model.PendingConsents.Count == 0)
+        {
+            <div class="alert alert-success py-2 mt-3 mb-0" role="status">
+                <i class="fa-solid fa-check me-1"></i>@Localizer["Scanner_Tickets_ConsentsOk"]
+            </div>
+        }
+        else
+        {
+            <div class="alert alert-warning py-2 mt-3 mb-0" role="alert">
+                <strong>@Localizer["Scanner_Tickets_ConsentsMissing"]</strong>
+                <ul class="mb-0 ps-3">
+                    @foreach (var name in Model.PendingConsents)
+                    {
+                        <li>@name</li>
+                    }
+                </ul>
+            </div>
+        }
+    }
+
+    @if (Model.ProvideItems is not null)
+    {
+        <h6 class="mt-3 mb-1">@Localizer["Scanner_Tickets_Provides"]</h6>
+        @if (Model.ProvideItems.Count == 0)
+        {
+            <div class="text-muted small">@Localizer["Scanner_Tickets_ProvidesNone"]</div>
+        }
+        else
+        {
+            <ul class="list-unstyled mb-0 small">
+                @foreach (var item in Model.ProvideItems)
+                {
+                    <li class="py-1 border-bottom">
+                        <span class="badge bg-secondary me-1">@item.Source</span>
+                        @item.Summary
+                        <span class="text-muted text-nowrap">&middot; @item.Start.ToMonthDayTime(tz)&ndash;@item.End.ToTime(tz)</span>
+                    </li>
+                }
+            </ul>
+        }
+    }
 }

--- a/tests/Humans.Web.Tests/Controllers/ScannerControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ScannerControllerTests.cs
@@ -1,6 +1,13 @@
 using AwesomeAssertions;
 using Humans.Application;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.EarlyEntry;
+using Humans.Application.Interfaces.Events;
+using Humans.Application.Interfaces.ICalFeed;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Controllers;
 using Humans.Web.Models;
@@ -16,9 +23,23 @@ namespace Humans.Web.Tests.Controllers;
 
 public class ScannerControllerTests
 {
-    private static ScannerController NewController(ITicketServiceRead tickets)
+    private static ScannerController NewController(
+        ITicketServiceRead tickets,
+        IUserServiceRead? users = null,
+        IEarlyEntryService? earlyEntry = null,
+        IConsentServiceRead? consents = null,
+        IICalFeedService? calendarFeed = null,
+        IEventServiceRead? events = null,
+        IBurnSettingsService? burnSettings = null)
     {
-        var ctrl = new ScannerController(tickets);
+        var ctrl = new ScannerController(
+            tickets,
+            users ?? Substitute.For<IUserServiceRead>(),
+            earlyEntry ?? Substitute.For<IEarlyEntryService>(),
+            consents ?? Substitute.For<IConsentServiceRead>(),
+            calendarFeed ?? Substitute.For<IICalFeedService>(),
+            events ?? Substitute.For<IEventServiceRead>(),
+            burnSettings ?? Substitute.For<IBurnSettingsService>());
 
         var services = new ServiceCollection();
         services.AddLogging();
@@ -55,20 +76,62 @@ public class ScannerControllerTests
         return tickets;
     }
 
+    private static TicketAttendeeInfo Attendee(
+        Guid? matchedUserId = null, TicketAttendeeStatus status = TicketAttendeeStatus.Valid) => new(
+        Id: Guid.NewGuid(),
+        VendorTicketId: "vt-1",
+        AttendeeName: "Ada Lovelace",
+        AttendeeEmail: "ada@example.com",
+        TicketTypeName: "General Admission",
+        Price: 10m,
+        Status: status,
+        MatchedUserId: matchedUserId,
+        Barcode: "xyz34Qy5");
+
+    private static BurnSettingsInfo ActiveBurn(int year = 2026) => new(
+        Id: Guid.NewGuid(),
+        EventName: "Elsewhere",
+        Year: year,
+        TimeZoneId: "Europe/Madrid",
+        GateOpeningDate: new LocalDate(year, 6, 17),
+        BuildStartOffset: -10,
+        EventEndOffset: 5,
+        StrikeEndOffset: 10,
+        FirstCrewStartOffset: -14,
+        SetupWeekStartOffset: -7,
+        PreEventWeekStartOffset: -3,
+        FinishingWeekendStartOffset: 3,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null);
+
+    private static ApprovedEventView OfferedEvent(
+        Guid submitterUserId, Guid? campId, string title, Instant startAt) => new(
+        Id: Guid.NewGuid(),
+        CampId: campId,
+        GuideSharedVenueId: null,
+        SubmitterUserId: submitterUserId,
+        CategoryId: Guid.NewGuid(),
+        CategorySlug: "workshops",
+        CategoryName: "Workshops",
+        CategoryIsSensitive: false,
+        VenueName: "The Dome",
+        Title: title,
+        Description: "desc",
+        LocationNote: null,
+        Host: "Ada",
+        StartAt: startAt,
+        DurationMinutes: 90,
+        IsRecurring: false,
+        RecurrenceDays: null,
+        PriorityRank: 0,
+        SubmittedAt: Instant.FromUtc(2026, 5, 1, 0, 0),
+        LastUpdatedAt: Instant.FromUtc(2026, 5, 1, 0, 0));
+
     [HumansFact]
     public async Task Card_MatchingBarcode_ReturnsFoundCard()
     {
-        var attendee = new TicketAttendeeInfo(
-            Id: Guid.NewGuid(),
-            VendorTicketId: "vt-1",
-            AttendeeName: "Ada Lovelace",
-            AttendeeEmail: "ada@example.com",
-            TicketTypeName: "General Admission",
-            Price: 10m,
-            Status: TicketAttendeeStatus.Valid,
-            MatchedUserId: null,
-            Barcode: "xyz34Qy5");
-        var tickets = TicketsWithAttendee(attendee);
+        var tickets = TicketsWithAttendee(Attendee());
         var ctrl = NewController(tickets);
 
         var result = await ctrl.Card("xyz34Qy5", default);
@@ -115,17 +178,7 @@ public class ScannerControllerTests
     [HumansFact]
     public async Task Card_UnmatchedBarcode_ReturnsNotFoundCard()
     {
-        var attendee = new TicketAttendeeInfo(
-            Id: Guid.NewGuid(),
-            VendorTicketId: "vt-1",
-            AttendeeName: "Ada Lovelace",
-            AttendeeEmail: "ada@example.com",
-            TicketTypeName: "General Admission",
-            Price: 10m,
-            Status: TicketAttendeeStatus.Valid,
-            MatchedUserId: null,
-            Barcode: "xyz34Qy5");
-        var tickets = TicketsWithAttendee(attendee);
+        var tickets = TicketsWithAttendee(Attendee());
         var ctrl = NewController(tickets);
 
         var result = await ctrl.Card("nope-0000", default);
@@ -135,5 +188,129 @@ public class ScannerControllerTests
         vm.Found.Should().BeFalse();
         vm.ScannedBarcode.Should().Be("nope-0000");
         vm.Stub.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task Card_NoMatchedUser_SkipsPerPersonEnrichment()
+    {
+        var tickets = TicketsWithAttendee(Attendee(matchedUserId: null));
+        var earlyEntry = Substitute.For<IEarlyEntryService>();
+        var consents = Substitute.For<IConsentServiceRead>();
+        var users = Substitute.For<IUserServiceRead>();
+        var ctrl = NewController(tickets, users: users, earlyEntry: earlyEntry, consents: consents);
+
+        var result = await ctrl.Card("xyz34Qy5", default);
+
+        var vm = result.Should().BeOfType<PartialViewResult>().Subject
+            .Model.Should().BeOfType<ScannerTicketCardViewModel>().Subject;
+        vm.Stub!.EarlyEntryDate.Should().BeNull();
+        vm.EarlyEntrySources.Should().BeNull();
+        vm.CheckedInAt.Should().BeNull();
+        vm.PendingConsents.Should().BeNull();
+        vm.ProvideItems.Should().BeNull();
+        await earlyEntry.DidNotReceive().GetForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await consents.DidNotReceive().GetPendingDocumentNamesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await users.DidNotReceive().GetUserInfoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Card_MatchedUser_EnrichesCardWithDoorContext()
+    {
+        var userId = Guid.NewGuid();
+        var checkedInAt = Instant.FromUtc(2026, 6, 17, 10, 30);
+        var tickets = TicketsWithAttendee(Attendee(userId, TicketAttendeeStatus.CheckedIn));
+
+        var earlyEntry = Substitute.For<IEarlyEntryService>();
+        earlyEntry.GetForUserAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new UserEarlyEntry(new LocalDate(2026, 6, 15), ["Teams: Gate"]));
+
+        var consents = Substitute.For<IConsentServiceRead>();
+        consents.GetPendingDocumentNamesAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { "Liability Waiver" });
+
+        var burnSettings = Substitute.For<IBurnSettingsService>();
+        burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ActiveBurn());
+
+        var users = Substitute.For<IUserServiceRead>();
+        users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>()).Returns(UserInfo.Create(
+            new User { Id = userId, PreferredLanguage = "en" },
+            [],
+            [
+                // Prior year's check-in must not leak into the current card.
+                new EventParticipation
+                {
+                    Id = Guid.NewGuid(), UserId = userId, Year = 2025,
+                    Status = ParticipationStatus.Attended, Source = ParticipationSource.TicketSync,
+                    CheckedInAt = Instant.FromUtc(2025, 6, 18, 9, 0),
+                },
+                new EventParticipation
+                {
+                    Id = Guid.NewGuid(), UserId = userId, Year = 2026,
+                    Status = ParticipationStatus.Attended, Source = ParticipationSource.TicketSync,
+                    CheckedInAt = checkedInAt,
+                },
+            ],
+            [], profile: null, [], [], [], []));
+
+        var calendarFeed = Substitute.For<IICalFeedService>();
+        var shiftItem = new CalendarFeedItem(
+            "shift-1@humans.nobodies.team", "Shifts", "Gate: Morning",
+            null, Instant.FromUtc(2026, 6, 18, 8, 0), Instant.FromUtc(2026, 6, 18, 12, 0), null, null);
+        var favouritedItem = new CalendarFeedItem(
+            "event-fav-20260618@humans.nobodies.team", "Events", "Someone Else's Concert",
+            null, Instant.FromUtc(2026, 6, 18, 20, 0), Instant.FromUtc(2026, 6, 18, 22, 0), null, null);
+        calendarFeed.GetFeedItemsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { shiftItem, favouritedItem });
+
+        var events = Substitute.For<IEventServiceRead>();
+        events.GetApprovedEventsAsync(null, null, null, null, Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                OfferedEvent(userId, campId: null, "Intro to Soldering", Instant.FromUtc(2026, 6, 17, 16, 0)),
+                OfferedEvent(userId, campId: Guid.NewGuid(), "Camp Workshop", Instant.FromUtc(2026, 6, 18, 16, 0)),
+                OfferedEvent(Guid.NewGuid(), campId: null, "Other Human's Talk", Instant.FromUtc(2026, 6, 18, 17, 0)),
+            });
+
+        var ctrl = NewController(tickets, users, earlyEntry, consents, calendarFeed, events, burnSettings);
+
+        var result = await ctrl.Card("xyz34Qy5", default);
+
+        var vm = result.Should().BeOfType<PartialViewResult>().Subject
+            .Model.Should().BeOfType<ScannerTicketCardViewModel>().Subject;
+        vm.Stub!.EarlyEntryDate.Should().Be(new LocalDate(2026, 6, 15));
+        vm.EarlyEntrySources.Should().Equal("Teams: Gate");
+        vm.CheckedInAt.Should().Be(checkedInAt);
+        vm.PendingConsents.Should().Equal("Liability Waiver");
+        vm.BurnTimeZone.Should().NotBeNull();
+        vm.BurnTimeZone!.Id.Should().Be("Europe/Madrid");
+
+        // Provide list: offered workshop + shift commitment, sorted by start;
+        // favourited feed events, camp submissions, and other humans' events excluded.
+        vm.ProvideItems.Should().NotBeNull();
+        vm.ProvideItems!.Select(i => i.Summary).Should().Equal("Intro to Soldering", "Gate: Morning");
+        vm.ProvideItems.Select(i => i.Source).Should().Equal("Events", "Shifts");
+    }
+
+    [HumansFact]
+    public async Task Card_MatchedUserAllConsentsSigned_PendingListIsEmptyNotNull()
+    {
+        var userId = Guid.NewGuid();
+        var tickets = TicketsWithAttendee(Attendee(userId));
+        var consents = Substitute.For<IConsentServiceRead>();
+        consents.GetPendingDocumentNamesAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<string>());
+
+        var ctrl = NewController(tickets, consents: consents);
+
+        var result = await ctrl.Card("xyz34Qy5", default);
+
+        var vm = result.Should().BeOfType<PartialViewResult>().Subject
+            .Model.Should().BeOfType<ScannerTicketCardViewModel>().Subject;
+        vm.PendingConsents.Should().NotBeNull();
+        vm.PendingConsents.Should().BeEmpty();
+        vm.ProvideItems.Should().NotBeNull();
+        vm.ProvideItems.Should().BeEmpty();
+        // No active burn configured on the default substitute → no check-in lookup.
+        vm.CheckedInAt.Should().BeNull();
     }
 }

--- a/tests/Humans.Web.Tests/Controllers/ScannerControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ScannerControllerTests.cs
@@ -106,7 +106,8 @@ public class ScannerControllerTests
         EarlyEntryClose: null);
 
     private static ApprovedEventView OfferedEvent(
-        Guid submitterUserId, Guid? campId, string title, Instant startAt) => new(
+        Guid submitterUserId, Guid? campId, string title, Instant startAt,
+        bool isRecurring = false, string? recurrenceDays = null) => new(
         Id: Guid.NewGuid(),
         CampId: campId,
         GuideSharedVenueId: null,
@@ -122,8 +123,8 @@ public class ScannerControllerTests
         Host: "Ada",
         StartAt: startAt,
         DurationMinutes: 90,
-        IsRecurring: false,
-        RecurrenceDays: null,
+        IsRecurring: isRecurring,
+        RecurrenceDays: recurrenceDays,
         PriorityRank: 0,
         SubmittedAt: Instant.FromUtc(2026, 5, 1, 0, 0),
         LastUpdatedAt: Instant.FromUtc(2026, 5, 1, 0, 0));
@@ -267,6 +268,10 @@ public class ScannerControllerTests
             .Returns(new[]
             {
                 OfferedEvent(userId, campId: null, "Intro to Soldering", Instant.FromUtc(2026, 6, 17, 16, 0)),
+                // Recurring on gate-opening day offsets 0 and 2 (gate opens 2026-06-17):
+                // expands to 2026-06-17 and 2026-06-19 at 08:00 Madrid (06:00 UTC).
+                OfferedEvent(userId, campId: null, "Daily Yoga", Instant.FromUtc(2026, 6, 18, 6, 0),
+                    isRecurring: true, recurrenceDays: "0,2"),
                 OfferedEvent(userId, campId: Guid.NewGuid(), "Camp Workshop", Instant.FromUtc(2026, 6, 18, 16, 0)),
                 OfferedEvent(Guid.NewGuid(), campId: null, "Other Human's Talk", Instant.FromUtc(2026, 6, 18, 17, 0)),
             });
@@ -284,11 +289,15 @@ public class ScannerControllerTests
         vm.BurnTimeZone.Should().NotBeNull();
         vm.BurnTimeZone!.Id.Should().Be("Europe/Madrid");
 
-        // Provide list: offered workshop + shift commitment, sorted by start;
-        // favourited feed events, camp submissions, and other humans' events excluded.
+        // Provide list: offered workshop + recurring occurrences + shift commitment,
+        // sorted by start; favourited feed events, camp submissions, and other
+        // humans' events excluded.
         vm.ProvideItems.Should().NotBeNull();
-        vm.ProvideItems!.Select(i => i.Summary).Should().Equal("Intro to Soldering", "Gate: Morning");
-        vm.ProvideItems.Select(i => i.Source).Should().Equal("Events", "Shifts");
+        vm.ProvideItems!.Select(i => i.Summary).Should().Equal(
+            "Daily Yoga", "Intro to Soldering", "Gate: Morning", "Daily Yoga");
+        vm.ProvideItems.Select(i => i.Source).Should().Equal("Events", "Events", "Shifts", "Events");
+        vm.ProvideItems[0].Start.Should().Be(Instant.FromUtc(2026, 6, 17, 6, 0));
+        vm.ProvideItems[3].Start.Should().Be(Instant.FromUtc(2026, 6, 19, 6, 0));
     }
 
     [HumansFact]


### PR DESCRIPTION
Implements nobodies-collective/Humans#860 — per-person door context on the `/Scanner/Tickets` card.

## What changed

When the scanned ticket has a `MatchedUserId` (previously discarded by `ScannerController.Card`), the card is enriched with four blocks; unmatched tickets render exactly as before.

- **Early Entry** — `IEarlyEntryService.GetForUserAsync` now feeds the stub's existing EE pill (was hardcoded `null`), plus an "Early entry via" row listing the granting sources (Teams grants / Camps / build shifts).
- **Check-in** — the per-person `CheckedInAt` timestamp for the active burn year (from the cached `UserInfo` participations), shown in the burn's timezone. Check-in stays read-only/vendor-synced; no write path added.
- **Consents** — `IConsentServiceRead.GetPendingDocumentNamesAsync`: green "All consents signed" when empty, otherwise a warning listing the missing document names.
- **Signed up to provide** — compact time-sorted list combining shift commitments (reusing the iCal feed's `Shifts` items, so team-name/absolute-time mapping isn't duplicated; the feed's `Events` half is favourites and is filtered out) and events this human is offering (`IEventServiceRead.GetApprovedEventsAsync` with the same `SubmitterUserId == userId && CampId is null` filter as the profile events card, #935).

The active burn year/timezone come from `IBurnSettingsService.GetActiveAsync` (same convention as the onsite roster). New `Scanner_Tickets_*` resource keys added in all six languages.

No new interfaces, service methods, or migrations — only existing cached read surfaces are consumed (`IEarlyEntryService`, `IConsentServiceRead`, `IICalFeedService`, `IEventServiceRead`, `IUserServiceRead`, `IBurnSettingsService`).

## Tests

`ScannerControllerTests` extended: matched-user enrichment (EE date + sources, current-year `CheckedInAt` with a prior-year decoy excluded, pending consents, provide-list contents/sort with favourited, camp-submitted, and other-user events excluded), unmatched-ticket passthrough with `DidNotReceive` assertions, and the all-consents-signed empty-not-null case. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
