### PR TITLE
refactor(email): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Email/EmailMessageFactory.cs
+++ b/src/Humans.Application/Services/Email/EmailMessageFactory.cs
@@ -14,7 +14,6 @@ namespace Humans.Application.Services.Email;
 /// </summary>
 public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessageFactory
 {
-    /// <inheritdoc />
     public EmailMessage ApplicationApproved(string userEmail, string userName, MembershipTier tier, string? culture = null)
     {
         var content = renderer.RenderApplicationApproved(userName, tier, culture);
@@ -22,7 +21,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "application_approved", MessageCategory.Governance);
     }
 
-    /// <inheritdoc />
     public EmailMessage ApplicationRejected(string userEmail, string userName, MembershipTier tier, string reason, string? culture = null)
     {
         var content = renderer.RenderApplicationRejected(userName, tier, reason, culture);
@@ -30,7 +28,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "application_rejected", MessageCategory.Governance);
     }
 
-    /// <inheritdoc />
     public EmailMessage ReConsentsRequired(string userEmail, string userName, IEnumerable<string> documentNames, string? culture = null)
     {
         var content = renderer.RenderReConsentsRequired(userName, documentNames.ToList(), culture);
@@ -38,7 +35,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "reconsents_required");
     }
 
-    /// <inheritdoc />
     public EmailMessage ReConsentReminder(string userEmail, string userName, IEnumerable<string> documentNames, int daysRemaining, string? culture = null)
     {
         var content = renderer.RenderReConsentReminder(userName, documentNames.ToList(), daysRemaining, culture);
@@ -46,7 +42,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "reconsent_reminder");
     }
 
-    /// <inheritdoc />
     public EmailMessage AccessSuspended(string userEmail, string userName, string reason, string? culture = null)
     {
         var content = renderer.RenderAccessSuspended(userName, reason, culture);
@@ -54,7 +49,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "access_suspended");
     }
 
-    /// <inheritdoc />
     public EmailMessage EmailVerification(string toEmail, string userName, string verificationUrl, bool isConflict = false, string? culture = null)
     {
         var content = renderer.RenderEmailVerification(userName, toEmail, verificationUrl, isConflict, culture);
@@ -62,7 +56,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "email_verification", TriggerImmediate: true);
     }
 
-    /// <inheritdoc />
     public EmailMessage AccountDeletionRequested(string userEmail, string userName, Instant deletionDate, string? culture = null)
     {
         var formattedDate = deletionDate.InUtc().Date.ToInvariantLongDate();
@@ -71,7 +64,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "deletion_requested");
     }
 
-    /// <inheritdoc />
     public EmailMessage AccountDeleted(string userEmail, string userName, string? culture = null)
     {
         var content = renderer.RenderAccountDeleted(userName, culture);
@@ -79,7 +71,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "account_deleted");
     }
 
-    /// <inheritdoc />
     public EmailMessage AddedToTeam(string userEmail, string userName, string teamName, string teamSlug, IEnumerable<(string Name, string? Url)> resources, string? culture = null)
     {
         var content = renderer.RenderAddedToTeam(userName, teamName, teamSlug, resources.ToList(), culture);
@@ -87,7 +78,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "added_to_team", MessageCategory.TeamUpdates);
     }
 
-    /// <inheritdoc />
     public EmailMessage SignupRejected(string userEmail, string userName, string? reason, string? culture = null)
     {
         var content = renderer.RenderSignupRejected(userName, reason, culture);
@@ -95,7 +85,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "signup_rejected", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage TermRenewalReminder(string userEmail, string userName, string tierName, string expiresAt, string? culture = null)
     {
         var content = renderer.RenderTermRenewalReminder(userName, tierName, expiresAt, culture);
@@ -103,7 +92,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "term_renewal_reminder", MessageCategory.Governance);
     }
 
-    /// <inheritdoc />
     public EmailMessage SurveyInvitation(string userEmail, string userName, string surveyTitle, string answerToken, string? culture = null)
     {
         var content = renderer.RenderSurveyInvitation(userName, surveyTitle, answerToken, culture);
@@ -111,7 +99,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "survey_invitation", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage SurveyReminder(string userEmail, string userName, string surveyTitle, string answerToken, string? culture = null)
     {
         var content = renderer.RenderSurveyReminder(userName, surveyTitle, answerToken, culture);
@@ -119,7 +106,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "survey_reminder", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage FeedbackResponse(string userEmail, string userName, string originalDescription, string responseMessage, string reportLink, string? culture = null)
     {
         var content = renderer.RenderFeedbackResponse(userName, originalDescription, responseMessage, reportLink, culture);
@@ -127,7 +113,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "feedback_response", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage FacilitatedMessage(string recipientEmail, string recipientName, string senderName, string messageText, bool includeContactInfo, string? senderEmail, string? culture = null)
     {
         var content = renderer.RenderFacilitatedMessage(recipientName, senderName, messageText, includeContactInfo, senderEmail, culture);
@@ -136,7 +121,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "facilitated_message", MessageCategory.FacilitatedMessages, ReplyTo: replyTo);
     }
 
-    /// <inheritdoc />
     public EmailMessage CoordinatorRotaMessage(CoordinatorRotaMessageRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -147,7 +131,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "coordinator_rota_message", MessageCategory.VolunteerUpdates, ReplyTo: request.SenderEmail);
     }
 
-    /// <inheritdoc />
     public EmailMessage CoordinatorTeamRotasMessage(CoordinatorTeamRotasMessageRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -158,7 +141,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "coordinator_team_rotas_message", MessageCategory.VolunteerUpdates, ReplyTo: request.SenderEmail);
     }
 
-    /// <inheritdoc />
     public EmailMessage MagicLinkLogin(string toEmail, string displayName, string magicLinkUrl, string? culture = null)
     {
         var content = renderer.RenderMagicLinkLogin(displayName, magicLinkUrl, culture);
@@ -166,7 +148,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "magic_link_login", TriggerImmediate: true);
     }
 
-    /// <inheritdoc />
     public EmailMessage MagicLinkSignup(string toEmail, string magicLinkUrl, string? culture = null)
     {
         var content = renderer.RenderMagicLinkSignup(magicLinkUrl, culture);
@@ -174,7 +155,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "magic_link_signup", TriggerImmediate: true);
     }
 
-    /// <inheritdoc />
     public EmailMessage WorkspaceCredentials(string recoveryEmail, string userName, string workspaceEmail, string tempPassword, string? culture = null)
     {
         var content = renderer.RenderWorkspaceCredentials(userName, workspaceEmail, tempPassword, culture);
@@ -182,7 +162,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "workspace_credentials", TriggerImmediate: true);
     }
 
-    /// <inheritdoc />
     public EmailMessage IssueComment(string to, string displayName, string issueTitle, string commentContent, string issueLink, string preferredLanguage)
     {
         var content = renderer.RenderIssueComment(displayName, issueTitle, commentContent, issueLink, preferredLanguage);
@@ -190,7 +169,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "issue_comment", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage CampaignCode(CampaignCodeEmailRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -201,7 +179,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             ReplyTo: request.ReplyTo, UserId: request.UserId, CampaignGrantId: request.CampaignGrantId);
     }
 
-    /// <inheritdoc />
     public EmailMessage EventLifecycle(EventLifecycleNotification request, string userEmail)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -210,7 +187,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             request.TemplateName(), TriggerImmediate: true);
     }
 
-    /// <inheritdoc />
     public EmailMessage GoogleGroupRemovalLossOfAccess(string removedEmail, string userName, string groupName, string groupEmail, string? culture = null)
     {
         var content = renderer.RenderGoogleGroupRemovalLossOfAccess(userName, groupName, groupEmail, culture);
@@ -218,7 +194,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "google_group_removal_loss_of_access", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage GoogleDriveRemovalLossOfAccess(string removedEmail, string userName, string folderName, string? culture = null)
     {
         var content = renderer.RenderGoogleDriveRemovalLossOfAccess(userName, folderName, culture);
@@ -226,7 +201,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "google_drive_removal_loss_of_access", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage GoogleAccessRemovalSecondaryCleanup(string removedEmail, string userName, string currentGoogleEmail, string? culture = null)
     {
         var content = renderer.RenderGoogleAccessRemovalSecondaryCleanup(userName, removedEmail, currentGoogleEmail, culture);
@@ -234,7 +208,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "google_access_removal_secondary_cleanup", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage TicketTransferRequested(string senderEmail, string senderName, string receiverName, string ticketLabel, string? culture = null)
     {
         var content = renderer.RenderTicketTransferRequested(senderName, receiverName, ticketLabel, culture);
@@ -242,7 +215,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "ticket_transfer_requested", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage TicketTransferTeamNotification(string senderName, string receiverName, string receiverEmail, string ticketLabel, string? reason, string reviewUrl)
     {
         var content = renderer.RenderTicketTransferTeamNotification(senderName, receiverName, receiverEmail, ticketLabel, reason, reviewUrl);
@@ -250,7 +222,6 @@ public sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessage
             "ticket_transfer_team", MessageCategory.System);
     }
 
-    /// <inheritdoc />
     public EmailMessage TicketTransferDecision(string toEmail, string toName, bool successful, string ticketLabel, string receiverName, string? reason, string? culture = null)
     {
         var content = renderer.RenderTicketTransferDecision(toName, successful, ticketLabel, receiverName, reason, culture);

--- a/src/Humans.Application/Services/Email/OutboxEmailService.cs
+++ b/src/Humans.Application/Services/Email/OutboxEmailService.cs
@@ -32,7 +32,6 @@ public sealed class OutboxEmailService(
     ICommunicationPreferenceService commPrefService,
     ILogger<OutboxEmailService> logger) : IEmailService
 {
-    /// <inheritdoc />
     public async Task SendAsync(EmailMessage message, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(message);

--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -48,7 +48,6 @@ public class ProcessEmailOutboxJob(
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        // 1. Check global pause flag
         if (await emailOutboxService.IsEmailPausedAsync(cancellationToken))
         {
             logger.LogInformation("Email sending is paused, skipping outbox processing");
@@ -58,7 +57,6 @@ public class ProcessEmailOutboxJob(
         var now = clock.GetCurrentInstant();
         var staleThreshold = now - Duration.FromMinutes(5);
 
-        // 2. Select batch of messages to process
         var messages = await outboxRepo.GetProcessingBatchAsync(
             now, staleThreshold, _settings.OutboxMaxRetries, _settings.OutboxBatchSize, cancellationToken);
 
@@ -67,11 +65,9 @@ public class ProcessEmailOutboxJob(
             return;
         }
 
-        // 3. Mark batch as picked up (prevents concurrent processor runs picking the same rows)
         await outboxRepo.MarkPickedUpAsync(
             messages.Select(m => m.Id).ToList(), now, cancellationToken);
 
-        // 4. Process each message
         foreach (var message in messages)
         {
             try
@@ -123,7 +119,6 @@ public class ProcessEmailOutboxJob(
             }
             catch (Exception ex)
             {
-                // Failure
                 var nextRetryAt = now + Duration.FromMinutes((long)Math.Pow(2, message.RetryCount + 1));
                 await outboxRepo.MarkFailedAsync(message.Id, now, ex.Message, nextRetryAt, cancellationToken);
                 metrics.RecordEmailFailed(message.TemplateName);
@@ -147,11 +142,9 @@ public class ProcessEmailOutboxJob(
             }
         }
 
-        // 5. Set outbox_pending gauge
         var pendingCount = await outboxRepo.GetPendingCountAsync(_settings.OutboxMaxRetries, cancellationToken);
         _outboxPendingMeter.Set(pendingCount);
 
-        // 6. Record successful job run
         metrics.RecordJobRun("process_email_outbox", "success");
     }
 }

--- a/src/Humans.Infrastructure/Repositories/Email/EmailOutboxRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Email/EmailOutboxRepository.cs
@@ -17,10 +17,6 @@ namespace Humans.Infrastructure.Repositories.Email;
 /// </summary>
 internal sealed class EmailOutboxRepository(IDbContextFactory<HumansDbContext> factory) : IEmailOutboxRepository
 {
-    // ==========================================================================
-    // Reads — admin dashboard and profile views
-    // ==========================================================================
-
     public async Task<int> GetTotalCountAsync(CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -74,10 +70,6 @@ internal sealed class EmailOutboxRepository(IDbContextFactory<HumansDbContext> f
             .CountAsync(m => m.SentAt == null && m.RetryCount < maxRetries, ct);
     }
 
-    // ==========================================================================
-    // Writes — admin operations
-    // ==========================================================================
-
     public async Task AddAsync(EmailOutboxMessage message, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -113,10 +105,6 @@ internal sealed class EmailOutboxRepository(IDbContextFactory<HumansDbContext> f
 
         return recipient;
     }
-
-    // ==========================================================================
-    // Processor — used by ProcessEmailOutboxJob
-    // ==========================================================================
 
     public async Task<IReadOnlyList<EmailOutboxMessage>> GetProcessingBatchAsync(
         Instant now,
@@ -189,10 +177,6 @@ internal sealed class EmailOutboxRepository(IDbContextFactory<HumansDbContext> f
         return true;
     }
 
-    // ==========================================================================
-    // Cleanup — used by CleanupEmailOutboxJob
-    // ==========================================================================
-
     public async Task<int> DeleteSentOlderThanAsync(Instant cutoff, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -207,9 +191,5 @@ internal sealed class EmailOutboxRepository(IDbContextFactory<HumansDbContext> f
         await ctx.SaveChangesAsync(ct);
         return toDelete.Count;
     }
-
-    // ==========================================================================
-    // Pause flag — IsEmailSendingPaused row in system_settings
-    // ==========================================================================
 
 }

--- a/src/Humans.Infrastructure/Services/BrandedEmailBodyComposer.cs
+++ b/src/Humans.Infrastructure/Services/BrandedEmailBodyComposer.cs
@@ -20,10 +20,7 @@ public sealed class BrandedEmailBodyComposer(IOptions<EmailSettings> settings, I
     private readonly string _baseUrl = settings.Value.BaseUrl;
     private readonly string _environmentName = hostEnvironment.EnvironmentName;
 
-    public (string HtmlBody, string PlainTextBody) Compose(string htmlContent, string? unsubscribeUrl = null)
-    {
-        return (
-            BrandedEmailTemplate.Wrap(htmlContent, _baseUrl, _environmentName, unsubscribeUrl),
-            HtmlPlainTextConverter.Convert(htmlContent));
-    }
+    public (string HtmlBody, string PlainTextBody) Compose(string htmlContent, string? unsubscribeUrl = null) => (
+        BrandedEmailTemplate.Wrap(htmlContent, _baseUrl, _environmentName, unsubscribeUrl),
+        HtmlPlainTextConverter.Convert(htmlContent));
 }

--- a/src/Humans.Infrastructure/Services/HangfireImmediateOutboxProcessor.cs
+++ b/src/Humans.Infrastructure/Services/HangfireImmediateOutboxProcessor.cs
@@ -14,8 +14,6 @@ namespace Humans.Infrastructure.Services;
 public sealed class HangfireImmediateOutboxProcessor(IBackgroundJobClient backgroundJobClient)
     : IImmediateOutboxProcessor
 {
-    public void TriggerImmediate()
-    {
+    public void TriggerImmediate() =>
         backgroundJobClient.Enqueue<ProcessEmailOutboxJob>(x => x.ExecuteAsync(default));
-    }
 }

--- a/src/Humans.Infrastructure/Services/SmtpEmailTransport.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailTransport.cs
@@ -58,9 +58,9 @@ public class SmtpEmailTransport(IOptions<EmailSettings> settings, ILogger<SmtpEm
             }
             message.Body = bodyBuilder.ToMessageBody();
 
-            // Set Message-Id domain to match From address (avoids Docker container hostname)
-            var fromDomain = _settings.FromAddress.Contains('@', StringComparison.Ordinal)
-                ? _settings.FromAddress[(_settings.FromAddress.IndexOf('@', StringComparison.Ordinal) + 1)..]
+            var atIndex = _settings.FromAddress.IndexOf('@', StringComparison.Ordinal);
+            var fromDomain = atIndex >= 0
+                ? _settings.FromAddress[(atIndex + 1)..]
                 : "nobodies.team";
             message.MessageId = $"{Guid.NewGuid()}@{fromDomain}";
 

--- a/src/Humans.Infrastructure/Services/SmtpEmailTransport.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailTransport.cs
@@ -58,6 +58,7 @@ public class SmtpEmailTransport(IOptions<EmailSettings> settings, ILogger<SmtpEm
             }
             message.Body = bodyBuilder.ToMessageBody();
 
+            // Set Message-Id domain to match From address (avoids Docker container hostname)
             var atIndex = _settings.FromAddress.IndexOf('@', StringComparison.Ordinal);
             var fromDomain = atIndex >= 0
                 ? _settings.FromAddress[(atIndex + 1)..]

--- a/src/Humans.Web/Controllers/EmailController.cs
+++ b/src/Humans.Web/Controllers/EmailController.cs
@@ -1,14 +1,13 @@
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
+using Humans.Application.Architecture;
+using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
-using Humans.Application.Architecture;
-using Humans.Application.Interfaces.Email;
-
-using Humans.Application.Interfaces.Users;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Humans.Web.Controllers;
 
@@ -98,7 +97,6 @@ public class EmailController(
         var settings = emailSettings.Value;
         var cultures = new[] { "en", "es", "de", "fr", "it", "ca" };
 
-        // Per-locale persona stubs for realistic previews
         var personas = new Dictionary<string, (string Name, string Email)>(StringComparer.Ordinal)
         {
             ["en"] = ("Sally Smith", "sally@example.com"),
@@ -189,5 +187,4 @@ public class EmailController(
 
         return View(new EmailPreviewViewModel { Previews = previews, FromAddress = settings.FromAddress });
     }
-
 }

--- a/src/Humans.Web/Extensions/Infrastructure/EmailInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/EmailInfrastructureExtensions.cs
@@ -50,10 +50,6 @@ internal static class EmailInfrastructureExtensions
 
         services.AddScoped<IEmailRenderer, EmailRenderer>();
 
-        // Email section — §15 repository pattern (issue #548).
-        // The outbox repository owns email_outbox_messages + the IsEmailSendingPaused
-        // system_settings row. Registered Singleton (IDbContextFactory-based) so the
-        // Application-layer services can inject it directly.
         services.AddSingleton<IEmailOutboxRepository, EmailOutboxRepository>();
         services.AddSingleton<IEmailBodyComposer, InfrastructureEmailBodyComposer>();
         services.AddScoped<IImmediateOutboxProcessor, HangfireImmediateOutboxProcessor>();


### PR DESCRIPTION
## Simplifications

- Removed repeated implementation-only `inheritdoc` comments from the Email message factory and outbox service.
- Removed section-divider and numbered step comments from the outbox repository and processor where the method names and statements already carry the structure.
- Simplified tiny method bodies in the branded body composer and immediate outbox processor.
- Simplified SMTP Message-Id domain extraction by computing the `@` index once.
- Cleaned the touched Email controller using block and removed a narrating preview comment.

## Net line delta

- 13 insertions, 82 deletions, net -69.

## Verification

- `dotnet build Humans.slnx -v quiet` succeeded; first cold run emitted existing baseline warnings, warm rerun was 0 warnings / 0 errors.
- `dotnet test Humans.slnx -v quiet` passed.

## Needs owner judgment

- Kept public Email interfaces, DTO records, controller actions/routes, configuration shape, and DI registrations unchanged.
- Kept Mailer out of scope: `docs/sections/_Index.md` lists Email and Mailer as distinct sections, and the simplification prompt names Email only.
- Left EF entity/configuration/migration files and shared recurring-job/root registration files untouched.
- Left the existing `EmailController.EmailPreview` HUM0031 shape as a grandfathered public admin preview workflow; extracting it would be a controller architecture change rather than a local simplification.