### PR TITLE
refactor(camps): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Camps/CampContactService.cs
+++ b/src/Humans.Application/Services/Camps/CampContactService.cs
@@ -31,7 +31,6 @@ public class CampContactService(
         IReadOnlyList<Guid> leadUserIds,
         string campDetailsUrl)
     {
-        // Rate limit: one message per camp per user per 10 minutes
         var rateLimitKey = CacheKeys.CampContactRateLimit(senderUserId, campId);
         if (!await cache.TryReserveAsync(rateLimitKey, TimeSpan.FromMinutes(10)))
         {
@@ -57,7 +56,24 @@ public class CampContactService(
                 $"Message sent to camp '{campDisplayName}' (contact info shared: {(includeContactInfo ? "yes" : "no")})",
                 senderUserId);
 
-            await SendLeadNotificationAsync(campId, campDisplayName, leadUserIds, campDetailsUrl);
+            if (leadUserIds.Count > 0)
+            {
+                try
+                {
+                    await notificationEmitter.SendAsync(
+                        NotificationSource.FacilitatedMessageReceived,
+                        NotificationClass.Informational,
+                        NotificationPriority.Normal,
+                        $"New message for {campDisplayName} - check your email",
+                        leadUserIds,
+                        actionUrl: campDetailsUrl,
+                        actionLabel: "View camp");
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to dispatch FacilitatedMessageReceived notification for camp {CampId}", campId);
+                }
+            }
 
             return new CampContactResult(Success: true, RateLimited: false);
         }
@@ -66,34 +82,6 @@ public class CampContactService(
             cache.InvalidateCampContactRateLimit(senderUserId, campId);
             logger.LogError(ex, "Failed to send facilitated message to camp {CampId}", campId);
             throw;
-        }
-    }
-
-    private async Task SendLeadNotificationAsync(
-        Guid campId,
-        string campDisplayName,
-        IReadOnlyList<Guid> leadUserIds,
-        string campDetailsUrl)
-    {
-        if (leadUserIds.Count == 0)
-        {
-            return;
-        }
-
-        try
-        {
-            await notificationEmitter.SendAsync(
-                NotificationSource.FacilitatedMessageReceived,
-                NotificationClass.Informational,
-                NotificationPriority.Normal,
-                $"New message for {campDisplayName} - check your email",
-                leadUserIds,
-                actionUrl: campDetailsUrl,
-                actionLabel: "View camp");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to dispatch FacilitatedMessageReceived notification for camp {CampId}", campId);
         }
     }
 }

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -120,13 +120,6 @@ public sealed class CampRoleService(
             definition.DeactivatedAt,
             definition.SpecialRole);
 
-    private static CampRoleAssignmentInfo CreateCampRoleAssignmentInfo(CampRoleAssignment assignment) =>
-        new(
-            assignment.Id,
-            assignment.CampSeasonId,
-            assignment.CampRoleDefinitionId,
-            assignment.CampMemberId);
-
     public async Task<UpdateCampRoleDefinitionResult> UpdateDefinitionAsync(Guid id, UpdateCampRoleDefinitionInput input, Guid actorUserId, CancellationToken ct = default)
     {
         ValidateMinimumRequired(input.SlotCount, input.MinimumRequired);
@@ -337,7 +330,13 @@ public sealed class CampRoleService(
     public async Task<CampRoleAssignmentInfo?> GetAssignmentByIdAsync(Guid assignmentId, CancellationToken ct = default)
     {
         var assignment = await repo.GetAssignmentByIdAsync(assignmentId, ct);
-        return assignment is null ? null : CreateCampRoleAssignmentInfo(assignment);
+        return assignment is null
+            ? null
+            : new CampRoleAssignmentInfo(
+                assignment.Id,
+                assignment.CampSeasonId,
+                assignment.CampRoleDefinitionId,
+                assignment.CampMemberId);
     }
 
     public async Task<bool> UnassignAsync(Guid assignmentId, Guid actorUserId, CancellationToken ct = default)
@@ -428,21 +427,54 @@ public sealed class CampRoleService(
         foreach (var specialRole in Enum.GetValues<CampSpecialRole>())
         {
             if (specialRole == CampSpecialRole.None) continue;
-            var defaults = GetSpecialRoleSeedDefaults(specialRole);
-            var ensured = await EnsureSpecialRoleAsync(
-                specialRole,
-                defaults.Name,
-                defaults.Slug,
-                defaults.SortOrder,
-                defaults.SlotCount,
-                defaults.MinimumRequired,
-                defaults.Description,
-                actorUserId, now, ct);
-            if (ensured.Created) definitionsCreated++;
-            if (specialRole == CampSpecialRole.Lead) campLead = ensured.Definition;
+            var (name, slug, sortOrder, slotCount, minimumRequired, description) = specialRole switch
+            {
+                CampSpecialRole.Lead => (
+                    CampSystemRoles.CampLeadName,
+                    CampSystemRoles.CampLeadSlug,
+                    CampSystemRoles.CampLeadSortOrder,
+                    CampSystemRoles.CampLeadSlotCount,
+                    CampSystemRoles.CampLeadMinimumRequired,
+                    "Authorizes camp-management actions (Edit, members, roles, leads) and camp-event submission. Sort-to-top of the camp's Roles panel."),
+                CampSpecialRole.Workshop => (
+                    CampSystemRoles.WorkshopLeadName,
+                    CampSystemRoles.WorkshopLeadSlug,
+                    CampSystemRoles.WorkshopLeadSortOrder,
+                    CampSystemRoles.WorkshopLeadSlotCount,
+                    CampSystemRoles.WorkshopLeadMinimumRequired,
+                    "Authorizes camp-event submission alongside Camp Lead. Does not grant general camp-management authority."),
+                _ => throw new InvalidOperationException($"No seed defaults for special role '{specialRole}'."),
+            };
+
+            var definition = await repo.GetSpecialDefinitionAsync(specialRole, ct);
+            if (definition is null)
+            {
+                definition = new CampRoleDefinition
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name,
+                    Slug = slug,
+                    Description = description,
+                    SlotCount = slotCount,
+                    MinimumRequired = minimumRequired,
+                    SortOrder = sortOrder,
+                    SpecialRole = specialRole,
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                };
+                await repo.AddDefinitionAsync(definition, ct);
+                await auditLog.LogAsync(
+                    AuditAction.CampRoleDefinitionCreated,
+                    nameof(CampRoleDefinition),
+                    definition.Id,
+                    $"Seeded system camp role '{name}'.",
+                    actorUserId);
+                definitionsCreated++;
+            }
+
+            if (specialRole == CampSpecialRole.Lead) campLead = definition;
         }
 
-        // (2) Walk legacy camp_leads → CampRoleAssignment against Camp Lead role.
         if (campLead is null)
             throw new InvalidOperationException("Camp Lead special role definition is missing after seed.");
         var leadSnapshots = await repo.GetLeadMigrationSnapshotsAsync(ct);
@@ -506,65 +538,6 @@ public sealed class CampRoleService(
             SkippedCampSlugs: skippedCampSlugs);
     }
 
-    private async Task<(CampRoleDefinition Definition, bool Created)> EnsureSpecialRoleAsync(
-        CampSpecialRole specialRole,
-        string name, string slug, int sortOrder, int slotCount, int minimumRequired,
-        string description, Guid actorUserId, Instant now, CancellationToken ct)
-    {
-        var existing = await repo.GetSpecialDefinitionAsync(specialRole, ct);
-        if (existing is not null) return (existing, false);
-
-        var def = new CampRoleDefinition
-        {
-            Id = Guid.NewGuid(),
-            Name = name,
-            Slug = slug,
-            Description = description,
-            SlotCount = slotCount,
-            MinimumRequired = minimumRequired,
-            SortOrder = sortOrder,
-            SpecialRole = specialRole,
-            CreatedAt = now,
-            UpdatedAt = now,
-        };
-        await repo.AddDefinitionAsync(def, ct);
-        await auditLog.LogAsync(
-            AuditAction.CampRoleDefinitionCreated,
-            nameof(CampRoleDefinition),
-            def.Id,
-            $"Seeded system camp role '{name}'.",
-            actorUserId);
-        return (def, true);
-    }
-
-    private static SpecialRoleSeedDefaults GetSpecialRoleSeedDefaults(CampSpecialRole specialRole) =>
-        specialRole switch
-        {
-            CampSpecialRole.Lead => new SpecialRoleSeedDefaults(
-                CampSystemRoles.CampLeadName,
-                CampSystemRoles.CampLeadSlug,
-                CampSystemRoles.CampLeadSortOrder,
-                CampSystemRoles.CampLeadSlotCount,
-                CampSystemRoles.CampLeadMinimumRequired,
-                "Authorizes camp-management actions (Edit, members, roles, leads) and camp-event submission. Sort-to-top of the camp's Roles panel."),
-            CampSpecialRole.Workshop => new SpecialRoleSeedDefaults(
-                CampSystemRoles.WorkshopLeadName,
-                CampSystemRoles.WorkshopLeadSlug,
-                CampSystemRoles.WorkshopLeadSortOrder,
-                CampSystemRoles.WorkshopLeadSlotCount,
-                CampSystemRoles.WorkshopLeadMinimumRequired,
-                "Authorizes camp-event submission alongside Camp Lead. Does not grant general camp-management authority."),
-            _ => throw new ArgumentOutOfRangeException(nameof(specialRole), specialRole, "No seed defaults for this special role."),
-        };
-
-    private sealed record SpecialRoleSeedDefaults(
-        string Name,
-        string Slug,
-        int SortOrder,
-        int SlotCount,
-        int MinimumRequired,
-        string Description);
-
     public async Task<CampRoleDrillDownData?> BuildDrillDownAsync(Guid roleDefinitionId, int year, CancellationToken ct = default)
     {
         var def = await repo.GetDefinitionByIdAsync(roleDefinitionId, ct);
@@ -589,7 +562,20 @@ public sealed class CampRoleService(
                     ? list.Select(a =>
                     {
                         var userId = a.CampMember.UserId;
-                        var googleEmail = TryGetGoogleEmail(userId, emailsByUserId);
+                        string? googleEmail = null;
+                        if (emailsByUserId.TryGetValue(userId, out var emails))
+                        {
+                            googleEmail = emails
+                                .Where(e => e.IsVerified && e.IsGoogle)
+                                .Select(e => e.Email)
+                                .FirstOrDefault()
+                                ?? emails
+                                    .Where(e => e.IsVerified)
+                                    .OrderBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
+                                    .Select(e => e.Email)
+                                    .FirstOrDefault();
+                        }
+
                         return new CampRoleDrillDownAssignee(userId, googleEmail, a.AssignedAt);
                     }).ToList()
                     : new List<CampRoleDrillDownAssignee>();
@@ -698,20 +684,4 @@ public sealed class CampRoleService(
     public string BuildGroupKey(int year, string slug) =>
         $"barrios-{year}-{slug}@{_googleOptions.Domain}";
 
-    private static string? TryGetGoogleEmail(
-        Guid userId,
-        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId)
-    {
-        if (!emailsByUserId.TryGetValue(userId, out var emails))
-            return null;
-        return emails
-            .Where(e => e.IsVerified && e.IsGoogle)
-            .Select(e => e.Email)
-            .FirstOrDefault()
-            ?? emails
-                .Where(e => e.IsVerified)
-                .OrderBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
-                .Select(e => e.Email)
-                .FirstOrDefault();
-    }
 }

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -62,8 +62,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         _logger = logger;
     }
 
-    // --- Registration ---
-
     public async Task<Camp> CreateCampAsync(
         Guid createdByUserId, string name, string contactEmail, string contactPhone,
         string? webOrSocialUrl, List<CampLink>? links, bool isSwissCamp, int timesAtNowhere,
@@ -160,8 +158,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         return camp;
     }
 
-    // --- Queries ---
-
     public async Task<CampInfo?> GetCampBySlugAsync(string slug, CancellationToken cancellationToken = default)
     {
         var camp = await _repo.GetBySlugAsync(slug, cancellationToken);
@@ -227,17 +223,10 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         return CampUserInfo.Resolve(camps, settings.PublicYear, userId);
     }
 
-    private async Task<List<Camp>> GetCampEntitiesForYearAsync(
-        int year, CancellationToken cancellationToken = default)
-    {
-        var camps = await _repo.GetAllCampsForYearAsync(year, cancellationToken);
-        return camps.ToList();
-    }
-
     public async Task<IReadOnlyList<(Guid CampId, string CampName, string CampSlug, Guid CampSeasonId)>>
         GetCampSeasonsForComplianceAsync(int year, CancellationToken cancellationToken = default)
     {
-        var camps = await GetCampEntitiesForYearAsync(year, cancellationToken);
+        var camps = await _repo.GetAllCampsForYearAsync(year, cancellationToken);
         // Canonical name lives on CampSeason (per-season), not Camp.
         return camps.SelectMany(c => c.Seasons.Where(s => s.Year == year).Select(s =>
             (c.Id, s.Name, c.Slug, s.Id))).ToList();
@@ -249,7 +238,10 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         if (settings is null)
             throw new InvalidOperationException("Camp settings not found.");
 
-        var info = CreateCampSettingsInfo(settings);
+        var info = new CampSettingsInfo(
+            settings.PublicYear,
+            settings.OpenSeasons.ToList(),
+            settings.EeStartDate);
         if (info.OpenSeasons.Count == 0)
         {
             return info;
@@ -383,7 +375,18 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
             Members = season.Members
                 .Where(m => m.Status != CampMemberStatus.Removed)
                 .OrderBy(m => m.RequestedAt)
-                .Select(m => CreateCampSeasonMemberInfo(m, roles?.MemberRoleNames))
+                .Select(m => new CampSeasonMemberInfo(
+                    m.Id,
+                    m.UserId,
+                    m.Status,
+                    m.RequestedAt,
+                    m.ConfirmedAt,
+                    m.HasEarlyEntry)
+                {
+                    Roles = roles?.MemberRoleNames.TryGetValue(m.Id, out var names) == true
+                        ? names
+                        : []
+                })
                 .ToList(),
             LeadUserIds = GetSpecialRoleUserIds(season.Id, CampSpecialRole.Lead, roles?.SpecialRoleUserIds),
             WorkshopLeadUserIds = GetSpecialRoleUserIds(season.Id, CampSpecialRole.Workshop, roles?.SpecialRoleUserIds)
@@ -400,28 +403,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
             ? userIds
             : [];
     }
-
-    private static CampSettingsInfo CreateCampSettingsInfo(CampSettings settings) =>
-        new(
-            settings.PublicYear,
-            settings.OpenSeasons.ToList(),
-            settings.EeStartDate);
-
-    private static CampSeasonMemberInfo CreateCampSeasonMemberInfo(
-        CampMember member,
-        IReadOnlyDictionary<Guid, IReadOnlyList<string>>? memberRoleNames = null) =>
-        new(
-            member.Id,
-            member.UserId,
-            member.Status,
-            member.RequestedAt,
-            member.ConfirmedAt,
-            member.HasEarlyEntry)
-        {
-            Roles = memberRoleNames is not null && memberRoleNames.TryGetValue(member.Id, out var names)
-                ? names
-                : []
-        };
 
     private static CampEditData CreateCampEditData(Camp camp, CampSeason season, LocalDate today)
     {
@@ -465,8 +446,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
                 .Select(h => new CampHistoricalNameSummary(h.Id, h.Name, h.Year, h.Source.ToString()))
                 .ToList());
     }
-
-    // --- Season management ---
 
     public async Task<CampSeason> OptInToSeasonAsync(
         Guid campId, int year, CancellationToken cancellationToken = default)
@@ -694,8 +673,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
 
     }
 
-    // --- Camp updates ---
-
     public async Task<CampUpdateResult> UpdateCampAsync(
         CampUpdateInput input,
         CancellationToken cancellationToken = default)
@@ -725,7 +702,19 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
                 "CampService");
 
             await UpdateSeasonAsync(input.SeasonId, input.SeasonData, cancellationToken);
-            await ChangeSeasonNameIfAllowedAsync(input.SeasonId, input.SeasonName, cancellationToken);
+
+            var currentSeason = await _repo.GetSeasonByIdAsync(input.SeasonId, cancellationToken)
+                ?? throw new InvalidOperationException("Season not found.");
+
+            if (!string.Equals(currentSeason.Name, input.SeasonName, StringComparison.Ordinal))
+            {
+                var today = _clock.GetCurrentInstant().InUtc().Date;
+                var nameLocked = currentSeason.NameLockDate.HasValue && today >= currentSeason.NameLockDate.Value;
+                if (!nameLocked)
+                {
+                    await ChangeSeasonNameAsync(currentSeason.Id, input.SeasonName, cancellationToken);
+                }
+            }
 
             return CampUpdateResult.Success();
         }
@@ -733,29 +722,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         {
             return CampUpdateResult.Failure(ex.Message);
         }
-    }
-
-    private async Task ChangeSeasonNameIfAllowedAsync(
-        Guid seasonId,
-        string seasonName,
-        CancellationToken cancellationToken)
-    {
-        var currentSeason = await _repo.GetSeasonByIdAsync(seasonId, cancellationToken)
-            ?? throw new InvalidOperationException("Season not found.");
-
-        if (string.Equals(currentSeason.Name, seasonName, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        var today = _clock.GetCurrentInstant().InUtc().Date;
-        var nameLocked = currentSeason.NameLockDate.HasValue && today >= currentSeason.NameLockDate.Value;
-        if (nameLocked)
-        {
-            return;
-        }
-
-        await ChangeSeasonNameAsync(currentSeason.Id, seasonName, cancellationToken);
     }
 
     public async Task DeleteCampAsync(Guid campId, CancellationToken cancellationToken = default)
@@ -787,8 +753,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
 
     }
 
-    // --- Historical names ---
-
     public async Task AddHistoricalNameAsync(
         Guid campId, string name, CancellationToken cancellationToken = default)
     {
@@ -814,8 +778,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         }
     }
 
-    // --- Cross-service queries (used by CityPlanningService) ---
-
     public async Task<CampSeasonInfo?> GetCampSeasonByIdAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default)
     {
@@ -833,8 +795,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         var row = await _repo.GetMemberLookupAsync(campMemberId, cancellationToken);
         return row is null ? null : new CampMemberLookup(row.Value.CampSeasonId, row.Value.UserId, row.Value.Status);
     }
-
-    // --- Images ---
 
     public async Task<CampImageUploadResult> UploadImageAsync(
         Guid campId, Stream fileStream, string fileName, string contentType, long length,
@@ -917,8 +877,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         await _repo.ReorderImagesAsync(campId, imageIdsInOrder, cancellationToken);
     }
 
-    // --- Settings (CampAdmin) ---
-
     public async Task SetPublicYearAsync(int year, CancellationToken cancellationToken = default)
     {
         await _repo.SetPublicYearAsync(year, cancellationToken);
@@ -939,8 +897,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
     {
         await _repo.SetNameLockDateForYearAsync(year, lockDate, cancellationToken);
     }
-
-    // --- Name change ---
 
     public async Task ChangeSeasonNameAsync(
         Guid seasonId, string newName, CancellationToken cancellationToken = default)
@@ -1000,8 +956,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
 
     }
 
-    // --- Private helpers ---
-
     private static CampSeason CreateSeasonFromData(
         Guid campId, int year, string name, CampSeasonData data, Instant now)
     {
@@ -1030,18 +984,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
             CreatedAt = now,
             UpdatedAt = now
         };
-    }
-
-    // --- Camp membership per season (see nobodies-collective/Humans#488) ---
-
-    private async Task<CampSeason?> ResolveOpenMembershipSeasonAsync(
-        Guid campId, CancellationToken cancellationToken)
-    {
-        var settings = await GetSettingsAsync(cancellationToken);
-        var camp = await _repo.GetByIdAsync(campId, cancellationToken);
-        return camp?.Seasons.FirstOrDefault(s =>
-            s.Year == settings.PublicYear
-            && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full));
     }
 
     private async Task InvalidateLeadBadgesAsync(Guid campId, CancellationToken cancellationToken)
@@ -1099,7 +1041,11 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
     public async Task<CampMemberRequestResult> RequestCampMembershipAsync(
         Guid campId, Guid userId, CancellationToken cancellationToken = default)
     {
-        var season = await ResolveOpenMembershipSeasonAsync(campId, cancellationToken);
+        var settings = await GetSettingsAsync(cancellationToken);
+        var camp = await _repo.GetByIdAsync(campId, cancellationToken);
+        var season = camp?.Seasons.FirstOrDefault(s =>
+            s.Year == settings.PublicYear
+            && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full));
         if (season is null)
         {
             return new CampMemberRequestResult(
@@ -1289,15 +1235,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         return AddCampMemberOutcome.Added;
     }
 
-    private async Task<AssignCampRoleOutcome> AddMemberAndAssignRoleAsync(
-        Guid campSeasonId, Guid roleDefinitionId, Guid userId, Guid actorUserId,
-        CancellationToken cancellationToken = default)
-    {
-        var memberId = await EnsureActiveCampMemberAsync(campSeasonId, userId, actorUserId, cancellationToken);
-        return await _campRoleService.Value.AssignAsync(
-            campSeasonId, roleDefinitionId, memberId, actorUserId, cancellationToken);
-    }
-
     public async Task<AssignCampRoleOutcome> AddMemberAndAssignRoleInActiveSeasonAsync(
         Guid campId, Guid roleDefinitionId, Guid userId, Guid actorUserId,
         CancellationToken cancellationToken = default)
@@ -1307,8 +1244,9 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         if (openSeason is null)
             return AssignCampRoleOutcome.SeasonNotFound;
 
-        return await AddMemberAndAssignRoleAsync(
-            openSeason.Id, roleDefinitionId, userId, actorUserId, cancellationToken);
+        var memberId = await EnsureActiveCampMemberAsync(openSeason.Id, userId, actorUserId, cancellationToken);
+        return await _campRoleService.Value.AssignAsync(
+            openSeason.Id, roleDefinitionId, memberId, actorUserId, cancellationToken);
     }
 
     public async Task WithdrawCampMembershipRequestAsync(
@@ -1354,8 +1292,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         return CampMembershipMutationResult.Success();
     }
 
-    // --- Account-merge fold ---
-
     public async Task ReassignAsync(Guid sourceUserId, Guid targetUserId, Guid actorUserId, Instant updatedAt,
         CancellationToken ct)
     {
@@ -1369,8 +1305,6 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         _leadBadgeInvalidator.Invalidate(sourceUserId);
         _leadBadgeInvalidator.Invalidate(targetUserId);
     }
-
-    // --- IUserDataContributor — GDPR export ---
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)
     {

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -200,17 +200,25 @@ public class CampAdminController(
         var user = await GetCurrentUserInfoAsync();
         if (user is null) return Unauthorized();
 
-        var (ok, parsed, parseError) = TryParseEeStartDate(eeStartDate);
-        if (!ok)
+        LocalDate? parsed = null;
+        if (!string.IsNullOrWhiteSpace(eeStartDate))
         {
-            SetError(parseError!);
-            return RedirectToAction(nameof(Index));
+            var parseResult = NodaTime.Text.LocalDatePattern.Iso.Parse(eeStartDate);
+            if (!parseResult.Success)
+            {
+                SetError("Invalid date format. Use yyyy-MM-dd.");
+                return RedirectToAction(nameof(Index));
+            }
+
+            parsed = parseResult.Value;
         }
 
         try
         {
             await campService.SetEeStartDateAsync(parsed, user.Id, cancellationToken);
-            SetSuccess(EeStartDateSuccessMessage(parsed));
+            SetSuccess(parsed.HasValue
+                ? $"EE start date set to {parsed.Value.ToDate()}."
+                : "EE start date cleared.");
         }
         catch (Exception ex)
         {
@@ -219,18 +227,6 @@ public class CampAdminController(
         }
 
         return RedirectToAction(nameof(Index));
-    }
-
-    private static string EeStartDateSuccessMessage(LocalDate? date) =>
-        date.HasValue ? $"EE start date set to {date.Value.ToDate()}." : "EE start date cleared.";
-
-    private static (bool Ok, LocalDate? Value, string? Error) TryParseEeStartDate(string? input)
-    {
-        if (string.IsNullOrWhiteSpace(input)) return (true, null, null);
-        var result = NodaTime.Text.LocalDatePattern.Iso.Parse(input);
-        return result.Success
-            ? (true, result.Value, null)
-            : (false, null, "Invalid date format. Use yyyy-MM-dd.");
     }
 
     [HttpPost("Reactivate/{seasonId:guid}")]
@@ -373,12 +369,6 @@ public class CampAdminController(
         return View("RoleDrillDown", vm);
     }
 
-    private IActionResult RedirectToRolesWithSuccess(string message)
-    {
-        SetSuccess(message);
-        return RedirectToAction(nameof(Roles));
-    }
-
     [HttpGet("Roles/Create")]
     public IActionResult CreateRole() => View("RoleForm", new CampRoleDefinitionFormViewModel());
 
@@ -446,12 +436,18 @@ public class CampAdminController(
             var input = new UpdateCampRoleDefinitionInput(
                 form.Name, form.Slug, form.Description, form.SlotCount, form.MinimumRequired, form.SortOrder);
             var result = await campRoleService.UpdateDefinitionAsync(id, input, user.Id, ct);
-            return result.Status switch
+            if (result.Status == UpdateCampRoleDefinitionStatus.Updated)
             {
-                UpdateCampRoleDefinitionStatus.Updated => RedirectToRolesWithSuccess(result.SuccessMessage),
-                UpdateCampRoleDefinitionStatus.NotFound => NotFound(),
-                _ => throw new InvalidOperationException($"Unexpected camp role update status '{result.Status}'.")
-            };
+                SetSuccess(result.SuccessMessage);
+                return RedirectToAction(nameof(Roles));
+            }
+
+            if (result.Status == UpdateCampRoleDefinitionStatus.NotFound)
+            {
+                return NotFound();
+            }
+
+            throw new InvalidOperationException($"Unexpected camp role update status '{result.Status}'.");
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Humans.Web/Controllers/CampComplianceController.cs
+++ b/src/Humans.Web/Controllers/CampComplianceController.cs
@@ -42,7 +42,26 @@ public class CampComplianceController(
         var rows = camps
             .Select(c => c.GetSeasonForYear(resolvedYear))
             .Where(s => s is not null && ActiveStatuses.Contains(s.Status))
-            .Select(s => BuildRow(s!, roleColumns))
+            .Select(s =>
+            {
+                var season = s!;
+                var activeMembers = season.ActiveMembers;
+                var cells = roleColumns.Select(col =>
+                {
+                    var assignees = activeMembers
+                        .Where(m => m.Roles.Contains(col.Name, StringComparer.Ordinal))
+                        .Select(m => m.UserId)
+                        .ToList();
+                    return new CampComplianceRoleCell(assignees, col.MinimumRequired);
+                }).ToList();
+
+                return new CampComplianceRow(
+                    season.Name,
+                    season.CampSlug,
+                    season.JoinedMemberCount ?? 0,
+                    season.MemberCount,
+                    cells);
+            })
             .OrderBy(r => r.CampName, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
@@ -52,27 +71,5 @@ public class CampComplianceController(
             Roles = roleColumns,
             Rows = rows,
         });
-    }
-
-    private static CampComplianceRow BuildRow(
-        CampSeasonInfo season, IReadOnlyList<CampComplianceRoleColumn> roleColumns)
-    {
-        var activeMembers = season.ActiveMembers;
-
-        var cells = roleColumns.Select(col =>
-        {
-            var assignees = activeMembers
-                .Where(m => m.Roles.Contains(col.Name, StringComparer.Ordinal))
-                .Select(m => m.UserId)
-                .ToList();
-            return new CampComplianceRoleCell(assignees, col.MinimumRequired);
-        }).ToList();
-
-        return new CampComplianceRow(
-            season.Name,
-            season.CampSlug,
-            season.JoinedMemberCount ?? 0,
-            season.MemberCount,
-            cells);
     }
 }

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -34,8 +34,6 @@ public class CampController(
     private readonly IUserServiceRead _userService = userService;
     private readonly IClock _clock = clock;
 
-    // --- Public routes ---
-
     [AllowAnonymous]
     [HttpGet("")]
     public async Task<IActionResult> Index(CampFilterViewModel? filters, CancellationToken ct = default)
@@ -53,12 +51,38 @@ public class CampController(
             ? new HashSet<Guid>()
             : camps.Where(camp => camp.IsLead(user.Id)).Select(camp => camp.Id).ToHashSet();
 
-        var cards = ApplyCampDirectoryFilters(
-                camps
-                    .Select(camp => new { Camp = camp, Season = camp.GetSeasonForYear(year) })
-                    .Where(row => row.Season is { Status: CampSeasonStatus.Active or CampSeasonStatus.Full })
-                    .Select(row => MapCampCard(row.Camp, row.Season!, roleSummaries)),
-                filters)
+        var directoryCards = camps
+            .Select(camp => new { Camp = camp, Season = camp.GetSeasonForYear(year) })
+            .Where(row => row.Season is { Status: CampSeasonStatus.Active or CampSeasonStatus.Full })
+            .Select(row => MapCampCard(row.Camp, row.Season!, roleSummaries));
+        if (filters?.Vibe.HasValue == true)
+        {
+            directoryCards = directoryCards.Where(card => card.Vibes.Contains(filters.Vibe.Value));
+        }
+
+        if (filters?.SoundZone.HasValue == true)
+        {
+            directoryCards = directoryCards.Where(card => card.SoundZone == filters.SoundZone.Value);
+        }
+
+        if (filters?.KidsFriendly == true)
+        {
+            directoryCards = directoryCards.Where(card => card.KidsWelcome == YesNoMaybe.Yes);
+        }
+
+        if (filters?.AcceptingMembers == true)
+        {
+            directoryCards = directoryCards.Where(card => card.AcceptingMembers == YesNoMaybe.Yes);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filters?.Search))
+        {
+            var q = filters.Search.Trim();
+            directoryCards = directoryCards.Where(card =>
+                card.Name.Contains(q, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var cards = directoryCards
             .OrderBy(card => leadCampIds.Contains(card.Id) ? 0 : 1)
             .ThenBy(card => card.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -90,40 +114,6 @@ public class CampController(
         };
 
         return View(viewModel);
-    }
-
-    private static IEnumerable<CampCardViewModel> ApplyCampDirectoryFilters(
-        IEnumerable<CampCardViewModel> camps,
-        CampFilterViewModel? filter)
-    {
-        if (filter?.Vibe.HasValue == true)
-        {
-            camps = camps.Where(card => card.Vibes.Contains(filter.Vibe.Value));
-        }
-
-        if (filter?.SoundZone.HasValue == true)
-        {
-            camps = camps.Where(card => card.SoundZone == filter.SoundZone.Value);
-        }
-
-        if (filter?.KidsFriendly == true)
-        {
-            camps = camps.Where(card => card.KidsWelcome == YesNoMaybe.Yes);
-        }
-
-        if (filter?.AcceptingMembers == true)
-        {
-            camps = camps.Where(card => card.AcceptingMembers == YesNoMaybe.Yes);
-        }
-
-        if (!string.IsNullOrWhiteSpace(filter?.Search))
-        {
-            var q = filter.Search.Trim();
-            camps = camps.Where(card =>
-                card.Name.Contains(q, StringComparison.OrdinalIgnoreCase));
-        }
-
-        return camps;
     }
 
     private static CampCardViewModel MapCampCard(
@@ -235,8 +225,6 @@ public class CampController(
         };
     }
 
-    // --- Facilitated Contact ---
-
     [Authorize]
     [HttpGet("{slug}/Contact")]
     public async Task<IActionResult> Contact(string slug)
@@ -309,8 +297,6 @@ public class CampController(
             return RedirectToAction(nameof(Details), new { slug });
         }
     }
-
-    // --- Registration ---
 
     [Authorize]
     [HttpGet("Register")]
@@ -399,8 +385,6 @@ public class CampController(
             return View(model);
         }
     }
-
-    // --- Edit ---
 
     [Authorize]
     [HttpGet("{slug}/Edit")]
@@ -585,8 +569,6 @@ public class CampController(
         return RedirectToAction(nameof(Edit), new { slug });
     }
 
-    // --- Season opt-in ---
-
     [Authorize]
     [HttpPost("{slug}/OptIn/{year:int}")]
     [ValidateAntiForgeryToken]
@@ -662,15 +644,10 @@ public class CampController(
         return RedirectToAction(nameof(Details), new { slug });
     }
 
-    // --- Lead management ---
-    //
     // The legacy AddLead / RemoveLead actions were retired in
     // issue nobodies-collective/Humans#753 (Camp Lead retired into the
     // CampRoleAssignment system role). Lead assignment is now performed via
     // the Camp Lead row in the unified Roles panel on the Members page.
-
-
-    // --- Historical name management ---
 
     [Authorize]
     [HttpPost("{slug}/HistoricalNames/Add")]
@@ -723,8 +700,6 @@ public class CampController(
 
         return RedirectToAction(nameof(Edit), new { slug });
     }
-
-    // --- Image management ---
 
     [Authorize]
     [HttpPost("{slug}/Images/Upload")]
@@ -812,8 +787,6 @@ public class CampController(
         return RedirectToAction(nameof(Edit), new { slug });
     }
 
-    // --- Camp membership per season (see nobodies-collective/Humans#488) ---
-
     [Authorize]
     [HttpPost("{slug}/Members/Request")]
     [ValidateAntiForgeryToken]
@@ -826,26 +799,20 @@ public class CampController(
         if (currentUserError is not null) return currentUserError;
 
         var result = await _campService.RequestCampMembershipAsync(camp.Id, user.Id);
-        SetCampMemberRequestNotice(result);
-
-        return RedirectToAction(nameof(Details), new { slug });
-    }
-
-    private void SetCampMemberRequestNotice(CampMemberRequestResult result)
-    {
         if (result.NoticeLevel == CampMemberRequestNoticeLevel.Success)
         {
             SetSuccess(result.Message);
-            return;
         }
-
-        if (result.NoticeLevel == CampMemberRequestNoticeLevel.Info)
+        else if (result.NoticeLevel == CampMemberRequestNoticeLevel.Info)
         {
             SetInfo(result.Message);
-            return;
+        }
+        else
+        {
+            SetError(result.Message);
         }
 
-        SetError(result.Message);
+        return RedirectToAction(nameof(Details), new { slug });
     }
 
     [Authorize]
@@ -977,19 +944,14 @@ public class CampController(
             camp.Id, campMemberId, granted, user.Id, cancellationToken);
 
         if (outcome == SetEarlyEntryOutcome.MemberNotFound) return NotFound();
-        ApplyEarlyEntryFlash(outcome, granted);
-        return RedirectToAction(nameof(Members), new { slug });
-    }
-
-    private void ApplyEarlyEntryFlash(SetEarlyEntryOutcome outcome, bool granted)
-    {
         if (outcome == SetEarlyEntryOutcome.Success)
             SetSuccess(granted ? "Early Entry granted." : "Early Entry revoked.");
         else if (outcome == SetEarlyEntryOutcome.SlotCapExceeded)
             SetError("Cannot grant Early Entry: slot cap reached for this camp.");
         else if (outcome == SetEarlyEntryOutcome.MemberNotActive)
             SetError("Only Active camp members can hold Early Entry.");
-        // NoChange: silent � UI already reflected the state.
+
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     [Authorize]
@@ -1018,8 +980,6 @@ public class CampController(
 
         return RedirectToAction(nameof(Members), new { slug });
     }
-
-    // --- Per-camp role assignments (see nobodies-collective/Humans#489) ---
 
     [Authorize]
     [HttpPost("{slug}/Roles/Assign")]
@@ -1125,8 +1085,6 @@ public class CampController(
 
         return RedirectToAction(nameof(Members), new { slug });
     }
-
-    // --- Helper methods ---
 
     private async Task PopulateCityPlanningViewBagAsync(UserInfo? currentUser, CancellationToken cancellationToken)
     {
@@ -1243,7 +1201,11 @@ public class CampController(
             Id = camp.Id,
             Slug = camp.Slug,
             Name = season.Name,
-            Links = CreateCampLinks(camp),
+            Links = camp.Links is { Count: > 0 }
+                ? [.. camp.Links]
+                : camp.WebOrSocialUrl is not null
+                    ? [new CampLink { Url = camp.WebOrSocialUrl }]
+                    : [],
             IsSwissCamp = camp.IsSwissCamp,
             HideHistoricalNames = camp.HideHistoricalNames,
             TimesAtNowhere = camp.TimesAtNowhere,
@@ -1277,18 +1239,6 @@ public class CampController(
             Membership = membership
         };
 
-    private static List<CampLink> CreateCampLinks(CampInfo camp)
-    {
-        if (camp.Links is { Count: > 0 })
-        {
-            return [.. camp.Links];
-        }
-
-        return camp.WebOrSocialUrl is not null
-            ? [new CampLink { Url = camp.WebOrSocialUrl }]
-            : [];
-    }
-
     /// <summary>
     /// Fills the read-only Roles panel and (for full-camp viewers) the Roster on the
     /// detail VM. Sourced from CampRoleAssignment — the same data as /Edit/Members —
@@ -1301,7 +1251,7 @@ public class CampController(
     {
         if (currentUser is null)
         {
-            return; // anonymous viewers do not see cards
+            return;
         }
 
         vm.RolesPanel = await BuildRolesPanelAsync(
@@ -1335,7 +1285,9 @@ public class CampController(
         var parsedLinks = links
             .Where(link => !string.IsNullOrWhiteSpace(link))
             .Select(link => link!.Trim())
-            .Where(IsHttpUrl)
+            .Where(link => Uri.TryCreate(link, UriKind.Absolute, out var parsed)
+                && (string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
+                    || string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)))
             .Select(link => new CampLink
             {
                 Url = link,
@@ -1344,12 +1296,5 @@ public class CampController(
             .ToList();
 
         return parsedLinks.Count > 0 ? parsedLinks : null;
-    }
-
-    private static bool IsHttpUrl(string url)
-    {
-        return Uri.TryCreate(url, UriKind.Absolute, out var parsed)
-            && (string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
-                || string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal));
     }
 }


### PR DESCRIPTION
## Simplifications
- Inlined thin private Camps service helpers for compliance reads, settings projection, season-member projection, season-name updates, active-season membership lookup, and add-member-then-assign-role flow.
- Collapsed CampRoleService single-use projection/seed helpers, including the assignment mapper, special-role defaults record/helper, and Google-email selector.
- Inlined one-call controller helpers for directory filters, membership notices, Early Entry flash messages, camp links, URL filtering, EE start-date parsing/success text, role-update redirects, and compliance row projection.
- Removed narrating section-label comments where they only repeated the code grouping.

## Net line delta
- 216 insertions, 386 deletions, net -170 lines.

## Verification
- `dotnet build Humans.slnx -v quiet` (warm rerun: 0 warnings, 0 errors)
- `dotnet test Humans.slnx -v quiet`

## Needs owner judgment
- Public Camps interfaces, controller actions/routes, DI registrations, DTO/view-model shapes, and EF/repository storage behavior were left untouched.
- `ICampInfoInvalidator` and other existing solution-wide analyzer warnings are outside this section simplification; first post-edit builds emitted existing baseline warnings, then the warm build was clean.
- Large one-call construction helpers such as `CreateCampEditData` and `CreateSeasonFromData` were left in place because inlining them would make the callers harder to read rather than simpler.