### PR TITLE
fix(camps): treat EE grants as consumed once the holder enters the event

### DIFF
--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -30,6 +30,7 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
     private readonly ICampLeadJoinRequestsBadgeCacheInvalidator _leadBadgeInvalidator;
     private readonly Lazy<ICampRoleService> _campRoleService;
     private readonly IEarlyEntryInvalidator _earlyEntryInvalidator;
+    private readonly IUserServiceRead _userServiceRead;
     private readonly IClock _clock;
     private readonly ILogger<CampService> _logger;
 
@@ -47,6 +48,7 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         ICampLeadJoinRequestsBadgeCacheInvalidator leadBadgeInvalidator,
         Lazy<ICampRoleService> campRoleService,
         IEarlyEntryInvalidator earlyEntryInvalidator,
+        IUserServiceRead userServiceRead,
         IClock clock,
         ILogger<CampService> logger)
     {
@@ -58,6 +60,7 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         _leadBadgeInvalidator = leadBadgeInvalidator;
         _campRoleService = campRoleService;
         _earlyEntryInvalidator = earlyEntryInvalidator;
+        _userServiceRead = userServiceRead;
         _clock = clock;
         _logger = logger;
     }
@@ -1024,11 +1027,17 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
                 member.Id, actorUserId, cancellationToken);
         }
 
+        // A grant whose holder already entered the event is consumed: keep the
+        // flag on the Removed row so the slot-cap count still includes it —
+        // otherwise removing the member frees the slot for a second entry.
+        var retainConsumedEeGrant = member.HasEarlyEntry
+            && await HasEnteredEventAsync(member.UserId, member.CampSeason.Year, cancellationToken);
+
         var now = _clock.GetCurrentInstant();
         member.Status = CampMemberStatus.Removed;
         member.RemovedAt = now;
         member.RemovedByUserId = actorUserId;
-        member.HasEarlyEntry = false;
+        member.HasEarlyEntry = retainConsumedEeGrant;
         await _repo.SaveMemberAsync(member, cancellationToken);
         _earlyEntryInvalidator.InvalidateUser(member.UserId);
 
@@ -1398,6 +1407,13 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
             if (current >= member.CampSeason.EeSlotCount)
                 return SetEarlyEntryOutcome.SlotCapExceeded;
         }
+        else if (await HasEnteredEventAsync(member.UserId, member.CampSeason.Year, cancellationToken))
+        {
+            // The grant is consumed once the holder is through the gate —
+            // revoking it would free the slot for someone else, yielding
+            // N+1 early entries from N slots.
+            return SetEarlyEntryOutcome.MemberAlreadyEntered;
+        }
 
         member.HasEarlyEntry = granted;
         await _repo.SaveMemberAsync(member, cancellationToken);
@@ -1415,4 +1431,15 @@ public sealed class CampService : ICampService, ICampRoleCampAccess, IUserDataCo
         return SetEarlyEntryOutcome.Success;
     }
 
+    /// <summary>
+    /// True when the user has an Attended participation row for the season's
+    /// year (gate check-in via ticket sync). Cross-section read off the cached
+    /// <see cref="UserInfo"/> per the I*ServiceRead pattern.
+    /// </summary>
+    private async ValueTask<bool> HasEnteredEventAsync(Guid userId, int year, CancellationToken ct)
+    {
+        var info = await _userServiceRead.GetUserInfoAsync(userId, ct);
+        return info?.EventParticipations.Any(p =>
+            p.Year == year && p.Status == ParticipationStatus.Attended) ?? false;
+    }
 }

--- a/src/Humans.Application/Services/Camps/SetEarlyEntryOutcome.cs
+++ b/src/Humans.Application/Services/Camps/SetEarlyEntryOutcome.cs
@@ -7,4 +7,5 @@ public enum SetEarlyEntryOutcome
     SlotCapExceeded,
     MemberNotActive,
     MemberNotFound,
+    MemberAlreadyEntered,
 }

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -716,11 +716,12 @@ internal sealed partial class CampRepository : ICampRepository
     public async Task<int> GetGrantedCountForSeasonAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default)
     {
+        // No status filter: HasEarlyEntry survives on Removed rows when the
+        // holder had already entered the event (consumed slot) — counting them
+        // keeps remove-and-regrant from yielding extra early entries.
         await using var ctx = await _factory.CreateDbContextAsync(cancellationToken);
         return await ctx.CampMembers
-            .CountAsync(m => m.CampSeasonId == campSeasonId
-                          && m.HasEarlyEntry
-                          && m.Status == CampMemberStatus.Active,
+            .CountAsync(m => m.CampSeasonId == campSeasonId && m.HasEarlyEntry,
                         cancellationToken);
     }
 

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -950,6 +950,8 @@ public class CampController(
             SetError("Cannot grant Early Entry: slot cap reached for this camp.");
         else if (outcome == SetEarlyEntryOutcome.MemberNotActive)
             SetError("Only Active camp members can hold Early Entry.");
+        else if (outcome == SetEarlyEntryOutcome.MemberAlreadyEntered)
+            SetError("Cannot revoke Early Entry: this member has already entered the event, so their slot is used.");
 
         return RedirectToAction(nameof(Members), new { slug });
     }

--- a/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.EarlyEntry;
@@ -21,6 +22,7 @@ public sealed class CampServiceEarlyEntryTests : ServiceTestHarness
     private readonly CampService _service;
     private readonly InMemoryFileStorage _fileStorage;
     private readonly ICampRoleService _campRoleService;
+    private readonly IUserServiceRead _userServiceRead;
 
     public CampServiceEarlyEntryTests()
         : base(Instant.FromUtc(2026, 3, 13, 12, 0))
@@ -33,6 +35,8 @@ public sealed class CampServiceEarlyEntryTests : ServiceTestHarness
         _campRoleService.RemoveAllForMemberAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(0));
 
+        _userServiceRead = Substitute.For<IUserServiceRead>();
+
         _service = new CampService(
             repo,
             AuditLog,
@@ -42,6 +46,7 @@ public sealed class CampServiceEarlyEntryTests : ServiceTestHarness
             Substitute.For<ICampLeadJoinRequestsBadgeCacheInvalidator>(),
             new Lazy<ICampRoleService>(() => _campRoleService),
             Substitute.For<IEarlyEntryInvalidator>(),
+            _userServiceRead,
             Clock,
             NullLogger<CampService>.Instance);
     }
@@ -370,6 +375,141 @@ public sealed class CampServiceEarlyEntryTests : ServiceTestHarness
         result.Succeeded.Should().BeTrue();
 
         var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id, Xunit.TestContext.Current.CancellationToken);
+        reloaded.HasEarlyEntry.Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // Entered-event guard — a grant is consumed once its holder is through the
+    // gate; it can no longer be revoked or freed by removal/leave.
+    // ==========================================================================
+
+    private void SetUserParticipation(Guid userId, int year, ParticipationStatus status)
+    {
+        var user = new User
+        {
+            Id = userId,
+            DisplayName = "Test",
+            PreferredLanguage = "en",
+            CreatedAt = Clock.GetCurrentInstant(),
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+        };
+        var participation = new EventParticipation
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Year = year,
+            Status = status,
+            Source = ParticipationSource.TicketSync,
+        };
+        _userServiceRead.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(UserInfo.Create(
+                user, [], [participation], [], null, [], [], [], [])));
+    }
+
+    [HumansFact]
+    public async Task SetEarlyEntryAsync_Revoke_ReturnsMemberAlreadyEntered_WhenHolderAttendedSeasonYear()
+    {
+        await SeedSettingsAsync();
+        var (camp, season) = await SeedCampWithSeasonAsync(initialEeSlotCount: 5);
+        var member = await SeedActiveMemberWithEarlyEntryAsync(season.Id);
+        SetUserParticipation(member.UserId, season.Year, ParticipationStatus.Attended);
+
+        var outcome = await _service.SetEarlyEntryAsync(
+            camp.Id, member.Id, granted: false, Guid.NewGuid(), cancellationToken: Xunit.TestContext.Current.CancellationToken);
+
+        outcome.Should().Be(SetEarlyEntryOutcome.MemberAlreadyEntered);
+
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id, Xunit.TestContext.Current.CancellationToken);
+        reloaded.HasEarlyEntry.Should().BeTrue();
+
+        await AuditLog.DidNotReceive().LogAsync(
+            AuditAction.CampEarlyEntryRevoked,
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task SetEarlyEntryAsync_Revoke_Succeeds_WhenHolderOnlyTicketed()
+    {
+        await SeedSettingsAsync();
+        var (camp, season) = await SeedCampWithSeasonAsync(initialEeSlotCount: 5);
+        var member = await SeedActiveMemberWithEarlyEntryAsync(season.Id);
+        SetUserParticipation(member.UserId, season.Year, ParticipationStatus.Ticketed);
+
+        var outcome = await _service.SetEarlyEntryAsync(
+            camp.Id, member.Id, granted: false, Guid.NewGuid(), cancellationToken: Xunit.TestContext.Current.CancellationToken);
+
+        outcome.Should().Be(SetEarlyEntryOutcome.Success);
+
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id, Xunit.TestContext.Current.CancellationToken);
+        reloaded.HasEarlyEntry.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task SetEarlyEntryAsync_Revoke_Succeeds_WhenHolderAttendedDifferentYear()
+    {
+        await SeedSettingsAsync();
+        var (camp, season) = await SeedCampWithSeasonAsync(initialEeSlotCount: 5);
+        var member = await SeedActiveMemberWithEarlyEntryAsync(season.Id);
+        SetUserParticipation(member.UserId, season.Year - 1, ParticipationStatus.Attended);
+
+        var outcome = await _service.SetEarlyEntryAsync(
+            camp.Id, member.Id, granted: false, Guid.NewGuid(), cancellationToken: Xunit.TestContext.Current.CancellationToken);
+
+        outcome.Should().Be(SetEarlyEntryOutcome.Success);
+    }
+
+    [HumansFact]
+    public async Task RemoveCampMemberAsync_RetainsHasEarlyEntry_WhenHolderAttended()
+    {
+        await SeedSettingsAsync();
+        var (camp, season) = await SeedCampWithSeasonAsync(initialEeSlotCount: 5);
+        var member = await SeedActiveMemberWithEarlyEntryAsync(season.Id);
+        SetUserParticipation(member.UserId, season.Year, ParticipationStatus.Attended);
+
+        await _service.RemoveCampMemberAsync(camp.Id, member.Id, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id, Xunit.TestContext.Current.CancellationToken);
+        reloaded.Status.Should().Be(CampMemberStatus.Removed);
+        reloaded.HasEarlyEntry.Should().BeTrue("the consumed slot must keep counting against the cap");
+    }
+
+    [HumansFact]
+    public async Task LeaveCampAsync_RetainsHasEarlyEntry_WhenHolderAttended()
+    {
+        await SeedSettingsAsync();
+        var (_, season) = await SeedCampWithSeasonAsync(initialEeSlotCount: 5);
+        var member = await SeedActiveMemberWithEarlyEntryAsync(season.Id);
+        SetUserParticipation(member.UserId, season.Year, ParticipationStatus.Attended);
+
+        var result = await _service.LeaveCampAsync(member.Id, member.UserId, Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeTrue();
+
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == member.Id, Xunit.TestContext.Current.CancellationToken);
+        reloaded.HasEarlyEntry.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task SetEarlyEntryAsync_Grant_CountsConsumedSlots_FromRemovedAttendedMembers()
+    {
+        await SeedSettingsAsync();
+        var (camp, season) = await SeedCampWithSeasonAsync(initialEeSlotCount: 1);
+        var entered = await SeedActiveMemberWithEarlyEntryAsync(season.Id);
+        SetUserParticipation(entered.UserId, season.Year, ParticipationStatus.Attended);
+
+        // The cheat: remove the member who already entered, then try to hand
+        // the freed slot to someone else.
+        await _service.RemoveCampMemberAsync(camp.Id, entered.Id, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        var second = await SeedActiveMemberAsync(season.Id);
+
+        var outcome = await _service.SetEarlyEntryAsync(
+            camp.Id, second.Id, granted: true, Guid.NewGuid(), cancellationToken: Xunit.TestContext.Current.CancellationToken);
+
+        outcome.Should().Be(SetEarlyEntryOutcome.SlotCapExceeded);
+
+        var reloaded = await Db.CampMembers.AsNoTracking().FirstAsync(m => m.Id == second.Id, Xunit.TestContext.Current.CancellationToken);
         reloaded.HasEarlyEntry.Should().BeFalse();
     }
 }

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -44,6 +44,7 @@ public sealed class CampServiceTests : ServiceTestHarness
             Substitute.For<ICampLeadJoinRequestsBadgeCacheInvalidator>(),
             new Lazy<ICampRoleService>(() => _campRoleService),
             Substitute.For<IEarlyEntryInvalidator>(),
+            Substitute.For<IUserServiceRead>(),
             Clock,
             NullLogger<CampService>.Instance);
     }


### PR DESCRIPTION
## Problem

A camp could revoke a member's Early Entry **after** that person had already entered the event, then hand the freed slot to someone else — N slots yielding N+1 early entries. The same leak existed via member removal and voluntary leave: `TransitionMemberToRemovedAsync` cleared `HasEarlyEntry`, and the slot-cap count (`GetGrantedCountForSeasonAsync`) only counted Active members, so the slot opened up immediately.

## Fix — a grant is *consumed* once its holder is through the gate

"Entered" = an `Attended` participation row for the season's year (set permanently by ticket sync). Read cross-section from the cached `UserInfo` via the existing `IUserServiceRead.GetUserInfoAsync` — no new interface surface.

- **Revoke blocked**: `SetEarlyEntryAsync(granted: false)` returns new outcome `MemberAlreadyEntered` when the holder attended the season year; `CampController` shows a matching error.
- **Removal/leave keeps the slot consumed**: `TransitionMemberToRemovedAsync` retains `HasEarlyEntry` on the Removed row when the holder attended (clears it otherwise, as before).
- **Cap counts consumed slots**: `GetGrantedCountForSeasonAsync` drops the Active-only filter. The flag only survives removal for consumed grants, so an any-status count is exactly active grants + consumed slots. Existing Removed rows in prod all have the flag cleared — no retroactive effect.

## Notes

- Blanket rule: `Attended` is also set by regular (non-early) gate entry, so post-opening revokes are blocked too — they'd be pointless anyway, and the simple rule avoids guessing entry windows.
- The displayed grant count on camp pages (`CampSeasonInfo.EarlyEntryGrantCount`) projects from loaded members, which exclude Removed rows — so after a removed-consumed slot it can read lower than the cap usage. Cosmetic, rare (only after removing an entered member), and fixing it would mean threading a second count through the cache projection; left as-is.
- Team EE grants (`TeamService.RemoveEarlyEntryGrantAsync`) have no slot cap, so revoke-and-regrant gains nothing there; not touched.

## Tests

6 new tests in `CampServiceEarlyEntryTests`: revoke blocked when attended (flag retained, no audit), revoke still allowed when only Ticketed or attended a different year, removal/leave retain the consumed flag, and the end-to-end cheat (cap 1 → remove entered holder → regrant) now returns `SlotCapExceeded`. Full suite green (4,558 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)