### PR TITLE
feat(google-sync): per-phase fault isolation in nightly reconciliation

### DIFF
--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -38,7 +38,7 @@ public class GoogleResourceReconciliationJob(
         {
             await googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Google reconciliation phase 'DriveFolder sync' failed");
             phaseFailures.Add("DriveFolder sync");
@@ -51,7 +51,7 @@ public class GoogleResourceReconciliationJob(
         {
             await googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFile, SyncAction.Execute, cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Google reconciliation phase 'DriveFile sync' failed");
             phaseFailures.Add("DriveFile sync");
@@ -65,7 +65,7 @@ public class GoogleResourceReconciliationJob(
         {
             await googleGroupSync.ReconcileAllAsync(SyncAction.Execute, cancellationToken);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Google reconciliation phase 'Group membership reconcile' failed");
             phaseFailures.Add("Group membership reconcile");
@@ -80,7 +80,7 @@ public class GoogleResourceReconciliationJob(
                 logger.LogInformation("Updated {Count} Drive folder path(s) during reconciliation", pathUpdates);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Google reconciliation phase 'Drive folder path updates' failed");
             phaseFailures.Add("Drive folder path updates");
@@ -95,7 +95,7 @@ public class GoogleResourceReconciliationJob(
                 logger.LogWarning("Corrected inherited access drift on {Count} Drive folder(s)", inheritanceCorrected);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Google reconciliation phase 'Inherited access enforcement' failed");
             phaseFailures.Add("Inherited access enforcement");
@@ -121,7 +121,7 @@ public class GoogleResourceReconciliationJob(
                             logger.LogError("Failed to auto-remediate settings for group '{GroupEmail}': {ErrorMessage}",
                                 report.GroupEmail, remediation.ErrorMessage);
                     }
-                    catch (Exception ex)
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         logger.LogError(ex, "Failed to auto-remediate settings for group '{GroupEmail}'", report.GroupEmail);
                     }
@@ -132,7 +132,7 @@ public class GoogleResourceReconciliationJob(
                 logger.LogWarning("Google Group settings check had {ErrorCount} error(s)", settingsResult.ErrorCount);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Google reconciliation phase 'Group settings check' failed");
             phaseFailures.Add("Group settings check");
@@ -155,7 +155,7 @@ public class GoogleResourceReconciliationJob(
                     actionLabel: "View sync status",
                     cancellationToken: cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogError(ex, "Failed to dispatch GoogleDriftDetected notification");
             }
@@ -183,7 +183,7 @@ public class GoogleResourceReconciliationJob(
                     actionLabel: "View sync status",
                     cancellationToken: cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogError(ex, "Failed to dispatch SyncError notification for phase failures");
             }

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -1,6 +1,7 @@
 using Hangfire;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
@@ -12,6 +13,8 @@ namespace Humans.Infrastructure.Jobs;
 /// <summary>
 /// Scheduled job that reconciles Google resources.
 /// Add/remove behavior is controlled by SyncSettings, enforced by the service gateway methods.
+/// Each top-level phase runs in isolation: a failure in one phase does not abort the others.
+/// A summary Admin alert fires via SyncError if any phase fails.
 /// </summary>
 [DisableConcurrentExecution(timeoutInSeconds: 300)]
 public class GoogleResourceReconciliationJob(
@@ -26,37 +29,82 @@ public class GoogleResourceReconciliationJob(
     {
         logger.LogInformation("Starting Google resource reconciliation at {Time}", clock.GetCurrentInstant());
 
+        var phaseFailures = new List<string>();
+        int inheritanceCorrected = 0;
+        var settingsResult = new GroupSettingsDriftResult();
+
+        // Phase 1: Sync Drive folders
         try
         {
-            // Reconcile every resource type teams can link. DriveFile is handled by the
-            // same Drive permission path as DriveFolder, and omitting it meant soft-deleted
-            // teams with linked files kept Google permissions indefinitely because no
-            // reconciliation pass ever touched them.
             await googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Google reconciliation phase 'DriveFolder sync' failed");
+            phaseFailures.Add("DriveFolder sync");
+        }
+
+        // Phase 2: Sync Drive files
+        // DriveFile is handled by the same Drive permission path as DriveFolder; omitting it
+        // meant soft-deleted teams with linked files kept Google permissions indefinitely.
+        try
+        {
             await googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFile, SyncAction.Execute, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Google reconciliation phase 'DriveFile sync' failed");
+            phaseFailures.Add("DriveFile sync");
+        }
 
-            // Provisioning of missing Google Groups is handled inside
-            // GoogleGroupSyncService.ReconcileAllAsync — when a claim references
-            // a group that doesn't yet exist in Google, the reconcile path
-            // creates it inline (best-effort) before reconciling membership.
+        // Phase 3: Reconcile Google Group membership
+        // Provisioning of missing Google Groups is handled inside ReconcileAllAsync — when a
+        // claim references a group that doesn't yet exist in Google, the reconcile path creates
+        // it inline (best-effort) before reconciling membership.
+        try
+        {
             await googleGroupSync.ReconcileAllAsync(SyncAction.Execute, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Google reconciliation phase 'Group membership reconcile' failed");
+            phaseFailures.Add("Group membership reconcile");
+        }
 
-            // Update Drive folder paths (detects renames and moves)
+        // Phase 4: Update Drive folder paths (detects renames and moves)
+        try
+        {
             var pathUpdates = await googleSyncService.UpdateDriveFolderPathsAsync(cancellationToken);
             if (pathUpdates > 0)
             {
                 logger.LogInformation("Updated {Count} Drive folder path(s) during reconciliation", pathUpdates);
             }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Google reconciliation phase 'Drive folder path updates' failed");
+            phaseFailures.Add("Drive folder path updates");
+        }
 
-            // Enforce inherited access restrictions on Drive folders
-            var inheritanceCorrected = await googleSyncService.EnforceInheritedAccessRestrictionsAsync(cancellationToken);
+        // Phase 5: Enforce inherited access restrictions on Drive folders
+        try
+        {
+            inheritanceCorrected = await googleSyncService.EnforceInheritedAccessRestrictionsAsync(cancellationToken);
             if (inheritanceCorrected > 0)
             {
                 logger.LogWarning("Corrected inherited access drift on {Count} Drive folder(s)", inheritanceCorrected);
             }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Google reconciliation phase 'Inherited access enforcement' failed");
+            phaseFailures.Add("Inherited access enforcement");
+        }
 
-            // Check Google Group settings for drift and auto-remediate
-            var settingsResult = await googleSyncService.CheckGroupSettingsAsync(cancellationToken);
+        // Phase 6: Check Google Group settings for drift and auto-remediate
+        try
+        {
+            settingsResult = await googleSyncService.CheckGroupSettingsAsync(cancellationToken);
             if (!settingsResult.Skipped && settingsResult.DriftCount > 0)
             {
                 logger.LogWarning("Google Group settings drift detected: {DriftCount} group(s) with settings drift out of {Total}",
@@ -83,38 +131,70 @@ public class GoogleResourceReconciliationJob(
             {
                 logger.LogWarning("Google Group settings check had {ErrorCount} error(s)", settingsResult.ErrorCount);
             }
-
-            // Notify Admin if any drift was detected and corrected
-            var totalDrift = inheritanceCorrected + settingsResult.DriftCount;
-            if (totalDrift > 0)
-            {
-                try
-                {
-                    await notificationService.SendToRoleAsync(
-                        NotificationSource.GoogleDriftDetected,
-                        NotificationClass.Informational,
-                        NotificationPriority.Normal,
-                        $"Google reconciliation fixed {totalDrift} drift issue(s)",
-                        RoleNames.Admin,
-                        body: $"Inheritance corrections: {inheritanceCorrected}, group settings drift: {settingsResult.DriftCount}",
-                        actionUrl: "/Admin/GoogleSync",
-                        actionLabel: "View sync status",
-                        cancellationToken: cancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to dispatch GoogleDriftDetected notification");
-                }
-            }
-
-            metrics.RecordJobRun("google_resource_reconciliation", "success");
-            logger.LogInformation("Completed Google resource reconciliation");
         }
         catch (Exception ex)
         {
-            metrics.RecordJobRun("google_resource_reconciliation", "failure");
-            logger.LogError(ex, "Error during Google resource reconciliation");
-            throw;
+            logger.LogError(ex, "Google reconciliation phase 'Group settings check' failed");
+            phaseFailures.Add("Group settings check");
+        }
+
+        // Notify Admin if any drift was detected and corrected
+        var totalDrift = inheritanceCorrected + settingsResult.DriftCount;
+        if (totalDrift > 0)
+        {
+            try
+            {
+                await notificationService.SendToRoleAsync(
+                    NotificationSource.GoogleDriftDetected,
+                    NotificationClass.Informational,
+                    NotificationPriority.Normal,
+                    $"Google reconciliation fixed {totalDrift} drift issue(s)",
+                    RoleNames.Admin,
+                    body: $"Inheritance corrections: {inheritanceCorrected}, group settings drift: {settingsResult.DriftCount}",
+                    actionUrl: "/Admin/GoogleSync",
+                    actionLabel: "View sync status",
+                    cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to dispatch GoogleDriftDetected notification");
+            }
+        }
+
+        // Emit a single summary alert if any phase failed; do not re-throw (Hangfire must not
+        // mark the whole run as failed when only some phases encountered errors).
+        if (phaseFailures.Count > 0)
+        {
+            var failedPhaseList = string.Join(", ", phaseFailures);
+            logger.LogError("Google reconciliation completed with {FailureCount} phase failure(s): {Phases}",
+                phaseFailures.Count, failedPhaseList);
+
+            try
+            {
+                await notificationService.SendToRoleAsync(
+                    NotificationSource.SyncError,
+                    NotificationClass.Actionable,
+                    NotificationPriority.High,
+                    $"Google reconciliation: {phaseFailures.Count} phase(s) failed",
+                    RoleNames.Admin,
+                    body: $"The following phase(s) encountered errors and did not complete: {failedPhaseList}. " +
+                          "Other phases ran normally. Check application logs for details.",
+                    actionUrl: "/Admin/GoogleSync",
+                    actionLabel: "View sync status",
+                    cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to dispatch SyncError notification for phase failures");
+            }
+
+            metrics.RecordJobRun("google_resource_reconciliation", "partial_failure");
+            logger.LogInformation("Completed Google resource reconciliation with phase failures");
+        }
+        else
+        {
+            metrics.RecordJobRun("google_resource_reconciliation", "success");
+            logger.LogInformation("Completed Google resource reconciliation");
         }
     }
 }

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleResourceReconciliationJobTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleResourceReconciliationJobTests.cs
@@ -1,7 +1,9 @@
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Humans.Application.DTOs;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
@@ -58,5 +60,18 @@ public class GoogleResourceReconciliationJobTests : IDisposable
             .SyncResourcesByTypeAsync(GoogleResourceType.Group, Arg.Any<SyncAction>(), Arg.Any<CancellationToken>());
         await _googleGroupSync.Received(1)
             .ReconcileAllAsync(SyncAction.Execute, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task ExecuteAsync_PropagatesCancellation_InsteadOfTreatingItAsPhaseFailure()
+    {
+        _googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        Func<Task> act = () => _job.ExecuteAsync();
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        await _googleGroupSync.DidNotReceive()
+            .ReconcileAllAsync(Arg.Any<SyncAction>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
Implements nobodies-collective/Humans#851.

## What changed

`GoogleResourceReconciliationJob.cs` — the single outer `try/catch` that re-threw and aborted all remaining phases on the first failure has been replaced with per-phase isolation.

## How each acceptance criterion is met

**A failure in one phase does not skip the remaining phases**
Each of the six phases (DriveFolder sync, DriveFile sync, Group membership reconcile, Drive folder path updates, Inherited access enforcement, Group settings check) is now wrapped in its own `try/catch`. An exception in any phase is caught, logged at `LogError`, and recorded in `phaseFailures`; execution continues to the next phase unconditionally.

**Per-phase outcomes are accumulated and a summary Admin alert fires on any phase failure**
Failed phase names are accumulated in a `List<string>`. After all phases complete, if the list is non-empty, a single `SendToRoleAsync(SyncError, Actionable, High)` fires to the Admin role with the list of failed phases in the body. This reuses the existing `SendToRoleAsync` path the job already uses for drift notifications.

**A partial success is not reported to Hangfire as a full failure**
The method no longer `throw`s on phase failure. It returns normally in all cases. Hangfire only marks a job as failed when the executed method throws; without the re-throw, a partial failure is not surfaced as a Hangfire failure.

## Other notes

- The existing `GoogleDriftDetected` informational notification (for drift corrections) is unchanged.
- Metrics now distinguish `"success"` (all phases clean) vs `"partial_failure"` (one or more phases threw).
- No new interfaces, types, DB migrations, or DI registrations.