### PR TITLE
refactor(tickets): retire buyer-fallback ticket ownership

### DIFF
--- a/docs/sections/Tickets.md
+++ b/docs/sections/Tickets.md
@@ -109,7 +109,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 - TicketAdmin **cannot** trigger a Full Re-sync or open the participation backfill page (both `AdminOnly`).
 - Nobody can edit ticket configuration (vendor `EventId`, API key, sync interval) from inside the app — those values come from `appsettings`'s `TicketVendor` section and the `TICKET_VENDOR_API_KEY` environment variable, set at deploy time.
 - Regular humans have no access to `/Tickets/*` (dashboard, orders, attendees, codes, gate list, who-hasn't-bought, sales aggregates) — the controller-wide policy is `TicketAdminBoardOrAdmin`.
-- A user **cannot** send an attendee they do not own (the order's `MatchedUserId` must equal the Sender's user id; validated in `TicketTransferService.CreateRequestAsync`).
+- A user **cannot** send an attendee they do not own (the attendee's `MatchedUserId` must equal the Sender's user id; validated via `TicketAttendeeOwnership.IsCurrentOwner` in `TicketTransferService.CreateRequestAsync`; buyer-only order ownership does not confer send rights).
 
 ## Routing
 

--- a/src/Humans.Application/Services/Tickets/TicketAttendeeOwnership.cs
+++ b/src/Humans.Application/Services/Tickets/TicketAttendeeOwnership.cs
@@ -3,12 +3,16 @@ using Humans.Domain.Entities;
 namespace Humans.Application.Services.Tickets;
 
 /// <summary>
-/// Current ticket holder = attendee.MatchedUserId else order.MatchedUserId; null if vendor-only.
+/// Current ticket holder = attendee.MatchedUserId; null if unmatched or vendor-only.
+/// The legacy buyer-fallback (attendee.TicketOrder?.MatchedUserId) was removed in
+/// nobodies-collective/Humans#856: every attendee matched via AttendeeContactImportService
+/// has its own MatchedUserId, so the order-buyer arm only leaked cross-account tickets.
+/// Unmatched attendees (MatchedUserId == null) are not owned by anyone until matched.
 /// </summary>
 public static class TicketAttendeeOwnership
 {
     public static Guid? CurrentOwner(TicketAttendee attendee) =>
-        attendee.MatchedUserId ?? attendee.TicketOrder?.MatchedUserId;
+        attendee.MatchedUserId;
 
     public static bool IsCurrentOwner(TicketAttendee attendee, Guid userId) =>
         CurrentOwner(attendee) == userId;

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -444,11 +444,14 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
     public async Task<IReadOnlyList<TicketAttendee>> GetAttendeesVisibleToUserAsync(
         Guid userId, CancellationToken ct = default)
     {
+        // Buyer-visibility arm (a.TicketOrder.MatchedUserId == userId) removed in
+        // nobodies-collective/Humans#856: it returned attendees owned by other accounts
+        // to the buyer, leaking cross-account ticket data. Ownership is attendee-only.
         await using var ctx = await factory.CreateDbContextAsync(ct);
         return await ctx.TicketAttendees
             .AsNoTracking()
             .Include(a => a.TicketOrder)
-            .Where(a => a.TicketOrder.MatchedUserId == userId || a.MatchedUserId == userId)
+            .Where(a => a.MatchedUserId == userId)
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -450,7 +450,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
         await using var ctx = await factory.CreateDbContextAsync(ct);
         return await ctx.TicketAttendees
             .AsNoTracking()
-            .Include(a => a.TicketOrder)
             .Where(a => a.MatchedUserId == userId)
             .ToListAsync(ct);
     }

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketAttendeeOwnershipTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketAttendeeOwnershipTests.cs
@@ -22,15 +22,17 @@ public sealed class TicketAttendeeOwnershipTests
     }
 
     [HumansFact]
-    public void CurrentOwner_FallsBackToOrderMatchedUserId_WhenAttendeeUnmatched()
+    public void CurrentOwner_ReturnsNull_WhenAttendeeUnmatched_EvenIfOrderHasBuyer()
     {
+        // Buyer-fallback removed in nobodies-collective/Humans#856.
+        // An unmatched attendee has no owner regardless of who bought the order.
         var attendee = new TicketAttendee
         {
             MatchedUserId = null,
             TicketOrder = new TicketOrder { MatchedUserId = UserA },
         };
 
-        TicketAttendeeOwnership.CurrentOwner(attendee).Should().Be(UserA);
+        TicketAttendeeOwnership.CurrentOwner(attendee).Should().BeNull();
     }
 
     [HumansFact]
@@ -67,15 +69,17 @@ public sealed class TicketAttendeeOwnershipTests
     }
 
     [HumansFact]
-    public void IsCurrentOwner_True_ForOrderBuyer_WhenAttendeeUnmatched()
+    public void IsCurrentOwner_False_ForOrderBuyer_WhenAttendeeUnmatched()
     {
+        // Buyer-fallback removed in nobodies-collective/Humans#856.
+        // A buyer is not the owner of an attendee with no MatchedUserId.
         var attendee = new TicketAttendee
         {
             MatchedUserId = null,
             TicketOrder = new TicketOrder { MatchedUserId = UserA },
         };
 
-        TicketAttendeeOwnership.IsCurrentOwner(attendee, UserA).Should().BeTrue();
+        TicketAttendeeOwnership.IsCurrentOwner(attendee, UserA).Should().BeFalse();
         TicketAttendeeOwnership.IsCurrentOwner(attendee, UserB).Should().BeFalse();
     }
 }

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketQueryService_HoldingsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketQueryService_HoldingsTests.cs
@@ -75,8 +75,10 @@ public sealed class TicketQueryService_HoldingsTests
         _ticketRepo.GetOrdersMatchedToUserAsync(UserA, Arg.Any<CancellationToken>())
             .Returns([order1, order2]);
 
-        // Order 1: attendee matched to UserA (counts), attendee unmatched (cascades to order buyer = UserA, counts)
-        // Order 2: attendee matched to UserB (does NOT count for UserA)
+        // GetAttendeesVisibleToUserAsync now returns only attendees where MatchedUserId == userId
+        // (buyer-fallback removed in nobodies-collective/Humans#856).
+        // Order 1: attendee matched to UserA (counts); unmatched attendee not returned by repo
+        // Order 2: attendee matched to UserB (not returned for UserA)
         // Order 3 (UserB's order): attendee matched to UserA via MatchedUserId (counts for UserA)
         var attendeeMatchedA_Order1 = new TicketAttendee
         {
@@ -85,22 +87,6 @@ public sealed class TicketQueryService_HoldingsTests
             MatchedUserId = UserA,
             TicketOrder = order1,
             TicketOrderId = order1Id,
-        };
-        var attendeeUnmatched_Order1 = new TicketAttendee
-        {
-            Id = Guid.NewGuid(),
-            AttendeeName = "Unmatched-Order1",
-            MatchedUserId = null,
-            TicketOrder = order1,
-            TicketOrderId = order1Id,
-        };
-        var attendeeMatchedB_Order2 = new TicketAttendee
-        {
-            Id = Guid.NewGuid(),
-            AttendeeName = "Matched-B-Order2",
-            MatchedUserId = UserB,
-            TicketOrder = order2,
-            TicketOrderId = order2Id,
         };
         var attendeeMatchedA_Order3 = new TicketAttendee
         {
@@ -114,15 +100,13 @@ public sealed class TicketQueryService_HoldingsTests
         _ticketRepo.GetAttendeesVisibleToUserAsync(UserA, Arg.Any<CancellationToken>())
             .Returns([
                 attendeeMatchedA_Order1,
-                attendeeUnmatched_Order1,
-                attendeeMatchedB_Order2,
                 attendeeMatchedA_Order3
             ]);
 
         var result = await Service.GetUserTicketHoldingsAsync(UserA);
 
         result.OrderCount.Should().Be(2);
-        result.Tickets.Should().HaveCount(3);
+        result.Tickets.Should().HaveCount(2);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
@@ -300,10 +300,10 @@ public sealed class TicketTransferServiceTests
 
     // ── helpers ─────────────────────────────────────────────────────────────────
 
-    private void StubAttendee(TicketAttendeeStatus status, Guid orderMatchedUserId)
+    private void StubAttendee(TicketAttendeeStatus status, Guid attendeeMatchedUserId)
     {
         _ticketRepo.GetAttendeeByIdAsync(_attendeeId, Arg.Any<CancellationToken>())
-            .Returns(MakeAttendee(_attendeeId, _orderId, orderMatchedUserId, status));
+            .Returns(MakeAttendee(_attendeeId, _orderId, attendeeMatchedUserId, status));
     }
 
     private static User MakeUser(Guid id, string displayName) => new()
@@ -328,8 +328,10 @@ public sealed class TicketTransferServiceTests
         communicationPreferences: []);
 
     private static TicketAttendee MakeAttendee(
-        Guid id, Guid orderId, Guid orderMatchedUserId, TicketAttendeeStatus status)
+        Guid id, Guid orderId, Guid attendeeMatchedUserId, TicketAttendeeStatus status)
     {
+        // Buyer-fallback removed in nobodies-collective/Humans#856.
+        // Ownership is determined by TicketAttendee.MatchedUserId only.
         var order = new TicketOrder
         {
             Id = orderId,
@@ -342,7 +344,7 @@ public sealed class TicketTransferServiceTests
             VendorEventId = "ev_test",
             PurchasedAt = Instant.FromUtc(2026, 3, 1, 10, 0),
             SyncedAt = Instant.FromUtc(2026, 3, 1, 10, 0),
-            MatchedUserId = orderMatchedUserId,
+            MatchedUserId = attendeeMatchedUserId,
         };
 
         return new TicketAttendee
@@ -358,6 +360,7 @@ public sealed class TicketTransferServiceTests
             Status = status,
             VendorEventId = "ev_test",
             SyncedAt = Instant.FromUtc(2026, 3, 1, 10, 0),
+            MatchedUserId = attendeeMatchedUserId,
         };
     }
 

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
@@ -99,8 +99,11 @@ public sealed class TicketTransferService_OnwardTransferTests
     }
 
     [HumansFact]
-    public async Task GetMyAttendees_AllowsBuyer_WhenAttendeeUnmatched()
+    public async Task GetMyAttendees_DeniesTransfer_WhenAttendeeUnmatched()
     {
+        // Buyer-fallback removed in nobodies-collective/Humans#856.
+        // An unmatched attendee (MatchedUserId == null) has no owner, so the buyer
+        // cannot send the ticket — it would be orphaned until matched via AttendeeContactImportService.
         var attendee = new TicketAttendee
         {
             Id = Guid.NewGuid(),
@@ -115,7 +118,9 @@ public sealed class TicketTransferService_OnwardTransferTests
 
         var rows = await _service.GetMyAttendeesAsync(UserA);
 
-        rows[0].CanSendTransfer.Should().BeTrue();
+        rows.Should().HaveCount(1);
+        rows[0].IsCurrentOwner.Should().BeFalse();
+        rows[0].CanSendTransfer.Should().BeFalse();
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

Removes the legacy buyer-fallback from ticket ownership, addressing nobodies-collective/Humans#856.

**Two changes:**
- `TicketAttendeeOwnership.CurrentOwner` — drops the `?? order.MatchedUserId` fallback; ownership is now `attendee.MatchedUserId` only.
- `TicketRepository.GetAttendeesVisibleToUserAsync` — removes the `a.TicketOrder.MatchedUserId == userId` buyer arm; attendees are now visible to exactly who holds them.

## Acceptance Criteria Met

| Criterion | Evidence |
|-----------|----------|
| Drop `?? order.MatchedUserId` arm from `CurrentOwner` | `TicketAttendeeOwnership.cs` line 10 — now returns `attendee.MatchedUserId` |
| Remove buyer-visibility arm from `GetAttendeesVisibleToUserAsync` | `TicketRepository.cs` line 444-454 — now `Where(a => a.MatchedUserId == userId)` only |
| Audit holdings list | `GetUserTicketHoldingsAsync` already filters by `IsCurrentOwner` — no change needed |
| Audit transfer wizard eligibility | `GetMyAttendeesAsync` now returns only attendee-matched rows; unmatched attendees no longer shown to buyer |
| Audit `/Profile/Me` | Uses `GetOrdersMatchedToUserAsync` (orders by buyer) — unaffected |
| Audit scanner | Uses `MatchedUserId` directly on the hit — unaffected |
| Confirm buyer "I bought these" view | Orders still surfaced via `GetOrdersMatchedToUserAsync`; that's explicit buyer-scoped |

## Premise Check Evidence

The issue claims "every attendee has `MatchedUserId` set (auto-account-creation guarantees it)." Code audit shows this is NOT currently an invariant:

- `TicketAttendee.MatchedUserId` is explicitly nullable (`TicketAttendee.cs` line 35: "Null if no match or no email")
- `TicketSyncService.BuildAttendeeEntity` (line 272-274) sets `matchedUserId = null` when `dto.AttendeeEmail is null` OR email lookup misses
- `ITicketRepository.GetUnmatchedActiveAttendeesAsync` exists and feeds `AttendeeContactImportService` — confirming unmatched attendees are a real, expected steady state
- `AttendeeContactImportService` is a **manually-triggered admin flow**, not automatic

The fallback removal is still safe because: an unmatched attendee has no owner, and the correct behavior is for it to NOT appear on anyone's holdings/transfer wizard until the admin runs the contact import. The old fallback incorrectly attributed unmatched attendees to the buyer, causing the cross-account leak.

## Tests Updated

- `TicketAttendeeOwnershipTests.cs` — two tests rewritten to assert null/false for the unmatched+buyer scenario
- `TicketQueryService_HoldingsTests.cs` — `CountsOrdersByBuyerAndAttendeeNamesByCurrentOwner` updated (expected tickets: 3 → 2; unmatched attendee no longer owned by buyer)
- `TicketTransferServiceTests.cs` — `MakeAttendee` now sets `MatchedUserId` on the **attendee** (not just the order); tests previously relied on buyer-fallback implicitly
- `TicketTransferService_OnwardTransferTests.cs` — `GetMyAttendees_AllowsBuyer_WhenAttendeeUnmatched` renamed to `_DeniesTransfer_WhenAttendeeUnmatched`, asserts `CanSendTransfer = false`

## Section Doc Update

`docs/sections/Tickets.md` negative access rule (line 112) corrected: "the order's `MatchedUserId`" → "the attendee's `MatchedUserId`"

Closes nobodies-collective/Humans#856

🤖 Generated with [Claude Code](https://claude.com/claude-code)