### PR TITLE
feat(testing): BrokenFact + DebuggerOnlyFact skip attributes

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -53,10 +53,13 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Shared HumansFact / HumansTheory attributes (5s default timeout, infinite forbidden). -->
+  <!-- Shared HumansFact / HumansTheory attributes (5s default timeout, infinite forbidden)
+       plus BrokenFact and DebuggerOnlyFact skip helpers. -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\HumansFactAttribute.cs" Link="Humans.Testing\HumansFactAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\HumansTheoryAttribute.cs" Link="Humans.Testing\HumansTheoryAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\BrokenFactAttribute.cs" Link="Humans.Testing\BrokenFactAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\DebuggerOnlyFactAttribute.cs" Link="Humans.Testing\DebuggerOnlyFactAttribute.cs" />
     <Using Include="Humans.Testing" />
   </ItemGroup>
 

--- a/tests/Humans.Domain.Tests/GlobalTimeoutDemoTest.cs
+++ b/tests/Humans.Domain.Tests/GlobalTimeoutDemoTest.cs
@@ -4,7 +4,7 @@ namespace Humans.Domain.Tests;
 
 /// <summary>
 /// Demonstration of xUnit v3's per-test <c>[Fact(Timeout = N)]</c>
-/// mechanism. Skipped by default; unskip locally and run to confirm the
+/// mechanism. Runs only under a debugger; attach and run to confirm the
 /// test runner cancels a cooperative long-running test at the configured
 /// millisecond budget (reported as a timeout-caused failure).
 ///
@@ -19,9 +19,7 @@ namespace Humans.Domain.Tests;
 /// </summary>
 public class GlobalTimeoutDemoTest
 {
-    [HumansFact(
-        Skip = "Demo test — unskip locally to verify the 500ms [HumansFact(Timeout)] enforcement. See nobodies-collective/Humans#586.",
-        Timeout = 500)]
+    [DebuggerOnlyFact(Timeout = 500)]
     public async Task Cooperative_loop_exceeding_timeout_is_cancelled()
     {
         // Wait cooperatively on the xUnit-provided cancellation token so the

--- a/tests/Humans.Domain.Tests/SkipAttributeSmokeTest.cs
+++ b/tests/Humans.Domain.Tests/SkipAttributeSmokeTest.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics;
+
+using Xunit;
+
+namespace Humans.Domain.Tests;
+
+public class SkipAttributeSmokeTest
+{
+    // ── BrokenFact construction ───────────────────────────────────────────────
+
+    [HumansFact]
+    public void BrokenFact_rejects_null_reason()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new BrokenFactAttribute(null!));
+        Assert.Contains("non-empty reason", ex.Message, StringComparison.Ordinal);
+    }
+
+    [HumansFact]
+    public void BrokenFact_rejects_empty_reason()
+    {
+        Assert.Throws<ArgumentException>(() => new BrokenFactAttribute(""));
+    }
+
+    [HumansFact]
+    public void BrokenFact_rejects_whitespace_reason()
+    {
+        Assert.Throws<ArgumentException>(() => new BrokenFactAttribute("   "));
+    }
+
+    [HumansFact]
+    public void BrokenFact_stores_reason_as_skip_message()
+    {
+        const string reason = "https://github.com/nobodies-collective/Humans/issues/999";
+        var attr = new BrokenFactAttribute(reason);
+        Assert.Equal(reason, attr.Skip);
+    }
+
+    /// <summary>
+    /// This test body would fail if ever executed — the BrokenFact skip
+    /// ensures it is never run. Its presence in the suite proves the
+    /// skip-in-CI contract.
+    /// </summary>
+    [BrokenFact("Demo — body must never execute. Tracked at nobodies-collective/Humans#586.")]
+    public void BrokenFact_demo_never_executes()
+    {
+        Assert.Fail("BrokenFact did not skip this test — the skip mechanism is broken.");
+    }
+
+    // ── DebuggerOnlyFact construction ─────────────────────────────────────────
+
+    [HumansFact]
+    public void DebuggerOnlyFact_constructs_without_error()
+    {
+        var attr = new DebuggerOnlyFactAttribute();
+        Assert.NotNull(attr);
+    }
+
+    [HumansFact]
+    public void DebuggerOnlyFact_has_non_empty_skip_message()
+    {
+        var attr = new DebuggerOnlyFactAttribute();
+        Assert.False(string.IsNullOrWhiteSpace(attr.Skip));
+    }
+
+    /// <summary>
+    /// Runs only under a debugger. Asserts <c>Debugger.IsAttached</c> so the
+    /// test is self-evidently true when executed intentionally and is skipped
+    /// in automated runs.
+    /// </summary>
+    [DebuggerOnlyFact]
+    public void DebuggerOnlyFact_demo_runs_only_under_debugger()
+    {
+        Assert.True(Debugger.IsAttached, "Expected a debugger to be attached.");
+    }
+}

--- a/tests/Humans.Testing/BrokenFactAttribute.cs
+++ b/tests/Humans.Testing/BrokenFactAttribute.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+
+namespace Humans.Testing;
+
+/// <summary>
+/// Marks a test as permanently skipped due to a known breakage. The required
+/// <paramref name="reason"/> should explain the breakage and reference the
+/// tracking issue (e.g. a URL to the relevant issue).
+///
+/// Prefer this over commenting out a broken test — the test body stays in
+/// place and the reason is visible in test output, keeping broken tests
+/// discoverable and tracked.
+/// </summary>
+public sealed class BrokenFactAttribute : HumansFactAttribute
+{
+    public BrokenFactAttribute(
+        string reason,
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException(
+                "BrokenFact requires a non-empty reason describing the breakage and where it is tracked.",
+                nameof(reason));
+        }
+
+        Skip = reason;
+    }
+}

--- a/tests/Humans.Testing/DebuggerOnlyFactAttribute.cs
+++ b/tests/Humans.Testing/DebuggerOnlyFactAttribute.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Humans.Testing;
+
+/// <summary>
+/// Marks a test that should only run when a debugger is attached. When no
+/// debugger is present the test is reported as skipped, keeping the suite
+/// green in CI while still allowing the test to be exercised by hand.
+///
+/// Intended for harness and diagnostic tests you run intentionally under a
+/// debugger rather than in the automated suite.
+/// </summary>
+public sealed class DebuggerOnlyFactAttribute : HumansFactAttribute
+{
+    private const string SkipMessage = "This test only runs under a debugger (attach one to execute it).";
+
+    public DebuggerOnlyFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+        SkipType = typeof(DebuggerRunCondition);
+        SkipUnless = nameof(DebuggerRunCondition.IsDebuggerAttached);
+        Skip = SkipMessage;
+    }
+}
+
+/// <summary>
+/// Condition type for <see cref="DebuggerOnlyFactAttribute"/>.
+/// xUnit v3 reads <see cref="IsDebuggerAttached"/> at runtime to decide
+/// whether to run or skip the test.
+/// </summary>
+public static class DebuggerRunCondition
+{
+    public static bool IsDebuggerAttached => Debugger.IsAttached;
+}

--- a/tests/Humans.Testing/HumansFactAttribute.cs
+++ b/tests/Humans.Testing/HumansFactAttribute.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Humans.Testing;
 
-public sealed class HumansFactAttribute : FactAttribute
+public class HumansFactAttribute : FactAttribute
 {
     public HumansFactAttribute(
         [CallerFilePath] string? sourceFilePath = null,


### PR DESCRIPTION
## Summary

Two additions to the `HumansFact` attribute family, giving us honest patterns for disabled tests instead of `Skip = ...` strings or commented-out bodies:

- **`[BrokenFact(reason)]`** — permanently skips a known-broken test. The reason is mandatory (throws `ArgumentException` on null/whitespace) and should reference the tracking issue, so broken tests stay visible in test output and discoverable in the suite.
- **`[DebuggerOnlyFact]`** — runs only when a debugger is attached, using xUnit v3 `SkipUnless` conditional gating (`DebuggerRunCondition.IsDebuggerAttached`). For harness/diagnostic tests you exercise by hand.

Both derive from `HumansFactAttribute` (unsealed in this PR), so the 30s timeout discipline and RS0030 banned-API shielding carry over with no new pragmas anywhere in test sources.

## Changes

- `tests/Humans.Testing/BrokenFactAttribute.cs`, `DebuggerOnlyFactAttribute.cs` — new attributes (+ xUnit v3 source-info constructor pass-through per xUnit3003)
- `tests/Humans.Testing/HumansFactAttribute.cs` — unsealed
- `tests/Directory.Build.props` — new files source-linked into every test project
- `tests/Humans.Domain.Tests/GlobalTimeoutDemoTest.cs` — converted to `[DebuggerOnlyFact(Timeout = 500)]` (was a Skip-string); doc comment updated, issue ref nobodies-collective/Humans#586 retained
- `tests/Humans.Domain.Tests/SkipAttributeSmokeTest.cs` — meta-tests: reason validation, skip contract demos for both attributes

## Test plan

- `dotnet build Humans.slnx -v quiet` — clean
- `dotnet test` (minus Integration): 4,140 passed, 3 skipped (the two demo skips + converted GlobalTimeoutDemoTest), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)