### PR TITLE
fix(infra): explicit 30s timeout on TicketTailor and MailerLite HTTP clients

### DIFF
--- a/src/Humans.Web/Extensions/Infrastructure/TicketVendorInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/TicketVendorInfrastructureExtensions.cs
@@ -22,7 +22,10 @@ internal static class TicketVendorInfrastructureExtensions
 
         if (environment.IsProduction())
         {
-            services.AddHttpClient<ITicketVendorService, TicketTailorService>();
+            services.AddHttpClient<ITicketVendorService, TicketTailorService>(client =>
+            {
+                client.Timeout = TimeSpan.FromSeconds(30);
+            });
         }
         else
         {

--- a/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
@@ -33,6 +33,7 @@ internal static class MailerSectionExtensions
         {
             var opts = sp.GetRequiredService<IOptions<MailerLiteOptions>>().Value;
             http.BaseAddress = new Uri(opts.BaseUrl);
+            http.Timeout = TimeSpan.FromSeconds(30);
             http.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Bearer", opts.ApiKey);
             http.DefaultRequestHeaders.Add("X-Version", opts.ApiVersion);


### PR DESCRIPTION
## Summary

Sets an explicit 30-second `HttpClient.Timeout` on both the TicketTailor and MailerLite HTTP clients, matching the existing Holded client pattern. Previously both defaulted to the 100-second `HttpClient` default, which could block Hangfire jobs long past the 300-second lock expiry if a vendor API hung.

## Acceptance Criteria

- [x] **TicketTailor and MailerLite clients have an explicit ~30s timeout**
  - `TicketVendorInfrastructureExtensions.cs`: `AddHttpClient<ITicketVendorService, TicketTailorService>` now passes a configure delegate setting `client.Timeout = TimeSpan.FromSeconds(30)`
  - `MailerSectionExtensions.cs`: the existing named-client configure delegate now sets `http.Timeout = TimeSpan.FromSeconds(30)`
- [ ] (Optional) bounded retry / circuit breaker on transient failures — not implemented; Polly wiring is out of scope for this lightweight fix

## Pattern

Follows the existing Holded pattern in `HoldedSectionExtensions.cs` exactly.

## Build

Green — 0 errors, 79 pre-existing warnings (no new warnings introduced).

Closes nobodies-collective/Humans#849