### PR TITLE
refactor(governance): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -93,54 +93,23 @@ public sealed class ApplicationDecisionService(
             await syncJob.SyncMembershipForUserAsync(
                 application.UserId, SystemTeamType.Asociados, cancellationToken);
 
-        var user = await userService.GetUserInfoAsync(application.UserId, cancellationToken);
-        if (user is not null)
-        {
-            var notificationEmails = await userEmailService.GetNotificationTargetEmailsAsync(
-                [application.UserId], cancellationToken);
-            if (notificationEmails.TryGetValue(application.UserId, out var recipientEmail)
-                && !string.IsNullOrWhiteSpace(recipientEmail))
-            {
-                try
-                {
-                    await emailService.SendAsync(emailMessages.ApplicationApproved(
-                        recipientEmail,
-                        user.BurnerName,
-                        application.MembershipTier,
-                        user.PreferredLanguage));
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to send approval email for {ApplicationId}", application.Id);
-                }
-            }
-            else
-            {
-                logger.LogWarning(
-                    "Skipping approval email for application {ApplicationId} because user {UserId} has no notification-target email",
-                    application.Id, application.UserId);
-            }
-        }
+        await SendDecisionEmailAsync(
+            application,
+            "approval",
+            (recipientEmail, user) => emailMessages.ApplicationApproved(
+                recipientEmail,
+                user.BurnerName,
+                application.MembershipTier,
+                user.PreferredLanguage),
+            cancellationToken);
 
-        try
-        {
-            await notificationService.SendAsync(
-                NotificationSource.ApplicationApproved,
-                NotificationClass.Informational,
-                NotificationPriority.Normal,
-                $"Your {application.MembershipTier} application has been approved",
-                [application.UserId],
-                body: $"Congratulations! Your {application.MembershipTier} application has been approved.",
-                actionUrl: "/Governance/MyApplications",
-                actionLabel: "View application",
-                cancellationToken: cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex,
-                "Failed to dispatch ApplicationApproved notification for {ApplicationId}",
-                application.Id);
-        }
+        await SendDecisionNotificationAsync(
+            application,
+            NotificationSource.ApplicationApproved,
+            $"Your {application.MembershipTier} application has been approved",
+            $"Congratulations! Your {application.MembershipTier} application has been approved.",
+            "ApplicationApproved",
+            cancellationToken);
 
         return new ApplicationDecisionResult(true);
     }
@@ -159,7 +128,6 @@ public sealed class ApplicationDecisionService(
         if (application.Status != ApplicationStatus.Submitted)
             return new ApplicationDecisionResult(false, "NotSubmitted");
 
-        // Capture voter ids before FinalizeAsync deletes them.
         var voterIds = await repository.GetVoterIdsForApplicationAsync(applicationId, cancellationToken);
 
         application.Reject(reviewerUserId, reason, clock);
@@ -185,55 +153,24 @@ public sealed class ApplicationDecisionService(
             "Application {ApplicationId} rejected by {UserId}",
             application.Id, reviewerUserId);
 
-        var user = await userService.GetUserInfoAsync(application.UserId, cancellationToken);
-        if (user is not null)
-        {
-            var notificationEmails = await userEmailService.GetNotificationTargetEmailsAsync(
-                [application.UserId], cancellationToken);
-            if (notificationEmails.TryGetValue(application.UserId, out var recipientEmail)
-                && !string.IsNullOrWhiteSpace(recipientEmail))
-            {
-                try
-                {
-                    await emailService.SendAsync(emailMessages.ApplicationRejected(
-                        recipientEmail,
-                        user.BurnerName,
-                        application.MembershipTier,
-                        reason,
-                        user.PreferredLanguage));
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to send rejection email for {ApplicationId}", application.Id);
-                }
-            }
-            else
-            {
-                logger.LogWarning(
-                    "Skipping rejection email for application {ApplicationId} because user {UserId} has no notification-target email",
-                    application.Id, application.UserId);
-            }
-        }
+        await SendDecisionEmailAsync(
+            application,
+            "rejection",
+            (recipientEmail, user) => emailMessages.ApplicationRejected(
+                recipientEmail,
+                user.BurnerName,
+                application.MembershipTier,
+                reason,
+                user.PreferredLanguage),
+            cancellationToken);
 
-        try
-        {
-            await notificationService.SendAsync(
-                NotificationSource.ApplicationRejected,
-                NotificationClass.Informational,
-                NotificationPriority.Normal,
-                $"Your {application.MembershipTier} application was not approved",
-                [application.UserId],
-                body: $"Your {application.MembershipTier} application was not approved.",
-                actionUrl: "/Governance/MyApplications",
-                actionLabel: "View application",
-                cancellationToken: cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex,
-                "Failed to dispatch ApplicationRejected notification for {ApplicationId}",
-                application.Id);
-        }
+        await SendDecisionNotificationAsync(
+            application,
+            NotificationSource.ApplicationRejected,
+            $"Your {application.MembershipTier} application was not approved",
+            $"Your {application.MembershipTier} application was not approved.",
+            "ApplicationRejected",
+            cancellationToken);
 
         return new ApplicationDecisionResult(true);
     }
@@ -242,22 +179,21 @@ public sealed class ApplicationDecisionService(
         Guid userId, CancellationToken ct = default)
     {
         var applications = await repository.GetByUserIdAsync(userId, ct);
-        return applications.Select(ToUserApplicationSnapshot).ToList();
+        return applications
+            .Select(application => new UserApplicationSnapshot(
+                application.Id,
+                application.UserId,
+                application.Status,
+                application.MembershipTier,
+                application.SubmittedAt,
+                application.ResolvedAt,
+                application.TermExpiresAt,
+                application.Motivation,
+                application.AdditionalInfo,
+                application.SignificantContribution,
+                application.RoleUnderstanding))
+            .ToList();
     }
-
-    private static UserApplicationSnapshot ToUserApplicationSnapshot(MemberApplication application) =>
-        new(
-            application.Id,
-            application.UserId,
-            application.Status,
-            application.MembershipTier,
-            application.SubmittedAt,
-            application.ResolvedAt,
-            application.TermExpiresAt,
-            application.Motivation,
-            application.AdditionalInfo,
-            application.SignificantContribution,
-            application.RoleUnderstanding);
 
     public async Task<ApplicationUserDetailDto?> GetUserApplicationDetailAsync(
         Guid applicationId, Guid userId, CancellationToken ct = default)
@@ -571,16 +507,15 @@ public sealed class ApplicationDecisionService(
     {
         var applications = await repository.GetExpiringApplicationsNeedingReminderAsync(
             today, reminderThreshold, ct);
-        return applications.Select(ToRenewalReminderCandidate).ToList();
+        return applications
+            .Select(application => new ApplicationRenewalReminderCandidate(
+                application.Id,
+                application.UserId,
+                application.MembershipTier,
+                application.SubmittedAt,
+                application.TermExpiresAt))
+            .ToList();
     }
-
-    private static ApplicationRenewalReminderCandidate ToRenewalReminderCandidate(MemberApplication application) =>
-        new(
-            application.Id,
-            application.UserId,
-            application.MembershipTier,
-            application.SubmittedAt,
-            application.TermExpiresAt);
 
     public Task<IReadOnlySet<(Guid UserId, MembershipTier Tier)>> GetPendingApplicationUserTiersAsync(
         CancellationToken ct = default) =>
@@ -692,5 +627,68 @@ public sealed class ApplicationDecisionService(
             .ToList();
 
         return (reviewerName, history);
+    }
+
+    private async Task SendDecisionEmailAsync(
+        MemberApplication application,
+        string decisionName,
+        Func<string, UserInfo, EmailMessage> buildMessage,
+        CancellationToken cancellationToken)
+    {
+        var user = await userService.GetUserInfoAsync(application.UserId, cancellationToken);
+        if (user is null)
+            return;
+
+        var notificationEmails = await userEmailService.GetNotificationTargetEmailsAsync(
+            [application.UserId], cancellationToken);
+        if (notificationEmails.TryGetValue(application.UserId, out var recipientEmail)
+            && !string.IsNullOrWhiteSpace(recipientEmail))
+        {
+            try
+            {
+                await emailService.SendAsync(buildMessage(recipientEmail, user));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to send {DecisionName} email for {ApplicationId}",
+                    decisionName, application.Id);
+            }
+        }
+        else
+        {
+            logger.LogWarning(
+                "Skipping {DecisionName} email for application {ApplicationId} because user {UserId} has no notification-target email",
+                decisionName, application.Id, application.UserId);
+        }
+    }
+
+    private async Task SendDecisionNotificationAsync(
+        MemberApplication application,
+        NotificationSource source,
+        string title,
+        string body,
+        string logName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await notificationService.SendAsync(
+                source,
+                NotificationClass.Informational,
+                NotificationPriority.Normal,
+                title,
+                [application.UserId],
+                body: body,
+                actionUrl: "/Governance/MyApplications",
+                actionLabel: "View application",
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to dispatch {NotificationName} notification for {ApplicationId}",
+                logName, application.Id);
+        }
     }
 }

--- a/src/Humans.Application/Services/Governance/MembershipCalculator.cs
+++ b/src/Humans.Application/Services/Governance/MembershipCalculator.cs
@@ -96,12 +96,10 @@ public sealed class MembershipCalculator(
             missingVersionIds);
     }
 
-    public async Task<bool> HasAllRequiredConsentsAsync(
+    public Task<bool> HasAllRequiredConsentsAsync(
         Guid userId,
-        CancellationToken cancellationToken = default)
-    {
-        return await HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
-    }
+        CancellationToken cancellationToken = default) =>
+        HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
 
     public async Task<bool> HasAllRequiredConsentsForTeamAsync(
         Guid userId,
@@ -118,12 +116,10 @@ public sealed class MembershipCalculator(
         return requiredVersions.All(v => consentedVersionIds.Contains(v.Id));
     }
 
-    public async Task<bool> HasAnyExpiredConsentsAsync(
+    public Task<bool> HasAnyExpiredConsentsAsync(
         Guid userId,
-        CancellationToken cancellationToken = default)
-    {
-        return await HasAnyExpiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
-    }
+        CancellationToken cancellationToken = default) =>
+        HasAnyExpiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
 
     public async Task<bool> HasAnyExpiredConsentsForTeamAsync(
         Guid userId,
@@ -134,13 +130,9 @@ public sealed class MembershipCalculator(
         var requiredVersions = await legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
         var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, ct);
 
-        return requiredVersions
-            .Where(v => !consentedVersionIds.Contains(v.Id))
-            .Any(v =>
-            {
-                var gracePeriod = Duration.FromDays(v.LegalDocumentGracePeriodDays);
-                return v.EffectiveFrom + gracePeriod <= now;
-            });
+        return requiredVersions.Any(v =>
+            !consentedVersionIds.Contains(v.Id) &&
+            v.EffectiveFrom + Duration.FromDays(v.LegalDocumentGracePeriodDays) <= now);
     }
 
     public async Task<IReadOnlyList<Guid>> GetMissingConsentVersionsAsync(
@@ -148,21 +140,18 @@ public sealed class MembershipCalculator(
         CancellationToken cancellationToken = default)
     {
         var requiredVersions = await legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
-        var requiredVersionIds = requiredVersions.Select(v => v.Id).ToList();
-
         var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, cancellationToken);
 
-        return requiredVersionIds
+        return requiredVersions
+            .Select(v => v.Id)
             .Where(id => !consentedVersionIds.Contains(id))
             .ToList();
     }
 
-    public async Task<bool> HasActiveRolesAsync(
+    public Task<bool> HasActiveRolesAsync(
         Guid userId,
-        CancellationToken cancellationToken = default)
-    {
-        return await membershipQuery.HasAnyActiveAssignmentAsync(userId, cancellationToken);
-    }
+        CancellationToken cancellationToken = default) =>
+        membershipQuery.HasAnyActiveAssignmentAsync(userId, cancellationToken);
 
     public async Task<IReadOnlyList<Guid>> GetUsersRequiringStatusUpdateAsync(
         CancellationToken cancellationToken = default)
@@ -174,12 +163,10 @@ public sealed class MembershipCalculator(
         return usersWithAnyExpiredConsents.ToList();
     }
 
-    public async Task<IReadOnlySet<Guid>> GetUsersWithAllRequiredConsentsAsync(
+    public Task<IReadOnlySet<Guid>> GetUsersWithAllRequiredConsentsAsync(
         IEnumerable<Guid> userIds,
-        CancellationToken cancellationToken = default)
-    {
-        return await GetUsersWithAllRequiredConsentsForTeamAsync(userIds, SystemTeamIds.Volunteers, cancellationToken);
-    }
+        CancellationToken cancellationToken = default) =>
+        GetUsersWithAllRequiredConsentsForTeamAsync(userIds, SystemTeamIds.Volunteers, cancellationToken);
 
     public async Task<IReadOnlySet<Guid>> GetUsersWithAllRequiredConsentsForTeamAsync(
         IEnumerable<Guid> userIds,
@@ -193,16 +180,14 @@ public sealed class MembershipCalculator(
         }
 
         var requiredVersions = await legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
-        var requiredVersionIds = requiredVersions.Select(v => v.Id).ToList();
-
-        if (requiredVersionIds.Count == 0)
+        if (requiredVersions.Count == 0)
         {
             return userIdList.ToHashSet();
         }
 
         var consentsByUser = await ConsentService.GetConsentMapForUsersAsync(userIdList, ct);
 
-        var requiredSet = requiredVersionIds.ToHashSet();
+        var requiredSet = requiredVersions.Select(v => v.Id).ToHashSet();
         var result = new HashSet<Guid>();
 
         foreach (var userId in userIdList)
@@ -230,34 +215,24 @@ public sealed class MembershipCalculator(
         var now = clock.GetCurrentInstant();
 
         var requiredVersions = await legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
-        var expiredVersions = requiredVersions
+        var expiredVersionIds = requiredVersions
             .Where(v =>
-            {
-                var gracePeriod = Duration.FromDays(v.LegalDocumentGracePeriodDays);
-                return v.EffectiveFrom + gracePeriod <= now;
-            })
-            .ToList();
+                v.EffectiveFrom + Duration.FromDays(v.LegalDocumentGracePeriodDays) <= now)
+            .Select(v => v.Id)
+            .ToHashSet();
 
-        if (expiredVersions.Count == 0)
+        if (expiredVersionIds.Count == 0)
         {
             return new HashSet<Guid>();
         }
-
-        var expiredVersionIds = expiredVersions.Select(v => v.Id).ToHashSet();
 
         var consentsByUser = await ConsentService.GetConsentMapForUsersAsync(userIdList, cancellationToken);
 
         var result = new HashSet<Guid>();
         foreach (var userId in userIdList)
         {
-            if (consentsByUser.TryGetValue(userId, out var consented))
-            {
-                if (expiredVersionIds.Any(id => !consented.Contains(id)))
-                {
-                    result.Add(userId);
-                }
-            }
-            else
+            if (!consentsByUser.TryGetValue(userId, out var consented) ||
+                expiredVersionIds.Any(id => !consented.Contains(id)))
             {
                 result.Add(userId);
             }

--- a/src/Humans.Application/Services/Governance/MembershipQuery.cs
+++ b/src/Humans.Application/Services/Governance/MembershipQuery.cs
@@ -14,12 +14,12 @@ public sealed class MembershipQuery(ITeamServiceRead teamService, IRoleAssignmen
         CancellationToken cancellationToken = default)
     {
         return (await teamService.GetTeamsAsync(cancellationToken)).Values
-            .Select(t => new { TeamInfo = t, Membership = t.Members.FirstOrDefault(m => m.UserId == userId) })
-            .Where(x => x.Membership is not null)
-            .Select(x => new MembershipTeamSnapshot(
-                x.TeamInfo.Id,
-                x.Membership!.Role,
-                x.TeamInfo.SystemTeamType))
+            .SelectMany(t => t.Members
+                .Where(m => m.UserId == userId)
+                .Select(m => new MembershipTeamSnapshot(
+                    t.Id,
+                    m.Role,
+                    t.SystemTeamType)))
             .ToList();
     }
 

--- a/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
@@ -31,13 +31,13 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
             .Where(a => a.UserId == userId)
             .ToListAsync(ct), ct);
 
-    public async Task<bool> AnySubmittedForUserAsync(Guid userId, CancellationToken ct = default) =>
-        await WithContextAsync(ctx => ctx.Applications.AnyAsync(
+    public Task<bool> AnySubmittedForUserAsync(Guid userId, CancellationToken ct = default) =>
+        WithContextAsync(ctx => ctx.Applications.AnyAsync(
             a => a.UserId == userId && a.Status == ApplicationStatus.Submitted,
             ct), ct);
 
-    public async Task<int> CountByStatusAsync(ApplicationStatus status, CancellationToken ct = default) =>
-        await WithContextAsync(ctx => ctx.Applications.CountAsync(a => a.Status == status, ct), ct);
+    public Task<int> CountByStatusAsync(ApplicationStatus status, CancellationToken ct = default) =>
+        WithContextAsync(ctx => ctx.Applications.CountAsync(a => a.Status == status, ct), ct);
 
     public async Task<(IReadOnlyList<MemberApplication> Items, int TotalCount)> GetFilteredAsync(
         ApplicationStatus? status,
@@ -130,9 +130,9 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
         return matched.ToHashSet();
     }
 
-    public async Task<MemberApplication?> GetSubmittedForUserAsync(
+    public Task<MemberApplication?> GetSubmittedForUserAsync(
         Guid userId, CancellationToken ct = default) =>
-        await WithContextAsync(ctx => ctx.Applications
+        WithContextAsync(ctx => ctx.Applications
             .AsNoTracking()
             .FirstOrDefaultAsync(
                 a => a.UserId == userId && a.Status == ApplicationStatus.Submitted,
@@ -155,8 +155,8 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
             .Where(a => a.Status == ApplicationStatus.Submitted)
             .ToListAsync(ct), ct);
 
-    public async Task<bool> HasBoardVotesAsync(Guid applicationId, CancellationToken ct = default) =>
-        await WithContextAsync(ctx => ctx.BoardVotes.AnyAsync(v => v.ApplicationId == applicationId, ct), ct);
+    public Task<bool> HasBoardVotesAsync(Guid applicationId, CancellationToken ct = default) =>
+        WithContextAsync(ctx => ctx.BoardVotes.AnyAsync(v => v.ApplicationId == applicationId, ct), ct);
 
     public async Task UpsertBoardVoteAsync(
         Guid applicationId,
@@ -194,9 +194,9 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task<int> GetUnvotedCountForBoardMemberAsync(
+    public Task<int> GetUnvotedCountForBoardMemberAsync(
         Guid boardMemberUserId, CancellationToken ct = default) =>
-        await WithContextAsync(ctx => ctx.Applications.CountAsync(
+        WithContextAsync(ctx => ctx.Applications.CountAsync(
             a => a.Status == ApplicationStatus.Submitted &&
                  !a.BoardVotes.Any(v => v.BoardMemberUserId == boardMemberUserId),
             ct), ct);
@@ -274,9 +274,9 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
             .Distinct()
             .ToListAsync(ct), ct);
 
-    public async Task<bool> HasActiveApprovedTierAsync(
+    public Task<bool> HasActiveApprovedTierAsync(
         Guid userId, MembershipTier tier, LocalDate today, CancellationToken ct = default) =>
-        await WithContextAsync(ctx => ctx.Applications
+        WithContextAsync(ctx => ctx.Applications
             .AsNoTracking()
             .AnyAsync(a =>
                 a.UserId == userId &&
@@ -302,10 +302,6 @@ internal sealed class ApplicationRepository(IDbContextFactory<HumansDbContext> f
             .GroupBy(r => r.UserId)
             .ToDictionary(g => g.Key, g => g.First().MembershipTier);
     }
-
-    // ==========================================================================
-    // Account-merge fold
-    // ==========================================================================
 
     public async Task<int> ReassignApplicationsToUserAsync(
         Guid sourceUserId, Guid targetUserId, Instant updatedAt,

--- a/src/Humans.Web/Controllers/GovernanceApplicationsController.cs
+++ b/src/Humans.Web/Controllers/GovernanceApplicationsController.cs
@@ -3,12 +3,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
-
-using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/GovernanceBoardVotingController.cs
+++ b/src/Humans.Web/Controllers/GovernanceBoardVotingController.cs
@@ -3,11 +3,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NodaTime;
 using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
-
-using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
@@ -156,8 +155,7 @@ public class GovernanceBoardVotingController(
         LocalDate? meetingDate = null;
         if (!string.IsNullOrWhiteSpace(model.BoardMeetingDate))
         {
-            var pattern = NodaTime.Text.LocalDatePattern.Iso;
-            var parseResult = pattern.Parse(model.BoardMeetingDate);
+            var parseResult = NodaTime.Text.LocalDatePattern.Iso.Parse(model.BoardMeetingDate);
             if (parseResult.Success)
                 meetingDate = parseResult.Value;
         }
@@ -177,19 +175,13 @@ public class GovernanceBoardVotingController(
 
         try
         {
-            ApplicationDecisionResult result;
-            if (model.Approved)
-            {
-                result = await applicationDecisionService.ApproveAsync(
+            var result = model.Approved
+                ? await applicationDecisionService.ApproveAsync(
                     model.ApplicationId, currentUser.Id,
-                    model.DecisionNote, meetingDate);
-            }
-            else
-            {
-                result = await applicationDecisionService.RejectAsync(
+                    model.DecisionNote, meetingDate)
+                : await applicationDecisionService.RejectAsync(
                     model.ApplicationId, currentUser.Id,
                     model.DecisionNote ?? string.Empty, meetingDate);
-            }
 
             if (!result.Success)
             {

--- a/src/Humans.Web/Controllers/GovernanceController.cs
+++ b/src/Humans.Web/Controllers/GovernanceController.cs
@@ -1,9 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Users;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
-using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 


### PR DESCRIPTION
## Simplifications

- Collapsed duplicated approval/rejection email and notification dispatch blocks into shared private Governance service helpers.
- Inlined single-use private application snapshot and renewal reminder projection helpers.
- Simplified membership consent checks by removing pass-through awaits, redundant intermediate lists, and nested expired-consent branching.
- Rewrote membership team projection to avoid an anonymous/null-forgiving LINQ shape.
- Removed no-op repository wrapper awaits for scalar read methods and deleted an implementation-only divider comment.
- Cleaned local Governance controller using placement and simplified board-vote finalization branching/date parsing.

## Net line delta

- 171 insertions, 211 deletions, net -40 lines.

## Verification

- `dotnet build Humans.slnx -v quiet` (first successful build emitted baseline warmup warnings outside this diff; warm rerun was 0 warnings/0 errors)
- `dotnet test Humans.slnx -v quiet`

## Needs owner judgment

- Public Governance interfaces, DTOs/view models, controller actions/routes, and DI registrations were left unchanged.
- Governance EF entities/configurations/migrations and storage behavior were left untouched.
- Public-interface XML/divider comments were left in place because public surface cleanup is outside this pass.
- Architecture comments documenting DI-cycle breaks, no-caching decisions, finalization ordering, and cross-section support boundaries were kept because they preserve non-obvious design context.
- Larger private workflow boundaries such as `ApproveAsync`, `RejectAsync`, `StitchHistoryAsync`, `FinalizeAsync`, and membership partitioning logic were kept because further inlining would obscure behavior rather than simplify it.