### PR TITLE
feat(shifts): post-event stats dashboard — completion/no-show rates by department

### DIFF
--- a/docs/features/shifts/post-event-stats.md
+++ b/docs/features/shifts/post-event-stats.md
@@ -1,0 +1,103 @@
+<!-- freshness:triggers
+  src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+  src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+  src/Humans.Application/DTOs/PostEventStats.cs
+  src/Humans.Infrastructure/Repositories/Shifts/ShiftManagementRepository.cs
+  src/Humans.Web/Controllers/ShiftDashboardController.cs
+  src/Humans.Web/Views/ShiftDashboard/PostEventStats.cshtml
+-->
+<!-- freshness:flag-on-change
+  Aggregation logic (period buckets, no-show rate formula, AdminOnly/hidden exclusions),
+  authorization gate, or department-row shape may have changed.
+-->
+
+# Post-Event Stats Dashboard
+
+## Business Context
+
+After an event, coordinators and admins need a quick debrief view: which departments had the most no-shows, and which periods (Set-Up / Event / Strike) drove the gaps? The existing coordinator dashboard answers real-time operational questions; this view answers the post-event accountability question — "how did we actually do?"
+
+Asked for in nobodies-collective/Humans#161 (partial scope — CSV exports are deferred pending a GDPR decision; this spec covers only the stats dashboard).
+
+## User Stories
+
+### US-PES.1: Admin Sees Event-Level Completion and No-Show Rates
+
+**As an** Admin / NoInfoAdmin / VolunteerCoordinator
+**I want to** see overall Confirmed, No-Show, and completion-rate counters for the active event
+**So that** I can assess at a glance how the event went
+
+**Acceptance Criteria:**
+- Four summary cards: Total Shifts, Total Confirmed, No-Shows, and Completion Rate
+- Completion Rate = `100 - NoShowPct` where `NoShowPct = NoShow / (Confirmed + NoShow) × 100` (rounded to nearest integer)
+- When there are no recorded outcomes (Confirmed + NoShow = 0), Completion Rate shows "—" with "no outcome data recorded"
+- AdminOnly shifts and rotas with `IsVisibleToVolunteers = false` are excluded from all counts
+
+### US-PES.2: Admin Sees Per-Department Breakdown
+
+**As an** Admin / NoInfoAdmin / VolunteerCoordinator
+**I want to** see a table with one row per top-level department showing confirmed, no-shows, completion rate, and per-period badges
+**So that** I can identify which departments drove no-show problems and in which periods
+
+**Acceptance Criteria:**
+- One row per parent team (department) that had at least one shift in the active event
+- Columns: Department name (linked to ShiftAdmin if the team has a slug), Confirmed, No-Shows, Completion badge, Set-Up badge, Event badge, Strike badge
+- Completion badge uses: green ≥ 90%, amber ≥ 75%, red < 75% (consistent across department-level column and all period columns)
+- Period badge shows completion percentage; dash ("—") when the period had no Confirmed or NoShow signups
+- Departments are sorted alphabetically (case-insensitive ordinal) — applied at the controller, not the service
+- Same AdminOnly / hidden rota exclusions as US-PES.1
+
+### US-PES.3: Dashboard Access Is Gated
+
+**As a** regular volunteer
+**I cannot** access the post-event stats dashboard
+
+**Acceptance Criteria:**
+- Route `GET /Shifts/Dashboard/PostEventStats` requires the `ShiftDashboardAccess` policy (Admin, NoInfoAdmin, VolunteerCoordinator)
+- Unauthenticated or unauthorized users are redirected to the login page / access-denied page per the standard middleware
+
+## Data Model
+
+No new tables or columns. Derived from existing `event_settings`, `rotas`, `shifts`, `shift_signups`, and `teams`.
+
+### Period assignment
+
+A shift's period is determined by its rota's `Period` property (`ShiftPeriod` enum: `Build`, `Event`, `Strike`, `All`). Shifts on an `All`-period rota are bucketed by day offset relative to `EventSettings.EventStartDate`:
+- Day offset < 0 → Build
+- Day offset 0..N (within event dates) → Event
+- Day offset > event end → Strike
+
+### Signup inclusion
+
+Only `ShiftSignupStatus.Confirmed` and `ShiftSignupStatus.NoShow` are counted. All other statuses (Pending, Refused, Bailed, Cancelled) are excluded from rates. A shift with zero Confirmed + NoShow signups is counted in TotalShifts but not in ShiftsWithData or rate calculations.
+
+### Department roll-up
+
+Each shift is attributed to the parent team of the rota's owning team (or the owning team itself if it has no parent). Only top-level departments appear as rows; sub-teams' signups roll up into their parent's bucket.
+
+## Routes
+
+| Method | URL | Controller action |
+|--------|-----|-------------------|
+| GET | `/Shifts/Dashboard/PostEventStats` | `ShiftDashboardController.PostEventStats` |
+
+Nav entry appears under Shifts in the admin sidebar, next to the existing shift dashboard entries.
+
+## Authorization
+
+`ShiftDashboardAccess` policy: Admin, NoInfoAdmin, VolunteerCoordinator.
+
+## DTOs
+
+- `PostEventStats` — top-level record: shift counts, overall totals, `NoShowPct`/`CompletionPct` computed properties, and the sorted department list.
+- `PostEventDepartmentRow` — per-department record: totals, `NoShowPct`/`CompletionPct` computed properties, and three `PostEventPeriodRow` sub-records.
+- `PostEventPeriodRow` — per-period record: `TotalConfirmed`, `TotalNoShow`, `NoShowPct`/`CompletionPct` computed properties.
+
+All three share the same rate formula: `NoShowPct = round(100 × NoShow / (Confirmed + NoShow))`, 0 when denominator is 0; `CompletionPct = clamp(100 − NoShowPct, 0, 100)`.
+
+## Related Features
+
+- [Shift Management](shift-management.md) — repository and service methods used by this feature.
+- [Department Coverage Pies](department-coverage-pies.md) — similar read-only aggregation over the same signup data.
+- Section invariants: [`docs/sections/Shifts.md`](../../sections/Shifts.md).
+- Upstream issue: nobodies-collective/Humans#161.

--- a/docs/features/shifts/shift-management.md
+++ b/docs/features/shifts/shift-management.md
@@ -196,6 +196,7 @@ Pending --> Cancelled   (system: shift deleted, account deletion)
 | `/Shifts/Summary[/{teamSlug}[/{rotaGuid}]]` | Read-only Shift Summary by Camp — confirmed-hour/count totals per human and per camp, at global / team-set / single-rota scope (`ShiftDepartmentManager` policy) |
 | `/Shifts/Preferences/Tags` | POST: Save volunteer tag preferences |
 | `/Shifts/Settings` | Admin: manage EventSettings |
+| `/Shifts/Dashboard/PostEventStats` | Post-event stats: completion/no-show rates by department and period (`ShiftDashboardAccess` policy) |
 | `/Teams/{slug}/Shifts` | Coordinator: manage rotas/shifts for a department |
 | `/` (Dashboard) | Shift signups ViewComponent + guided discovery when no signups |
 | `/Human/{id}/Admin` | Shift signups ViewComponent (admin view of user's shifts) |

--- a/docs/sections/Shifts.md
+++ b/docs/sections/Shifts.md
@@ -204,6 +204,7 @@ Selected routes:
 | `GET /Teams/{slug}/Shifts/Tags/Search` | Tag autocomplete |
 | `POST /Teams/{slug}/Shifts/Tags/Create` | Create new tag |
 | `GET /Shifts/Dashboard` | Cross-department coordinator dashboard |
+| `GET /Shifts/Dashboard/PostEventStats` | Post-event stats: completion/no-show rates by department (`ShiftDashboardAccess`) |
 | `GET /Shifts/Dashboard/SearchVolunteers` | Dashboard volunteer search |
 | `POST /Shifts/Dashboard/Voluntell` | Dashboard voluntell |
 

--- a/src/Humans.Application/DTOs/PostEventStats.cs
+++ b/src/Humans.Application/DTOs/PostEventStats.cs
@@ -9,7 +9,22 @@ public record PostEventStats(
     int ShiftsWithData,
     int TotalConfirmed,
     int TotalNoShow,
-    IReadOnlyList<PostEventDepartmentRow> Departments);
+    IReadOnlyList<PostEventDepartmentRow> Departments)
+{
+    /// <summary>
+    /// No-show rate as a percentage 0..100, or 0 when no signups to measure.
+    /// </summary>
+    public int NoShowPct => (TotalConfirmed + TotalNoShow) > 0
+        ? (int)Math.Round(100.0 * TotalNoShow / (TotalConfirmed + TotalNoShow), MidpointRounding.AwayFromZero)
+        : 0;
+
+    /// <summary>
+    /// Completion rate as a percentage 0..100, or 0 when no signups to measure.
+    /// </summary>
+    public int CompletionPct => (TotalConfirmed + TotalNoShow) > 0
+        ? Math.Clamp(100 - NoShowPct, 0, 100)
+        : 0;
+}
 
 /// <summary>
 /// Per-department row for the post-event stats dashboard.
@@ -23,7 +38,22 @@ public record PostEventDepartmentRow(
     int TotalNoShow,
     PostEventPeriodRow Build,
     PostEventPeriodRow Event,
-    PostEventPeriodRow Strike);
+    PostEventPeriodRow Strike)
+{
+    /// <summary>
+    /// No-show rate as a percentage 0..100, or 0 when no signups to measure.
+    /// </summary>
+    public int NoShowPct => (TotalConfirmed + TotalNoShow) > 0
+        ? (int)Math.Round(100.0 * TotalNoShow / (TotalConfirmed + TotalNoShow), MidpointRounding.AwayFromZero)
+        : 0;
+
+    /// <summary>
+    /// Completion rate as a percentage 0..100, or 0 when no signups to measure.
+    /// </summary>
+    public int CompletionPct => (TotalConfirmed + TotalNoShow) > 0
+        ? Math.Clamp(100 - NoShowPct, 0, 100)
+        : 0;
+}
 
 /// <summary>
 /// Confirmed/no-show counts for a single shift period within a department.

--- a/src/Humans.Application/DTOs/PostEventStats.cs
+++ b/src/Humans.Application/DTOs/PostEventStats.cs
@@ -1,0 +1,46 @@
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// Post-event statistics dashboard: completion and no-show rates across the whole event,
+/// broken down by department and period.
+/// </summary>
+public record PostEventStats(
+    int TotalShifts,
+    int ShiftsWithData,
+    int TotalConfirmed,
+    int TotalNoShow,
+    IReadOnlyList<PostEventDepartmentRow> Departments);
+
+/// <summary>
+/// Per-department row for the post-event stats dashboard.
+/// Includes Build, Event, and Strike period breakdowns.
+/// </summary>
+public record PostEventDepartmentRow(
+    Guid DepartmentId,
+    string DepartmentName,
+    string? DepartmentSlug,
+    int TotalConfirmed,
+    int TotalNoShow,
+    PostEventPeriodRow Build,
+    PostEventPeriodRow Event,
+    PostEventPeriodRow Strike);
+
+/// <summary>
+/// Confirmed/no-show counts for a single shift period within a department.
+/// </summary>
+public record PostEventPeriodRow(int TotalConfirmed, int TotalNoShow)
+{
+    /// <summary>
+    /// No-show rate as a percentage 0..100, or 0 when no signups to measure.
+    /// </summary>
+    public int NoShowPct => (TotalConfirmed + TotalNoShow) > 0
+        ? (int)Math.Round(100.0 * TotalNoShow / (TotalConfirmed + TotalNoShow), MidpointRounding.AwayFromZero)
+        : 0;
+
+    /// <summary>
+    /// Completion rate as a percentage 0..100, or 0 when no signups to measure.
+    /// </summary>
+    public int CompletionPct => (TotalConfirmed + TotalNoShow) > 0
+        ? Math.Clamp(100 - NoShowPct, 0, 100)
+        : 0;
+}

--- a/src/Humans.Application/Interfaces/Repositories/IShiftManagementRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IShiftManagementRepository.cs
@@ -226,6 +226,15 @@ public partial interface IShiftManagementRepository : IRepository
         int? maxDayOffset,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns Confirmed and NoShow signup counts per shift for the given event.
+    /// Used by the post-event stats dashboard to compute completion/no-show rates.
+    /// Shifts with no Confirmed or NoShow signups are omitted from the result.
+    /// </summary>
+    Task<IReadOnlyList<ShiftSignupStatusCount>> GetSignupStatusCountsForEventAsync(
+        Guid eventSettingsId,
+        CancellationToken ct = default);
+
     // ==========================================================================
     // Shift tags
     // ==========================================================================
@@ -354,3 +363,13 @@ public sealed record ShiftEventQuery(
     int? MinDayOffset = null,
     int? MaxDayOffset = null,
     ShiftEventQueryFlags Flags = ShiftEventQueryFlags.None);
+
+/// <summary>
+/// Confirmed and NoShow counts for one shift, used by the post-event stats dashboard.
+/// </summary>
+public sealed record ShiftSignupStatusCount(
+    Guid ShiftId,
+    Guid RotaTeamId,
+    int DayOffset,
+    int ConfirmedCount,
+    int NoShowCount);

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -368,6 +368,17 @@ public interface IShiftManagementService : IApplicationService
     /// </summary>
     Task<int> DeleteShiftProfilesForUserAsync(
         Guid userId, CancellationToken ct = default);
+
+    // === Post-Event Stats ===
+
+    /// <summary>
+    /// Builds post-event statistics: completion and no-show rates for every shift
+    /// in the event, aggregated globally and broken down by department and period.
+    /// Returns null when <paramref name="eventSettingsId"/> resolves to no event.
+    /// </summary>
+    Task<PostEventStats?> GetPostEventStatsAsync(
+        Guid eventSettingsId,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -2087,7 +2087,6 @@ public sealed class ShiftManagementService(
                 Build: ToPeriodRow(kvp.Value, ShiftPeriod.Build),
                 Event: ToPeriodRow(kvp.Value, ShiftPeriod.Event),
                 Strike: ToPeriodRow(kvp.Value, ShiftPeriod.Strike)))
-            .OrderBy(r => r.DepartmentName, StringComparer.Ordinal)
             .ToList();
 
         return new PostEventStats(

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -2002,4 +2002,99 @@ public sealed class ShiftManagementService(
         viewInvalidator.InvalidateUser(sourceUserId);
         viewInvalidator.InvalidateUser(targetUserId);
     }
+
+    public async Task<PostEventStats?> GetPostEventStatsAsync(
+        Guid eventSettingsId,
+        CancellationToken ct = default)
+    {
+        var es = await repo.GetEventSettingsByIdAsync(eventSettingsId, ct);
+        if (es is null)
+            return null;
+
+        // Load all shifts so we can compute totals (including shifts with zero signups).
+        var allShifts = await repo.GetEventShiftsAsync(new ShiftEventQuery(
+            eventSettingsId,
+            Flags: ShiftEventQueryFlags.ExcludeAdminOnly | ShiftEventQueryFlags.ExcludeHiddenRotas), ct);
+
+        // Load confirmed/no-show counts per shift from DB.
+        var signupCounts = await repo.GetSignupStatusCountsForEventAsync(eventSettingsId, ct);
+        var countsByShiftId = signupCounts.ToDictionary(r => r.ShiftId);
+
+        // Resolve team lookup so we can map shifts to their parent department.
+        var teamIdsOnRotas = allShifts.Select(s => s.Rota.TeamId).Distinct().ToList();
+        var teamLookup = await GetTeamLookupWithParentsAsync(teamIdsOnRotas, ct);
+
+        Guid DeptIdOf(Shift s)
+        {
+            if (!teamLookup.TryGetValue(s.Rota.TeamId, out var team)) return s.Rota.TeamId;
+            return team.ParentTeamId ?? team.Id;
+        }
+
+        string DeptNameOf(Guid deptId) =>
+            teamLookup.TryGetValue(deptId, out var t) ? t.Name : string.Empty;
+
+        string? DeptSlugOf(Guid deptId) =>
+            teamLookup.TryGetValue(deptId, out var t) ? t.Slug : null;
+
+        int totalConfirmed = 0;
+        int totalNoShow = 0;
+        int shiftsWithData = 0;
+
+        // Aggregate per shift into per-department, per-period buckets.
+        var deptBuckets = new Dictionary<Guid, Dictionary<ShiftPeriod, (int Confirmed, int NoShow)>>();
+
+        foreach (var shift in allShifts)
+        {
+            var deptId = DeptIdOf(shift);
+            var period = shift.GetShiftPeriod(es);
+
+            if (!deptBuckets.TryGetValue(deptId, out var periodBucket))
+            {
+                periodBucket = new Dictionary<ShiftPeriod, (int, int)>
+                {
+                    [ShiftPeriod.Build] = (0, 0),
+                    [ShiftPeriod.Event] = (0, 0),
+                    [ShiftPeriod.Strike] = (0, 0),
+                };
+                deptBuckets[deptId] = periodBucket;
+            }
+
+            if (!countsByShiftId.TryGetValue(shift.Id, out var counts))
+                continue;
+
+            totalConfirmed += counts.ConfirmedCount;
+            totalNoShow += counts.NoShowCount;
+            if (counts.ConfirmedCount + counts.NoShowCount > 0)
+                shiftsWithData++;
+
+            var cur = periodBucket[period];
+            periodBucket[period] = (cur.Confirmed + counts.ConfirmedCount, cur.NoShow + counts.NoShowCount);
+        }
+
+        PostEventPeriodRow ToPeriodRow(Dictionary<ShiftPeriod, (int Confirmed, int NoShow)> bucket, ShiftPeriod p)
+        {
+            var v = bucket[p];
+            return new PostEventPeriodRow(v.Confirmed, v.NoShow);
+        }
+
+        var departments = deptBuckets
+            .Select(kvp => new PostEventDepartmentRow(
+                DepartmentId: kvp.Key,
+                DepartmentName: DeptNameOf(kvp.Key),
+                DepartmentSlug: DeptSlugOf(kvp.Key),
+                TotalConfirmed: kvp.Value.Values.Sum(v => v.Confirmed),
+                TotalNoShow: kvp.Value.Values.Sum(v => v.NoShow),
+                Build: ToPeriodRow(kvp.Value, ShiftPeriod.Build),
+                Event: ToPeriodRow(kvp.Value, ShiftPeriod.Event),
+                Strike: ToPeriodRow(kvp.Value, ShiftPeriod.Strike)))
+            .OrderBy(r => r.DepartmentName, StringComparer.Ordinal)
+            .ToList();
+
+        return new PostEventStats(
+            TotalShifts: allShifts.Count,
+            ShiftsWithData: shiftsWithData,
+            TotalConfirmed: totalConfirmed,
+            TotalNoShow: totalNoShow,
+            Departments: departments);
+    }
 }

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
@@ -543,6 +543,39 @@ internal sealed partial class ShiftRepository : IShiftManagementRepository
         return await query.Select(x => x.CreatedAt).ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<ShiftSignupStatusCount>> GetSignupStatusCountsForEventAsync(
+        Guid eventSettingsId,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+
+        // Project to shift-id, rota team-id, day-offset, and status in one query.
+        // Only Confirmed and NoShow statuses are relevant for post-event stats.
+        var statusValues = new[] { SignupStatus.Confirmed, SignupStatus.NoShow };
+
+        var rows = await (
+            from su in ctx.ShiftSignups.AsNoTracking()
+            join sh in ctx.Shifts.AsNoTracking() on su.ShiftId equals sh.Id
+            join r in ctx.Rotas.AsNoTracking() on sh.RotaId equals r.Id
+            where r.EventSettingsId == eventSettingsId && statusValues.Contains(su.Status)
+            select new { su.ShiftId, r.TeamId, sh.DayOffset, su.Status }
+        ).ToListAsync(ct);
+
+        return rows
+            .GroupBy(x => x.ShiftId)
+            .Select(g =>
+            {
+                var first = g.First();
+                return new ShiftSignupStatusCount(
+                    ShiftId: first.ShiftId,
+                    RotaTeamId: first.TeamId,
+                    DayOffset: first.DayOffset,
+                    ConfirmedCount: g.Count(x => x.Status == SignupStatus.Confirmed),
+                    NoShowCount: g.Count(x => x.Status == SignupStatus.NoShow));
+            })
+            .ToList();
+    }
+
     // ==========================================================================
     // Shift tags
     // ==========================================================================

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -89,7 +89,13 @@ public class ShiftDashboardController(
         }
 
         ViewData["Title"] = "Post-Event Stats";
-        return View(stats);
+        var ordered = stats with
+        {
+            Departments = stats.Departments
+                .OrderBy(r => r.DepartmentName, StringComparer.Ordinal)
+                .ToList()
+        };
+        return View(ordered);
     }
 
     // Auth: narrow policy overrides controller-level wider one (subteam managers can't reach directly).

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -70,6 +70,29 @@ public class ShiftDashboardController(
         return View(model);
     }
 
+    [Authorize(Policy = PolicyNames.ShiftDashboardAccess)]
+    [HttpGet("PostEventStats")]
+    public async Task<IActionResult> PostEventStats()
+    {
+        var es = await shiftMgmt.GetActiveAsync();
+        if (es is null)
+        {
+            SetError("No active event settings configured.");
+            return RedirectToAction(nameof(HomeController.Index), "Home");
+        }
+
+        var stats = await shiftMgmt.GetPostEventStatsAsync(es.Id);
+        if (stats is null)
+        {
+            SetError("Could not load post-event statistics.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        ViewData["Title"] = "Post-Event Stats";
+        ViewData["EventSettings"] = es;
+        return View(stats);
+    }
+
     // Auth: narrow policy overrides controller-level wider one (subteam managers can't reach directly).
     [Authorize(Policy = PolicyNames.ShiftDashboardAccess)]
     [HttpGet("SearchVolunteers")]

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -89,7 +89,6 @@ public class ShiftDashboardController(
         }
 
         ViewData["Title"] = "Post-Event Stats";
-        ViewData["EventSettings"] = es;
         return View(stats);
     }
 

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -32,6 +32,7 @@ public static class AdminNavTree
             new("Summary by camp", "Shifts", "Summary", null, null, "fa-solid fa-campground",        PolicyNames.ShiftDepartmentManager),
             new("Workload",  "ShiftWorkloadAdmin", "Index",   null, null, "fa-solid fa-scale-unbalanced", PolicyNames.ShiftDashboardAccess),
             new("Early entry", "EarlyEntryRoster", "Index", null, null, "fa-solid fa-door-open",       PolicyNames.ShiftDashboardAccess),
+            new("Post-event stats", "ShiftDashboard", "PostEventStats", null, null, "fa-solid fa-chart-bar", PolicyNames.ShiftDashboardAccess),
             new("Orphan signups",  "Shifts", "OrphanSignups", null, null, "fa-solid fa-user-secret",  PolicyNames.AdminOnly)
         ]),
         new("Barrios", [

--- a/src/Humans.Web/Views/ShiftDashboard/PostEventStats.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/PostEventStats.cshtml
@@ -1,0 +1,195 @@
+@model Humans.Application.DTOs.PostEventStats
+@using Humans.Domain.Enums
+@using Humans.Web.Controllers
+
+@{
+    ViewData["Title"] = "Post-Event Stats";
+
+    var es = ViewData["EventSettings"] as Humans.Domain.Entities.EventSettings;
+
+    static string NoShowBadgeClass(int pct) =>
+        pct == 0 ? "bg-success" : pct <= 10 ? "bg-warning text-dark" : "bg-danger";
+
+    static string CompletionBadgeClass(int pct) =>
+        pct >= 90 ? "bg-success" : pct >= 75 ? "bg-warning text-dark" : "bg-danger";
+
+    int totalSignups = Model.TotalConfirmed + Model.TotalNoShow;
+    int overallNoShowPct = totalSignups > 0
+        ? (int)Math.Round(100.0 * Model.TotalNoShow / totalSignups, MidpointRounding.AwayFromZero)
+        : 0;
+    int overallCompletionPct = totalSignups > 0 ? Math.Clamp(100 - overallNoShowPct, 0, 100) : 0;
+}
+
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-controller="Shifts" asp-action="Index">Shifts</a></li>
+            <li class="breadcrumb-item"><a asp-controller="ShiftDashboard" asp-action="Index">Shift Dashboard</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Post-Event Stats</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2>Post-Event Stats</h2>
+    </div>
+
+    <p class="text-muted mb-4">
+        Completion and no-show rates across all confirmed/no-show signups in the event.
+        Only shifts marked with <strong>NoShow</strong> by a coordinator are counted — shifts with no
+        outcome recorded are excluded from the no-show rate.
+    </p>
+
+    @* Summary counters *@
+    <div class="row g-3 mb-4">
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">Total Shifts</div>
+                    <div class="fs-3 fw-bold">@Model.TotalShifts</div>
+                    <div class="text-muted small">@Model.ShiftsWithData with outcome data</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">Confirmed</div>
+                    <div class="fs-3 fw-bold text-success">@Model.TotalConfirmed</div>
+                    <div class="text-muted small">completed signups</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card h-100 @(Model.TotalNoShow > 0 ? "border-warning" : "")">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">No-Shows</div>
+                    <div class="fs-3 fw-bold @(Model.TotalNoShow > 0 ? "text-warning" : "")">@Model.TotalNoShow</div>
+                    <div class="text-muted small">recorded no-shows</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">Completion Rate</div>
+                    @if (totalSignups > 0)
+                    {
+                        <div class="fs-3 fw-bold">@overallCompletionPct%</div>
+                        <div class="text-muted small">@overallNoShowPct% no-show rate</div>
+                    }
+                    else
+                    {
+                        <div class="fs-3 fw-bold text-muted">—</div>
+                        <div class="text-muted small">no outcome data recorded</div>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @* Department breakdown table *@
+    @if (Model.Departments.Count == 0)
+    {
+        <div class="alert alert-info">No departments with shift data found for this event.</div>
+    }
+    else
+    {
+        <div class="card">
+            <div class="card-header fw-semibold">Department Breakdown</div>
+            <div class="table-responsive">
+                <table class="table table-sm table-hover mb-0 align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Department</th>
+                            <th class="text-end">Confirmed</th>
+                            <th class="text-end">No-Shows</th>
+                            <th class="text-end">Completion</th>
+                            <th class="text-center">Set-Up</th>
+                            <th class="text-center">Event</th>
+                            <th class="text-center">Strike</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var dept in Model.Departments)
+                    {
+                        int deptTotal = dept.TotalConfirmed + dept.TotalNoShow;
+                        int deptNoShowPct = deptTotal > 0
+                            ? (int)Math.Round(100.0 * dept.TotalNoShow / deptTotal, MidpointRounding.AwayFromZero)
+                            : 0;
+                        int deptCompletionPct = deptTotal > 0 ? Math.Clamp(100 - deptNoShowPct, 0, 100) : 0;
+
+                        <tr>
+                            <td>
+                                @if (dept.DepartmentSlug is not null)
+                                {
+                                    <a asp-controller="ShiftAdmin" asp-action="Index"
+                                       asp-route-slug="@dept.DepartmentSlug" class="text-decoration-none">
+                                        @dept.DepartmentName
+                                    </a>
+                                }
+                                else
+                                {
+                                    @dept.DepartmentName
+                                }
+                            </td>
+                            <td class="text-end">@dept.TotalConfirmed</td>
+                            <td class="text-end">@dept.TotalNoShow</td>
+                            <td class="text-end">
+                                @if (deptTotal > 0)
+                                {
+                                    <span class="badge @CompletionBadgeClass(deptCompletionPct)">@deptCompletionPct%</span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
+                                }
+                            </td>
+                            <td class="text-center">
+                                @if (dept.Build.TotalConfirmed + dept.Build.TotalNoShow > 0)
+                                {
+                                    <span class="badge @NoShowBadgeClass(dept.Build.NoShowPct)" title="@dept.Build.TotalConfirmed confirmed, @dept.Build.TotalNoShow no-shows">
+                                        @dept.Build.CompletionPct%
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">—</span>
+                                }
+                            </td>
+                            <td class="text-center">
+                                @if (dept.Event.TotalConfirmed + dept.Event.TotalNoShow > 0)
+                                {
+                                    <span class="badge @NoShowBadgeClass(dept.Event.NoShowPct)" title="@dept.Event.TotalConfirmed confirmed, @dept.Event.TotalNoShow no-shows">
+                                        @dept.Event.CompletionPct%
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">—</span>
+                                }
+                            </td>
+                            <td class="text-center">
+                                @if (dept.Strike.TotalConfirmed + dept.Strike.TotalNoShow > 0)
+                                {
+                                    <span class="badge @NoShowBadgeClass(dept.Strike.NoShowPct)" title="@dept.Strike.TotalConfirmed confirmed, @dept.Strike.TotalNoShow no-shows">
+                                        @dept.Strike.CompletionPct%
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">—</span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <p class="text-muted small mt-2">
+            <i class="fa-solid fa-circle-info me-1"></i>
+            Period badges show completion rate (green ≥ 90%, amber ≥ 75%, red &lt; 75%).
+            AdminOnly shifts and hidden rotas are excluded.
+        </p>
+    }
+</div>

--- a/src/Humans.Web/Views/ShiftDashboard/PostEventStats.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/PostEventStats.cshtml
@@ -3,17 +3,10 @@
 @{
     ViewData["Title"] = "Post-Event Stats";
 
-    static string NoShowBadgeClass(int pct) =>
-        pct == 0 ? "bg-success" : pct <= 10 ? "bg-warning text-dark" : "bg-danger";
-
     static string CompletionBadgeClass(int pct) =>
         pct >= 90 ? "bg-success" : pct >= 75 ? "bg-warning text-dark" : "bg-danger";
 
     int totalSignups = Model.TotalConfirmed + Model.TotalNoShow;
-    int overallNoShowPct = totalSignups > 0
-        ? (int)Math.Round(100.0 * Model.TotalNoShow / totalSignups, MidpointRounding.AwayFromZero)
-        : 0;
-    int overallCompletionPct = totalSignups > 0 ? Math.Clamp(100 - overallNoShowPct, 0, 100) : 0;
 }
 
 <div class="container py-4">
@@ -70,8 +63,8 @@
                     <div class="text-muted small text-uppercase">Completion Rate</div>
                     @if (totalSignups > 0)
                     {
-                        <div class="fs-3 fw-bold">@overallCompletionPct%</div>
-                        <div class="text-muted small">@overallNoShowPct% no-show rate</div>
+                        <div class="fs-3 fw-bold">@Model.CompletionPct%</div>
+                        <div class="text-muted small">@Model.NoShowPct% no-show rate</div>
                     }
                     else
                     {
@@ -109,10 +102,6 @@
                     @foreach (var dept in Model.Departments)
                     {
                         int deptTotal = dept.TotalConfirmed + dept.TotalNoShow;
-                        int deptNoShowPct = deptTotal > 0
-                            ? (int)Math.Round(100.0 * dept.TotalNoShow / deptTotal, MidpointRounding.AwayFromZero)
-                            : 0;
-                        int deptCompletionPct = deptTotal > 0 ? Math.Clamp(100 - deptNoShowPct, 0, 100) : 0;
 
                         <tr>
                             <td>
@@ -133,7 +122,7 @@
                             <td class="text-end">
                                 @if (deptTotal > 0)
                                 {
-                                    <span class="badge @CompletionBadgeClass(deptCompletionPct)">@deptCompletionPct%</span>
+                                    <span class="badge @CompletionBadgeClass(dept.CompletionPct)">@dept.CompletionPct%</span>
                                 }
                                 else
                                 {
@@ -143,7 +132,7 @@
                             <td class="text-center">
                                 @if (dept.Build.TotalConfirmed + dept.Build.TotalNoShow > 0)
                                 {
-                                    <span class="badge @NoShowBadgeClass(dept.Build.NoShowPct)" title="@dept.Build.TotalConfirmed confirmed, @dept.Build.TotalNoShow no-shows">
+                                    <span class="badge @CompletionBadgeClass(dept.Build.CompletionPct)" title="@dept.Build.TotalConfirmed confirmed, @dept.Build.TotalNoShow no-shows">
                                         @dept.Build.CompletionPct%
                                     </span>
                                 }
@@ -155,7 +144,7 @@
                             <td class="text-center">
                                 @if (dept.Event.TotalConfirmed + dept.Event.TotalNoShow > 0)
                                 {
-                                    <span class="badge @NoShowBadgeClass(dept.Event.NoShowPct)" title="@dept.Event.TotalConfirmed confirmed, @dept.Event.TotalNoShow no-shows">
+                                    <span class="badge @CompletionBadgeClass(dept.Event.CompletionPct)" title="@dept.Event.TotalConfirmed confirmed, @dept.Event.TotalNoShow no-shows">
                                         @dept.Event.CompletionPct%
                                     </span>
                                 }
@@ -167,7 +156,7 @@
                             <td class="text-center">
                                 @if (dept.Strike.TotalConfirmed + dept.Strike.TotalNoShow > 0)
                                 {
-                                    <span class="badge @NoShowBadgeClass(dept.Strike.NoShowPct)" title="@dept.Strike.TotalConfirmed confirmed, @dept.Strike.TotalNoShow no-shows">
+                                    <span class="badge @CompletionBadgeClass(dept.Strike.CompletionPct)" title="@dept.Strike.TotalConfirmed confirmed, @dept.Strike.TotalNoShow no-shows">
                                         @dept.Strike.CompletionPct%
                                     </span>
                                 }

--- a/src/Humans.Web/Views/ShiftDashboard/PostEventStats.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/PostEventStats.cshtml
@@ -1,11 +1,7 @@
 @model Humans.Application.DTOs.PostEventStats
-@using Humans.Domain.Enums
-@using Humans.Web.Controllers
 
 @{
     ViewData["Title"] = "Post-Event Stats";
-
-    var es = ViewData["EventSettings"] as Humans.Domain.Entities.EventSettings;
 
     static string NoShowBadgeClass(int pct) =>
         pct == 0 ? "bg-success" : pct <= 10 ? "bg-warning text-dark" : "bg-danger";


### PR DESCRIPTION
## How each remaining-scope criterion is met

**Post-event stats dashboard (nobodies-collective/Humans#161):**

- **Completion rates** — `PostEventPeriodRow.CompletionPct` computed as `100 - NoShowPct`; shown per-department, per-period (Set-Up / Event / Strike) and as an overall summary counter.
- **No-show rates** — `PostEventPeriodRow.NoShowPct` = `NoShow / (Confirmed + NoShow)` × 100; shown per-department, per-period, and as overall totals.
- **Department breakdowns** — `PostEventDepartmentRow` one row per parent team; each row carries Build/Event/Strike period columns with colour-coded completion badges (green ≥90%, amber ≥75%, red <75%).

**Route:** `GET /Shifts/Dashboard/PostEventStats` gated by `ShiftDashboardAccess` (Admin, NoInfoAdmin, VolunteerCoordinator). Nav entry added under Shifts in the admin sidebar.

**What's excluded:**
- AdminOnly shifts and hidden rotas are excluded from all aggregations (matching the coordinator dashboard behaviour).
- Shifts with zero Confirmed or NoShow signups are counted in TotalShifts but not in ShiftsWithData or the rate calculations.

## CSV exports — NOT BUILT (GDPR pending)

CSV exports (department rota, all rotas, early-entry list, cantina setup) are not included in this PR. Peter has an explicit GDPR go/no-go pending on these exports. This PR does not close nobodies-collective/Humans#161 — the issue stays open until the CSV decision is made.

## Architecture

- New repo method: `GetSignupStatusCountsForEventAsync` — single query projecting `(ShiftId, RotaTeamId, DayOffset, Status)` for Confirmed/NoShow statuses, grouped in memory.
- New service method: `GetPostEventStatsAsync` — loads shifts via existing `GetEventShiftsAsync`, stitches team lookup via `GetTeamLookupWithParentsAsync`, aggregates per-department per-period in O(n) pass.
- New DTOs: `PostEventStats`, `PostEventDepartmentRow`, `PostEventPeriodRow` in `Humans.Application.DTOs`.
- Controller action: pure parse+dispatch, no business logic.
- No EF migrations required (read-only path over existing tables).