### PR TITLE
refactor(teams): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Teams/TeamPageService.cs
+++ b/src/Humans.Application/Services/Teams/TeamPageService.cs
@@ -40,9 +40,9 @@ public sealed class TeamPageService(
                 detail.IsAuthenticated ? member.JoinedAt : null))
             .ToList();
 
-        var pageContentUpdatedByDisplayName = await GetPageContentUpdatedByDisplayNameAsync(
-            detail.Team.PageContentUpdatedByUserId,
-            cancellationToken);
+        var pageContentUpdatedBy = detail.Team.PageContentUpdatedByUserId.HasValue
+            ? await userService.GetUserInfoAsync(detail.Team.PageContentUpdatedByUserId.Value, cancellationToken)
+            : null;
 
         var resources = detail.IsAuthenticated
             ? (await teamResourceService.GetTeamResourcesAsync(detail.Team.Id, cancellationToken))
@@ -75,21 +75,8 @@ public sealed class TeamPageService(
             detail.CanCurrentUserEditTeam,
             detail.CurrentUserPendingRequestId,
             detail.PendingRequestCount,
-            pageContentUpdatedByDisplayName,
+            pageContentUpdatedBy?.BurnerName,
             shiftsSummary);
-    }
-
-    private async Task<string?> GetPageContentUpdatedByDisplayNameAsync(
-        Guid? userId,
-        CancellationToken cancellationToken)
-    {
-        if (!userId.HasValue)
-        {
-            return null;
-        }
-
-        var user = await userService.GetUserInfoAsync(userId.Value, cancellationToken);
-        return user?.BurnerName;
     }
 
     private async Task<TeamPageShiftsSummary?> GetShiftsSummaryAsync(
@@ -116,41 +103,24 @@ public sealed class TeamPageService(
         }
 
         var activeChildTeamIds = childTeams.Select(c => c.Id).ToList();
+        var teamIds = new List<Guid>(activeChildTeamIds.Count + 1) { team.Id };
+        teamIds.AddRange(activeChildTeamIds);
 
-        if (activeChildTeamIds.Count > 0)
-        {
-            var allTeamIds = new List<Guid>(activeChildTeamIds.Count + 1) { team.Id };
-            allTeamIds.AddRange(activeChildTeamIds);
-
-            var aggregatedData = await shiftManagementService.GetShiftsSummaryAsync(activeEvent.Id, allTeamIds);
-            if (aggregatedData is null)
-            {
-                return new TeamPageShiftsSummary(0, 0, 0, 0, canManageShifts);
-            }
-
-            var childTeamCountWithShifts = activeChildTeamIds
-                .Count(aggregatedData.TeamIdsWithShifts.Contains);
-
-            return new TeamPageShiftsSummary(
-                aggregatedData.TotalSlots,
-                aggregatedData.ConfirmedCount,
-                aggregatedData.PendingCount,
-                aggregatedData.UniqueVolunteerCount,
-                canManageShifts,
-                childTeamCountWithShifts);
-        }
-
-        var summaryData = await shiftManagementService.GetShiftsSummaryAsync(activeEvent.Id, [team.Id]);
+        var summaryData = await shiftManagementService.GetShiftsSummaryAsync(activeEvent.Id, teamIds);
         if (summaryData is null)
         {
             return new TeamPageShiftsSummary(0, 0, 0, 0, canManageShifts);
         }
+
+        var childTeamCountWithShifts = activeChildTeamIds
+            .Count(summaryData.TeamIdsWithShifts.Contains);
 
         return new TeamPageShiftsSummary(
             summaryData.TotalSlots,
             summaryData.ConfirmedCount,
             summaryData.PendingCount,
             summaryData.UniqueVolunteerCount,
-            canManageShifts);
+            canManageShifts,
+            childTeamCountWithShifts);
     }
 }

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -490,50 +490,6 @@ public sealed class TeamService(
         return team;
     }
 
-    private async Task UpdateTeamPageContentCoreAsync(
-        Guid teamId,
-        string? pageContent,
-        List<CallToAction> callsToAction,
-        bool isPublicPage,
-        bool showCoordinatorsOnPublicPage,
-        Guid updatedByUserId,
-        CancellationToken cancellationToken = default)
-    {
-        var team = await repo.FindForMutationAsync(teamId, cancellationToken)
-            ?? throw new InvalidOperationException($"Team {teamId} not found");
-
-        if (callsToAction.Count > 3)
-            throw new InvalidOperationException("A team can have at most 3 calls to action.");
-
-        if (callsToAction.Count(c => c.Style == CallToActionStyle.Primary) > 1)
-            throw new InvalidOperationException("Only one primary call to action is allowed.");
-
-        var canBePublic = !team.IsSystemTeam && !team.ParentTeamId.HasValue;
-
-        if (isPublicPage && !canBePublic)
-            throw new InvalidOperationException("Only departments (non-system, top-level teams) can be made public.");
-
-        var normalizedShowCoordinatorsOnPublicPage =
-            canBePublic && isPublicPage && showCoordinatorsOnPublicPage;
-
-        var now = clock.GetCurrentInstant();
-        team.PageContent = pageContent;
-        team.CallsToAction = callsToAction;
-        team.IsPublicPage = isPublicPage;
-        team.ShowCoordinatorsOnPublicPage = normalizedShowCoordinatorsOnPublicPage;
-        team.PageContentUpdatedAt = now;
-        team.PageContentUpdatedByUserId = updatedByUserId;
-        team.UpdatedAt = now;
-
-        await repo.UpdateTeamAsync(team, cancellationToken);
-
-        await auditLogService.LogAsync(
-            AuditAction.TeamPageContentUpdated, nameof(Team), teamId,
-            $"Team page content updated. Public: {isPublicPage}",
-            updatedByUserId);
-
-    }
-
     public async Task<TeamPageUpdateResult> UpdateTeamPageContentAsync(
         Guid teamId,
         string? pageContent,
@@ -550,14 +506,35 @@ public sealed class TeamService(
 
         try
         {
-            await UpdateTeamPageContentCoreAsync(
-                teamId,
-                pageContent,
-                normalizedCallsToAction,
-                isPublicPage,
-                showCoordinatorsOnPublicPage,
-                updatedByUserId,
-                cancellationToken);
+            var team = await repo.FindForMutationAsync(teamId, cancellationToken)
+                ?? throw new InvalidOperationException($"Team {teamId} not found");
+
+            if (normalizedCallsToAction.Count > 3)
+                throw new InvalidOperationException("A team can have at most 3 calls to action.");
+
+            if (normalizedCallsToAction.Count(c => c.Style == CallToActionStyle.Primary) > 1)
+                throw new InvalidOperationException("Only one primary call to action is allowed.");
+
+            var canBePublic = !team.IsSystemTeam && !team.ParentTeamId.HasValue;
+
+            if (isPublicPage && !canBePublic)
+                throw new InvalidOperationException("Only departments (non-system, top-level teams) can be made public.");
+
+            var now = clock.GetCurrentInstant();
+            team.PageContent = pageContent;
+            team.CallsToAction = normalizedCallsToAction;
+            team.IsPublicPage = isPublicPage;
+            team.ShowCoordinatorsOnPublicPage = canBePublic && isPublicPage && showCoordinatorsOnPublicPage;
+            team.PageContentUpdatedAt = now;
+            team.PageContentUpdatedByUserId = updatedByUserId;
+            team.UpdatedAt = now;
+
+            await repo.UpdateTeamAsync(team, cancellationToken);
+
+            await auditLogService.LogAsync(
+                AuditAction.TeamPageContentUpdated, nameof(Team), teamId,
+                $"Team page content updated. Public: {isPublicPage}",
+                updatedByUserId);
 
             return TeamPageUpdateResult.Success();
         }
@@ -769,19 +746,13 @@ public sealed class TeamService(
         return user?.BurnerName ?? "Someone";
     }
 
-    private async Task<bool> TryAddMemberOnlyAsync(TeamMember member, CancellationToken ct)
-    {
-        // DB unique constraint backstops the caller's pre-check.
-        return await repo.TryAddMemberAsync(member, ct);
-    }
-
     private async Task<bool> TryAddMemberWithOutboxAsync(
         TeamMember member,
         GoogleSyncOutboxEvent? outboxEvent,
         CancellationToken ct)
     {
         if (outboxEvent is null)
-            return await TryAddMemberOnlyAsync(member, ct);
+            return await repo.TryAddMemberAsync(member, ct);
 
         using var scope = CreateTransactionScope();
         var success = await repo.TryAddMemberAsync(member, ct);
@@ -1074,7 +1045,13 @@ public sealed class TeamService(
         CancellationToken cancellationToken = default)
     {
         var requests = await repo.GetPendingForTeamAsync(teamId, cancellationToken);
-        var usersById = await GetJoinRequestUsersByIdAsync(requests, cancellationToken);
+        var usersById = requests.Count == 0
+            ? new Dictionary<Guid, UserInfo>()
+            : await UserService.GetUserInfosAsync(
+                requests.Select(request => request.UserId)
+                    .Distinct()
+                    .ToList(),
+                cancellationToken);
         return requests
             .Select(request => ToJoinRequestSnapshot(request, usersById))
             .ToList();
@@ -1489,13 +1466,6 @@ public sealed class TeamService(
         return definitions.Select(definition => ToRoleDefinitionSnapshot(definition)).ToList();
     }
 
-    private async Task<IReadOnlyList<TeamRoleDefinitionSnapshot>> GetAllRoleDefinitionsAsync(
-        CancellationToken cancellationToken = default)
-    {
-        var definitions = await repo.GetAllRoleDefinitionsAsync(cancellationToken);
-        return definitions.Select(definition => ToRoleDefinitionSnapshot(definition)).ToList();
-    }
-
     private static TeamRoleDefinitionSnapshot ToRoleDefinitionSnapshot(
         TeamRoleDefinition definition,
         Team? fallbackTeam = null) =>
@@ -1527,7 +1497,9 @@ public sealed class TeamService(
         string? period,
         CancellationToken cancellationToken = default)
     {
-        var definitions = await GetAllRoleDefinitionsAsync(cancellationToken);
+        var definitions = (await repo.GetAllRoleDefinitionsAsync(cancellationToken))
+            .Select(definition => ToRoleDefinitionSnapshot(definition))
+            .ToList();
         var assignedUserIds = definitions
             .SelectMany(d => d.Assignments)
             .Select(a => a.AssignedUserId)
@@ -1557,7 +1529,13 @@ public sealed class TeamService(
                     definition.Id,
                     slotIndex + 1,
                     slotPriority.ToString(),
-                    GetPriorityBadgeClass(slotPriority),
+                    slotPriority switch
+                    {
+                        SlotPriority.Critical => "bg-danger",
+                        SlotPriority.Important => "bg-warning text-dark",
+                        SlotPriority.NiceToHave => "bg-secondary",
+                        _ => "bg-light text-dark"
+                    },
                     definition.Period.ToString(),
                     assignment is not null,
                     assignment?.AssignedUserId,
@@ -2063,7 +2041,7 @@ public sealed class TeamService(
         CustomSlug: team.CustomSlug,
         ManagementRoleHolderUserIds: managementHolders.TryGetValue(team.Id, out var holders) ? holders : null,
         RoleDefinitions: roleDefinitionsByTeam.TryGetValue(team.Id, out var defs)
-            ? defs.Select(d => ProjectRoleDefinitionSnapshot(d, team)).ToList()
+            ? defs.Select(d => ToRoleDefinitionSnapshot(d, team)).ToList()
             : null,
         ChildTeamIds: childIdsByParent.TryGetValue(team.Id, out var childIds) ? childIds : null,
         ShowCoordinatorsOnPublicPage: team.ShowCoordinatorsOnPublicPage,
@@ -2074,32 +2052,9 @@ public sealed class TeamService(
         PendingRequestCount: pendingCounts.TryGetValue(team.Id, out var pending) ? pending : 0,
         EarlyEntryEnabled: team.EarlyEntryEnabled);
 
-    private static TeamRoleDefinitionSnapshot ProjectRoleDefinitionSnapshot(TeamRoleDefinition d, Team team) =>
-        new(
-            d.Id,
-            d.TeamId,
-            team.Name,
-            team.Slug,
-            d.Name,
-            d.Description,
-            d.SlotCount,
-            d.EstimatedHours,
-            d.Priorities,
-            d.SortOrder,
-            d.IsManagement,
-            d.Period,
-            d.IsPublic,
-            d.Assignments
-                .Select(a => new TeamRoleAssignmentSnapshot(
-                    a.Id,
-                    a.TeamMemberId,
-                    a.SlotIndex,
-                    a.TeamMember?.UserId))
-                .ToList());
-
     private void InvalidateShiftAuthorizationIfNeeded(Guid userId, IEnumerable<TeamRoleAssignment> roleAssignments)
     {
-        if (roleAssignments.Any(IsShiftAuthorizationAssignment))
+        if (roleAssignments.Any(assignment => IsShiftAuthorizationDefinition(assignment.TeamRoleDefinition)))
             shiftAuthInvalidator.Invalidate(userId);
     }
 
@@ -2122,9 +2077,6 @@ public sealed class TeamService(
             ? team
             : throw new InvalidOperationException($"Team {definition.TeamId} not found");
     }
-
-    private static bool IsShiftAuthorizationAssignment(TeamRoleAssignment assignment) =>
-        IsShiftAuthorizationDefinition(assignment.TeamRoleDefinition);
 
 #pragma warning disable CS0618 // TeamRoleDefinition.Team — in-section nav read.
     private static bool IsShiftAuthorizationDefinition(TeamRoleDefinition definition) =>
@@ -2151,19 +2103,6 @@ public sealed class TeamService(
 #pragma warning restore CS0618
             }
         }
-    }
-
-    private async Task<IReadOnlyDictionary<Guid, UserInfo>> GetJoinRequestUsersByIdAsync(
-        IReadOnlyList<TeamJoinRequest> requests,
-        CancellationToken ct)
-    {
-        if (requests.Count == 0)
-            return new Dictionary<Guid, UserInfo>();
-
-        var userIds = requests.Select(request => request.UserId)
-            .Distinct()
-            .ToList();
-        return await UserService.GetUserInfosAsync(userIds, ct);
     }
 
     private async Task StitchRoleAssignmentUserSlicesAsync(
@@ -2399,15 +2338,6 @@ public sealed class TeamService(
         TeamMember member,
         IReadOnlyDictionary<Guid, UserInfo> usersById) =>
         usersById.GetValueOrDefault(member.UserId)?.BurnerName ?? string.Empty;
-
-    private static string GetPriorityBadgeClass(SlotPriority priority) =>
-        priority switch
-        {
-            SlotPriority.Critical => "bg-danger",
-            SlotPriority.Important => "bg-warning text-dark",
-            SlotPriority.NiceToHave => "bg-secondary",
-            _ => "bg-light text-dark"
-        };
 
     private static void ValidateRoleName(string name)
     {

--- a/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
@@ -1256,7 +1256,6 @@ internal sealed class TeamRepository(IDbContextFactory<HumansDbContext> factory)
 
         await using var db = await factory.CreateDbContextAsync(ct);
 
-        // Inserts
         foreach (var userId in userIdsToAdd)
         {
             db.TeamMembers.Add(new TeamMember
@@ -1283,7 +1282,6 @@ internal sealed class TeamRepository(IDbContextFactory<HumansDbContext> factory)
 
             foreach (var member in members)
             {
-                // Clean up role slot assignments before ending the membership.
                 if (member.RoleAssignments.Count > 0)
                 {
                     db.Set<TeamRoleAssignment>().RemoveRange(member.RoleAssignments);

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -433,7 +433,10 @@ public class TeamAdminController(
         }
 
         var result = await teamResourceService.LinkDriveResourceAsync(team.Id, model.ResourceUrl, model.PermissionLevel);
-        SetDriveResourceLinkResult(result);
+        if (result.Success)
+            SetSuccess($"Drive resource '{result.Resource!.Name}' linked successfully.");
+        else
+            SetError(BuildResourceLinkError(result, "Failed to link Drive resource."));
 
         return RedirectToAction(nameof(Resources), new { slug });
     }
@@ -466,7 +469,10 @@ public class TeamAdminController(
         }
 
         var result = await teamResourceService.LinkGroupAsync(team.Id, model.GroupEmail);
-        SetGroupResourceLinkResult(result);
+        if (result.Success)
+            SetSuccess(string.Format(localizer["TeamAdmin_GroupLinked"].Value, result.Resource!.Name));
+        else
+            SetError(BuildResourceLinkError(result, localizer["TeamAdmin_GroupLinkFailed"].Value));
 
         return RedirectToAction(nameof(Resources), new { slug });
     }
@@ -572,9 +578,6 @@ public class TeamAdminController(
     [HttpPost("Resources/{resourceId}/Sync")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncResource(string slug, Guid resourceId)
-        => await SyncResourceCoreAsync(slug, resourceId);
-
-    private async Task<IActionResult> SyncResourceCoreAsync(string slug, Guid resourceId)
     {
         var (currentUserNotFound, user) = await RequireCurrentUserAsync();
         if (currentUserNotFound is not null)
@@ -599,7 +602,10 @@ public class TeamAdminController(
                 resourceId,
                 SyncAction.Execute,
                 HttpContext.RequestAborted);
-            SetResourceSyncResult(diff.ErrorMessage);
+            if (diff.ErrorMessage is not null)
+                SetError(string.Format(localizer["TeamAdmin_ResourceSyncFailed"].Value, diff.ErrorMessage));
+            else
+                SetSuccess(localizer["TeamAdmin_ResourceSynced"].Value);
         }
         catch (Exception ex)
         {
@@ -608,36 +614,6 @@ public class TeamAdminController(
         }
 
         return RedirectToAction(nameof(Resources), new { slug });
-    }
-
-    private void SetResourceSyncResult(string? syncError)
-    {
-        if (syncError is not null)
-            SetError(string.Format(localizer["TeamAdmin_ResourceSyncFailed"].Value, syncError));
-        else
-            SetSuccess(localizer["TeamAdmin_ResourceSynced"].Value);
-    }
-
-    private void SetDriveResourceLinkResult(LinkResourceResult result)
-    {
-        if (result.Success)
-        {
-            SetSuccess($"Drive resource '{result.Resource!.Name}' linked successfully.");
-            return;
-        }
-
-        SetError(BuildResourceLinkError(result, "Failed to link Drive resource."));
-    }
-
-    private void SetGroupResourceLinkResult(LinkResourceResult result)
-    {
-        if (result.Success)
-        {
-            SetSuccess(string.Format(localizer["TeamAdmin_GroupLinked"].Value, result.Resource!.Name));
-            return;
-        }
-
-        SetError(BuildResourceLinkError(result, localizer["TeamAdmin_GroupLinkFailed"].Value));
     }
 
     private string BuildResourceLinkError(LinkResourceResult result, string defaultMessage)
@@ -748,7 +724,7 @@ public class TeamAdminController(
         var (teamError, user, team) = await ResolveTeamManagementAsync(slug);
         if (teamError is not null)
         {
-            return RoleEditTeamError(isAjax, teamError);
+            return isAjax ? Unauthorized() : teamError;
         }
 
         try
@@ -763,30 +739,21 @@ public class TeamAdminController(
                 priorities, model.SortOrder, model.IsManagement, model.Period, user.Id,
                 model.IsPublic, canToggleManagement, model.EstimatedHours);
 
-            return RoleEditSuccess(isAjax, slug, $"Role '{model.Name}' updated.");
+            if (isAjax)
+                return Json(new { success = true, message = $"Role '{model.Name}' updated." });
+
+            SetSuccess($"Role '{model.Name}' updated.");
+            return RedirectToAction(nameof(Roles), new { slug });
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
             logger.LogWarning(ex, "Failed to update role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
-            return RoleEditError(isAjax, slug, ex.Message);
+            if (isAjax)
+                return Json(new { success = false, message = ex.Message });
+
+            SetError(ex.Message);
+            return RedirectToAction(nameof(Roles), new { slug });
         }
-    }
-
-    private IActionResult RoleEditTeamError(bool isAjax, IActionResult teamError) =>
-        isAjax ? Unauthorized() : teamError;
-
-    private IActionResult RoleEditSuccess(bool isAjax, string slug, string message)
-    {
-        if (isAjax) return Json(new { success = true, message });
-        SetSuccess(message);
-        return RedirectToAction(nameof(Roles), new { slug });
-    }
-
-    private IActionResult RoleEditError(bool isAjax, string slug, string message)
-    {
-        if (isAjax) return Json(new { success = false, message });
-        SetError(message);
-        return RedirectToAction(nameof(Roles), new { slug });
     }
 
     [HttpPost("Roles/{roleId}/Delete")]
@@ -916,7 +883,6 @@ public class TeamAdminController(
 
         var canBePublic = !teamEntity.IsSystemTeam && !teamEntity.ParentTeamId.HasValue;
 
-        // Ensure we always show 3 CTA slots
         var ctas = (teamEntity.CallsToAction ?? [])
             .Select(c => new CallToActionViewModel { Text = c.Text, Url = c.Url, Style = c.Style })
             .ToList();

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -592,7 +592,26 @@ public class TeamController(
 
         // Parent-then-children flat list; children inherit the parent's bucket.
         List<AdminTeamViewModel>? currentBucket = null;
-        foreach (var team in result.Teams.Select(MapAdminTeamSummary))
+        foreach (var team in result.Teams.Select(summary => new AdminTeamViewModel
+        {
+            Id = summary.Id,
+            Name = summary.Name,
+            Slug = summary.Slug,
+            IsActive = summary.IsActive,
+            RequiresApproval = summary.RequiresApproval,
+            IsSystemTeam = summary.IsSystemTeam,
+            SystemTeamType = Enum.TryParse<SystemTeamType>(summary.SystemTeamType, out var stt) ? stt : null,
+            MemberCount = summary.MemberCount,
+            PendingRequestCount = summary.PendingRequestCount,
+            HasMailGroup = summary.HasMailGroup,
+            GoogleGroupEmail = summary.GoogleGroupEmail,
+            DriveResourceCount = summary.DriveResourceCount,
+            RoleSlotCount = summary.RoleSlotCount,
+            CreatedAt = summary.CreatedAt.ToDateTimeUtc(),
+            IsChildTeam = summary.IsChildTeam,
+            PendingShiftSignupCount = summary.PendingShiftSignupCount,
+            IsHidden = summary.IsHidden
+        }))
         {
             if (!team.IsChildTeam)
             {
@@ -810,27 +829,6 @@ public class TeamController(
 
         return RedirectToAction(nameof(Summary));
     }
-
-    private static AdminTeamViewModel MapAdminTeamSummary(AdminTeamSummary team) => new()
-    {
-        Id = team.Id,
-        Name = team.Name,
-        Slug = team.Slug,
-        IsActive = team.IsActive,
-        RequiresApproval = team.RequiresApproval,
-        IsSystemTeam = team.IsSystemTeam,
-        SystemTeamType = Enum.TryParse<SystemTeamType>(team.SystemTeamType, out var stt) ? stt : null,
-        MemberCount = team.MemberCount,
-        PendingRequestCount = team.PendingRequestCount,
-        HasMailGroup = team.HasMailGroup,
-        GoogleGroupEmail = team.GoogleGroupEmail,
-        DriveResourceCount = team.DriveResourceCount,
-        RoleSlotCount = team.RoleSlotCount,
-        CreatedAt = team.CreatedAt.ToDateTimeUtc(),
-        IsChildTeam = team.IsChildTeam,
-        PendingShiftSignupCount = team.PendingShiftSignupCount,
-        IsHidden = team.IsHidden
-    };
 
     [HttpGet("{teamId:guid}/GoogleResources")]
     [Authorize(Policy = PolicyNames.TeamsAdminBoardOrAdmin)]


### PR DESCRIPTION
## Simplifications

- Collapsed single-use private Teams service helpers into their only callers where the workflow stayed readable.
- Reused the existing role-definition snapshot mapper instead of a duplicate private projection.
- Flattened duplicate team-page shift summary branches into one service call path.
- Inlined small TeamAdmin response wrappers and removed narrating comments.

## Net line delta

- `104 insertions, 242 deletions` across 5 C# files: net `-138` lines.
- Commits: 1.

## Verification

- `dotnet build Humans.slnx -v quiet`
- `dotnet test Humans.slnx -v quiet`

## Needs owner judgment

- Public Teams surfaces were left untouched, including service/repository interface methods and DI registrations that may overlap but are outside this simplification-only pass.
- Test-exposed internal helpers such as `TeamEarlyEntryProjection`, `FindCurrentEventAttendeeByBarcode`, and `BuildTicketLookupRows` remain because they are still production-used and covered by focused tests.
- Remaining private projection helpers in `TeamController.Details` were not inlined because that action is already baseline HUM0031 debt; inlining them would increase controller complexity without a clear simplification win.
- Existing solution-wide analyzer warnings outside the Teams simplification diff were left untouched.