### PR TITLE
refactor(shifts): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -99,9 +99,9 @@ public sealed class ShiftManagementService(
     public async Task<bool> CanApproveSignupsAsync(Guid userId, Guid departmentTeamId)
     {
         // Admin, NoInfoAdmin, and VolunteerCoordinator can approve signups system-wide
-        if (await HasActiveRoleAsync(userId, RoleNames.Admin) ||
-            await HasActiveRoleAsync(userId, RoleNames.NoInfoAdmin) ||
-            await HasActiveRoleAsync(userId, RoleNames.VolunteerCoordinator))
+        if (await RoleAssignmentService.HasActiveRoleAsync(userId, RoleNames.Admin) ||
+            await RoleAssignmentService.HasActiveRoleAsync(userId, RoleNames.NoInfoAdmin) ||
+            await RoleAssignmentService.HasActiveRoleAsync(userId, RoleNames.VolunteerCoordinator))
             return true;
 
         return await IsDeptCoordinatorAsync(userId, departmentTeamId);
@@ -115,11 +115,6 @@ public sealed class ShiftManagementService(
             return await TeamService.GetUserCoordinatedTeamIdsAsync(userId);
         });
         return result ?? [];
-    }
-
-    private async Task<bool> HasActiveRoleAsync(Guid userId, string roleName)
-    {
-        return await RoleAssignmentService.HasActiveRoleAsync(userId, roleName);
     }
 
     /// <summary>
@@ -1248,7 +1243,7 @@ public sealed class ShiftManagementService(
     {
         var es = await repo.GetEventSettingsByIdAsync(eventSettingsId);
         if (es is null)
-            return EmptyOverview();
+            return new DashboardOverview(0, 0, 0, 0, new PeriodBreakdown(0, 0, 0), 0, 0, 0, 0, []);
 
         var allShifts = await repo.GetEventShiftsAsync(new ShiftEventQuery(
             eventSettingsId,
@@ -1323,9 +1318,6 @@ public sealed class ShiftManagementService(
                 ? 100.0 * v.FilledSlots / v.TotalSlots
                 : 0d;
     }
-
-    private static DashboardOverview EmptyOverview() => new(
-        0, 0, 0, 0, new PeriodBreakdown(0, 0, 0), 0, 0, 0, 0, []);
 
     private static List<DepartmentStaffingRow> BuildDepartmentRows(
         IReadOnlyList<Shift> shifts,

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -53,7 +53,7 @@ public sealed class ShiftSignupService(
 
         var es = shift.Rota.EventSettings;
         var now = clock.GetCurrentInstant();
-        isPrivileged = isPrivileged || await IsPrivilegedAsync(userId, shift.Rota.TeamId);
+        isPrivileged = isPrivileged || await shiftMgmt.CanApproveSignupsAsync(userId, shift.Rota.TeamId);
 
         if (!es.IsShiftBrowsingOpen && !isPrivileged)
             return SignupResult.Fail("Shift browsing is not currently open.");
@@ -156,7 +156,7 @@ public sealed class ShiftSignupService(
         var now = clock.GetCurrentInstant();
         if (signup.Shift.IsEarlyEntry && es.EarlyEntryClose.HasValue && now >= es.EarlyEntryClose.Value)
         {
-            var isPrivileged = await IsPrivilegedAsync(reviewerUserId, signup.Shift.Rota.TeamId);
+            var isPrivileged = await shiftMgmt.CanApproveSignupsAsync(reviewerUserId, signup.Shift.Rota.TeamId);
             if (!isPrivileged)
                 return SignupResult.Fail("Cannot approve build shift signups after early entry close.");
         }
@@ -212,7 +212,7 @@ public sealed class ShiftSignupService(
         var es = signup.Shift.Rota.EventSettings;
         var now = clock.GetCurrentInstant();
         var isOwner = signup.UserId == actorUserId;
-        var isPrivileged = await IsPrivilegedAsync(actorUserId, signup.Shift.Rota.TeamId);
+        var isPrivileged = await shiftMgmt.CanApproveSignupsAsync(actorUserId, signup.Shift.Rota.TeamId);
 
         // Auth: must be signup owner or privileged (dept coordinator/NoInfoAdmin/Admin)
         if (!isOwner && !isPrivileged)
@@ -515,11 +515,18 @@ public sealed class ShiftSignupService(
 
         var es = rota.EventSettings;
         var now = clock.GetCurrentInstant();
-        isPrivileged = isPrivileged || await IsPrivilegedAsync(userId, rota.TeamId);
+        isPrivileged = isPrivileged || await shiftMgmt.CanApproveSignupsAsync(userId, rota.TeamId);
 
-        var gateFailure = ValidateRangeSignupGate(rota, es, now, isPrivileged);
-        if (gateFailure is not null)
-            return gateFailure;
+        if (!es.IsShiftBrowsingOpen && !isPrivileged)
+            return SignupResult.Fail("Shift browsing is not currently open.");
+
+        if (rota.Period == RotaPeriod.Build
+            && es.EarlyEntryClose.HasValue
+            && now >= es.EarlyEntryClose.Value
+            && !isPrivileged)
+        {
+            return SignupResult.Fail("Early entry signups are closed.");
+        }
 
         var shiftsInRange = SelectAllDayRangeShifts(rota, startDayOffset, endDayOffset);
 
@@ -543,14 +550,22 @@ public sealed class ShiftSignupService(
 
         shiftsInRange = conflictSelection.Shifts;
         if (shiftsInRange.Count == 0)
-            return BuildEmptyRangeSignupResult(conflictSelection.Warnings);
+            return conflictSelection.Warnings.Count > 0
+                ? SignupResult.Fail(string.Join(" ", conflictSelection.Warnings) + " Nothing to add.")
+                : SignupResult.Fail("No shifts found in the specified date range.");
 
         var capacitySelection = await SelectCapacityAvailableRangeShiftsAsync(shiftsInRange);
         if (capacitySelection.AvailableShifts.Count == 0)
             return SignupResult.Fail("All shifts in this range are at capacity.");
 
-        string? warning = CombineRangeWarnings(conflictSelection.Warnings);
-        warning = AppendFullDayRangeWarning(warning, capacitySelection.FullDayOffsets, es);
+        string? warning = conflictSelection.Warnings.Count > 0
+            ? string.Join(" ", conflictSelection.Warnings)
+            : null;
+        if (capacitySelection.FullDayOffsets.Count > 0)
+        {
+            var dayList = FormatRangeDayList(es, capacitySelection.FullDayOffsets);
+            warning = AppendRangeWarning(warning, $"Day(s) {dayList} are at capacity.");
+        }
 
         var availableShifts = capacitySelection.AvailableShifts;
 
@@ -580,26 +595,6 @@ public sealed class ShiftSignupService(
         }
 
         return SignupResult.Ok(createdSignups.LastSignup, warning);
-    }
-
-    private static SignupResult? ValidateRangeSignupGate(
-        Rota rota,
-        EventSettings eventSettings,
-        Instant now,
-        bool isPrivileged)
-    {
-        if (!eventSettings.IsShiftBrowsingOpen && !isPrivileged)
-            return SignupResult.Fail("Shift browsing is not currently open.");
-
-        if (rota.Period == RotaPeriod.Build
-            && eventSettings.EarlyEntryClose.HasValue
-            && now >= eventSettings.EarlyEntryClose.Value
-            && !isPrivileged)
-        {
-            return SignupResult.Fail("Early entry signups are closed.");
-        }
-
-        return null;
     }
 
     private static RangeSignupCandidateSelection PruneDuplicateRangeShifts(
@@ -690,11 +685,6 @@ public sealed class ShiftSignupService(
         return conflictingDays;
     }
 
-    private static SignupResult BuildEmptyRangeSignupResult(IReadOnlyList<string> warnings)
-        => warnings.Count > 0
-            ? SignupResult.Fail(string.Join(" ", warnings) + " Nothing to add.")
-            : SignupResult.Fail("No shifts found in the specified date range.");
-
     private async Task<RangeCapacitySelection> SelectCapacityAvailableRangeShiftsAsync(List<Shift> shiftsInRange)
     {
         var shiftIdsInRange = shiftsInRange.Select(s => s.Id).ToHashSet();
@@ -709,21 +699,6 @@ public sealed class ShiftSignupService(
             .ToList();
 
         return new RangeCapacitySelection(availableShifts, fullDays);
-    }
-
-    private static string? CombineRangeWarnings(IReadOnlyList<string> warnings)
-        => warnings.Count > 0 ? string.Join(" ", warnings) : null;
-
-    private static string? AppendFullDayRangeWarning(
-        string? warning,
-        IReadOnlyCollection<int> fullDays,
-        EventSettings eventSettings)
-    {
-        if (fullDays.Count == 0)
-            return warning;
-
-        var dayList = FormatRangeDayList(eventSettings, fullDays);
-        return AppendRangeWarning(warning, $"Day(s) {dayList} are at capacity.");
     }
 
     private async Task<string?> AppendEarlyEntryRangeWarningAsync(
@@ -846,7 +821,7 @@ public sealed class ShiftSignupService(
 
             if (signup.Shift.IsEarlyEntry && es.EarlyEntryClose.HasValue && now >= es.EarlyEntryClose.Value)
             {
-                var isPrivileged = await IsPrivilegedAsync(reviewerUserId, signup.Shift.Rota.TeamId);
+                var isPrivileged = await shiftMgmt.CanApproveSignupsAsync(reviewerUserId, signup.Shift.Rota.TeamId);
                 if (!isPrivileged)
                     return SignupResult.Fail("Cannot approve build shift signups after early entry close.");
             }
@@ -962,7 +937,7 @@ public sealed class ShiftSignupService(
         var es = firstSignup.Shift.Rota.EventSettings;
         var now = clock.GetCurrentInstant();
         var isOwner = firstSignup.UserId == actorUserId;
-        var isPrivileged = await IsPrivilegedAsync(actorUserId, firstSignup.Shift.Rota.TeamId);
+        var isPrivileged = await shiftMgmt.CanApproveSignupsAsync(actorUserId, firstSignup.Shift.Rota.TeamId);
 
         if (!isOwner && !isPrivileged)
             throw new InvalidOperationException("Not authorized to bail this signup block.");
@@ -1041,12 +1016,9 @@ public sealed class ShiftSignupService(
     {
         var signups = await repo.GetForUsersAsync([userId]);
         return signups
-            .Where(IsActiveSignup)
+            .Where(signup => signup.Status is SignupStatus.Pending or SignupStatus.Confirmed)
             .ToList();
     }
-
-    private static bool IsActiveSignup(ShiftSignup signup) =>
-        signup.Status is SignupStatus.Pending or SignupStatus.Confirmed;
 
     private async Task<string?> CheckOverlapAsync(Guid userId, Shift targetShift, EventSettings es)
     {
@@ -1103,11 +1075,6 @@ public sealed class ShiftSignupService(
             return "Early entry capacity reached.";
 
         return null;
-    }
-
-    private async Task<bool> IsPrivilegedAsync(Guid userId, Guid departmentTeamId)
-    {
-        return await shiftMgmt.CanApproveSignupsAsync(userId, departmentTeamId);
     }
 
     private async Task CheckAndNotifyCoverageGapAsync(ShiftSignup signup, Shift shift)

--- a/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
+++ b/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
@@ -38,13 +38,12 @@ public sealed class VolunteerTrackingExportService(
             .GroupBy(d => d.TeamId)
             .ToDictionary(g => g.Key, g => g.First().TeamName);
 
-        // Filtered team name (if filtered) for the filename + summary.
         string? filteredTeamName = request.DepartmentId is Guid deptId
             ? teamNames.GetValueOrDefault(deptId)
             : null;
 
         if (shifts.Count == 0)
-            return BuildEmptyModel(request, days, filteredTeamName);
+            return BuildModel(request, days, Array.Empty<DepartmentGroup>(), new int[days.Count], filteredTeamName);
 
         // Look up the event time zone via the existing IShiftManagementService surface
         // (EventSettings.TimeZoneId is the IANA id). Avoids a new interface method.
@@ -58,7 +57,7 @@ public sealed class VolunteerTrackingExportService(
         // (2) Per user: primary team = team with most total hours; first-shift date.
         var userIds = perUserPerDay.Keys.Select(k => k.userId).Distinct().ToList();
         var playaNames = await LoadPlayaNamesAsync(userIds, ct);
-        var firstShiftDay = ComputeFirstShiftDay(shifts, zone);
+        var firstShiftDay = ShiftEarlyEntryProjection.FirstShiftDayByUser(shifts, zone);
         var primaryTeam = ComputePrimaryTeam(perUserPerDay);
 
         // (3) Build cells per user.
@@ -151,9 +150,6 @@ public sealed class VolunteerTrackingExportService(
         return result;
     }
 
-    private static Dictionary<Guid, LocalDate> ComputeFirstShiftDay(IReadOnlyList<ConfirmedShiftRow> shifts, DateTimeZone zone) =>
-        ShiftEarlyEntryProjection.FirstShiftDayByUser(shifts, zone);
-
     private static Dictionary<Guid, (Guid teamId, string teamName)> ComputePrimaryTeam(
         Dictionary<(Guid userId, LocalDate day), List<(Guid teamId, string teamName, double hours)>> bucket)
     {
@@ -196,7 +192,7 @@ public sealed class VolunteerTrackingExportService(
             var count = 0;
             foreach (var (userId, row) in rows)
             {
-                if (firstShiftDay[userId] > d) continue;        // hasn't arrived yet
+                if (firstShiftDay[userId] > d) continue;
                 if (row.Cells[i].Kind == CellKind.Worked) count++;
             }
             totals[i] = count;
@@ -211,11 +207,6 @@ public sealed class VolunteerTrackingExportService(
         for (var i = 0; i < count; i++) days[i] = start.PlusDays(i);
         return days;
     }
-
-    private static string BuildMethodologyBlurb() =>
-        "Rows = humans with >=1 confirmed shift in range. Cell color = the team they worked most " +
-        "hours that day. White cell = day before their first confirmed shift (arrival day). " +
-        "Totals row = humans on-site that day (used for meal counts). Names shown are playa names.";
 
     private static string BuildFileName(VolunteerExportRequest req, string? departmentSlug)
     {
@@ -282,11 +273,6 @@ public sealed class VolunteerTrackingExportService(
         return ShiftEarlyEntryProjection.Project(rows, zone, teamNames);
     }
 
-    private static VolunteerExportModel BuildEmptyModel(VolunteerExportRequest request, IReadOnlyList<LocalDate> days, string? filteredTeamName)
-    {
-        return BuildModel(request, days, Array.Empty<DepartmentGroup>(), new int[days.Count], filteredTeamName);
-    }
-
     private static VolunteerExportModel BuildModel(
         VolunteerExportRequest request,
         IReadOnlyList<LocalDate> days,
@@ -298,7 +284,9 @@ public sealed class VolunteerTrackingExportService(
         var periodLabel = request.Period?.ToString() ?? "custom";
         var slug = filteredTeamName is null ? null : SlugifyTeamName(filteredTeamName);
         return new VolunteerExportModel(
-            MethodologyBlurb: BuildMethodologyBlurb(),
+            MethodologyBlurb: "Rows = humans with >=1 confirmed shift in range. Cell color = the team they worked most " +
+                "hours that day. White cell = day before their first confirmed shift (arrival day). " +
+                "Totals row = humans on-site that day (used for meal counts). Names shown are playa names.",
             FilterSummary: $"Department: {deptName} - Range: {request.StartDate} -> {request.EndDate} ({periodLabel})",
             GeneratedAtUtc: request.GeneratedAtUtc,
             GeneratedByName: request.ActorPlayaName,

--- a/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
+++ b/src/Humans.Application/Services/Shifts/VolunteerTrackingExportService.cs
@@ -208,14 +208,6 @@ public sealed class VolunteerTrackingExportService(
         return days;
     }
 
-    private static string BuildFileName(VolunteerExportRequest req, string? departmentSlug)
-    {
-        var prefix = departmentSlug is { Length: > 0 } slug
-            ? $"volunteer-tracking-{slug}-"
-            : "volunteer-tracking-";
-        return $"{prefix}{req.StartDate.ToInvariantDate()}-to-{req.EndDate.ToInvariantDate()}.xlsx";
-    }
-
     private static string SlugifyTeamName(string teamName)
     {
         // Spec §File Output slugification rule:
@@ -283,6 +275,9 @@ public sealed class VolunteerTrackingExportService(
         var deptName = filteredTeamName ?? "All";
         var periodLabel = request.Period?.ToString() ?? "custom";
         var slug = filteredTeamName is null ? null : SlugifyTeamName(filteredTeamName);
+        var filePrefix = slug is { Length: > 0 }
+            ? $"volunteer-tracking-{slug}-"
+            : "volunteer-tracking-";
         return new VolunteerExportModel(
             MethodologyBlurb: "Rows = humans with >=1 confirmed shift in range. Cell color = the team they worked most " +
                 "hours that day. White cell = day before their first confirmed shift (arrival day). " +
@@ -293,6 +288,6 @@ public sealed class VolunteerTrackingExportService(
             Days: days,
             Groups: groups,
             TotalsPerDay: totals,
-            SuggestedFileName: BuildFileName(request, slug));
+            SuggestedFileName: $"{filePrefix}{request.StartDate.ToInvariantDate()}-to-{request.EndDate.ToInvariantDate()}.xlsx");
     }
 }

--- a/src/Humans.Application/Services/Shifts/VolunteerTrackingService.cs
+++ b/src/Humans.Application/Services/Shifts/VolunteerTrackingService.cs
@@ -29,7 +29,10 @@ public sealed class VolunteerTrackingService(
         var all = await trackingRepo.GetAvailabilityForEventAsync(eventSettingsId);
         return all
             .Where(g => g.AvailableDayOffsets.Contains(dayOffset))
-            .Select(ToSnapshot)
+            .Select(availability => new GeneralAvailabilitySnapshot(
+                availability.UserId,
+                availability.EventSettingsId,
+                availability.AvailableDayOffsets))
             .ToList();
     }
 
@@ -57,17 +60,11 @@ public sealed class VolunteerTrackingService(
         return true;
     }
 
-    private static GeneralAvailabilitySnapshot ToSnapshot(GeneralAvailability availability) =>
-        new(
-            availability.UserId,
-            availability.EventSettingsId,
-            availability.AvailableDayOffsets);
-
     public async Task<VolunteerTrackingViewModel> GetTrackingDataAsync(CancellationToken ct = default)
     {
         var es = await shiftManagement.GetActiveEventSettingsAsync(ct).ConfigureAwait(false);
         if (es is null)
-            return EmptyTrackingViewModel();
+            return new VolunteerTrackingViewModel(false, 0, default, default, [], []);
 
         var zone = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
         var today = clock.GetCurrentInstant().InZone(zone).Date;
@@ -101,15 +98,6 @@ public sealed class VolunteerTrackingService(
             mainRows,
             unbookedRows);
     }
-
-    private static VolunteerTrackingViewModel EmptyTrackingViewModel() =>
-        new(
-            false,
-            0,
-            default,
-            default,
-            [],
-            []);
 
     private static Dictionary<Guid, ParticipationStatus> BuildParticipationStatusMap(
         IEnumerable<UserInfo> users,
@@ -479,10 +467,6 @@ public sealed class VolunteerTrackingService(
             cells.Add(new VolunteerCell(day, state, rotaNames, declared));
         }
 
-        var dayOffSummaries = (bs?.DayOffs ?? [])
-            .Select(x => new DayOffSummary(x.DayOffset, x.Reason))
-            .ToList();
-
         var row = new VolunteerHeatmapRow(
             userId,
             firstSignupDay,
@@ -490,7 +474,7 @@ public sealed class VolunteerTrackingService(
             bs?.BarrioSetupStartDate,
             gapCount,
             cells,
-            dayOffSummaries);
+            BuildDayOffSummaries(bs));
 
         return new VolunteerBuildStripDto(es.BuildStartOffset, es.GateOpeningDate, row);
     }

--- a/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
+++ b/src/Humans.Application/Services/Shifts/Workload/WorkloadService.cs
@@ -266,7 +266,13 @@ public sealed class WorkloadService(
                 if (assignment.AssignedUserId is not { } userId) continue;
                 perUser.TryGetValue(userId, out var h);
                 h ??= new RolePersonHours(0, 0, 0, 0);
-                perUser[userId] = AddByPeriod(h, role.Period, est);
+                perUser[userId] = role.Period switch
+                {
+                    RolePeriod.Build => h with { Build = h.Build + est },
+                    RolePeriod.Event => h with { Event = h.Event + est },
+                    RolePeriod.Strike => h with { Strike = h.Strike + est },
+                    _ => h with { YearRound = h.YearRound + est },
+                };
             }
         }
         return perUser;
@@ -291,13 +297,4 @@ public sealed class WorkloadService(
         }
         return perTeam;
     }
-
-    private static RolePersonHours AddByPeriod(RolePersonHours h, RolePeriod period, int est) =>
-        period switch
-        {
-            RolePeriod.Build => h with { Build = h.Build + est },
-            RolePeriod.Event => h with { Event = h.Event + est },
-            RolePeriod.Strike => h with { Strike = h.Strike + est },
-            _ => h with { YearRound = h.YearRound + est },
-        };
 }

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -657,7 +657,13 @@ public class ShiftAdminController(
                 await GetShiftForTeamAsync(shiftId, team.Id),
                 query,
                 ShiftRoleChecks.CanViewMedical(User));
-            return ToVolunteerSearchActionResult(result);
+            return result.Status switch
+            {
+                VolunteerSearchBuildStatus.EmptyQuery => Json(Array.Empty<VolunteerSearchResult>()),
+                VolunteerSearchBuildStatus.NotFound => NotFound(),
+                VolunteerSearchBuildStatus.Success => Json(result.Results),
+                _ => throw new InvalidOperationException($"Unexpected volunteer search status '{result.Status}'.")
+            };
         }
         catch (Exception ex)
         {
@@ -665,15 +671,6 @@ public class ShiftAdminController(
             return StatusCode(500, new { error = "Search failed." });
         }
     }
-
-    private IActionResult ToVolunteerSearchActionResult(VolunteerSearchBuildResult result) =>
-        result.Status switch
-        {
-            VolunteerSearchBuildStatus.EmptyQuery => Json(Array.Empty<VolunteerSearchResult>()),
-            VolunteerSearchBuildStatus.NotFound => NotFound(),
-            VolunteerSearchBuildStatus.Success => Json(result.Results),
-            _ => throw new InvalidOperationException($"Unexpected volunteer search status '{result.Status}'.")
-        };
 
     [HttpPost("Voluntell")]
     [ValidateAntiForgeryToken]

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -109,7 +109,13 @@ public class ShiftDashboardController(
                 await shiftMgmt.GetShiftByIdAsync(shiftId),
                 query,
                 ShiftRoleChecks.CanViewMedical(User));
-            return ToVolunteerSearchActionResult(result);
+            return result.Status switch
+            {
+                VolunteerSearchBuildStatus.EmptyQuery => Json(Array.Empty<VolunteerSearchResult>()),
+                VolunteerSearchBuildStatus.NotFound => NotFound(),
+                VolunteerSearchBuildStatus.Success => Json(result.Results),
+                _ => throw new InvalidOperationException($"Unexpected volunteer search status '{result.Status}'.")
+            };
         }
         catch (Exception ex)
         {
@@ -117,15 +123,6 @@ public class ShiftDashboardController(
             return StatusCode(500, new { error = "Search failed." });
         }
     }
-
-    private IActionResult ToVolunteerSearchActionResult(VolunteerSearchBuildResult result) =>
-        result.Status switch
-        {
-            VolunteerSearchBuildStatus.EmptyQuery => Json(Array.Empty<VolunteerSearchResult>()),
-            VolunteerSearchBuildStatus.NotFound => NotFound(),
-            VolunteerSearchBuildStatus.Success => Json(result.Results),
-            _ => throw new InvalidOperationException($"Unexpected volunteer search status '{result.Status}'.")
-        };
 
     // Auth: narrow policy overrides controller-level wider one — only ShiftDashboardAccess can assign.
     [Authorize(Policy = PolicyNames.ShiftDashboardAccess)]

--- a/src/Humans.Web/Controllers/ShiftWorkloadAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftWorkloadAdminController.cs
@@ -1,4 +1,3 @@
-using Humans.Application.DTOs.Shifts.Workload;
 using Humans.Application.Interfaces.Shifts.Workload;
 using Humans.Application.Interfaces.Users;
 using Humans.Web.Authorization;
@@ -17,33 +16,22 @@ public class ShiftWorkloadAdminController(IUserServiceRead userService, IWorkloa
     public async Task<IActionResult> Index(CancellationToken ct)
     {
         var report = await workloadService.GetForActiveEventAsync(ct);
-        return View(SortForDisplay(report));
-    }
+        if (report is null)
+            return View(report);
 
-    // Display sort at presentation layer (memory/architecture/display-sort-in-controllers.md).
-    private static WorkloadReport? SortForDisplay(WorkloadReport? report)
-    {
-        if (report is null) return null;
-
-        var byRota = report.ByRota
-            .OrderBy(r => r.TeamName, StringComparer.Ordinal)
-            .ThenBy(r => r.RotaName, StringComparer.Ordinal)
-            .ToList();
-
-        var byDepartment = report.ByDepartment
-            .OrderBy(r => r.TeamName, StringComparer.Ordinal)
-            .ToList();
-
-        var byPerson = report.ByPerson
-            .OrderByDescending(r => r.TotalHours)
-            .ThenBy(r => r.DisplayName, StringComparer.Ordinal)
-            .ToList();
-
-        return report with
+        return View(report with
         {
-            ByPerson = byPerson,
-            ByRota = byRota,
-            ByDepartment = byDepartment,
-        };
+            ByPerson = report.ByPerson
+                .OrderByDescending(r => r.TotalHours)
+                .ThenBy(r => r.DisplayName, StringComparer.Ordinal)
+                .ToList(),
+            ByRota = report.ByRota
+                .OrderBy(r => r.TeamName, StringComparer.Ordinal)
+                .ThenBy(r => r.RotaName, StringComparer.Ordinal)
+                .ToList(),
+            ByDepartment = report.ByDepartment
+                .OrderBy(r => r.TeamName, StringComparer.Ordinal)
+                .ToList(),
+        });
     }
 }

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -61,7 +61,7 @@ public class ShiftsController(
         var hasSignups = userSignups.Count > 0;
         var userActiveSignupsForUi = await LoadUserActiveSignupsForUiAsync(user.Id);
 
-        if (!CanBrowseShifts(es, isPrivileged, hasSignups))
+        if (!es.IsShiftBrowsingOpen && !isPrivileged && !hasSignups)
             return View("BrowsingClosed");
 
         var model = await browsePageBuilder.BuildAsync(new ShiftBrowsePageRequest(
@@ -88,9 +88,6 @@ public class ShiftsController(
 
         return View(model);
     }
-
-    private static bool CanBrowseShifts(EventSettings eventSettings, bool isPrivileged, bool hasSignups) =>
-        eventSettings.IsShiftBrowsingOpen || isPrivileged || hasSignups;
 
     // No legal name → bounce to onboarding widget (Names step); signup needs it for the rota report.
     private IActionResult? RedirectIfNameMissing(UserInfo user)
@@ -295,7 +292,6 @@ public class ShiftsController(
         return string.IsNullOrEmpty(user.Profile?.DietaryPreference);
     }
 
-    // True when the shift qualifies for a cantina meal and the user has no DietaryPreference yet.
     private async Task<bool> ShiftNeedsDietaryFirstAsync(UserInfo user, Guid shiftId)
     {
         var shift = await shiftMgmt.GetShiftByIdAsync(shiftId);
@@ -372,7 +368,15 @@ public class ShiftsController(
             SignupsBlockedByMissingDietary = await ComputeSignupsBlockedByMissingDietaryAsync(user, HttpContext.RequestAborted),
         };
 
-        var mineTeamNames = await LoadTeamNamesForSignupsAsync(signups);
+        var teamIds = ShiftSignupBucketer.GetTeamIds(signups);
+        IReadOnlyDictionary<Guid, string> mineTeamNames = new Dictionary<Guid, string>();
+        if (teamIds.Count > 0)
+        {
+            var teamsById = await teamService.GetTeamsAsync();
+            mineTeamNames = teamIds
+                .Where(teamsById.ContainsKey)
+                .ToDictionary(id => id, id => teamsById[id].Name);
+        }
         var buckets = ShiftSignupBucketer.Build(signups, es, mineTeamNames, now, onMissingSignupData: signup =>
             logger.LogWarning(
                 "Skipping shift signup {SignupId} for user {UserId} because related shift data was missing",
@@ -383,34 +387,9 @@ public class ShiftsController(
         model.Pending = buckets.Pending;
         model.Past = buckets.Past;
 
-        PopulateAvailability(model, userView, es);
-        await EnsureICalUrlAsync(model, user);
-
-        return View(model);
-    }
-
-    private async Task<IReadOnlyDictionary<Guid, string>> LoadTeamNamesForSignupsAsync(IReadOnlyList<ShiftSignup> signups)
-    {
-        var teamIds = ShiftSignupBucketer.GetTeamIds(signups);
-        if (teamIds.Count == 0)
-            return new Dictionary<Guid, string>();
-        var teamsById = await teamService.GetTeamsAsync();
-        return teamIds
-            .Where(teamsById.ContainsKey)
-            .ToDictionary(id => id, id => teamsById[id].Name);
-    }
-
-    private static void PopulateAvailability(MyShiftsViewModel model, ShiftUserView userView, EventSettings? eventSettings)
-    {
-        if (eventSettings is null) return;
-
-        // see #720: availability via cached ShiftUserView (null when no row for event).
-        if (userView.Availability is not null)
+        if (es is not null && userView.Availability is not null)
             model.AvailableDayOffsets = userView.Availability.AvailableDayOffsets.ToList();
-    }
 
-    private async Task EnsureICalUrlAsync(MyShiftsViewModel model, UserInfo user)
-    {
         var token = user.ICalToken;
         if (token is null)
         {
@@ -419,6 +398,8 @@ public class ShiftsController(
         }
 
         model.ICalUrl = $"{Request.Scheme}://{Request.Host}/api/ical/{user.Id}/{token}.ics";
+
+        return View(model);
     }
 
     [HttpPost("Mine/Availability")]
@@ -515,7 +496,12 @@ public class ShiftsController(
 
         var parsed = EventSettingsFormMapper.Parse(model);
         if (!parsed.Success)
-            return ViewWithFormErrors(model, parsed.Errors);
+        {
+            foreach (var error in parsed.Errors)
+                ModelState.AddModelError(error.FieldName, error.Message);
+
+            return View(model);
+        }
 
         var draft = parsed.Draft!;
 
@@ -534,14 +520,6 @@ public class ShiftsController(
 
         SetSuccess("Event settings saved.");
         return RedirectToAction(nameof(Settings));
-    }
-
-    private IActionResult ViewWithFormErrors(EventSettingsViewModel model, IReadOnlyList<EventSettingsFormError> errors)
-    {
-        foreach (var error in errors)
-            ModelState.AddModelError(error.FieldName, error.Message);
-
-        return View(model);
     }
 
     private async Task<IReadOnlyList<UserSignupConflictItem>> LoadUserActiveSignupsForUiAsync(Guid userId)

--- a/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
@@ -26,7 +26,6 @@ internal static class ShiftsSectionExtensions
 {
     internal static IServiceCollection AddShiftsSection(this IServiceCollection services)
     {
-        // ShiftRepository backs both management and signup interfaces; authorization invalidation remains on the management service.
         services.AddScoped<ShiftRepository>();
         services.AddScoped<IShiftManagementRepository>(sp => sp.GetRequiredService<ShiftRepository>());
         services.AddScoped<ShiftsShiftManagementService>();

--- a/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
@@ -43,14 +43,12 @@ internal static class ShiftsSectionExtensions
         // CantinaAdminOrAdmin authorization policy, not a bespoke service.
         services.AddScoped<ICantinaRosterService, CantinaRosterServiceImpl>();
 
-        // ShiftSignup mutations share the scoped ShiftRepository change-tracker.
         services.AddScoped<ShiftsShiftSignupService>();
         services.AddScoped<IShiftSignupService>(sp => sp.GetRequiredService<ShiftsShiftSignupService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<ShiftsShiftSignupService>());
         services.AddScoped<ICalendarFeedContributor>(sp => sp.GetRequiredService<ShiftsShiftSignupService>());
         services.AddScoped<IUserMerge>(sp => sp.GetRequiredService<ShiftsShiftSignupService>());
 
-        // VolunteerTracking - scoped user-oriented repository for build status and availability mutations.
         services.AddScoped<IVolunteerTrackingRepository, VolunteerTrackingRepository>();
         services.AddScoped<ShiftsVolunteerTrackingService>();
         services.AddScoped<IVolunteerTrackingService>(sp => sp.GetRequiredService<ShiftsVolunteerTrackingService>());
@@ -69,7 +67,6 @@ internal static class ShiftsSectionExtensions
         services.AddSingleton<IShiftView>(sp => sp.GetRequiredService<CachingShiftViewService>());
         services.AddSingleton<IShiftViewInvalidator>(sp => sp.GetRequiredService<CachingShiftViewService>());
 
-        // Surface both ShiftView caches (User + Rota) on /Debug/CacheStats.
         services.AddSingleton<ICacheStats>(sp => sp.GetRequiredService<CachingShiftViewService>().UserCacheStats);
         services.AddSingleton<ICacheStats>(sp => sp.GetRequiredService<CachingShiftViewService>().RotaCacheStats);
 


### PR DESCRIPTION
## Simplifications

- Collapsed private single-caller indirection in Shifts services/controllers where the call site stayed clearer inline.
- Removed unused private helpers and narrating comments from Shifts DI/export code.
- Deduplicated private day-off summary mapping inside volunteer tracking.
- Simplified range-signup warning/gate construction and small controller/service branches without changing public surface.

## Net line delta

- `103 insertions, 224 deletions` across 10 C# files: net `-121` lines.
- Commits: 2.

## Verification

- `dotnet build Humans.slnx -v quiet`
- `dotnet test Humans.slnx -v quiet`

## Needs owner judgment

- Public Shifts surfaces were left untouched, including public interfaces/DI registrations and public constants such as `ShiftManagementService.AllDayShiftStartTime` / `AllDayShiftEndTime`.
- `ShiftsController.ToggleDay` remains grandfathered analyzer debt; simplifying it further would require moving workflow structure or service extraction outside this pass.
- Existing solution-wide analyzer warnings outside the Shifts simplification diff were left untouched.