### PR TITLE
fix(store,infra): pre-prod review findings — pending-payment double-charge guard, external health checks, reconciliation pending status, log sink hardening

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -26,7 +26,8 @@ public record StoreRecordedStripePayment(
     string PaymentIntentId,
     Guid OrderId,
     decimal AmountEur,
-    Instant ReceivedAt);
+    Instant ReceivedAt,
+    StorePaymentStatus Status);
 
 /// <summary>
 /// Repository for the Store section's tables: <c>store_products</c>,

--- a/src/Humans.Application/Services/Store/Dtos/StripeReconciliation.cs
+++ b/src/Humans.Application/Services/Store/Dtos/StripeReconciliation.cs
@@ -10,6 +10,12 @@ public enum StripeReconciliationStatus
 {
     /// <summary>Paid session whose PaymentIntent is already a recorded payment.</summary>
     Recorded,
+    /// <summary>
+    /// Paid session whose PaymentIntent is recorded but still <c>Pending</c> locally — Stripe has
+    /// confirmed the money, the settlement webhook hasn't landed yet. The amount is NOT counted
+    /// toward the order balance, so don't read this as "accounted for".
+    /// </summary>
+    RecordedPending,
     /// <summary>Paid session, order resolved and billable, but not yet recorded — recordable.</summary>
     Missing,
     /// <summary>Paid session with no resolvable billable order (missing metadata, deleted order, or Team order).</summary>
@@ -57,6 +63,7 @@ public sealed record StripeReconciliationReport(
     IReadOnlyList<StripeOrphanPayment> Orphans)
 {
     public int RecordedCount => Rows.Count(r => r.Status == StripeReconciliationStatus.Recorded);
+    public int RecordedPendingCount => Rows.Count(r => r.Status == StripeReconciliationStatus.RecordedPending);
     public int MissingCount => Rows.Count(r => r.Status == StripeReconciliationStatus.Missing);
     public int UnmatchedCount => Rows.Count(r => r.Status == StripeReconciliationStatus.Unmatched);
 

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -137,12 +137,17 @@ public class StoreService(
 
         var priceChanges = await LoadOrderPriceChangesAsync(order, ct);
 
+        // A pending async payment (e.g. SEPA mandate captured, not yet cleared) is excluded from
+        // BalanceEur, so without this guard the full balance would stay payable a second time
+        // while the mandate settles — a double-charge window.
+        var hasPendingPayment = order.Payments.Any(p => p.Status == StorePaymentStatus.Pending);
+
         return new StoreOrderPageData(
             order,
             catalog,
             order.CounterpartyDisplayName,
             canEdit,
-            canPayAuthorized && order.BalanceEur > 0 && order.CounterpartyType == StoreOrderCounterpartyType.Camp,
+            canPayAuthorized && order.BalanceEur > 0 && !hasPendingPayment && order.CounterpartyType == StoreOrderCounterpartyType.Camp,
             stripeService.IsStoreCheckoutConfigured,
             priceChanges);
     }
@@ -622,6 +627,9 @@ public class StoreService(
         if (amountEur > order.BalanceEur)
             throw new InvalidOperationException($"Payment amount cannot exceed the outstanding balance (EUR {order.BalanceEur:0.00}).");
 
+        if (order.Payments.Any(p => p.Status == StorePaymentStatus.Pending))
+            throw new InvalidOperationException("A payment on this order is pending settlement. Wait for it to clear or fail before paying again.");
+
         var description = $"Nobodies Collective - {order.CounterpartyName ?? "Camp order"}"
             + (string.IsNullOrWhiteSpace(order.Label) ? string.Empty : $" ({order.Label})");
 
@@ -683,7 +691,7 @@ public class StoreService(
         var stripeQueried = sessionsOrNull is not null;
         var sessions = sessionsOrNull ?? [];
         var recorded = await repo.GetRecordedStripePaymentsAsync(ct);
-        var recordedPis = recorded.Select(p => p.PaymentIntentId).ToHashSet(StringComparer.Ordinal);
+        var recordedByPi = recorded.ToDictionary(p => p.PaymentIntentId, p => p.Status, StringComparer.Ordinal);
 
         // Resolve each distinct matched order once (Stripe-side and recorded-side) for its
         // display label and billable check.
@@ -704,7 +712,7 @@ public class StoreService(
             rows.Add(new StripeReconciliationRow(
                 s.SessionId, s.PaymentIntentId, s.AmountEur, s.PaymentStatus, s.CreatedAt,
                 s.OrderId, order?.CounterpartyDisplayName,
-                ClassifyStripeSession(s, order, recordedPis)));
+                ClassifyStripeSession(s, order, recordedByPi)));
         }
 
         // Orphans: recorded Stripe payments whose PI is absent from the Stripe list — but only
@@ -731,12 +739,16 @@ public class StoreService(
     }
 
     private static StripeReconciliationStatus ClassifyStripeSession(
-        StoreCheckoutSessionData s, OrderDto? order, IReadOnlySet<string> recordedPis)
+        StoreCheckoutSessionData s, OrderDto? order, IReadOnlyDictionary<string, StorePaymentStatus> recordedByPi)
     {
         if (!string.Equals(s.PaymentStatus, "paid", StringComparison.Ordinal))
             return StripeReconciliationStatus.Unpaid;
-        if (s.PaymentIntentId is { } pi && recordedPis.Contains(pi))
-            return StripeReconciliationStatus.Recorded;
+        if (s.PaymentIntentId is { } pi && recordedByPi.TryGetValue(pi, out var paymentStatus))
+            // Stripe says paid but the local row hasn't settled — the amount is not in the
+            // balance yet, so it must not present as plain "Recorded".
+            return paymentStatus == StorePaymentStatus.Pending
+                ? StripeReconciliationStatus.RecordedPending
+                : StripeReconciliationStatus.Recorded;
         if (order is null || s.PaymentIntentId is null || order.CounterpartyType == StoreOrderCounterpartyType.Team)
             return StripeReconciliationStatus.Unmatched;
         return StripeReconciliationStatus.Missing;

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StorePaymentConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StorePaymentConfiguration.cs
@@ -13,13 +13,13 @@ public class StorePaymentConfiguration : IEntityTypeConfiguration<StorePayment>
         b.HasKey(x => x.Id);
         b.Property(x => x.AmountEur).HasColumnType("numeric(12,2)");
         b.Property(x => x.Method).HasConversion<int>();
-        // Stored as string; default Paid means existing rows (all pre-date async support and are,
-        // by construction, settled) land on Paid at column-add time without a data backfill, and a
-        // forgotten Status on a sync/manual insert still records as Paid. See nobodies-collective/Humans#638.
+        // Stored as string. The column default served the AddStorePaymentStatus migration
+        // (existing pre-async rows landed on Paid without a data backfill); EF-side it was the
+        // enum-zero sentinel trap (HasDefaultValue on the CLR default), so it was dropped after
+        // that migration ran — the entity's C# initializer covers inserts.
         b.Property(x => x.Status)
             .HasConversion<string>()
-            .HasMaxLength(50)
-            .HasDefaultValue(StorePaymentStatus.Paid);
+            .HasMaxLength(50);
         b.Property(x => x.StripePaymentIntentId).HasMaxLength(200);
         b.Property(x => x.ExternalRef).HasMaxLength(200);
         b.Property(x => x.Notes).HasMaxLength(1000);

--- a/src/Humans.Infrastructure/Migrations/20260611183802_DropStorePaymentStatusDefault.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260611183802_DropStorePaymentStatusDefault.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611183802_DropStorePaymentStatusDefault")]
+    partial class DropStorePaymentStatusDefault
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260611183802_DropStorePaymentStatusDefault.cs
+++ b/src/Humans.Infrastructure/Migrations/20260611183802_DropStorePaymentStatusDefault.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropStorePaymentStatusDefault : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "store_payments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldDefaultValue: "Paid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "store_payments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "Paid",
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -256,7 +256,7 @@ internal sealed class StoreRepository(IDbContextFactory<HumansDbContext> factory
         return await ctx.StorePayments.AsNoTracking()
             .Where(p => p.StripePaymentIntentId != null)
             .Select(p => new StoreRecordedStripePayment(
-                p.StripePaymentIntentId!, p.OrderId, p.AmountEur, p.ReceivedAt))
+                p.StripePaymentIntentId!, p.OrderId, p.AmountEur, p.ReceivedAt, p.Status))
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
+++ b/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
@@ -17,6 +17,12 @@ public sealed class InMemoryLogSink(int warningCapacity = 1000, int errorCapacit
     private readonly ConcurrentQueue<LogEvent> _errors = new();
     private readonly ConcurrentDictionary<LogEventLevel, long> _lifetimeCounts = new();
 
+    // Writer-side locks: ConcurrentQueue.Count is a snapshot, so unlocked enqueue-then-trim
+    // lets two concurrent writers both see "over capacity" and over-evict. Readers enumerate
+    // the queues lock-free; that stays safe.
+    private readonly Lock _warningsLock = new();
+    private readonly Lock _errorsLock = new();
+
     /// <summary>UTC timestamp captured when the sink (and process) started.</summary>
     public DateTimeOffset StartedAt { get; } = DateTimeOffset.UtcNow;
 
@@ -25,19 +31,31 @@ public sealed class InMemoryLogSink(int warningCapacity = 1000, int errorCapacit
 
     public void Emit(LogEvent logEvent)
     {
+        // The pipeline filters at Warning today; this floor keeps a future lowered minimum
+        // (e.g. Information during a diagnostic session) from flooding the warning buffer
+        // and evicting the events this sink exists to retain.
+        if (logEvent.Level < LogEventLevel.Warning)
+            return;
+
         _lifetimeCounts.AddOrUpdate(logEvent.Level, 1, (_, count) => count + 1);
 
         if (logEvent.Level >= LogEventLevel.Error)
         {
-            _errors.Enqueue(logEvent);
-            while (_errors.Count > errorCapacity)
-                _errors.TryDequeue(out _);
+            lock (_errorsLock)
+            {
+                _errors.Enqueue(logEvent);
+                while (_errors.Count > errorCapacity)
+                    _errors.TryDequeue(out _);
+            }
         }
         else
         {
-            _warnings.Enqueue(logEvent);
-            while (_warnings.Count > warningCapacity)
-                _warnings.TryDequeue(out _);
+            lock (_warningsLock)
+            {
+                _warnings.Enqueue(logEvent);
+                while (_warnings.Count > warningCapacity)
+                    _warnings.TryDequeue(out _);
+            }
         }
     }
 

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -263,15 +263,19 @@ builder.Services.AddOpenTelemetry()
 
 builder.Services.AddSingleton(new ActivitySource(serviceName, serviceVersion));
 
+// "external" marks third-party reachability checks. They surface on /health for diagnostics
+// but are excluded from /health/ready — a vendor outage must never fail the readiness probe
+// and block or roll back a deploy.
+string[] external = ["external"];
 var healthChecks = builder.Services.AddHealthChecks()
     .AddNpgSql(sp => sp.GetRequiredService<NpgsqlDataSource>(), name: "postgresql")
     .AddCheck<ConfigurationHealthCheck>("configuration")
-    .AddCheck<SmtpHealthCheck>("smtp")
-    .AddCheck<GitHubHealthCheck>("github")
-    .AddCheck<GoogleWorkspaceHealthCheck>("google-workspace")
-    .AddCheck<AnthropicHealthCheck>("anthropic-api-reachable")
+    .AddCheck<SmtpHealthCheck>("smtp", tags: external)
+    .AddCheck<GitHubHealthCheck>("github", tags: external)
+    .AddCheck<GoogleWorkspaceHealthCheck>("google-workspace", tags: external)
+    .AddCheck<AnthropicHealthCheck>("anthropic-api-reachable", tags: external)
     .AddCheck<AgentDocsHealthCheck>("agent-grounding-docs")
-    .AddCheck<TicketVendorHealthCheck>("ticket-vendor");
+    .AddCheck<TicketVendorHealthCheck>("ticket-vendor", tags: external);
 
 // Hangfire health check reads JobStorage.Current; only register it when
 // the rest of the Hangfire stack is wired (i.e. outside Testing).
@@ -619,7 +623,9 @@ app.MapHealthChecks("/health/live", new HealthCheckOptions
 
 app.MapHealthChecks("/health/ready", new HealthCheckOptions
 {
-    Predicate = _ => true // Readiness check - confirms all dependencies are available
+    // Readiness check - confirms our own stack (DB, config, Hangfire) is available.
+    // Third-party reachability ("external") is diagnostic-only on /health.
+    Predicate = r => !r.Tags.Contains("external")
 });
 
 app.MapPrometheusScrapingEndpoint("/metrics");

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -278,6 +278,10 @@ else
     {
         <p class="text-muted">No outstanding balance.</p>
     }
+    else if (pendingTotal > 0)
+    {
+        <p class="text-muted">Payment is disabled while a payment is pending settlement.</p>
+    }
     else
     {
         <p class="text-muted">Payments are recorded by the finance team.</p>

--- a/src/Humans.Web/Views/StoreAdmin/Payments.cshtml
+++ b/src/Humans.Web/Views/StoreAdmin/Payments.cshtml
@@ -12,6 +12,7 @@
     private static (string Css, string Label) StatusBadge(StripeReconciliationStatus status) => status switch
     {
         StripeReconciliationStatus.Recorded => ("bg-success", "Recorded"),
+        StripeReconciliationStatus.RecordedPending => ("bg-warning text-dark", "Recorded (pending settlement)"),
         StripeReconciliationStatus.Missing => ("bg-danger", "Missing"),
         StripeReconciliationStatus.Unmatched => ("bg-warning text-dark", "Unmatched"),
         _ => ("bg-secondary", "Unpaid"),
@@ -58,6 +59,10 @@ else if (!report.StripeQueried)
     <div class="card-body d-flex flex-wrap align-items-center gap-3">
         <div>
             <span class="badge bg-success">@report.RecordedCount recorded</span>
+            @if (report.RecordedPendingCount > 0)
+            {
+                <span class="badge bg-warning text-dark">@report.RecordedPendingCount pending settlement</span>
+            }
             <span class="badge bg-danger">@report.MissingCount missing</span>
             <span class="badge bg-warning text-dark">@report.UnmatchedCount unmatched</span>
         </div>

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceStripeReconciliationTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceStripeReconciliationTests.cs
@@ -81,7 +81,7 @@ public class StoreServiceStripeReconciliationTests
         });
         _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
         {
-            new("pi_recorded", recordedOrder, 100m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+            new("pi_recorded", recordedOrder, 100m, Instant.FromUtc(2026, 5, 1, 0, 0), StorePaymentStatus.Paid),
         });
         _repo.GetOrderWithLinesAndPaymentsAsync(recordedOrder, Arg.Any<CancellationToken>()).Returns(CampOrder(recordedOrder));
         _repo.GetOrderWithLinesAndPaymentsAsync(missingOrder, Arg.Any<CancellationToken>()).Returns(CampOrder(missingOrder));
@@ -99,13 +99,38 @@ public class StoreServiceStripeReconciliationTests
     }
 
     [HumansFact]
+    public async Task GetStripeReconciliationAsync_classifies_pending_local_row_as_recorded_pending()
+    {
+        var order = Guid.NewGuid();
+        // Stripe shows the session as paid, but the local row is still Pending (the
+        // async_payment_succeeded webhook hasn't landed) — must not present as plain Recorded.
+        _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreCheckoutSessionData>
+        {
+            Session("cs_pending", order, "pi_pending", 100m, "paid"),
+        });
+        _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
+        {
+            new("pi_pending", order, 100m, Instant.FromUtc(2026, 5, 1, 0, 0), StorePaymentStatus.Pending),
+        });
+        _repo.GetOrderWithLinesAndPaymentsAsync(order, Arg.Any<CancellationToken>()).Returns(CampOrder(order));
+
+        var report = await _service.GetStripeReconciliationAsync(Xunit.TestContext.Current.CancellationToken);
+
+        report.Rows.Should().ContainSingle()
+            .Which.Status.Should().Be(StripeReconciliationStatus.RecordedPending);
+        report.RecordedCount.Should().Be(0);
+        report.RecordedPendingCount.Should().Be(1);
+        report.MissingCount.Should().Be(0);
+    }
+
+    [HumansFact]
     public async Task GetStripeReconciliationAsync_flags_orphan_recorded_payment_absent_from_stripe()
     {
         var order = Guid.NewGuid();
         _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreCheckoutSessionData>());
         _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
         {
-            new("pi_orphan", order, 500m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+            new("pi_orphan", order, 500m, Instant.FromUtc(2026, 5, 1, 0, 0), StorePaymentStatus.Paid),
         });
         _repo.GetOrderWithLinesAndPaymentsAsync(order, Arg.Any<CancellationToken>()).Returns(CampOrder(order));
 
@@ -140,7 +165,7 @@ public class StoreServiceStripeReconciliationTests
             .Returns((IReadOnlyList<StoreCheckoutSessionData>?)null);
         _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
         {
-            new("pi_x", order, 500m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+            new("pi_x", order, 500m, Instant.FromUtc(2026, 5, 1, 0, 0), StorePaymentStatus.Paid),
         });
 
         var report = await _service.GetStripeReconciliationAsync(Xunit.TestContext.Current.CancellationToken);
@@ -167,7 +192,7 @@ public class StoreServiceStripeReconciliationTests
         });
         _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
         {
-            new("pi_recorded", recordedOrder, 100m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+            new("pi_recorded", recordedOrder, 100m, Instant.FromUtc(2026, 5, 1, 0, 0), StorePaymentStatus.Paid),
         });
         _repo.GetOrderByIdAsync(missingOrder, Arg.Any<CancellationToken>()).Returns(CampOrder(missingOrder));
         _repo.GetOrderByIdAsync(teamOrder, Arg.Any<CancellationToken>()).Returns(TeamOrder(teamOrder));


### PR DESCRIPTION
## Context

Pre-production review of everything on `origin/main` not yet on `upstream/main` (47 commits, 618 files) surfaced 1 CRITICAL, 4 IMPORTANT, and 1 fixable MINOR finding. This PR fixes all six before the batch promotes to production.

## Fixes

### 1. CRITICAL — double-payment window while a SEPA debit is pending
`BalanceCalculator` excludes `Pending` payments from the balance (correct for cleared funds), but nothing suppressed payment while one was pending: an order with a €200 pending SEPA debit still showed `CanPay = true` with €200 pre-filled, and the `amountEur > BalanceEur` guard passed — a second card payment could double-charge before the mandate settled.
- `GetOrderPageDataAsync`: `CanPay` now suppresses while any payment is `Pending`.
- `CreateStripeCheckoutSessionAsync`: rejects when a payment is pending (defense-in-depth).
- `Order.cshtml`: explains why payment is disabled.

### 2. Stripe reconciliation misclassified Pending as "Recorded"
A session paid on Stripe whose local row is still `Pending` (settlement webhook delayed/missed) showed as plain **Recorded**, telling an admin the money was accounted for when it isn't counted toward the balance. New `RecordedPending` status — `StoreRecordedStripePayment` enriched with `Status`, classification distinguishes pending rows, Payments admin page shows a warning badge and summary count. New test covers the scenario.

### 3. External health checks excluded from the readiness probe
This batch added `TicketVendorHealthCheck` and removed TicketTailor's silent-5xx fallback — a TicketTailor outage at deploy time would 503 `/health/ready` and could block or roll back a deploy. All third-party reachability checks (smtp, github, google-workspace, anthropic, ticket-vendor) are now tagged `external` and excluded from `/health/ready`; they remain visible on `/health` for diagnostics.
> **Deploy note:** confirm Coolify probes `/health/ready` (or `/health/live`), not `/health` — `/health` still reflects external outages by design.

### 4. `HasDefaultValue(StorePaymentStatus.Paid)` enum-zero sentinel removed
The rejected `HasDefaultValue(0)` pattern. The DB default only served the `AddStorePaymentStatus` migration backfill (already applied on QA). Config drops it; migration `DropStorePaymentStatusDefault` regenerated via `dotnet ef` (no hand edits); entity keeps its C# initializer; the sole production insert path sets `Status` explicitly. **EF migration reviewer: clean.**

### 5. `InMemoryLogSink` Warning floor
The sink branched at `>= Error` with no lower bound — a future lowered pipeline minimum (e.g. Information during diagnostics) would flood the warning buffer and evict real warnings. `Emit` now drops anything below `Warning`.

### 6. `InMemoryLogSink` eviction race
`ConcurrentQueue.Count` is a snapshot, so concurrent writers could both see "over capacity" and over-evict. Writer-side `Lock`s around enqueue+trim; readers stay lock-free.

## Verification

- `dotnet test Humans.slnx`: **4,088 passed, 0 failed** (1 pre-existing skip)
- EF migration reviewer agent: clean (symmetric Up/Down, snapshot diff exactly scoped, no insert path relies on the dropped default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)