### PR TITLE
refactor(users): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Users/AccountMergeService.cs
+++ b/src/Humans.Application/Services/Users/AccountMergeService.cs
@@ -144,7 +144,14 @@ public sealed class AccountMergeService(
         }
         finally
         {
-            InvalidateMergeCaches(survivorUserId, archivedUserId);
+            roleAssignmentService.InvalidateClaimsCacheForUser(archivedUserId);
+            roleAssignmentService.InvalidateClaimsCacheForUser(survivorUserId);
+            roleAssignmentService.InvalidateNavBadgeCache();
+            roleAssignmentService.InvalidateRoleAssignmentCache();
+            notificationService.InvalidateBadgeCachesForUsers([archivedUserId, survivorUserId]);
+            consentCacheInvalidator.InvalidateUser(archivedUserId);
+            consentCacheInvalidator.InvalidateUser(survivorUserId);
+            activeTeamsCacheInvalidator.Invalidate();
         }
     }
 
@@ -199,20 +206,6 @@ public sealed class AccountMergeService(
             req.AdminNotes = notes ?? "Resolved by merge.";
             await mergeRepository.UpdateAsync(req, ct);
         }
-    }
-
-    // Cache-aside eviction after a merge. Runs in MergeAsync's finally so a partial/failed
-    // run still clears stale per-user reads.
-    private void InvalidateMergeCaches(Guid survivorUserId, Guid archivedUserId)
-    {
-        roleAssignmentService.InvalidateClaimsCacheForUser(archivedUserId);
-        roleAssignmentService.InvalidateClaimsCacheForUser(survivorUserId);
-        roleAssignmentService.InvalidateNavBadgeCache();
-        roleAssignmentService.InvalidateRoleAssignmentCache();
-        notificationService.InvalidateBadgeCachesForUsers([archivedUserId, survivorUserId]);
-        consentCacheInvalidator.InvalidateUser(archivedUserId);
-        consentCacheInvalidator.InvalidateUser(survivorUserId);
-        activeTeamsCacheInvalidator.Invalidate();
     }
 
     public async Task RejectAsync(

--- a/src/Humans.Application/Services/Users/AccountProvisioningService.cs
+++ b/src/Humans.Application/Services/Users/AccountProvisioningService.cs
@@ -55,7 +55,6 @@ public sealed class AccountProvisioningService(
             }
         }
 
-        // Create new User + UserEmail.
         var resolvedDisplayName = string.IsNullOrWhiteSpace(displayName)
             ? email.Split('@')[0]
             : displayName;
@@ -161,7 +160,16 @@ public sealed class AccountProvisioningService(
             logger.LogError(ex,
                 "Failed to create UserEmail for magic-link signup {UserId} ({Email}); rolling back user",
                 user.Id, email);
-            await TryDeleteOrphanUserAsync(user);
+            try
+            {
+                await userManager.DeleteAsync(user);
+            }
+            catch (Exception deleteEx)
+            {
+                logger.LogError(deleteEx,
+                    "Failed to clean up orphan user {UserId} after AddVerifiedEmailAsync failure",
+                    user.Id);
+            }
             return new MagicLinkSignupCompletionResult(
                 MagicLinkSignupCompletionOutcome.Failed,
                 User: null);
@@ -177,19 +185,5 @@ public sealed class AccountProvisioningService(
         return new MagicLinkSignupCompletionResult(
             MagicLinkSignupCompletionOutcome.Created,
             user);
-    }
-
-    private async Task TryDeleteOrphanUserAsync(User user)
-    {
-        try
-        {
-            await userManager.DeleteAsync(user);
-        }
-        catch (Exception deleteEx)
-        {
-            logger.LogError(deleteEx,
-                "Failed to clean up orphan user {UserId} after AddVerifiedEmailAsync failure",
-                user.Id);
-        }
     }
 }

--- a/src/Humans.Application/Services/Users/UnsubscribeService.cs
+++ b/src/Humans.Application/Services/Users/UnsubscribeService.cs
@@ -17,7 +17,6 @@ public sealed class UnsubscribeService(
 {
     public async Task<UnsubscribeTokenResult> ValidateTokenAsync(string token, CancellationToken ct = default)
     {
-        // Try category-aware token first.
         var result = preferenceService.ValidateUnsubscribeToken(token);
         if (result.Status == TokenValidationStatus.Valid)
         {
@@ -29,28 +28,9 @@ public sealed class UnsubscribeService(
             return UnsubscribeTokenResult.Valid(result.UserId, info?.BurnerName ?? string.Empty, result.Category);
         }
 
-        // Expired new-format — don't fall through to legacy.
         if (result.Status == TokenValidationStatus.Expired)
             return UnsubscribeTokenResult.Expired();
 
-        // Fall back to legacy campaign-only token.
-        return await ValidateLegacyTokenAsync(token, ct);
-    }
-
-    public async Task<UnsubscribeTokenResult> ConfirmUnsubscribeAsync(string token, string source, CancellationToken ct = default)
-    {
-        var result = await ValidateTokenAsync(token, ct);
-        if (!result.IsValid || !result.UserId.HasValue || !result.Category.HasValue)
-            return result;
-
-        await preferenceService.UpdatePreferenceAsync(
-            result.UserId.Value, result.Category.Value, optedOut: true, source: source);
-
-        return result;
-    }
-
-    private async Task<UnsubscribeTokenResult> ValidateLegacyTokenAsync(string token, CancellationToken ct)
-    {
         var protector = dataProtection
             .CreateProtector("CampaignUnsubscribe")
             .ToTimeLimitedDataProtector();
@@ -71,11 +51,23 @@ public sealed class UnsubscribeService(
             return UnsubscribeTokenResult.Invalid();
         }
 
-        var user = await userRepository.GetByIdAsync(userId, ct);
-        if (user is null)
+        var legacyUser = await userRepository.GetByIdAsync(userId, ct);
+        if (legacyUser is null)
             return UnsubscribeTokenResult.Invalid();
 
-        var info = await userService.GetUserInfoAsync(userId, ct);
-        return UnsubscribeTokenResult.Valid(userId, info?.BurnerName ?? string.Empty, MessageCategory.Marketing, isLegacy: true);
+        var legacyInfo = await userService.GetUserInfoAsync(userId, ct);
+        return UnsubscribeTokenResult.Valid(userId, legacyInfo?.BurnerName ?? string.Empty, MessageCategory.Marketing, isLegacy: true);
+    }
+
+    public async Task<UnsubscribeTokenResult> ConfirmUnsubscribeAsync(string token, string source, CancellationToken ct = default)
+    {
+        var result = await ValidateTokenAsync(token, ct);
+        if (!result.IsValid || !result.UserId.HasValue || !result.Category.HasValue)
+            return result;
+
+        await preferenceService.UpdatePreferenceAsync(
+            result.UserId.Value, result.Category.Value, optedOut: true, source: source);
+
+        return result;
     }
 }

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -259,13 +259,6 @@ public sealed class UserService(
                 return false;
         }
 
-        return await SetGoogleEmailStatusInternalAsync(userId, status, ct);
-    }
-
-    // Private write — Try variant is the only external entry point (sync-driven; Rejected is terminal).
-    private async Task<bool> SetGoogleEmailStatusInternalAsync(
-        Guid userId, GoogleEmailStatus status, CancellationToken ct = default)
-    {
         return await repo.SetGoogleEmailStatusAsync(userId, status, ct);
     }
 

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -25,13 +25,10 @@ public sealed class UserService(
     IClock clock,
     ILogger<UserService> logger) : IUserService, IUserDataContributor
 {
-    private static readonly TrackedLock[] ProfileStubLocks = CreateProfileStubLocks(32);
-    private static TrackedLock[] CreateProfileStubLocks(int count)
-    {
-        var locks = new TrackedLock[count];
-        for (var i = 0; i < count; i++) locks[i] = new TrackedLock($"UserService.ProfileStub[{i}]");
-        return locks;
-    }
+    private static readonly TrackedLock[] ProfileStubLocks = Enumerable
+        .Range(0, 32)
+        .Select(i => new TrackedLock($"UserService.ProfileStub[{i}]"))
+        .ToArray();
 
     private static TrackedLock ProfileStubLockFor(Guid userId) =>
         ProfileStubLocks[(uint)userId.GetHashCode() % (uint)ProfileStubLocks.Length];
@@ -227,20 +224,16 @@ public sealed class UserService(
 
         foreach (var user in userList)
         {
+            if (user.UserEmails.Count > 0)
+                continue;
+
             var emails = emailsByUser.TryGetValue(user.Id, out var found)
                 ? found
                 : [];
-            AttachUserEmails(user, emails);
+
+            foreach (var email in emails)
+                user.UserEmails.Add(email);
         }
-    }
-
-    private static void AttachUserEmails(User user, IEnumerable<UserEmail> emails)
-    {
-        if (user.UserEmails.Count > 0)
-            return;
-
-        foreach (var email in emails)
-            user.UserEmails.Add(email);
     }
 
     public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
@@ -360,7 +353,17 @@ public sealed class UserService(
         UserProfileOnboardingCommand command,
         CancellationToken ct = default)
     {
-        ValidateProfileOnboardingCommand(command);
+        switch (command.Mutation)
+        {
+            case UserProfileOnboardingMutation.RecordConsentCheck
+                when command.ConsentCheckStatus is not ConsentCheckStatus.Cleared and not ConsentCheckStatus.Flagged:
+                throw new ArgumentException(
+                    "RecordConsentCheck only accepts Cleared or Flagged; use SetConsentCheckPending for the system-driven Pending transition.",
+                    nameof(command));
+
+            case UserProfileOnboardingMutation.SetSuspension when command.Suspended is null:
+                throw new ArgumentException("SetSuspension requires Suspended.", nameof(command));
+        }
 
         var profile = await repo.GetByUserIdAsync(userId, ct);
         if (profile is null)
@@ -372,7 +375,13 @@ public sealed class UserService(
             case UserProfileOnboardingMutation.RecordConsentCheck:
                 if (command.ConsentCheckStatus == ConsentCheckStatus.Cleared && profile.RejectedAt is not null)
                     return new OnboardingResult(false, "AlreadyRejected");
-                ApplyConsentCheck(profile, command, now);
+                var cleared = command.ConsentCheckStatus == ConsentCheckStatus.Cleared;
+                profile.ConsentCheckStatus = command.ConsentCheckStatus;
+                profile.ConsentCheckAt = now;
+                profile.ConsentCheckedByUserId = command.ActorUserId;
+                profile.ConsentCheckNotes = command.Notes;
+                profile.IsApproved = cleared;
+                profile.UpdatedAt = now;
                 break;
 
             case UserProfileOnboardingMutation.RejectSignup:
@@ -386,7 +395,16 @@ public sealed class UserService(
                 break;
 
             case UserProfileOnboardingMutation.SetSuspension:
-                ApplySuspension(profile, command, now);
+                var suspended = command.Suspended!.Value;
+                profile.IsSuspended = suspended;
+                profile.State = suspended
+                    ? (command.AdminSuspension ? ProfileState.AdminSuspended : ProfileState.Suspended)
+                    : HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
+
+                if (suspended)
+                    profile.AdminNotes = command.Notes;
+
+                profile.UpdatedAt = now;
                 break;
 
             case UserProfileOnboardingMutation.SetConsentCheckPending:
@@ -482,7 +500,7 @@ public sealed class UserService(
         };
 
         // see #635 (section 15i) - Stub->Active promotion (mirrors UserInfo.HasRequiredNameFields).
-        if (!IsSuspendedState(profile.State))
+        if (profile.State is not (ProfileState.Suspended or ProfileState.AdminSuspended))
         {
             profile.State = HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
         }
@@ -659,7 +677,9 @@ public sealed class UserService(
             UpdatedAt = now,
         };
 
-        await AddRowWithInvariantsAsync(row, ct);
+        await repo.AddUserEmailAsync(row, ct);
+        await EnsurePrimaryInvariantAsync(row.UserId, ct);
+        await EnsureGoogleInvariantAsync(row.UserId, ct);
         return new UserEmailAddResult(row.Id, Added: true, isConflict);
     }
 
@@ -897,7 +917,11 @@ public sealed class UserService(
             .Where(e => e.IsVerified && e.IsGoogle)
             .Select(e => e.Email)
             .FirstOrDefault();
-        var effectiveEmail = SelectEffectiveEmail(userEmails, user.IdentityEmailColumn);
+        var effectiveEmail = userEmails
+            .Where(e => e.IsVerified)
+            .OrderByDescending(e => e.IsPrimary)
+            .Select(e => e.Email)
+            .FirstOrDefault() ?? user.IdentityEmailColumn;
 
         var shaped = new
         {
@@ -1041,15 +1065,6 @@ public sealed class UserService(
         ];
     }
 
-    private static string? SelectEffectiveEmail(
-        IReadOnlyCollection<UserEmail> userEmails,
-        string? fallbackEmail) =>
-        userEmails
-            .Where(e => e.IsVerified)
-            .OrderByDescending(e => e.IsPrimary)
-            .Select(e => e.Email)
-            .FirstOrDefault() ?? fallbackEmail;
-
     private async Task SetPrimaryEmailAsync(Guid userId, Guid emailId, CancellationToken ct)
     {
         var emails = (await repo.GetUserEmailsByUserIdForMutationAsync(userId, ct)).ToList();
@@ -1173,13 +1188,6 @@ public sealed class UserService(
             await repo.UpdateUserEmailsAsync(changed, ct);
     }
 
-    private async Task AddRowWithInvariantsAsync(UserEmail row, CancellationToken ct)
-    {
-        await repo.AddUserEmailAsync(row, ct);
-        await EnsurePrimaryInvariantAsync(row.UserId, ct);
-        await EnsureGoogleInvariantAsync(row.UserId, ct);
-    }
-
     private async Task SeedUserStateIfNullAsync(User user, UserInfo info, CancellationToken ct)
     {
         if (user.State is null && info.State is { } seeded)
@@ -1190,63 +1198,10 @@ public sealed class UserService(
     // profile transitions that can change the stored state (e.g. Bare after a name submit).
     private void InvalidateClaims(Guid userId) => roleAssignmentClaimsInvalidator.Invalidate(userId);
 
-    private static void ApplyConsentCheck(
-        Profile profile,
-        UserProfileOnboardingCommand command,
-        Instant now)
-    {
-        var cleared = command.ConsentCheckStatus == ConsentCheckStatus.Cleared;
-        profile.ConsentCheckStatus = command.ConsentCheckStatus;
-        profile.ConsentCheckAt = now;
-        profile.ConsentCheckedByUserId = command.ActorUserId;
-        profile.ConsentCheckNotes = command.Notes;
-        profile.IsApproved = cleared;
-        profile.UpdatedAt = now;
-    }
-
-    private static void ApplySuspension(
-        Profile profile,
-        UserProfileOnboardingCommand command,
-        Instant now)
-    {
-        var suspended = command.Suspended!.Value;
-
-        profile.IsSuspended = suspended;
-
-        // Dual-write until IsSuspended is dropped. State is the canonical shape
-        // exposed through UserInfo.
-        profile.State = suspended
-            ? (command.AdminSuspension ? ProfileState.AdminSuspended : ProfileState.Suspended)
-            : HasRequiredNameFields(profile) ? ProfileState.Active : ProfileState.Stub;
-
-        if (suspended)
-            profile.AdminNotes = command.Notes;
-
-        profile.UpdatedAt = now;
-    }
-
     private static bool HasRequiredNameFields(Profile profile) =>
         !string.IsNullOrWhiteSpace(profile.BurnerName)
         && !string.IsNullOrWhiteSpace(profile.FirstName)
         && !string.IsNullOrWhiteSpace(profile.LastName);
-
-    private static bool IsSuspendedState(ProfileState? state) =>
-        state is ProfileState.Suspended or ProfileState.AdminSuspended;
-
-    private static void ValidateProfileOnboardingCommand(UserProfileOnboardingCommand command)
-    {
-        switch (command.Mutation)
-        {
-            case UserProfileOnboardingMutation.RecordConsentCheck
-                when command.ConsentCheckStatus is not ConsentCheckStatus.Cleared and not ConsentCheckStatus.Flagged:
-                throw new ArgumentException(
-                    "RecordConsentCheck only accepts Cleared or Flagged; use SetConsentCheckPending for the system-driven Pending transition.",
-                    nameof(command));
-
-            case UserProfileOnboardingMutation.SetSuspension when command.Suspended is null:
-                throw new ArgumentException("SetSuspension requires Suspended.", nameof(command));
-        }
-    }
 
     private static string? GetAlternateEmail(string normalizedEmail)
     {

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.ContactFields.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.ContactFields.cs
@@ -91,13 +91,13 @@ internal sealed partial class UserRepository
         // comparison configured, so we use case-insensitive match to keep the
         // collapse correct for emails/usernames where casing may differ. Target
         // wins on collision.
-        var targetKeys = new HashSet<(ContactFieldType FieldType, string Value)>(
-            targetRows.Select(cf => (cf.FieldType, cf.Value)),
-            new FieldTypeValueComparer());
+        var targetKeys = targetRows
+            .Select(cf => (cf.FieldType, Value: cf.Value.ToLowerInvariant()))
+            .ToHashSet();
 
         foreach (var src in sourceRows)
         {
-            var key = (src.FieldType, src.Value);
+            var key = (src.FieldType, Value: src.Value.ToLowerInvariant());
             if (targetKeys.Contains(key))
             {
                 // Target already has the same (FieldType, Value) — drop source.
@@ -117,18 +117,4 @@ internal sealed partial class UserRepository
         return await ctx.ContactFields
             .CountAsync(cf => cf.ProfileId == targetProfileId.Value, ct);
     }
-
-    private sealed class FieldTypeValueComparer
-        : IEqualityComparer<(ContactFieldType FieldType, string Value)>
-    {
-        public bool Equals(
-            (ContactFieldType FieldType, string Value) x,
-            (ContactFieldType FieldType, string Value) y) =>
-            x.FieldType == y.FieldType
-            && string.Equals(x.Value, y.Value, StringComparison.OrdinalIgnoreCase);
-
-        public int GetHashCode((ContactFieldType FieldType, string Value) obj) =>
-            HashCode.Combine(obj.FieldType, obj.Value.ToLowerInvariant());
-    }
 }
-

--- a/src/Humans.Web/Controllers/UnsubscribeController.cs
+++ b/src/Humans.Web/Controllers/UnsubscribeController.cs
@@ -20,13 +20,11 @@ public class UnsubscribeController(IUnsubscribeService unsubscribeService, ILogg
 
         if (!result.IsLegacy)
         {
-            // New tokens redirect to comms preferences (no session).
             return RedirectToAction(
                 nameof(GuestController.CommunicationPreferences), "Guest",
                 new { utoken = token });
         }
 
-        // Legacy: show confirmation page.
         ViewData["DisplayName"] = result.DisplayName;
         ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
         return View();
@@ -46,13 +44,11 @@ public class UnsubscribeController(IUnsubscribeService unsubscribeService, ILogg
 
         if (!result.IsLegacy)
         {
-            // New tokens redirect to comms preferences (no session).
             return RedirectToAction(
                 nameof(GuestController.CommunicationPreferences), "Guest",
                 new { utoken = token });
         }
 
-        // Legacy: show done page.
         ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
         return View("Done");
     }

--- a/src/Humans.Web/Controllers/UsersAdminController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminController.cs
@@ -128,6 +128,9 @@ public sealed class UsersAdminController(
         var mergedToName = info.MergedToUserId is Guid mergedTo
             ? (await _userService.GetUserInfoAsync(mergedTo, ct))?.BurnerName
             : null;
+        var rejectedByName = info.Profile?.RejectedByUserId is Guid rejectedByUserId
+            ? (await _userService.GetUserInfoAsync(rejectedByUserId, ct))?.BurnerName
+            : null;
 
         var viewModel = AdminHumanDetailViewModelBuilder.Build(
             info,
@@ -139,7 +142,7 @@ public sealed class UsersAdminController(
             campaignGrants,
             outboxCount,
             clock.GetCurrentInstant(),
-            await GetRejectedByNameAsync(info.Profile, ct),
+            rejectedByName,
             revealedIban,
             mergedToName);
 
@@ -153,7 +156,20 @@ public sealed class UsersAdminController(
     {
         var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null) return Forbid();
-        return await RevealIbanCoreAsync(id, actor.Id, ct);
+
+        var info = await _userService.GetUserInfoAsync(id, ct);
+        var iban = info?.Profile?.Iban;
+        if (iban is null)
+        {
+            SetError("No IBAN on record for this user.");
+            return RedirectToAction(nameof(AdminDetail), new { id });
+        }
+
+        await auditLogService.LogAsync(
+            AuditAction.IbanReveal, nameof(User), id,
+            $"Admin revealed IBAN for user {id}", actor.Id);
+        TempData["RevealedIban"] = iban;
+        return RedirectToAction(nameof(AdminDetail), new { id });
     }
 
     [HttpGet("{id:guid}/Outbox")]
@@ -208,10 +224,10 @@ public sealed class UsersAdminController(
         var result = await onboardingService.RejectSignupAsync(id, currentUser.Id, reason);
         if (!result.Success)
         {
-            if (string.Equals(result.ErrorKey, "AlreadyRejected", StringComparison.Ordinal))
-                SetError("This human has already been rejected.");
-            else
+            if (!string.Equals(result.ErrorKey, "AlreadyRejected", StringComparison.Ordinal))
                 return NotFound();
+
+            SetError("This human has already been rejected.");
             return RedirectToAction(nameof(AdminDetail), new { id });
         }
 
@@ -222,11 +238,8 @@ public sealed class UsersAdminController(
     [HttpGet("{id:guid}/Roles/Add")]
     public async Task<IActionResult> AddRole(Guid id)
     {
-        var info = await _userService.GetUserInfoAsync(id);
-        if (info is null)
-        {
+        if (await _userService.GetUserInfoAsync(id) is null)
             return NotFound();
-        }
 
         var viewModel = new CreateRoleAssignmentViewModel
         {
@@ -241,16 +254,14 @@ public sealed class UsersAdminController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> AddRole(Guid id, CreateRoleAssignmentViewModel model)
     {
-        var info = await _userService.GetUserInfoAsync(id);
-        if (info is null)
-        {
+        if (await _userService.GetUserInfoAsync(id) is null)
             return NotFound();
-        }
 
         if (string.IsNullOrWhiteSpace(model.RoleName))
         {
             ModelState.AddModelError(nameof(model.RoleName), "Please select a role.");
-            PopulateRoleAssignmentForm(model, id);
+            model.UserId = id;
+            model.AvailableRoles = [.. RoleChecks.GetAssignableRoles(User)];
             return View(model);
         }
 
@@ -273,7 +284,11 @@ public sealed class UsersAdminController(
         var result = await roleAssignmentService.AssignRoleAsync(
             id, model.RoleName, currentUser.Id, model.Notes);
 
-        SetRoleAssignmentResult(model.RoleName, result.Success);
+        if (result.Success)
+            SetSuccess(string.Format(localizer["Admin_RoleAssigned"].Value, model.RoleName));
+        else
+            SetError(string.Format(localizer["Admin_RoleAlreadyActive"].Value, model.RoleName));
+
         return RedirectToAction(nameof(AdminDetail), new { id });
     }
 
@@ -307,7 +322,14 @@ public sealed class UsersAdminController(
         var result = await roleAssignmentService.EndRoleAsync(
             roleId, currentUser.Id, notes);
 
-        SetRoleEndedResult(result.Success, roleAssignment.RoleName, roleAssignment.UserDisplayName);
+        if (result.Success)
+            SetSuccess(string.Format(
+                localizer["Admin_RoleEnded"].Value,
+                roleAssignment.RoleName,
+                roleAssignment.UserDisplayName));
+        else
+            SetError(localizer["Admin_RoleNotActive"].Value);
+
         return RedirectToAction(nameof(AdminDetail), new { id = roleAssignment.UserId });
     }
 
@@ -411,56 +433,4 @@ public sealed class UsersAdminController(
             statusFilter);
     }
 
-    private async Task<string?> GetRejectedByNameAsync(ProfileInfo? profile, CancellationToken ct)
-    {
-        if (profile?.RejectedByUserId is null)
-            return null;
-
-        var rejectedByInfo = await _userService.GetUserInfoAsync(profile.RejectedByUserId.Value, ct);
-        return rejectedByInfo?.BurnerName;
-    }
-
-    private async Task<IActionResult> RevealIbanCoreAsync(Guid id, Guid actorId, CancellationToken ct)
-    {
-        var info = await _userService.GetUserInfoAsync(id, ct);
-        var iban = info?.Profile?.Iban;
-        if (iban is null)
-        {
-            SetError("No IBAN on record for this user.");
-            return RedirectToAction(nameof(AdminDetail), new { id });
-        }
-        await auditLogService.LogAsync(
-            AuditAction.IbanReveal, nameof(User), id,
-            $"Admin revealed IBAN for user {id}", actorId);
-        TempData["RevealedIban"] = iban;
-        return RedirectToAction(nameof(AdminDetail), new { id });
-    }
-
-    private void PopulateRoleAssignmentForm(CreateRoleAssignmentViewModel model, Guid userId)
-    {
-        model.UserId = userId;
-        model.AvailableRoles = [.. RoleChecks.GetAssignableRoles(User)];
-    }
-
-    private void SetRoleAssignmentResult(string roleName, bool success)
-    {
-        if (success)
-        {
-            SetSuccess(string.Format(localizer["Admin_RoleAssigned"].Value, roleName));
-            return;
-        }
-
-        SetError(string.Format(localizer["Admin_RoleAlreadyActive"].Value, roleName));
-    }
-
-    private void SetRoleEndedResult(bool success, string roleName, string userDisplayName)
-    {
-        if (success)
-        {
-            SetSuccess(string.Format(localizer["Admin_RoleEnded"].Value, roleName, userDisplayName));
-            return;
-        }
-
-        SetError(localizer["Admin_RoleNotActive"].Value);
-    }
 }

--- a/src/Humans.Web/Controllers/UsersAdminController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminController.cs
@@ -2,7 +2,6 @@
 // @e2e: profile.spec.ts
 using Humans.Application;
 using Humans.Application.Authorization;
-using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Admin;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
@@ -57,7 +56,35 @@ public sealed class UsersAdminController(
         int page = 1,
         CancellationToken ct = default)
     {
-        var allRows = await BuildAdminHumansAsync(search, filter, ct);
+        var allUsers = await _userService.GetAllUserInfosAsync(ct).ConfigureAwait(false);
+        var allUserIds = allUsers.Select(u => u.Id).ToList();
+        var notificationEmails =
+            await userEmailService.GetNotificationEmailsByUserIdsAsync(allUserIds, ct);
+
+        IReadOnlySet<Guid>? searchUserIds = null;
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var searchResults = await _userService.SearchUsersAsync(
+                search, PersonSearchFields.AdminAll, limit: int.MaxValue, ct);
+
+            var byEmail = allUsers
+                .Where(u =>
+                    (u.Email ?? string.Empty).Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                    u.BurnerName.Contains(search, StringComparison.OrdinalIgnoreCase))
+                .Select(u => u.Id);
+
+            searchUserIds = searchResults
+                .Select(r => r.UserId)
+                .Concat(byEmail)
+                .ToHashSet();
+        }
+
+        var allRows = AdminHumanListAssembler.Assemble(
+            allUsers,
+            notificationEmails,
+            searchUserIds,
+            filter);
+
         var viewModel = AdminHumanListViewModelBuilder.Build(
             allRows,
             search,
@@ -396,41 +423,6 @@ public sealed class UsersAdminController(
 
         SetSuccess($"Purged {displayName}. They will get a fresh account on next login.");
         return RedirectToAction(nameof(AdminList));
-    }
-
-    private async Task<IReadOnlyList<AdminHumanRow>> BuildAdminHumansAsync(
-        string? search, string? statusFilter, CancellationToken ct)
-    {
-        var allUsers = await _userService.GetAllUserInfosAsync(ct).ConfigureAwait(false);
-        var allUserIds = allUsers.Select(u => u.Id).ToList();
-        var notificationEmails =
-            await userEmailService.GetNotificationEmailsByUserIdsAsync(allUserIds, ct);
-
-        IReadOnlySet<Guid>? searchUserIds = null;
-        if (!string.IsNullOrWhiteSpace(search))
-        {
-            // Uncapped: used as a match set to filter the admin list (ordering is the table's own),
-            // so a hard cap would silently drop matching humans. Cheap at ~500 users.
-            var searchResults = await _userService.SearchUsersAsync(
-                search, PersonSearchFields.AdminAll, limit: int.MaxValue, ct);
-
-            var byEmail = allUsers
-                .Where(u =>
-                    (u.Email ?? string.Empty).Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                    u.BurnerName.Contains(search, StringComparison.OrdinalIgnoreCase))
-                .Select(u => u.Id);
-
-            searchUserIds = searchResults
-                .Select(r => r.UserId)
-                .Concat(byEmail)
-                .ToHashSet();
-        }
-
-        return AdminHumanListAssembler.Assemble(
-            allUsers,
-            notificationEmails,
-            searchUserIds,
-            statusFilter);
     }
 
 }


### PR DESCRIPTION
## Simplifications

### Removed private indirection
- Inlined single-caller Users admin helpers for rejected-by lookup, IBAN reveal, role form population, role-result flash messages, and admin-list row assembly.
- Inlined small `UserService` helpers for Google email status forwarding, profile onboarding mutations, primary/user-email invariant calls, effective-email selection, profile-state suspension checks, and user-email hydration.
- Inlined the legacy unsubscribe-token validation path into the only public validator.
- Inlined the account-provisioning rollback helper into the only failure path.
- Inlined the account-merge cache invalidation helper into the `finally` block that owns it.

### Removed dead private structure
- Removed the contact-field merge comparer class by normalizing contact-field keys at the call site.

### Simplified local flow and comments
- Flattened rejected-signup handling and redundant role/user null-check locals.
- Removed comments that only restated obvious unsubscribe/provisioning flow.
- Kept ordering/rationale comments where they document merge, deletion, EF, or cache behavior.

## Net line delta
- 202 insertions, 286 deletions, net -84 lines.

## Verification
- `dotnet build Humans.slnx -v quiet` succeeded. The solution still emits existing analyzer warnings, so this is not globally zero-warning.
- `dotnet test Humans.slnx -v quiet` passed on rerun. One prior full-suite run had unrelated integration failures; an isolated rerun of one failed integration test passed, then the full suite passed.

## Needs owner judgment
- `UsersAdminDebugController.ApplySort` remains grandfathered with `HUM0031`. Reducing that warning cleanly would require moving screen sorting or adding a lookup structure, which is not a behavior-preserving simplification-only change.
- Public Users interfaces and DI registrations were left untouched even where analyzer warnings exist, per the no-public-surface/no-DI-change rule.
- Existing solution-wide analyzer warnings outside this Users simplification diff remain untouched.