### PR TITLE
feat(diagnostics): operation timing for external calls + /Debug/Timings page

### DIFF
--- a/src/Humans.Application/Diagnostics/OperationTimingRegistry.cs
+++ b/src/Humans.Application/Diagnostics/OperationTimingRegistry.cs
@@ -1,3 +1,5 @@
+using NodaTime;
+
 namespace Humans.Application.Diagnostics;
 
 /// <summary>
@@ -67,7 +69,7 @@ public sealed class OperationTimingRegistry
         private double _minMs = double.MaxValue;
         private double _maxMs;
         private double _lastMs;
-        private DateTime _lastAtUtc;
+        private Instant _lastAt;
 
         public void Add(double ms)
         {
@@ -76,7 +78,7 @@ public sealed class OperationTimingRegistry
             if (ms < _minMs) _minMs = ms;
             if (ms > _maxMs) _maxMs = ms;
             _lastMs = ms;
-            _lastAtUtc = DateTime.UtcNow;
+            _lastAt = SystemClock.Instance.GetCurrentInstant();
         }
 
         public OperationTimingSnapshot ToSnapshot(string key) => new(
@@ -86,7 +88,7 @@ public sealed class OperationTimingRegistry
             MinMs: _count > 0 ? _minMs : 0,
             MaxMs: _maxMs,
             LastMs: _lastMs,
-            LastAtUtc: _lastAtUtc);
+            LastAt: _lastAt);
     }
 }
 
@@ -97,7 +99,7 @@ public sealed record OperationTimingSnapshot(
     double MinMs,
     double MaxMs,
     double LastMs,
-    DateTime LastAtUtc)
+    Instant LastAt)
 {
     public double AvgMs => Count > 0 ? TotalMs / Count : 0;
 }

--- a/src/Humans.Application/Diagnostics/OperationTimingRegistry.cs
+++ b/src/Humans.Application/Diagnostics/OperationTimingRegistry.cs
@@ -1,0 +1,105 @@
+namespace Humans.Application.Diagnostics;
+
+/// <summary>
+/// In-process registry of operation timing aggregates and swallowed-exception counts.
+/// Thread-safe via per-entry locks; designed for a single-server deployment at ~500 users.
+/// </summary>
+public sealed class OperationTimingRegistry
+{
+    public static readonly OperationTimingRegistry Instance = new();
+
+    private readonly Dictionary<string, OperationAggregate> _timings =
+        new(StringComparer.Ordinal);
+
+    private readonly Dictionary<string, long> _swallowed =
+        new(StringComparer.Ordinal);
+
+    private readonly Lock _timingsLock = new();
+    private readonly Lock _swallowedLock = new();
+
+    public void Record(string key, double elapsedMs)
+    {
+        lock (_timingsLock)
+        {
+            if (!_timings.TryGetValue(key, out var agg))
+            {
+                agg = new OperationAggregate();
+                _timings[key] = agg;
+            }
+            agg.Add(elapsedMs);
+        }
+    }
+
+    public void IncrementSwallowed(string key)
+    {
+        lock (_swallowedLock)
+        {
+            _swallowed.TryGetValue(key, out var count);
+            _swallowed[key] = count + 1;
+        }
+    }
+
+    public IReadOnlyList<OperationTimingSnapshot> GetTimings()
+    {
+        lock (_timingsLock)
+        {
+            return _timings
+                .Select(kvp => kvp.Value.ToSnapshot(kvp.Key))
+                .ToList();
+        }
+    }
+
+    public IReadOnlyList<SwallowedExceptionSnapshot> GetSwallowed()
+    {
+        lock (_swallowedLock)
+        {
+            return _swallowed
+                .Select(kvp => new SwallowedExceptionSnapshot(kvp.Key, kvp.Value))
+                .ToList();
+        }
+    }
+
+    // Mutable aggregate kept in the dictionary; access is always under _timingsLock.
+    private sealed class OperationAggregate
+    {
+        private long _count;
+        private double _totalMs;
+        private double _minMs = double.MaxValue;
+        private double _maxMs;
+        private double _lastMs;
+        private DateTime _lastAtUtc;
+
+        public void Add(double ms)
+        {
+            _count++;
+            _totalMs += ms;
+            if (ms < _minMs) _minMs = ms;
+            if (ms > _maxMs) _maxMs = ms;
+            _lastMs = ms;
+            _lastAtUtc = DateTime.UtcNow;
+        }
+
+        public OperationTimingSnapshot ToSnapshot(string key) => new(
+            Key: key,
+            Count: _count,
+            TotalMs: _totalMs,
+            MinMs: _count > 0 ? _minMs : 0,
+            MaxMs: _maxMs,
+            LastMs: _lastMs,
+            LastAtUtc: _lastAtUtc);
+    }
+}
+
+public sealed record OperationTimingSnapshot(
+    string Key,
+    long Count,
+    double TotalMs,
+    double MinMs,
+    double MaxMs,
+    double LastMs,
+    DateTime LastAtUtc)
+{
+    public double AvgMs => Count > 0 ? TotalMs / Count : 0;
+}
+
+public sealed record SwallowedExceptionSnapshot(string Key, long Count);

--- a/src/Humans.Application/Extensions/LoggerTimingExtensions.cs
+++ b/src/Humans.Application/Extensions/LoggerTimingExtensions.cs
@@ -49,9 +49,9 @@ public static class LoggerTimingExtensions
     {
         >= 30_000 => LogLevel.Error,
         >= 15_000 => LogLevel.Warning,
-        >= 5_000  => LogLevel.Information,
-        >= 1_000  => LogLevel.Debug,
-        _         => LogLevel.None,
+        >= 5_000 => LogLevel.Information,
+        >= 1_000 => LogLevel.Debug,
+        _ => LogLevel.None,
     };
 
     private static string DeriveClassName(string filePath)

--- a/src/Humans.Application/Extensions/LoggerTimingExtensions.cs
+++ b/src/Humans.Application/Extensions/LoggerTimingExtensions.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Humans.Application.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Application.Extensions;
+
+public static class LoggerTimingExtensions
+{
+    /// <summary>
+    /// Starts a scoped timer. On dispose, records elapsed into <see cref="OperationTimingRegistry.Instance"/>
+    /// and logs at a severity that escalates with duration (silent &lt;1 s, Debug ≥1 s, Info ≥5 s,
+    /// Warning ≥15 s, Error ≥30 s).
+    /// </summary>
+    public static OperationTimer TimeOperation(
+        this ILogger logger,
+        string? detail = null,
+        [CallerMemberName] string operation = "",
+        [CallerFilePath] string filePath = "")
+    {
+        var className = DeriveClassName(filePath);
+        var key = $"{className}.{operation}";
+        return new OperationTimer(logger, key, detail);
+    }
+
+    /// <summary>
+    /// Logs a deliberately-swallowed exception at Error and increments the swallowed-exception
+    /// counter in <see cref="OperationTimingRegistry.Instance"/>.
+    /// </summary>
+    public static void Eat(
+        this ILogger logger,
+        Exception exception,
+        string? detail = null,
+        [CallerMemberName] string operation = "",
+        [CallerFilePath] string filePath = "")
+    {
+        var className = DeriveClassName(filePath);
+        var key = $"{className}.{operation}";
+        OperationTimingRegistry.Instance.IncrementSwallowed(key);
+
+        if (detail is not null)
+            logger.LogError(exception, "Swallowed exception in {Operation} ({Detail})", key, detail);
+        else
+            logger.LogError(exception, "Swallowed exception in {Operation}", key);
+    }
+
+    // Visible to tests so the threshold logic can be verified without sleeping.
+    internal static LogLevel SelectLogLevel(double elapsedMs) => elapsedMs switch
+    {
+        >= 30_000 => LogLevel.Error,
+        >= 15_000 => LogLevel.Warning,
+        >= 5_000  => LogLevel.Information,
+        >= 1_000  => LogLevel.Debug,
+        _         => LogLevel.None,
+    };
+
+    private static string DeriveClassName(string filePath)
+    {
+        var name = Path.GetFileNameWithoutExtension(filePath);
+        return string.IsNullOrEmpty(name) ? "Unknown" : name;
+    }
+}
+
+/// <summary>
+/// Disposable timer returned by <see cref="LoggerTimingExtensions.TimeOperation"/>.
+/// Seal as a class (not struct) so <c>using var</c> captures a reference that survives async continuations.
+/// </summary>
+public sealed class OperationTimer : IDisposable
+{
+    private readonly ILogger _logger;
+    private readonly string _key;
+    private readonly string? _detail;
+    private readonly Stopwatch _sw;
+    private bool _disposed;
+
+    internal OperationTimer(ILogger logger, string key, string? detail)
+    {
+        _logger = logger;
+        _key = key;
+        _detail = detail;
+        _sw = Stopwatch.StartNew();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _sw.Stop();
+        var elapsedMs = _sw.Elapsed.TotalMilliseconds;
+
+        OperationTimingRegistry.Instance.Record(_key, elapsedMs);
+
+        var level = LoggerTimingExtensions.SelectLogLevel(elapsedMs);
+        if (level == LogLevel.None) return;
+
+        if (_detail is not null)
+            _logger.Log(level, "{Operation} completed in {ElapsedMs:F1} ms ({Detail})", _key, elapsedMs, _detail);
+        else
+            _logger.Log(level, "{Operation} completed in {ElapsedMs:F1} ms", _key, elapsedMs);
+    }
+}

--- a/src/Humans.Infrastructure/Services/Anthropic/AnthropicClient.cs
+++ b/src/Humans.Infrastructure/Services/Anthropic/AnthropicClient.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Anthropic.Core;
 using Anthropic.Models.Messages;
 using Humans.Application.Configuration;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Application.Models;
 using Microsoft.Extensions.Logging;
@@ -33,6 +34,7 @@ public sealed class AnthropicClient : IAnthropicClient
         AnthropicRequest request,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        using var timer = _logger.TimeOperation();
         var sdkRequest = new MessageCreateParams
         {
             Model = request.Model,

--- a/src/Humans.Infrastructure/Services/GitHubLegalDocumentConnector.cs
+++ b/src/Humans.Infrastructure/Services/GitHubLegalDocumentConnector.cs
@@ -1,9 +1,10 @@
 using System.Text.RegularExpressions;
+using Humans.Application.Extensions;
+using Humans.Application.Configuration;
+using Humans.Application.Interfaces.Legal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Octokit;
-using Humans.Application.Configuration;
-using Humans.Application.Interfaces.Legal;
 
 namespace Humans.Infrastructure.Services;
 
@@ -47,6 +48,7 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
     public async Task<IReadOnlyDictionary<string, string>> DiscoverLanguageFilesAsync(
         string folderPath, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         var languageFiles = new Dictionary<string, string>(StringComparer.Ordinal);
 
         try
@@ -88,6 +90,7 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
 
     public async Task<GitHubFileContent?> GetFileContentAsync(string path, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         try
         {
             var contents = await _client.Repository.Content.GetAllContentsByRef(
@@ -117,6 +120,7 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
 
     public async Task<string?> GetCommitMessageAsync(string sha, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         try
         {
             var commit = await _client.Repository.Commit.Get(_settings.Owner, _settings.Repository, sha);
@@ -133,6 +137,7 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
 
     public async Task<string?> GetLatestCommitShaAsync(string path, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         try
         {
             var commits = await _client.Repository.Commit.GetAll(
@@ -152,6 +157,7 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
     public async Task<IReadOnlyDictionary<string, string>> GetFolderContentByPrefixAsync(
         string folderPath, string filePrefix, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         var files = await _client.Repository.Content.GetAllContents(
             _settings.Owner,
             _settings.Repository,

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDirectoryClient.cs
@@ -1,5 +1,6 @@
 using Google.Apis.Admin.Directory.directory_v1;
 using Google.Apis.Services;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,7 @@ public sealed class GoogleDirectoryClient(
 
     public async Task<DirectoryUserListResult> ListDomainUsersAsync(CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var service = await GetDirectoryServiceAsync(ct);
@@ -72,6 +74,7 @@ public sealed class GoogleDirectoryClient(
 
     public async Task<DirectoryGroupListResult> ListDomainGroupsAsync(CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var service = await GetDirectoryServiceAsync(ct);

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDriveActivityClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDriveActivityClient.cs
@@ -5,10 +5,11 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DriveActivity.v2;
 using Google.Apis.DriveActivity.v2.Data;
 using Google.Apis.Services;
+using Humans.Application.Extensions;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Humans.Infrastructure.Configuration;
-using Humans.Application.Interfaces.GoogleIntegration;
 
 namespace Humans.Infrastructure.Services.GoogleWorkspace;
 
@@ -38,6 +39,7 @@ public sealed class GoogleDriveActivityClient(
 
     public async Task<string> GetServiceAccountEmailAsync(CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         if (_serviceAccountEmailResolved && _serviceAccountEmail is not null)
         {
             return _serviceAccountEmail;
@@ -60,6 +62,7 @@ public sealed class GoogleDriveActivityClient(
 
     public async Task<string?> GetServiceAccountClientIdAsync(CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         if (_serviceAccountClientIdResolved)
         {
             return _serviceAccountClientId;
@@ -84,6 +87,7 @@ public sealed class GoogleDriveActivityClient(
         string sinceIsoTimestamp,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var activityService = await GetActivityServiceAsync();
         string? pageToken = null;
 
@@ -121,6 +125,7 @@ public sealed class GoogleDriveActivityClient(
 
     public async Task<string?> TryResolvePersonEmailAsync(string peopleId, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         if (!peopleId.StartsWith("people/", StringComparison.Ordinal))
         {
             // Already an email, no lookup needed.

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDrivePermissionsClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDrivePermissionsClient.cs
@@ -1,5 +1,6 @@
 using Google.Apis.Drive.v3;
 using Google.Apis.Services;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
@@ -42,6 +43,7 @@ public sealed class GoogleDrivePermissionsClient(
         string? parentFolderId,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var drive = await GetDriveServiceAsync(ct);
@@ -80,6 +82,7 @@ public sealed class GoogleDrivePermissionsClient(
         string fileId,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var drive = await GetDriveServiceAsync(ct);
@@ -128,6 +131,7 @@ public sealed class GoogleDrivePermissionsClient(
         string role,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var drive = await GetDriveServiceAsync(ct);
@@ -174,6 +178,7 @@ public sealed class GoogleDrivePermissionsClient(
         string permissionId,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var drive = await GetDriveServiceAsync(ct);
@@ -195,6 +200,7 @@ public sealed class GoogleDrivePermissionsClient(
         string fileId,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var drive = await GetDriveServiceAsync(ct);
@@ -227,6 +233,7 @@ public sealed class GoogleDrivePermissionsClient(
         bool disabled,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var drive = await GetDriveServiceAsync(ct);
@@ -253,6 +260,7 @@ public sealed class GoogleDrivePermissionsClient(
         string driveId,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var drive = await GetDriveServiceAsync(ct);

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleGroupMembershipClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleGroupMembershipClient.cs
@@ -1,6 +1,7 @@
 using Google.Apis.Admin.Directory.directory_v1;
 using Google.Apis.Admin.Directory.directory_v1.Data;
 using Google.Apis.Services;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
@@ -40,6 +41,7 @@ public sealed class GoogleGroupMembershipClient(
         string groupGoogleId,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var memberships = new List<GroupMembership>();
         string? pageToken = null;
 
@@ -88,6 +90,7 @@ public sealed class GoogleGroupMembershipClient(
         string memberEmail,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var directory = await GetDirectoryServiceAsync(ct);
@@ -127,6 +130,7 @@ public sealed class GoogleGroupMembershipClient(
         string membershipResourceName,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         // Resource name shape: groups/{groupKey}/memberships/{memberKey}.
         // The Directory delete needs the group and member keys separately.
         var parts = membershipResourceName.Split('/');

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleGroupProvisioningClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleGroupProvisioningClient.cs
@@ -2,6 +2,7 @@ using Google.Apis.CloudIdentity.v1;
 using Google.Apis.CloudIdentity.v1.Data;
 using Google.Apis.Groupssettings.v1;
 using Google.Apis.Services;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
@@ -35,6 +36,7 @@ public sealed class GoogleGroupProvisioningClient(
         string description,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var cloudIdentity = await GetCloudIdentityServiceAsync(ct);
@@ -115,6 +117,7 @@ public sealed class GoogleGroupProvisioningClient(
         string groupEmail,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var cloudIdentity = await GetCloudIdentityServiceAsync(ct);
@@ -139,6 +142,7 @@ public sealed class GoogleGroupProvisioningClient(
         string groupEmail,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var groupsSettings = await GetGroupsSettingsServiceAsync(ct);
@@ -163,6 +167,7 @@ public sealed class GoogleGroupProvisioningClient(
         GroupSettingsExpected expected,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var groupsSettings = await GetGroupsSettingsServiceAsync(ct);

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleTranslationClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleTranslationClient.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
@@ -26,6 +27,7 @@ public sealed class GoogleTranslationClient(
     public async Task<IReadOnlyList<string>> TranslateAsync(
         IReadOnlyList<string> texts, string sourceLanguage, string targetLanguage, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         if (texts.Count == 0) return [];
 
         var credential = await GoogleCredentialLoader.LoadScopedAsync(settings.Value, ct, Scope);

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/TeamResourceGoogleClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/TeamResourceGoogleClient.cs
@@ -3,6 +3,7 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudIdentity.v1;
 using Google.Apis.Drive.v3;
 using Google.Apis.Services;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,7 @@ public sealed class TeamResourceGoogleClient(
         bool expectFolder,
         CancellationToken ct = default)
     {
+        using var timer = logger.TimeOperation();
         _ = expectFolder; // Ignored: the real connector uses the MIME type returned by Drive.
         try
         {
@@ -65,6 +67,7 @@ public sealed class TeamResourceGoogleClient(
 
     public async Task<GroupLookupResult> LookupGroupAsync(string groupEmail, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         try
         {
             var cloudIdentity = await GetCloudIdentityServiceAsync(ct);
@@ -97,6 +100,7 @@ public sealed class TeamResourceGoogleClient(
 
     public async Task<string> GetServiceAccountEmailAsync(CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         if (_serviceAccountEmail is not null)
         {
             return _serviceAccountEmail;

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
@@ -2,9 +2,11 @@ using Google.Apis.Admin.Directory.directory_v1;
 using Google.Apis.Admin.Directory.directory_v1.Data;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
-using Microsoft.Extensions.Options;
-using Humans.Infrastructure.Configuration;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Humans.Infrastructure.Services.GoogleWorkspace;
 
@@ -14,8 +16,9 @@ namespace Humans.Infrastructure.Services.GoogleWorkspace;
 /// service account. This is the only file that imports <c>Google.Apis.*</c> for
 /// user-account management; the Application-layer service never sees SDK types.
 /// </summary>
-public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSettings> settings)
-    : IWorkspaceUserDirectoryClient
+public sealed class WorkspaceUserDirectoryClient(
+    IOptions<GoogleWorkspaceSettings> settings,
+    ILogger<WorkspaceUserDirectoryClient> logger) : IWorkspaceUserDirectoryClient
 {
     private readonly GoogleWorkspaceSettings _settings = settings.Value;
     private DirectoryService? _directoryService;
@@ -67,6 +70,7 @@ public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSetting
     public async Task<IReadOnlyList<WorkspaceUserAccount>> ListAccountsAsync(
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var service = await GetDirectoryServiceAsync();
         var accounts = new List<WorkspaceUserAccount>();
         string? pageToken = null;
@@ -99,6 +103,7 @@ public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSetting
     public async Task<WorkspaceUserAccount?> GetAccountAsync(
         string primaryEmail, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         // Users.Get() returns 403 for our service account, but Users.List() with
         // a query filter works. Use that to check if an account exists.
         var service = await GetDirectoryServiceAsync();
@@ -121,6 +126,7 @@ public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSetting
         string? recoveryEmail,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var service = await GetDirectoryServiceAsync();
 
         var newUser = new User
@@ -149,6 +155,7 @@ public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSetting
 
     public async Task SuspendAccountAsync(string primaryEmail, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var service = await GetDirectoryServiceAsync();
         var update = new User { Suspended = true };
         await service.Users.Update(update, primaryEmail).ExecuteAsync(ct);
@@ -156,6 +163,7 @@ public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSetting
 
     public async Task ReactivateAccountAsync(string primaryEmail, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var service = await GetDirectoryServiceAsync();
         var update = new User { Suspended = false };
         await service.Users.Update(update, primaryEmail).ExecuteAsync(ct);
@@ -164,6 +172,7 @@ public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSetting
     public async Task ResetPasswordAsync(
         string primaryEmail, string newPassword, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var service = await GetDirectoryServiceAsync();
         var update = new User
         {
@@ -176,6 +185,7 @@ public sealed class WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSetting
     public async Task<IReadOnlyList<string>> GenerateBackupCodesAsync(
         string primaryEmail, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var service = await GetDirectoryServiceAsync();
 
         // Generate issues a fresh set of codes. Google always issues 10 codes and

--- a/src/Humans.Infrastructure/Services/Holded/HoldedClient.cs
+++ b/src/Humans.Infrastructure/Services/Holded/HoldedClient.cs
@@ -1,6 +1,9 @@
 using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Holded;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 
@@ -10,13 +13,16 @@ public sealed class HoldedClient : IHoldedClient
 {
     private readonly HttpClient _http;
     private readonly HoldedClientOptions _options;
+    private readonly ILogger<HoldedClient> _logger;
 
     public HoldedClient(
         HttpClient http,
-        IOptions<HoldedClientOptions> options)
+        IOptions<HoldedClientOptions> options,
+        ILogger<HoldedClient> logger)
     {
         _http = http;
         _options = options.Value;
+        _logger = logger;
 
         if (_http.BaseAddress is null && !string.IsNullOrEmpty(_options.BaseUrl))
             _http.BaseAddress = new Uri(_options.BaseUrl);
@@ -259,8 +265,10 @@ public sealed class HoldedClient : IHoldedClient
         req.Headers.Add("key", _options.ApiKey);
 
     private async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage req, CancellationToken ct)
+        HttpRequestMessage req, CancellationToken ct,
+        [CallerMemberName] string caller = "")
     {
+        using var _ = _logger.TimeOperation(operation: caller);
         HttpResponseMessage resp;
         try
         {

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
 using Microsoft.Extensions.Logging;
@@ -257,8 +258,10 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
         => SendAsync(method, url, content: null, ct);
 
     private async Task<HttpResponseMessage> SendAsync(
-        HttpMethod method, string url, HttpContent? content, CancellationToken ct)
+        HttpMethod method, string url, HttpContent? content, CancellationToken ct,
+        [CallerMemberName] string caller = "")
     {
+        using var _ = logger.TimeOperation(operation: caller);
         var http = httpFactory.CreateClient(HttpClientName);
         using var req = new HttpRequestMessage(method, url);
         if (content is not null) req.Content = content;

--- a/src/Humans.Infrastructure/Services/StripeService.cs
+++ b/src/Humans.Infrastructure/Services/StripeService.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -76,6 +77,7 @@ public class StripeService(IOptions<StripeSettings> settings, ILogger<StripeServ
         string lineItemDescription,
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         if (amountEur <= 0)
             throw new ArgumentOutOfRangeException(nameof(amountEur), "Checkout amount must be positive.");
         if (!_settings.IsStoreCheckoutConfigured)
@@ -140,6 +142,7 @@ public class StripeService(IOptions<StripeSettings> settings, ILogger<StripeServ
     public async Task<StripePaymentDetails?> GetPaymentDetailsAsync(
         string paymentIntentId, CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         var client = new StripeClient(_settings.TicketsKey);
         var piService = new PaymentIntentService(client);
 
@@ -197,6 +200,7 @@ public class StripeService(IOptions<StripeSettings> settings, ILogger<StripeServ
 
     public StoreCheckoutWebhookEvent? ParseStoreCheckoutEvent(string body, string signature)
     {
+        using var _ = logger.TimeOperation();
         if (!_settings.IsStoreWebhookConfigured)
         {
             logger.LogWarning("Store webhook parse attempted while STRIPE_STORE_WEBHOOK_SECRET is unset.");
@@ -235,6 +239,7 @@ public class StripeService(IOptions<StripeSettings> settings, ILogger<StripeServ
     public async Task<IReadOnlyList<StoreCheckoutSessionData>?> ListStoreCheckoutSessionsAsync(
         CancellationToken ct = default)
     {
+        using var _ = logger.TimeOperation();
         if (!_settings.IsStoreCheckoutConfigured)
         {
             logger.LogWarning("Store Checkout Session list requested while STRIPE_STORE_KEY is unset; Stripe not queried.");

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using Humans.Application;
 using Humans.Application.Configuration;
 using Humans.Application.DTOs;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Tickets;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -57,6 +58,7 @@ public class TicketTailorService : ITicketVendorService
     public async Task<IReadOnlyList<VendorOrderDto>> GetOrdersAsync(
         Instant? since, string eventId, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         var orders = new List<VendorOrderDto>();
         string? cursor = null;
 
@@ -114,6 +116,7 @@ public class TicketTailorService : ITicketVendorService
     public async Task<IReadOnlyList<VendorTicketDto>> GetIssuedTicketsAsync(
         Instant? since, string eventId, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         var tickets = new List<VendorTicketDto>();
         string? cursor = null;
 
@@ -160,6 +163,7 @@ public class TicketTailorService : ITicketVendorService
     public async Task<VendorEventSummaryDto> GetEventSummaryAsync(
         string eventId, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         var cacheKey = CacheKeys.TicketEventSummary(eventId);
         if (_cache.TryGetValue<VendorEventSummaryDto>(cacheKey, out var cachedSummary) &&
             cachedSummary is not null)
@@ -205,6 +209,7 @@ public class TicketTailorService : ITicketVendorService
     public async Task<IReadOnlyList<string>> GenerateDiscountCodesAsync(
         DiscountCodeSpec spec, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         var codes = new List<string>();
         for (var i = 0; i < spec.Count; i++)
         {
@@ -233,6 +238,7 @@ public class TicketTailorService : ITicketVendorService
     public async Task<IReadOnlyList<DiscountCodeStatusDto>> GetDiscountCodeUsageAsync(
         IEnumerable<string> codes, CancellationToken ct = default)
     {
+        using var _ = _logger.TimeOperation();
         var results = new List<DiscountCodeStatusDto>();
 
         foreach (var code in codes)

--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -295,7 +295,7 @@ public class DebugController(
                 MinMs = Math.Round(t.MinMs, 2),
                 MaxMs = Math.Round(t.MaxMs, 2),
                 TotalMs = Math.Round(t.TotalMs, 2),
-                LastAtUtc = t.LastAtUtc,
+                LastAtUtc = t.LastAt.ToDateTimeUtc(),
             })
             .ToList();
 

--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -1,4 +1,5 @@
 using Humans.Application.Configuration;
+using Humans.Application.Diagnostics;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Admin;
 using Humans.Application.Interfaces.Caching;
@@ -276,6 +277,38 @@ public class DebugController(
             StatusCodes: statusRows);
 
         return View(vm);
+    }
+
+    [HttpGet("Timings")]
+    public IActionResult Timings()
+    {
+        var registry = OperationTimingRegistry.Instance;
+
+        var entries = registry.GetTimings()
+            .OrderByDescending(t => t.TotalMs)
+            .Select(t => new TimingEntryViewModel
+            {
+                Operation = t.Key,
+                Count = t.Count,
+                LastMs = Math.Round(t.LastMs, 2),
+                AvgMs = Math.Round(t.AvgMs, 2),
+                MinMs = Math.Round(t.MinMs, 2),
+                MaxMs = Math.Round(t.MaxMs, 2),
+                TotalMs = Math.Round(t.TotalMs, 2),
+                LastAtUtc = t.LastAtUtc,
+            })
+            .ToList();
+
+        var swallowed = registry.GetSwallowed()
+            .OrderByDescending(s => s.Count)
+            .Select(s => new SwallowedEntryViewModel
+            {
+                Operation = s.Key,
+                Count = s.Count,
+            })
+            .ToList();
+
+        return View(new TimingsViewModel { Entries = entries, Swallowed = swallowed });
     }
 
     [HttpGet("FormatGallery")]

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -346,3 +346,27 @@ public class AudienceSegmentationViewModel
     /// <summary>Currently selected event year filter, or null for all time.</summary>
     public int? SelectedYear { get; set; }
 }
+
+public class TimingsViewModel
+{
+    public List<TimingEntryViewModel> Entries { get; set; } = [];
+    public List<SwallowedEntryViewModel> Swallowed { get; set; } = [];
+}
+
+public class TimingEntryViewModel
+{
+    public string Operation { get; set; } = string.Empty;
+    public long Count { get; set; }
+    public double LastMs { get; set; }
+    public double AvgMs { get; set; }
+    public double MinMs { get; set; }
+    public double MaxMs { get; set; }
+    public double TotalMs { get; set; }
+    public DateTime LastAtUtc { get; set; }
+}
+
+public class SwallowedEntryViewModel
+{
+    public string Operation { get; set; } = string.Empty;
+    public long Count { get; set; }
+}

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -101,6 +101,7 @@ public static class AdminNavTree
             new("DB stats",        "Debug", "DbStats",       null, null, "fa-solid fa-database",            PolicyNames.AdminOnly),
             new("Cache stats",     "Debug", "CacheStats",    null, null, "fa-solid fa-bolt",                PolicyNames.AdminOnly),
             new("Client stats",    "Debug", "ClientStats",   null, null, "fa-solid fa-display",             PolicyNames.AdminOnly),
+            new("Timings",         "Debug", "Timings",       null, null, "fa-solid fa-stopwatch",           PolicyNames.AdminOnly),
             new("All users (debug)", "UsersAdminDebug", "Index", null, null, "fa-solid fa-bug-slash", PolicyNames.AdminOnly),
             new("Configuration",   "Debug", "Configuration", null, null, "fa-solid fa-gear",                PolicyNames.AdminOnly),
             new("Maintenance",     "Debug", "Maintenance",   null, null, "fa-solid fa-screwdriver-wrench",  PolicyNames.AdminOnly),

--- a/src/Humans.Web/Views/Debug/Timings.cshtml
+++ b/src/Humans.Web/Views/Debug/Timings.cshtml
@@ -1,0 +1,57 @@
+@using Humans.Web.Models.Tables
+@model TimingsViewModel
+@{
+    ViewData["Title"] = "Operation Timings";
+}
+
+<div class="page-head">
+    <div>
+        <h1 class="title">Operation Timings</h1>
+        <p class="sub">@Model.Entries.Count operation(s) recorded since last restart</p>
+    </div>
+    <div class="d-flex align-items-center gap-3">
+        <a asp-controller="Admin" asp-action="Index" class="btn btn-outline-secondary btn-sm">
+            <i class="fa-solid fa-arrow-left me-1"></i>Admin
+        </a>
+    </div>
+</div>
+
+@if (Model.Entries.Count == 0)
+{
+    <div class="alert alert-info">
+        <i class="fa-solid fa-info-circle me-1"></i>No timing data recorded yet. Use the app to generate data.
+    </div>
+}
+else
+{
+    var timingsTable = TableModel.For(Model.Entries)
+        .Column("Operation", r => r.Operation)
+        .Column("Count", r => r.Count, c => c.Number().End())
+        .Column("Last (ms)", r => r.LastMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
+        .Column("Avg (ms)", r => r.AvgMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
+        .Column("Min (ms)", r => r.MinMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
+        .Column("Max (ms)", r => r.MaxMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
+        .Column("Total (ms)", r => r.TotalMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
+        .Column("Last At (UTC)", r => r.LastAtUtc == default ? "—" : r.LastAtUtc.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture), c => c.End())
+        .Id("timingsTable")
+        .Build();
+    <partial name="_Table" model="timingsTable" />
+}
+
+<h2 class="h5 mt-4">Swallowed Exceptions</h2>
+@if (Model.Swallowed.Count == 0)
+{
+    <div class="alert alert-info">
+        <i class="fa-solid fa-info-circle me-1"></i>No swallowed exceptions recorded.
+    </div>
+}
+else
+{
+    var swallowedTable = TableModel.For(Model.Swallowed)
+        .RowCss(_ => "table-danger")
+        .Column("Operation", r => r.Operation)
+        .Column("Count", r => r.Count, c => c.Number().End())
+        .Id("swallowedTable")
+        .Build();
+    <partial name="_Table" model="swallowedTable" />
+}

--- a/src/Humans.Web/Views/Debug/Timings.cshtml
+++ b/src/Humans.Web/Views/Debug/Timings.cshtml
@@ -32,7 +32,7 @@ else
         .Column("Min (ms)", r => r.MinMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
         .Column("Max (ms)", r => r.MaxMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
         .Column("Total (ms)", r => r.TotalMs.ToString("F2", System.Globalization.CultureInfo.CurrentCulture), c => c.End())
-        .Column("Last At (UTC)", r => r.LastAtUtc == default ? "—" : r.LastAtUtc.ToString("yyyy-MM-dd HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture), c => c.End())
+        .Column("Last At (UTC)", r => r.LastAtUtc == default ? "—" : r.LastAtUtc.ToInvariantTimestamp(), c => c.End())
         .Id("timingsTable")
         .Build();
     <partial name="_Table" model="timingsTable" />

--- a/tests/Humans.Application.Tests/Diagnostics/OperationTimingRegistryTests.cs
+++ b/tests/Humans.Application.Tests/Diagnostics/OperationTimingRegistryTests.cs
@@ -1,0 +1,101 @@
+using AwesomeAssertions;
+using Humans.Application.Diagnostics;
+
+namespace Humans.Application.Tests.Diagnostics;
+
+public class OperationTimingRegistryTests
+{
+    [HumansFact]
+    public void Single_record_produces_correct_aggregates()
+    {
+        var reg = new OperationTimingRegistry();
+        reg.Record("Foo.Bar", 200.0);
+
+        var snapshots = reg.GetTimings();
+        snapshots.Should().HaveCount(1);
+
+        var s = snapshots[0];
+        s.Key.Should().Be("Foo.Bar");
+        s.Count.Should().Be(1);
+        s.TotalMs.Should().Be(200.0);
+        s.MinMs.Should().Be(200.0);
+        s.MaxMs.Should().Be(200.0);
+        s.LastMs.Should().Be(200.0);
+        s.AvgMs.Should().Be(200.0);
+    }
+
+    [HumansFact]
+    public void Multiple_records_accumulate_min_max_total_correctly()
+    {
+        var reg = new OperationTimingRegistry();
+        reg.Record("Op.Method", 100.0);
+        reg.Record("Op.Method", 300.0);
+        reg.Record("Op.Method", 200.0);
+
+        var s = reg.GetTimings()[0];
+        s.Count.Should().Be(3);
+        s.TotalMs.Should().Be(600.0);
+        s.MinMs.Should().Be(100.0);
+        s.MaxMs.Should().Be(300.0);
+        s.LastMs.Should().Be(200.0);
+        s.AvgMs.Should().Be(200.0);
+    }
+
+    [HumansFact]
+    public void Records_for_different_keys_are_isolated()
+    {
+        var reg = new OperationTimingRegistry();
+        reg.Record("A.X", 50.0);
+        reg.Record("B.Y", 150.0);
+
+        var timings = reg.GetTimings().ToDictionary(t => t.Key, StringComparer.Ordinal);
+        timings["A.X"].TotalMs.Should().Be(50.0);
+        timings["B.Y"].TotalMs.Should().Be(150.0);
+    }
+
+    [HumansFact]
+    public void Snapshot_is_immutable_from_subsequent_records()
+    {
+        var reg = new OperationTimingRegistry();
+        reg.Record("Key", 10.0);
+        var before = reg.GetTimings();
+
+        reg.Record("Key", 20.0);
+        var after = reg.GetTimings();
+
+        before[0].Count.Should().Be(1);
+        after[0].Count.Should().Be(2);
+    }
+
+    [HumansFact]
+    public void Swallowed_exception_counter_increments_per_key()
+    {
+        var reg = new OperationTimingRegistry();
+        reg.IncrementSwallowed("A.Method");
+        reg.IncrementSwallowed("A.Method");
+        reg.IncrementSwallowed("B.Other");
+
+        var swallowed = reg.GetSwallowed().ToDictionary(s => s.Key, StringComparer.Ordinal);
+        swallowed["A.Method"].Count.Should().Be(2);
+        swallowed["B.Other"].Count.Should().Be(1);
+    }
+
+    [HumansFact]
+    public void Concurrent_records_produce_consistent_count()
+    {
+        var reg = new OperationTimingRegistry();
+        const int iterations = 1000;
+
+        Parallel.For(0, iterations, i => reg.Record("Concurrent.Op", i));
+
+        var s = reg.GetTimings()[0];
+        s.Count.Should().Be(iterations);
+    }
+
+    [HumansFact]
+    public void Avg_ms_is_zero_on_empty_registry()
+    {
+        var snapshot = new OperationTimingSnapshot("K", 0, 0, 0, 0, 0, default);
+        snapshot.AvgMs.Should().Be(0);
+    }
+}

--- a/tests/Humans.Application.Tests/Extensions/LoggerTimingExtensionsTests.cs
+++ b/tests/Humans.Application.Tests/Extensions/LoggerTimingExtensionsTests.cs
@@ -1,0 +1,94 @@
+using AwesomeAssertions;
+using Humans.Application.Diagnostics;
+using Humans.Application.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Humans.Application.Tests.Extensions;
+
+public class LoggerTimingExtensionsTests
+{
+    // ── SelectLogLevel threshold coverage ──────────────────────────────────
+
+    [HumansTheory]
+    [InlineData(0,      LogLevel.None)]
+    [InlineData(999,    LogLevel.None)]
+    [InlineData(1000,   LogLevel.Debug)]
+    [InlineData(4999,   LogLevel.Debug)]
+    [InlineData(5000,   LogLevel.Information)]
+    [InlineData(14999,  LogLevel.Information)]
+    [InlineData(15000,  LogLevel.Warning)]
+    [InlineData(29999,  LogLevel.Warning)]
+    [InlineData(30000,  LogLevel.Error)]
+    [InlineData(60000,  LogLevel.Error)]
+    public void SelectLogLevel_maps_elapsed_to_expected_level(double ms, LogLevel expected)
+    {
+        LoggerTimingExtensions.SelectLogLevel(ms).Should().Be(expected);
+    }
+
+    // ── TimeOperation records into the registry ─────────────────────────────
+
+    [HumansFact]
+    public void TimeOperation_records_entry_under_derived_key()
+    {
+        var logger = NullLogger.Instance;
+        var registry = OperationTimingRegistry.Instance;
+
+        // Use the extension with an explicit operation + filePath to get a
+        // deterministic key without relying on CallerMemberName.
+        using (logger.TimeOperation(operation: "RecordingTestMethod", filePath: "/path/to/TestClass.cs"))
+        {
+            // body executes here
+        }
+
+        var timings = registry.GetTimings();
+        timings.Should().Contain(t => t.Key == "TestClass.RecordingTestMethod");
+    }
+
+    [HumansFact]
+    public void TimeOperation_increments_count_on_repeated_calls()
+    {
+        var logger = NullLogger.Instance;
+        var registry = OperationTimingRegistry.Instance;
+        const string op = "RepeatOp";
+        const string file = "/src/RepeatClass.cs";
+
+        using (logger.TimeOperation(operation: op, filePath: file)) { }
+        using (logger.TimeOperation(operation: op, filePath: file)) { }
+
+        var snapshot = registry.GetTimings()
+            .FirstOrDefault(t => string.Equals(t.Key, "RepeatClass.RepeatOp", StringComparison.Ordinal));
+        snapshot.Should().NotBeNull();
+        snapshot!.Count.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    // ── Eat increments swallowed counter ───────────────────────────────────
+
+    [HumansFact]
+    public void Eat_increments_swallowed_counter_in_registry()
+    {
+        var logger = NullLogger.Instance;
+        var registry = OperationTimingRegistry.Instance;
+
+        logger.Eat(
+            new InvalidOperationException("oops"),
+            operation: "EatTestMethod",
+            filePath: "/src/EatTestClass.cs");
+
+        var swallowed = registry.GetSwallowed();
+        swallowed.Should().Contain(s => s.Key == "EatTestClass.EatTestMethod" && s.Count >= 1);
+    }
+
+    // ── OperationTimer disposes correctly ──────────────────────────────────
+
+    [HumansFact]
+    public void OperationTimer_double_dispose_is_safe()
+    {
+        var logger = NullLogger.Instance;
+        var timer = logger.TimeOperation(operation: "DoubleDispose", filePath: "/src/SafeClass.cs");
+        timer.Dispose();
+        var act = timer.Dispose; // second dispose
+        act.Should().NotThrow();
+    }
+}

--- a/tests/Humans.Application.Tests/Extensions/LoggerTimingExtensionsTests.cs
+++ b/tests/Humans.Application.Tests/Extensions/LoggerTimingExtensionsTests.cs
@@ -12,16 +12,16 @@ public class LoggerTimingExtensionsTests
     // ── SelectLogLevel threshold coverage ──────────────────────────────────
 
     [HumansTheory]
-    [InlineData(0,      LogLevel.None)]
-    [InlineData(999,    LogLevel.None)]
-    [InlineData(1000,   LogLevel.Debug)]
-    [InlineData(4999,   LogLevel.Debug)]
-    [InlineData(5000,   LogLevel.Information)]
-    [InlineData(14999,  LogLevel.Information)]
-    [InlineData(15000,  LogLevel.Warning)]
-    [InlineData(29999,  LogLevel.Warning)]
-    [InlineData(30000,  LogLevel.Error)]
-    [InlineData(60000,  LogLevel.Error)]
+    [InlineData(0, LogLevel.None)]
+    [InlineData(999, LogLevel.None)]
+    [InlineData(1000, LogLevel.Debug)]
+    [InlineData(4999, LogLevel.Debug)]
+    [InlineData(5000, LogLevel.Information)]
+    [InlineData(14999, LogLevel.Information)]
+    [InlineData(15000, LogLevel.Warning)]
+    [InlineData(29999, LogLevel.Warning)]
+    [InlineData(30000, LogLevel.Error)]
+    [InlineData(60000, LogLevel.Error)]
     public void SelectLogLevel_maps_elapsed_to_expected_level(double ms, LogLevel expected)
     {
         LoggerTimingExtensions.SelectLogLevel(ms).Should().Be(expected);

--- a/tests/Humans.Application.Tests/Services/Holded/HoldedClientContactTests.cs
+++ b/tests/Humans.Application.Tests/Services/Holded/HoldedClientContactTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using AwesomeAssertions;
 using Humans.Application.Interfaces.Holded;
 using Humans.Infrastructure.Services.Holded;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
 
@@ -12,7 +13,8 @@ public class HoldedClientContactTests
 {
     private static HoldedClient Make(StubHandler handler) =>
         new(new HttpClient(handler) { BaseAddress = new Uri("https://api.holded.com") },
-            Options.Create(new HoldedClientOptions { ApiKey = "test-key" }));
+            Options.Create(new HoldedClientOptions { ApiKey = "test-key" }),
+            NullLogger<HoldedClient>.Instance);
 
     [HumansFact]
     public async Task GetContact_parses_supplierRecord_num()

--- a/tests/Humans.Application.Tests/Services/Holded/HoldedClientReadTests.cs
+++ b/tests/Humans.Application.Tests/Services/Holded/HoldedClientReadTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using AwesomeAssertions;
 using Humans.Infrastructure.Services.Holded;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
 
@@ -12,7 +13,8 @@ public class HoldedClientReadTests
     private static HoldedClient Make(StubHandler handler) =>
         new(
             new HttpClient(handler) { BaseAddress = new Uri("https://api.holded.com") },
-            Options.Create(new HoldedClientOptions { ApiKey = "test-key" }));
+            Options.Create(new HoldedClientOptions { ApiKey = "test-key" }),
+            NullLogger<HoldedClient>.Instance);
 
     [HumansFact]
     public async Task ListExpenseAccounts_parses_num_and_name()

--- a/tests/Humans.Application.Tests/Services/Holded/HoldedClientTests.cs
+++ b/tests/Humans.Application.Tests/Services/Holded/HoldedClientTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using AwesomeAssertions;
 using Humans.Application.Interfaces.Holded;
 using Humans.Infrastructure.Services.Holded;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
 
@@ -13,7 +14,8 @@ public class HoldedClientTests
     private static HoldedClient Make(StubHandler handler) =>
         new(
             new HttpClient(handler) { BaseAddress = new Uri("https://api.holded.com") },
-            Options.Create(new HoldedClientOptions { ApiKey = "test-key" }));
+            Options.Create(new HoldedClientOptions { ApiKey = "test-key" }),
+            NullLogger<HoldedClient>.Instance);
 
     [HumansFact]
     public async Task CreatePurchaseDocumentAsync_PostsExpectedJson_AndReturnsId()


### PR DESCRIPTION
## Summary

Operation-level timing for every external third-party call, surfaced on a new `/Debug/Timings` admin page — slow providers and swallowed failures become visible instead of anecdotal.

**`logger.TimeOperation()`** (`Humans.Application.Extensions.LoggerTimingExtensions`) — a `using var`-scoped timer keyed `{ClassName}.{Method}` via caller info. On dispose it records into the registry and logs with escalating severity: silent <1s, Debug ≥1s, Information ≥5s, Warning ≥15s, Error ≥30s. Threshold mapping is a pure internal function (`SelectLogLevel`) so tests don't sleep.

**`logger.Eat(exception)`** — for deliberately-swallowed exceptions: logs at Error and increments a per-operation counter, so "caught and ignored" failures still aggregate somewhere visible.

**`OperationTimingRegistry`** (`Humans.Application.Diagnostics`) — per-operation Count / Total / Min / Max / Last / LastAt aggregates plus swallowed-exception counters; thread-safe; `static Instance` following the `InMemoryLogSink.Instance` precedent. Application-layer because it's pure BCL and Infrastructure/Web both consume it.

## Call sites now timed

- **MailerLite** and **Holded** — at their private `SendAsync` choke points, with `[CallerMemberName]` pass-through so stats show the public method (e.g. `HoldedClient.CreatePurchaseDocumentAsync`)
- **Google Workspace** — all 8 clients (group provisioning/membership, Drive permissions/activity, directory ×2, team resources, translation), one `using var` per public method
- **Stripe**, **Ticket Tailor**, **GitHub legal docs**, **Anthropic** (streaming — timer spans full stream consumption)

`HoldedClient` and `WorkspaceUserDirectoryClient` gained `ILogger<T>` constructor parameters (resolved by existing DI registrations; Holded unit tests updated with `NullLogger`).

## Debug page

`/Debug/Timings` (AdminOnly, Diagnostics nav group, `fa-stopwatch`): operations table sorted by total time (Operation / Count / Last / Avg / Min / Max / Total / Last At) plus a swallowed-exceptions table. Follows the `DbStats`/`CacheStats` page idiom; sorting/rounding in the controller per the architecture rules.

## Test plan

- New: `OperationTimingRegistryTests` (aggregates, key isolation, snapshot immutability, swallowed counts, Parallel.For concurrency smoke) and `LoggerTimingExtensionsTests` (all threshold cases, key derivation, repeat counts, Eat, double-dispose).
- `dotnet build Humans.slnx -v quiet` — clean
- `dotnet test` (minus Integration): 4,155 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
