### PR TITLE
feat(nav): surface member help corpus + fix stale merge-warning copy

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -914,7 +914,7 @@
     <value>Fusionar comptes?</value>
   </data>
   <data name="Emails_MergeWarningBody" xml:space="preserve">
-    <value>La fusió de comptes serveix per combinar dos comptes que pertanyen a la mateixa persona (per exemple, un correu antic i un de nou, tots dos teus). No és una manera de compartir o transferir entrades, reserves o altres elements entre dues persones diferents. La transferència d'entrades entre humans és una funció separada, properament.</value>
+    <value>La fusió de comptes serveix per combinar dos comptes que pertanyen a la mateixa persona (per exemple, un correu antic i un de nou, tots dos teus). No és una manera de compartir o transferir entrades, reserves o altres elements entre dues persones diferents. Per transferir una entrada a un altre humà, utilitza la funció de transferència d'entrades a /Tickets/Transfers.</value>
   </data>
   <data name="Emails_VerificationWillBeSent" xml:space="preserve">
     <value>S’enviarà un correu de verificació a aquesta adreça.</value>
@@ -4609,6 +4609,9 @@
   </data>
   <data name="Nav_Staff" xml:space="preserve">
     <value>Equip</value>
+  </data>
+  <data name="Nav_Guide" xml:space="preserve">
+    <value>Ajuda</value>
   </data>
   <data name="ProfileCard_Suspended" xml:space="preserve">
     <value>Suspès</value>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -914,7 +914,7 @@
     <value>Konten zusammenführen?</value>
   </data>
   <data name="Emails_MergeWarningBody" xml:space="preserve">
-    <value>Das Zusammenführen von Konten dient dazu, zwei Konten zu kombinieren, die derselben Person gehören (zum Beispiel eine alte und eine neue E-Mail-Adresse, die beide dir gehören). Es ist kein Weg, Tickets, Buchungen oder andere Elemente zwischen zwei verschiedenen Personen zu teilen oder zu übertragen. Die Ticket-Übertragung zwischen Menschen ist eine separate Funktion und wird in Kürze verfügbar sein.</value>
+    <value>Das Zusammenführen von Konten dient dazu, zwei Konten zu kombinieren, die derselben Person gehören (zum Beispiel eine alte und eine neue E-Mail-Adresse, die beide dir gehören). Es ist kein Weg, Tickets, Buchungen oder andere Elemente zwischen zwei verschiedenen Personen zu teilen oder zu übertragen. Um ein Ticket an einen anderen Menschen zu übertragen, nutze die Ticket-Übertragungsfunktion unter /Tickets/Transfers.</value>
   </data>
   <data name="Emails_VerificationWillBeSent" xml:space="preserve">
     <value>Eine Bestätigungs-E-Mail wird an diese Adresse gesendet.</value>
@@ -4609,6 +4609,9 @@
   </data>
   <data name="Nav_Staff" xml:space="preserve">
     <value>Team</value>
+  </data>
+  <data name="Nav_Guide" xml:space="preserve">
+    <value>Hilfe</value>
   </data>
   <data name="ProfileCard_Suspended" xml:space="preserve">
     <value>Gesperrt</value>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -914,7 +914,7 @@
     <value>¿Fusionar cuentas?</value>
   </data>
   <data name="Emails_MergeWarningBody" xml:space="preserve">
-    <value>La fusión de cuentas sirve para combinar dos cuentas que pertenecen a la misma persona (por ejemplo, un correo antiguo y uno nuevo, ambos tuyos). No es una forma de compartir o transferir entradas, reservas u otros elementos entre dos personas distintas. La transferencia de entradas entre humanos es una función aparte, próximamente.</value>
+    <value>La fusión de cuentas sirve para combinar dos cuentas que pertenecen a la misma persona (por ejemplo, un correo antiguo y uno nuevo, ambos tuyos). No es una forma de compartir o transferir entradas, reservas u otros elementos entre dos personas distintas. Para transferir una entrada a otro humano, utiliza la función de transferencia de entradas en /Tickets/Transfers.</value>
   </data>
   <data name="Emails_VerificationWillBeSent" xml:space="preserve">
     <value>Se enviará un correo de verificación a esta dirección.</value>
@@ -4633,6 +4633,9 @@
   </data>
   <data name="Nav_Staff" xml:space="preserve">
     <value>Equipo</value>
+  </data>
+  <data name="Nav_Guide" xml:space="preserve">
+    <value>Ayuda</value>
   </data>
   <data name="ProfileCard_Suspended" xml:space="preserve">
     <value>Suspendido</value>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -914,7 +914,7 @@
     <value>Fusionner des comptes ?</value>
   </data>
   <data name="Emails_MergeWarningBody" xml:space="preserve">
-    <value>La fusion de comptes sert à combiner deux comptes appartenant à la même personne (par exemple, un ancien et un nouvel e-mail, tous deux les vôtres). Ce n'est pas un moyen de partager ou de transférer des billets, des réservations ou d'autres éléments entre deux personnes différentes. Le transfert de billets entre humains est une fonctionnalité distincte, bientôt disponible.</value>
+    <value>La fusion de comptes sert à combiner deux comptes appartenant à la même personne (par exemple, un ancien et un nouvel e-mail, tous deux les vôtres). Ce n'est pas un moyen de partager ou de transférer des billets, des réservations ou d'autres éléments entre deux personnes différentes. Pour transférer un billet à un autre humain, utilisez la fonctionnalité de transfert de billets sur /Tickets/Transfers.</value>
   </data>
   <data name="Emails_VerificationWillBeSent" xml:space="preserve">
     <value>Un e-mail de vérification sera envoyé à cette adresse.</value>
@@ -4609,6 +4609,9 @@
   </data>
   <data name="Nav_Staff" xml:space="preserve">
     <value>Équipe</value>
+  </data>
+  <data name="Nav_Guide" xml:space="preserve">
+    <value>Aide</value>
   </data>
   <data name="ProfileCard_Suspended" xml:space="preserve">
     <value>Suspendu</value>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -914,7 +914,7 @@
     <value>Unire account?</value>
   </data>
   <data name="Emails_MergeWarningBody" xml:space="preserve">
-    <value>L'unione degli account serve a combinare due account che appartengono alla stessa persona (per esempio, una vecchia e una nuova e-mail, entrambe tue). Non è un modo per condividere o trasferire biglietti, prenotazioni o altri elementi tra due persone diverse. Il trasferimento di biglietti tra umani è una funzionalità separata, in arrivo a breve.</value>
+    <value>L'unione degli account serve a combinare due account che appartengono alla stessa persona (per esempio, una vecchia e una nuova e-mail, entrambe tue). Non è un modo per condividere o trasferire biglietti, prenotazioni o altri elementi tra due persone diverse. Per trasferire un biglietto a un altro umano, usa la funzione di trasferimento biglietti su /Tickets/Transfers.</value>
   </data>
   <data name="Emails_VerificationWillBeSent" xml:space="preserve">
     <value>Verrà inviata un'e-mail di verifica a questo indirizzo.</value>
@@ -4609,6 +4609,9 @@
   </data>
   <data name="Nav_Staff" xml:space="preserve">
     <value>Staff</value>
+  </data>
+  <data name="Nav_Guide" xml:space="preserve">
+    <value>Aiuto</value>
   </data>
   <data name="ProfileCard_Suspended" xml:space="preserve">
     <value>Sospeso</value>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -370,7 +370,7 @@
   <data name="Emails_YourEmails" xml:space="preserve"><value>Your Email Addresses</value></data>
   <data name="Emails_AddNew" xml:space="preserve"><value>Add Email Address</value></data>
   <data name="Emails_MergeWarningTitle" xml:space="preserve"><value>Merging accounts?</value></data>
-  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>Account merge is for combining two accounts that belong to the same person (for example, an old email and a new email that are both yours). It is not a way to share or transfer tickets, bookings, or other items between two different people. Ticket transfer between humans is a separate feature, coming soon.</value></data>
+  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>Account merge is for combining two accounts that belong to the same person (for example, an old email and a new email that are both yours). It is not a way to share or transfer tickets, bookings, or other items between two different people. To transfer a ticket to another human, use the ticket transfer feature at /Tickets/Transfers.</value></data>
   <data name="Emails_VerificationWillBeSent" xml:space="preserve"><value>A verification email will be sent to this address.</value></data>
   <data name="Emails_SendVerification" xml:space="preserve"><value>Send Verification Email</value></data>
   <data name="Emails_ResendCooldown" xml:space="preserve"><value>You can request a new verification email in {0} minute(s).</value><comment>{0} = minutes remaining</comment></data>
@@ -1872,6 +1872,7 @@
   <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Schedule conflict</value></data>
   <data name="Nav_Legal" xml:space="preserve"><value>Legal</value></data>
   <data name="Nav_Staff" xml:space="preserve"><value>Staff</value></data>
+  <data name="Nav_Guide" xml:space="preserve"><value>Help</value></data>
   <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspended</value></data>
   <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Pending</value></data>
   <data name="ProfileCard_Teams" xml:space="preserve"><value>Teams:</value></data>

--- a/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
@@ -83,6 +83,11 @@
                     <i class="fa-solid fa-shield-halved fa-fw"></i> @Localizer["Nav_Privacy"]
                 </a>
             </li>
+            <li>
+                <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Guide" asp-action="Index">
+                    <i class="fa-solid fa-circle-question fa-fw"></i> @Localizer["Nav_Guide"]
+                </a>
+            </li>
 
             <li><hr class="dropdown-divider" /></li>
 


### PR DESCRIPTION
Closes nobodies-collective/Humans#855.

## Acceptance criteria

| Criterion | Status | How |
|-----------|--------|-----|
| Member help corpus reachable from top-level nav surface | Done | Added a **Help** link (`fa-circle-question` icon) to the avatar/profile dropdown in `_LoginPartial.cshtml`, pointing at `/Guide`. Added `Nav_Guide` resource key (value: "Help") to `SharedResource.resx`. |
| Account-merge warning reflects that ticket transfer ships | Done | Updated `Emails_MergeWarningBody` in `SharedResource.resx`: removed "coming soon" wording, replaced with "use the ticket transfer feature at /Tickets/Transfers." |
| Ticket stub shows active event name/year (not hardcoded literal) | Deferred | Per nobodies-collective/Humans#855 comment: "Elsewhere 2026 is the correct event name, this part is fine, we'll fix it post event." No change made. |

## Files changed

- `src/Humans.Web/Views/Shared/_LoginPartial.cshtml` — Help link in avatar dropdown
- `src/Humans.Web/Resources/SharedResource.resx` — `Nav_Guide` key + `Emails_MergeWarningBody` fix