### PR TITLE
feat(debug): per-severity log buffers - warnings can no longer evict errors

### DIFF
--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -9,6 +9,7 @@ using Humans.Web.Infrastructure;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Serilog.Events;
 
 namespace Humans.Web.Controllers;
 
@@ -30,14 +31,24 @@ public class DebugController(
     IAdminDatabaseDiagnosticsService databaseDiagnostics) : HumansControllerBase(userService)
 {
     [HttpGet("Logs")]
-    public IActionResult Logs(int count = 1000)
+    public IActionResult Logs(int count = 1000, string? minLevel = null)
     {
         count = Math.Clamp(count, 1, 1000);
+
+        LogEventLevel? minLogLevel = minLevel?.ToUpperInvariant() switch
+        {
+            "WARNING" => LogEventLevel.Warning,
+            "ERROR" => LogEventLevel.Error,
+            "FATAL" => LogEventLevel.Fatal,
+            _ => null
+        };
+
         var sink = InMemoryLogSink.Instance;
-        var events = sink.GetEvents(count);
+        var events = sink.GetEvents(count, minLogLevel);
         ViewBag.LifetimeCounts = sink.GetLifetimeCounts();
         ViewBag.SinkStartedAt = sink.StartedAt;
         ViewBag.TotalEvents = sink.TotalEvents;
+        ViewBag.MinLevel = minLevel;
         return View(events);
     }
 

--- a/src/Humans.Web/Controllers/LogApiController.cs
+++ b/src/Humans.Web/Controllers/LogApiController.cs
@@ -33,14 +33,9 @@ public class LogApiController : ControllerBase
                 return BadRequest(new { error = $"Invalid minLevel '{minLevel}'. Valid values: Warning, Error, Fatal" });
         }
 
-        var events = InMemoryLogSink.Instance.GetEvents();
+        var events = InMemoryLogSink.Instance.GetEvents(count, minLogLevel);
 
-        if (minLogLevel.HasValue)
-        {
-            events = events.Where(e => e.Level >= minLogLevel.Value).ToList();
-        }
-
-        var result = events.Take(count).Select(e => new
+        var result = events.Select(e => new
         {
             Timestamp = e.Timestamp.UtcDateTime,
             Level = e.Level.ToString(),

--- a/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
+++ b/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
@@ -5,13 +5,16 @@ using Serilog.Events;
 namespace Humans.Web.Infrastructure;
 
 /// <summary>
-/// Serilog sink that keeps the last N log events in a circular buffer.
+/// Serilog sink that keeps the last N log events in per-severity circular buffers.
+/// Warnings go to their own buffer; Error and Fatal share a separate buffer so that
+/// high-volume warnings cannot evict error events.
 /// Used by the Admin/Logs page to display recent warnings and errors
 /// without needing to query Docker logs.
 /// </summary>
-public sealed class InMemoryLogSink(int capacity = 1000) : ILogEventSink
+public sealed class InMemoryLogSink(int warningCapacity = 1000, int errorCapacity = 1000) : ILogEventSink
 {
-    private readonly ConcurrentQueue<LogEvent> _events = new();
+    private readonly ConcurrentQueue<LogEvent> _warnings = new();
+    private readonly ConcurrentQueue<LogEvent> _errors = new();
     private readonly ConcurrentDictionary<LogEventLevel, long> _lifetimeCounts = new();
 
     /// <summary>UTC timestamp captured when the sink (and process) started.</summary>
@@ -23,13 +26,38 @@ public sealed class InMemoryLogSink(int capacity = 1000) : ILogEventSink
     public void Emit(LogEvent logEvent)
     {
         _lifetimeCounts.AddOrUpdate(logEvent.Level, 1, (_, count) => count + 1);
-        _events.Enqueue(logEvent);
-        while (_events.Count > capacity)
-            _events.TryDequeue(out _);
+
+        if (logEvent.Level >= LogEventLevel.Error)
+        {
+            _errors.Enqueue(logEvent);
+            while (_errors.Count > errorCapacity)
+                _errors.TryDequeue(out _);
+        }
+        else
+        {
+            _warnings.Enqueue(logEvent);
+            while (_warnings.Count > warningCapacity)
+                _warnings.TryDequeue(out _);
+        }
     }
 
-    public IReadOnlyList<LogEvent> GetEvents(int count = 1000) =>
-        _events.Reverse().Take(count).ToList();
+    /// <summary>
+    /// Returns buffered events, newest first, up to <paramref name="count"/> entries.
+    /// When <paramref name="minLevel"/> is supplied only events at or above that level
+    /// are included; omit it (or pass <c>null</c>) for all buffered levels.
+    /// </summary>
+    public IReadOnlyList<LogEvent> GetEvents(int count = 1000, LogEventLevel? minLevel = null)
+    {
+        var source = minLevel >= LogEventLevel.Error
+            ? _errors.AsEnumerable()
+            : _warnings.Concat(_errors);
+
+        return source
+            .Where(e => minLevel == null || e.Level >= minLevel)
+            .OrderByDescending(e => e.Timestamp)
+            .Take(count)
+            .ToList();
+    }
 
     /// <summary>
     /// Returns cumulative counts per log level since application start.

--- a/src/Humans.Web/Views/Debug/Logs.cshtml
+++ b/src/Humans.Web/Views/Debug/Logs.cshtml
@@ -7,6 +7,7 @@
 
     var startedAt = ViewBag.SinkStartedAt is DateTimeOffset sa ? sa : DateTimeOffset.UtcNow;
     var totalEvents = ViewBag.TotalEvents is long te ? te : 0L;
+    var minLevel = ViewBag.MinLevel as string;
     var uptime = DateTimeOffset.UtcNow - startedAt;
     if (uptime < TimeSpan.Zero) { uptime = TimeSpan.Zero; }
 
@@ -42,6 +43,23 @@
             <div>Showing @Model.Count of last 1000 (in-memory buffer)</div>
             <div><small>@eventsPerHour.ToString("#,##0") events/hour</small></div>
         </div>
+    </div>
+
+    <div class="d-flex gap-2 mb-3 flex-wrap align-items-center">
+        @{
+            var filterLinks = new[]
+            {
+                (Label: "All", Value: (string?)null),
+                (Label: "Errors only", Value: "Error"),
+            };
+        }
+        @foreach (var (label, value) in filterLinks)
+        {
+            var isActive = string.Equals(minLevel, value, StringComparison.OrdinalIgnoreCase)
+                           || (value == null && minLevel == null);
+            <a asp-action="Logs" asp-route-minLevel="@value"
+               class="btn btn-sm @(isActive ? "btn-secondary" : "btn-outline-secondary")">@label</a>
+        }
     </div>
 
     <div class="d-flex gap-2 mb-3 flex-wrap align-items-center">

--- a/tests/Humans.Web.Tests/Infrastructure/InMemoryLogSinkTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/InMemoryLogSinkTests.cs
@@ -1,0 +1,162 @@
+using AwesomeAssertions;
+using Humans.Web.Infrastructure;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Humans.Web.Tests.Infrastructure;
+
+public class InMemoryLogSinkTests
+{
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static LogEvent MakeEvent(LogEventLevel level, DateTimeOffset? timestamp = null) => new(
+        timestamp: timestamp ?? DateTimeOffset.UtcNow,
+        level: level,
+        exception: null,
+        messageTemplate: new MessageTemplate([]),
+        properties: []);
+
+    // ── warning buffer cycles; earlier errors are still present ──────────────
+
+    [HumansFact]
+    public void WarningsCannotEvictErrors()
+    {
+        // Warning cap = 3, error cap = 10.  Flood warnings past their cap while
+        // keeping one error emitted before the flood.  The error must survive.
+        var sink = new InMemoryLogSink(warningCapacity: 3, errorCapacity: 10);
+
+        var error = MakeEvent(LogEventLevel.Error);
+        sink.Emit(error);
+
+        for (var i = 0; i < 5; i++)
+            sink.Emit(MakeEvent(LogEventLevel.Warning));
+
+        var all = sink.GetEvents(count: 1000);
+        all.Should().Contain(error, "error must not be evicted by warning overflow");
+    }
+
+    // ── error buffer respects its own cap ────────────────────────────────────
+
+    [HumansFact]
+    public void ErrorBufferCapsAtErrorCapacity()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 100, errorCapacity: 3);
+
+        for (var i = 0; i < 5; i++)
+            sink.Emit(MakeEvent(LogEventLevel.Error));
+
+        var events = sink.GetEvents(count: 1000, minLevel: LogEventLevel.Error);
+        events.Should().HaveCount(3, "error buffer must drop oldest when full");
+    }
+
+    [HumansFact]
+    public void FatalEventsUseErrorBuffer()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 100, errorCapacity: 2);
+
+        for (var i = 0; i < 4; i++)
+            sink.Emit(MakeEvent(LogEventLevel.Fatal));
+
+        var events = sink.GetEvents(count: 1000, minLevel: LogEventLevel.Error);
+        events.Should().HaveCount(2);
+    }
+
+    // ── merged GetEvents ordering (newest first) ─────────────────────────────
+
+    [HumansFact]
+    public void GetEvents_ReturnsNewestFirst()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 10, errorCapacity: 10);
+        var t0 = DateTimeOffset.UtcNow;
+
+        sink.Emit(MakeEvent(LogEventLevel.Warning, t0.AddSeconds(1)));
+        sink.Emit(MakeEvent(LogEventLevel.Error, t0.AddSeconds(3)));
+        sink.Emit(MakeEvent(LogEventLevel.Warning, t0.AddSeconds(2)));
+
+        var events = sink.GetEvents(count: 1000);
+
+        events.Should().HaveCount(3);
+        events[0].Timestamp.Should().Be(t0.AddSeconds(3));
+        events[1].Timestamp.Should().Be(t0.AddSeconds(2));
+        events[2].Timestamp.Should().Be(t0.AddSeconds(1));
+    }
+
+    // ── minimum-level filter ─────────────────────────────────────────────────
+
+    [HumansFact]
+    public void GetEvents_MinLevelError_ExcludesWarnings()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 10, errorCapacity: 10);
+
+        sink.Emit(MakeEvent(LogEventLevel.Warning));
+        sink.Emit(MakeEvent(LogEventLevel.Error));
+        sink.Emit(MakeEvent(LogEventLevel.Fatal));
+
+        var events = sink.GetEvents(count: 1000, minLevel: LogEventLevel.Error);
+
+        events.Should().HaveCount(2);
+        events.Should().OnlyContain(e => e.Level >= LogEventLevel.Error);
+    }
+
+    [HumansFact]
+    public void GetEvents_NoMinLevel_ReturnsAllBufferedLevels()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 10, errorCapacity: 10);
+
+        sink.Emit(MakeEvent(LogEventLevel.Warning));
+        sink.Emit(MakeEvent(LogEventLevel.Error));
+
+        sink.GetEvents(count: 1000).Should().HaveCount(2);
+    }
+
+    [HumansFact]
+    public void GetEvents_CountLimitsResults()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 10, errorCapacity: 10);
+
+        for (var i = 0; i < 5; i++)
+            sink.Emit(MakeEvent(LogEventLevel.Warning));
+        for (var i = 0; i < 5; i++)
+            sink.Emit(MakeEvent(LogEventLevel.Error));
+
+        sink.GetEvents(count: 3).Should().HaveCount(3);
+    }
+
+    // ── lifetime counts unaffected by eviction ───────────────────────────────
+
+    [HumansFact]
+    public void LifetimeCounts_SurviveWarningEviction()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 2, errorCapacity: 10);
+
+        for (var i = 0; i < 5; i++)
+            sink.Emit(MakeEvent(LogEventLevel.Warning));
+
+        var counts = sink.GetLifetimeCounts();
+        counts[LogEventLevel.Warning].Should().Be(5, "lifetime count must not drop when buffer cycles");
+    }
+
+    [HumansFact]
+    public void LifetimeCounts_SurviveErrorEviction()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 10, errorCapacity: 2);
+
+        for (var i = 0; i < 4; i++)
+            sink.Emit(MakeEvent(LogEventLevel.Error));
+
+        var counts = sink.GetLifetimeCounts();
+        counts[LogEventLevel.Error].Should().Be(4);
+    }
+
+    [HumansFact]
+    public void TotalEvents_SumsAllLevels()
+    {
+        var sink = new InMemoryLogSink(warningCapacity: 1, errorCapacity: 1);
+
+        sink.Emit(MakeEvent(LogEventLevel.Warning));
+        sink.Emit(MakeEvent(LogEventLevel.Warning)); // evicts the first
+        sink.Emit(MakeEvent(LogEventLevel.Error));
+
+        sink.TotalEvents.Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Summary

`InMemoryLogSink` previously kept one shared 1000-event queue, so a burst of noisy warnings could evict every buffered error. It now keeps **Warning** events and **Error/Fatal** events in separate ring buffers (each capped at 1000 as a memory backstop), so errors are effectively retained while warnings cycle.

## Changes

- `src/Humans.Web/Infrastructure/InMemoryLogSink.cs` — per-severity buffers; `GetEvents(count, minLevel)` merges newest-first with an optional minimum-level filter; constructor takes per-buffer capacities for testability; lifetime counts and `StartedAt` unchanged.
- `src/Humans.Web/Controllers/DebugController.cs` + `Views/Debug/Logs.cshtml` — `/Debug/Logs` gains **All / Errors only** filter links (`?minLevel=Error`). A "Warnings only" link was deliberately not added: `minLevel` is a minimum-level filter shared with the API, and Warning-and-above equals everything buffered.
- `src/Humans.Web/Controllers/LogApiController.cs` — passes `count` + `minLevel` straight to the sink instead of over-fetching and filtering afterward; API behavior unchanged.
- `tests/Humans.Web.Tests/Infrastructure/InMemoryLogSinkTests.cs` — 9 tests: warning churn cannot evict earlier errors (the core regression guard), per-buffer caps, Fatal routing, merged ordering, min-level filter, count limit, lifetime counts surviving eviction.

## Test plan

- `dotnet build Humans.slnx -v quiet` — clean
- `dotnet test` (minus Integration): 4,144 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
