### PR TITLE
feat(tickets): let the gate terminal use the onsite roster

### DIFF
--- a/docs/authorization-inventory.md
+++ b/docs/authorization-inventory.md
@@ -85,7 +85,7 @@ The `Source` column reflects the constant referenced in the attribute as it appe
 | `TicketTransferController` | Class | `[Authorize]` (authenticated) | — |
 | `TicketTransferAdminController` | Class | `TicketAdmin, Admin` | `PolicyNames.TicketAdminOrAdmin` |
 | `TicketsContactsAdminController` | Class | `TicketAdmin, Admin` | `PolicyNames.TicketAdminOrAdmin` |
-| `TicketsOnsiteAdminController` | Class | `TicketAdmin, Admin, Board` | `PolicyNames.TicketAdminBoardOrAdmin` |
+| `TicketsOnsiteAdminController` | Class | `TicketAdmin, Admin, Board` OR the gate-terminal shared account (by well-known id) | `PolicyNames.ScannerAccess` (gate staff check the onsite roster from the door alongside the scanner) |
 | `TicketsGateAdminController` | Class | `TicketAdmin, Admin` | `PolicyNames.TicketAdminOrAdmin` (gate credential management at `/Tickets/Admin/Gate` — `Index` GET, `SetPassword` POST both inherit) |
 
 ### Scanner Section

--- a/src/Humans.Web/Controllers/TicketsOnsiteAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsOnsiteAdminController.cs
@@ -15,8 +15,10 @@ namespace Humans.Web.Controllers;
 /// delegated to <see cref="IOnsiteRosterService"/>; this controller stays a
 /// thin HTTP adapter per
 /// <c>memory/architecture/no-business-logic-in-controllers.md</c>.
+/// ScannerAccess (not TicketAdminBoardOrAdmin) so the shared gate-terminal
+/// account can check the roster from the door alongside the ticket scanner.
 /// </summary>
-[Authorize(Policy = PolicyNames.TicketAdminBoardOrAdmin)]
+[Authorize(Policy = PolicyNames.ScannerAccess)]
 [Route("Tickets/Admin/Onsite")]
 public sealed class TicketsOnsiteAdminController(
     IUserServiceRead userService,

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -21,7 +21,7 @@ public static class AdminNavTree
             new("Transfer requests",  "TicketTransferAdmin", "Index", null, null, "fa-solid fa-right-left",  PolicyNames.TicketAdminOrAdmin,
                  PillCount: PillCounts.TransferQueue),
             new("Attendee contacts",  "TicketsContactsAdmin", "Index", null, null, "fa-solid fa-address-book", PolicyNames.TicketAdminOrAdmin),
-            new("Onsite roster",      "TicketsOnsiteAdmin", "Index", null, null, "fa-solid fa-clipboard-list", PolicyNames.TicketAdminBoardOrAdmin),
+            new("Onsite roster",      "TicketsOnsiteAdmin", "Index", null, null, "fa-solid fa-clipboard-list", PolicyNames.ScannerAccess),
             // Campaigns distribute ticket-vendor discount codes (email is just the
             // delivery channel) — Tickets, not Messaging. See docs/sections/Campaigns.md.
             new("Campaigns",          "Campaign",       "Index", null, null, "fa-solid fa-bullhorn",    PolicyNames.AdminOnly),

--- a/tests/Humans.Application.Tests/Authorization/EndpointAuthorizationTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/EndpointAuthorizationTests.cs
@@ -40,6 +40,7 @@ public class EndpointAuthorizationTests
         { typeof(OnboardingReviewController), "Reject", "ConsentCoordinatorBoardOrAdmin" },
         { typeof(FinanceController), null, "FinanceAdminOrAdmin" },
         { typeof(ScannerController), null, "ScannerAccess" },
+        { typeof(TicketsOnsiteAdminController), null, "ScannerAccess" },
         { typeof(TicketsGateAdminController), null, "TicketAdminOrAdmin" },
         { typeof(ShiftDashboardController), null, "ShiftDepartmentManager" },
         { typeof(ShiftDashboardController), "SearchVolunteers", "ShiftDashboardAccess" },


### PR DESCRIPTION
## What

The gate user (shared gate-terminal account) can now use https://humans.nobodies.team/Tickets/Admin/Onsite.

## How

Pure reuse — no new policy or surface:

- `TicketsOnsiteAdminController` switches from `TicketAdminBoardOrAdmin` to the existing `ScannerAccess` policy, which is exactly the same role set (TicketAdmin / Board / Admin) **plus** the gate-terminal account admitted by well-known id.
- The "Onsite roster" sidebar entry in `AdminNavTree` follows suit, so the gate terminal sees the roster link in the admin sidebar on the Scanner pages it already uses (`_AdminLayout`, per-item filtering).
- `docs/authorization-inventory.md` row updated.
- Policy pinned in `EndpointAuthorizationTests` alongside the existing `ScannerController` pin.

No change for existing admin roles — TicketAdmin/Board/Admin all pass `ScannerAccess`, so the e2e sidebar matrix and sidebar component tests are untouched.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors
- Authorization + sidebar tests (271) and `TicketsOnsiteAdminControllerTests` (3) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)