### PR TITLE
refactor(expenses): code simplification pass — dead code, unused abstractions

### DIFF
--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -40,8 +40,6 @@ public sealed class ExpenseReportService(
     IOptions<TravelReimbursementConfig> travelConfig) : IExpenseReportService,
         IExpenseReportBackgroundProcessor, IUserDataContributor
 {
-    // Stored for future Holded Finance integration tasks (creditor status polling etc.).
-    private readonly IHoldedFinanceService _holdedFinance = holdedFinance;
     private readonly TravelReimbursementConfig _travel = travelConfig.Value;
 
     internal static string AttachmentKey(Guid id, string extension) =>
@@ -69,7 +67,7 @@ public sealed class ExpenseReportService(
                 RegisteredInHolded: false, OwedToMember: 0m, MemberRegisteredTotal: 0m,
                 OtherAmount: 0m, Paid: false, PaidOn: null, TotalPaid: 0m, Payments: []);
 
-        var status = await _holdedFinance.GetCreditorStatusAsync(
+        var status = await holdedFinance.GetCreditorStatusAsync(
             report.HoldedSupplierAccountNum, report.HoldedContactId, ct);
 
         var memberReports = await repo.GetForSubmitterAsync(report.SubmitterUserId, ct);
@@ -120,8 +118,8 @@ public sealed class ExpenseReportService(
         CancellationToken ct = default)
     {
         var attachment = owningReport.Lines
-            .Select(l => l.Attachment)
-            .FirstOrDefault(a => a?.Id == attachmentId);
+            .FirstOrDefault(l => l.Attachment?.Id == attachmentId)?
+            .Attachment;
         if (attachment is null) return null;
 
         var bytes = await fileStorage.TryReadAsync(
@@ -152,7 +150,7 @@ public sealed class ExpenseReportService(
 
         return year.Groups
             .SelectMany(g => g.Categories)
-            .Where(c => c.TeamId.HasValue && teamIds.Contains(c.TeamId.Value))
+            .Where(c => c.TeamId is { } teamId && teamIds.Contains(teamId))
             .Select(c => c.Id)
             .ToList();
     }
@@ -215,22 +213,15 @@ public sealed class ExpenseReportService(
         await repo.UpdateDraftAsync(updated, ct);
     }
 
-    public async Task<ExpenseMutationResult> UpdateDraftWithResultAsync(
+    public Task<ExpenseMutationResult> UpdateDraftWithResultAsync(
         Guid reportId, Guid submitterUserId,
         Guid budgetCategoryId, string? note,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             await UpdateDraftAsync(reportId, submitterUserId, budgetCategoryId, note, ct);
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error updating expense report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error updating expense report {ReportId}", null, reportId);
 
     internal async Task<Guid> AddLineAsync(
         Guid reportId, Guid submitterUserId,
@@ -253,29 +244,21 @@ public sealed class ExpenseReportService(
         return line.Id;
     }
 
-    public async Task<ExpenseMutationResult> AddLineWithResultAsync(
+    public Task<ExpenseMutationResult> AddLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.Receipt, ct);
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error adding line to report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error adding line to report {ReportId}", null, reportId);
 
-    public async Task<ExpenseMutationResult> AddMileageLineWithResultAsync(
+    public Task<ExpenseMutationResult> AddMileageLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string origin, string destination, decimal km,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var rate = _travel.MileageRatePerKm;
             var amount = Math.Round(km * rate, 2, MidpointRounding.AwayFromZero);
@@ -286,20 +269,13 @@ public sealed class ExpenseReportService(
                 $"€{amount.ToString("0.00", CultureInfo.InvariantCulture)}";
             await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.Mileage, ct);
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error adding mileage line to report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error adding mileage line to report {ReportId}", null, reportId);
 
-    public async Task<ExpenseMutationResult> AddPerDiemLineWithResultAsync(
+    public Task<ExpenseMutationResult> AddPerDiemLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         PerDiemKind kind, int days, string? note,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var rate = kind == PerDiemKind.Overnight ? _travel.PerDiemOvernightRate : _travel.PerDiemDayTripRate;
             var amount = Math.Round(days * rate, 2, MidpointRounding.AwayFromZero);
@@ -313,13 +289,7 @@ public sealed class ExpenseReportService(
                 description += $" — {note.Trim()}";
             await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.PerDiem, ct);
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error adding per-diem line to report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error adding per-diem line to report {ReportId}", null, reportId);
 
     internal async Task UpdateLineAsync(
         Guid reportId, Guid submitterUserId,
@@ -349,22 +319,15 @@ public sealed class ExpenseReportService(
         if (!ok) throw new InvalidOperationException("Failed to update line.");
     }
 
-    public async Task<ExpenseMutationResult> UpdateLineWithResultAsync(
+    public Task<ExpenseMutationResult> UpdateLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         Guid lineId, string description, decimal amount,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             await UpdateLineAsync(reportId, submitterUserId, lineId, description, amount, ct);
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error updating line {LineId} on report {ReportId}", lineId, reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error updating line {LineId} on report {ReportId}", null, lineId, reportId);
 
     internal async Task RemoveLineAsync(
         Guid reportId, Guid submitterUserId, Guid lineId,
@@ -395,23 +358,15 @@ public sealed class ExpenseReportService(
         if (!ok) throw new InvalidOperationException("Failed to remove line.");
     }
 
-    public async Task<ExpenseMutationResult> RemoveLineWithResultAsync(
+    public Task<ExpenseMutationResult> RemoveLineWithResultAsync(
         Guid reportId, Guid submitterUserId, Guid lineId,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             await RemoveLineAsync(reportId, submitterUserId, lineId, ct);
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error removing line {LineId} from report {ReportId}", lineId, reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error removing line {LineId} from report {ReportId}", null, lineId, reportId);
 
-    /// <summary>Max attachment size validated at the service layer (20 MB).</summary>
     private const long AttachmentMaxBytes = 20 * 1024 * 1024;
 
     private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
@@ -463,22 +418,15 @@ public sealed class ExpenseReportService(
         return attachmentId;
     }
 
-    public async Task<ExpenseMutationResult> AttachFileToLineWithResultAsync(
+    public Task<ExpenseMutationResult> AttachFileToLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         Guid lineId, string originalFileName, string contentType,
-        Stream content, CancellationToken ct = default)
-    {
-        try
+        Stream content, CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             await AttachFileToLineAsync(reportId, submitterUserId, lineId, originalFileName, contentType, content, ct);
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error uploading attachment to line {LineId} on report {ReportId}", lineId, reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error uploading attachment to line {LineId} on report {ReportId}", null, lineId, reportId);
 
     public async Task RemoveAttachmentFromLineAsync(
         Guid reportId, Guid submitterUserId,
@@ -539,11 +487,10 @@ public sealed class ExpenseReportService(
         {
             throw new InvalidOperationException("Submitter must have first and last name set on their profile.");
         }
-        var payeeName = legalName;
         var payeeIban = profile.Iban;
 
         var now = clock.GetCurrentInstant();
-        var ok = await repo.SubmitAsync(reportId, payeeName, payeeIban, now, ct);
+        var ok = await repo.SubmitAsync(reportId, legalName, payeeIban, now, ct);
         if (!ok) return false;
 
         await auditLogService.LogAsync(
@@ -555,22 +502,15 @@ public sealed class ExpenseReportService(
         return true;
     }
 
-    public async Task<ExpenseMutationResult> SubmitWithResultAsync(
-        Guid reportId, Guid submitterUserId, CancellationToken ct = default)
-    {
-        try
+    public Task<ExpenseMutationResult> SubmitWithResultAsync(
+        Guid reportId, Guid submitterUserId, CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var submitted = await SubmitAsync(reportId, submitterUserId, ct);
             return submitted
                 ? ExpenseMutationResult.Success
                 : ExpenseMutationResult.Failure("Could not submit the report. Receipt lines need an attachment and your payment IBAN must be set.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error submitting expense report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure($"Submission failed: {ex.Message}");
-        }
-    }
+        }, "Error submitting expense report {ReportId}", "Submission failed", reportId);
 
     internal async Task<bool> WithdrawAsync(
         Guid reportId, Guid submitterUserId, CancellationToken ct = default)
@@ -592,22 +532,15 @@ public sealed class ExpenseReportService(
 
         return true;
     }
-    public async Task<ExpenseMutationResult> WithdrawWithResultAsync(
-        Guid reportId, Guid submitterUserId, CancellationToken ct = default)
-    {
-        try
+    public Task<ExpenseMutationResult> WithdrawWithResultAsync(
+        Guid reportId, Guid submitterUserId, CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var withdrawn = await WithdrawAsync(reportId, submitterUserId, ct);
             return withdrawn
                 ? ExpenseMutationResult.Success
                 : ExpenseMutationResult.Failure("Could not withdraw this report.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error withdrawing expense report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure($"Withdrawal failed: {ex.Message}");
-        }
-    }
+        }, "Error withdrawing expense report {ReportId}", "Withdrawal failed", reportId);
 
     public async Task<ExpenseIbanSaveResult> SaveSubmitterIbanWithResultAsync(
         Guid submitterUserId, string? iban, CancellationToken ct = default)
@@ -652,6 +585,25 @@ public sealed class ExpenseReportService(
     private static ExpenseIbanSaveResult IbanFailure(string message, bool isValidationError) =>
         new(Succeeded: false, IsValidationError: isValidationError, Message: message);
 
+    private async Task<ExpenseMutationResult> RunMutationAsync(
+        Func<Task<ExpenseMutationResult>> mutation,
+        string logMessage,
+        string? exceptionPrefix,
+        params object?[] logArgs)
+    {
+        try
+        {
+            return await mutation();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, logMessage, logArgs);
+            return ExpenseMutationResult.Failure(exceptionPrefix is null
+                ? ex.Message
+                : $"{exceptionPrefix}: {ex.Message}");
+        }
+    }
+
     internal async Task<bool> CoordinatorEndorseAsync(
         Guid reportId, Guid coordinatorUserId, CancellationToken ct = default)
     {
@@ -673,22 +625,15 @@ public sealed class ExpenseReportService(
         return true;
     }
 
-    public async Task<ExpenseMutationResult> CoordinatorEndorseWithResultAsync(
-        Guid reportId, Guid coordinatorUserId, CancellationToken ct = default)
-    {
-        try
+    public Task<ExpenseMutationResult> CoordinatorEndorseWithResultAsync(
+        Guid reportId, Guid coordinatorUserId, CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var endorsed = await CoordinatorEndorseAsync(reportId, coordinatorUserId, ct);
             return endorsed
                 ? ExpenseMutationResult.Success
                 : ExpenseMutationResult.Failure("Could not endorse the report. It may no longer be in Submitted status.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error endorsing expense report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure($"Endorsement failed: {ex.Message}");
-        }
-    }
+        }, "Error endorsing expense report {ReportId}", "Endorsement failed", reportId);
 
     internal async Task<bool> CoordinatorRejectAsync(
         Guid reportId, Guid coordinatorUserId, string reason,
@@ -712,23 +657,16 @@ public sealed class ExpenseReportService(
         return true;
     }
 
-    public async Task<ExpenseMutationResult> CoordinatorRejectWithResultAsync(
+    public Task<ExpenseMutationResult> CoordinatorRejectWithResultAsync(
         Guid reportId, Guid coordinatorUserId, string reason,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var rejected = await CoordinatorRejectAsync(reportId, coordinatorUserId, reason, ct);
             return rejected
                 ? ExpenseMutationResult.Success
                 : ExpenseMutationResult.Failure("Could not reject the report. It may no longer be in Submitted status.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error coordinator-rejecting expense report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure($"Rejection failed: {ex.Message}");
-        }
-    }
+        }, "Error coordinator-rejecting expense report {ReportId}", "Rejection failed", reportId);
 
     internal async Task<bool> ApproveAsync(
         Guid reportId, Guid actorUserId, Guid? overrideCategoryId,
@@ -760,23 +698,16 @@ public sealed class ExpenseReportService(
         return true;
     }
 
-    public async Task<ExpenseMutationResult> ApproveWithResultAsync(
+    public Task<ExpenseMutationResult> ApproveWithResultAsync(
         Guid reportId, Guid actorUserId, Guid? overrideCategoryId,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var approved = await ApproveAsync(reportId, actorUserId, overrideCategoryId, ct);
             return approved
                 ? ExpenseMutationResult.Success
                 : ExpenseMutationResult.Failure("Could not approve the report. It may not be in an approvable status.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error approving expense report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure($"Approval failed: {ex.Message}");
-        }
-    }
+        }, "Error approving expense report {ReportId}", "Approval failed", reportId);
 
     internal async Task<bool> FinanceRejectAsync(
         Guid reportId, Guid actorUserId, string reason,
@@ -798,23 +729,16 @@ public sealed class ExpenseReportService(
         return true;
     }
 
-    public async Task<ExpenseMutationResult> FinanceRejectWithResultAsync(
+    public Task<ExpenseMutationResult> FinanceRejectWithResultAsync(
         Guid reportId, Guid actorUserId, string reason,
-        CancellationToken ct = default)
-    {
-        try
+        CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var rejected = await FinanceRejectAsync(reportId, actorUserId, reason, ct);
             return rejected
                 ? ExpenseMutationResult.Success
                 : ExpenseMutationResult.Failure("Could not reject the report. It may not be in a rejectable status.");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error finance-rejecting expense report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure($"Rejection failed: {ex.Message}");
-        }
-    }
+        }, "Error finance-rejecting expense report {ReportId}", "Rejection failed", reportId);
 
     public async Task<IReadOnlyList<Guid>> MarkSepaSentAsync(
         IReadOnlyCollection<Guid> reportIds, Guid actorUserId,
@@ -838,10 +762,9 @@ public sealed class ExpenseReportService(
         return flippedIds;
     }
 
-    public async Task<ExpenseMutationResult> ReopenSepaWithResultAsync(
-        Guid reportId, Guid actorUserId, CancellationToken ct = default)
-    {
-        try
+    public Task<ExpenseMutationResult> ReopenSepaWithResultAsync(
+        Guid reportId, Guid actorUserId, CancellationToken ct = default) =>
+        RunMutationAsync(async () =>
         {
             var now = clock.GetCurrentInstant();
             var ok = await repo.ReopenSepaAsync(reportId, now, ct);
@@ -858,13 +781,7 @@ public sealed class ExpenseReportService(
                 actorUserId);
 
             return ExpenseMutationResult.Success;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error reopening SEPA for report {ReportId}", reportId);
-            return ExpenseMutationResult.Failure(ex.Message);
-        }
-    }
+        }, "Error reopening SEPA for report {ReportId}", null, reportId);
 
     internal async Task<bool> MarkPaidAsync(
         Guid reportId, Instant paidAt, CancellationToken ct = default)
@@ -881,11 +798,9 @@ public sealed class ExpenseReportService(
         return true;
     }
 
-    /// <summary>True iff the category has at least one budget coordinator.</summary>
     internal async Task<bool> CategoryRequiresCoordinatorEndorsementAsync(
         Guid categoryId, CancellationToken ct = default)
     {
-        // True iff category's team has ≥1 active Coordinator (cache hit, no DB).
         var category = await budgetService.GetCategoryByIdAsync(categoryId);
         if (category is null || category.TeamId is null)
             return false;
@@ -936,7 +851,15 @@ public sealed class ExpenseReportService(
                 }
 
                 var category = await budgetService.GetCategoryByIdAsync(report.BudgetCategoryId);
-                var tag = BuildHoldedTag(category?.BudgetGroup?.Name, category?.Name);
+                var groupName = category?.BudgetGroup?.Name;
+                var categoryName = category?.Name;
+                var groupSlug = string.IsNullOrWhiteSpace(groupName)
+                    ? "unknown"
+                    : SlugHelper.GenerateSlug(groupName);
+                var categorySlug = string.IsNullOrWhiteSpace(categoryName)
+                    ? "unknown"
+                    : SlugHelper.GenerateSlug(categoryName);
+                var tag = $"{groupSlug}-{categorySlug}";
 
                 var submitterName = string.IsNullOrWhiteSpace(report.PayeeName)
                     ? "Unknown"
@@ -952,8 +875,11 @@ public sealed class ExpenseReportService(
                         break;
 
                     case HoldedExpenseOutboxEventType.UpdateIncomingDocTag:
-                        await ProcessHoldedUpdateTagAsync(
-                            outboxEvent.Id, report, tag, now, ct);
+                        await holdedClient.UpdatePurchaseDocumentTagsAsync(
+                            report.HoldedDocId!,
+                            [tag],
+                            ct);
+                        await repo.MarkOutboxProcessedAsync(outboxEvent.Id, now, ct);
                         break;
 
                     default:
@@ -1017,7 +943,7 @@ public sealed class ExpenseReportService(
                             report.Id, report.HoldedContactId, accountNum, clock.GetCurrentInstant(), ct);
                 }
 
-                var status = await _holdedFinance.GetCreditorStatusAsync(
+                var status = await holdedFinance.GetCreditorStatusAsync(
                     accountNum, report.HoldedContactId, ct);
                 if (status is null) continue;
 
@@ -1174,33 +1100,6 @@ public sealed class ExpenseReportService(
         }, ct);
     }
 
-    private async Task ProcessHoldedUpdateTagAsync(
-        Guid outboxEventId,
-        ExpenseReportDto report,
-        string tag,
-        Instant now,
-        CancellationToken ct)
-    {
-        await holdedClient.UpdatePurchaseDocumentTagsAsync(
-            report.HoldedDocId!,
-            [tag],
-            ct);
-
-        await repo.MarkOutboxProcessedAsync(outboxEventId, now, ct);
-    }
-
-    private static string BuildHoldedTag(string? groupName, string? categoryName)
-    {
-        var groupSlug = string.IsNullOrWhiteSpace(groupName)
-            ? "unknown"
-            : SlugHelper.GenerateSlug(groupName);
-        var categorySlug = string.IsNullOrWhiteSpace(categoryName)
-            ? "unknown"
-            : SlugHelper.GenerateSlug(categoryName);
-        return $"{groupSlug}-{categorySlug}";
-    }
-
-    /// <summary>Loads report; enforces submitter + editable state (Draft/Submitted/CoordinatorEndorsed).</summary>
     private async Task<ExpenseReportDto> RequireEditableReportAsync(
         Guid reportId, Guid submitterUserId, CancellationToken ct)
     {
@@ -1215,10 +1114,6 @@ public sealed class ExpenseReportService(
         return report;
     }
 
-    /// <summary>
-    /// Checks the actor is a coordinator of the team that owns the category.
-    /// Throws <see cref="UnauthorizedAccessException"/> if not.
-    /// </summary>
     private async Task RequireCoordinatorForCategoryAsync(
         Guid categoryId, Guid actorUserId, CancellationToken ct)
     {

--- a/src/Humans.Infrastructure/Repositories/Expenses/ExpenseReportMapper.cs
+++ b/src/Humans.Infrastructure/Repositories/Expenses/ExpenseReportMapper.cs
@@ -3,10 +3,6 @@ using Humans.Domain.Entities;
 
 namespace Humans.Infrastructure.Repositories.Expenses;
 
-/// <summary>
-/// Static projection helpers that map EF entities to DTOs.
-/// Lives in Infrastructure (which owns EF) so the Application layer stays clean.
-/// </summary>
 internal static class ExpenseReportMapper
 {
     internal static ExpenseReportDto ToDto(ExpenseReport r) => new()
@@ -35,29 +31,27 @@ internal static class ExpenseReportMapper
         HoldedSupplierAccountNum = r.HoldedSupplierAccountNum,
         CreatedAt = r.CreatedAt,
         UpdatedAt = r.UpdatedAt,
-        Lines = r.Lines.Select(ToLineDto).ToList()
-    };
-
-    internal static ExpenseLineDto ToLineDto(ExpenseLine l) => new()
-    {
-        Id = l.Id,
-        ExpenseReportId = l.ExpenseReportId,
-        Description = l.Description,
-        Amount = l.Amount,
-        LineType = l.LineType,
-        AttachmentId = l.AttachmentId,
-        Attachment = l.Attachment is null ? null : ToAttachmentDto(l.Attachment),
-        SortOrder = l.SortOrder
-    };
-
-    internal static ExpenseAttachmentDto ToAttachmentDto(ExpenseAttachment a) => new()
-    {
-        Id = a.Id,
-        OriginalFileName = a.OriginalFileName,
-        Extension = a.Extension,
-        ContentType = a.ContentType,
-        SizeBytes = a.SizeBytes,
-        UploadedByUserId = a.UploadedByUserId,
-        UploadedAt = a.UploadedAt
+        Lines = r.Lines.Select(l => new ExpenseLineDto
+        {
+            Id = l.Id,
+            ExpenseReportId = l.ExpenseReportId,
+            Description = l.Description,
+            Amount = l.Amount,
+            LineType = l.LineType,
+            AttachmentId = l.AttachmentId,
+            Attachment = l.Attachment is null
+                ? null
+                : new ExpenseAttachmentDto
+                {
+                    Id = l.Attachment.Id,
+                    OriginalFileName = l.Attachment.OriginalFileName,
+                    Extension = l.Attachment.Extension,
+                    ContentType = l.Attachment.ContentType,
+                    SizeBytes = l.Attachment.SizeBytes,
+                    UploadedByUserId = l.Attachment.UploadedByUserId,
+                    UploadedAt = l.Attachment.UploadedAt
+                },
+            SortOrder = l.SortOrder
+        }).ToList()
     };
 }

--- a/src/Humans.Web/Authorization/Requirements/ExpenseReportAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/ExpenseReportAuthorizationHandler.cs
@@ -21,40 +21,27 @@ public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetServi
         ExpenseReportOperationRequirement requirement,
         ExpenseReportDto resource)
     {
-        var userId = GetUserId(context.User);
-        if (userId is null)
+        if (!Guid.TryParse(context.User.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
             return;
 
         var op = requirement.Operation;
         var isFinanceAdmin = RoleChecks.IsFinanceAdmin(context.User); // includes Admin
-        var isSubmitter = resource.SubmitterUserId == userId.Value;
+        var isSubmitter = resource.SubmitterUserId == userId;
 
-        // ─── FinanceAdmin + Admin: broad access ────────────────────────────────
-        // Per docs/sections/Expenses.md actors table, FinanceAdmin has all coordinator
-        // capabilities (Endorse, CoordinatorReject — gated to Submitted) plus the
-        // finance-only operations. Admin is a superset of FinanceAdmin.
-        if (isFinanceAdmin)
-        {
-            if (op is ExpenseReportOperation.View
+        if (isFinanceAdmin
+            && (op is ExpenseReportOperation.View
                     or ExpenseReportOperation.Approve
                     or ExpenseReportOperation.FinanceReject
                     or ExpenseReportOperation.CategoryOverride
                     or ExpenseReportOperation.IncludeInSepaPayout
-                    or ExpenseReportOperation.ReopenSepa)
-            {
-                context.Succeed(requirement);
-                return;
-            }
-
-            if (op is ExpenseReportOperation.Endorse or ExpenseReportOperation.CoordinatorReject
-                && resource.Status == ExpenseReportStatus.Submitted)
-            {
-                context.Succeed(requirement);
-                return;
-            }
+                    or ExpenseReportOperation.ReopenSepa
+                || (op is ExpenseReportOperation.Endorse or ExpenseReportOperation.CoordinatorReject
+                    && resource.Status == ExpenseReportStatus.Submitted)))
+        {
+            context.Succeed(requirement);
+            return;
         }
 
-        // ─── Submitter rules ───────────────────────────────────────────────────
         if (isSubmitter)
         {
             if (op == ExpenseReportOperation.View)
@@ -63,9 +50,6 @@ public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetServi
                 return;
             }
 
-            // Submitter can only edit (header + lines) while in Draft.
-            // Lines are frozen at submission — ExpenseReportService.RequireEditableReportAsync
-            // enforces this, and the Edit GET/POST controllers also restrict to Draft.
             if (op == ExpenseReportOperation.Edit &&
                 resource.Status == ExpenseReportStatus.Draft)
             {
@@ -80,9 +64,6 @@ public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetServi
                 return;
             }
 
-            // Submitter can withdraw from any non-terminal post-Draft status.
-            // Per docs/sections/Expenses.md invariant: terminal alternates include
-            // Withdrawn from Submitted/CoordinatorEndorsed/Approved.
             if (op == ExpenseReportOperation.Withdraw &&
                 resource.Status is ExpenseReportStatus.Submitted
                     or ExpenseReportStatus.CoordinatorEndorsed
@@ -93,36 +74,16 @@ public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetServi
             }
         }
 
-        // ─── Coordinator checks (require async lookups) ────────────────────────
-        // Only relevant for Endorse, CoordinatorReject, or View
-        if (op is ExpenseReportOperation.Endorse
+        if ((op is ExpenseReportOperation.Endorse
                 or ExpenseReportOperation.CoordinatorReject
                 or ExpenseReportOperation.View)
+            && await IsCoordinatorOfReportCategoryAsync(userId, resource)
+            && (op == ExpenseReportOperation.View || resource.Status == ExpenseReportStatus.Submitted))
         {
-            if (await IsCoordinatorOfReportCategoryAsync(userId.Value, resource))
-            {
-                // Coordinator may view any report in their category
-                if (op == ExpenseReportOperation.View)
-                {
-                    context.Succeed(requirement);
-                    return;
-                }
-
-                // Coordinator may endorse/reject only while in Submitted status
-                if (op is ExpenseReportOperation.Endorse or ExpenseReportOperation.CoordinatorReject
-                    && resource.Status == ExpenseReportStatus.Submitted)
-                {
-                    context.Succeed(requirement);
-                }
-            }
+            context.Succeed(requirement);
         }
     }
 
-    /// <summary>
-    /// Returns true iff the user is a coordinator of the team that owns the
-    /// report's budget category. Returns false if the category has no team,
-    /// or if the team lookup fails.
-    /// </summary>
     private async Task<bool> IsCoordinatorOfReportCategoryAsync(Guid userId, ExpenseReportDto report)
     {
         var category = await budgetService.GetCategoryByIdAsync(report.BudgetCategoryId);
@@ -131,12 +92,5 @@ public sealed class ExpenseReportAuthorizationHandler(IBudgetService budgetServi
 
         var teamsById = await teamService.GetTeamsAsync();
         return TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, category.TeamId.Value, userId);
-    }
-
-    private static Guid? GetUserId(ClaimsPrincipal user)
-    {
-        var claim = user.FindFirst(ClaimTypes.NameIdentifier);
-        if (claim is null) return null;
-        return Guid.TryParse(claim.Value, out var id) ? id : null;
     }
 }

--- a/src/Humans.Web/Authorization/Requirements/IbanAccessHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/IbanAccessHandler.cs
@@ -21,41 +21,29 @@ public sealed class IbanAccessHandler(IExpenseReportServiceRead expenseReports)
         AuthorizationHandlerContext context,
         IbanAccessRequirement requirement)
     {
-        var userId = GetUserId(context.User);
-        if (userId is null)
+        if (!Guid.TryParse(context.User.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
             return;
 
-        // Self access: the requester is the IBAN owner
-        if (userId.Value == requirement.TargetUserId)
+        if (userId == requirement.TargetUserId)
         {
             context.Succeed(requirement);
             return;
         }
 
-        // Admin on admin page (e.g. /Admin/Users/{id} with Reveal IBAN action)
         if (requirement.IsAdminPageContext && RoleChecks.IsAdmin(context.User))
         {
             context.Succeed(requirement);
             return;
         }
 
-        // FinanceAdmin in a report context: allowed only if the report exists
-        // and is neither Draft nor Withdrawn
-        if (requirement.ReportId.HasValue && RoleChecks.IsFinanceAdmin(context.User))
+        if (requirement.ReportId is { } reportId && RoleChecks.IsFinanceAdmin(context.User))
         {
-            var report = await expenseReports.GetAsync(requirement.ReportId.Value);
+            var report = await expenseReports.GetAsync(reportId);
             if (report is not null &&
                 report.Status is not ExpenseReportStatus.Draft and not ExpenseReportStatus.Withdrawn)
             {
                 context.Succeed(requirement);
             }
         }
-    }
-
-    private static Guid? GetUserId(ClaimsPrincipal user)
-    {
-        var claim = user.FindFirst(ClaimTypes.NameIdentifier);
-        if (claim is null) return null;
-        return Guid.TryParse(claim.Value, out var id) ? id : null;
     }
 }

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -235,8 +235,7 @@ public sealed class ExpensesController(
             if (report is null) return NotFound();
             if (report.SubmitterUserId != user.Id) return Forbid();
 
-            var editableStatuses = new[] { ExpenseReportStatus.Draft };
-            if (!editableStatuses.Contains(report.Status))
+            if (report.Status != ExpenseReportStatus.Draft)
             {
                 SetError("This report can no longer be edited.");
                 return RedirectToAction(nameof(Detail), new { id });
@@ -305,10 +304,7 @@ public sealed class ExpensesController(
         }
 
         var result = await service.AddLineWithResultAsync(id, user.Id, input.Description, input.Amount);
-        if (!result.Succeeded)
-            SetError($"Failed to add line: {result.ErrorMessage}");
-        else
-            SetSuccess("Line added.");
+        SetMutationResultWithDetails(result, "Line added.", "Failed to add line");
 
         return RedirectToAction(nameof(Edit), new { id });
     }
@@ -332,10 +328,7 @@ public sealed class ExpensesController(
 
         var result = await service.AddMileageLineWithResultAsync(
             id, user.Id, input.Origin, input.Destination, input.Km);
-        if (!result.Succeeded)
-            SetError($"Failed to add mileage line: {result.ErrorMessage}");
-        else
-            SetSuccess("Mileage line added.");
+        SetMutationResultWithDetails(result, "Mileage line added.", "Failed to add mileage line");
 
         return RedirectToAction(nameof(Edit), new { id });
     }
@@ -359,10 +352,7 @@ public sealed class ExpensesController(
 
         var result = await service.AddPerDiemLineWithResultAsync(
             id, user.Id, input.Kind, input.Days, input.Note);
-        if (!result.Succeeded)
-            SetError($"Failed to add per-diem line: {result.ErrorMessage}");
-        else
-            SetSuccess("Per-diem line added.");
+        SetMutationResultWithDetails(result, "Per-diem line added.", "Failed to add per-diem line");
 
         return RedirectToAction(nameof(Edit), new { id });
     }
@@ -385,10 +375,7 @@ public sealed class ExpensesController(
         }
 
         var result = await service.UpdateLineWithResultAsync(id, user.Id, input.LineId, input.Description, input.Amount);
-        if (!result.Succeeded)
-            SetError($"Failed to update line: {result.ErrorMessage}");
-        else
-            SetSuccess("Line updated.");
+        SetMutationResultWithDetails(result, "Line updated.", "Failed to update line");
 
         return RedirectToAction(nameof(Edit), new { id });
     }
@@ -405,10 +392,7 @@ public sealed class ExpensesController(
         if (report.SubmitterUserId != user.Id) return Forbid();
 
         var result = await service.RemoveLineWithResultAsync(id, user.Id, lineId);
-        if (!result.Succeeded)
-            SetError($"Failed to remove line: {result.ErrorMessage}");
-        else
-            SetSuccess("Line removed.");
+        SetMutationResultWithDetails(result, "Line removed.", "Failed to remove line");
 
         return RedirectToAction(nameof(Edit), new { id });
     }
@@ -435,10 +419,7 @@ public sealed class ExpensesController(
         var result = await service.AttachFileToLineWithResultAsync(
             id, user.Id, lineId, file.FileName, file.ContentType, stream);
 
-        if (result.Succeeded)
-            SetSuccess("Attachment uploaded.");
-        else
-            SetError(result.ErrorMessage ?? "Failed to upload attachment.");
+        SetMutationResult(result, "Attachment uploaded.", "Failed to upload attachment.");
 
         return RedirectToAction(nameof(Edit), new { id });
     }
@@ -479,10 +460,7 @@ public sealed class ExpensesController(
         if (report.SubmitterUserId != user.Id) return Forbid();
 
         var result = await service.SubmitWithResultAsync(id, user.Id);
-        if (result.Succeeded)
-            SetSuccess("Report submitted.");
-        else
-            SetError(result.ErrorMessage ?? "Could not submit the report.");
+        SetMutationResult(result, "Report submitted.", "Could not submit the report.");
 
         return RedirectToAction(nameof(Detail), new { id });
     }
@@ -496,11 +474,10 @@ public sealed class ExpensesController(
 
         var report = await expenseReadService.GetAsync(id);
         if (report is null) return NotFound();
-        if (report.SubmitterUserId != user.Id) return Forbid(); var result = await service.WithdrawWithResultAsync(id, user.Id);
-        if (result.Succeeded)
-            SetSuccess("Report withdrawn.");
-        else
-            SetError(result.ErrorMessage ?? "Could not withdraw this report.");
+        if (report.SubmitterUserId != user.Id) return Forbid();
+
+        var result = await service.WithdrawWithResultAsync(id, user.Id);
+        SetMutationResult(result, "Report withdrawn.", "Could not withdraw this report.");
         return RedirectToAction(nameof(Detail), new { id });
     }
 
@@ -626,10 +603,7 @@ public sealed class ExpensesController(
         if (!authResult.Succeeded) return Forbid();
 
         var result = await service.CoordinatorEndorseWithResultAsync(id, user.Id);
-        if (result.Succeeded)
-            SetSuccess("Report endorsed.");
-        else
-            SetError(result.ErrorMessage ?? "Could not endorse the report.");
+        SetMutationResult(result, "Report endorsed.", "Could not endorse the report.");
 
         return RedirectToAction(nameof(Coordinator));
     }
@@ -655,10 +629,7 @@ public sealed class ExpensesController(
         }
 
         var result = await service.CoordinatorRejectWithResultAsync(id, user.Id, input.Reason);
-        if (result.Succeeded)
-            SetSuccess("Report rejected.");
-        else
-            SetError(result.ErrorMessage ?? "Could not reject the report.");
+        SetMutationResult(result, "Report rejected.", "Could not reject the report.");
 
         return RedirectToAction(nameof(Coordinator));
     }
@@ -697,10 +668,7 @@ public sealed class ExpensesController(
         if (!authResult.Succeeded) return Forbid();
 
         var result = await service.ApproveWithResultAsync(id, user.Id, input.OverrideCategoryId);
-        if (result.Succeeded)
-            SetSuccess("Report approved.");
-        else
-            SetError(result.ErrorMessage ?? "Could not approve the report.");
+        SetMutationResult(result, "Report approved.", "Could not approve the report.");
 
         return RedirectToAction(nameof(Review));
     }
@@ -727,10 +695,7 @@ public sealed class ExpensesController(
         }
 
         var result = await service.FinanceRejectWithResultAsync(id, user.Id, input.Reason);
-        if (result.Succeeded)
-            SetSuccess("Report rejected.");
-        else
-            SetError(result.ErrorMessage ?? "Could not reject the report.");
+        SetMutationResult(result, "Report rejected.", "Could not reject the report.");
 
         return RedirectToAction(nameof(Review));
     }
@@ -777,7 +742,32 @@ public sealed class ExpensesController(
 
         try
         {
-            return await ExecuteSepaGenerateAsync(ids, user.Id, ct);
+            var eligible = await ResolveEligibleForSepaAsync(ids, ct);
+            if (eligible.Count == 0)
+            {
+                SetError("None of the selected reports could be included in the SEPA payout. Reports must be in Approved status.");
+                return RedirectToAction(nameof(Review));
+            }
+
+            // XML before flip so failure at either step leaves a retry-safe state.
+            var now = clock.GetCurrentInstant();
+            var xml = sepaBuilder.BuildPain001(sepaConfig.Value, now, eligible);
+
+            var flippedIds = await service.MarkSepaSentAsync(
+                eligible.Select(r => r.Id).ToList(), user.Id, ct);
+            if (flippedIds.Count == 0)
+            {
+                SetError("No reports were transitioned to SEPA Sent. They may have already been processed.");
+                return RedirectToAction(nameof(Review));
+            }
+
+            var fileName = $"sepa-{now.ToDateTimeUtc().ToFileTimestamp()}.xml";
+
+            logger.LogInformation(
+                "SEPA pain.001 generated by {UserId}: {EligibleCount} eligible, {FlippedCount} flipped to SepaSent",
+                user.Id, eligible.Count, flippedIds.Count);
+
+            return File(Encoding.UTF8.GetBytes(xml), "application/xml", fileName);
         }
         catch (Exception ex)
         {
@@ -785,37 +775,6 @@ public sealed class ExpensesController(
             SetError("Failed to generate SEPA file.");
             return RedirectToAction(nameof(Review));
         }
-    }
-
-    private async Task<IActionResult> ExecuteSepaGenerateAsync(
-        List<Guid> ids, Guid actorUserId, CancellationToken ct)
-    {
-        var eligible = await ResolveEligibleForSepaAsync(ids, ct);
-        if (eligible.Count == 0)
-        {
-            SetError("None of the selected reports could be included in the SEPA payout. Reports must be in Approved status.");
-            return RedirectToAction(nameof(Review));
-        }
-
-        // XML before flip so failure at either step leaves a retry-safe state.
-        var now = clock.GetCurrentInstant();
-        var xml = sepaBuilder.BuildPain001(sepaConfig.Value, now, eligible);
-
-        var flippedIds = await service.MarkSepaSentAsync(
-            eligible.Select(r => r.Id).ToList(), actorUserId, ct);
-        if (flippedIds.Count == 0)
-        {
-            SetError("No reports were transitioned to SEPA Sent. They may have already been processed.");
-            return RedirectToAction(nameof(Review));
-        }
-
-        var fileName = $"sepa-{now.ToDateTimeUtc().ToFileTimestamp()}.xml";
-
-        logger.LogInformation(
-            "SEPA pain.001 generated by {UserId}: {EligibleCount} eligible, {FlippedCount} flipped to SepaSent",
-            actorUserId, eligible.Count, flippedIds.Count);
-
-        return File(Encoding.UTF8.GetBytes(xml), "application/xml", fileName);
     }
 
     private async Task<List<ExpenseReportDto>> ResolveEligibleForSepaAsync(
@@ -867,6 +826,24 @@ public sealed class ExpensesController(
                 .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
                 .Select(c => new BudgetCategoryOption(c.Id, g.Name, c.Name)))
             .ToList();
+    }
+
+    private void SetMutationResult(
+        ExpenseMutationResult result, string successMessage, string fallbackErrorMessage)
+    {
+        if (result.Succeeded)
+            SetSuccess(successMessage);
+        else
+            SetError(result.ErrorMessage ?? fallbackErrorMessage);
+    }
+
+    private void SetMutationResultWithDetails(
+        ExpenseMutationResult result, string successMessage, string errorPrefix)
+    {
+        if (result.Succeeded)
+            SetSuccess(successMessage);
+        else
+            SetError(result.ErrorMessage is null ? errorPrefix : $"{errorPrefix}: {result.ErrorMessage}");
     }
 
     private async Task<(bool HasIban, string? MaskedIban)> GetIbanViewAsync(Guid userId)

--- a/src/Humans.Web/Extensions/Sections/ExpensesSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ExpensesSectionExtensions.cs
@@ -15,7 +15,6 @@ internal static class ExpensesSectionExtensions
         this IServiceCollection services, IConfiguration config)
     {
         services.AddSingleton<IExpenseRepository, ExpenseRepository>();
-        // Register each Expenses surface against the same scoped orchestrator instance.
         services.AddScoped<ExpensesExpenseReportService>();
         services.AddScoped<IExpenseReportServiceRead>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
         services.AddScoped<IExpenseReportService>(sp => sp.GetRequiredService<ExpensesExpenseReportService>());
@@ -24,7 +23,6 @@ internal static class ExpensesSectionExtensions
         services.AddScoped<HoldedExpenseOutboxJob>();
         services.AddScoped<ExpensePaidPollingJob>();
 
-        // SEPA config — bind from appsettings "Sepa" section; allow IBAN override via env var.
         services.Configure<SepaConfig>(opts =>
         {
             config.GetSection("Sepa").Bind(opts);
@@ -34,7 +32,6 @@ internal static class ExpensesSectionExtensions
         });
         services.AddSingleton<ISepaPaymentFileBuilder, SepaPaymentFileBuilder>();
 
-        // Travel-reimbursement rates — bind from appsettings "TravelReimbursement"; defaults are the 2026 values.
         services.Configure<TravelReimbursementConfig>(config.GetSection("TravelReimbursement"));
 
         return services;


### PR DESCRIPTION
## Categorized simplifications

- Dead/private code and comments: removed stale Holded finance storage, obsolete mapper/helper comments, DI narration, private authorization/user-id helpers, and small single-caller Holded helpers.
- Repeated private logic: centralized expense mutation result logging/error handling in `RunMutationAsync`; centralized controller mutation flash handling.
- Conditionals and lookups: simplified attachment lookup, coordinator category filtering, draft edit status checks, authorization role/status checks, and IBAN report-id handling.
- Private projection/indirection: inlined single-use mapper projections and the single-use SEPA generate wrapper while keeping public actions/routes unchanged.

Net line delta: -195 lines (195 insertions, 390 deletions).

Gate:
- `dotnet build Humans.slnx -v quiet` (warm rerun: 0 warnings, 0 errors)
- `dotnet test Humans.slnx -v quiet`

## Needs owner judgment

- Public Expenses interfaces, DTOs/view models, controller routes/actions, and DI registrations were left unchanged.
- EF entities/configurations/migrations/storage were left untouched.
- Kept `ResolveEligibleForSepaAsync` and `IsCoordinatorOfReportCategoryAsync` even though each has one caller; inlining would make the controller/action policy flow harder to scan or risk controller analyzer churn.
- Kept the larger Holded create/upsert workflow helpers and explanatory comments around idempotency, supplier-account backfill, creditor balance settlement, and legal-name/IBAN handling because they document external API invariants.
- Kept SEPA XML builder private XML helpers because inlining the XML construction would make the banking payload harder to audit.
- Solution-wide baseline analyzer warnings remain outside Expenses scope; the required warm build rerun is clean.