### PR TITLE
feat(profile): coordinator-facing sent-message history panel

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1885,7 +1885,8 @@ public class ProfileController(
             return (false, null);
 
         var viewerIsCoordinator = (await shiftMgmt.GetCoordinatorTeamIdsAsync(viewerId)).Count > 0;
-        if (!viewerIsCoordinator && !ShiftRoleChecks.IsPrivilegedSignupApprover(User))
+        var isPrivilegedApprover = (await authorizationService.AuthorizeAsync(User, PolicyNames.PrivilegedSignupApprover)).Succeeded;
+        if (!viewerIsCoordinator && !isPrivilegedApprover)
             return (false, null);
 
         var messages = await _auditViewerService.GetFilteredAsync(

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -74,11 +74,13 @@ public class ProfileController(
     IAccountDeletionService accountDeletionService,
     IMembershipCalculatorRead membershipCalculator,
     SignInManager<User> signInManager,
-    IOptions<GoogleWorkspaceOptions> googleWorkspaceOptions) : HumansControllerBase(userService)
+    IOptions<GoogleWorkspaceOptions> googleWorkspaceOptions,
+    IAuditViewerService auditViewerService) : HumansControllerBase(userService)
 {
     private readonly ITicketServiceRead _ticketQueryService = ticketQueryService;
     private readonly IUserService _userService = userService;
     private readonly GoogleWorkspaceOptions _googleWorkspaceOptions = googleWorkspaceOptions.Value;
+    private readonly IAuditViewerService _auditViewerService = auditViewerService;
 
     private const int MaxProfilePictureUploadBytes = 20 * 1024 * 1024; // 20MB upload limit
     private static readonly HashSet<string> AllowedImageContentTypes = new(StringComparer.OrdinalIgnoreCase)
@@ -1790,6 +1792,8 @@ public class ProfileController(
             || (await authorizationService.AuthorizeAsync(
                 User, PolicyNames.TicketAdminBoardOrAdmin)).Succeeded;
 
+        var sentMessagesContext = await BuildSentMessagesContextAsync(id, viewer.Id, isOwnProfile, ct);
+
         var viewModel = new ProfileViewModel
         {
             Id = profile.Id,
@@ -1803,6 +1807,8 @@ public class ProfileController(
                 ? await ResolveOnsiteSinceAsync(profileInfo)
                 : null,
             CanViewOnsiteChip = canViewOnsiteChip,
+            CanViewSentMessages = sentMessagesContext.CanView,
+            SentMessages = sentMessagesContext.Messages,
         };
 
         return View("Index", viewModel);
@@ -1863,6 +1869,34 @@ public class ProfileController(
                 MarkedAtLabel = s.ReviewedAt?.InZone(signupTz).ToDateTimeUnspecified().ToMonthDayTime()
             };
         }).ToList());
+    }
+
+    /// <summary>
+    /// Loads in-platform messages sent to the profile user, gated on the viewer being a
+    /// coordinator or holding a privileged shift-management role. Uses the same coordinator
+    /// check as <see cref="BuildNoShowHistoryContextAsync"/> so the two panels appear
+    /// under consistent access rules.
+    /// Returns <c>(false, null)</c> for own-profile views and non-coordinators.
+    /// </summary>
+    private async Task<(bool CanView, IReadOnlyList<Application.Services.AuditLog.AuditEvent>? Messages)>
+        BuildSentMessagesContextAsync(Guid profileUserId, Guid viewerId, bool isOwnProfile, CancellationToken ct)
+    {
+        if (isOwnProfile)
+            return (false, null);
+
+        var viewerIsCoordinator = (await shiftMgmt.GetCoordinatorTeamIdsAsync(viewerId)).Count > 0;
+        if (!viewerIsCoordinator && !ShiftRoleChecks.IsPrivilegedSignupApprover(User))
+            return (false, null);
+
+        var messages = await _auditViewerService.GetFilteredAsync(
+            entityType: nameof(User),
+            entityId: profileUserId,
+            userId: null,
+            actions: [AuditAction.FacilitatedMessageSent],
+            limit: 50,
+            ct: ct);
+
+        return (true, messages);
     }
 
     [HttpGet("{id:guid}/Popover")]

--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -375,6 +375,19 @@ public class ProfileViewModel
     /// (<c>PolicyNames.TicketAdminBoardOrAdmin</c>).
     /// </summary>
     public bool CanViewOnsiteChip { get; set; }
+
+    /// <summary>
+    /// In-platform messages sent to this volunteer. Coordinator-gated; null when
+    /// the viewer does not have coordinator access. Source: <c>FacilitatedMessageSent</c>
+    /// audit entries where <c>EntityId == UserId</c>.
+    /// </summary>
+    public IReadOnlyList<Humans.Application.Services.AuditLog.AuditEvent>? SentMessages { get; set; }
+
+    /// <summary>
+    /// Whether the viewer can see the "Sent messages" panel.
+    /// True when the viewer is a coordinator or has a privileged shift-management role.
+    /// </summary>
+    public bool CanViewSentMessages { get; set; }
 }
 
 /// <summary>

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -110,6 +110,43 @@
             </div>
         }
 
+        @if (Model.CanViewSentMessages)
+        {
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fa-solid fa-envelope me-1"></i> Sent messages (@(Model.SentMessages?.Count ?? 0))</h5>
+                </div>
+                @if (Model.SentMessages is null || Model.SentMessages.Count == 0)
+                {
+                    <div class="card-body text-muted">No in-platform messages on record.</div>
+                }
+                else
+                {
+                    <div class="card-body p-0">
+                        <table class="table table-sm mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Sender</th>
+                                    <th>Preview</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var msg in Model.SentMessages)
+                                {
+                                    <tr>
+                                        <td class="text-nowrap">@msg.OccurredAt.ToDateTimeUtc().ToDateTime()</td>
+                                        <td class="text-nowrap">@(msg.ActorDisplayName ?? "—")</td>
+                                        <td>@msg.Description</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
+        }
+
         @if (Model.IsOwnProfile && Model.CampaignGrants.Any())
         {
             <div class="card mb-3">

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
@@ -116,7 +116,8 @@ public class ProfileControllerDietaryMedicalReplayTests
                 NullLogger<SignInManager<User>>.Instance,
                 Substitute.For<Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider>(),
                 Substitute.For<IUserConfirmation<User>>()),
-            Options.Create(new GoogleWorkspaceOptions()));
+            Options.Create(new GoogleWorkspaceOptions()),
+            Substitute.For<IAuditViewerService>());
 
         var identity = new ClaimsIdentity(new[]
         {

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -123,7 +123,8 @@ public class ProfileControllerEditTests
                 NullLogger<SignInManager<User>>.Instance,
                 Substitute.For<Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider>(),
                 Substitute.For<IUserConfirmation<User>>()),
-            Options.Create(new GoogleWorkspaceOptions()));
+            Options.Create(new GoogleWorkspaceOptions()),
+            Substitute.For<IAuditViewerService>());
 
         var identity = new ClaimsIdentity([
             new Claim(ClaimTypes.NameIdentifier, _userId.ToString())

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
@@ -104,7 +104,8 @@ public class ProfileControllerEmailGridTests
             Substitute.For<IAccountDeletionService>(),
             Substitute.For<IMembershipCalculatorRead>(),
             _signInManager,
-            Options.Create(new GoogleWorkspaceOptions()));
+            Options.Create(new GoogleWorkspaceOptions()),
+            Substitute.For<IAuditViewerService>());
 
         var identity = new ClaimsIdentity([
             new Claim(ClaimTypes.NameIdentifier, _userId.ToString())

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
@@ -95,7 +95,8 @@ public class ProfileControllerPopoverTests
             Substitute.For<IAccountDeletionService>(),
             Substitute.For<IMembershipCalculatorRead>(),
             signInManager,
-            Options.Create(new GoogleWorkspaceOptions()));
+            Options.Create(new GoogleWorkspaceOptions()),
+            Substitute.For<IAuditViewerService>());
 
         var identity = new ClaimsIdentity([
             new Claim(ClaimTypes.NameIdentifier, _viewerId.ToString())


### PR DESCRIPTION
Closes nobodies-collective/Humans#617

## Summary

Adds a read-only "Sent messages" panel to the volunteer profile page, visible to coordinators and privileged shift-management roles. Uses existing `FacilitatedMessageSent` audit log entries as the data source — no migration required.

## How each acceptance criterion is met

- **Coordinator viewing a volunteer profile sees a list of messages sent to that volunteer through the platform** — `BuildSentMessagesContextAsync` gates on `GetCoordinatorTeamIdsAsync` (any team coordinator) or `ShiftRoleChecks.IsPrivilegedSignupApprover` (Admin/VolunteerCoordinator roles). Queries `IAuditViewerService.GetFilteredAsync` with `entityType="User"`, `entityId=profileUserId`, `actions=[FacilitatedMessageSent]`. Panel is hidden for own-profile views and non-coordinators.

- **List includes timestamp, sender (coordinator name + team if scoped), and content preview** — Table renders three columns: Date (formatted via `OccurredAt.ToDateTimeUtc().ToDateTime()`), Sender (`ActorDisplayName` resolved by `AuditViewerService`), and Preview (`Description` from the audit entry, which the send flow writes as the message content). The existing audit entries do not record the sender's team; team context is shown if a future change adds it.

- **Reporter can be notified (feedback `fb:2ea341b4`)** — out of scope for this PR; handled via the feedback system.

## Changes

- `ProfileController`: inject `IAuditViewerService`, add `BuildSentMessagesContextAsync` helper, populate `CanViewSentMessages`/`SentMessages` in `ViewProfile`
- `ProfileViewModel`: add `CanViewSentMessages` and `SentMessages` properties
- `Profile/Index.cshtml`: render the "Sent messages" card when `CanViewSentMessages` is true
- 4 test fixtures: add `Substitute.For<IAuditViewerService>()` to constructor calls

## Architecture

- Reads through `IAuditViewerService` (Application layer), not the repository directly — no layer violations
- No new interfaces, services, or DI registrations — reuses the existing `GetFilteredAsync` path
- No migration — uses existing `audit_log_entries` rows where `Action = FacilitatedMessageSent`