### PR TITLE
fix: address unaddressed Claude review findings from the last 30 days of prod PRs

### DIFF
--- a/src/Humans.Application/Extensions/DateFormattingExtensions.cs
+++ b/src/Humans.Application/Extensions/DateFormattingExtensions.cs
@@ -144,6 +144,6 @@ public static class DateFormattingExtensions
         LocalDateTimePattern.CreateWithInvariantCulture("yyyy-MM-ddTHH:mm");
 
     /// <summary>Ops-notice date, "ddd MMMM d" (e.g. "Mon January 5").</summary>
-    public static readonly LocalDateTimePattern OpsNoticeDatePattern =
-        LocalDateTimePattern.CreateWithInvariantCulture("ddd MMMM d");
+    public static readonly LocalDatePattern OpsNoticeDatePattern =
+        LocalDatePattern.CreateWithInvariantCulture("ddd MMMM d");
 }

--- a/src/Humans.Application/Interfaces/Caching/IRoleAssignmentCacheInvalidator.cs
+++ b/src/Humans.Application/Interfaces/Caching/IRoleAssignmentCacheInvalidator.cs
@@ -5,8 +5,10 @@ namespace Humans.Application.Interfaces.Caching;
 /// <summary>
 /// Cross-section signal for the global role-assignment cache. Implemented
 /// by the Singleton <c>CachingRoleAssignmentService</c> decorator and
-/// consumed by the <c>RoleAssignmentSaveChangesInterceptor</c>, which
-/// fires after EF persists any write to <c>role_assignments</c>.
+/// called by <c>RoleAssignmentService</c>'s mutating methods (and, via
+/// <c>IRoleAssignmentService.InvalidateRoleAssignmentCache()</c>, by
+/// <c>AccountMergeService</c> after a merge fold). No EF interceptor —
+/// all <c>role_assignments</c> writes go through <c>RoleAssignmentService</c>.
 /// </summary>
 /// <remarks>
 /// Bag-shaped cache (whole-set replacement on rebuild) — same pattern as

--- a/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
+++ b/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
@@ -52,9 +52,10 @@ public interface IMailerLiteService : IApplicationService
     Task UnassignSubscriberFromGroupAsync(string subscriberId, string groupId, CancellationToken ct = default);
 
     /// <summary>
-    /// Bulk-creates-or-updates subscribers from a list of emails and assigns them
-    /// to the target group in one MailerLite call (chunked per
-    /// <c>MailerLiteOptions.BulkImportChunkSize</c> by the implementation).
+    /// Creates-or-updates each email as a MailerLite subscriber (via individual
+    /// POST /api/subscribers calls) and assigns them to the target group.
+    /// Partial failure is possible: <see cref="BulkImportResult.Errors"/> counts
+    /// per-email failures; successfully processed emails are still assigned.
     /// Same prefix guard as assign.
     /// </summary>
     Task<BulkImportResult> BulkImportSubscribersToGroupAsync(

--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -354,8 +354,8 @@ public sealed class RotaCoordinatorMessageService(
         var local = zoned.LocalDateTime;
         // Invariant culture: stable parseable shape for short ops notices.
         return isAllDay
-            ? DateFormattingExtensions.OpsNoticeDatePattern.Format(local)
-            : $"{DateFormattingExtensions.OpsNoticeDatePattern.Format(local)} @ {DateFormattingExtensions.TimeOfDayPattern.Format(local.TimeOfDay)}";
+            ? DateFormattingExtensions.OpsNoticeDatePattern.Format(local.Date)
+            : $"{DateFormattingExtensions.OpsNoticeDatePattern.Format(local.Date)} @ {DateFormattingExtensions.TimeOfDayPattern.Format(local.TimeOfDay)}";
     }
 
     private static string Truncate(string text, int max) =>

--- a/src/Humans.Application/Services/Users/AccountProvisioningService.cs
+++ b/src/Humans.Application/Services/Users/AccountProvisioningService.cs
@@ -63,7 +63,6 @@ public sealed class AccountProvisioningService(
         var now = clock.GetCurrentInstant();
 
         var newUserId = Guid.NewGuid();
-#pragma warning disable HUM_USER_DISPLAYNAME // Account provisioning seeds the legacy Identity fallback column.
         var newUser = new User
         {
             Id = newUserId,
@@ -71,7 +70,6 @@ public sealed class AccountProvisioningService(
             ContactSource = source,
             CreatedAt = now,
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var result = await userManager.CreateAsync(newUser);
         if (!result.Succeeded)
@@ -134,7 +132,6 @@ public sealed class AccountProvisioningService(
         }
 
         var now = clock.GetCurrentInstant();
-#pragma warning disable HUM_USER_DISPLAYNAME // Sanctioned creation-time BurnerName fallback (memory/architecture/burnername-is-the-display-name.md).
         var user = new User
         {
             Id = Guid.NewGuid(),
@@ -142,7 +139,6 @@ public sealed class AccountProvisioningService(
             CreatedAt = now,
             LastLoginAt = now
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var createResult = await userManager.CreateAsync(user);
         if (!createResult.Succeeded)

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -906,7 +906,6 @@ public sealed class UserService(
             .FirstOrDefault();
         var effectiveEmail = SelectEffectiveEmail(userEmails, user.IdentityEmailColumn);
 
-#pragma warning disable HUM_USER_DISPLAYNAME // GDPR export must include the legacy Identity column value.
         var shaped = new
         {
             user.Id,
@@ -922,7 +921,6 @@ public sealed class UserService(
             CreatedAt = user.CreatedAt.ToIso8601(),
             LastLoginAt = user.LastLoginAt.ToIso8601()
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var participations = await repo.GetEventParticipationsByUserIdAsync(userId, ct);
         var participationsShaped = participations
@@ -1220,9 +1218,7 @@ public sealed class UserService(
     {
         var suspended = command.Suspended!.Value;
 
-#pragma warning disable HUM_PROFILE_ISSUSPENDED
         profile.IsSuspended = suspended;
-#pragma warning restore HUM_PROFILE_ISSUSPENDED
 
         // Dual-write until IsSuspended is dropped. State is the canonical shape
         // exposed through UserInfo.

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -429,14 +429,12 @@ public sealed record UserInfo(
                 c.UpdatedAt, c.UpdateSource, c.SubscribedAt))
             .ToList();
 
-#pragma warning disable HUM_USER_DISPLAYNAME // User.DisplayName is only the creation-time fallback for profileless UserInfo.BurnerName.
         var legacyDisplayName = user.DisplayName;
         var burnerName = profileInfo is not null && !string.IsNullOrWhiteSpace(profileInfo.BurnerName)
             ? profileInfo.BurnerName
             : legacyDisplayName;
         var isGdprAnonymized = string.Equals(
             legacyDisplayName, GdprAnonymizedBurnerName, StringComparison.Ordinal);
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var info = new UserInfo(
             Id: user.Id,

--- a/src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs
+++ b/src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs
@@ -157,7 +157,6 @@ public sealed class UserInfoSaveChangesInterceptor(
 
     private static User CloneUserInfoFields(User user)
     {
-#pragma warning disable HUM_USER_DISPLAYNAME // DisplayName is part of the cached legacy user-column mirror.
         return new User
         {
             Id = user.Id,
@@ -181,7 +180,6 @@ public sealed class UserInfoSaveChangesInterceptor(
             MergedAt = user.MergedAt,
             Email = user.IdentityEmailColumn,
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
     }
 
     private sealed class PendingUserInfoInvalidations

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -123,9 +123,7 @@ internal sealed partial class UserRepository : IUserRepository
         if (user is null)
             return false;
 
-#pragma warning disable HUM_USER_DISPLAYNAME // Repository mutates the legacy Identity fallback column.
         user.DisplayName = displayName;
-#pragma warning restore HUM_USER_DISPLAYNAME
         await ctx.SaveChangesAsync(ct);
         return true;
     }
@@ -276,9 +274,7 @@ internal sealed partial class UserRepository : IUserRepository
         user.MergedToUserId = targetUserId;
         user.MergedAt = now;
 
-#pragma warning disable HUM_USER_DISPLAYNAME // Merge tombstone label is an allowed legacy column write.
         user.DisplayName = "Merged User";
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         // Scrub the legacy Identity email/username PII from the tombstone. The address
         // already moved to the survivor's UserEmail rows during the fan-out, so keeping
@@ -486,7 +482,6 @@ internal sealed partial class UserRepository : IUserRepository
         if (user is null)
             return null;
 
-#pragma warning disable HUM_USER_DISPLAYNAME // Purge returns and rewrites the legacy label for audit/debug flows.
         var displayName = user.DisplayName;
 
         // Drop external logins so a returning Google user can land on a fresh
@@ -497,7 +492,6 @@ internal sealed partial class UserRepository : IUserRepository
         ctx.Set<IdentityUserLogin<Guid>>().RemoveRange(logins);
 
         user.DisplayName = $"Purged ({displayName})";
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         user.LockoutEnabled = true;
         user.LockoutEnd = DateTimeOffset.MaxValue;
@@ -541,12 +535,10 @@ internal sealed partial class UserRepository : IUserRepository
             return null;
 
         var originalEmail = user.Email;
-#pragma warning disable HUM_USER_DISPLAYNAME // Deletion export records the original legacy label before anonymization.
         var originalDisplayName = user.DisplayName;
         var preferredLanguage = user.PreferredLanguage;
 
         user.DisplayName = UserInfo.GdprAnonymizedBurnerName;
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         // Scrub the legacy Identity email/username PII. The address was already removed
         // from UserEmail rows (RemoveAllUserEmailsForUserAndSaveAsync runs first), but the

--- a/src/Humans.Infrastructure/Services/Auth/CachingRoleAssignmentService.cs
+++ b/src/Humans.Infrastructure/Services/Auth/CachingRoleAssignmentService.cs
@@ -11,9 +11,12 @@ namespace Humans.Infrastructure.Services.Auth;
 /// Singleton caching decorator for <see cref="IRoleAssignmentService"/>.
 /// Caches the full set of <c>role_assignments</c> rows so cross-section reads
 /// such as <see cref="GetActiveCountsByRoleAsync"/> can be derived in memory
-/// at any clock instant. Invalidated wholesale by
-/// <c>RoleAssignmentSaveChangesInterceptor</c> after any persisted write
-/// to <c>role_assignments</c>.
+/// at any clock instant. Invalidated wholesale via explicit
+/// <c>IRoleAssignmentCacheInvalidator.InvalidateAll()</c> calls inside
+/// <c>RoleAssignmentService</c>'s mutating methods, and via
+/// <c>IRoleAssignmentService.InvalidateRoleAssignmentCache()</c> from
+/// <c>AccountMergeService</c> after a merge fold. No EF interceptor —
+/// all writes go through <c>RoleAssignmentService</c>.
 /// </summary>
 /// <remarks>
 /// Mirrors <c>CachingLegalDocumentSyncService</c>: warmed on startup via the

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -277,11 +277,13 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
             };
             if (delay > TimeSpan.Zero)
             {
+                logger.LogWarning("MailerLite rate limit low ({Remaining} remaining); backing off {Delay:0.#}s before next call",
+                    remaining, delay.TotalSeconds);
                 try
                 {
                     await Task.Delay(delay, ct);
                 }
-                catch
+                catch (OperationCanceledException)
                 {
                     // Dispose so we don't leak the socket — caller never sees this response.
                     resp.Dispose();

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -324,7 +324,6 @@ public sealed class CachingUserService(
 
     private static UserInfo WithUserFields(UserInfo current, User user)
     {
-#pragma warning disable HUM_USER_DISPLAYNAME // User.DisplayName is a legacy user-column mirror.
         var legacyDisplayName = user.DisplayName;
         return current with
         {
@@ -350,7 +349,6 @@ public sealed class CachingUserService(
             MergedAt = user.MergedAt,
             IdentityEmailColumn = user.IdentityEmailColumn,
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
     }
 
     private static string ResolveBurnerName(string legacyDisplayName, ProfileInfo? profile) =>
@@ -423,7 +421,6 @@ public sealed class CachingUserService(
     /// </summary>
     private static User RehydrateUser(UserInfo info)
     {
-#pragma warning disable HUM_USER_DISPLAYNAME // Rehydrated legacy User.DisplayName now carries the resolved BurnerName fallback.
         var user = new User
         {
             Id = info.Id,
@@ -449,7 +446,6 @@ public sealed class CachingUserService(
             MergedAt = info.MergedAt,
             Email = info.IdentityEmailColumn,
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         foreach (var e in info.UserEmails)
         {

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -267,7 +267,6 @@ public class AccountController(
         string? name)
     {
         var newUserId = Guid.NewGuid();
-#pragma warning disable HUM_USER_DISPLAYNAME // OAuth signup seeds the legacy Identity fallback column.
         var user = new User
         {
             Id = newUserId,
@@ -275,7 +274,6 @@ public class AccountController(
             CreatedAt = clock.GetCurrentInstant(),
             LastLoginAt = clock.GetCurrentInstant()
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var createResult = await userManager.CreateAsync(user);
         if (!createResult.Succeeded)

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -158,7 +158,7 @@ public class BudgetController(
         }
         catch (Exception ex)
         {
-            logger.LogWarning("Failed to create line item in category {CategoryId}: {Reason}", budgetCategoryId, ex.Message);
+            logger.LogError(ex, "Failed to create line item in category {CategoryId}", budgetCategoryId);
             SetError($"Failed to create line item: {ex.Message}");
         }
 
@@ -189,7 +189,7 @@ public class BudgetController(
         }
         catch (Exception ex)
         {
-            logger.LogWarning("Failed to update line item {LineItemId}: {Reason}", id, ex.Message);
+            logger.LogError(ex, "Failed to update line item {LineItemId}", id);
             SetError($"Failed to update line item: {ex.Message}");
         }
 
@@ -216,7 +216,7 @@ public class BudgetController(
         }
         catch (Exception ex)
         {
-            logger.LogWarning("Failed to delete line item {LineItemId}: {Reason}", id, ex.Message);
+            logger.LogError(ex, "Failed to delete line item {LineItemId}", id);
             SetError($"Failed to delete line item: {ex.Message}");
         }
         return RedirectToAction(nameof(CategoryDetail), new { id = lineItem.BudgetCategoryId });

--- a/src/Humans.Web/Controllers/CantinaController.cs
+++ b/src/Humans.Web/Controllers/CantinaController.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Cantina;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Web.Authorization;
 using Humans.Web.Cantina;
 using Microsoft.AspNetCore.Authorization;
@@ -19,7 +20,7 @@ namespace Humans.Web.Controllers;
 /// </summary>
 [Authorize(Policy = PolicyNames.CantinaAdminOrAdmin)]
 [Route("Cantina")]
-public sealed class CantinaController : Controller
+public sealed class CantinaController : HumansControllerBase
 {
     private readonly ICantinaRosterService _roster;
     private readonly IShiftManagementService _shiftMgmt;
@@ -30,7 +31,8 @@ public sealed class CantinaController : Controller
         ICantinaRosterService roster,
         IShiftManagementService shiftMgmt,
         IClock clock,
-        ILogger<CantinaController> logger)
+        ILogger<CantinaController> logger,
+        IUserServiceRead userService) : base(userService)
     {
         _roster = roster;
         _shiftMgmt = shiftMgmt;

--- a/src/Humans.Web/Controllers/GovernanceBoardVotingController.cs
+++ b/src/Humans.Web/Controllers/GovernanceBoardVotingController.cs
@@ -146,6 +146,7 @@ public class GovernanceBoardVotingController(
 
     [HttpPost("Finalize")]
     [ValidateAntiForgeryToken]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Finalize(BoardVotingFinalizeModel model)
     {
         var currentUser = await GetCurrentUserInfoAsync();

--- a/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
@@ -91,7 +91,6 @@ public sealed class DevPersonaSeeder(
         var roleName = isCoordinatorPersona ? null : RoleNameFromSlug(slug);
         var roles = roleName is not null ? new[] { roleName } : Array.Empty<string>();
 
-#pragma warning disable HUM_USER_DISPLAYNAME // Dev persona seeding writes the legacy Identity fallback column.
         var user = new User
         {
             Id = id,
@@ -99,7 +98,6 @@ public sealed class DevPersonaSeeder(
             CreatedAt = now,
             LastLoginAt = now
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var result = await userManager.CreateAsync(user);
         if (!result.Succeeded)
@@ -240,7 +238,6 @@ public sealed class DevPersonaSeeder(
     /// </summary>
     private async Task SeedProfilelessUserAsync(Guid id, string email, string displayName, Instant now)
     {
-#pragma warning disable HUM_USER_DISPLAYNAME // Dev guest seeding writes the legacy Identity fallback column.
         var user = new User
         {
             Id = id,
@@ -248,7 +245,6 @@ public sealed class DevPersonaSeeder(
             CreatedAt = now,
             LastLoginAt = now
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var result = await userManager.CreateAsync(user);
         if (!result.Succeeded)

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -271,7 +271,6 @@ public sealed class DevelopmentDashboardSeeder(
             // Id.ToString(). Without an explicit Id, every loop iteration resolves
             // to UserName = Guid.Empty.ToString() and fails on the second insert.
             var userId = Guid.NewGuid();
-#pragma warning disable HUM_USER_DISPLAYNAME // Development dashboard seeding writes the legacy Identity fallback column.
             var user = new User
             {
                 Id = userId,
@@ -279,7 +278,6 @@ public sealed class DevelopmentDashboardSeeder(
                 CreatedAt = createdAt,
                 LastLoginAt = now.Minus(Duration.FromDays(lastLoginDaysAgo)).Minus(Duration.FromHours(_rng.Next(0, 23))),
             };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
             var createResult = await userManager.CreateAsync(user);
             if (!createResult.Succeeded)

--- a/src/Humans.Web/Infrastructure/GateTerminalAccountSeeder.cs
+++ b/src/Humans.Web/Infrastructure/GateTerminalAccountSeeder.cs
@@ -86,14 +86,12 @@ public sealed class GateTerminalAccountSeeder(
     private async Task<User?> ProvisionAsync(Guid actorUserId)
     {
         var now = clock.GetCurrentInstant();
-#pragma warning disable HUM_USER_DISPLAYNAME // System-account seeding writes the legacy Identity fallback column (same as DevPersonaSeeder).
         var user = new User
         {
             Id = SystemUserIds.GateTerminal,
             DisplayName = SystemUserIds.GateTerminalDisplayName,
             CreatedAt = now
         };
-#pragma warning restore HUM_USER_DISPLAYNAME
 
         var created = await userManager.CreateAsync(user);
         if (!created.Succeeded)

--- a/src/Humans.Web/Views/Scanner/_TicketCard.cshtml
+++ b/src/Humans.Web/Views/Scanner/_TicketCard.cshtml
@@ -44,7 +44,7 @@ else
             @if (Model.TransferredAt.HasValue)
             {
                 <dt class="col-sm-4">@Localizer["Scanner_Tickets_TransferredOn"]</dt>
-                <dd class="col-sm-8">@Model.TransferredAt.Value.ToDate(DateTimeZone.Utc)</dd>
+                <dd class="col-sm-8">@Model.TransferredAt.Value.ToDate(tz)</dd>
             }
         }
     </dl>


### PR DESCRIPTION
Sweep of unaddressed Claude review findings on production promotion PRs (nobodies-collective/Humans #707–#859, last 30 days). 36 findings were audited against current main; 13 were already fixed/moot, and this PR fixes the 9 areas Peter selected — one commit per fix.

## Fixes

1. **Governance (BLOCK, security)** — `Finalize` POST now carries `[Authorize(Policy = PolicyNames.AdminOnly)]`; previously any Board member could finalize a tier application by crafting the POST (upstream #707).
2. **Pragma sweep (BLOCK, hard rule)** — all 17 `#pragma warning disable HUM*` pairs removed across 10 files (upstream #795, #859). Note: the review's prescribed `[Grandfathered]` conversion is not applicable — `HUM_USER_DISPLAYNAME` / `HUM_PROFILE_ISSUSPENDED` are `[Obsolete]`-sourced compiler diagnostics that no analyzer downgrades. `Directory.Build.props` already routes `HUM_USER_DISPLAYNAME` through `WarningsNotAsErrors` with the documented intent that legitimate-consumer sites stay **visible as warnings**, so the rule-compliant state is no suppression at all. The build now shows those warnings (build remains green; `HUM_PROFILE_ISSUSPENDED` is in global `NoWarn`).
3. **MailerLiteClient** — bare `catch` around `Task.Delay` typed to `OperationCanceledException`; rate-limit back-off now logs a `LogWarning` with remaining quota and delay (upstream #718).
4. **BudgetController** — three line-item catch blocks restored to `LogError(ex, …)` instead of `LogWarning("… {Reason}", ex.Message)` (upstream #814).
5. **CantinaController** — extends `HumansControllerBase` per controller-base conventions (upstream #804).
6. **IMailerLiteService docstring** — no longer references the removed `BulkImportChunkSize` or claims a single bulk call (upstream #717).
7. **Role-assignment cache docstrings** — both docs now name the real invalidation path (inline `InvalidateAll()` in `RoleAssignmentService` + `AccountMergeService` after merge fold) instead of the non-existent `RoleAssignmentSaveChangesInterceptor` (upstream #752).
8. **OpsNoticeDatePattern** — `LocalDatePattern` for the date-only format; caller formats `local.Date` (upstream #833).
9. **Scanner ticket card** — `TransferredAt` rendered in the ambient event timezone like every other timestamp on the card, not pinned UTC (upstream #843).

Explicitly skipped per Peter: ExpenseLine EF sentinel (#836) and the remaining low-priority architecture items.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors
- `dotnet test Humans.slnx -v quiet` — 4,524 passed, 0 failed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)