### PR TITLE
docs(guide): accuracy review of the member guide corpus

### DIFF
--- a/docs/features/governance/membership-tiers.md
+++ b/docs/features/governance/membership-tiers.md
@@ -78,11 +78,11 @@ Volunteer is the default tier for everyone. No badge is displayed for Volunteers
 - User retains current tier/access while application is pending
 - On approval, tier is upgraded; on rejection, stays at current tier
 
-### US-15.3: View Tier Status
+### US-15.3: View My Tier and Application
 
 **As a** human
 **I want to** see my current tier and any pending application
-**So that** I understand my standing
+**So that** I know where my application stands
 
 **Acceptance Criteria:**
 - Dashboard shows Colaborador/Asociado badge if applicable (no badge for Volunteer)

--- a/docs/guide/AiHelper.md
+++ b/docs/guide/AiHelper.md
@@ -27,7 +27,8 @@ have to use it, and everything in the app works without it.
   up, transfer your ticket, or edit your profile behind your back.
 - It's only there when you're **signed in**. Signed-out visitors don't see it.
 - It's not a person. It's usually right, but if something matters, double-check
-  with your coordinator or [humans@nobodies.team](mailto:humans@nobodies.team).
+  with your coordinator or in [#🧘-humans-app](https://discord.gg/fq7gr29p) on
+  Discord.
 
 ## Is it private?
 
@@ -51,7 +52,7 @@ Worth knowing, in plain terms:
 | Do I have to use it? | No — it's optional, and the app works fine without it |
 | Will it do things for me? | No. It can tee things up, but you press the button |
 | Can it see my stuff? | It knows your account so it can help (your teams, shifts, tickets, to-dos). It can't see your passwords |
-| It gave me a wrong answer | It happens — check with your coordinator or email [humans@nobodies.team](mailto:humans@nobodies.team) |
+| It gave me a wrong answer | It happens — check with your coordinator, or file an issue via the same help button so it gets fixed |
 | I'd rather just report a bug | Same help button → "Create issue" (or "Feedback") files it for the team |
 
 ## Related

--- a/docs/guide/AiHelper.md
+++ b/docs/guide/AiHelper.md
@@ -1,9 +1,10 @@
 # The in-app AI helper
 
 See the round **help button** in the bottom-right corner of the app (it's got a
-question mark on it)? Tap it and you'll get two choices: **report a problem**, or
-**talk with the AI helper** — a friendly chat assistant that can answer questions
-about the app and your account.
+question mark on it)? Tap it and you'll get a short menu: **talk with the AI
+helper** — a friendly chat assistant that can answer questions about the app and
+your account — plus **create an issue** and **send feedback** for when something's
+broken or you have an idea.
 
 Think of it as someone who has read this whole guide and knows your account, who
 you can ask things in plain words like *"how do I sign up for a shift?"* or
@@ -51,7 +52,7 @@ Worth knowing, in plain terms:
 | Will it do things for me? | No. It can tee things up, but you press the button |
 | Can it see my stuff? | It knows your account so it can help (your teams, shifts, tickets, to-dos). It can't see your passwords |
 | It gave me a wrong answer | It happens — check with your coordinator or email [humans@nobodies.team](mailto:humans@nobodies.team) |
-| I'd rather just report a bug | Same help button → "report a problem" fills out an issue for the team |
+| I'd rather just report a bug | Same help button → "Create issue" (or "Feedback") files it for the team |
 
 ## Related
 

--- a/docs/guide/Camps.md
+++ b/docs/guide/Camps.md
@@ -115,6 +115,6 @@ If you are a **Camp Lead**, you can manage your specific camp. You cannot edit c
 ## Related sections
 
 - [Profiles](Profiles.md) — camp leads are linked to human accounts; a valid profile is required to be a lead.
-- [Governance](Governance.md) — Colaborador application is the prerequisite for becoming a camp lead.
+- [Governance](Governance.md) — many camp leads are also Colaboradores, but tier status is not a system requirement for registering or leading a camp.
 - [City Planning](CityPlanning.md) — what happens to the placement data your camp profile feeds in.
 - [Glossary](Glossary.md) — definitions for "barrio", "season", "Camp Lead", "sound zone", and other camp terms.

--- a/docs/guide/Camps.md
+++ b/docs/guide/Camps.md
@@ -115,6 +115,6 @@ If you are a **Camp Lead**, you can manage your specific camp. You cannot edit c
 ## Related sections
 
 - [Profiles](Profiles.md) — camp leads are linked to human accounts; a valid profile is required to be a lead.
-- [Governance](Governance.md) — many camp leads are also Colaboradores, but tier status is not a system requirement for registering or leading a camp.
+- [Governance](Governance.md) — many camp leads are also Colaboradores, but that is not a system requirement for registering or leading a camp.
 - [City Planning](CityPlanning.md) — what happens to the placement data your camp profile feeds in.
 - [Glossary](Glossary.md) — definitions for "barrio", "season", "Camp Lead", "sound zone", and other camp terms.

--- a/docs/guide/Camps.md
+++ b/docs/guide/Camps.md
@@ -109,7 +109,7 @@ If you are a **Camp Lead**, you can manage your specific camp. You cannot edit c
 | City Planning / Placement | Melo — via Discord or the city planning channel |
 | Water, LNT, power obligations | Barrio Support — comms go out via Humans to camp leads |
 | Barrio store / purchasing | Production & Logistics — [daniela@nobodies.team](mailto:daniela@nobodies.team) |
-| App issues | [humans@nobodies.team](mailto:humans@nobodies.team) |
+| App issues | The in-app help button (AI helper / file an issue); [humans@nobodies.team](mailto:humans@nobodies.team) only as a last resort |
 | General questions | [#🎪-barrios](https://discord.gg/rBZxDv8z) on Discord |
 
 ## Related sections

--- a/docs/guide/CityPlanning.md
+++ b/docs/guide/CityPlanning.md
@@ -64,6 +64,6 @@ Map admin access is held by **Camp Admin**, **[Admin](Glossary.md#admin)**, and 
 
 ## Related sections
 
-- [Camps](Camps.md) — `CampSeason` is the anchor entity; placement requires an approved camp season for the current year, and Primary/Co-Leads are the ones allowed to edit that camp's polygon.
+- [Camps](Camps.md) — `CampSeason` is the anchor entity; placement requires an approved camp season for the current year, and the camp's leads are the ones allowed to edit that camp's polygon.
 - [Teams](Teams.md) — membership in the City Planning team (slug `city-planning`) grants map admin access without needing a global Camp Admin or Admin role.
 - [Glossary](Glossary.md) — definitions for "barrio", "sound zone", "limit zone", and related terms.

--- a/docs/guide/CityPlanning.md
+++ b/docs/guide/CityPlanning.md
@@ -16,7 +16,7 @@
 
 ## What this section is for
 
-City Planning is an interactive aerial map where [camps](Glossary.md#barrio) stake out their physical footprint before the event. Camp leads draw a polygon for their own [barrio](Glossary.md#barrio) during the placement phase; everyone else sees the evolving layout live, color-coded by [sound zone](Glossary.md#sound-zone). Map admins manage the placement lifecycle, upload overlays (site boundary, official zones), and export placements as GeoJSON.
+City Planning is an interactive aerial map where [camps](Glossary.md#barrio) stake out their physical footprint before the event. Camp leads draw their own [barrio](Glossary.md#barrio)'s placement during the placement phase; everyone else sees the evolving layout live, color-coded by [sound zone](Glossary.md#sound-zone). Map admins manage the placement lifecycle, upload overlays (site boundary, official zones), and export placements as GeoJSON.
 
 Three entities back this section: `CityPlanningSettings` (per-year singleton, controls whether placement is open and holds overlay GeoJSON), `CampPolygon` (one polygon per camp season), and `CampPolygonHistory` (append-only audit trail of every save and restore).
 
@@ -35,35 +35,35 @@ An API under `/api/city-planning/` and a SignalR hub at `/hubs/city-planning` po
 
 Anyone signed in can open the map and watch it evolve:
 
-- **View the map** at [/CityPlanning](/CityPlanning). Every placed barrio shows its name label and sound-zone color. Polygons outside the limit zone get a red crosshatch; overlaps with another camp get orange dashed stripes; both prepend a warning indicator to the label.
-- **Find your camp.** If you lead a camp that has been placed, your polygon draws with a heavier outline and more opaque fill so it stands out.
-- **See who else is on the map.** Other humans' cursors appear live as they move. When anyone saves a polygon the map updates for everyone — no refresh needed.
+- **View the map** at [/CityPlanning](/CityPlanning). Every placed barrio shows its name label and sound-zone color. Placements outside the limit zone get a red crosshatch; overlaps with another camp get orange dashed stripes; both prepend a warning indicator to the label.
+- **Find your camp.** If you lead a camp that has been placed, your placement draws with a heavier outline and more opaque fill so it stands out.
+- **See who else is on the map.** Other humans' cursors appear live as they move. When anyone saves a placement the map updates for everyone — no refresh needed.
 - **Check the placement phase.** A card shows whether placement is open or closed, and a help modal lists the scheduled open and close dates (informational, Spain time).
 
 If you are a **Camp Lead** and placement is open, you also get tools to place and adjust your own barrio:
 
-- **Place your barrio.** Enter edit mode for your camp, draw the polygon, and save. Area and edge lengths update live while you draw.
-- **Adjust an existing polygon.** Move vertices, reshape, or reposition. Saving writes a history entry with the note "Saved".
+- **Place your barrio.** Enter edit mode for your camp, draw your placement on the map, and save. Area and edge lengths update live while you draw.
+- **Adjust an existing placement.** Move corners, reshape, or reposition. Saving writes a history entry with the note "Saved".
 - **View history.** The offcanvas lists every prior version with timestamp and the human who made the change.
 
-You can only edit your own camp's polygon, and only while placement is open. To change it after placement closes, ask a map admin.
+You can only edit your own camp's placement, and only while placement is open. To change it after placement closes, ask a map admin.
 
 ## As a Board member / Admin (Camp Admin)
 
-Map admin access is held by **Camp Admin**, **[Admin](Glossary.md#admin)**, and members of the **City Planning team** (slug `city-planning`). Map admins act on any polygon at any time — the placement-open restriction doesn't apply to you.
+Map admin access is held by **Camp Admin**, **[Admin](Glossary.md#admin)**, and members of the **City Planning team** (slug `city-planning`). Map admins act on any placement at any time — the placement-open restriction doesn't apply to you.
 
-- **Edit any camp's polygon.** Draw, reshape, or move any polygon regardless of who leads the camp and regardless of placement phase.
-- **Place on behalf of a camp.** The admin dropdown lists camp seasons without a polygon; pick one to start drawing.
-- **Restore a prior version.** From a polygon's history, choose a past version and restore. The current state writes to history first with the note "Restored from {timestamp}", then the polygon is overwritten. History is append-only — nothing is ever lost.
+- **Edit any camp's placement.** Draw, reshape, or move any placement regardless of who leads the camp and regardless of placement phase.
+- **Place on behalf of a camp.** The admin dropdown lists camp seasons without a placement; pick one to start drawing.
+- **Restore a prior version.** From a placement's history, choose a past version and restore. The current state writes to history first with the note "Restored from {timestamp}", then the placement is overwritten. History is append-only — nothing is ever lost.
 - **Toggle placement.** From [/CityPlanning/Admin](/CityPlanning/Admin), open or close placement. Timestamps are recorded. Closing blocks camp leads from editing but not you.
 - **Set informational placement dates.** Scheduled open and close datetimes show in the help modal. They do not auto-open or auto-close the phase.
-- **Upload a limit zone.** A GeoJSON FeatureCollection defining the site boundary. Renders as a dashed outline coloured by each feature's `SoundZone` property (white dashes when the property is absent); polygons drawn outside it are flagged. Download and delete are supported.
+- **Upload a limit zone.** A GeoJSON FeatureCollection defining the site boundary. Renders as a dashed outline coloured by each feature's `SoundZone` property (white dashes when the property is absent); placements drawn outside it are flagged. Download and delete are supported.
 - **Upload official zones.** A GeoJSON FeatureCollection of named read-only overlay zones (dark gray, labeled). Each Feature needs a `name` property. Download and delete supported.
-- **Export all placements.** Download every polygon for a year as a single GeoJSON FeatureCollection for logistics, signage, and public materials.
-- **Import placements.** Upload a GeoJSON FeatureCollection to bulk-update polygons. The admin panel previews matched and unrecognized features before you confirm; matched camps are updated through the same save path as a manual edit (so each import row writes a history entry).
+- **Export all placements.** Download every placement for a year as a single GeoJSON FeatureCollection for logistics, signage, and public materials.
+- **Import placements.** Upload a GeoJSON FeatureCollection to bulk-update placements. The admin panel previews matched and unrecognized features before you confirm; matched camps are updated through the same save path as a manual edit (so each import row writes a history entry).
 
 ## Related sections
 
-- [Camps](Camps.md) — `CampSeason` is the anchor entity; placement requires an approved camp season for the current year, and the camp's leads are the ones allowed to edit that camp's polygon.
+- [Camps](Camps.md) — `CampSeason` is the anchor entity; placement requires an approved camp season for the current year, and the camp's leads are the ones allowed to edit that camp's placement.
 - [Teams](Teams.md) — membership in the City Planning team (slug `city-planning`) grants map admin access without needing a global Camp Admin or Admin role.
 - [Glossary](Glossary.md) — definitions for "barrio", "sound zone", "limit zone", and related terms.

--- a/docs/guide/Email.md
+++ b/docs/guide/Email.md
@@ -24,7 +24,9 @@ different things both get called "email" and people mix them up constantly,
 so it's worth keeping them straight:
 
 1. **Personal mailboxes** — `yourname@nobodies.team`. A full Workspace account
-   with its own inbox, archive, and password. One per [human](Glossary.md#human).
+   with its own inbox, archive, and password. Granted to a
+   [human](Glossary.md#human) when their role or data access needs one — not
+   to everyone.
 2. **Group emails** — `teamname@nobodies.team`. A shared address that fans
    out to every member of a [team](Glossary.md#team). Not an inbox you log
    into by default; some teams may also have a single shared inbox they all
@@ -68,11 +70,18 @@ not the person.
 
 ### Assign a `@nobodies.team` address to someone on your team
 
-If a member of your team doesn't have a `@nobodies.team` address yet, you
-can provision one for them from your team's members page
-(`/Teams/{slug}/Members`) — you choose the address prefix as part of the
-flow. If you can't find it, use the round help button (bottom right) or email
-[humans@nobodies.team](mailto:humans@nobodies.team).
+If a member of your team needs a `@nobodies.team` address, you can provision
+one for them from your team's members page (`/Teams/{slug}/Members`) — you
+choose the address prefix as part of the flow. If you can't find it, use the
+round help button (bottom right).
+
+> **Provision on need, not by default.** Grant an address when the person's
+> role calls for it (externally facing, coordinating) or they're handling
+> other humans' personal data — not as a perk. It carries required 2FA, and
+> once provisioned it becomes their primary account for everything they do
+> through Humans (Drive, group email). Make sure they know what they're
+> taking on — point them at
+> [Your `@nobodies.team` email](EmailAccount.md#before-you-take-one-on).
 
 ### Group email membership follows team membership
 

--- a/docs/guide/Email.md
+++ b/docs/guide/Email.md
@@ -69,9 +69,9 @@ not the person.
 ### Assign a `@nobodies.team` address to someone on your team
 
 If a member of your team doesn't have a `@nobodies.team` address yet, you
-can assign one for them from the Humans app. The flow lives on the human's
-profile admin page; if you can't find it, ask in the app's feedback button
-(three dots in a speech bubble, bottom right) or email
+can provision one for them from your team's members page
+(`/Teams/{slug}/Members`) — you choose the address prefix as part of the
+flow. If you can't find it, use the round help button (bottom right) or email
 [humans@nobodies.team](mailto:humans@nobodies.team).
 
 ### Group email membership follows team membership

--- a/docs/guide/EmailAccount.md
+++ b/docs/guide/EmailAccount.md
@@ -1,9 +1,9 @@
 # Your `@nobodies.team` email
 
-Everyone who volunteers gets their own email address that ends in
-`@nobodies.team` — for example `rosa@nobodies.team`. It's a real, full email
-account (it's Google underneath, so it looks and works just like Gmail). It's
-yours for as long as you're active with us.
+Volunteers can get their own email address ending in `@nobodies.team` — for
+example `rosa@nobodies.team`. It's a real, full email account (it's Google
+underneath, so it looks and works just like Gmail). It's yours for as long as
+you're active with us.
 
 The short version: **use your `@nobodies.team` address for anything to do with
 the org**, and keep your personal email for your personal life. That way the
@@ -13,13 +13,12 @@ private inbox.
 
 ## How to get one
 
-- **Signed up recently?** You were asked which address you'd like
-  (`firstname@…`, `firstname.lastname@…`, or similar) and it was set up for you
-  automatically.
-- **Been around a while and don't have one yet?** Just ask. Your team
-  coordinator can set one up for you from the app, or you can use the help
-  button (the round button, bottom-right of any page) or email
-  [humans@nobodies.team](mailto:humans@nobodies.team).
+Accounts are set up for you — there's nothing to do yourself. Your team
+coordinator can create one from your team's page in the app (they pick the
+address with you, e.g. `firstname@…` or `firstname.lastname@…`), and admins
+can do the same. If you don't have one yet, just ask your coordinator, use the
+help button (the round button, bottom-right of any page), or email
+[humans@nobodies.team](mailto:humans@nobodies.team).
 
 ## Signing in for the first time
 

--- a/docs/guide/EmailAccount.md
+++ b/docs/guide/EmailAccount.md
@@ -1,24 +1,44 @@
 # Your `@nobodies.team` email
 
-Volunteers can get their own email address ending in `@nobodies.team` — for
+Some volunteers have their own email address ending in `@nobodies.team` — for
 example `rosa@nobodies.team`. It's a real, full email account (it's Google
 underneath, so it looks and works just like Gmail). It's yours for as long as
 you're active with us.
 
-The short version: **use your `@nobodies.team` address for anything to do with
-the org**, and keep your personal email for your personal life. That way the
-right people can reach you, and when someone hands a job on to the next person,
-the email history goes with the role instead of getting lost in someone's
-private inbox.
+These accounts aren't handed out to everyone. They're granted where there's an
+**actual use** for one: your role needs it (coordinating, externally facing —
+ticketing, comms, production), or you're handling other humans' personal data.
+
+If you have one, the short version is: **use your `@nobodies.team` address for
+anything to do with the org**, and keep your personal email for your personal
+life. That way the right people can reach you, and when someone hands a job on
+to the next person, the email history goes with the role instead of getting
+lost in someone's private inbox.
+
+## Before you take one on
+
+An account comes with real responsibility, so know what you're signing up for:
+
+- **Two-step verification is required** — genuine sign-in friction you'll live
+  with from day one (see [Two-step verification](TwoStepVerification.md)).
+- **It becomes your primary account for everything you do through Humans** —
+  the app uses it as your Google service email, so every team's Drive folders
+  and group emails flow through it from then on.
+- **You'll be running two email accounts side by side.** Chrome handles
+  multiple accounts well, but if you're not used to juggling accounts, be wary
+  — it's easy to miss things in the inbox you don't check.
+
+If your role doesn't need one, you're not missing out: the app and your team's
+emails work fine with your personal address.
 
 ## How to get one
 
-Accounts are set up for you — there's nothing to do yourself. Your team
-coordinator can create one from your team's page in the app (they pick the
-address with you, e.g. `firstname@…` or `firstname.lastname@…`), and admins
-can do the same. If you don't have one yet, just ask your coordinator, use the
-help button (the round button, bottom-right of any page), or email
-[humans@nobodies.team](mailto:humans@nobodies.team).
+Accounts are set up for you — there's nothing to do yourself. If your role
+needs one, your team coordinator can create it from your team's page in the
+app (they pick the address with you, e.g. `firstname@…` or
+`firstname.lastname@…`), and admins can do the same. Unsure whether your role
+qualifies? Ask your coordinator, or use the help button (the round button,
+bottom-right of any page).
 
 ## Signing in for the first time
 
@@ -78,12 +98,12 @@ like that for your team, ask your coordinator whether it's set up.
 
 | If you're wondering… | Here's the answer |
 |---|---|
-| I never got my `@nobodies.team` details | Ask your coordinator (they can set one up), or use the help button in the app, or email [humans@nobodies.team](mailto:humans@nobodies.team) |
+| I never got my `@nobodies.team` details | They're granted where a role needs one, not to everyone. If yours does, ask your coordinator (they can set one up) or use the help button in the app |
 | I forgot my password | Go to [accounts.google.com](https://accounts.google.com), choose "forgot password", and use your `@nobodies.team` address |
 | Can I just use my normal Gmail? | For personal things, sure. For anything org-related (vendors, other teams, the wider community), please use your `@nobodies.team` address |
 | What's my team's shared address? | It's on your team's page in the app, or ask your coordinator |
-| I'm not getting the team's emails | First check with your coordinator that you're actually on the team in the app. If you are and they're still not arriving, use the help button or email [humans@nobodies.team](mailto:humans@nobodies.team) |
-| I don't have a Google account of my own | You don't need one to use the app — any email works to sign in. You still get a `@nobodies.team` address as part of joining |
+| I'm not getting the team's emails | First check with your coordinator that you're actually on the team in the app. If you are and they're still not arriving, use the help button; [humans@nobodies.team](mailto:humans@nobodies.team) is the last resort |
+| I don't have a Google account of my own | You don't need one to use the app — any email works to sign in. A `@nobodies.team` address only enters the picture if your role needs one |
 
 ## Related
 

--- a/docs/guide/GettingStarted.md
+++ b/docs/guide/GettingStarted.md
@@ -1,12 +1,12 @@
 # Getting Started
 
-This page walks you through your first session in the Humans app: signing up, completing your profile, consenting to the legal documents, and finding your way around. Three steps take you from a new account to an active [Volunteer](Glossary.md#volunteer) with the full app unlocked: sign up, complete your profile (your legal name is the key field), and consent to the legal documents. Everything is self-service and automatic — a [Consent Coordinator](Glossary.md#consent-coordinator) reviews new signups afterwards as an audit check, but that review never holds up your access.
+This page walks you through your first session in the Humans app: signing up, completing your profile, consenting to the legal documents, and finding your way around. Three steps take you from a new account to an active [Volunteer](Glossary.md#volunteer) with the full app unlocked: sign up, complete your profile (your legal name is the key field), and consent to the legal documents. Everything is self-service and automatic.
 
 ## 1. Sign up
 
 Go to `/Account/Login`. You have two ways in:
 
-- **Sign in with Google.** Your display name and picture come across automatically. If your email was already imported from a mailing list, Google sign-in claims that existing record rather than creating a duplicate.
+- **Sign in with Google.** Your display name comes across automatically. If your email was already imported from a mailing list, Google sign-in claims that existing record rather than creating a duplicate.
 - **Email me a login link.** Type your address and the system mails you a one-time magic link that expires in 15 minutes. If you do not have an account yet, the same flow creates one and asks you to pick a display name.
 
 If you land on `/Guest`, that means you are signed in but have no profile yet — step 2 is next. The full signup pipeline is documented in [Onboarding](Onboarding.md). Can't get in, or stuck on the login link? See [Signing in & getting unstuck](SigningIn.md).
@@ -16,7 +16,7 @@ If you land on `/Guest`, that means you are signed in but have no profile yet �
 Open `/Profile/Me/Edit` (the Home dashboard also nudges you here via its Getting Started checklist). You fill in:
 
 - Your name, pronouns, city, country, bio, and birthday (month and day).
-- A profile picture, if you want one that is not your Google avatar.
+- A profile picture, if you want one.
 - Any contact fields you want to share — Phone, Signal, Telegram, WhatsApp, Discord, or a custom "Other" handle. Each field has its own **visibility** setting: Board only, Coordinators and Board, My teams, or All active humans. You pick one per field when you add it.
 - An emergency contact (optional, recommended).
 - Your skills and shift preferences (you'll be nudged through `/Profile/Me/ShiftInfo` separately). **Fill these in honestly and fully** — coordinators search by skill to find the right person for a role, so a thin profile is harder to place.
@@ -29,13 +29,11 @@ Go to `/Consent`. You see the documents that apply to everyone, grouped by the V
 
 Your signature is written as an immutable record: the document version, a hash of the exact text, the timestamp, your IP, and your browser. Nobody can edit or delete that entry afterwards — not Admin, not the database owner. That is what makes the audit trail worth something.
 
-Once every required document is signed, your record lands in the Consent Coordinator review queue. Profile completion and consent run in parallel — you can do them in either order. See [Legal and Consent](LegalAndConsent.md) for the full picture.
+Profile completion and consent run in parallel — you can do them in either order. See [Legal and Consent](LegalAndConsent.md) for the full picture.
 
 ## 4. You're a Volunteer
 
-Entering your legal name is what opens the app, and once you have also signed every required document, the scheduled sync adds you to the Volunteers system team automatically — no manual step, no waiting on a person.
-
-A Consent Coordinator then reviews your record and either **clears** it or **flags** it. That review is an audit check, not a gate: it doesn't hold up your access or your Volunteers membership. A flag is a note for the Board or an Admin to follow up on; only suspension or a rejected signup actually removes access.
+Entering your legal name is what opens the app, and once you have also signed every required document, the scheduled sync adds you to the Volunteers system team automatically — no manual step, no waiting on a person. (Only suspension or a rejected signup removes access.)
 
 If an Admin has provisioned a `@nobodies.team` Google Workspace account for you, you also get a credentials email at your personal address with a temporary password and a 2FA setup prompt. That address then becomes your Google service email for every team you join. Teams with linked Google Groups or [Shared Drive](Glossary.md#shared-drive) folders grant you access on the next sync. See [Your `@nobodies.team` email](EmailAccount.md) for how the mailbox works and how to use your team's group address, and [Two-step verification (2FA)](TwoStepVerification.md) for that required sign-in step. [Email](Email.md) and [Google Integration](GoogleIntegration.md) cover the fuller reference and the sync mechanics underneath.
 
@@ -78,7 +76,7 @@ If an Admin has provisioned a `@nobodies.team` Google Workspace account for you,
 | [volunteers@nobodies.team](mailto:volunteers@nobodies.team) | General volunteer queries, finding a role |
 | [tickets@nobodies.team](mailto:tickets@nobodies.team) | Ticket questions |
 | [inclusion@nobodies.team](mailto:inclusion@nobodies.team) | Accessibility and low-income ticket programme |
-| [humans@nobodies.team](mailto:humans@nobodies.team) | Technical issues with the app or your `@nobodies.team` account |
+| [humans@nobodies.team](mailto:humans@nobodies.team) | **Last resort** for app or `@nobodies.team` account issues — use the in-app help button and Discord first |
 | [#🤝-recruitment-relationships](https://discord.gg/pcq2DRH6) on Discord | Quick questions and connecting with the team |
 | [#🧘-humans-app](https://discord.gg/fq7gr29p) on Discord | Humans app feedback and bug reports |
 

--- a/docs/guide/GettingStarted.md
+++ b/docs/guide/GettingStarted.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This page walks you through your first session in the Humans app: signing up, completing your profile, consenting to the legal documents, and finding your way around. Four steps take you from a new account to an active [Volunteer](Glossary.md#volunteer) with the full app unlocked: sign up, complete your profile, consent to the legal documents, and wait for a [Consent Coordinator](Glossary.md#consent-coordinator) to clear you. Everything on this page is self-service; the only place another [human](Glossary.md#human) gets involved is the safety check at the end.
+This page walks you through your first session in the Humans app: signing up, completing your profile, consenting to the legal documents, and finding your way around. Three steps take you from a new account to an active [Volunteer](Glossary.md#volunteer) with the full app unlocked: sign up, complete your profile (your legal name is the key field), and consent to the legal documents. Everything is self-service and automatic — a [Consent Coordinator](Glossary.md#consent-coordinator) reviews new signups afterwards as an audit check, but that review never holds up your access.
 
 ## 1. Sign up
 
@@ -9,7 +9,7 @@ Go to `/Account/Login`. You have two ways in:
 - **Sign in with Google.** Your display name and picture come across automatically. If your email was already imported from a mailing list, Google sign-in claims that existing record rather than creating a duplicate.
 - **Email me a login link.** Type your address and the system mails you a one-time magic link that expires in 15 minutes. If you do not have an account yet, the same flow creates one and asks you to pick a display name.
 
-If you land on `/GuestDashboard`, that means you are signed in but have no profile yet — step 2 is next. The full signup pipeline is documented in [Onboarding](Onboarding.md). Can't get in, or stuck on the login link? See [Signing in & getting unstuck](SigningIn.md).
+If you land on `/Guest`, that means you are signed in but have no profile yet — step 2 is next. The full signup pipeline is documented in [Onboarding](Onboarding.md). Can't get in, or stuck on the login link? See [Signing in & getting unstuck](SigningIn.md).
 
 ## 2. Complete your profile
 
@@ -17,7 +17,7 @@ Open `/Profile/Me/Edit` (the Home dashboard also nudges you here via its Getting
 
 - Your name, pronouns, city, country, bio, and birthday (month and day).
 - A profile picture, if you want one that is not your Google avatar.
-- Any contact fields you want to share — Phone, Signal, Telegram, WhatsApp, Discord, or a custom "Other" handle. Each field has its own **visibility** setting: Board only, Coordinators and Board, My teams, or All active humans. Pick per field; the default is All active humans.
+- Any contact fields you want to share — Phone, Signal, Telegram, WhatsApp, Discord, or a custom "Other" handle. Each field has its own **visibility** setting: Board only, Coordinators and Board, My teams, or All active humans. You pick one per field when you add it.
 - An emergency contact (optional, recommended).
 - Your skills and shift preferences (you'll be nudged through `/Profile/Me/ShiftInfo` separately). **Fill these in honestly and fully** — coordinators search by skill to find the right person for a role, so a thin profile is harder to place.
 
@@ -29,13 +29,13 @@ Go to `/Consent`. You see the documents that apply to everyone, grouped by the V
 
 Your signature is written as an immutable record: the document version, a hash of the exact text, the timestamp, your IP, and your browser. Nobody can edit or delete that entry afterwards — not Admin, not the database owner. That is what makes the audit trail worth something.
 
-Once every required document is signed, your safety check automatically flips to **Pending** and a Consent Coordinator is notified. Profile completion and consent run in parallel — you can do them in either order. See [Legal and Consent](LegalAndConsent.md) for the full picture.
+Once every required document is signed, your record lands in the Consent Coordinator review queue. Profile completion and consent run in parallel — you can do them in either order. See [Legal and Consent](LegalAndConsent.md) for the full picture.
 
 ## 4. You're a Volunteer
 
-A Consent Coordinator reviews your profile and either **clears** it or **flags** it. Clearing is the common path — flagging pauses onboarding until a Board member or Admin resolves the note the coordinator left.
+Entering your legal name is what opens the app, and once you have also signed every required document, the scheduled sync adds you to the Volunteers system team automatically — no manual step, no waiting on a person.
 
-When your profile is cleared **and** every required document is signed, the app does the rest automatically: you are added to the Volunteers system team, the rest of the app unlocks, and a welcome notification appears in the app. No manual Board step is needed.
+A Consent Coordinator then reviews your record and either **clears** it or **flags** it. That review is an audit check, not a gate: it doesn't hold up your access or your Volunteers membership. A flag is a note for the Board or an Admin to follow up on; only suspension or a rejected signup actually removes access.
 
 If an Admin has provisioned a `@nobodies.team` Google Workspace account for you, you also get a credentials email at your personal address with a temporary password and a 2FA setup prompt. That address then becomes your Google service email for every team you join. Teams with linked Google Groups or [Shared Drive](Glossary.md#shared-drive) folders grant you access on the next sync. See [Your `@nobodies.team` email](EmailAccount.md) for how the mailbox works and how to use your team's group address, and [Two-step verification (2FA)](TwoStepVerification.md) for that required sign-in step. [Email](Email.md) and [Google Integration](GoogleIntegration.md) cover the fuller reference and the sync mechanics underneath.
 
@@ -82,7 +82,7 @@ If an Admin has provisioned a `@nobodies.team` Google Workspace account for you,
 | [#🤝-recruitment-relationships](https://discord.gg/pcq2DRH6) on Discord | Quick questions and connecting with the team |
 | [#🧘-humans-app](https://discord.gg/fq7gr29p) on Discord | Humans app feedback and bug reports |
 
-You can also use the feedback button (three dots in a speech bubble, bottom right of the app) for anything related to the app itself.
+You can also use the round help button (question mark, bottom right of the app) for anything related to the app itself — it offers the AI helper, issue filing, and feedback.
 
 ## Key terms
 

--- a/docs/guide/Glossary.md
+++ b/docs/guide/Glossary.md
@@ -159,4 +159,4 @@ documents; admission is automatic. See [Onboarding](Onboarding.md).
 
 The role that acts as a facilitation contact for onboarding, with read-only
 access to the onboarding review queue. Distinct from the Consent Coordinator,
-who clears consents. See [Onboarding](Onboarding.md).
+who reviews consents. See [Onboarding](Onboarding.md).

--- a/docs/guide/Glossary.md
+++ b/docs/guide/Glossary.md
@@ -140,7 +140,7 @@ service to `None` is the fast kill switch. See
 
 A team the app manages automatically — Volunteers, Coordinators, Board,
 Asociados, Colaboradores, Barrio Leads. You can't join or leave a system team
-by hand; membership follows role assignments, tier status, and (for Barrio
+by hand; membership follows role assignments, membership tier, and (for Barrio
 Leads) active camp leadership. See [Teams](Teams.md).
 
 ## Team

--- a/docs/guide/Glossary.md
+++ b/docs/guide/Glossary.md
@@ -52,9 +52,10 @@ application and a Board vote. 2-year term. See [Governance](Governance.md).
 
 ## Consent Coordinator
 
-The coordinator role that reviews a human's signed consents and clears them
-for activation as a Volunteer. See [Legal & Consent](LegalAndConsent.md) and
-[Onboarding](Onboarding.md).
+The coordinator role that reviews a new human's signed consents and records a
+clear or a flag. The review is an audit annotation — it does not gate Volunteer
+access or Volunteers-team membership. See [Legal & Consent](LegalAndConsent.md)
+and [Onboarding](Onboarding.md).
 
 ## Coordinator
 
@@ -138,8 +139,9 @@ service to `None` is the fast kill switch. See
 ## System team
 
 A team the app manages automatically — Volunteers, Coordinators, Board,
-Asociados, Colaboradores. You can't join or leave a system team by hand;
-membership follows role assignments and tier status. See [Teams](Teams.md).
+Asociados, Colaboradores, Barrio Leads. You can't join or leave a system team
+by hand; membership follows role assignments, tier status, and (for Barrio
+Leads) active camp leadership. See [Teams](Teams.md).
 
 ## Team
 
@@ -149,9 +151,9 @@ See [Teams](Teams.md).
 
 ## Volunteer
 
-The default membership tier — the standard human. Everyone starts here after
-completing signup, profile setup, consent, and Consent Coordinator clearance.
-See [Onboarding](Onboarding.md).
+The default membership tier — the standard human. Everyone lands here after
+completing signup, entering their legal name, and signing the required
+documents; admission is automatic. See [Onboarding](Onboarding.md).
 
 ## Volunteer Coordinator
 

--- a/docs/guide/GoogleIntegration.md
+++ b/docs/guide/GoogleIntegration.md
@@ -40,7 +40,7 @@ All Drive resources are on **Shared Drives only** (no personal My Drive), and th
 
 ### Why you may have a `@nobodies.team` account
 
-An admin can provision a `@nobodies.team` account for you. You get a credentials email at your **personal** address — username, temporary password, sign-in link — and on first login you must change the password and set up 2FA. That address then becomes your **Google service email** (the app's [service account](Glossary.md#service-account) uses it to add you to Groups and Shared Drive folders for every team). Until provisioning happens, your OAuth login email is used instead.
+A coordinator or admin can provision a `@nobodies.team` account for you when your role or data access needs one — accounts are granted on need, not to everyone. You get a credentials email at your **personal** address — username, temporary password, sign-in link — and on first login you must change the password and set up 2FA. That address then becomes your **Google service email** (the app's [service account](Glossary.md#service-account) uses it to add you to Groups and Shared Drive folders for every team). Until provisioning happens, your OAuth login email is used instead.
 
 For how to use the mailbox itself, set up two-factor auth, and send "as" your team's group address, see [Email](Email.md).
 

--- a/docs/guide/Governance.md
+++ b/docs/guide/Governance.md
@@ -21,7 +21,7 @@
 
 ## What this section is for
 
-Governance handles **tier applications** — applying to become a [**Colaborador**](Glossary.md#colaborador) or [**Asociado**](Glossary.md#asociado) — along with the [**Board vote**](Glossary.md#board-vote) that decides those applications and the **[coordinator](Glossary.md#coordinator) and admin [role assignments](Glossary.md#role-assignment)** that track who can do what. It is **not** how you become a [Volunteer](Glossary.md#volunteer). Volunteer access is a separate, parallel path handled through profile setup and consent (with a non-gating Consent Coordinator review alongside) — see [Onboarding.md](Onboarding.md) for that flow. Tier applications never block Volunteer access, and Volunteer access never depends on a [Board](Glossary.md#board) decision.
+Governance handles **tier applications** — applying to become a [**Colaborador**](Glossary.md#colaborador) or [**Asociado**](Glossary.md#asociado) — along with the [**Board vote**](Glossary.md#board-vote) that decides those applications and the **[coordinator](Glossary.md#coordinator) and admin [role assignments](Glossary.md#role-assignment)** that track who can do what. It is **not** how you become a [Volunteer](Glossary.md#volunteer). Volunteer access is a separate, parallel path handled through profile setup and consent — see [Onboarding.md](Onboarding.md) for that flow. Tier applications never block Volunteer access, and Volunteer access never depends on a [Board](Glossary.md#board) decision.
 
 Both tiers run on synchronized 2-year terms that expire on December 31 of the next appropriate odd year. Terms, votes, and role assignments all leave an audit trail on your profile and on the human detail page.
 
@@ -104,6 +104,6 @@ Application state history, past and present role assignments, and the collective
 ## Related sections
 
 - [Profiles](Profiles.md) — [membership tier](Glossary.md#membership-tier) lives on the profile and is updated automatically on approval. (It is not auto-reset on term expiry — only the system-team membership changes then.)
-- [Legal and Consent](LegalAndConsent.md) — the consent signing flow and the Consent Coordinator audit review, independent of Board voting.
+- [Legal and Consent](LegalAndConsent.md) — the consent signing flow, independent of Board voting.
 - [Onboarding](Onboarding.md) — how a new human becomes a Volunteer. Tier applications do not replace or block this.
 - [Teams](Teams.md) — the Colaboradors and Asociados system teams that approved applicants join.

--- a/docs/guide/Governance.md
+++ b/docs/guide/Governance.md
@@ -21,7 +21,7 @@
 
 ## What this section is for
 
-Governance handles **tier applications** — applying to become a [**Colaborador**](Glossary.md#colaborador) or [**Asociado**](Glossary.md#asociado) — along with the [**Board vote**](Glossary.md#board-vote) that decides those applications and the **[coordinator](Glossary.md#coordinator) and admin [role assignments](Glossary.md#role-assignment)** that track who can do what. It is **not** how you become a [Volunteer](Glossary.md#volunteer). Volunteer access is a separate, parallel path handled through profile setup, consent, and a safety check by a Consent Coordinator — see [Onboarding.md](Onboarding.md) for that flow. Tier applications never block Volunteer access, and Volunteer access never depends on a [Board](Glossary.md#board) decision.
+Governance handles **tier applications** — applying to become a [**Colaborador**](Glossary.md#colaborador) or [**Asociado**](Glossary.md#asociado) — along with the [**Board vote**](Glossary.md#board-vote) that decides those applications and the **[coordinator](Glossary.md#coordinator) and admin [role assignments](Glossary.md#role-assignment)** that track who can do what. It is **not** how you become a [Volunteer](Glossary.md#volunteer). Volunteer access is a separate, parallel path handled through profile setup and consent (with a non-gating Consent Coordinator review alongside) — see [Onboarding.md](Onboarding.md) for that flow. Tier applications never block Volunteer access, and Volunteer access never depends on a [Board](Glossary.md#board) decision.
 
 Both tiers run on synchronized 2-year terms that expire on December 31 of the next appropriate odd year. Terms, votes, and role assignments all leave an audit trail on your profile and on the human detail page.
 
@@ -104,6 +104,6 @@ Application state history, past and present role assignments, and the collective
 ## Related sections
 
 - [Profiles](Profiles.md) — [membership tier](Glossary.md#membership-tier) lives on the profile and is updated automatically on approval. (It is not auto-reset on term expiry — only the system-team membership changes then.)
-- [Legal and Consent](LegalAndConsent.md) — the Consent Coordinator safety check for Volunteer access, independent of Board voting.
+- [Legal and Consent](LegalAndConsent.md) — the consent signing flow and the Consent Coordinator audit review, independent of Board voting.
 - [Onboarding](Onboarding.md) — how a new human becomes a Volunteer. Tier applications do not replace or block this.
 - [Teams](Teams.md) — the Colaboradors and Asociados system teams that approved applicants join.

--- a/docs/guide/LegalAndConsent.md
+++ b/docs/guide/LegalAndConsent.md
@@ -35,7 +35,7 @@ This section also surfaces your two core GDPR rights: a copy of everything the o
 - **Your consents** (`/Consent`) — any signed-in human reviews documents they've signed and re-signs when versions change.
 - **My Data** (`/Profile/Me/Privacy`) — Download my Data (Article 15) and Account Deletion (Article 17).
 - **Statutes** (`/Legal`) — anyone, including signed-out visitors, reads the association's current statutes (pulled directly from GitHub).
-- **Onboarding review queue** (`/OnboardingReview`) — [Consent Coordinator](Glossary.md#consent-coordinator), [Volunteer Coordinator](Glossary.md#volunteer-coordinator), [Board](Glossary.md#board), and [Admin](Glossary.md#admin) view humans awaiting activation; only Consent Coordinator, Board, and Admin can clear, flag, or reject.
+- **Onboarding review queue** (`/OnboardingReview`) — [Consent Coordinator](Glossary.md#consent-coordinator), [Volunteer Coordinator](Glossary.md#volunteer-coordinator), [Board](Glossary.md#board), and [Admin](Glossary.md#admin) view new signups; only Consent Coordinator, Board, and Admin can clear, flag, or reject.
 - **Manage documents** (`/Legal/Admin/Documents`) — Board and Admin create, edit, archive, and publish legal documents.
 
 ## As a [Volunteer](Glossary.md#volunteer)

--- a/docs/guide/Onboarding.md
+++ b/docs/guide/Onboarding.md
@@ -24,13 +24,13 @@
 
 ## What this section is for
 
-Onboarding is the path from signing up to becoming an active [Volunteer](Glossary.md#volunteer). It covers four things: creating your account, filling out your profile, consenting to the required legal documents, and being reviewed by a [Consent Coordinator](Glossary.md#consent-coordinator). Entering your legal name sets `UserState == Active`, which opens the app. Your legal name plus all required consents determine Volunteers-system-team provisioning for Google Workspace; the coordinator review is a parallel audit track and does not gate provisioning.
+Onboarding is the path from signing up to becoming an active [Volunteer](Glossary.md#volunteer). It covers three things: creating your account, filling out your profile, and consenting to the required legal documents. Entering your legal name sets `UserState == Active`, which opens the app. Your legal name plus all required consents determine Volunteers-system-team provisioning for Google Workspace.
 
 Onboarding is about Volunteer access only. Applying for **Colaborador** or **Asociado** is a separate tier application that runs in parallel through [Board](Glossary.md#board) voting — it never blocks your Volunteer access, and is covered in the Governance guide.
 
 If you are brand new, start with [GettingStarted.md](GettingStarted.md).
 
-![TODO: screenshot — the "Things to do" checklist on the Home dashboard showing the three onboarding steps (Complete your profile / Accept agreements / Coordinator review) with a mix of completed and pending items]
+![TODO: screenshot — the "Things to do" checklist on the Home dashboard showing the onboarding steps (Complete your profile / Accept agreements) with a mix of completed and pending items]
 
 ## Key pages at a glance
 
@@ -47,7 +47,7 @@ If you are brand new, start with [GettingStarted.md](GettingStarted.md).
 
 You have two ways to create an account:
 
-- **Google OAuth.** Click "Sign in with Google" on the login page. Your display name and picture come across automatically. If you already have an account with the same email — verified or not — Google sign-in links to it rather than creating a duplicate (the OAuth callback checks verified UserEmails, then unverified UserEmails, then `User.Email`).
+- **Google OAuth.** Click "Sign in with Google" on the login page. Your display name comes across automatically. If you already have an account with the same email — verified or not — Google sign-in links to it rather than creating a duplicate (the OAuth callback checks verified UserEmails, then unverified UserEmails, then `User.Email`).
 - **Magic link.** Enter your email and click "Send me a login link". You receive a one-time link that expires in 15 minutes. If no account exists yet, the same flow creates one (via the "Complete signup" page) and asks you for a burner name and your first and last name. To prevent email-scanner replay, the link goes to a landing page with a confirm button — clicking the button is what actually signs you in.
 
 If your email was imported from a mailing list, your account already exists and clicking your first magic link claims it.
@@ -64,15 +64,11 @@ During this one-shot setup you also see a tier selector. Leave it on **Volunteer
 
 ### 3. Sign the required legal documents
 
-Visit `/Consent` and sign each required document. Signatures are append-only — they cannot be edited or deleted. Once every required document is signed, your **Coordinator review** task on the dashboard moves to pending and a Consent Coordinator is notified. The coordinator review and the legal-document signing run in parallel: the review is an audit track and does not gate Volunteers-team admission. You enter the Volunteers team once you have entered your legal name and signed all required documents.
+Visit `/Consent` and sign each required document. Signatures are append-only — they cannot be edited or deleted. You enter the Volunteers team once you have entered your legal name and signed all required documents.
 
-### 4. Wait for your Coordinator review to clear
+### 4. Become an active Volunteer
 
-A Consent Coordinator reviews your profile and either **clears** it or **flags** it. Both are audit annotations: a flag does not pause your Volunteers-team provisioning or your app access. Only a rejected signup (which records a rejection timestamp) removes you from the Volunteers team.
-
-### 5. Become an active Volunteer
-
-When you enter your legal name, your stored `UserState` becomes `Active` and the app opens. When you have a legal name and all required documents are signed, the scheduled system-team sync adds you to the Volunteers Google Workspace provisioning group. If review flags your status, Board/Admin handles the review from `/OnboardingReview`; a rejected signup can also be handled from `/Users/Admin/{id}`.
+When you enter your legal name, your stored `UserState` becomes `Active` and the app opens. When you have a legal name and all required documents are signed, the scheduled system-team sync adds you to the Volunteers Google Workspace provisioning group. Only a rejected signup (which records a rejection timestamp and reason) removes you from the Volunteers team.
 
 While you are still onboarding, you can reach your profile, consents, feedback, legal documents, public camp pages, calendar, and the home dashboard — most of the app is gated until you are active.
 

--- a/docs/guide/Profiles.md
+++ b/docs/guide/Profiles.md
@@ -56,7 +56,9 @@ On the edit page, add contact fields for Phone, Signal, Telegram, WhatsApp, Disc
 - **Board only** — only Board members can see it
 - **Coordinators and Board** — Coordinators of any team plus the Board
 - **My teams** — humans who share a team with you
-- **All active humans** — any active human in the system (the default)
+- **All active humans** — any active human in the system
+
+There is no preselected level — you choose one when you add the field.
 
 ![TODO: screenshot — `/Profile/Me/Edit` contact fields section, showing the per-field visibility dropdown with all four levels]
 
@@ -116,6 +118,6 @@ Use `/Users/Admin/{id}/Roles/Add` to assign or end [role assignments](Glossary.m
 
 ## Related sections
 
-- [Legal and Consent](LegalAndConsent.md) — consent clearance gates Volunteer activation and flows through the profile
+- [Legal and Consent](LegalAndConsent.md) — your signed consents (plus your legal name) drive Volunteers-team admission, and consent status flows through the profile
 - [Teams](Teams.md) — sharing a team with another human raises what you can see on their profile
 - [Onboarding](Onboarding.md) — completing your profile is a required step in the signup pipeline

--- a/docs/guide/Profiles.md
+++ b/docs/guide/Profiles.md
@@ -64,7 +64,7 @@ There is no preselected level — you choose one when you add the field.
 
 ### Upload a profile picture
 
-On the edit page, choose an image (JPEG, PNG, WebP, or HEIC/HEIF/AVIF from a phone camera, up to 20 MB). The system rotates and resizes it server-side to a long edge of 1000 px and re-encodes as JPEG. Your custom picture takes precedence over your Google avatar everywhere in the app. You can remove it later to revert to the Google avatar.
+On the edit page, choose an image (JPEG, PNG, WebP, or HEIC/HEIF/AVIF from a phone camera, up to 20 MB). The system rotates and resizes it server-side to a long edge of 1000 px and re-encodes as JPEG. You can remove or replace it later.
 
 ### Manage your email addresses
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -31,8 +31,10 @@ with for support; nothing else relies on it.
 
 The app is at [humans.nobodies.team](https://humans.nobodies.team/),
 available in English, Español, Deutsch, Français, Italiano, and Català.
-Questions go to [humans@nobodies.team](mailto:humans@nobodies.team) or
-[#🧘-humans-app](https://discord.gg/fq7gr29p) on Discord.
+Questions: start with the in-app help button (AI helper, issue filing,
+feedback) or ask in [#🧘-humans-app](https://discord.gg/fq7gr29p) on Discord.
+[humans@nobodies.team](mailto:humans@nobodies.team) is third-level support —
+email it only when nothing else worked.
 
 ## Start here
 

--- a/docs/guide/SigningIn.md
+++ b/docs/guide/SigningIn.md
@@ -11,7 +11,7 @@ Go to the login page (`/Account/Login`). You'll see two options:
 - **Email me a login link.** Type your email address and we send you a link.
   Click it and you're in. Nothing to memorize.
 - **Sign in with Google.** One click, using a Google account you're already
-  signed into. Your name and photo come across automatically.
+  signed into. Your name comes across automatically.
 
 Either works. The login link is the simplest if you're not sure.
 
@@ -42,8 +42,8 @@ A few things to know about the link:
 | I clicked the link but nothing happened | Make sure you click the **button** on the page the link opens — that's the step that signs you in |
 | Google sign-in won't go through | Try the "email me a login link" option instead — it gets you to the same place |
 | I'm signed in but the app looks empty / locked | You're in, but your profile isn't finished yet. Fill it in (you'll be nudged to `/Profile/Me/Edit`) and the rest opens up — see [Getting Started](GettingStarted.md) |
-| I think I have two accounts | Don't make a third one. Email [humans@nobodies.team](mailto:humans@nobodies.team) and they can merge them for you |
-| Totally stuck | Email [humans@nobodies.team](mailto:humans@nobodies.team) or ask in [#🧘-humans-app](https://discord.gg/fq7gr29p) on Discord |
+| I think I have two accounts | Don't make a third one. Sign in to either and use the help button (bottom right) to file an issue so they can be merged |
+| Totally stuck | Ask in [#🧘-humans-app](https://discord.gg/fq7gr29p) on Discord. If you truly can't get in and nobody there could help, email [humans@nobodies.team](mailto:humans@nobodies.team) as a last resort |
 
 ## A note on your two logins
 

--- a/docs/guide/TwoStepVerification.md
+++ b/docs/guide/TwoStepVerification.md
@@ -57,10 +57,11 @@ Phones get lost, replaced, and dropped in the desert. Set up at least one backup
 Don't panic, and don't make a second account.
 
 1. If you saved **backup codes**, use one of those to get in.
-2. No backup codes and no phone? Email
-   [humans@nobodies.team](mailto:humans@nobodies.team) or use the help button in
-   the app (the round button, bottom-right). An admin can help sort out your
-   `@nobodies.team` account from the Google side.
+2. No backup codes and no phone? Use the help button in the app (the round
+   button, bottom-right — the app sign-in is separate from your email, so you
+   can still get in there) or ask in Discord. If nothing else worked, email
+   [humans@nobodies.team](mailto:humans@nobodies.team) as a last resort. An
+   admin can help sort out your `@nobodies.team` account from the Google side.
 
 ## Quick answers
 
@@ -68,8 +69,8 @@ Don't panic, and don't make a second account.
 |---|---|
 | Do I really have to? | Yes, on your `@nobodies.team` account — it's required and it's quick |
 | Does this change how I get into the app? | No. The app login is separate — see [Signing in & getting unstuck](SigningIn.md) |
-| What if I don't have a smartphone? | Backup codes work without a smartphone, and a phone that receives texts can also be used. If you're stuck, email [humans@nobodies.team](mailto:humans@nobodies.team) |
-| I got a new phone | Sign in with a backup code, then add the new phone under Security → 2-Step Verification. If you're locked out, email [humans@nobodies.team](mailto:humans@nobodies.team) |
+| What if I don't have a smartphone? | Backup codes work without a smartphone, and a phone that receives texts can also be used. If you're stuck, use the in-app help button |
+| I got a new phone | Sign in with a backup code, then add the new phone under Security → 2-Step Verification. If you're locked out, use the in-app help button; [humans@nobodies.team](mailto:humans@nobodies.team) is the last resort |
 | Is it on my personal Gmail too? | Only if you turn it on there yourself — which is a good idea, but separate from your `@nobodies.team` account |
 
 ## Related

--- a/docs/guide/YourData.md
+++ b/docs/guide/YourData.md
@@ -13,7 +13,7 @@ see it**:
 - **Board only** — just the Board.
 - **Coordinators and Board** — team coordinators plus the Board.
 - **My teams** — only people who share a team with you.
-- **All active humans** — anyone active in the system (this is the default).
+- **All active humans** — anyone active in the system.
 
 You set these on your profile's edit page (`/Profile/Me/Edit`). When someone
 looks at your profile, they only see the things your settings allow — so you can,

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -144,7 +144,9 @@ Atomic rules. Fetch the body when the description's trigger matches your task. T
 - [`coolify-build-constraint`](product/coolify-build-constraint.md) — Coolify strips `.git`; never `COPY .git` in Dockerfile; use `SOURCE_COMMIT` build arg
 - [`humans-terminology`](product/humans-terminology.md) — UI uses "humans"; never "members"/"volunteers"/"users". Stays English in es/de/fr/it.
 - [`no-event-name-nowhere`](product/no-event-name-nowhere.md) — never use "Nowhere" in user-facing text (legal); "Elsewhere" is the current event name
+- [`no-ranking-language`](product/no-ranking-language.md) — never "tier status"/"standing"/"level"; tiers are commitments, not ranks. Say "membership tier".
 - [`no-url-aliases`](product/no-url-aliases.md) — single canonical URL per page; only sanctioned alias is Barrios↔Camps
+- [`placement-not-polygon`](product/placement-not-polygon.md) — member-facing copy says a camp's "placement", never "polygon" (jargon). Code entities unaffected.
 - [`profile-visibility-acceptable`](product/profile-visibility-acceptable.md) — basic profile info visible to other authenticated users (incl. suspended/unapproved) is intentional, not a security finding
 - [`vol-being-removed`](product/vol-being-removed.md) — TRANSITIONAL. `/Vol/*` is being removed; don't extend new UX or flag inconsistency with `/Shifts`
 - [`voting-not-prominent`](product/voting-not-prominent.md) — Voting/Review/Applications serve ~8 people; don't headline. Default order = daily-traffic-across-the-whole-audience.

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -142,7 +142,10 @@ Atomic rules. Fetch the body when the description's trigger matches your task. T
 
 - [`birthday-not-dob`](product/birthday-not-dob.md) — store birthday (month + day only); UI says "birthday", never "date of birth"
 - [`coolify-build-constraint`](product/coolify-build-constraint.md) — Coolify strips `.git`; never `COPY .git` in Dockerfile; use `SOURCE_COMMIT` build arg
+- [`humans-at-is-third-level`](product/humans-at-is-third-level.md) — humans@ is Peter, 3rd-level support; copy ladder = help button → coordinator/Discord → humans@ last resort
 - [`humans-terminology`](product/humans-terminology.md) — UI uses "humans"; never "members"/"volunteers"/"users". Stays English in es/de/fr/it.
+- [`member-copy-distractions`](product/member-copy-distractions.md) — member-facing copy: no Google-avatar mentions; no Consent Coordinator narrative in the volunteer journey
+- [`nobodies-email-need-based`](product/nobodies-email-need-based.md) — @nobodies.team accounts granted on need (role/PII), never default; copy must carry the 2FA/primary-account caution
 - [`no-event-name-nowhere`](product/no-event-name-nowhere.md) — never use "Nowhere" in user-facing text (legal); "Elsewhere" is the current event name
 - [`no-ranking-language`](product/no-ranking-language.md) — never "tier status"/"standing"/"level"; tiers are commitments, not ranks. Say "membership tier".
 - [`no-url-aliases`](product/no-url-aliases.md) — single canonical URL per page; only sanctioned alias is Barrios↔Camps

--- a/memory/product/humans-at-is-third-level.md
+++ b/memory/product/humans-at-is-third-level.md
@@ -1,0 +1,20 @@
+---
+name: humans@ is third-level support — never front-line in copy
+description: humans@nobodies.team is Peter personally. Docs/UI copy must never offer it as a general support contact. The support ladder is — in-app help button (AI helper / Create issue / Feedback) → coordinator / #🧘-humans-app Discord → humans@ only when nothing else worked.
+---
+
+`humans@nobodies.team` goes to Peter personally — the person with by far the most hours on the project. It is **third-level support**: copy, docs, emails, and UI must never present it as a general helpdesk or a parallel first option.
+
+The support ladder every "need help?" mention must follow:
+
+1. **In-app help button** (round question-mark, bottom right): AI helper, Create issue, Feedback.
+2. **Your coordinator** or **#🧘-humans-app on Discord**.
+3. **humans@nobodies.team** — last resort, when nothing else worked. Where mentioned, label it as such.
+
+**Why:** Peter, 2026-06-11 (guide accuracy review): «people should NOT be emailing humans@ for general support requests. that address is me … humans@ is for 3rd level support when nothing else worked.»
+
+**How to apply:**
+
+- Never write "questions go to humans@…" or list it alongside Discord as an equal option.
+- In tables/lists of contacts, mark it "last resort" explicitly.
+- Prefer dropping it entirely where the help button + coordinator cover the case.

--- a/memory/product/member-copy-distractions.md
+++ b/memory/product/member-copy-distractions.md
@@ -1,0 +1,17 @@
+---
+name: Member-facing copy — no Google avatars, no Consent Coordinator narrative
+description: Two distractions banned from member-facing guide/UI copy — (1) Google-provided avatars are not used; never mention them. (2) The Consent Coordinator review is invisible to the member journey (it gates nothing; only rejection matters) — don't mention it in volunteer-facing onboarding copy. Role-facing docs for the coordinators themselves are fine.
+---
+
+Two things must stay out of **member-facing** copy (guide docs, onboarding views, emails):
+
+1. **Google-provided avatars.** The app doesn't use them. Don't write "your picture comes across from Google" or "revert to your Google avatar" — just talk about the profile picture you upload.
+2. **The Consent Coordinator review.** From the member's perspective it isn't in line for anything — admission to Volunteers is automatic on legal name + consents, and only a rejected signup changes anything. Mentioning the review in the volunteer journey is a distraction. The role's own documentation (Onboarding/LegalAndConsent "As a Coordinator" sections, Glossary entry) is the right place for it.
+
+**Why:** Peter, 2026-06-11 (guide accuracy review): «we don't use google provided avatars, mention of them is a distraction» · «consent coordinator stuff is not in line for anything at the moment unless the person is rejected.. so it shouldn't be even mentioned in these documents, it's a distraction».
+
+**How to apply:**
+
+- Sign-in copy: "your display name comes across automatically" — no picture/photo claims.
+- Onboarding copy: three steps (sign up, profile/legal name, consents) → automatic Volunteer admission; mention rejection as the only removal path. No review-queue narrative.
+- Coordinator/Board/Admin-facing sections may document the review queue normally.

--- a/memory/product/no-ranking-language.md
+++ b/memory/product/no-ranking-language.md
@@ -1,0 +1,15 @@
+---
+name: No ranking language — tiers are commitments, not ranks
+description: Never use phrases that frame membership tiers as rankings — "tier status", "standing", "level", "upgrade your status", "higher tier". Tiers (Volunteer / Colaborador / Asociado) describe different commitments and responsibilities, not a hierarchy. Say "membership tier" when referring to the tier itself.
+---
+
+Never write phrases that imply humans are ranked — **"tier status"**, "standing", "level", "rank", "higher/lower tier", "upgrade your status" — in any copy, docs, commit messages, or PR text. The membership tiers (Volunteer, Colaborador, Asociado) describe **different commitments and responsibilities**, not a ladder; ranking framing is the antithesis of the org's culture.
+
+**Why:** Peter, 2026-06-11 (guide accuracy review): «"tier status" should not be a phrase in your lexicon, it implies people have rankings which is the anthesis of our culture».
+
+**How to apply:**
+
+- Refer to the tier itself as **"membership tier"** (the established [Glossary](../../docs/guide/Glossary.md) term) or name the tier directly ("Colaborador", "Asociado").
+- Describe tier changes as applications/approvals ("apply for Asociado", "the Board approved the application"), never as promotions or status upgrades.
+- Volunteer is the default everyone has — never frame it as the "lowest" tier or Asociado as the "highest".
+- Related: [[humans-terminology]] — the org's other branded-vocabulary rule.

--- a/memory/product/nobodies-email-need-based.md
+++ b/memory/product/nobodies-email-need-based.md
@@ -1,0 +1,17 @@
+---
+name: "@nobodies.team accounts are need-based, not a free-for-all"
+description: "@nobodies.team accounts are granted only where there's an actual use — the role needs it (coordinating, externally facing) or the person handles other humans' PII. Copy/docs must never frame them as something everyone gets, and must caution about the responsibility: required 2FA, becomes the primary account for all Humans actions, two-inbox burden."
+---
+
+`@nobodies.team` Workspace accounts are **granted on need, never by default**: the human's role requires one (coordinating, externally facing — ticketing, comms, production) or they access other humans' personal data. Docs, UI copy, and features must never present them as a perk everyone gets or a self-service request.
+
+Any copy describing them must also carry the caution: required 2FA (real sign-in friction), the address becomes the person's **primary account for everything done through Humans** (Google service email → all Drive/group access flows through it), and it means running two email accounts side by side (Chrome handles this well, but people not used to juggling accounts should be wary).
+
+**Why:** Peter, 2026-06-11 (guide accuracy review): «this isn't a free for all. They should be granted to those having an actual use for them, either in their role, or because they're accessing pii. … it should be cautioned to the responsibility (and 2fa pain) that comes with it. Having one makes it the primary account for all humans actions as well.»
+
+**How to apply:**
+
+- Guide/UI copy: "granted where a role needs one", never "everyone gets".
+- Coordinator-facing provisioning copy reminds: provision on need, point the human at the responsibility caution first (docs/guide/EmailAccount.md "Before you take one on").
+- Don't build self-service request flows for these accounts without Peter's sign-off.
+- Related: [[humans-terminology]].

--- a/memory/product/placement-not-polygon.md
+++ b/memory/product/placement-not-polygon.md
@@ -1,0 +1,15 @@
+---
+name: User-facing copy says "placement", not "polygon"
+description: In member-facing text (guide docs, views, emails), a camp's map shape is its "placement" — "polygon" is technical jargon a regular user wouldn't know. Code/entities (CampPolygon) and GeoJSON admin specifics are unaffected.
+---
+
+In **member-facing** copy — guide docs, Razor views, emails, notifications — refer to a camp's shape on the City Planning map as its **placement** ("edit your camp's placement", "placements outside the limit zone"). Never "polygon".
+
+**Why:** Peter, 2026-06-11 (guide accuracy review): «"camp's polygon" is technical jargon a regular user wouldn't know. this is the "camp's placement" for normal human speak».
+
+**How to apply:**
+
+- Guide docs and UI strings: "placement", "draw your placement", "move corners" (not "vertices").
+- Entity and code names (`CampPolygon`, `CampPolygonHistory`) and developer docs stay as-is.
+- Admin GeoJSON import/export specifics may stay technical where they describe file formats, but prefer "placement" wherever the sentence is about the camp's shape.
+- Related: [[humans-terminology]], [[no-ranking-language]] — the org's other plain-speech/branded-vocabulary rules.


### PR DESCRIPTION
Closes nobodies-collective/Humans#862. Fable-tier accuracy review requested in nobodies-collective/Humans#855 ("those guides need a proper review for accuracy. Opus put some crap assumptions in there").

All 28 docs in `docs/guide/` were read; every fix below was verified against code, not memory. The freshness-maintained section docs (Onboarding, LegalAndConsent, Teams, Shifts, Tickets, etc.) were checked and found accurate; the inaccuracies clustered in the hand-written entry/common-questions docs without freshness triggers.

## Fixes (per doc, with code evidence)

| Doc | Fix | Evidence |
|---|---|---|
| GettingStarted | Volunteer activation described as gated on Consent Coordinator clearance — it is not. Rewrote intro + steps 3/4: name + consents admit you automatically; review is a parallel audit | `SystemTeamSyncJob.cs:180` — "Name-only access switch… Flagged consent-check is an audit annotation that no longer gates admission" |
| GettingStarted | `/GuestDashboard` → `/Guest` | `GuestController` default route |
| GettingStarted, Profiles, YourData | "default is All active humans" for contact-field visibility — there is no preselected default; the add-field dropdown is a required "Choose visibility" | `Views/Profile/Edit.cshtml:729-731` |
| GettingStarted, Email | "feedback button (three dots in a speech bubble)" → round question-mark help button with three-item menu | `HelpWidget/Default.cshtml:18` (`fa-question`) |
| Glossary (Consent Coordinator, Volunteer) | Same gating correction as GettingStarted | `SystemTeamSyncJob.cs:180` |
| Glossary (System team) | Added Barrio Leads to the system-team list | `SystemTeamSyncJob` syncs Barrio Leads; Teams.md already listed it |
| Profiles, Governance | Related-links/intro restated the clearance-gates claim — corrected | same |
| EmailAccount | "Everyone gets an address / you were asked which address you'd like at signup, set up automatically" — invented; no signup-time chooser exists. Provisioning is coordinator/admin-initiated | `TeamAdminController.cs:272` (`ProvisionEmail`, coordinator picks `emailPrefix`); admin path on `/Users/Admin/{id}` |
| Email | Coordinator provisioning flow pointed at "the human's profile admin page" → it lives on `/Teams/{slug}/Members` | `TeamAdminController.cs:272` |
| AiHelper | "two choices: report a problem or talk with the AI helper" → three-item menu (AI agent / Create issue / Feedback) | `HelpWidget/Default.cshtml:25-44` |
| Camps | Related-link claimed Colaborador application is "the prerequisite" for camp leads, contradicting the doc body — registration is plain `[Authorize]` | `CampController.cs:315-317` |
| CityPlanning | Retired "Primary/Co-Leads" term → camp leads | Glossary/Camps note the distinction is retired |

## Verified-accurate (no change needed)

Magic-link 15-min expiry + 60s cooldown (`MagicLinkService.cs:24-25`), 30-day deletion grace (`AccountDeletionService.cs:51`), six languages en/es/de/it/fr/ca (`CultureCodeExtensions.cs`), transfer cancel-while-pending (`TicketTransferController.cs:96`), four visibility levels (`ContactFieldVisibility.cs`).

Not touched: 2026 operational content (arrival dates, on-site contacts, headcount caps, Discord links) — organizational facts not verifiable from code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
