### PR TITLE
feat(scanner): shrink ticket-scanner camera pane, add manual barcode entry

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -2925,6 +2925,12 @@
   <data name="Scanner_Tickets_Intro" xml:space="preserve">
     <value>Escaneja una entrada per veure'n els detalls.</value>
   </data>
+  <data name="Scanner_Tickets_ManualEntry_Placeholder" xml:space="preserve">
+    <value>Escriu o enganxa un codi de barres</value>
+  </data>
+  <data name="Scanner_Tickets_ManualEntry_Lookup" xml:space="preserve">
+    <value>Cerca</value>
+  </data>
   <data name="Scanner_Tickets_CardBlurb" xml:space="preserve">
     <value>Escaneja el codi de barres d'una entrada per veure el titular, l'estat i l'historial de transferències.</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -2925,6 +2925,12 @@
   <data name="Scanner_Tickets_Intro" xml:space="preserve">
     <value>Scanne ein Ticket, um seine Details zu sehen.</value>
   </data>
+  <data name="Scanner_Tickets_ManualEntry_Placeholder" xml:space="preserve">
+    <value>Barcode eingeben oder einfügen</value>
+  </data>
+  <data name="Scanner_Tickets_ManualEntry_Lookup" xml:space="preserve">
+    <value>Suchen</value>
+  </data>
   <data name="Scanner_Tickets_CardBlurb" xml:space="preserve">
     <value>Scanne den Barcode eines Tickets, um Inhaber, Status und Übertragungsverlauf zu sehen.</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -2949,6 +2949,12 @@
   <data name="Scanner_Tickets_Intro" xml:space="preserve">
     <value>Escanea una entrada para ver sus detalles.</value>
   </data>
+  <data name="Scanner_Tickets_ManualEntry_Placeholder" xml:space="preserve">
+    <value>Escribe o pega un código de barras</value>
+  </data>
+  <data name="Scanner_Tickets_ManualEntry_Lookup" xml:space="preserve">
+    <value>Buscar</value>
+  </data>
   <data name="Scanner_Tickets_CardBlurb" xml:space="preserve">
     <value>Escanea el código de barras de una entrada para ver el titular, el estado y el historial de transferencias.</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -2925,6 +2925,12 @@
   <data name="Scanner_Tickets_Intro" xml:space="preserve">
     <value>Scanne un billet pour voir ses détails.</value>
   </data>
+  <data name="Scanner_Tickets_ManualEntry_Placeholder" xml:space="preserve">
+    <value>Saisis ou colle un code-barres</value>
+  </data>
+  <data name="Scanner_Tickets_ManualEntry_Lookup" xml:space="preserve">
+    <value>Rechercher</value>
+  </data>
   <data name="Scanner_Tickets_CardBlurb" xml:space="preserve">
     <value>Scanne le code-barres d'un billet pour voir le titulaire, le statut et l'historique des transferts.</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -2925,6 +2925,12 @@
   <data name="Scanner_Tickets_Intro" xml:space="preserve">
     <value>Scansiona un biglietto per vederne i dettagli.</value>
   </data>
+  <data name="Scanner_Tickets_ManualEntry_Placeholder" xml:space="preserve">
+    <value>Digita o incolla un codice a barre</value>
+  </data>
+  <data name="Scanner_Tickets_ManualEntry_Lookup" xml:space="preserve">
+    <value>Cerca</value>
+  </data>
   <data name="Scanner_Tickets_CardBlurb" xml:space="preserve">
     <value>Scansiona il codice a barre di un biglietto per vedere il titolare, lo stato e la cronologia dei trasferimenti.</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1259,6 +1259,8 @@
   <data name="Scanner_Barcode_Error_NoDecoder" xml:space="preserve"><value>Your browser doesn't have a built-in barcode decoder and the fallback library failed to load. Try a recent mobile Chrome or Safari.</value></data>
   <data name="Scanner_Tickets_Title" xml:space="preserve"><value>Ticket lookup</value></data>
   <data name="Scanner_Tickets_Intro" xml:space="preserve"><value>Scan a ticket to see its details.</value></data>
+  <data name="Scanner_Tickets_ManualEntry_Placeholder" xml:space="preserve"><value>Type or paste a barcode</value></data>
+  <data name="Scanner_Tickets_ManualEntry_Lookup" xml:space="preserve"><value>Look up</value></data>
   <data name="Scanner_Tickets_CardBlurb" xml:space="preserve"><value>Scan a ticket barcode to view the ticket holder, status, and transfer history.</value></data>
   <data name="Scanner_Tickets_Open" xml:space="preserve"><value>Open ticket lookup</value></data>
   <data name="Scanner_Tickets_NotFound" xml:space="preserve"><value>No ticket found for this code:</value></data>

--- a/src/Humans.Web/Views/Scanner/Tickets.cshtml
+++ b/src/Humans.Web/Views/Scanner/Tickets.cshtml
@@ -14,7 +14,7 @@
 <p class="text-muted">@Localizer["Scanner_Tickets_Intro"]</p>
 
 <div class="row g-3">
-    <div class="col-lg-7">
+    <div class="col-lg-5">
         <div class="card">
             <div class="card-body">
                 <div class="d-flex gap-2 mb-3">
@@ -42,7 +42,23 @@
         </div>
     </div>
 
-    <div class="col-lg-5">
+    <div class="col-lg-7">
+        <form id="scanner-manual" class="mb-3">
+            <div class="input-group">
+                <input type="text"
+                       id="scanner-manual-input"
+                       class="form-control"
+                       autocomplete="off"
+                       autocapitalize="off"
+                       spellcheck="false"
+                       placeholder="@Localizer["Scanner_Tickets_ManualEntry_Placeholder"]"
+                       aria-label="@Localizer["Scanner_Tickets_ManualEntry_Placeholder"]">
+                <button type="submit" class="btn btn-outline-primary">
+                    <i class="fa-solid fa-magnifying-glass me-1" aria-hidden="true"></i>
+                    @Localizer["Scanner_Tickets_ManualEntry_Lookup"]
+                </button>
+            </div>
+        </form>
         <div id="scanner-card"></div>
     </div>
 </div>
@@ -58,6 +74,8 @@
             status: document.getElementById('scanner-status'),
             error: document.getElementById('scanner-error'),
             card: document.getElementById('scanner-card'),
+            manualForm: document.getElementById('scanner-manual'),
+            manualInput: document.getElementById('scanner-manual-input'),
             cardUrl: '@Url.Action("Card", "Scanner")',
             labels: {
                 starting: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Status_Starting"].Value)),

--- a/src/Humans.Web/wwwroot/js/scanner/tickets.js
+++ b/src/Humans.Web/wwwroot/js/scanner/tickets.js
@@ -1,19 +1,28 @@
 import { initBarcodeScanner } from './barcode.js';
 
 export function initTicketScanner(refs) {
-    const { card, cardUrl, ...scannerRefs } = refs;
+    const { card, cardUrl, manualForm, manualInput, ...scannerRefs } = refs;
+
+    const lookup = async (value) => {
+        try {
+            const resp = await fetch(`${cardUrl}?barcode=${encodeURIComponent(value)}`,
+                { headers: { 'X-Requested-With': 'fetch' } });
+            if (resp.ok) card.innerHTML = await resp.text();
+        } catch (err) {
+            console.error('Scanner: ticket lookup failed', err);
+        }
+    };
+
+    manualForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const value = manualInput.value.trim();
+        if (value) void lookup(value);
+    });
+
     initBarcodeScanner({
         ...scannerRefs,
         results: null,
         resultsEmpty: null,
-        onHit: async (value) => {
-            try {
-                const resp = await fetch(`${cardUrl}?barcode=${encodeURIComponent(value)}`,
-                    { headers: { 'X-Requested-With': 'fetch' } });
-                if (resp.ok) card.innerHTML = await resp.text();
-            } catch (err) {
-                console.error('Scanner: ticket lookup failed', err);
-            }
-        },
+        onHit: lookup,
     });
 }


### PR DESCRIPTION
## What

Two tweaks to `/Scanner/Tickets`:

1. **Smaller camera pane** — the webcam column drops from `col-lg-7` to `col-lg-5` (~2/3 of its previous width on desktop; unchanged stacking on mobile, where full width is what you want at the gate).
2. **Manual barcode entry** — an input + "Look up" button at the top of the right column. Typing or pasting a barcode and hitting Enter/the button fetches the same `Scanner/Tickets/Card` partial as a camera hit; the camera does not need to be running.

## How

- `tickets.js` extracts the existing `onHit` fetch into a shared `lookup()` used by both the camera callback and the new form submit — no new endpoint, no server changes.
- Two new localized strings (`Scanner_Tickets_ManualEntry_Placeholder`, `Scanner_Tickets_ManualEntry_Lookup`) added to all six `SharedResource` resx files.

## Testing

- `dotnet build Humans.slnx -v quiet` — 0 errors.
- `dotnet test Humans.slnx -v quiet` — all pass except `Volunteer_cannot_create_order_against_someone_elses_camp_season` (Store/Camps integration test, unrelated to this change), which passes when re-run in isolation — flaky under parallel run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
