### PR TITLE
feat(i18n): localize public pages from the sweep report - views, enums, 3,700 translations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 
-    <!-- Only include English and Spanish satellite assemblies -->
-    <SatelliteResourceLanguages>en;es</SatelliteResourceLanguages>
+    <!-- Ship satellite assemblies for every culture in CultureCatalog.SupportedCultureCodes -->
+    <SatelliteResourceLanguages>en;es;ca;de;fr;it</SatelliteResourceLanguages>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!--

--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -10,6 +10,7 @@ using Humans.Web.Infrastructure;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
 using Serilog.Events;
 
 namespace Humans.Web.Controllers;
@@ -324,6 +325,10 @@ public class DebugController(
 
     [HttpGet("FormatGallery")]
     public IActionResult FormatGallery() => View(FormatGalleryModelBuilder.Build());
+
+    [HttpGet("Translations")]
+    public IActionResult Translations([FromServices] IStringLocalizer<SharedResource> localizer) =>
+        View(TranslationsGalleryModelBuilder.Build(localizer));
 
     private static string StatusCategory(int statusCode) => statusCode switch
     {

--- a/src/Humans.Web/Extensions/EnumLocalizationExtensions.cs
+++ b/src/Humans.Web/Extensions/EnumLocalizationExtensions.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
+
+namespace Humans.Web.Extensions;
+
+/// <summary>
+/// Localized display of enum values via the SharedResource key convention
+/// <c>Enum_{TypeName}_{Value}</c> (e.g. <c>Enum_CampVibe_LiveMusic</c>).
+/// A missing key falls back to the PascalCase name split into words, which the
+/// localization sweep still flags — so untranslated values stay visible.
+/// </summary>
+public static class EnumLocalizationExtensions
+{
+    /// <summary>Localized display text for a single enum value.</summary>
+    public static string EnumDisplay<TEnum>(this IStringLocalizer<SharedResource> localizer, TEnum value)
+        where TEnum : struct, Enum
+    {
+        var localized = localizer[$"Enum_{typeof(TEnum).Name}_{value}"];
+        return localized.ResourceNotFound ? Humanize(value.ToString()) : localized.Value;
+    }
+
+    /// <summary>
+    /// Select-list items for every value of <typeparamref name="TEnum"/> with localized
+    /// display text. Item values are the enum names, matching how the model binder and the
+    /// previous <c>new SelectList(Enum.GetValues&lt;T&gt;())</c> call sites round-trip.
+    /// </summary>
+    public static List<SelectListItem> EnumSelectItems<TEnum>(this IStringLocalizer<SharedResource> localizer, TEnum? selected = null)
+        where TEnum : struct, Enum =>
+        [.. Enum.GetValues<TEnum>().Select(v => new SelectListItem(
+            localizer.EnumDisplay(v),
+            v.ToString(),
+            selected.HasValue && EqualityComparer<TEnum>.Default.Equals(v, selected.Value)))];
+
+    private static string Humanize(string name)
+    {
+        var sb = new StringBuilder(name.Length + 4);
+        for (var i = 0; i < name.Length; i++)
+        {
+            if (i > 0 && char.IsUpper(name[i]) && !char.IsUpper(name[i - 1]))
+                sb.Append(' ');
+            sb.Append(name[i]);
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Humans.Web/Models/TranslationsGalleryViewModel.cs
+++ b/src/Humans.Web/Models/TranslationsGalleryViewModel.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using Humans.Web.Extensions;
+using Microsoft.Extensions.Localization;
+
+namespace Humans.Web.Models;
+
+/// <summary>
+/// Every SharedResource key with its value in each supported culture, grouped by key
+/// prefix, so translation coverage and drift are visible at a glance. Powers
+/// <c>/Debug/Translations</c>. Enumerated through the real localizer — not a hand list —
+/// so a new key can never hide from the audit.
+/// </summary>
+public sealed record TranslationsGalleryViewModel(
+    IReadOnlyList<string> Languages,
+    IReadOnlyList<TranslationGroup> Groups,
+    int TotalKeys,
+    IReadOnlyDictionary<string, int> MissingByLanguage,
+    IReadOnlyDictionary<string, IReadOnlyList<string>> OrphanKeysByLanguage);
+
+/// <summary>Keys sharing one prefix (the text before the first underscore).</summary>
+public sealed record TranslationGroup(
+    string Prefix,
+    IReadOnlyList<TranslationRow> Rows,
+    IReadOnlyDictionary<string, int> MissingByLanguage);
+
+/// <summary>One resource key; a null per-language value means the key is untranslated there.</summary>
+public sealed record TranslationRow(
+    string Key,
+    string English,
+    IReadOnlyDictionary<string, string?> Values);
+
+public static class TranslationsGalleryModelBuilder
+{
+    public static TranslationsGalleryViewModel Build(IStringLocalizer<SharedResource> localizer)
+    {
+        var languages = CultureCatalog.SupportedCultureCodes
+            .Where(c => !string.Equals(c, CultureCatalog.DefaultCultureCode, StringComparison.Ordinal))
+            .ToList();
+
+        // en = the neutral resx (walk parent cultures); each language = only what its own file defines,
+        // so a missing entry shows as a gap instead of silently falling back to English.
+        var english = ReadAll(localizer, CultureCatalog.DefaultCultureCode, includeParentCultures: true);
+        var perLanguage = languages.ToDictionary(
+            l => l,
+            l => ReadAll(localizer, l, includeParentCultures: false),
+            StringComparer.Ordinal);
+
+        var rows = english
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => new TranslationRow(
+                kv.Key,
+                kv.Value,
+                languages.ToDictionary(l => l, l => perLanguage[l].GetValueOrDefault(kv.Key), StringComparer.Ordinal)))
+            .ToList();
+
+        var groups = rows
+            .GroupBy(r => r.Key.Split('_', 2)[0], StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => new TranslationGroup(
+                g.Key,
+                [.. g],
+                languages.ToDictionary(l => l, l => g.Count(r => r.Values[l] is null), StringComparer.Ordinal)))
+            .ToList();
+
+        // Keys a language file defines that en no longer does — stale leftovers worth deleting.
+        var orphans = languages.ToDictionary(
+            l => l,
+            l => (IReadOnlyList<string>)[.. perLanguage[l].Keys
+                .Where(k => !english.ContainsKey(k))
+                .OrderBy(k => k, StringComparer.Ordinal)],
+            StringComparer.Ordinal);
+
+        return new TranslationsGalleryViewModel(
+            languages,
+            groups,
+            rows.Count,
+            languages.ToDictionary(l => l, l => rows.Count(r => r.Values[l] is null), StringComparer.Ordinal),
+            orphans);
+    }
+
+    private static Dictionary<string, string> ReadAll(IStringLocalizer localizer, string culture, bool includeParentCultures)
+    {
+        var previous = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+        try
+        {
+            return localizer.GetAllStrings(includeParentCultures)
+                .ToDictionary(s => s.Name, s => s.Value, StringComparer.Ordinal);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -6010,5 +6010,626 @@
   <data name="AccountDeletion_ScheduledFor" xml:space="preserve"><value>S'eliminarà permanentment el {0} tret que el cancel·lis.</value></data>
   <data name="AccountDeletion_Unscheduled" xml:space="preserve"><value>S'eliminarà permanentment tret que el cancel·lis.</value></data>
   <data name="AccountDeletion_CancelButton" xml:space="preserve"><value>Cancel·la la sol·licitud d'eliminació</value></data>
+  <data name="About_AdditionalHelp" xml:space="preserve"><value>Amb l'ajuda addicional de</value></data>
+  <data name="About_AdditionalHelpAnd" xml:space="preserve"><value>i</value></data>
+  <data name="About_AnthropicNote" xml:space="preserve"><value>Les respostes conversacionals de l'assistent les genera l'API d'Anthropic. No s'utilitza cap dada per a l'entrenament de models, segons el DPA d'Anthropic.</value></data>
+  <data name="About_Cat_AILLM" xml:space="preserve"><value>IA/LLM</value></data>
+  <data name="About_Cat_BackgroundJobs" xml:space="preserve"><value>Tasques en segon pla</value></data>
+  <data name="About_Cat_Calendar" xml:space="preserve"><value>Calendari</value></data>
+  <data name="About_Cat_CSV" xml:space="preserve"><value>CSV</value></data>
+  <data name="About_Cat_Database" xml:space="preserve"><value>Base de dades</value></data>
+  <data name="About_Cat_DateTime" xml:space="preserve"><value>Data/hora</value></data>
+  <data name="About_Cat_Email" xml:space="preserve"><value>Correu</value></data>
+  <data name="About_Cat_Framework" xml:space="preserve"><value>Framework</value></data>
+  <data name="About_Cat_GitHubAPI" xml:space="preserve"><value>API de GitHub</value></data>
+  <data name="About_Cat_GoogleAPIs" xml:space="preserve"><value>API de Google</value></data>
+  <data name="About_Cat_HealthChecks" xml:space="preserve"><value>Comprovacions d'estat</value></data>
+  <data name="About_Cat_ImageProcessing" xml:space="preserve"><value>Processament d'imatges</value></data>
+  <data name="About_Cat_Logging" xml:space="preserve"><value>Registre</value></data>
+  <data name="About_Cat_Markdown" xml:space="preserve"><value>Markdown</value></data>
+  <data name="About_Cat_Observability" xml:space="preserve"><value>Observabilitat</value></data>
+  <data name="About_Cat_Payments" xml:space="preserve"><value>Pagaments</value></data>
+  <data name="About_Cat_Resilience" xml:space="preserve"><value>Resiliència</value></data>
+  <data name="About_Cat_Sanitization" xml:space="preserve"><value>Sanejament</value></data>
+  <data name="About_Cat_Spreadsheet" xml:space="preserve"><value>Full de càlcul</value></data>
+  <data name="About_Cat_StateMachine" xml:space="preserve"><value>Màquina d'estats</value></data>
+  <data name="About_Cat_UserAgent" xml:space="preserve"><value>User-Agent</value></data>
+  <data name="About_ColCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="About_ColLibrary" xml:space="preserve"><value>Biblioteca</value></data>
+  <data name="About_ColLicense" xml:space="preserve"><value>Llicència</value></data>
+  <data name="About_ColPackage" xml:space="preserve"><value>Paquet</value></data>
+  <data name="About_ColVersion" xml:space="preserve"><value>Versió</value></data>
+  <data name="About_DotNetDesc" xml:space="preserve"><value>ASP.NET Core MVC amb vistes Razor, Identity i tota la pila de Microsoft. El bastiment que ho manté tot unit.</value></data>
+  <data name="About_FrontendHeading" xml:space="preserve"><value>Dependències de frontend / CDN</value></data>
+  <data name="About_GoogleDesc" xml:space="preserve"><value>Admin Directory, Drive i Groups — aprovisionament d'unitats compartides, carpetes i llistes de correu perquè ningú no ho hagi de fer a mà.</value></data>
+  <data name="About_HangfireDesc" xml:space="preserve"><value>Tasques en segon pla per a la sincronització, la conciliació i tot allò que no hauria de bloquejar una sol·licitud HTTP. Amb PostgreSQL al darrere i tauler de control inclòs.</value></data>
+  <data name="About_IngredientsHeading" xml:space="preserve"><value>Els ingredients</value></data>
+  <data name="About_IngredientsIntro" xml:space="preserve"><value>Tot taller necessita els seus materials. Això és el que conforma Humans:</value></data>
+  <data name="About_Intro" xml:space="preserve"><value>Humans és el sistema de membres que manté Nobodies Collective en funcionament — incorporació d'humans, aprovisionament d'equips, seguiment de la governança i tota la lampisteria que permet a una associació sense ànim de lucre espanyola operar amb la memòria organitzativa d'una entitat deu vegades més gran. Construït amb cura, mantingut amb tossuderia i desplegat amb els dits creuats.</value></data>
+  <data name="About_License_Apache2" xml:space="preserve"><value>requereix avís de drets d'autor, una còpia de la llicència i una declaració dels canvis si s'ha modificat. Tots els paquets s'utilitzen sense modificar.</value></data>
+  <data name="About_License_BSD2" xml:space="preserve"><value>requereix avís de drets d'autor a la documentació.</value></data>
+  <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>requereix avís de drets d'autor; aquesta pàgina compleix aquesta obligació.</value></data>
+  <data name="About_License_ISC" xml:space="preserve"><value>permissiva, funcionalment equivalent a BSD-2-Clause; cal avís de drets d'autor.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>la biblioteca ha de poder ser substituïble per l'usuari final. S'utilitza com a paquets NuGet sense modificar (enllaçats dinàmicament), complint les obligacions de la LGPL.</value></data>
+  <data name="About_License_MIT" xml:space="preserve"><value>requereix avís de drets d'autor; aquesta pàgina compleix aquesta obligació.</value></data>
+  <data name="About_License_PostgreSQL" xml:space="preserve"><value>permissiva, semblant a MIT; cal avís de drets d'autor.</value></data>
+  <data name="About_License_SILOFL" xml:space="preserve"><value>lliure d'utilitzar i redistribuir; les tipografies no es poden vendre per separat.</value></data>
+  <data name="About_LicenseBody" xml:space="preserve"><value>Humans és programari lliure, publicat sota la</value></data>
+  <data name="About_LicenseComplianceHeading" xml:space="preserve"><value>Resum de compliment de llicències</value></data>
+  <data name="About_LicenseComplianceSummary" xml:space="preserve"><value>Totes les dependències de producció utilitzen llicències permissives o de copyleft feble. No s'ha trobat cap infracció.</value></data>
+  <data name="About_LicenseExplanation" xml:space="preserve"><value>Pots utilitzar, estudiar, modificar i redistribuir aquest programari. Si executes una versió modificada i permets que altres hi interactuïn a través d'una xarxa, has de posar a disposició el teu codi font modificat sota la mateixa llicència.</value></data>
+  <data name="About_LicenseFullText" xml:space="preserve"><value>Text complet de la llicència:</value></data>
+  <data name="About_LicenseHeading" xml:space="preserve"><value>Llicència</value></data>
+  <data name="About_LicenseSourceCode" xml:space="preserve"><value>Codi font:</value></data>
+  <data name="About_MadeBy" xml:space="preserve"><value>Fet per</value></data>
+  <data name="About_MadeByTail" xml:space="preserve"><value>amb amor per a la comunitat Nobodies.</value></data>
+  <data name="About_MailKitDesc" xml:space="preserve"><value>Correu transaccional per a notificacions i incorporació. L'única biblioteca que fa que SMTP sembli gairebé agradable.</value></data>
+  <data name="About_MeetTheStaff" xml:space="preserve"><value>Coneix l'equip</value></data>
+  <data name="About_NeedHelp" xml:space="preserve"><value>Necessites ajuda?</value></data>
+  <data name="About_NuGetPackagesHeading" xml:space="preserve"><value>Paquets NuGet</value></data>
+  <data name="About_OpenSourceLicensesHeading" xml:space="preserve"><value>Llicències de codi obert</value></data>
+  <data name="About_OpenSourceLicensesIntro" xml:space="preserve"><value>Humans s'aixeca a les espatlles de projectes de codi obert. La taula de sota llista cada dependència de producció, la seva versió i la seva llicència.</value></data>
+  <data name="About_OtelDesc" xml:space="preserve"><value>Registre estructurat, traces distribuïdes i mètriques de Prometheus. Perquè "funciona a la meva màquina" no és una estratègia de monitoratge.</value></data>
+  <data name="About_PostgresDesc" xml:space="preserve"><value>Dades relacionals amb Entity Framework Core i Npgsql. Tipus NodaTime de dalt a baix — cap DateTime a la vista.</value></data>
+  <data name="About_Staff_BackToAbout" xml:space="preserve"><value>Torna a Sobre</value></data>
+  <data name="About_Staff_Empty" xml:space="preserve"><value>No s'ha trobat cap titular de rol actiu. Sembla que el castell està buit.</value></data>
+  <data name="About_Staff_Intro" xml:space="preserve"><value>Tot col·lectiu necessita els seus guardians. Aquests són els humans que dediquen el seu temps i la seva energia a mantenir Nobodies en marxa — de la governança al suport tècnic, de la confiança i seguretat a l'alquímia de les entrades.</value></data>
+  <data name="About_Staff_Title" xml:space="preserve"><value>Els humans darrere de la cortina</value></data>
+  <data name="About_Title" xml:space="preserve"><value>Sobre Humans</value></data>
+  <data name="AccountStatus_ConsentSuspendedBody" xml:space="preserve"><value>El teu accés està suspès fins que completis els consentiments legals requerits.</value></data>
+  <data name="AccountStatus_HeadingAdminSuspended" xml:space="preserve"><value>Un administrador ha suspès el teu compte</value></data>
+  <data name="AccountStatus_ReviewConsents" xml:space="preserve"><value>Revisa els consentiments requerits</value></data>
+  <data name="Budget_ColAmount" xml:space="preserve"><value>Import (€)</value></data>
+  <data name="Budget_ColCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Budget_ColShare" xml:space="preserve"><value>Percentatge</value></data>
+  <data name="Budget_DepartmentDetail" xml:space="preserve"><value>Detall del departament</value></data>
+  <data name="Budget_Expenses" xml:space="preserve"><value>Despeses</value></data>
+  <data name="Budget_ExpensesBreakdown" xml:space="preserve"><value>Desglossament de despeses</value></data>
+  <data name="Budget_Income" xml:space="preserve"><value>Ingressos</value></data>
+  <data name="Budget_IncomeBreakdown" xml:space="preserve"><value>Desglossament d'ingressos</value></data>
+  <data name="Budget_NetBalance" xml:space="preserve"><value>Saldo net</value></data>
+  <data name="Budget_NoActiveBudget" xml:space="preserve"><value>Cap pressupost actiu</value></data>
+  <data name="Budget_NoActiveBudgetSubtitle" xml:space="preserve"><value>No hi ha cap any pressupostari actiu per mostrar. Un administrador de finances en configurarà un quan comenci la planificació del pressupost.</value></data>
+  <data name="Budget_NoDataSubtitle" xml:space="preserve"><value>Les assignacions del pressupost apareixeran aquí un cop l'equip de finances les hagi configurat.</value></data>
+  <data name="Budget_NoDataYet" xml:space="preserve"><value>Encara no hi ha dades de pressupost disponibles</value></data>
+  <data name="Budget_NoExpenseItems" xml:space="preserve"><value>Encara no hi ha cap partida de despeses.</value></data>
+  <data name="Budget_NoIncomeItems" xml:space="preserve"><value>Encara no hi ha cap partida d'ingressos.</value></data>
+  <data name="Budget_OverviewSubtitle" xml:space="preserve"><value>Com es distribueix el pressupost de {0} entre departaments i infraestructura.</value></data>
+  <data name="Budget_OverviewTitle" xml:space="preserve"><value>Resum del pressupost</value></data>
+  <data name="Budget_Title" xml:space="preserve"><value>Pressupost</value></data>
+  <data name="Budget_TitleYear" xml:space="preserve"><value>Pressupost - {0}</value></data>
+  <data name="Budget_TotalExpenses" xml:space="preserve"><value>Despeses totals</value></data>
+  <data name="Budget_TotalIncome" xml:space="preserve"><value>Ingressos totals</value></data>
+  <data name="Calendar_Agenda" xml:space="preserve"><value>Agenda</value></data>
+  <data name="Calendar_AllDay" xml:space="preserve"><value>tot el dia</value></data>
+  <data name="Calendar_AllDayEvent" xml:space="preserve"><value>Esdeveniment de tot el dia</value></data>
+  <data name="Calendar_AllDayLabel" xml:space="preserve"><value>Tot el dia</value></data>
+  <data name="Calendar_AllTeamsMonthView" xml:space="preserve"><value>Tots els equips (vista de mes)</value></data>
+  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>Totes les hores es mostren en {0}.</value></data>
+  <data name="Calendar_BackToCalendar" xml:space="preserve"><value>Torna al calendari</value></data>
+  <data name="Calendar_CancelOccurrenceConfirm" xml:space="preserve"><value>Vols cancel·lar només aquesta ocurrència?</value></data>
+  <data name="Calendar_CancelThisOccurrence" xml:space="preserve"><value>Cancel·la aquesta</value></data>
+  <data name="Calendar_ChangeHistory" xml:space="preserve"><value>Historial de canvis</value></data>
+  <data name="Calendar_Continues" xml:space="preserve"><value>continua</value></data>
+  <data name="Calendar_Created" xml:space="preserve"><value>Creat el {0}</value></data>
+  <data name="Calendar_CreateEvent" xml:space="preserve"><value>Crea esdeveniment</value></data>
+  <data name="Calendar_DeleteConfirm" xml:space="preserve"><value>Vols eliminar aquest esdeveniment i totes les seves ocurrències?</value></data>
+  <data name="Calendar_Description" xml:space="preserve"><value>Descripció</value></data>
+  <data name="Calendar_EditEvent" xml:space="preserve"><value>Edita esdeveniment</value></data>
+  <data name="Calendar_EditSingleOccurrence" xml:space="preserve"><value>Edita una sola ocurrència</value></data>
+  <data name="Calendar_EditSingleOccurrenceHeading" xml:space="preserve"><value>Edita una sola ocurrència</value></data>
+  <data name="Calendar_EditThisOccurrence" xml:space="preserve"><value>Edita aquesta ocurrència</value></data>
+  <data name="Calendar_End" xml:space="preserve"><value>Fi</value></data>
+  <data name="Calendar_EndDate" xml:space="preserve"><value>Data de fi</value></data>
+  <data name="Calendar_EndDateHelp" xml:space="preserve"><value>Inclusiva — deixa-la en blanc per a un esdeveniment d'un sol dia.</value></data>
+  <data name="Calendar_EventTitle" xml:space="preserve"><value>Esdeveniment</value></data>
+  <data name="Calendar_FirstStart" xml:space="preserve"><value>Primer inici</value></data>
+  <data name="Calendar_FormTitle" xml:space="preserve"><value>Títol</value></data>
+  <data name="Calendar_LastUpdated" xml:space="preserve"><value>· Última actualització {0}</value></data>
+  <data name="Calendar_LocationUrl" xml:space="preserve"><value>URL de la ubicació</value></data>
+  <data name="Calendar_MoreCount" xml:space="preserve"><value>+{0} més</value></data>
+  <data name="Calendar_NewEvent" xml:space="preserve"><value>Nou esdeveniment</value></data>
+  <data name="Calendar_Next" xml:space="preserve"><value>Següent</value></data>
+  <data name="Calendar_NoEventsInRange" xml:space="preserve"><value>No hi ha esdeveniments en el rang seleccionat.</value></data>
+  <data name="Calendar_OverrideDescription" xml:space="preserve"><value>Substitueix la descripció</value></data>
+  <data name="Calendar_OverrideEnd" xml:space="preserve"><value>Substitueix el final</value></data>
+  <data name="Calendar_OverrideInstructions" xml:space="preserve"><value>Substitueix només aquesta ocurrència de l'esdeveniment recurrent. Deixa un camp en blanc per heretar el valor de l'esdeveniment principal.</value></data>
+  <data name="Calendar_OverrideLocation" xml:space="preserve"><value>Substitueix la ubicació</value></data>
+  <data name="Calendar_OverrideLocationUrl" xml:space="preserve"><value>Substitueix l'URL de la ubicació</value></data>
+  <data name="Calendar_OverrideStart" xml:space="preserve"><value>Substitueix l'inici</value></data>
+  <data name="Calendar_OverrideTitle" xml:space="preserve"><value>Substitueix el títol</value></data>
+  <data name="Calendar_OwningTeam" xml:space="preserve"><value>Equip propietari</value></data>
+  <data name="Calendar_Prev" xml:space="preserve"><value>Anterior</value></data>
+  <data name="Calendar_Recurrence" xml:space="preserve"><value>Recurrència</value></data>
+  <data name="Calendar_RecurrenceTimezoneHelpPrefix" xml:space="preserve"><value>TZ IANA, p. ex.</value></data>
+  <data name="Calendar_RecurrenceTimezoneLabel" xml:space="preserve"><value>Zona horària de la recurrència</value></data>
+  <data name="Calendar_RecurrenceTimezoneNote" xml:space="preserve"><value>Zona horària: {0}</value></data>
+  <data name="Calendar_RecurringEvent" xml:space="preserve"><value>Esdeveniment recurrent</value></data>
+  <data name="Calendar_RRule" xml:space="preserve"><value>RRULE</value></data>
+  <data name="Calendar_RRuleHelpPrefix" xml:space="preserve"><value>RRULE de l'RFC 5545. Deixa-ho en blanc per a un esdeveniment únic. Exemple:</value></data>
+  <data name="Calendar_SaveOverride" xml:space="preserve"><value>Desa la substitució</value></data>
+  <data name="Calendar_Start" xml:space="preserve"><value>Inici</value></data>
+  <data name="Calendar_StartDate" xml:space="preserve"><value>Data d'inici</value></data>
+  <data name="Calendar_TeamFallback" xml:space="preserve"><value>Equip</value></data>
+  <data name="Calendar_Title" xml:space="preserve"><value>Calendari</value></data>
+  <data name="Calendar_Today" xml:space="preserve"><value>Avui</value></data>
+  <data name="Calendar_UpcomingOccurrences" xml:space="preserve"><value>Properes ocurrències</value></data>
+  <data name="Calendar_ViewAriaLabel" xml:space="preserve"><value>Vista del calendari</value></data>
+  <data name="Calendar_ViewGrid" xml:space="preserve"><value>Graella</value></data>
+  <data name="Calendar_ViewList" xml:space="preserve"><value>Llista</value></data>
+  <data name="Calendar_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Camp_AboutHeading" xml:space="preserve"><value>Sobre el teu {0}</value></data>
+  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>Accepteu nous humans?</value></data>
+  <data name="Camp_AdultPlayspaceLabel" xml:space="preserve"><value>Espai de joc per a adults</value></data>
+  <data name="Camp_BlurbLongLabel" xml:space="preserve"><value>Descripció completa</value></data>
+  <data name="Camp_BlurbLongPlaceholder" xml:space="preserve"><value>Explica al món com és el teu barri.</value></data>
+  <data name="Camp_BlurbShortLabel" xml:space="preserve"><value>Descripció curta</value></data>
+  <data name="Camp_BlurbShortPlaceholder" xml:space="preserve"><value>Una o dues frases sobre el teu barri (màx. 300 caràcters)</value></data>
+  <data name="Camp_CommunityHeading" xml:space="preserve"><value>Comunitat</value></data>
+  <data name="Camp_ContactEmailLabel" xml:space="preserve"><value>Correu de contacte</value></data>
+  <data name="Camp_ContactPhoneLabel" xml:space="preserve"><value>Telèfon de contacte</value></data>
+  <data name="Camp_ContactPhonePlaceholder" xml:space="preserve"><value>+34 612 345 678</value></data>
+  <data name="Camp_CultureHeading" xml:space="preserve"><value>Cultura i esdeveniments</value></data>
+  <data name="Camp_Edit_AutoCreatedFromNameChange" xml:space="preserve"><value>Creat automàticament per un canvi de nom</value></data>
+  <data name="Camp_Edit_ContainersSeparate" xml:space="preserve"><value>Els contenidors ara es gestionen per separat.</value></data>
+  <data name="Camp_Edit_HideHistoricalNames" xml:space="preserve"><value>Amaga els noms històrics</value></data>
+  <data name="Camp_Edit_HistoricalNamesHeading" xml:space="preserve"><value>Noms històrics</value></data>
+  <data name="Camp_Edit_HistoricalNamesHelp" xml:space="preserve"><value>Noms amb què es coneixia aquest barri anteriorment.</value></data>
+  <data name="Camp_Edit_ImageAlt" xml:space="preserve"><value>Imatge del barri</value></data>
+  <data name="Camp_Edit_ImagesHeading" xml:space="preserve"><value>Imatges ({0}/{1})</value></data>
+  <data name="Camp_Edit_ImageUploadHelp" xml:space="preserve"><value>JPEG, PNG o WebP. Màx. 10 MB.</value></data>
+  <data name="Camp_Edit_ManageContainers" xml:space="preserve"><value>Gestiona els contenidors →</value></data>
+  <data name="Camp_Edit_MembersRolesDescription" xml:space="preserve"><value>Gestiona els membres actius, els rols, els líders i les sol·licituds d'incorporació pendents.</value></data>
+  <data name="Camp_Edit_MembersRolesHeading" xml:space="preserve"><value>Membres i rols</value></data>
+  <data name="Camp_Edit_NameLocked" xml:space="preserve"><value>El nom està bloquejat per a aquesta temporada.</value></data>
+  <data name="Camp_Edit_OpenMembersRoles" xml:space="preserve"><value>Obre membres i rols</value></data>
+  <data name="Camp_Edit_OpenStore" xml:space="preserve"><value>Obre la botiga</value></data>
+  <data name="Camp_Edit_PreviousNamePlaceholder" xml:space="preserve"><value>Nom anterior del barri</value></data>
+  <data name="Camp_Edit_StoreDescription" xml:space="preserve"><value>Fes una comanda per a aquest barri.</value></data>
+  <data name="Camp_Edit_StoreHeading" xml:space="preserve"><value>Botiga</value></data>
+  <data name="Camp_Edit_UploadImage" xml:space="preserve"><value>Puja una imatge</value></data>
+  <data name="Camp_ElectricalGridLabel" xml:space="preserve"><value>Xarxa elèctrica</value></data>
+  <data name="Camp_HistoryHeading" xml:space="preserve"><value>Història</value></data>
+  <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Accepta membres</value></data>
+  <data name="Camp_Index_AllOption" xml:space="preserve"><value>Tots</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guia de barris 2026</value></data>
+  <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filtra</value></data>
+  <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Nens benvinguts</value></data>
+  <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>No s'ha trobat cap {0} per als filtres seleccionats.</value></data>
+  <data name="Camp_Index_NoSearchResults" xml:space="preserve"><value>Cap {0} coincideix amb la teva cerca.</value></data>
+  <data name="Camp_Index_PendingApproval" xml:space="preserve"><value>pendent d'aprovació</value></data>
+  <data name="Camp_Index_SearchLabel" xml:space="preserve"><value>Cerca</value></data>
+  <data name="Camp_Index_SearchPlaceholder" xml:space="preserve"><value>Escriu el nom d'un {0}…</value></data>
+  <data name="Camp_Index_ShowLeadPositions" xml:space="preserve"><value>Mostra les posicions de lideratge</value></data>
+  <data name="Camp_Index_SoundZoneLabel" xml:space="preserve"><value>Zona de so</value></data>
+  <data name="Camp_Index_VibeLabel" xml:space="preserve"><value>Ambient</value></data>
+  <data name="Camp_KidsAreaDescriptionLabel" xml:space="preserve"><value>Descripció de la zona infantil</value></data>
+  <data name="Camp_KidsAreaDescriptionPlaceholder" xml:space="preserve"><value>Descriu la teva zona infantil si escau</value></data>
+  <data name="Camp_KidsVisitingLabel" xml:space="preserve"><value>Política de visites de nens</value></data>
+  <data name="Camp_KidsWelcomeLabel" xml:space="preserve"><value>Nens benvinguts?</value></data>
+  <data name="Camp_LanguagesLabel" xml:space="preserve"><value>Idiomes parlats</value></data>
+  <data name="Camp_LanguagesPlaceholder" xml:space="preserve"><value>p. ex. anglès, espanyol, alemany</value></data>
+  <data name="Camp_MarkdownSupported" xml:space="preserve"><value>S'admet el format Markdown</value></data>
+  <data name="Camp_MemberCountLabel" xml:space="preserve"><value>Humans previstos</value></data>
+  <data name="Camp_NoPreference" xml:space="preserve"><value>Sense preferència</value></data>
+  <data name="Camp_NotSure" xml:space="preserve"><value>No n'estic segur</value></data>
+  <data name="Camp_PerformanceSpaceLabel" xml:space="preserve"><value>Espai d'actuacions</value></data>
+  <data name="Camp_PerformanceTypesLabel" xml:space="preserve"><value>Tipus d'actuacions</value></data>
+  <data name="Camp_PerformanceTypesPlaceholder" xml:space="preserve"><value>p. ex. música, teatre, tallers</value></data>
+  <data name="Camp_PlacementHeading" xml:space="preserve"><value>Ubicació</value></data>
+  <data name="Camp_PreviousNamesHelp" xml:space="preserve"><value>Si el teu barri ha tingut noms diferents en anys anteriors, llista'ls aquí.</value></data>
+  <data name="Camp_PreviousNamesLabel" xml:space="preserve"><value>Noms anteriors</value></data>
+  <data name="Camp_PreviousNamesPlaceholder" xml:space="preserve"><value>Llista de noms anteriors del barri separats per comes</value></data>
+  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Registre</value></data>
+  <data name="Camp_Register_Heading" xml:space="preserve"><value>Registra el teu {0}</value></data>
+  <data name="Camp_Register_ImportantInfo" xml:space="preserve"><value>Informació important</value></data>
+  <data name="Camp_Register_Season" xml:space="preserve"><value>temporada</value></data>
+  <data name="Camp_Register_Submit" xml:space="preserve"><value>Registra {0}</value></data>
+  <data name="Camp_SoundZoneLabel" xml:space="preserve"><value>Preferència de zona de so</value></data>
+  <data name="Camp_SpaceRequirementLabel" xml:space="preserve"><value>Requisit d'espai</value></data>
+  <data name="Camp_TimesParticipatingLabel" xml:space="preserve"><value>Vegades participant</value></data>
+  <data name="Camp_VibesLabel" xml:space="preserve"><value>Ambient</value></data>
+  <data name="CampCard_AcceptingMembers" xml:space="preserve"><value>Accepta membres</value></data>
+  <data name="CampCard_Full" xml:space="preserve"><value>Complet</value></data>
+  <data name="CampCard_KidsWelcome" xml:space="preserve"><value>Nens benvinguts</value></data>
+  <data name="CampCard_TimesAtNowhere" xml:space="preserve"><value>{0} any(s)</value></data>
+  <data name="Common_Actions" xml:space="preserve"><value>Accions</value></data>
+  <data name="Common_Admin" xml:space="preserve"><value>Administrador</value></data>
+  <data name="Common_Amount" xml:space="preserve"><value>Import</value></data>
+  <data name="Common_Clear" xml:space="preserve"><value>Esborra</value></data>
+  <data name="Common_Created" xml:space="preserve"><value>Creat</value></data>
+  <data name="Common_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="Common_DeleteImage" xml:space="preserve"><value>Elimina la imatge</value></data>
+  <data name="Common_Department" xml:space="preserve"><value>Departament</value></data>
+  <data name="Common_MoveDown" xml:space="preserve"><value>Mou avall</value></data>
+  <data name="Common_MoveUp" xml:space="preserve"><value>Mou amunt</value></data>
+  <data name="Common_Other" xml:space="preserve"><value>Altres</value></data>
+  <data name="Common_Preview" xml:space="preserve"><value>Vista prèvia</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Treu</value></data>
+  <data name="Common_Required" xml:space="preserve"><value>(obligatori)</value></data>
+  <data name="Common_Sender" xml:space="preserve"><value>Remitent</value></data>
+  <data name="Common_Shift" xml:space="preserve"><value>Torn</value></data>
+  <data name="Common_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="Common_View" xml:space="preserve"><value>Veure</value></data>
+  <data name="CommPrefs_AlwaysOn" xml:space="preserve"><value>Sempre actiu</value></data>
+  <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Hola {0},&lt;/p&gt;
+&lt;p&gt;Estàs convidat/da a completar l'enquesta &lt;strong&gt;{1}&lt;/strong&gt;. Només et portarà uns minuts.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Obre l'enquesta&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Gràcies,&lt;br/&gt;El Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Si us plau, completa: {0}</value></data>
+  <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Hola {0},&lt;/p&gt;
+&lt;p&gt;Només un recordatori que l'enquesta &lt;strong&gt;{1}&lt;/strong&gt; encara espera la teva resposta.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Obre l'enquesta&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Gràcies,&lt;br/&gt;El Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyReminder_Subject" xml:space="preserve"><value>Recordatori: {0}</value></data>
+  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Etiquetat amb {0} però sense cap fila AspNetUserLogins coincident — s'autorepara en el proper inici de sessió OAuth.</value></data>
+  <data name="EmailGrid_WorkspaceLocked" xml:space="preserve"><value>Bloquejat per la fila del correu de Workspace</value></data>
+  <data name="Enum_AdultPlayspacePolicy_NightOnly" xml:space="preserve"><value>Només de nit</value></data>
+  <data name="Enum_AdultPlayspacePolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_AdultPlayspacePolicy_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Enum_CampVibe_Adult" xml:space="preserve"><value>Adults</value></data>
+  <data name="Enum_CampVibe_ChillOut" xml:space="preserve"><value>Relax</value></data>
+  <data name="Enum_CampVibe_ElectronicMusic" xml:space="preserve"><value>Música electrònica</value></data>
+  <data name="Enum_CampVibe_Games" xml:space="preserve"><value>Jocs</value></data>
+  <data name="Enum_CampVibe_Lecture" xml:space="preserve"><value>Xerrada</value></data>
+  <data name="Enum_CampVibe_LiveMusic" xml:space="preserve"><value>Música en directe</value></data>
+  <data name="Enum_CampVibe_Queer" xml:space="preserve"><value>Queer</value></data>
+  <data name="Enum_CampVibe_Sober" xml:space="preserve"><value>Sobri</value></data>
+  <data name="Enum_CampVibe_Wellness" xml:space="preserve"><value>Benestar</value></data>
+  <data name="Enum_CampVibe_Workshop" xml:space="preserve"><value>Taller</value></data>
+  <data name="Enum_ContactFieldType_Discord" xml:space="preserve"><value>Discord</value></data>
+  <data name="Enum_ContactFieldType_Other" xml:space="preserve"><value>Altres</value></data>
+  <data name="Enum_ContactFieldType_Phone" xml:space="preserve"><value>Telèfon</value></data>
+  <data name="Enum_ContactFieldType_Signal" xml:space="preserve"><value>Signal</value></data>
+  <data name="Enum_ContactFieldType_Telegram" xml:space="preserve"><value>Telegram</value></data>
+  <data name="Enum_ContactFieldType_WhatsApp" xml:space="preserve"><value>WhatsApp</value></data>
+  <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Tots els humans actius</value></data>
+  <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Només la junta</value></data>
+  <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinadors + Junta</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Els meus equips (+ coordinadors i junta)</value></data>
+  <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
+  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Subministrament propi</value></data>
+  <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Vermell</value></data>
+  <data name="Enum_ElectricalGrid_Unknown" xml:space="preserve"><value>Desconegut</value></data>
+  <data name="Enum_ElectricalGrid_Yellow" xml:space="preserve"><value>Groc</value></data>
+  <data name="Enum_EmailOutboxStatus_Failed" xml:space="preserve"><value>Fallit</value></data>
+  <data name="Enum_EmailOutboxStatus_Queued" xml:space="preserve"><value>A la cua</value></data>
+  <data name="Enum_EmailOutboxStatus_Sent" xml:space="preserve"><value>Enviat</value></data>
+  <data name="Enum_EventStatus_Approved" xml:space="preserve"><value>Aprovat</value></data>
+  <data name="Enum_EventStatus_Draft" xml:space="preserve"><value>Esborrany</value></data>
+  <data name="Enum_EventStatus_Pending" xml:space="preserve"><value>Pendent</value></data>
+  <data name="Enum_EventStatus_Rejected" xml:space="preserve"><value>Rebutjat</value></data>
+  <data name="Enum_EventStatus_ResubmitRequested" xml:space="preserve"><value>Canvis sol·licitats</value></data>
+  <data name="Enum_EventStatus_Withdrawn" xml:space="preserve"><value>Retirat</value></data>
+  <data name="Enum_ExpenseReportStatus_Approved" xml:space="preserve"><value>Aprovat</value></data>
+  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Avalat pel coordinador</value></data>
+  <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Esborrany</value></data>
+  <data name="Enum_ExpenseReportStatus_Paid" xml:space="preserve"><value>Pagat</value></data>
+  <data name="Enum_ExpenseReportStatus_SepaSent" xml:space="preserve"><value>SEPA enviat</value></data>
+  <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Presentat</value></data>
+  <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Retirat</value></data>
+  <data name="Enum_FeedbackCategory_Bug" xml:space="preserve"><value>Error</value></data>
+  <data name="Enum_FeedbackCategory_FeatureRequest" xml:space="preserve"><value>Petició de funcionalitat</value></data>
+  <data name="Enum_FeedbackCategory_Question" xml:space="preserve"><value>Pregunta</value></data>
+  <data name="Enum_FeedbackStatus_Acknowledged" xml:space="preserve"><value>Confirmat</value></data>
+  <data name="Enum_FeedbackStatus_Open" xml:space="preserve"><value>Obert</value></data>
+  <data name="Enum_FeedbackStatus_Resolved" xml:space="preserve"><value>Resolt</value></data>
+  <data name="Enum_FeedbackStatus_WontFix" xml:space="preserve"><value>No es corregirà</value></data>
+  <data name="Enum_IssueCategory_Bug" xml:space="preserve"><value>Error</value></data>
+  <data name="Enum_IssueCategory_Feature" xml:space="preserve"><value>Funcionalitat</value></data>
+  <data name="Enum_IssueCategory_Question" xml:space="preserve"><value>Pregunta</value></data>
+  <data name="Enum_KidsVisitingPolicy_DaytimeOnly" xml:space="preserve"><value>Només de dia</value></data>
+  <data name="Enum_KidsVisitingPolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_KidsVisitingPolicy_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Enum_LanguageProficiency_Basic" xml:space="preserve"><value>Bàsic</value></data>
+  <data name="Enum_LanguageProficiency_Conversational" xml:space="preserve"><value>Conversacional</value></data>
+  <data name="Enum_LanguageProficiency_Fluent" xml:space="preserve"><value>Fluid</value></data>
+  <data name="Enum_LanguageProficiency_Native" xml:space="preserve"><value>Nadiu</value></data>
+  <data name="Enum_PerformanceSpaceStatus_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_PerformanceSpaceStatus_WorkingOnIt" xml:space="preserve"><value>Hi estem treballant</value></data>
+  <data name="Enum_PerformanceSpaceStatus_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Enum_RolePeriod_Build" xml:space="preserve"><value>Muntatge</value></data>
+  <data name="Enum_RolePeriod_Event" xml:space="preserve"><value>Esdeveniment</value></data>
+  <data name="Enum_RolePeriod_Strike" xml:space="preserve"><value>Desmuntatge</value></data>
+  <data name="Enum_RolePeriod_YearRound" xml:space="preserve"><value>Tot l'any</value></data>
+  <data name="Enum_SlotPriority_Critical" xml:space="preserve"><value>Crítica</value></data>
+  <data name="Enum_SlotPriority_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Enum_SlotPriority_NiceToHave" xml:space="preserve"><value>Estaria bé</value></data>
+  <data name="Enum_SlotPriority_None" xml:space="preserve"><value>Cap</value></data>
+  <data name="Enum_SoundZone_Blue" xml:space="preserve"><value>Blau</value></data>
+  <data name="Enum_SoundZone_Green" xml:space="preserve"><value>Verd</value></data>
+  <data name="Enum_SoundZone_Orange" xml:space="preserve"><value>Taronja</value></data>
+  <data name="Enum_SoundZone_Red" xml:space="preserve"><value>Vermell</value></data>
+  <data name="Enum_SoundZone_Surprise" xml:space="preserve"><value>Sorpresa</value></data>
+  <data name="Enum_SoundZone_Yellow" xml:space="preserve"><value>Groc</value></data>
+  <data name="Enum_SpaceSize_Sqm1000" xml:space="preserve"><value>1000 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1200" xml:space="preserve"><value>1200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm150" xml:space="preserve"><value>150 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1500" xml:space="preserve"><value>1500 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1800" xml:space="preserve"><value>1800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2200" xml:space="preserve"><value>2200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2800" xml:space="preserve"><value>2800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm300" xml:space="preserve"><value>300 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm450" xml:space="preserve"><value>450 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm600" xml:space="preserve"><value>600 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm800" xml:space="preserve"><value>800 m²</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Camp" xml:space="preserve"><value>Barri</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Team" xml:space="preserve"><value>Equip</value></data>
+  <data name="Enum_TicketTransferStatus_Approved" xml:space="preserve"><value>Completada</value></data>
+  <data name="Enum_TicketTransferStatus_Cancelled" xml:space="preserve"><value>Cancel·lada</value></data>
+  <data name="Enum_TicketTransferStatus_Pending" xml:space="preserve"><value>Pendent de revisió</value></data>
+  <data name="Enum_TicketTransferStatus_Rejected" xml:space="preserve"><value>Cancel·lada per l'equip</value></data>
+  <data name="Enum_YesNoMaybe_Maybe" xml:space="preserve"><value>Potser</value></data>
+  <data name="Enum_YesNoMaybe_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_YesNoMaybe_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Events_AddBarrioEvent" xml:space="preserve"><value>Afegeix un esdeveniment de barri</value></data>
+  <data name="Events_AddToFavourites" xml:space="preserve"><value>Afegeix als preferits</value></data>
+  <data name="Events_AllCategories" xml:space="preserve"><value>Totes les categories</value></data>
+  <data name="Events_AllTimesIn" xml:space="preserve"><value>Totes les hores en {0}. Pot aplicar-se la Playa Time!</value></data>
+  <data name="Events_AllTimesInShort" xml:space="preserve"><value>Totes les hores en {0}</value></data>
+  <data name="Events_AllVenues" xml:space="preserve"><value>Tots els espais</value></data>
+  <data name="Events_BrowseTitle" xml:space="preserve"><value>Explora els esdeveniments</value></data>
+  <data name="Events_ColActions" xml:space="preserve"><value>Accions</value></data>
+  <data name="Events_ColCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Events_ColDateTime" xml:space="preserve"><value>Data i hora</value></data>
+  <data name="Events_ColEventName" xml:space="preserve"><value>Nom de l'esdeveniment</value></data>
+  <data name="Events_ColPriority" xml:space="preserve"><value>Prioritat</value></data>
+  <data name="Events_ConflictBadge" xml:space="preserve"><value>Conflicte d'horari amb un altre esdeveniment preferit</value></data>
+  <data name="Events_DownloadCsv" xml:space="preserve"><value>Descarrega el CSV d'esdeveniments</value></data>
+  <data name="Events_DurationMin" xml:space="preserve"><value>{0} min</value></data>
+  <data name="Events_FavouritesOnly" xml:space="preserve"><value>Només</value></data>
+  <data name="Events_FilterCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Events_FilterDay" xml:space="preserve"><value>Dia</value></data>
+  <data name="Events_FilterSearch" xml:space="preserve"><value>Cerca</value></data>
+  <data name="Events_FilterVenue" xml:space="preserve"><value>Espai</value></data>
+  <data name="Events_MyPersonalEvents" xml:space="preserve"><value>Els meus esdeveniments personals</value></data>
+  <data name="Events_MySchedule" xml:space="preserve"><value>La meva agenda</value></data>
+  <data name="Events_MySubmissions" xml:space="preserve"><value>Les meves propostes</value></data>
+  <data name="Events_MySubmissionsTitle" xml:space="preserve"><value>Les meves propostes d'esdeveniments</value></data>
+  <data name="Events_NoBarrioEvents" xml:space="preserve"><value>Encara no s'ha proposat cap esdeveniment per a aquest barri.</value></data>
+  <data name="Events_NoEventsFound" xml:space="preserve"><value>No s'ha trobat cap esdeveniment. Prova d'ajustar els filtres.</value></data>
+  <data name="Events_NoPersonalEvents" xml:space="preserve"><value>Encara no has proposat cap esdeveniment personal.</value></data>
+  <data name="Events_RemoveFromFavourites" xml:space="preserve"><value>Treu dels preferits</value></data>
+  <data name="Events_RemoveFromSchedule" xml:space="preserve"><value>Treu de l'agenda</value></data>
+  <data name="Events_RemoveFromScheduleConfirm" xml:space="preserve"><value>Vols treure aquest esdeveniment de la teva agenda?</value></data>
+  <data name="Events_ScheduleEmpty" xml:space="preserve"><value>Encara no has marcat cap esdeveniment com a preferit. Explora la {0} per afegir esdeveniments a la teva agenda.</value></data>
+  <data name="Events_ScheduleEmptyLink" xml:space="preserve"><value>guia d'esdeveniments</value></data>
+  <data name="Events_ScheduleTitle" xml:space="preserve"><value>La meva agenda</value></data>
+  <data name="Events_SearchPlaceholder" xml:space="preserve"><value>Cerca per títol o descripció…</value></data>
+  <data name="Events_StatApproved" xml:space="preserve"><value>Aprovats</value></data>
+  <data name="Events_StatPending" xml:space="preserve"><value>Pendents</value></data>
+  <data name="Events_StatSubmitted" xml:space="preserve"><value>Enviats</value></data>
+  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Període de propostes:</value></data>
+  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>El període de propostes no està obert actualment. Contacta amb un administrador per configurar els ajustos de la guia.</value></data>
+  <data name="Events_SubmitNewEvent" xml:space="preserve"><value>Proposa un nou esdeveniment</value></data>
+  <data name="Events_UploadColErrors" xml:space="preserve"><value>Errors</value></data>
+  <data name="Events_UploadColEvent" xml:space="preserve"><value>Esdeveniment</value></data>
+  <data name="Events_UploadColRow" xml:space="preserve"><value>Fila</value></data>
+  <data name="Events_UploadCsv" xml:space="preserve"><value>Puja un CSV</value></data>
+  <data name="Events_UploadFailed" xml:space="preserve"><value>La pujada ha fallat.</value></data>
+  <data name="Events_UploadFailedDetail" xml:space="preserve"><value>Corregeix els errors de sota i torna-ho a provar. No s'ha desat cap esdeveniment.</value></data>
+  <data name="Events_WithdrawConfirm" xml:space="preserve"><value>Vols retirar aquest esdeveniment?</value></data>
+  <data name="Expenses_ColReport" xml:space="preserve"><value>Informe</value></data>
+  <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Presentat</value></data>
+  <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Presentat per</value></data>
+  <data name="Expenses_CoordinatorQueue" xml:space="preserve"><value>Cua del coordinador</value></data>
+  <data name="Expenses_CoordinatorQueueTitle" xml:space="preserve"><value>Informes de despeses — Cua del coordinador</value></data>
+  <data name="Expenses_Endorse" xml:space="preserve"><value>Avala</value></data>
+  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Vols avalar aquest informe de despeses?</value></data>
+  <data name="Expenses_FileFirst" xml:space="preserve"><value>Presenta el teu primer informe</value></data>
+  <data name="Expenses_IouHeader" xml:space="preserve"><value>El que el col·lectiu et deu</value></data>
+  <data name="Expenses_IouLastPayment" xml:space="preserve"><value>Últim pagament</value></data>
+  <data name="Expenses_IouOtherAmountNote" xml:space="preserve"><value>El teu saldo de Holded inclou {0} no relacionats amb aquests informes (articles avançats en nom del col·lectiu, ajustos, etc.), de manera que les files de sota no sumaran necessàriament aquesta xifra.</value></data>
+  <data name="Expenses_IouOwed" xml:space="preserve"><value>Deute amb tu (saldo de Holded)</value></data>
+  <data name="Expenses_IouPaid" xml:space="preserve"><value>Pagat fins ara</value></data>
+  <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Article</value></data>
+  <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Els meus informes de despeses</value></data>
+  <data name="Expenses_NewReport" xml:space="preserve"><value>Nou informe</value></data>
+  <data name="Expenses_NoActiveYear" xml:space="preserve"><value>De moment no hi ha cap any pressupostari actiu. No es poden presentar informes de despeses fins que no s'activi un any pressupostari.</value></data>
+  <data name="Expenses_NoIban" xml:space="preserve"><value>Encara no has establert el teu IBAN de pagament. Se't demanarà que l'estableixis quan presentis un informe.</value></data>
+  <data name="Expenses_NoReports" xml:space="preserve"><value>Encara no hi ha informes de despeses.</value></data>
+  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No hi ha cap informe esperant el teu aval.</value></data>
+  <data name="Expenses_Reject" xml:space="preserve"><value>Rebutja</value></data>
+  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>Qui l'ha presentat veurà aquest motiu. Explica clarament per què l'informe no es pot avalar.</value></data>
+  <data name="Expenses_RejectModalTitle" xml:space="preserve"><value>Rebutja l'informe</value></data>
+  <data name="Expenses_RejectReasonLabel" xml:space="preserve"><value>Motiu del rebuig</value></data>
+  <data name="Expenses_RejectReasonPlaceholder" xml:space="preserve"><value>p. ex. Falten rebuts de la línia 2</value></data>
+  <data name="Feedback_AssignedToName" xml:space="preserve"><value>Assignat a {0}</value></data>
+  <data name="Feedback_CategoryOnPage" xml:space="preserve"><value>{0} a {1}</value></data>
+  <data name="Feedback_TeamName" xml:space="preserve"><value>Equip: {0}</value></data>
+  <data name="Issue_ColComments" xml:space="preserve"><value>Comentaris</value></data>
+  <data name="Issue_ColReporter" xml:space="preserve"><value>Informador</value></data>
+  <data name="Issue_ColStatus" xml:space="preserve"><value>Estat</value></data>
+  <data name="Issue_ColTitle" xml:space="preserve"><value>Títol</value></data>
+  <data name="Issue_ColUpdated" xml:space="preserve"><value>Actualitzada</value></data>
+  <data name="Issue_CountSummary" xml:space="preserve"><value>{0} obertes · {1} en total</value></data>
+  <data name="LinkedAccounts_Account" xml:space="preserve"><value>Compte</value></data>
+  <data name="LinkedAccounts_Actions" xml:space="preserve"><value>Accions</value></data>
+  <data name="LinkedAccounts_ConfirmUnlink" xml:space="preserve"><value>Vols desvincular aquest compte? Ja no podràs iniciar sessió amb ell.</value></data>
+  <data name="LinkedAccounts_Description" xml:space="preserve"><value>Proveïdors OAuth vinculats actualment al teu compte. Pots fer servir qualsevol d'ells per iniciar sessió.</value></data>
+  <data name="LinkedAccounts_Empty" xml:space="preserve"><value>No hi ha comptes OAuth vinculats.</value></data>
+  <data name="LinkedAccounts_LastSignInMethod" xml:space="preserve"><value>Únic mètode d'inici de sessió — no es pot desvincular.</value></data>
+  <data name="LinkedAccounts_LinkedOn" xml:space="preserve"><value>Vinculat el</value></data>
+  <data name="LinkedAccounts_Provider" xml:space="preserve"><value>Proveïdor</value></data>
+  <data name="LinkedAccounts_Title" xml:space="preserve"><value>Comptes vinculats</value></data>
+  <data name="LinkedAccounts_UnlinkBlockedLastSignInMethod" xml:space="preserve"><value>No es pot desvincular — aquest és el teu únic mètode d'inici de sessió restant.</value></data>
+  <data name="MarkdownHelp_Bold" xml:space="preserve"><value>negreta</value></data>
+  <data name="MarkdownHelp_ColYouGet" xml:space="preserve"><value>Obtens</value></data>
+  <data name="MarkdownHelp_ColYouType" xml:space="preserve"><value>Escrius</value></data>
+  <data name="MarkdownHelp_EmbeddedImage" xml:space="preserve"><value>imatge incrustada</value></data>
+  <data name="MarkdownHelp_First" xml:space="preserve"><value>primer</value></data>
+  <data name="MarkdownHelp_Heading1" xml:space="preserve"><value>Encapçalament 1</value></data>
+  <data name="MarkdownHelp_Heading2" xml:space="preserve"><value>Encapçalament 2</value></data>
+  <data name="MarkdownHelp_InlineCode" xml:space="preserve"><value>codi en línia</value></data>
+  <data name="MarkdownHelp_Intro" xml:space="preserve"><value>Markdown és una manera senzilla de donar format al text. Escriu la sintaxi de l'esquerra i es mostra com es veu a la dreta.</value></data>
+  <data name="MarkdownHelp_Italic" xml:space="preserve"><value>cursiva</value></data>
+  <data name="MarkdownHelp_ItemOne" xml:space="preserve"><value>element u</value></data>
+  <data name="MarkdownHelp_ItemTwo" xml:space="preserve"><value>element dos</value></data>
+  <data name="MarkdownHelp_LinkText" xml:space="preserve"><value>text de l'enllaç</value></data>
+  <data name="MarkdownHelp_QuoteText" xml:space="preserve"><value>text citat</value></data>
+  <data name="MarkdownHelp_Second" xml:space="preserve"><value>segon</value></data>
+  <data name="MarkdownHelp_Strikethrough" xml:space="preserve"><value>ratllat</value></data>
+  <data name="MarkdownHelp_TableAdmin" xml:space="preserve"><value>Administrador</value></data>
+  <data name="MarkdownHelp_TableHuman" xml:space="preserve"><value>Human</value></data>
+  <data name="MarkdownHelp_TableName" xml:space="preserve"><value>Nom</value></data>
+  <data name="MarkdownHelp_TableRole" xml:space="preserve"><value>Rol</value></data>
+  <data name="MarkdownHelp_TablesHeading" xml:space="preserve"><value>Taules</value></data>
+  <data name="MarkdownHelp_TaskDone" xml:space="preserve"><value>Fet</value></data>
+  <data name="MarkdownHelp_TaskListsHeading" xml:space="preserve"><value>Llistes de tasques</value></data>
+  <data name="MarkdownHelp_TaskToDo" xml:space="preserve"><value>Per fer</value></data>
+  <data name="MarkdownHelp_Title" xml:space="preserve"><value>Referència ràpida de Markdown</value></data>
+  <data name="Onboarding_BurnerNameExplainer" xml:space="preserve"><value>El nom que tothom veu al sistema. Que sigui únic ajuda, però no és obligatori, tot i que pot ser difícil trobar el "Bob" entre els milers d'humans que hi ha aquí si algú et ve a buscar.</value></data>
+  <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>El nom amb què tothom et coneixerà.</value></data>
+  <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Nom burner</value></data>
+  <data name="Onboarding_Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>no</value></data>
+  <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>exportem aquesta informació, i només la divulgaríem si ho exigís la llei o una auditoria formal.</value></data>
+  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Es guarda internament, només visible per als administradors, i s'utilitza només on la llei espanyola ho requereix — per exemple, el nostre registre d'auditoria que vas acceptar l'acord de voluntariat en una data i hora concretes. Explícitament</value></data>
+  <data name="Onboarding_LegalNameLabel" xml:space="preserve"><value>Nom legal</value></data>
+  <data name="Onboarding_NameRequiredBeforeShifts" xml:space="preserve"><value>Afegeix primer el teu nom — el necessitem abans que puguis apuntar-te a torns.</value></data>
+  <data name="Onboarding_NamesSubtitle" xml:space="preserve"><value>Dos passos breus abans de triar un torn.</value></data>
+  <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Benvingut/da — comencem pel teu nom</value></data>
+  <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Crític</value></data>
+  <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'esdeveniment només té un {0}% dels torns "crítics" coberts. Si no s'omplen, l'esdeveniment podria cancel·lar-se, ja que no seria viable ni segur tirar-lo endavant.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si en pots omplir alguns, o pots venir abans de l'esdeveniment o quedar-te al desmuntatge, prioritza'ls a l'hora de triar els teus torns.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT:</value></data>
+  <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>També hi ha {0} torns "importants" oberts.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hi ha {0} torns "importants" oberts. Si pots venir abans de l'esdeveniment o quedar-te al desmuntatge, prioritza'ls.</value></data>
+  <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Ara mateix no hi ha cap esdeveniment actiu. Pots acabar la incorporació sense triar cap torn.</value></data>
+  <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>De moment no hi ha torns crítics oberts — prova amb Importants o Tots.</value></data>
+  <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>De moment no hi ha torns importants oberts — prova amb Tots.</value></data>
+  <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Ara no</value></data>
+  <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Tria un torn</value></data>
+  <data name="Outbox_AdminTitle" xml:space="preserve"><value>Correus</value></data>
+  <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Torna a Administració</value></data>
+  <data name="Outbox_BackToProfile" xml:space="preserve"><value>Torna al perfil</value></data>
+  <data name="Outbox_DescriptionAdmin" xml:space="preserve"><value>Correus que el sistema ha enviat a aquest human.</value></data>
+  <data name="Outbox_DescriptionSelf" xml:space="preserve"><value>Correus que el sistema t'ha enviat (en els últims 150 dies).</value></data>
+  <data name="Outbox_Empty" xml:space="preserve"><value>No hi ha cap correu registrat.</value></data>
+  <data name="Outbox_Subject" xml:space="preserve"><value>Assumpte</value></data>
+  <data name="Privacy_ThirdParty_GooglePolicyLink" xml:space="preserve"><value>Política de privacitat de Google</value></data>
+  <data name="Profile_Assigned" xml:space="preserve"><value>Assignat</value></data>
+  <data name="Profile_Campaign" xml:space="preserve"><value>Campanya</value></data>
+  <data name="Profile_Code" xml:space="preserve"><value>Codi</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Dairy" xml:space="preserve"><value>Lactis</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Egg" xml:space="preserve"><value>Ou</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Peanut" xml:space="preserve"><value>Cacauet</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Sesame" xml:space="preserve"><value>Sèsam</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Shellfish" xml:space="preserve"><value>Marisc</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Soy" xml:space="preserve"><value>Soja</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Treenut" xml:space="preserve"><value>Fruits secs</value></data>
+  <data name="Profile_DietaryMedical_Allergy_WheatGluten" xml:space="preserve"><value>Blat/Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_FODMAP" xml:space="preserve"><value>FODMAP</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Gluten" xml:space="preserve"><value>Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Histamine" xml:space="preserve"><value>Histamina</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Lactose" xml:space="preserve"><value>Lactosa</value></data>
+  <data name="Profile_MarkedAt" xml:space="preserve"><value>Marcat el</value></data>
+  <data name="Profile_MarkedBy" xml:space="preserve"><value>Marcat per</value></data>
+  <data name="Profile_MyCodes" xml:space="preserve"><value>Els meus codis</value></data>
+  <data name="Profile_MyEmails" xml:space="preserve"><value>Els meus correus</value></data>
+  <data name="Profile_NoSentMessages" xml:space="preserve"><value>No hi ha cap missatge dins la plataforma registrat.</value></data>
+  <data name="Profile_NoShowHistory" xml:space="preserve"><value>Historial d'absències ({0})</value></data>
+  <data name="Profile_OnsiteSince" xml:space="preserve"><value>Al recinte des de {0}</value></data>
+  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Check-in fet a la porta</value></data>
+  <data name="Profile_Redeemed" xml:space="preserve"><value>Bescanviat</value></data>
+  <data name="Profile_SentMessages" xml:space="preserve"><value>Missatges enviats ({0})</value></data>
+  <data name="Profile_ShiftInfo" xml:space="preserve"><value>Informació del torn</value></data>
+  <data name="ProfileEdit_CityPlaceholder" xml:space="preserve"><value>Comença a escriure la teva ciutat…</value></data>
+  <data name="ProfileEdit_ContactType" xml:space="preserve"><value>Tipus</value></data>
+  <data name="ProfileEdit_ContactValue" xml:space="preserve"><value>Valor</value></data>
+  <data name="ProfileEdit_ContactValuePlaceholder" xml:space="preserve"><value>Introdueix la informació de contacte</value></data>
+  <data name="ProfileEdit_ContactVisibility" xml:space="preserve"><value>Visibilitat</value></data>
+  <data name="ProfileEdit_CustomLabelPlaceholder" xml:space="preserve"><value>p. ex., Discord</value></data>
+  <data name="ProfileEdit_Description" xml:space="preserve"><value>Descripció</value></data>
+  <data name="ProfileEdit_DescriptionPlaceholder" xml:space="preserve"><value>p. ex., Líder de la porta</value></data>
+  <data name="ProfileEdit_EventName" xml:space="preserve"><value>Nom de l'esdeveniment</value></data>
+  <data name="ProfileEdit_EventNamePlaceholder" xml:space="preserve"><value>p. ex., Burning Man 2024</value></data>
+  <data name="ProfileEdit_LanguageLabel" xml:space="preserve"><value>Idioma</value></data>
+  <data name="ProfileEdit_ProficiencyLabel" xml:space="preserve"><value>Nivell</value></data>
+  <data name="ProfileEdit_RelationshipPlaceholder" xml:space="preserve"><value>p. ex., Parella, Pare/Mare</value></data>
+  <data name="ProfileEdit_RemoveContactField" xml:space="preserve"><value>Treu aquest camp de contacte</value></data>
+  <data name="ProfileEdit_RemoveEntry" xml:space="preserve"><value>Treu aquesta entrada</value></data>
+  <data name="ProfileEdit_RemoveLanguage" xml:space="preserve"><value>Treu aquest idioma</value></data>
+  <data name="ProfileEdit_SelectLanguage" xml:space="preserve"><value>— Selecciona un idioma —</value></data>
+  <data name="Roster_All" xml:space="preserve"><value>Tots</value></data>
+  <data name="Roster_ColAssignedTo" xml:space="preserve"><value>Assignat a</value></data>
+  <data name="Roster_ColPeriod" xml:space="preserve"><value>Període</value></data>
+  <data name="Roster_ColPriority" xml:space="preserve"><value>Prioritat</value></data>
+  <data name="Roster_ColRole" xml:space="preserve"><value>Rol</value></data>
+  <data name="Roster_ColSlot" xml:space="preserve"><value>Plaça</value></data>
+  <data name="Roster_ColTeam" xml:space="preserve"><value>Equip</value></data>
+  <data name="Roster_NoSlots" xml:space="preserve"><value>No hi ha places de rol definides als equips.</value></data>
+  <data name="Roster_PeriodFilter" xml:space="preserve"><value>Període: {0}</value></data>
+  <data name="Roster_PriorityFilter" xml:space="preserve"><value>Prioritat: {0}</value></data>
+  <data name="Roster_SlotOpen" xml:space="preserve"><value>Oberta</value></data>
+  <data name="Roster_StatusFilled" xml:space="preserve"><value>Coberta</value></data>
+  <data name="Roster_StatusFilter" xml:space="preserve"><value>Estat: {0}</value></data>
+  <data name="Roster_StatusOpen" xml:space="preserve"><value>Oberta</value></data>
+  <data name="Roster_Title" xml:space="preserve"><value>Llista de l'equip</value></data>
+  <data name="Search_FilterAll" xml:space="preserve"><value>Tot</value></data>
+  <data name="Search_FilterCamps" xml:space="preserve"><value>Barris</value></data>
+  <data name="Search_FilterEvents" xml:space="preserve"><value>Esdeveniments</value></data>
+  <data name="Search_FilterHumans" xml:space="preserve"><value>Humans</value></data>
+  <data name="Search_FilterShifts" xml:space="preserve"><value>Torns</value></data>
+  <data name="Search_FilterTeams" xml:space="preserve"><value>Equips</value></data>
+  <data name="Search_GlobalHint" xml:space="preserve"><value>Escriu almenys 2 caràcters per cercar entre humans, equips, barris i torns.</value></data>
+  <data name="Search_GlobalHintEvents" xml:space="preserve"><value>Escriu almenys 2 caràcters per cercar entre humans, equips, barris, torns i esdeveniments.</value></data>
+  <data name="Search_GlobalNoResults" xml:space="preserve"><value>Cap resultat per a {0}.</value></data>
+  <data name="Search_GlobalPlaceholder" xml:space="preserve"><value>Cerca humans, equips, barris, torns…</value></data>
+  <data name="Search_GlobalPlaceholderEvents" xml:space="preserve"><value>Cerca humans, equips, barris, torns, esdeveniments…</value></data>
+  <data name="Search_GlobalTitle" xml:space="preserve"><value>Cerca</value></data>
+  <data name="Store_AdminCatalog" xml:space="preserve"><value>Catàleg</value></data>
+  <data name="Store_AdminPayments" xml:space="preserve"><value>Pagaments</value></data>
+  <data name="Store_AdminSummary" xml:space="preserve"><value>Resum</value></data>
+  <data name="Store_CatalogHeading" xml:space="preserve"><value>Catàleg ({0})</value></data>
+  <data name="Store_ColBalance" xml:space="preserve"><value>Saldo</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Dipòsit</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Dipòsits</value></data>
+  <data name="Store_ColDescription" xml:space="preserve"><value>Descripció</value></data>
+  <data name="Store_ColLines" xml:space="preserve"><value>Línies</value></data>
+  <data name="Store_ColLinesVat" xml:space="preserve"><value>Línies + IVA</value></data>
+  <data name="Store_ColName" xml:space="preserve"><value>Nom</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Demana per</value></data>
+  <data name="Store_ColState" xml:space="preserve"><value>Estat</value></data>
+  <data name="Store_ColUnitPrice" xml:space="preserve"><value>Preu unitari (IVA inclòs)</value></data>
+  <data name="Store_CreateOrder" xml:space="preserve"><value>Crea una comanda</value></data>
+  <data name="Store_DeleteOrderConfirm" xml:space="preserve"><value>Vols eliminar aquesta comanda amb saldo zero? Això no es pot desfer.</value></data>
+  <data name="Store_DeleteOrderTitle" xml:space="preserve"><value>Elimina (saldo zero)</value></data>
+  <data name="Store_NoCounterpartiesAlert" xml:space="preserve"><value>No lideres cap barri ni coordines cap departament amb una temporada activa enguany. El catàleg de sota és de només lectura.</value></data>
+  <data name="Store_NoOrders" xml:space="preserve"><value>Encara no hi ha comandes.</value></data>
+  <data name="Store_NoProducts" xml:space="preserve"><value>No hi ha cap producte actiu per a {0}.</value></data>
+  <data name="Store_OpenOrder" xml:space="preserve"><value>Obre</value></data>
+  <data name="Store_StartOrder" xml:space="preserve"><value>Inicia una comanda</value></data>
+  <data name="Store_Title" xml:space="preserve"><value>Botiga</value></data>
+  <data name="Teams_Departments" xml:space="preserve"><value>Departaments</value></data>
+  <data name="Teams_HiddenTeams" xml:space="preserve"><value>Equips ocults</value></data>
+  <data name="Teams_HiddenTeamsNote" xml:space="preserve"><value>(visible només per als administradors)</value></data>
+  <data name="Teams_Summary" xml:space="preserve"><value>Resum</value></data>
+  <data name="Teams_SyncStatus" xml:space="preserve"><value>Estat de sincronització</value></data>
+  <data name="Teams_SystemTeams" xml:space="preserve"><value>Equips del sistema</value></data>
+  <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Transferència ja pendent</value></data>
+  <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Cancel·la la sol·licitud</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Ja ha fet el check-in — no es pot transferir</value></data>
+  <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>Això sol·licitarà la transferència de l'entrada {0} ({1}) a {2}.</value></data>
+  <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>El nostre equip d'entrades ho processarà i t'ho farà saber aviat.</value></data>
+  <data name="TicketTransfer_Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="TicketTransfer_NoneTransferable" xml:space="preserve"><value>Cap de les teves entrades es pot transferir ara mateix.</value></data>
+  <data name="TicketTransfer_NoRequests" xml:space="preserve"><value>No has sol·licitat cap transferència.</value></data>
+  <data name="TicketTransfer_NoTickets" xml:space="preserve"><value>No tens cap entrada per transferir.</value></data>
+  <data name="TicketTransfer_NotTransferable" xml:space="preserve"><value>No transferible</value></data>
+  <data name="TicketTransfer_ReasonLabel" xml:space="preserve"><value>Motiu de la transferència (opcional, visible per a l'equip d'entrades)</value></data>
+  <data name="TicketTransfer_RecipientPlaceholder" xml:space="preserve"><value>Cerca per nom, o enganxa el seu correu exacte…</value></data>
+  <data name="TicketTransfer_Requested" xml:space="preserve"><value>Sol·licitada</value></data>
+  <data name="TicketTransfer_RequestTransfer" xml:space="preserve"><value>Sol·licita la transferència</value></data>
+  <data name="TicketTransfer_StatusApproved" xml:space="preserve"><value>Completada</value></data>
+  <data name="TicketTransfer_StatusCancelled" xml:space="preserve"><value>Cancel·lada</value></data>
+  <data name="TicketTransfer_StatusRejected" xml:space="preserve"><value>Cancel·lada per l'equip</value></data>
+  <data name="TicketTransfer_Step1" xml:space="preserve"><value>1. Tria l'entrada que vols transferir</value></data>
+  <data name="TicketTransfer_Step2" xml:space="preserve"><value>2. A qui l'envies?</value></data>
+  <data name="TicketTransfer_Step3" xml:space="preserve"><value>3. Confirma</value></data>
+  <data name="TicketTransfer_Title" xml:space="preserve"><value>Transfereix una entrada</value></data>
+  <data name="TicketTransfer_YourRequests" xml:space="preserve"><value>Les teves sol·licituds de transferència</value></data>
 </root>
-<!-- ReSharper restore MarkupTextTypo -->

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -6159,7 +6159,7 @@
   <data name="Calendar_ViewList" xml:space="preserve"><value>Llista</value></data>
   <data name="Calendar_Yes" xml:space="preserve"><value>Sí</value></data>
   <data name="Camp_AboutHeading" xml:space="preserve"><value>Sobre el teu {0}</value></data>
-  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>Accepteu nous humans?</value></data>
+  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>Acceptes nous humans?</value></data>
   <data name="Camp_AdultPlayspaceLabel" xml:space="preserve"><value>Espai de joc per a adults</value></data>
   <data name="Camp_BlurbLongLabel" xml:space="preserve"><value>Descripció completa</value></data>
   <data name="Camp_BlurbLongPlaceholder" xml:space="preserve"><value>Explica al món com és el teu barri.</value></data>
@@ -6192,7 +6192,7 @@
   <data name="Camp_HistoryHeading" xml:space="preserve"><value>Història</value></data>
   <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Accepta membres</value></data>
   <data name="Camp_Index_AllOption" xml:space="preserve"><value>Tots</value></data>
-  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guia de barris 2026</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guia de Barrio 2026</value></data>
   <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filtra</value></data>
   <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Nens benvinguts</value></data>
   <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>No s'ha trobat cap {0} per als filtres seleccionats.</value></data>
@@ -6592,7 +6592,7 @@
   <data name="Store_ColLines" xml:space="preserve"><value>Línies</value></data>
   <data name="Store_ColLinesVat" xml:space="preserve"><value>Línies + IVA</value></data>
   <data name="Store_ColName" xml:space="preserve"><value>Nom</value></data>
-  <data name="Store_ColOrderBy" xml:space="preserve"><value>Demana per</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Demana abans del</value></data>
   <data name="Store_ColState" xml:space="preserve"><value>Estat</value></data>
   <data name="Store_ColUnitPrice" xml:space="preserve"><value>Preu unitari (IVA inclòs)</value></data>
   <data name="Store_CreateOrder" xml:space="preserve"><value>Crea una comanda</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -6050,7 +6050,7 @@
   <data name="About_License_BSD2" xml:space="preserve"><value>erfordert einen Copyright-Hinweis in der Dokumentation.</value></data>
   <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>erfordert einen Copyright-Hinweis; diese Seite erfüllt diese Verpflichtung.</value></data>
   <data name="About_License_ISC" xml:space="preserve"><value>permissiv, funktional gleichwertig zu BSD-2-Clause; Copyright-Hinweis erforderlich.</value></data>
-  <data name="About_License_LGPL30" xml:space="preserve"><value>die Bibliothek muss für die Endnutzer austauschbar sein. Wird als unveränderte NuGet-Pakete (dynamisch eingebunden) genutzt, was die LGPL-Verpflichtungen erfüllt.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>die Bibliothek muss für die Endnutzer austauschbar sein. Werden als unveränderte NuGet-Pakete (dynamisch eingebunden) genutzt, was die LGPL-Verpflichtungen erfüllt.</value></data>
   <data name="About_License_MIT" xml:space="preserve"><value>erfordert einen Copyright-Hinweis; diese Seite erfüllt diese Verpflichtung.</value></data>
   <data name="About_License_PostgreSQL" xml:space="preserve"><value>permissiv, MIT-ähnlich; Copyright-Hinweis erforderlich.</value></data>
   <data name="About_License_SILOFL" xml:space="preserve"><value>frei nutzbar und weiterverbreitbar; Schriften dürfen nicht eigenständig verkauft werden.</value></data>
@@ -6105,12 +6105,12 @@
   <data name="Calendar_AllDayEvent" xml:space="preserve"><value>Ganztägige Veranstaltung</value></data>
   <data name="Calendar_AllDayLabel" xml:space="preserve"><value>Ganztägig</value></data>
   <data name="Calendar_AllTeamsMonthView" xml:space="preserve"><value>Alle Teams (Monatsansicht)</value></data>
-  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>Alle Zeiten angezeigt in {0}.</value></data>
+  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>Alle Zeiten werden in {0} angezeigt.</value></data>
   <data name="Calendar_BackToCalendar" xml:space="preserve"><value>Zurück zum Kalender</value></data>
   <data name="Calendar_CancelOccurrenceConfirm" xml:space="preserve"><value>Nur diesen Termin absagen?</value></data>
   <data name="Calendar_CancelThisOccurrence" xml:space="preserve"><value>Diesen absagen</value></data>
   <data name="Calendar_ChangeHistory" xml:space="preserve"><value>Änderungsverlauf</value></data>
-  <data name="Calendar_Continues" xml:space="preserve"><value>fortlaufend</value></data>
+  <data name="Calendar_Continues" xml:space="preserve"><value>Fortsetzung</value></data>
   <data name="Calendar_Created" xml:space="preserve"><value>Erstellt {0}</value></data>
   <data name="Calendar_CreateEvent" xml:space="preserve"><value>Veranstaltung erstellen</value></data>
   <data name="Calendar_DeleteConfirm" xml:space="preserve"><value>Diese Veranstaltung und alle ihre Termine löschen?</value></data>
@@ -6264,7 +6264,7 @@
 &lt;p&gt;&lt;a href="{2}"&gt;Umfrage öffnen&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;Vielen Dank,&lt;br/&gt;Das Nobodies Collective&lt;/p&gt;</value></data>
   <data name="Email_SurveyReminder_Subject" xml:space="preserve"><value>Erinnerung: {0}</value></data>
-  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Mit {0} getaggt, aber keine passende AspNetUserLogins-Zeile — heilt sich beim nächsten OAuth-Login von selbst.</value></data>
+  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Mit {0} getaggt, aber keine passende AspNetUserLogins-Zeile — korrigiert sich beim nächsten OAuth-Login von selbst.</value></data>
   <data name="EmailGrid_WorkspaceLocked" xml:space="preserve"><value>Gesperrt durch die Workspace-E-Mail-Zeile</value></data>
   <data name="Enum_AdultPlayspacePolicy_NightOnly" xml:space="preserve"><value>Nur nachts</value></data>
   <data name="Enum_AdultPlayspacePolicy_No" xml:space="preserve"><value>Nein</value></data>
@@ -6401,8 +6401,8 @@
   <data name="Events_StatApproved" xml:space="preserve"><value>Genehmigt</value></data>
   <data name="Events_StatPending" xml:space="preserve"><value>Ausstehend</value></data>
   <data name="Events_StatSubmitted" xml:space="preserve"><value>Eingereicht</value></data>
-  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Einreichungsfrist:</value></data>
-  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>Die Einreichungsfrist ist derzeit nicht geöffnet. Wende dich an einen Admin, um die Guide-Einstellungen zu konfigurieren.</value></data>
+  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Einreichungszeitraum:</value></data>
+  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>Der Einreichungszeitraum ist derzeit nicht geöffnet. Wende dich an einen Admin, um die Guide-Einstellungen zu konfigurieren.</value></data>
   <data name="Events_SubmitNewEvent" xml:space="preserve"><value>Neue Veranstaltung einreichen</value></data>
   <data name="Events_UploadColErrors" xml:space="preserve"><value>Fehler</value></data>
   <data name="Events_UploadColEvent" xml:space="preserve"><value>Veranstaltung</value></data>
@@ -6586,8 +6586,8 @@
   <data name="Store_AdminSummary" xml:space="preserve"><value>Übersicht</value></data>
   <data name="Store_CatalogHeading" xml:space="preserve"><value>Katalog ({0})</value></data>
   <data name="Store_ColBalance" xml:space="preserve"><value>Saldo</value></data>
-  <data name="Store_ColDeposit" xml:space="preserve"><value>Anzahlung</value></data>
-  <data name="Store_ColDeposits" xml:space="preserve"><value>Anzahlungen</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Kaution</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Kautionen</value></data>
   <data name="Store_ColDescription" xml:space="preserve"><value>Beschreibung</value></data>
   <data name="Store_ColLines" xml:space="preserve"><value>Positionen</value></data>
   <data name="Store_ColLinesVat" xml:space="preserve"><value>Positionen + MwSt.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -6010,4 +6010,626 @@
   <data name="AccountDeletion_ScheduledFor" xml:space="preserve"><value>Es wird am {0} endgültig gelöscht, sofern du nicht abbrichst.</value></data>
   <data name="AccountDeletion_Unscheduled" xml:space="preserve"><value>Es wird endgültig gelöscht, sofern du nicht abbrichst.</value></data>
   <data name="AccountDeletion_CancelButton" xml:space="preserve"><value>Löschanforderung abbrechen</value></data>
+  <data name="About_AdditionalHelp" xml:space="preserve"><value>Mit zusätzlicher Hilfe von</value></data>
+  <data name="About_AdditionalHelpAnd" xml:space="preserve"><value>und</value></data>
+  <data name="About_AnthropicNote" xml:space="preserve"><value>Antworten des Konversationsassistenten werden über die API von Anthropic erzeugt. Gemäß der DPA von Anthropic werden keine Daten zum Modelltraining verwendet.</value></data>
+  <data name="About_Cat_AILLM" xml:space="preserve"><value>KI/LLM</value></data>
+  <data name="About_Cat_BackgroundJobs" xml:space="preserve"><value>Hintergrundjobs</value></data>
+  <data name="About_Cat_Calendar" xml:space="preserve"><value>Kalender</value></data>
+  <data name="About_Cat_CSV" xml:space="preserve"><value>CSV</value></data>
+  <data name="About_Cat_Database" xml:space="preserve"><value>Datenbank</value></data>
+  <data name="About_Cat_DateTime" xml:space="preserve"><value>Datum/Uhrzeit</value></data>
+  <data name="About_Cat_Email" xml:space="preserve"><value>E-Mail</value></data>
+  <data name="About_Cat_Framework" xml:space="preserve"><value>Framework</value></data>
+  <data name="About_Cat_GitHubAPI" xml:space="preserve"><value>GitHub-API</value></data>
+  <data name="About_Cat_GoogleAPIs" xml:space="preserve"><value>Google-APIs</value></data>
+  <data name="About_Cat_HealthChecks" xml:space="preserve"><value>Health Checks</value></data>
+  <data name="About_Cat_ImageProcessing" xml:space="preserve"><value>Bildverarbeitung</value></data>
+  <data name="About_Cat_Logging" xml:space="preserve"><value>Logging</value></data>
+  <data name="About_Cat_Markdown" xml:space="preserve"><value>Markdown</value></data>
+  <data name="About_Cat_Observability" xml:space="preserve"><value>Observability</value></data>
+  <data name="About_Cat_Payments" xml:space="preserve"><value>Zahlungen</value></data>
+  <data name="About_Cat_Resilience" xml:space="preserve"><value>Resilienz</value></data>
+  <data name="About_Cat_Sanitization" xml:space="preserve"><value>Bereinigung</value></data>
+  <data name="About_Cat_Spreadsheet" xml:space="preserve"><value>Tabellenkalkulation</value></data>
+  <data name="About_Cat_StateMachine" xml:space="preserve"><value>Zustandsautomat</value></data>
+  <data name="About_Cat_UserAgent" xml:space="preserve"><value>User-Agent</value></data>
+  <data name="About_ColCategory" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="About_ColLibrary" xml:space="preserve"><value>Bibliothek</value></data>
+  <data name="About_ColLicense" xml:space="preserve"><value>Lizenz</value></data>
+  <data name="About_ColPackage" xml:space="preserve"><value>Paket</value></data>
+  <data name="About_ColVersion" xml:space="preserve"><value>Version</value></data>
+  <data name="About_DotNetDesc" xml:space="preserve"><value>ASP.NET Core MVC mit Razor-Views, Identity und dem gesamten Microsoft-Stack. Das Gerüst, das alles zusammenhält.</value></data>
+  <data name="About_FrontendHeading" xml:space="preserve"><value>Frontend-/CDN-Abhängigkeiten</value></data>
+  <data name="About_GoogleDesc" xml:space="preserve"><value>Admin Directory, Drive und Groups — Bereitstellung von Shared Drives, Ordnern und Verteilerlisten, damit das niemand von Hand machen muss.</value></data>
+  <data name="About_HangfireDesc" xml:space="preserve"><value>Hintergrundjobs für Sync, Abgleich und alles, was eine HTTP-Anfrage nicht blockieren sollte. PostgreSQL-gestützt, Dashboard inklusive.</value></data>
+  <data name="About_IngredientsHeading" xml:space="preserve"><value>Die Zutaten</value></data>
+  <data name="About_IngredientsIntro" xml:space="preserve"><value>Jede Werkstatt braucht ihr Material. Daraus ist Humans gebaut:</value></data>
+  <data name="About_Intro" xml:space="preserve"><value>Humans ist das Mitgliedschaftssystem, das Nobodies Collective am Laufen hält — Onboarding von Humans, Team-Bereitstellung, Governance-Tracking und all die Verkabelung, die es einem spanischen Verein ermöglicht, mit dem Organisationsgedächtnis von etwas Zehnmal so Großem zu arbeiten. Mit Sorgfalt gebaut, mit Sturheit gepflegt und mit gekreuzten Fingern ausgerollt.</value></data>
+  <data name="About_License_Apache2" xml:space="preserve"><value>erfordert einen Copyright-Hinweis, eine Lizenzkopie und eine Angabe von Änderungen, falls modifiziert. Alle Pakete werden unverändert verwendet.</value></data>
+  <data name="About_License_BSD2" xml:space="preserve"><value>erfordert einen Copyright-Hinweis in der Dokumentation.</value></data>
+  <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>erfordert einen Copyright-Hinweis; diese Seite erfüllt diese Verpflichtung.</value></data>
+  <data name="About_License_ISC" xml:space="preserve"><value>permissiv, funktional gleichwertig zu BSD-2-Clause; Copyright-Hinweis erforderlich.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>die Bibliothek muss für die Endnutzer austauschbar sein. Wird als unveränderte NuGet-Pakete (dynamisch eingebunden) genutzt, was die LGPL-Verpflichtungen erfüllt.</value></data>
+  <data name="About_License_MIT" xml:space="preserve"><value>erfordert einen Copyright-Hinweis; diese Seite erfüllt diese Verpflichtung.</value></data>
+  <data name="About_License_PostgreSQL" xml:space="preserve"><value>permissiv, MIT-ähnlich; Copyright-Hinweis erforderlich.</value></data>
+  <data name="About_License_SILOFL" xml:space="preserve"><value>frei nutzbar und weiterverbreitbar; Schriften dürfen nicht eigenständig verkauft werden.</value></data>
+  <data name="About_LicenseBody" xml:space="preserve"><value>Humans ist freie Software, veröffentlicht unter der</value></data>
+  <data name="About_LicenseComplianceHeading" xml:space="preserve"><value>Zusammenfassung zur Lizenzkonformität</value></data>
+  <data name="About_LicenseComplianceSummary" xml:space="preserve"><value>Alle produktiven Abhängigkeiten nutzen permissive oder schwach-copyleft Lizenzen. Keine Verstöße gefunden.</value></data>
+  <data name="About_LicenseExplanation" xml:space="preserve"><value>Du darfst diese Software verwenden, studieren, verändern und weiterverbreiten. Wenn du eine veränderte Version betreibst und andere über ein Netzwerk damit interagieren lässt, musst du deinen veränderten Quellcode unter derselben Lizenz verfügbar machen.</value></data>
+  <data name="About_LicenseFullText" xml:space="preserve"><value>Vollständiger Lizenztext:</value></data>
+  <data name="About_LicenseHeading" xml:space="preserve"><value>Lizenz</value></data>
+  <data name="About_LicenseSourceCode" xml:space="preserve"><value>Quellcode:</value></data>
+  <data name="About_MadeBy" xml:space="preserve"><value>Gemacht von</value></data>
+  <data name="About_MadeByTail" xml:space="preserve"><value>mit Liebe für die Nobodies Community.</value></data>
+  <data name="About_MailKitDesc" xml:space="preserve"><value>Transaktionale E-Mails für Benachrichtigungen und Onboarding. Die eine Bibliothek, die SMTP fast angenehm anfühlen lässt.</value></data>
+  <data name="About_MeetTheStaff" xml:space="preserve"><value>Lerne das Team kennen</value></data>
+  <data name="About_NeedHelp" xml:space="preserve"><value>Brauchst du Hilfe?</value></data>
+  <data name="About_NuGetPackagesHeading" xml:space="preserve"><value>NuGet-Pakete</value></data>
+  <data name="About_OpenSourceLicensesHeading" xml:space="preserve"><value>Open-Source-Lizenzen</value></data>
+  <data name="About_OpenSourceLicensesIntro" xml:space="preserve"><value>Humans steht auf den Schultern von Open-Source-Projekten. Die Tabelle unten listet jede produktive Abhängigkeit, ihre Version und Lizenz auf.</value></data>
+  <data name="About_OtelDesc" xml:space="preserve"><value>Strukturiertes Logging, verteilte Traces und Prometheus-Metriken. Denn „läuft auf meiner Maschine“ ist keine Monitoring-Strategie.</value></data>
+  <data name="About_PostgresDesc" xml:space="preserve"><value>Relationale Daten mit Entity Framework Core und Npgsql. NodaTime-Typen bis ganz nach unten — kein DateTime in Sicht.</value></data>
+  <data name="About_Staff_BackToAbout" xml:space="preserve"><value>Zurück zu Über uns</value></data>
+  <data name="About_Staff_Empty" xml:space="preserve"><value>Keine aktiven Rolleninhaber gefunden. Die Burg scheint leer zu sein.</value></data>
+  <data name="About_Staff_Intro" xml:space="preserve"><value>Jedes Kollektiv braucht seine Hüter. Das sind die Humans, die ihre Zeit und Energie spenden, um Nobodies am Laufen zu halten — von der Governance bis zum technischen Support, von Trust and Safety bis zur Ticket-Alchemie.</value></data>
+  <data name="About_Staff_Title" xml:space="preserve"><value>Die Humans hinter dem Vorhang</value></data>
+  <data name="About_Title" xml:space="preserve"><value>Über Humans</value></data>
+  <data name="AccountStatus_ConsentSuspendedBody" xml:space="preserve"><value>Dein Zugang ist gesperrt, bis du die erforderlichen rechtlichen Einwilligungen abschließt.</value></data>
+  <data name="AccountStatus_HeadingAdminSuspended" xml:space="preserve"><value>Dein Konto wurde von einem Administrator gesperrt</value></data>
+  <data name="AccountStatus_ReviewConsents" xml:space="preserve"><value>Erforderliche Einwilligungen prüfen</value></data>
+  <data name="Budget_ColAmount" xml:space="preserve"><value>Betrag (€)</value></data>
+  <data name="Budget_ColCategory" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="Budget_ColShare" xml:space="preserve"><value>Anteil</value></data>
+  <data name="Budget_DepartmentDetail" xml:space="preserve"><value>Abteilungsdetails</value></data>
+  <data name="Budget_Expenses" xml:space="preserve"><value>Ausgaben</value></data>
+  <data name="Budget_ExpensesBreakdown" xml:space="preserve"><value>Aufschlüsselung der Ausgaben</value></data>
+  <data name="Budget_Income" xml:space="preserve"><value>Einnahmen</value></data>
+  <data name="Budget_IncomeBreakdown" xml:space="preserve"><value>Aufschlüsselung der Einnahmen</value></data>
+  <data name="Budget_NetBalance" xml:space="preserve"><value>Nettosaldo</value></data>
+  <data name="Budget_NoActiveBudget" xml:space="preserve"><value>Kein aktives Budget</value></data>
+  <data name="Budget_NoActiveBudgetSubtitle" xml:space="preserve"><value>Es gibt kein aktives Budgetjahr zum Anzeigen. Ein Finanz-Admin richtet eines ein, sobald die Budgetplanung beginnt.</value></data>
+  <data name="Budget_NoDataSubtitle" xml:space="preserve"><value>Budgetzuweisungen erscheinen hier, sobald sie vom Finanzteam eingerichtet wurden.</value></data>
+  <data name="Budget_NoDataYet" xml:space="preserve"><value>Budgetdaten noch nicht verfügbar</value></data>
+  <data name="Budget_NoExpenseItems" xml:space="preserve"><value>Noch keine Ausgabenposten.</value></data>
+  <data name="Budget_NoIncomeItems" xml:space="preserve"><value>Noch keine Einnahmenposten.</value></data>
+  <data name="Budget_OverviewSubtitle" xml:space="preserve"><value>Wie das {0}-Budget auf Abteilungen und Infrastruktur verteilt wird.</value></data>
+  <data name="Budget_OverviewTitle" xml:space="preserve"><value>Budget-Übersicht</value></data>
+  <data name="Budget_Title" xml:space="preserve"><value>Budget</value></data>
+  <data name="Budget_TitleYear" xml:space="preserve"><value>Budget - {0}</value></data>
+  <data name="Budget_TotalExpenses" xml:space="preserve"><value>Gesamtausgaben</value></data>
+  <data name="Budget_TotalIncome" xml:space="preserve"><value>Gesamteinnahmen</value></data>
+  <data name="Calendar_Agenda" xml:space="preserve"><value>Agenda</value></data>
+  <data name="Calendar_AllDay" xml:space="preserve"><value>ganztägig</value></data>
+  <data name="Calendar_AllDayEvent" xml:space="preserve"><value>Ganztägige Veranstaltung</value></data>
+  <data name="Calendar_AllDayLabel" xml:space="preserve"><value>Ganztägig</value></data>
+  <data name="Calendar_AllTeamsMonthView" xml:space="preserve"><value>Alle Teams (Monatsansicht)</value></data>
+  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>Alle Zeiten angezeigt in {0}.</value></data>
+  <data name="Calendar_BackToCalendar" xml:space="preserve"><value>Zurück zum Kalender</value></data>
+  <data name="Calendar_CancelOccurrenceConfirm" xml:space="preserve"><value>Nur diesen Termin absagen?</value></data>
+  <data name="Calendar_CancelThisOccurrence" xml:space="preserve"><value>Diesen absagen</value></data>
+  <data name="Calendar_ChangeHistory" xml:space="preserve"><value>Änderungsverlauf</value></data>
+  <data name="Calendar_Continues" xml:space="preserve"><value>fortlaufend</value></data>
+  <data name="Calendar_Created" xml:space="preserve"><value>Erstellt {0}</value></data>
+  <data name="Calendar_CreateEvent" xml:space="preserve"><value>Veranstaltung erstellen</value></data>
+  <data name="Calendar_DeleteConfirm" xml:space="preserve"><value>Diese Veranstaltung und alle ihre Termine löschen?</value></data>
+  <data name="Calendar_Description" xml:space="preserve"><value>Beschreibung</value></data>
+  <data name="Calendar_EditEvent" xml:space="preserve"><value>Veranstaltung bearbeiten</value></data>
+  <data name="Calendar_EditSingleOccurrence" xml:space="preserve"><value>Einzelnen Termin bearbeiten</value></data>
+  <data name="Calendar_EditSingleOccurrenceHeading" xml:space="preserve"><value>Einen einzelnen Termin bearbeiten</value></data>
+  <data name="Calendar_EditThisOccurrence" xml:space="preserve"><value>Diesen Termin bearbeiten</value></data>
+  <data name="Calendar_End" xml:space="preserve"><value>Ende</value></data>
+  <data name="Calendar_EndDate" xml:space="preserve"><value>Enddatum</value></data>
+  <data name="Calendar_EndDateHelp" xml:space="preserve"><value>Einschließlich — leer lassen für eine eintägige Veranstaltung.</value></data>
+  <data name="Calendar_EventTitle" xml:space="preserve"><value>Veranstaltung</value></data>
+  <data name="Calendar_FirstStart" xml:space="preserve"><value>Erster Beginn</value></data>
+  <data name="Calendar_FormTitle" xml:space="preserve"><value>Titel</value></data>
+  <data name="Calendar_LastUpdated" xml:space="preserve"><value>· Zuletzt aktualisiert {0}</value></data>
+  <data name="Calendar_LocationUrl" xml:space="preserve"><value>Orts-URL</value></data>
+  <data name="Calendar_MoreCount" xml:space="preserve"><value>+{0} weitere</value></data>
+  <data name="Calendar_NewEvent" xml:space="preserve"><value>Neue Veranstaltung</value></data>
+  <data name="Calendar_Next" xml:space="preserve"><value>Weiter</value></data>
+  <data name="Calendar_NoEventsInRange" xml:space="preserve"><value>Keine Veranstaltungen im ausgewählten Zeitraum.</value></data>
+  <data name="Calendar_OverrideDescription" xml:space="preserve"><value>Beschreibung überschreiben</value></data>
+  <data name="Calendar_OverrideEnd" xml:space="preserve"><value>Ende überschreiben</value></data>
+  <data name="Calendar_OverrideInstructions" xml:space="preserve"><value>Überschreibe nur diesen Termin der wiederkehrenden Veranstaltung. Lass ein Feld leer, um den Wert von der übergeordneten Veranstaltung zu übernehmen.</value></data>
+  <data name="Calendar_OverrideLocation" xml:space="preserve"><value>Ort überschreiben</value></data>
+  <data name="Calendar_OverrideLocationUrl" xml:space="preserve"><value>Orts-URL überschreiben</value></data>
+  <data name="Calendar_OverrideStart" xml:space="preserve"><value>Beginn überschreiben</value></data>
+  <data name="Calendar_OverrideTitle" xml:space="preserve"><value>Titel überschreiben</value></data>
+  <data name="Calendar_OwningTeam" xml:space="preserve"><value>Verantwortliches Team</value></data>
+  <data name="Calendar_Prev" xml:space="preserve"><value>Zurück</value></data>
+  <data name="Calendar_Recurrence" xml:space="preserve"><value>Wiederholung</value></data>
+  <data name="Calendar_RecurrenceTimezoneHelpPrefix" xml:space="preserve"><value>IANA-Zeitzone, z. B.</value></data>
+  <data name="Calendar_RecurrenceTimezoneLabel" xml:space="preserve"><value>Zeitzone der Wiederholung</value></data>
+  <data name="Calendar_RecurrenceTimezoneNote" xml:space="preserve"><value>Zeitzone: {0}</value></data>
+  <data name="Calendar_RecurringEvent" xml:space="preserve"><value>Wiederkehrende Veranstaltung</value></data>
+  <data name="Calendar_RRule" xml:space="preserve"><value>RRULE</value></data>
+  <data name="Calendar_RRuleHelpPrefix" xml:space="preserve"><value>RFC 5545 RRULE. Leer lassen für eine einzelne Veranstaltung. Beispiel:</value></data>
+  <data name="Calendar_SaveOverride" xml:space="preserve"><value>Überschreibung speichern</value></data>
+  <data name="Calendar_Start" xml:space="preserve"><value>Beginn</value></data>
+  <data name="Calendar_StartDate" xml:space="preserve"><value>Startdatum</value></data>
+  <data name="Calendar_TeamFallback" xml:space="preserve"><value>Team</value></data>
+  <data name="Calendar_Title" xml:space="preserve"><value>Kalender</value></data>
+  <data name="Calendar_Today" xml:space="preserve"><value>Heute</value></data>
+  <data name="Calendar_UpcomingOccurrences" xml:space="preserve"><value>Kommende Termine</value></data>
+  <data name="Calendar_ViewAriaLabel" xml:space="preserve"><value>Kalenderansicht</value></data>
+  <data name="Calendar_ViewGrid" xml:space="preserve"><value>Raster</value></data>
+  <data name="Calendar_ViewList" xml:space="preserve"><value>Liste</value></data>
+  <data name="Calendar_Yes" xml:space="preserve"><value>Ja</value></data>
+  <data name="Camp_AboutHeading" xml:space="preserve"><value>Über dein {0}</value></data>
+  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>Neue Humans aufnehmen?</value></data>
+  <data name="Camp_AdultPlayspaceLabel" xml:space="preserve"><value>Adult Playspace</value></data>
+  <data name="Camp_BlurbLongLabel" xml:space="preserve"><value>Vollständige Beschreibung</value></data>
+  <data name="Camp_BlurbLongPlaceholder" xml:space="preserve"><value>Erzähl der Welt von deinem Camp.</value></data>
+  <data name="Camp_BlurbShortLabel" xml:space="preserve"><value>Kurzbeschreibung</value></data>
+  <data name="Camp_BlurbShortPlaceholder" xml:space="preserve"><value>Ein oder zwei Sätze über dein Camp (max. 300 Zeichen)</value></data>
+  <data name="Camp_CommunityHeading" xml:space="preserve"><value>Community</value></data>
+  <data name="Camp_ContactEmailLabel" xml:space="preserve"><value>Kontakt-E-Mail</value></data>
+  <data name="Camp_ContactPhoneLabel" xml:space="preserve"><value>Kontakttelefon</value></data>
+  <data name="Camp_ContactPhonePlaceholder" xml:space="preserve"><value>+34 612 345 678</value></data>
+  <data name="Camp_CultureHeading" xml:space="preserve"><value>Kultur &amp; Veranstaltungen</value></data>
+  <data name="Camp_Edit_AutoCreatedFromNameChange" xml:space="preserve"><value>Automatisch durch Namensänderung erstellt</value></data>
+  <data name="Camp_Edit_ContainersSeparate" xml:space="preserve"><value>Container werden jetzt separat verwaltet.</value></data>
+  <data name="Camp_Edit_HideHistoricalNames" xml:space="preserve"><value>Historische Namen ausblenden</value></data>
+  <data name="Camp_Edit_HistoricalNamesHeading" xml:space="preserve"><value>Historische Namen</value></data>
+  <data name="Camp_Edit_HistoricalNamesHelp" xml:space="preserve"><value>Namen, unter denen dieses Camp zuvor bekannt war.</value></data>
+  <data name="Camp_Edit_ImageAlt" xml:space="preserve"><value>Camp-Bild</value></data>
+  <data name="Camp_Edit_ImagesHeading" xml:space="preserve"><value>Bilder ({0}/{1})</value></data>
+  <data name="Camp_Edit_ImageUploadHelp" xml:space="preserve"><value>JPEG, PNG oder WebP. Max. 10 MB.</value></data>
+  <data name="Camp_Edit_ManageContainers" xml:space="preserve"><value>Container verwalten →</value></data>
+  <data name="Camp_Edit_MembersRolesDescription" xml:space="preserve"><value>Verwalte aktive Mitglieder, Rollen, Leads und ausstehende Beitrittsanfragen.</value></data>
+  <data name="Camp_Edit_MembersRolesHeading" xml:space="preserve"><value>Mitglieder &amp; Rollen</value></data>
+  <data name="Camp_Edit_NameLocked" xml:space="preserve"><value>Der Name ist für diese Saison gesperrt.</value></data>
+  <data name="Camp_Edit_OpenMembersRoles" xml:space="preserve"><value>Mitglieder &amp; Rollen öffnen</value></data>
+  <data name="Camp_Edit_OpenStore" xml:space="preserve"><value>Store öffnen</value></data>
+  <data name="Camp_Edit_PreviousNamePlaceholder" xml:space="preserve"><value>Früherer Camp-Name</value></data>
+  <data name="Camp_Edit_StoreDescription" xml:space="preserve"><value>Gib eine Bestellung für dieses Camp auf.</value></data>
+  <data name="Camp_Edit_StoreHeading" xml:space="preserve"><value>Store</value></data>
+  <data name="Camp_Edit_UploadImage" xml:space="preserve"><value>Bild hochladen</value></data>
+  <data name="Camp_ElectricalGridLabel" xml:space="preserve"><value>Stromnetz</value></data>
+  <data name="Camp_HistoryHeading" xml:space="preserve"><value>Verlauf</value></data>
+  <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Nimmt Mitglieder auf</value></data>
+  <data name="Camp_Index_AllOption" xml:space="preserve"><value>Alle</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Barrio-Guide 2026</value></data>
+  <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filtern</value></data>
+  <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Kinder willkommen</value></data>
+  <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>Keine {0} für die ausgewählten Filter gefunden.</value></data>
+  <data name="Camp_Index_NoSearchResults" xml:space="preserve"><value>Keine {0} entsprechen deiner Suche.</value></data>
+  <data name="Camp_Index_PendingApproval" xml:space="preserve"><value>Genehmigung ausstehend</value></data>
+  <data name="Camp_Index_SearchLabel" xml:space="preserve"><value>Suche</value></data>
+  <data name="Camp_Index_SearchPlaceholder" xml:space="preserve"><value>Gib einen {0}-Namen ein…</value></data>
+  <data name="Camp_Index_ShowLeadPositions" xml:space="preserve"><value>Lead-Positionen anzeigen</value></data>
+  <data name="Camp_Index_SoundZoneLabel" xml:space="preserve"><value>Soundzone</value></data>
+  <data name="Camp_Index_VibeLabel" xml:space="preserve"><value>Vibe</value></data>
+  <data name="Camp_KidsAreaDescriptionLabel" xml:space="preserve"><value>Beschreibung des Kinderbereichs</value></data>
+  <data name="Camp_KidsAreaDescriptionPlaceholder" xml:space="preserve"><value>Beschreibe deinen Kinderbereich, falls vorhanden</value></data>
+  <data name="Camp_KidsVisitingLabel" xml:space="preserve"><value>Richtlinie für Kinderbesuche</value></data>
+  <data name="Camp_KidsWelcomeLabel" xml:space="preserve"><value>Kinder willkommen?</value></data>
+  <data name="Camp_LanguagesLabel" xml:space="preserve"><value>Gesprochene Sprachen</value></data>
+  <data name="Camp_LanguagesPlaceholder" xml:space="preserve"><value>z. B. Englisch, Spanisch, Deutsch</value></data>
+  <data name="Camp_MarkdownSupported" xml:space="preserve"><value>Markdown-Formatierung wird unterstützt</value></data>
+  <data name="Camp_MemberCountLabel" xml:space="preserve"><value>Erwartete Humans</value></data>
+  <data name="Camp_NoPreference" xml:space="preserve"><value>Keine Präferenz</value></data>
+  <data name="Camp_NotSure" xml:space="preserve"><value>Nicht sicher</value></data>
+  <data name="Camp_PerformanceSpaceLabel" xml:space="preserve"><value>Performance-Bereich</value></data>
+  <data name="Camp_PerformanceTypesLabel" xml:space="preserve"><value>Arten von Performances</value></data>
+  <data name="Camp_PerformanceTypesPlaceholder" xml:space="preserve"><value>z. B. Musik, Theater, Workshops</value></data>
+  <data name="Camp_PlacementHeading" xml:space="preserve"><value>Platzierung</value></data>
+  <data name="Camp_PreviousNamesHelp" xml:space="preserve"><value>Falls dein Camp in vergangenen Jahren andere Namen hatte, liste sie hier auf.</value></data>
+  <data name="Camp_PreviousNamesLabel" xml:space="preserve"><value>Frühere Namen</value></data>
+  <data name="Camp_PreviousNamesPlaceholder" xml:space="preserve"><value>Kommagetrennte Liste früherer Camp-Namen</value></data>
+  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Registrieren</value></data>
+  <data name="Camp_Register_Heading" xml:space="preserve"><value>Registriere dein {0}</value></data>
+  <data name="Camp_Register_ImportantInfo" xml:space="preserve"><value>Wichtige Informationen</value></data>
+  <data name="Camp_Register_Season" xml:space="preserve"><value>Saison</value></data>
+  <data name="Camp_Register_Submit" xml:space="preserve"><value>{0} registrieren</value></data>
+  <data name="Camp_SoundZoneLabel" xml:space="preserve"><value>Soundzonen-Präferenz</value></data>
+  <data name="Camp_SpaceRequirementLabel" xml:space="preserve"><value>Platzbedarf</value></data>
+  <data name="Camp_TimesParticipatingLabel" xml:space="preserve"><value>Anzahl der Teilnahmen</value></data>
+  <data name="Camp_VibesLabel" xml:space="preserve"><value>Vibes</value></data>
+  <data name="CampCard_AcceptingMembers" xml:space="preserve"><value>Nimmt Mitglieder auf</value></data>
+  <data name="CampCard_Full" xml:space="preserve"><value>Voll</value></data>
+  <data name="CampCard_KidsWelcome" xml:space="preserve"><value>Kinder willkommen</value></data>
+  <data name="CampCard_TimesAtNowhere" xml:space="preserve"><value>{0} Jahr(e)</value></data>
+  <data name="Common_Actions" xml:space="preserve"><value>Aktionen</value></data>
+  <data name="Common_Admin" xml:space="preserve"><value>Admin</value></data>
+  <data name="Common_Amount" xml:space="preserve"><value>Betrag</value></data>
+  <data name="Common_Clear" xml:space="preserve"><value>Zurücksetzen</value></data>
+  <data name="Common_Created" xml:space="preserve"><value>Erstellt</value></data>
+  <data name="Common_Date" xml:space="preserve"><value>Datum</value></data>
+  <data name="Common_DeleteImage" xml:space="preserve"><value>Bild löschen</value></data>
+  <data name="Common_Department" xml:space="preserve"><value>Abteilung</value></data>
+  <data name="Common_MoveDown" xml:space="preserve"><value>Nach unten</value></data>
+  <data name="Common_MoveUp" xml:space="preserve"><value>Nach oben</value></data>
+  <data name="Common_Other" xml:space="preserve"><value>Sonstiges</value></data>
+  <data name="Common_Preview" xml:space="preserve"><value>Vorschau</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Entfernen</value></data>
+  <data name="Common_Required" xml:space="preserve"><value>(erforderlich)</value></data>
+  <data name="Common_Sender" xml:space="preserve"><value>Absender</value></data>
+  <data name="Common_Shift" xml:space="preserve"><value>Schicht</value></data>
+  <data name="Common_Total" xml:space="preserve"><value>Gesamt</value></data>
+  <data name="Common_View" xml:space="preserve"><value>Ansehen</value></data>
+  <data name="CommPrefs_AlwaysOn" xml:space="preserve"><value>Immer aktiv</value></data>
+  <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Hallo {0},&lt;/p&gt;
+&lt;p&gt;du bist eingeladen, die Umfrage &lt;strong&gt;{1}&lt;/strong&gt; auszufüllen. Es dauert nur ein paar Minuten.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Umfrage öffnen&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Vielen Dank,&lt;br/&gt;Das Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Bitte ausfüllen: {0}</value></data>
+  <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Hallo {0},&lt;/p&gt;
+&lt;p&gt;nur eine Erinnerung, dass die Umfrage &lt;strong&gt;{1}&lt;/strong&gt; noch auf deine Antwort wartet.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Umfrage öffnen&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Vielen Dank,&lt;br/&gt;Das Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyReminder_Subject" xml:space="preserve"><value>Erinnerung: {0}</value></data>
+  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Mit {0} getaggt, aber keine passende AspNetUserLogins-Zeile — heilt sich beim nächsten OAuth-Login von selbst.</value></data>
+  <data name="EmailGrid_WorkspaceLocked" xml:space="preserve"><value>Gesperrt durch die Workspace-E-Mail-Zeile</value></data>
+  <data name="Enum_AdultPlayspacePolicy_NightOnly" xml:space="preserve"><value>Nur nachts</value></data>
+  <data name="Enum_AdultPlayspacePolicy_No" xml:space="preserve"><value>Nein</value></data>
+  <data name="Enum_AdultPlayspacePolicy_Yes" xml:space="preserve"><value>Ja</value></data>
+  <data name="Enum_CampVibe_Adult" xml:space="preserve"><value>Adult</value></data>
+  <data name="Enum_CampVibe_ChillOut" xml:space="preserve"><value>Chill-out</value></data>
+  <data name="Enum_CampVibe_ElectronicMusic" xml:space="preserve"><value>Elektronische Musik</value></data>
+  <data name="Enum_CampVibe_Games" xml:space="preserve"><value>Spiele</value></data>
+  <data name="Enum_CampVibe_Lecture" xml:space="preserve"><value>Vortrag</value></data>
+  <data name="Enum_CampVibe_LiveMusic" xml:space="preserve"><value>Live-Musik</value></data>
+  <data name="Enum_CampVibe_Queer" xml:space="preserve"><value>Queer</value></data>
+  <data name="Enum_CampVibe_Sober" xml:space="preserve"><value>Nüchtern</value></data>
+  <data name="Enum_CampVibe_Wellness" xml:space="preserve"><value>Wellness</value></data>
+  <data name="Enum_CampVibe_Workshop" xml:space="preserve"><value>Workshop</value></data>
+  <data name="Enum_ContactFieldType_Discord" xml:space="preserve"><value>Discord</value></data>
+  <data name="Enum_ContactFieldType_Other" xml:space="preserve"><value>Sonstiges</value></data>
+  <data name="Enum_ContactFieldType_Phone" xml:space="preserve"><value>Telefon</value></data>
+  <data name="Enum_ContactFieldType_Signal" xml:space="preserve"><value>Signal</value></data>
+  <data name="Enum_ContactFieldType_Telegram" xml:space="preserve"><value>Telegram</value></data>
+  <data name="Enum_ContactFieldType_WhatsApp" xml:space="preserve"><value>WhatsApp</value></data>
+  <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Alle aktiven Humans</value></data>
+  <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Nur Vorstand</value></data>
+  <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Koordinatoren + Vorstand</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Meine Teams (+ Koordinatoren &amp; Vorstand)</value></data>
+  <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
+  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Eigene Versorgung</value></data>
+  <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Rot</value></data>
+  <data name="Enum_ElectricalGrid_Unknown" xml:space="preserve"><value>Unbekannt</value></data>
+  <data name="Enum_ElectricalGrid_Yellow" xml:space="preserve"><value>Gelb</value></data>
+  <data name="Enum_EmailOutboxStatus_Failed" xml:space="preserve"><value>Fehlgeschlagen</value></data>
+  <data name="Enum_EmailOutboxStatus_Queued" xml:space="preserve"><value>In Warteschlange</value></data>
+  <data name="Enum_EmailOutboxStatus_Sent" xml:space="preserve"><value>Gesendet</value></data>
+  <data name="Enum_EventStatus_Approved" xml:space="preserve"><value>Genehmigt</value></data>
+  <data name="Enum_EventStatus_Draft" xml:space="preserve"><value>Entwurf</value></data>
+  <data name="Enum_EventStatus_Pending" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="Enum_EventStatus_Rejected" xml:space="preserve"><value>Abgelehnt</value></data>
+  <data name="Enum_EventStatus_ResubmitRequested" xml:space="preserve"><value>Änderungen angefordert</value></data>
+  <data name="Enum_EventStatus_Withdrawn" xml:space="preserve"><value>Zurückgezogen</value></data>
+  <data name="Enum_ExpenseReportStatus_Approved" xml:space="preserve"><value>Genehmigt</value></data>
+  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Vom Koordinator befürwortet</value></data>
+  <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Entwurf</value></data>
+  <data name="Enum_ExpenseReportStatus_Paid" xml:space="preserve"><value>Bezahlt</value></data>
+  <data name="Enum_ExpenseReportStatus_SepaSent" xml:space="preserve"><value>SEPA gesendet</value></data>
+  <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Eingereicht</value></data>
+  <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Zurückgezogen</value></data>
+  <data name="Enum_FeedbackCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_FeedbackCategory_FeatureRequest" xml:space="preserve"><value>Feature-Wunsch</value></data>
+  <data name="Enum_FeedbackCategory_Question" xml:space="preserve"><value>Frage</value></data>
+  <data name="Enum_FeedbackStatus_Acknowledged" xml:space="preserve"><value>Bestätigt</value></data>
+  <data name="Enum_FeedbackStatus_Open" xml:space="preserve"><value>Offen</value></data>
+  <data name="Enum_FeedbackStatus_Resolved" xml:space="preserve"><value>Gelöst</value></data>
+  <data name="Enum_FeedbackStatus_WontFix" xml:space="preserve"><value>Wird nicht behoben</value></data>
+  <data name="Enum_IssueCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_IssueCategory_Feature" xml:space="preserve"><value>Feature</value></data>
+  <data name="Enum_IssueCategory_Question" xml:space="preserve"><value>Frage</value></data>
+  <data name="Enum_KidsVisitingPolicy_DaytimeOnly" xml:space="preserve"><value>Nur tagsüber</value></data>
+  <data name="Enum_KidsVisitingPolicy_No" xml:space="preserve"><value>Nein</value></data>
+  <data name="Enum_KidsVisitingPolicy_Yes" xml:space="preserve"><value>Ja</value></data>
+  <data name="Enum_LanguageProficiency_Basic" xml:space="preserve"><value>Grundkenntnisse</value></data>
+  <data name="Enum_LanguageProficiency_Conversational" xml:space="preserve"><value>Konversationssicher</value></data>
+  <data name="Enum_LanguageProficiency_Fluent" xml:space="preserve"><value>Fließend</value></data>
+  <data name="Enum_LanguageProficiency_Native" xml:space="preserve"><value>Muttersprache</value></data>
+  <data name="Enum_PerformanceSpaceStatus_No" xml:space="preserve"><value>Nein</value></data>
+  <data name="Enum_PerformanceSpaceStatus_WorkingOnIt" xml:space="preserve"><value>In Arbeit</value></data>
+  <data name="Enum_PerformanceSpaceStatus_Yes" xml:space="preserve"><value>Ja</value></data>
+  <data name="Enum_RolePeriod_Build" xml:space="preserve"><value>Aufbau</value></data>
+  <data name="Enum_RolePeriod_Event" xml:space="preserve"><value>Veranstaltung</value></data>
+  <data name="Enum_RolePeriod_Strike" xml:space="preserve"><value>Abbau</value></data>
+  <data name="Enum_RolePeriod_YearRound" xml:space="preserve"><value>Ganzjährig</value></data>
+  <data name="Enum_SlotPriority_Critical" xml:space="preserve"><value>Kritisch</value></data>
+  <data name="Enum_SlotPriority_Important" xml:space="preserve"><value>Wichtig</value></data>
+  <data name="Enum_SlotPriority_NiceToHave" xml:space="preserve"><value>Wünschenswert</value></data>
+  <data name="Enum_SlotPriority_None" xml:space="preserve"><value>Keine</value></data>
+  <data name="Enum_SoundZone_Blue" xml:space="preserve"><value>Blau</value></data>
+  <data name="Enum_SoundZone_Green" xml:space="preserve"><value>Grün</value></data>
+  <data name="Enum_SoundZone_Orange" xml:space="preserve"><value>Orange</value></data>
+  <data name="Enum_SoundZone_Red" xml:space="preserve"><value>Rot</value></data>
+  <data name="Enum_SoundZone_Surprise" xml:space="preserve"><value>Überraschung</value></data>
+  <data name="Enum_SoundZone_Yellow" xml:space="preserve"><value>Gelb</value></data>
+  <data name="Enum_SpaceSize_Sqm1000" xml:space="preserve"><value>1000 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1200" xml:space="preserve"><value>1200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm150" xml:space="preserve"><value>150 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1500" xml:space="preserve"><value>1500 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1800" xml:space="preserve"><value>1800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2200" xml:space="preserve"><value>2200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2800" xml:space="preserve"><value>2800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm300" xml:space="preserve"><value>300 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm450" xml:space="preserve"><value>450 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm600" xml:space="preserve"><value>600 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm800" xml:space="preserve"><value>800 m²</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Camp" xml:space="preserve"><value>Camp</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Team" xml:space="preserve"><value>Team</value></data>
+  <data name="Enum_TicketTransferStatus_Approved" xml:space="preserve"><value>Abgeschlossen</value></data>
+  <data name="Enum_TicketTransferStatus_Cancelled" xml:space="preserve"><value>Storniert</value></data>
+  <data name="Enum_TicketTransferStatus_Pending" xml:space="preserve"><value>Prüfung ausstehend</value></data>
+  <data name="Enum_TicketTransferStatus_Rejected" xml:space="preserve"><value>Vom Team storniert</value></data>
+  <data name="Enum_YesNoMaybe_Maybe" xml:space="preserve"><value>Vielleicht</value></data>
+  <data name="Enum_YesNoMaybe_No" xml:space="preserve"><value>Nein</value></data>
+  <data name="Enum_YesNoMaybe_Yes" xml:space="preserve"><value>Ja</value></data>
+  <data name="Events_AddBarrioEvent" xml:space="preserve"><value>Barrio-Veranstaltung hinzufügen</value></data>
+  <data name="Events_AddToFavourites" xml:space="preserve"><value>Zu Favoriten hinzufügen</value></data>
+  <data name="Events_AllCategories" xml:space="preserve"><value>Alle Kategorien</value></data>
+  <data name="Events_AllTimesIn" xml:space="preserve"><value>Alle Zeiten in {0}. Playa Time kann gelten!</value></data>
+  <data name="Events_AllTimesInShort" xml:space="preserve"><value>Alle Zeiten in {0}</value></data>
+  <data name="Events_AllVenues" xml:space="preserve"><value>Alle Orte</value></data>
+  <data name="Events_BrowseTitle" xml:space="preserve"><value>Veranstaltungen durchsuchen</value></data>
+  <data name="Events_ColActions" xml:space="preserve"><value>Aktionen</value></data>
+  <data name="Events_ColCategory" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="Events_ColDateTime" xml:space="preserve"><value>Datum &amp; Uhrzeit</value></data>
+  <data name="Events_ColEventName" xml:space="preserve"><value>Veranstaltungsname</value></data>
+  <data name="Events_ColPriority" xml:space="preserve"><value>Priorität</value></data>
+  <data name="Events_ConflictBadge" xml:space="preserve"><value>Zeitkonflikt mit einer anderen favorisierten Veranstaltung</value></data>
+  <data name="Events_DownloadCsv" xml:space="preserve"><value>Veranstaltungs-CSV herunterladen</value></data>
+  <data name="Events_DurationMin" xml:space="preserve"><value>{0} Min.</value></data>
+  <data name="Events_FavouritesOnly" xml:space="preserve"><value>Nur</value></data>
+  <data name="Events_FilterCategory" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="Events_FilterDay" xml:space="preserve"><value>Tag</value></data>
+  <data name="Events_FilterSearch" xml:space="preserve"><value>Suche</value></data>
+  <data name="Events_FilterVenue" xml:space="preserve"><value>Ort</value></data>
+  <data name="Events_MyPersonalEvents" xml:space="preserve"><value>Meine persönlichen Veranstaltungen</value></data>
+  <data name="Events_MySchedule" xml:space="preserve"><value>Mein Programm</value></data>
+  <data name="Events_MySubmissions" xml:space="preserve"><value>Meine Einreichungen</value></data>
+  <data name="Events_MySubmissionsTitle" xml:space="preserve"><value>Meine eingereichten Veranstaltungen</value></data>
+  <data name="Events_NoBarrioEvents" xml:space="preserve"><value>Für dieses Barrio wurden noch keine Veranstaltungen eingereicht.</value></data>
+  <data name="Events_NoEventsFound" xml:space="preserve"><value>Keine Veranstaltungen gefunden. Passe deine Filter an.</value></data>
+  <data name="Events_NoPersonalEvents" xml:space="preserve"><value>Du hast noch keine persönlichen Veranstaltungen eingereicht.</value></data>
+  <data name="Events_RemoveFromFavourites" xml:space="preserve"><value>Aus Favoriten entfernen</value></data>
+  <data name="Events_RemoveFromSchedule" xml:space="preserve"><value>Aus dem Programm entfernen</value></data>
+  <data name="Events_RemoveFromScheduleConfirm" xml:space="preserve"><value>Diese Veranstaltung aus deinem Programm entfernen?</value></data>
+  <data name="Events_ScheduleEmpty" xml:space="preserve"><value>Du hast noch keine Veranstaltungen favorisiert. Durchsuche {0}, um Veranstaltungen zu deinem Programm hinzuzufügen.</value></data>
+  <data name="Events_ScheduleEmptyLink" xml:space="preserve"><value>den Veranstaltungsguide</value></data>
+  <data name="Events_ScheduleTitle" xml:space="preserve"><value>Mein Programm</value></data>
+  <data name="Events_SearchPlaceholder" xml:space="preserve"><value>Titel oder Beschreibung durchsuchen…</value></data>
+  <data name="Events_StatApproved" xml:space="preserve"><value>Genehmigt</value></data>
+  <data name="Events_StatPending" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="Events_StatSubmitted" xml:space="preserve"><value>Eingereicht</value></data>
+  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Einreichungsfrist:</value></data>
+  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>Die Einreichungsfrist ist derzeit nicht geöffnet. Wende dich an einen Admin, um die Guide-Einstellungen zu konfigurieren.</value></data>
+  <data name="Events_SubmitNewEvent" xml:space="preserve"><value>Neue Veranstaltung einreichen</value></data>
+  <data name="Events_UploadColErrors" xml:space="preserve"><value>Fehler</value></data>
+  <data name="Events_UploadColEvent" xml:space="preserve"><value>Veranstaltung</value></data>
+  <data name="Events_UploadColRow" xml:space="preserve"><value>Zeile</value></data>
+  <data name="Events_UploadCsv" xml:space="preserve"><value>CSV hochladen</value></data>
+  <data name="Events_UploadFailed" xml:space="preserve"><value>Upload fehlgeschlagen.</value></data>
+  <data name="Events_UploadFailedDetail" xml:space="preserve"><value>Behebe die folgenden Fehler und versuche es erneut. Es wurden keine Veranstaltungen gespeichert.</value></data>
+  <data name="Events_WithdrawConfirm" xml:space="preserve"><value>Diese Veranstaltung zurückziehen?</value></data>
+  <data name="Expenses_ColReport" xml:space="preserve"><value>Abrechnung</value></data>
+  <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Eingereicht</value></data>
+  <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Eingereicht von</value></data>
+  <data name="Expenses_CoordinatorQueue" xml:space="preserve"><value>Koordinator-Warteschlange</value></data>
+  <data name="Expenses_CoordinatorQueueTitle" xml:space="preserve"><value>Spesenabrechnungen — Koordinator-Warteschlange</value></data>
+  <data name="Expenses_Endorse" xml:space="preserve"><value>Befürworten</value></data>
+  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Diese Spesenabrechnung befürworten?</value></data>
+  <data name="Expenses_FileFirst" xml:space="preserve"><value>Reiche deine erste Abrechnung ein</value></data>
+  <data name="Expenses_IouHeader" xml:space="preserve"><value>Was das Kollektiv dir schuldet</value></data>
+  <data name="Expenses_IouLastPayment" xml:space="preserve"><value>Letzte Zahlung</value></data>
+  <data name="Expenses_IouOtherAmountNote" xml:space="preserve"><value>Dein Holded-Saldo enthält {0}, die nicht zu diesen Abrechnungen gehören (im Namen des Kollektivs ausgelegte Posten, Anpassungen usw.), daher ergeben die Zeilen unten nicht zwangsläufig diese Summe.</value></data>
+  <data name="Expenses_IouOwed" xml:space="preserve"><value>Dir geschuldet (Holded-Saldo)</value></data>
+  <data name="Expenses_IouPaid" xml:space="preserve"><value>Bisher bezahlt</value></data>
+  <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Position</value></data>
+  <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Meine Spesenabrechnungen</value></data>
+  <data name="Expenses_NewReport" xml:space="preserve"><value>Neue Abrechnung</value></data>
+  <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Es gibt derzeit kein aktives Budgetjahr. Spesenabrechnungen können erst eingereicht werden, wenn ein Budgetjahr aktiviert ist.</value></data>
+  <data name="Expenses_NoIban" xml:space="preserve"><value>Du hast deine Zahlungs-IBAN noch nicht hinterlegt. Du wirst beim Einreichen einer Abrechnung aufgefordert, sie anzugeben.</value></data>
+  <data name="Expenses_NoReports" xml:space="preserve"><value>Noch keine Spesenabrechnungen.</value></data>
+  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Keine Abrechnungen, die auf deine Befürwortung warten.</value></data>
+  <data name="Expenses_Reject" xml:space="preserve"><value>Ablehnen</value></data>
+  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>Der Einreichende sieht diesen Grund. Erkläre klar, warum die Abrechnung nicht befürwortet werden kann.</value></data>
+  <data name="Expenses_RejectModalTitle" xml:space="preserve"><value>Abrechnung ablehnen</value></data>
+  <data name="Expenses_RejectReasonLabel" xml:space="preserve"><value>Ablehnungsgrund</value></data>
+  <data name="Expenses_RejectReasonPlaceholder" xml:space="preserve"><value>z. B. Fehlende Belege für Position 2</value></data>
+  <data name="Feedback_AssignedToName" xml:space="preserve"><value>Zugewiesen an {0}</value></data>
+  <data name="Feedback_CategoryOnPage" xml:space="preserve"><value>{0} auf {1}</value></data>
+  <data name="Feedback_TeamName" xml:space="preserve"><value>Team: {0}</value></data>
+  <data name="Issue_ColComments" xml:space="preserve"><value>Kommentare</value></data>
+  <data name="Issue_ColReporter" xml:space="preserve"><value>Melder</value></data>
+  <data name="Issue_ColStatus" xml:space="preserve"><value>Status</value></data>
+  <data name="Issue_ColTitle" xml:space="preserve"><value>Titel</value></data>
+  <data name="Issue_ColUpdated" xml:space="preserve"><value>Aktualisiert</value></data>
+  <data name="Issue_CountSummary" xml:space="preserve"><value>{0} offen · {1} gesamt</value></data>
+  <data name="LinkedAccounts_Account" xml:space="preserve"><value>Konto</value></data>
+  <data name="LinkedAccounts_Actions" xml:space="preserve"><value>Aktionen</value></data>
+  <data name="LinkedAccounts_ConfirmUnlink" xml:space="preserve"><value>Dieses Konto trennen? Du kannst dich dann nicht mehr damit anmelden.</value></data>
+  <data name="LinkedAccounts_Description" xml:space="preserve"><value>Derzeit mit deinem Konto verknüpfte OAuth-Anbieter. Du kannst dich mit jedem davon anmelden.</value></data>
+  <data name="LinkedAccounts_Empty" xml:space="preserve"><value>Keine verknüpften OAuth-Konten.</value></data>
+  <data name="LinkedAccounts_LastSignInMethod" xml:space="preserve"><value>Einzige Anmeldemethode — kann nicht getrennt werden.</value></data>
+  <data name="LinkedAccounts_LinkedOn" xml:space="preserve"><value>Verknüpft am</value></data>
+  <data name="LinkedAccounts_Provider" xml:space="preserve"><value>Anbieter</value></data>
+  <data name="LinkedAccounts_Title" xml:space="preserve"><value>Verknüpfte Konten</value></data>
+  <data name="LinkedAccounts_UnlinkBlockedLastSignInMethod" xml:space="preserve"><value>Trennen nicht möglich — dies ist deine einzige verbleibende Anmeldemethode.</value></data>
+  <data name="MarkdownHelp_Bold" xml:space="preserve"><value>fett</value></data>
+  <data name="MarkdownHelp_ColYouGet" xml:space="preserve"><value>Du erhältst</value></data>
+  <data name="MarkdownHelp_ColYouType" xml:space="preserve"><value>Du tippst</value></data>
+  <data name="MarkdownHelp_EmbeddedImage" xml:space="preserve"><value>eingebettetes Bild</value></data>
+  <data name="MarkdownHelp_First" xml:space="preserve"><value>erstens</value></data>
+  <data name="MarkdownHelp_Heading1" xml:space="preserve"><value>Überschrift 1</value></data>
+  <data name="MarkdownHelp_Heading2" xml:space="preserve"><value>Überschrift 2</value></data>
+  <data name="MarkdownHelp_InlineCode" xml:space="preserve"><value>Inline-Code</value></data>
+  <data name="MarkdownHelp_Intro" xml:space="preserve"><value>Markdown ist eine einfache Möglichkeit, Text zu formatieren. Gib die Syntax links ein, und sie wird wie rechts gezeigt dargestellt.</value></data>
+  <data name="MarkdownHelp_Italic" xml:space="preserve"><value>kursiv</value></data>
+  <data name="MarkdownHelp_ItemOne" xml:space="preserve"><value>Eintrag eins</value></data>
+  <data name="MarkdownHelp_ItemTwo" xml:space="preserve"><value>Eintrag zwei</value></data>
+  <data name="MarkdownHelp_LinkText" xml:space="preserve"><value>Linktext</value></data>
+  <data name="MarkdownHelp_QuoteText" xml:space="preserve"><value>Zitattext</value></data>
+  <data name="MarkdownHelp_Second" xml:space="preserve"><value>zweitens</value></data>
+  <data name="MarkdownHelp_Strikethrough" xml:space="preserve"><value>durchgestrichen</value></data>
+  <data name="MarkdownHelp_TableAdmin" xml:space="preserve"><value>Admin</value></data>
+  <data name="MarkdownHelp_TableHuman" xml:space="preserve"><value>Human</value></data>
+  <data name="MarkdownHelp_TableName" xml:space="preserve"><value>Name</value></data>
+  <data name="MarkdownHelp_TableRole" xml:space="preserve"><value>Rolle</value></data>
+  <data name="MarkdownHelp_TablesHeading" xml:space="preserve"><value>Tabellen</value></data>
+  <data name="MarkdownHelp_TaskDone" xml:space="preserve"><value>Erledigt</value></data>
+  <data name="MarkdownHelp_TaskListsHeading" xml:space="preserve"><value>Aufgabenlisten</value></data>
+  <data name="MarkdownHelp_TaskToDo" xml:space="preserve"><value>Zu erledigen</value></data>
+  <data name="MarkdownHelp_Title" xml:space="preserve"><value>Markdown-Kurzreferenz</value></data>
+  <data name="Onboarding_BurnerNameExplainer" xml:space="preserve"><value>Der Name, den alle im System sehen. Eindeutigkeit hilft, ist aber nicht erforderlich, auch wenn es schwierig sein kann, „Bob“ unter den paar Tausend Humans hier zu finden, falls jemand nach dir sucht.</value></data>
+  <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>Der Name, unter dem dich alle kennen werden.</value></data>
+  <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner Name</value></data>
+  <data name="Onboarding_Continue" xml:space="preserve"><value>Weiter</value></data>
+  <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>nicht</value></data>
+  <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>und würden sie nur offenlegen, wenn das Gesetz oder eine förmliche Prüfung es erfordert.</value></data>
+  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Wird intern gespeichert, ist nur für Admins sichtbar und wird nur dort verwendet, wo das spanische Recht es verlangt — zum Beispiel für unseren Prüfnachweis, dass du der Volunteer-Vereinbarung zu einem bestimmten Datum und einer bestimmten Uhrzeit zugestimmt hast. Wir exportieren diese Information ausdrücklich</value></data>
+  <data name="Onboarding_LegalNameLabel" xml:space="preserve"><value>Bürgerlicher Name</value></data>
+  <data name="Onboarding_NameRequiredBeforeShifts" xml:space="preserve"><value>Füge zuerst deinen Namen hinzu — wir brauchen ihn, bevor du dich für Schichten anmelden kannst.</value></data>
+  <data name="Onboarding_NamesSubtitle" xml:space="preserve"><value>Zwei kurze Schritte, bevor du eine Schicht auswählst.</value></data>
+  <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Willkommen — fangen wir mit deinem Namen an</value></data>
+  <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Kritisch</value></data>
+  <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Wichtig</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Bei der Veranstaltung sind nur {0}% der „kritischen“ Schichten besetzt. Wenn diese nicht besetzt werden, könnte die Veranstaltung abgesagt werden, da es nicht möglich oder sicher wäre, sie durchzuführen.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Wenn du einige davon übernehmen kannst oder vor der Veranstaltung kommen bzw. zum Abbau bleiben kannst, priorisiere diese bitte bei der Auswahl deiner Schichten.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>WICHTIG:</value></data>
+  <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Es sind außerdem {0} „wichtige“ Schichten offen.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Es sind {0} „wichtige“ Schichten offen. Wenn du vor der Veranstaltung kommen oder zum Abbau bleiben kannst, priorisiere diese bitte.</value></data>
+  <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Derzeit keine aktive Veranstaltung. Du kannst das Onboarding abschließen, ohne eine Schicht auszuwählen.</value></data>
+  <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Derzeit keine kritischen Schichten offen — probiere Wichtig oder Alle.</value></data>
+  <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Derzeit keine wichtigen Schichten offen — probiere Alle.</value></data>
+  <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Nicht jetzt</value></data>
+  <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Wähle eine Schicht</value></data>
+  <data name="Outbox_AdminTitle" xml:space="preserve"><value>E-Mails</value></data>
+  <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Zurück zur Administration</value></data>
+  <data name="Outbox_BackToProfile" xml:space="preserve"><value>Zurück zum Profil</value></data>
+  <data name="Outbox_DescriptionAdmin" xml:space="preserve"><value>E-Mails, die das System an diesen Human gesendet hat.</value></data>
+  <data name="Outbox_DescriptionSelf" xml:space="preserve"><value>E-Mails, die das System an dich gesendet hat (innerhalb der letzten 150 Tage).</value></data>
+  <data name="Outbox_Empty" xml:space="preserve"><value>Keine E-Mails vorhanden.</value></data>
+  <data name="Outbox_Subject" xml:space="preserve"><value>Betreff</value></data>
+  <data name="Privacy_ThirdParty_GooglePolicyLink" xml:space="preserve"><value>Datenschutzerklärung von Google</value></data>
+  <data name="Profile_Assigned" xml:space="preserve"><value>Zugewiesen</value></data>
+  <data name="Profile_Campaign" xml:space="preserve"><value>Kampagne</value></data>
+  <data name="Profile_Code" xml:space="preserve"><value>Code</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Dairy" xml:space="preserve"><value>Milchprodukte</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Egg" xml:space="preserve"><value>Ei</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Peanut" xml:space="preserve"><value>Erdnuss</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Sesame" xml:space="preserve"><value>Sesam</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Shellfish" xml:space="preserve"><value>Schalentiere</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Soy" xml:space="preserve"><value>Soja</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Treenut" xml:space="preserve"><value>Schalenfrucht</value></data>
+  <data name="Profile_DietaryMedical_Allergy_WheatGluten" xml:space="preserve"><value>Weizen/Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_FODMAP" xml:space="preserve"><value>FODMAP</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Gluten" xml:space="preserve"><value>Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Histamine" xml:space="preserve"><value>Histamin</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Lactose" xml:space="preserve"><value>Laktose</value></data>
+  <data name="Profile_MarkedAt" xml:space="preserve"><value>Markiert am</value></data>
+  <data name="Profile_MarkedBy" xml:space="preserve"><value>Markiert von</value></data>
+  <data name="Profile_MyCodes" xml:space="preserve"><value>Meine Codes</value></data>
+  <data name="Profile_MyEmails" xml:space="preserve"><value>Meine E-Mails</value></data>
+  <data name="Profile_NoSentMessages" xml:space="preserve"><value>Keine plattforminternen Nachrichten vorhanden.</value></data>
+  <data name="Profile_NoShowHistory" xml:space="preserve"><value>No-Show-Verlauf ({0})</value></data>
+  <data name="Profile_OnsiteSince" xml:space="preserve"><value>Vor Ort seit {0}</value></data>
+  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Am Tor eingecheckt</value></data>
+  <data name="Profile_Redeemed" xml:space="preserve"><value>Eingelöst</value></data>
+  <data name="Profile_SentMessages" xml:space="preserve"><value>Gesendete Nachrichten ({0})</value></data>
+  <data name="Profile_ShiftInfo" xml:space="preserve"><value>Schichtinfo</value></data>
+  <data name="ProfileEdit_CityPlaceholder" xml:space="preserve"><value>Beginne, deine Stadt einzutippen…</value></data>
+  <data name="ProfileEdit_ContactType" xml:space="preserve"><value>Typ</value></data>
+  <data name="ProfileEdit_ContactValue" xml:space="preserve"><value>Wert</value></data>
+  <data name="ProfileEdit_ContactValuePlaceholder" xml:space="preserve"><value>Kontaktdaten eingeben</value></data>
+  <data name="ProfileEdit_ContactVisibility" xml:space="preserve"><value>Sichtbarkeit</value></data>
+  <data name="ProfileEdit_CustomLabelPlaceholder" xml:space="preserve"><value>z. B. Discord</value></data>
+  <data name="ProfileEdit_Description" xml:space="preserve"><value>Beschreibung</value></data>
+  <data name="ProfileEdit_DescriptionPlaceholder" xml:space="preserve"><value>z. B. Gate Lead</value></data>
+  <data name="ProfileEdit_EventName" xml:space="preserve"><value>Veranstaltungsname</value></data>
+  <data name="ProfileEdit_EventNamePlaceholder" xml:space="preserve"><value>z. B. Burning Man 2024</value></data>
+  <data name="ProfileEdit_LanguageLabel" xml:space="preserve"><value>Sprache</value></data>
+  <data name="ProfileEdit_ProficiencyLabel" xml:space="preserve"><value>Kenntnisstand</value></data>
+  <data name="ProfileEdit_RelationshipPlaceholder" xml:space="preserve"><value>z. B. Partner, Elternteil</value></data>
+  <data name="ProfileEdit_RemoveContactField" xml:space="preserve"><value>Dieses Kontaktfeld entfernen</value></data>
+  <data name="ProfileEdit_RemoveEntry" xml:space="preserve"><value>Diesen Eintrag entfernen</value></data>
+  <data name="ProfileEdit_RemoveLanguage" xml:space="preserve"><value>Diese Sprache entfernen</value></data>
+  <data name="ProfileEdit_SelectLanguage" xml:space="preserve"><value>— Sprache wählen —</value></data>
+  <data name="Roster_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="Roster_ColAssignedTo" xml:space="preserve"><value>Zugewiesen an</value></data>
+  <data name="Roster_ColPeriod" xml:space="preserve"><value>Zeitraum</value></data>
+  <data name="Roster_ColPriority" xml:space="preserve"><value>Priorität</value></data>
+  <data name="Roster_ColRole" xml:space="preserve"><value>Rolle</value></data>
+  <data name="Roster_ColSlot" xml:space="preserve"><value>Slot</value></data>
+  <data name="Roster_ColTeam" xml:space="preserve"><value>Team</value></data>
+  <data name="Roster_NoSlots" xml:space="preserve"><value>Keine Rollen-Slots über die Teams hinweg definiert.</value></data>
+  <data name="Roster_PeriodFilter" xml:space="preserve"><value>Zeitraum: {0}</value></data>
+  <data name="Roster_PriorityFilter" xml:space="preserve"><value>Priorität: {0}</value></data>
+  <data name="Roster_SlotOpen" xml:space="preserve"><value>Offen</value></data>
+  <data name="Roster_StatusFilled" xml:space="preserve"><value>Besetzt</value></data>
+  <data name="Roster_StatusFilter" xml:space="preserve"><value>Status: {0}</value></data>
+  <data name="Roster_StatusOpen" xml:space="preserve"><value>Offen</value></data>
+  <data name="Roster_Title" xml:space="preserve"><value>Team-Dienstplan</value></data>
+  <data name="Search_FilterAll" xml:space="preserve"><value>Alle</value></data>
+  <data name="Search_FilterCamps" xml:space="preserve"><value>Camps</value></data>
+  <data name="Search_FilterEvents" xml:space="preserve"><value>Veranstaltungen</value></data>
+  <data name="Search_FilterHumans" xml:space="preserve"><value>Humans</value></data>
+  <data name="Search_FilterShifts" xml:space="preserve"><value>Schichten</value></data>
+  <data name="Search_FilterTeams" xml:space="preserve"><value>Teams</value></data>
+  <data name="Search_GlobalHint" xml:space="preserve"><value>Gib mindestens 2 Zeichen ein, um Humans, Teams, Camps und Schichten zu durchsuchen.</value></data>
+  <data name="Search_GlobalHintEvents" xml:space="preserve"><value>Gib mindestens 2 Zeichen ein, um Humans, Teams, Camps, Schichten und Veranstaltungen zu durchsuchen.</value></data>
+  <data name="Search_GlobalNoResults" xml:space="preserve"><value>Keine Ergebnisse für {0}.</value></data>
+  <data name="Search_GlobalPlaceholder" xml:space="preserve"><value>Humans, Teams, Camps, Schichten durchsuchen…</value></data>
+  <data name="Search_GlobalPlaceholderEvents" xml:space="preserve"><value>Humans, Teams, Camps, Schichten, Veranstaltungen durchsuchen…</value></data>
+  <data name="Search_GlobalTitle" xml:space="preserve"><value>Suche</value></data>
+  <data name="Store_AdminCatalog" xml:space="preserve"><value>Katalog</value></data>
+  <data name="Store_AdminPayments" xml:space="preserve"><value>Zahlungen</value></data>
+  <data name="Store_AdminSummary" xml:space="preserve"><value>Übersicht</value></data>
+  <data name="Store_CatalogHeading" xml:space="preserve"><value>Katalog ({0})</value></data>
+  <data name="Store_ColBalance" xml:space="preserve"><value>Saldo</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Anzahlung</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Anzahlungen</value></data>
+  <data name="Store_ColDescription" xml:space="preserve"><value>Beschreibung</value></data>
+  <data name="Store_ColLines" xml:space="preserve"><value>Positionen</value></data>
+  <data name="Store_ColLinesVat" xml:space="preserve"><value>Positionen + MwSt.</value></data>
+  <data name="Store_ColName" xml:space="preserve"><value>Name</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Bestellen bis</value></data>
+  <data name="Store_ColState" xml:space="preserve"><value>Status</value></data>
+  <data name="Store_ColUnitPrice" xml:space="preserve"><value>Einzelpreis (inkl. MwSt.)</value></data>
+  <data name="Store_CreateOrder" xml:space="preserve"><value>Bestellung erstellen</value></data>
+  <data name="Store_DeleteOrderConfirm" xml:space="preserve"><value>Diese Bestellung mit Saldo null löschen? Dies kann nicht rückgängig gemacht werden.</value></data>
+  <data name="Store_DeleteOrderTitle" xml:space="preserve"><value>Löschen (Saldo null)</value></data>
+  <data name="Store_NoCounterpartiesAlert" xml:space="preserve"><value>Du leitest keine Camps und koordinierst keine Abteilungen mit einer aktiven Saison in diesem Jahr. Der Katalog unten ist schreibgeschützt.</value></data>
+  <data name="Store_NoOrders" xml:space="preserve"><value>Noch keine Bestellungen.</value></data>
+  <data name="Store_NoProducts" xml:space="preserve"><value>Für {0} sind keine Produkte aktiv.</value></data>
+  <data name="Store_OpenOrder" xml:space="preserve"><value>Öffnen</value></data>
+  <data name="Store_StartOrder" xml:space="preserve"><value>Bestellung starten</value></data>
+  <data name="Store_Title" xml:space="preserve"><value>Store</value></data>
+  <data name="Teams_Departments" xml:space="preserve"><value>Abteilungen</value></data>
+  <data name="Teams_HiddenTeams" xml:space="preserve"><value>Versteckte Teams</value></data>
+  <data name="Teams_HiddenTeamsNote" xml:space="preserve"><value>(nur für Admins sichtbar)</value></data>
+  <data name="Teams_Summary" xml:space="preserve"><value>Übersicht</value></data>
+  <data name="Teams_SyncStatus" xml:space="preserve"><value>Sync-Status</value></data>
+  <data name="Teams_SystemTeams" xml:space="preserve"><value>System-Teams</value></data>
+  <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Übertragung bereits ausstehend</value></data>
+  <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Anfrage stornieren</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Bereits eingecheckt — kann nicht übertragen werden</value></data>
+  <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>Damit wird die Übertragung von Ticket {0} ({1}) an {2} angefragt.</value></data>
+  <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>Unser Ticketing-Team bearbeitet dies und gibt dir in Kürze Bescheid.</value></data>
+  <data name="TicketTransfer_Continue" xml:space="preserve"><value>Weiter</value></data>
+  <data name="TicketTransfer_NoneTransferable" xml:space="preserve"><value>Keines deiner Tickets kann derzeit übertragen werden.</value></data>
+  <data name="TicketTransfer_NoRequests" xml:space="preserve"><value>Du hast keine Übertragungen angefragt.</value></data>
+  <data name="TicketTransfer_NoTickets" xml:space="preserve"><value>Du hast keine Tickets zum Übertragen.</value></data>
+  <data name="TicketTransfer_NotTransferable" xml:space="preserve"><value>Nicht übertragbar</value></data>
+  <data name="TicketTransfer_ReasonLabel" xml:space="preserve"><value>Grund für die Übertragung (optional, für das Ticket-Team sichtbar)</value></data>
+  <data name="TicketTransfer_RecipientPlaceholder" xml:space="preserve"><value>Nach Namen suchen oder genaue E-Mail-Adresse einfügen…</value></data>
+  <data name="TicketTransfer_Requested" xml:space="preserve"><value>Angefragt</value></data>
+  <data name="TicketTransfer_RequestTransfer" xml:space="preserve"><value>Übertragung anfragen</value></data>
+  <data name="TicketTransfer_StatusApproved" xml:space="preserve"><value>Abgeschlossen</value></data>
+  <data name="TicketTransfer_StatusCancelled" xml:space="preserve"><value>Storniert</value></data>
+  <data name="TicketTransfer_StatusRejected" xml:space="preserve"><value>Vom Team storniert</value></data>
+  <data name="TicketTransfer_Step1" xml:space="preserve"><value>1. Wähle das zu übertragende Ticket</value></data>
+  <data name="TicketTransfer_Step2" xml:space="preserve"><value>2. An wen sendest du es?</value></data>
+  <data name="TicketTransfer_Step3" xml:space="preserve"><value>3. Bestätigen</value></data>
+  <data name="TicketTransfer_Title" xml:space="preserve"><value>Ticket übertragen</value></data>
+  <data name="TicketTransfer_YourRequests" xml:space="preserve"><value>Deine Übertragungsanfragen</value></data>
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -6059,4 +6059,614 @@
   <data name="AccountDeletion_ScheduledFor" xml:space="preserve"><value>Se eliminará permanentemente el {0} a menos que la canceles.</value></data>
   <data name="AccountDeletion_Unscheduled" xml:space="preserve"><value>Se eliminará permanentemente a menos que la canceles.</value></data>
   <data name="AccountDeletion_CancelButton" xml:space="preserve"><value>Cancelar solicitud de eliminación</value></data>
+  <data name="About_AdditionalHelp" xml:space="preserve"><value>Con ayuda adicional de</value></data>
+  <data name="About_AdditionalHelpAnd" xml:space="preserve"><value>y</value></data>
+  <data name="About_AnthropicNote" xml:space="preserve"><value>Las respuestas del asistente conversacional las produce la API de Anthropic. No se usan datos para el entrenamiento de modelos, según el DPA de Anthropic.</value></data>
+  <data name="About_Cat_AILLM" xml:space="preserve"><value>IA/LLM</value></data>
+  <data name="About_Cat_BackgroundJobs" xml:space="preserve"><value>Trabajos en segundo plano</value></data>
+  <data name="About_Cat_Calendar" xml:space="preserve"><value>Calendario</value></data>
+  <data name="About_Cat_CSV" xml:space="preserve"><value>CSV</value></data>
+  <data name="About_Cat_Database" xml:space="preserve"><value>Base de datos</value></data>
+  <data name="About_Cat_DateTime" xml:space="preserve"><value>Fecha/Hora</value></data>
+  <data name="About_Cat_Email" xml:space="preserve"><value>Correo electrónico</value></data>
+  <data name="About_Cat_Framework" xml:space="preserve"><value>Framework</value></data>
+  <data name="About_Cat_GitHubAPI" xml:space="preserve"><value>API de GitHub</value></data>
+  <data name="About_Cat_GoogleAPIs" xml:space="preserve"><value>APIs de Google</value></data>
+  <data name="About_Cat_HealthChecks" xml:space="preserve"><value>Comprobaciones de estado</value></data>
+  <data name="About_Cat_ImageProcessing" xml:space="preserve"><value>Procesamiento de imágenes</value></data>
+  <data name="About_Cat_Logging" xml:space="preserve"><value>Registro</value></data>
+  <data name="About_Cat_Markdown" xml:space="preserve"><value>Markdown</value></data>
+  <data name="About_Cat_Observability" xml:space="preserve"><value>Observabilidad</value></data>
+  <data name="About_Cat_Payments" xml:space="preserve"><value>Pagos</value></data>
+  <data name="About_Cat_Resilience" xml:space="preserve"><value>Resiliencia</value></data>
+  <data name="About_Cat_Sanitization" xml:space="preserve"><value>Saneamiento</value></data>
+  <data name="About_Cat_Spreadsheet" xml:space="preserve"><value>Hoja de cálculo</value></data>
+  <data name="About_Cat_StateMachine" xml:space="preserve"><value>Máquina de estados</value></data>
+  <data name="About_Cat_UserAgent" xml:space="preserve"><value>User-Agent</value></data>
+  <data name="About_ColCategory" xml:space="preserve"><value>Categoría</value></data>
+  <data name="About_ColLibrary" xml:space="preserve"><value>Biblioteca</value></data>
+  <data name="About_ColLicense" xml:space="preserve"><value>Licencia</value></data>
+  <data name="About_ColPackage" xml:space="preserve"><value>Paquete</value></data>
+  <data name="About_ColVersion" xml:space="preserve"><value>Versión</value></data>
+  <data name="About_DotNetDesc" xml:space="preserve"><value>ASP.NET Core MVC con vistas Razor, Identity y todo el stack de Microsoft. El armazón que lo mantiene todo unido.</value></data>
+  <data name="About_FrontendHeading" xml:space="preserve"><value>Dependencias de frontend / CDN</value></data>
+  <data name="About_GoogleDesc" xml:space="preserve"><value>Admin Directory, Drive y Groups — aprovisionando Shared Drives, carpetas y listas de correo para que nadie tenga que hacerlo a mano.</value></data>
+  <data name="About_HangfireDesc" xml:space="preserve"><value>Trabajos en segundo plano para sincronización, conciliación y cualquier cosa que no deba bloquear una petición HTTP. Respaldado por PostgreSQL, panel incluido.</value></data>
+  <data name="About_IngredientsHeading" xml:space="preserve"><value>Los ingredientes</value></data>
+  <data name="About_IngredientsIntro" xml:space="preserve"><value>Todo taller necesita sus materiales. Esto es de lo que está hecho Humans:</value></data>
+  <data name="About_Intro" xml:space="preserve"><value>Humans es el sistema de membresía que mantiene en marcha a Nobodies Collective — incorporación de humans, aprovisionamiento de equipos, seguimiento de la gobernanza y toda la fontanería que permite a una asociación sin ánimo de lucro española operar con la memoria organizativa de algo diez veces su tamaño. Construido con esmero, mantenido con tozudez y desplegado con los dedos cruzados.</value></data>
+  <data name="About_License_Apache2" xml:space="preserve"><value>requiere aviso de copyright, copia de la licencia y declaración de cambios si se modifica. Todos los paquetes se usan sin modificar.</value></data>
+  <data name="About_License_BSD2" xml:space="preserve"><value>requiere aviso de copyright en la documentación.</value></data>
+  <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>requiere aviso de copyright; esta página cumple con esa obligación.</value></data>
+  <data name="About_License_ISC" xml:space="preserve"><value>permisiva, funcionalmente equivalente a BSD-2-Clause; requiere aviso de copyright.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>la biblioteca debe poder ser reemplazada por el usuario final. Se consume como paquetes NuGet sin modificar (enlazados dinámicamente), cumpliendo las obligaciones de la LGPL.</value></data>
+  <data name="About_License_MIT" xml:space="preserve"><value>requiere aviso de copyright; esta página cumple con esa obligación.</value></data>
+  <data name="About_License_PostgreSQL" xml:space="preserve"><value>permisiva, similar a MIT; requiere aviso de copyright.</value></data>
+  <data name="About_License_SILOFL" xml:space="preserve"><value>libre de usar y redistribuir; las fuentes no pueden venderse por separado.</value></data>
+  <data name="About_LicenseBody" xml:space="preserve"><value>Humans es software libre, publicado bajo la</value></data>
+  <data name="About_LicenseComplianceHeading" xml:space="preserve"><value>Resumen de cumplimiento de licencias</value></data>
+  <data name="About_LicenseComplianceSummary" xml:space="preserve"><value>Todas las dependencias de producción usan licencias permisivas o de copyleft débil. No se han encontrado infracciones.</value></data>
+  <data name="About_LicenseExplanation" xml:space="preserve"><value>Puedes usar, estudiar, modificar y redistribuir este software. Si ejecutas una versión modificada y permites que otros interactúen con ella a través de una red, debes poner tu código fuente modificado a disposición bajo la misma licencia.</value></data>
+  <data name="About_LicenseFullText" xml:space="preserve"><value>Texto completo de la licencia:</value></data>
+  <data name="About_LicenseHeading" xml:space="preserve"><value>Licencia</value></data>
+  <data name="About_LicenseSourceCode" xml:space="preserve"><value>Código fuente:</value></data>
+  <data name="About_MadeBy" xml:space="preserve"><value>Hecho por</value></data>
+  <data name="About_MadeByTail" xml:space="preserve"><value>con cariño para la comunidad de Nobodies.</value></data>
+  <data name="About_MailKitDesc" xml:space="preserve"><value>Correo transaccional para notificaciones e incorporación. La única biblioteca que hace que SMTP resulte casi agradable.</value></data>
+  <data name="About_MeetTheStaff" xml:space="preserve"><value>Conoce al equipo</value></data>
+  <data name="About_NeedHelp" xml:space="preserve"><value>¿Necesitas ayuda?</value></data>
+  <data name="About_NuGetPackagesHeading" xml:space="preserve"><value>Paquetes NuGet</value></data>
+  <data name="About_OpenSourceLicensesHeading" xml:space="preserve"><value>Licencias de código abierto</value></data>
+  <data name="About_OpenSourceLicensesIntro" xml:space="preserve"><value>Humans está construido sobre los hombros de proyectos de código abierto. La tabla siguiente enumera cada dependencia de producción, su versión y su licencia.</value></data>
+  <data name="About_OtelDesc" xml:space="preserve"><value>Registro estructurado, trazas distribuidas y métricas de Prometheus. Porque "funciona en mi máquina" no es una estrategia de monitorización.</value></data>
+  <data name="About_PostgresDesc" xml:space="preserve"><value>Datos relacionales con Entity Framework Core y Npgsql. Tipos de NodaTime de arriba abajo — ni un DateTime a la vista.</value></data>
+  <data name="About_Staff_BackToAbout" xml:space="preserve"><value>Volver a Acerca de</value></data>
+  <data name="About_Staff_Empty" xml:space="preserve"><value>No se encontraron titulares de roles activos. El castillo parece estar vacío.</value></data>
+  <data name="About_Staff_Intro" xml:space="preserve"><value>Todo colectivo necesita a quienes lo cuidan. Estos son los humans que ofrecen su tiempo y energía para mantener Nobodies en marcha — desde la gobernanza al soporte técnico, desde la confianza y seguridad hasta la alquimia de las entradas.</value></data>
+  <data name="About_Staff_Title" xml:space="preserve"><value>Los humans detrás del telón</value></data>
+  <data name="About_Title" xml:space="preserve"><value>Acerca de Humans</value></data>
+  <data name="AccountStatus_ConsentSuspendedBody" xml:space="preserve"><value>Tu acceso está suspendido hasta que completes los consentimientos legales requeridos.</value></data>
+  <data name="AccountStatus_HeadingAdminSuspended" xml:space="preserve"><value>Tu cuenta ha sido suspendida por un administrador</value></data>
+  <data name="AccountStatus_ReviewConsents" xml:space="preserve"><value>Revisar los consentimientos requeridos</value></data>
+  <data name="Budget_ColAmount" xml:space="preserve"><value>Importe (€)</value></data>
+  <data name="Budget_ColCategory" xml:space="preserve"><value>Categoría</value></data>
+  <data name="Budget_ColShare" xml:space="preserve"><value>Proporción</value></data>
+  <data name="Budget_DepartmentDetail" xml:space="preserve"><value>Detalle por departamento</value></data>
+  <data name="Budget_Expenses" xml:space="preserve"><value>Gastos</value></data>
+  <data name="Budget_ExpensesBreakdown" xml:space="preserve"><value>Desglose de gastos</value></data>
+  <data name="Budget_Income" xml:space="preserve"><value>Ingresos</value></data>
+  <data name="Budget_IncomeBreakdown" xml:space="preserve"><value>Desglose de ingresos</value></data>
+  <data name="Budget_NetBalance" xml:space="preserve"><value>Saldo neto</value></data>
+  <data name="Budget_NoActiveBudget" xml:space="preserve"><value>Sin presupuesto activo</value></data>
+  <data name="Budget_NoActiveBudgetSubtitle" xml:space="preserve"><value>No hay ningún año presupuestario activo que mostrar. Un administrador de finanzas configurará uno cuando comience la planificación del presupuesto.</value></data>
+  <data name="Budget_NoDataSubtitle" xml:space="preserve"><value>Las asignaciones del presupuesto aparecerán aquí una vez que el equipo de finanzas las configure.</value></data>
+  <data name="Budget_NoDataYet" xml:space="preserve"><value>Datos del presupuesto aún no disponibles</value></data>
+  <data name="Budget_NoExpenseItems" xml:space="preserve"><value>Aún no hay partidas de gastos.</value></data>
+  <data name="Budget_NoIncomeItems" xml:space="preserve"><value>Aún no hay partidas de ingresos.</value></data>
+  <data name="Budget_OverviewSubtitle" xml:space="preserve"><value>Cómo se reparte el presupuesto de {0} entre departamentos e infraestructura.</value></data>
+  <data name="Budget_OverviewTitle" xml:space="preserve"><value>Resumen del presupuesto</value></data>
+  <data name="Budget_Title" xml:space="preserve"><value>Presupuesto</value></data>
+  <data name="Budget_TitleYear" xml:space="preserve"><value>Presupuesto - {0}</value></data>
+  <data name="Budget_TotalExpenses" xml:space="preserve"><value>Gastos totales</value></data>
+  <data name="Budget_TotalIncome" xml:space="preserve"><value>Ingresos totales</value></data>
+  <data name="Calendar_Agenda" xml:space="preserve"><value>Agenda</value></data>
+  <data name="Calendar_AllDay" xml:space="preserve"><value>todo el día</value></data>
+  <data name="Calendar_AllDayEvent" xml:space="preserve"><value>Evento de todo el día</value></data>
+  <data name="Calendar_AllDayLabel" xml:space="preserve"><value>Todo el día</value></data>
+  <data name="Calendar_AllTeamsMonthView" xml:space="preserve"><value>Todos los equipos (vista mensual)</value></data>
+  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>Todas las horas se muestran en {0}.</value></data>
+  <data name="Calendar_BackToCalendar" xml:space="preserve"><value>Volver al calendario</value></data>
+  <data name="Calendar_CancelOccurrenceConfirm" xml:space="preserve"><value>¿Cancelar solo esta repetición?</value></data>
+  <data name="Calendar_CancelThisOccurrence" xml:space="preserve"><value>Cancelar esta</value></data>
+  <data name="Calendar_ChangeHistory" xml:space="preserve"><value>Historial de cambios</value></data>
+  <data name="Calendar_Continues" xml:space="preserve"><value>continúa</value></data>
+  <data name="Calendar_Created" xml:space="preserve"><value>Creado {0}</value></data>
+  <data name="Calendar_CreateEvent" xml:space="preserve"><value>Crear evento</value></data>
+  <data name="Calendar_DeleteConfirm" xml:space="preserve"><value>¿Eliminar este evento y todas sus repeticiones?</value></data>
+  <data name="Calendar_Description" xml:space="preserve"><value>Descripción</value></data>
+  <data name="Calendar_EditEvent" xml:space="preserve"><value>Editar evento</value></data>
+  <data name="Calendar_EditSingleOccurrence" xml:space="preserve"><value>Editar una sola repetición</value></data>
+  <data name="Calendar_EditSingleOccurrenceHeading" xml:space="preserve"><value>Editar una sola repetición</value></data>
+  <data name="Calendar_EditThisOccurrence" xml:space="preserve"><value>Editar esta repetición</value></data>
+  <data name="Calendar_End" xml:space="preserve"><value>Fin</value></data>
+  <data name="Calendar_EndDate" xml:space="preserve"><value>Fecha de fin</value></data>
+  <data name="Calendar_EndDateHelp" xml:space="preserve"><value>Inclusive — déjalo en blanco para un evento de un solo día.</value></data>
+  <data name="Calendar_EventTitle" xml:space="preserve"><value>Evento</value></data>
+  <data name="Calendar_FirstStart" xml:space="preserve"><value>Primer inicio</value></data>
+  <data name="Calendar_FormTitle" xml:space="preserve"><value>Título</value></data>
+  <data name="Calendar_LastUpdated" xml:space="preserve"><value>· Última actualización {0}</value></data>
+  <data name="Calendar_LocationUrl" xml:space="preserve"><value>URL de ubicación</value></data>
+  <data name="Calendar_MoreCount" xml:space="preserve"><value>+{0} más</value></data>
+  <data name="Calendar_NewEvent" xml:space="preserve"><value>Nuevo evento</value></data>
+  <data name="Calendar_Next" xml:space="preserve"><value>Siguiente</value></data>
+  <data name="Calendar_NoEventsInRange" xml:space="preserve"><value>No hay eventos en el rango seleccionado.</value></data>
+  <data name="Calendar_OverrideDescription" xml:space="preserve"><value>Sobrescribir descripción</value></data>
+  <data name="Calendar_OverrideEnd" xml:space="preserve"><value>Sobrescribir fin</value></data>
+  <data name="Calendar_OverrideInstructions" xml:space="preserve"><value>Sobrescribe solo esta repetición del evento recurrente. Deja un campo en blanco para heredar el valor del evento principal.</value></data>
+  <data name="Calendar_OverrideLocation" xml:space="preserve"><value>Sobrescribir ubicación</value></data>
+  <data name="Calendar_OverrideLocationUrl" xml:space="preserve"><value>Sobrescribir URL de ubicación</value></data>
+  <data name="Calendar_OverrideStart" xml:space="preserve"><value>Sobrescribir inicio</value></data>
+  <data name="Calendar_OverrideTitle" xml:space="preserve"><value>Sobrescribir título</value></data>
+  <data name="Calendar_OwningTeam" xml:space="preserve"><value>Equipo propietario</value></data>
+  <data name="Calendar_Prev" xml:space="preserve"><value>Anterior</value></data>
+  <data name="Calendar_Recurrence" xml:space="preserve"><value>Repetición</value></data>
+  <data name="Calendar_RecurrenceTimezoneHelpPrefix" xml:space="preserve"><value>TZ de IANA, p. ej.</value></data>
+  <data name="Calendar_RecurrenceTimezoneLabel" xml:space="preserve"><value>Zona horaria de la repetición</value></data>
+  <data name="Calendar_RecurrenceTimezoneNote" xml:space="preserve"><value>Zona horaria: {0}</value></data>
+  <data name="Calendar_RecurringEvent" xml:space="preserve"><value>Evento recurrente</value></data>
+  <data name="Calendar_RRule" xml:space="preserve"><value>RRULE</value></data>
+  <data name="Calendar_RRuleHelpPrefix" xml:space="preserve"><value>RRULE de RFC 5545. Déjalo en blanco para un evento único. Ejemplo:</value></data>
+  <data name="Calendar_SaveOverride" xml:space="preserve"><value>Guardar sobrescritura</value></data>
+  <data name="Calendar_Start" xml:space="preserve"><value>Inicio</value></data>
+  <data name="Calendar_StartDate" xml:space="preserve"><value>Fecha de inicio</value></data>
+  <data name="Calendar_TeamFallback" xml:space="preserve"><value>Equipo</value></data>
+  <data name="Calendar_Title" xml:space="preserve"><value>Calendario</value></data>
+  <data name="Calendar_Today" xml:space="preserve"><value>Hoy</value></data>
+  <data name="Calendar_UpcomingOccurrences" xml:space="preserve"><value>Próximas repeticiones</value></data>
+  <data name="Calendar_ViewAriaLabel" xml:space="preserve"><value>Vista de calendario</value></data>
+  <data name="Calendar_ViewGrid" xml:space="preserve"><value>Cuadrícula</value></data>
+  <data name="Calendar_ViewList" xml:space="preserve"><value>Lista</value></data>
+  <data name="Calendar_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Camp_AboutHeading" xml:space="preserve"><value>Sobre tu {0}</value></data>
+  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>¿Aceptáis nuevos humans?</value></data>
+  <data name="Camp_AdultPlayspaceLabel" xml:space="preserve"><value>Espacio de juego para adultos</value></data>
+  <data name="Camp_BlurbLongLabel" xml:space="preserve"><value>Descripción completa</value></data>
+  <data name="Camp_BlurbLongPlaceholder" xml:space="preserve"><value>Cuéntale al mundo sobre tu barrio.</value></data>
+  <data name="Camp_BlurbShortLabel" xml:space="preserve"><value>Descripción breve</value></data>
+  <data name="Camp_BlurbShortPlaceholder" xml:space="preserve"><value>Una o dos frases sobre tu barrio (máx. 300 caracteres)</value></data>
+  <data name="Camp_CommunityHeading" xml:space="preserve"><value>Comunidad</value></data>
+  <data name="Camp_ContactEmailLabel" xml:space="preserve"><value>Correo de contacto</value></data>
+  <data name="Camp_ContactPhoneLabel" xml:space="preserve"><value>Teléfono de contacto</value></data>
+  <data name="Camp_ContactPhonePlaceholder" xml:space="preserve"><value>+34 612 345 678</value></data>
+  <data name="Camp_CultureHeading" xml:space="preserve"><value>Cultura y eventos</value></data>
+  <data name="Camp_Edit_AutoCreatedFromNameChange" xml:space="preserve"><value>Creado automáticamente por un cambio de nombre</value></data>
+  <data name="Camp_Edit_ContainersSeparate" xml:space="preserve"><value>Los contenedores ahora se gestionan por separado.</value></data>
+  <data name="Camp_Edit_HideHistoricalNames" xml:space="preserve"><value>Ocultar nombres históricos</value></data>
+  <data name="Camp_Edit_HistoricalNamesHeading" xml:space="preserve"><value>Nombres históricos</value></data>
+  <data name="Camp_Edit_HistoricalNamesHelp" xml:space="preserve"><value>Nombres por los que este barrio fue conocido anteriormente.</value></data>
+  <data name="Camp_Edit_ImageAlt" xml:space="preserve"><value>Imagen del barrio</value></data>
+  <data name="Camp_Edit_ImagesHeading" xml:space="preserve"><value>Imágenes ({0}/{1})</value></data>
+  <data name="Camp_Edit_ImageUploadHelp" xml:space="preserve"><value>JPEG, PNG o WebP. Máx. 10MB.</value></data>
+  <data name="Camp_Edit_ManageContainers" xml:space="preserve"><value>Gestionar contenedores →</value></data>
+  <data name="Camp_Edit_MembersRolesDescription" xml:space="preserve"><value>Gestiona los miembros activos, los roles, los líderes y las solicitudes de unión pendientes.</value></data>
+  <data name="Camp_Edit_MembersRolesHeading" xml:space="preserve"><value>Miembros y roles</value></data>
+  <data name="Camp_Edit_NameLocked" xml:space="preserve"><value>El nombre está bloqueado para esta temporada.</value></data>
+  <data name="Camp_Edit_OpenMembersRoles" xml:space="preserve"><value>Abrir miembros y roles</value></data>
+  <data name="Camp_Edit_OpenStore" xml:space="preserve"><value>Abrir tienda</value></data>
+  <data name="Camp_Edit_PreviousNamePlaceholder" xml:space="preserve"><value>Nombre anterior del barrio</value></data>
+  <data name="Camp_Edit_StoreDescription" xml:space="preserve"><value>Haz un pedido para este barrio.</value></data>
+  <data name="Camp_Edit_StoreHeading" xml:space="preserve"><value>Tienda</value></data>
+  <data name="Camp_Edit_UploadImage" xml:space="preserve"><value>Subir imagen</value></data>
+  <data name="Camp_ElectricalGridLabel" xml:space="preserve"><value>Red eléctrica</value></data>
+  <data name="Camp_HistoryHeading" xml:space="preserve"><value>Historia</value></data>
+  <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Acepta miembros</value></data>
+  <data name="Camp_Index_AllOption" xml:space="preserve"><value>Todos</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guía del Barrio 2026</value></data>
+  <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filtrar</value></data>
+  <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Niños bienvenidos</value></data>
+  <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>No se encontró ningún {0} con los filtros seleccionados.</value></data>
+  <data name="Camp_Index_NoSearchResults" xml:space="preserve"><value>Ningún {0} coincide con tu búsqueda.</value></data>
+  <data name="Camp_Index_PendingApproval" xml:space="preserve"><value>pendiente de aprobación</value></data>
+  <data name="Camp_Index_SearchLabel" xml:space="preserve"><value>Buscar</value></data>
+  <data name="Camp_Index_SearchPlaceholder" xml:space="preserve"><value>Escribe el nombre de un {0}…</value></data>
+  <data name="Camp_Index_ShowLeadPositions" xml:space="preserve"><value>Mostrar puestos de líder</value></data>
+  <data name="Camp_Index_SoundZoneLabel" xml:space="preserve"><value>Zona de sonido</value></data>
+  <data name="Camp_Index_VibeLabel" xml:space="preserve"><value>Vibra</value></data>
+  <data name="Camp_KidsAreaDescriptionLabel" xml:space="preserve"><value>Descripción de la zona infantil</value></data>
+  <data name="Camp_KidsAreaDescriptionPlaceholder" xml:space="preserve"><value>Describe tu zona infantil si procede</value></data>
+  <data name="Camp_KidsVisitingLabel" xml:space="preserve"><value>Política de visita de niños</value></data>
+  <data name="Camp_KidsWelcomeLabel" xml:space="preserve"><value>¿Niños bienvenidos?</value></data>
+  <data name="Camp_LanguagesLabel" xml:space="preserve"><value>Idiomas hablados</value></data>
+  <data name="Camp_LanguagesPlaceholder" xml:space="preserve"><value>p. ej. inglés, español, alemán</value></data>
+  <data name="Camp_MarkdownSupported" xml:space="preserve"><value>Se admite el formato Markdown</value></data>
+  <data name="Camp_MemberCountLabel" xml:space="preserve"><value>Humans previstos</value></data>
+  <data name="Camp_NoPreference" xml:space="preserve"><value>Sin preferencia</value></data>
+  <data name="Camp_NotSure" xml:space="preserve"><value>No estoy seguro</value></data>
+  <data name="Camp_PerformanceSpaceLabel" xml:space="preserve"><value>Espacio de actuación</value></data>
+  <data name="Camp_PerformanceTypesLabel" xml:space="preserve"><value>Tipos de actuación</value></data>
+  <data name="Camp_PerformanceTypesPlaceholder" xml:space="preserve"><value>p. ej. música, teatro, talleres</value></data>
+  <data name="Camp_PlacementHeading" xml:space="preserve"><value>Ubicación</value></data>
+  <data name="Camp_PreviousNamesHelp" xml:space="preserve"><value>Si tu barrio ha tenido nombres distintos en años anteriores, indícalos aquí.</value></data>
+  <data name="Camp_PreviousNamesLabel" xml:space="preserve"><value>Nombres anteriores</value></data>
+  <data name="Camp_PreviousNamesPlaceholder" xml:space="preserve"><value>Lista separada por comas de nombres anteriores del barrio</value></data>
+  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Registrar</value></data>
+  <data name="Camp_Register_Heading" xml:space="preserve"><value>Registra tu {0}</value></data>
+  <data name="Camp_Register_ImportantInfo" xml:space="preserve"><value>Información importante</value></data>
+  <data name="Camp_Register_Season" xml:space="preserve"><value>temporada</value></data>
+  <data name="Camp_Register_Submit" xml:space="preserve"><value>Registrar {0}</value></data>
+  <data name="Camp_SoundZoneLabel" xml:space="preserve"><value>Preferencia de zona de sonido</value></data>
+  <data name="Camp_SpaceRequirementLabel" xml:space="preserve"><value>Espacio necesario</value></data>
+  <data name="Camp_TimesParticipatingLabel" xml:space="preserve"><value>Veces participando</value></data>
+  <data name="Camp_VibesLabel" xml:space="preserve"><value>Vibras</value></data>
+  <data name="CampCard_AcceptingMembers" xml:space="preserve"><value>Acepta miembros</value></data>
+  <data name="CampCard_Full" xml:space="preserve"><value>Completo</value></data>
+  <data name="CampCard_KidsWelcome" xml:space="preserve"><value>Niños bienvenidos</value></data>
+  <data name="CampCard_TimesAtNowhere" xml:space="preserve"><value>{0} año(s)</value></data>
+  <data name="Common_Actions" xml:space="preserve"><value>Acciones</value></data>
+  <data name="Common_Admin" xml:space="preserve"><value>Administrador</value></data>
+  <data name="Common_Amount" xml:space="preserve"><value>Importe</value></data>
+  <data name="Common_Clear" xml:space="preserve"><value>Limpiar</value></data>
+  <data name="Common_Created" xml:space="preserve"><value>Creado</value></data>
+  <data name="Common_Date" xml:space="preserve"><value>Fecha</value></data>
+  <data name="Common_DeleteImage" xml:space="preserve"><value>Eliminar imagen</value></data>
+  <data name="Common_Department" xml:space="preserve"><value>Departamento</value></data>
+  <data name="Common_MoveDown" xml:space="preserve"><value>Bajar</value></data>
+  <data name="Common_MoveUp" xml:space="preserve"><value>Subir</value></data>
+  <data name="Common_Other" xml:space="preserve"><value>Otro</value></data>
+  <data name="Common_Preview" xml:space="preserve"><value>Vista previa</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Quitar</value></data>
+  <data name="Common_Required" xml:space="preserve"><value>(obligatorio)</value></data>
+  <data name="Common_Sender" xml:space="preserve"><value>Remitente</value></data>
+  <data name="Common_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="Common_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="Common_View" xml:space="preserve"><value>Ver</value></data>
+  <data name="CommPrefs_AlwaysOn" xml:space="preserve"><value>Siempre activo</value></data>
+  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Etiquetado con {0} pero sin fila correspondiente en AspNetUserLogins — se autocorrige en el próximo inicio de sesión por OAuth.</value></data>
+  <data name="EmailGrid_WorkspaceLocked" xml:space="preserve"><value>Bloqueado por la fila de correo de Workspace</value></data>
+  <data name="Enum_AdultPlayspacePolicy_NightOnly" xml:space="preserve"><value>Solo de noche</value></data>
+  <data name="Enum_AdultPlayspacePolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_AdultPlayspacePolicy_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Enum_CampVibe_Adult" xml:space="preserve"><value>Adultos</value></data>
+  <data name="Enum_CampVibe_ChillOut" xml:space="preserve"><value>Chill out</value></data>
+  <data name="Enum_CampVibe_ElectronicMusic" xml:space="preserve"><value>Música electrónica</value></data>
+  <data name="Enum_CampVibe_Games" xml:space="preserve"><value>Juegos</value></data>
+  <data name="Enum_CampVibe_Lecture" xml:space="preserve"><value>Charla</value></data>
+  <data name="Enum_CampVibe_LiveMusic" xml:space="preserve"><value>Música en vivo</value></data>
+  <data name="Enum_CampVibe_Queer" xml:space="preserve"><value>Queer</value></data>
+  <data name="Enum_CampVibe_Sober" xml:space="preserve"><value>Sobrio</value></data>
+  <data name="Enum_CampVibe_Wellness" xml:space="preserve"><value>Bienestar</value></data>
+  <data name="Enum_CampVibe_Workshop" xml:space="preserve"><value>Taller</value></data>
+  <data name="Enum_ContactFieldType_Discord" xml:space="preserve"><value>Discord</value></data>
+  <data name="Enum_ContactFieldType_Other" xml:space="preserve"><value>Otro</value></data>
+  <data name="Enum_ContactFieldType_Phone" xml:space="preserve"><value>Teléfono</value></data>
+  <data name="Enum_ContactFieldType_Signal" xml:space="preserve"><value>Signal</value></data>
+  <data name="Enum_ContactFieldType_Telegram" xml:space="preserve"><value>Telegram</value></data>
+  <data name="Enum_ContactFieldType_WhatsApp" xml:space="preserve"><value>WhatsApp</value></data>
+  <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Todos los humans activos</value></data>
+  <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Solo la Junta</value></data>
+  <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinadores + Junta</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Mis equipos (+ coordinadores y junta)</value></data>
+  <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
+  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Suministro propio</value></data>
+  <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Roja</value></data>
+  <data name="Enum_ElectricalGrid_Unknown" xml:space="preserve"><value>Desconocida</value></data>
+  <data name="Enum_ElectricalGrid_Yellow" xml:space="preserve"><value>Amarilla</value></data>
+  <data name="Enum_EmailOutboxStatus_Failed" xml:space="preserve"><value>Fallido</value></data>
+  <data name="Enum_EmailOutboxStatus_Queued" xml:space="preserve"><value>En cola</value></data>
+  <data name="Enum_EmailOutboxStatus_Sent" xml:space="preserve"><value>Enviado</value></data>
+  <data name="Enum_EventStatus_Approved" xml:space="preserve"><value>Aprobado</value></data>
+  <data name="Enum_EventStatus_Draft" xml:space="preserve"><value>Borrador</value></data>
+  <data name="Enum_EventStatus_Pending" xml:space="preserve"><value>Pendiente</value></data>
+  <data name="Enum_EventStatus_Rejected" xml:space="preserve"><value>Rechazado</value></data>
+  <data name="Enum_EventStatus_ResubmitRequested" xml:space="preserve"><value>Cambios solicitados</value></data>
+  <data name="Enum_EventStatus_Withdrawn" xml:space="preserve"><value>Retirado</value></data>
+  <data name="Enum_ExpenseReportStatus_Approved" xml:space="preserve"><value>Aprobado</value></data>
+  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Avalado por el coordinador</value></data>
+  <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Borrador</value></data>
+  <data name="Enum_ExpenseReportStatus_Paid" xml:space="preserve"><value>Pagado</value></data>
+  <data name="Enum_ExpenseReportStatus_SepaSent" xml:space="preserve"><value>SEPA enviado</value></data>
+  <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Enviado</value></data>
+  <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Retirado</value></data>
+  <data name="Enum_FeedbackCategory_Bug" xml:space="preserve"><value>Error</value></data>
+  <data name="Enum_FeedbackCategory_FeatureRequest" xml:space="preserve"><value>Petición de funcionalidad</value></data>
+  <data name="Enum_FeedbackCategory_Question" xml:space="preserve"><value>Pregunta</value></data>
+  <data name="Enum_FeedbackStatus_Acknowledged" xml:space="preserve"><value>Recibido</value></data>
+  <data name="Enum_FeedbackStatus_Open" xml:space="preserve"><value>Abierto</value></data>
+  <data name="Enum_FeedbackStatus_Resolved" xml:space="preserve"><value>Resuelto</value></data>
+  <data name="Enum_FeedbackStatus_WontFix" xml:space="preserve"><value>No se corregirá</value></data>
+  <data name="Enum_IssueCategory_Bug" xml:space="preserve"><value>Error</value></data>
+  <data name="Enum_IssueCategory_Feature" xml:space="preserve"><value>Funcionalidad</value></data>
+  <data name="Enum_IssueCategory_Question" xml:space="preserve"><value>Pregunta</value></data>
+  <data name="Enum_KidsVisitingPolicy_DaytimeOnly" xml:space="preserve"><value>Solo de día</value></data>
+  <data name="Enum_KidsVisitingPolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_KidsVisitingPolicy_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Enum_LanguageProficiency_Basic" xml:space="preserve"><value>Básico</value></data>
+  <data name="Enum_LanguageProficiency_Conversational" xml:space="preserve"><value>Conversacional</value></data>
+  <data name="Enum_LanguageProficiency_Fluent" xml:space="preserve"><value>Fluido</value></data>
+  <data name="Enum_LanguageProficiency_Native" xml:space="preserve"><value>Nativo</value></data>
+  <data name="Enum_PerformanceSpaceStatus_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_PerformanceSpaceStatus_WorkingOnIt" xml:space="preserve"><value>En ello</value></data>
+  <data name="Enum_PerformanceSpaceStatus_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Enum_RolePeriod_Build" xml:space="preserve"><value>Montaje</value></data>
+  <data name="Enum_RolePeriod_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="Enum_RolePeriod_Strike" xml:space="preserve"><value>Desmontaje</value></data>
+  <data name="Enum_RolePeriod_YearRound" xml:space="preserve"><value>Todo el año</value></data>
+  <data name="Enum_SlotPriority_Critical" xml:space="preserve"><value>Crítica</value></data>
+  <data name="Enum_SlotPriority_Important" xml:space="preserve"><value>Importante</value></data>
+  <data name="Enum_SlotPriority_NiceToHave" xml:space="preserve"><value>Deseable</value></data>
+  <data name="Enum_SlotPriority_None" xml:space="preserve"><value>Ninguna</value></data>
+  <data name="Enum_SoundZone_Blue" xml:space="preserve"><value>Azul</value></data>
+  <data name="Enum_SoundZone_Green" xml:space="preserve"><value>Verde</value></data>
+  <data name="Enum_SoundZone_Orange" xml:space="preserve"><value>Naranja</value></data>
+  <data name="Enum_SoundZone_Red" xml:space="preserve"><value>Roja</value></data>
+  <data name="Enum_SoundZone_Surprise" xml:space="preserve"><value>Sorpresa</value></data>
+  <data name="Enum_SoundZone_Yellow" xml:space="preserve"><value>Amarilla</value></data>
+  <data name="Enum_SpaceSize_Sqm1000" xml:space="preserve"><value>1000 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1200" xml:space="preserve"><value>1200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm150" xml:space="preserve"><value>150 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1500" xml:space="preserve"><value>1500 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1800" xml:space="preserve"><value>1800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2200" xml:space="preserve"><value>2200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2800" xml:space="preserve"><value>2800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm300" xml:space="preserve"><value>300 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm450" xml:space="preserve"><value>450 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm600" xml:space="preserve"><value>600 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm800" xml:space="preserve"><value>800 m²</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Camp" xml:space="preserve"><value>Barrio</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Team" xml:space="preserve"><value>Equipo</value></data>
+  <data name="Enum_TicketTransferStatus_Approved" xml:space="preserve"><value>Completada</value></data>
+  <data name="Enum_TicketTransferStatus_Cancelled" xml:space="preserve"><value>Cancelada</value></data>
+  <data name="Enum_TicketTransferStatus_Pending" xml:space="preserve"><value>Pendiente de revisión</value></data>
+  <data name="Enum_TicketTransferStatus_Rejected" xml:space="preserve"><value>Cancelada por el equipo</value></data>
+  <data name="Enum_YesNoMaybe_Maybe" xml:space="preserve"><value>Quizá</value></data>
+  <data name="Enum_YesNoMaybe_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_YesNoMaybe_Yes" xml:space="preserve"><value>Sí</value></data>
+  <data name="Events_AddBarrioEvent" xml:space="preserve"><value>Añadir evento del barrio</value></data>
+  <data name="Events_AddToFavourites" xml:space="preserve"><value>Añadir a favoritos</value></data>
+  <data name="Events_AllCategories" xml:space="preserve"><value>Todas las categorías</value></data>
+  <data name="Events_AllTimesIn" xml:space="preserve"><value>Todas las horas en {0}. ¡Puede aplicarse la Playa Time!</value></data>
+  <data name="Events_AllTimesInShort" xml:space="preserve"><value>Todas las horas en {0}</value></data>
+  <data name="Events_AllVenues" xml:space="preserve"><value>Todos los lugares</value></data>
+  <data name="Events_BrowseTitle" xml:space="preserve"><value>Explorar eventos</value></data>
+  <data name="Events_ColActions" xml:space="preserve"><value>Acciones</value></data>
+  <data name="Events_ColCategory" xml:space="preserve"><value>Categoría</value></data>
+  <data name="Events_ColDateTime" xml:space="preserve"><value>Fecha y hora</value></data>
+  <data name="Events_ColEventName" xml:space="preserve"><value>Nombre del evento</value></data>
+  <data name="Events_ColPriority" xml:space="preserve"><value>Prioridad</value></data>
+  <data name="Events_ConflictBadge" xml:space="preserve"><value>Conflicto de horario con otro evento favorito</value></data>
+  <data name="Events_DownloadCsv" xml:space="preserve"><value>Descargar CSV de eventos</value></data>
+  <data name="Events_DurationMin" xml:space="preserve"><value>{0} min</value></data>
+  <data name="Events_FavouritesOnly" xml:space="preserve"><value>Solo favoritos</value></data>
+  <data name="Events_FilterCategory" xml:space="preserve"><value>Categoría</value></data>
+  <data name="Events_FilterDay" xml:space="preserve"><value>Día</value></data>
+  <data name="Events_FilterSearch" xml:space="preserve"><value>Buscar</value></data>
+  <data name="Events_FilterVenue" xml:space="preserve"><value>Lugar</value></data>
+  <data name="Events_MyPersonalEvents" xml:space="preserve"><value>Mis eventos personales</value></data>
+  <data name="Events_MySchedule" xml:space="preserve"><value>Mi agenda</value></data>
+  <data name="Events_MySubmissions" xml:space="preserve"><value>Mis propuestas</value></data>
+  <data name="Events_MySubmissionsTitle" xml:space="preserve"><value>Mis propuestas de eventos</value></data>
+  <data name="Events_NoBarrioEvents" xml:space="preserve"><value>Aún no se han propuesto eventos para este barrio.</value></data>
+  <data name="Events_NoEventsFound" xml:space="preserve"><value>No se encontraron eventos. Prueba a ajustar tus filtros.</value></data>
+  <data name="Events_NoPersonalEvents" xml:space="preserve"><value>Aún no has propuesto ningún evento personal.</value></data>
+  <data name="Events_RemoveFromFavourites" xml:space="preserve"><value>Quitar de favoritos</value></data>
+  <data name="Events_RemoveFromSchedule" xml:space="preserve"><value>Quitar de la agenda</value></data>
+  <data name="Events_RemoveFromScheduleConfirm" xml:space="preserve"><value>¿Quitar este evento de tu agenda?</value></data>
+  <data name="Events_ScheduleEmpty" xml:space="preserve"><value>Aún no has marcado ningún evento como favorito. Explora la {0} para añadir eventos a tu agenda.</value></data>
+  <data name="Events_ScheduleEmptyLink" xml:space="preserve"><value>guía de eventos</value></data>
+  <data name="Events_ScheduleTitle" xml:space="preserve"><value>Mi agenda</value></data>
+  <data name="Events_SearchPlaceholder" xml:space="preserve"><value>Buscar por título o descripción…</value></data>
+  <data name="Events_StatApproved" xml:space="preserve"><value>Aprobados</value></data>
+  <data name="Events_StatPending" xml:space="preserve"><value>Pendientes</value></data>
+  <data name="Events_StatSubmitted" xml:space="preserve"><value>Enviados</value></data>
+  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Periodo de propuestas:</value></data>
+  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>El periodo de propuestas no está abierto en este momento. Contacta con un administrador para configurar los ajustes de la guía.</value></data>
+  <data name="Events_SubmitNewEvent" xml:space="preserve"><value>Proponer nuevo evento</value></data>
+  <data name="Events_UploadColErrors" xml:space="preserve"><value>Errores</value></data>
+  <data name="Events_UploadColEvent" xml:space="preserve"><value>Evento</value></data>
+  <data name="Events_UploadColRow" xml:space="preserve"><value>Fila</value></data>
+  <data name="Events_UploadCsv" xml:space="preserve"><value>Subir CSV</value></data>
+  <data name="Events_UploadFailed" xml:space="preserve"><value>La subida falló.</value></data>
+  <data name="Events_UploadFailedDetail" xml:space="preserve"><value>Corrige los errores de abajo e inténtalo de nuevo. No se guardó ningún evento.</value></data>
+  <data name="Events_WithdrawConfirm" xml:space="preserve"><value>¿Retirar este evento?</value></data>
+  <data name="Expenses_ColReport" xml:space="preserve"><value>Informe</value></data>
+  <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Enviado</value></data>
+  <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Enviado por</value></data>
+  <data name="Expenses_CoordinatorQueue" xml:space="preserve"><value>Cola del coordinador</value></data>
+  <data name="Expenses_CoordinatorQueueTitle" xml:space="preserve"><value>Informes de gastos — Cola del coordinador</value></data>
+  <data name="Expenses_Endorse" xml:space="preserve"><value>Avalar</value></data>
+  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>¿Avalar este informe de gastos?</value></data>
+  <data name="Expenses_FileFirst" xml:space="preserve"><value>Presenta tu primer informe</value></data>
+  <data name="Expenses_IouHeader" xml:space="preserve"><value>Lo que el colectivo te debe</value></data>
+  <data name="Expenses_IouLastPayment" xml:space="preserve"><value>Último pago</value></data>
+  <data name="Expenses_IouOtherAmountNote" xml:space="preserve"><value>Tu saldo en Holded incluye {0} no relacionado con estos informes (artículos adelantados en nombre del colectivo, ajustes, etc.), así que las filas de abajo no tienen por qué sumar ese total.</value></data>
+  <data name="Expenses_IouOwed" xml:space="preserve"><value>Te debe (saldo en Holded)</value></data>
+  <data name="Expenses_IouPaid" xml:space="preserve"><value>Pagado hasta la fecha</value></data>
+  <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Concepto</value></data>
+  <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Mis informes de gastos</value></data>
+  <data name="Expenses_NewReport" xml:space="preserve"><value>Nuevo informe</value></data>
+  <data name="Expenses_NoActiveYear" xml:space="preserve"><value>No hay ningún año presupuestario activo en este momento. No se pueden presentar informes de gastos hasta que se active un año presupuestario.</value></data>
+  <data name="Expenses_NoIban" xml:space="preserve"><value>Aún no has establecido tu IBAN de pago. Se te pedirá que lo establezcas cuando envíes un informe.</value></data>
+  <data name="Expenses_NoReports" xml:space="preserve"><value>Aún no hay informes de gastos.</value></data>
+  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No hay informes a la espera de tu aval.</value></data>
+  <data name="Expenses_Reject" xml:space="preserve"><value>Rechazar</value></data>
+  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>Quien lo envió verá este motivo. Explica con claridad por qué no se puede avalar el informe.</value></data>
+  <data name="Expenses_RejectModalTitle" xml:space="preserve"><value>Rechazar informe</value></data>
+  <data name="Expenses_RejectReasonLabel" xml:space="preserve"><value>Motivo del rechazo</value></data>
+  <data name="Expenses_RejectReasonPlaceholder" xml:space="preserve"><value>p. ej. Faltan recibos de la línea 2</value></data>
+  <data name="Feedback_AssignedToName" xml:space="preserve"><value>Asignado a {0}</value></data>
+  <data name="Feedback_CategoryOnPage" xml:space="preserve"><value>{0} en {1}</value></data>
+  <data name="Feedback_TeamName" xml:space="preserve"><value>Equipo: {0}</value></data>
+  <data name="Issue_ColComments" xml:space="preserve"><value>Comentarios</value></data>
+  <data name="Issue_ColReporter" xml:space="preserve"><value>Autor</value></data>
+  <data name="Issue_ColStatus" xml:space="preserve"><value>Estado</value></data>
+  <data name="Issue_ColTitle" xml:space="preserve"><value>Título</value></data>
+  <data name="Issue_ColUpdated" xml:space="preserve"><value>Actualizado</value></data>
+  <data name="Issue_CountSummary" xml:space="preserve"><value>{0} abiertas · {1} en total</value></data>
+  <data name="LinkedAccounts_Account" xml:space="preserve"><value>Cuenta</value></data>
+  <data name="LinkedAccounts_Actions" xml:space="preserve"><value>Acciones</value></data>
+  <data name="LinkedAccounts_ConfirmUnlink" xml:space="preserve"><value>¿Desvincular esta cuenta? Ya no podrás iniciar sesión con ella.</value></data>
+  <data name="LinkedAccounts_Description" xml:space="preserve"><value>Proveedores OAuth vinculados actualmente a tu cuenta. Puedes usar cualquiera de ellos para iniciar sesión.</value></data>
+  <data name="LinkedAccounts_Empty" xml:space="preserve"><value>No hay cuentas OAuth vinculadas.</value></data>
+  <data name="LinkedAccounts_LastSignInMethod" xml:space="preserve"><value>Único método de inicio de sesión — no se puede desvincular.</value></data>
+  <data name="LinkedAccounts_LinkedOn" xml:space="preserve"><value>Vinculada el</value></data>
+  <data name="LinkedAccounts_Provider" xml:space="preserve"><value>Proveedor</value></data>
+  <data name="LinkedAccounts_Title" xml:space="preserve"><value>Cuentas vinculadas</value></data>
+  <data name="LinkedAccounts_UnlinkBlockedLastSignInMethod" xml:space="preserve"><value>No se puede desvincular — este es tu único método de inicio de sesión restante.</value></data>
+  <data name="MarkdownHelp_Bold" xml:space="preserve"><value>negrita</value></data>
+  <data name="MarkdownHelp_ColYouGet" xml:space="preserve"><value>Obtienes</value></data>
+  <data name="MarkdownHelp_ColYouType" xml:space="preserve"><value>Escribes</value></data>
+  <data name="MarkdownHelp_EmbeddedImage" xml:space="preserve"><value>imagen incrustada</value></data>
+  <data name="MarkdownHelp_First" xml:space="preserve"><value>primero</value></data>
+  <data name="MarkdownHelp_Heading1" xml:space="preserve"><value>Encabezado 1</value></data>
+  <data name="MarkdownHelp_Heading2" xml:space="preserve"><value>Encabezado 2</value></data>
+  <data name="MarkdownHelp_InlineCode" xml:space="preserve"><value>código en línea</value></data>
+  <data name="MarkdownHelp_Intro" xml:space="preserve"><value>Markdown es una forma sencilla de dar formato al texto. Escribe la sintaxis de la izquierda y se mostrará como aparece a la derecha.</value></data>
+  <data name="MarkdownHelp_Italic" xml:space="preserve"><value>cursiva</value></data>
+  <data name="MarkdownHelp_ItemOne" xml:space="preserve"><value>elemento uno</value></data>
+  <data name="MarkdownHelp_ItemTwo" xml:space="preserve"><value>elemento dos</value></data>
+  <data name="MarkdownHelp_LinkText" xml:space="preserve"><value>texto del enlace</value></data>
+  <data name="MarkdownHelp_QuoteText" xml:space="preserve"><value>texto de cita</value></data>
+  <data name="MarkdownHelp_Second" xml:space="preserve"><value>segundo</value></data>
+  <data name="MarkdownHelp_Strikethrough" xml:space="preserve"><value>tachado</value></data>
+  <data name="MarkdownHelp_TableAdmin" xml:space="preserve"><value>Administrador</value></data>
+  <data name="MarkdownHelp_TableHuman" xml:space="preserve"><value>Human</value></data>
+  <data name="MarkdownHelp_TableName" xml:space="preserve"><value>Nombre</value></data>
+  <data name="MarkdownHelp_TableRole" xml:space="preserve"><value>Rol</value></data>
+  <data name="MarkdownHelp_TablesHeading" xml:space="preserve"><value>Tablas</value></data>
+  <data name="MarkdownHelp_TaskDone" xml:space="preserve"><value>Hecho</value></data>
+  <data name="MarkdownHelp_TaskListsHeading" xml:space="preserve"><value>Listas de tareas</value></data>
+  <data name="MarkdownHelp_TaskToDo" xml:space="preserve"><value>Por hacer</value></data>
+  <data name="MarkdownHelp_Title" xml:space="preserve"><value>Referencia rápida de Markdown</value></data>
+  <data name="Onboarding_BurnerNameExplainer" xml:space="preserve"><value>El nombre que ve todo el mundo en el sistema. Que sea único ayuda, pero no es obligatorio, aunque puede ser difícil encontrar a "Bob" entre los pocos miles de humans que hay aquí si alguien viene buscándote.</value></data>
+  <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>El nombre por el que todos te conocerán.</value></data>
+  <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
+  <data name="Onboarding_Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>no</value></data>
+  <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>exportamos esta información, y solo la revelaríamos si lo exigiera la ley o una auditoría formal.</value></data>
+  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Se guarda internamente, solo es visible para los administradores y se usa únicamente donde la ley española lo exige — por ejemplo, en nuestro registro de auditoría de que aceptaste el Acuerdo de Voluntariado en una fecha y hora concretas. Explícitamente</value></data>
+  <data name="Onboarding_LegalNameLabel" xml:space="preserve"><value>Nombre legal</value></data>
+  <data name="Onboarding_NameRequiredBeforeShifts" xml:space="preserve"><value>Añade tu nombre primero — lo necesitamos antes de que puedas apuntarte a turnos.</value></data>
+  <data name="Onboarding_NamesSubtitle" xml:space="preserve"><value>Dos pasos cortos antes de que elijas un turno.</value></data>
+  <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Bienvenido — empecemos por tu nombre</value></data>
+  <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Crítico</value></data>
+  <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Importante</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>El evento solo tiene cubierto el {0}% de los turnos "críticos". Si no se cubren, el evento podría cancelarse, ya que no sería viable ni seguro llevarlo a cabo.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si puedes cubrir alguno de esos, o puedes venir antes del evento o quedarte al desmontaje, por favor priorízalos al elegir tus turnos.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANTE:</value></data>
+  <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>También hay {0} turnos "importantes" abiertos.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hay {0} turnos "importantes" abiertos. Si puedes venir antes del evento o quedarte al desmontaje, por favor priorízalos.</value></data>
+  <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>No hay ningún evento activo ahora mismo. Puedes terminar la incorporación sin elegir un turno.</value></data>
+  <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No hay turnos críticos abiertos en este momento — prueba con Importantes o Todos.</value></data>
+  <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No hay turnos importantes abiertos en este momento — prueba con Todos.</value></data>
+  <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Ahora no</value></data>
+  <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Elige un turno</value></data>
+  <data name="Outbox_AdminTitle" xml:space="preserve"><value>Correos</value></data>
+  <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Volver a Administración</value></data>
+  <data name="Outbox_BackToProfile" xml:space="preserve"><value>Volver al perfil</value></data>
+  <data name="Outbox_DescriptionAdmin" xml:space="preserve"><value>Correos que el sistema ha enviado a este human.</value></data>
+  <data name="Outbox_DescriptionSelf" xml:space="preserve"><value>Correos que el sistema te ha enviado (en los últimos 150 días).</value></data>
+  <data name="Outbox_Empty" xml:space="preserve"><value>No hay correos registrados.</value></data>
+  <data name="Outbox_Subject" xml:space="preserve"><value>Asunto</value></data>
+  <data name="Privacy_ThirdParty_GooglePolicyLink" xml:space="preserve"><value>Política de Privacidad de Google</value></data>
+  <data name="Profile_Assigned" xml:space="preserve"><value>Asignado</value></data>
+  <data name="Profile_Campaign" xml:space="preserve"><value>Campaña</value></data>
+  <data name="Profile_Code" xml:space="preserve"><value>Código</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Dairy" xml:space="preserve"><value>Lácteos</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Egg" xml:space="preserve"><value>Huevo</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Peanut" xml:space="preserve"><value>Cacahuete</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Sesame" xml:space="preserve"><value>Sésamo</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Shellfish" xml:space="preserve"><value>Marisco</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Soy" xml:space="preserve"><value>Soja</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Treenut" xml:space="preserve"><value>Frutos secos de árbol</value></data>
+  <data name="Profile_DietaryMedical_Allergy_WheatGluten" xml:space="preserve"><value>Trigo/Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_FODMAP" xml:space="preserve"><value>FODMAP</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Gluten" xml:space="preserve"><value>Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Histamine" xml:space="preserve"><value>Histamina</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Lactose" xml:space="preserve"><value>Lactosa</value></data>
+  <data name="Profile_MarkedAt" xml:space="preserve"><value>Marcado el</value></data>
+  <data name="Profile_MarkedBy" xml:space="preserve"><value>Marcado por</value></data>
+  <data name="Profile_MyCodes" xml:space="preserve"><value>Mis códigos</value></data>
+  <data name="Profile_MyEmails" xml:space="preserve"><value>Mis correos</value></data>
+  <data name="Profile_NoSentMessages" xml:space="preserve"><value>No hay mensajes en la plataforma registrados.</value></data>
+  <data name="Profile_NoShowHistory" xml:space="preserve"><value>Historial de ausencias ({0})</value></data>
+  <data name="Profile_OnsiteSince" xml:space="preserve"><value>En el sitio desde {0}</value></data>
+  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Check-in en la puerta realizado</value></data>
+  <data name="Profile_Redeemed" xml:space="preserve"><value>Canjeado</value></data>
+  <data name="Profile_SentMessages" xml:space="preserve"><value>Mensajes enviados ({0})</value></data>
+  <data name="Profile_ShiftInfo" xml:space="preserve"><value>Información del turno</value></data>
+  <data name="ProfileEdit_CityPlaceholder" xml:space="preserve"><value>Empieza a escribir tu ciudad…</value></data>
+  <data name="ProfileEdit_ContactType" xml:space="preserve"><value>Tipo</value></data>
+  <data name="ProfileEdit_ContactValue" xml:space="preserve"><value>Valor</value></data>
+  <data name="ProfileEdit_ContactValuePlaceholder" xml:space="preserve"><value>Introduce la información de contacto</value></data>
+  <data name="ProfileEdit_ContactVisibility" xml:space="preserve"><value>Visibilidad</value></data>
+  <data name="ProfileEdit_CustomLabelPlaceholder" xml:space="preserve"><value>p. ej., Discord</value></data>
+  <data name="ProfileEdit_Description" xml:space="preserve"><value>Descripción</value></data>
+  <data name="ProfileEdit_DescriptionPlaceholder" xml:space="preserve"><value>p. ej., Líder de puerta</value></data>
+  <data name="ProfileEdit_EventName" xml:space="preserve"><value>Nombre del evento</value></data>
+  <data name="ProfileEdit_EventNamePlaceholder" xml:space="preserve"><value>p. ej., Burning Man 2024</value></data>
+  <data name="ProfileEdit_LanguageLabel" xml:space="preserve"><value>Idioma</value></data>
+  <data name="ProfileEdit_ProficiencyLabel" xml:space="preserve"><value>Nivel</value></data>
+  <data name="ProfileEdit_RelationshipPlaceholder" xml:space="preserve"><value>p. ej., pareja, madre/padre</value></data>
+  <data name="ProfileEdit_RemoveContactField" xml:space="preserve"><value>Quitar este campo de contacto</value></data>
+  <data name="ProfileEdit_RemoveEntry" xml:space="preserve"><value>Quitar esta entrada</value></data>
+  <data name="ProfileEdit_RemoveLanguage" xml:space="preserve"><value>Quitar este idioma</value></data>
+  <data name="ProfileEdit_SelectLanguage" xml:space="preserve"><value>— Selecciona idioma —</value></data>
+  <data name="Roster_All" xml:space="preserve"><value>Todos</value></data>
+  <data name="Roster_ColAssignedTo" xml:space="preserve"><value>Asignado a</value></data>
+  <data name="Roster_ColPeriod" xml:space="preserve"><value>Periodo</value></data>
+  <data name="Roster_ColPriority" xml:space="preserve"><value>Prioridad</value></data>
+  <data name="Roster_ColRole" xml:space="preserve"><value>Rol</value></data>
+  <data name="Roster_ColSlot" xml:space="preserve"><value>Plaza</value></data>
+  <data name="Roster_ColTeam" xml:space="preserve"><value>Equipo</value></data>
+  <data name="Roster_NoSlots" xml:space="preserve"><value>No hay plazas de rol definidas en los equipos.</value></data>
+  <data name="Roster_PeriodFilter" xml:space="preserve"><value>Periodo: {0}</value></data>
+  <data name="Roster_PriorityFilter" xml:space="preserve"><value>Prioridad: {0}</value></data>
+  <data name="Roster_SlotOpen" xml:space="preserve"><value>Abierta</value></data>
+  <data name="Roster_StatusFilled" xml:space="preserve"><value>Cubierto</value></data>
+  <data name="Roster_StatusFilter" xml:space="preserve"><value>Estado: {0}</value></data>
+  <data name="Roster_StatusOpen" xml:space="preserve"><value>Abierto</value></data>
+  <data name="Roster_Title" xml:space="preserve"><value>Lista del equipo</value></data>
+  <data name="Search_FilterAll" xml:space="preserve"><value>Todos</value></data>
+  <data name="Search_FilterCamps" xml:space="preserve"><value>Barrios</value></data>
+  <data name="Search_FilterEvents" xml:space="preserve"><value>Eventos</value></data>
+  <data name="Search_FilterHumans" xml:space="preserve"><value>Humans</value></data>
+  <data name="Search_FilterShifts" xml:space="preserve"><value>Turnos</value></data>
+  <data name="Search_FilterTeams" xml:space="preserve"><value>Equipos</value></data>
+  <data name="Search_GlobalHint" xml:space="preserve"><value>Escribe al menos 2 caracteres para buscar entre humans, equipos, barrios y turnos.</value></data>
+  <data name="Search_GlobalHintEvents" xml:space="preserve"><value>Escribe al menos 2 caracteres para buscar entre humans, equipos, barrios, turnos y eventos.</value></data>
+  <data name="Search_GlobalNoResults" xml:space="preserve"><value>No hay resultados para {0}.</value></data>
+  <data name="Search_GlobalPlaceholder" xml:space="preserve"><value>Busca humans, equipos, barrios, turnos…</value></data>
+  <data name="Search_GlobalPlaceholderEvents" xml:space="preserve"><value>Busca humans, equipos, barrios, turnos, eventos…</value></data>
+  <data name="Search_GlobalTitle" xml:space="preserve"><value>Buscar</value></data>
+  <data name="Store_AdminCatalog" xml:space="preserve"><value>Catálogo</value></data>
+  <data name="Store_AdminPayments" xml:space="preserve"><value>Pagos</value></data>
+  <data name="Store_AdminSummary" xml:space="preserve"><value>Resumen</value></data>
+  <data name="Store_CatalogHeading" xml:space="preserve"><value>Catálogo ({0})</value></data>
+  <data name="Store_ColBalance" xml:space="preserve"><value>Saldo</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Depósito</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Depósitos</value></data>
+  <data name="Store_ColDescription" xml:space="preserve"><value>Descripción</value></data>
+  <data name="Store_ColLines" xml:space="preserve"><value>Líneas</value></data>
+  <data name="Store_ColLinesVat" xml:space="preserve"><value>Líneas + IVA</value></data>
+  <data name="Store_ColName" xml:space="preserve"><value>Nombre</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Pedir por</value></data>
+  <data name="Store_ColState" xml:space="preserve"><value>Estado</value></data>
+  <data name="Store_ColUnitPrice" xml:space="preserve"><value>Precio unitario (IVA incl.)</value></data>
+  <data name="Store_CreateOrder" xml:space="preserve"><value>Crear pedido</value></data>
+  <data name="Store_DeleteOrderConfirm" xml:space="preserve"><value>¿Eliminar este pedido con saldo cero? Esto no se puede deshacer.</value></data>
+  <data name="Store_DeleteOrderTitle" xml:space="preserve"><value>Eliminar (saldo cero)</value></data>
+  <data name="Store_NoCounterpartiesAlert" xml:space="preserve"><value>No lideras ningún barrio ni coordinas ningún departamento con una temporada activa este año. El catálogo de abajo es de solo lectura.</value></data>
+  <data name="Store_NoOrders" xml:space="preserve"><value>Aún no hay pedidos.</value></data>
+  <data name="Store_NoProducts" xml:space="preserve"><value>No hay productos activos para {0}.</value></data>
+  <data name="Store_OpenOrder" xml:space="preserve"><value>Abrir</value></data>
+  <data name="Store_StartOrder" xml:space="preserve"><value>Iniciar pedido</value></data>
+  <data name="Store_Title" xml:space="preserve"><value>Tienda</value></data>
+  <data name="Teams_Departments" xml:space="preserve"><value>Departamentos</value></data>
+  <data name="Teams_HiddenTeams" xml:space="preserve"><value>Equipos ocultos</value></data>
+  <data name="Teams_HiddenTeamsNote" xml:space="preserve"><value>(visible solo para administradores)</value></data>
+  <data name="Teams_Summary" xml:space="preserve"><value>Resumen</value></data>
+  <data name="Teams_SyncStatus" xml:space="preserve"><value>Estado de sincronización</value></data>
+  <data name="Teams_SystemTeams" xml:space="preserve"><value>Equipos del sistema</value></data>
+  <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Transferencia ya pendiente</value></data>
+  <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Cancelar solicitud</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Ya ha hecho el check-in — no se puede transferir</value></data>
+  <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>Esto solicitará transferir la entrada {0} ({1}) a {2}.</value></data>
+  <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>Nuestro equipo de entradas lo procesará y te avisará en breve.</value></data>
+  <data name="TicketTransfer_Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="TicketTransfer_NoneTransferable" xml:space="preserve"><value>Ninguna de tus entradas se puede transferir ahora mismo.</value></data>
+  <data name="TicketTransfer_NoRequests" xml:space="preserve"><value>No has solicitado ninguna transferencia.</value></data>
+  <data name="TicketTransfer_NoTickets" xml:space="preserve"><value>No tienes ninguna entrada para transferir.</value></data>
+  <data name="TicketTransfer_NotTransferable" xml:space="preserve"><value>No transferible</value></data>
+  <data name="TicketTransfer_ReasonLabel" xml:space="preserve"><value>Motivo de la transferencia (opcional, visible para el equipo de entradas)</value></data>
+  <data name="TicketTransfer_RecipientPlaceholder" xml:space="preserve"><value>Busca por nombre o pega su correo exacto…</value></data>
+  <data name="TicketTransfer_Requested" xml:space="preserve"><value>Solicitada</value></data>
+  <data name="TicketTransfer_RequestTransfer" xml:space="preserve"><value>Solicitar transferencia</value></data>
+  <data name="TicketTransfer_StatusApproved" xml:space="preserve"><value>Completada</value></data>
+  <data name="TicketTransfer_StatusCancelled" xml:space="preserve"><value>Cancelada</value></data>
+  <data name="TicketTransfer_StatusRejected" xml:space="preserve"><value>Cancelada por el equipo</value></data>
+  <data name="TicketTransfer_Step1" xml:space="preserve"><value>1. Elige la entrada que vas a transferir</value></data>
+  <data name="TicketTransfer_Step2" xml:space="preserve"><value>2. ¿A quién se la envías?</value></data>
+  <data name="TicketTransfer_Step3" xml:space="preserve"><value>3. Confirmar</value></data>
+  <data name="TicketTransfer_Title" xml:space="preserve"><value>Transferir una entrada</value></data>
+  <data name="TicketTransfer_YourRequests" xml:space="preserve"><value>Tus solicitudes de transferencia</value></data>
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -6325,7 +6325,7 @@
   <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Todos los humans activos</value></data>
   <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Solo la Junta</value></data>
   <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinadores + Junta</value></data>
-  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Mis equipos (+ coordinadores y junta)</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Mis equipos (+ coordinadores y Junta)</value></data>
   <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
   <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Suministro propio</value></data>
   <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Roja</value></data>
@@ -6629,7 +6629,7 @@
   <data name="Store_ColLines" xml:space="preserve"><value>Líneas</value></data>
   <data name="Store_ColLinesVat" xml:space="preserve"><value>Líneas + IVA</value></data>
   <data name="Store_ColName" xml:space="preserve"><value>Nombre</value></data>
-  <data name="Store_ColOrderBy" xml:space="preserve"><value>Pedir por</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Pedir antes del</value></data>
   <data name="Store_ColState" xml:space="preserve"><value>Estado</value></data>
   <data name="Store_ColUnitPrice" xml:space="preserve"><value>Precio unitario (IVA incl.)</value></data>
   <data name="Store_CreateOrder" xml:space="preserve"><value>Crear pedido</value></data>
@@ -6649,7 +6649,7 @@
   <data name="Teams_SystemTeams" xml:space="preserve"><value>Equipos del sistema</value></data>
   <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Transferencia ya pendiente</value></data>
   <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Cancelar solicitud</value></data>
-  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Ya ha hecho el check-in — no se puede transferir</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Ya has hecho el check-in — no se puede transferir</value></data>
   <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>Esto solicitará transferir la entrada {0} ({1}) a {2}.</value></data>
   <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>Nuestro equipo de entradas lo procesará y te avisará en breve.</value></data>
   <data name="TicketTransfer_Continue" xml:space="preserve"><value>Continuar</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -6050,7 +6050,7 @@
   <data name="About_License_BSD2" xml:space="preserve"><value>exige une mention de copyright dans la documentation.</value></data>
   <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>exige une mention de copyright ; cette page satisfait cette obligation.</value></data>
   <data name="About_License_ISC" xml:space="preserve"><value>permissive, fonctionnellement équivalente à BSD-2-Clause ; mention de copyright requise.</value></data>
-  <data name="About_License_LGPL30" xml:space="preserve"><value>la bibliothèque doit pouvoir être remplacée par l'utilisateur final. Consommées en tant que paquets NuGet non modifiés (liaison dynamique), ce qui satisfait les obligations de la LGPL.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>la bibliothèque doit pouvoir être remplacée par l'utilisateur final. Consommée en tant que paquets NuGet non modifiés (liaison dynamique), ce qui satisfait les obligations de la LGPL.</value></data>
   <data name="About_License_MIT" xml:space="preserve"><value>exige une mention de copyright ; cette page satisfait cette obligation.</value></data>
   <data name="About_License_PostgreSQL" xml:space="preserve"><value>permissive, semblable à MIT ; mention de copyright requise.</value></data>
   <data name="About_License_SILOFL" xml:space="preserve"><value>libres d'utilisation et de redistribution ; les polices ne peuvent pas être vendues séparément.</value></data>
@@ -6288,9 +6288,9 @@
   <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Tous les humans actifs</value></data>
   <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Conseil uniquement</value></data>
   <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinateurs + Conseil</value></data>
-  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Mes équipes (+ coordinateurs &amp; conseil)</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Mes équipes (+ coordinateurs &amp; Conseil)</value></data>
   <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
-  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Alimentation propre</value></data>
+  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Alimentation autonome</value></data>
   <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Rouge</value></data>
   <data name="Enum_ElectricalGrid_Unknown" xml:space="preserve"><value>Inconnu</value></data>
   <data name="Enum_ElectricalGrid_Yellow" xml:space="preserve"><value>Jaune</value></data>
@@ -6530,7 +6530,7 @@
   <data name="Profile_MarkedBy" xml:space="preserve"><value>Marqué par</value></data>
   <data name="Profile_MyCodes" xml:space="preserve"><value>Mes codes</value></data>
   <data name="Profile_MyEmails" xml:space="preserve"><value>Mes e-mails</value></data>
-  <data name="Profile_NoSentMessages" xml:space="preserve"><value>Aucun message dans la plateforme enregistré.</value></data>
+  <data name="Profile_NoSentMessages" xml:space="preserve"><value>Aucun message enregistré sur la plateforme.</value></data>
   <data name="Profile_NoShowHistory" xml:space="preserve"><value>Historique des absences ({0})</value></data>
   <data name="Profile_OnsiteSince" xml:space="preserve"><value>Sur place depuis {0}</value></data>
   <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Enregistré à l'entrée</value></data>
@@ -6580,14 +6580,14 @@
   <data name="Search_GlobalNoResults" xml:space="preserve"><value>Aucun résultat pour {0}.</value></data>
   <data name="Search_GlobalPlaceholder" xml:space="preserve"><value>Rechercher des humans, équipes, camps, quarts…</value></data>
   <data name="Search_GlobalPlaceholderEvents" xml:space="preserve"><value>Rechercher des humans, équipes, camps, quarts, événements…</value></data>
-  <data name="Search_GlobalTitle" xml:space="preserve"><value>Rechercher</value></data>
+  <data name="Search_GlobalTitle" xml:space="preserve"><value>Recherche</value></data>
   <data name="Store_AdminCatalog" xml:space="preserve"><value>Catalogue</value></data>
   <data name="Store_AdminPayments" xml:space="preserve"><value>Paiements</value></data>
   <data name="Store_AdminSummary" xml:space="preserve"><value>Résumé</value></data>
   <data name="Store_CatalogHeading" xml:space="preserve"><value>Catalogue ({0})</value></data>
   <data name="Store_ColBalance" xml:space="preserve"><value>Solde</value></data>
-  <data name="Store_ColDeposit" xml:space="preserve"><value>Acompte</value></data>
-  <data name="Store_ColDeposits" xml:space="preserve"><value>Acomptes</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Caution</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Cautions</value></data>
   <data name="Store_ColDescription" xml:space="preserve"><value>Description</value></data>
   <data name="Store_ColLines" xml:space="preserve"><value>Lignes</value></data>
   <data name="Store_ColLinesVat" xml:space="preserve"><value>Lignes + TVA</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -6010,4 +6010,626 @@
   <data name="AccountDeletion_ScheduledFor" xml:space="preserve"><value>Il sera définitivement supprimé le {0} sauf si vous annulez.</value></data>
   <data name="AccountDeletion_Unscheduled" xml:space="preserve"><value>Il sera définitivement supprimé sauf si vous annulez.</value></data>
   <data name="AccountDeletion_CancelButton" xml:space="preserve"><value>Annuler la demande de suppression</value></data>
+  <data name="About_AdditionalHelp" xml:space="preserve"><value>Avec l'aide supplémentaire de</value></data>
+  <data name="About_AdditionalHelpAnd" xml:space="preserve"><value>et</value></data>
+  <data name="About_AnthropicNote" xml:space="preserve"><value>Les réponses conversationnelles de l'assistant sont produites par l'API d'Anthropic. Aucune donnée n'est utilisée pour l'entraînement des modèles, conformément au DPA d'Anthropic.</value></data>
+  <data name="About_Cat_AILLM" xml:space="preserve"><value>IA/LLM</value></data>
+  <data name="About_Cat_BackgroundJobs" xml:space="preserve"><value>Tâches en arrière-plan</value></data>
+  <data name="About_Cat_Calendar" xml:space="preserve"><value>Calendrier</value></data>
+  <data name="About_Cat_CSV" xml:space="preserve"><value>CSV</value></data>
+  <data name="About_Cat_Database" xml:space="preserve"><value>Base de données</value></data>
+  <data name="About_Cat_DateTime" xml:space="preserve"><value>Date/Heure</value></data>
+  <data name="About_Cat_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="About_Cat_Framework" xml:space="preserve"><value>Framework</value></data>
+  <data name="About_Cat_GitHubAPI" xml:space="preserve"><value>API GitHub</value></data>
+  <data name="About_Cat_GoogleAPIs" xml:space="preserve"><value>API Google</value></data>
+  <data name="About_Cat_HealthChecks" xml:space="preserve"><value>Contrôles de santé</value></data>
+  <data name="About_Cat_ImageProcessing" xml:space="preserve"><value>Traitement d'images</value></data>
+  <data name="About_Cat_Logging" xml:space="preserve"><value>Journalisation</value></data>
+  <data name="About_Cat_Markdown" xml:space="preserve"><value>Markdown</value></data>
+  <data name="About_Cat_Observability" xml:space="preserve"><value>Observabilité</value></data>
+  <data name="About_Cat_Payments" xml:space="preserve"><value>Paiements</value></data>
+  <data name="About_Cat_Resilience" xml:space="preserve"><value>Résilience</value></data>
+  <data name="About_Cat_Sanitization" xml:space="preserve"><value>Assainissement</value></data>
+  <data name="About_Cat_Spreadsheet" xml:space="preserve"><value>Tableur</value></data>
+  <data name="About_Cat_StateMachine" xml:space="preserve"><value>Machine à états</value></data>
+  <data name="About_Cat_UserAgent" xml:space="preserve"><value>User-Agent</value></data>
+  <data name="About_ColCategory" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="About_ColLibrary" xml:space="preserve"><value>Bibliothèque</value></data>
+  <data name="About_ColLicense" xml:space="preserve"><value>Licence</value></data>
+  <data name="About_ColPackage" xml:space="preserve"><value>Paquet</value></data>
+  <data name="About_ColVersion" xml:space="preserve"><value>Version</value></data>
+  <data name="About_DotNetDesc" xml:space="preserve"><value>ASP.NET Core MVC avec vues Razor, Identity et toute la pile Microsoft. Le cadre qui maintient l'ensemble.</value></data>
+  <data name="About_FrontendHeading" xml:space="preserve"><value>Dépendances frontend / CDN</value></data>
+  <data name="About_GoogleDesc" xml:space="preserve"><value>Admin Directory, Drive et Groups — provisionnement de Shared Drives, de dossiers et de listes de diffusion pour que personne n'ait à le faire à la main.</value></data>
+  <data name="About_HangfireDesc" xml:space="preserve"><value>Tâches en arrière-plan pour la synchronisation, la réconciliation et tout ce qui ne devrait pas bloquer une requête HTTP. Adossé à PostgreSQL, tableau de bord inclus.</value></data>
+  <data name="About_IngredientsHeading" xml:space="preserve"><value>Les ingrédients</value></data>
+  <data name="About_IngredientsIntro" xml:space="preserve"><value>Tout atelier a besoin de ses matériaux. Voici ce dont Humans est fait :</value></data>
+  <data name="About_Intro" xml:space="preserve"><value>Humans est le système d'adhésion qui fait tourner Nobodies Collective — intégration des humans, provisionnement des équipes, suivi de la gouvernance, et toute la tuyauterie qui permet à une association espagnole à but non lucratif de fonctionner avec la mémoire organisationnelle d'une structure dix fois plus grande. Conçu avec soin, maintenu avec obstination, et déployé les doigts croisés.</value></data>
+  <data name="About_License_Apache2" xml:space="preserve"><value>exige une mention de copyright, une copie de la licence et une déclaration des modifications le cas échéant. Tous les paquets sont utilisés sans modification.</value></data>
+  <data name="About_License_BSD2" xml:space="preserve"><value>exige une mention de copyright dans la documentation.</value></data>
+  <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>exige une mention de copyright ; cette page satisfait cette obligation.</value></data>
+  <data name="About_License_ISC" xml:space="preserve"><value>permissive, fonctionnellement équivalente à BSD-2-Clause ; mention de copyright requise.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>la bibliothèque doit pouvoir être remplacée par l'utilisateur final. Consommées en tant que paquets NuGet non modifiés (liaison dynamique), ce qui satisfait les obligations de la LGPL.</value></data>
+  <data name="About_License_MIT" xml:space="preserve"><value>exige une mention de copyright ; cette page satisfait cette obligation.</value></data>
+  <data name="About_License_PostgreSQL" xml:space="preserve"><value>permissive, semblable à MIT ; mention de copyright requise.</value></data>
+  <data name="About_License_SILOFL" xml:space="preserve"><value>libres d'utilisation et de redistribution ; les polices ne peuvent pas être vendues séparément.</value></data>
+  <data name="About_LicenseBody" xml:space="preserve"><value>Humans est un logiciel libre, publié sous la</value></data>
+  <data name="About_LicenseComplianceHeading" xml:space="preserve"><value>Résumé de la conformité des licences</value></data>
+  <data name="About_LicenseComplianceSummary" xml:space="preserve"><value>Toutes les dépendances de production utilisent des licences permissives ou à copyleft faible. Aucune violation détectée.</value></data>
+  <data name="About_LicenseExplanation" xml:space="preserve"><value>Vous pouvez utiliser, étudier, modifier et redistribuer ce logiciel. Si vous exécutez une version modifiée et permettez à d'autres d'interagir avec elle sur un réseau, vous devez mettre à disposition votre code source modifié sous la même licence.</value></data>
+  <data name="About_LicenseFullText" xml:space="preserve"><value>Texte complet de la licence :</value></data>
+  <data name="About_LicenseHeading" xml:space="preserve"><value>Licence</value></data>
+  <data name="About_LicenseSourceCode" xml:space="preserve"><value>Code source :</value></data>
+  <data name="About_MadeBy" xml:space="preserve"><value>Réalisé par</value></data>
+  <data name="About_MadeByTail" xml:space="preserve"><value>avec amour pour la communauté Nobodies.</value></data>
+  <data name="About_MailKitDesc" xml:space="preserve"><value>E-mails transactionnels pour les notifications et l'intégration. La seule bibliothèque qui rend SMTP presque agréable.</value></data>
+  <data name="About_MeetTheStaff" xml:space="preserve"><value>Rencontrez l'équipe</value></data>
+  <data name="About_NeedHelp" xml:space="preserve"><value>Besoin d'aide ?</value></data>
+  <data name="About_NuGetPackagesHeading" xml:space="preserve"><value>Paquets NuGet</value></data>
+  <data name="About_OpenSourceLicensesHeading" xml:space="preserve"><value>Licences open source</value></data>
+  <data name="About_OpenSourceLicensesIntro" xml:space="preserve"><value>Humans repose sur les épaules de projets open source. Le tableau ci-dessous liste chaque dépendance de production, sa version et sa licence.</value></data>
+  <data name="About_OtelDesc" xml:space="preserve"><value>Journalisation structurée, traces distribuées et métriques Prometheus. Parce que « ça marche sur ma machine » n'est pas une stratégie de supervision.</value></data>
+  <data name="About_PostgresDesc" xml:space="preserve"><value>Données relationnelles avec Entity Framework Core et Npgsql. Des types NodaTime de bout en bout — aucun DateTime en vue.</value></data>
+  <data name="About_Staff_BackToAbout" xml:space="preserve"><value>Retour à À propos</value></data>
+  <data name="About_Staff_Empty" xml:space="preserve"><value>Aucun titulaire de rôle actif trouvé. Le château semble vide.</value></data>
+  <data name="About_Staff_Intro" xml:space="preserve"><value>Tout collectif a besoin de ses gardiens. Voici les humans qui donnent de leur temps et de leur énergie pour faire tourner Nobodies — de la gouvernance au support technique, de la confiance et la sécurité à l'alchimie des billets.</value></data>
+  <data name="About_Staff_Title" xml:space="preserve"><value>Les humans dans les coulisses</value></data>
+  <data name="About_Title" xml:space="preserve"><value>À propos de Humans</value></data>
+  <data name="AccountStatus_ConsentSuspendedBody" xml:space="preserve"><value>Votre accès est suspendu jusqu'à ce que vous complétiez les consentements légaux requis.</value></data>
+  <data name="AccountStatus_HeadingAdminSuspended" xml:space="preserve"><value>Votre compte a été suspendu par un administrateur</value></data>
+  <data name="AccountStatus_ReviewConsents" xml:space="preserve"><value>Consulter les consentements requis</value></data>
+  <data name="Budget_ColAmount" xml:space="preserve"><value>Montant (€)</value></data>
+  <data name="Budget_ColCategory" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="Budget_ColShare" xml:space="preserve"><value>Part</value></data>
+  <data name="Budget_DepartmentDetail" xml:space="preserve"><value>Détail par département</value></data>
+  <data name="Budget_Expenses" xml:space="preserve"><value>Dépenses</value></data>
+  <data name="Budget_ExpensesBreakdown" xml:space="preserve"><value>Répartition des dépenses</value></data>
+  <data name="Budget_Income" xml:space="preserve"><value>Recettes</value></data>
+  <data name="Budget_IncomeBreakdown" xml:space="preserve"><value>Répartition des recettes</value></data>
+  <data name="Budget_NetBalance" xml:space="preserve"><value>Solde net</value></data>
+  <data name="Budget_NoActiveBudget" xml:space="preserve"><value>Aucun budget actif</value></data>
+  <data name="Budget_NoActiveBudgetSubtitle" xml:space="preserve"><value>Aucune année budgétaire active à afficher. Un admin finances en configurera une au début de la planification budgétaire.</value></data>
+  <data name="Budget_NoDataSubtitle" xml:space="preserve"><value>Les allocations budgétaires apparaîtront ici une fois configurées par l'équipe finances.</value></data>
+  <data name="Budget_NoDataYet" xml:space="preserve"><value>Données budgétaires pas encore disponibles</value></data>
+  <data name="Budget_NoExpenseItems" xml:space="preserve"><value>Aucune ligne de dépense pour le moment.</value></data>
+  <data name="Budget_NoIncomeItems" xml:space="preserve"><value>Aucune ligne de recette pour le moment.</value></data>
+  <data name="Budget_OverviewSubtitle" xml:space="preserve"><value>Comment le budget {0} est réparti entre les départements et l'infrastructure.</value></data>
+  <data name="Budget_OverviewTitle" xml:space="preserve"><value>Aperçu du budget</value></data>
+  <data name="Budget_Title" xml:space="preserve"><value>Budget</value></data>
+  <data name="Budget_TitleYear" xml:space="preserve"><value>Budget - {0}</value></data>
+  <data name="Budget_TotalExpenses" xml:space="preserve"><value>Dépenses totales</value></data>
+  <data name="Budget_TotalIncome" xml:space="preserve"><value>Recettes totales</value></data>
+  <data name="Calendar_Agenda" xml:space="preserve"><value>Agenda</value></data>
+  <data name="Calendar_AllDay" xml:space="preserve"><value>toute la journée</value></data>
+  <data name="Calendar_AllDayEvent" xml:space="preserve"><value>Événement sur toute la journée</value></data>
+  <data name="Calendar_AllDayLabel" xml:space="preserve"><value>Toute la journée</value></data>
+  <data name="Calendar_AllTeamsMonthView" xml:space="preserve"><value>Toutes les équipes (vue mensuelle)</value></data>
+  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>Tous les horaires sont affichés en {0}.</value></data>
+  <data name="Calendar_BackToCalendar" xml:space="preserve"><value>Retour au calendrier</value></data>
+  <data name="Calendar_CancelOccurrenceConfirm" xml:space="preserve"><value>Annuler uniquement cette occurrence ?</value></data>
+  <data name="Calendar_CancelThisOccurrence" xml:space="preserve"><value>Annuler celle-ci</value></data>
+  <data name="Calendar_ChangeHistory" xml:space="preserve"><value>Historique des modifications</value></data>
+  <data name="Calendar_Continues" xml:space="preserve"><value>se poursuit</value></data>
+  <data name="Calendar_Created" xml:space="preserve"><value>Créé le {0}</value></data>
+  <data name="Calendar_CreateEvent" xml:space="preserve"><value>Créer un événement</value></data>
+  <data name="Calendar_DeleteConfirm" xml:space="preserve"><value>Supprimer cet événement et toutes ses occurrences ?</value></data>
+  <data name="Calendar_Description" xml:space="preserve"><value>Description</value></data>
+  <data name="Calendar_EditEvent" xml:space="preserve"><value>Modifier l'événement</value></data>
+  <data name="Calendar_EditSingleOccurrence" xml:space="preserve"><value>Modifier une seule occurrence</value></data>
+  <data name="Calendar_EditSingleOccurrenceHeading" xml:space="preserve"><value>Modifier une seule occurrence</value></data>
+  <data name="Calendar_EditThisOccurrence" xml:space="preserve"><value>Modifier cette occurrence</value></data>
+  <data name="Calendar_End" xml:space="preserve"><value>Fin</value></data>
+  <data name="Calendar_EndDate" xml:space="preserve"><value>Date de fin</value></data>
+  <data name="Calendar_EndDateHelp" xml:space="preserve"><value>Incluse — laissez vide pour un événement d'une seule journée.</value></data>
+  <data name="Calendar_EventTitle" xml:space="preserve"><value>Événement</value></data>
+  <data name="Calendar_FirstStart" xml:space="preserve"><value>Premier début</value></data>
+  <data name="Calendar_FormTitle" xml:space="preserve"><value>Titre</value></data>
+  <data name="Calendar_LastUpdated" xml:space="preserve"><value>· Dernière mise à jour {0}</value></data>
+  <data name="Calendar_LocationUrl" xml:space="preserve"><value>URL du lieu</value></data>
+  <data name="Calendar_MoreCount" xml:space="preserve"><value>+{0} de plus</value></data>
+  <data name="Calendar_NewEvent" xml:space="preserve"><value>Nouvel événement</value></data>
+  <data name="Calendar_Next" xml:space="preserve"><value>Suiv.</value></data>
+  <data name="Calendar_NoEventsInRange" xml:space="preserve"><value>Aucun événement dans la plage sélectionnée.</value></data>
+  <data name="Calendar_OverrideDescription" xml:space="preserve"><value>Remplacer la description</value></data>
+  <data name="Calendar_OverrideEnd" xml:space="preserve"><value>Remplacer la fin</value></data>
+  <data name="Calendar_OverrideInstructions" xml:space="preserve"><value>Remplacez uniquement cette occurrence de l'événement récurrent. Laissez un champ vide pour hériter de la valeur de l'événement parent.</value></data>
+  <data name="Calendar_OverrideLocation" xml:space="preserve"><value>Remplacer le lieu</value></data>
+  <data name="Calendar_OverrideLocationUrl" xml:space="preserve"><value>Remplacer l'URL du lieu</value></data>
+  <data name="Calendar_OverrideStart" xml:space="preserve"><value>Remplacer le début</value></data>
+  <data name="Calendar_OverrideTitle" xml:space="preserve"><value>Remplacer le titre</value></data>
+  <data name="Calendar_OwningTeam" xml:space="preserve"><value>Équipe propriétaire</value></data>
+  <data name="Calendar_Prev" xml:space="preserve"><value>Préc.</value></data>
+  <data name="Calendar_Recurrence" xml:space="preserve"><value>Récurrence</value></data>
+  <data name="Calendar_RecurrenceTimezoneHelpPrefix" xml:space="preserve"><value>TZ IANA, p. ex.</value></data>
+  <data name="Calendar_RecurrenceTimezoneLabel" xml:space="preserve"><value>Fuseau horaire de la récurrence</value></data>
+  <data name="Calendar_RecurrenceTimezoneNote" xml:space="preserve"><value>Fuseau horaire : {0}</value></data>
+  <data name="Calendar_RecurringEvent" xml:space="preserve"><value>Événement récurrent</value></data>
+  <data name="Calendar_RRule" xml:space="preserve"><value>RRULE</value></data>
+  <data name="Calendar_RRuleHelpPrefix" xml:space="preserve"><value>RRULE RFC 5545. Laissez vide pour un événement unique. Exemple :</value></data>
+  <data name="Calendar_SaveOverride" xml:space="preserve"><value>Enregistrer le remplacement</value></data>
+  <data name="Calendar_Start" xml:space="preserve"><value>Début</value></data>
+  <data name="Calendar_StartDate" xml:space="preserve"><value>Date de début</value></data>
+  <data name="Calendar_TeamFallback" xml:space="preserve"><value>Équipe</value></data>
+  <data name="Calendar_Title" xml:space="preserve"><value>Calendrier</value></data>
+  <data name="Calendar_Today" xml:space="preserve"><value>Aujourd'hui</value></data>
+  <data name="Calendar_UpcomingOccurrences" xml:space="preserve"><value>Prochaines occurrences</value></data>
+  <data name="Calendar_ViewAriaLabel" xml:space="preserve"><value>Vue calendrier</value></data>
+  <data name="Calendar_ViewGrid" xml:space="preserve"><value>Grille</value></data>
+  <data name="Calendar_ViewList" xml:space="preserve"><value>Liste</value></data>
+  <data name="Calendar_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="Camp_AboutHeading" xml:space="preserve"><value>À propos de votre {0}</value></data>
+  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>Accueille de nouveaux humans ?</value></data>
+  <data name="Camp_AdultPlayspaceLabel" xml:space="preserve"><value>Espace de jeu pour adultes</value></data>
+  <data name="Camp_BlurbLongLabel" xml:space="preserve"><value>Description complète</value></data>
+  <data name="Camp_BlurbLongPlaceholder" xml:space="preserve"><value>Parlez au monde de votre camp.</value></data>
+  <data name="Camp_BlurbShortLabel" xml:space="preserve"><value>Description courte</value></data>
+  <data name="Camp_BlurbShortPlaceholder" xml:space="preserve"><value>Une ou deux phrases sur votre camp (300 caractères max)</value></data>
+  <data name="Camp_CommunityHeading" xml:space="preserve"><value>Communauté</value></data>
+  <data name="Camp_ContactEmailLabel" xml:space="preserve"><value>E-mail de contact</value></data>
+  <data name="Camp_ContactPhoneLabel" xml:space="preserve"><value>Téléphone de contact</value></data>
+  <data name="Camp_ContactPhonePlaceholder" xml:space="preserve"><value>+34 612 345 678</value></data>
+  <data name="Camp_CultureHeading" xml:space="preserve"><value>Culture &amp; événements</value></data>
+  <data name="Camp_Edit_AutoCreatedFromNameChange" xml:space="preserve"><value>Créé automatiquement à partir d'un changement de nom</value></data>
+  <data name="Camp_Edit_ContainersSeparate" xml:space="preserve"><value>Les conteneurs sont désormais gérés séparément.</value></data>
+  <data name="Camp_Edit_HideHistoricalNames" xml:space="preserve"><value>Masquer les noms historiques</value></data>
+  <data name="Camp_Edit_HistoricalNamesHeading" xml:space="preserve"><value>Noms historiques</value></data>
+  <data name="Camp_Edit_HistoricalNamesHelp" xml:space="preserve"><value>Noms sous lesquels ce camp était précédemment connu.</value></data>
+  <data name="Camp_Edit_ImageAlt" xml:space="preserve"><value>Image du camp</value></data>
+  <data name="Camp_Edit_ImagesHeading" xml:space="preserve"><value>Images ({0}/{1})</value></data>
+  <data name="Camp_Edit_ImageUploadHelp" xml:space="preserve"><value>JPEG, PNG ou WebP. 10 Mo max.</value></data>
+  <data name="Camp_Edit_ManageContainers" xml:space="preserve"><value>Gérer les conteneurs →</value></data>
+  <data name="Camp_Edit_MembersRolesDescription" xml:space="preserve"><value>Gérez les membres actifs, les rôles, les leads et les demandes d'adhésion en attente.</value></data>
+  <data name="Camp_Edit_MembersRolesHeading" xml:space="preserve"><value>Membres &amp; rôles</value></data>
+  <data name="Camp_Edit_NameLocked" xml:space="preserve"><value>Le nom est verrouillé pour cette saison.</value></data>
+  <data name="Camp_Edit_OpenMembersRoles" xml:space="preserve"><value>Ouvrir membres &amp; rôles</value></data>
+  <data name="Camp_Edit_OpenStore" xml:space="preserve"><value>Ouvrir la boutique</value></data>
+  <data name="Camp_Edit_PreviousNamePlaceholder" xml:space="preserve"><value>Nom de camp précédent</value></data>
+  <data name="Camp_Edit_StoreDescription" xml:space="preserve"><value>Passez une commande pour ce camp.</value></data>
+  <data name="Camp_Edit_StoreHeading" xml:space="preserve"><value>Boutique</value></data>
+  <data name="Camp_Edit_UploadImage" xml:space="preserve"><value>Téléverser une image</value></data>
+  <data name="Camp_ElectricalGridLabel" xml:space="preserve"><value>Réseau électrique</value></data>
+  <data name="Camp_HistoryHeading" xml:space="preserve"><value>Historique</value></data>
+  <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Accueille des membres</value></data>
+  <data name="Camp_Index_AllOption" xml:space="preserve"><value>Tous</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guide des Barrios 2026</value></data>
+  <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filtrer</value></data>
+  <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Enfants bienvenus</value></data>
+  <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>Aucun {0} trouvé pour les filtres sélectionnés.</value></data>
+  <data name="Camp_Index_NoSearchResults" xml:space="preserve"><value>Aucun {0} ne correspond à votre recherche.</value></data>
+  <data name="Camp_Index_PendingApproval" xml:space="preserve"><value>en attente d'approbation</value></data>
+  <data name="Camp_Index_SearchLabel" xml:space="preserve"><value>Rechercher</value></data>
+  <data name="Camp_Index_SearchPlaceholder" xml:space="preserve"><value>Tapez un nom de {0}…</value></data>
+  <data name="Camp_Index_ShowLeadPositions" xml:space="preserve"><value>Afficher les postes de lead</value></data>
+  <data name="Camp_Index_SoundZoneLabel" xml:space="preserve"><value>Zone sonore</value></data>
+  <data name="Camp_Index_VibeLabel" xml:space="preserve"><value>Ambiance</value></data>
+  <data name="Camp_KidsAreaDescriptionLabel" xml:space="preserve"><value>Description de l'espace enfants</value></data>
+  <data name="Camp_KidsAreaDescriptionPlaceholder" xml:space="preserve"><value>Décrivez votre espace enfants le cas échéant</value></data>
+  <data name="Camp_KidsVisitingLabel" xml:space="preserve"><value>Politique de visite des enfants</value></data>
+  <data name="Camp_KidsWelcomeLabel" xml:space="preserve"><value>Enfants bienvenus ?</value></data>
+  <data name="Camp_LanguagesLabel" xml:space="preserve"><value>Langues parlées</value></data>
+  <data name="Camp_LanguagesPlaceholder" xml:space="preserve"><value>p. ex. anglais, espagnol, allemand</value></data>
+  <data name="Camp_MarkdownSupported" xml:space="preserve"><value>La mise en forme Markdown est prise en charge</value></data>
+  <data name="Camp_MemberCountLabel" xml:space="preserve"><value>Humans attendus</value></data>
+  <data name="Camp_NoPreference" xml:space="preserve"><value>Aucune préférence</value></data>
+  <data name="Camp_NotSure" xml:space="preserve"><value>Pas sûr</value></data>
+  <data name="Camp_PerformanceSpaceLabel" xml:space="preserve"><value>Espace de performance</value></data>
+  <data name="Camp_PerformanceTypesLabel" xml:space="preserve"><value>Types de performances</value></data>
+  <data name="Camp_PerformanceTypesPlaceholder" xml:space="preserve"><value>p. ex. musique, théâtre, ateliers</value></data>
+  <data name="Camp_PlacementHeading" xml:space="preserve"><value>Placement</value></data>
+  <data name="Camp_PreviousNamesHelp" xml:space="preserve"><value>Si votre camp a porté différents noms au fil des ans, indiquez-les ici.</value></data>
+  <data name="Camp_PreviousNamesLabel" xml:space="preserve"><value>Noms précédents</value></data>
+  <data name="Camp_PreviousNamesPlaceholder" xml:space="preserve"><value>Liste des anciens noms de camp séparés par des virgules</value></data>
+  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Inscrire</value></data>
+  <data name="Camp_Register_Heading" xml:space="preserve"><value>Inscrivez votre {0}</value></data>
+  <data name="Camp_Register_ImportantInfo" xml:space="preserve"><value>Informations importantes</value></data>
+  <data name="Camp_Register_Season" xml:space="preserve"><value>saison</value></data>
+  <data name="Camp_Register_Submit" xml:space="preserve"><value>Inscrire {0}</value></data>
+  <data name="Camp_SoundZoneLabel" xml:space="preserve"><value>Préférence de zone sonore</value></data>
+  <data name="Camp_SpaceRequirementLabel" xml:space="preserve"><value>Besoin en espace</value></data>
+  <data name="Camp_TimesParticipatingLabel" xml:space="preserve"><value>Nombre de participations</value></data>
+  <data name="Camp_VibesLabel" xml:space="preserve"><value>Ambiances</value></data>
+  <data name="CampCard_AcceptingMembers" xml:space="preserve"><value>Accueille des membres</value></data>
+  <data name="CampCard_Full" xml:space="preserve"><value>Complet</value></data>
+  <data name="CampCard_KidsWelcome" xml:space="preserve"><value>Enfants bienvenus</value></data>
+  <data name="CampCard_TimesAtNowhere" xml:space="preserve"><value>{0} an(s)</value></data>
+  <data name="Common_Actions" xml:space="preserve"><value>Actions</value></data>
+  <data name="Common_Admin" xml:space="preserve"><value>Admin</value></data>
+  <data name="Common_Amount" xml:space="preserve"><value>Montant</value></data>
+  <data name="Common_Clear" xml:space="preserve"><value>Effacer</value></data>
+  <data name="Common_Created" xml:space="preserve"><value>Créé</value></data>
+  <data name="Common_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="Common_DeleteImage" xml:space="preserve"><value>Supprimer l'image</value></data>
+  <data name="Common_Department" xml:space="preserve"><value>Département</value></data>
+  <data name="Common_MoveDown" xml:space="preserve"><value>Descendre</value></data>
+  <data name="Common_MoveUp" xml:space="preserve"><value>Monter</value></data>
+  <data name="Common_Other" xml:space="preserve"><value>Autre</value></data>
+  <data name="Common_Preview" xml:space="preserve"><value>Aperçu</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Retirer</value></data>
+  <data name="Common_Required" xml:space="preserve"><value>(requis)</value></data>
+  <data name="Common_Sender" xml:space="preserve"><value>Expéditeur</value></data>
+  <data name="Common_Shift" xml:space="preserve"><value>Quart</value></data>
+  <data name="Common_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="Common_View" xml:space="preserve"><value>Voir</value></data>
+  <data name="CommPrefs_AlwaysOn" xml:space="preserve"><value>Toujours actif</value></data>
+  <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Bonjour {0},&lt;/p&gt;
+&lt;p&gt;Vous êtes invité à compléter le sondage &lt;strong&gt;{1}&lt;/strong&gt;. Cela ne prend que quelques minutes.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Ouvrir le sondage&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Merci,&lt;br/&gt;Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Merci de compléter : {0}</value></data>
+  <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Bonjour {0},&lt;/p&gt;
+&lt;p&gt;Petit rappel : le sondage &lt;strong&gt;{1}&lt;/strong&gt; attend toujours votre réponse.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Ouvrir le sondage&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Merci,&lt;br/&gt;Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyReminder_Subject" xml:space="preserve"><value>Rappel : {0}</value></data>
+  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Marqué avec {0} mais sans ligne AspNetUserLogins correspondante — se corrige automatiquement à la prochaine connexion OAuth.</value></data>
+  <data name="EmailGrid_WorkspaceLocked" xml:space="preserve"><value>Verrouillé par la ligne d'e-mail Workspace</value></data>
+  <data name="Enum_AdultPlayspacePolicy_NightOnly" xml:space="preserve"><value>La nuit seulement</value></data>
+  <data name="Enum_AdultPlayspacePolicy_No" xml:space="preserve"><value>Non</value></data>
+  <data name="Enum_AdultPlayspacePolicy_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="Enum_CampVibe_Adult" xml:space="preserve"><value>Adulte</value></data>
+  <data name="Enum_CampVibe_ChillOut" xml:space="preserve"><value>Détente</value></data>
+  <data name="Enum_CampVibe_ElectronicMusic" xml:space="preserve"><value>Musique électronique</value></data>
+  <data name="Enum_CampVibe_Games" xml:space="preserve"><value>Jeux</value></data>
+  <data name="Enum_CampVibe_Lecture" xml:space="preserve"><value>Conférence</value></data>
+  <data name="Enum_CampVibe_LiveMusic" xml:space="preserve"><value>Musique live</value></data>
+  <data name="Enum_CampVibe_Queer" xml:space="preserve"><value>Queer</value></data>
+  <data name="Enum_CampVibe_Sober" xml:space="preserve"><value>Sobre</value></data>
+  <data name="Enum_CampVibe_Wellness" xml:space="preserve"><value>Bien-être</value></data>
+  <data name="Enum_CampVibe_Workshop" xml:space="preserve"><value>Atelier</value></data>
+  <data name="Enum_ContactFieldType_Discord" xml:space="preserve"><value>Discord</value></data>
+  <data name="Enum_ContactFieldType_Other" xml:space="preserve"><value>Autre</value></data>
+  <data name="Enum_ContactFieldType_Phone" xml:space="preserve"><value>Téléphone</value></data>
+  <data name="Enum_ContactFieldType_Signal" xml:space="preserve"><value>Signal</value></data>
+  <data name="Enum_ContactFieldType_Telegram" xml:space="preserve"><value>Telegram</value></data>
+  <data name="Enum_ContactFieldType_WhatsApp" xml:space="preserve"><value>WhatsApp</value></data>
+  <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Tous les humans actifs</value></data>
+  <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Conseil uniquement</value></data>
+  <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinateurs + Conseil</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>Mes équipes (+ coordinateurs &amp; conseil)</value></data>
+  <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
+  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Alimentation propre</value></data>
+  <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Rouge</value></data>
+  <data name="Enum_ElectricalGrid_Unknown" xml:space="preserve"><value>Inconnu</value></data>
+  <data name="Enum_ElectricalGrid_Yellow" xml:space="preserve"><value>Jaune</value></data>
+  <data name="Enum_EmailOutboxStatus_Failed" xml:space="preserve"><value>Échoué</value></data>
+  <data name="Enum_EmailOutboxStatus_Queued" xml:space="preserve"><value>En file</value></data>
+  <data name="Enum_EmailOutboxStatus_Sent" xml:space="preserve"><value>Envoyé</value></data>
+  <data name="Enum_EventStatus_Approved" xml:space="preserve"><value>Approuvé</value></data>
+  <data name="Enum_EventStatus_Draft" xml:space="preserve"><value>Brouillon</value></data>
+  <data name="Enum_EventStatus_Pending" xml:space="preserve"><value>En attente</value></data>
+  <data name="Enum_EventStatus_Rejected" xml:space="preserve"><value>Rejeté</value></data>
+  <data name="Enum_EventStatus_ResubmitRequested" xml:space="preserve"><value>Modifications demandées</value></data>
+  <data name="Enum_EventStatus_Withdrawn" xml:space="preserve"><value>Retiré</value></data>
+  <data name="Enum_ExpenseReportStatus_Approved" xml:space="preserve"><value>Approuvée</value></data>
+  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Validée par le coordinateur</value></data>
+  <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Brouillon</value></data>
+  <data name="Enum_ExpenseReportStatus_Paid" xml:space="preserve"><value>Payée</value></data>
+  <data name="Enum_ExpenseReportStatus_SepaSent" xml:space="preserve"><value>SEPA envoyé</value></data>
+  <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Soumise</value></data>
+  <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Retirée</value></data>
+  <data name="Enum_FeedbackCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_FeedbackCategory_FeatureRequest" xml:space="preserve"><value>Demande de fonctionnalité</value></data>
+  <data name="Enum_FeedbackCategory_Question" xml:space="preserve"><value>Question</value></data>
+  <data name="Enum_FeedbackStatus_Acknowledged" xml:space="preserve"><value>Pris en compte</value></data>
+  <data name="Enum_FeedbackStatus_Open" xml:space="preserve"><value>Ouvert</value></data>
+  <data name="Enum_FeedbackStatus_Resolved" xml:space="preserve"><value>Résolu</value></data>
+  <data name="Enum_FeedbackStatus_WontFix" xml:space="preserve"><value>Ne sera pas corrigé</value></data>
+  <data name="Enum_IssueCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_IssueCategory_Feature" xml:space="preserve"><value>Fonctionnalité</value></data>
+  <data name="Enum_IssueCategory_Question" xml:space="preserve"><value>Question</value></data>
+  <data name="Enum_KidsVisitingPolicy_DaytimeOnly" xml:space="preserve"><value>En journée seulement</value></data>
+  <data name="Enum_KidsVisitingPolicy_No" xml:space="preserve"><value>Non</value></data>
+  <data name="Enum_KidsVisitingPolicy_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="Enum_LanguageProficiency_Basic" xml:space="preserve"><value>Notions</value></data>
+  <data name="Enum_LanguageProficiency_Conversational" xml:space="preserve"><value>Conversationnel</value></data>
+  <data name="Enum_LanguageProficiency_Fluent" xml:space="preserve"><value>Courant</value></data>
+  <data name="Enum_LanguageProficiency_Native" xml:space="preserve"><value>Langue maternelle</value></data>
+  <data name="Enum_PerformanceSpaceStatus_No" xml:space="preserve"><value>Non</value></data>
+  <data name="Enum_PerformanceSpaceStatus_WorkingOnIt" xml:space="preserve"><value>En cours</value></data>
+  <data name="Enum_PerformanceSpaceStatus_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="Enum_RolePeriod_Build" xml:space="preserve"><value>Montage</value></data>
+  <data name="Enum_RolePeriod_Event" xml:space="preserve"><value>Événement</value></data>
+  <data name="Enum_RolePeriod_Strike" xml:space="preserve"><value>Démontage</value></data>
+  <data name="Enum_RolePeriod_YearRound" xml:space="preserve"><value>Toute l'année</value></data>
+  <data name="Enum_SlotPriority_Critical" xml:space="preserve"><value>Critique</value></data>
+  <data name="Enum_SlotPriority_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Enum_SlotPriority_NiceToHave" xml:space="preserve"><value>Souhaitable</value></data>
+  <data name="Enum_SlotPriority_None" xml:space="preserve"><value>Aucune</value></data>
+  <data name="Enum_SoundZone_Blue" xml:space="preserve"><value>Bleue</value></data>
+  <data name="Enum_SoundZone_Green" xml:space="preserve"><value>Verte</value></data>
+  <data name="Enum_SoundZone_Orange" xml:space="preserve"><value>Orange</value></data>
+  <data name="Enum_SoundZone_Red" xml:space="preserve"><value>Rouge</value></data>
+  <data name="Enum_SoundZone_Surprise" xml:space="preserve"><value>Surprise</value></data>
+  <data name="Enum_SoundZone_Yellow" xml:space="preserve"><value>Jaune</value></data>
+  <data name="Enum_SpaceSize_Sqm1000" xml:space="preserve"><value>1000 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1200" xml:space="preserve"><value>1200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm150" xml:space="preserve"><value>150 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1500" xml:space="preserve"><value>1500 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1800" xml:space="preserve"><value>1800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2200" xml:space="preserve"><value>2200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2800" xml:space="preserve"><value>2800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm300" xml:space="preserve"><value>300 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm450" xml:space="preserve"><value>450 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm600" xml:space="preserve"><value>600 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm800" xml:space="preserve"><value>800 m²</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Camp" xml:space="preserve"><value>Camp</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Team" xml:space="preserve"><value>Équipe</value></data>
+  <data name="Enum_TicketTransferStatus_Approved" xml:space="preserve"><value>Terminé</value></data>
+  <data name="Enum_TicketTransferStatus_Cancelled" xml:space="preserve"><value>Annulé</value></data>
+  <data name="Enum_TicketTransferStatus_Pending" xml:space="preserve"><value>En attente de révision</value></data>
+  <data name="Enum_TicketTransferStatus_Rejected" xml:space="preserve"><value>Annulé par l'équipe</value></data>
+  <data name="Enum_YesNoMaybe_Maybe" xml:space="preserve"><value>Peut-être</value></data>
+  <data name="Enum_YesNoMaybe_No" xml:space="preserve"><value>Non</value></data>
+  <data name="Enum_YesNoMaybe_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="Events_AddBarrioEvent" xml:space="preserve"><value>Ajouter un événement de barrio</value></data>
+  <data name="Events_AddToFavourites" xml:space="preserve"><value>Ajouter aux favoris</value></data>
+  <data name="Events_AllCategories" xml:space="preserve"><value>Toutes les catégories</value></data>
+  <data name="Events_AllTimesIn" xml:space="preserve"><value>Tous les horaires en {0}. L'heure de la Playa peut s'appliquer !</value></data>
+  <data name="Events_AllTimesInShort" xml:space="preserve"><value>Tous les horaires en {0}</value></data>
+  <data name="Events_AllVenues" xml:space="preserve"><value>Tous les lieux</value></data>
+  <data name="Events_BrowseTitle" xml:space="preserve"><value>Parcourir les événements</value></data>
+  <data name="Events_ColActions" xml:space="preserve"><value>Actions</value></data>
+  <data name="Events_ColCategory" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="Events_ColDateTime" xml:space="preserve"><value>Date &amp; heure</value></data>
+  <data name="Events_ColEventName" xml:space="preserve"><value>Nom de l'événement</value></data>
+  <data name="Events_ColPriority" xml:space="preserve"><value>Priorité</value></data>
+  <data name="Events_ConflictBadge" xml:space="preserve"><value>Conflit d'horaire avec un autre événement en favori</value></data>
+  <data name="Events_DownloadCsv" xml:space="preserve"><value>Télécharger le CSV des événements</value></data>
+  <data name="Events_DurationMin" xml:space="preserve"><value>{0} min</value></data>
+  <data name="Events_FavouritesOnly" xml:space="preserve"><value>Uniquement</value></data>
+  <data name="Events_FilterCategory" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="Events_FilterDay" xml:space="preserve"><value>Jour</value></data>
+  <data name="Events_FilterSearch" xml:space="preserve"><value>Rechercher</value></data>
+  <data name="Events_FilterVenue" xml:space="preserve"><value>Lieu</value></data>
+  <data name="Events_MyPersonalEvents" xml:space="preserve"><value>Mes événements personnels</value></data>
+  <data name="Events_MySchedule" xml:space="preserve"><value>Mon programme</value></data>
+  <data name="Events_MySubmissions" xml:space="preserve"><value>Mes propositions</value></data>
+  <data name="Events_MySubmissionsTitle" xml:space="preserve"><value>Mes propositions d'événements</value></data>
+  <data name="Events_NoBarrioEvents" xml:space="preserve"><value>Aucun événement encore proposé pour ce barrio.</value></data>
+  <data name="Events_NoEventsFound" xml:space="preserve"><value>Aucun événement trouvé. Essayez d'ajuster vos filtres.</value></data>
+  <data name="Events_NoPersonalEvents" xml:space="preserve"><value>Vous n'avez pas encore proposé d'événement personnel.</value></data>
+  <data name="Events_RemoveFromFavourites" xml:space="preserve"><value>Retirer des favoris</value></data>
+  <data name="Events_RemoveFromSchedule" xml:space="preserve"><value>Retirer du programme</value></data>
+  <data name="Events_RemoveFromScheduleConfirm" xml:space="preserve"><value>Retirer cet événement de votre programme ?</value></data>
+  <data name="Events_ScheduleEmpty" xml:space="preserve"><value>Vous n'avez encore mis aucun événement en favori. Parcourez le {0} pour ajouter des événements à votre programme.</value></data>
+  <data name="Events_ScheduleEmptyLink" xml:space="preserve"><value>guide des événements</value></data>
+  <data name="Events_ScheduleTitle" xml:space="preserve"><value>Mon programme</value></data>
+  <data name="Events_SearchPlaceholder" xml:space="preserve"><value>Rechercher dans le titre ou la description…</value></data>
+  <data name="Events_StatApproved" xml:space="preserve"><value>Approuvés</value></data>
+  <data name="Events_StatPending" xml:space="preserve"><value>En attente</value></data>
+  <data name="Events_StatSubmitted" xml:space="preserve"><value>Soumis</value></data>
+  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Période de soumission :</value></data>
+  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>La période de soumission n'est pas ouverte actuellement. Contactez un admin pour configurer les paramètres du guide.</value></data>
+  <data name="Events_SubmitNewEvent" xml:space="preserve"><value>Proposer un nouvel événement</value></data>
+  <data name="Events_UploadColErrors" xml:space="preserve"><value>Erreurs</value></data>
+  <data name="Events_UploadColEvent" xml:space="preserve"><value>Événement</value></data>
+  <data name="Events_UploadColRow" xml:space="preserve"><value>Ligne</value></data>
+  <data name="Events_UploadCsv" xml:space="preserve"><value>Téléverser un CSV</value></data>
+  <data name="Events_UploadFailed" xml:space="preserve"><value>Échec du téléversement.</value></data>
+  <data name="Events_UploadFailedDetail" xml:space="preserve"><value>Corrigez les erreurs ci-dessous et réessayez. Aucun événement n'a été enregistré.</value></data>
+  <data name="Events_WithdrawConfirm" xml:space="preserve"><value>Retirer cet événement ?</value></data>
+  <data name="Expenses_ColReport" xml:space="preserve"><value>Note</value></data>
+  <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Soumise</value></data>
+  <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Soumise par</value></data>
+  <data name="Expenses_CoordinatorQueue" xml:space="preserve"><value>File du coordinateur</value></data>
+  <data name="Expenses_CoordinatorQueueTitle" xml:space="preserve"><value>Notes de frais — File du coordinateur</value></data>
+  <data name="Expenses_Endorse" xml:space="preserve"><value>Valider</value></data>
+  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Valider cette note de frais ?</value></data>
+  <data name="Expenses_FileFirst" xml:space="preserve"><value>Déposez votre première note</value></data>
+  <data name="Expenses_IouHeader" xml:space="preserve"><value>Ce que le collectif vous doit</value></data>
+  <data name="Expenses_IouLastPayment" xml:space="preserve"><value>Dernier paiement</value></data>
+  <data name="Expenses_IouOtherAmountNote" xml:space="preserve"><value>Votre solde Holded inclut {0} sans rapport avec ces notes (achats avancés pour le compte du collectif, ajustements, etc.), si bien que les lignes ci-dessous n'en feront pas nécessairement la somme.</value></data>
+  <data name="Expenses_IouOwed" xml:space="preserve"><value>Dû à vous (solde Holded)</value></data>
+  <data name="Expenses_IouPaid" xml:space="preserve"><value>Payé à ce jour</value></data>
+  <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Article</value></data>
+  <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Mes notes de frais</value></data>
+  <data name="Expenses_NewReport" xml:space="preserve"><value>Nouvelle note</value></data>
+  <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Il n'y a aucune année budgétaire active pour le moment. Les notes de frais ne peuvent pas être déposées tant qu'une année budgétaire n'est pas activée.</value></data>
+  <data name="Expenses_NoIban" xml:space="preserve"><value>Vous n'avez pas encore renseigné votre IBAN de paiement. Vous serez invité à le faire au moment de soumettre une note.</value></data>
+  <data name="Expenses_NoReports" xml:space="preserve"><value>Aucune note de frais pour le moment.</value></data>
+  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Aucune note en attente de votre validation.</value></data>
+  <data name="Expenses_Reject" xml:space="preserve"><value>Rejeter</value></data>
+  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>L'auteur verra ce motif. Expliquez clairement pourquoi la note ne peut pas être validée.</value></data>
+  <data name="Expenses_RejectModalTitle" xml:space="preserve"><value>Rejeter la note</value></data>
+  <data name="Expenses_RejectReasonLabel" xml:space="preserve"><value>Motif du rejet</value></data>
+  <data name="Expenses_RejectReasonPlaceholder" xml:space="preserve"><value>p. ex. Justificatifs manquants pour la ligne 2</value></data>
+  <data name="Feedback_AssignedToName" xml:space="preserve"><value>Assigné à {0}</value></data>
+  <data name="Feedback_CategoryOnPage" xml:space="preserve"><value>{0} sur {1}</value></data>
+  <data name="Feedback_TeamName" xml:space="preserve"><value>Équipe : {0}</value></data>
+  <data name="Issue_ColComments" xml:space="preserve"><value>Commentaires</value></data>
+  <data name="Issue_ColReporter" xml:space="preserve"><value>Rapporteur</value></data>
+  <data name="Issue_ColStatus" xml:space="preserve"><value>Statut</value></data>
+  <data name="Issue_ColTitle" xml:space="preserve"><value>Titre</value></data>
+  <data name="Issue_ColUpdated" xml:space="preserve"><value>Mis à jour</value></data>
+  <data name="Issue_CountSummary" xml:space="preserve"><value>{0} ouvert(s) · {1} au total</value></data>
+  <data name="LinkedAccounts_Account" xml:space="preserve"><value>Compte</value></data>
+  <data name="LinkedAccounts_Actions" xml:space="preserve"><value>Actions</value></data>
+  <data name="LinkedAccounts_ConfirmUnlink" xml:space="preserve"><value>Dissocier ce compte ? Vous ne pourrez plus l'utiliser pour vous connecter.</value></data>
+  <data name="LinkedAccounts_Description" xml:space="preserve"><value>Fournisseurs OAuth actuellement liés à votre compte. Vous pouvez utiliser n'importe lequel pour vous connecter.</value></data>
+  <data name="LinkedAccounts_Empty" xml:space="preserve"><value>Aucun compte OAuth lié.</value></data>
+  <data name="LinkedAccounts_LastSignInMethod" xml:space="preserve"><value>Seule méthode de connexion — impossible de dissocier.</value></data>
+  <data name="LinkedAccounts_LinkedOn" xml:space="preserve"><value>Lié le</value></data>
+  <data name="LinkedAccounts_Provider" xml:space="preserve"><value>Fournisseur</value></data>
+  <data name="LinkedAccounts_Title" xml:space="preserve"><value>Comptes liés</value></data>
+  <data name="LinkedAccounts_UnlinkBlockedLastSignInMethod" xml:space="preserve"><value>Impossible de dissocier — c'est votre seule méthode de connexion restante.</value></data>
+  <data name="MarkdownHelp_Bold" xml:space="preserve"><value>gras</value></data>
+  <data name="MarkdownHelp_ColYouGet" xml:space="preserve"><value>Vous obtenez</value></data>
+  <data name="MarkdownHelp_ColYouType" xml:space="preserve"><value>Vous tapez</value></data>
+  <data name="MarkdownHelp_EmbeddedImage" xml:space="preserve"><value>image intégrée</value></data>
+  <data name="MarkdownHelp_First" xml:space="preserve"><value>premier</value></data>
+  <data name="MarkdownHelp_Heading1" xml:space="preserve"><value>Titre 1</value></data>
+  <data name="MarkdownHelp_Heading2" xml:space="preserve"><value>Titre 2</value></data>
+  <data name="MarkdownHelp_InlineCode" xml:space="preserve"><value>code en ligne</value></data>
+  <data name="MarkdownHelp_Intro" xml:space="preserve"><value>Le Markdown est une manière simple de mettre en forme du texte. Tapez la syntaxe à gauche et elle s'affiche comme indiqué à droite.</value></data>
+  <data name="MarkdownHelp_Italic" xml:space="preserve"><value>italique</value></data>
+  <data name="MarkdownHelp_ItemOne" xml:space="preserve"><value>élément un</value></data>
+  <data name="MarkdownHelp_ItemTwo" xml:space="preserve"><value>élément deux</value></data>
+  <data name="MarkdownHelp_LinkText" xml:space="preserve"><value>texte du lien</value></data>
+  <data name="MarkdownHelp_QuoteText" xml:space="preserve"><value>texte de citation</value></data>
+  <data name="MarkdownHelp_Second" xml:space="preserve"><value>deuxième</value></data>
+  <data name="MarkdownHelp_Strikethrough" xml:space="preserve"><value>barré</value></data>
+  <data name="MarkdownHelp_TableAdmin" xml:space="preserve"><value>Admin</value></data>
+  <data name="MarkdownHelp_TableHuman" xml:space="preserve"><value>Human</value></data>
+  <data name="MarkdownHelp_TableName" xml:space="preserve"><value>Nom</value></data>
+  <data name="MarkdownHelp_TableRole" xml:space="preserve"><value>Rôle</value></data>
+  <data name="MarkdownHelp_TablesHeading" xml:space="preserve"><value>Tableaux</value></data>
+  <data name="MarkdownHelp_TaskDone" xml:space="preserve"><value>Terminé</value></data>
+  <data name="MarkdownHelp_TaskListsHeading" xml:space="preserve"><value>Listes de tâches</value></data>
+  <data name="MarkdownHelp_TaskToDo" xml:space="preserve"><value>À faire</value></data>
+  <data name="MarkdownHelp_Title" xml:space="preserve"><value>Aide-mémoire Markdown</value></data>
+  <data name="Onboarding_BurnerNameExplainer" xml:space="preserve"><value>Le nom que tout le monde voit dans le système. L'unicité aide mais n'est pas obligatoire, même s'il pourrait être difficile de trouver « Bob » parmi les quelques milliers de humans présents si quelqu'un vous cherche.</value></data>
+  <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>Le nom sous lequel tout le monde vous connaîtra.</value></data>
+  <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
+  <data name="Onboarding_Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>pas</value></data>
+  <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>cette information, et nous ne la divulguerions que si la loi ou un audit formel l'exigeait.</value></data>
+  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Conservé en interne, visible uniquement par les Admins, et utilisé seulement là où la loi espagnole l'exige — par exemple, notre enregistrement d'audit attestant que vous avez accepté l'Accord de bénévolat à une date et une heure précises. Nous n'exportons explicitement</value></data>
+  <data name="Onboarding_LegalNameLabel" xml:space="preserve"><value>Nom légal</value></data>
+  <data name="Onboarding_NameRequiredBeforeShifts" xml:space="preserve"><value>Ajoutez d'abord votre nom — nous en avons besoin avant que vous puissiez vous inscrire aux quarts.</value></data>
+  <data name="Onboarding_NamesSubtitle" xml:space="preserve"><value>Deux courtes étapes avant de choisir un quart.</value></data>
+  <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Bienvenue — commençons par votre nom</value></data>
+  <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critique</value></data>
+  <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'événement n'a que {0} % des quarts « critiques » pourvus. S'ils ne sont pas pourvus, l'événement pourrait être annulé car il ne serait pas viable ni sûr de l'organiser.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si vous pouvez en pourvoir certains, ou si vous pouvez venir avant l'événement ou rester pour le démontage, veuillez les prioriser lors du choix de vos quarts.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT :</value></data>
+  <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Il y a également {0} quarts « importants » à pourvoir.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Il y a {0} quarts « importants » à pourvoir. Si vous pouvez venir avant l'événement ou rester pour le démontage, veuillez les prioriser.</value></data>
+  <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Aucun événement actif pour le moment. Vous pouvez terminer l'intégration sans choisir de quart.</value></data>
+  <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Aucun quart critique à pourvoir pour le moment — essayez Important ou Tous.</value></data>
+  <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Aucun quart important à pourvoir pour le moment — essayez Tous.</value></data>
+  <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Pas maintenant</value></data>
+  <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Choisissez un quart</value></data>
+  <data name="Outbox_AdminTitle" xml:space="preserve"><value>E-mails</value></data>
+  <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Retour à Administration</value></data>
+  <data name="Outbox_BackToProfile" xml:space="preserve"><value>Retour au profil</value></data>
+  <data name="Outbox_DescriptionAdmin" xml:space="preserve"><value>E-mails que le système a envoyés à ce human.</value></data>
+  <data name="Outbox_DescriptionSelf" xml:space="preserve"><value>E-mails que le système vous a envoyés (au cours des 150 derniers jours).</value></data>
+  <data name="Outbox_Empty" xml:space="preserve"><value>Aucun e-mail enregistré.</value></data>
+  <data name="Outbox_Subject" xml:space="preserve"><value>Objet</value></data>
+  <data name="Privacy_ThirdParty_GooglePolicyLink" xml:space="preserve"><value>Politique de confidentialité de Google</value></data>
+  <data name="Profile_Assigned" xml:space="preserve"><value>Attribué</value></data>
+  <data name="Profile_Campaign" xml:space="preserve"><value>Campagne</value></data>
+  <data name="Profile_Code" xml:space="preserve"><value>Code</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Dairy" xml:space="preserve"><value>Produits laitiers</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Egg" xml:space="preserve"><value>Œuf</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Peanut" xml:space="preserve"><value>Arachide</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Sesame" xml:space="preserve"><value>Sésame</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Shellfish" xml:space="preserve"><value>Crustacés</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Soy" xml:space="preserve"><value>Soja</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Treenut" xml:space="preserve"><value>Fruits à coque</value></data>
+  <data name="Profile_DietaryMedical_Allergy_WheatGluten" xml:space="preserve"><value>Blé/Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_FODMAP" xml:space="preserve"><value>FODMAP</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Gluten" xml:space="preserve"><value>Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Histamine" xml:space="preserve"><value>Histamine</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Lactose" xml:space="preserve"><value>Lactose</value></data>
+  <data name="Profile_MarkedAt" xml:space="preserve"><value>Marqué le</value></data>
+  <data name="Profile_MarkedBy" xml:space="preserve"><value>Marqué par</value></data>
+  <data name="Profile_MyCodes" xml:space="preserve"><value>Mes codes</value></data>
+  <data name="Profile_MyEmails" xml:space="preserve"><value>Mes e-mails</value></data>
+  <data name="Profile_NoSentMessages" xml:space="preserve"><value>Aucun message dans la plateforme enregistré.</value></data>
+  <data name="Profile_NoShowHistory" xml:space="preserve"><value>Historique des absences ({0})</value></data>
+  <data name="Profile_OnsiteSince" xml:space="preserve"><value>Sur place depuis {0}</value></data>
+  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Enregistré à l'entrée</value></data>
+  <data name="Profile_Redeemed" xml:space="preserve"><value>Utilisé</value></data>
+  <data name="Profile_SentMessages" xml:space="preserve"><value>Messages envoyés ({0})</value></data>
+  <data name="Profile_ShiftInfo" xml:space="preserve"><value>Infos du quart</value></data>
+  <data name="ProfileEdit_CityPlaceholder" xml:space="preserve"><value>Commencez à saisir votre ville…</value></data>
+  <data name="ProfileEdit_ContactType" xml:space="preserve"><value>Type</value></data>
+  <data name="ProfileEdit_ContactValue" xml:space="preserve"><value>Valeur</value></data>
+  <data name="ProfileEdit_ContactValuePlaceholder" xml:space="preserve"><value>Saisissez les coordonnées</value></data>
+  <data name="ProfileEdit_ContactVisibility" xml:space="preserve"><value>Visibilité</value></data>
+  <data name="ProfileEdit_CustomLabelPlaceholder" xml:space="preserve"><value>p. ex. Discord</value></data>
+  <data name="ProfileEdit_Description" xml:space="preserve"><value>Description</value></data>
+  <data name="ProfileEdit_DescriptionPlaceholder" xml:space="preserve"><value>p. ex. Lead de l'entrée</value></data>
+  <data name="ProfileEdit_EventName" xml:space="preserve"><value>Nom de l'événement</value></data>
+  <data name="ProfileEdit_EventNamePlaceholder" xml:space="preserve"><value>p. ex. Burning Man 2024</value></data>
+  <data name="ProfileEdit_LanguageLabel" xml:space="preserve"><value>Langue</value></data>
+  <data name="ProfileEdit_ProficiencyLabel" xml:space="preserve"><value>Niveau</value></data>
+  <data name="ProfileEdit_RelationshipPlaceholder" xml:space="preserve"><value>p. ex. partenaire, parent</value></data>
+  <data name="ProfileEdit_RemoveContactField" xml:space="preserve"><value>Retirer ce champ de contact</value></data>
+  <data name="ProfileEdit_RemoveEntry" xml:space="preserve"><value>Retirer cette entrée</value></data>
+  <data name="ProfileEdit_RemoveLanguage" xml:space="preserve"><value>Retirer cette langue</value></data>
+  <data name="ProfileEdit_SelectLanguage" xml:space="preserve"><value>— Sélectionner une langue —</value></data>
+  <data name="Roster_All" xml:space="preserve"><value>Tous</value></data>
+  <data name="Roster_ColAssignedTo" xml:space="preserve"><value>Assigné à</value></data>
+  <data name="Roster_ColPeriod" xml:space="preserve"><value>Période</value></data>
+  <data name="Roster_ColPriority" xml:space="preserve"><value>Priorité</value></data>
+  <data name="Roster_ColRole" xml:space="preserve"><value>Rôle</value></data>
+  <data name="Roster_ColSlot" xml:space="preserve"><value>Poste</value></data>
+  <data name="Roster_ColTeam" xml:space="preserve"><value>Équipe</value></data>
+  <data name="Roster_NoSlots" xml:space="preserve"><value>Aucun poste défini parmi les équipes.</value></data>
+  <data name="Roster_PeriodFilter" xml:space="preserve"><value>Période : {0}</value></data>
+  <data name="Roster_PriorityFilter" xml:space="preserve"><value>Priorité : {0}</value></data>
+  <data name="Roster_SlotOpen" xml:space="preserve"><value>À pourvoir</value></data>
+  <data name="Roster_StatusFilled" xml:space="preserve"><value>Pourvu</value></data>
+  <data name="Roster_StatusFilter" xml:space="preserve"><value>Statut : {0}</value></data>
+  <data name="Roster_StatusOpen" xml:space="preserve"><value>À pourvoir</value></data>
+  <data name="Roster_Title" xml:space="preserve"><value>Liste de l'équipe</value></data>
+  <data name="Search_FilterAll" xml:space="preserve"><value>Tous</value></data>
+  <data name="Search_FilterCamps" xml:space="preserve"><value>Camps</value></data>
+  <data name="Search_FilterEvents" xml:space="preserve"><value>Événements</value></data>
+  <data name="Search_FilterHumans" xml:space="preserve"><value>Humans</value></data>
+  <data name="Search_FilterShifts" xml:space="preserve"><value>Quarts</value></data>
+  <data name="Search_FilterTeams" xml:space="preserve"><value>Équipes</value></data>
+  <data name="Search_GlobalHint" xml:space="preserve"><value>Tapez au moins 2 caractères pour rechercher parmi les humans, équipes, camps et quarts.</value></data>
+  <data name="Search_GlobalHintEvents" xml:space="preserve"><value>Tapez au moins 2 caractères pour rechercher parmi les humans, équipes, camps, quarts et événements.</value></data>
+  <data name="Search_GlobalNoResults" xml:space="preserve"><value>Aucun résultat pour {0}.</value></data>
+  <data name="Search_GlobalPlaceholder" xml:space="preserve"><value>Rechercher des humans, équipes, camps, quarts…</value></data>
+  <data name="Search_GlobalPlaceholderEvents" xml:space="preserve"><value>Rechercher des humans, équipes, camps, quarts, événements…</value></data>
+  <data name="Search_GlobalTitle" xml:space="preserve"><value>Rechercher</value></data>
+  <data name="Store_AdminCatalog" xml:space="preserve"><value>Catalogue</value></data>
+  <data name="Store_AdminPayments" xml:space="preserve"><value>Paiements</value></data>
+  <data name="Store_AdminSummary" xml:space="preserve"><value>Résumé</value></data>
+  <data name="Store_CatalogHeading" xml:space="preserve"><value>Catalogue ({0})</value></data>
+  <data name="Store_ColBalance" xml:space="preserve"><value>Solde</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Acompte</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Acomptes</value></data>
+  <data name="Store_ColDescription" xml:space="preserve"><value>Description</value></data>
+  <data name="Store_ColLines" xml:space="preserve"><value>Lignes</value></data>
+  <data name="Store_ColLinesVat" xml:space="preserve"><value>Lignes + TVA</value></data>
+  <data name="Store_ColName" xml:space="preserve"><value>Nom</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Commander avant le</value></data>
+  <data name="Store_ColState" xml:space="preserve"><value>État</value></data>
+  <data name="Store_ColUnitPrice" xml:space="preserve"><value>Prix unitaire (TVA incluse)</value></data>
+  <data name="Store_CreateOrder" xml:space="preserve"><value>Créer la commande</value></data>
+  <data name="Store_DeleteOrderConfirm" xml:space="preserve"><value>Supprimer cette commande au solde nul ? Cette action est irréversible.</value></data>
+  <data name="Store_DeleteOrderTitle" xml:space="preserve"><value>Supprimer (solde nul)</value></data>
+  <data name="Store_NoCounterpartiesAlert" xml:space="preserve"><value>Vous ne dirigez aucun camp et ne coordonnez aucun département ayant une saison active cette année. Le catalogue ci-dessous est en lecture seule.</value></data>
+  <data name="Store_NoOrders" xml:space="preserve"><value>Aucune commande pour le moment.</value></data>
+  <data name="Store_NoProducts" xml:space="preserve"><value>Aucun produit n'est actif pour {0}.</value></data>
+  <data name="Store_OpenOrder" xml:space="preserve"><value>Ouvrir</value></data>
+  <data name="Store_StartOrder" xml:space="preserve"><value>Démarrer une commande</value></data>
+  <data name="Store_Title" xml:space="preserve"><value>Boutique</value></data>
+  <data name="Teams_Departments" xml:space="preserve"><value>Départements</value></data>
+  <data name="Teams_HiddenTeams" xml:space="preserve"><value>Équipes masquées</value></data>
+  <data name="Teams_HiddenTeamsNote" xml:space="preserve"><value>(visibles par les admins uniquement)</value></data>
+  <data name="Teams_Summary" xml:space="preserve"><value>Résumé</value></data>
+  <data name="Teams_SyncStatus" xml:space="preserve"><value>État de synchronisation</value></data>
+  <data name="Teams_SystemTeams" xml:space="preserve"><value>Équipes système</value></data>
+  <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Transfert déjà en attente</value></data>
+  <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Annuler la demande</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Déjà enregistré — ne peut pas être transféré</value></data>
+  <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>Ceci demandera le transfert du billet {0} ({1}) à {2}.</value></data>
+  <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>Notre équipe billetterie traitera cette demande et vous tiendra informé sous peu.</value></data>
+  <data name="TicketTransfer_Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="TicketTransfer_NoneTransferable" xml:space="preserve"><value>Aucun de vos billets ne peut être transféré pour le moment.</value></data>
+  <data name="TicketTransfer_NoRequests" xml:space="preserve"><value>Vous n'avez demandé aucun transfert.</value></data>
+  <data name="TicketTransfer_NoTickets" xml:space="preserve"><value>Vous n'avez aucun billet à transférer.</value></data>
+  <data name="TicketTransfer_NotTransferable" xml:space="preserve"><value>Non transférable</value></data>
+  <data name="TicketTransfer_ReasonLabel" xml:space="preserve"><value>Motif du transfert (facultatif, visible par l'équipe billetterie)</value></data>
+  <data name="TicketTransfer_RecipientPlaceholder" xml:space="preserve"><value>Recherchez par nom, ou collez son e-mail exact…</value></data>
+  <data name="TicketTransfer_Requested" xml:space="preserve"><value>Demandé</value></data>
+  <data name="TicketTransfer_RequestTransfer" xml:space="preserve"><value>Demander le transfert</value></data>
+  <data name="TicketTransfer_StatusApproved" xml:space="preserve"><value>Terminé</value></data>
+  <data name="TicketTransfer_StatusCancelled" xml:space="preserve"><value>Annulé</value></data>
+  <data name="TicketTransfer_StatusRejected" xml:space="preserve"><value>Annulé par l'équipe</value></data>
+  <data name="TicketTransfer_Step1" xml:space="preserve"><value>1. Choisissez le billet à transférer</value></data>
+  <data name="TicketTransfer_Step2" xml:space="preserve"><value>2. À qui l'envoyez-vous ?</value></data>
+  <data name="TicketTransfer_Step3" xml:space="preserve"><value>3. Confirmer</value></data>
+  <data name="TicketTransfer_Title" xml:space="preserve"><value>Transférer un billet</value></data>
+  <data name="TicketTransfer_YourRequests" xml:space="preserve"><value>Vos demandes de transfert</value></data>
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -6010,4 +6010,626 @@
   <data name="AccountDeletion_ScheduledFor" xml:space="preserve"><value>Sarà eliminato definitivamente il {0} a meno che tu non annulli.</value></data>
   <data name="AccountDeletion_Unscheduled" xml:space="preserve"><value>Sarà eliminato definitivamente a meno che tu non annulli.</value></data>
   <data name="AccountDeletion_CancelButton" xml:space="preserve"><value>Annulla la richiesta di eliminazione</value></data>
+  <data name="About_AdditionalHelp" xml:space="preserve"><value>Con l'aiuto aggiuntivo di</value></data>
+  <data name="About_AdditionalHelpAnd" xml:space="preserve"><value>e</value></data>
+  <data name="About_AnthropicNote" xml:space="preserve"><value>Le risposte conversazionali dell'assistente sono prodotte dall'API di Anthropic. Nessun dato viene usato per l'addestramento dei modelli secondo il DPA di Anthropic.</value></data>
+  <data name="About_Cat_AILLM" xml:space="preserve"><value>AI/LLM</value></data>
+  <data name="About_Cat_BackgroundJobs" xml:space="preserve"><value>Job in background</value></data>
+  <data name="About_Cat_Calendar" xml:space="preserve"><value>Calendario</value></data>
+  <data name="About_Cat_CSV" xml:space="preserve"><value>CSV</value></data>
+  <data name="About_Cat_Database" xml:space="preserve"><value>Database</value></data>
+  <data name="About_Cat_DateTime" xml:space="preserve"><value>Data/Ora</value></data>
+  <data name="About_Cat_Email" xml:space="preserve"><value>Email</value></data>
+  <data name="About_Cat_Framework" xml:space="preserve"><value>Framework</value></data>
+  <data name="About_Cat_GitHubAPI" xml:space="preserve"><value>API GitHub</value></data>
+  <data name="About_Cat_GoogleAPIs" xml:space="preserve"><value>API Google</value></data>
+  <data name="About_Cat_HealthChecks" xml:space="preserve"><value>Health check</value></data>
+  <data name="About_Cat_ImageProcessing" xml:space="preserve"><value>Elaborazione immagini</value></data>
+  <data name="About_Cat_Logging" xml:space="preserve"><value>Logging</value></data>
+  <data name="About_Cat_Markdown" xml:space="preserve"><value>Markdown</value></data>
+  <data name="About_Cat_Observability" xml:space="preserve"><value>Osservabilità</value></data>
+  <data name="About_Cat_Payments" xml:space="preserve"><value>Pagamenti</value></data>
+  <data name="About_Cat_Resilience" xml:space="preserve"><value>Resilienza</value></data>
+  <data name="About_Cat_Sanitization" xml:space="preserve"><value>Sanitizzazione</value></data>
+  <data name="About_Cat_Spreadsheet" xml:space="preserve"><value>Foglio di calcolo</value></data>
+  <data name="About_Cat_StateMachine" xml:space="preserve"><value>Macchina a stati</value></data>
+  <data name="About_Cat_UserAgent" xml:space="preserve"><value>User-Agent</value></data>
+  <data name="About_ColCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="About_ColLibrary" xml:space="preserve"><value>Libreria</value></data>
+  <data name="About_ColLicense" xml:space="preserve"><value>Licenza</value></data>
+  <data name="About_ColPackage" xml:space="preserve"><value>Pacchetto</value></data>
+  <data name="About_ColVersion" xml:space="preserve"><value>Versione</value></data>
+  <data name="About_DotNetDesc" xml:space="preserve"><value>ASP.NET Core MVC con viste Razor, Identity e l'intero stack Microsoft. L'intelaiatura che tiene insieme tutto.</value></data>
+  <data name="About_FrontendHeading" xml:space="preserve"><value>Dipendenze frontend / CDN</value></data>
+  <data name="About_GoogleDesc" xml:space="preserve"><value>Admin Directory, Drive e Groups — provisioning di Shared Drive, cartelle e mailing list così nessuno deve farlo a mano.</value></data>
+  <data name="About_HangfireDesc" xml:space="preserve"><value>Job in background per la sincronizzazione, la riconciliazione e tutto ciò che non dovrebbe bloccare una richiesta HTTP. Basato su PostgreSQL, dashboard inclusa.</value></data>
+  <data name="About_IngredientsHeading" xml:space="preserve"><value>Gli ingredienti</value></data>
+  <data name="About_IngredientsIntro" xml:space="preserve"><value>Ogni laboratorio ha bisogno dei suoi materiali. Ecco di cosa è fatto Humans:</value></data>
+  <data name="About_Intro" xml:space="preserve"><value>Humans è il sistema di membership che tiene in piedi Nobodies Collective — onboarding degli humans, provisioning dei team, tracciamento della governance e tutta l'idraulica che permette a un'associazione no profit spagnola di operare con la memoria organizzativa di qualcosa dieci volte più grande. Costruito con cura, mantenuto con testardaggine e messo in produzione incrociando le dita.</value></data>
+  <data name="About_License_Apache2" xml:space="preserve"><value>richiede l'avviso di copyright, una copia della licenza e una dichiarazione delle modifiche se modificata. Tutti i pacchetti sono usati senza modifiche.</value></data>
+  <data name="About_License_BSD2" xml:space="preserve"><value>richiede l'avviso di copyright nella documentazione.</value></data>
+  <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>richiede l'avviso di copyright; questa pagina soddisfa tale obbligo.</value></data>
+  <data name="About_License_ISC" xml:space="preserve"><value>permissiva, funzionalmente equivalente alla BSD-2-Clause; richiede l'avviso di copyright.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>la libreria deve essere sostituibile dall'utente finale. Consumata come pacchetti NuGet non modificati (collegati dinamicamente), soddisfacendo gli obblighi LGPL.</value></data>
+  <data name="About_License_MIT" xml:space="preserve"><value>richiede l'avviso di copyright; questa pagina soddisfa tale obbligo.</value></data>
+  <data name="About_License_PostgreSQL" xml:space="preserve"><value>permissiva, simile alla MIT; richiede l'avviso di copyright.</value></data>
+  <data name="About_License_SILOFL" xml:space="preserve"><value>liberamente utilizzabile e ridistribuibile; i font non possono essere venduti separatamente.</value></data>
+  <data name="About_LicenseBody" xml:space="preserve"><value>Humans è software libero, rilasciato sotto la</value></data>
+  <data name="About_LicenseComplianceHeading" xml:space="preserve"><value>Riepilogo conformità delle licenze</value></data>
+  <data name="About_LicenseComplianceSummary" xml:space="preserve"><value>Tutte le dipendenze di produzione usano licenze permissive o weak-copyleft. Nessuna violazione rilevata.</value></data>
+  <data name="About_LicenseExplanation" xml:space="preserve"><value>Puoi usare, studiare, modificare e ridistribuire questo software. Se esegui una versione modificata e permetti ad altri di interagire con essa attraverso una rete, devi rendere disponibile il tuo codice sorgente modificato sotto la stessa licenza.</value></data>
+  <data name="About_LicenseFullText" xml:space="preserve"><value>Testo completo della licenza:</value></data>
+  <data name="About_LicenseHeading" xml:space="preserve"><value>Licenza</value></data>
+  <data name="About_LicenseSourceCode" xml:space="preserve"><value>Codice sorgente:</value></data>
+  <data name="About_MadeBy" xml:space="preserve"><value>Realizzato da</value></data>
+  <data name="About_MadeByTail" xml:space="preserve"><value>con amore per la comunità Nobodies.</value></data>
+  <data name="About_MailKitDesc" xml:space="preserve"><value>Email transazionali per notifiche e onboarding. L'unica libreria che rende SMTP quasi piacevole.</value></data>
+  <data name="About_MeetTheStaff" xml:space="preserve"><value>Conosci lo staff</value></data>
+  <data name="About_NeedHelp" xml:space="preserve"><value>Hai bisogno di aiuto?</value></data>
+  <data name="About_NuGetPackagesHeading" xml:space="preserve"><value>Pacchetti NuGet</value></data>
+  <data name="About_OpenSourceLicensesHeading" xml:space="preserve"><value>Licenze open source</value></data>
+  <data name="About_OpenSourceLicensesIntro" xml:space="preserve"><value>Humans è costruito sulle spalle di progetti open source. La tabella qui sotto elenca ogni dipendenza di produzione, la sua versione e la licenza.</value></data>
+  <data name="About_OtelDesc" xml:space="preserve"><value>Logging strutturato, tracce distribuite e metriche Prometheus. Perché "funziona sulla mia macchina" non è una strategia di monitoraggio.</value></data>
+  <data name="About_PostgresDesc" xml:space="preserve"><value>Dati relazionali con Entity Framework Core e Npgsql. Tipi NodaTime fino in fondo — nessun DateTime in vista.</value></data>
+  <data name="About_Staff_BackToAbout" xml:space="preserve"><value>Torna a Chi siamo</value></data>
+  <data name="About_Staff_Empty" xml:space="preserve"><value>Nessun titolare di ruolo attivo trovato. Il castello sembra essere vuoto.</value></data>
+  <data name="About_Staff_Intro" xml:space="preserve"><value>Ogni collettivo ha bisogno dei suoi custodi. Questi sono gli humans che dedicano il loro tempo e la loro energia per far funzionare Nobodies — dalla governance al supporto tecnico, dalla trust and safety all'alchimia dei biglietti.</value></data>
+  <data name="About_Staff_Title" xml:space="preserve"><value>Gli humans dietro le quinte</value></data>
+  <data name="About_Title" xml:space="preserve"><value>Informazioni su Humans</value></data>
+  <data name="AccountStatus_ConsentSuspendedBody" xml:space="preserve"><value>Il Suo accesso è sospeso finché non completa i consensi legali richiesti.</value></data>
+  <data name="AccountStatus_HeadingAdminSuspended" xml:space="preserve"><value>Il Suo account è stato sospeso da un amministratore</value></data>
+  <data name="AccountStatus_ReviewConsents" xml:space="preserve"><value>Esamina i consensi richiesti</value></data>
+  <data name="Budget_ColAmount" xml:space="preserve"><value>Importo (€)</value></data>
+  <data name="Budget_ColCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Budget_ColShare" xml:space="preserve"><value>Quota</value></data>
+  <data name="Budget_DepartmentDetail" xml:space="preserve"><value>Dettaglio dipartimento</value></data>
+  <data name="Budget_Expenses" xml:space="preserve"><value>Spese</value></data>
+  <data name="Budget_ExpensesBreakdown" xml:space="preserve"><value>Ripartizione delle spese</value></data>
+  <data name="Budget_Income" xml:space="preserve"><value>Entrate</value></data>
+  <data name="Budget_IncomeBreakdown" xml:space="preserve"><value>Ripartizione delle entrate</value></data>
+  <data name="Budget_NetBalance" xml:space="preserve"><value>Saldo netto</value></data>
+  <data name="Budget_NoActiveBudget" xml:space="preserve"><value>Nessun budget attivo</value></data>
+  <data name="Budget_NoActiveBudgetSubtitle" xml:space="preserve"><value>Non c'è alcun anno di budget attivo da mostrare. Un admin finanze ne imposterà uno quando inizierà la pianificazione del budget.</value></data>
+  <data name="Budget_NoDataSubtitle" xml:space="preserve"><value>Le allocazioni di budget appariranno qui una volta impostate dal team finanze.</value></data>
+  <data name="Budget_NoDataYet" xml:space="preserve"><value>Dati del budget non ancora disponibili</value></data>
+  <data name="Budget_NoExpenseItems" xml:space="preserve"><value>Ancora nessuna voce di spesa.</value></data>
+  <data name="Budget_NoIncomeItems" xml:space="preserve"><value>Ancora nessuna voce di entrata.</value></data>
+  <data name="Budget_OverviewSubtitle" xml:space="preserve"><value>Come il budget {0} è distribuito tra dipartimenti e infrastruttura.</value></data>
+  <data name="Budget_OverviewTitle" xml:space="preserve"><value>Panoramica del budget</value></data>
+  <data name="Budget_Title" xml:space="preserve"><value>Budget</value></data>
+  <data name="Budget_TitleYear" xml:space="preserve"><value>Budget - {0}</value></data>
+  <data name="Budget_TotalExpenses" xml:space="preserve"><value>Spese totali</value></data>
+  <data name="Budget_TotalIncome" xml:space="preserve"><value>Entrate totali</value></data>
+  <data name="Calendar_Agenda" xml:space="preserve"><value>Agenda</value></data>
+  <data name="Calendar_AllDay" xml:space="preserve"><value>tutto il giorno</value></data>
+  <data name="Calendar_AllDayEvent" xml:space="preserve"><value>Evento di tutto il giorno</value></data>
+  <data name="Calendar_AllDayLabel" xml:space="preserve"><value>Tutto il giorno</value></data>
+  <data name="Calendar_AllTeamsMonthView" xml:space="preserve"><value>Tutti i team (vista mensile)</value></data>
+  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>Tutti gli orari sono mostrati in {0}.</value></data>
+  <data name="Calendar_BackToCalendar" xml:space="preserve"><value>Torna al calendario</value></data>
+  <data name="Calendar_CancelOccurrenceConfirm" xml:space="preserve"><value>Annullare solo questa occorrenza?</value></data>
+  <data name="Calendar_CancelThisOccurrence" xml:space="preserve"><value>Annulla questa</value></data>
+  <data name="Calendar_ChangeHistory" xml:space="preserve"><value>Cronologia delle modifiche</value></data>
+  <data name="Calendar_Continues" xml:space="preserve"><value>continua</value></data>
+  <data name="Calendar_Created" xml:space="preserve"><value>Creato {0}</value></data>
+  <data name="Calendar_CreateEvent" xml:space="preserve"><value>Crea evento</value></data>
+  <data name="Calendar_DeleteConfirm" xml:space="preserve"><value>Eliminare questo evento e tutte le sue occorrenze?</value></data>
+  <data name="Calendar_Description" xml:space="preserve"><value>Descrizione</value></data>
+  <data name="Calendar_EditEvent" xml:space="preserve"><value>Modifica evento</value></data>
+  <data name="Calendar_EditSingleOccurrence" xml:space="preserve"><value>Modifica singola occorrenza</value></data>
+  <data name="Calendar_EditSingleOccurrenceHeading" xml:space="preserve"><value>Modifica una singola occorrenza</value></data>
+  <data name="Calendar_EditThisOccurrence" xml:space="preserve"><value>Modifica questa occorrenza</value></data>
+  <data name="Calendar_End" xml:space="preserve"><value>Fine</value></data>
+  <data name="Calendar_EndDate" xml:space="preserve"><value>Data di fine</value></data>
+  <data name="Calendar_EndDateHelp" xml:space="preserve"><value>Inclusiva — lascia vuoto per un evento di un solo giorno.</value></data>
+  <data name="Calendar_EventTitle" xml:space="preserve"><value>Evento</value></data>
+  <data name="Calendar_FirstStart" xml:space="preserve"><value>Primo inizio</value></data>
+  <data name="Calendar_FormTitle" xml:space="preserve"><value>Titolo</value></data>
+  <data name="Calendar_LastUpdated" xml:space="preserve"><value>· Ultimo aggiornamento {0}</value></data>
+  <data name="Calendar_LocationUrl" xml:space="preserve"><value>URL del luogo</value></data>
+  <data name="Calendar_MoreCount" xml:space="preserve"><value>+{0} altri</value></data>
+  <data name="Calendar_NewEvent" xml:space="preserve"><value>Nuovo evento</value></data>
+  <data name="Calendar_Next" xml:space="preserve"><value>Succ.</value></data>
+  <data name="Calendar_NoEventsInRange" xml:space="preserve"><value>Nessun evento nell'intervallo selezionato.</value></data>
+  <data name="Calendar_OverrideDescription" xml:space="preserve"><value>Sovrascrivi descrizione</value></data>
+  <data name="Calendar_OverrideEnd" xml:space="preserve"><value>Sovrascrivi fine</value></data>
+  <data name="Calendar_OverrideInstructions" xml:space="preserve"><value>Sovrascrivi solo questa occorrenza dell'evento ricorrente. Lascia un campo vuoto per ereditare il valore dall'evento principale.</value></data>
+  <data name="Calendar_OverrideLocation" xml:space="preserve"><value>Sovrascrivi luogo</value></data>
+  <data name="Calendar_OverrideLocationUrl" xml:space="preserve"><value>Sovrascrivi URL del luogo</value></data>
+  <data name="Calendar_OverrideStart" xml:space="preserve"><value>Sovrascrivi inizio</value></data>
+  <data name="Calendar_OverrideTitle" xml:space="preserve"><value>Sovrascrivi titolo</value></data>
+  <data name="Calendar_OwningTeam" xml:space="preserve"><value>Team proprietario</value></data>
+  <data name="Calendar_Prev" xml:space="preserve"><value>Prec.</value></data>
+  <data name="Calendar_Recurrence" xml:space="preserve"><value>Ricorrenza</value></data>
+  <data name="Calendar_RecurrenceTimezoneHelpPrefix" xml:space="preserve"><value>TZ IANA, es.</value></data>
+  <data name="Calendar_RecurrenceTimezoneLabel" xml:space="preserve"><value>Fuso orario della ricorrenza</value></data>
+  <data name="Calendar_RecurrenceTimezoneNote" xml:space="preserve"><value>Fuso orario: {0}</value></data>
+  <data name="Calendar_RecurringEvent" xml:space="preserve"><value>Evento ricorrente</value></data>
+  <data name="Calendar_RRule" xml:space="preserve"><value>RRULE</value></data>
+  <data name="Calendar_RRuleHelpPrefix" xml:space="preserve"><value>RRULE RFC 5545. Lascia vuoto per un evento singolo. Esempio:</value></data>
+  <data name="Calendar_SaveOverride" xml:space="preserve"><value>Salva sovrascrittura</value></data>
+  <data name="Calendar_Start" xml:space="preserve"><value>Inizio</value></data>
+  <data name="Calendar_StartDate" xml:space="preserve"><value>Data di inizio</value></data>
+  <data name="Calendar_TeamFallback" xml:space="preserve"><value>Team</value></data>
+  <data name="Calendar_Title" xml:space="preserve"><value>Calendario</value></data>
+  <data name="Calendar_Today" xml:space="preserve"><value>Oggi</value></data>
+  <data name="Calendar_UpcomingOccurrences" xml:space="preserve"><value>Prossime occorrenze</value></data>
+  <data name="Calendar_ViewAriaLabel" xml:space="preserve"><value>Vista calendario</value></data>
+  <data name="Calendar_ViewGrid" xml:space="preserve"><value>Griglia</value></data>
+  <data name="Calendar_ViewList" xml:space="preserve"><value>Elenco</value></data>
+  <data name="Calendar_Yes" xml:space="preserve"><value>Sì</value></data>
+  <data name="Camp_AboutHeading" xml:space="preserve"><value>Informazioni sul tuo {0}</value></data>
+  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>Accetti nuovi humans?</value></data>
+  <data name="Camp_AdultPlayspaceLabel" xml:space="preserve"><value>Playspace per adulti</value></data>
+  <data name="Camp_BlurbLongLabel" xml:space="preserve"><value>Descrizione completa</value></data>
+  <data name="Camp_BlurbLongPlaceholder" xml:space="preserve"><value>Racconta al mondo del tuo camp.</value></data>
+  <data name="Camp_BlurbShortLabel" xml:space="preserve"><value>Descrizione breve</value></data>
+  <data name="Camp_BlurbShortPlaceholder" xml:space="preserve"><value>Una o due frasi sul tuo camp (max 300 caratteri)</value></data>
+  <data name="Camp_CommunityHeading" xml:space="preserve"><value>Comunità</value></data>
+  <data name="Camp_ContactEmailLabel" xml:space="preserve"><value>Email di contatto</value></data>
+  <data name="Camp_ContactPhoneLabel" xml:space="preserve"><value>Telefono di contatto</value></data>
+  <data name="Camp_ContactPhonePlaceholder" xml:space="preserve"><value>+34 612 345 678</value></data>
+  <data name="Camp_CultureHeading" xml:space="preserve"><value>Cultura ed eventi</value></data>
+  <data name="Camp_Edit_AutoCreatedFromNameChange" xml:space="preserve"><value>Creato automaticamente da un cambio di nome</value></data>
+  <data name="Camp_Edit_ContainersSeparate" xml:space="preserve"><value>I contenitori ora sono gestiti separatamente.</value></data>
+  <data name="Camp_Edit_HideHistoricalNames" xml:space="preserve"><value>Nascondi nomi storici</value></data>
+  <data name="Camp_Edit_HistoricalNamesHeading" xml:space="preserve"><value>Nomi storici</value></data>
+  <data name="Camp_Edit_HistoricalNamesHelp" xml:space="preserve"><value>Nomi con cui questo camp era conosciuto in precedenza.</value></data>
+  <data name="Camp_Edit_ImageAlt" xml:space="preserve"><value>Immagine del camp</value></data>
+  <data name="Camp_Edit_ImagesHeading" xml:space="preserve"><value>Immagini ({0}/{1})</value></data>
+  <data name="Camp_Edit_ImageUploadHelp" xml:space="preserve"><value>JPEG, PNG o WebP. Max 10MB.</value></data>
+  <data name="Camp_Edit_ManageContainers" xml:space="preserve"><value>Gestisci contenitori →</value></data>
+  <data name="Camp_Edit_MembersRolesDescription" xml:space="preserve"><value>Gestisci membri attivi, ruoli, lead e richieste di adesione in sospeso.</value></data>
+  <data name="Camp_Edit_MembersRolesHeading" xml:space="preserve"><value>Membri e ruoli</value></data>
+  <data name="Camp_Edit_NameLocked" xml:space="preserve"><value>Il nome è bloccato per questa stagione.</value></data>
+  <data name="Camp_Edit_OpenMembersRoles" xml:space="preserve"><value>Apri membri e ruoli</value></data>
+  <data name="Camp_Edit_OpenStore" xml:space="preserve"><value>Apri store</value></data>
+  <data name="Camp_Edit_PreviousNamePlaceholder" xml:space="preserve"><value>Nome precedente del camp</value></data>
+  <data name="Camp_Edit_StoreDescription" xml:space="preserve"><value>Effettua un ordine per questo camp.</value></data>
+  <data name="Camp_Edit_StoreHeading" xml:space="preserve"><value>Store</value></data>
+  <data name="Camp_Edit_UploadImage" xml:space="preserve"><value>Carica immagine</value></data>
+  <data name="Camp_ElectricalGridLabel" xml:space="preserve"><value>Rete elettrica</value></data>
+  <data name="Camp_HistoryHeading" xml:space="preserve"><value>Storia</value></data>
+  <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Accetta membri</value></data>
+  <data name="Camp_Index_AllOption" xml:space="preserve"><value>Tutti</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guida ai Barrios 2026</value></data>
+  <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filtra</value></data>
+  <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Bambini benvenuti</value></data>
+  <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>Nessun {0} trovato per i filtri selezionati.</value></data>
+  <data name="Camp_Index_NoSearchResults" xml:space="preserve"><value>Nessun {0} corrisponde alla tua ricerca.</value></data>
+  <data name="Camp_Index_PendingApproval" xml:space="preserve"><value>in attesa di approvazione</value></data>
+  <data name="Camp_Index_SearchLabel" xml:space="preserve"><value>Cerca</value></data>
+  <data name="Camp_Index_SearchPlaceholder" xml:space="preserve"><value>Scrivi il nome di un {0}…</value></data>
+  <data name="Camp_Index_ShowLeadPositions" xml:space="preserve"><value>Mostra posizioni di lead</value></data>
+  <data name="Camp_Index_SoundZoneLabel" xml:space="preserve"><value>Zona sonora</value></data>
+  <data name="Camp_Index_VibeLabel" xml:space="preserve"><value>Vibe</value></data>
+  <data name="Camp_KidsAreaDescriptionLabel" xml:space="preserve"><value>Descrizione dell'area bambini</value></data>
+  <data name="Camp_KidsAreaDescriptionPlaceholder" xml:space="preserve"><value>Descrivi la tua area bambini, se presente</value></data>
+  <data name="Camp_KidsVisitingLabel" xml:space="preserve"><value>Politica sulle visite dei bambini</value></data>
+  <data name="Camp_KidsWelcomeLabel" xml:space="preserve"><value>Bambini benvenuti?</value></data>
+  <data name="Camp_LanguagesLabel" xml:space="preserve"><value>Lingue parlate</value></data>
+  <data name="Camp_LanguagesPlaceholder" xml:space="preserve"><value>es. Inglese, Spagnolo, Tedesco</value></data>
+  <data name="Camp_MarkdownSupported" xml:space="preserve"><value>È supportata la formattazione Markdown</value></data>
+  <data name="Camp_MemberCountLabel" xml:space="preserve"><value>Humans previsti</value></data>
+  <data name="Camp_NoPreference" xml:space="preserve"><value>Nessuna preferenza</value></data>
+  <data name="Camp_NotSure" xml:space="preserve"><value>Non so</value></data>
+  <data name="Camp_PerformanceSpaceLabel" xml:space="preserve"><value>Spazio per performance</value></data>
+  <data name="Camp_PerformanceTypesLabel" xml:space="preserve"><value>Tipi di performance</value></data>
+  <data name="Camp_PerformanceTypesPlaceholder" xml:space="preserve"><value>es. Musica, Teatro, Workshop</value></data>
+  <data name="Camp_PlacementHeading" xml:space="preserve"><value>Posizionamento</value></data>
+  <data name="Camp_PreviousNamesHelp" xml:space="preserve"><value>Se il tuo camp ha avuto nomi diversi negli anni passati, elencali qui.</value></data>
+  <data name="Camp_PreviousNamesLabel" xml:space="preserve"><value>Nomi precedenti</value></data>
+  <data name="Camp_PreviousNamesPlaceholder" xml:space="preserve"><value>Elenco separato da virgole dei nomi precedenti del camp</value></data>
+  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Registra</value></data>
+  <data name="Camp_Register_Heading" xml:space="preserve"><value>Registra il tuo {0}</value></data>
+  <data name="Camp_Register_ImportantInfo" xml:space="preserve"><value>Informazioni importanti</value></data>
+  <data name="Camp_Register_Season" xml:space="preserve"><value>stagione</value></data>
+  <data name="Camp_Register_Submit" xml:space="preserve"><value>Registra {0}</value></data>
+  <data name="Camp_SoundZoneLabel" xml:space="preserve"><value>Preferenza zona sonora</value></data>
+  <data name="Camp_SpaceRequirementLabel" xml:space="preserve"><value>Spazio richiesto</value></data>
+  <data name="Camp_TimesParticipatingLabel" xml:space="preserve"><value>Numero di partecipazioni</value></data>
+  <data name="Camp_VibesLabel" xml:space="preserve"><value>Vibes</value></data>
+  <data name="CampCard_AcceptingMembers" xml:space="preserve"><value>Accetta membri</value></data>
+  <data name="CampCard_Full" xml:space="preserve"><value>Completo</value></data>
+  <data name="CampCard_KidsWelcome" xml:space="preserve"><value>Bambini benvenuti</value></data>
+  <data name="CampCard_TimesAtNowhere" xml:space="preserve"><value>{0} anno/i</value></data>
+  <data name="Common_Actions" xml:space="preserve"><value>Azioni</value></data>
+  <data name="Common_Admin" xml:space="preserve"><value>Admin</value></data>
+  <data name="Common_Amount" xml:space="preserve"><value>Importo</value></data>
+  <data name="Common_Clear" xml:space="preserve"><value>Cancella</value></data>
+  <data name="Common_Created" xml:space="preserve"><value>Creato</value></data>
+  <data name="Common_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="Common_DeleteImage" xml:space="preserve"><value>Elimina immagine</value></data>
+  <data name="Common_Department" xml:space="preserve"><value>Dipartimento</value></data>
+  <data name="Common_MoveDown" xml:space="preserve"><value>Sposta giù</value></data>
+  <data name="Common_MoveUp" xml:space="preserve"><value>Sposta su</value></data>
+  <data name="Common_Other" xml:space="preserve"><value>Altro</value></data>
+  <data name="Common_Preview" xml:space="preserve"><value>Anteprima</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Rimuovi</value></data>
+  <data name="Common_Required" xml:space="preserve"><value>(obbligatorio)</value></data>
+  <data name="Common_Sender" xml:space="preserve"><value>Mittente</value></data>
+  <data name="Common_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="Common_Total" xml:space="preserve"><value>Totale</value></data>
+  <data name="Common_View" xml:space="preserve"><value>Visualizza</value></data>
+  <data name="CommPrefs_AlwaysOn" xml:space="preserve"><value>Sempre attivo</value></data>
+  <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Ciao {0},&lt;/p&gt;
+&lt;p&gt;Sei invitato a completare il sondaggio &lt;strong&gt;{1}&lt;/strong&gt;. Bastano pochi minuti.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Apri il sondaggio&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Grazie,&lt;br/&gt;Il Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Completa: {0}</value></data>
+  <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
+&lt;p&gt;Ciao {0},&lt;/p&gt;
+&lt;p&gt;Solo un promemoria: il sondaggio &lt;strong&gt;{1}&lt;/strong&gt; è ancora in attesa della tua risposta.&lt;/p&gt;
+&lt;p&gt;&lt;a href="{2}"&gt;Apri il sondaggio&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Grazie,&lt;br/&gt;Il Nobodies Collective&lt;/p&gt;</value></data>
+  <data name="Email_SurveyReminder_Subject" xml:space="preserve"><value>Promemoria: {0}</value></data>
+  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Contrassegnata con {0} ma senza riga AspNetUserLogins corrispondente — si auto-corregge al prossimo accesso OAuth.</value></data>
+  <data name="EmailGrid_WorkspaceLocked" xml:space="preserve"><value>Bloccata dalla riga email Workspace</value></data>
+  <data name="Enum_AdultPlayspacePolicy_NightOnly" xml:space="preserve"><value>Solo di notte</value></data>
+  <data name="Enum_AdultPlayspacePolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_AdultPlayspacePolicy_Yes" xml:space="preserve"><value>Sì</value></data>
+  <data name="Enum_CampVibe_Adult" xml:space="preserve"><value>Adulti</value></data>
+  <data name="Enum_CampVibe_ChillOut" xml:space="preserve"><value>Chill out</value></data>
+  <data name="Enum_CampVibe_ElectronicMusic" xml:space="preserve"><value>Musica elettronica</value></data>
+  <data name="Enum_CampVibe_Games" xml:space="preserve"><value>Giochi</value></data>
+  <data name="Enum_CampVibe_Lecture" xml:space="preserve"><value>Conferenza</value></data>
+  <data name="Enum_CampVibe_LiveMusic" xml:space="preserve"><value>Musica dal vivo</value></data>
+  <data name="Enum_CampVibe_Queer" xml:space="preserve"><value>Queer</value></data>
+  <data name="Enum_CampVibe_Sober" xml:space="preserve"><value>Sobrio</value></data>
+  <data name="Enum_CampVibe_Wellness" xml:space="preserve"><value>Benessere</value></data>
+  <data name="Enum_CampVibe_Workshop" xml:space="preserve"><value>Workshop</value></data>
+  <data name="Enum_ContactFieldType_Discord" xml:space="preserve"><value>Discord</value></data>
+  <data name="Enum_ContactFieldType_Other" xml:space="preserve"><value>Altro</value></data>
+  <data name="Enum_ContactFieldType_Phone" xml:space="preserve"><value>Telefono</value></data>
+  <data name="Enum_ContactFieldType_Signal" xml:space="preserve"><value>Signal</value></data>
+  <data name="Enum_ContactFieldType_Telegram" xml:space="preserve"><value>Telegram</value></data>
+  <data name="Enum_ContactFieldType_WhatsApp" xml:space="preserve"><value>WhatsApp</value></data>
+  <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Tutti gli humans attivi</value></data>
+  <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Solo Consiglio</value></data>
+  <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinatori + Consiglio</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>I miei team (+ coordinatori e consiglio)</value></data>
+  <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
+  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Fornitura propria</value></data>
+  <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Rosso</value></data>
+  <data name="Enum_ElectricalGrid_Unknown" xml:space="preserve"><value>Sconosciuto</value></data>
+  <data name="Enum_ElectricalGrid_Yellow" xml:space="preserve"><value>Giallo</value></data>
+  <data name="Enum_EmailOutboxStatus_Failed" xml:space="preserve"><value>Fallita</value></data>
+  <data name="Enum_EmailOutboxStatus_Queued" xml:space="preserve"><value>In coda</value></data>
+  <data name="Enum_EmailOutboxStatus_Sent" xml:space="preserve"><value>Inviata</value></data>
+  <data name="Enum_EventStatus_Approved" xml:space="preserve"><value>Approvato</value></data>
+  <data name="Enum_EventStatus_Draft" xml:space="preserve"><value>Bozza</value></data>
+  <data name="Enum_EventStatus_Pending" xml:space="preserve"><value>In attesa</value></data>
+  <data name="Enum_EventStatus_Rejected" xml:space="preserve"><value>Rifiutato</value></data>
+  <data name="Enum_EventStatus_ResubmitRequested" xml:space="preserve"><value>Modifiche richieste</value></data>
+  <data name="Enum_EventStatus_Withdrawn" xml:space="preserve"><value>Ritirato</value></data>
+  <data name="Enum_ExpenseReportStatus_Approved" xml:space="preserve"><value>Approvata</value></data>
+  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Approvata dal coordinatore</value></data>
+  <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Bozza</value></data>
+  <data name="Enum_ExpenseReportStatus_Paid" xml:space="preserve"><value>Pagata</value></data>
+  <data name="Enum_ExpenseReportStatus_SepaSent" xml:space="preserve"><value>SEPA inviato</value></data>
+  <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Presentata</value></data>
+  <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Ritirata</value></data>
+  <data name="Enum_FeedbackCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_FeedbackCategory_FeatureRequest" xml:space="preserve"><value>Richiesta di funzionalità</value></data>
+  <data name="Enum_FeedbackCategory_Question" xml:space="preserve"><value>Domanda</value></data>
+  <data name="Enum_FeedbackStatus_Acknowledged" xml:space="preserve"><value>Preso in carico</value></data>
+  <data name="Enum_FeedbackStatus_Open" xml:space="preserve"><value>Aperto</value></data>
+  <data name="Enum_FeedbackStatus_Resolved" xml:space="preserve"><value>Risolto</value></data>
+  <data name="Enum_FeedbackStatus_WontFix" xml:space="preserve"><value>Non verrà risolto</value></data>
+  <data name="Enum_IssueCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_IssueCategory_Feature" xml:space="preserve"><value>Funzionalità</value></data>
+  <data name="Enum_IssueCategory_Question" xml:space="preserve"><value>Domanda</value></data>
+  <data name="Enum_KidsVisitingPolicy_DaytimeOnly" xml:space="preserve"><value>Solo di giorno</value></data>
+  <data name="Enum_KidsVisitingPolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_KidsVisitingPolicy_Yes" xml:space="preserve"><value>Sì</value></data>
+  <data name="Enum_LanguageProficiency_Basic" xml:space="preserve"><value>Base</value></data>
+  <data name="Enum_LanguageProficiency_Conversational" xml:space="preserve"><value>Conversazionale</value></data>
+  <data name="Enum_LanguageProficiency_Fluent" xml:space="preserve"><value>Fluente</value></data>
+  <data name="Enum_LanguageProficiency_Native" xml:space="preserve"><value>Madrelingua</value></data>
+  <data name="Enum_PerformanceSpaceStatus_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_PerformanceSpaceStatus_WorkingOnIt" xml:space="preserve"><value>Ci stiamo lavorando</value></data>
+  <data name="Enum_PerformanceSpaceStatus_Yes" xml:space="preserve"><value>Sì</value></data>
+  <data name="Enum_RolePeriod_Build" xml:space="preserve"><value>Montaggio</value></data>
+  <data name="Enum_RolePeriod_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="Enum_RolePeriod_Strike" xml:space="preserve"><value>Smontaggio</value></data>
+  <data name="Enum_RolePeriod_YearRound" xml:space="preserve"><value>Tutto l'anno</value></data>
+  <data name="Enum_SlotPriority_Critical" xml:space="preserve"><value>Critico</value></data>
+  <data name="Enum_SlotPriority_Important" xml:space="preserve"><value>Importante</value></data>
+  <data name="Enum_SlotPriority_NiceToHave" xml:space="preserve"><value>Gradito</value></data>
+  <data name="Enum_SlotPriority_None" xml:space="preserve"><value>Nessuna</value></data>
+  <data name="Enum_SoundZone_Blue" xml:space="preserve"><value>Blu</value></data>
+  <data name="Enum_SoundZone_Green" xml:space="preserve"><value>Verde</value></data>
+  <data name="Enum_SoundZone_Orange" xml:space="preserve"><value>Arancione</value></data>
+  <data name="Enum_SoundZone_Red" xml:space="preserve"><value>Rosso</value></data>
+  <data name="Enum_SoundZone_Surprise" xml:space="preserve"><value>Sorpresa</value></data>
+  <data name="Enum_SoundZone_Yellow" xml:space="preserve"><value>Giallo</value></data>
+  <data name="Enum_SpaceSize_Sqm1000" xml:space="preserve"><value>1000 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1200" xml:space="preserve"><value>1200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm150" xml:space="preserve"><value>150 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1500" xml:space="preserve"><value>1500 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1800" xml:space="preserve"><value>1800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2200" xml:space="preserve"><value>2200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2800" xml:space="preserve"><value>2800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm300" xml:space="preserve"><value>300 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm450" xml:space="preserve"><value>450 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm600" xml:space="preserve"><value>600 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm800" xml:space="preserve"><value>800 m²</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Camp" xml:space="preserve"><value>Camp</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Team" xml:space="preserve"><value>Team</value></data>
+  <data name="Enum_TicketTransferStatus_Approved" xml:space="preserve"><value>Completato</value></data>
+  <data name="Enum_TicketTransferStatus_Cancelled" xml:space="preserve"><value>Annullato</value></data>
+  <data name="Enum_TicketTransferStatus_Pending" xml:space="preserve"><value>In attesa di revisione</value></data>
+  <data name="Enum_TicketTransferStatus_Rejected" xml:space="preserve"><value>Annullato dal team</value></data>
+  <data name="Enum_YesNoMaybe_Maybe" xml:space="preserve"><value>Forse</value></data>
+  <data name="Enum_YesNoMaybe_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_YesNoMaybe_Yes" xml:space="preserve"><value>Sì</value></data>
+  <data name="Events_AddBarrioEvent" xml:space="preserve"><value>Aggiungi evento del barrio</value></data>
+  <data name="Events_AddToFavourites" xml:space="preserve"><value>Aggiungi ai preferiti</value></data>
+  <data name="Events_AllCategories" xml:space="preserve"><value>Tutte le categorie</value></data>
+  <data name="Events_AllTimesIn" xml:space="preserve"><value>Tutti gli orari in {0}. Potrebbe valere il Playa Time!</value></data>
+  <data name="Events_AllTimesInShort" xml:space="preserve"><value>Tutti gli orari in {0}</value></data>
+  <data name="Events_AllVenues" xml:space="preserve"><value>Tutti i luoghi</value></data>
+  <data name="Events_BrowseTitle" xml:space="preserve"><value>Sfoglia gli eventi</value></data>
+  <data name="Events_ColActions" xml:space="preserve"><value>Azioni</value></data>
+  <data name="Events_ColCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Events_ColDateTime" xml:space="preserve"><value>Data e ora</value></data>
+  <data name="Events_ColEventName" xml:space="preserve"><value>Nome evento</value></data>
+  <data name="Events_ColPriority" xml:space="preserve"><value>Priorità</value></data>
+  <data name="Events_ConflictBadge" xml:space="preserve"><value>Sovrapposizione di orario con un altro evento preferito</value></data>
+  <data name="Events_DownloadCsv" xml:space="preserve"><value>Scarica CSV eventi</value></data>
+  <data name="Events_DurationMin" xml:space="preserve"><value>{0} min</value></data>
+  <data name="Events_FavouritesOnly" xml:space="preserve"><value>Solo</value></data>
+  <data name="Events_FilterCategory" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Events_FilterDay" xml:space="preserve"><value>Giorno</value></data>
+  <data name="Events_FilterSearch" xml:space="preserve"><value>Cerca</value></data>
+  <data name="Events_FilterVenue" xml:space="preserve"><value>Luogo</value></data>
+  <data name="Events_MyPersonalEvents" xml:space="preserve"><value>I miei eventi personali</value></data>
+  <data name="Events_MySchedule" xml:space="preserve"><value>Il mio programma</value></data>
+  <data name="Events_MySubmissions" xml:space="preserve"><value>Le mie proposte</value></data>
+  <data name="Events_MySubmissionsTitle" xml:space="preserve"><value>Le mie proposte di evento</value></data>
+  <data name="Events_NoBarrioEvents" xml:space="preserve"><value>Nessun evento ancora proposto per questo barrio.</value></data>
+  <data name="Events_NoEventsFound" xml:space="preserve"><value>Nessun evento trovato. Prova a modificare i filtri.</value></data>
+  <data name="Events_NoPersonalEvents" xml:space="preserve"><value>Non hai ancora proposto eventi personali.</value></data>
+  <data name="Events_RemoveFromFavourites" xml:space="preserve"><value>Rimuovi dai preferiti</value></data>
+  <data name="Events_RemoveFromSchedule" xml:space="preserve"><value>Rimuovi dal programma</value></data>
+  <data name="Events_RemoveFromScheduleConfirm" xml:space="preserve"><value>Rimuovere questo evento dal tuo programma?</value></data>
+  <data name="Events_ScheduleEmpty" xml:space="preserve"><value>Non hai ancora aggiunto eventi ai preferiti. Sfoglia la {0} per aggiungere eventi al tuo programma.</value></data>
+  <data name="Events_ScheduleEmptyLink" xml:space="preserve"><value>guida agli eventi</value></data>
+  <data name="Events_ScheduleTitle" xml:space="preserve"><value>Il mio programma</value></data>
+  <data name="Events_SearchPlaceholder" xml:space="preserve"><value>Cerca per titolo o descrizione…</value></data>
+  <data name="Events_StatApproved" xml:space="preserve"><value>Approvati</value></data>
+  <data name="Events_StatPending" xml:space="preserve"><value>In attesa</value></data>
+  <data name="Events_StatSubmitted" xml:space="preserve"><value>Proposti</value></data>
+  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Finestra per le proposte:</value></data>
+  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>La finestra per le proposte non è attualmente aperta. Contatta un admin per configurare le impostazioni della guida.</value></data>
+  <data name="Events_SubmitNewEvent" xml:space="preserve"><value>Proponi un nuovo evento</value></data>
+  <data name="Events_UploadColErrors" xml:space="preserve"><value>Errori</value></data>
+  <data name="Events_UploadColEvent" xml:space="preserve"><value>Evento</value></data>
+  <data name="Events_UploadColRow" xml:space="preserve"><value>Riga</value></data>
+  <data name="Events_UploadCsv" xml:space="preserve"><value>Carica CSV</value></data>
+  <data name="Events_UploadFailed" xml:space="preserve"><value>Caricamento fallito.</value></data>
+  <data name="Events_UploadFailedDetail" xml:space="preserve"><value>Correggi gli errori qui sotto e riprova. Nessun evento è stato salvato.</value></data>
+  <data name="Events_WithdrawConfirm" xml:space="preserve"><value>Ritirare questo evento?</value></data>
+  <data name="Expenses_ColReport" xml:space="preserve"><value>Nota</value></data>
+  <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Presentata</value></data>
+  <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Presentata da</value></data>
+  <data name="Expenses_CoordinatorQueue" xml:space="preserve"><value>Coda del coordinatore</value></data>
+  <data name="Expenses_CoordinatorQueueTitle" xml:space="preserve"><value>Note spese — Coda del coordinatore</value></data>
+  <data name="Expenses_Endorse" xml:space="preserve"><value>Approva</value></data>
+  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Approvare questa nota spese?</value></data>
+  <data name="Expenses_FileFirst" xml:space="preserve"><value>Presenta la tua prima nota</value></data>
+  <data name="Expenses_IouHeader" xml:space="preserve"><value>Quanto il collettivo ti deve</value></data>
+  <data name="Expenses_IouLastPayment" xml:space="preserve"><value>Ultimo pagamento</value></data>
+  <data name="Expenses_IouOtherAmountNote" xml:space="preserve"><value>Il tuo saldo Holded include {0} non collegati a queste note (spese anticipate per conto del collettivo, rettifiche, ecc.), quindi le righe qui sotto non corrispondono necessariamente alla somma.</value></data>
+  <data name="Expenses_IouOwed" xml:space="preserve"><value>Dovuto a te (saldo Holded)</value></data>
+  <data name="Expenses_IouPaid" xml:space="preserve"><value>Pagato finora</value></data>
+  <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Voce</value></data>
+  <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Le mie note spese</value></data>
+  <data name="Expenses_NewReport" xml:space="preserve"><value>Nuova nota</value></data>
+  <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Al momento non c'è alcun anno di budget attivo. Le note spese non possono essere presentate finché un anno di budget non viene attivato.</value></data>
+  <data name="Expenses_NoIban" xml:space="preserve"><value>Non hai ancora impostato il tuo IBAN per i pagamenti. Ti verrà chiesto di impostarlo quando presenti una nota.</value></data>
+  <data name="Expenses_NoReports" xml:space="preserve"><value>Ancora nessuna nota spese.</value></data>
+  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Nessuna nota in attesa della tua approvazione.</value></data>
+  <data name="Expenses_Reject" xml:space="preserve"><value>Rifiuta</value></data>
+  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>Chi ha presentato la nota vedrà questo motivo. Spiega chiaramente perché la nota non può essere approvata.</value></data>
+  <data name="Expenses_RejectModalTitle" xml:space="preserve"><value>Rifiuta nota</value></data>
+  <data name="Expenses_RejectReasonLabel" xml:space="preserve"><value>Motivo del rifiuto</value></data>
+  <data name="Expenses_RejectReasonPlaceholder" xml:space="preserve"><value>es. Ricevute mancanti per la riga 2</value></data>
+  <data name="Feedback_AssignedToName" xml:space="preserve"><value>Assegnato a {0}</value></data>
+  <data name="Feedback_CategoryOnPage" xml:space="preserve"><value>{0} su {1}</value></data>
+  <data name="Feedback_TeamName" xml:space="preserve"><value>Team: {0}</value></data>
+  <data name="Issue_ColComments" xml:space="preserve"><value>Commenti</value></data>
+  <data name="Issue_ColReporter" xml:space="preserve"><value>Segnalatore</value></data>
+  <data name="Issue_ColStatus" xml:space="preserve"><value>Stato</value></data>
+  <data name="Issue_ColTitle" xml:space="preserve"><value>Titolo</value></data>
+  <data name="Issue_ColUpdated" xml:space="preserve"><value>Aggiornata</value></data>
+  <data name="Issue_CountSummary" xml:space="preserve"><value>{0} aperte · {1} totali</value></data>
+  <data name="LinkedAccounts_Account" xml:space="preserve"><value>Account</value></data>
+  <data name="LinkedAccounts_Actions" xml:space="preserve"><value>Azioni</value></data>
+  <data name="LinkedAccounts_ConfirmUnlink" xml:space="preserve"><value>Scollegare questo account? Non potrai più usarlo per accedere.</value></data>
+  <data name="LinkedAccounts_Description" xml:space="preserve"><value>Provider OAuth attualmente collegati al tuo account. Puoi usare uno qualsiasi di questi per accedere.</value></data>
+  <data name="LinkedAccounts_Empty" xml:space="preserve"><value>Nessun account OAuth collegato.</value></data>
+  <data name="LinkedAccounts_LastSignInMethod" xml:space="preserve"><value>Unico metodo di accesso — non scollegabile.</value></data>
+  <data name="LinkedAccounts_LinkedOn" xml:space="preserve"><value>Collegato il</value></data>
+  <data name="LinkedAccounts_Provider" xml:space="preserve"><value>Provider</value></data>
+  <data name="LinkedAccounts_Title" xml:space="preserve"><value>Account collegati</value></data>
+  <data name="LinkedAccounts_UnlinkBlockedLastSignInMethod" xml:space="preserve"><value>Impossibile scollegare — è il tuo unico metodo di accesso rimasto.</value></data>
+  <data name="MarkdownHelp_Bold" xml:space="preserve"><value>grassetto</value></data>
+  <data name="MarkdownHelp_ColYouGet" xml:space="preserve"><value>Ottieni</value></data>
+  <data name="MarkdownHelp_ColYouType" xml:space="preserve"><value>Tu scrivi</value></data>
+  <data name="MarkdownHelp_EmbeddedImage" xml:space="preserve"><value>immagine incorporata</value></data>
+  <data name="MarkdownHelp_First" xml:space="preserve"><value>primo</value></data>
+  <data name="MarkdownHelp_Heading1" xml:space="preserve"><value>Titolo 1</value></data>
+  <data name="MarkdownHelp_Heading2" xml:space="preserve"><value>Titolo 2</value></data>
+  <data name="MarkdownHelp_InlineCode" xml:space="preserve"><value>codice inline</value></data>
+  <data name="MarkdownHelp_Intro" xml:space="preserve"><value>Markdown è un modo semplice per formattare il testo. Scrivi la sintassi a sinistra e viene resa come mostrato a destra.</value></data>
+  <data name="MarkdownHelp_Italic" xml:space="preserve"><value>corsivo</value></data>
+  <data name="MarkdownHelp_ItemOne" xml:space="preserve"><value>primo elemento</value></data>
+  <data name="MarkdownHelp_ItemTwo" xml:space="preserve"><value>secondo elemento</value></data>
+  <data name="MarkdownHelp_LinkText" xml:space="preserve"><value>testo del link</value></data>
+  <data name="MarkdownHelp_QuoteText" xml:space="preserve"><value>testo della citazione</value></data>
+  <data name="MarkdownHelp_Second" xml:space="preserve"><value>secondo</value></data>
+  <data name="MarkdownHelp_Strikethrough" xml:space="preserve"><value>barrato</value></data>
+  <data name="MarkdownHelp_TableAdmin" xml:space="preserve"><value>Admin</value></data>
+  <data name="MarkdownHelp_TableHuman" xml:space="preserve"><value>Human</value></data>
+  <data name="MarkdownHelp_TableName" xml:space="preserve"><value>Nome</value></data>
+  <data name="MarkdownHelp_TableRole" xml:space="preserve"><value>Ruolo</value></data>
+  <data name="MarkdownHelp_TablesHeading" xml:space="preserve"><value>Tabelle</value></data>
+  <data name="MarkdownHelp_TaskDone" xml:space="preserve"><value>Fatto</value></data>
+  <data name="MarkdownHelp_TaskListsHeading" xml:space="preserve"><value>Elenchi di attività</value></data>
+  <data name="MarkdownHelp_TaskToDo" xml:space="preserve"><value>Da fare</value></data>
+  <data name="MarkdownHelp_Title" xml:space="preserve"><value>Guida rapida a Markdown</value></data>
+  <data name="Onboarding_BurnerNameExplainer" xml:space="preserve"><value>Il nome che tutti nel sistema vedono. L'unicità aiuta ma non è obbligatoria, anche se potrebbe essere difficile trovare "Bob" tra le diverse migliaia di humans qui se qualcuno ti sta cercando.</value></data>
+  <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>Il nome con cui tutti ti conosceranno.</value></data>
+  <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
+  <data name="Onboarding_Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>non</value></data>
+  <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>esportiamo queste informazioni, e le divulgheremmo solo se richiesto dalla legge o da un audit formale.</value></data>
+  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Conservato internamente, visibile solo agli Admin e usato solo dove lo richiede la legge spagnola — per esempio, il nostro registro di audit attestante che hai accettato l'Accordo del Volontario in una data e ora specifiche. Esplicitamente</value></data>
+  <data name="Onboarding_LegalNameLabel" xml:space="preserve"><value>Nome legale</value></data>
+  <data name="Onboarding_NameRequiredBeforeShifts" xml:space="preserve"><value>Aggiungi prima il tuo nome — ci serve prima che tu possa iscriverti ai turni.</value></data>
+  <data name="Onboarding_NamesSubtitle" xml:space="preserve"><value>Due brevi passaggi prima di scegliere un turno.</value></data>
+  <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Benvenuto — iniziamo dal tuo nome</value></data>
+  <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critico</value></data>
+  <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Importante</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'evento ha riempito solo il {0}% dei turni "critici". Se non vengono riempiti, l'evento potrebbe essere annullato perché non sarebbe sostenibile o sicuro organizzarlo.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Se riesci a riempirne alcuni, o se puoi venire prima dell'evento o restare per lo smontaggio, dai priorità a questi quando scegli i tuoi turni.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANTE:</value></data>
+  <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Ci sono anche {0} turni "importanti" aperti.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Ci sono {0} turni "importanti" aperti. Se puoi venire prima dell'evento o restare per lo smontaggio, dai priorità a questi.</value></data>
+  <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Nessun evento attivo al momento. Puoi completare l'onboarding senza scegliere un turno.</value></data>
+  <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Nessun turno critico aperto al momento — prova Importanti o Tutti.</value></data>
+  <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Nessun turno importante aperto al momento — prova Tutti.</value></data>
+  <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Non adesso</value></data>
+  <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Scegli un turno</value></data>
+  <data name="Outbox_AdminTitle" xml:space="preserve"><value>Email</value></data>
+  <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Torna ad Amministrazione</value></data>
+  <data name="Outbox_BackToProfile" xml:space="preserve"><value>Torna al Profilo</value></data>
+  <data name="Outbox_DescriptionAdmin" xml:space="preserve"><value>Email che il sistema ha inviato a questo human.</value></data>
+  <data name="Outbox_DescriptionSelf" xml:space="preserve"><value>Email che il sistema ti ha inviato (negli ultimi 150 giorni).</value></data>
+  <data name="Outbox_Empty" xml:space="preserve"><value>Nessuna email registrata.</value></data>
+  <data name="Outbox_Subject" xml:space="preserve"><value>Oggetto</value></data>
+  <data name="Privacy_ThirdParty_GooglePolicyLink" xml:space="preserve"><value>Informativa sulla privacy di Google</value></data>
+  <data name="Profile_Assigned" xml:space="preserve"><value>Assegnato</value></data>
+  <data name="Profile_Campaign" xml:space="preserve"><value>Campagna</value></data>
+  <data name="Profile_Code" xml:space="preserve"><value>Codice</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Dairy" xml:space="preserve"><value>Latticini</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Egg" xml:space="preserve"><value>Uova</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Peanut" xml:space="preserve"><value>Arachidi</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Sesame" xml:space="preserve"><value>Sesamo</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Shellfish" xml:space="preserve"><value>Crostacei</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Soy" xml:space="preserve"><value>Soia</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Treenut" xml:space="preserve"><value>Frutta a guscio</value></data>
+  <data name="Profile_DietaryMedical_Allergy_WheatGluten" xml:space="preserve"><value>Frumento/Glutine</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_FODMAP" xml:space="preserve"><value>FODMAP</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Gluten" xml:space="preserve"><value>Glutine</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Histamine" xml:space="preserve"><value>Istamina</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Lactose" xml:space="preserve"><value>Lattosio</value></data>
+  <data name="Profile_MarkedAt" xml:space="preserve"><value>Segnato il</value></data>
+  <data name="Profile_MarkedBy" xml:space="preserve"><value>Segnato da</value></data>
+  <data name="Profile_MyCodes" xml:space="preserve"><value>I miei codici</value></data>
+  <data name="Profile_MyEmails" xml:space="preserve"><value>Le mie email</value></data>
+  <data name="Profile_NoSentMessages" xml:space="preserve"><value>Nessun messaggio sulla piattaforma registrato.</value></data>
+  <data name="Profile_NoShowHistory" xml:space="preserve"><value>Cronologia assenze ({0})</value></data>
+  <data name="Profile_OnsiteSince" xml:space="preserve"><value>Sul posto da {0}</value></data>
+  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Registrato all'ingresso</value></data>
+  <data name="Profile_Redeemed" xml:space="preserve"><value>Riscattato</value></data>
+  <data name="Profile_SentMessages" xml:space="preserve"><value>Messaggi inviati ({0})</value></data>
+  <data name="Profile_ShiftInfo" xml:space="preserve"><value>Info turno</value></data>
+  <data name="ProfileEdit_CityPlaceholder" xml:space="preserve"><value>Inizia a scrivere la tua città…</value></data>
+  <data name="ProfileEdit_ContactType" xml:space="preserve"><value>Tipo</value></data>
+  <data name="ProfileEdit_ContactValue" xml:space="preserve"><value>Valore</value></data>
+  <data name="ProfileEdit_ContactValuePlaceholder" xml:space="preserve"><value>Inserisci le informazioni di contatto</value></data>
+  <data name="ProfileEdit_ContactVisibility" xml:space="preserve"><value>Visibilità</value></data>
+  <data name="ProfileEdit_CustomLabelPlaceholder" xml:space="preserve"><value>es. Discord</value></data>
+  <data name="ProfileEdit_Description" xml:space="preserve"><value>Descrizione</value></data>
+  <data name="ProfileEdit_DescriptionPlaceholder" xml:space="preserve"><value>es. Gate Lead</value></data>
+  <data name="ProfileEdit_EventName" xml:space="preserve"><value>Nome evento</value></data>
+  <data name="ProfileEdit_EventNamePlaceholder" xml:space="preserve"><value>es. Burning Man 2024</value></data>
+  <data name="ProfileEdit_LanguageLabel" xml:space="preserve"><value>Lingua</value></data>
+  <data name="ProfileEdit_ProficiencyLabel" xml:space="preserve"><value>Livello</value></data>
+  <data name="ProfileEdit_RelationshipPlaceholder" xml:space="preserve"><value>es. Partner, Genitore</value></data>
+  <data name="ProfileEdit_RemoveContactField" xml:space="preserve"><value>Rimuovi questo campo di contatto</value></data>
+  <data name="ProfileEdit_RemoveEntry" xml:space="preserve"><value>Rimuovi questa voce</value></data>
+  <data name="ProfileEdit_RemoveLanguage" xml:space="preserve"><value>Rimuovi questa lingua</value></data>
+  <data name="ProfileEdit_SelectLanguage" xml:space="preserve"><value>— Seleziona lingua —</value></data>
+  <data name="Roster_All" xml:space="preserve"><value>Tutti</value></data>
+  <data name="Roster_ColAssignedTo" xml:space="preserve"><value>Assegnato a</value></data>
+  <data name="Roster_ColPeriod" xml:space="preserve"><value>Periodo</value></data>
+  <data name="Roster_ColPriority" xml:space="preserve"><value>Priorità</value></data>
+  <data name="Roster_ColRole" xml:space="preserve"><value>Ruolo</value></data>
+  <data name="Roster_ColSlot" xml:space="preserve"><value>Slot</value></data>
+  <data name="Roster_ColTeam" xml:space="preserve"><value>Team</value></data>
+  <data name="Roster_NoSlots" xml:space="preserve"><value>Nessuno slot di ruolo definito nei team.</value></data>
+  <data name="Roster_PeriodFilter" xml:space="preserve"><value>Periodo: {0}</value></data>
+  <data name="Roster_PriorityFilter" xml:space="preserve"><value>Priorità: {0}</value></data>
+  <data name="Roster_SlotOpen" xml:space="preserve"><value>Aperto</value></data>
+  <data name="Roster_StatusFilled" xml:space="preserve"><value>Occupato</value></data>
+  <data name="Roster_StatusFilter" xml:space="preserve"><value>Stato: {0}</value></data>
+  <data name="Roster_StatusOpen" xml:space="preserve"><value>Aperto</value></data>
+  <data name="Roster_Title" xml:space="preserve"><value>Elenco del team</value></data>
+  <data name="Search_FilterAll" xml:space="preserve"><value>Tutti</value></data>
+  <data name="Search_FilterCamps" xml:space="preserve"><value>Camp</value></data>
+  <data name="Search_FilterEvents" xml:space="preserve"><value>Eventi</value></data>
+  <data name="Search_FilterHumans" xml:space="preserve"><value>Humans</value></data>
+  <data name="Search_FilterShifts" xml:space="preserve"><value>Turni</value></data>
+  <data name="Search_FilterTeams" xml:space="preserve"><value>Team</value></data>
+  <data name="Search_GlobalHint" xml:space="preserve"><value>Scrivi almeno 2 caratteri per cercare tra humans, team, camp e turni.</value></data>
+  <data name="Search_GlobalHintEvents" xml:space="preserve"><value>Scrivi almeno 2 caratteri per cercare tra humans, team, camp, turni ed eventi.</value></data>
+  <data name="Search_GlobalNoResults" xml:space="preserve"><value>Nessun risultato per {0}.</value></data>
+  <data name="Search_GlobalPlaceholder" xml:space="preserve"><value>Cerca humans, team, camp, turni…</value></data>
+  <data name="Search_GlobalPlaceholderEvents" xml:space="preserve"><value>Cerca humans, team, camp, turni, eventi…</value></data>
+  <data name="Search_GlobalTitle" xml:space="preserve"><value>Cerca</value></data>
+  <data name="Store_AdminCatalog" xml:space="preserve"><value>Catalogo</value></data>
+  <data name="Store_AdminPayments" xml:space="preserve"><value>Pagamenti</value></data>
+  <data name="Store_AdminSummary" xml:space="preserve"><value>Riepilogo</value></data>
+  <data name="Store_CatalogHeading" xml:space="preserve"><value>Catalogo ({0})</value></data>
+  <data name="Store_ColBalance" xml:space="preserve"><value>Saldo</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Deposito</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Depositi</value></data>
+  <data name="Store_ColDescription" xml:space="preserve"><value>Descrizione</value></data>
+  <data name="Store_ColLines" xml:space="preserve"><value>Righe</value></data>
+  <data name="Store_ColLinesVat" xml:space="preserve"><value>Righe + IVA</value></data>
+  <data name="Store_ColName" xml:space="preserve"><value>Nome</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Ordina per</value></data>
+  <data name="Store_ColState" xml:space="preserve"><value>Stato</value></data>
+  <data name="Store_ColUnitPrice" xml:space="preserve"><value>Prezzo unitario (IVA incl.)</value></data>
+  <data name="Store_CreateOrder" xml:space="preserve"><value>Crea ordine</value></data>
+  <data name="Store_DeleteOrderConfirm" xml:space="preserve"><value>Eliminare questo ordine con saldo zero? L'operazione non può essere annullata.</value></data>
+  <data name="Store_DeleteOrderTitle" xml:space="preserve"><value>Elimina (saldo zero)</value></data>
+  <data name="Store_NoCounterpartiesAlert" xml:space="preserve"><value>Non sei lead di alcun camp né coordini alcun dipartimento con una stagione attiva quest'anno. Il catalogo qui sotto è in sola lettura.</value></data>
+  <data name="Store_NoOrders" xml:space="preserve"><value>Ancora nessun ordine.</value></data>
+  <data name="Store_NoProducts" xml:space="preserve"><value>Nessun prodotto attivo per {0}.</value></data>
+  <data name="Store_OpenOrder" xml:space="preserve"><value>Apri</value></data>
+  <data name="Store_StartOrder" xml:space="preserve"><value>Avvia ordine</value></data>
+  <data name="Store_Title" xml:space="preserve"><value>Store</value></data>
+  <data name="Teams_Departments" xml:space="preserve"><value>Dipartimenti</value></data>
+  <data name="Teams_HiddenTeams" xml:space="preserve"><value>Team nascosti</value></data>
+  <data name="Teams_HiddenTeamsNote" xml:space="preserve"><value>(visibile solo agli admin)</value></data>
+  <data name="Teams_Summary" xml:space="preserve"><value>Riepilogo</value></data>
+  <data name="Teams_SyncStatus" xml:space="preserve"><value>Stato sincronizzazione</value></data>
+  <data name="Teams_SystemTeams" xml:space="preserve"><value>Team di sistema</value></data>
+  <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Trasferimento già in sospeso</value></data>
+  <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Annulla richiesta</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Già registrato — non può essere trasferito</value></data>
+  <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>Questo richiederà il trasferimento del biglietto {0} ({1}) a {2}.</value></data>
+  <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>Il nostro team biglietti lo elaborerà e ti farà sapere a breve.</value></data>
+  <data name="TicketTransfer_Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="TicketTransfer_NoneTransferable" xml:space="preserve"><value>Nessuno dei tuoi biglietti può essere trasferito in questo momento.</value></data>
+  <data name="TicketTransfer_NoRequests" xml:space="preserve"><value>Non hai richiesto alcun trasferimento.</value></data>
+  <data name="TicketTransfer_NoTickets" xml:space="preserve"><value>Non hai biglietti da trasferire.</value></data>
+  <data name="TicketTransfer_NotTransferable" xml:space="preserve"><value>Non trasferibile</value></data>
+  <data name="TicketTransfer_ReasonLabel" xml:space="preserve"><value>Motivo del trasferimento (facoltativo, visibile al team biglietti)</value></data>
+  <data name="TicketTransfer_RecipientPlaceholder" xml:space="preserve"><value>Cerca per nome, o incolla la sua email esatta…</value></data>
+  <data name="TicketTransfer_Requested" xml:space="preserve"><value>Richiesto</value></data>
+  <data name="TicketTransfer_RequestTransfer" xml:space="preserve"><value>Richiedi trasferimento</value></data>
+  <data name="TicketTransfer_StatusApproved" xml:space="preserve"><value>Completato</value></data>
+  <data name="TicketTransfer_StatusCancelled" xml:space="preserve"><value>Annullato</value></data>
+  <data name="TicketTransfer_StatusRejected" xml:space="preserve"><value>Annullato dal team</value></data>
+  <data name="TicketTransfer_Step1" xml:space="preserve"><value>1. Scegli il biglietto da trasferire</value></data>
+  <data name="TicketTransfer_Step2" xml:space="preserve"><value>2. A chi lo stai inviando?</value></data>
+  <data name="TicketTransfer_Step3" xml:space="preserve"><value>3. Conferma</value></data>
+  <data name="TicketTransfer_Title" xml:space="preserve"><value>Trasferisci un biglietto</value></data>
+  <data name="TicketTransfer_YourRequests" xml:space="preserve"><value>Le tue richieste di trasferimento</value></data>
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -6076,9 +6076,9 @@
   <data name="About_Staff_Intro" xml:space="preserve"><value>Ogni collettivo ha bisogno dei suoi custodi. Questi sono gli humans che dedicano il loro tempo e la loro energia per far funzionare Nobodies — dalla governance al supporto tecnico, dalla trust and safety all'alchimia dei biglietti.</value></data>
   <data name="About_Staff_Title" xml:space="preserve"><value>Gli humans dietro le quinte</value></data>
   <data name="About_Title" xml:space="preserve"><value>Informazioni su Humans</value></data>
-  <data name="AccountStatus_ConsentSuspendedBody" xml:space="preserve"><value>Il Suo accesso è sospeso finché non completa i consensi legali richiesti.</value></data>
+  <data name="AccountStatus_ConsentSuspendedBody" xml:space="preserve"><value>Il Suo accesso è sospeso finché non avrà completato i consensi legali richiesti.</value></data>
   <data name="AccountStatus_HeadingAdminSuspended" xml:space="preserve"><value>Il Suo account è stato sospeso da un amministratore</value></data>
-  <data name="AccountStatus_ReviewConsents" xml:space="preserve"><value>Esamina i consensi richiesti</value></data>
+  <data name="AccountStatus_ReviewConsents" xml:space="preserve"><value>Esamini i consensi richiesti</value></data>
   <data name="Budget_ColAmount" xml:space="preserve"><value>Importo (€)</value></data>
   <data name="Budget_ColCategory" xml:space="preserve"><value>Categoria</value></data>
   <data name="Budget_ColShare" xml:space="preserve"><value>Quota</value></data>
@@ -6192,7 +6192,7 @@
   <data name="Camp_HistoryHeading" xml:space="preserve"><value>Storia</value></data>
   <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Accetta membri</value></data>
   <data name="Camp_Index_AllOption" xml:space="preserve"><value>Tutti</value></data>
-  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guida ai Barrios 2026</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Guida ai Barrio 2026</value></data>
   <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filtra</value></data>
   <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Bambini benvenuti</value></data>
   <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>Nessun {0} trovato per i filtri selezionati.</value></data>
@@ -6220,7 +6220,7 @@
   <data name="Camp_PreviousNamesHelp" xml:space="preserve"><value>Se il tuo camp ha avuto nomi diversi negli anni passati, elencali qui.</value></data>
   <data name="Camp_PreviousNamesLabel" xml:space="preserve"><value>Nomi precedenti</value></data>
   <data name="Camp_PreviousNamesPlaceholder" xml:space="preserve"><value>Elenco separato da virgole dei nomi precedenti del camp</value></data>
-  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Registra</value></data>
+  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Registrazione</value></data>
   <data name="Camp_Register_Heading" xml:space="preserve"><value>Registra il tuo {0}</value></data>
   <data name="Camp_Register_ImportantInfo" xml:space="preserve"><value>Informazioni importanti</value></data>
   <data name="Camp_Register_Season" xml:space="preserve"><value>stagione</value></data>
@@ -6288,7 +6288,7 @@
   <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>Tutti gli humans attivi</value></data>
   <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Solo Consiglio</value></data>
   <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinatori + Consiglio</value></data>
-  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>I miei team (+ coordinatori e consiglio)</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>I miei team (+ coordinatori e Consiglio)</value></data>
   <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
   <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Fornitura propria</value></data>
   <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Rosso</value></data>
@@ -6304,7 +6304,7 @@
   <data name="Enum_EventStatus_ResubmitRequested" xml:space="preserve"><value>Modifiche richieste</value></data>
   <data name="Enum_EventStatus_Withdrawn" xml:space="preserve"><value>Ritirato</value></data>
   <data name="Enum_ExpenseReportStatus_Approved" xml:space="preserve"><value>Approvata</value></data>
-  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Approvata dal coordinatore</value></data>
+  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Avallata dal coordinatore</value></data>
   <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Bozza</value></data>
   <data name="Enum_ExpenseReportStatus_Paid" xml:space="preserve"><value>Pagata</value></data>
   <data name="Enum_ExpenseReportStatus_SepaSent" xml:space="preserve"><value>SEPA inviato</value></data>
@@ -6416,8 +6416,8 @@
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Presentata da</value></data>
   <data name="Expenses_CoordinatorQueue" xml:space="preserve"><value>Coda del coordinatore</value></data>
   <data name="Expenses_CoordinatorQueueTitle" xml:space="preserve"><value>Note spese — Coda del coordinatore</value></data>
-  <data name="Expenses_Endorse" xml:space="preserve"><value>Approva</value></data>
-  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Approvare questa nota spese?</value></data>
+  <data name="Expenses_Endorse" xml:space="preserve"><value>Avalla</value></data>
+  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Avallare questa nota spese?</value></data>
   <data name="Expenses_FileFirst" xml:space="preserve"><value>Presenta la tua prima nota</value></data>
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Quanto il collettivo ti deve</value></data>
   <data name="Expenses_IouLastPayment" xml:space="preserve"><value>Ultimo pagamento</value></data>
@@ -6430,9 +6430,9 @@
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Al momento non c'è alcun anno di budget attivo. Le note spese non possono essere presentate finché un anno di budget non viene attivato.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Non hai ancora impostato il tuo IBAN per i pagamenti. Ti verrà chiesto di impostarlo quando presenti una nota.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Ancora nessuna nota spese.</value></data>
-  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Nessuna nota in attesa della tua approvazione.</value></data>
+  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Nessuna nota in attesa del tuo avallo.</value></data>
   <data name="Expenses_Reject" xml:space="preserve"><value>Rifiuta</value></data>
-  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>Chi ha presentato la nota vedrà questo motivo. Spiega chiaramente perché la nota non può essere approvata.</value></data>
+  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>Chi ha presentato la nota vedrà questo motivo. Spiega chiaramente perché la nota non può essere avallata.</value></data>
   <data name="Expenses_RejectModalTitle" xml:space="preserve"><value>Rifiuta nota</value></data>
   <data name="Expenses_RejectReasonLabel" xml:space="preserve"><value>Motivo del rifiuto</value></data>
   <data name="Expenses_RejectReasonPlaceholder" xml:space="preserve"><value>es. Ricevute mancanti per la riga 2</value></data>
@@ -6486,7 +6486,7 @@
   <data name="Onboarding_Continue" xml:space="preserve"><value>Continua</value></data>
   <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>non</value></data>
   <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>esportiamo queste informazioni, e le divulgheremmo solo se richiesto dalla legge o da un audit formale.</value></data>
-  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Conservato internamente, visibile solo agli Admin e usato solo dove lo richiede la legge spagnola — per esempio, il nostro registro di audit attestante che hai accettato l'Accordo del Volontario in una data e ora specifiche. Esplicitamente</value></data>
+  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Conservato internamente, visibile solo agli Admin e usato solo dove lo richiede la legge spagnola — per esempio, il nostro registro di audit attestante che hai accettato l'Accordo di volontariato in una data e ora specifiche. Esplicitamente</value></data>
   <data name="Onboarding_LegalNameLabel" xml:space="preserve"><value>Nome legale</value></data>
   <data name="Onboarding_NameRequiredBeforeShifts" xml:space="preserve"><value>Aggiungi prima il tuo nome — ci serve prima che tu possa iscriverti ai turni.</value></data>
   <data name="Onboarding_NamesSubtitle" xml:space="preserve"><value>Due brevi passaggi prima di scegliere un turno.</value></data>
@@ -6533,7 +6533,7 @@
   <data name="Profile_NoSentMessages" xml:space="preserve"><value>Nessun messaggio sulla piattaforma registrato.</value></data>
   <data name="Profile_NoShowHistory" xml:space="preserve"><value>Cronologia assenze ({0})</value></data>
   <data name="Profile_OnsiteSince" xml:space="preserve"><value>Sul posto da {0}</value></data>
-  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Registrato all'ingresso</value></data>
+  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Check-in effettuato al gate</value></data>
   <data name="Profile_Redeemed" xml:space="preserve"><value>Riscattato</value></data>
   <data name="Profile_SentMessages" xml:space="preserve"><value>Messaggi inviati ({0})</value></data>
   <data name="Profile_ShiftInfo" xml:space="preserve"><value>Info turno</value></data>
@@ -6592,7 +6592,7 @@
   <data name="Store_ColLines" xml:space="preserve"><value>Righe</value></data>
   <data name="Store_ColLinesVat" xml:space="preserve"><value>Righe + IVA</value></data>
   <data name="Store_ColName" xml:space="preserve"><value>Nome</value></data>
-  <data name="Store_ColOrderBy" xml:space="preserve"><value>Ordina per</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Ordina entro il</value></data>
   <data name="Store_ColState" xml:space="preserve"><value>Stato</value></data>
   <data name="Store_ColUnitPrice" xml:space="preserve"><value>Prezzo unitario (IVA incl.)</value></data>
   <data name="Store_CreateOrder" xml:space="preserve"><value>Crea ordine</value></data>
@@ -6612,7 +6612,7 @@
   <data name="Teams_SystemTeams" xml:space="preserve"><value>Team di sistema</value></data>
   <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Trasferimento già in sospeso</value></data>
   <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Annulla richiesta</value></data>
-  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Già registrato — non può essere trasferito</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Check-in già effettuato — non può essere trasferito</value></data>
   <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>Questo richiederà il trasferimento del biglietto {0} ({1}) a {2}.</value></data>
   <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>Il nostro team biglietti lo elaborerà e ti farà sapere a breve.</value></data>
   <data name="TicketTransfer_Continue" xml:space="preserve"><value>Continua</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2474,4 +2474,600 @@
   <data name="AccountDeletion_ScheduledFor" xml:space="preserve"><value>It will be permanently deleted on {0} unless you cancel.</value></data>
   <data name="AccountDeletion_Unscheduled" xml:space="preserve"><value>It will be permanently deleted unless you cancel.</value></data>
   <data name="AccountDeletion_CancelButton" xml:space="preserve"><value>Cancel deletion request</value></data>
+  <data name="About_AdditionalHelp" xml:space="preserve"><value>With additional help from</value></data>
+  <data name="About_AdditionalHelpAnd" xml:space="preserve"><value>and</value></data>
+  <data name="About_AnthropicNote" xml:space="preserve"><value>Conversational helper responses are produced by Anthropic's API. No data is used for model training per Anthropic's DPA.</value></data>
+  <data name="About_Cat_AILLM" xml:space="preserve"><value>AI/LLM</value></data>
+  <data name="About_Cat_BackgroundJobs" xml:space="preserve"><value>Background Jobs</value></data>
+  <data name="About_Cat_Calendar" xml:space="preserve"><value>Calendar</value></data>
+  <data name="About_Cat_CSV" xml:space="preserve"><value>CSV</value></data>
+  <data name="About_Cat_Database" xml:space="preserve"><value>Database</value></data>
+  <data name="About_Cat_DateTime" xml:space="preserve"><value>Date/Time</value></data>
+  <data name="About_Cat_Email" xml:space="preserve"><value>Email</value></data>
+  <data name="About_Cat_Framework" xml:space="preserve"><value>Framework</value></data>
+  <data name="About_Cat_GitHubAPI" xml:space="preserve"><value>GitHub API</value></data>
+  <data name="About_Cat_GoogleAPIs" xml:space="preserve"><value>Google APIs</value></data>
+  <data name="About_Cat_HealthChecks" xml:space="preserve"><value>Health Checks</value></data>
+  <data name="About_Cat_ImageProcessing" xml:space="preserve"><value>Image Processing</value></data>
+  <data name="About_Cat_Logging" xml:space="preserve"><value>Logging</value></data>
+  <data name="About_Cat_Markdown" xml:space="preserve"><value>Markdown</value></data>
+  <data name="About_Cat_Observability" xml:space="preserve"><value>Observability</value></data>
+  <data name="About_Cat_Payments" xml:space="preserve"><value>Payments</value></data>
+  <data name="About_Cat_Resilience" xml:space="preserve"><value>Resilience</value></data>
+  <data name="About_Cat_Sanitization" xml:space="preserve"><value>Sanitization</value></data>
+  <data name="About_Cat_Spreadsheet" xml:space="preserve"><value>Spreadsheet</value></data>
+  <data name="About_Cat_StateMachine" xml:space="preserve"><value>State Machine</value></data>
+  <data name="About_Cat_UserAgent" xml:space="preserve"><value>User-Agent</value></data>
+  <data name="About_ColCategory" xml:space="preserve"><value>Category</value></data>
+  <data name="About_ColLibrary" xml:space="preserve"><value>Library</value></data>
+  <data name="About_ColLicense" xml:space="preserve"><value>License</value></data>
+  <data name="About_ColPackage" xml:space="preserve"><value>Package</value></data>
+  <data name="About_ColVersion" xml:space="preserve"><value>Version</value></data>
+  <data name="About_DotNetDesc" xml:space="preserve"><value>ASP.NET Core MVC with Razor views, Identity, and the whole Microsoft stack. The frame that holds everything together.</value></data>
+  <data name="About_FrontendHeading" xml:space="preserve"><value>Frontend / CDN Dependencies</value></data>
+  <data name="About_GoogleDesc" xml:space="preserve"><value>Admin Directory, Drive, and Groups — provisioning Shared Drives, folders, and mailing lists so nobody has to do it by hand.</value></data>
+  <data name="About_HangfireDesc" xml:space="preserve"><value>Background jobs for sync, reconciliation, and anything that shouldn't block an HTTP request. PostgreSQL-backed, dashboard included.</value></data>
+  <data name="About_IngredientsHeading" xml:space="preserve"><value>The Ingredients</value></data>
+  <data name="About_IngredientsIntro" xml:space="preserve"><value>Every workshop needs its materials. Here is what Humans is built from:</value></data>
+  <data name="About_Intro" xml:space="preserve"><value>Humans is the membership system that keeps Nobodies Collective running — human onboarding, team provisioning, governance tracking, and all the plumbing that lets a Spanish nonprofit operate with the organisational memory of something ten times its size. Built with care, maintained with stubbornness, and deployed with crossed fingers.</value></data>
+  <data name="About_License_Apache2" xml:space="preserve"><value>requires copyright notice, license copy, and statement of changes if modified. All packages are used unmodified.</value></data>
+  <data name="About_License_BSD2" xml:space="preserve"><value>requires copyright notice in documentation.</value></data>
+  <data name="About_License_BSD3MapLibre" xml:space="preserve"><value>requires copyright notice; this page satisfies that obligation.</value></data>
+  <data name="About_License_ISC" xml:space="preserve"><value>permissive, functionally equivalent to BSD-2-Clause; copyright notice required.</value></data>
+  <data name="About_License_LGPL30" xml:space="preserve"><value>the library must be replaceable by the end user. Consumed as unmodified NuGet packages (dynamically linked), satisfying LGPL obligations.</value></data>
+  <data name="About_License_MIT" xml:space="preserve"><value>requires copyright notice; this page satisfies that obligation.</value></data>
+  <data name="About_License_PostgreSQL" xml:space="preserve"><value>permissive, MIT-like; copyright notice required.</value></data>
+  <data name="About_License_SILOFL" xml:space="preserve"><value>free to use and redistribute; fonts cannot be sold standalone.</value></data>
+  <data name="About_LicenseBody" xml:space="preserve"><value>Humans is free software, released under the</value></data>
+  <data name="About_LicenseComplianceHeading" xml:space="preserve"><value>License Compliance Summary</value></data>
+  <data name="About_LicenseComplianceSummary" xml:space="preserve"><value>All production dependencies use permissive or weak-copyleft licenses. No violations found.</value></data>
+  <data name="About_LicenseExplanation" xml:space="preserve"><value>You may use, study, modify, and redistribute this software. If you run a modified version and let others interact with it over a network, you must make your modified source available under the same license.</value></data>
+  <data name="About_LicenseFullText" xml:space="preserve"><value>Full license text:</value></data>
+  <data name="About_LicenseHeading" xml:space="preserve"><value>License</value></data>
+  <data name="About_LicenseSourceCode" xml:space="preserve"><value>Source code:</value></data>
+  <data name="About_MadeBy" xml:space="preserve"><value>Made by</value></data>
+  <data name="About_MadeByTail" xml:space="preserve"><value>with love for the Nobodies Community.</value></data>
+  <data name="About_MailKitDesc" xml:space="preserve"><value>Transactional email for notifications and onboarding. The one library that makes SMTP feel almost pleasant.</value></data>
+  <data name="About_MeetTheStaff" xml:space="preserve"><value>Meet the Staff</value></data>
+  <data name="About_NeedHelp" xml:space="preserve"><value>Need help?</value></data>
+  <data name="About_NuGetPackagesHeading" xml:space="preserve"><value>NuGet Packages</value></data>
+  <data name="About_OpenSourceLicensesHeading" xml:space="preserve"><value>Open Source Licenses</value></data>
+  <data name="About_OpenSourceLicensesIntro" xml:space="preserve"><value>Humans is built on the shoulders of open-source projects. The table below lists every production dependency, its version, and license.</value></data>
+  <data name="About_OtelDesc" xml:space="preserve"><value>Structured logging, distributed traces, and Prometheus metrics. Because "it works on my machine" isn't a monitoring strategy.</value></data>
+  <data name="About_PostgresDesc" xml:space="preserve"><value>Relational data with Entity Framework Core and Npgsql. NodaTime types all the way down — no DateTime in sight.</value></data>
+  <data name="About_Staff_BackToAbout" xml:space="preserve"><value>Back to About</value></data>
+  <data name="About_Staff_Empty" xml:space="preserve"><value>No active role holders found. The castle appears to be empty.</value></data>
+  <data name="About_Staff_Intro" xml:space="preserve"><value>Every collective needs its keepers. These are the humans who volunteer their time and energy to keep Nobodies running — from governance to tech support, from trust and safety to ticket alchemy.</value></data>
+  <data name="About_Staff_Title" xml:space="preserve"><value>The Humans Behind the Curtain</value></data>
+  <data name="About_Title" xml:space="preserve"><value>About Humans</value></data>
+  <data name="Budget_ColAmount" xml:space="preserve"><value>Amount (€)</value></data>
+  <data name="Budget_ColCategory" xml:space="preserve"><value>Category</value></data>
+  <data name="Budget_ColShare" xml:space="preserve"><value>Share</value></data>
+  <data name="Budget_DepartmentDetail" xml:space="preserve"><value>Department Detail</value></data>
+  <data name="Budget_Expenses" xml:space="preserve"><value>Expenses</value></data>
+  <data name="Budget_ExpensesBreakdown" xml:space="preserve"><value>Expenses Breakdown</value></data>
+  <data name="Budget_Income" xml:space="preserve"><value>Income</value></data>
+  <data name="Budget_IncomeBreakdown" xml:space="preserve"><value>Income Breakdown</value></data>
+  <data name="Budget_NetBalance" xml:space="preserve"><value>Net Balance</value></data>
+  <data name="Budget_NoActiveBudget" xml:space="preserve"><value>No Active Budget</value></data>
+  <data name="Budget_NoActiveBudgetSubtitle" xml:space="preserve"><value>There is no active budget year to display. A finance admin will set one up when budget planning begins.</value></data>
+  <data name="Budget_NoDataSubtitle" xml:space="preserve"><value>Budget allocations will appear here once they are set up by the finance team.</value></data>
+  <data name="Budget_NoDataYet" xml:space="preserve"><value>Budget data not available yet</value></data>
+  <data name="Budget_NoExpenseItems" xml:space="preserve"><value>No expense line items yet.</value></data>
+  <data name="Budget_NoIncomeItems" xml:space="preserve"><value>No income line items yet.</value></data>
+  <data name="Budget_OverviewSubtitle" xml:space="preserve"><value>How the {0} budget is allocated across departments and infrastructure.</value></data>
+  <data name="Budget_OverviewTitle" xml:space="preserve"><value>Budget Overview</value></data>
+  <data name="Budget_Title" xml:space="preserve"><value>Budget</value></data>
+  <data name="Budget_TitleYear" xml:space="preserve"><value>Budget - {0}</value></data>
+  <data name="Budget_TotalExpenses" xml:space="preserve"><value>Total Expenses</value></data>
+  <data name="Budget_TotalIncome" xml:space="preserve"><value>Total Income</value></data>
+  <data name="Calendar_Agenda" xml:space="preserve"><value>Agenda</value></data>
+  <data name="Calendar_AllDay" xml:space="preserve"><value>all day</value></data>
+  <data name="Calendar_AllDayEvent" xml:space="preserve"><value>All-day event</value></data>
+  <data name="Calendar_AllDayLabel" xml:space="preserve"><value>All-day</value></data>
+  <data name="Calendar_AllTeamsMonthView" xml:space="preserve"><value>All teams (month view)</value></data>
+  <data name="Calendar_AllTimesShownIn" xml:space="preserve"><value>All times shown in {0}.</value></data>
+  <data name="Calendar_BackToCalendar" xml:space="preserve"><value>Back to calendar</value></data>
+  <data name="Calendar_CancelOccurrenceConfirm" xml:space="preserve"><value>Cancel just this occurrence?</value></data>
+  <data name="Calendar_CancelThisOccurrence" xml:space="preserve"><value>Cancel this</value></data>
+  <data name="Calendar_ChangeHistory" xml:space="preserve"><value>Change history</value></data>
+  <data name="Calendar_Continues" xml:space="preserve"><value>continues</value></data>
+  <data name="Calendar_Created" xml:space="preserve"><value>Created {0}</value></data>
+  <data name="Calendar_CreateEvent" xml:space="preserve"><value>Create event</value></data>
+  <data name="Calendar_DeleteConfirm" xml:space="preserve"><value>Delete this event and all its occurrences?</value></data>
+  <data name="Calendar_Description" xml:space="preserve"><value>Description</value></data>
+  <data name="Calendar_EditEvent" xml:space="preserve"><value>Edit event</value></data>
+  <data name="Calendar_EditSingleOccurrence" xml:space="preserve"><value>Edit single occurrence</value></data>
+  <data name="Calendar_EditSingleOccurrenceHeading" xml:space="preserve"><value>Edit a single occurrence</value></data>
+  <data name="Calendar_EditThisOccurrence" xml:space="preserve"><value>Edit this occurrence</value></data>
+  <data name="Calendar_End" xml:space="preserve"><value>End</value></data>
+  <data name="Calendar_EndDate" xml:space="preserve"><value>End date</value></data>
+  <data name="Calendar_EndDateHelp" xml:space="preserve"><value>Inclusive — leave blank for a single-day event.</value></data>
+  <data name="Calendar_EventTitle" xml:space="preserve"><value>Event</value></data>
+  <data name="Calendar_FirstStart" xml:space="preserve"><value>First start</value></data>
+  <data name="Calendar_FormTitle" xml:space="preserve"><value>Title</value></data>
+  <data name="Calendar_LastUpdated" xml:space="preserve"><value>· Last updated {0}</value></data>
+  <data name="Calendar_LocationUrl" xml:space="preserve"><value>Location URL</value></data>
+  <data name="Calendar_MoreCount" xml:space="preserve"><value>+{0} more</value></data>
+  <data name="Calendar_NewEvent" xml:space="preserve"><value>New event</value></data>
+  <data name="Calendar_Next" xml:space="preserve"><value>Next</value></data>
+  <data name="Calendar_NoEventsInRange" xml:space="preserve"><value>No events in the selected range.</value></data>
+  <data name="Calendar_OverrideDescription" xml:space="preserve"><value>Override description</value></data>
+  <data name="Calendar_OverrideEnd" xml:space="preserve"><value>Override end</value></data>
+  <data name="Calendar_OverrideInstructions" xml:space="preserve"><value>Override only this occurrence of the recurring event. Leave a field blank to inherit the value from the parent event.</value></data>
+  <data name="Calendar_OverrideLocation" xml:space="preserve"><value>Override location</value></data>
+  <data name="Calendar_OverrideLocationUrl" xml:space="preserve"><value>Override location URL</value></data>
+  <data name="Calendar_OverrideStart" xml:space="preserve"><value>Override start</value></data>
+  <data name="Calendar_OverrideTitle" xml:space="preserve"><value>Override title</value></data>
+  <data name="Calendar_OwningTeam" xml:space="preserve"><value>Owning team</value></data>
+  <data name="Calendar_Prev" xml:space="preserve"><value>Prev</value></data>
+  <data name="Calendar_Recurrence" xml:space="preserve"><value>Recurrence</value></data>
+  <data name="Calendar_RecurrenceTimezoneHelpPrefix" xml:space="preserve"><value>IANA TZ, e.g.</value></data>
+  <data name="Calendar_RecurrenceTimezoneLabel" xml:space="preserve"><value>Recurrence timezone</value></data>
+  <data name="Calendar_RecurrenceTimezoneNote" xml:space="preserve"><value>Timezone: {0}</value></data>
+  <data name="Calendar_RecurringEvent" xml:space="preserve"><value>Recurring event</value></data>
+  <data name="Calendar_RRule" xml:space="preserve"><value>RRULE</value></data>
+  <data name="Calendar_RRuleHelpPrefix" xml:space="preserve"><value>RFC 5545 RRULE. Leave blank for single event. Example:</value></data>
+  <data name="Calendar_SaveOverride" xml:space="preserve"><value>Save override</value></data>
+  <data name="Calendar_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="Calendar_StartDate" xml:space="preserve"><value>Start date</value></data>
+  <data name="Calendar_TeamFallback" xml:space="preserve"><value>Team</value></data>
+  <data name="Calendar_Title" xml:space="preserve"><value>Calendar</value></data>
+  <data name="Calendar_Today" xml:space="preserve"><value>Today</value></data>
+  <data name="Calendar_UpcomingOccurrences" xml:space="preserve"><value>Upcoming occurrences</value></data>
+  <data name="Calendar_ViewAriaLabel" xml:space="preserve"><value>Calendar view</value></data>
+  <data name="Calendar_ViewGrid" xml:space="preserve"><value>Grid</value></data>
+  <data name="Calendar_ViewList" xml:space="preserve"><value>List</value></data>
+  <data name="Calendar_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="Camp_AboutHeading" xml:space="preserve"><value>About Your {0}</value></data>
+  <data name="Camp_AcceptingMembersLabel" xml:space="preserve"><value>Accepting New Humans?</value></data>
+  <data name="Camp_AdultPlayspaceLabel" xml:space="preserve"><value>Adult Playspace</value></data>
+  <data name="Camp_BlurbLongLabel" xml:space="preserve"><value>Full Description</value></data>
+  <data name="Camp_BlurbLongPlaceholder" xml:space="preserve"><value>Tell the world about your camp.</value></data>
+  <data name="Camp_BlurbShortLabel" xml:space="preserve"><value>Short Description</value></data>
+  <data name="Camp_BlurbShortPlaceholder" xml:space="preserve"><value>One or two sentences about your camp (max 300 chars)</value></data>
+  <data name="Camp_CommunityHeading" xml:space="preserve"><value>Community</value></data>
+  <data name="Camp_ContactEmailLabel" xml:space="preserve"><value>Contact Email</value></data>
+  <data name="Camp_ContactPhoneLabel" xml:space="preserve"><value>Contact Phone</value></data>
+  <data name="Camp_ContactPhonePlaceholder" xml:space="preserve"><value>+34 612 345 678</value></data>
+  <data name="Camp_CultureHeading" xml:space="preserve"><value>Culture &amp; Events</value></data>
+  <data name="Camp_Edit_AutoCreatedFromNameChange" xml:space="preserve"><value>Auto-created from name change</value></data>
+  <data name="Camp_Edit_ContainersSeparate" xml:space="preserve"><value>Containers are now managed separately.</value></data>
+  <data name="Camp_Edit_HideHistoricalNames" xml:space="preserve"><value>Hide historical names</value></data>
+  <data name="Camp_Edit_HistoricalNamesHeading" xml:space="preserve"><value>Historical Names</value></data>
+  <data name="Camp_Edit_HistoricalNamesHelp" xml:space="preserve"><value>Names this camp was previously known as.</value></data>
+  <data name="Camp_Edit_ImageAlt" xml:space="preserve"><value>Camp image</value></data>
+  <data name="Camp_Edit_ImagesHeading" xml:space="preserve"><value>Images ({0}/{1})</value></data>
+  <data name="Camp_Edit_ImageUploadHelp" xml:space="preserve"><value>JPEG, PNG, or WebP. Max 10MB.</value></data>
+  <data name="Camp_Edit_ManageContainers" xml:space="preserve"><value>Manage containers →</value></data>
+  <data name="Camp_Edit_MembersRolesDescription" xml:space="preserve"><value>Manage active members, roles, leads, and pending join requests.</value></data>
+  <data name="Camp_Edit_MembersRolesHeading" xml:space="preserve"><value>Members &amp; Roles</value></data>
+  <data name="Camp_Edit_NameLocked" xml:space="preserve"><value>Name is locked for this season.</value></data>
+  <data name="Camp_Edit_OpenMembersRoles" xml:space="preserve"><value>Open members &amp; roles</value></data>
+  <data name="Camp_Edit_OpenStore" xml:space="preserve"><value>Open store</value></data>
+  <data name="Camp_Edit_PreviousNamePlaceholder" xml:space="preserve"><value>Previous camp name</value></data>
+  <data name="Camp_Edit_StoreDescription" xml:space="preserve"><value>Place an order for this camp.</value></data>
+  <data name="Camp_Edit_StoreHeading" xml:space="preserve"><value>Store</value></data>
+  <data name="Camp_Edit_UploadImage" xml:space="preserve"><value>Upload Image</value></data>
+  <data name="Camp_ElectricalGridLabel" xml:space="preserve"><value>Electrical Grid</value></data>
+  <data name="Camp_HistoryHeading" xml:space="preserve"><value>History</value></data>
+  <data name="Camp_Index_AcceptingMembersFilter" xml:space="preserve"><value>Accepting Members</value></data>
+  <data name="Camp_Index_AllOption" xml:space="preserve"><value>All</value></data>
+  <data name="Camp_Index_BarrioGuide" xml:space="preserve"><value>Barrio Guide 2026</value></data>
+  <data name="Camp_Index_FilterButton" xml:space="preserve"><value>Filter</value></data>
+  <data name="Camp_Index_KidsWelcomeFilter" xml:space="preserve"><value>Kids Welcome</value></data>
+  <data name="Camp_Index_NoFilterResults" xml:space="preserve"><value>No {0} found for the selected filters.</value></data>
+  <data name="Camp_Index_NoSearchResults" xml:space="preserve"><value>No {0} match your search.</value></data>
+  <data name="Camp_Index_PendingApproval" xml:space="preserve"><value>pending approval</value></data>
+  <data name="Camp_Index_SearchLabel" xml:space="preserve"><value>Search</value></data>
+  <data name="Camp_Index_SearchPlaceholder" xml:space="preserve"><value>Type a {0} name…</value></data>
+  <data name="Camp_Index_ShowLeadPositions" xml:space="preserve"><value>Show lead positions</value></data>
+  <data name="Camp_Index_SoundZoneLabel" xml:space="preserve"><value>Sound Zone</value></data>
+  <data name="Camp_Index_VibeLabel" xml:space="preserve"><value>Vibe</value></data>
+  <data name="Camp_KidsAreaDescriptionLabel" xml:space="preserve"><value>Kids Area Description</value></data>
+  <data name="Camp_KidsAreaDescriptionPlaceholder" xml:space="preserve"><value>Describe your kids area if applicable</value></data>
+  <data name="Camp_KidsVisitingLabel" xml:space="preserve"><value>Kids Visiting Policy</value></data>
+  <data name="Camp_KidsWelcomeLabel" xml:space="preserve"><value>Kids Welcome?</value></data>
+  <data name="Camp_LanguagesLabel" xml:space="preserve"><value>Languages Spoken</value></data>
+  <data name="Camp_LanguagesPlaceholder" xml:space="preserve"><value>e.g. English, Spanish, German</value></data>
+  <data name="Camp_MarkdownSupported" xml:space="preserve"><value>Markdown formatting is supported</value></data>
+  <data name="Camp_MemberCountLabel" xml:space="preserve"><value>Expected Humans</value></data>
+  <data name="Camp_NoPreference" xml:space="preserve"><value>No Preference</value></data>
+  <data name="Camp_NotSure" xml:space="preserve"><value>Not Sure</value></data>
+  <data name="Camp_PerformanceSpaceLabel" xml:space="preserve"><value>Performance Space</value></data>
+  <data name="Camp_PerformanceTypesLabel" xml:space="preserve"><value>Performance Types</value></data>
+  <data name="Camp_PerformanceTypesPlaceholder" xml:space="preserve"><value>e.g. Music, Theater, Workshops</value></data>
+  <data name="Camp_PlacementHeading" xml:space="preserve"><value>Placement</value></data>
+  <data name="Camp_PreviousNamesHelp" xml:space="preserve"><value>If your camp has had different names in past years, list them here.</value></data>
+  <data name="Camp_PreviousNamesLabel" xml:space="preserve"><value>Previous Names</value></data>
+  <data name="Camp_PreviousNamesPlaceholder" xml:space="preserve"><value>Comma-separated list of previous camp names</value></data>
+  <data name="Camp_Register_Breadcrumb" xml:space="preserve"><value>Register</value></data>
+  <data name="Camp_Register_Heading" xml:space="preserve"><value>Register Your {0}</value></data>
+  <data name="Camp_Register_ImportantInfo" xml:space="preserve"><value>Important Information</value></data>
+  <data name="Camp_Register_Season" xml:space="preserve"><value>season</value></data>
+  <data name="Camp_Register_Submit" xml:space="preserve"><value>Register {0}</value></data>
+  <data name="Camp_SoundZoneLabel" xml:space="preserve"><value>Sound Zone Preference</value></data>
+  <data name="Camp_SpaceRequirementLabel" xml:space="preserve"><value>Space Requirement</value></data>
+  <data name="Camp_TimesParticipatingLabel" xml:space="preserve"><value>Times Participating</value></data>
+  <data name="Camp_VibesLabel" xml:space="preserve"><value>Vibes</value></data>
+  <data name="CampCard_AcceptingMembers" xml:space="preserve"><value>Accepting Members</value></data>
+  <data name="CampCard_Full" xml:space="preserve"><value>Full</value></data>
+  <data name="CampCard_KidsWelcome" xml:space="preserve"><value>Kids Welcome</value></data>
+  <data name="CampCard_TimesAtNowhere" xml:space="preserve"><value>{0} year(s)</value></data>
+  <data name="Common_Actions" xml:space="preserve"><value>Actions</value></data>
+  <data name="Common_Admin" xml:space="preserve"><value>Admin</value></data>
+  <data name="Common_Amount" xml:space="preserve"><value>Amount</value></data>
+  <data name="Common_Clear" xml:space="preserve"><value>Clear</value></data>
+  <data name="Common_Created" xml:space="preserve"><value>Created</value></data>
+  <data name="Common_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="Common_DeleteImage" xml:space="preserve"><value>Delete image</value></data>
+  <data name="Common_Department" xml:space="preserve"><value>Department</value></data>
+  <data name="Common_MoveDown" xml:space="preserve"><value>Move down</value></data>
+  <data name="Common_MoveUp" xml:space="preserve"><value>Move up</value></data>
+  <data name="Common_Other" xml:space="preserve"><value>Other</value></data>
+  <data name="Common_Preview" xml:space="preserve"><value>Preview</value></data>
+  <data name="Common_Remove" xml:space="preserve"><value>Remove</value></data>
+  <data name="Common_Required" xml:space="preserve"><value>(required)</value></data>
+  <data name="Common_Sender" xml:space="preserve"><value>Sender</value></data>
+  <data name="Common_Shift" xml:space="preserve"><value>Shift</value></data>
+  <data name="Common_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="Common_View" xml:space="preserve"><value>View</value></data>
+  <data name="CommPrefs_AlwaysOn" xml:space="preserve"><value>Always on</value></data>
+  <data name="EmailGrid_OrphanProviderTag" xml:space="preserve"><value>Tagged with {0} but no matching AspNetUserLogins row — self-heals on next OAuth sign-in.</value></data>
+  <data name="EmailGrid_WorkspaceLocked" xml:space="preserve"><value>Locked by the Workspace email row</value></data>
+  <data name="Enum_AdultPlayspacePolicy_NightOnly" xml:space="preserve"><value>Night only</value></data>
+  <data name="Enum_AdultPlayspacePolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_AdultPlayspacePolicy_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="Enum_CampVibe_Adult" xml:space="preserve"><value>Adult</value></data>
+  <data name="Enum_CampVibe_ChillOut" xml:space="preserve"><value>Chill out</value></data>
+  <data name="Enum_CampVibe_ElectronicMusic" xml:space="preserve"><value>Electronic music</value></data>
+  <data name="Enum_CampVibe_Games" xml:space="preserve"><value>Games</value></data>
+  <data name="Enum_CampVibe_Lecture" xml:space="preserve"><value>Lecture</value></data>
+  <data name="Enum_CampVibe_LiveMusic" xml:space="preserve"><value>Live music</value></data>
+  <data name="Enum_CampVibe_Queer" xml:space="preserve"><value>Queer</value></data>
+  <data name="Enum_CampVibe_Sober" xml:space="preserve"><value>Sober</value></data>
+  <data name="Enum_CampVibe_Wellness" xml:space="preserve"><value>Wellness</value></data>
+  <data name="Enum_CampVibe_Workshop" xml:space="preserve"><value>Workshop</value></data>
+  <data name="Enum_ContactFieldType_Discord" xml:space="preserve"><value>Discord</value></data>
+  <data name="Enum_ContactFieldType_Other" xml:space="preserve"><value>Other</value></data>
+  <data name="Enum_ContactFieldType_Phone" xml:space="preserve"><value>Phone</value></data>
+  <data name="Enum_ContactFieldType_Signal" xml:space="preserve"><value>Signal</value></data>
+  <data name="Enum_ContactFieldType_Telegram" xml:space="preserve"><value>Telegram</value></data>
+  <data name="Enum_ContactFieldType_WhatsApp" xml:space="preserve"><value>WhatsApp</value></data>
+  <data name="Enum_ContactFieldVisibility_AllActiveProfiles" xml:space="preserve"><value>All active humans</value></data>
+  <data name="Enum_ContactFieldVisibility_BoardOnly" xml:space="preserve"><value>Board only</value></data>
+  <data name="Enum_ContactFieldVisibility_CoordinatorsAndBoard" xml:space="preserve"><value>Coordinators + Board</value></data>
+  <data name="Enum_ContactFieldVisibility_MyTeams" xml:space="preserve"><value>My teams (+ coordinators &amp; board)</value></data>
+  <data name="Enum_ElectricalGrid_Norg" xml:space="preserve"><value>Norg</value></data>
+  <data name="Enum_ElectricalGrid_OwnSupply" xml:space="preserve"><value>Own supply</value></data>
+  <data name="Enum_ElectricalGrid_Red" xml:space="preserve"><value>Red</value></data>
+  <data name="Enum_ElectricalGrid_Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="Enum_ElectricalGrid_Yellow" xml:space="preserve"><value>Yellow</value></data>
+  <data name="Enum_EmailOutboxStatus_Failed" xml:space="preserve"><value>Failed</value></data>
+  <data name="Enum_EmailOutboxStatus_Queued" xml:space="preserve"><value>Queued</value></data>
+  <data name="Enum_EmailOutboxStatus_Sent" xml:space="preserve"><value>Sent</value></data>
+  <data name="Enum_EventStatus_Approved" xml:space="preserve"><value>Approved</value></data>
+  <data name="Enum_EventStatus_Draft" xml:space="preserve"><value>Draft</value></data>
+  <data name="Enum_EventStatus_Pending" xml:space="preserve"><value>Pending</value></data>
+  <data name="Enum_EventStatus_Rejected" xml:space="preserve"><value>Rejected</value></data>
+  <data name="Enum_EventStatus_ResubmitRequested" xml:space="preserve"><value>Changes requested</value></data>
+  <data name="Enum_EventStatus_Withdrawn" xml:space="preserve"><value>Withdrawn</value></data>
+  <data name="Enum_ExpenseReportStatus_Approved" xml:space="preserve"><value>Approved</value></data>
+  <data name="Enum_ExpenseReportStatus_CoordinatorEndorsed" xml:space="preserve"><value>Coordinator endorsed</value></data>
+  <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Draft</value></data>
+  <data name="Enum_ExpenseReportStatus_Paid" xml:space="preserve"><value>Paid</value></data>
+  <data name="Enum_ExpenseReportStatus_SepaSent" xml:space="preserve"><value>SEPA sent</value></data>
+  <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Submitted</value></data>
+  <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Withdrawn</value></data>
+  <data name="Enum_FeedbackCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_FeedbackCategory_FeatureRequest" xml:space="preserve"><value>Feature request</value></data>
+  <data name="Enum_FeedbackCategory_Question" xml:space="preserve"><value>Question</value></data>
+  <data name="Enum_FeedbackStatus_Acknowledged" xml:space="preserve"><value>Acknowledged</value></data>
+  <data name="Enum_FeedbackStatus_Open" xml:space="preserve"><value>Open</value></data>
+  <data name="Enum_FeedbackStatus_Resolved" xml:space="preserve"><value>Resolved</value></data>
+  <data name="Enum_FeedbackStatus_WontFix" xml:space="preserve"><value>Won't fix</value></data>
+  <data name="Enum_IssueCategory_Bug" xml:space="preserve"><value>Bug</value></data>
+  <data name="Enum_IssueCategory_Feature" xml:space="preserve"><value>Feature</value></data>
+  <data name="Enum_IssueCategory_Question" xml:space="preserve"><value>Question</value></data>
+  <data name="Enum_KidsVisitingPolicy_DaytimeOnly" xml:space="preserve"><value>Daytime only</value></data>
+  <data name="Enum_KidsVisitingPolicy_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_KidsVisitingPolicy_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="Enum_LanguageProficiency_Basic" xml:space="preserve"><value>Basic</value></data>
+  <data name="Enum_LanguageProficiency_Conversational" xml:space="preserve"><value>Conversational</value></data>
+  <data name="Enum_LanguageProficiency_Fluent" xml:space="preserve"><value>Fluent</value></data>
+  <data name="Enum_LanguageProficiency_Native" xml:space="preserve"><value>Native</value></data>
+  <data name="Enum_PerformanceSpaceStatus_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_PerformanceSpaceStatus_WorkingOnIt" xml:space="preserve"><value>Working on it</value></data>
+  <data name="Enum_PerformanceSpaceStatus_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="Enum_RolePeriod_Build" xml:space="preserve"><value>Set-up</value></data>
+  <data name="Enum_RolePeriod_Event" xml:space="preserve"><value>Event</value></data>
+  <data name="Enum_RolePeriod_Strike" xml:space="preserve"><value>Strike</value></data>
+  <data name="Enum_RolePeriod_YearRound" xml:space="preserve"><value>Year-round</value></data>
+  <data name="Enum_SlotPriority_Critical" xml:space="preserve"><value>Critical</value></data>
+  <data name="Enum_SlotPriority_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Enum_SlotPriority_NiceToHave" xml:space="preserve"><value>Nice to have</value></data>
+  <data name="Enum_SlotPriority_None" xml:space="preserve"><value>None</value></data>
+  <data name="Enum_SoundZone_Blue" xml:space="preserve"><value>Blue</value></data>
+  <data name="Enum_SoundZone_Green" xml:space="preserve"><value>Green</value></data>
+  <data name="Enum_SoundZone_Orange" xml:space="preserve"><value>Orange</value></data>
+  <data name="Enum_SoundZone_Red" xml:space="preserve"><value>Red</value></data>
+  <data name="Enum_SoundZone_Surprise" xml:space="preserve"><value>Surprise</value></data>
+  <data name="Enum_SoundZone_Yellow" xml:space="preserve"><value>Yellow</value></data>
+  <data name="Enum_SpaceSize_Sqm1000" xml:space="preserve"><value>1000 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1200" xml:space="preserve"><value>1200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm150" xml:space="preserve"><value>150 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1500" xml:space="preserve"><value>1500 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm1800" xml:space="preserve"><value>1800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2200" xml:space="preserve"><value>2200 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm2800" xml:space="preserve"><value>2800 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm300" xml:space="preserve"><value>300 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm450" xml:space="preserve"><value>450 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm600" xml:space="preserve"><value>600 m²</value></data>
+  <data name="Enum_SpaceSize_Sqm800" xml:space="preserve"><value>800 m²</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Camp" xml:space="preserve"><value>Camp</value></data>
+  <data name="Enum_StoreOrderCounterpartyType_Team" xml:space="preserve"><value>Team</value></data>
+  <data name="Enum_TicketTransferStatus_Approved" xml:space="preserve"><value>Completed</value></data>
+  <data name="Enum_TicketTransferStatus_Cancelled" xml:space="preserve"><value>Cancelled</value></data>
+  <data name="Enum_TicketTransferStatus_Pending" xml:space="preserve"><value>Pending review</value></data>
+  <data name="Enum_TicketTransferStatus_Rejected" xml:space="preserve"><value>Cancelled by team</value></data>
+  <data name="Enum_YesNoMaybe_Maybe" xml:space="preserve"><value>Maybe</value></data>
+  <data name="Enum_YesNoMaybe_No" xml:space="preserve"><value>No</value></data>
+  <data name="Enum_YesNoMaybe_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="Events_AddBarrioEvent" xml:space="preserve"><value>Add barrio event</value></data>
+  <data name="Events_AddToFavourites" xml:space="preserve"><value>Add to favourites</value></data>
+  <data name="Events_AllCategories" xml:space="preserve"><value>All categories</value></data>
+  <data name="Events_AllTimesIn" xml:space="preserve"><value>All times in {0}. Playa Time may apply!</value></data>
+  <data name="Events_AllTimesInShort" xml:space="preserve"><value>All times in {0}</value></data>
+  <data name="Events_AllVenues" xml:space="preserve"><value>All venues</value></data>
+  <data name="Events_BrowseTitle" xml:space="preserve"><value>Browse Events</value></data>
+  <data name="Events_ColActions" xml:space="preserve"><value>Actions</value></data>
+  <data name="Events_ColCategory" xml:space="preserve"><value>Category</value></data>
+  <data name="Events_ColDateTime" xml:space="preserve"><value>Date &amp; time</value></data>
+  <data name="Events_ColEventName" xml:space="preserve"><value>Event name</value></data>
+  <data name="Events_ColPriority" xml:space="preserve"><value>Priority</value></data>
+  <data name="Events_ConflictBadge" xml:space="preserve"><value>Time conflict with another favourited event</value></data>
+  <data name="Events_DownloadCsv" xml:space="preserve"><value>Download events CSV</value></data>
+  <data name="Events_DurationMin" xml:space="preserve"><value>{0} min</value></data>
+  <data name="Events_FavouritesOnly" xml:space="preserve"><value>Only</value></data>
+  <data name="Events_FilterCategory" xml:space="preserve"><value>Category</value></data>
+  <data name="Events_FilterDay" xml:space="preserve"><value>Day</value></data>
+  <data name="Events_FilterSearch" xml:space="preserve"><value>Search</value></data>
+  <data name="Events_FilterVenue" xml:space="preserve"><value>Venue</value></data>
+  <data name="Events_MyPersonalEvents" xml:space="preserve"><value>My personal events</value></data>
+  <data name="Events_MySchedule" xml:space="preserve"><value>My Schedule</value></data>
+  <data name="Events_MySubmissions" xml:space="preserve"><value>My Submissions</value></data>
+  <data name="Events_MySubmissionsTitle" xml:space="preserve"><value>My Event Submissions</value></data>
+  <data name="Events_NoBarrioEvents" xml:space="preserve"><value>No events submitted yet for this barrio.</value></data>
+  <data name="Events_NoEventsFound" xml:space="preserve"><value>No events found. Try adjusting your filters.</value></data>
+  <data name="Events_NoPersonalEvents" xml:space="preserve"><value>You haven’t submitted any personal events yet.</value></data>
+  <data name="Events_RemoveFromFavourites" xml:space="preserve"><value>Remove from favourites</value></data>
+  <data name="Events_RemoveFromSchedule" xml:space="preserve"><value>Remove from schedule</value></data>
+  <data name="Events_RemoveFromScheduleConfirm" xml:space="preserve"><value>Remove this event from your schedule?</value></data>
+  <data name="Events_ScheduleEmpty" xml:space="preserve"><value>You haven’t favourited any events yet. Browse the {0} to add events to your schedule.</value></data>
+  <data name="Events_ScheduleEmptyLink" xml:space="preserve"><value>event guide</value></data>
+  <data name="Events_ScheduleTitle" xml:space="preserve"><value>My Schedule</value></data>
+  <data name="Events_SearchPlaceholder" xml:space="preserve"><value>Search title or description…</value></data>
+  <data name="Events_StatApproved" xml:space="preserve"><value>Approved</value></data>
+  <data name="Events_StatPending" xml:space="preserve"><value>Pending</value></data>
+  <data name="Events_StatSubmitted" xml:space="preserve"><value>Submitted</value></data>
+  <data name="Events_SubmissionWindow" xml:space="preserve"><value>Submission window:</value></data>
+  <data name="Events_SubmissionWindowClosed" xml:space="preserve"><value>Submission window is not currently open. Contact an admin to configure guide settings.</value></data>
+  <data name="Events_SubmitNewEvent" xml:space="preserve"><value>Submit new event</value></data>
+  <data name="Events_UploadColErrors" xml:space="preserve"><value>Errors</value></data>
+  <data name="Events_UploadColEvent" xml:space="preserve"><value>Event</value></data>
+  <data name="Events_UploadColRow" xml:space="preserve"><value>Row</value></data>
+  <data name="Events_UploadCsv" xml:space="preserve"><value>Upload CSV</value></data>
+  <data name="Events_UploadFailed" xml:space="preserve"><value>Upload failed.</value></data>
+  <data name="Events_UploadFailedDetail" xml:space="preserve"><value>Fix the errors below and try again. No events were saved.</value></data>
+  <data name="Events_WithdrawConfirm" xml:space="preserve"><value>Withdraw this event?</value></data>
+  <data name="Expenses_ColReport" xml:space="preserve"><value>Report</value></data>
+  <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Submitted</value></data>
+  <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Submitted by</value></data>
+  <data name="Expenses_CoordinatorQueue" xml:space="preserve"><value>Coordinator queue</value></data>
+  <data name="Expenses_CoordinatorQueueTitle" xml:space="preserve"><value>Expense Reports — Coordinator Queue</value></data>
+  <data name="Expenses_Endorse" xml:space="preserve"><value>Endorse</value></data>
+  <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Endorse this expense report?</value></data>
+  <data name="Expenses_FileFirst" xml:space="preserve"><value>File your first report</value></data>
+  <data name="Expenses_IouHeader" xml:space="preserve"><value>What the collective owes you</value></data>
+  <data name="Expenses_IouLastPayment" xml:space="preserve"><value>Last payment</value></data>
+  <data name="Expenses_IouOtherAmountNote" xml:space="preserve"><value>Your Holded balance includes {0} unrelated to these reports (items fronted on the collective's behalf, adjustments, etc.), so the rows below won't necessarily sum to it.</value></data>
+  <data name="Expenses_IouOwed" xml:space="preserve"><value>Owed to you (Holded balance)</value></data>
+  <data name="Expenses_IouPaid" xml:space="preserve"><value>Paid to date</value></data>
+  <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Item</value></data>
+  <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>My Expense Reports</value></data>
+  <data name="Expenses_NewReport" xml:space="preserve"><value>New Report</value></data>
+  <data name="Expenses_NoActiveYear" xml:space="preserve"><value>There is no active budget year at the moment. Expense reports cannot be filed until a budget year is activated.</value></data>
+  <data name="Expenses_NoIban" xml:space="preserve"><value>You have not yet set your payment IBAN. You will be prompted to set it when you submit a report.</value></data>
+  <data name="Expenses_NoReports" xml:space="preserve"><value>No expense reports yet.</value></data>
+  <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No reports awaiting your endorsement.</value></data>
+  <data name="Expenses_Reject" xml:space="preserve"><value>Reject</value></data>
+  <data name="Expenses_RejectModalBody" xml:space="preserve"><value>The submitter will see this reason. Explain clearly why the report cannot be endorsed.</value></data>
+  <data name="Expenses_RejectModalTitle" xml:space="preserve"><value>Reject Report</value></data>
+  <data name="Expenses_RejectReasonLabel" xml:space="preserve"><value>Rejection reason</value></data>
+  <data name="Expenses_RejectReasonPlaceholder" xml:space="preserve"><value>e.g. Missing receipts for line 2</value></data>
+  <data name="Feedback_AssignedToName" xml:space="preserve"><value>Assigned to {0}</value></data>
+  <data name="Feedback_CategoryOnPage" xml:space="preserve"><value>{0} on {1}</value></data>
+  <data name="Feedback_TeamName" xml:space="preserve"><value>Team: {0}</value></data>
+  <data name="Issue_ColComments" xml:space="preserve"><value>Comments</value></data>
+  <data name="Issue_ColReporter" xml:space="preserve"><value>Reporter</value></data>
+  <data name="Issue_ColStatus" xml:space="preserve"><value>Status</value></data>
+  <data name="Issue_ColTitle" xml:space="preserve"><value>Title</value></data>
+  <data name="Issue_ColUpdated" xml:space="preserve"><value>Updated</value></data>
+  <data name="Issue_CountSummary" xml:space="preserve"><value>{0} open · {1} total</value></data>
+  <data name="MarkdownHelp_Bold" xml:space="preserve"><value>bold</value></data>
+  <data name="MarkdownHelp_ColYouGet" xml:space="preserve"><value>You get</value></data>
+  <data name="MarkdownHelp_ColYouType" xml:space="preserve"><value>You type</value></data>
+  <data name="MarkdownHelp_EmbeddedImage" xml:space="preserve"><value>embedded image</value></data>
+  <data name="MarkdownHelp_First" xml:space="preserve"><value>first</value></data>
+  <data name="MarkdownHelp_Heading1" xml:space="preserve"><value>Heading 1</value></data>
+  <data name="MarkdownHelp_Heading2" xml:space="preserve"><value>Heading 2</value></data>
+  <data name="MarkdownHelp_InlineCode" xml:space="preserve"><value>inline code</value></data>
+  <data name="MarkdownHelp_Intro" xml:space="preserve"><value>Markdown is a simple way to format text. Type the syntax on the left and it renders as shown on the right.</value></data>
+  <data name="MarkdownHelp_Italic" xml:space="preserve"><value>italic</value></data>
+  <data name="MarkdownHelp_ItemOne" xml:space="preserve"><value>item one</value></data>
+  <data name="MarkdownHelp_ItemTwo" xml:space="preserve"><value>item two</value></data>
+  <data name="MarkdownHelp_LinkText" xml:space="preserve"><value>link text</value></data>
+  <data name="MarkdownHelp_QuoteText" xml:space="preserve"><value>quote text</value></data>
+  <data name="MarkdownHelp_Second" xml:space="preserve"><value>second</value></data>
+  <data name="MarkdownHelp_Strikethrough" xml:space="preserve"><value>strikethrough</value></data>
+  <data name="MarkdownHelp_TableAdmin" xml:space="preserve"><value>Admin</value></data>
+  <data name="MarkdownHelp_TableHuman" xml:space="preserve"><value>Human</value></data>
+  <data name="MarkdownHelp_TableName" xml:space="preserve"><value>Name</value></data>
+  <data name="MarkdownHelp_TableRole" xml:space="preserve"><value>Role</value></data>
+  <data name="MarkdownHelp_TablesHeading" xml:space="preserve"><value>Tables</value></data>
+  <data name="MarkdownHelp_TaskDone" xml:space="preserve"><value>Done</value></data>
+  <data name="MarkdownHelp_TaskListsHeading" xml:space="preserve"><value>Task Lists</value></data>
+  <data name="MarkdownHelp_TaskToDo" xml:space="preserve"><value>To do</value></data>
+  <data name="MarkdownHelp_Title" xml:space="preserve"><value>Markdown Quick Reference</value></data>
+  <data name="Onboarding_BurnerNameExplainer" xml:space="preserve"><value>The name everyone in the system sees. Uniqueness helps but isn't required, though it may be hard to find "Bob" among the few thousand humans here if someone comes looking for you.</value></data>
+  <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>The name everyone will know you by.</value></data>
+  <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
+  <data name="Onboarding_Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>not</value></data>
+  <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>export this information, and would only disclose it if required by law or a formal audit.</value></data>
+  <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Kept internally, visible only to Admins, and used only where Spanish law requires it — for example, our audit record that you agreed to the Volunteer Agreement on a specific date and time. We explicitly do</value></data>
+  <data name="Onboarding_LegalNameLabel" xml:space="preserve"><value>Legal name</value></data>
+  <data name="Onboarding_NamesSubtitle" xml:space="preserve"><value>Two short steps before you pick a shift.</value></data>
+  <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Welcome — let's start with your name</value></data>
+  <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critical</value></data>
+  <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>The event has only {0}% of the "critical" shifts filled. If these are not filled, the event might be cancelled as it would not be viable or safe to run it.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>If you're able to fill some of those, or you're able to come pre-event or stay for strike, please prioritize those when picking your shifts.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT:</value></data>
+  <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>There are also {0} "important" shifts open.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>There are {0} "important" shifts open. If you're able to come pre-event or stay for strike, please prioritize those.</value></data>
+  <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>No active event right now. You can finish onboarding without picking a shift.</value></data>
+  <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No critical shifts open at the moment — try Important or All.</value></data>
+  <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No important shifts open at the moment — try All.</value></data>
+  <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Not right now</value></data>
+  <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Pick a shift</value></data>
+  <data name="Outbox_AdminTitle" xml:space="preserve"><value>Emails</value></data>
+  <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Back to Admin</value></data>
+  <data name="Outbox_BackToProfile" xml:space="preserve"><value>Back to Profile</value></data>
+  <data name="Outbox_DescriptionAdmin" xml:space="preserve"><value>Emails the system has sent to this human.</value></data>
+  <data name="Outbox_DescriptionSelf" xml:space="preserve"><value>Emails the system has sent to you (within the last 150 days).</value></data>
+  <data name="Outbox_Empty" xml:space="preserve"><value>No emails on record.</value></data>
+  <data name="Outbox_Subject" xml:space="preserve"><value>Subject</value></data>
+  <data name="Privacy_ThirdParty_GooglePolicyLink" xml:space="preserve"><value>Google's Privacy Policy</value></data>
+  <data name="Profile_Assigned" xml:space="preserve"><value>Assigned</value></data>
+  <data name="Profile_Campaign" xml:space="preserve"><value>Campaign</value></data>
+  <data name="Profile_Code" xml:space="preserve"><value>Code</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Dairy" xml:space="preserve"><value>Dairy</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Egg" xml:space="preserve"><value>Egg</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Peanut" xml:space="preserve"><value>Peanut</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Sesame" xml:space="preserve"><value>Sesame</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Shellfish" xml:space="preserve"><value>Shellfish</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Soy" xml:space="preserve"><value>Soy</value></data>
+  <data name="Profile_DietaryMedical_Allergy_Treenut" xml:space="preserve"><value>Tree nut</value></data>
+  <data name="Profile_DietaryMedical_Allergy_WheatGluten" xml:space="preserve"><value>Wheat/Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_FODMAP" xml:space="preserve"><value>FODMAP</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Gluten" xml:space="preserve"><value>Gluten</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Histamine" xml:space="preserve"><value>Histamine</value></data>
+  <data name="Profile_DietaryMedical_Intolerance_Lactose" xml:space="preserve"><value>Lactose</value></data>
+  <data name="Profile_MarkedAt" xml:space="preserve"><value>Marked At</value></data>
+  <data name="Profile_MarkedBy" xml:space="preserve"><value>Marked By</value></data>
+  <data name="Profile_MyCodes" xml:space="preserve"><value>My Codes</value></data>
+  <data name="Profile_MyEmails" xml:space="preserve"><value>My Emails</value></data>
+  <data name="Profile_NoSentMessages" xml:space="preserve"><value>No in-platform messages on record.</value></data>
+  <data name="Profile_NoShowHistory" xml:space="preserve"><value>No-Show History ({0})</value></data>
+  <data name="Profile_OnsiteSince" xml:space="preserve"><value>Onsite since {0}</value></data>
+  <data name="Profile_OnsiteTitle" xml:space="preserve"><value>Checked in at the gate</value></data>
+  <data name="Profile_Redeemed" xml:space="preserve"><value>Redeemed</value></data>
+  <data name="Profile_SentMessages" xml:space="preserve"><value>Sent messages ({0})</value></data>
+  <data name="Profile_ShiftInfo" xml:space="preserve"><value>Shift Info</value></data>
+  <data name="ProfileEdit_CityPlaceholder" xml:space="preserve"><value>Start typing your city…</value></data>
+  <data name="ProfileEdit_ContactType" xml:space="preserve"><value>Type</value></data>
+  <data name="ProfileEdit_ContactValue" xml:space="preserve"><value>Value</value></data>
+  <data name="ProfileEdit_ContactValuePlaceholder" xml:space="preserve"><value>Enter contact info</value></data>
+  <data name="ProfileEdit_ContactVisibility" xml:space="preserve"><value>Visibility</value></data>
+  <data name="ProfileEdit_CustomLabelPlaceholder" xml:space="preserve"><value>e.g., Discord</value></data>
+  <data name="ProfileEdit_Description" xml:space="preserve"><value>Description</value></data>
+  <data name="ProfileEdit_DescriptionPlaceholder" xml:space="preserve"><value>e.g., Gate Lead</value></data>
+  <data name="ProfileEdit_EventName" xml:space="preserve"><value>Event Name</value></data>
+  <data name="ProfileEdit_EventNamePlaceholder" xml:space="preserve"><value>e.g., Burning Man 2024</value></data>
+  <data name="ProfileEdit_LanguageLabel" xml:space="preserve"><value>Language</value></data>
+  <data name="ProfileEdit_ProficiencyLabel" xml:space="preserve"><value>Proficiency</value></data>
+  <data name="ProfileEdit_RelationshipPlaceholder" xml:space="preserve"><value>e.g., Partner, Parent</value></data>
+  <data name="ProfileEdit_RemoveContactField" xml:space="preserve"><value>Remove this contact field</value></data>
+  <data name="ProfileEdit_RemoveEntry" xml:space="preserve"><value>Remove this entry</value></data>
+  <data name="ProfileEdit_RemoveLanguage" xml:space="preserve"><value>Remove this language</value></data>
+  <data name="ProfileEdit_SelectLanguage" xml:space="preserve"><value>— Select language —</value></data>
+  <data name="Roster_All" xml:space="preserve"><value>All</value></data>
+  <data name="Roster_ColAssignedTo" xml:space="preserve"><value>Assigned To</value></data>
+  <data name="Roster_ColPeriod" xml:space="preserve"><value>Period</value></data>
+  <data name="Roster_ColPriority" xml:space="preserve"><value>Priority</value></data>
+  <data name="Roster_ColRole" xml:space="preserve"><value>Role</value></data>
+  <data name="Roster_ColSlot" xml:space="preserve"><value>Slot</value></data>
+  <data name="Roster_ColTeam" xml:space="preserve"><value>Team</value></data>
+  <data name="Roster_NoSlots" xml:space="preserve"><value>No role slots defined across teams.</value></data>
+  <data name="Roster_PeriodFilter" xml:space="preserve"><value>Period: {0}</value></data>
+  <data name="Roster_PriorityFilter" xml:space="preserve"><value>Priority: {0}</value></data>
+  <data name="Roster_SlotOpen" xml:space="preserve"><value>Open</value></data>
+  <data name="Roster_StatusFilled" xml:space="preserve"><value>Filled</value></data>
+  <data name="Roster_StatusFilter" xml:space="preserve"><value>Status: {0}</value></data>
+  <data name="Roster_StatusOpen" xml:space="preserve"><value>Open</value></data>
+  <data name="Roster_Title" xml:space="preserve"><value>Team Roster</value></data>
+  <data name="Search_FilterAll" xml:space="preserve"><value>All</value></data>
+  <data name="Search_FilterCamps" xml:space="preserve"><value>Camps</value></data>
+  <data name="Search_FilterEvents" xml:space="preserve"><value>Events</value></data>
+  <data name="Search_FilterHumans" xml:space="preserve"><value>Humans</value></data>
+  <data name="Search_FilterShifts" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Search_FilterTeams" xml:space="preserve"><value>Teams</value></data>
+  <data name="Search_GlobalHint" xml:space="preserve"><value>Type at least 2 characters to search across humans, teams, camps, shifts.</value></data>
+  <data name="Search_GlobalHintEvents" xml:space="preserve"><value>Type at least 2 characters to search across humans, teams, camps, shifts, and events.</value></data>
+  <data name="Search_GlobalNoResults" xml:space="preserve"><value>No results for {0}.</value></data>
+  <data name="Search_GlobalPlaceholder" xml:space="preserve"><value>Search humans, teams, camps, shifts…</value></data>
+  <data name="Search_GlobalPlaceholderEvents" xml:space="preserve"><value>Search humans, teams, camps, shifts, events…</value></data>
+  <data name="Search_GlobalTitle" xml:space="preserve"><value>Search</value></data>
+  <data name="Store_AdminCatalog" xml:space="preserve"><value>Catalog</value></data>
+  <data name="Store_AdminPayments" xml:space="preserve"><value>Payments</value></data>
+  <data name="Store_AdminSummary" xml:space="preserve"><value>Summary</value></data>
+  <data name="Store_CatalogHeading" xml:space="preserve"><value>Catalog ({0})</value></data>
+  <data name="Store_ColBalance" xml:space="preserve"><value>Balance</value></data>
+  <data name="Store_ColDeposit" xml:space="preserve"><value>Deposit</value></data>
+  <data name="Store_ColDeposits" xml:space="preserve"><value>Deposits</value></data>
+  <data name="Store_ColDescription" xml:space="preserve"><value>Description</value></data>
+  <data name="Store_ColLines" xml:space="preserve"><value>Lines</value></data>
+  <data name="Store_ColLinesVat" xml:space="preserve"><value>Lines + VAT</value></data>
+  <data name="Store_ColName" xml:space="preserve"><value>Name</value></data>
+  <data name="Store_ColOrderBy" xml:space="preserve"><value>Order by</value></data>
+  <data name="Store_ColState" xml:space="preserve"><value>State</value></data>
+  <data name="Store_ColUnitPrice" xml:space="preserve"><value>Unit price (incl. VAT)</value></data>
+  <data name="Store_CreateOrder" xml:space="preserve"><value>Create order</value></data>
+  <data name="Store_DeleteOrderConfirm" xml:space="preserve"><value>Delete this zero-balance order? This cannot be undone.</value></data>
+  <data name="Store_DeleteOrderTitle" xml:space="preserve"><value>Delete (zero balance)</value></data>
+  <data name="Store_NoCounterpartiesAlert" xml:space="preserve"><value>You don’t lead any camps or coordinate any departments with an active season this year. The catalog below is read-only.</value></data>
+  <data name="Store_NoOrders" xml:space="preserve"><value>No orders yet.</value></data>
+  <data name="Store_NoProducts" xml:space="preserve"><value>No products are active for {0}.</value></data>
+  <data name="Store_OpenOrder" xml:space="preserve"><value>Open</value></data>
+  <data name="Store_StartOrder" xml:space="preserve"><value>Start order</value></data>
+  <data name="Store_Title" xml:space="preserve"><value>Store</value></data>
+  <data name="Teams_Departments" xml:space="preserve"><value>Departments</value></data>
+  <data name="Teams_HiddenTeams" xml:space="preserve"><value>Hidden Teams</value></data>
+  <data name="Teams_HiddenTeamsNote" xml:space="preserve"><value>(visible to admins only)</value></data>
+  <data name="Teams_Summary" xml:space="preserve"><value>Summary</value></data>
+  <data name="Teams_SyncStatus" xml:space="preserve"><value>Sync Status</value></data>
+  <data name="Teams_SystemTeams" xml:space="preserve"><value>System Teams</value></data>
+  <data name="TicketTransfer_AlreadyPending" xml:space="preserve"><value>Transfer already pending</value></data>
+  <data name="TicketTransfer_CancelRequest" xml:space="preserve"><value>Cancel request</value></data>
+  <data name="TicketTransfer_CheckedIn" xml:space="preserve"><value>Already checked in — can’t be transferred</value></data>
+  <data name="TicketTransfer_ConfirmDetails" xml:space="preserve"><value>This will request transferring ticket {0} ({1}) to {2}.</value></data>
+  <data name="TicketTransfer_ConfirmNote" xml:space="preserve"><value>Our ticketing team will process this and let you know shortly.</value></data>
+  <data name="TicketTransfer_Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="TicketTransfer_NoneTransferable" xml:space="preserve"><value>None of your tickets can be transferred right now.</value></data>
+  <data name="TicketTransfer_NoRequests" xml:space="preserve"><value>You haven’t requested any transfers.</value></data>
+  <data name="TicketTransfer_NoTickets" xml:space="preserve"><value>You don’t have any tickets to transfer.</value></data>
+  <data name="TicketTransfer_NotTransferable" xml:space="preserve"><value>Not transferable</value></data>
+  <data name="TicketTransfer_ReasonLabel" xml:space="preserve"><value>Reason for the transfer (optional, visible to the ticket team)</value></data>
+  <data name="TicketTransfer_RecipientPlaceholder" xml:space="preserve"><value>Search by name, or paste their exact email…</value></data>
+  <data name="TicketTransfer_Requested" xml:space="preserve"><value>Requested</value></data>
+  <data name="TicketTransfer_RequestTransfer" xml:space="preserve"><value>Request transfer</value></data>
+  <data name="TicketTransfer_StatusApproved" xml:space="preserve"><value>Completed</value></data>
+  <data name="TicketTransfer_StatusCancelled" xml:space="preserve"><value>Cancelled</value></data>
+  <data name="TicketTransfer_StatusRejected" xml:space="preserve"><value>Cancelled by team</value></data>
+  <data name="TicketTransfer_Step1" xml:space="preserve"><value>1. Choose the ticket to transfer</value></data>
+  <data name="TicketTransfer_Step2" xml:space="preserve"><value>2. Who are you sending it to?</value></data>
+  <data name="TicketTransfer_Step3" xml:space="preserve"><value>3. Confirm</value></data>
+  <data name="TicketTransfer_Title" xml:space="preserve"><value>Transfer a ticket</value></data>
+  <data name="TicketTransfer_YourRequests" xml:space="preserve"><value>Your transfer requests</value></data>
 </root>

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -142,7 +142,8 @@ public static class AdminNavTree
         new("Design", System: true, Items: [
             new("Color palette", "ColorPalette",  "Index", null, null, "fa-solid fa-palette", PolicyNames.AdminOnly),
             new("Components",    "WidgetGallery", "Index", null, null, "fa-solid fa-shapes",  PolicyNames.AdminOnly),
-            new("Date formats",  "Debug",         "FormatGallery", null, null, "fa-solid fa-clock", PolicyNames.AdminOnly)
+            new("Date formats",  "Debug",         "FormatGallery", null, null, "fa-solid fa-clock", PolicyNames.AdminOnly),
+            new("Translations",  "Debug",         "Translations",  null, null, "fa-solid fa-language", PolicyNames.AdminOnly)
         ]),
         new("Temp", System: true, Items: [
             new("Picture migration",          "ProfilePictureMigrationAdmin", "Index", null, null, "fa-solid fa-image",     PolicyNames.AdminOnly),

--- a/src/Humans.Web/Views/About/Index.cshtml
+++ b/src/Humans.Web/Views/About/Index.cshtml
@@ -3,32 +3,29 @@
 }
 
 <div class="text-center my-5">
-    <h1 class="display-4">About Humans</h1>
+    <h1 class="display-4">@Localizer["About_Title"]</h1>
     <p class="lead mt-3">
-        Made by <a href="https://github.com/peterdrier" target="_blank" rel="noopener noreferrer">Peter</a> with love for the Nobodies Community.
+        @Localizer["About_MadeBy"] <a href="https://github.com/peterdrier" target="_blank" rel="noopener noreferrer">Peter</a> @Localizer["About_MadeByTail"]
     </p>
     <p class="text-muted" style="max-width: 640px; margin: 0 auto;">
-        Humans is the membership system that keeps Nobodies Collective running — human onboarding,
-        team provisioning, governance tracking, and all the plumbing that lets a Spanish nonprofit
-        operate with the organisational memory of something ten times its size.
-        Built with care, maintained with stubbornness, and deployed with crossed fingers.
+        @Localizer["About_Intro"]
     </p>
     <p class="mt-3 mb-0">
-        Need help? <a href="mailto:humans@nobodies.team">humans@nobodies.team</a>
+        @Localizer["About_NeedHelp"] <a href="mailto:humans@nobodies.team">humans@nobodies.team</a>
     </p>
     <p class="mt-4 mb-0 text-muted">
-        With additional help from
+        @Localizer["About_AdditionalHelp"]
         <a href="https://github.com/jokin" target="_blank" rel="noopener noreferrer">Jokin</a>,
         <a href="https://github.com/veryaaron" target="_blank" rel="noopener noreferrer">Aaron</a>,
         <a href="https://github.com/davinov" target="_blank" rel="noopener noreferrer">David</a>,
         <a href="https://github.com/laugongim" target="_blank" rel="noopener noreferrer">Laura</a>,
-        and <a href="https://github.com/swombat" target="_blank" rel="noopener noreferrer">Daniel</a>.
+        @Localizer["About_AdditionalHelpAnd"] <a href="https://github.com/swombat" target="_blank" rel="noopener noreferrer">Daniel</a>.
     </p>
     @if (User.Identity?.IsAuthenticated == true)
     {
         <p class="mt-4">
             <a asp-controller="About" asp-action="Staff" class="btn btn-outline-primary">
-                <i class="fa-solid fa-users me-1"></i> Meet the Staff
+                <i class="fa-solid fa-users me-1"></i> @Localizer["About_MeetTheStaff"]
             </a>
         </p>
     }
@@ -36,19 +33,17 @@
 
 <div class="card border-primary mb-5" style="max-width: 720px; margin: 0 auto;">
     <div class="card-body">
-        <h5 class="card-title"><i class="fa-solid fa-section me-2"></i>License</h5>
+        <h5 class="card-title"><i class="fa-solid fa-section me-2"></i>@Localizer["About_LicenseHeading"]</h5>
         <p class="mb-2">
-            Humans is free software, released under the
+            @Localizer["About_LicenseBody"]
             <strong>GNU Affero General Public License v3.0</strong> (AGPL-3.0).
         </p>
         <p class="mb-2 small text-muted">
-            You may use, study, modify, and redistribute this software. If you run a modified version
-            and let others interact with it over a network, you must make your modified source available
-            under the same license.
+            @Localizer["About_LicenseExplanation"]
         </p>
         <p class="mb-0 small">
-            Full license text: <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener noreferrer">gnu.org/licenses/agpl-3.0</a>
-            &middot; Source code: <a href="https://github.com/peterdrier/Humans" target="_blank" rel="noopener noreferrer">github.com/peterdrier/Humans</a>
+            @Localizer["About_LicenseFullText"] <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener noreferrer">gnu.org/licenses/agpl-3.0</a>
+            &middot; @Localizer["About_LicenseSourceCode"] <a href="https://github.com/peterdrier/Humans" target="_blank" rel="noopener noreferrer">github.com/peterdrier/Humans</a>
         </p>
     </div>
 </div>
@@ -56,51 +51,45 @@
 <hr />
 
 <section class="my-5">
-    <h2><i class="fa-solid fa-flask-vial me-2"></i>The Ingredients</h2>
+    <h2><i class="fa-solid fa-flask-vial me-2"></i>@Localizer["About_IngredientsHeading"]</h2>
     <p>
-        Every workshop needs its materials. Here is what Humans is built from:
+        @Localizer["About_IngredientsIntro"]
     </p>
     <div class="row g-4 mt-2">
         <div class="col-md-4">
             <h5><i class="fa-brands fa-microsoft me-1"></i>.NET 10</h5>
             <p class="text-muted small mb-0">
-                ASP.NET Core MVC with Razor views, Identity, and the whole Microsoft stack.
-                The frame that holds everything together.
+                @Localizer["About_DotNetDesc"]
             </p>
         </div>
         <div class="col-md-4">
             <h5><i class="fa-solid fa-database me-1"></i>PostgreSQL + EF Core</h5>
             <p class="text-muted small mb-0">
-                Relational data with Entity Framework Core and Npgsql.
-                NodaTime types all the way down — no <code>DateTime</code> in sight.
+                @Localizer["About_PostgresDesc"]
             </p>
         </div>
         <div class="col-md-4">
             <h5><i class="fa-brands fa-google me-1"></i>Google Workspace APIs</h5>
             <p class="text-muted small mb-0">
-                Admin Directory, Drive, and Groups — provisioning Shared Drives,
-                folders, and mailing lists so nobody has to do it by hand.
+                @Localizer["About_GoogleDesc"]
             </p>
         </div>
         <div class="col-md-4">
             <h5><i class="fa-solid fa-clock me-1"></i>Hangfire</h5>
             <p class="text-muted small mb-0">
-                Background jobs for sync, reconciliation, and anything that shouldn't
-                block an HTTP request. PostgreSQL-backed, dashboard included.
+                @Localizer["About_HangfireDesc"]
             </p>
         </div>
         <div class="col-md-4">
             <h5><i class="fa-solid fa-chart-line me-1"></i>OpenTelemetry + Serilog</h5>
             <p class="text-muted small mb-0">
-                Structured logging, distributed traces, and Prometheus metrics.
-                Because "it works on my machine" isn't a monitoring strategy.
+                @Localizer["About_OtelDesc"]
             </p>
         </div>
         <div class="col-md-4">
             <h5><i class="fa-solid fa-envelope me-1"></i>MailKit</h5>
             <p class="text-muted small mb-0">
-                Transactional email for notifications and onboarding.
-                The one library that makes SMTP feel almost pleasant.
+                @Localizer["About_MailKitDesc"]
             </p>
         </div>
     </div>
@@ -109,30 +98,29 @@
 <hr />
 
 <section class="my-5">
-    <h2><i class="fa-solid fa-scale-balanced me-2"></i>Open Source Licenses</h2>
+    <h2><i class="fa-solid fa-scale-balanced me-2"></i>@Localizer["About_OpenSourceLicensesHeading"]</h2>
     <p>
-        Humans is built on the shoulders of open-source projects.
-        The table below lists every production dependency, its version, and license.
+        @Localizer["About_OpenSourceLicensesIntro"]
     </p>
 
-    <h4 class="mt-4">NuGet Packages</h4>
+    <h4 class="mt-4">@Localizer["About_NuGetPackagesHeading"]</h4>
     <p class="small text-muted">
-        Conversational helper responses are produced by Anthropic's API. No data is used for model training per Anthropic's DPA.
+        @Localizer["About_AnthropicNote"]
     </p>
     <div class="table-responsive">
         <table class="table table-sm table-striped align-middle">
             <thead class="table-dark">
                 <tr>
-                    <th>Category</th>
-                    <th>Package</th>
-                    <th>Version</th>
-                    <th>License</th>
+                    <th>@Localizer["About_ColCategory"]</th>
+                    <th>@Localizer["About_ColPackage"]</th>
+                    <th>@Localizer["About_ColVersion"]</th>
+                    <th>@Localizer["About_ColLicense"]</th>
                 </tr>
             </thead>
             <tbody>
                 @* — AI/LLM — *@
                 <tr>
-                    <td>AI/LLM</td>
+                    <td>@Localizer["About_Cat_AILLM"]</td>
                     <td><a href="https://www.nuget.org/packages/Anthropic" target="_blank" rel="noopener noreferrer">Anthropic</a></td>
                     <td>12.27.0</td>
                     <td>MIT</td>
@@ -140,43 +128,43 @@
 
                 @* — Framework — *@
                 <tr>
-                    <td>Framework</td>
+                    <td>@Localizer["About_Cat_Framework"]</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.Identity.EntityFrameworkCore" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.Identity.EntityFrameworkCore</a></td>
                     <td>10.0.8</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
-                    <td>Framework</td>
+                    <td>@Localizer["About_Cat_Framework"]</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.Authentication.Google</a></td>
                     <td>10.0.8</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
-                    <td>Framework</td>
+                    <td>@Localizer["About_Cat_Framework"]</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.DataProtection.EntityFrameworkCore</a></td>
                     <td>10.0.8</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
-                    <td>Framework</td>
+                    <td>@Localizer["About_Cat_Framework"]</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.DataProtection.Extensions</a></td>
                     <td>10.0.8</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
-                    <td>Framework</td>
+                    <td>@Localizer["About_Cat_Framework"]</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation</a></td>
                     <td>10.0.8</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
-                    <td>Framework</td>
+                    <td>@Localizer["About_Cat_Framework"]</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.EntityFrameworkCore" target="_blank" rel="noopener noreferrer">Microsoft.EntityFrameworkCore</a></td>
                     <td>10.0.8</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
-                    <td>Framework</td>
+                    <td>@Localizer["About_Cat_Framework"]</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.Extensions.Localization" target="_blank" rel="noopener noreferrer">Microsoft.Extensions.Localization</a></td>
                     <td>10.0.8</td>
                     <td>MIT</td>
@@ -184,13 +172,13 @@
 
                 @* — Database — *@
                 <tr>
-                    <td>Database</td>
+                    <td>@Localizer["About_Cat_Database"]</td>
                     <td><a href="https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL" target="_blank" rel="noopener noreferrer">Npgsql.EntityFrameworkCore.PostgreSQL</a></td>
                     <td>10.0.1</td>
                     <td>PostgreSQL</td>
                 </tr>
                 <tr>
-                    <td>Database</td>
+                    <td>@Localizer["About_Cat_Database"]</td>
                     <td><a href="https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" target="_blank" rel="noopener noreferrer">Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime</a></td>
                     <td>10.0.1</td>
                     <td>PostgreSQL</td>
@@ -198,13 +186,13 @@
 
                 @* — Date/Time — *@
                 <tr>
-                    <td>Date/Time</td>
+                    <td>@Localizer["About_Cat_DateTime"]</td>
                     <td><a href="https://www.nuget.org/packages/NodaTime" target="_blank" rel="noopener noreferrer">NodaTime</a></td>
                     <td>3.3.2</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Date/Time</td>
+                    <td>@Localizer["About_Cat_DateTime"]</td>
                     <td><a href="https://www.nuget.org/packages/NodaTime.Serialization.SystemTextJson" target="_blank" rel="noopener noreferrer">NodaTime.Serialization.SystemTextJson</a></td>
                     <td>1.3.1</td>
                     <td>Apache-2.0</td>
@@ -212,7 +200,7 @@
 
                 @* — Calendar — *@
                 <tr>
-                    <td>Calendar</td>
+                    <td>@Localizer["About_Cat_Calendar"]</td>
                     <td><a href="https://www.nuget.org/packages/Ical.Net" target="_blank" rel="noopener noreferrer">Ical.Net</a></td>
                     <td>5.2.2</td>
                     <td>MIT</td>
@@ -220,7 +208,7 @@
 
                 @* — Spreadsheet — *@
                 <tr>
-                    <td>Spreadsheet</td>
+                    <td>@Localizer["About_Cat_Spreadsheet"]</td>
                     <td><a href="https://www.nuget.org/packages/ClosedXML" target="_blank" rel="noopener noreferrer">ClosedXML</a></td>
                     <td>0.105.0</td>
                     <td>MIT</td>
@@ -228,7 +216,7 @@
 
                 @* — CSV — *@
                 <tr>
-                    <td>CSV</td>
+                    <td>@Localizer["About_Cat_CSV"]</td>
                     <td><a href="https://www.nuget.org/packages/CsvHelper" target="_blank" rel="noopener noreferrer">CsvHelper</a></td>
                     <td>33.1.0</td>
                     <td>MS-PL / Apache-2.0</td>
@@ -236,7 +224,7 @@
 
                 @* — State Machine — *@
                 <tr>
-                    <td>State Machine</td>
+                    <td>@Localizer["About_Cat_StateMachine"]</td>
                     <td><a href="https://www.nuget.org/packages/Stateless" target="_blank" rel="noopener noreferrer">Stateless</a></td>
                     <td>5.20.1</td>
                     <td>Apache-2.0</td>
@@ -244,19 +232,19 @@
 
                 @* — Background Jobs — *@
                 <tr>
-                    <td>Background Jobs</td>
+                    <td>@Localizer["About_Cat_BackgroundJobs"]</td>
                     <td><a href="https://www.nuget.org/packages/Hangfire.Core" target="_blank" rel="noopener noreferrer">Hangfire.Core</a></td>
                     <td>1.8.23</td>
                     <td>LGPL-3.0</td>
                 </tr>
                 <tr>
-                    <td>Background Jobs</td>
+                    <td>@Localizer["About_Cat_BackgroundJobs"]</td>
                     <td><a href="https://www.nuget.org/packages/Hangfire.AspNetCore" target="_blank" rel="noopener noreferrer">Hangfire.AspNetCore</a></td>
                     <td>1.8.23</td>
                     <td>LGPL-3.0</td>
                 </tr>
                 <tr>
-                    <td>Background Jobs</td>
+                    <td>@Localizer["About_Cat_BackgroundJobs"]</td>
                     <td><a href="https://www.nuget.org/packages/Hangfire.PostgreSql" target="_blank" rel="noopener noreferrer">Hangfire.PostgreSql</a></td>
                     <td>1.21.1</td>
                     <td>LGPL-3.0</td>
@@ -264,7 +252,7 @@
 
                 @* — Email — *@
                 <tr>
-                    <td>Email</td>
+                    <td>@Localizer["About_Cat_Email"]</td>
                     <td><a href="https://www.nuget.org/packages/MailKit" target="_blank" rel="noopener noreferrer">MailKit</a></td>
                     <td>4.17.0</td>
                     <td>MIT</td>
@@ -272,7 +260,7 @@
 
                 @* — GitHub API — *@
                 <tr>
-                    <td>GitHub API</td>
+                    <td>@Localizer["About_Cat_GitHubAPI"]</td>
                     <td><a href="https://www.nuget.org/packages/Octokit" target="_blank" rel="noopener noreferrer">Octokit</a></td>
                     <td>14.0.0</td>
                     <td>MIT</td>
@@ -280,37 +268,37 @@
 
                 @* — Google APIs — *@
                 <tr>
-                    <td>Google APIs</td>
+                    <td>@Localizer["About_Cat_GoogleAPIs"]</td>
                     <td><a href="https://www.nuget.org/packages/Google.Apis.Admin.Directory.directory_v1" target="_blank" rel="noopener noreferrer">Google.Apis.Admin.Directory.directory_v1</a></td>
                     <td>1.74.0.4159</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Google APIs</td>
+                    <td>@Localizer["About_Cat_GoogleAPIs"]</td>
                     <td><a href="https://www.nuget.org/packages/Google.Apis.CloudIdentity.v1" target="_blank" rel="noopener noreferrer">Google.Apis.CloudIdentity.v1</a></td>
                     <td>1.74.0.4161</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Google APIs</td>
+                    <td>@Localizer["About_Cat_GoogleAPIs"]</td>
                     <td><a href="https://www.nuget.org/packages/Google.Apis.Drive.v3" target="_blank" rel="noopener noreferrer">Google.Apis.Drive.v3</a></td>
                     <td>1.74.0.4135</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Google APIs</td>
+                    <td>@Localizer["About_Cat_GoogleAPIs"]</td>
                     <td><a href="https://www.nuget.org/packages/Google.Apis.DriveActivity.v2" target="_blank" rel="noopener noreferrer">Google.Apis.DriveActivity.v2</a></td>
                     <td>1.74.0.3880</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Google APIs</td>
+                    <td>@Localizer["About_Cat_GoogleAPIs"]</td>
                     <td><a href="https://www.nuget.org/packages/Google.Apis.Groupssettings.v1" target="_blank" rel="noopener noreferrer">Google.Apis.Groupssettings.v1</a></td>
                     <td>1.74.0.2721</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Google APIs</td>
+                    <td>@Localizer["About_Cat_GoogleAPIs"]</td>
                     <td><a href="https://www.nuget.org/packages/Google.Apis.Auth" target="_blank" rel="noopener noreferrer">Google.Apis.Auth</a></td>
                     <td>1.75.0</td>
                     <td>Apache-2.0</td>
@@ -318,7 +306,7 @@
 
                 @* — Resilience — *@
                 <tr>
-                    <td>Resilience</td>
+                    <td>@Localizer["About_Cat_Resilience"]</td>
                     <td><a href="https://www.nuget.org/packages/Polly" target="_blank" rel="noopener noreferrer">Polly</a></td>
                     <td>8.6.6</td>
                     <td>BSD-3-Clause</td>
@@ -326,43 +314,43 @@
 
                 @* — Observability — *@
                 <tr>
-                    <td>Observability</td>
+                    <td>@Localizer["About_Cat_Observability"]</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol" target="_blank" rel="noopener noreferrer">OpenTelemetry.Exporter.OpenTelemetryProtocol</a></td>
                     <td>1.15.3</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Observability</td>
+                    <td>@Localizer["About_Cat_Observability"]</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore" target="_blank" rel="noopener noreferrer">OpenTelemetry.Exporter.Prometheus.AspNetCore</a></td>
                     <td>1.15.0-beta.1</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Observability</td>
+                    <td>@Localizer["About_Cat_Observability"]</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting" target="_blank" rel="noopener noreferrer">OpenTelemetry.Extensions.Hosting</a></td>
                     <td>1.15.3</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Observability</td>
+                    <td>@Localizer["About_Cat_Observability"]</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore" target="_blank" rel="noopener noreferrer">OpenTelemetry.Instrumentation.AspNetCore</a></td>
                     <td>1.15.2</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Observability</td>
+                    <td>@Localizer["About_Cat_Observability"]</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EntityFrameworkCore" target="_blank" rel="noopener noreferrer">OpenTelemetry.Instrumentation.EntityFrameworkCore</a></td>
                     <td>1.15.0-beta.1</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Observability</td>
+                    <td>@Localizer["About_Cat_Observability"]</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http" target="_blank" rel="noopener noreferrer">OpenTelemetry.Instrumentation.Http</a></td>
                     <td>1.15.1</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Observability</td>
+                    <td>@Localizer["About_Cat_Observability"]</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime" target="_blank" rel="noopener noreferrer">OpenTelemetry.Instrumentation.Runtime</a></td>
                     <td>1.15.1</td>
                     <td>Apache-2.0</td>
@@ -370,25 +358,25 @@
 
                 @* — Logging — *@
                 <tr>
-                    <td>Logging</td>
+                    <td>@Localizer["About_Cat_Logging"]</td>
                     <td><a href="https://www.nuget.org/packages/Serilog" target="_blank" rel="noopener noreferrer">Serilog</a></td>
                     <td>4.3.1</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Logging</td>
+                    <td>@Localizer["About_Cat_Logging"]</td>
                     <td><a href="https://www.nuget.org/packages/Serilog.AspNetCore" target="_blank" rel="noopener noreferrer">Serilog.AspNetCore</a></td>
                     <td>10.0.0</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Logging</td>
+                    <td>@Localizer["About_Cat_Logging"]</td>
                     <td><a href="https://www.nuget.org/packages/Serilog.Sinks.Debug" target="_blank" rel="noopener noreferrer">Serilog.Sinks.Debug</a></td>
                     <td>3.0.0</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Logging</td>
+                    <td>@Localizer["About_Cat_Logging"]</td>
                     <td><a href="https://www.nuget.org/packages/Serilog.Sinks.OpenTelemetry" target="_blank" rel="noopener noreferrer">Serilog.Sinks.OpenTelemetry</a></td>
                     <td>4.2.0</td>
                     <td>Apache-2.0</td>
@@ -396,7 +384,7 @@
 
                 @* — Image Processing — *@
                 <tr>
-                    <td>Image Processing</td>
+                    <td>@Localizer["About_Cat_ImageProcessing"]</td>
                     <td><a href="https://www.nuget.org/packages/Magick.NET-Q8-AnyCPU" target="_blank" rel="noopener noreferrer">Magick.NET-Q8-AnyCPU</a></td>
                     <td>14.14.0</td>
                     <td>Apache-2.0</td>
@@ -404,13 +392,13 @@
 
                 @* — Markdown / Sanitization — *@
                 <tr>
-                    <td>Markdown</td>
+                    <td>@Localizer["About_Cat_Markdown"]</td>
                     <td><a href="https://www.nuget.org/packages/Markdig" target="_blank" rel="noopener noreferrer">Markdig</a></td>
                     <td>1.2.0</td>
                     <td>BSD-2-Clause</td>
                 </tr>
                 <tr>
-                    <td>Sanitization</td>
+                    <td>@Localizer["About_Cat_Sanitization"]</td>
                     <td><a href="https://www.nuget.org/packages/HtmlSanitizer" target="_blank" rel="noopener noreferrer">HtmlSanitizer</a></td>
                     <td>9.0.892</td>
                     <td>MIT</td>
@@ -418,7 +406,7 @@
 
                 @* — User-Agent — *@
                 <tr>
-                    <td>User-Agent</td>
+                    <td>@Localizer["About_Cat_UserAgent"]</td>
                     <td><a href="https://www.nuget.org/packages/MyCSharp.HttpUserAgentParser" target="_blank" rel="noopener noreferrer">MyCSharp.HttpUserAgentParser</a></td>
                     <td>3.1.6</td>
                     <td>MIT</td>
@@ -426,7 +414,7 @@
 
                 @* — Payments — *@
                 <tr>
-                    <td>Payments</td>
+                    <td>@Localizer["About_Cat_Payments"]</td>
                     <td><a href="https://www.nuget.org/packages/Stripe.net" target="_blank" rel="noopener noreferrer">Stripe.net</a></td>
                     <td>51.1.0</td>
                     <td>Apache-2.0</td>
@@ -434,19 +422,19 @@
 
                 @* — Health Checks — *@
                 <tr>
-                    <td>Health Checks</td>
+                    <td>@Localizer["About_Cat_HealthChecks"]</td>
                     <td><a href="https://www.nuget.org/packages/AspNetCore.HealthChecks.NpgSql" target="_blank" rel="noopener noreferrer">AspNetCore.HealthChecks.NpgSql</a></td>
                     <td>9.0.0</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Health Checks</td>
+                    <td>@Localizer["About_Cat_HealthChecks"]</td>
                     <td><a href="https://www.nuget.org/packages/AspNetCore.HealthChecks.Hangfire" target="_blank" rel="noopener noreferrer">AspNetCore.HealthChecks.Hangfire</a></td>
                     <td>9.0.0</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
-                    <td>Health Checks</td>
+                    <td>@Localizer["About_Cat_HealthChecks"]</td>
                     <td><a href="https://www.nuget.org/packages/AspNetCore.HealthChecks.Uris" target="_blank" rel="noopener noreferrer">AspNetCore.HealthChecks.Uris</a></td>
                     <td>9.0.0</td>
                     <td>Apache-2.0</td>
@@ -455,14 +443,14 @@
         </table>
     </div>
 
-    <h4 class="mt-4">Frontend / CDN Dependencies</h4>
+    <h4 class="mt-4">@Localizer["About_FrontendHeading"]</h4>
     <div class="table-responsive">
         <table class="table table-sm table-striped align-middle">
             <thead class="table-dark">
                 <tr>
-                    <th>Library</th>
-                    <th>Version</th>
-                    <th>License</th>
+                    <th>@Localizer["About_ColLibrary"]</th>
+                    <th>@Localizer["About_ColVersion"]</th>
+                    <th>@Localizer["About_ColLicense"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -520,23 +508,22 @@
         </table>
     </div>
 
-    <h4 class="mt-4">License Compliance Summary</h4>
+    <h4 class="mt-4">@Localizer["About_LicenseComplianceHeading"]</h4>
     <div class="card">
         <div class="card-body">
-            <p class="mb-2"><strong>All production dependencies use permissive or weak-copyleft licenses. No violations found.</strong></p>
+            <p class="mb-2"><strong>@Localizer["About_LicenseComplianceSummary"]</strong></p>
             <ul class="mb-0 small">
-                <li><strong>MIT</strong> &mdash; requires copyright notice; this page satisfies that obligation.</li>
-                <li><strong>BSD-3-Clause</strong> (MapLibre GL JS) &mdash; requires copyright notice; this page satisfies that obligation.</li>
-                <li><strong>ISC</strong> (maplibre-gl-draw) &mdash; permissive, functionally equivalent to BSD-2-Clause; copyright notice required.</li>
-                <li><strong>Apache-2.0</strong> &mdash; requires copyright notice, license copy, and statement of changes if modified. All packages are used unmodified.</li>
-                <li><strong>BSD-2-Clause / BSD-3-Clause</strong> &mdash; requires copyright notice in documentation.</li>
-                <li><strong>PostgreSQL License</strong> &mdash; permissive, MIT-like; copyright notice required.</li>
+                <li><strong>MIT</strong> &mdash; @Localizer["About_License_MIT"]</li>
+                <li><strong>BSD-3-Clause</strong> (MapLibre GL JS) &mdash; @Localizer["About_License_BSD3MapLibre"]</li>
+                <li><strong>ISC</strong> (maplibre-gl-draw) &mdash; @Localizer["About_License_ISC"]</li>
+                <li><strong>Apache-2.0</strong> &mdash; @Localizer["About_License_Apache2"]</li>
+                <li><strong>BSD-2-Clause / BSD-3-Clause</strong> &mdash; @Localizer["About_License_BSD2"]</li>
+                <li><strong>PostgreSQL License</strong> &mdash; @Localizer["About_License_PostgreSQL"]</li>
                 <li>
-                    <strong>LGPL-3.0</strong> (Hangfire) &mdash; the library must be replaceable by the end user. Consumed as
-                    unmodified NuGet packages (dynamically linked), satisfying LGPL obligations.
+                    <strong>LGPL-3.0</strong> (Hangfire) &mdash; @Localizer["About_License_LGPL30"]
                     Source available at <a href="https://github.com/HangfireIO/Hangfire" target="_blank" rel="noopener noreferrer">github.com/HangfireIO/Hangfire</a>.
                 </li>
-                <li><strong>SIL OFL 1.1</strong> (fonts) &mdash; free to use and redistribute; fonts cannot be sold standalone.</li>
+                <li><strong>SIL OFL 1.1</strong> (fonts) &mdash; @Localizer["About_License_SILOFL"]</li>
             </ul>
         </div>
     </div>

--- a/src/Humans.Web/Views/About/Staff.cshtml
+++ b/src/Humans.Web/Views/About/Staff.cshtml
@@ -1,15 +1,14 @@
 @model StaffViewModel
 @{
-    ViewData["Title"] = "The Humans Behind the Curtain";
+    ViewData["Title"] = Localizer["About_Staff_Title"].Value;
 }
 
 <div class="text-center my-5">
     <h1 class="display-4" style="font-family: 'Cormorant Garamond', serif; font-weight: 700;">
-        <i class="fa-solid fa-scroll me-2"></i>The Humans Behind the Curtain
+        <i class="fa-solid fa-scroll me-2"></i>@Localizer["About_Staff_Title"]
     </h1>
     <p class="lead mt-3" style="max-width: 700px; margin: 0 auto; font-style: italic;">
-        Every collective needs its keepers. These are the humans who volunteer their time and energy
-        to keep Nobodies running &mdash; from governance to tech support, from trust and safety to ticket alchemy.
+        @Localizer["About_Staff_Intro"]
     </p>
 </div>
 
@@ -17,7 +16,7 @@
 {
     <div class="text-center text-muted my-5">
         <i class="fa-solid fa-ghost fa-3x mb-3"></i>
-        <p>No active role holders found. The castle appears to be empty.</p>
+        <p>@Localizer["About_Staff_Empty"]</p>
     </div>
 }
 else
@@ -51,6 +50,6 @@ else
 
 <div class="text-center my-5">
     <a asp-controller="About" asp-action="Index" class="btn btn-outline-secondary">
-        <i class="fa-solid fa-arrow-left me-1"></i> Back to About
+        <i class="fa-solid fa-arrow-left me-1"></i> @Localizer["About_Staff_BackToAbout"]
     </a>
 </div>

--- a/src/Humans.Web/Views/Budget/NoActiveBudget.cshtml
+++ b/src/Humans.Web/Views/Budget/NoActiveBudget.cshtml
@@ -1,14 +1,14 @@
 @{
-    ViewData["Title"] = "Budget";
+    ViewData["Title"] = Localizer["Budget_Title"].Value;
 }
 
-<h1 class="mb-4">Budget</h1>
+<h1 class="mb-4">@Localizer["Budget_Title"]</h1>
 
 
 <div class="card">
     <div class="card-body text-center py-5">
         <i class="fa-solid fa-chart-pie fa-3x text-muted mb-3"></i>
-        <h4 class="text-muted">No Active Budget</h4>
-        <p class="text-muted mb-0">There is no active budget year to display. A finance admin will set one up when budget planning begins.</p>
+        <h4 class="text-muted">@Localizer["Budget_NoActiveBudget"]</h4>
+        <p class="text-muted mb-0">@Localizer["Budget_NoActiveBudgetSubtitle"]</p>
     </div>
 </div>

--- a/src/Humans.Web/Views/Budget/Summary.cshtml
+++ b/src/Humans.Web/Views/Budget/Summary.cshtml
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Html
 @model Humans.Web.Models.BudgetSummaryViewModel
 @{
-    ViewData["Title"] = $"Budget - {Model.YearName}";
+    ViewData["Title"] = Localizer["Budget_TitleYear", Model.YearName].Value;
     var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase };
     var incomeLabels = Model.IncomeSlices.Select(s => s.Name).ToList();
     var incomeData = Model.IncomeSlices.Select(s => s.Amount).ToList();
@@ -11,23 +11,23 @@
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1 class="mb-0">Budget Overview</h1>
+    <h1 class="mb-0">@Localizer["Budget_OverviewTitle"]</h1>
     @if (Model.IsCoordinator)
     {
         <a asp-action="Index" class="btn btn-outline-primary">
-            <i class="fa-solid fa-list me-1"></i>Department Detail
+            <i class="fa-solid fa-list me-1"></i>@Localizer["Budget_DepartmentDetail"]
         </a>
     }
 </div>
 
 
-<p class="text-muted mb-4">How the @Model.YearName budget is allocated across departments and infrastructure.</p>
+<p class="text-muted mb-4">@Localizer["Budget_OverviewSubtitle", Model.YearName]</p>
 
 <div class="row mb-4">
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Total Income</h6>
+                <h6 class="card-subtitle mb-2 text-muted">@Localizer["Budget_TotalIncome"]</h6>
                 <h3 class="card-title mb-0 text-success">@Model.TotalIncome.ToEuro()</h3>
             </div>
         </div>
@@ -35,7 +35,7 @@
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Total Expenses</h6>
+                <h6 class="card-subtitle mb-2 text-muted">@Localizer["Budget_TotalExpenses"]</h6>
                 <h3 class="card-title mb-0 text-danger">@Math.Abs(Model.TotalExpenses).ToEuro()</h3>
             </div>
         </div>
@@ -43,7 +43,7 @@
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Net Balance</h6>
+                <h6 class="card-subtitle mb-2 text-muted">@Localizer["Budget_NetBalance"]</h6>
                 <h3 class="card-title mb-0 @(Model.NetBalance >= 0 ? "text-success" : "text-danger")">
                     @Model.NetBalance.ToEuro()
                 </h3>
@@ -58,7 +58,7 @@
         <div class="col-lg-6 mb-4">
             <div class="card h-100">
                 <div class="card-header">
-                    <i class="fa-solid fa-arrow-trend-up me-1 text-success"></i>Income
+                    <i class="fa-solid fa-arrow-trend-up me-1 text-success"></i>@Localizer["Budget_Income"]
                 </div>
                 <div class="card-body">
                     @if (Model.IncomeSlices.Any())
@@ -69,7 +69,7 @@
                     {
                         <div class="text-center text-muted py-4">
                             <i class="fa-solid fa-chart-pie fa-2x mb-2"></i>
-                            <p class="mb-0">No income line items yet.</p>
+                            <p class="mb-0">@Localizer["Budget_NoIncomeItems"]</p>
                         </div>
                     }
                 </div>
@@ -79,7 +79,7 @@
         <div class="col-lg-6 mb-4">
             <div class="card h-100">
                 <div class="card-header">
-                    <i class="fa-solid fa-arrow-trend-down me-1 text-danger"></i>Expenses
+                    <i class="fa-solid fa-arrow-trend-down me-1 text-danger"></i>@Localizer["Budget_Expenses"]
                 </div>
                 <div class="card-body">
                     @if (Model.ExpenseSlices.Any())
@@ -90,7 +90,7 @@
                     {
                         <div class="text-center text-muted py-4">
                             <i class="fa-solid fa-chart-pie fa-2x mb-2"></i>
-                            <p class="mb-0">No expense line items yet.</p>
+                            <p class="mb-0">@Localizer["Budget_NoExpenseItems"]</p>
                         </div>
                     }
                 </div>
@@ -103,13 +103,13 @@
         {
             <div class="col-lg-6 mb-4">
                 <div class="card">
-                    <div class="card-header">Income Breakdown</div>
+                    <div class="card-header">@Localizer["Budget_IncomeBreakdown"]</div>
                     <div class="card-body p-0">
                         @{
                             var incomeTable = TableModel.For(Model.IncomeSlices)
-                                .Column("Category", r => r.Name)
-                                .Column("Amount (€)", r => r.Amount, c => c.Currency().End())
-                                .Column("Share", r => r.Percentage.ToString("N1", System.Globalization.CultureInfo.CurrentCulture) + "%", c => c.End())
+                                .Column(Localizer["Budget_ColCategory"].Value, r => r.Name)
+                                .Column(Localizer["Budget_ColAmount"].Value, r => r.Amount, c => c.Currency().End())
+                                .Column(Localizer["Budget_ColShare"].Value, r => r.Percentage.ToString("N1", System.Globalization.CultureInfo.CurrentCulture) + "%", c => c.End())
                                 .Build();
                         }
                         <partial name="_Table" model="incomeTable" />
@@ -121,13 +121,13 @@
         {
             <div class="col-lg-6 mb-4">
                 <div class="card">
-                    <div class="card-header">Expenses Breakdown</div>
+                    <div class="card-header">@Localizer["Budget_ExpensesBreakdown"]</div>
                     <div class="card-body p-0">
                         @{
                             var expenseTable = TableModel.For(Model.ExpenseSlices)
-                                .Column("Category", r => r.Name)
-                                .Column("Amount (€)", r => r.Amount, c => c.Currency().End())
-                                .Column("Share", r => r.Percentage.ToString("N1", System.Globalization.CultureInfo.CurrentCulture) + "%", c => c.End())
+                                .Column(Localizer["Budget_ColCategory"].Value, r => r.Name)
+                                .Column(Localizer["Budget_ColAmount"].Value, r => r.Amount, c => c.Currency().End())
+                                .Column(Localizer["Budget_ColShare"].Value, r => r.Percentage.ToString("N1", System.Globalization.CultureInfo.CurrentCulture) + "%", c => c.End())
                                 .Build();
                         }
                         <partial name="_Table" model="expenseTable" />
@@ -232,8 +232,8 @@ else
     <div class="card">
         <div class="card-body text-center py-5">
             <i class="fa-solid fa-chart-pie fa-3x text-muted mb-3"></i>
-            <h4 class="text-muted">Budget data not available yet</h4>
-            <p class="text-muted mb-0">Budget allocations will appear here once they are set up by the finance team.</p>
+            <h4 class="text-muted">@Localizer["Budget_NoDataYet"]</h4>
+            <p class="text-muted mb-0">@Localizer["Budget_NoDataSubtitle"]</p>
         </div>
     </div>
 }

--- a/src/Humans.Web/Views/Calendar/Agenda.cshtml
+++ b/src/Humans.Web/Views/Calendar/Agenda.cshtml
@@ -3,7 +3,7 @@
 @using Humans.Web.Models.Calendar
 @model Humans.Web.Models.Calendar.CalendarAgendaViewModel
 @{
-    ViewData["Title"] = "Calendar — Agenda";
+    ViewData["Title"] = $"{Localizer["Calendar_Title"].Value} — {Localizer["Calendar_Agenda"].Value}";
     ViewData["ActiveView"] = "agenda";
     var zone = DateTimeZoneProviders.Tzdb[Model.ViewerTimezoneLabel];
 
@@ -35,17 +35,17 @@
     <partial name="_CalendarViewPills" />
 
     <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1 class="h3 mb-0">Agenda</h1>
+        <h1 class="h3 mb-0">@Localizer["Calendar_Agenda"]</h1>
         <div>
-            <a class="btn btn-sm btn-primary" asp-action="Create">New event</a>
+            <a class="btn btn-sm btn-primary" asp-action="Create">@Localizer["Calendar_NewEvent"]</a>
         </div>
     </div>
 
-    <p class="text-muted small">All times shown in @Model.ViewerTimezoneLabel.</p>
+    <p class="text-muted small">@Localizer["Calendar_AllTimesShownIn", Model.ViewerTimezoneLabel]</p>
 
     @if (!grouped.Any())
     {
-        <p class="text-muted">No events in the selected range.</p>
+        <p class="text-muted">@Localizer["Calendar_NoEventsInRange"]</p>
     }
     else
     {
@@ -62,7 +62,7 @@
                         @if (hideTime)
                         {
                             <span class="badge bg-light text-dark me-2">
-                                @(isContinuation ? "continues" : "all day")
+                                @(isContinuation ? Localizer["Calendar_Continues"].Value : Localizer["Calendar_AllDay"].Value)
                             </span>
                         }
                         else

--- a/src/Humans.Web/Views/Calendar/Create.cshtml
+++ b/src/Humans.Web/Views/Calendar/Create.cshtml
@@ -1,15 +1,15 @@
 @model Humans.Web.Models.Calendar.CalendarEventFormViewModel
 @{
-    ViewData["Title"] = "New event";
+    ViewData["Title"] = Localizer["Calendar_NewEvent"].Value;
 }
 
 <div class="container py-4">
-    <h1 class="h3 mb-3">New event</h1>
+    <h1 class="h3 mb-3">@Localizer["Calendar_NewEvent"]</h1>
 
     <form method="post" asp-action="Create">
         @Html.AntiForgeryToken()
         <partial name="_CalendarEventFormFields" model="Model" />
-        <button type="submit" class="btn btn-primary">Create event</button>
-        <a class="btn btn-link" asp-action="Index">Cancel</a>
+        <button type="submit" class="btn btn-primary">@Localizer["Calendar_CreateEvent"]</button>
+        <a class="btn btn-link" asp-action="Index">@Localizer["Common_Cancel"]</a>
     </form>
 </div>

--- a/src/Humans.Web/Views/Calendar/Edit.cshtml
+++ b/src/Humans.Web/Views/Calendar/Edit.cshtml
@@ -1,15 +1,15 @@
 @model Humans.Web.Models.Calendar.CalendarEventFormViewModel
 @{
-    ViewData["Title"] = "Edit event";
+    ViewData["Title"] = Localizer["Calendar_EditEvent"].Value;
 }
 
 <div class="container py-4">
-    <h1 class="h3 mb-3">Edit event</h1>
+    <h1 class="h3 mb-3">@Localizer["Calendar_EditEvent"]</h1>
 
     <form method="post" asp-action="Edit" asp-route-id="@Model.Id">
         @Html.AntiForgeryToken()
         <partial name="_CalendarEventFormFields" model="Model" />
-        <button type="submit" class="btn btn-primary">Save changes</button>
-        <a class="btn btn-link" asp-action="Event" asp-route-id="@Model.Id">Cancel</a>
+        <button type="submit" class="btn btn-primary">@Localizer["Common_Save"]</button>
+        <a class="btn btn-link" asp-action="Event" asp-route-id="@Model.Id">@Localizer["Common_Cancel"]</a>
     </form>
 </div>

--- a/src/Humans.Web/Views/Calendar/Event.cshtml
+++ b/src/Humans.Web/Views/Calendar/Event.cshtml
@@ -1,7 +1,7 @@
 @using NodaTime
 @model Humans.Web.Models.Calendar.CalendarEventViewModel
 @{
-    ViewData["Title"] = $"Event — {Model.Event.Title}";
+    ViewData["Title"] = $"{Localizer["Calendar_EventTitle"].Value} — {Model.Event.Title}";
     var zone = DateTimeZoneProviders.Tzdb[Model.ViewerTimezoneLabel];
     var firstLocal = Model.Event.StartUtc.InZone(zone).LocalDateTime;
     var endLocal = Model.Event.EndUtc?.InZone(zone).LocalDateTime;
@@ -18,18 +18,18 @@
         @if (Model.CanEdit)
         {
             <div>
-                <a class="btn btn-sm btn-outline-primary" asp-action="Edit" asp-route-id="@Model.Event.Id">Edit</a>
+                <a class="btn btn-sm btn-outline-primary" asp-action="Edit" asp-route-id="@Model.Event.Id">@Localizer["Common_Edit"]</a>
                 <form asp-action="Delete" asp-route-id="@Model.Event.Id" method="post" class="d-inline"
-                      data-confirm="Delete this event and all its occurrences?">
+                      data-confirm="@Localizer["Calendar_DeleteConfirm"]">
                     @Html.AntiForgeryToken()
-                    <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                    <button type="submit" class="btn btn-sm btn-outline-danger">@Localizer["Common_Delete"]</button>
                 </form>
             </div>
         }
     </div>
 
     <dl class="row">
-        <dt class="col-sm-3">First start</dt>
+        <dt class="col-sm-3">@Localizer["Calendar_FirstStart"]</dt>
         <dd class="col-sm-9">
             @firstLocal.ToMonthDayTime()
             <small class="text-muted">(@Model.ViewerTimezoneLabel)</small>
@@ -37,19 +37,19 @@
 
         @if (endLocal is { } el)
         {
-            <dt class="col-sm-3">End</dt>
+            <dt class="col-sm-3">@Localizer["Calendar_End"]</dt>
             <dd class="col-sm-9">@el.ToMonthDayTime()</dd>
         }
 
         @if (Model.Event.IsAllDay)
         {
-            <dt class="col-sm-3">All-day</dt>
-            <dd class="col-sm-9">Yes</dd>
+            <dt class="col-sm-3">@Localizer["Calendar_AllDayLabel"]</dt>
+            <dd class="col-sm-9">@Localizer["Calendar_Yes"]</dd>
         }
 
         @if (!string.IsNullOrWhiteSpace(Model.Event.Location))
         {
-            <dt class="col-sm-3">Location</dt>
+            <dt class="col-sm-3">@Localizer["Profile_Location"]</dt>
             <dd class="col-sm-9">
                 @if (!string.IsNullOrWhiteSpace(Model.Event.LocationUrl))
                 {
@@ -64,23 +64,23 @@
 
         @if (!string.IsNullOrWhiteSpace(Model.Event.Description))
         {
-            <dt class="col-sm-3">Description</dt>
+            <dt class="col-sm-3">@Localizer["Calendar_Description"]</dt>
             <dd class="col-sm-9">@Html.SanitizedMarkdown(Model.Event.Description)</dd>
         }
 
         @if (!string.IsNullOrWhiteSpace(Model.Event.RecurrenceRule))
         {
-            <dt class="col-sm-3">Recurrence</dt>
+            <dt class="col-sm-3">@Localizer["Calendar_Recurrence"]</dt>
             <dd class="col-sm-9">
                 <code>@Model.Event.RecurrenceRule</code>
-                <small class="text-muted d-block">Timezone: @Model.Event.RecurrenceTimezone</small>
+                <small class="text-muted d-block">@Localizer["Calendar_RecurrenceTimezoneNote", Model.Event.RecurrenceTimezone ?? string.Empty]</small>
             </dd>
         }
     </dl>
 
     @if (Model.UpcomingOccurrences.Count > 0)
     {
-        <h2 class="h5 mt-4">Upcoming occurrences</h2>
+        <h2 class="h5 mt-4">@Localizer["Calendar_UpcomingOccurrences"]</h2>
         <ul class="list-unstyled">
             @foreach (var o in Model.UpcomingOccurrences)
             {
@@ -99,15 +99,15 @@
                            asp-action="EditOccurrence"
                            asp-route-id="@Model.Event.Id"
                            asp-route-originalStartUtc="@o.OriginalOccurrenceStartUtc.Value.ToString()">
-                            Edit this occurrence
+                            @Localizer["Calendar_EditThisOccurrence"]
                         </a>
                         <form asp-action="CancelOccurrence"
                               asp-route-id="@Model.Event.Id"
                               asp-route-originalStartUtc="@o.OriginalOccurrenceStartUtc.Value.ToString()"
                               method="post" class="d-inline"
-                              data-confirm="Cancel just this occurrence?">
+                              data-confirm="@Localizer["Calendar_CancelOccurrenceConfirm"]">
                             @Html.AntiForgeryToken()
-                            <button type="submit" class="btn btn-sm btn-outline-warning">Cancel this</button>
+                            <button type="submit" class="btn btn-sm btn-outline-warning">@Localizer["Calendar_CancelThisOccurrence"]</button>
                         </form>
                     }
                 </li>
@@ -120,10 +120,10 @@
         var updatedLocal = Model.Event.UpdatedAt.InZone(zone).LocalDateTime;
     }
     <p class="text-muted small mt-4">
-        Created @createdLocal.ToDateTime()
+        @Localizer["Calendar_Created", createdLocal.ToDateTime()]
         @if (Model.Event.UpdatedAt != Model.Event.CreatedAt)
         {
-            <span>· Last updated @updatedLocal.ToDateTime()</span>
+            <span>@Localizer["Calendar_LastUpdated", updatedLocal.ToDateTime()]</span>
         }
     </p>
 
@@ -131,11 +131,11 @@
     {
         entityType = nameof(CalendarEvent),
         entityId = Model.Event.Id,
-        title = "Change history",
+        title = Localizer["Calendar_ChangeHistory"].Value,
         limit = 50
     })
 
     <p class="mt-3">
-        <a class="btn btn-link" asp-action="Index">Back to calendar</a>
+        <a class="btn btn-link" asp-action="Index">@Localizer["Calendar_BackToCalendar"]</a>
     </p>
 </div>

--- a/src/Humans.Web/Views/Calendar/Index.cshtml
+++ b/src/Humans.Web/Views/Calendar/Index.cshtml
@@ -2,7 +2,7 @@
 @using Humans.Web.Models.Calendar
 @model Humans.Web.Models.Calendar.CalendarMonthViewModel
 @{
-    ViewData["Title"] = $"Calendar — {Model.Month.Year}-{Model.Month.Month:D2}";
+    ViewData["Title"] = $"{Localizer["Calendar_Title"].Value} — {Model.Month.Year}-{Model.Month.Month:D2}";
     ViewData["ActiveView"] = "grid";
     var zone = DateTimeZoneProviders.Tzdb[Model.ViewerTimezoneLabel];
     var prev = Model.Month.PlusMonths(-1);
@@ -39,7 +39,10 @@
     }
 
     var culture = System.Globalization.CultureInfo.CurrentCulture;
-    var dayHeaders = new[] { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
+    // Monday-first week; abbreviated day names come from culture data, not resources.
+    var dayHeaders = Enumerable.Range(0, 7)
+        .Select(i => culture.DateTimeFormat.GetAbbreviatedDayName((DayOfWeek)((i + 1) % 7)))
+        .ToArray();
 }
 
 <div class="container py-4">
@@ -48,14 +51,14 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1 class="h3 mb-0">@Model.Month.Year @culture.DateTimeFormat.GetMonthName(Model.Month.Month)</h1>
         <div>
-            <a class="btn btn-sm btn-primary" asp-action="Create">New event</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="Index" asp-route-year="@prev.Year" asp-route-month="@prev.Month" asp-route-teamId="@Model.FilterTeamId">&larr; Prev</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="Index">Today</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="Index" asp-route-year="@next.Year" asp-route-month="@next.Month" asp-route-teamId="@Model.FilterTeamId">Next &rarr;</a>
+            <a class="btn btn-sm btn-primary" asp-action="Create">@Localizer["Calendar_NewEvent"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="Index" asp-route-year="@prev.Year" asp-route-month="@prev.Month" asp-route-teamId="@Model.FilterTeamId">&larr; @Localizer["Calendar_Prev"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="Index">@Localizer["Calendar_Today"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="Index" asp-route-year="@next.Year" asp-route-month="@next.Month" asp-route-teamId="@Model.FilterTeamId">@Localizer["Calendar_Next"] &rarr;</a>
         </div>
     </div>
 
-    <p class="text-muted small">All times shown in @Model.ViewerTimezoneLabel.</p>
+    <p class="text-muted small">@Localizer["Calendar_AllTimesShownIn", Model.ViewerTimezoneLabel]</p>
 
     <table class="table table-bordered calendar-grid" style="table-layout: fixed;">
         <thead>
@@ -143,7 +146,7 @@
                             @if (moreCount > 0)
                             {
                                 var isoDay = day.ToInvariantDate();
-                                <a class="small text-muted" asp-action="Agenda" asp-route-from="@isoDay" asp-route-to="@isoDay" asp-route-teamId="@Model.FilterTeamId">+@moreCount more</a>
+                                <a class="small text-muted" asp-action="Agenda" asp-route-from="@isoDay" asp-route-to="@isoDay" asp-route-teamId="@Model.FilterTeamId">@Localizer["Calendar_MoreCount", moreCount]</a>
                             }
                         </td>
                     }

--- a/src/Humans.Web/Views/Calendar/List.cshtml
+++ b/src/Humans.Web/Views/Calendar/List.cshtml
@@ -1,7 +1,7 @@
 @using NodaTime
 @model Humans.Web.Models.Calendar.CalendarMonthViewModel
 @{
-    ViewData["Title"] = $"Calendar — {Model.Month.Year}-{Model.Month.Month:D2}";
+    ViewData["Title"] = $"{Localizer["Calendar_Title"].Value} — {Model.Month.Year}-{Model.Month.Month:D2}";
     ViewData["ActiveView"] = "list";
     var zone = DateTimeZoneProviders.Tzdb[Model.ViewerTimezoneLabel];
     var prev = Model.Month.PlusMonths(-1);
@@ -21,14 +21,14 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1 class="h3 mb-0">@Model.Month.Year @System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(Model.Month.Month)</h1>
         <div>
-            <a class="btn btn-sm btn-primary" asp-action="Create">New event</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="List" asp-route-year="@prev.Year" asp-route-month="@prev.Month" asp-route-teamId="@Model.FilterTeamId">&larr; Prev</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="List">Today</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="List" asp-route-year="@next.Year" asp-route-month="@next.Month" asp-route-teamId="@Model.FilterTeamId">Next &rarr;</a>
+            <a class="btn btn-sm btn-primary" asp-action="Create">@Localizer["Calendar_NewEvent"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="List" asp-route-year="@prev.Year" asp-route-month="@prev.Month" asp-route-teamId="@Model.FilterTeamId">&larr; @Localizer["Calendar_Prev"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="List">@Localizer["Calendar_Today"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="List" asp-route-year="@next.Year" asp-route-month="@next.Month" asp-route-teamId="@Model.FilterTeamId">@Localizer["Calendar_Next"] &rarr;</a>
         </div>
     </div>
 
-    <p class="text-muted small">All times shown in @Model.ViewerTimezoneLabel.</p>
+    <p class="text-muted small">@Localizer["Calendar_AllTimesShownIn", Model.ViewerTimezoneLabel]</p>
 
     <table class="table table-bordered align-top">
         <tbody>

--- a/src/Humans.Web/Views/Calendar/OccurrenceEdit.cshtml
+++ b/src/Humans.Web/Views/Calendar/OccurrenceEdit.cshtml
@@ -1,12 +1,12 @@
 @model Humans.Web.Models.Calendar.OccurrenceOverrideFormViewModel
 @{
-    ViewData["Title"] = "Edit single occurrence";
+    ViewData["Title"] = Localizer["Calendar_EditSingleOccurrence"].Value;
 }
 
 <div class="container py-4">
-    <h1 class="h3 mb-3">Edit a single occurrence</h1>
+    <h1 class="h3 mb-3">@Localizer["Calendar_EditSingleOccurrenceHeading"]</h1>
     <p class="text-muted">
-        Override only this occurrence of the recurring event. Leave a field blank to inherit the value from the parent event.
+        @Localizer["Calendar_OverrideInstructions"]
     </p>
 
     <form method="post"
@@ -20,36 +20,36 @@
 
         <div class="row">
             <div class="col-md-6 mb-3">
-                <label asp-for="OverrideStartLocal" class="form-label">Override start</label>
+                <label asp-for="OverrideStartLocal" class="form-label">@Localizer["Calendar_OverrideStart"]</label>
                 <input asp-for="OverrideStartLocal" type="datetime-local" class="form-control" />
             </div>
             <div class="col-md-6 mb-3">
-                <label asp-for="OverrideEndLocal" class="form-label">Override end</label>
+                <label asp-for="OverrideEndLocal" class="form-label">@Localizer["Calendar_OverrideEnd"]</label>
                 <input asp-for="OverrideEndLocal" type="datetime-local" class="form-control" />
             </div>
         </div>
 
         <div class="mb-3">
-            <label asp-for="OverrideTitle" class="form-label">Override title</label>
+            <label asp-for="OverrideTitle" class="form-label">@Localizer["Calendar_OverrideTitle"]</label>
             <input asp-for="OverrideTitle" class="form-control" />
         </div>
 
         <div class="mb-3">
-            <label asp-for="OverrideLocation" class="form-label">Override location</label>
+            <label asp-for="OverrideLocation" class="form-label">@Localizer["Calendar_OverrideLocation"]</label>
             <input asp-for="OverrideLocation" class="form-control" />
         </div>
 
         <div class="mb-3">
-            <label asp-for="OverrideLocationUrl" class="form-label">Override location URL</label>
+            <label asp-for="OverrideLocationUrl" class="form-label">@Localizer["Calendar_OverrideLocationUrl"]</label>
             <input asp-for="OverrideLocationUrl" type="url" class="form-control" placeholder="https://..." />
         </div>
 
         <div class="mb-3">
-            <label asp-for="OverrideDescription" class="form-label">Override description</label>
+            <label asp-for="OverrideDescription" class="form-label">@Localizer["Calendar_OverrideDescription"]</label>
             <textarea asp-for="OverrideDescription" class="form-control" rows="3"></textarea>
         </div>
 
-        <button type="submit" class="btn btn-primary">Save override</button>
-        <a class="btn btn-link" asp-action="Event" asp-route-id="@Model.EventId">Cancel</a>
+        <button type="submit" class="btn btn-primary">@Localizer["Calendar_SaveOverride"]</button>
+        <a class="btn btn-link" asp-action="Event" asp-route-id="@Model.EventId">@Localizer["Common_Cancel"]</a>
     </form>
 </div>

--- a/src/Humans.Web/Views/Calendar/Team.cshtml
+++ b/src/Humans.Web/Views/Calendar/Team.cshtml
@@ -3,8 +3,8 @@
 @using Humans.Web.Models.Calendar
 @model Humans.Web.Models.Calendar.CalendarMonthViewModel
 @{
-    var teamName = ViewData["TeamName"] as string ?? "Team";
-    ViewData["Title"] = $"Calendar — {teamName}";
+    var teamName = ViewData["TeamName"] as string ?? Localizer["Calendar_TeamFallback"].Value;
+    ViewData["Title"] = $"{Localizer["Calendar_Title"].Value} — {teamName}";
     var zone = DateTimeZoneProviders.Tzdb[Model.ViewerTimezoneLabel];
     var prev = Model.Month.PlusMonths(-1);
     var next = Model.Month.PlusMonths(1);
@@ -41,14 +41,14 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1 class="h3 mb-0">@teamName — @Model.Month.Year @System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(Model.Month.Month)</h1>
         <div>
-            <a class="btn btn-sm btn-primary" asp-action="Create" asp-route-teamId="@Model.FilterTeamId">New event</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="Team" asp-route-teamId="@Model.FilterTeamId" asp-route-year="@prev.Year" asp-route-month="@prev.Month">&larr; Prev</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="Team" asp-route-teamId="@Model.FilterTeamId">Today</a>
-            <a class="btn btn-sm btn-outline-secondary" asp-action="Team" asp-route-teamId="@Model.FilterTeamId" asp-route-year="@next.Year" asp-route-month="@next.Month">Next &rarr;</a>
+            <a class="btn btn-sm btn-primary" asp-action="Create" asp-route-teamId="@Model.FilterTeamId">@Localizer["Calendar_NewEvent"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="Team" asp-route-teamId="@Model.FilterTeamId" asp-route-year="@prev.Year" asp-route-month="@prev.Month">&larr; @Localizer["Calendar_Prev"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="Team" asp-route-teamId="@Model.FilterTeamId">@Localizer["Calendar_Today"]</a>
+            <a class="btn btn-sm btn-outline-secondary" asp-action="Team" asp-route-teamId="@Model.FilterTeamId" asp-route-year="@next.Year" asp-route-month="@next.Month">@Localizer["Calendar_Next"] &rarr;</a>
         </div>
     </div>
 
-    <p class="text-muted small">All times shown in @Model.ViewerTimezoneLabel.</p>
+    <p class="text-muted small">@Localizer["Calendar_AllTimesShownIn", Model.ViewerTimezoneLabel]</p>
 
     <table class="table table-bordered align-top">
         <tbody>
@@ -74,7 +74,7 @@
                                     @if (hideTime)
                                     {
                                         <span class="badge bg-light text-dark">
-                                            @(isContinuation ? "continues" : "all day")
+                                            @(isContinuation ? Localizer["Calendar_Continues"].Value : Localizer["Calendar_AllDay"].Value)
                                         </span>
                                     }
                                     else
@@ -92,6 +92,6 @@
     </table>
 
     <p class="mt-3">
-        <a class="btn btn-link" asp-action="Index">All teams (month view)</a>
+        <a class="btn btn-link" asp-action="Index">@Localizer["Calendar_AllTeamsMonthView"]</a>
     </p>
 </div>

--- a/src/Humans.Web/Views/Calendar/_CalendarEventFormFields.cshtml
+++ b/src/Humans.Web/Views/Calendar/_CalendarEventFormFields.cshtml
@@ -4,13 +4,13 @@
 <div asp-validation-summary="All" class="text-danger mb-2"></div>
 
 <div class="mb-3">
-    <label asp-for="Title" class="form-label">Title</label>
+    <label asp-for="Title" class="form-label">@Localizer["Calendar_FormTitle"]</label>
     <input asp-for="Title" class="form-control" />
     <span asp-validation-for="Title" class="text-danger small"></span>
 </div>
 
 <div class="mb-3">
-    <label asp-for="OwningTeamId" class="form-label">Owning team</label>
+    <label asp-for="OwningTeamId" class="form-label">@Localizer["Calendar_OwningTeam"]</label>
     <select asp-for="OwningTeamId" class="form-select"
             asp-items="@(Model.TeamOptions.Select(t => new SelectListItem(t.Name, t.Id.ToString())))">
     </select>
@@ -19,17 +19,17 @@
 
 <div class="form-check mb-3">
     <input asp-for="IsAllDay" class="form-check-input" id="calendar-event-isallday" />
-    <label asp-for="IsAllDay" class="form-check-label">All-day event</label>
+    <label asp-for="IsAllDay" class="form-check-label">@Localizer["Calendar_AllDayEvent"]</label>
 </div>
 
 <div class="row @(Model.IsAllDay ? "d-none" : null)" data-when-timed>
     <div class="col-md-6 mb-3">
-        <label asp-for="StartLocal" class="form-label">Start</label>
+        <label asp-for="StartLocal" class="form-label">@Localizer["Calendar_Start"]</label>
         <input asp-for="StartLocal" type="datetime-local" class="form-control" />
         <span asp-validation-for="StartLocal" class="text-danger small"></span>
     </div>
     <div class="col-md-6 mb-3">
-        <label asp-for="EndLocal" class="form-label">End</label>
+        <label asp-for="EndLocal" class="form-label">@Localizer["Calendar_End"]</label>
         <input asp-for="EndLocal" type="datetime-local" class="form-control" />
         <span asp-validation-for="EndLocal" class="text-danger small"></span>
     </div>
@@ -37,31 +37,31 @@
 
 <div class="row @(Model.IsAllDay ? null : "d-none")" data-when-allday>
     <div class="col-md-6 mb-3">
-        <label asp-for="StartDateLocal" class="form-label">Start date</label>
+        <label asp-for="StartDateLocal" class="form-label">@Localizer["Calendar_StartDate"]</label>
         <input asp-for="StartDateLocal" type="date" class="form-control" />
         <span asp-validation-for="StartDateLocal" class="text-danger small"></span>
     </div>
     <div class="col-md-6 mb-3">
-        <label asp-for="EndDateLocal" class="form-label">End date</label>
+        <label asp-for="EndDateLocal" class="form-label">@Localizer["Calendar_EndDate"]</label>
         <input asp-for="EndDateLocal" type="date" class="form-control" />
         <span asp-validation-for="EndDateLocal" class="text-danger small"></span>
-        <small class="text-muted">Inclusive — leave blank for a single-day event.</small>
+        <small class="text-muted">@Localizer["Calendar_EndDateHelp"]</small>
     </div>
 </div>
 
 <div class="mb-3">
-    <label asp-for="Location" class="form-label">Location</label>
+    <label asp-for="Location" class="form-label">@Localizer["Profile_Location"]</label>
     <input asp-for="Location" class="form-control" />
 </div>
 
 <div class="mb-3">
-    <label asp-for="LocationUrl" class="form-label">Location URL</label>
+    <label asp-for="LocationUrl" class="form-label">@Localizer["Calendar_LocationUrl"]</label>
     <input asp-for="LocationUrl" type="url" class="form-control" placeholder="https://..." />
     <span asp-validation-for="LocationUrl" class="text-danger small"></span>
 </div>
 
 <div class="mb-3">
-    <label asp-for="Description" class="form-label">Description</label>
+    <label asp-for="Description" class="form-label">@Localizer["Calendar_Description"]</label>
     <textarea asp-for="Description" class="form-control" rows="4"></textarea>
 </div>
 
@@ -69,19 +69,19 @@
 
 <div class="form-check mb-3">
     <input asp-for="IsRecurring" class="form-check-input" />
-    <label asp-for="IsRecurring" class="form-check-label">Recurring event</label>
+    <label asp-for="IsRecurring" class="form-check-label">@Localizer["Calendar_RecurringEvent"]</label>
 </div>
 
 <div class="row">
     <div class="col-md-8 mb-3">
-        <label asp-for="RecurrenceRule" class="form-label">RRULE</label>
+        <label asp-for="RecurrenceRule" class="form-label">@Localizer["Calendar_RRule"]</label>
         <input asp-for="RecurrenceRule" class="form-control" placeholder="FREQ=WEEKLY;BYDAY=TU" />
-        <small class="text-muted">RFC 5545 RRULE. Leave blank for single event. Example: <code>FREQ=WEEKLY;BYDAY=TU;COUNT=10</code></small>
+        <small class="text-muted">@Localizer["Calendar_RRuleHelpPrefix"] <code>FREQ=WEEKLY;BYDAY=TU;COUNT=10</code></small>
     </div>
     <div class="col-md-4 mb-3">
-        <label asp-for="RecurrenceTimezone" class="form-label">Recurrence timezone</label>
+        <label asp-for="RecurrenceTimezone" class="form-label">@Localizer["Calendar_RecurrenceTimezoneLabel"]</label>
         <input asp-for="RecurrenceTimezone" class="form-control" />
-        <small class="text-muted">IANA TZ, e.g. <code>Europe/Madrid</code></small>
+        <small class="text-muted">@Localizer["Calendar_RecurrenceTimezoneHelpPrefix"] <code>Europe/Madrid</code></small>
     </div>
 </div>
 

--- a/src/Humans.Web/Views/Calendar/_CalendarViewPills.cshtml
+++ b/src/Humans.Web/Views/Calendar/_CalendarViewPills.cshtml
@@ -3,8 +3,8 @@
     string Cls(string v) => "btn btn-sm " + (string.Equals(v, active, StringComparison.Ordinal) ? "btn-primary" : "btn-outline-secondary");
 }
 
-<div class="btn-group mb-3" role="group" aria-label="Calendar view">
-    <a class="@Cls("grid")" asp-action="Index">Grid</a>
-    <a class="@Cls("list")" asp-action="List">List</a>
-    <a class="@Cls("agenda")" asp-action="Agenda">Agenda</a>
+<div class="btn-group mb-3" role="group" aria-label="@Localizer["Calendar_ViewAriaLabel"]">
+    <a class="@Cls("grid")" asp-action="Index">@Localizer["Calendar_ViewGrid"]</a>
+    <a class="@Cls("list")" asp-action="List">@Localizer["Calendar_ViewList"]</a>
+    <a class="@Cls("agenda")" asp-action="Agenda">@Localizer["Calendar_Agenda"]</a>
 </div>

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -1,17 +1,17 @@
 @model Humans.Web.Models.CampEditViewModel
 @{
-    ViewData["Title"] = $"Edit {Model.Name}";
+    ViewData["Title"] = $"{Localizer["Common_Edit"]} {Model.Name}";
 }
 
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Camp_Plural"]</a></li>
         <li class="breadcrumb-item"><a asp-action="Details" asp-route-slug="@Model.Slug">@Model.Name</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Edit</li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Common_Edit"]</li>
     </ol>
 </nav>
 
-<h1 class="mb-4">Edit @Model.Name <small class="text-muted">(@Model.Year)</small></h1>
+<h1 class="mb-4">@Localizer["Common_Edit"] @Model.Name <small class="text-muted">(@Model.Year)</small></h1>
 
 
 <div asp-validation-summary="All" class="text-danger mb-3"></div>
@@ -35,7 +35,7 @@
                             {
                                 <input asp-for="Name" class="form-control" readonly />
                                 <div class="form-text text-warning">
-                                    <i class="fa-solid fa-lock me-1"></i> Name is locked for this season.
+                                    <i class="fa-solid fa-lock me-1"></i> @Localizer["Camp_Edit_NameLocked"]
                                 </div>
                             }
                             else
@@ -44,12 +44,12 @@
                             }
                         </div>
                         <div class="col-md-6">
-                            <label asp-for="ContactEmail" class="form-label">Contact Email</label>
+                            <label asp-for="ContactEmail" class="form-label">@Localizer["Camp_ContactEmailLabel"]</label>
                             <input asp-for="ContactEmail" class="form-control" type="email" required />
                         </div>
                         <div class="col-md-6">
-                            <label asp-for="ContactPhone" class="form-label">Contact Phone</label>
-                            <input asp-for="ContactPhone" class="form-control" type="tel" pattern="\+[\d\s\-()]{6,20}" placeholder="+34 612 345 678" />
+                            <label asp-for="ContactPhone" class="form-label">@Localizer["Camp_ContactPhoneLabel"]</label>
+                            <input asp-for="ContactPhone" class="form-control" type="tel" pattern="\+[\d\s\-()]{6,20}" placeholder="@Localizer["Camp_ContactPhonePlaceholder"]" />
                         </div>
                         <div class="col-12">
                             <label class="form-label">@Localizer["Camp_Edit_Links"]</label>
@@ -78,7 +78,7 @@
                             }
                         </div>
                         <div class="col-md-3">
-                            <label asp-for="TimesAtNowhere" class="form-label">Times Participating</label>
+                            <label asp-for="TimesAtNowhere" class="form-label">@Localizer["Camp_TimesParticipatingLabel"]</label>
                             <input asp-for="TimesAtNowhere" class="form-control" type="number" min="0" />
                         </div>
                         <div class="col-md-3">
@@ -90,7 +90,7 @@
                         <div class="col-md-3">
                             <div class="form-check mt-4">
                                 <input asp-for="HideHistoricalNames" class="form-check-input" />
-                                <label asp-for="HideHistoricalNames" class="form-check-label">Hide historical names</label>
+                                <label asp-for="HideHistoricalNames" class="form-check-label">@Localizer["Camp_Edit_HideHistoricalNames"]</label>
                             </div>
                         </div>
                     </div>
@@ -98,19 +98,19 @@
             </div>
 
             <div class="card mb-4">
-                <div class="card-header"><i class="fa-solid fa-pen-fancy me-1"></i> About Your @Localizer["Camp_Singular"]</div>
+                <div class="card-header"><i class="fa-solid fa-pen-fancy me-1"></i> @Localizer["Camp_AboutHeading", Localizer["Camp_Singular"]]</div>
                 <div class="card-body">
                     <div class="row g-3">
                         <div class="col-12">
-                            <label asp-for="BlurbShort" class="form-label">Short Description</label>
+                            <label asp-for="BlurbShort" class="form-label">@Localizer["Camp_BlurbShortLabel"]</label>
                             <textarea asp-for="BlurbShort" class="form-control" rows="2" maxlength="300" required></textarea>
                         </div>
                         <div class="col-12">
-                            <label asp-for="BlurbLong" class="form-label">Full Description</label>
+                            <label asp-for="BlurbLong" class="form-label">@Localizer["Camp_BlurbLongLabel"]</label>
                             <markdown-editor asp-for="BlurbLong" rows="6" required="true" />
                         </div>
                         <div class="col-md-6">
-                            <label asp-for="Languages" class="form-label">Languages Spoken</label>
+                            <label asp-for="Languages" class="form-label">@Localizer["Camp_LanguagesLabel"]</label>
                             <input asp-for="Languages" class="form-control" required />
                         </div>
                     </div>
@@ -118,40 +118,40 @@
             </div>
 
             <div class="card mb-4">
-                <div class="card-header"><i class="fa-solid fa-users me-1"></i> Community</div>
+                <div class="card-header"><i class="fa-solid fa-users me-1"></i> @Localizer["Camp_CommunityHeading"]</div>
                 <div class="card-body">
                     <div class="row g-3">
                         <div class="col-md-4">
-                            <label asp-for="AcceptingMembers" class="form-label">Accepting New Humans?</label>
+                            <label asp-for="AcceptingMembers" class="form-label">@Localizer["Camp_AcceptingMembersLabel"]</label>
                             <select asp-for="AcceptingMembers" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
+                                    asp-items="@Localizer.EnumSelectItems<YesNoMaybe>()"></select>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="KidsWelcome" class="form-label">Kids Welcome?</label>
+                            <label asp-for="KidsWelcome" class="form-label">@Localizer["Camp_KidsWelcomeLabel"]</label>
                             <select asp-for="KidsWelcome" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
+                                    asp-items="@Localizer.EnumSelectItems<YesNoMaybe>()"></select>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="KidsVisiting" class="form-label">Kids Visiting Policy</label>
+                            <label asp-for="KidsVisiting" class="form-label">@Localizer["Camp_KidsVisitingLabel"]</label>
                             <select asp-for="KidsVisiting" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<KidsVisitingPolicy>()))"></select>
+                                    asp-items="@Localizer.EnumSelectItems<KidsVisitingPolicy>()"></select>
                         </div>
                         <div class="col-12">
-                            <label asp-for="KidsAreaDescription" class="form-label">Kids Area Description</label>
+                            <label asp-for="KidsAreaDescription" class="form-label">@Localizer["Camp_KidsAreaDescriptionLabel"]</label>
                             <textarea asp-for="KidsAreaDescription" class="form-control" rows="2"></textarea>
                             <div class="form-text">
                                 <a href="#" data-bs-toggle="modal" data-bs-target="#markdownHelpModal">
-                                    <i class="fa-solid fa-circle-info me-1"></i>Markdown formatting is supported
+                                    <i class="fa-solid fa-circle-info me-1"></i>@Localizer["Camp_MarkdownSupported"]
                                 </a>
                             </div>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="AdultPlayspace" class="form-label">Adult Playspace</label>
+                            <label asp-for="AdultPlayspace" class="form-label">@Localizer["Camp_AdultPlayspaceLabel"]</label>
                             <select asp-for="AdultPlayspace" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<AdultPlayspacePolicy>()))"></select>
+                                    asp-items="@Localizer.EnumSelectItems<AdultPlayspacePolicy>()"></select>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="MemberCount" class="form-label">Expected Humans</label>
+                            <label asp-for="MemberCount" class="form-label">@Localizer["Camp_MemberCountLabel"]</label>
                             <input asp-for="MemberCount" class="form-control" type="number" min="1" />
                         </div>
                     </div>
@@ -159,20 +159,20 @@
             </div>
 
             <div class="card mb-4">
-                <div class="card-header"><i class="fa-solid fa-masks-theater me-1"></i> Culture & Events</div>
+                <div class="card-header"><i class="fa-solid fa-masks-theater me-1"></i> @Localizer["Camp_CultureHeading"]</div>
                 <div class="card-body">
                     <div class="row g-3">
                         <div class="col-md-4">
-                            <label asp-for="HasPerformanceSpace" class="form-label">Performance Space</label>
+                            <label asp-for="HasPerformanceSpace" class="form-label">@Localizer["Camp_PerformanceSpaceLabel"]</label>
                             <select asp-for="HasPerformanceSpace" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<PerformanceSpaceStatus>()))"></select>
+                                    asp-items="@Localizer.EnumSelectItems<PerformanceSpaceStatus>()"></select>
                         </div>
                         <div class="col-md-8">
-                            <label asp-for="PerformanceTypes" class="form-label">Performance Types</label>
+                            <label asp-for="PerformanceTypes" class="form-label">@Localizer["Camp_PerformanceTypesLabel"]</label>
                             <input asp-for="PerformanceTypes" class="form-control" />
                         </div>
                         <div class="col-12">
-                            <label class="form-label">Vibes</label>
+                            <label class="form-label">@Localizer["Camp_VibesLabel"]</label>
                             <div class="d-flex flex-wrap gap-3">
                                 @foreach (var vibe in Enum.GetValues<CampVibe>())
                                 {
@@ -181,7 +181,7 @@
                                                name="Vibes" value="@vibe"
                                                id="vibe-@vibe"
                                                checked="@(Model.Vibes.Contains(vibe) ? "checked" : null)" />
-                                        <label class="form-check-label" for="vibe-@vibe">@vibe</label>
+                                        <label class="form-check-label" for="vibe-@vibe">@Localizer.EnumDisplay(vibe)</label>
                                     </div>
                                 }
                             </div>
@@ -191,37 +191,37 @@
             </div>
 
             <div class="card mb-4">
-                <div class="card-header"><i class="fa-solid fa-map-location-dot me-1"></i> Placement</div>
+                <div class="card-header"><i class="fa-solid fa-map-location-dot me-1"></i> @Localizer["Camp_PlacementHeading"]</div>
                 <div class="card-body">
                     <div class="row g-3">
                         <div class="col-md-4">
-                            <label asp-for="SoundZone" class="form-label">Sound Zone Preference</label>
+                            <label asp-for="SoundZone" class="form-label">@Localizer["Camp_SoundZoneLabel"]</label>
                             <select asp-for="SoundZone" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<SoundZone>()))">
-                                <option value="">No Preference</option>
+                                    asp-items="@Localizer.EnumSelectItems<SoundZone>()">
+                                <option value="">@Localizer["Camp_NoPreference"]</option>
                             </select>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="SpaceRequirement" class="form-label">Space Requirement</label>
+                            <label asp-for="SpaceRequirement" class="form-label">@Localizer["Camp_SpaceRequirementLabel"]</label>
                             <select asp-for="SpaceRequirement" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<SpaceSize>()))">
-                                <option value="">Not Sure</option>
+                                    asp-items="@Localizer.EnumSelectItems<SpaceSize>()">
+                                <option value="">@Localizer["Camp_NotSure"]</option>
                             </select>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="ElectricalGrid" class="form-label">Electrical Grid</label>
+                            <label asp-for="ElectricalGrid" class="form-label">@Localizer["Camp_ElectricalGridLabel"]</label>
                             <select asp-for="ElectricalGrid" class="form-select"
-                                    asp-items="@(new SelectList(Enum.GetValues<ElectricalGrid>()))">
-                                <option value="">Unknown</option>
+                                    asp-items="@Localizer.EnumSelectItems<ElectricalGrid>()">
+                                <option value="">@Localizer["Common_Unknown"]</option>
                             </select>
                         </div>
                         <div class="col-12">
                             <div class="alert alert-info mb-0">
                                 <i class="fa-solid fa-box me-1"></i>
-                                Containers are now managed separately.
+                                @Localizer["Camp_Edit_ContainersSeparate"]
                                 <a asp-controller="Container" asp-action="Index"
                                    asp-route-slug="@Model.Slug" asp-route-year="@Model.Year"
-                                   class="alert-link">Manage containers →</a>
+                                   class="alert-link">@Localizer["Camp_Edit_ManageContainers"]</a>
                             </div>
                         </div>
                     </div>
@@ -229,9 +229,9 @@
             </div>
 
             <div class="d-flex justify-content-between mb-4">
-                <a asp-action="Details" asp-route-slug="@Model.Slug" class="btn btn-outline-secondary">Cancel</a>
+                <a asp-action="Details" asp-route-slug="@Model.Slug" class="btn btn-outline-secondary">@Localizer["Common_Cancel"]</a>
                 <button type="submit" class="btn btn-primary">
-                    <i class="fa-solid fa-floppy-disk me-1"></i> Save Changes
+                    <i class="fa-solid fa-floppy-disk me-1"></i> @Localizer["Common_Save"]
                 </button>
             </div>
         </form>
@@ -241,35 +241,35 @@
         @* Members & Roles — moved to dedicated page (issue nobodies-collective#641) *@
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-users-gear me-1"></i> Members & Roles
+                <i class="fa-solid fa-users-gear me-1"></i> @Localizer["Camp_Edit_MembersRolesHeading"]
             </div>
             <div class="card-body">
                 <p class="card-text small text-muted mb-3">
-                    Manage active members, roles, leads, and pending join requests.
+                    @Localizer["Camp_Edit_MembersRolesDescription"]
                 </p>
                 <a asp-action="Members" asp-route-slug="@Model.Slug" class="btn btn-primary">
-                    <i class="fa-solid fa-users-gear me-1"></i> Open members & roles
+                    <i class="fa-solid fa-users-gear me-1"></i> @Localizer["Camp_Edit_OpenMembersRoles"]
                 </a>
             </div>
         </div>
 
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-cart-shopping me-1"></i> Store
+                <i class="fa-solid fa-cart-shopping me-1"></i> @Localizer["Camp_Edit_StoreHeading"]
             </div>
             <div class="card-body">
                 <p class="card-text small text-muted mb-3">
-                    Place an order for this camp.
+                    @Localizer["Camp_Edit_StoreDescription"]
                 </p>
                 <a asp-controller="Store" asp-action="Index" class="btn btn-primary">
-                    <i class="fa-solid fa-cart-shopping me-1"></i> Open store
+                    <i class="fa-solid fa-cart-shopping me-1"></i> @Localizer["Camp_Edit_OpenStore"]
                 </a>
             </div>
         </div>
 
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-images me-1"></i> Images (@Model.Images.Count/5)
+                <i class="fa-solid fa-images me-1"></i> @Localizer["Camp_Edit_ImagesHeading", Model.Images.Count, 5]
             </div>
             @if (Model.Images.Count > 0)
             {
@@ -278,7 +278,7 @@
                     {
                         <li class="list-group-item">
                             <div class="d-flex align-items-center gap-2">
-                                <img src="@image.Url" alt="Camp image" class="rounded"
+                                <img src="@image.Url" alt="@Localizer["Camp_Edit_ImageAlt"]" class="rounded"
                                      style="width: 60px; height: 60px; object-fit: cover;" />
                                 <span class="text-muted small">#@(image.SortOrder + 1)</span>
                                 <div class="ms-auto d-flex gap-1">
@@ -297,7 +297,7 @@
                                         {
                                             <input type="hidden" name="imageIds" value="@id" />
                                         }
-                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move up" @(currentIdx == 0 ? "disabled" : null)>
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="@Localizer["Common_MoveUp"]" @(currentIdx == 0 ? "disabled" : null)>
                                             <i class="fa-solid fa-arrow-up"></i>
                                         </button>
                                     </form>
@@ -315,14 +315,14 @@
                                         {
                                             <input type="hidden" name="imageIds" value="@id" />
                                         }
-                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move down" @(downIdx == Model.Images.Count - 1 ? "disabled" : null)>
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="@Localizer["Common_MoveDown"]" @(downIdx == Model.Images.Count - 1 ? "disabled" : null)>
                                             <i class="fa-solid fa-arrow-down"></i>
                                         </button>
                                     </form>
                                     <form asp-action="DeleteImage" asp-route-slug="@Model.Slug" asp-route-imageId="@image.Id"
                                           method="post" class="d-inline">
                                         @Html.AntiForgeryToken()
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete image">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="@Localizer["Common_DeleteImage"]">
                                             <i class="fa-solid fa-trash"></i>
                                         </button>
                                     </form>
@@ -338,9 +338,9 @@
                     <form asp-action="UploadImage" asp-route-slug="@Model.Slug" method="post" enctype="multipart/form-data">
                         @Html.AntiForgeryToken()
                         <input type="file" name="file" class="form-control mb-2" accept="image/jpeg,image/png,image/webp" required />
-                        <div class="form-text mb-2">JPEG, PNG, or WebP. Max 10MB.</div>
+                        <div class="form-text mb-2">@Localizer["Camp_Edit_ImageUploadHelp"]</div>
                         <button type="submit" class="btn btn-outline-primary w-100">
-                            <i class="fa-solid fa-upload me-1"></i> Upload Image
+                            <i class="fa-solid fa-upload me-1"></i> @Localizer["Camp_Edit_UploadImage"]
                         </button>
                     </form>
                 </div>
@@ -349,7 +349,7 @@
 
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-clock-rotate-left me-1"></i> Historical Names
+                <i class="fa-solid fa-clock-rotate-left me-1"></i> @Localizer["Camp_Edit_HistoricalNamesHeading"]
             </div>
             @if (Model.ExistingHistoricalNames.Count > 0)
             {
@@ -365,12 +365,12 @@
                                 }
                                 @if (string.Equals(name.Source, "NameChange", StringComparison.Ordinal))
                                 {
-                                    <small class="text-muted ms-1" title="Auto-created from name change"><i class="fa-solid fa-rotate"></i></small>
+                                    <small class="text-muted ms-1" title="@Localizer["Camp_Edit_AutoCreatedFromNameChange"]"><i class="fa-solid fa-rotate"></i></small>
                                 }
                             </div>
                             <form asp-action="RemoveHistoricalName" asp-route-slug="@Model.Slug" asp-route-nameId="@name.Id" method="post" class="d-inline">
                                 @Html.AntiForgeryToken()
-                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove">
+                                <button type="submit" class="btn btn-sm btn-outline-danger" title="@Localizer["Common_Remove"]">
                                     <i class="fa-solid fa-xmark"></i>
                                 </button>
                             </form>
@@ -381,12 +381,12 @@
             <div class="card-body">
                 <form asp-action="AddHistoricalName" asp-route-slug="@Model.Slug" method="post" class="input-group">
                     @Html.AntiForgeryToken()
-                    <input type="text" name="name" class="form-control form-control-sm" placeholder="Previous camp name" maxlength="256" />
-                    <button type="submit" class="btn btn-outline-success btn-sm" title="Add">
+                    <input type="text" name="name" class="form-control form-control-sm" placeholder="@Localizer["Camp_Edit_PreviousNamePlaceholder"]" maxlength="256" />
+                    <button type="submit" class="btn btn-outline-success btn-sm" title="@Localizer["Common_Add"]">
                         <i class="fa-solid fa-plus"></i>
                     </button>
                 </form>
-                <div class="form-text">Names this camp was previously known as.</div>
+                <div class="form-text">@Localizer["Camp_Edit_HistoricalNamesHelp"]</div>
             </div>
         </div>
 

--- a/src/Humans.Web/Views/Camp/Index.cshtml
+++ b/src/Humans.Web/Views/Camp/Index.cshtml
@@ -18,13 +18,13 @@
         </a>
         <a href="https://drive.google.com/file/d/1orfoEDH6uFz3Hn6ioaqVo-EG_Iuv1Dji/view"
            class="btn btn-outline-secondary" target="_blank" rel="noopener noreferrer">
-            <i class="fa-solid fa-book me-1"></i> Barrio Guide 2026
+            <i class="fa-solid fa-book me-1"></i> @Localizer["Camp_Index_BarrioGuide"]
             <i class="fa-solid fa-arrow-up-right-from-square ms-1"></i>
         </a>
         @if (Humans.Web.Authorization.RoleAssignmentClaimsTransformation.IsActive(User))
         {
             <a asp-action="Register" class="btn btn-primary">
-                <i class="fa-solid fa-plus me-1"></i> Register Your @Localizer["Camp_Singular"]
+                <i class="fa-solid fa-plus me-1"></i> @Localizer["Camp_Register_Submit", Localizer["Camp_Singular"]]
             </a>
         }
     </div>
@@ -35,44 +35,44 @@
     <div class="card-body">
         <div class="form-check mb-3">
             <input asp-for="Filters.ShowLeadPositions" class="form-check-input" type="checkbox" />
-            <label asp-for="Filters.ShowLeadPositions" class="form-check-label">Show lead positions</label>
+            <label asp-for="Filters.ShowLeadPositions" class="form-check-label">@Localizer["Camp_Index_ShowLeadPositions"]</label>
         </div>
         <div class="row g-3 align-items-end">
             <div class="col-md-12">
-                <label asp-for="Filters.Search" class="form-label">Search</label>
+                <label asp-for="Filters.Search" class="form-label">@Localizer["Camp_Index_SearchLabel"]</label>
                 <input type="search" asp-for="Filters.Search" id="camp-name-search" class="form-control"
-                       placeholder="Type a @Localizer["Camp_Singular"].ToString().ToLower() name…"
+                       placeholder="@Localizer["Camp_Index_SearchPlaceholder", Localizer["Camp_Singular"].Value.ToLower()]"
                        autocomplete="off" />
             </div>
             <div class="col-md-3">
-                <label class="form-label">Vibe</label>
+                <label class="form-label">@Localizer["Camp_Index_VibeLabel"]</label>
                 <select asp-for="Filters.Vibe" class="form-select"
-                        asp-items="@(new SelectList(Enum.GetValues<CampVibe>()))">
-                    <option value="">All</option>
+                        asp-items="@Localizer.EnumSelectItems<CampVibe>()">
+                    <option value="">@Localizer["Camp_Index_AllOption"]</option>
                 </select>
             </div>
             <div class="col-md-3">
-                <label class="form-label">Sound Zone</label>
+                <label class="form-label">@Localizer["Camp_Index_SoundZoneLabel"]</label>
                 <select asp-for="Filters.SoundZone" class="form-select"
-                        asp-items="@(new SelectList(Enum.GetValues<SoundZone>()))">
-                    <option value="">All</option>
+                        asp-items="@Localizer.EnumSelectItems<SoundZone>()">
+                    <option value="">@Localizer["Camp_Index_AllOption"]</option>
                 </select>
             </div>
             <div class="col-md-2">
                 <div class="form-check mt-4">
                     <input asp-for="Filters.KidsFriendly" class="form-check-input" type="checkbox" />
-                    <label asp-for="Filters.KidsFriendly" class="form-check-label">Kids Welcome</label>
+                    <label asp-for="Filters.KidsFriendly" class="form-check-label">@Localizer["Camp_Index_KidsWelcomeFilter"]</label>
                 </div>
             </div>
             <div class="col-md-2">
                 <div class="form-check mt-4">
                     <input asp-for="Filters.AcceptingMembers" class="form-check-input" type="checkbox" />
-                    <label asp-for="Filters.AcceptingMembers" class="form-check-label">Accepting Members</label>
+                    <label asp-for="Filters.AcceptingMembers" class="form-check-label">@Localizer["Camp_Index_AcceptingMembersFilter"]</label>
                 </div>
             </div>
             <div class="col-md-2">
                 <button type="submit" class="btn btn-outline-primary w-100">
-                    <i class="fa-solid fa-filter me-1"></i> Filter
+                    <i class="fa-solid fa-filter me-1"></i> @Localizer["Camp_Index_FilterButton"]
                 </button>
             </div>
         </div>
@@ -80,12 +80,12 @@
 </form>
 
 <div id="camp-search-empty" class="alert alert-info" style="display: none;">
-    No @Localizer["Camp_Plural"] match your search.
+    @Localizer["Camp_Index_NoSearchResults", Localizer["Camp_Plural"]]
 </div>
 
 @if (Model.MyCamps.Any())
 {
-    <h4 class="mb-3">My @Localizer["Camp_Plural"] <small class="text-muted">(pending approval)</small></h4>
+    <h4 class="mb-3">My @Localizer["Camp_Plural"] <small class="text-muted">(@Localizer["Camp_Index_PendingApproval"])</small></h4>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
         @foreach (var camp in Model.MyCamps)
         {
@@ -106,7 +106,7 @@
 else
 {
     <div class="alert alert-info">
-        No @Localizer["Camp_Plural"] found for the selected filters.
+        @Localizer["Camp_Index_NoFilterResults", Localizer["Camp_Plural"]]
     </div>
 }
 

--- a/src/Humans.Web/Views/Camp/Register.cshtml
+++ b/src/Humans.Web/Views/Camp/Register.cshtml
@@ -1,16 +1,16 @@
 @model Humans.Web.Models.CampRegisterViewModel
 @{
-    ViewData["Title"] = $"Register Your {Localizer["Camp_Singular"]} — {ViewData["SeasonYear"]}";
+    ViewData["Title"] = $"{Localizer["Camp_Register_Heading", Localizer["Camp_Singular"]]} — {ViewData["SeasonYear"]}";
 }
 
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Camp_Plural"]</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Register</li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Camp_Register_Breadcrumb"]</li>
     </ol>
 </nav>
 
-<h1 class="mb-4">Register Your @Localizer["Camp_Singular"] <small class="text-muted">(@ViewData["SeasonYear"] season)</small></h1>
+<h1 class="mb-4">@Localizer["Camp_Register_Heading", Localizer["Camp_Singular"]] <small class="text-muted">(@ViewData["SeasonYear"] @Localizer["Camp_Register_Season"])</small></h1>
 
 
 @{
@@ -20,7 +20,7 @@
 {
     <div class="card mb-4 border-primary">
         <div class="card-header bg-primary bg-opacity-10">
-            <i class="fa-solid fa-circle-info me-1"></i> Important Information
+            <i class="fa-solid fa-circle-info me-1"></i> @Localizer["Camp_Register_ImportantInfo"]
         </div>
         <div class="card-body">
             @Html.SanitizedMarkdown(registrationInfo)
@@ -42,12 +42,12 @@
                     <input asp-for="Name" class="form-control" required />
                 </div>
                 <div class="col-md-6">
-                    <label asp-for="ContactEmail" class="form-label">Contact Email</label>
+                    <label asp-for="ContactEmail" class="form-label">@Localizer["Camp_ContactEmailLabel"]</label>
                     <input asp-for="ContactEmail" class="form-control" type="email" required />
                 </div>
                 <div class="col-md-6">
-                    <label asp-for="ContactPhone" class="form-label">Contact Phone</label>
-                    <input asp-for="ContactPhone" class="form-control" type="tel" pattern="\+[\d\s\-()]{6,20}" placeholder="+34 612 345 678" />
+                    <label asp-for="ContactPhone" class="form-label">@Localizer["Camp_ContactPhoneLabel"]</label>
+                    <input asp-for="ContactPhone" class="form-control" type="tel" pattern="\+[\d\s\-()]{6,20}" placeholder="@Localizer["Camp_ContactPhonePlaceholder"]" />
                 </div>
                 <div class="col-12">
                     <label class="form-label">@Localizer["Camp_Edit_Links"]</label>
@@ -79,7 +79,7 @@
                     </button>
                 </div>
                 <div class="col-md-3">
-                    <label asp-for="TimesAtNowhere" class="form-label">Times Participating</label>
+                    <label asp-for="TimesAtNowhere" class="form-label">@Localizer["Camp_TimesParticipatingLabel"]</label>
                     <input asp-for="TimesAtNowhere" class="form-control" type="number" min="0" />
                 </div>
                 <div class="col-md-3">
@@ -93,63 +93,63 @@
     </div>
 
     <div class="card mb-4">
-        <div class="card-header"><i class="fa-solid fa-pen-fancy me-1"></i> About Your @Localizer["Camp_Singular"]</div>
+        <div class="card-header"><i class="fa-solid fa-pen-fancy me-1"></i> @Localizer["Camp_AboutHeading", Localizer["Camp_Singular"]]</div>
         <div class="card-body">
             <div class="row g-3">
                 <div class="col-12">
-                    <label asp-for="BlurbShort" class="form-label">Short Description</label>
+                    <label asp-for="BlurbShort" class="form-label">@Localizer["Camp_BlurbShortLabel"]</label>
                     <textarea asp-for="BlurbShort" class="form-control" rows="2" maxlength="300"
-                              placeholder="One or two sentences about your camp (max 300 chars)" required></textarea>
+                              placeholder="@Localizer["Camp_BlurbShortPlaceholder"]" required></textarea>
                 </div>
                 <div class="col-12">
-                    <label asp-for="BlurbLong" class="form-label">Full Description</label>
+                    <label asp-for="BlurbLong" class="form-label">@Localizer["Camp_BlurbLongLabel"]</label>
                     <markdown-editor asp-for="BlurbLong" rows="6" required="true"
-                                     placeholder="Tell the world about your camp." />
+                                     placeholder="@Localizer["Camp_BlurbLongPlaceholder"]" />
                 </div>
                 <div class="col-md-6">
-                    <label asp-for="Languages" class="form-label">Languages Spoken</label>
-                    <input asp-for="Languages" class="form-control" placeholder="e.g. English, Spanish, German" required />
+                    <label asp-for="Languages" class="form-label">@Localizer["Camp_LanguagesLabel"]</label>
+                    <input asp-for="Languages" class="form-control" placeholder="@Localizer["Camp_LanguagesPlaceholder"]" required />
                 </div>
             </div>
         </div>
     </div>
 
     <div class="card mb-4">
-        <div class="card-header"><i class="fa-solid fa-users me-1"></i> Community</div>
+        <div class="card-header"><i class="fa-solid fa-users me-1"></i> @Localizer["Camp_CommunityHeading"]</div>
         <div class="card-body">
             <div class="row g-3">
                 <div class="col-md-4">
-                    <label asp-for="AcceptingMembers" class="form-label">Accepting New Humans?</label>
+                    <label asp-for="AcceptingMembers" class="form-label">@Localizer["Camp_AcceptingMembersLabel"]</label>
                     <select asp-for="AcceptingMembers" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
+                            asp-items="@Localizer.EnumSelectItems<YesNoMaybe>()"></select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="KidsWelcome" class="form-label">Kids Welcome?</label>
+                    <label asp-for="KidsWelcome" class="form-label">@Localizer["Camp_KidsWelcomeLabel"]</label>
                     <select asp-for="KidsWelcome" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
+                            asp-items="@Localizer.EnumSelectItems<YesNoMaybe>()"></select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="KidsVisiting" class="form-label">Kids Visiting Policy</label>
+                    <label asp-for="KidsVisiting" class="form-label">@Localizer["Camp_KidsVisitingLabel"]</label>
                     <select asp-for="KidsVisiting" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<KidsVisitingPolicy>()))"></select>
+                            asp-items="@Localizer.EnumSelectItems<KidsVisitingPolicy>()"></select>
                 </div>
                 <div class="col-12">
-                    <label asp-for="KidsAreaDescription" class="form-label">Kids Area Description</label>
+                    <label asp-for="KidsAreaDescription" class="form-label">@Localizer["Camp_KidsAreaDescriptionLabel"]</label>
                     <textarea asp-for="KidsAreaDescription" class="form-control" rows="2"
-                              placeholder="Describe your kids area if applicable"></textarea>
+                              placeholder="@Localizer["Camp_KidsAreaDescriptionPlaceholder"]"></textarea>
                     <div class="form-text">
                         <a href="#" data-bs-toggle="modal" data-bs-target="#markdownHelpModal">
-                            <i class="fa-solid fa-circle-info me-1"></i>Markdown formatting is supported
+                            <i class="fa-solid fa-circle-info me-1"></i>@Localizer["Camp_MarkdownSupported"]
                         </a>
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="AdultPlayspace" class="form-label">Adult Playspace</label>
+                    <label asp-for="AdultPlayspace" class="form-label">@Localizer["Camp_AdultPlayspaceLabel"]</label>
                     <select asp-for="AdultPlayspace" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<AdultPlayspacePolicy>()))"></select>
+                            asp-items="@Localizer.EnumSelectItems<AdultPlayspacePolicy>()"></select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="MemberCount" class="form-label">Expected Humans</label>
+                    <label asp-for="MemberCount" class="form-label">@Localizer["Camp_MemberCountLabel"]</label>
                     <input asp-for="MemberCount" class="form-control" type="number" min="1" />
                 </div>
             </div>
@@ -157,20 +157,20 @@
     </div>
 
     <div class="card mb-4">
-        <div class="card-header"><i class="fa-solid fa-masks-theater me-1"></i> Culture & Events</div>
+        <div class="card-header"><i class="fa-solid fa-masks-theater me-1"></i> @Localizer["Camp_CultureHeading"]</div>
         <div class="card-body">
             <div class="row g-3">
                 <div class="col-md-4">
-                    <label asp-for="HasPerformanceSpace" class="form-label">Performance Space</label>
+                    <label asp-for="HasPerformanceSpace" class="form-label">@Localizer["Camp_PerformanceSpaceLabel"]</label>
                     <select asp-for="HasPerformanceSpace" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<PerformanceSpaceStatus>()))"></select>
+                            asp-items="@Localizer.EnumSelectItems<PerformanceSpaceStatus>()"></select>
                 </div>
                 <div class="col-md-8">
-                    <label asp-for="PerformanceTypes" class="form-label">Performance Types</label>
-                    <input asp-for="PerformanceTypes" class="form-control" placeholder="e.g. Music, Theater, Workshops" />
+                    <label asp-for="PerformanceTypes" class="form-label">@Localizer["Camp_PerformanceTypesLabel"]</label>
+                    <input asp-for="PerformanceTypes" class="form-control" placeholder="@Localizer["Camp_PerformanceTypesPlaceholder"]" />
                 </div>
                 <div class="col-12">
-                    <label class="form-label">Vibes</label>
+                    <label class="form-label">@Localizer["Camp_VibesLabel"]</label>
                     <div class="d-flex flex-wrap gap-3">
                         @foreach (var vibe in Enum.GetValues<CampVibe>())
                         {
@@ -179,7 +179,7 @@
                                        name="Vibes" value="@vibe"
                                        id="vibe-@vibe"
                                        checked="@(Model.Vibes.Contains(vibe) ? "checked" : null)" />
-                                <label class="form-check-label" for="vibe-@vibe">@vibe</label>
+                                <label class="form-check-label" for="vibe-@vibe">@Localizer.EnumDisplay(vibe)</label>
                             </div>
                         }
                     </div>
@@ -189,28 +189,28 @@
     </div>
 
     <div class="card mb-4">
-        <div class="card-header"><i class="fa-solid fa-map-location-dot me-1"></i> Placement</div>
+        <div class="card-header"><i class="fa-solid fa-map-location-dot me-1"></i> @Localizer["Camp_PlacementHeading"]</div>
         <div class="card-body">
             <div class="row g-3">
                 <div class="col-md-4">
-                    <label asp-for="SoundZone" class="form-label">Sound Zone Preference</label>
+                    <label asp-for="SoundZone" class="form-label">@Localizer["Camp_SoundZoneLabel"]</label>
                     <select asp-for="SoundZone" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<SoundZone>()))">
-                        <option value="">No Preference</option>
+                            asp-items="@Localizer.EnumSelectItems<SoundZone>()">
+                        <option value="">@Localizer["Camp_NoPreference"]</option>
                     </select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="SpaceRequirement" class="form-label">Space Requirement</label>
+                    <label asp-for="SpaceRequirement" class="form-label">@Localizer["Camp_SpaceRequirementLabel"]</label>
                     <select asp-for="SpaceRequirement" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<SpaceSize>()))">
-                        <option value="">Not Sure</option>
+                            asp-items="@Localizer.EnumSelectItems<SpaceSize>()">
+                        <option value="">@Localizer["Camp_NotSure"]</option>
                     </select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="ElectricalGrid" class="form-label">Electrical Grid</label>
+                    <label asp-for="ElectricalGrid" class="form-label">@Localizer["Camp_ElectricalGridLabel"]</label>
                     <select asp-for="ElectricalGrid" class="form-select"
-                            asp-items="@(new SelectList(Enum.GetValues<ElectricalGrid>()))">
-                        <option value="">Unknown</option>
+                            asp-items="@Localizer.EnumSelectItems<ElectricalGrid>()">
+                        <option value="">@Localizer["Common_Unknown"]</option>
                     </select>
                 </div>
             </div>
@@ -218,23 +218,23 @@
     </div>
 
     <div class="card mb-4">
-        <div class="card-header"><i class="fa-solid fa-clock-rotate-left me-1"></i> History</div>
+        <div class="card-header"><i class="fa-solid fa-clock-rotate-left me-1"></i> @Localizer["Camp_HistoryHeading"]</div>
         <div class="card-body">
             <div class="row g-3">
                 <div class="col-12">
-                    <label asp-for="HistoricalNames" class="form-label">Previous Names</label>
+                    <label asp-for="HistoricalNames" class="form-label">@Localizer["Camp_PreviousNamesLabel"]</label>
                     <input asp-for="HistoricalNames" class="form-control"
-                           placeholder="Comma-separated list of previous camp names" />
-                    <div class="form-text">If your camp has had different names in past years, list them here.</div>
+                           placeholder="@Localizer["Camp_PreviousNamesPlaceholder"]" />
+                    <div class="form-text">@Localizer["Camp_PreviousNamesHelp"]</div>
                 </div>
             </div>
         </div>
     </div>
 
     <div class="d-flex justify-content-between">
-        <a asp-action="Index" class="btn btn-outline-secondary">Cancel</a>
+        <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["Common_Cancel"]</a>
         <button type="submit" class="btn btn-primary">
-            <i class="fa-solid fa-paper-plane me-1"></i> Register @Localizer["Camp_Singular"]
+            <i class="fa-solid fa-paper-plane me-1"></i> @Localizer["Camp_Register_Submit", Localizer["Camp_Singular"]]
         </button>
     </div>
 </form>

--- a/src/Humans.Web/Views/Camp/_CampCard.cshtml
+++ b/src/Humans.Web/Views/Camp/_CampCard.cshtml
@@ -30,34 +30,34 @@
             <div class="d-flex flex-wrap gap-1 mb-2">
                 @foreach (var vibe in Model.Vibes)
                 {
-                    <span class="badge bg-secondary">@vibe</span>
+                    <span class="badge bg-secondary">@Localizer.EnumDisplay(vibe)</span>
                 }
                 @if (Model.SoundZone.HasValue)
                 {
                     <span class="badge bg-info">
-                        <i class="fa-solid fa-volume-high me-1"></i>@Model.SoundZone
+                        <i class="fa-solid fa-volume-high me-1"></i>@Localizer.EnumDisplay(Model.SoundZone.Value)
                     </span>
                 }
             </div>
             <div class="d-flex flex-wrap gap-1 mt-auto">
                 @if (Model.AcceptingMembers == YesNoMaybe.Yes)
                 {
-                    <span class="badge bg-success">Accepting Members</span>
+                    <span class="badge bg-success">@Localizer["CampCard_AcceptingMembers"]</span>
                 }
                 @if (Model.KidsWelcome == YesNoMaybe.Yes)
                 {
                     <span class="badge bg-primary">
-                        <i class="fa-solid fa-children me-1"></i>Kids Welcome
+                        <i class="fa-solid fa-children me-1"></i>@Localizer["CampCard_KidsWelcome"]
                     </span>
                 }
                 @if (Model.Status == CampSeasonStatus.Full)
                 {
-                    <span class="badge bg-warning text-dark">Full</span>
+                    <span class="badge bg-warning text-dark">@Localizer["CampCard_Full"]</span>
                 }
                 @if (Model.TimesAtNowhere > 0)
                 {
                     <span class="badge bg-light text-dark border">
-                        <i class="fa-solid fa-fire text-warning me-1"></i>@Model.TimesAtNowhere year@(Model.TimesAtNowhere != 1 ? "s" : "")
+                        <i class="fa-solid fa-fire text-warning me-1"></i>@Localizer["CampCard_TimesAtNowhere", Model.TimesAtNowhere]
                     </span>
                 }
             </div>

--- a/src/Humans.Web/Views/Debug/Translations.cshtml
+++ b/src/Humans.Web/Views/Debug/Translations.cshtml
@@ -1,0 +1,148 @@
+@model Humans.Web.Models.TranslationsGalleryViewModel
+@{
+    ViewData["Title"] = "Translations gallery";
+}
+
+<page-header title="Translations gallery">
+    <a asp-controller="Admin" asp-action="Index" class="btn btn-outline-secondary btn-sm">
+        <i class="fa-solid fa-arrow-left me-1"></i>Admin
+    </a>
+</page-header>
+
+<div class="alert alert-info">
+    <i class="fa-solid fa-circle-info me-1"></i>
+    Every <code>SharedResource</code> key in every supported culture, enumerated through the real
+    localizer — a new key can't hide from this audit. A <span class="badge bg-warning text-dark">—</span>
+    cell means the key is missing from that language file (the app falls back to English there).
+    Coordinator/admin-only key families are intentionally untranslated.
+</div>
+
+<div class="d-flex flex-wrap gap-3 align-items-center mb-3">
+    <strong>@Model.TotalKeys keys</strong>
+    @foreach (var lang in Model.Languages)
+    {
+        var missing = Model.MissingByLanguage[lang];
+        <span>
+            <code>@lang</code>
+            @if (missing == 0)
+            {
+                <span class="badge bg-success">complete</span>
+            }
+            else
+            {
+                <span class="badge bg-warning text-dark">@missing missing</span>
+            }
+        </span>
+    }
+</div>
+
+<div class="d-flex flex-wrap gap-2 align-items-center mb-3">
+    <input type="search" id="loc-filter" class="form-control form-control-sm" style="max-width: 320px"
+           placeholder="Filter by key or text…" autocomplete="off" />
+    <div class="form-check form-check-inline mb-0">
+        <input class="form-check-input" type="checkbox" id="loc-missing-only" />
+        <label class="form-check-label" for="loc-missing-only">Only rows with missing translations</label>
+    </div>
+</div>
+
+<nav class="d-flex flex-wrap gap-1 mb-4" aria-label="Key prefix groups">
+    @foreach (var group in Model.Groups)
+    {
+        var groupMissing = group.MissingByLanguage.Values.Sum();
+        <a class="btn btn-outline-secondary btn-sm" href="#loc-group-@group.Prefix">
+            @group.Prefix <span class="text-muted">(@group.Rows.Count)</span>
+            @if (groupMissing > 0)
+            {
+                <span class="badge bg-warning text-dark ms-1">@groupMissing</span>
+            }
+        </a>
+    }
+</nav>
+
+@if (Model.OrphanKeysByLanguage.Any(kv => kv.Value.Count > 0))
+{
+    <div class="alert alert-warning">
+        <strong>Orphan keys</strong> — present in a language file but no longer in the English resx; safe to delete:
+        <ul class="mb-0">
+            @foreach (var (lang, keys) in Model.OrphanKeysByLanguage.Where(kv => kv.Value.Count > 0))
+            {
+                <li><code>@lang</code>: @string.Join(", ", keys)</li>
+            }
+        </ul>
+    </div>
+}
+
+@foreach (var group in Model.Groups)
+{
+    <h2 class="h5 mt-4" id="loc-group-@group.Prefix">
+        @group.Prefix
+        <small class="text-muted">— @group.Rows.Count @(group.Rows.Count == 1 ? "key" : "keys")</small>
+    </h2>
+    <div class="table-responsive">
+        <table class="table table-sm table-striped align-middle small loc-table">
+            <thead>
+                <tr>
+                    <th style="min-width: 16rem">Key</th>
+                    <th>en</th>
+                    @foreach (var lang in Model.Languages)
+                    {
+                        <th>@lang</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in group.Rows)
+                {
+                    var hasMissing = row.Values.Values.Any(v => v is null);
+                    <tr data-loc-missing="@(hasMissing ? "1" : "0")">
+                        <td><code>@row.Key</code></td>
+                        <td>@row.English</td>
+                        @foreach (var lang in Model.Languages)
+                        {
+                            var value = row.Values[lang];
+                            @if (value is null)
+                            {
+                                <td class="table-warning text-center">—</td>
+                            }
+                            else
+                            {
+                                <td>@value</td>
+                            }
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@section Scripts {
+    <script>
+        (function () {
+            const filter = document.getElementById('loc-filter');
+            const missingOnly = document.getElementById('loc-missing-only');
+            const rows = Array.from(document.querySelectorAll('.loc-table tbody tr'));
+
+            function apply() {
+                const needle = filter.value.trim().toLowerCase();
+                const onlyMissing = missingOnly.checked;
+                for (const row of rows) {
+                    const matchesText = needle === '' || row.textContent.toLowerCase().includes(needle);
+                    const matchesMissing = !onlyMissing || row.dataset.locMissing === '1';
+                    row.classList.toggle('d-none', !(matchesText && matchesMissing));
+                }
+                // Hide a group's heading and table when every row in it is filtered out.
+                for (const table of document.querySelectorAll('.loc-table')) {
+                    const wrapper = table.closest('.table-responsive');
+                    const heading = wrapper.previousElementSibling;
+                    const anyVisible = Array.from(table.tBodies[0].rows).some(r => !r.classList.contains('d-none'));
+                    wrapper.classList.toggle('d-none', !anyVisible);
+                    heading.classList.toggle('d-none', !anyVisible);
+                }
+            }
+
+            filter.addEventListener('input', apply);
+            missingOnly.addEventListener('change', apply);
+        })();
+    </script>
+}

--- a/src/Humans.Web/Views/Events/Browse.cshtml
+++ b/src/Humans.Web/Views/Events/Browse.cshtml
@@ -1,6 +1,6 @@
 @model Humans.Web.Models.Events.BrowseViewModel
 @{
-    ViewData["Title"] = "Browse Events";
+    ViewData["Title"] = Localizer["Events_BrowseTitle"].Value;
     var hasFilters = Model.FilterDays.Count > 0 || Model.FilterCategoryId.HasValue || Model.FilterVenueId.HasValue
                      || !string.IsNullOrEmpty(Model.SearchQuery) || Model.FavouritesOnly;
 }
@@ -15,12 +15,12 @@
     }
 }
 
-<h2 class="mb-3">Browse Events</h2>
+<h2 class="mb-3">@Localizer["Events_BrowseTitle"]</h2>
 
 @if (Model.TimeZoneId != null)
 {
     <p class="text-muted small">
-        <i class="fa-solid fa-clock me-1"></i>All times in <strong>@Model.TimeZoneId</strong>. Playa Time may apply!
+        <i class="fa-solid fa-clock me-1"></i>@Localizer["Events_AllTimesIn", Model.TimeZoneId!]
     </p>
 }
 
@@ -29,7 +29,7 @@
         @if (Model.Days.Count > 0)
         {
             <div class="mb-3">
-                <label class="form-label small mb-1 d-block">Day</label>
+                <label class="form-label small mb-1 d-block">@Localizer["Events_FilterDay"]</label>
                 <div class="d-flex flex-wrap gap-1">
                     @foreach (var d in Model.Days)
                     {
@@ -47,9 +47,9 @@
         }
         <div class="row g-2 align-items-end">
             <div class="col-md-3">
-                <label class="form-label small mb-1">Category</label>
+                <label class="form-label small mb-1">@Localizer["Events_FilterCategory"]</label>
                 <select name="categoryId" class="form-select form-select-sm js-auto-submit">
-                    <option value="">All categories</option>
+                    <option value="">@Localizer["Events_AllCategories"]</option>
                     @foreach (var c in Model.Categories)
                     {
                         <option value="@c.Id" selected="@(Model.FilterCategoryId == c.Id ? "selected" : null)">@c.Name</option>
@@ -57,9 +57,9 @@
                 </select>
             </div>
             <div class="col-md-3">
-                <label class="form-label small mb-1">Venue</label>
+                <label class="form-label small mb-1">@Localizer["Events_FilterVenue"]</label>
                 <select name="venueId" class="form-select form-select-sm js-auto-submit">
-                    <option value="">All venues</option>
+                    <option value="">@Localizer["Events_AllVenues"]</option>
                     @foreach (var v in Model.Venues)
                     {
                         <option value="@v.Id" selected="@(Model.FilterVenueId == v.Id ? "selected" : null)">@v.Name</option>
@@ -67,16 +67,16 @@
                 </select>
             </div>
             <div class="col-md-3">
-                <label class="form-label small mb-1">Search</label>
+                <label class="form-label small mb-1">@Localizer["Events_FilterSearch"]</label>
                 <input type="text" name="q" value="@Model.SearchQuery" class="form-control form-control-sm"
-                       placeholder="Search title or description..." />
+                       placeholder="@Localizer["Events_SearchPlaceholder"]" />
             </div>
             <div class="col-md-2 d-flex align-items-end gap-2">
                 <div class="form-check">
                     <input type="checkbox" name="favouritesOnly" value="true" class="form-check-input js-auto-submit"
                            id="favouritesOnly" checked="@(Model.FavouritesOnly ? "checked" : null)" />
                     <label class="form-check-label small" for="favouritesOnly">
-                        <i class="fa-solid fa-heart text-danger"></i> Only
+                        <i class="fa-solid fa-heart text-danger"></i> @Localizer["Events_FavouritesOnly"]
                     </label>
                 </div>
                 <button type="submit" class="btn btn-sm btn-primary">
@@ -86,7 +86,7 @@
             @if (hasFilters)
             {
                 <div class="col-md-1 d-flex align-items-end">
-                    <a asp-action="Browse" class="btn btn-sm btn-outline-secondary">Clear</a>
+                    <a asp-action="Browse" class="btn btn-sm btn-outline-secondary">@Localizer["Common_Clear"]</a>
                 </div>
             }
         </div>
@@ -96,7 +96,7 @@
 @if (Model.DayGroups.Count == 0)
 {
     <div class="alert alert-secondary">
-        No events found. Try adjusting your filters.
+        @Localizer["Events_NoEventsFound"]
     </div>
 }
 else
@@ -124,7 +124,7 @@ else
                                 <input type="hidden" name="days" value="@d" />
                             }
                             <button type="submit" class="btn btn-sm @(item.IsFavourited ? "btn-danger" : "btn-outline-danger")"
-                                    title="@(item.IsFavourited ? "Remove from favourites" : "Add to favourites")">
+                                    title="@(item.IsFavourited ? Localizer["Events_RemoveFromFavourites"].Value : Localizer["Events_AddToFavourites"].Value)">
                                 <i class="fa-solid fa-heart"></i>
                             </button>
                         </form>
@@ -161,9 +161,9 @@ else
 
 <div class="mt-3 d-flex gap-2">
     <a asp-action="Schedule" class="btn btn-outline-secondary">
-        <i class="fa-solid fa-calendar me-1"></i>My Schedule
+        <i class="fa-solid fa-calendar me-1"></i>@Localizer["Events_MySchedule"]
     </a>
     <a asp-action="MySubmissions" class="btn btn-outline-secondary">
-        <i class="fa-solid fa-list me-1"></i>My Submissions
+        <i class="fa-solid fa-list me-1"></i>@Localizer["Events_MySubmissions"]
     </a>
 </div>

--- a/src/Humans.Web/Views/Events/MySubmissions.cshtml
+++ b/src/Humans.Web/Views/Events/MySubmissions.cshtml
@@ -2,16 +2,16 @@
 @using Microsoft.AspNetCore.Html
 @model Humans.Web.Models.Events.MySubmissionsViewModel
 @{
-    ViewData["Title"] = "My Event Submissions";
+    ViewData["Title"] = Localizer["Events_MySubmissionsTitle"].Value;
 }
 
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item active" aria-current="page">My Event Submissions</li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Events_MySubmissionsTitle"]</li>
     </ol>
 </nav>
 
-<h2 class="mb-4">My Event Submissions</h2>
+<h2 class="mb-4">@Localizer["Events_MySubmissionsTitle"]</h2>
 
 
 @if (!Model.IsSubmissionOpen)
@@ -20,7 +20,7 @@
         <i class="fa-solid fa-clock me-1"></i>
         @if (Model.SubmissionOpenAt.HasValue && Model.SubmissionCloseAt.HasValue)
         {
-            <text>Submission window: @Model.SubmissionOpenAt.Value.ToDateTime() — @Model.SubmissionCloseAt.Value.ToDateTime()</text>
+            <text>@Localizer["Events_SubmissionWindow"] @Model.SubmissionOpenAt.Value.ToDateTime() — @Model.SubmissionCloseAt.Value.ToDateTime()</text>
             if (Model.TimeZoneId != null)
             {
                 <text> (@Model.TimeZoneId)</text>
@@ -28,7 +28,7 @@
         }
         else
         {
-            <text>Submission window is not currently open. Contact an admin to configure guide settings.</text>
+            <text>@Localizer["Events_SubmissionWindowClosed"]</text>
         }
     </div>
 }
@@ -36,11 +36,11 @@
 @* ── Personal events block ── *@
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <span><i class="fa-solid fa-user me-1"></i> My personal events</span>
+        <span><i class="fa-solid fa-user me-1"></i> @Localizer["Events_MyPersonalEvents"]</span>
         @if (Model.IsSubmissionOpen)
         {
             <a asp-action="Submit" class="btn btn-sm btn-primary">
-                <i class="fa-solid fa-plus me-1"></i>Submit new event
+                <i class="fa-solid fa-plus me-1"></i>@Localizer["Events_SubmitNewEvent"]
             </a>
         }
     </div>
@@ -50,7 +50,7 @@
                 <div class="card text-center border-0 bg-light">
                     <div class="card-body py-2">
                         <div class="fs-5 fw-bold">@Model.Personal.SubmittedCount</div>
-                        <small class="text-muted">Submitted</small>
+                        <small class="text-muted">@Localizer["Events_StatSubmitted"]</small>
                     </div>
                 </div>
             </div>
@@ -58,7 +58,7 @@
                 <div class="card text-center border-0 bg-light">
                     <div class="card-body py-2">
                         <div class="fs-5 fw-bold text-warning">@Model.Personal.PendingCount</div>
-                        <small class="text-muted">Pending</small>
+                        <small class="text-muted">@Localizer["Events_StatPending"]</small>
                     </div>
                 </div>
             </div>
@@ -66,7 +66,7 @@
                 <div class="card text-center border-0 bg-light">
                     <div class="card-body py-2">
                         <div class="fs-5 fw-bold text-success">@Model.Personal.ApprovedCount</div>
-                        <small class="text-muted">Approved</small>
+                        <small class="text-muted">@Localizer["Events_StatApproved"]</small>
                     </div>
                 </div>
             </div>
@@ -74,22 +74,22 @@
 
         @if (Model.Personal.Events.Count == 0)
         {
-            <p class="text-muted mb-0">You haven't submitted any personal events yet.</p>
+            <p class="text-muted mb-0">@Localizer["Events_NoPersonalEvents"]</p>
         }
         else
         {
             Func<IndividualEventRowViewModel, IHtmlContent> personalStatusCell =
-                @<text><span class="badge @item.StatusBadgeClass">@item.Status</span></text>;
+                @<text><span class="badge @item.StatusBadgeClass">@Localizer.EnumDisplay(item.Status)</span></text>;
             Func<IndividualEventRowViewModel, IHtmlContent> personalActionsCell = @<text>
                 @if (item.CanEdit)
                 {
                     <a asp-action="Edit" asp-route-eventId="@item.Id" class="btn btn-sm btn-outline-primary me-1">
-                        <i class="fa-solid fa-pen me-1"></i>Edit
+                        <i class="fa-solid fa-pen me-1"></i>@Localizer["Common_Edit"]
                     </a>
                 }
                 @if (item.CanWithdraw)
                 {
-                    <form method="post" asp-action="Withdraw" asp-route-eventId="@item.Id" class="d-inline" data-confirm="Withdraw this event?">
+                    <form method="post" asp-action="Withdraw" asp-route-eventId="@item.Id" class="d-inline" data-confirm="@Localizer["Events_WithdrawConfirm"].Value">
                         @Html.AntiForgeryToken()
                         <button type="submit" class="btn btn-sm btn-outline-danger">
                             <i class="fa-solid fa-xmark"></i>
@@ -98,11 +98,11 @@
                 }
             </text>;
             var personalTable = TableModel.For(Model.Personal.Events)
-                .Column("Event name", r => r.Title)
-                .Column("Category", r => r.CategoryName)
-                .Column("Date & time", r => r.StartAt.ToMonthDayTime())
-                .Template("Status", personalStatusCell)
-                .Template("Actions", personalActionsCell, c => c.NoSort())
+                .Column(Localizer["Events_ColEventName"].Value, r => r.Title)
+                .Column(Localizer["Events_ColCategory"].Value, r => r.CategoryName)
+                .Column(Localizer["Events_ColDateTime"].Value, r => r.StartAt.ToMonthDayTime())
+                .Template(Localizer["Common_Status"].Value, personalStatusCell)
+                .Template(Localizer["Events_ColActions"].Value, personalActionsCell, c => c.NoSort())
                 .Build();
             <partial name="_Table" model="personalTable" />
         }
@@ -112,7 +112,7 @@
 @* ── Barrio blocks (one per led barrio) ── *@
 @{
     Func<CampEventRowViewModel, IHtmlContent> barrioStatusCell =
-        @<text><span class="badge @item.StatusBadgeClass">@item.Status</span></text>;
+        @<text><span class="badge @item.StatusBadgeClass">@Localizer.EnumDisplay(item.Status)</span></text>;
 }
 @foreach (var barrio in Model.Barrios)
 {
@@ -122,7 +122,7 @@
             @if (Model.IsSubmissionOpen)
             {
                 <a asp-action="BarrioSubmit" asp-route-slug="@barrio.CampSlug" class="btn btn-sm btn-primary">
-                    <i class="fa-solid fa-plus me-1"></i>Add barrio event
+                    <i class="fa-solid fa-plus me-1"></i>@Localizer["Events_AddBarrioEvent"]
                 </a>
             }
         </div>
@@ -132,7 +132,7 @@
                     <div class="card text-center border-0 bg-light">
                         <div class="card-body py-2">
                             <div class="fs-5 fw-bold">@barrio.SubmittedCount</div>
-                            <small class="text-muted">Submitted</small>
+                            <small class="text-muted">@Localizer["Events_StatSubmitted"]</small>
                         </div>
                     </div>
                 </div>
@@ -140,7 +140,7 @@
                     <div class="card text-center border-0 bg-light">
                         <div class="card-body py-2">
                             <div class="fs-5 fw-bold text-warning">@barrio.PendingCount</div>
-                            <small class="text-muted">Pending</small>
+                            <small class="text-muted">@Localizer["Events_StatPending"]</small>
                         </div>
                     </div>
                 </div>
@@ -148,7 +148,7 @@
                     <div class="card text-center border-0 bg-light">
                         <div class="card-body py-2">
                             <div class="fs-5 fw-bold text-success">@barrio.ApprovedCount</div>
-                            <small class="text-muted">Approved</small>
+                            <small class="text-muted">@Localizer["Events_StatApproved"]</small>
                         </div>
                     </div>
                 </div>
@@ -156,7 +156,7 @@
 
             @if (barrio.Events.Count == 0)
             {
-                <p class="text-muted mb-3">No events submitted yet for this barrio.</p>
+                <p class="text-muted mb-3">@Localizer["Events_NoBarrioEvents"]</p>
             }
             else
             {
@@ -164,12 +164,12 @@
                     @if (item.CanEdit)
                     {
                         <a asp-action="BarrioEdit" asp-route-slug="@barrio.CampSlug" asp-route-eventId="@item.Id" class="btn btn-sm btn-outline-primary me-1">
-                            <i class="fa-solid fa-pen me-1"></i>Edit
+                            <i class="fa-solid fa-pen me-1"></i>@Localizer["Common_Edit"]
                         </a>
                     }
                     @if (item.CanWithdraw)
                     {
-                        <form method="post" asp-action="BarrioWithdraw" asp-route-slug="@barrio.CampSlug" asp-route-eventId="@item.Id" class="d-inline" data-confirm="Withdraw this event?">
+                        <form method="post" asp-action="BarrioWithdraw" asp-route-slug="@barrio.CampSlug" asp-route-eventId="@item.Id" class="d-inline" data-confirm="@Localizer["Events_WithdrawConfirm"].Value">
                             @Html.AntiForgeryToken()
                             <button type="submit" class="btn btn-sm btn-outline-danger">
                                 <i class="fa-solid fa-xmark"></i>
@@ -178,12 +178,12 @@
                     }
                 </text>;
                 var barrioTable = TableModel.For(barrio.Events)
-                    .Column("Event name", r => r.Title)
-                    .Column("Category", r => r.CategoryName)
-                    .Column("Date & time", r => r.StartAt.ToMonthDayTime())
-                    .Column("Priority", r => r.PriorityRank)
-                    .Template("Status", barrioStatusCell)
-                    .Template("Actions", barrioActionsCell, c => c.NoSort())
+                    .Column(Localizer["Events_ColEventName"].Value, r => r.Title)
+                    .Column(Localizer["Events_ColCategory"].Value, r => r.CategoryName)
+                    .Column(Localizer["Events_ColDateTime"].Value, r => r.StartAt.ToMonthDayTime())
+                    .Column(Localizer["Events_ColPriority"].Value, r => r.PriorityRank)
+                    .Template(Localizer["Common_Status"].Value, barrioStatusCell)
+                    .Template(Localizer["Events_ColActions"].Value, barrioActionsCell, c => c.NoSort())
                     .Build();
                 <partial name="_Table" model="barrioTable" />
             }
@@ -191,13 +191,13 @@
             <hr class="my-3" />
             <div class="d-flex align-items-center gap-3 flex-wrap">
                 <a asp-action="BulkUploadTemplate" asp-route-slug="@barrio.CampSlug" class="btn btn-sm btn-outline-secondary">
-                    <i class="fa-solid fa-file-csv me-1"></i>Download events CSV
+                    <i class="fa-solid fa-file-csv me-1"></i>@Localizer["Events_DownloadCsv"]
                 </a>
                 <form method="post" asp-action="BulkUploadImport" asp-route-slug="@barrio.CampSlug" enctype="multipart/form-data" class="d-flex align-items-center gap-2">
                     @Html.AntiForgeryToken()
                     <input type="file" name="file" accept=".csv" class="form-control form-control-sm" style="max-width: 260px;" />
                     <button type="submit" class="btn btn-sm btn-outline-primary">
-                        <i class="fa-solid fa-upload me-1"></i>Upload CSV
+                        <i class="fa-solid fa-upload me-1"></i>@Localizer["Events_UploadCsv"]
                     </button>
                 </form>
             </div>
@@ -205,15 +205,15 @@
             @if (barrio.BulkUploadErrors.Count > 0)
             {
                 <div class="alert alert-danger mt-3">
-                    <strong>Upload failed.</strong> Fix the errors below and try again. No events were saved.
+                    <strong>@Localizer["Events_UploadFailed"]</strong> @Localizer["Events_UploadFailedDetail"]
                 </div>
                 <div class="table-responsive">
                     <table class="table table-sm table-bordered align-middle mb-0">
                         <thead class="table-danger">
                             <tr>
-                                <th style="width: 60px;">Row</th>
-                                <th>Event</th>
-                                <th>Errors</th>
+                                <th style="width: 60px;">@Localizer["Events_UploadColRow"]</th>
+                                <th>@Localizer["Events_UploadColEvent"]</th>
+                                <th>@Localizer["Events_UploadColErrors"]</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/Humans.Web/Views/Events/Schedule.cshtml
+++ b/src/Humans.Web/Views/Events/Schedule.cshtml
@@ -1,22 +1,22 @@
 @model Humans.Web.Models.Events.ScheduleViewModel
 @{
-    ViewData["Title"] = "My Schedule";
+    ViewData["Title"] = Localizer["Events_ScheduleTitle"].Value;
 }
 
-<h2 class="mb-3">My Schedule</h2>
+<h2 class="mb-3">@Localizer["Events_ScheduleTitle"]</h2>
 
 
 @if (Model.TimeZoneId != null)
 {
     <p class="text-muted small">
-        <i class="fa-solid fa-clock me-1"></i>All times in <strong>@Model.TimeZoneId</strong>
+        <i class="fa-solid fa-clock me-1"></i>@Localizer["Events_AllTimesInShort", Model.TimeZoneId!]
     </p>
 }
 
 @if (Model.DayGroups.Count == 0)
 {
     <div class="alert alert-secondary">
-        You haven't favourited any events yet. Browse the <a asp-controller="Events" asp-action="Browse">event guide</a> to add events to your schedule.
+        @Html.Raw(string.Format(Localizer["Events_ScheduleEmpty"].Value, "<a href=\"" + Url.Action("Browse", "Events") + "\">" + Localizer["Events_ScheduleEmptyLink"].Value + "</a>"))
     </div>
 }
 else
@@ -32,23 +32,23 @@ else
                         <div>
                             @if (item.HasConflict)
                             {
-                                <span class="badge bg-warning text-dark me-1" title="Time conflict with another favourited event">
+                                <span class="badge bg-warning text-dark me-1" title="@Localizer["Events_ConflictBadge"]">
                                     <i class="fa-solid fa-triangle-exclamation"></i>
                                 </span>
                             }
                             <strong>@item.Title</strong>
                             <span class="badge bg-secondary ms-1">@item.CategoryName</span>
                         </div>
-                        <form method="post" asp-action="Unfavourite" asp-route-eventId="@item.EventId" asp-route-day="@item.FavouriteDayOffset" class="d-inline" data-confirm="Remove this event from your schedule?">
+                        <form method="post" asp-action="Unfavourite" asp-route-eventId="@item.EventId" asp-route-day="@item.FavouriteDayOffset" class="d-inline" data-confirm="@Localizer["Events_RemoveFromScheduleConfirm"].Value">
                             @Html.AntiForgeryToken()
-                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove from schedule">
+                            <button type="submit" class="btn btn-sm btn-outline-danger" title="@Localizer["Events_RemoveFromSchedule"]">
                                 <i class="fa-solid fa-heart-crack"></i>
                             </button>
                         </form>
                     </div>
                     <div class="mt-1 small text-muted">
                         <i class="fa-solid fa-clock me-1"></i>@item.StartAt.ToTime() — @item.StartAt.AddMinutes(item.DurationMinutes).ToTime()
-                        (@item.DurationMinutes min)
+                        (@Localizer["Events_DurationMin", item.DurationMinutes])
                         @if (item.CampName != null)
                         {
                             <text> &middot; <i class="fa-solid fa-campground me-1"></i>@item.CampName</text>
@@ -69,5 +69,5 @@ else
 }
 
 <a asp-action="MySubmissions" class="btn btn-outline-secondary">
-    <i class="fa-solid fa-arrow-left me-1"></i>My Submissions
+    <i class="fa-solid fa-arrow-left me-1"></i>@Localizer["Events_MySubmissions"]
 </a>

--- a/src/Humans.Web/Views/Expenses/Coordinator.cshtml
+++ b/src/Humans.Web/Views/Expenses/Coordinator.cshtml
@@ -3,24 +3,24 @@
 @using Humans.Web.Models.Tables
 @using Microsoft.AspNetCore.Html
 @{
-    ViewData["Title"] = "Expense Reports — Coordinator Queue";
+    ViewData["Title"] = Localizer["Expenses_CoordinatorQueueTitle"].Value;
 }
 
 <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item active" aria-current="page">Coordinator Queue</li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Expenses_CoordinatorQueue"]</li>
     </ol>
 </nav>
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1>Coordinator Queue</h1>
+    <h1>@Localizer["Expenses_CoordinatorQueue"]</h1>
 </div>
 
 
 @if (!Model.Reports.Any())
 {
     <div class="alert alert-info">
-        <i class="fa-solid fa-inbox me-2"></i>No reports awaiting your endorsement.
+        <i class="fa-solid fa-inbox me-2"></i>@Localizer["Expenses_NoReportsAwaiting"]
     </div>
 }
 else
@@ -32,32 +32,32 @@ else
     Func<ExpenseReportDto, IHtmlContent> actionsCell = @<text>
         <div class="d-flex gap-2 justify-content-end">
             <a asp-action="Detail" asp-route-id="@item.Id" class="btn btn-sm btn-outline-secondary">
-                <i class="fa-solid fa-eye me-1"></i>View
+                <i class="fa-solid fa-eye me-1"></i>@Localizer["Common_View"]
             </a>
             @if (item.Status == ExpenseReportStatus.Submitted)
             {
                 <form asp-action="Endorse" asp-route-id="@item.Id" method="post" class="d-inline">
                     @Html.AntiForgeryToken()
                     <button type="submit" class="btn btn-sm btn-success"
-                            data-confirm="Endorse this expense report?">
-                        <i class="fa-solid fa-check me-1"></i>Endorse
+                            data-confirm="@Localizer["Expenses_EndorseConfirm"].Value">
+                        <i class="fa-solid fa-check me-1"></i>@Localizer["Expenses_Endorse"]
                     </button>
                 </form>
                 <button type="button" class="btn btn-sm btn-outline-danger"
                         data-bs-toggle="modal"
                         data-bs-target="#rejectModal-@item.Id">
-                    <i class="fa-solid fa-xmark me-1"></i>Reject
+                    <i class="fa-solid fa-xmark me-1"></i>@Localizer["Expenses_Reject"]
                 </button>
             }
         </div>
     </text>;
     var table = TableModel.For(Model.Reports)
-        .Template("Report", reportCell)
-        .Column("Submitted by", r => Model.SubmitterNames.TryGetValue(r.SubmitterUserId, out var name) ? name : "(unknown)")
-        .Column("Total", r => r.Total, c => c.Currency().End())
-        .Column("Status", r => r.Status, c => c.EnumBadge())
-        .Template("Submitted", submittedAtCell)
-        .Template("Actions", actionsCell, c => c.NoSort().End())
+        .Template(Localizer["Expenses_ColReport"].Value, reportCell)
+        .Column(Localizer["Expenses_ColSubmittedBy"].Value, r => Model.SubmitterNames.TryGetValue(r.SubmitterUserId, out var name) ? name : Localizer["Common_Unknown"].Value)
+        .Column(Localizer["Common_Total"].Value, r => r.Total, c => c.Currency().End())
+        .Column(Localizer["Common_Status"].Value, r => r.Status, c => c.EnumBadge())
+        .Template(Localizer["Expenses_ColSubmitted"].Value, submittedAtCell)
+        .Template(Localizer["Common_Actions"].Value, actionsCell, c => c.NoSort().End())
         .Build();
     <partial name="_Table" model="table" />
 
@@ -70,23 +70,23 @@ else
                     <form asp-action="CoordinatorReject" asp-route-id="@r.Id" method="post">
                         @Html.AntiForgeryToken()
                         <div class="modal-header">
-                            <h5 class="modal-title" id="rejectModalLabel-@r.Id">Reject Report</h5>
+                            <h5 class="modal-title" id="rejectModalLabel-@r.Id">@Localizer["Expenses_RejectModalTitle"]</h5>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
                             <p class="text-muted">
-                                The submitter will see this reason. Explain clearly why the report cannot be endorsed.
+                                @Localizer["Expenses_RejectModalBody"]
                             </p>
                             <div class="mb-3">
-                                <label for="reason-@r.Id" class="form-label fw-semibold">Rejection reason <span class="text-danger">*</span></label>
+                                <label for="reason-@r.Id" class="form-label fw-semibold">@Localizer["Expenses_RejectReasonLabel"] <span class="text-danger">*</span></label>
                                 <textarea class="form-control" id="reason-@r.Id" name="Reason"
                                           rows="3" maxlength="1000" required
-                                          placeholder="e.g. Missing receipts for line 2"></textarea>
+                                          placeholder="@Localizer["Expenses_RejectReasonPlaceholder"].Value"></textarea>
                             </div>
                         </div>
                         <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                            <button type="submit" class="btn btn-danger">Reject</button>
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">@Localizer["Common_Cancel"]</button>
+                            <button type="submit" class="btn btn-danger">@Localizer["Expenses_Reject"]</button>
                         </div>
                     </form>
                 </div>

--- a/src/Humans.Web/Views/Expenses/Index.cshtml
+++ b/src/Humans.Web/Views/Expenses/Index.cshtml
@@ -3,16 +3,16 @@
 @using Humans.Web.Models.Tables
 @using Microsoft.AspNetCore.Html
 @{
-    ViewData["Title"] = "My Expense Reports";
+    ViewData["Title"] = Localizer["Expenses_MyReportsTitle"].Value;
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1 class="mb-0">My Expense Reports</h1>
+    <h1 class="mb-0">@Localizer["Expenses_MyReportsTitle"]</h1>
     <div class="d-flex gap-2">
         @if (Model.IsCoordinator)
         {
             <a asp-action="Coordinator" class="btn btn-outline-secondary">
-                <i class="fa-solid fa-list-check me-1"></i>Coordinator queue
+                <i class="fa-solid fa-list-check me-1"></i>@Localizer["Expenses_CoordinatorQueue"]
                 @if (Model.CoordinatorQueueCount > 0)
                 {
                     <span class="badge text-bg-secondary ms-1">@Model.CoordinatorQueueCount</span>
@@ -22,7 +22,7 @@
         @if (Model.HasActiveYear)
         {
             <a asp-action="New" class="btn btn-primary">
-                <i class="fa-solid fa-plus me-1"></i>New Report
+                <i class="fa-solid fa-plus me-1"></i>@Localizer["Expenses_NewReport"]
             </a>
         }
     </div>
@@ -32,19 +32,19 @@
 @if (Model.Iou is { } iou)
 {
     <div class="card mb-4 border-info">
-        <div class="card-header bg-info-subtle"><strong><i class="fa-solid fa-building-columns me-1"></i>What the collective owes you</strong></div>
+        <div class="card-header bg-info-subtle"><strong><i class="fa-solid fa-building-columns me-1"></i>@Localizer["Expenses_IouHeader"]</strong></div>
         <div class="card-body">
             <div class="row text-center">
                 <div class="col-md-4">
-                    <div class="text-muted small">Owed to you (Holded balance)</div>
+                    <div class="text-muted small">@Localizer["Expenses_IouOwed"]</div>
                     <div class="fs-4 fw-semibold">@iou.OwedToMember.ToEuro()</div>
                 </div>
                 <div class="col-md-4">
-                    <div class="text-muted small">Paid to date</div>
+                    <div class="text-muted small">@Localizer["Expenses_IouPaid"]</div>
                     <div class="fs-4">@iou.TotalPaid.ToEuro()</div>
                 </div>
                 <div class="col-md-4">
-                    <div class="text-muted small">Last payment</div>
+                    <div class="text-muted small">@Localizer["Expenses_IouLastPayment"]</div>
                     <div class="fs-4">@(iou.LastPaymentDate is { } d ? d.ToInvariantDate() : "—")</div>
                 </div>
             </div>
@@ -52,8 +52,7 @@
             {
                 <p class="text-muted small mb-0 mt-3">
                     <i class="fa-solid fa-circle-info me-1"></i>
-                    Your Holded balance includes @iou.OtherAmount.ToEuro() unrelated to these reports
-                    (items fronted on the collective's behalf, adjustments, etc.), so the rows below won't necessarily sum to it.
+                    @Localizer["Expenses_IouOtherAmountNote", iou.OtherAmount.ToEuro()]
                 </p>
             }
         </div>
@@ -67,7 +66,7 @@
                 @item.Label
                 @if (item.Status is { } st)
                 {
-                    <span class="badge bg-secondary ms-1">@st</span>
+                    <span class="badge bg-secondary ms-1">@Localizer.EnumDisplay(st)</span>
                 }
             </text>;
             Func<ExpenseLedgerRow, IHtmlContent> ledgerAmountCell =
@@ -75,13 +74,13 @@
             Func<ExpenseLedgerRow, IHtmlContent> ledgerActionCell = @<text>
                 @if (item.ReportId is { } rid)
                 {
-                    <a asp-action="Detail" asp-route-id="@rid" class="btn btn-sm btn-outline-secondary">View</a>
+                    <a asp-action="Detail" asp-route-id="@rid" class="btn btn-sm btn-outline-secondary">@Localizer["Common_View"]</a>
                 }
             </text>;
             var ledgerTable = TableModel.For(Model.Ledger)
-                .Column("Date", r => r.Date.ToInvariantDate())
-                .Template("Item", ledgerItemCell)
-                .Template("Amount", ledgerAmountCell, c => c.NoSort().End())
+                .Column(Localizer["Common_Date"].Value, r => r.Date.ToInvariantDate())
+                .Template(Localizer["Expenses_LedgerColItem"].Value, ledgerItemCell)
+                .Template(Localizer["Common_Amount"].Value, ledgerAmountCell, c => c.NoSort().End())
                 .Template("", ledgerActionCell, c => c.NoSort().End())
                 .RowCss(r => r.IsPayment ? "table-success" : null)
                 .Build();
@@ -93,14 +92,14 @@
 @if (!Model.HasActiveYear)
 {
     <div class="alert alert-info">
-        There is no active budget year at the moment. Expense reports cannot be filed until a budget year is activated.
+        @Localizer["Expenses_NoActiveYear"]
     </div>
 }
 else if (!Model.HasIban)
 {
     <div class="alert alert-warning">
         <i class="fa-solid fa-circle-exclamation me-1"></i>
-        You have not yet set your payment IBAN. You will be prompted to set it when you submit a report.
+        @Localizer["Expenses_NoIban"]
     </div>
 }
 
@@ -109,10 +108,10 @@ else if (!Model.HasIban)
     <div class="card">
         <div class="card-body text-center text-muted py-5">
             <i class="fa-solid fa-receipt fa-2x mb-3 d-block"></i>
-            <p class="mb-0">No expense reports yet.</p>
+            <p class="mb-0">@Localizer["Expenses_NoReports"]</p>
             @if (Model.HasActiveYear)
             {
-                <a asp-action="New" class="btn btn-outline-primary mt-3">File your first report</a>
+                <a asp-action="New" class="btn btn-outline-primary mt-3">@Localizer["Expenses_FileFirst"]</a>
             }
         </div>
     </div>
@@ -120,13 +119,13 @@ else if (!Model.HasIban)
 else
 {
     Func<ExpenseReportDto, IHtmlContent> reportActionCell =
-        @<text><a asp-action="Detail" asp-route-id="@item.Id" class="btn btn-sm btn-outline-secondary">View</a></text>;
+        @<text><a asp-action="Detail" asp-route-id="@item.Id" class="btn btn-sm btn-outline-secondary">@Localizer["Common_View"]</a></text>;
     var reportRows = Model.Reports.OrderByDescending(x => x.CreatedAt).ToList();
     var reportsTable = TableModel.For(reportRows)
-        .Column("Created", r => r.CreatedAt, c => c.Date())
-        .Column("Category", r => Model.CategoryNames.TryGetValue(r.BudgetCategoryId, out var cat) ? cat : r.BudgetCategoryId.ToString())
-        .Column("Status", r => r.Status, c => c.EnumBadge())
-        .Column("Total", r => r.Total, c => c.Currency().End())
+        .Column(Localizer["Common_Created"].Value, r => r.CreatedAt, c => c.Date())
+        .Column(Localizer["Budget_ColCategory"].Value, r => Model.CategoryNames.TryGetValue(r.BudgetCategoryId, out var cat) ? cat : r.BudgetCategoryId.ToString())
+        .Column(Localizer["Common_Status"].Value, r => r.Status, c => c.EnumBadge())
+        .Column(Localizer["Common_Total"].Value, r => r.Total, c => c.Currency().End())
         .Template("", reportActionCell, c => c.NoSort().End())
         .Build();
     <partial name="_Table" model="reportsTable" />

--- a/src/Humans.Web/Views/Feedback/Index.cshtml
+++ b/src/Humans.Web/Views/Feedback/Index.cshtml
@@ -13,11 +13,11 @@
             {
                 if (Model.StatusFilter == s)
                 {
-                    <option value="@s" selected>@s</option>
+                    <option value="@s" selected>@Localizer.EnumDisplay(s)</option>
                 }
                 else
                 {
-                    <option value="@s">@s</option>
+                    <option value="@s">@Localizer.EnumDisplay(s)</option>
                 }
             }
         </select>
@@ -27,11 +27,11 @@
             {
                 if (Model.CategoryFilter == c)
                 {
-                    <option value="@c" selected>@c</option>
+                    <option value="@c" selected>@Localizer.EnumDisplay(c)</option>
                 }
                 else
                 {
-                    <option value="@c">@c</option>
+                    <option value="@c">@Localizer.EnumDisplay(c)</option>
                 }
             }
         </select>
@@ -127,7 +127,7 @@
                      data-report-id="@report.Id"
                      style="cursor: pointer;">
                     <div class="d-flex justify-content-between align-items-start mb-1">
-                        <span class="fw-semibold small">@report.Category on @(report.PageUrl.Length > 30 ? report.PageUrl[..30] + "..." : report.PageUrl)</span>
+                        <span class="fw-semibold small">@Localizer["Feedback_CategoryOnPage", Localizer.EnumDisplay(report.Category), (report.PageUrl.Length > 30 ? report.PageUrl[..30] + "..." : report.PageUrl)]</span>
                         @{
                             var badgeClass = report.Status switch
                             {
@@ -137,7 +137,7 @@
                                 _ => "bg-secondary"
                             };
                         }
-                        <span class="badge @badgeClass" style="font-size: 0.7rem;">@report.Status</span>
+                        <span class="badge @badgeClass" style="font-size: 0.7rem;">@Localizer.EnumDisplay(report.Status)</span>
                     </div>
                     @if (Model.IsAdmin)
                     {
@@ -155,14 +155,14 @@
                                 @if (!string.IsNullOrEmpty(report.AssignedToName))
                                 {
                                     <span class="badge bg-primary bg-opacity-10 text-primary border border-primary-subtle" style="font-size: 0.65rem;"
-                                          title="Assigned to @report.AssignedToName">
+                                          title="@Localizer["Feedback_AssignedToName", report.AssignedToName]">
                                         <i class="fa-solid fa-user fa-xs"></i> @(report.AssignedToName.Length > 12 ? report.AssignedToName[..12] + "..." : report.AssignedToName)
                                     </span>
                                 }
                                 @if (!string.IsNullOrEmpty(report.AssignedToTeamName))
                                 {
                                     <span class="badge bg-warning bg-opacity-10 text-warning-emphasis border border-warning-subtle" style="font-size: 0.65rem;"
-                                          title="Team: @report.AssignedToTeamName">
+                                          title="@Localizer["Feedback_TeamName", report.AssignedToTeamName]">
                                         <i class="fa-solid fa-users fa-xs"></i> @(report.AssignedToTeamName.Length > 12 ? report.AssignedToTeamName[..12] + "..." : report.AssignedToTeamName)
                                     </span>
                                 }

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -80,7 +80,7 @@
                                                class="form-check-input"
                                                checked
                                                disabled />
-                                        <span class="text-muted small">Always on</span>
+                                        <span class="text-muted small">@Localizer["CommPrefs_AlwaysOn"]</span>
                                     }
                                 </td>
                                 <td class="text-center">
@@ -98,7 +98,7 @@
                                                class="form-check-input"
                                                checked
                                                disabled />
-                                        <span class="text-muted small">Always on</span>
+                                        <span class="text-muted small">@Localizer["CommPrefs_AlwaysOn"]</span>
                                     }
                                 </td>
                             </tr>

--- a/src/Humans.Web/Views/Home/Privacy.cshtml
+++ b/src/Humans.Web/Views/Home/Privacy.cshtml
@@ -87,7 +87,7 @@
 <h2>@Localizer["Privacy_ThirdPartyTitle"]</h2>
 <p>@Localizer["Privacy_ThirdPartyIntro"]</p>
 <ul>
-    <li><strong>Google OAuth:</strong> @Localizer["Privacy_ThirdParty_GoogleOAuth"] (Google's <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>)</li>
+    <li><strong>Google OAuth:</strong> @Localizer["Privacy_ThirdParty_GoogleOAuth"] (<a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">@Localizer["Privacy_ThirdParty_GooglePolicyLink"]</a>)</li>
     <li><strong>Google Workspace:</strong> @Localizer["Privacy_ThirdParty_GoogleWorkspace"]</li>
 </ul>
 

--- a/src/Humans.Web/Views/Issues/Index.cshtml
+++ b/src/Humans.Web/Views/Issues/Index.cshtml
@@ -8,7 +8,7 @@
         <div>
             <h2 class="mb-1">@Localizer["Issue_PageTitle"]</h2>
             <p class="text-muted small mb-0">
-                @Model.OpenCount open · @Model.TotalCount total
+                @Localizer["Issue_CountSummary", Model.OpenCount, Model.TotalCount]
             </p>
         </div>
         <a class="btn btn-primary" asp-action="New">
@@ -106,11 +106,11 @@
             <table class="table table-hover table-sm align-middle issues-table mb-0">
                 <thead class="visually-hidden">
                     <tr>
-                        <th>Status</th>
-                        <th>Title</th>
-                        <th>Reporter</th>
-                        <th>Updated</th>
-                        <th>Comments</th>
+                        <th>@Localizer["Issue_ColStatus"]</th>
+                        <th>@Localizer["Issue_ColTitle"]</th>
+                        <th>@Localizer["Issue_ColReporter"]</th>
+                        <th>@Localizer["Issue_ColUpdated"]</th>
+                        <th>@Localizer["Issue_ColComments"]</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/Humans.Web/Views/Issues/New.cshtml
+++ b/src/Humans.Web/Views/Issues/New.cshtml
@@ -32,11 +32,11 @@
                             {
                                 if (Model.Category == c)
                                 {
-                                    <option value="@c" selected>@IssuePresentation.CategoryEmoji(c) @c</option>
+                                    <option value="@c" selected>@IssuePresentation.CategoryEmoji(c) @Localizer.EnumDisplay(c)</option>
                                 }
                                 else
                                 {
-                                    <option value="@c">@IssuePresentation.CategoryEmoji(c) @c</option>
+                                    <option value="@c">@IssuePresentation.CategoryEmoji(c) @Localizer.EnumDisplay(c)</option>
                                 }
                             }
                         </select>

--- a/src/Humans.Web/Views/OnboardingWidget/Names.cshtml
+++ b/src/Humans.Web/Views/OnboardingWidget/Names.cshtml
@@ -1,24 +1,19 @@
 @model Humans.Web.Models.OnboardingWidget.NamesViewModel
 @{
-    ViewData["Title"] = "Welcome — let's start with your name";
+    ViewData["Title"] = Localizer["Onboarding_NamesTitle"].Value;
 }
 
 <div class="row justify-content-center">
     <div class="col-md-8 col-lg-6">
-        <h1 class="mb-3">Welcome — let's start with your name</h1>
-        <p class="text-muted mb-4">Two short steps before you pick a shift.</p>
+        <h1 class="mb-3">@Localizer["Onboarding_NamesTitle"]</h1>
+        <p class="text-muted mb-4">@Localizer["Onboarding_NamesSubtitle"]</p>
 
         <div class="alert alert-info small" role="note">
             <p class="mb-2">
-                <strong>Legal name</strong> — Kept internally, visible only to Admins, and used only
-                where Spanish law requires it — for example, our audit record that you agreed to the
-                Volunteer Agreement on a specific date and time. We explicitly do <strong>not</strong>
-                export this information, and would only disclose it if required by law or a formal audit.
+                <strong>@Localizer["Onboarding_LegalNameLabel"]</strong> — @Localizer["Onboarding_LegalNameExplainerPre"] <strong>@Localizer["Onboarding_LegalNameExplainerEmphasis"]</strong> @Localizer["Onboarding_LegalNameExplainerPost"]
             </p>
             <p class="mb-0">
-                <strong>Burner name</strong> — The name everyone in the system sees. Uniqueness helps
-                but isn't required, though it may be hard to find "Bob" among the few thousand humans
-                here if someone comes looking for you.
+                <strong>@Localizer["Onboarding_BurnerNameLabel"]</strong> — @Localizer["Onboarding_BurnerNameExplainer"]
             </p>
         </div>
 
@@ -38,11 +33,11 @@
             <div class="mb-4">
                 <label asp-for="BurnerName" class="form-label"></label>
                 <input asp-for="BurnerName" class="form-control" />
-                <small class="form-text text-muted">The name everyone will know you by.</small>
+                <small class="form-text text-muted">@Localizer["Onboarding_BurnerNameHelp"]</small>
                 <span asp-validation-for="BurnerName" class="text-danger"></span>
             </div>
 
-            <button type="submit" class="btn btn-primary btn-lg">Continue</button>
+            <button type="submit" class="btn btn-primary btn-lg">@Localizer["Onboarding_Continue"]</button>
         </form>
     </div>
 </div>

--- a/src/Humans.Web/Views/OnboardingWidget/Shifts.cshtml
+++ b/src/Humans.Web/Views/OnboardingWidget/Shifts.cshtml
@@ -1,6 +1,6 @@
 @model Humans.Web.Models.OnboardingWidget.ShiftsStepViewModel
 @{
-    ViewData["Title"] = "Pick a shift";
+    ViewData["Title"] = Localizer["Onboarding_ShiftsTitle"].Value;
     var browse = Model.BrowseModel;
     var es = browse.EventSettings;
     var hasShifts = es is not null && browse.UrgencyRankedRotas.Count > 0;
@@ -12,36 +12,36 @@
 <div class="container py-4">
     <div class="row justify-content-center">
         <div class="col-lg-10">
-            <h1 class="mb-2">Pick a shift</h1>
+            <h1 class="mb-2">@Localizer["Onboarding_ShiftsTitle"]</h1>
 
             @if (Model.HasAnyCritical)
             {
                 <div class="alert alert-danger" role="alert">
-                    <strong>IMPORTANT:</strong> The event has only @Model.CriticalFilledPercent% of the &ldquo;critical&rdquo; shifts filled. If these are not filled, the event might be cancelled as it would not be viable or safe to run it.
+                    <strong>@Localizer["Onboarding_ShiftsCriticalHeading"]</strong> @Localizer["Onboarding_ShiftsCriticalBody", Model.CriticalFilledPercent ?? 0]
                     @if (Model.HasAnyImportant)
                     {
-                        <div class="mt-2 mb-0">There are also @Model.ImportantOpenCount &ldquo;important&rdquo; shifts open.</div>
+                        <div class="mt-2 mb-0">@Localizer["Onboarding_ShiftsImportantAlsoOpen", Model.ImportantOpenCount]</div>
                     }
-                    <div class="mt-2 mb-0">If you&rsquo;re able to fill some of those, or you&rsquo;re able to come pre-event or stay for strike, please prioritize those when picking your shifts.</div>
+                    <div class="mt-2 mb-0">@Localizer["Onboarding_ShiftsCriticalCta"]</div>
                 </div>
             }
             else if (Model.HasAnyImportant)
             {
                 <div class="alert alert-warning" role="alert">
-                    There are @Model.ImportantOpenCount &ldquo;important&rdquo; shifts open. If you&rsquo;re able to come pre-event or stay for strike, please prioritize those.
+                    @Localizer["Onboarding_ShiftsImportantBody", Model.ImportantOpenCount]
                 </div>
             }
 
             <div class="d-flex flex-wrap gap-2 align-items-center mb-3">
                 <div class="btn-group" role="group" aria-label="Shift priority filter">
-                    <a asp-action="Shifts" asp-route-priority="critical" class="@PillCss("critical")">Critical</a>
-                    <a asp-action="Shifts" asp-route-priority="important" class="@PillCss("important")">Important</a>
-                    <a asp-action="Shifts" asp-route-priority="all" class="@PillCss("all")">All</a>
+                    <a asp-action="Shifts" asp-route-priority="critical" class="@PillCss("critical")">@Localizer["Onboarding_PriorityCritical"]</a>
+                    <a asp-action="Shifts" asp-route-priority="important" class="@PillCss("important")">@Localizer["Onboarding_PriorityImportant"]</a>
+                    <a asp-action="Shifts" asp-route-priority="all" class="@PillCss("all")">@Localizer["Shifts_All"]</a>
                 </div>
                 <form asp-action="Skip" method="post" class="d-inline ms-auto">
                     @Html.AntiForgeryToken()
                     <button type="submit" class="btn btn-outline-secondary btn-sm">
-                        Not right now
+                        @Localizer["Onboarding_ShiftsNotNow"]
                     </button>
                 </form>
             </div>
@@ -53,19 +53,19 @@
                 <div class="alert alert-info text-center my-4">
                     @if (es is null)
                     {
-                        <p class="mb-0">No active event right now. You can finish onboarding without picking a shift.</p>
+                        <p class="mb-0">@Localizer["Onboarding_ShiftsNoActiveEvent"]</p>
                     }
                     else if (selected == "critical")
                     {
-                        <p class="mb-0">No critical shifts open at the moment — try Important or All.</p>
+                        <p class="mb-0">@Localizer["Onboarding_ShiftsNoCritical"]</p>
                     }
                     else if (selected == "important")
                     {
-                        <p class="mb-0">No important shifts open at the moment — try All.</p>
+                        <p class="mb-0">@Localizer["Onboarding_ShiftsNoImportant"]</p>
                     }
                     else
                     {
-                        <p class="mb-0">No shifts available at the moment.</p>
+                        <p class="mb-0">@Localizer["Shifts_NoShiftsAvailable"]</p>
                     }
                 </div>
             }

--- a/src/Humans.Web/Views/Profile/DietaryMedical.cshtml
+++ b/src/Humans.Web/Views/Profile/DietaryMedical.cshtml
@@ -38,7 +38,7 @@
                 <legend class="h6">
                     @Localizer["Profile_DietaryMedical_DietaryPreference_Label"]
                     <span class="text-danger" aria-hidden="true">*</span>
-                    <span class="visually-hidden">(required)</span>
+                    <span class="visually-hidden">@Localizer["Common_Required"]</span>
                 </legend>
                 @foreach (var pref in DietaryMedicalViewModel.DietaryPreferences)
                 {
@@ -72,7 +72,7 @@
                                    value="@opt"
                                    id="al-@opt"
                                    checked="@(isChecked ? "checked" : null)" />
-                            <label class="form-check-label" for="al-@opt">@opt</label>
+                            <label class="form-check-label" for="al-@opt">@Localizer[$"Profile_DietaryMedical_Allergy_{opt.Replace(" ", "").Replace("/", "")}"]</label>
                         </div>
                     }
                 </div>
@@ -84,7 +84,7 @@
                            value="@DietaryMedicalViewModel.OtherOption"
                            id="al-@DietaryMedicalViewModel.OtherOption"
                            checked="@(Model.Allergies.Contains(DietaryMedicalViewModel.OtherOption) ? "checked" : null)" />
-                    <label class="form-check-label" for="al-@DietaryMedicalViewModel.OtherOption">@DietaryMedicalViewModel.OtherOption</label>
+                    <label class="form-check-label" for="al-@DietaryMedicalViewModel.OtherOption">@Localizer["Common_Other"]</label>
                 </div>
                 <div class="mt-3" id="allergy-other-wrapper" style="display: @(Model.Allergies.Contains(DietaryMedicalViewModel.OtherOption) ? "block" : "none");">
                     <label asp-for="AllergyOtherText" class="form-label">@Localizer["Profile_DietaryMedical_AllergyOther_Label"]</label>
@@ -107,7 +107,7 @@
                                    value="@opt"
                                    id="in-@opt"
                                    checked="@(isChecked ? "checked" : null)" />
-                            <label class="form-check-label" for="in-@opt">@opt</label>
+                            <label class="form-check-label" for="in-@opt">@Localizer[$"Profile_DietaryMedical_Intolerance_{opt.Replace(" ", "").Replace("/", "")}"]</label>
                         </div>
                     }
                 </div>
@@ -119,7 +119,7 @@
                            value="@DietaryMedicalViewModel.OtherOption"
                            id="in-@DietaryMedicalViewModel.OtherOption"
                            checked="@(Model.Intolerances.Contains(DietaryMedicalViewModel.OtherOption) ? "checked" : null)" />
-                    <label class="form-check-label" for="in-@DietaryMedicalViewModel.OtherOption">@DietaryMedicalViewModel.OtherOption</label>
+                    <label class="form-check-label" for="in-@DietaryMedicalViewModel.OtherOption">@Localizer["Common_Other"]</label>
                 </div>
                 <div class="mt-3" id="intolerance-other-wrapper" style="display: @(Model.Intolerances.Contains(DietaryMedicalViewModel.OtherOption) ? "block" : "none");">
                     <label asp-for="IntoleranceOtherText" class="form-label">@Localizer["Profile_DietaryMedical_IntoleranceOther_Label"]</label>

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -7,7 +7,7 @@
     <div class="col-12" style="max-width: 900px;">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+                <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Nav_MyProfile"]</a></li>
                 <li class="breadcrumb-item active" aria-current="page">@Localizer["ProfileEdit_Title"]</li>
             </ol>
         </nav>
@@ -83,7 +83,7 @@
                     <div class="mb-3">
                         <label for="locationSearch" class="form-label">@Localizer["ProfileEdit_City"]</label>
                         <gmp-place-autocomplete id="locationSearch"
-                                                placeholder="Start typing your city..."
+                                                placeholder="@Localizer["ProfileEdit_CityPlaceholder"].Value"
                                                 style="width: 100%;">
                         </gmp-place-autocomplete>
                         <div class="form-text">@Localizer["ProfileEdit_CityHelp"]</div>
@@ -142,9 +142,9 @@
                     @if (Model.EditableContactFields.Count > 0)
                     {
                         <div class="row g-2 mb-1 text-muted small d-none d-md-flex">
-                            <div class="col-md-2">Type</div>
-                            <div class="col-md-3">Value</div>
-                            <div class="col-md-3">Visibility</div>
+                            <div class="col-md-2">@Localizer["ProfileEdit_ContactType"]</div>
+                            <div class="col-md-3">@Localizer["ProfileEdit_ContactValue"]</div>
+                            <div class="col-md-3">@Localizer["ProfileEdit_ContactVisibility"]</div>
                         </div>
                     }
                     <div id="contactFieldsContainer">
@@ -161,21 +161,21 @@
                                                 var fieldType = Model.EditableContactFields[i].FieldType;
                                             }
                                             <select name="EditableContactFields[@i].FieldType" id="EditableContactFields_@(i)__FieldType" class="form-select form-select-sm field-type-select">
-                                                <option value="Phone" selected="@(fieldType == ContactFieldType.Phone ? "selected" : null)">Phone</option>
-                                                <option value="Signal" selected="@(fieldType == ContactFieldType.Signal ? "selected" : null)">Signal</option>
-                                                <option value="Telegram" selected="@(fieldType == ContactFieldType.Telegram ? "selected" : null)">Telegram</option>
-                                                <option value="WhatsApp" selected="@(fieldType == ContactFieldType.WhatsApp ? "selected" : null)">WhatsApp</option>
-                                                <option value="Discord" selected="@(fieldType == ContactFieldType.Discord ? "selected" : null)">Discord</option>
-                                                <option value="Other" selected="@(fieldType == ContactFieldType.Other ? "selected" : null)">Other</option>
+                                                <option value="Phone" selected="@(fieldType == ContactFieldType.Phone ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldType.Phone)</option>
+                                                <option value="Signal" selected="@(fieldType == ContactFieldType.Signal ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldType.Signal)</option>
+                                                <option value="Telegram" selected="@(fieldType == ContactFieldType.Telegram ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldType.Telegram)</option>
+                                                <option value="WhatsApp" selected="@(fieldType == ContactFieldType.WhatsApp ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldType.WhatsApp)</option>
+                                                <option value="Discord" selected="@(fieldType == ContactFieldType.Discord ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldType.Discord)</option>
+                                                <option value="Other" selected="@(fieldType == ContactFieldType.Other ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldType.Other)</option>
                                             </select>
                                         </div>
 
                                         <div class="col-md-2 custom-label-col" style="display: @(Model.EditableContactFields[i].FieldType == ContactFieldType.Other ? "block" : "none");">
-                                            <input type="text" name="EditableContactFields[@i].CustomLabel" id="EditableContactFields_@(i)__CustomLabel" value="@Model.EditableContactFields[i].CustomLabel" class="form-control form-control-sm custom-label-input" placeholder="e.g., Discord" />
+                                            <input type="text" name="EditableContactFields[@i].CustomLabel" id="EditableContactFields_@(i)__CustomLabel" value="@Model.EditableContactFields[i].CustomLabel" class="form-control form-control-sm custom-label-input" placeholder="@Localizer["ProfileEdit_CustomLabelPlaceholder"].Value" />
                                         </div>
 
                                         <div class="col-md-3">
-                                            <input type="text" name="EditableContactFields[@i].Value" id="EditableContactFields_@(i)__Value" value="@Model.EditableContactFields[i].Value" class="form-control form-control-sm contact-value-input" required placeholder="Enter contact info" />
+                                            <input type="text" name="EditableContactFields[@i].Value" id="EditableContactFields_@(i)__Value" value="@Model.EditableContactFields[i].Value" class="form-control form-control-sm contact-value-input" required placeholder="@Localizer["ProfileEdit_ContactValuePlaceholder"].Value" />
                                             @{
                                                 var fieldKey = $"EditableContactFields[{i}].Value";
                                                 var fieldErrors = ViewData.ModelState[fieldKey]?.Errors;
@@ -195,16 +195,16 @@
                                                 var visibility = Model.EditableContactFields[i].Visibility;
                                             }
                                             <select name="EditableContactFields[@i].Visibility" id="EditableContactFields_@(i)__Visibility" class="form-select form-select-sm">
-                                                <option value="AllActiveProfiles" selected="@(visibility == ContactFieldVisibility.AllActiveProfiles ? "selected" : null)">All active humans</option>
-                                                <option value="MyTeams" selected="@(visibility == ContactFieldVisibility.MyTeams ? "selected" : null)">My teams (+ coordinators & board)</option>
-                                                <option value="CoordinatorsAndBoard" selected="@(visibility == ContactFieldVisibility.CoordinatorsAndBoard ? "selected" : null)">Coordinators + Board</option>
-                                                <option value="BoardOnly" selected="@(visibility == ContactFieldVisibility.BoardOnly ? "selected" : null)">Board only</option>
+                                                <option value="AllActiveProfiles" selected="@(visibility == ContactFieldVisibility.AllActiveProfiles ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldVisibility.AllActiveProfiles)</option>
+                                                <option value="MyTeams" selected="@(visibility == ContactFieldVisibility.MyTeams ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldVisibility.MyTeams)</option>
+                                                <option value="CoordinatorsAndBoard" selected="@(visibility == ContactFieldVisibility.CoordinatorsAndBoard ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldVisibility.CoordinatorsAndBoard)</option>
+                                                <option value="BoardOnly" selected="@(visibility == ContactFieldVisibility.BoardOnly ? "selected" : null)">@Localizer.EnumDisplay(ContactFieldVisibility.BoardOnly)</option>
                                             </select>
                                         </div>
 
                                         <div class="col-md-2 text-end">
-                                            <button type="button" class="btn btn-outline-danger btn-sm remove-contact-field" title="Remove this contact field">
-                                                <i class="fa-solid fa-trash me-1"></i> Remove
+                                            <button type="button" class="btn btn-outline-danger btn-sm remove-contact-field" title="@Localizer["ProfileEdit_RemoveContactField"].Value">
+                                                <i class="fa-solid fa-trash me-1"></i> @Localizer["Common_Remove"]
                                             </button>
                                         </div>
                                     </div>
@@ -259,9 +259,9 @@
                                         <input type="hidden" name="EditableLanguages[@i].Id" value="@Model.EditableLanguages[i].Id" />
 
                                         <div class="col-md-5">
-                                            <label class="form-label small" for="EditableLanguages_@(i)__LanguageCode">Language</label>
+                                            <label class="form-label small" for="EditableLanguages_@(i)__LanguageCode">@Localizer["ProfileEdit_LanguageLabel"]</label>
                                             <select name="EditableLanguages[@i].LanguageCode" id="EditableLanguages_@(i)__LanguageCode" class="form-select form-select-sm language-code-select" required>
-                                                <option value="">— Select language —</option>
+                                                <option value="">@Localizer["ProfileEdit_SelectLanguage"]</option>
                                                 @foreach (var lang in LanguageCatalog.Languages)
                                                 {
                                                     <option value="@lang.Key" selected="@(Model.EditableLanguages[i].LanguageCode == lang.Key ? "selected" : null)">@lang.Value (@lang.Key)</option>
@@ -273,18 +273,18 @@
                                             @{
                                                 var proficiency = Model.EditableLanguages[i].Proficiency;
                                             }
-                                            <label class="form-label small" for="EditableLanguages_@(i)__Proficiency">Proficiency</label>
+                                            <label class="form-label small" for="EditableLanguages_@(i)__Proficiency">@Localizer["ProfileEdit_ProficiencyLabel"]</label>
                                             <select name="EditableLanguages[@i].Proficiency" id="EditableLanguages_@(i)__Proficiency" class="form-select form-select-sm" required>
-                                                <option value="Basic" selected="@(proficiency == LanguageProficiency.Basic ? "selected" : null)">Basic</option>
-                                                <option value="Conversational" selected="@(proficiency == LanguageProficiency.Conversational ? "selected" : null)">Conversational</option>
-                                                <option value="Fluent" selected="@(proficiency == LanguageProficiency.Fluent ? "selected" : null)">Fluent</option>
-                                                <option value="Native" selected="@(proficiency == LanguageProficiency.Native ? "selected" : null)">Native</option>
+                                                <option value="Basic" selected="@(proficiency == LanguageProficiency.Basic ? "selected" : null)">@Localizer.EnumDisplay(LanguageProficiency.Basic)</option>
+                                                <option value="Conversational" selected="@(proficiency == LanguageProficiency.Conversational ? "selected" : null)">@Localizer.EnumDisplay(LanguageProficiency.Conversational)</option>
+                                                <option value="Fluent" selected="@(proficiency == LanguageProficiency.Fluent ? "selected" : null)">@Localizer.EnumDisplay(LanguageProficiency.Fluent)</option>
+                                                <option value="Native" selected="@(proficiency == LanguageProficiency.Native ? "selected" : null)">@Localizer.EnumDisplay(LanguageProficiency.Native)</option>
                                             </select>
                                         </div>
 
                                         <div class="col-md-3 text-end">
-                                            <button type="button" class="btn btn-outline-danger btn-sm remove-language" title="Remove this language">
-                                                <i class="fa-solid fa-trash me-1"></i> Remove
+                                            <button type="button" class="btn btn-outline-danger btn-sm remove-language" title="@Localizer["ProfileEdit_RemoveLanguage"].Value">
+                                                <i class="fa-solid fa-trash me-1"></i> @Localizer["Common_Remove"]
                                             </button>
                                         </div>
                                     </div>
@@ -336,7 +336,7 @@
                                            value="@opt"
                                            id="al-@opt"
                                            checked="@(isChecked ? "checked" : null)" />
-                                    <label class="form-check-label" for="al-@opt">@opt</label>
+                                    <label class="form-check-label" for="al-@opt">@Localizer[$"Profile_DietaryMedical_Allergy_{opt.Replace(" ", "").Replace("/", "")}"]</label>
                                 </div>
                             }
                         </div>
@@ -348,7 +348,7 @@
                                    value="@DietaryMedicalViewModel.OtherOption"
                                    id="al-@DietaryMedicalViewModel.OtherOption"
                                    checked="@(Model.Allergies.Contains(DietaryMedicalViewModel.OtherOption) ? "checked" : null)" />
-                            <label class="form-check-label" for="al-@DietaryMedicalViewModel.OtherOption">@DietaryMedicalViewModel.OtherOption</label>
+                            <label class="form-check-label" for="al-@DietaryMedicalViewModel.OtherOption">@Localizer["Common_Other"]</label>
                         </div>
                         <div class="mt-3" id="allergy-other-wrapper" style="display: @(Model.Allergies.Contains(DietaryMedicalViewModel.OtherOption) ? "block" : "none");">
                             <label asp-for="AllergyOtherText" class="form-label">@Localizer["Profile_DietaryMedical_AllergyOther_Label"]</label>
@@ -377,23 +377,23 @@
                                     <input type="hidden" name="EditableVolunteerHistory[@i].Id" value="@(Model.EditableVolunteerHistory[i].Id?.ToString() ?? string.Empty)" />
                                     <div class="row g-2 align-items-start">
                                         <div class="col-md-2">
-                                            <label class="form-label small" for="EditableVolunteerHistory_@(i)__DateString">Date</label>
+                                            <label class="form-label small" for="EditableVolunteerHistory_@(i)__DateString">@Localizer["Common_Date"]</label>
                                             <input type="date" name="EditableVolunteerHistory[@i].DateString" id="EditableVolunteerHistory_@(i)__DateString" value="@Model.EditableVolunteerHistory[i].DateString" class="form-control form-control-sm" required />
                                         </div>
 
                                         <div class="col-md-4">
-                                            <label class="form-label small" for="EditableVolunteerHistory_@(i)__EventName">Event Name</label>
-                                            <input type="text" name="EditableVolunteerHistory[@i].EventName" id="EditableVolunteerHistory_@(i)__EventName" value="@Model.EditableVolunteerHistory[i].EventName" class="form-control form-control-sm" required placeholder="e.g., Burning Man 2024" maxlength="256" />
+                                            <label class="form-label small" for="EditableVolunteerHistory_@(i)__EventName">@Localizer["ProfileEdit_EventName"]</label>
+                                            <input type="text" name="EditableVolunteerHistory[@i].EventName" id="EditableVolunteerHistory_@(i)__EventName" value="@Model.EditableVolunteerHistory[i].EventName" class="form-control form-control-sm" required placeholder="@Localizer["ProfileEdit_EventNamePlaceholder"].Value" maxlength="256" />
                                         </div>
 
                                         <div class="col-md-4">
-                                            <label class="form-label small" for="EditableVolunteerHistory_@(i)__Description">Description</label>
-                                            <input type="text" name="EditableVolunteerHistory[@i].Description" id="EditableVolunteerHistory_@(i)__Description" value="@Model.EditableVolunteerHistory[i].Description" class="form-control form-control-sm" placeholder="e.g., Gate Lead" maxlength="2000" />
+                                            <label class="form-label small" for="EditableVolunteerHistory_@(i)__Description">@Localizer["ProfileEdit_Description"]</label>
+                                            <input type="text" name="EditableVolunteerHistory[@i].Description" id="EditableVolunteerHistory_@(i)__Description" value="@Model.EditableVolunteerHistory[i].Description" class="form-control form-control-sm" placeholder="@Localizer["ProfileEdit_DescriptionPlaceholder"].Value" maxlength="2000" />
                                         </div>
 
                                         <div class="col-md-2 text-end" style="padding-top: 1.5rem;">
-                                            <button type="button" class="btn btn-outline-danger btn-sm remove-volunteer-history" title="Remove this entry">
-                                                <i class="fa-solid fa-trash me-1"></i> Remove
+                                            <button type="button" class="btn btn-outline-danger btn-sm remove-volunteer-history" title="@Localizer["ProfileEdit_RemoveEntry"].Value">
+                                                <i class="fa-solid fa-trash me-1"></i> @Localizer["Common_Remove"]
                                             </button>
                                         </div>
                                     </div>
@@ -697,6 +697,24 @@
                 return Math.max(...indices) + 1;
             }
 
+            const _cfLabels = {
+                phone: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldType.Phone))),
+                signal: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldType.Signal))),
+                telegram: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldType.Telegram))),
+                whatsapp: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldType.WhatsApp))),
+                discord: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldType.Discord))),
+                other: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldType.Other))),
+                visAllActive: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldVisibility.AllActiveProfiles))),
+                visMyTeams: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldVisibility.MyTeams))),
+                visCoordBoard: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldVisibility.CoordinatorsAndBoard))),
+                visBoardOnly: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(ContactFieldVisibility.BoardOnly))),
+                chooseVisibility: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Profile_ChooseVisibility"].Value)),
+                customLabelPlaceholder: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_CustomLabelPlaceholder"].Value)),
+                contactValuePlaceholder: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_ContactValuePlaceholder"].Value)),
+                removeTitle: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_RemoveContactField"].Value)),
+                removeLabel: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Common_Remove"].Value))
+            };
+
             function createContactFieldRow(index) {
                 const html = `
                     <div class="contact-field-row card mb-2" data-index="${index}">
@@ -707,37 +725,37 @@
 
                                 <div class="col-md-2">
                                     <select name="EditableContactFields[${index}].FieldType" id="EditableContactFields_${index}__FieldType" class="form-select form-select-sm field-type-select">
-                                        <option value="Phone">Phone</option>
-                                        <option value="Signal">Signal</option>
-                                        <option value="Telegram">Telegram</option>
-                                        <option value="WhatsApp">WhatsApp</option>
-                                        <option value="Discord">Discord</option>
-                                        <option value="Other">Other</option>
+                                        <option value="Phone">${_cfLabels.phone}</option>
+                                        <option value="Signal">${_cfLabels.signal}</option>
+                                        <option value="Telegram">${_cfLabels.telegram}</option>
+                                        <option value="WhatsApp">${_cfLabels.whatsapp}</option>
+                                        <option value="Discord">${_cfLabels.discord}</option>
+                                        <option value="Other">${_cfLabels.other}</option>
                                     </select>
                                 </div>
 
                                 <div class="col-md-2 custom-label-col" style="display: none;">
-                                    <input type="text" name="EditableContactFields[${index}].CustomLabel" id="EditableContactFields_${index}__CustomLabel" class="form-control form-control-sm custom-label-input" placeholder="e.g., Discord" />
+                                    <input type="text" name="EditableContactFields[${index}].CustomLabel" id="EditableContactFields_${index}__CustomLabel" class="form-control form-control-sm custom-label-input" placeholder="${_cfLabels.customLabelPlaceholder}" />
                                 </div>
 
                                 <div class="col-md-3">
-                                    <input type="text" name="EditableContactFields[${index}].Value" id="EditableContactFields_${index}__Value" class="form-control form-control-sm contact-value-input" placeholder="Enter contact info" />
+                                    <input type="text" name="EditableContactFields[${index}].Value" id="EditableContactFields_${index}__Value" class="form-control form-control-sm contact-value-input" placeholder="${_cfLabels.contactValuePlaceholder}" />
                                     <span class="text-danger small field-validation-error" data-valmsg-for="EditableContactFields[${index}].Value"></span>
                                 </div>
 
                                 <div class="col-md-3">
                                     <select name="EditableContactFields[${index}].Visibility" id="EditableContactFields_${index}__Visibility" class="form-select form-select-sm" required>
-                                        <option value="" selected disabled>@Localizer["Profile_ChooseVisibility"]</option>
-                                        <option value="AllActiveProfiles">All active humans</option>
-                                        <option value="MyTeams">My teams (+ coordinators & board)</option>
-                                        <option value="CoordinatorsAndBoard">Coordinators + Board</option>
-                                        <option value="BoardOnly">Board only</option>
+                                        <option value="" selected disabled>${_cfLabels.chooseVisibility}</option>
+                                        <option value="AllActiveProfiles">${_cfLabels.visAllActive}</option>
+                                        <option value="MyTeams">${_cfLabels.visMyTeams}</option>
+                                        <option value="CoordinatorsAndBoard">${_cfLabels.visCoordBoard}</option>
+                                        <option value="BoardOnly">${_cfLabels.visBoardOnly}</option>
                                     </select>
                                 </div>
 
                                 <div class="col-md-2 text-end">
-                                    <button type="button" class="btn btn-outline-danger btn-sm remove-contact-field" title="Remove this contact field">
-                                        <i class="fa-solid fa-trash me-1"></i> Remove
+                                    <button type="button" class="btn btn-outline-danger btn-sm remove-contact-field" title="${_cfLabels.removeTitle}">
+                                        <i class="fa-solid fa-trash me-1"></i> ${_cfLabels.removeLabel}
                                     </button>
                                 </div>
                             </div>
@@ -752,7 +770,7 @@
             const phoneTypes = ['Phone', 'WhatsApp'];
             const phonePlaceholder = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Validation_PhonePlaceholder"].Value));
             const phoneTitle = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Validation_PhoneHint"].Value));
-            const defaultPlaceholder = 'Enter contact info';
+            const defaultPlaceholder = _cfLabels.contactValuePlaceholder;
 
             function applyPhoneValidation(valueInput, isPhone) {
                 if (isPhone) {
@@ -823,6 +841,16 @@
             const addButton = document.getElementById('addVolunteerHistory');
             if (!container || !addButton) return;
 
+            const _vhLabels = {
+                date: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Common_Date"].Value)),
+                eventName: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_EventName"].Value)),
+                eventNamePlaceholder: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_EventNamePlaceholder"].Value)),
+                description: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_Description"].Value)),
+                descriptionPlaceholder: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_DescriptionPlaceholder"].Value)),
+                removeTitle: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_RemoveEntry"].Value)),
+                removeLabel: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Common_Remove"].Value))
+            };
+
             function getNextIndex() {
                 const rows = container.querySelectorAll('.volunteer-history-row');
                 if (rows.length === 0) return 0;
@@ -837,23 +865,23 @@
                             <input type="hidden" name="EditableVolunteerHistory[${index}].Id" value="" />
                             <div class="row g-2 align-items-start">
                                 <div class="col-md-2">
-                                    <label class="form-label small" for="EditableVolunteerHistory_${index}__DateString">Date</label>
+                                    <label class="form-label small" for="EditableVolunteerHistory_${index}__DateString">${_vhLabels.date}</label>
                                     <input type="date" name="EditableVolunteerHistory[${index}].DateString" id="EditableVolunteerHistory_${index}__DateString" class="form-control form-control-sm" required />
                                 </div>
 
                                 <div class="col-md-4">
-                                    <label class="form-label small" for="EditableVolunteerHistory_${index}__EventName">Event Name</label>
-                                    <input type="text" name="EditableVolunteerHistory[${index}].EventName" id="EditableVolunteerHistory_${index}__EventName" class="form-control form-control-sm" required placeholder="e.g., Burning Man 2024" maxlength="256" />
+                                    <label class="form-label small" for="EditableVolunteerHistory_${index}__EventName">${_vhLabels.eventName}</label>
+                                    <input type="text" name="EditableVolunteerHistory[${index}].EventName" id="EditableVolunteerHistory_${index}__EventName" class="form-control form-control-sm" required placeholder="${_vhLabels.eventNamePlaceholder}" maxlength="256" />
                                 </div>
 
                                 <div class="col-md-4">
-                                    <label class="form-label small" for="EditableVolunteerHistory_${index}__Description">Description</label>
-                                    <input type="text" name="EditableVolunteerHistory[${index}].Description" id="EditableVolunteerHistory_${index}__Description" class="form-control form-control-sm" placeholder="e.g., Gate Lead" maxlength="2000" />
+                                    <label class="form-label small" for="EditableVolunteerHistory_${index}__Description">${_vhLabels.description}</label>
+                                    <input type="text" name="EditableVolunteerHistory[${index}].Description" id="EditableVolunteerHistory_${index}__Description" class="form-control form-control-sm" placeholder="${_vhLabels.descriptionPlaceholder}" maxlength="2000" />
                                 </div>
 
                                 <div class="col-md-2 text-end" style="padding-top: 1.5rem;">
-                                    <button type="button" class="btn btn-outline-danger btn-sm remove-volunteer-history" title="Remove this entry">
-                                        <i class="fa-solid fa-trash me-1"></i> Remove
+                                    <button type="button" class="btn btn-outline-danger btn-sm remove-volunteer-history" title="${_vhLabels.removeTitle}">
+                                        <i class="fa-solid fa-trash me-1"></i> ${_vhLabels.removeLabel}
                                     </button>
                                 </div>
                             </div>
@@ -911,6 +939,18 @@
 
             const languageOptions = `@Html.Raw(string.Join("", LanguageCatalog.Languages.Select(l => $"<option value=\"{l.Key}\">{l.Value} ({l.Key})</option>")))`;
 
+            const _langLabels = {
+                languageLabel: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_LanguageLabel"].Value)),
+                selectLanguage: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_SelectLanguage"].Value)),
+                proficiencyLabel: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_ProficiencyLabel"].Value)),
+                basic: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(LanguageProficiency.Basic))),
+                conversational: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(LanguageProficiency.Conversational))),
+                fluent: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(LanguageProficiency.Fluent))),
+                native: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer.EnumDisplay(LanguageProficiency.Native))),
+                removeTitle: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["ProfileEdit_RemoveLanguage"].Value)),
+                removeLabel: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Common_Remove"].Value))
+            };
+
             function getNextIndex() {
                 const rows = container.querySelectorAll('.language-row');
                 if (rows.length === 0) return 0;
@@ -926,26 +966,26 @@
                                 <input type="hidden" name="EditableLanguages[${index}].Id" value="" />
 
                                 <div class="col-md-5">
-                                    <label class="form-label small" for="EditableLanguages_${index}__LanguageCode">Language</label>
+                                    <label class="form-label small" for="EditableLanguages_${index}__LanguageCode">${_langLabels.languageLabel}</label>
                                     <select name="EditableLanguages[${index}].LanguageCode" id="EditableLanguages_${index}__LanguageCode" class="form-select form-select-sm language-code-select" required>
-                                        <option value="">— Select language —</option>
+                                        <option value="">${_langLabels.selectLanguage}</option>
                                         ${languageOptions}
                                     </select>
                                 </div>
 
                                 <div class="col-md-4">
-                                    <label class="form-label small" for="EditableLanguages_${index}__Proficiency">Proficiency</label>
+                                    <label class="form-label small" for="EditableLanguages_${index}__Proficiency">${_langLabels.proficiencyLabel}</label>
                                     <select name="EditableLanguages[${index}].Proficiency" id="EditableLanguages_${index}__Proficiency" class="form-select form-select-sm" required>
-                                        <option value="Basic">Basic</option>
-                                        <option value="Conversational">Conversational</option>
-                                        <option value="Fluent">Fluent</option>
-                                        <option value="Native" selected>Native</option>
+                                        <option value="Basic">${_langLabels.basic}</option>
+                                        <option value="Conversational">${_langLabels.conversational}</option>
+                                        <option value="Fluent">${_langLabels.fluent}</option>
+                                        <option value="Native" selected>${_langLabels.native}</option>
                                     </select>
                                 </div>
 
                                 <div class="col-md-3 text-end">
-                                    <button type="button" class="btn btn-outline-danger btn-sm remove-language" title="Remove this language">
-                                        <i class="fa-solid fa-trash me-1"></i> Remove
+                                    <button type="button" class="btn btn-outline-danger btn-sm remove-language" title="${_langLabels.removeTitle}">
+                                        <i class="fa-solid fa-trash me-1"></i> ${_langLabels.removeLabel}
                                     </button>
                                 </div>
                             </div>

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -27,7 +27,7 @@
                 }
                 else
                 {
-                    <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+                    <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Nav_MyProfile"]</a></li>
                 }
                 <li class="breadcrumb-item active" aria-current="page">@Localizer["Emails_Title"]</li>
             </ol>
@@ -133,7 +133,7 @@
                                     {
                                         <div class="small text-warning">
                                             <i class="fa-solid fa-triangle-exclamation me-1"></i>
-                                            Tagged with @row.Provider but no matching AspNetUserLogins row — self-heals on next OAuth sign-in.
+                                            @Localizer["EmailGrid_OrphanProviderTag", row.Provider ?? string.Empty]
                                         </div>
                                     }
                                 </td>
@@ -208,7 +208,7 @@
                                     else if (workspaceLocked && row.IsVerified)
                                     {
                                         @* Verified but Workspace lock held elsewhere — don't claim "verify first" *@
-                                        <span class="text-muted small" title="Locked by the Workspace email row">—</span>
+                                        <span class="text-muted small" title="@Localizer["EmailGrid_WorkspaceLocked"].Value">—</span>
                                     }
                                     else
                                     {
@@ -258,7 +258,7 @@
                                     }
                                     else if (workspaceLocked && row.IsVerified)
                                     {
-                                        <span class="text-muted small" title="Locked by the Workspace email row">—</span>
+                                        <span class="text-muted small" title="@Localizer["EmailGrid_WorkspaceLocked"].Value">—</span>
                                     }
                                     else
                                     {

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -15,16 +15,16 @@
             <div class="d-flex gap-2">
                 <vc:access-matrix section="Profile" />
                 <a asp-controller="UsersAdmin" asp-action="AdminDetail" asp-route-id="@Model.UserId" class="btn btn-sm btn-outline-secondary" authorize-policy="HumanAdminBoardOrAdmin">
-                    <i class="fa-solid fa-user-shield"></i> Admin <i class="fa-solid fa-lock auth-lock-icon"></i>
+                    <i class="fa-solid fa-user-shield"></i> @Localizer["Common_Admin"] <i class="fa-solid fa-lock auth-lock-icon"></i>
                 </a>
             </div>
         </div>
 
         @if (Model.CanViewOnsiteChip && Model.OnsiteSince is not null)
         {
-            <span class="badge text-bg-success mb-2" title="Checked in at the gate">
+            <span class="badge text-bg-success mb-2" title="@Localizer["Profile_OnsiteTitle"].Value">
                 <i class="fa-solid fa-circle-check"></i>
-                Onsite since @Model.OnsiteSince.Value.ToDateTime()
+                @Localizer["Profile_OnsiteSince", Model.OnsiteSince.Value.ToDateTime()]
             </span>
         }
 
@@ -93,16 +93,16 @@
         {
             <div class="card mb-3">
                 <div class="card-header">
-                    <h5 class="mb-0"><i class="fa-solid fa-user-xmark me-1"></i> No-Show History (@Model.NoShowHistory!.Count)</h5>
+                    <h5 class="mb-0"><i class="fa-solid fa-user-xmark me-1"></i> @Localizer["Profile_NoShowHistory", Model.NoShowHistory!.Count]</h5>
                 </div>
                 <div class="card-body p-0">
                     @{
                         var noShowTable = TableModel.For(Model.NoShowHistory!)
-                            .Column("Shift", r => r.ShiftLabel)
-                            .Column("Department", r => r.DepartmentName)
-                            .Column("Date", r => r.ShiftDateLabel)
-                            .Column("Marked By", r => r.MarkedByName)
-                            .Column("Marked At", r => r.MarkedAtLabel)
+                            .Column(Localizer["Common_Shift"].Value, r => r.ShiftLabel)
+                            .Column(Localizer["Common_Department"].Value, r => r.DepartmentName)
+                            .Column(Localizer["Common_Date"].Value, r => r.ShiftDateLabel)
+                            .Column(Localizer["Profile_MarkedBy"].Value, r => r.MarkedByName)
+                            .Column(Localizer["Profile_MarkedAt"].Value, r => r.MarkedAtLabel)
                             .Build();
                     }
                     <partial name="_Table" model="noShowTable" />
@@ -114,11 +114,11 @@
         {
             <div class="card mb-3">
                 <div class="card-header">
-                    <h5 class="mb-0"><i class="fa-solid fa-envelope me-1"></i> Sent messages (@(Model.SentMessages?.Count ?? 0))</h5>
+                    <h5 class="mb-0"><i class="fa-solid fa-envelope me-1"></i> @Localizer["Profile_SentMessages", Model.SentMessages?.Count ?? 0]</h5>
                 </div>
                 @if (Model.SentMessages is null || Model.SentMessages.Count == 0)
                 {
-                    <div class="card-body text-muted">No in-platform messages on record.</div>
+                    <div class="card-body text-muted">@Localizer["Profile_NoSentMessages"]</div>
                 }
                 else
                 {
@@ -126,9 +126,9 @@
                         <table class="table table-sm mb-0">
                             <thead>
                                 <tr>
-                                    <th>Date</th>
-                                    <th>Sender</th>
-                                    <th>Preview</th>
+                                    <th>@Localizer["Common_Date"]</th>
+                                    <th>@Localizer["Common_Sender"]</th>
+                                    <th>@Localizer["Common_Preview"]</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -151,7 +151,7 @@
         {
             <div class="card mb-3">
                 <div class="card-header">
-                    <h5 class="mb-0">My Codes</h5>
+                    <h5 class="mb-0">@Localizer["Profile_MyCodes"]</h5>
                 </div>
                 <div class="card-body p-0">
                     @{
@@ -167,10 +167,10 @@
                                 }
                             </text>;
                         var grantsTable = TableModel.For(Model.CampaignGrants)
-                            .Column("Campaign", g => g.CampaignTitle)
-                            .Column("Code", g => g.Code)
-                            .Column("Assigned", g => g.AssignedAt, c => c.Date())
-                            .Template("Redeemed", redeemedCell)
+                            .Column(Localizer["Profile_Campaign"].Value, g => g.CampaignTitle)
+                            .Column(Localizer["Profile_Code"].Value, g => g.Code)
+                            .Column(Localizer["Profile_Assigned"].Value, g => g.AssignedAt, c => c.Date())
+                            .Template(Localizer["Profile_Redeemed"].Value, redeemedCell)
                             .Build();
                     }
                     <partial name="_Table" model="grantsTable" />
@@ -195,13 +195,13 @@
                             <span class="badge bg-warning text-dark float-end">@Model.PendingConsentCount</span>
                         }
                     </a>
-                    <a asp-controller="Profile" asp-action="ShiftInfo" class="list-group-item list-group-item-action">Shift Info</a>
+                    <a asp-controller="Profile" asp-action="ShiftInfo" class="list-group-item list-group-item-action">@Localizer["Profile_ShiftInfo"]</a>
                     <a asp-controller="Profile" asp-action="DietaryMedical" class="list-group-item list-group-item-action">@Localizer["Profile_DietaryMedical_PageTitle"]</a>
                     <a asp-controller="Profile" asp-action="Emails" class="list-group-item list-group-item-action">@Localizer["Emails_Title"]</a>
-                    <a asp-controller="Profile" asp-action="CommunicationPreferences" class="list-group-item list-group-item-action">Communication Preferences</a>
+                    <a asp-controller="Profile" asp-action="CommunicationPreferences" class="list-group-item list-group-item-action">@Localizer["CommPrefs_Title"]</a>
                     <a asp-controller="Governance" asp-action="Index" class="list-group-item list-group-item-action">@Localizer["Nav_Governance"]</a>
                     <a asp-controller="Profile" asp-action="Privacy" class="list-group-item list-group-item-action">@Localizer["ProfilePrivacy_Title"]</a>
-                    <a asp-controller="Profile" asp-action="MyOutbox" class="list-group-item list-group-item-action">My Emails</a>
+                    <a asp-controller="Profile" asp-action="MyOutbox" class="list-group-item list-group-item-action">@Localizer["Profile_MyEmails"]</a>
                 </div>
             </div>
         </div>

--- a/src/Humans.Web/Views/Profile/Outbox.cshtml
+++ b/src/Humans.Web/Views/Profile/Outbox.cshtml
@@ -2,7 +2,7 @@
 @{
     var humanId = (Guid?)ViewBag.HumanId;
     var isAdminView = humanId.HasValue;
-    ViewData["Title"] = isAdminView ? "Emails" : "My Emails";
+    ViewData["Title"] = isAdminView ? Localizer["Outbox_AdminTitle"].Value : Localizer["Profile_MyEmails"].Value;
     Layout = isAdminView ? "_AdminLayout" : "_Layout";
 }
 
@@ -13,25 +13,25 @@
             @if (isAdminView)
             {
                 <a asp-controller="UsersAdmin" asp-action="AdminDetail" asp-route-id="@humanId.Value" class="btn btn-outline-secondary btn-sm">
-                    <i class="fa-solid fa-arrow-left me-1"></i>Back to Admin
+                    <i class="fa-solid fa-arrow-left me-1"></i>@Localizer["Outbox_BackToAdmin"]
                 </a>
             }
             else
             {
                 <a asp-action="Index" class="btn btn-outline-secondary btn-sm">
-                    <i class="fa-solid fa-arrow-left me-1"></i>Back to Profile
+                    <i class="fa-solid fa-arrow-left me-1"></i>@Localizer["Outbox_BackToProfile"]
                 </a>
             }
         </div>
 
 
         <p class="text-muted">
-            @(isAdminView ? "Emails the system has sent to this human." : "Emails the system has sent to you (within the last 150 days).")
+            @(isAdminView ? Localizer["Outbox_DescriptionAdmin"].Value : Localizer["Outbox_DescriptionSelf"].Value)
         </p>
 
         @if (!Model.Any())
         {
-            <div class="text-muted text-center py-5">No emails on record.</div>
+            <div class="text-muted text-center py-5">@Localizer["Outbox_Empty"]</div>
         }
         else
         {
@@ -40,9 +40,9 @@
                     <table class="table table-hover mb-0">
                         <thead>
                             <tr>
-                                <th>Subject</th>
-                                <th>Status</th>
-                                <th>Date</th>
+                                <th>@Localizer["Outbox_Subject"]</th>
+                                <th>@Localizer["Common_Status"]</th>
+                                <th>@Localizer["Common_Date"]</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -59,7 +59,7 @@
                                 var collapseId = $"msg-body-{i}";
                                 <tr data-bs-toggle="collapse" data-bs-target="#@collapseId" role="button" style="cursor: pointer;">
                                     <td>@msg.Subject</td>
-                                    <td><span class="badge @statusClass">@msg.Status</span></td>
+                                    <td><span class="badge @statusClass">@Localizer.EnumDisplay(msg.Status)</span></td>
                                     <td>@msg.CreatedAt.ToDateTimeUtc().ToDateTime()</td>
                                 </tr>
                                 <tr class="collapse" id="@collapseId">

--- a/src/Humans.Web/Views/Profile/Privacy.cshtml
+++ b/src/Humans.Web/Views/Profile/Privacy.cshtml
@@ -5,7 +5,7 @@
 
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Nav_MyProfile"]</a></li>
         <li class="breadcrumb-item active" aria-current="page">@Localizer["ProfilePrivacy_Title"]</li>
     </ol>
 </nav>

--- a/src/Humans.Web/Views/Profile/_EditSectionPrivate.cshtml
+++ b/src/Humans.Web/Views/Profile/_EditSectionPrivate.cshtml
@@ -38,7 +38,7 @@
             </div>
             <div class="col-md-4">
                 <label asp-for="EmergencyContactRelationship" class="form-label">@Localizer["Profile_EmergencyContactRelationship"]</label>
-                <input asp-for="EmergencyContactRelationship" class="form-control" placeholder="e.g., Partner, Parent" />
+                <input asp-for="EmergencyContactRelationship" class="form-control" placeholder="@Localizer["ProfileEdit_RelationshipPlaceholder"].Value" />
                 <span asp-validation-for="EmergencyContactRelationship" class="text-danger"></span>
             </div>
         </div>

--- a/src/Humans.Web/Views/Search/Index.cshtml
+++ b/src/Humans.Web/Views/Search/Index.cshtml
@@ -3,7 +3,7 @@
 @model Humans.Web.Models.GlobalSearchViewModel
 
 @{
-    ViewData["Title"] = "Search";
+    ViewData["Title"] = Localizer["Search_GlobalTitle"].Value;
     var eventsEnabled = Configuration.GetValue<bool>("Features:Events");
 
     string ChipUrl(SearchResultType? filter)
@@ -23,7 +23,7 @@
         count > 0 && (!Model.Filter.HasValue || Model.Filter == type);
 }
 
-<h2><i class="fa-solid fa-magnifying-glass me-2"></i>Search</h2>
+<h2><i class="fa-solid fa-magnifying-glass me-2"></i>@Localizer["Search_GlobalTitle"]</h2>
 
 <form method="get" class="mb-4" asp-action="Index" asp-controller="Search">
     @if (Model.Filter.HasValue)
@@ -32,10 +32,10 @@
     }
     <div class="input-group" style="max-width: 600px;">
         <input type="text" name="q" class="form-control" value="@Model.Query"
-               placeholder="@(eventsEnabled ? "Search humans, teams, camps, shifts, events…" : "Search humans, teams, camps, shifts…")"
+               placeholder="@(eventsEnabled ? Localizer["Search_GlobalPlaceholderEvents"].Value : Localizer["Search_GlobalPlaceholder"].Value)"
                autofocus aria-label="Search query" />
         <button type="submit" class="btn btn-primary">
-            <i class="fa-solid fa-magnifying-glass me-1"></i>Search
+            <i class="fa-solid fa-magnifying-glass me-1"></i>@Localizer["Search_GlobalTitle"]
         </button>
     </div>
 </form>
@@ -44,38 +44,38 @@
 {
     <div class="alert alert-info">
         <i class="fa-solid fa-circle-info me-2"></i>
-        Type at least 2 characters to search across humans, teams, camps, shifts@(eventsEnabled ? ", and events" : "").
+        @(eventsEnabled ? Localizer["Search_GlobalHintEvents"] : Localizer["Search_GlobalHint"])
     </div>
 }
 else if (Model.QueryIsTooShort)
 {
     <div class="alert alert-info">
         <i class="fa-solid fa-circle-info me-2"></i>
-        Please enter at least 2 characters.
+        @Localizer["Search_MinChars"]
     </div>
 }
 else
 {
     <div class="d-flex flex-wrap gap-2 mb-3" role="group" aria-label="Filter results by type">
         <a href="@ChipUrl(null)" class="@ChipClass(null)">
-            All (@Model.TotalCount)
+            @Localizer["Search_FilterAll"] (@Model.TotalCount)
         </a>
         <a href="@ChipUrl(SearchResultType.Human)" class="@ChipClass(SearchResultType.Human)">
-            <i class="fa-solid fa-user me-1"></i>Humans (@Model.HumanCount)
+            <i class="fa-solid fa-user me-1"></i>@Localizer["Search_FilterHumans"] (@Model.HumanCount)
         </a>
         <a href="@ChipUrl(SearchResultType.Team)" class="@ChipClass(SearchResultType.Team)">
-            <i class="fa-solid fa-users me-1"></i>Teams (@Model.TeamCount)
+            <i class="fa-solid fa-users me-1"></i>@Localizer["Search_FilterTeams"] (@Model.TeamCount)
         </a>
         <a href="@ChipUrl(SearchResultType.Camp)" class="@ChipClass(SearchResultType.Camp)">
-            <i class="fa-solid fa-campground me-1"></i>Camps (@Model.CampCount)
+            <i class="fa-solid fa-campground me-1"></i>@Localizer["Search_FilterCamps"] (@Model.CampCount)
         </a>
         <a href="@ChipUrl(SearchResultType.Shift)" class="@ChipClass(SearchResultType.Shift)">
-            <i class="fa-solid fa-clock me-1"></i>Shifts (@Model.ShiftCount)
+            <i class="fa-solid fa-clock me-1"></i>@Localizer["Search_FilterShifts"] (@Model.ShiftCount)
         </a>
         @if (eventsEnabled)
         {
             <a href="@ChipUrl(SearchResultType.Event)" class="@ChipClass(SearchResultType.Event)">
-                <i class="fa-solid fa-calendar-day me-1"></i>Events (@Model.EventCount)
+                <i class="fa-solid fa-calendar-day me-1"></i>@Localizer["Search_FilterEvents"] (@Model.EventCount)
             </a>
         }
     </div>
@@ -83,38 +83,38 @@ else
     @if (!Model.HasResults)
     {
         <div class="alert alert-light">
-            No results for <strong>@Model.Query</strong>.
+            @Html.Raw(string.Format(Localizer["Search_GlobalNoResults"].Value, "<strong>" + Html.Encode(Model.Query) + "</strong>"))
         </div>
     }
     else
     {
         @if (ShowSection(SearchResultType.Human, Model.HumanCount))
         {
-            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-user me-2"></i>Humans</h3>
+            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-user me-2"></i>@Localizer["Search_FilterHumans"]</h3>
             @await Html.PartialAsync("_HumanSearchResults", Model.HumanResults)
         }
 
         @if (ShowSection(SearchResultType.Team, Model.TeamCount))
         {
-            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-users me-2"></i>Teams</h3>
+            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-users me-2"></i>@Localizer["Search_FilterTeams"]</h3>
             <partial name="_GlobalSearchSection" model="Model.TeamResults" view-data="@(new ViewDataDictionary(ViewData) { { "Icon", "fa-solid fa-users" } })" />
         }
 
         @if (ShowSection(SearchResultType.Camp, Model.CampCount))
         {
-            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-campground me-2"></i>Camps</h3>
+            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-campground me-2"></i>@Localizer["Search_FilterCamps"]</h3>
             <partial name="_GlobalSearchSection" model="Model.CampResults" view-data="@(new ViewDataDictionary(ViewData) { { "Icon", "fa-solid fa-campground" } })" />
         }
 
         @if (ShowSection(SearchResultType.Shift, Model.ShiftCount))
         {
-            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-clock me-2"></i>Shifts</h3>
+            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-clock me-2"></i>@Localizer["Search_FilterShifts"]</h3>
             <partial name="_GlobalSearchSection" model="Model.ShiftResults" view-data="@(new ViewDataDictionary(ViewData) { { "Icon", "fa-solid fa-clock" } })" />
         }
 
         @if (eventsEnabled && ShowSection(SearchResultType.Event, Model.EventCount))
         {
-            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-calendar-day me-2"></i>Events</h3>
+            <h3 class="h5 mt-4 mb-2"><i class="fa-solid fa-calendar-day me-2"></i>@Localizer["Search_FilterEvents"]</h3>
             <partial name="_GlobalSearchSection" model="Model.EventResults" view-data="@(new ViewDataDictionary(ViewData) { { "Icon", "fa-solid fa-calendar-day" } })" />
         }
     }

--- a/src/Humans.Web/Views/Search/Index.cshtml
+++ b/src/Humans.Web/Views/Search/Index.cshtml
@@ -1,4 +1,5 @@
 @using Humans.Application.DTOs
+@using Microsoft.AspNetCore.Html
 @inject IConfiguration Configuration
 @model Humans.Web.Models.GlobalSearchViewModel
 
@@ -83,7 +84,13 @@ else
     @if (!Model.HasResults)
     {
         <div class="alert alert-light">
-            @Html.Raw(string.Format(Localizer["Search_GlobalNoResults"].Value, "<strong>" + Html.Encode(Model.Query) + "</strong>"))
+            @{
+                // AppendFormat HTML-encodes every arg that isn't already IHtmlContent.
+                var noResults = new HtmlContentBuilder().AppendFormat(
+                    Localizer["Search_GlobalNoResults"].Value,
+                    new HtmlString($"<strong>{Html.Encode(Model.Query)}</strong>"));
+            }
+            @noResults
         </div>
     }
     else

--- a/src/Humans.Web/Views/Shared/_MarkdownHelp.cshtml
+++ b/src/Humans.Web/Views/Shared/_MarkdownHelp.cshtml
@@ -4,50 +4,50 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="markdownHelpModalLabel">
-                    <i class="fa-solid fa-circle-info me-1"></i> Markdown Quick Reference
+                    <i class="fa-solid fa-circle-info me-1"></i> @Localizer["MarkdownHelp_Title"]
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 <p class="text-muted mb-3">
-                    Markdown is a simple way to format text. Type the syntax on the left and it renders as shown on the right.
+                    @Localizer["MarkdownHelp_Intro"]
                 </p>
 
                 <table class="table table-sm table-bordered align-middle">
                     <thead>
                         <tr>
-                            <th style="width: 50%;">You type</th>
-                            <th style="width: 50%;">You get</th>
+                            <th style="width: 50%;">@Localizer["MarkdownHelp_ColYouType"]</th>
+                            <th style="width: 50%;">@Localizer["MarkdownHelp_ColYouGet"]</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr>
                             <td><code>**bold**</code></td>
-                            <td><strong>bold</strong></td>
+                            <td><strong>@Localizer["MarkdownHelp_Bold"]</strong></td>
                         </tr>
                         <tr>
                             <td><code>*italic*</code></td>
-                            <td><em>italic</em></td>
+                            <td><em>@Localizer["MarkdownHelp_Italic"]</em></td>
                         </tr>
                         <tr>
                             <td><code>~~strikethrough~~</code></td>
-                            <td><del>strikethrough</del></td>
+                            <td><del>@Localizer["MarkdownHelp_Strikethrough"]</del></td>
                         </tr>
                         <tr>
                             <td><code>[link text](https://example.com)</code></td>
-                            <td><a href="#">link text</a></td>
+                            <td><a href="#">@Localizer["MarkdownHelp_LinkText"]</a></td>
                         </tr>
                         <tr>
                             <td><code>![description](https://…/photo.jpg)</code></td>
-                            <td><i class="fa-solid fa-image me-1 text-muted"></i><em>embedded image</em></td>
+                            <td><i class="fa-solid fa-image me-1 text-muted"></i><em>@Localizer["MarkdownHelp_EmbeddedImage"]</em></td>
                         </tr>
                         <tr>
                             <td><code># Heading 1</code></td>
-                            <td><strong style="font-size: 1.3em;">Heading 1</strong></td>
+                            <td><strong style="font-size: 1.3em;">@Localizer["MarkdownHelp_Heading1"]</strong></td>
                         </tr>
                         <tr>
                             <td><code>## Heading 2</code></td>
-                            <td><strong style="font-size: 1.1em;">Heading 2</strong></td>
+                            <td><strong style="font-size: 1.1em;">@Localizer["MarkdownHelp_Heading2"]</strong></td>
                         </tr>
                         <tr>
                             <td>
@@ -55,7 +55,7 @@
                                 <code>- item two</code>
                             </td>
                             <td>
-                                <ul class="mb-0"><li>item one</li><li>item two</li></ul>
+                                <ul class="mb-0"><li>@Localizer["MarkdownHelp_ItemOne"]</li><li>@Localizer["MarkdownHelp_ItemTwo"]</li></ul>
                             </td>
                         </tr>
                         <tr>
@@ -64,16 +64,16 @@
                                 <code>2. second</code>
                             </td>
                             <td>
-                                <ol class="mb-0"><li>first</li><li>second</li></ol>
+                                <ol class="mb-0"><li>@Localizer["MarkdownHelp_First"]</li><li>@Localizer["MarkdownHelp_Second"]</li></ol>
                             </td>
                         </tr>
                         <tr>
                             <td><code>&gt; quote text</code></td>
-                            <td><blockquote class="mb-0 ps-2 border-start border-3">quote text</blockquote></td>
+                            <td><blockquote class="mb-0 ps-2 border-start border-3">@Localizer["MarkdownHelp_QuoteText"]</blockquote></td>
                         </tr>
                         <tr>
                             <td><code>`inline code`</code></td>
-                            <td><code>inline code</code></td>
+                            <td><code>@Localizer["MarkdownHelp_InlineCode"]</code></td>
                         </tr>
                         <tr>
                             <td><code>---</code></td>
@@ -82,7 +82,7 @@
                     </tbody>
                 </table>
 
-                <h6 class="mt-4 mb-2">Tables</h6>
+                <h6 class="mt-4 mb-2">@Localizer["MarkdownHelp_TablesHeading"]</h6>
                 <div class="row">
                     <div class="col-md-6">
                         <pre class="bg-light p-2 rounded small mb-0">| Name   | Role  |
@@ -92,16 +92,16 @@
                     </div>
                     <div class="col-md-6">
                         <table class="table table-sm table-bordered mb-0">
-                            <thead><tr><th>Name</th><th>Role</th></tr></thead>
+                            <thead><tr><th>@Localizer["MarkdownHelp_TableName"]</th><th>@Localizer["MarkdownHelp_TableRole"]</th></tr></thead>
                             <tbody>
-                                <tr><td>Alice</td><td>Admin</td></tr>
-                                <tr><td>Bob</td><td>Human</td></tr>
+                                <tr><td>Alice</td><td>@Localizer["MarkdownHelp_TableAdmin"]</td></tr>
+                                <tr><td>Bob</td><td>@Localizer["MarkdownHelp_TableHuman"]</td></tr>
                             </tbody>
                         </table>
                     </div>
                 </div>
 
-                <h6 class="mt-4 mb-2">Task Lists</h6>
+                <h6 class="mt-4 mb-2">@Localizer["MarkdownHelp_TaskListsHeading"]</h6>
                 <div class="row">
                     <div class="col-md-6">
                         <pre class="bg-light p-2 rounded small mb-0">- [x] Done
@@ -109,14 +109,14 @@
                     </div>
                     <div class="col-md-6">
                         <ul class="list-unstyled mb-0">
-                            <li><input type="checkbox" checked disabled /> Done</li>
-                            <li><input type="checkbox" disabled /> To do</li>
+                            <li><input type="checkbox" checked disabled /> @Localizer["MarkdownHelp_TaskDone"]</li>
+                            <li><input type="checkbox" disabled /> @Localizer["MarkdownHelp_TaskToDo"]</li>
                         </ul>
                     </div>
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">@Localizer["Common_Close"]</button>
             </div>
         </div>
     </div>

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -2,16 +2,16 @@
 @using Microsoft.AspNetCore.Html
 @model Humans.Web.Models.StoreIndexViewModel
 @{
-    ViewData["Title"] = "Store";
+    ViewData["Title"] = Localizer["Store_Title"].Value;
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1 class="mb-0">Store</h1>
+    <h1 class="mb-0">@Localizer["Store_Title"]</h1>
     <div class="d-flex align-items-center gap-2">
         <div class="btn-group" authorize-policy="StoreCatalogAdmin">
-            <a asp-controller="StoreAdmin" asp-action="Catalog" class="btn btn-sm btn-outline-secondary">Catalog</a>
-            <a asp-controller="StoreAdmin" asp-action="Summary" class="btn btn-sm btn-outline-secondary">Summary</a>
-            <a asp-controller="StoreAdmin" asp-action="Payments" class="btn btn-sm btn-outline-secondary">Payments</a>
+            <a asp-controller="StoreAdmin" asp-action="Catalog" class="btn btn-sm btn-outline-secondary">@Localizer["Store_AdminCatalog"]</a>
+            <a asp-controller="StoreAdmin" asp-action="Summary" class="btn btn-sm btn-outline-secondary">@Localizer["Store_AdminSummary"]</a>
+            <a asp-controller="StoreAdmin" asp-action="Payments" class="btn btn-sm btn-outline-secondary">@Localizer["Store_AdminPayments"]</a>
         </div>
         <span class="badge bg-secondary fs-6">@Model.Year</span>
     </div>
@@ -21,8 +21,7 @@
 @if (!Model.Counterparties.Any())
 {
     <div class="alert alert-info">
-        You don't lead any camps or coordinate any departments with an active
-        season this year. The catalog below is read-only.
+        @Localizer["Store_NoCounterpartiesAlert"]
     </div>
 }
 else
@@ -33,14 +32,14 @@ else
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h2 class="h5 mb-0">
                     @cp.DisplayName
-                    <span class="badge bg-light text-dark ms-2">@cp.CounterpartyType</span>
+                    <span class="badge bg-light text-dark ms-2">@Localizer.EnumDisplay(cp.CounterpartyType)</span>
                 </h2>
                 @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp && cp.Orders.Count == 0 && Model.CanManageByCounterparty[cp.CounterpartyId])
                 {
                     <form asp-action="Create" asp-route-campSeasonId="@cp.CounterpartyId"
                           method="post" class="d-flex gap-2 align-items-center mb-0">
                         @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-sm btn-primary">Start order</button>
+                        <button type="submit" class="btn btn-sm btn-primary">@Localizer["Store_StartOrder"]</button>
                     </form>
                 }
                 else if (cp.CounterpartyType == StoreOrderCounterpartyType.Team && cp.Orders.Count == 0 && Model.CanManageByCounterparty[cp.CounterpartyId])
@@ -48,7 +47,7 @@ else
                     <form asp-action="CreateTeamOrder" asp-route-teamId="@cp.CounterpartyId"
                           method="post" class="mb-0">
                         @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-sm btn-primary">Create order</button>
+                        <button type="submit" class="btn btn-sm btn-primary">@Localizer["Store_CreateOrder"]</button>
                     </form>
                 }
             </div>
@@ -58,16 +57,16 @@ else
                     <table class="table table-sm mb-0">
                         <thead>
                             <tr>
-                                <th>State</th>
+                                <th>@Localizer["Store_ColState"]</th>
                                 @if (cp.CounterpartyType == StoreOrderCounterpartyType.Camp)
                                 {
-                                    <th class="text-end">Lines + VAT</th>
-                                    <th class="text-end">Deposits</th>
-                                    <th class="text-end">Balance</th>
+                                    <th class="text-end">@Localizer["Store_ColLinesVat"]</th>
+                                    <th class="text-end">@Localizer["Store_ColDeposits"]</th>
+                                    <th class="text-end">@Localizer["Store_ColBalance"]</th>
                                 }
                                 else
                                 {
-                                    <th class="text-end">Lines</th>
+                                    <th class="text-end">@Localizer["Store_ColLines"]</th>
                                 }
                                 <th></th>
                             </tr>
@@ -94,13 +93,13 @@ else
                                                 <form asp-action="Delete" asp-route-id="@order.Id" method="post" class="mb-0">
                                                     @Html.AntiForgeryToken()
                                                     <button type="submit" class="btn btn-sm btn-outline-danger"
-                                                            title="Delete (zero balance)"
-                                                            data-confirm="Delete this zero-balance order? This cannot be undone.">
+                                                            title="@Localizer["Store_DeleteOrderTitle"]"
+                                                            data-confirm="@Localizer["Store_DeleteOrderConfirm"].Value">
                                                         <i class="fa-solid fa-trash"></i>
                                                     </button>
                                                 </form>
                                             }
-                                            <a asp-action="Order" asp-route-id="@order.Id" class="btn btn-sm btn-outline-primary">Open</a>
+                                            <a asp-action="Order" asp-route-id="@order.Id" class="btn btn-sm btn-outline-primary">@Localizer["Store_OpenOrder"]</a>
                                         </div>
                                     </td>
                                 </tr>
@@ -110,17 +109,17 @@ else
                 }
                 else
                 {
-                    <div class="p-3 text-muted">No orders yet.</div>
+                    <div class="p-3 text-muted">@Localizer["Store_NoOrders"]</div>
                 }
             </div>
         </div>
     }
 }
 
-<h2 class="h4 mb-3">Catalog (@Model.Year)</h2>
+<h2 class="h4 mb-3">@Localizer["Store_CatalogHeading", Model.Year]</h2>
 @if (!Model.Catalog.Any())
 {
-    <div class="alert alert-secondary">No products are active for @Model.Year.</div>
+    <div class="alert alert-secondary">@Localizer["Store_NoProducts", Model.Year]</div>
 }
 else
 {
@@ -132,11 +131,11 @@ else
             <div class="text-muted small">(@item.UnitPriceEur.ToEuro() + @item.VatRatePercent.ToString("0.##", System.Globalization.CultureInfo.CurrentCulture)% VAT)</div>
         </text>;
     var catalogTable = TableModel.For(Model.Catalog)
-        .Column("Name", r => r.Name)
-        .Template("Description", catalogDescriptionCell)
-        .Template("Unit price (incl. VAT)", catalogPriceCell, c => c.NoSort().End())
-        .Column("Deposit", r => r.DepositAmountEur, c => c.Currency().End())
-        .Column("Order by", r => r.OrderableUntil.ToDate())
+        .Column(Localizer["Store_ColName"].Value, r => r.Name)
+        .Template(Localizer["Store_ColDescription"].Value, catalogDescriptionCell)
+        .Template(Localizer["Store_ColUnitPrice"].Value, catalogPriceCell, c => c.NoSort().End())
+        .Column(Localizer["Store_ColDeposit"].Value, r => r.DepositAmountEur, c => c.Currency().End())
+        .Column(Localizer["Store_ColOrderBy"].Value, r => r.OrderableUntil.ToDate())
         .Build();
     <partial name="_Table" model="catalogTable" />
 }

--- a/src/Humans.Web/Views/Team/Index.cshtml
+++ b/src/Humans.Web/Views/Team/Index.cshtml
@@ -19,8 +19,8 @@
             <a asp-action="Map" class="btn btn-outline-secondary">@Localizer["Map_Title"]</a>
             @if ((await AuthService.AuthorizeAsync(User, PolicyNames.TeamsAdminBoardOrAdmin)).Succeeded)
             {
-                <a asp-action="Summary" class="btn btn-outline-secondary">Summary <i class="fa-solid fa-lock auth-lock-icon"></i></a>
-                <a asp-controller="Google" asp-action="Sync" class="btn btn-outline-info">Sync Status <i class="fa-solid fa-lock auth-lock-icon"></i></a>
+                <a asp-action="Summary" class="btn btn-outline-secondary">@Localizer["Teams_Summary"] <i class="fa-solid fa-lock auth-lock-icon"></i></a>
+                <a asp-controller="Google" asp-action="Sync" class="btn btn-outline-info">@Localizer["Teams_SyncStatus"] <i class="fa-solid fa-lock auth-lock-icon"></i></a>
             }
             @if (Model.CanCreateTeam)
             {
@@ -49,7 +49,7 @@
 
     @if (Model.Departments.Any())
     {
-        <h4 class="mb-3">Departments</h4>
+        <h4 class="mb-3">@Localizer["Teams_Departments"]</h4>
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
             @foreach (var team in Model.Departments)
             {
@@ -60,7 +60,7 @@
 
     @if (Model.SystemTeams.Any())
     {
-        <h4 class="mb-3">System Teams</h4>
+        <h4 class="mb-3">@Localizer["Teams_SystemTeams"]</h4>
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
             @foreach (var team in Model.SystemTeams)
             {
@@ -72,8 +72,8 @@
     @if (Model.HiddenTeams.Any())
     {
         <h4 class="mb-3">
-            Hidden Teams
-            <small class="text-muted fs-6">(visible to admins only)</small>
+            @Localizer["Teams_HiddenTeams"]
+            <small class="text-muted fs-6">@Localizer["Teams_HiddenTeamsNote"]</small>
             <i class="fa-solid fa-lock auth-lock-icon"></i>
         </h4>
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">

--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -1,70 +1,70 @@
 @model Humans.Web.Models.RosterSummaryViewModel
 
 @{
-    ViewData["Title"] = "Team Roster";
+    ViewData["Title"] = Localizer["Roster_Title"].Value;
 }
 
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Teams_Title"]</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Team Roster</li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Roster_Title"]</li>
     </ol>
 </nav>
 
-<h2>Team Roster</h2>
+<h2>@Localizer["Roster_Title"]</h2>
 
 <div class="mb-3 d-flex gap-2">
     <div class="dropdown">
         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-            Priority: @(Model.PriorityFilter ?? "All")
+            @Localizer["Roster_PriorityFilter", Model.PriorityFilter ?? Localizer["Roster_All"].Value]
         </button>
         <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { status = Model.StatusFilter, period = Model.PeriodFilter })">All</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "Critical", status = Model.StatusFilter, period = Model.PeriodFilter })">Critical</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "Important", status = Model.StatusFilter, period = Model.PeriodFilter })">Important</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "NiceToHave", status = Model.StatusFilter, period = Model.PeriodFilter })">Nice to Have</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "None", status = Model.StatusFilter, period = Model.PeriodFilter })">None</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { status = Model.StatusFilter, period = Model.PeriodFilter })">@Localizer["Roster_All"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "Critical", status = Model.StatusFilter, period = Model.PeriodFilter })">@Localizer["Enum_SlotPriority_Critical"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "Important", status = Model.StatusFilter, period = Model.PeriodFilter })">@Localizer["Enum_SlotPriority_Important"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "NiceToHave", status = Model.StatusFilter, period = Model.PeriodFilter })">@Localizer["Enum_SlotPriority_NiceToHave"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = "None", status = Model.StatusFilter, period = Model.PeriodFilter })">@Localizer["Enum_SlotPriority_None"]</a></li>
         </ul>
     </div>
     <div class="dropdown">
         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-            Status: @(Model.StatusFilter ?? "All")
+            @Localizer["Roster_StatusFilter", Model.StatusFilter ?? Localizer["Roster_All"].Value]
         </button>
         <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, period = Model.PeriodFilter })">All</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = "Open", period = Model.PeriodFilter })">Open</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = "Filled", period = Model.PeriodFilter })">Filled</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, period = Model.PeriodFilter })">@Localizer["Roster_All"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = "Open", period = Model.PeriodFilter })">@Localizer["Roster_StatusOpen"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = "Filled", period = Model.PeriodFilter })">@Localizer["Roster_StatusFilled"]</a></li>
         </ul>
     </div>
     <div class="dropdown">
         <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-            Period: @(Model.PeriodFilter ?? "All")
+            @Localizer["Roster_PeriodFilter", Model.PeriodFilter ?? Localizer["Roster_All"].Value]
         </button>
         <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter })">All</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "YearRound" })">Year-round</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Build" })">Set-up</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Event" })">Event</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Strike" })">Strike</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter })">@Localizer["Roster_All"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "YearRound" })">@Localizer["Enum_RolePeriod_YearRound"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Build" })">@Localizer["Shifts_SetUp"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Event" })">@Localizer["Shifts_Event"]</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Strike" })">@Localizer["Shifts_Strike"]</a></li>
         </ul>
     </div>
 </div>
 
 @if (!Model.Slots.Any())
 {
-    <div class="alert alert-info">No role slots defined across teams.</div>
+    <div class="alert alert-info">@Localizer["Roster_NoSlots"]</div>
 }
 else
 {
     <table class="table table-hover">
         <thead>
             <tr>
-                <th>Team</th>
-                <th>Role</th>
-                <th>Period</th>
-                <th>Slot</th>
-                <th>Priority</th>
-                <th>Assigned To</th>
+                <th>@Localizer["Roster_ColTeam"]</th>
+                <th>@Localizer["Roster_ColRole"]</th>
+                <th>@Localizer["Roster_ColPeriod"]</th>
+                <th>@Localizer["Roster_ColSlot"]</th>
+                <th>@Localizer["Roster_ColPriority"]</th>
+                <th>@Localizer["Roster_ColAssignedTo"]</th>
             </tr>
         </thead>
         <tbody>
@@ -96,11 +96,11 @@ else
                             RolePeriod.Strike => "bg-secondary",
                             _ => "bg-light text-dark"
                         };
-                        var periodLabel = slot.Period switch { RolePeriod.YearRound => "Year-round", RolePeriod.Build => "Set-up", _ => slot.Period.ToString() };
+                        var periodLabel = Localizer.EnumDisplay(slot.Period);
                     }
                     <td><span class="badge @periodBadge">@periodLabel</span></td>
                     <td>@slot.SlotNumber</td>
-                    <td><span class="badge @slot.PriorityBadgeClass">@(slot.Priority == SlotPriority.NiceToHave ? "Nice to Have" : slot.Priority.ToString())</span></td>
+                    <td><span class="badge @slot.PriorityBadgeClass">@Localizer.EnumDisplay(slot.Priority)</span></td>
                     <td>
                         @if (slot.IsFilled && slot.AssignedUserId.HasValue)
                         {
@@ -112,7 +112,7 @@ else
                         }
                         else
                         {
-                            <span class="text-muted fst-italic">Open</span>
+                            <span class="text-muted fst-italic">@Localizer["Roster_SlotOpen"]</span>
                         }
                     </td>
                 </tr>

--- a/src/Humans.Web/Views/TicketTransfer/Index.cshtml
+++ b/src/Humans.Web/Views/TicketTransfer/Index.cshtml
@@ -1,5 +1,6 @@
 @model Humans.Web.Models.TicketTransferWizardViewModel
 @using Humans.Application.DTOs
+@using Microsoft.AspNetCore.Html
 @{
     ViewData["Title"] = Localizer["TicketTransfer_Title"].Value;
     // Show every ticket the user currently holds (not the ones they merely bought for others,
@@ -125,10 +126,16 @@ else
     var c = Model.Confirm;
     <h2 class="h5 mb-3">@Localizer["TicketTransfer_Step3"]</h2>
     <div class="alert alert-success" style="max-width:560px">
-        @Html.Raw(string.Format(Localizer["TicketTransfer_ConfirmDetails"].Value,
-            "<strong>" + Html.Encode(c.VendorTicketId) + "</strong>",
-            Html.Encode(c.AttendeeName),
-            "<strong>" + Html.Encode(c.ReceiverLegalName) + " — " + Html.Encode(c.ReceiverEmail) + "</strong>"))<br />
+        @{
+            // AppendFormat HTML-encodes every arg that isn't already IHtmlContent —
+            // AttendeeName goes in plain and is encoded for us.
+            var confirmDetails = new HtmlContentBuilder().AppendFormat(
+                Localizer["TicketTransfer_ConfirmDetails"].Value,
+                new HtmlString($"<strong>{Html.Encode(c.VendorTicketId)}</strong>"),
+                c.AttendeeName,
+                new HtmlString($"<strong>{Html.Encode(c.ReceiverLegalName)} — {Html.Encode(c.ReceiverEmail)}</strong>"));
+        }
+        @confirmDetails<br />
         @Localizer["TicketTransfer_ConfirmNote"]
     </div>
     <form asp-action="Submit" method="post">

--- a/src/Humans.Web/Views/TicketTransfer/Index.cshtml
+++ b/src/Humans.Web/Views/TicketTransfer/Index.cshtml
@@ -1,7 +1,7 @@
 @model Humans.Web.Models.TicketTransferWizardViewModel
 @using Humans.Application.DTOs
 @{
-    ViewData["Title"] = "Transfer a ticket";
+    ViewData["Title"] = Localizer["TicketTransfer_Title"].Value;
     // Show every ticket the user currently holds (not the ones they merely bought for others,
     // and not voided ones); only Valid + no-pending ones are selectable.
     var held = Model.MyTickets
@@ -9,12 +9,12 @@
         .ToList();
     var sendable = held.Where(t => t.CanSendTransfer).ToList();
     string NotSendableReason(MyAttendeeRowDto t) =>
-        t.HasPendingOutgoingTransfer ? "Transfer already pending"
-        : t.Status == TicketAttendeeStatus.CheckedIn ? "Already checked in — can't be transferred"
-        : "Not transferable";
+        t.HasPendingOutgoingTransfer ? Localizer["TicketTransfer_AlreadyPending"].Value
+        : t.Status == TicketAttendeeStatus.CheckedIn ? Localizer["TicketTransfer_CheckedIn"].Value
+        : Localizer["TicketTransfer_NotTransferable"].Value;
 }
 
-<h1>Transfer a ticket</h1>
+<h1>@Localizer["TicketTransfer_Title"]</h1>
 
 
 @if (Model.Error is not null)
@@ -26,15 +26,15 @@
 {
     @if (held.Count == 0)
     {
-        <div class="alert alert-info">You don't have any tickets to transfer.</div>
-        <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">Back</a>
+        <div class="alert alert-info">@Localizer["TicketTransfer_NoTickets"]</div>
+        <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">@Localizer["Common_Back"]</a>
     }
     else
     {
         <form asp-action="Confirm" method="post">
             @Html.AntiForgeryToken()
 
-            <h2 class="h5 mb-3">1. Choose the ticket to transfer</h2>
+            <h2 class="h5 mb-3">@Localizer["TicketTransfer_Step1"]</h2>
             <div class="mb-4 d-flex flex-column gap-2">
                 @foreach (var t in held)
                 {
@@ -60,28 +60,28 @@
 
             @if (sendable.Count > 0)
             {
-                <h2 class="h5 mb-3">2. Who are you sending it to?</h2>
+                <h2 class="h5 mb-3">@Localizer["TicketTransfer_Step2"]</h2>
                 <div class="mb-4" style="max-width:480px">
                     <vc:human-search field-name="receiverUserId" scope="Name" allow-email="true"
-                                     placeholder="Search by name, or paste their exact email…" />
+                                     placeholder="@Localizer["TicketTransfer_RecipientPlaceholder"]" />
                 </div>
 
-                <button type="submit" class="btn btn-primary">Continue</button>
-                <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">Cancel</a>
+                <button type="submit" class="btn btn-primary">@Localizer["TicketTransfer_Continue"]</button>
+                <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">@Localizer["Common_Cancel"]</a>
             }
             else
             {
-                <p class="text-muted">None of your tickets can be transferred right now.</p>
-                <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">Back</a>
+                <p class="text-muted">@Localizer["TicketTransfer_NoneTransferable"]</p>
+                <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">@Localizer["Common_Back"]</a>
             }
         </form>
     }
 
     <hr class="my-4" />
-    <h2 class="h5 mb-3">Your transfer requests</h2>
+    <h2 class="h5 mb-3">@Localizer["TicketTransfer_YourRequests"]</h2>
     @if (Model.MyTransfers.Count == 0)
     {
-        <p class="text-muted">You haven't requested any transfers.</p>
+        <p class="text-muted">@Localizer["TicketTransfer_NoRequests"]</p>
     }
     else
     {
@@ -90,10 +90,10 @@
             {
                 var (label, cls) = r.Status switch
                 {
-                    TicketTransferStatus.Pending => ("Pending review", "bg-warning text-dark"),
-                    TicketTransferStatus.Approved => ("Completed", "bg-success"),
-                    TicketTransferStatus.Rejected => ("Cancelled by team", "bg-secondary"),
-                    TicketTransferStatus.Cancelled => ("Cancelled", "bg-secondary"),
+                    TicketTransferStatus.Pending => (Localizer["TicketTransfer_Pending"].Value, "bg-warning text-dark"),
+                    TicketTransferStatus.Approved => (Localizer["TicketTransfer_StatusApproved"].Value, "bg-success"),
+                    TicketTransferStatus.Rejected => (Localizer["TicketTransfer_StatusRejected"].Value, "bg-secondary"),
+                    TicketTransferStatus.Cancelled => (Localizer["TicketTransfer_StatusCancelled"].Value, "bg-secondary"),
                     _ => (r.Status.ToString(), "bg-secondary"),
                 };
                 <div class="list-group-item d-flex justify-content-between align-items-center gap-3 flex-wrap">
@@ -101,7 +101,7 @@
                         <div><strong>@r.OriginalAttendeeName</strong> → @r.ReceiverLegalName
                             <span class="text-muted">(@r.ReceiverEmail)</span></div>
                         <small class="text-muted">
-                            Requested @r.RequestedAt.ToDateTime()@(string.IsNullOrWhiteSpace(r.AdminNotes) ? "" : $" · {r.AdminNotes}")
+                            @Localizer["TicketTransfer_Requested"] @r.RequestedAt.ToDateTime()@(string.IsNullOrWhiteSpace(r.AdminNotes) ? "" : $" · {r.AdminNotes}")
                         </small>
                     </div>
                     <div class="d-flex align-items-center gap-2">
@@ -111,7 +111,7 @@
                             <form asp-action="Cancel" method="post" class="m-0">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="id" value="@r.Id" />
-                                <button type="submit" class="btn btn-sm btn-outline-danger">Cancel request</button>
+                                <button type="submit" class="btn btn-sm btn-outline-danger">@Localizer["TicketTransfer_CancelRequest"]</button>
                             </form>
                         }
                     </div>
@@ -123,21 +123,23 @@
 else
 {
     var c = Model.Confirm;
-    <h2 class="h5 mb-3">3. Confirm</h2>
+    <h2 class="h5 mb-3">@Localizer["TicketTransfer_Step3"]</h2>
     <div class="alert alert-success" style="max-width:560px">
-        This will request transferring ticket <strong>@c.VendorTicketId</strong> (@c.AttendeeName)
-        to <strong>@c.ReceiverLegalName — @c.ReceiverEmail</strong>.<br />
-        Our ticketing team will process this and let you know shortly.
+        @Html.Raw(string.Format(Localizer["TicketTransfer_ConfirmDetails"].Value,
+            "<strong>" + Html.Encode(c.VendorTicketId) + "</strong>",
+            Html.Encode(c.AttendeeName),
+            "<strong>" + Html.Encode(c.ReceiverLegalName) + " — " + Html.Encode(c.ReceiverEmail) + "</strong>"))<br />
+        @Localizer["TicketTransfer_ConfirmNote"]
     </div>
     <form asp-action="Submit" method="post">
         @Html.AntiForgeryToken()
         <input type="hidden" name="attendeeId" value="@c.AttendeeId" />
         <input type="hidden" name="receiverUserId" value="@c.ReceiverUserId" />
         <div class="mb-3" style="max-width:560px">
-            <label for="reason" class="form-label">Reason for the transfer (optional, visible to the ticket team)</label>
+            <label for="reason" class="form-label">@Localizer["TicketTransfer_ReasonLabel"]</label>
             <textarea id="reason" name="reason" rows="2" class="form-control" maxlength="1000">@Model.Reason</textarea>
         </div>
-        <button type="submit" class="btn btn-primary">Request transfer</button>
-        <a class="btn btn-outline-secondary" asp-action="Index">Back</a>
+        <button type="submit" class="btn btn-primary">@Localizer["TicketTransfer_RequestTransfer"]</button>
+        <a class="btn btn-outline-secondary" asp-action="Index">@Localizer["Common_Back"]</a>
     </form>
 }

--- a/tests/Humans.Integration.Tests/Localization/SweepRouteCatalog.cs
+++ b/tests/Humans.Integration.Tests/Localization/SweepRouteCatalog.cs
@@ -31,10 +31,11 @@ internal sealed record RouteCandidate(string Url, Audience Audience, string Cont
 internal static class SweepRouteCatalog
 {
     // Dev/operational tooling that is not a localizable member page; GET to these is noise (and a
-    // GET to a seeder could mutate state), so they are excluded up front.
+    // GET to a seeder could mutate state), so they are excluded up front. ColorPalette is the
+    // anonymous design-reference page — developer-facing and English-only by design.
     private static readonly HashSet<string> ExcludedControllers = new(StringComparer.OrdinalIgnoreCase)
     {
-        "DevLogin", "DevSeed",
+        "DevLogin", "DevSeed", "ColorPalette",
     };
 
     public static SweepCatalog Build(IServiceProvider services)


### PR DESCRIPTION
## Summary

Works the [localization coverage sweep report](https://github.com/peterdrier/Humans/actions/runs/27299520019) (run 27299520019): localizes the public/auth pages, introduces the enum localization solution, and fills pre-existing member-facing translation gaps.

**Section:** cross-cutting (i18n)

### Enum solution
`EnumLocalizationExtensions` (Web layer): `Enum_{TypeName}_{Value}` key convention with a humanized fallback.
- `Localizer.EnumSelectItems<TEnum>()` replaces `new SelectList(Enum.GetValues<TEnum>())` — option values stay enum names, so model binding round-trips unchanged
- `Localizer.EnumDisplay(value)` for badges/chips/labels
- 18 enum types covered (CampVibe, SoundZone, SpaceSize, ElectricalGrid, FeedbackStatus, ExpenseReportStatus, SlotPriority, RolePeriod, ContactFieldType, ContactFieldVisibility, LanguageProficiency, …) — no more raw `Sqm800` / `WorkingOnIt` / `LiveMusic` in selects

### Views (43 files)
Camp (Register/Edit/Index/_CampCard), Calendar (all views; grid day headers now use culture abbreviated day names), Profile (Edit/Index/ShiftInfo/DietaryMedical/Emails/Outbox/Privacy + Guest CommunicationPreferences), Events (Browse/MySubmissions/Schedule), Store, TicketTransfer, Search, Issues, Feedback, Budget, Expenses, OnboardingWidget (Names/Shifts), Team (Index/Roster), About (Index/Staff), Shared/_MarkdownHelp, Home/Privacy.

### Resources
- **+596 en keys**, grouped by prefix
- **+610–614 values per language (es/ca/de/fr/it, ~3,700 total)** — register and vocabulary matched to each file's existing precedent; also fills pre-existing member-facing gaps (`AccountStatus_*`, `LinkedAccounts_*`, `Email_Survey*`, `Onboarding_NameRequiredBeforeShifts`)
- Admin-exempt groups (`EmailRota_*`, `EmailTeamRotas_*`, `Email_Coordinator*`, `VolTrack_*`) intentionally not backfilled per `memory/code/localization-admin-exempt.md`
- `Directory.Build.props` now ships satellite assemblies for all six supported cultures — it previously limited published builds to `en;es`, so de/ca/fr/it translations (including ~1,971 pre-existing ones) never reached deployments (Codex review catch)

### Debug tooling
- `/Debug/Translations` gallery — every key × 6 cultures, grouped by prefix, coverage badges, text filter + only-missing toggle, orphan-key detection (admin sidebar → Design)
- Sweep catalog: `ColorPalette` excluded (deliberately anonymous design-reference page, English-only by design)

### Translation verification
Antigravity (Gemini) review pass completed per language: 34 verified corrections applied (endorse/approve collision in it, Kaution/Caution deposit fixes in de/fr, order-deadline column in es/ca/it, register/grammar fixes); 9 suggestions rejected as domain errors (Asociado/Colaborador tier terms proposed for camp members).

## Out of scope (sweep findings not addressed here)
- **Section Help guides/glossaries/access matrices** (~520 findings) — hardcoded English markdown in `SectionHelpContent.cs` + `AccessMatrixViewComponent`; needs a storage design for localized markdown before translation makes sense
- **ShiftInfo chips** ("Early Bird", "Bartending", …) — C# viewmodel constants, need localizer injection at the builder, not view edits
- **Account/Login dev panel** — dev-only UI
- `/Survey/Answer` returns 500 in the sweep — pre-existing bug, unrelated to localization
- Sweep's admin-page coverage is blinded by 429 rate-limiting — not pursued; admin pages are English-only by design

## Verification
- `dotnet build` clean, `dotnet test` 4,558 passed / 0 failed (local integration timeouts under machine load reproduce on no specific test and pass in isolation; CI green)
- Programmatic checks: every `Localizer["…"]` key in modified views exists in resx; key parity + `{0}` placeholder parity verified for all 5 translation files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
