### PR TITLE
Simplify GoogleIntegration private helpers

### DIFF
--- a/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/DriveActivityMonitorService.cs
@@ -159,7 +159,13 @@ public sealed class DriveActivityMonitorService(
         // audit_log_entries is the AuditLog section's repository. Audit is logged
         // after the business save (per IAuditLogService) and regardless of the
         // marker outcome — anomalies must surface even on a partial-failure run.
-        await AdvanceLastRunMarkerAsync(newMarker, cancellationToken);
+        if (newMarker is not null)
+        {
+            await systemSettings.SetValueAsync(
+                SystemSettingKeys.DriveActivityMonitorLastRunAt,
+                newMarker.Value.ToIso8601(),
+                cancellationToken);
+        }
 
         foreach (var (resourceId, description) in anomalies)
         {
@@ -234,18 +240,6 @@ public sealed class DriveActivityMonitorService(
             "Could not parse stored Drive activity monitor timestamp '{Value}', falling back to default lookback",
             value);
         return null;
-    }
-
-    private Task AdvanceLastRunMarkerAsync(
-        Instant? newLastRunAt,
-        CancellationToken cancellationToken)
-    {
-        return newLastRunAt is null
-            ? Task.CompletedTask
-            : systemSettings.SetValueAsync(
-                SystemSettingKeys.DriveActivityMonitorLastRunAt,
-                newLastRunAt.Value.ToIso8601(),
-                cancellationToken);
     }
 
     private static bool IsInitiatedByServiceAccount(

--- a/src/Humans.Application/Services/GoogleIntegration/EmailProvisioningService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/EmailProvisioningService.cs
@@ -70,7 +70,6 @@ public sealed class EmailProvisioningService(
                     ErrorMessage: $"{fullEmail} is the Google Group address for team \"{conflictingTeamName}\" and cannot be used as a personal account.");
             }
 
-            // Check if account already exists in Google Workspace
             var existing = await workspaceUserService.GetAccountAsync(fullEmail);
             if (existing is not null)
                 return new EmailProvisioningResult(false, fullEmail, ErrorMessage: $"Account {fullEmail} already exists in Google Workspace.");
@@ -85,10 +84,8 @@ public sealed class EmailProvisioningService(
             // ORDERING IS CRITICAL — do NOT reorder. Recovery email must be captured BEFORE AddVerifiedEmailAsync flips the notification target to @nobodies.team.
             // 1. Capture recovery (personal) email  2. Provision Workspace  3. Link @nobodies.team  4. Send creds to recovery
 
-            // Step 1: Capture recovery email BEFORE the notification target changes.
             var recoveryEmail = await ResolveRecoveryEmailAsync(userId, user.Email);
 
-            // Step 2: Generate temp password and provision in Google Workspace.
             var tempPassword = PasswordGenerator.GenerateTemporary();
             await workspaceUserService.ProvisionAccountAsync(
                 fullEmail, firstName, lastName, tempPassword,
@@ -114,14 +111,12 @@ public sealed class EmailProvisioningService(
                 await userEmailService.SetGoogleAsync(userId, workspaceRow.Id, provisionedByUserId);
             }
 
-            // Audit
             await auditLogService.LogAsync(
                 AuditAction.WorkspaceAccountProvisioned,
                 "WorkspaceAccount", userId,
                 $"Provisioned and linked @nobodies.team account: {fullEmail}",
                 provisionedByUserId);
 
-            // Step 4: Send credentials to the PERSONAL email captured in step 1.
             if (!string.IsNullOrEmpty(recoveryEmail))
             {
                 await emailService.SendAsync(emailMessages.WorkspaceCredentials(
@@ -129,7 +124,6 @@ public sealed class EmailProvisioningService(
                     user.PreferredLanguage));
             }
 
-            // In-app notification (best-effort)
             try
             {
                 await notificationService.SendAsync(

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -200,7 +200,6 @@ public sealed class GoogleAdminService(
                 ErrorMessage: $"{fullEmail} is the Google Group address for team \"{conflictingTeamName}\" and cannot be used as a personal account.");
         }
 
-        // Check if account already exists
         var existing = await workspaceUserService.GetAccountAsync(fullEmail, ct);
         if (existing is not null)
         {
@@ -522,7 +521,6 @@ public sealed class GoogleAdminService(
                     ErrorMessage: "Human not found.");
             }
 
-            // Check not already linked (case-insensitive, any user)
             var alreadyLinked = await userEmailService.IsEmailLinkedToAnyUserAsync(email, ct);
             if (alreadyLinked)
             {

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -177,7 +177,15 @@ public sealed class GoogleGroupSyncService(
         }
 
         expectedMembersByUserId ??= await HydrateExpectedMembersByUserIdAsync(claim.UserIds, ct);
-        var expectedMembers = BuildExpectedMembersByEmail(claim.UserIds, expectedMembersByUserId);
+        var expectedMembers = new Dictionary<string, ExpectedMember>(NormalizingEmailComparer.Instance);
+        foreach (var userId in claim.UserIds)
+        {
+            if (expectedMembersByUserId.TryGetValue(userId, out var member))
+            {
+                expectedMembers[member.Email] = member;
+            }
+        }
+
         var list = await membershipClient.ListMembershipsAsync(lookup.GroupNumericId, ct);
         if (list.Memberships is null)
         {
@@ -320,18 +328,6 @@ public sealed class GoogleGroupSyncService(
             .Where(member => !string.IsNullOrWhiteSpace(member.MemberEmail))
             .GroupBy(member => member.MemberEmail!, NormalizingEmailComparer.Instance)
             .ToDictionary(group => group.Key, group => group.First().ResourceName, NormalizingEmailComparer.Instance);
-        var members = BuildExpectedGroupMemberStatuses(expectedMembers, currentByEmail);
-
-        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(ct);
-        AddExtraGroupMemberStatuses(members, expectedMembers.Keys, currentByEmail.Keys, serviceAccountEmail);
-
-        return new GroupMembershipPlan(members, currentByEmail);
-    }
-
-    private static List<MemberSyncStatus> BuildExpectedGroupMemberStatuses(
-        IReadOnlyDictionary<string, ExpectedMember> expectedMembers,
-        IReadOnlyDictionary<string, string> currentByEmail)
-    {
         var members = new List<MemberSyncStatus>();
         foreach (var (email, expected) in expectedMembers)
         {
@@ -344,22 +340,16 @@ public sealed class GoogleGroupSyncService(
                 ProfilePictureUrl: expected.ProfilePictureUrl));
         }
 
-        return members;
-    }
-
-    private static void AddExtraGroupMemberStatuses(
-        List<MemberSyncStatus> members,
-        IEnumerable<string> expectedEmails,
-        IEnumerable<string> currentEmails,
-        string serviceAccountEmail)
-    {
-        var expectedEmailSet = expectedEmails.ToHashSet(NormalizingEmailComparer.Instance);
-        foreach (var email in currentEmails.Where(email =>
+        var serviceAccountEmail = await teamResourceClient.GetServiceAccountEmailAsync(ct);
+        var expectedEmailSet = expectedMembers.Keys.ToHashSet(NormalizingEmailComparer.Instance);
+        foreach (var email in currentByEmail.Keys.Where(email =>
                      !expectedEmailSet.Contains(email) &&
                      !string.Equals(email, serviceAccountEmail, StringComparison.OrdinalIgnoreCase)))
         {
             members.Add(new MemberSyncStatus(email, email, MemberSyncState.Extra, []));
         }
+
+        return new GroupMembershipPlan(members, currentByEmail);
     }
 
     private async Task<ResourceSyncDiff?> ApplyGroupMembershipChangesAsync(
@@ -421,7 +411,17 @@ public sealed class GoogleGroupSyncService(
             }
 
             if (resource is not null && add.Outcome == GroupMembershipMutationOutcome.Added)
-                await LogGroupMemberAddedAsync(resource, member.Email);
+            {
+                await auditLogService.LogGoogleSyncAsync(
+                    AuditAction.GoogleResourceAccessGranted,
+                    resource.Id,
+                    $"Granted Google Group access to {member.Email} ({resource.Name})",
+                    nameof(GoogleGroupSyncService),
+                    member.Email,
+                    "MEMBER",
+                    GoogleSyncSource.ScheduledSync,
+                    success: true);
+            }
         }
 
         return null;
@@ -456,7 +456,17 @@ public sealed class GoogleGroupSyncService(
             }
 
             if (resource is not null)
-                await LogGroupMemberRemovedAsync(resource, member.Email);
+            {
+                await auditLogService.LogGoogleSyncAsync(
+                    AuditAction.GoogleResourceAccessRevoked,
+                    resource.Id,
+                    $"Removed {member.Email} from Google Group ({resource.Name})",
+                    nameof(GoogleGroupSyncService),
+                    member.Email,
+                    "MEMBER",
+                    GoogleSyncSource.ScheduledSync,
+                    success: true);
+            }
 
             await NotifyRemovalAsync(member.Email, resource, claim.GroupKey, ct);
         }
@@ -480,34 +490,26 @@ public sealed class GoogleGroupSyncService(
             claim.GroupKey,
             email,
             error);
-        await RecordMemberErrorAsync(resource, email, error, auditAction, ct);
+        if (resource is not null)
+        {
+            await teamResourceService.RecordResourceErrorAsync(resource.Id, error, ct);
+            await auditLogService.LogGoogleSyncAsync(
+                auditAction,
+                resource.Id,
+                error,
+                nameof(GoogleGroupSyncService),
+                email,
+                "MEMBER",
+                GoogleSyncSource.ScheduledSync,
+                success: false,
+                errorMessage: error);
+        }
+
         if (scheduleRetryOnFailure)
             await ScheduleRetryAsync(claim.GroupKey, error, nextRetryAttempt);
 
         return BuildErrorDiff(claim.GroupKey, resource, error, members);
     }
-
-    private Task LogGroupMemberAddedAsync(GoogleResourceSnapshot resource, string email)
-        => auditLogService.LogGoogleSyncAsync(
-            AuditAction.GoogleResourceAccessGranted,
-            resource.Id,
-            $"Granted Google Group access to {email} ({resource.Name})",
-            nameof(GoogleGroupSyncService),
-            email,
-            "MEMBER",
-            GoogleSyncSource.ScheduledSync,
-            success: true);
-
-    private Task LogGroupMemberRemovedAsync(GoogleResourceSnapshot resource, string email)
-        => auditLogService.LogGoogleSyncAsync(
-            AuditAction.GoogleResourceAccessRevoked,
-            resource.Id,
-            $"Removed {email} from Google Group ({resource.Name})",
-            nameof(GoogleGroupSyncService),
-            email,
-            "MEMBER",
-            GoogleSyncSource.ScheduledSync,
-            success: true);
 
     private async Task<Dictionary<Guid, ExpectedMember>> HydrateExpectedMembersByUserIdAsync(
         IReadOnlyCollection<Guid> userIds,
@@ -529,7 +531,19 @@ public sealed class GoogleGroupSyncService(
             if (user.IsSuspended)
                 continue;
 
-            var email = TryGetGoogleEmail(userId, emailsByUserId);
+            var emails = emailsByUserId.TryGetValue(userId, out var list)
+                ? list
+                : [];
+
+            var email = emails
+                .Where(e => e.IsVerified && e.IsGoogle)
+                .Select(e => e.Email)
+                .FirstOrDefault()
+                ?? emails
+                    .Where(e => e.IsVerified && e.Provider != null)
+                    .OrderBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
+                    .Select(e => e.Email)
+                    .FirstOrDefault();
             if (email is null)
                 continue;
 
@@ -539,39 +553,6 @@ public sealed class GoogleGroupSyncService(
         }
 
         return result;
-    }
-
-    private static Dictionary<string, ExpectedMember> BuildExpectedMembersByEmail(
-        IReadOnlyCollection<Guid> userIds,
-        IReadOnlyDictionary<Guid, ExpectedMember> expectedMembersByUserId)
-    {
-        var result = new Dictionary<string, ExpectedMember>(NormalizingEmailComparer.Instance);
-        foreach (var userId in userIds)
-        {
-            if (expectedMembersByUserId.TryGetValue(userId, out var member))
-                result[member.Email] = member;
-        }
-
-        return result;
-    }
-
-    private static string? TryGetGoogleEmail(
-        Guid userId,
-        IReadOnlyDictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>> emailsByUserId)
-    {
-        var emails = emailsByUserId.TryGetValue(userId, out var list)
-            ? list
-            : [];
-
-        return emails
-            .Where(e => e.IsVerified && e.IsGoogle)
-            .Select(e => e.Email)
-            .FirstOrDefault()
-            ?? emails
-                .Where(e => e.IsVerified && e.Provider != null)
-                .OrderBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
-                .Select(e => e.Email)
-                .FirstOrDefault();
     }
 
     private async Task<ResourceSyncDiff> BuildCollisionDiffAsync(
@@ -637,29 +618,6 @@ public sealed class GoogleGroupSyncService(
             return Task.CompletedTask;
 
         return teamResourceService.RecordResourceErrorAsync(resource.Id, error, ct);
-    }
-
-    private async Task RecordMemberErrorAsync(
-        GoogleResourceSnapshot? resource,
-        string email,
-        string error,
-        AuditAction action,
-        CancellationToken ct)
-    {
-        if (resource is not null)
-        {
-            await teamResourceService.RecordResourceErrorAsync(resource.Id, error, ct);
-            await auditLogService.LogGoogleSyncAsync(
-                action,
-                resource.Id,
-                error,
-                nameof(GoogleGroupSyncService),
-                email,
-                "MEMBER",
-                GoogleSyncSource.ScheduledSync,
-                success: false,
-                errorMessage: error);
-        }
     }
 
     private async Task<string> HandleGroupAddFailureAsync(

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleRemovalNotificationService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleRemovalNotificationService.cs
@@ -48,7 +48,6 @@ public sealed class GoogleRemovalNotificationService(
             return;
         }
 
-        // Load the user with all UserEmails so we can run the variant selector.
         var usersById = await userService.GetUserInfosAsync([userId.Value], cancellationToken);
         if (!usersById.TryGetValue(userId.Value, out var user))
         {
@@ -63,10 +62,11 @@ public sealed class GoogleRemovalNotificationService(
             : removedEmail;
         var culture = string.IsNullOrWhiteSpace(user.PreferredLanguage) ? "en" : user.PreferredLanguage;
 
-        // Variant selector: does the user retain another verified IsGoogle
-        // address that is NOT the one being removed? If yes → secondary
-        // cleanup (Variant 2). Otherwise → loss of access (Variant 1).
-        var otherGoogleEmail = FindOtherVerifiedGoogleEmail(user, removedEmail);
+        var otherGoogleEmail = user.UserEmails
+            .FirstOrDefault(ue => ue.IsVerified
+                && ue.IsGoogle
+                && !string.Equals(ue.Email, removedEmail, StringComparison.OrdinalIgnoreCase))
+            ?.Email;
 
         if (otherGoogleEmail is not null)
         {
@@ -121,28 +121,5 @@ public sealed class GoogleRemovalNotificationService(
                 "Sent Google removal Variant 1 (drive loss-of-access) to {Email} for user {UserId} folder {Folder}",
                 removedEmail, user.Id, displayName);
         }
-    }
-
-    /// <summary>
-    /// Returns a verified <c>IsGoogle</c> email belonging to the user that
-    /// is NOT <paramref name="removedEmail"/>, or <c>null</c> when no such
-    /// row exists. Drives the Variant 1 / Variant 2 split.
-    /// </summary>
-    private static string? FindOtherVerifiedGoogleEmail(UserInfo user, string removedEmail)
-    {
-        foreach (var ue in user.UserEmails)
-        {
-            if (!ue.IsVerified || !ue.IsGoogle)
-            {
-                continue;
-            }
-            if (string.Equals(ue.Email, removedEmail, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-            return ue.Email;
-        }
-
-        return null;
     }
 }

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -575,7 +575,6 @@ public sealed class GoogleWorkspaceSyncService(
 
         try
         {
-            // Expected: union of all linked teams' active members + child team rollup.
             var membersByEmail = await BuildExpectedDriveMembersByEmailAsync(
                 resources,
                 teamsById,
@@ -585,7 +584,6 @@ public sealed class GoogleWorkspaceSyncService(
 
             var linkedTeams = BuildDriveLinkedTeams(resources, teamsById);
 
-            // Current: Drive permissions.
             var permsResult = await drivePermissions.ListPermissionsAsync(primary.GoogleId, cancellationToken);
             if (permsResult.Permissions is null)
             {
@@ -601,11 +599,14 @@ public sealed class GoogleWorkspaceSyncService(
             var permissions = permsResult.Permissions;
             var permissionSnapshot = BuildDrivePermissionSnapshot(permissions);
 
-            var members = await BuildDriveMemberStatusesAsync(
-                membersByEmail,
-                levelByTeamSlug,
-                permissionSnapshot,
-                cancellationToken);
+            var members = membersByEmail
+                .Select(entry => BuildExpectedDriveMemberStatus(
+                    entry.Key,
+                    entry.Value,
+                    levelByTeamSlug,
+                    permissionSnapshot))
+                .ToList();
+            await AddExtraDriveMemberStatusesAsync(members, membersByEmail, permissionSnapshot, cancellationToken);
 
             if (action == SyncAction.Execute)
             {
@@ -712,7 +713,10 @@ public sealed class GoogleWorkspaceSyncService(
 
         if (membersByEmail.TryGetValue(memberEmail, out var existing))
         {
-            AddDriveTeamLink(existing.TeamLinks, teamLink);
+            if (!existing.TeamLinks.Any(link => string.Equals(link.Name, teamLink.Name, StringComparison.Ordinal)))
+            {
+                existing.TeamLinks.Add(teamLink);
+            }
             return;
         }
 
@@ -721,12 +725,6 @@ public sealed class GoogleWorkspaceSyncService(
             member.UserId,
             member.ProfilePictureUrl,
             [teamLink]);
-    }
-
-    private static void AddDriveTeamLink(List<TeamLink> links, TeamLink teamLink)
-    {
-        if (!links.Any(link => string.Equals(link.Name, teamLink.Name, StringComparison.Ordinal)))
-            links.Add(teamLink);
     }
 
     private static List<TeamLink> BuildDriveLinkedTeams(
@@ -784,24 +782,6 @@ public sealed class GoogleWorkspaceSyncService(
         }
 
         return snapshot;
-    }
-
-    private async Task<List<MemberSyncStatus>> BuildDriveMemberStatusesAsync(
-        IReadOnlyDictionary<string, DriveExpectedMember> membersByEmail,
-        IReadOnlyDictionary<string, DrivePermissionLevel> levelByTeamSlug,
-        DrivePermissionSnapshot permissionSnapshot,
-        CancellationToken cancellationToken)
-    {
-        var members = membersByEmail
-            .Select(entry => BuildExpectedDriveMemberStatus(
-                entry.Key,
-                entry.Value,
-                levelByTeamSlug,
-                permissionSnapshot))
-            .ToList();
-
-        await AddExtraDriveMemberStatusesAsync(members, membersByEmail, permissionSnapshot, cancellationToken);
-        return members;
     }
 
     private static MemberSyncStatus BuildExpectedDriveMemberStatus(
@@ -1000,7 +980,6 @@ public sealed class GoogleWorkspaceSyncService(
         var activeResources = await resourceRepository.GetActiveByTeamIdAsync(teamId, cancellationToken);
         var existingGroup = activeResources.FirstOrDefault(r => r.ResourceType == GoogleResourceType.Group);
 
-        // If prefix was cleared, deactivate any active group resource.
         if (team.GoogleGroupPrefix is null)
         {
             if (existingGroup is not null)
@@ -1034,7 +1013,6 @@ public sealed class GoogleWorkspaceSyncService(
 
         var email = $"{team.GoogleGroupPrefix}@{_options.Domain}";
 
-        // Cross-team active conflict check.
         var activeConflict = await FindActiveGroupByUrlAsync(expectedUrl, cancellationToken);
         if (activeConflict is not null)
         {
@@ -1046,7 +1024,6 @@ public sealed class GoogleWorkspaceSyncService(
             return GroupLinkResult.Error($"This group is already linked to team \"{conflictName}\".");
         }
 
-        // Inactive-for-this-team reactivation scenario.
         var inactiveForTeam = await FindInactiveGroupForTeamByUrlAsync(teamId, expectedUrl, cancellationToken);
         if (inactiveForTeam is not null && !confirmReactivation)
         {
@@ -1077,7 +1054,6 @@ public sealed class GoogleWorkspaceSyncService(
             return GroupLinkResult.Ok();
         }
 
-        // Deactivate the old resource if prefix changed.
         if (existingGroup is not null)
         {
             await resourceRepository.DeactivateAsync(existingGroup.Id, cancellationToken);
@@ -1293,7 +1269,6 @@ public sealed class GoogleWorkspaceSyncService(
         var allGroups = listResult.Groups;
         logger.LogInformation("Found {Count} Google Groups on domain {Domain}", allGroups.Count, _options.Domain);
 
-        // Build a lookup: group prefix → linked Team (active, with GoogleGroupPrefix set).
         var teams = (await teamService.GetTeamsAsync(cancellationToken)).Values
             .Where(t => t.IsActive);
         var teamsByPrefix = teams
@@ -1364,7 +1339,6 @@ public sealed class GoogleWorkspaceSyncService(
 
         var groupInfos = (await Task.WhenAll(tasks)).ToList();
 
-        // Sort: linked groups first, then alphabetically by email.
         var sorted = groupInfos
             .OrderBy(g => g.LinkedTeamId is null ? 1 : 0)
             .ThenBy(g => g.GroupEmail, StringComparer.OrdinalIgnoreCase)
@@ -1382,7 +1356,6 @@ public sealed class GoogleWorkspaceSyncService(
     {
         var driveResources = await resourceRepository.GetActiveDriveFoldersAsync(cancellationToken);
 
-        // Filter to resources whose team is still active.
         if (driveResources.Count == 0) return 0;
         var teamsById = await teamService.GetTeamsAsync(cancellationToken);
         var filtered = driveResources
@@ -1745,31 +1718,21 @@ public sealed class GoogleWorkspaceSyncService(
     private async Task<GoogleResource?> FindInactiveGroupForTeamByUrlAsync(
         Guid teamId, string expectedUrl, CancellationToken ct)
     {
-        // Re-use FindInactiveGroupByCandidatesAsync as a best-effort lookup:
-        // it matches by GoogleId / email, so feeding it the prefix@domain form
-        // lets the email-based branch hit.
-        var email = ExtractGroupEmailFromUrl(expectedUrl);
-        if (email is null) return null;
-        return await resourceRepository.FindInactiveGroupByCandidatesAsync(
-            teamId,
-            googleNumericId: email, // empty-result on numeric id; email branch matches via ILike
-            normalizedGroupEmail: email,
-            ct);
-    }
-
-    private static string? ExtractGroupEmailFromUrl(string url)
-    {
-        // Expected URL form: https://groups.google.com/a/{domain}/g/{prefix}
-        var parts = url.Split("/g/");
+        var parts = expectedUrl.Split("/g/");
         if (parts.Length != 2) return null;
         var prefix = parts[1].Split('/')[0];
-        // Reconstruct the email: {prefix}@{domain from URL}
         var beforeG = parts[0];
         var aIdx = beforeG.LastIndexOf("/a/", StringComparison.Ordinal);
         if (aIdx < 0) return null;
         var domain = beforeG[(aIdx + 3)..];
-        return string.IsNullOrEmpty(prefix) || string.IsNullOrEmpty(domain)
+        var email = string.IsNullOrEmpty(prefix) || string.IsNullOrEmpty(domain)
             ? null : $"{prefix}@{domain}";
+        if (email is null) return null;
+        return await resourceRepository.FindInactiveGroupByCandidatesAsync(
+            teamId,
+            googleNumericId: email,
+            normalizedGroupEmail: email,
+            ct);
     }
 
     /// <summary>

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
@@ -81,5 +81,4 @@ public sealed class GoogleWorkspaceUserService(
             codes.Count, primaryEmail);
         return codes;
     }
-
 }

--- a/src/Humans.Application/Services/GoogleIntegration/SyncSettingsService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/SyncSettingsService.cs
@@ -12,7 +12,14 @@ public sealed class SyncSettingsService(ISyncSettingsRepository repository, IClo
     public async Task<IReadOnlyList<SyncServiceSettingsInfo>> GetAllAsync(CancellationToken ct = default)
     {
         var rows = await repository.GetAllAsync(ct);
-        return rows.Select(CreateSyncServiceSettingsInfo).ToList();
+        return rows
+            .Select(settings => new SyncServiceSettingsInfo(
+                settings.Id,
+                settings.ServiceType,
+                settings.SyncMode,
+                settings.UpdatedAt,
+                settings.UpdatedByUserId))
+            .ToList();
     }
 
     public Task<SyncMode> GetModeAsync(SyncServiceType serviceType, CancellationToken ct = default)
@@ -29,11 +36,4 @@ public sealed class SyncSettingsService(ISyncSettingsRepository repository, IClo
         }
     }
 
-    private static SyncServiceSettingsInfo CreateSyncServiceSettingsInfo(SyncServiceSettings settings) =>
-        new(
-            settings.Id,
-            settings.ServiceType,
-            settings.SyncMode,
-            settings.UpdatedAt,
-            settings.UpdatedByUserId);
 }

--- a/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/TeamResourceService.cs
@@ -34,10 +34,6 @@ public sealed partial class TeamResourceService(
     private IRoleAssignmentService RoleAssignmentService
         => serviceProvider.GetRequiredService<IRoleAssignmentService>();
 
-    // ==========================================================================
-    // Reads
-    // ==========================================================================
-
     public async Task<IReadOnlyList<GoogleResourceSnapshot>> GetTeamResourcesAsync(Guid teamId, CancellationToken ct = default)
     {
         var resources = await repository.GetActiveByTeamIdAsync(teamId, ct);
@@ -183,10 +179,6 @@ public sealed partial class TeamResourceService(
             resource.DrivePermissionLevel,
             resource.RestrictInheritedAccess);
 
-    // ==========================================================================
-    // Link — Drive folder
-    // ==========================================================================
-
     public async Task<LinkResourceResult> LinkDriveFolderAsync(
         Guid teamId,
         string folderUrl,
@@ -223,7 +215,19 @@ public sealed partial class TeamResourceService(
         var inactive = await repository.FindInactiveByGoogleIdAsync(teamId, folderId, GoogleResourceType.DriveFolder, ct);
         var resource = await ReactivateOrInsertAsync(
             inactive,
-            () => BuildDriveFolderResource(teamId, lookup.Item, permissionLevel, now),
+            () => new GoogleResource
+            {
+                Id = Guid.NewGuid(),
+                TeamId = teamId,
+                ResourceType = GoogleResourceType.DriveFolder,
+                GoogleId = lookup.Item.Id,
+                Name = lookup.Item.FullPath,
+                Url = lookup.Item.WebViewLink,
+                ProvisionedAt = now,
+                LastSyncedAt = now,
+                IsActive = true,
+                DrivePermissionLevel = permissionLevel,
+            },
             id => repository.ReactivateAsync(id, lookup.Item.FullPath, lookup.Item.WebViewLink, now, null, permissionLevel, ct),
             "Drive folder",
             ct);
@@ -233,25 +237,6 @@ public sealed partial class TeamResourceService(
 
         return new LinkResourceResult(true, Resource: resource);
     }
-
-    private static GoogleResource BuildDriveFolderResource(
-        Guid teamId, DriveItem item, DrivePermissionLevel permissionLevel, Instant now) => new()
-        {
-            Id = Guid.NewGuid(),
-            TeamId = teamId,
-            ResourceType = GoogleResourceType.DriveFolder,
-            GoogleId = item.Id,
-            Name = item.FullPath,
-            Url = item.WebViewLink,
-            ProvisionedAt = now,
-            LastSyncedAt = now,
-            IsActive = true,
-            DrivePermissionLevel = permissionLevel,
-        };
-
-    // ==========================================================================
-    // Link — Drive file
-    // ==========================================================================
 
     public async Task<LinkResourceResult> LinkDriveFileAsync(
         Guid teamId,
@@ -289,7 +274,19 @@ public sealed partial class TeamResourceService(
         var inactive = await repository.FindInactiveByGoogleIdAsync(teamId, fileId, GoogleResourceType.DriveFile, ct);
         var resource = await ReactivateOrInsertAsync(
             inactive,
-            () => BuildDriveFileResource(teamId, lookup.Item, permissionLevel, now),
+            () => new GoogleResource
+            {
+                Id = Guid.NewGuid(),
+                TeamId = teamId,
+                ResourceType = GoogleResourceType.DriveFile,
+                GoogleId = lookup.Item.Id,
+                Name = lookup.Item.FullPath,
+                Url = lookup.Item.WebViewLink,
+                ProvisionedAt = now,
+                LastSyncedAt = now,
+                IsActive = true,
+                DrivePermissionLevel = permissionLevel,
+            },
             id => repository.ReactivateAsync(id, lookup.Item.FullPath, lookup.Item.WebViewLink, now, null, permissionLevel, ct),
             "Drive file",
             ct);
@@ -299,21 +296,6 @@ public sealed partial class TeamResourceService(
 
         return new LinkResourceResult(true, Resource: resource);
     }
-
-    private static GoogleResource BuildDriveFileResource(
-        Guid teamId, DriveItem item, DrivePermissionLevel permissionLevel, Instant now) => new()
-        {
-            Id = Guid.NewGuid(),
-            TeamId = teamId,
-            ResourceType = GoogleResourceType.DriveFile,
-            GoogleId = item.Id,
-            Name = item.FullPath,
-            Url = item.WebViewLink,
-            ProvisionedAt = now,
-            LastSyncedAt = now,
-            IsActive = true,
-            DrivePermissionLevel = permissionLevel,
-        };
 
     public async Task<LinkResourceResult> LinkDriveResourceAsync(
         Guid teamId,
@@ -334,10 +316,6 @@ public sealed partial class TeamResourceService(
         return new LinkResourceResult(false,
             ErrorMessage: "Invalid Google Drive URL. Please use a folder URL (https://drive.google.com/drive/folders/...) or a file URL (https://docs.google.com/spreadsheets/d/...).");
     }
-
-    // ==========================================================================
-    // Link — Google Group
-    // ==========================================================================
 
     public async Task<LinkResourceResult> LinkGroupAsync(Guid teamId, string groupEmail, CancellationToken ct = default)
     {
@@ -380,7 +358,18 @@ public sealed partial class TeamResourceService(
 
         var resource = await ReactivateOrInsertAsync(
             inactive,
-            () => BuildGroupResource(teamId, lookup.Group, url, now),
+            () => new GoogleResource
+            {
+                Id = Guid.NewGuid(),
+                TeamId = teamId,
+                ResourceType = GoogleResourceType.Group,
+                GoogleId = lookup.Group.NumericId,
+                Name = lookup.Group.NormalizedEmail,
+                Url = url,
+                ProvisionedAt = now,
+                LastSyncedAt = now,
+                IsActive = true,
+            },
             id => repository.ReactivateAsync(id, lookup.Group.NormalizedEmail, url, now, lookup.Group.NumericId, null, ct),
             "Group",
             ct);
@@ -390,20 +379,6 @@ public sealed partial class TeamResourceService(
 
         return new LinkResourceResult(true, Resource: resource);
     }
-
-    private static GoogleResource BuildGroupResource(
-        Guid teamId, ResolvedGroup group, string url, Instant now) => new()
-        {
-            Id = Guid.NewGuid(),
-            TeamId = teamId,
-            ResourceType = GoogleResourceType.Group,
-            GoogleId = group.NumericId,
-            Name = group.NormalizedEmail,
-            Url = url,
-            ProvisionedAt = now,
-            LastSyncedAt = now,
-            IsActive = true,
-        };
 
     private async Task<GoogleResource> ReactivateOrInsertAsync(
         GoogleResource? inactive,
@@ -427,10 +402,6 @@ public sealed partial class TeamResourceService(
         await repository.AddAsync(fresh, ct);
         return fresh;
     }
-
-    // ==========================================================================
-    // Unlink / Deactivate
-    // ==========================================================================
 
     public async Task UnlinkResourceAsync(Guid resourceId, CancellationToken ct = default)
     {
@@ -470,10 +441,6 @@ public sealed partial class TeamResourceService(
             "Deactivated {Count} Google resources (type={ResourceType}) for soft-deleted team {TeamId}",
             deactivated.Count, resourceType?.ToString() ?? "all", teamId);
     }
-
-    // ==========================================================================
-    // Permission changes
-    // ==========================================================================
 
     public async Task UpdatePermissionLevelAsync(Guid resourceId, DrivePermissionLevel level, CancellationToken ct = default)
     {
@@ -534,10 +501,6 @@ public sealed partial class TeamResourceService(
         }
     }
 
-    // ==========================================================================
-    // Authorization / sharing instructions
-    // ==========================================================================
-
     public async Task<bool> CanManageTeamResourcesAsync(Guid teamId, Guid userId, CancellationToken ct = default)
     {
         if (await RoleAssignmentService.IsUserBoardMemberAsync(userId, ct))
@@ -560,10 +523,6 @@ public sealed partial class TeamResourceService(
 
     public Task<string> GetServiceAccountEmailAsync(CancellationToken ct = default)
         => googleClient.GetServiceAccountEmailAsync(ct);
-
-    // ==========================================================================
-    // Internal helpers — URL / email parsing and Google error mapping
-    // ==========================================================================
 
     private async Task<LinkResourceResult> BuildDriveLookupErrorAsync(
         GoogleClientError? error,

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -138,7 +138,6 @@ public class GoogleResourceReconciliationJob(
             phaseFailures.Add("Group settings check");
         }
 
-        // Notify Admin if any drift was detected and corrected
         var totalDrift = inheritanceCorrected + settingsResult.DriftCount;
         if (totalDrift > 0)
         {

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -60,7 +60,6 @@ public class ProcessGoogleSyncOutboxJob(
                 return;
             }
 
-            // Pre-load contextual info for richer error messages
             var userIds = pendingEvents.Select(e => e.UserId).Distinct().ToList();
             var teamIds = pendingEvents.Select(e => e.TeamId).Distinct().ToList();
             var users = await userService.GetUserInfosAsync(userIds, cancellationToken);
@@ -113,7 +112,7 @@ public class ProcessGoogleSyncOutboxJob(
                         }
                     }
                 }
-                catch (Google.GoogleApiException ex) when (IsPermanentError(ex))
+                catch (Google.GoogleApiException ex) when (ex.Error?.Code is int code && PermanentErrorCodes.Contains(code))
                 {
                     metrics.RecordSyncOperation("permanent_failure");
 
@@ -132,7 +131,6 @@ public class ProcessGoogleSyncOutboxJob(
                         teamName,
                         ex.Error?.Code);
 
-                    // Mark user's Google email as Rejected
                     await userService.TrySetGoogleEmailStatusFromSyncAsync(
                         outboxEvent.UserId, GoogleEmailStatus.Rejected, cancellationToken);
 
@@ -214,10 +212,5 @@ public class ProcessGoogleSyncOutboxJob(
             logger.LogError(ex, "Error processing Google sync outbox");
             throw;
         }
-    }
-
-    private static bool IsPermanentError(Google.GoogleApiException ex)
-    {
-        return ex.Error?.Code is int code && PermanentErrorCodes.Contains(code);
     }
 }

--- a/src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleResourceRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleResourceRepository.cs
@@ -16,10 +16,6 @@ namespace Humans.Infrastructure.Repositories.GoogleIntegration;
 /// </summary>
 internal sealed class GoogleResourceRepository(IDbContextFactory<HumansDbContext> factory) : IGoogleResourceRepository
 {
-    // ==========================================================================
-    // Reads
-    // ==========================================================================
-
     public async Task<GoogleResource?> GetByIdAsync(Guid resourceId, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -167,10 +163,6 @@ internal sealed class GoogleResourceRepository(IDbContextFactory<HumansDbContext
                 && r.ResourceType == GoogleResourceType.Group
                 && !r.IsActive, ct);
     }
-
-    // ==========================================================================
-    // Writes
-    // ==========================================================================
 
     public async Task AddAsync(GoogleResource resource, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
@@ -86,7 +86,6 @@ public sealed class StubWorkspaceUserDirectoryClient(ILogger<StubWorkspaceUserDi
     public Task<IReadOnlyList<string>> GenerateBackupCodesAsync(string primaryEmail, CancellationToken ct = default)
     {
         logger.LogInformation("[Stub] Generated backup codes for fake account: {Email}", primaryEmail);
-        // Return 10 placeholder codes for local development visibility.
         IReadOnlyList<string> codes =
         [
             "1111-1111", "2222-2222", "3333-3333", "4444-4444", "5555-5555",

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/TeamResourceGoogleClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/TeamResourceGoogleClient.cs
@@ -106,12 +106,6 @@ public sealed class TeamResourceGoogleClient(
             return _serviceAccountEmail;
         }
 
-        _serviceAccountEmail = await ExtractServiceAccountEmailAsync(ct);
-        return _serviceAccountEmail;
-    }
-
-    private async Task<string> ExtractServiceAccountEmailAsync(CancellationToken ct)
-    {
         string? json = null;
 
         if (!string.IsNullOrEmpty(_settings.ServiceAccountKeyJson))
@@ -128,11 +122,13 @@ public sealed class TeamResourceGoogleClient(
             using var doc = JsonDocument.Parse(json);
             if (doc.RootElement.TryGetProperty("client_email", out var emailElement))
             {
-                return emailElement.GetString() ?? "unknown@serviceaccount.iam.gserviceaccount.com";
+                _serviceAccountEmail = emailElement.GetString() ?? "unknown@serviceaccount.iam.gserviceaccount.com";
+                return _serviceAccountEmail;
             }
         }
 
-        return "unknown@serviceaccount.iam.gserviceaccount.com";
+        _serviceAccountEmail = "unknown@serviceaccount.iam.gserviceaccount.com";
+        return _serviceAccountEmail;
     }
 
     /// <summary>

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
@@ -142,7 +142,6 @@ public sealed class WorkspaceUserDirectoryClient(
             OrgUnitPath = "/"
         };
 
-        // Set recovery email if provided (for password resets and initial notification)
         if (!string.IsNullOrEmpty(recoveryEmail) &&
             !recoveryEmail.EndsWith("@nobodies.team", StringComparison.OrdinalIgnoreCase))
         {
@@ -192,7 +191,6 @@ public sealed class WorkspaceUserDirectoryClient(
         // invalidates any previously issued set in the same call.
         await service.VerificationCodes.Generate(primaryEmail).ExecuteAsync(ct);
 
-        // List returns the freshly generated codes so we can surface them to the admin.
         var response = await service.VerificationCodes.List(primaryEmail).ExecuteAsync(ct);
 
         var codes = response.Items?

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -25,8 +25,6 @@ public class GoogleController(
     IGoogleAdminService googleAdminService,
     ILogger<GoogleController> logger) : HumansControllerBase(userService)
 {
-    // --- Sync Settings ---
-
     [HttpGet("SyncSettings")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> SyncSettings(
@@ -85,8 +83,6 @@ public class GoogleController(
         return RedirectToAction(nameof(SyncSettings));
     }
 
-    // --- System Team Sync ---
-
     [HttpPost("SyncSystemTeams")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
@@ -126,8 +122,6 @@ public class GoogleController(
 
         return View(report);
     }
-
-    // --- Google Group Settings ---
 
     [HttpPost("CheckGroupSettings")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
@@ -227,8 +221,6 @@ public class GoogleController(
         return RedirectToAction(nameof(AllGroups));
     }
 
-    // --- All Domain Groups ---
-
     [HttpGet("AllGroups")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> AllGroups()
@@ -273,8 +265,6 @@ public class GoogleController(
 
         return RedirectToAction(nameof(AllGroups));
     }
-
-    // --- Resource Sync Dashboard ---
 
     [HttpGet("Sync")]
     [Authorize(Policy = PolicyNames.TeamsAdminBoardOrAdmin)]
@@ -353,8 +343,6 @@ public class GoogleController(
         }
     }
 
-    // --- Human Email Provisioning ---
-
     [HttpPost("Human/{id:guid}/ProvisionEmail")]
     [Authorize(Policy = PolicyNames.HumanAdminOrAdmin)]
     [ValidateAntiForgeryToken]
@@ -391,8 +379,6 @@ public class GoogleController(
 
         return RedirectToAction(nameof(UsersAdminController.AdminDetail), "UsersAdmin", new { id });
     }
-
-    // --- Workspace Accounts ---
 
     [HttpGet("Accounts")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
@@ -611,8 +597,6 @@ public class GoogleController(
         return RedirectToAction(nameof(Accounts));
     }
 
-    // --- Sync Outbox ---
-
     [HttpGet("SyncOutbox")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> SyncOutbox(
@@ -725,8 +709,6 @@ public class GoogleController(
         return RedirectToAction(nameof(UsersAdminController.AdminDetail), "UsersAdmin", new { id });
     }
 
-    // --- Email Rename Detection ---
-
     [HttpPost("CheckEmailRenames")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
@@ -766,8 +748,6 @@ public class GoogleController(
         return View(result);
     }
 
-    // --- Email Flag Violations (admin remediation) ---
-
     [HttpGet("EmailFlagViolations")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> EmailFlagViolations(
@@ -778,16 +758,12 @@ public class GoogleController(
         return View(violations);
     }
 
-    // --- Index ---
-
     [HttpGet("")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult Index()
     {
         return View();
     }
-
-    // --- Helpers ---
 
     private static string FormatServiceName(SyncServiceType type) => type switch
     {

--- a/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
@@ -17,10 +17,6 @@ internal static class GoogleWorkspaceInfrastructureExtensions
         IHostEnvironment environment)
     {
         services.Configure<GoogleWorkspaceSettings>(configuration.GetSection(GoogleWorkspaceSettings.SectionName));
-        // §15 Part 2b — Application-layer sync service reads non-sensitive
-        // fields (Domain, CustomerId, TeamFoldersParentId, Groups) through
-        // this Application-owned options type. Same appsettings section as
-        // GoogleWorkspaceSettings so a single config surface drives both.
         services.Configure<GoogleWorkspaceOptions>(configuration.GetSection(GoogleWorkspaceOptions.SectionName));
         services.AddSingleton(_ =>
         {
@@ -33,9 +29,6 @@ internal static class GoogleWorkspaceInfrastructureExtensions
         var hasGoogleCredentials = !string.IsNullOrEmpty(googleWorkspaceConfig["ServiceAccountKeyPath"]) ||
                                    !string.IsNullOrEmpty(googleWorkspaceConfig["ServiceAccountKeyJson"]);
 
-        // Application-layer service uses the repo + one of the two Google
-        // connector implementations below. Stub connector is used when no
-        // service-account credentials are configured (dev only).
         services.AddScoped<ITeamResourceService, TeamResourceService>();
 
         if (hasGoogleCredentials)
@@ -45,25 +38,14 @@ internal static class GoogleWorkspaceInfrastructureExtensions
             services.AddScoped<ITeamResourceGoogleClient, TeamResourceGoogleClient>();
             services.AddScoped<IGoogleDriveActivityClient, GoogleDriveActivityClient>();
 
-            // Google Integration §15 migration (issue #554) — workspace users.
-            // Application-layer service depends only on the shape-neutral
-            // IWorkspaceUserDirectoryClient connector; the real and stub
-            // implementations live in Humans.Infrastructure.
             services.AddScoped<IWorkspaceUserDirectoryClient, WorkspaceUserDirectoryClient>();
             services.AddScoped<IGoogleWorkspaceUserService, GoogleWorkspaceUserService>();
 
-            // §15 Part 2a (issue #574) — SDK bridge interfaces for the
-            // GoogleWorkspaceSyncService migration in Part 2b (#575). These
-            // are registered alongside the existing SDK-direct service
-            // (dual-path during 2a → 2b transition). GoogleWorkspaceSyncService
-            // continues to import Google.Apis.* directly until Part 2b strips
-            // it; no Application-layer imports are added here.
             services.AddScoped<IGoogleGroupMembershipClient, GoogleGroupMembershipClient>();
             services.AddScoped<IGoogleGroupProvisioningClient, GoogleGroupProvisioningClient>();
             services.AddScoped<IGoogleDrivePermissionsClient, GoogleDrivePermissionsClient>();
             services.AddScoped<IGoogleDirectoryClient, GoogleDirectoryClient>();
 
-            // Cloud Translation (REST, same service account) — Survey's "pre-fill translations".
             services.AddHttpClient<IGoogleTranslationClient, GoogleTranslationClient>();
         }
         else if (environment.IsProduction())
@@ -82,11 +64,6 @@ internal static class GoogleWorkspaceInfrastructureExtensions
             services.AddScoped<IWorkspaceUserDirectoryClient, StubWorkspaceUserDirectoryClient>();
             services.AddScoped<IGoogleWorkspaceUserService, GoogleWorkspaceUserService>();
 
-            // §15 Part 2a (issue #574) — stub SDK bridge interfaces for dev
-            // environments without Google credentials. Registered as
-            // Singletons so each stub's in-memory state survives across
-            // scoped requests (matching the once-per-process behaviour of
-            // the real SDK client handles).
             services.AddSingleton<IGoogleGroupMembershipClient, StubGoogleGroupMembershipClient>();
             services.AddSingleton<IGoogleGroupProvisioningClient, StubGoogleGroupProvisioningClient>();
             services.AddSingleton<IGoogleDrivePermissionsClient, StubGoogleDrivePermissionsClient>();
@@ -97,7 +74,6 @@ internal static class GoogleWorkspaceInfrastructureExtensions
         services.AddScoped<IGoogleGroupSyncScheduler, HangfireGoogleGroupSyncScheduler>();
         services.AddScoped<IGoogleGroupSync, GoogleGroupSyncService>();
         services.AddScoped<IGoogleTranslationService, GoogleTranslationService>();
-
 
         services.AddScoped<GoogleResourceReconciliationJob>();
         services.AddScoped<DriveActivityMonitorJob>();

--- a/src/Humans.Web/Health/GoogleWorkspaceHealthCheck.cs
+++ b/src/Humans.Web/Health/GoogleWorkspaceHealthCheck.cs
@@ -21,7 +21,6 @@ public class GoogleWorkspaceHealthCheck(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
-        // Skip check if not configured
         if (string.IsNullOrEmpty(_settings.ServiceAccountKeyPath) &&
             string.IsNullOrEmpty(_settings.ServiceAccountKeyJson))
         {


### PR DESCRIPTION
## Summary
- Inline single-call private projection/wrapper helpers where the call site is clearer in GoogleIntegration services and adapters.
- Remove label-only and narrating comments from GoogleIntegration services, repositories, controller grouping, DI registration, and health/client code.
- Keep public GoogleIntegration interfaces, routes/actions, DTO/view models, DI contracts, EF storage/configuration, and generated regex/test-exposed internals unchanged.

## Owner judgment
- Large one-call reconciliation phases in GoogleWorkspaceSyncService and GoogleGroupSyncService were left intact because their names preserve sync-step readability.
- Google API mapper/helper methods and policy predicates were left where inlining would obscure API boundary behavior.
- Existing solution-wide analyzer warnings outside this diff were not changed.

## Verification
- `dotnet build Humans.slnx -v quiet` (first run succeeded with existing baseline warnings)
- `dotnet build Humans.slnx -v quiet` (warm rerun: 0 warnings, 0 errors)
- `dotnet test Humans.slnx -v quiet`