### PR TITLE
refactor(budget): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Budget/BudgetService.cs
+++ b/src/Humans.Application/Services/Budget/BudgetService.cs
@@ -288,7 +288,6 @@ public sealed class BudgetService(
         if (category is null)
             return null;
 
-        // Stitch team names via ITeamService.
         var teamIds = category.LineItems
             .Select(li => li.ResponsibleTeamId)
             .Where(tid => tid.HasValue)
@@ -573,9 +572,7 @@ public sealed class BudgetService(
 
     public BudgetSummaryResult ComputeBudgetSummary(IReadOnlyList<BudgetGroupDetail> groups)
     {
-        var groupsList = groups;
-
-        var budgetLineItems = groupsList
+        var budgetLineItems = groups
             .SelectMany(g => g.Categories)
             .SelectMany(c => c.LineItems)
             .Where(li => !li.IsCashflowOnly)
@@ -599,7 +596,7 @@ public sealed class BudgetService(
         var totalExpenses = expenses - vatExpenses;
         var netBalance = totalIncome + totalExpenses;
 
-        var incomeCategories = groupsList
+        var incomeCategories = groups
             .SelectMany(g => g.Categories)
             .Select(c => new { c.Name, Total = c.LineItems.Where(li => li.Amount > 0 && !li.IsCashflowOnly).Sum(li => li.Amount) })
             .Where(c => c.Total > 0)
@@ -619,7 +616,7 @@ public sealed class BudgetService(
             })
             .ToList();
 
-        var expenseCategories = groupsList
+        var expenseCategories = groups
             .SelectMany(g => g.Categories)
             .Select(c => new { c.Name, Total = Math.Abs(c.LineItems.Where(li => li.Amount < 0 && !li.IsCashflowOnly).Sum(li => li.Amount)) })
             .Where(c => c.Total > 0)
@@ -658,11 +655,10 @@ public sealed class BudgetService(
 
     public BudgetSummaryResult ComputeBudgetSummaryWithBuffers(IReadOnlyList<BudgetGroupDetail> groups)
     {
-        var groupList = groups;
-        var summary = ComputeBudgetSummary(groupList);
+        var summary = ComputeBudgetSummary(groups);
 
         // Per-group buffer: allocated minus line-item total (negative = expense, positive = income).
-        var groupBuffers = groupList
+        var groupBuffers = groups
             .Where(g => !g.IsTicketingGroup)
             .Select(g => new
             {
@@ -827,13 +823,10 @@ public sealed class BudgetService(
 
             var daysInWeek = Period.Between(weekStart, weekEnd.PlusDays(1), PeriodUnits.Days).Days;
             var weekTickets = (int)Math.Round(dailyRate * daysInWeek);
-            if (isFirstWeek && projectionStart <= projection.StartDate.Value)
+            if (isFirstWeek)
             {
-                weekTickets += initialBurst;
-                isFirstWeek = false;
-            }
-            else
-            {
+                if (projectionStart <= projection.StartDate.Value)
+                    weekTickets += initialBurst;
                 isFirstWeek = false;
             }
             if (weekTickets <= 0) weekTickets = 1;
@@ -845,7 +838,7 @@ public sealed class BudgetService(
 
             projections.Add(new TicketingWeekProjection
             {
-                WeekLabel = FormatTicketingWeekLabel(weekStart, weekEnd),
+                WeekLabel = $"{weekStart.ToWeekdayDayMonth()}–{weekEnd.ToWeekdayDayMonth()}",
                 WeekStart = weekStart,
                 WeekEnd = weekEnd,
                 ProjectedTickets = weekTickets,
@@ -903,11 +896,6 @@ public sealed class BudgetService(
         // NodaTime IsoDayOfWeek: Monday=1, Sunday=7.
         var dayOfWeek = (int)date.DayOfWeek;
         return date.PlusDays(-(dayOfWeek - 1));
-    }
-
-    private static string FormatTicketingWeekLabel(LocalDate monday, LocalDate sunday)
-    {
-        return $"{monday.ToWeekdayDayMonth()}–{sunday.ToWeekdayDayMonth()}";
     }
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)

--- a/src/Humans.Infrastructure/Repositories/Budget/BudgetRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Budget/BudgetRepository.cs
@@ -20,8 +20,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
     private const string TicketingGroupName = "Ticketing";
     private const string TicketingProjectedPrefix = "Projected: ";
 
-    // Budget Years — reads
-
     public async Task<IReadOnlyList<BudgetYear>> GetAllYearsAsync(
         bool includeArchived, CancellationToken ct = default)
     {
@@ -88,8 +86,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             .FirstOrDefaultAsync(y => y.Id == activeId.Value, ct);
     }
 
-    // Budget Years — atomic mutations
-
     public async Task CreateYearWithScaffoldAsync(
         BudgetYearDraft draft, CancellationToken ct = default)
     {
@@ -107,7 +103,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
 
         ctx.BudgetYears.Add(budgetYear);
 
-        // Auto-create "Departments" group.
         var departmentGroup = new BudgetGroup
         {
             Id = Guid.NewGuid(),
@@ -121,7 +116,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
         };
         ctx.BudgetGroups.Add(departmentGroup);
 
-        // Auto-create categories for teams with HasBudget.
         var deptSortOrder = 0;
         foreach (var team in draft.BudgetableTeams)
         {
@@ -139,7 +133,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             });
         }
 
-        // Auto-create "Ticketing" group + projection + default categories.
         var ticketingGroup = new BudgetGroup
         {
             Id = Guid.NewGuid(),
@@ -161,26 +154,7 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             UpdatedAt = draft.Now
         });
 
-        var ticketingCategories = new[]
-        {
-            (Name: TicketRevenueCategoryName, Sort: 0),
-            (Name: ProcessingFeesCategoryName, Sort: 1)
-        };
-
-        foreach (var (name, sort) in ticketingCategories)
-        {
-            ctx.BudgetCategories.Add(new BudgetCategory
-            {
-                Id = Guid.NewGuid(),
-                BudgetGroupId = ticketingGroup.Id,
-                Name = name,
-                AllocatedAmount = 0,
-                ExpenditureType = ExpenditureType.OpEx,
-                SortOrder = sort,
-                CreatedAt = draft.Now,
-                UpdatedAt = draft.Now
-            });
-        }
+        AddDefaultTicketingCategories(ctx, ticketingGroup.Id, draft.Now);
 
         AddDescriptionAudit(ctx, budgetYear.Id, nameof(BudgetYear), budgetYear.Id,
             $"Created budget year '{draft.Name}' ({draft.Year})",
@@ -423,26 +397,7 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             UpdatedAt = now
         });
 
-        var ticketingCategories = new[]
-        {
-            (Name: TicketRevenueCategoryName, Sort: 0),
-            (Name: ProcessingFeesCategoryName, Sort: 1)
-        };
-
-        foreach (var (name, sort) in ticketingCategories)
-        {
-            ctx.BudgetCategories.Add(new BudgetCategory
-            {
-                Id = Guid.NewGuid(),
-                BudgetGroupId = ticketingGroup.Id,
-                Name = name,
-                AllocatedAmount = 0,
-                ExpenditureType = ExpenditureType.OpEx,
-                SortOrder = sort,
-                CreatedAt = now,
-                UpdatedAt = now
-            });
-        }
+        AddDefaultTicketingCategories(ctx, ticketingGroup.Id, now);
 
         AddDescriptionAudit(ctx, budgetYearId, nameof(BudgetGroup), ticketingGroup.Id,
             "Added Ticketing group with projection parameters",
@@ -451,8 +406,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
         await ctx.SaveChangesAsync(ct);
         return true;
     }
-
-    // Budget Groups — atomic mutations
 
     public async Task<BudgetGroup> CreateGroupAsync(
         Guid budgetYearId,
@@ -572,8 +525,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
         return true;
     }
 
-    // Budget Categories — reads
-
     public async Task<BudgetCategory?> GetCategoryByIdAsync(Guid id, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -589,8 +540,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             .Include(c => c.LineItems)
             .FirstOrDefaultAsync(c => c.Id == id, ct);
     }
-
-    // Budget Categories — atomic mutations
 
     public async Task<BudgetCategory> CreateCategoryAsync(
         Guid budgetGroupId,
@@ -715,8 +664,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
         return true;
     }
 
-    // Budget Line Items — reads
-
     public async Task<BudgetLineItem?> GetLineItemByIdAsync(Guid id, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -725,8 +672,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             .AsNoTracking()
             .FirstOrDefaultAsync(li => li.Id == id, ct);
     }
-
-    // Budget Line Items — atomic mutations
 
     public async Task<BudgetLineItem> CreateLineItemAsync(
         BudgetLineItemDraft draft,
@@ -882,8 +827,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
         return true;
     }
 
-    // Ticketing Projection — reads
-
     public async Task<TicketingProjection?> GetTicketingProjectionAsync(
         Guid budgetGroupId, CancellationToken ct = default)
     {
@@ -902,8 +845,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             .AsNoTracking()
             .FirstOrDefaultAsync(g => g.Id == groupId, ct);
     }
-
-    // Ticketing Projection — atomic mutations
 
     public async Task<bool> UpdateTicketingProjectionAsync(
         TicketingProjectionUpdate update,
@@ -1043,8 +984,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
         return created;
     }
 
-    // Audit Log — reads (append-only per §12)
-
     public async Task<IReadOnlyList<BudgetAuditLog>> GetAuditLogAsync(
         Guid? budgetYearId, CancellationToken ct = default)
     {
@@ -1093,10 +1032,31 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             .ToListAsync(ct);
     }
 
-    // Private helpers
-
     // Spanish IVA rate applied to Stripe and TicketTailor processing fees.
     private const int TicketingFeeVatRate = 21;
+
+    private static void AddDefaultTicketingCategories(
+        HumansDbContext ctx, Guid ticketingGroupId, Instant now)
+    {
+        foreach (var (name, sortOrder) in new[]
+        {
+            (Name: TicketRevenueCategoryName, SortOrder: 0),
+            (Name: ProcessingFeesCategoryName, SortOrder: 1)
+        })
+        {
+            ctx.BudgetCategories.Add(new BudgetCategory
+            {
+                Id = Guid.NewGuid(),
+                BudgetGroupId = ticketingGroupId,
+                Name = name,
+                AllocatedAmount = 0,
+                ExpenditureType = ExpenditureType.OpEx,
+                SortOrder = sortOrder,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        }
+    }
 
     private static async Task EnsureYearNotClosedAsync(
         HumansDbContext ctx, Guid budgetYearId, CancellationToken ct)
@@ -1189,13 +1149,10 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
             var daysInWeek = Period.Between(weekStart, weekEnd.PlusDays(1), PeriodUnits.Days).Days;
 
             var weekTickets = (int)Math.Round(dailyRate * daysInWeek);
-            if (isFirstWeek && projectionStart <= projection.StartDate.Value)
+            if (isFirstWeek)
             {
-                weekTickets += initialBurst;
-                isFirstWeek = false;
-            }
-            else
-            {
+                if (projectionStart <= projection.StartDate.Value)
+                    weekTickets += initialBurst;
                 isFirstWeek = false;
             }
 
@@ -1206,7 +1163,7 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
                 + weekTickets * projection.StripeFeeFixed;
             var ttFees = weekRevenue * projection.TicketTailorFeePercent / 100m;
 
-            var weekLabel = FormatTicketingWeekLabel(weekStart, weekEnd);
+            var weekLabel = $"{weekStart.ToWeekdayDayMonth()}–{weekEnd.ToWeekdayDayMonth()}";
 
             created += UpsertTicketingLineItem(ctx, revenueCategory,
                 $"{TicketingProjectedPrefix}Week of {weekLabel}",
@@ -1236,11 +1193,6 @@ internal sealed class BudgetRepository(IDbContextFactory<HumansDbContext> factor
         // NodaTime IsoDayOfWeek: Monday=1, Sunday=7.
         var dayOfWeek = (int)date.DayOfWeek;
         return date.PlusDays(-(dayOfWeek - 1));
-    }
-
-    private static string FormatTicketingWeekLabel(LocalDate monday, LocalDate sunday)
-    {
-        return $"{monday.ToWeekdayDayMonth()}–{sunday.ToWeekdayDayMonth()}";
     }
 
     private static void RemoveProjectedItems(HumansDbContext ctx, BudgetCategory category)

--- a/src/Humans.Web/Authorization/Requirements/BudgetAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/BudgetAuthorizationHandler.cs
@@ -24,28 +24,22 @@ public class BudgetAuthorizationHandler(IBudgetService budgetService)
         BudgetOperationRequirement requirement,
         BudgetCategorySnapshot resource)
     {
-        // Admin and FinanceAdmin can edit any budget category
         if (RoleChecks.IsFinanceAdmin(context.User))
         {
             context.Succeed(requirement);
             return;
         }
 
-        // Non-admin: deny on deleted budget years
         if (resource.BudgetGroup?.BudgetYear?.IsDeleted == true)
             return;
 
-        // Non-admin: deny on restricted groups
         if (resource.BudgetGroup?.IsRestricted == true)
             return;
 
-        // Category must be linked to a team for coordinator-based access
         if (!resource.TeamId.HasValue)
             return;
 
-        // Check if user is a coordinator for the category's department
-        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
-        if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
+        if (!Guid.TryParse(context.User.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
             return;
 
         var coordinatorTeamIds = await budgetService.GetEffectiveCoordinatorTeamIdsAsync(userId);

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -1,13 +1,12 @@
 using Humans.Application.Interfaces.Budget;
 using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
-
-using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
@@ -222,7 +221,6 @@ public class BudgetController(
         return RedirectToAction(nameof(CategoryDetail), new { id = lineItem.BudgetCategoryId });
     }
 
-    /// <summary>Load category + auth-check Edit; returns IActionResult on deny, null on allow.</summary>
     private async Task<IActionResult?> AuthorizeCategoryEditAsync(Guid categoryId)
     {
         var category = await budgetService.GetCategoryByIdAsync(categoryId);

--- a/src/Humans.Web/Extensions/Sections/BudgetSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/BudgetSectionExtensions.cs
@@ -12,18 +12,11 @@ internal static class BudgetSectionExtensions
 {
     internal static IServiceCollection AddBudgetSection(this IServiceCollection services)
     {
-        // Budget section - section 15b repository pattern (issue #572).
-        // No caching decorator: Budget pages are admin-only and low-traffic.
-        // BudgetRepository uses IDbContextFactory<HumansDbContext> so it can be
-        // Singleton; every method opens its own short-lived DbContext. Multi-entity
-        // mutations that must be atomic (e.g., CreateYearWithScaffoldAsync) happen
-        // inside a single repository method so they commit together.
         services.AddSingleton<IBudgetRepository, BudgetRepository>();
         services.AddScoped<BudgetBudgetService>();
         services.AddScoped<IBudgetService>(sp => sp.GetRequiredService<BudgetBudgetService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<BudgetBudgetService>());
 
-        // Reads the canonical Tickets read model and delegates Budget-owned mutations to IBudgetService.
         services.AddScoped<ITicketingBudgetService, TicketsTicketingBudgetService>();
 
         return services;


### PR DESCRIPTION
## Simplifications

- Collapsed duplicated Ticketing default-category creation in BudgetRepository into one private helper.
- Removed private single-caller ticketing week-label helpers after inlining the simple format expression.
- Removed redundant summary locals and simplified first-week projection state updates.
- Simplified Budget authorization claim parsing without changing access checks.
- Removed narrating comments and section divider comments from Budget C# implementation files.

## Net line delta

- 40 insertions, 115 deletions, net -75 lines.

## Verification

- `dotnet build Humans.slnx -v quiet`
- `dotnet test Humans.slnx -v quiet`

## Needs owner judgment

- Public Budget interfaces, DTOs/view models, controller actions/routes, and DI registrations were left unchanged.
- Budget EF entities/configurations/migrations and storage behavior were left untouched.
- Ticketing-to-Budget bridge classes remain under the Tickets-owned bridge boundary documented for the section.
- Larger private projection/workflow helpers such as `ToYearDetail`, `ToGroupDetail`, `ToCategoryDetail`, `ToLineItemSnapshot`, `ValidateVatRate`, `LoadTicketingGroupForMutationAsync`, `MaterializeProjectedWeeks`, `RemoveProjectedItems`, `SumActualTicketsSold`, and `UpdateProjectionFromActuals` were kept because inlining them would obscure calculation or mutation boundaries rather than simplify callers.