### PR TITLE
feat(threading): TrackedLock - named mutex with wait diagnostics and timeout

### DIFF
--- a/src/Humans.Application/Interfaces/Caching/TrackedCache.cs
+++ b/src/Humans.Application/Interfaces/Caching/TrackedCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Humans.Application.Threading;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -13,7 +14,7 @@ public class TrackedCache<TKey, TValue> : IHostedService, ICacheStats where TKey
 {
     private readonly ConcurrentDictionary<TKey, TValue> _dict = new();
     private readonly bool _warmOnStartup;
-    private readonly SemaphoreSlim _warmLock = new(1, 1);
+    private readonly TrackedLock _warmLock;
     private readonly ILogger _logger;
     private volatile bool _warmedUp;
     private long _hits;
@@ -32,6 +33,7 @@ public class TrackedCache<TKey, TValue> : IHostedService, ICacheStats where TKey
         Name = name;
         _warmOnStartup = warmOnStartup;
         _logger = logger;
+        _warmLock = new TrackedLock($"{name}.WarmLock");
     }
 
     public int Entries => _dict.Count;
@@ -207,17 +209,10 @@ public class TrackedCache<TKey, TValue> : IHostedService, ICacheStats where TKey
     protected async Task EnsureWarmedAsync(CancellationToken ct)
     {
         if (_warmedUp) return;
-        await _warmLock.WaitAsync(ct);
-        try
-        {
-            if (_warmedUp) return;
-            await WarmAllAsync(ct);
-            _warmedUp = true;
-        }
-        finally
-        {
-            _warmLock.Release();
-        }
+        using var _ = await _warmLock.AcquireAsync(_logger, ct);
+        if (_warmedUp) return;
+        await WarmAllAsync(ct);
+        _warmedUp = true;
     }
 
     Task IHostedService.StartAsync(CancellationToken ct) =>

--- a/src/Humans.Application/Services/Profiles/ProfileEditorService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileEditorService.cs
@@ -2,6 +2,7 @@ using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Application.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace Humans.Application.Services.Profiles;
@@ -12,16 +13,16 @@ public sealed class ProfileEditorService(
     ILogger<ProfileEditorService> logger) : IProfileEditorService
 {
     // Serialize full save orchestration so DB picture metadata and file writes stay ordered per user.
-    private static readonly SemaphoreSlim[] UserLocks = CreateUserLocks(32);
+    private static readonly TrackedLock[] UserLocks = CreateUserLocks(32);
 
-    private static SemaphoreSlim[] CreateUserLocks(int count)
+    private static TrackedLock[] CreateUserLocks(int count)
     {
-        var locks = new SemaphoreSlim[count];
-        for (var i = 0; i < count; i++) locks[i] = new SemaphoreSlim(1, 1);
+        var locks = new TrackedLock[count];
+        for (var i = 0; i < count; i++) locks[i] = new TrackedLock($"ProfileEditor.User[{i}]");
         return locks;
     }
 
-    private static SemaphoreSlim LockFor(Guid userId) =>
+    private static TrackedLock LockFor(Guid userId) =>
         UserLocks[(uint)userId.GetHashCode() % (uint)UserLocks.Length];
 
     public async Task<Guid> SaveProfileAsync(
@@ -30,25 +31,18 @@ public sealed class ProfileEditorService(
         ProfileSaveRequest request,
         CancellationToken ct = default)
     {
-        var gate = LockFor(userId);
-        await gate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            var storageResult = await userService.SaveProfileAsync(
-                userId,
-                ToUserProfileSaveCommand(displayName, request),
-                ct);
+        using var _ = await LockFor(userId).AcquireAsync(logger, ct);
 
-            await ApplyProfilePictureFileMutationAsync(storageResult, request, ct);
+        var storageResult = await userService.SaveProfileAsync(
+            userId,
+            ToUserProfileSaveCommand(displayName, request),
+            ct);
 
-            logger.LogInformation("User {UserId} updated their profile", userId);
+        await ApplyProfilePictureFileMutationAsync(storageResult, request, ct);
 
-            return storageResult.ProfileId;
-        }
-        finally
-        {
-            gate.Release();
-        }
+        logger.LogInformation("User {UserId} updated their profile", userId);
+
+        return storageResult.ProfileId;
     }
 
     private static UserProfileSaveCommand ToUserProfileSaveCommand(

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -8,6 +8,7 @@ using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
+using Humans.Application.Threading;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
@@ -24,15 +25,15 @@ public sealed class UserService(
     IClock clock,
     ILogger<UserService> logger) : IUserService, IUserDataContributor
 {
-    private static readonly SemaphoreSlim[] ProfileStubLocks = CreateProfileStubLocks(32);
-    private static SemaphoreSlim[] CreateProfileStubLocks(int count)
+    private static readonly TrackedLock[] ProfileStubLocks = CreateProfileStubLocks(32);
+    private static TrackedLock[] CreateProfileStubLocks(int count)
     {
-        var locks = new SemaphoreSlim[count];
-        for (var i = 0; i < count; i++) locks[i] = new SemaphoreSlim(1, 1);
+        var locks = new TrackedLock[count];
+        for (var i = 0; i < count; i++) locks[i] = new TrackedLock($"UserService.ProfileStub[{i}]");
         return locks;
     }
 
-    private static SemaphoreSlim ProfileStubLockFor(Guid userId) =>
+    private static TrackedLock ProfileStubLockFor(Guid userId) =>
         ProfileStubLocks[(uint)userId.GetHashCode() % (uint)ProfileStubLocks.Length];
 
     // --- User reads ---
@@ -304,49 +305,42 @@ public sealed class UserService(
         string? lastName = null,
         CancellationToken ct = default)
     {
-        var gate = ProfileStubLockFor(userId);
-        await gate.WaitAsync(ct).ConfigureAwait(false);
-        try
+        using var _ = await ProfileStubLockFor(userId).AcquireAsync(logger, ct);
+
+        var existing = await repo.GetByUserIdAsync(userId, ct);
+        if (existing is not null) return false;
+
+        var info = await GetUserInfoAsync(userId, ct);
+        if (info is null)
+            return false;
+
+        if (info.IsTombstone)
         {
-            var existing = await repo.GetByUserIdAsync(userId, ct);
-            if (existing is not null) return false;
-
-            var info = await GetUserInfoAsync(userId, ct);
-            if (info is null)
-                return false;
-
-            if (info.IsTombstone)
-            {
-                logger.LogError(
-                    "EnsureStubProfileAsync called for tombstone user {UserId} (MergedAt={MergedAt}) - refusing to create Stub Profile",
-                    userId, info.MergedAt);
-                return false;
-            }
-
-            var now = clock.GetCurrentInstant();
-            var profile = new Profile
-            {
-                Id = Guid.NewGuid(),
-                UserId = userId,
-                CreatedAt = now,
-                UpdatedAt = now,
-                BurnerName = (burnerName ?? string.Empty).Trim(),
-                FirstName = (firstName ?? string.Empty).Trim(),
-                LastName = (lastName ?? string.Empty).Trim(),
-            };
-
-            // Seeded names (magic-link signup) promote straight to Active, mirroring
-            // SaveProfileAsync; import/OAuth paths pass no names and stay Stub. see #635 / #812.
-            profile.State = HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
-
-            await repo.AddAsync(profile, ct);
-            InvalidateClaims(userId);
-            return true;
+            logger.LogError(
+                "EnsureStubProfileAsync called for tombstone user {UserId} (MergedAt={MergedAt}) - refusing to create Stub Profile",
+                userId, info.MergedAt);
+            return false;
         }
-        finally
+
+        var now = clock.GetCurrentInstant();
+        var profile = new Profile
         {
-            gate.Release();
-        }
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            CreatedAt = now,
+            UpdatedAt = now,
+            BurnerName = (burnerName ?? string.Empty).Trim(),
+            FirstName = (firstName ?? string.Empty).Trim(),
+            LastName = (lastName ?? string.Empty).Trim(),
+        };
+
+        // Seeded names (magic-link signup) promote straight to Active, mirroring
+        // SaveProfileAsync; import/OAuth paths pass no names and stay Stub. see #635 / #812.
+        profile.State = HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
+
+        await repo.AddAsync(profile, ct);
+        InvalidateClaims(userId);
+        return true;
     }
 
     public async Task<bool> SetMembershipTierAsync(
@@ -421,100 +415,93 @@ public sealed class UserService(
         UserProfileSaveCommand command,
         CancellationToken ct = default)
     {
-        var gate = ProfileStubLockFor(userId);
-        await gate.WaitAsync(ct).ConfigureAwait(false);
-        try
+        using var _ = await ProfileStubLockFor(userId).AcquireAsync(logger, ct);
+
+        var now = clock.GetCurrentInstant();
+        var profile = await repo.GetByUserIdAsync(userId, ct);
+
+        if (profile is null)
         {
-            var now = clock.GetCurrentInstant();
-            var profile = await repo.GetByUserIdAsync(userId, ct);
-
-            if (profile is null)
+            profile = new Profile
             {
-                profile = new Profile
-                {
-                    Id = Guid.NewGuid(),
-                    UserId = userId,
-                    CreatedAt = now,
-                    UpdatedAt = now,
-                    State = ProfileState.Stub,
-                };
-                await repo.AddAsync(profile, ct);
-            }
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                CreatedAt = now,
+                UpdatedAt = now,
+                State = ProfileState.Stub,
+            };
+            await repo.AddAsync(profile, ct);
+        }
 
-            var previousPictureContentType = profile.ProfilePictureContentType;
+        var previousPictureContentType = profile.ProfilePictureContentType;
 
-            profile.BurnerName = command.BurnerName;
-            profile.FirstName = command.FirstName;
-            profile.LastName = command.LastName;
-            profile.City = command.City;
-            profile.CountryCode = command.CountryCode;
-            profile.Latitude = command.Latitude;
-            profile.Longitude = command.Longitude;
-            profile.PlaceId = command.PlaceId;
-            profile.Bio = command.Bio?.TrimEnd();
-            profile.Pronouns = command.Pronouns;
-            profile.ContributionInterests = command.ContributionInterests?.TrimEnd();
-            profile.BoardNotes = command.BoardNotes?.TrimEnd();
-            profile.EmergencyContactName = command.EmergencyContactName;
-            profile.EmergencyContactPhone = command.EmergencyContactPhone;
-            profile.EmergencyContactRelationship = command.EmergencyContactRelationship;
-            profile.NoPriorBurnExperience = command.NoPriorBurnExperience;
+        profile.BurnerName = command.BurnerName;
+        profile.FirstName = command.FirstName;
+        profile.LastName = command.LastName;
+        profile.City = command.City;
+        profile.CountryCode = command.CountryCode;
+        profile.Latitude = command.Latitude;
+        profile.Longitude = command.Longitude;
+        profile.PlaceId = command.PlaceId;
+        profile.Bio = command.Bio?.TrimEnd();
+        profile.Pronouns = command.Pronouns;
+        profile.ContributionInterests = command.ContributionInterests?.TrimEnd();
+        profile.BoardNotes = command.BoardNotes?.TrimEnd();
+        profile.EmergencyContactName = command.EmergencyContactName;
+        profile.EmergencyContactPhone = command.EmergencyContactPhone;
+        profile.EmergencyContactRelationship = command.EmergencyContactRelationship;
+        profile.NoPriorBurnExperience = command.NoPriorBurnExperience;
 
-            // Edit page owns meal preference + allergies (not intolerances/medical —
-            // those are written via SaveDietaryMedicalAsync). Only touch these when
-            // the command carries them, so a non-dietary save path can't clobber.
-            if (command.DietaryPreference is not null || command.Allergies is not null || command.AllergyOtherText is not null)
+        // Edit page owns meal preference + allergies (not intolerances/medical —
+        // those are written via SaveDietaryMedicalAsync). Only touch these when
+        // the command carries them, so a non-dietary save path can't clobber.
+        if (command.DietaryPreference is not null || command.Allergies is not null || command.AllergyOtherText is not null)
+        {
+            profile.DietaryPreference = string.IsNullOrWhiteSpace(command.DietaryPreference) ? null : command.DietaryPreference;
+            profile.Allergies = command.Allergies ?? [];
+            profile.AllergyOtherText = command.AllergyOtherText;
+        }
+
+        profile.UpdatedAt = now;
+
+        // LocalDate year=4 lets Feb 29 validate.
+        if (command.BirthdayMonth is >= 1 and <= 12 && command.BirthdayDay is >= 1 and <= 31)
+        {
+            try
             {
-                profile.DietaryPreference = string.IsNullOrWhiteSpace(command.DietaryPreference) ? null : command.DietaryPreference;
-                profile.Allergies = command.Allergies ?? [];
-                profile.AllergyOtherText = command.AllergyOtherText;
+                profile.DateOfBirth = new LocalDate(4, command.BirthdayMonth.Value, command.BirthdayDay.Value);
             }
-
-            profile.UpdatedAt = now;
-
-            // LocalDate year=4 lets Feb 29 validate.
-            if (command.BirthdayMonth is >= 1 and <= 12 && command.BirthdayDay is >= 1 and <= 31)
-            {
-                try
-                {
-                    profile.DateOfBirth = new LocalDate(4, command.BirthdayMonth.Value, command.BirthdayDay.Value);
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    profile.DateOfBirth = null;
-                }
-            }
-            else
+            catch (ArgumentOutOfRangeException)
             {
                 profile.DateOfBirth = null;
             }
-
-            profile.ProfilePictureContentType = command.PictureMutation switch
-            {
-                UserProfilePictureMutation.Remove => null,
-                UserProfilePictureMutation.Set => command.ProfilePictureContentType,
-                _ => profile.ProfilePictureContentType,
-            };
-
-            // see #635 (section 15i) - Stub->Active promotion (mirrors UserInfo.HasRequiredNameFields).
-            if (!IsSuspendedState(profile.State))
-            {
-                profile.State = HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
-            }
-
-            await repo.UpdateAsync(profile, ct);
-            await repo.UpdateDisplayNameAsync(userId, command.DisplayName, ct);
-            InvalidateClaims(userId);
-
-            return new UserProfileSaveResult(
-                profile.Id,
-                previousPictureContentType,
-                profile.ProfilePictureContentType);
         }
-        finally
+        else
         {
-            gate.Release();
+            profile.DateOfBirth = null;
         }
+
+        profile.ProfilePictureContentType = command.PictureMutation switch
+        {
+            UserProfilePictureMutation.Remove => null,
+            UserProfilePictureMutation.Set => command.ProfilePictureContentType,
+            _ => profile.ProfilePictureContentType,
+        };
+
+        // see #635 (section 15i) - Stub->Active promotion (mirrors UserInfo.HasRequiredNameFields).
+        if (!IsSuspendedState(profile.State))
+        {
+            profile.State = HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
+        }
+
+        await repo.UpdateAsync(profile, ct);
+        await repo.UpdateDisplayNameAsync(userId, command.DisplayName, ct);
+        InvalidateClaims(userId);
+
+        return new UserProfileSaveResult(
+            profile.Id,
+            previousPictureContentType,
+            profile.ProfilePictureContentType);
     }
 
     public async Task SaveDietaryMedicalAsync(
@@ -522,39 +509,32 @@ public sealed class UserService(
         UserProfileDietaryMedicalCommand command,
         CancellationToken ct = default)
     {
-        var gate = ProfileStubLockFor(userId);
-        await gate.WaitAsync(ct).ConfigureAwait(false);
-        try
+        using var _ = await ProfileStubLockFor(userId).AcquireAsync(logger, ct);
+
+        var now = clock.GetCurrentInstant();
+        var profile = await repo.GetByUserIdAsync(userId, ct);
+        if (profile is null)
         {
-            var now = clock.GetCurrentInstant();
-            var profile = await repo.GetByUserIdAsync(userId, ct);
-            if (profile is null)
+            profile = new Profile
             {
-                profile = new Profile
-                {
-                    Id = Guid.NewGuid(),
-                    UserId = userId,
-                    CreatedAt = now,
-                    UpdatedAt = now,
-                    State = ProfileState.Stub,
-                };
-                await repo.AddAsync(profile, ct);
-            }
-
-            profile.DietaryPreference = command.DietaryPreference;
-            profile.Allergies = command.Allergies;
-            profile.AllergyOtherText = command.AllergyOtherText;
-            profile.Intolerances = command.Intolerances;
-            profile.IntoleranceOtherText = command.IntoleranceOtherText;
-            profile.MedicalConditions = command.MedicalConditions;
-            profile.UpdatedAt = now;
-
-            await repo.UpdateAsync(profile, ct);
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                CreatedAt = now,
+                UpdatedAt = now,
+                State = ProfileState.Stub,
+            };
+            await repo.AddAsync(profile, ct);
         }
-        finally
-        {
-            gate.Release();
-        }
+
+        profile.DietaryPreference = command.DietaryPreference;
+        profile.Allergies = command.Allergies;
+        profile.AllergyOtherText = command.AllergyOtherText;
+        profile.Intolerances = command.Intolerances;
+        profile.IntoleranceOtherText = command.IntoleranceOtherText;
+        profile.MedicalConditions = command.MedicalConditions;
+        profile.UpdatedAt = now;
+
+        await repo.UpdateAsync(profile, ct);
     }
 
     public async Task<UserProfilePictureContentTypeResult> SetProfilePictureContentTypeAsync(

--- a/src/Humans.Application/Threading/TrackedLock.cs
+++ b/src/Humans.Application/Threading/TrackedLock.cs
@@ -22,6 +22,7 @@ public sealed class TrackedLock
 
     public string Name { get; }
 
+    /// <summary>Creates a named lock with optional timeout and log-threshold overrides.</summary>
     /// <param name="name">Human-readable name used in log messages and exception text.</param>
     /// <param name="timeout">Maximum time to wait before throwing <see cref="TimeoutException"/>. Defaults to 60 seconds.</param>
     /// <param name="debugThreshold">Wait ≥ this logs at Debug. Defaults to 1 second.</param>
@@ -55,7 +56,7 @@ public sealed class TrackedLock
     {
         var start = TimeProvider.System.GetTimestamp();
 
-        var acquired = await _semaphore.WaitAsync((int)_timeout.TotalMilliseconds, ct).ConfigureAwait(false);
+        var acquired = await _semaphore.WaitAsync(_timeout, ct).ConfigureAwait(false);
 
         var elapsed = TimeProvider.System.GetElapsedTime(start);
 

--- a/src/Humans.Application/Threading/TrackedLock.cs
+++ b/src/Humans.Application/Threading/TrackedLock.cs
@@ -1,0 +1,125 @@
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Application.Threading;
+
+/// <summary>
+/// A named mutex wrapper around <see cref="SemaphoreSlim"/> that measures wait time,
+/// logs slow acquisitions with escalating severity, and converts hard-lock timeouts
+/// into diagnosable <see cref="TimeoutException"/> failures.
+/// </summary>
+/// <remarks>
+/// The logger is passed at acquire time (not construction) so instances can be stored
+/// in static fields without a DI dependency.
+/// </remarks>
+public sealed class TrackedLock
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private readonly TimeSpan _debugThreshold;
+    private readonly TimeSpan _informationThreshold;
+    private readonly TimeSpan _warningThreshold;
+    private readonly TimeSpan _timeout;
+
+    public string Name { get; }
+
+    /// <param name="name">Human-readable name used in log messages and exception text.</param>
+    /// <param name="timeout">Maximum time to wait before throwing <see cref="TimeoutException"/>. Defaults to 60 seconds.</param>
+    /// <param name="debugThreshold">Wait ≥ this logs at Debug. Defaults to 1 second.</param>
+    /// <param name="informationThreshold">Wait ≥ this logs at Information. Defaults to 5 seconds.</param>
+    /// <param name="warningThreshold">Wait ≥ this logs at Warning. Defaults to 15 seconds.</param>
+    public TrackedLock(
+        string name,
+        TimeSpan? timeout = null,
+        TimeSpan? debugThreshold = null,
+        TimeSpan? informationThreshold = null,
+        TimeSpan? warningThreshold = null)
+    {
+        Name = name;
+        _timeout = timeout ?? TimeSpan.FromSeconds(60);
+        _debugThreshold = debugThreshold ?? TimeSpan.FromSeconds(1);
+        _informationThreshold = informationThreshold ?? TimeSpan.FromSeconds(5);
+        _warningThreshold = warningThreshold ?? TimeSpan.FromSeconds(15);
+    }
+
+    /// <summary>
+    /// Acquires the lock asynchronously. Returns a <see cref="Releaser"/> that releases
+    /// it exactly once when disposed. Use in a <c>using var</c> statement.
+    /// </summary>
+    /// <exception cref="TimeoutException">
+    /// Thrown when the lock is not acquired within the configured timeout.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="ct"/> is cancelled while waiting.
+    /// </exception>
+    public async ValueTask<Releaser> AcquireAsync(ILogger logger, CancellationToken ct = default)
+    {
+        var start = TimeProvider.System.GetTimestamp();
+
+        var acquired = await _semaphore.WaitAsync((int)_timeout.TotalMilliseconds, ct).ConfigureAwait(false);
+
+        var elapsed = TimeProvider.System.GetElapsedTime(start);
+
+        if (!acquired)
+        {
+            logger.LogError(
+                "Lock '{LockName}' timed out after {ElapsedMs}ms waiting for acquisition",
+                Name, (long)elapsed.TotalMilliseconds);
+            throw new TimeoutException(
+                $"Lock '{Name}' was not acquired within {_timeout.TotalSeconds:0}s.");
+        }
+
+        var level = WaitToLogLevel(elapsed, _debugThreshold, _informationThreshold, _warningThreshold);
+        if (level.HasValue)
+        {
+            logger.Log(level.Value,
+                "Lock '{LockName}' waited {ElapsedMs}ms before acquisition",
+                Name, (long)elapsed.TotalMilliseconds);
+        }
+
+        return new Releaser(_semaphore);
+    }
+
+    /// <summary>
+    /// Maps a wait duration to a log level using the configured thresholds.
+    /// Returns null when the wait is below all thresholds (no log needed).
+    /// Internal for direct unit testing.
+    /// </summary>
+    internal static LogLevel? WaitToLogLevel(
+        TimeSpan elapsed,
+        TimeSpan debugThreshold,
+        TimeSpan informationThreshold,
+        TimeSpan warningThreshold)
+    {
+        if (elapsed >= warningThreshold) return LogLevel.Warning;
+        if (elapsed >= informationThreshold) return LogLevel.Information;
+        if (elapsed >= debugThreshold) return LogLevel.Debug;
+        return null;
+    }
+
+    /// <summary>
+    /// Releases the underlying <see cref="SemaphoreSlim"/> exactly once on dispose.
+    /// Double-dispose is safe and silently ignored, including across struct copies.
+    /// </summary>
+    public readonly struct Releaser : IDisposable
+    {
+        // A thin class wrapper holds the mutable release-once counter so the
+        // outer struct stays readonly (no defensive-copy hazard) while still
+        // supporting the single-release invariant across copies.
+        private sealed class State(SemaphoreSlim semaphore)
+        {
+            private int _released;
+
+            public void Release()
+            {
+                if (Interlocked.Exchange(ref _released, 1) == 0)
+                    semaphore.Release();
+            }
+        }
+
+        private readonly State? _state;
+
+        internal Releaser(SemaphoreSlim semaphore) => _state = new State(semaphore);
+
+        public void Dispose() => _state?.Release();
+    }
+}

--- a/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
+++ b/src/Humans.Infrastructure/Services/Events/CachingEventService.cs
@@ -4,6 +4,7 @@ using Humans.Application.DTOs.Events;
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Threading;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,7 +62,7 @@ public sealed class CachingEventService(
     private volatile IReadOnlyList<EventVenueView> _venues = [];
     private volatile EventGuideSettingsView? _settings;
 
-    private readonly SemaphoreSlim _loadLock = new(1, 1);
+    private readonly TrackedLock _loadLock = new("CachingEventService.Load");
     private volatile bool _isLoaded;
 
     /// <summary>Diagnostics surface for <c>/Debug/CacheStats</c>.</summary>
@@ -448,34 +449,27 @@ public sealed class CachingEventService(
     {
         if (_isLoaded) return;
 
-        await _loadLock.WaitAsync(ct);
-        try
-        {
-            if (_isLoaded) return;
+        using var _ = await _loadLock.AcquireAsync(logger, ct);
+        if (_isLoaded) return;
 
-            // Snapshot holds ALL rows (active + inactive) — admin Edit pages
-            // and slug-uniqueness must see inactive rows, matching the DB.
-            // Active-only filtering happens at projection time in
-            // GetActiveCategoriesAsync / GetActiveVenuesAsync.
-            var categories = await WithInner(inner => inner.GetAllCategoriesAsync(ct));
-            var venues = await WithInner(inner => inner.GetAllVenuesAsync(ct));
-            var settings = await WithInner(inner => inner.GetGuideSettingsAsync(ct));
-            var approved = await WithInner(inner => inner.GetApprovedEventsAsync(null, null, null, null, [], ct));
+        // Snapshot holds ALL rows (active + inactive) — admin Edit pages
+        // and slug-uniqueness must see inactive rows, matching the DB.
+        // Active-only filtering happens at projection time in
+        // GetActiveCategoriesAsync / GetActiveVenuesAsync.
+        var categories = await WithInner(inner => inner.GetAllCategoriesAsync(ct));
+        var venues = await WithInner(inner => inner.GetAllVenuesAsync(ct));
+        var settings = await WithInner(inner => inner.GetGuideSettingsAsync(ct));
+        var approved = await WithInner(inner => inner.GetApprovedEventsAsync(null, null, null, null, [], ct));
 
-            _categories = categories.Select(ManageInfoToCategoryView).ToList();
-            _venues = venues.Select(ManageInfoToVenueView).ToList();
-            _settings = settings;
+        _categories = categories.Select(ManageInfoToCategoryView).ToList();
+        _venues = venues.Select(ManageInfoToVenueView).ToList();
+        _settings = settings;
 
-            _eventCache.Clear();
-            foreach (var ev in approved)
-                _eventCache.Set(ev.Id, ev);
+        _eventCache.Clear();
+        foreach (var ev in approved)
+            _eventCache.Set(ev.Id, ev);
 
-            _isLoaded = true;
-        }
-        finally
-        {
-            _loadLock.Release();
-        }
+        _isLoaded = true;
     }
 
     private async Task EnsureLoadedAsync(CancellationToken ct)

--- a/src/Humans.Infrastructure/Services/GuideContentService.cs
+++ b/src/Humans.Infrastructure/Services/GuideContentService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Humans.Application.Constants;
 using Humans.Application.Interfaces;
+using Humans.Application.Threading;
 using Humans.Infrastructure.Configuration;
 
 namespace Humans.Infrastructure.Services;
@@ -16,7 +17,7 @@ public sealed class GuideContentService(
 {
     private const string CacheKeyPrefix = "guide:";
 
-    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private readonly TrackedLock _refreshLock = new("GuideContentService.Refresh");
 
     public async Task<string> GetRenderedAsync(string fileStem, CancellationToken cancellationToken = default)
     {
@@ -46,58 +47,52 @@ public sealed class GuideContentService(
 
     private async Task PopulateAsync(bool isRefresh, CancellationToken cancellationToken)
     {
-        await _refreshLock.WaitAsync(cancellationToken);
-        try
+        using var gate = await _refreshLock.AcquireAsync(logger, cancellationToken);
+
+        var hasStale = GuideFiles.All.Any(s => cache.TryGetValue(CacheKey(s), out string? _));
+
+        var settings1 = settings.Value;
+        var ttl = TimeSpan.FromHours(Math.Max(1, settings1.CacheTtlHours));
+        var anyFailures = false;
+        var newEntries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var stem in GuideFiles.All)
         {
-            var hasStale = GuideFiles.All.Any(s => cache.TryGetValue(CacheKey(s), out string? _));
-
-            var settings1 = settings.Value;
-            var ttl = TimeSpan.FromHours(Math.Max(1, settings1.CacheTtlHours));
-            var anyFailures = false;
-            var newEntries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var stem in GuideFiles.All)
+            try
             {
-                try
-                {
-                    var markdown = await source.GetMarkdownAsync(stem, cancellationToken);
-                    var html = renderer.Render(markdown, stem);
-                    newEntries[stem] = html;
-                }
-                catch (Exception ex)
-                {
-                    anyFailures = true;
-                    logger.LogWarning(ex,
-                        "Failed to fetch or render guide file {FileStem}; {Outcome}",
-                        stem,
-                        hasStale ? "keeping stale cached copy" : "no stale copy available");
-                }
+                var markdown = await source.GetMarkdownAsync(stem, cancellationToken);
+                var html = renderer.Render(markdown, stem);
+                newEntries[stem] = html;
             }
-
-            if (!hasStale && newEntries.Count == 0)
+            catch (Exception ex)
             {
-                throw new GuideContentUnavailableException(
-                    "Guide content is unavailable and the cache is cold.");
-            }
-
-            foreach (var (stem, html) in newEntries)
-            {
-                cache.Set(CacheKey(stem), html, new MemoryCacheEntryOptions
-                {
-                    SlidingExpiration = ttl
-                });
-            }
-
-            if (anyFailures)
-            {
-                logger.LogWarning(
-                    "Guide refresh completed with failures (isRefresh={IsRefresh}); stale entries retained.",
-                    isRefresh);
+                anyFailures = true;
+                logger.LogWarning(ex,
+                    "Failed to fetch or render guide file {FileStem}; {Outcome}",
+                    stem,
+                    hasStale ? "keeping stale cached copy" : "no stale copy available");
             }
         }
-        finally
+
+        if (!hasStale && newEntries.Count == 0)
         {
-            _refreshLock.Release();
+            throw new GuideContentUnavailableException(
+                "Guide content is unavailable and the cache is cold.");
+        }
+
+        foreach (var (stem, html) in newEntries)
+        {
+            cache.Set(CacheKey(stem), html, new MemoryCacheEntryOptions
+            {
+                SlidingExpiration = ttl
+            });
+        }
+
+        if (anyFailures)
+        {
+            logger.LogWarning(
+                "Guide refresh completed with failures (isRefresh={IsRefresh}); stale entries retained.",
+                isRefresh);
         }
     }
 

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
+using Humans.Application.Threading;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 
@@ -22,7 +23,7 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
     private const string HumansGroupPrefix = "Humans - ";
 
     private static readonly JsonSerializerOptions Json = BuildJson();
-    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly TrackedLock _gate = new("MailerLiteClient.Gate");
 
     private IReadOnlyList<MailerLiteSubscriber>? _subscribers;
     private MailerLiteAccountSummary? _summary;
@@ -63,15 +64,8 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
 
     public async Task RefreshAsync(CancellationToken ct = default)
     {
-        await _gate.WaitAsync(ct);
-        try
-        {
-            await PopulateLockedAsync(ct);
-        }
-        finally
-        {
-            _gate.Release();
-        }
+        using var _ = await _gate.AcquireAsync(logger, ct);
+        await PopulateLockedAsync(ct);
     }
 
     public async Task<MailerLiteGroup> CreateGroupAsync(string name, CancellationToken ct = default)
@@ -165,30 +159,19 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
     // Merge under the gate — nullifying would cascade into a full subscriber re-fetch.
     private async Task AppendToGroupsCacheAsync(MailerLiteGroup newGroup, CancellationToken ct)
     {
-        await _gate.WaitAsync(ct);
-        try
-        {
-            if (_groups is not null)
-                _groups = _groups.Append(newGroup).ToList();
-        }
-        finally { _gate.Release(); }
+        using var _ = await _gate.AcquireAsync(logger, ct);
+        if (_groups is not null)
+            _groups = _groups.Append(newGroup).ToList();
     }
 
     private async Task EnsurePopulatedAsync(CancellationToken ct)
     {
         if (_subscribers is not null && _summary is not null && _groups is not null)
             return;
-        await _gate.WaitAsync(ct);
-        try
-        {
-            if (_subscribers is not null && _summary is not null && _groups is not null)
-                return;
-            await PopulateLockedAsync(ct);
-        }
-        finally
-        {
-            _gate.Release();
-        }
+        using var _ = await _gate.AcquireAsync(logger, ct);
+        if (_subscribers is not null && _summary is not null && _groups is not null)
+            return;
+        await PopulateLockedAsync(ct);
     }
 
     // Throw leaves the prior cache intact; callers retry.

--- a/tests/Humans.Application.Tests/Threading/TrackedLockTests.cs
+++ b/tests/Humans.Application.Tests/Threading/TrackedLockTests.cs
@@ -1,0 +1,193 @@
+using AwesomeAssertions;
+using Humans.Application.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Threading;
+
+public class TrackedLockTests
+{
+    // =========================================================================
+    // Uncontended acquire / release
+    // =========================================================================
+
+    [HumansFact]
+    public async Task AcquireAsync_uncontended_acquires_and_releases()
+    {
+        var sut = new TrackedLock("test");
+
+        using (var releaser = await sut.AcquireAsync(NullLogger.Instance))
+        {
+            // Inside the lock — no exception means it was acquired.
+        }
+
+        // After dispose the lock must be available again.
+        var act = async () =>
+        {
+            using var r = await sut.AcquireAsync(NullLogger.Instance,
+                CancellationToken.None);
+        };
+        await act.Should().NotThrowAsync("lock should be available again after the first release");
+    }
+
+    // =========================================================================
+    // Releaser is single-release (double-dispose safe)
+    // =========================================================================
+
+    [HumansFact]
+    public async Task Releaser_double_dispose_is_safe()
+    {
+        var sut = new TrackedLock("test");
+
+        var releaser = await sut.AcquireAsync(NullLogger.Instance);
+        releaser.Dispose();
+
+        var act = () => { releaser.Dispose(); };
+        act.Should().NotThrow("second dispose must be silently ignored");
+
+        // Lock should be acquirable exactly once after a single release.
+        using var r2 = await sut.AcquireAsync(NullLogger.Instance);
+    }
+
+    // =========================================================================
+    // Mutual exclusion: two concurrent acquirers serialize
+    // =========================================================================
+
+    [HumansFact]
+    public async Task AcquireAsync_serializes_concurrent_acquirers()
+    {
+        var sut = new TrackedLock("test");
+        var insideConcurrently = false;
+        var violation = false;
+
+        var first = await sut.AcquireAsync(NullLogger.Instance);
+
+        var secondTask = Task.Run(async () =>
+        {
+            using var r = await sut.AcquireAsync(NullLogger.Instance);
+            if (insideConcurrently) violation = true;
+        });
+
+        // Give the second task a moment to reach WaitAsync.
+        await Task.Delay(20);
+        insideConcurrently = true;
+        first.Dispose();
+        insideConcurrently = false;
+
+        await secondTask;
+        violation.Should().BeFalse("the two acquirers must not be inside the lock simultaneously");
+    }
+
+    // =========================================================================
+    // WaitToLogLevel pure-function thresholds
+    // =========================================================================
+
+    [HumansTheory]
+    [InlineData(0, null)]          // below debug → no log
+    [InlineData(500, null)]        // 500ms < 1s debug threshold → no log
+    [InlineData(1000, LogLevel.Debug)]
+    [InlineData(4999, LogLevel.Debug)]
+    [InlineData(5000, LogLevel.Information)]
+    [InlineData(14999, LogLevel.Information)]
+    [InlineData(15000, LogLevel.Warning)]
+    [InlineData(60000, LogLevel.Warning)]
+    public void WaitToLogLevel_returns_expected_level(int elapsedMs, LogLevel? expected)
+    {
+        var debug = TimeSpan.FromSeconds(1);
+        var info = TimeSpan.FromSeconds(5);
+        var warn = TimeSpan.FromSeconds(15);
+
+        var result = TrackedLock.WaitToLogLevel(
+            TimeSpan.FromMilliseconds(elapsedMs), debug, info, warn);
+
+        result.Should().Be(expected);
+    }
+
+    // =========================================================================
+    // Contended wait logs via the injected logger
+    // =========================================================================
+
+    [HumansFact]
+    public async Task AcquireAsync_contended_logs_when_wait_exceeds_debug_threshold()
+    {
+        // Tiny thresholds so the test doesn't sleep for real seconds.
+        var sut = new TrackedLock("contended-test",
+            timeout: TimeSpan.FromSeconds(5),
+            debugThreshold: TimeSpan.FromMilliseconds(1),
+            informationThreshold: TimeSpan.FromSeconds(60),
+            warningThreshold: TimeSpan.FromSeconds(120));
+
+        var logger = Substitute.For<ILogger>();
+
+        // Acquire first to force contention.
+        var first = await sut.AcquireAsync(NullLogger.Instance);
+
+        var secondTask = Task.Run(async () =>
+        {
+            // Small delay ensures the waiter spends > 1ms waiting.
+            using var r = await sut.AcquireAsync(logger);
+        });
+
+        await Task.Delay(10);
+        first.Dispose();
+        await secondTask;
+
+        logger.Received().Log(
+            LogLevel.Debug,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Is<Exception?>(e => e == null),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    // =========================================================================
+    // Timeout: throws TimeoutException with lock name in message
+    // =========================================================================
+
+    [HumansFact]
+    public async Task AcquireAsync_throws_TimeoutException_when_lock_held_past_timeout()
+    {
+        const string lockName = "timeout-test-lock";
+        var sut = new TrackedLock(lockName,
+            timeout: TimeSpan.FromMilliseconds(30));
+
+        var logger = NullLogger.Instance;
+
+        // Hold the lock indefinitely.
+        var holder = await sut.AcquireAsync(logger);
+
+        var act = async () => await sut.AcquireAsync(logger);
+
+        var ex = await act.Should().ThrowAsync<TimeoutException>();
+        ex.WithMessage($"*{lockName}*");
+
+        holder.Dispose();
+    }
+
+    // =========================================================================
+    // Cancellation: waiting acquire honours a cancelled token
+    // =========================================================================
+
+    [HumansFact]
+    public async Task AcquireAsync_cancelled_token_throws_OperationCanceledException()
+    {
+        var sut = new TrackedLock("cancel-test",
+            timeout: TimeSpan.FromSeconds(10));
+
+        // Hold the lock so the second acquire has to wait.
+        var holder = await sut.AcquireAsync(NullLogger.Instance);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+        var act = async () =>
+        {
+            using var r = await sut.AcquireAsync(NullLogger.Instance, cts.Token);
+        };
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        holder.Dispose();
+    }
+}

--- a/tests/Humans.Application.Tests/Threading/TrackedLockTests.cs
+++ b/tests/Humans.Application.Tests/Threading/TrackedLockTests.cs
@@ -59,25 +59,25 @@ public class TrackedLockTests
     public async Task AcquireAsync_serializes_concurrent_acquirers()
     {
         var sut = new TrackedLock("test");
-        var insideConcurrently = false;
+        var insideLock = 0;
         var violation = false;
 
-        var first = await sut.AcquireAsync(NullLogger.Instance);
-
-        var secondTask = Task.Run(async () =>
+        // The occupancy counter is only ever touched while holding the lock,
+        // so observing it above 1 proves two holders overlapped — no timing
+        // window can produce a false positive.
+        var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(async () =>
         {
-            using var r = await sut.AcquireAsync(NullLogger.Instance);
-            if (insideConcurrently) violation = true;
-        });
+            for (var i = 0; i < 25; i++)
+            {
+                using var r = await sut.AcquireAsync(NullLogger.Instance);
+                if (Interlocked.Increment(ref insideLock) > 1) violation = true;
+                await Task.Yield();
+                Interlocked.Decrement(ref insideLock);
+            }
+        })).ToArray();
 
-        // Give the second task a moment to reach WaitAsync.
-        await Task.Delay(20);
-        insideConcurrently = true;
-        first.Dispose();
-        insideConcurrently = false;
-
-        await secondTask;
-        violation.Should().BeFalse("the two acquirers must not be inside the lock simultaneously");
+        await Task.WhenAll(tasks);
+        violation.Should().BeFalse("two acquirers must never be inside the lock simultaneously");
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

New `Humans.Application.Threading.TrackedLock` — a named mutex wrapper around `SemaphoreSlim(1,1)` that turns silent lock contention into log signal:

- Measures wait time on every acquisition and logs with escalating severity: Debug ≥1s, Information ≥5s, Warning ≥15s (thresholds injectable for tests).
- Hard timeout (default 60s): logs Error and throws `TimeoutException` naming the lock instead of hanging forever.
- The logger is passed at **acquire** time, not construction, so static stripe arrays work without DI.
- `Releaser` readonly struct releases exactly once; double-dispose safe across copies.

Lives in Application (BCL + logging abstractions only) since both Application and Infrastructure services need it.

## Adoption (near-mechanical swaps, guarded logic unchanged)

- `ProfileEditorService.UserLocks` and `UserService.ProfileStubLocks` — 32-stripe static arrays, named per stripe
- `MailerLiteClient` gate (external API population)
- `GuideContentService` refresh lock (GitHub fetch)
- `CachingEventService` warm-load lock
- `TrackedCache` warm lock (logger already available)

**Skipped by design:** `GateLoginThrottle` (trivial in-memory `Lock`), `DevLoginController` (dev-only), `GoogleWorkspaceSyncService`'s `SemaphoreSlim(5)` (bounded concurrency, not a mutex), test stubs.

## ⚠️ Behavior change

A lock held >60s now surfaces as `TimeoutException` at the waiting caller rather than an indefinite hang. At ~500 users / single server, a 60-second wait on any of these locks is already a catastrophic anomaly — this converts silent deadlocks into diagnosable failures.

## Test plan

- `tests/Humans.Application.Tests/Threading/TrackedLockTests.cs` — uncontended acquire/release, double-dispose safety, mutual exclusion, threshold mapping table, contended-wait logging via injected thresholds, timeout throws with lock name, cancellation; all sub-second, no real sleeps.
- `dotnet build Humans.slnx -v quiet` — clean
- `dotnet test` (minus Integration): 4,148 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
