### PR TITLE
refactor(tickets): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -119,7 +119,16 @@ public sealed class AttendeeContactImportService(
             }
         }
 
-        var result = BuildImportResult(importState, start);
+        var result = new AttendeeImportResult(
+            TotalAttempted: importState.Attempted,
+            UsersCreated: importState.Created,
+            AttachedToExistingVerified: importState.Attached,
+            UnverifiedRowsDeletedAndUserCreated: importState.Replaced,
+            AmbiguousSkipped: importState.Ambiguous,
+            NoEmailSkipped: importState.NoEmail,
+            VanishedBetweenPlanAndApply: importState.Vanished,
+            Errors: importState.Errors,
+            Elapsed: clock.GetCurrentInstant() - start);
 
         await audit.LogAsync(
             AuditAction.TicketContactsImported,
@@ -246,18 +255,6 @@ public sealed class AttendeeContactImportService(
 
         state.NewlyMatchedUserIds.Add(userId);
     }
-
-    private AttendeeImportResult BuildImportResult(AttendeeImportApplyState state, Instant start)
-        => new(
-            TotalAttempted: state.Attempted,
-            UsersCreated: state.Created,
-            AttachedToExistingVerified: state.Attached,
-            UnverifiedRowsDeletedAndUserCreated: state.Replaced,
-            AmbiguousSkipped: state.Ambiguous,
-            NoEmailSkipped: state.NoEmail,
-            VanishedBetweenPlanAndApply: state.Vanished,
-            Errors: state.Errors,
-            Elapsed: clock.GetCurrentInstant() - start);
 
     private async Task<AttendeeImportDecision> ClassifyAsync(
         TicketAttendee a,

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -835,8 +835,6 @@ public sealed class TicketQueryService(
     private static bool ContainsIgnoreCase(string? source, string value) =>
         source?.Contains(value, StringComparison.OrdinalIgnoreCase) == true;
 
-    // Invalidation no-ops on the inner; CachingTicketQueryService intercepts.
     public Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default) =>
         ticketRepository.GetOrderDriftAsync(ct);
-
 }

--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -138,7 +138,6 @@ public sealed class TicketSyncService(
             syncState.LastError = null;
             await ticketRepository.PersistSyncStateAsync(syncState, ct);
 
-            // invalidate ticket caches via seam (§15c)
             ticketCache.InvalidateVendorEventSummary(eventId);
             ticketCache.InvalidateAll();
 
@@ -380,7 +379,7 @@ public sealed class TicketSyncService(
 
         foreach (var attendee in order.Attendees)
         {
-            if (!IsRevenueAttendee(attendee))
+            if (attendee.Status is not (TicketAttendeeStatus.Valid or TicketAttendeeStatus.CheckedIn))
                 continue;
 
             var taxableAmount = Math.Min(attendee.Price, TicketConstants.VipThresholdEuros);
@@ -392,9 +391,6 @@ public sealed class TicketSyncService(
 
         return Math.Round(totalVat, 2);
     }
-
-    private static bool IsRevenueAttendee(TicketAttendee attendee) =>
-        attendee.Status == TicketAttendeeStatus.Valid || attendee.Status == TicketAttendeeStatus.CheckedIn;
 
     public async Task<bool> IsInErrorStateAsync(CancellationToken ct = default)
     {

--- a/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
@@ -38,7 +38,7 @@ public sealed class TicketingBudgetService(
                     return new TicketingWeeklyActuals(
                         Monday: monday,
                         Sunday: sunday,
-                        WeekLabel: FormatWeekLabel(monday, sunday),
+                        WeekLabel: $"{monday.ToWeekdayDayMonth()}–{sunday.ToWeekdayDayMonth()}",
                         TicketCount: g.Sum(o => o.Attendees.Count(a =>
                             a.Status == TicketAttendeeStatus.Valid ||
                             a.Status == TicketAttendeeStatus.CheckedIn)),
@@ -103,8 +103,4 @@ public sealed class TicketingBudgetService(
         return date.PlusDays(-(dayOfWeek - 1));
     }
 
-    private static string FormatWeekLabel(LocalDate monday, LocalDate sunday)
-    {
-        return $"{monday.ToWeekdayDayMonth()}–{sunday.ToWeekdayDayMonth()}";
-    }
 }

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -24,8 +24,6 @@ namespace Humans.Infrastructure.Repositories.Tickets;
 /// </remarks>
 internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factory) : ITicketRepository
 {
-    // ── TicketSyncState ──────────────────────────────────────────────────────
-
     public async Task<TicketSyncState?> GetSyncStateAsync(CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -57,9 +55,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
         syncState.LastSyncAt = null;
         await ctx.SaveChangesAsync(ct);
     }
-
-
-    // ── TicketOrder reads (detached) ─────────────────────────────────────────
 
     public async Task<IReadOnlyDictionary<string, TicketOrder>> GetOrdersByVendorIdsAsync(
         IReadOnlyCollection<string> vendorOrderIds,
@@ -142,8 +137,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
             .ToListAsync(ct);
     }
 
-    // ── TicketAttendee reads (detached) ──────────────────────────────────────
-
     public async Task<TicketAttendee?> GetAttendeeByIdAsync(Guid attendeeId, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -175,8 +168,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
             .Select(a => new MatchedAttendeeRow(a.VendorTicketId, a.MatchedUserId!.Value, a.Status))
             .ToListAsync(ct);
     }
-
-    // ── TicketOrder / TicketAttendee writes ──────────────────────────────────
 
     public async Task UpsertOrdersAsync(
         IReadOnlyList<TicketOrder> orders,
@@ -802,14 +793,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
         }).ToList();
     }
 
-    // ==========================================================================
-    // Reads — TicketSyncState
-    // ==========================================================================
-
-    // ==========================================================================
-    // Writes — TicketSyncState (crash-recovery reset)
-    // ==========================================================================
-
     public async Task<TicketSyncState?> ResetStaleRunningStateAsync(
         Instant olderThan,
         Instant now,
@@ -835,10 +818,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
         return state;
     }
 
-    // ==========================================================================
-    // Admin diagnostics
-    // ==========================================================================
-
     public async Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -863,10 +842,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
                 o.VendorDashboardUrl))
             .ToListAsync(ct);
     }
-
-    // ==========================================================================
-    // Account-merge fold
-    // ==========================================================================
 
     public async Task<int> ReassignToUserAsync(
         Guid sourceUserId, Guid targetUserId, Instant updatedAt,
@@ -902,10 +877,6 @@ internal sealed class TicketRepository(IDbContextFactory<HumansDbContext> factor
         return await ctx.TicketAttendees
             .CountAsync(a => a.MatchedUserId == targetUserId, ct);
     }
-
-    // ==========================================================================
-    // Helpers
-    // ==========================================================================
 
     private static bool HasSearchTerm(
         [NotNullWhen(true)] string? value, int minLength = 2) =>

--- a/src/Humans.Infrastructure/Services/StubTicketVendorService.cs
+++ b/src/Humans.Infrastructure/Services/StubTicketVendorService.cs
@@ -105,7 +105,6 @@ public sealed class StubTicketVendorService : ITicketVendorService
         var orders = new List<VendorOrderDto>();
         var tickets = new List<VendorTicketDto>();
 
-        // Build the ticket pool with the defined mix
         var ticketPool = new List<(string Type, decimal Price)>();
         foreach (var (name, price, count) in TicketMix)
         {
@@ -113,14 +112,12 @@ public sealed class StubTicketVendorService : ITicketVendorService
                 ticketPool.Add((name, price));
         }
 
-        // Deterministic shuffle
         ticketPool = ticketPool
             .Select((t, i) => (t, Sort: DeterministicHash($"shuffle:{i}")))
             .OrderBy(x => x.Sort)
             .Select(x => x.t)
             .ToList();
 
-        // Build orders: 1 fixed peter-order (2 tickets) + 149 two-ticket + 300 single-ticket = 600 total
         var orderSizes = Enumerable.Repeat(2, 149)
             .Concat(Enumerable.Repeat(1, 300))
             .Select((size, i) => (Size: size, Sort: DeterministicHash($"order-size:{i}")))
@@ -144,10 +141,13 @@ public sealed class StubTicketVendorService : ITicketVendorService
                 : BuildPerson(orderIndex);
             var purchasedAt = BuildPurchaseInstant(saleStart, orderIndex, orderSizes.Count);
 
-            // Some orders get donations
-            var donation = GetDonation(orderIndex, orderTickets);
+            var hasVip = orderTickets.Any(t => string.Equals(t.Type, "VIP", StringComparison.Ordinal));
+            var donation = hasVip && orderIndex % 2 == 0
+                ? 100m
+                : orderIndex % 4 == 0
+                    ? 25m
+                    : 0m;
 
-            // Some orders get discount codes
             string? discountCode = null;
             decimal? discountAmount = null;
             if (orderIndex % 11 == 0)
@@ -219,7 +219,6 @@ public sealed class StubTicketVendorService : ITicketVendorService
         Debug.Assert(ticketCursor == ticketPool.Count,
             $"Ticket pool size mismatch: cursor {ticketCursor} != pool size {ticketPool.Count}");
 
-        // Add a few non-paid orders
         var nonPaidStatuses = new[] { "pending", "pending", "refunded", "cancelled" };
         for (var i = 0; i < nonPaidStatuses.Length; i++)
         {
@@ -255,14 +254,6 @@ public sealed class StubTicketVendorService : ITicketVendorService
         }
 
         return new SampleData(orders, tickets);
-    }
-
-    private static decimal GetDonation(int orderIndex, List<(string Type, decimal Price)> orderTickets)
-    {
-        var hasVip = orderTickets.Any(t => string.Equals(t.Type, "VIP", StringComparison.Ordinal));
-        if (hasVip && orderIndex % 2 == 0) return 100m;
-        if (orderIndex % 4 == 0) return 25m;
-        return 0m;
     }
 
     private static Instant BuildPurchaseInstant(LocalDate saleStart, int orderIndex, int totalOrders)

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -43,10 +43,9 @@ public class TicketTailorService : ITicketVendorService
     {
         _httpClient = httpClient;
         _cache = cache;
-        var settings1 = settings.Value;
         _logger = logger;
 
-        var apiKey = settings1.ApiKey;
+        var apiKey = settings.Value.ApiKey;
         if (!string.IsNullOrEmpty(apiKey))
         {
             var authBytes = Encoding.ASCII.GetBytes($"{apiKey}:");
@@ -312,7 +311,6 @@ public class TicketTailorService : ITicketVendorService
         return donationCents > 0 ? donationCents / 100m : 0m;
     }
 
-    // --- TicketTailor API response models ---
     // Must be internal (not private) for System.Text.Json deserialization
 
     internal sealed record TtPaginatedResponse<T>(

--- a/src/Humans.Infrastructure/Services/Tickets/CachingTicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/Tickets/CachingTicketQueryService.cs
@@ -44,8 +44,8 @@ public sealed class CachingTicketQueryService : ITicketService, ITicketCacheInva
 
     public async Task<IReadOnlyList<TicketOrderInfo>> GetTicketOrdersAsync(CancellationToken ct = default)
     {
-        var orders = await GetOrdersAsync(ct);
-        return orders.Values.ToList();
+        await _orders.EnsureWarmedForReadAsync(ct);
+        return _orders.AsReadOnlyDictionary.Values.ToList();
     }
 
     public async Task<UserTicketHoldings> GetUserTicketHoldingsAsync(
@@ -144,13 +144,6 @@ public sealed class CachingTicketQueryService : ITicketService, ITicketCacheInva
     }
 
     Task IHostedService.StopAsync(CancellationToken ct) => Task.CompletedTask;
-
-    private async Task<IReadOnlyDictionary<Guid, TicketOrderInfo>> GetOrdersAsync(
-        CancellationToken ct = default)
-    {
-        await _orders.EnsureWarmedForReadAsync(ct);
-        return _orders.AsReadOnlyDictionary;
-    }
 
     private async Task<TResult> WithInner<TResult>(Func<ITicketService, Task<TResult>> action)
     {

--- a/src/Humans.Web/Controllers/TicketTransferAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketTransferAdminController.cs
@@ -1,12 +1,11 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-
-using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
@@ -27,9 +26,15 @@ public sealed class TicketTransferAdminController(
             .OrderBy(r => r.RequestedAt)
             .ToList();
 
-        IReadOnlyList<TicketTransferRowDto> rows = string.Equals(tab, "all", StringComparison.Ordinal)
-            ? await BuildAllAsync(ct)
-            : pending;
+        IReadOnlyList<TicketTransferRowDto> rows = pending;
+        if (string.Equals(tab, "all", StringComparison.Ordinal))
+        {
+            var combined = new List<TicketTransferRowDto>();
+            foreach (var status in Enum.GetValues<TicketTransferStatus>())
+                combined.AddRange(await service.GetByStatusAsync(status, ct));
+
+            rows = combined.OrderByDescending(r => r.RequestedAt).ToList();
+        }
 
         var drift = (await ticketQueryService.GetOrderDriftAsync(ct))
             .OrderByDescending(r => r.IssuedCount - r.ValidCount)
@@ -40,15 +45,6 @@ public sealed class TicketTransferAdminController(
             PendingCount: pending.Count,
             Rows: rows,
             Drift: drift));
-    }
-
-    private async Task<IReadOnlyList<TicketTransferRowDto>> BuildAllAsync(CancellationToken ct)
-    {
-        var statuses = Enum.GetValues<TicketTransferStatus>();
-        var combined = new List<TicketTransferRowDto>();
-        foreach (var s in statuses)
-            combined.AddRange(await service.GetByStatusAsync(s, ct));
-        return combined.OrderByDescending(r => r.RequestedAt).ToList();
     }
 
     [HttpGet("Detail/{id:guid}")]

--- a/src/Humans.Web/Controllers/TicketTransferController.cs
+++ b/src/Humans.Web/Controllers/TicketTransferController.cs
@@ -16,7 +16,6 @@ public sealed class TicketTransferController(
     IUserServiceRead userService,
     ILogger<TicketTransferController> logger) : HumansControllerBase(userService)
 {
-    // Step A + B of the wizard: pick a ticket, pick a recipient.
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken ct)
     {
@@ -34,7 +33,6 @@ public sealed class TicketTransferController(
         });
     }
 
-    // Step C: resolve the chosen (ticket, recipient) pair server-side and show the confirmation.
     [HttpPost("Confirm")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Confirm(Guid attendeeId, Guid receiverUserId, CancellationToken ct)
@@ -58,7 +56,6 @@ public sealed class TicketTransferController(
         });
     }
 
-    // Final submit.
     [HttpPost("")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Submit(Guid attendeeId, Guid receiverUserId, string? reason, CancellationToken ct)

--- a/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
@@ -1,11 +1,10 @@
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
 using Humans.Web.Authorization;
 using Humans.Web.Models.Tickets;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-
-using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
@@ -20,7 +19,16 @@ public sealed class TicketsContactsAdminController(
     {
         var plan = await import.BuildPlanAsync(ct);
         var rows = plan.Decisions
-            .OrderBy(d => SortKey(d.Outcome))
+            .OrderBy(d => d.Outcome switch
+            {
+                AttendeeImportOutcome.AmbiguousMultipleVerified => 0,
+                AttendeeImportOutcome.DeleteUnverifiedThenCreate => 1,
+                AttendeeImportOutcome.CreateNewUser => 2,
+                AttendeeImportOutcome.AttachVerified => 3,
+                AttendeeImportOutcome.SkipNoEmail => 4,
+                AttendeeImportOutcome.SkipVoided => 5,
+                _ => 99,
+            })
             .ThenBy(d => d.Email, StringComparer.OrdinalIgnoreCase)
             .Select(d => new AttendeeImportDecisionRow(
                 d.AttendeeId, d.Email, d.AttendeeName, d.VendorTicketId,
@@ -58,14 +66,4 @@ public sealed class TicketsContactsAdminController(
         return RedirectToAction(nameof(Index));
     }
 
-    private static int SortKey(AttendeeImportOutcome o) => o switch
-    {
-        AttendeeImportOutcome.AmbiguousMultipleVerified => 0,
-        AttendeeImportOutcome.DeleteUnverifiedThenCreate => 1,
-        AttendeeImportOutcome.CreateNewUser => 2,
-        AttendeeImportOutcome.AttachVerified => 3,
-        AttendeeImportOutcome.SkipNoEmail => 4,
-        AttendeeImportOutcome.SkipVoided => 5,
-        _ => 99,
-    };
 }

--- a/src/Humans.Web/Extensions/Infrastructure/TicketVendorInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/TicketVendorInfrastructureExtensions.cs
@@ -11,7 +11,6 @@ internal static class TicketVendorInfrastructureExtensions
         IConfiguration configuration,
         IHostEnvironment environment)
     {
-        // Ticket vendor integration
         var ticketVendorApiKey = Environment.GetEnvironmentVariable("TICKET_VENDOR_API_KEY") ?? string.Empty;
 
         services.Configure<TicketVendorSettings>(opts =>
@@ -29,7 +28,6 @@ internal static class TicketVendorInfrastructureExtensions
         }
         else
         {
-            // Stub is self-contained — fill in defaults so IsConfigured passes
             services.PostConfigure<TicketVendorSettings>(opts =>
             {
                 if (string.IsNullOrEmpty(opts.EventId)) opts.EventId = "stub-event";

--- a/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
@@ -18,13 +18,11 @@ internal static class TicketsSectionExtensions
 {
     internal static IServiceCollection AddTicketsSection(this IServiceCollection services)
     {
-        // TicketSync — see #545c.
         services.AddSingleton<ITicketRepository, TicketRepository>();
         services.AddScoped<TicketsTicketSyncService>();
         services.AddScoped<ITicketSyncService>(sp => sp.GetRequiredService<TicketsTicketSyncService>());
         services.AddScoped<IUserMerge>(sp => sp.GetRequiredService<TicketsTicketSyncService>());
 
-        // T-07 keyed-inner + Singleton decorator. IUserDataContributor on the inner — GDPR contributor is one-per-section.
         services.AddKeyedScoped<ITicketService, TicketsTicketQueryService>(
             CachingTicketQueryService.InnerServiceKey);
         services.AddScoped<TicketsTicketQueryService>();
@@ -41,11 +39,9 @@ internal static class TicketsSectionExtensions
         services.AddSingleton<ITicketTransferRepository, TicketTransferRepository>();
         services.AddScoped<ITicketTransferService, TicketTransferService>();
 
-        // Orchestrates user provisioning from unmatched ticket attendees.
         services.AddScoped<IAttendeeContactImportService, AttendeeContactImportService>();
         services.AddScoped<TicketDashboardPageBuilder>();
 
-        // "Who's onsite" roster orchestrator (#736).
         services.AddScoped<IOnsiteRosterService, OnsiteRosterService>();
 
         services.AddScoped<IUserParticipationBackfillService, UserParticipationBackfillService>();

--- a/src/Humans.Web/ViewComponents/TicketHoldingsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/TicketHoldingsViewComponent.cs
@@ -16,7 +16,6 @@ public sealed class TicketHoldingsViewComponent(
         if (!showEmpty && holdings.OrderCount == 0 && holdings.Tickets.Count == 0)
             return Content(string.Empty);
 
-        // The holder's own EE (earliest date across sources), shown on each of their stubs.
         var earlyEntry = await earlyEntryService.GetForUserAsync(userId, HttpContext.RequestAborted);
 
         var stubs = holdings.Tickets


### PR DESCRIPTION
## Simplifications

- Inlined thin private helpers where the call site is clearer: attendee import result construction, VAT revenue-attendee check, week label formatting, ticket orders cache read, stub-vendor donation calculation, transfer admin all-status rows, and contact-import outcome sort.
- Removed narrating section-label comments and obsolete workflow labels from Tickets services, repositories, controllers, view components, and DI wiring.
- Removed a redundant TicketTailor settings local and cleaned the touched controller using blocks.

## Net line delta

- 42 insertions, 118 deletions, net -76.

## Verification

- `dotnet build Humans.slnx -v quiet` succeeded; first cold run emitted existing baseline warnings, warm rerun was 0 warnings / 0 errors.
- `dotnet test Humans.slnx -v quiet` passed.

## Needs owner judgment

- Kept public Tickets interfaces, DTOs, controller actions/routes, and DI registrations unchanged.
- Left `ITicketCacheInvalidator` and EF ticket configuration/navigation analyzer warnings untouched; public surface and EF/storage changes are out of scope for this pass.
- Kept larger private workflow/projection helpers in `TicketQueryService`, `TicketSyncService`, `TicketTransferService`, `OnsiteRosterService`, and TicketTailor API mapping because inlining them would make the primary workflows harder to read.
- Left Store, EarlyEntry, shared root files, public view models, Domain entities, and EF migrations/configuration outside this PR per section boundaries.