### PR TITLE
feat(expenses): SEPA batch reopen action after failed download (nobodies-collective/Humans#850)

### DIFF
--- a/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
+++ b/src/Humans.Application/Interfaces/Expenses/IExpenseReportService.cs
@@ -70,6 +70,15 @@ public interface IExpenseReportService : IExpenseReportServiceRead, IApplication
         IReadOnlyCollection<Guid> reportIds, Guid actorUserId,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Reverts a <see cref="ExpenseReportStatus.SepaSent"/> report back to
+    /// <see cref="ExpenseReportStatus.Approved"/> so the admin can include it in a fresh SEPA
+    /// batch after a failed download. Returns <see cref="ExpenseMutationResult.Failure"/> if the
+    /// report is not in <c>SepaSent</c> status.
+    /// </summary>
+    Task<ExpenseMutationResult> ReopenSepaWithResultAsync(
+        Guid reportId, Guid actorUserId, CancellationToken ct = default);
+
     Task<ExpenseMutationResult> AddMileageLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string origin, string destination, decimal km,

--- a/src/Humans.Application/Interfaces/Repositories/IExpenseRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IExpenseRepository.cs
@@ -76,6 +76,14 @@ public interface IExpenseRepository : IRepository
         NodaTime.Instant sepaSentAt,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Reverts a <see cref="Humans.Domain.Enums.ExpenseReportStatus.SepaSent"/> report back to
+    /// <see cref="Humans.Domain.Enums.ExpenseReportStatus.Approved"/> so the admin can re-include
+    /// it in a fresh SEPA batch after a failed download.
+    /// Only transitions from <c>SepaSent</c>; no-op (returns false) for any other status.
+    /// </summary>
+    Task<bool> ReopenSepaAsync(Guid reportId, NodaTime.Instant updatedAt, CancellationToken ct = default);
+
     Task<bool> MarkPaidAsync(
         Guid reportId, NodaTime.Instant paidAt, CancellationToken ct = default);
 

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -838,6 +838,23 @@ public sealed class ExpenseReportService(
         return flippedIds;
     }
 
+    public async Task<ExpenseMutationResult> ReopenSepaWithResultAsync(
+        Guid reportId, Guid actorUserId, CancellationToken ct = default)
+    {
+        var now = clock.GetCurrentInstant();
+        var ok = await repo.ReopenSepaAsync(reportId, now, ct);
+        if (!ok)
+            return ExpenseMutationResult.Failure("Report is not in SepaSent status and cannot be reopened.");
+
+        await auditLogService.LogAsync(
+            AuditAction.ExpenseSepaReopened,
+            "ExpenseReport", reportId,
+            "Reopened from SepaSent to Approved — download failed, batch can be regenerated.",
+            actorUserId);
+
+        return ExpenseMutationResult.Success;
+    }
+
     internal async Task<bool> MarkPaidAsync(
         Guid reportId, Instant paidAt, CancellationToken ct = default)
     {

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -844,7 +844,10 @@ public sealed class ExpenseReportService(
         var now = clock.GetCurrentInstant();
         var ok = await repo.ReopenSepaAsync(reportId, now, ct);
         if (!ok)
+        {
+            logger.LogWarning("ReopenSepa guard failed for report {ReportId}: not in SepaSent status", reportId);
             return ExpenseMutationResult.Failure("Report is not in SepaSent status and cannot be reopened.");
+        }
 
         await auditLogService.LogAsync(
             AuditAction.ExpenseSepaReopened,
@@ -1255,6 +1258,7 @@ public sealed class ExpenseReportService(
             AuditAction.ExpenseWithdraw,
             AuditAction.ExpenseCategoryOverride,
             AuditAction.ExpenseSepaSent,
+            AuditAction.ExpenseSepaReopened,
             AuditAction.ExpensePaid,
             AuditAction.ExpenseAttachmentUploaded,
             AuditAction.ExpenseAttachmentRemoved,

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -148,6 +148,7 @@ public enum AuditAction
     ExpenseWithdraw,
     ExpenseCategoryOverride,
     ExpenseSepaSent,
+    ExpenseSepaReopened,
     ExpensePaid,
     IbanSet,
     IbanRemove,

--- a/src/Humans.Infrastructure/Repositories/Expenses/ExpenseRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Expenses/ExpenseRepository.cs
@@ -321,6 +321,19 @@ internal sealed class ExpenseRepository(IDbContextFactory<HumansDbContext> facto
         return rows.Select(r => r.Id).ToList();
     }
 
+    public async Task<bool> ReopenSepaAsync(Guid reportId, Instant updatedAt, CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        var r = await ctx.ExpenseReports
+            .FirstOrDefaultAsync(x => x.Id == reportId, ct);
+        if (r is null || r.Status != ExpenseReportStatus.SepaSent) return false;
+        r.Status = ExpenseReportStatus.Approved;
+        r.SepaSentAt = null;
+        r.UpdatedAt = updatedAt;
+        await ctx.SaveChangesAsync(ct);
+        return true;
+    }
+
     public async Task<bool> MarkPaidAsync(
         Guid reportId, Instant paidAt, CancellationToken ct = default)
     {

--- a/src/Humans.Web/Authorization/Requirements/ExpenseReportAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/ExpenseReportAuthorizationHandler.cs
@@ -39,7 +39,8 @@ public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetServi
                     or ExpenseReportOperation.Approve
                     or ExpenseReportOperation.FinanceReject
                     or ExpenseReportOperation.CategoryOverride
-                    or ExpenseReportOperation.IncludeInSepaPayout)
+                    or ExpenseReportOperation.IncludeInSepaPayout
+                    or ExpenseReportOperation.ReopenSepa)
             {
                 context.Succeed(requirement);
                 return;

--- a/src/Humans.Web/Authorization/Requirements/ExpenseReportOperation.cs
+++ b/src/Humans.Web/Authorization/Requirements/ExpenseReportOperation.cs
@@ -15,5 +15,6 @@ public enum ExpenseReportOperation
     Approve,
     FinanceReject,
     CategoryOverride,
-    IncludeInSepaPayout
+    IncludeInSepaPayout,
+    ReopenSepa
 }

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -730,6 +730,30 @@ public sealed class ExpensesController(
         return RedirectToAction(nameof(Review));
     }
 
+    [HttpPost("{id:guid}/Sepa/Reopen")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = PolicyNames.FinanceAdminOrAdmin)]
+    public async Task<IActionResult> SepaReopen(Guid id)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var report = await expenseReadService.GetAsync(id);
+        if (report is null) return NotFound();
+
+        var authResult = await authService.AuthorizeAsync(User, report,
+            new ExpenseReportOperationRequirement(ExpenseReportOperation.ReopenSepa));
+        if (!authResult.Succeeded) return Forbid();
+
+        var result = await service.ReopenSepaWithResultAsync(id, user.Id);
+        if (result.Succeeded)
+            SetSuccess("Report reopened — it is now Approved and can be included in a new SEPA batch.");
+        else
+            SetError(result.ErrorMessage ?? "Could not reopen the report.");
+
+        return RedirectToAction(nameof(Review));
+    }
+
     [HttpPost("Sepa/Generate")]
     [ValidateAntiForgeryToken]
     [Authorize(Policy = PolicyNames.FinanceAdminOrAdmin)]

--- a/src/Humans.Web/Views/Expenses/Review.cshtml
+++ b/src/Humans.Web/Views/Expenses/Review.cshtml
@@ -107,14 +107,11 @@ else
                                     }
                                     @if (r.Status == ExpenseReportStatus.SepaSent)
                                     {
-                                        <form asp-action="SepaReopen" asp-route-id="@r.Id" method="post"
-                                              style="display:inline">
-                                            @Html.AntiForgeryToken()
-                                            <button type="submit" class="btn btn-sm btn-outline-warning"
-                                                    onclick="return confirm('Reopen this report? It will return to Approved so you can include it in a new SEPA batch.')">
-                                                <i class="fa-solid fa-rotate-left me-1"></i>Reopen SEPA
-                                            </button>
-                                        </form>
+                                        <button type="button" class="btn btn-sm btn-outline-warning"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#reopenSepaModal-@r.Id">
+                                            <i class="fa-solid fa-rotate-left me-1"></i>Reopen SEPA
+                                        </button>
                                     }
                                 </div>
                             </td>
@@ -188,6 +185,37 @@ else
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                             <button type="submit" class="btn btn-danger">Reject</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    }
+
+    @foreach (var r in Model.Reports.Where(x => x.Status == ExpenseReportStatus.SepaSent))
+    {
+        <div class="modal fade" id="reopenSepaModal-@r.Id" tabindex="-1"
+             aria-labelledby="reopenSepaModalLabel-@r.Id" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <form asp-action="SepaReopen" asp-route-id="@r.Id" method="post">
+                        @Html.AntiForgeryToken()
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="reopenSepaModalLabel-@r.Id">Reopen SEPA Batch</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <p>
+                                Reopen report <strong>@r.Id.ToString()[..8]…</strong>?
+                            </p>
+                            <p class="text-muted mb-0">
+                                It will return to <strong>Approved</strong> status so you can include it in a new SEPA batch.
+                                Use this only if the previous download failed before the file reached your bank.
+                            </p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-warning">Reopen</button>
                         </div>
                     </form>
                 </div>

--- a/src/Humans.Web/Views/Expenses/Review.cshtml
+++ b/src/Humans.Web/Views/Expenses/Review.cshtml
@@ -105,6 +105,17 @@ else
                                             <i class="fa-solid fa-xmark me-1"></i>Reject
                                         </button>
                                     }
+                                    @if (r.Status == ExpenseReportStatus.SepaSent)
+                                    {
+                                        <form asp-action="SepaReopen" asp-route-id="@r.Id" method="post"
+                                              style="display:inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit" class="btn btn-sm btn-outline-warning"
+                                                    onclick="return confirm('Reopen this report? It will return to Approved so you can include it in a new SEPA batch.')">
+                                                <i class="fa-solid fa-rotate-left me-1"></i>Reopen SEPA
+                                            </button>
+                                        </form>
+                                    }
                                 </div>
                             </td>
                         </tr>

--- a/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
@@ -1167,6 +1167,43 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task ReopenSepaWithResultAsync_RevertsToApproved_AndAudits()
+    {
+        var (_, category) = SetupActiveYear();
+        var actor = Guid.NewGuid();
+        var reportId = Guid.NewGuid();
+        await SeedReportWithStatus(reportId, Guid.NewGuid(), category.Id, Guid.NewGuid(),
+            ExpenseReportStatus.SepaSent);
+
+        var result = await _sut.ReopenSepaWithResultAsync(reportId, actor);
+        result.Succeeded.Should().BeTrue();
+
+        (await _sut.GetAsync(reportId))!.Status.Should().Be(ExpenseReportStatus.Approved);
+        (await _sut.GetAsync(reportId))!.SepaSentAt.Should().BeNull();
+        await AuditLog.Received(1).LogAsync(
+            AuditAction.ExpenseSepaReopened, "ExpenseReport", reportId,
+            Arg.Any<string>(), actor);
+    }
+
+    [HumansFact]
+    public async Task ReopenSepaWithResultAsync_ReturnsFailure_WhenNotSepaSent()
+    {
+        var (_, category) = SetupActiveYear();
+        var reportId = Guid.NewGuid();
+        await SeedReportWithStatus(reportId, Guid.NewGuid(), category.Id, Guid.NewGuid(),
+            ExpenseReportStatus.Approved);
+
+        var result = await _sut.ReopenSepaWithResultAsync(reportId, Guid.NewGuid());
+        result.Succeeded.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+
+        (await _sut.GetAsync(reportId))!.Status.Should().Be(ExpenseReportStatus.Approved);
+        await AuditLog.DidNotReceive().LogAsync(
+            AuditAction.ExpenseSepaReopened, "ExpenseReport", reportId,
+            Arg.Any<string>(), Arg.Any<Guid>());
+    }
+
+    [HumansFact]
     public async Task MarkPaidAsync_FlipsToPaid_AndAuditsJob()
     {
         var (_, category) = SetupActiveYear();


### PR DESCRIPTION
## Summary

Stacked on #949 (nobodies-collective/Humans#638). Merge #949 first; this PR retargets to main when its base branch is deleted.

Fixes the SEPA lost-payout window from nobodies-collective/Humans#850: adds an admin **Reopen SEPA** action that transitions a `SepaSent` report back to `Approved`, so a failed download does not permanently strand the payout.

## Acceptance Criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| AC1 | Store webhook does not record payment for `unpaid` session | Covered by #949 | `StoreService.cs` `HandleCheckoutSessionCompletedAsync` gates on `session.PaymentStatus == "paid"` → records `StorePaymentStatus.Pending` otherwise; `BalanceCalculator.cs` excludes `Pending`/`Failed` from balance |
| AC2 | Admin can reopen / re-download a SEPA batch after a failed download | Implemented here | `ExpensesController.SepaReopen` POST; "Reopen SEPA" button (Bootstrap modal) on `SepaSent` rows in `Review.cshtml` |
| AC3 | Stranded `SepaSent` report recoverable without a DB edit | Implemented here | `ReopenSepaWithResultAsync` → `ReopenSepaAsync` flips `SepaSent → Approved`, clears `SepaSentAt`; report re-eligible for `SepaGenerate` |

## Changes

- **Domain** — `AuditAction.ExpenseSepaReopened`
- **Application** — `IExpenseRepository.ReopenSepaAsync`; `IExpenseReportService.ReopenSepaWithResultAsync`; `ExpenseReportService` implementation; `ExpenseReportOperation.ReopenSepa`
- **Infrastructure** — `ExpenseRepository.ReopenSepaAsync`: only transitions from `SepaSent`, clears `SepaSentAt`, no-ops on any other status
- **Web** — `ExpensesController.SepaReopen` POST with resource-based auth (`ReopenSepa` op → FinanceAdmin/Admin); Bootstrap confirm modal in `Review.cshtml` (no inline event handlers — CSP-clean)
- **Tests** — 2 new `ExpenseReportServiceTests`: success path + non-SepaSent guard

## Test plan

- [ ] Build passes: `dotnet build Humans.slnx -v quiet`
- [ ] All tests pass: `dotnet test Humans.slnx -v quiet`
- [ ] On the Review queue, a `SepaSent` report shows a "Reopen SEPA" button; clicking opens the Bootstrap confirm modal
- [ ] Confirming the modal POSTs to `SepaReopen`, flips the report to `Approved`, shows success toast, report now selectable in the SEPA Generate form
- [ ] Non-SepaSent reports do not show the "Reopen SEPA" button
- [ ] Audit log records `ExpenseSepaReopened` with the acting user id

🤖 Generated with [Claude Code](https://claude.com/claude-code)