### PR TITLE
feat(debug): rolling 1000-entry buffer of HTTP error responses at /Debug/HttpErrors

### DIFF
--- a/docs/features/debug/client-stats.md
+++ b/docs/features/debug/client-stats.md
@@ -97,11 +97,11 @@ every request → ASP.NET Core records http.server.request.duration
 ## What was deliberately left out
 
 - **No persistence / longer windows.** Counts are since-deploy; week/month trends would need a side-table, out of scope for a debug aid.
-- **No 5xx detail buffer (yet).** Only counts today. A circular buffer of recent server-error detail is the natural future addition if errors become a concern.
 - **No tablet class.** Device type is Mobile / Desktop / Bot (collapsed) — sufficient for "pc/mac/phone". The separate Bots table breaks the collapsed Bot bucket down by crawler name.
 
 ## Related Features
 
+- [`docs/features/debug/http-errors.md`](http-errors.md) — the per-request detail buffer behind the status-code tally (status > 399, last 1000).
 - [`docs/sections/Debug.md`](../../sections/Debug.md) — the Debug section that owns this screen.
 - [`docs/features/active-user-metrics.md`](../active-user-metrics.md) — the sibling in-memory metric (active users); same reset-on-restart constraint.
 - `OpenTelemetry` / Prometheus `/metrics` — the existing export the status-code MeterListener rides alongside.

--- a/docs/features/debug/http-errors.md
+++ b/docs/features/debug/http-errors.md
@@ -1,0 +1,73 @@
+<!-- freshness:triggers
+  src/Humans.Application/Interfaces/IClientStatsTracker.cs
+  src/Humans.Infrastructure/Services/ClientStatsTracker.cs
+  src/Humans.Web/Middleware/ClientStatsMiddleware.cs
+  src/Humans.Web/Controllers/DebugController.cs
+  src/Humans.Web/Views/Debug/HttpErrors.cshtml
+-->
+<!-- freshness:flag-on-change
+  The >399 capture predicate, the 499-for-aborted convention, the re-execute
+  skip (status-code pages) and re-execute record (exception handler), the 429
+  OnRejected hook, buffer capacity / truncation bounds, and the
+  in-memory/reset-on-restart guarantee — review when any of these change.
+-->
+
+# HTTP Errors (Debug)
+
+A `/Debug/HttpErrors` screen showing the last 1000 error responses (status > 399)
+with per-request detail: when, code, method, URL, IP, authenticated user, and
+classified User-Agent. All in-memory, no DB.
+
+## Business Context
+
+`/Debug/ClientStats` showed ~1000 client errors (400/404/405/499) as bare counts —
+the status tally is fed by a `MeterListener` that only ever sees `(code, count)`,
+so the errors could not be attributed to bots, broken links, or real users. The
+project owner asked for a rolling buffer of the last 1000 such errors, "similar
+to `/Debug/Logs` in setup", with who (IP), when, code, URL, and User-Agent.
+
+Same constraint as [client-stats](client-stats.md): the container bounces daily
+or more often, so the buffer is "since this deploy", not historical. Acceptable
+for a debug aid.
+
+## User Stories
+
+### US-HE.1: Admin attributes error traffic
+**As an** Admin
+**I want** `/Debug/HttpErrors` to list recent error responses with request detail
+**So that** I can tell bot probes from broken links from real user problems
+**Acceptance:**
+- Every response with status > 399 is captured, across all traffic (pages, assets, API, probes)
+- Each row: UTC timestamp, status code, method, URL, IP, authenticated user (when present), classified client label with raw UA as tooltip
+- Newest first; `?count=` clamped to 1..1000 (default 1000)
+- Per-code lifetime counts (since app start) survive buffer eviction and toggle row visibility
+- Linked from the Diagnostics nav and the ClientStats status-code panel
+
+## Design Decisions
+
+- **Storage** — ring buffer (capacity 1000) on the existing `ClientStatsTracker`,
+  enqueue-then-trim-under-lock like `InMemoryLogSink`. URL truncated to 200 chars,
+  UA to 150; whole buffer stays under ~1 MB. Client label is derived by the
+  tracker at record time via `UserAgentClassifier` (Web never calls Infrastructure).
+- **Capture point** — `ClientStatsMiddleware` after `await next()`. Three special cases:
+  - **Aborted requests record as 499** (nginx convention, matching ASP.NET Core's
+    request metric), including aborts that surface as cancellation exceptions.
+  - **`UseStatusCodePagesWithReExecute` re-runs are skipped** (`IStatusCodeReExecuteFeature`)
+    so each error records once, with the real request path.
+  - **`UseExceptionHandler` re-executes are recorded** (that's the only pass that
+    completes normally) using `IExceptionHandlerPathFeature.Path` so unhandled
+    500s keep the failing URL instead of `/Home/Error`.
+- **429s** — the rate limiter rejects before this middleware runs, so the
+  limiter's `OnRejected` callback in `Program.cs` records them via the shared
+  `ClientStatsMiddleware.BuildEntry`.
+- **Known gap (stated on the page)** — requests Kestrel rejects before the
+  pipeline (malformed HTTP) never reach middleware, so buffer counts can run
+  slightly below the ClientStats meter tally.
+- **Not Serilog** — logging each 4xx as a warning would let bot 404 floods evict
+  real warnings from the `InMemoryLogSink` buffer; rejected.
+
+## Related Features
+
+- [client-stats](client-stats.md) — same vertical; hosts the status-code tally
+  that motivated this buffer and links to this page.
+- `docs/features/debug/` siblings; section context in `docs/sections/`.

--- a/src/Humans.Application/Interfaces/IClientStatsTracker.cs
+++ b/src/Humans.Application/Interfaces/IClientStatsTracker.cs
@@ -55,15 +55,19 @@ public sealed record ClientStatCount(string Label, long Count);
 /// One error response captured for the <c>/Debug/HttpErrors</c> rolling buffer.
 /// <paramref name="UserId"/> is the authenticated user's id when the request
 /// carried one — bot noise and anonymous traffic leave it null.
+/// <paramref name="ClientLabel"/> is derived from <paramref name="UserAgent"/>
+/// by the tracker at record time (bot name, or browser · OS); callers leave it
+/// at its default.
 /// </summary>
 public sealed record ClientErrorEntry(
-    DateTimeOffset Timestamp,
+    NodaTime.Instant Timestamp,
     int StatusCode,
     string Method,
     string Url,
     string IpAddress,
     Guid? UserId,
-    string UserAgent);
+    string UserAgent,
+    string ClientLabel = "");
 
 /// <summary>Rolling-buffer view: recent entries (newest first) plus lifetime per-code counts.</summary>
 public sealed record ClientErrorsSnapshot(

--- a/src/Humans.Application/Interfaces/IClientStatsTracker.cs
+++ b/src/Humans.Application/Interfaces/IClientStatsTracker.cs
@@ -23,6 +23,19 @@ public interface IClientStatsTracker
 
     /// <summary>Snapshot of all counts since process start.</summary>
     ClientStatsSnapshot GetSnapshot();
+
+    /// <summary>
+    /// Record one error response (status &gt; 399, or an aborted request recorded
+    /// as 499) into the rolling buffer. URL and User-Agent are truncated on
+    /// storage to bound memory.
+    /// </summary>
+    void RecordError(ClientErrorEntry entry);
+
+    /// <summary>
+    /// The most recent error responses, newest first, up to <paramref name="count"/>,
+    /// plus lifetime per-status-code counts that survive buffer eviction.
+    /// </summary>
+    ClientErrorsSnapshot GetErrorsSnapshot(int count);
 }
 
 /// <summary>Immutable view of the client-stats counters at a point in time.</summary>
@@ -37,3 +50,23 @@ public sealed record ClientStatsSnapshot(
 
 /// <summary>A single labelled count (e.g. <c>"Windows" → 42</c>).</summary>
 public sealed record ClientStatCount(string Label, long Count);
+
+/// <summary>
+/// One error response captured for the <c>/Debug/HttpErrors</c> rolling buffer.
+/// <paramref name="UserId"/> is the authenticated user's id when the request
+/// carried one — bot noise and anonymous traffic leave it null.
+/// </summary>
+public sealed record ClientErrorEntry(
+    DateTimeOffset Timestamp,
+    int StatusCode,
+    string Method,
+    string Url,
+    string IpAddress,
+    Guid? UserId,
+    string UserAgent);
+
+/// <summary>Rolling-buffer view: recent entries (newest first) plus lifetime per-code counts.</summary>
+public sealed record ClientErrorsSnapshot(
+    long TotalErrors,
+    IReadOnlyDictionary<int, long> LifetimeCounts,
+    IReadOnlyList<ClientErrorEntry> Recent);

--- a/src/Humans.Infrastructure/Services/ClientStatsTracker.cs
+++ b/src/Humans.Infrastructure/Services/ClientStatsTracker.cs
@@ -68,10 +68,16 @@ public sealed class ClientStatsTracker : IClientStatsTracker
     {
         _errorCounts.AddOrUpdate(entry.StatusCode, 1, static (_, v) => v + 1);
 
+        // Classify before truncation so the label sees the full UA string.
+        var c = UserAgentClassifier.Classify(entry.UserAgent);
+        var label = c.BotName
+            ?? (c is { Browser: "Unknown", Os: "Unknown" } ? "Unknown" : $"{c.Browser} · {c.Os}");
+
         entry = entry with
         {
             Url = Truncate(entry.Url, MaxUrlLength),
-            UserAgent = Truncate(entry.UserAgent, MaxUserAgentLength)
+            UserAgent = Truncate(entry.UserAgent, MaxUserAgentLength),
+            ClientLabel = label
         };
 
         lock (_errorsLock)

--- a/src/Humans.Infrastructure/Services/ClientStatsTracker.cs
+++ b/src/Humans.Infrastructure/Services/ClientStatsTracker.cs
@@ -19,6 +19,17 @@ public sealed class ClientStatsTracker : IClientStatsTracker
     private const int MaxResolutionBuckets = 200;
     private readonly ConcurrentDictionary<string, long> _resolutions = new(StringComparer.Ordinal);
 
+    // Rolling buffer of error responses, same enqueue-then-trim-under-lock pattern
+    // as InMemoryLogSink (ConcurrentQueue.Count is a snapshot, so unlocked writers
+    // could both see "over capacity" and over-evict; readers stay lock-free).
+    // URL and UA are truncated on storage: 1000 entries × ~600 B stays under 1 MB.
+    private const int ErrorCapacity = 1000;
+    private const int MaxUrlLength = 200;
+    private const int MaxUserAgentLength = 150;
+    private readonly ConcurrentQueue<ClientErrorEntry> _errors = new();
+    private readonly Lock _errorsLock = new();
+    private readonly ConcurrentDictionary<int, long> _errorCounts = new();
+
     private long _totalPageViews;
     private long _totalResolutionSamples;
 
@@ -53,6 +64,30 @@ public sealed class ClientStatsTracker : IClientStatsTracker
             Bump(_resolutions, "Other");
     }
 
+    public void RecordError(ClientErrorEntry entry)
+    {
+        _errorCounts.AddOrUpdate(entry.StatusCode, 1, static (_, v) => v + 1);
+
+        entry = entry with
+        {
+            Url = Truncate(entry.Url, MaxUrlLength),
+            UserAgent = Truncate(entry.UserAgent, MaxUserAgentLength)
+        };
+
+        lock (_errorsLock)
+        {
+            _errors.Enqueue(entry);
+            while (_errors.Count > ErrorCapacity)
+                _errors.TryDequeue(out _);
+        }
+    }
+
+    public ClientErrorsSnapshot GetErrorsSnapshot(int count) => new(
+        TotalErrors: _errorCounts.Values.Sum(),
+        LifetimeCounts: _errorCounts.ToDictionary(kv => kv.Key, kv => kv.Value),
+        // Queue enumeration is oldest-first; reverse for newest-first display.
+        Recent: _errors.Reverse().Take(count).ToList());
+
     public ClientStatsSnapshot GetSnapshot() => new(
         TotalPageViews: Interlocked.Read(ref _totalPageViews),
         OperatingSystems: Rank(_operatingSystems),
@@ -64,6 +99,9 @@ public sealed class ClientStatsTracker : IClientStatsTracker
 
     private static void Bump(ConcurrentDictionary<string, long> map, string key)
         => map.AddOrUpdate(key, 1, static (_, v) => v + 1);
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length <= maxLength ? value : value[..maxLength];
 
     private static IReadOnlyList<ClientStatCount> Rank(ConcurrentDictionary<string, long> map)
         => map.Select(kv => new ClientStatCount(kv.Key, kv.Value))

--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -6,6 +6,7 @@ using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Users;
 using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
+using Humans.Web.Extensions;
 using Humans.Web.Infrastructure;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -57,7 +58,7 @@ public class DebugController(
     [HttpGet("HttpErrors")]
     public IActionResult HttpErrors(int count = 1000)
     {
-        count = Math.Clamp(count, 1, 1000);
+        count = count.ClampPageSize(1, 1000);
 
         var snapshot = clientStats.GetErrorsSnapshot(count);
 
@@ -67,14 +68,9 @@ public class DebugController(
                 .OrderBy(kv => kv.Key)
                 .Select(kv => new HttpErrorCountRow(kv.Key, kv.Value))
                 .ToList(),
-            Entries: snapshot.Recent.Select(e =>
-            {
-                var c = Humans.Infrastructure.Services.UserAgentClassifier.Classify(e.UserAgent);
-                var label = c.BotName
-                    ?? (c is { Browser: "Unknown", Os: "Unknown" } ? "Unknown" : $"{c.Browser} · {c.Os}");
-                return new HttpErrorRow(
-                    e.Timestamp, e.StatusCode, e.Method, e.Url, e.IpAddress, e.UserId, label, e.UserAgent);
-            }).ToList());
+            Entries: snapshot.Recent.Select(e => new HttpErrorRow(
+                e.Timestamp.ToDateTimeUtc(), e.StatusCode, e.Method, e.Url,
+                e.IpAddress, e.UserId, e.ClientLabel, e.UserAgent)).ToList());
 
         return View(vm);
     }

--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -54,6 +54,31 @@ public class DebugController(
         return View(events);
     }
 
+    [HttpGet("HttpErrors")]
+    public IActionResult HttpErrors(int count = 1000)
+    {
+        count = Math.Clamp(count, 1, 1000);
+
+        var snapshot = clientStats.GetErrorsSnapshot(count);
+
+        var vm = new HttpErrorsViewModel(
+            TotalErrors: snapshot.TotalErrors,
+            LifetimeCounts: snapshot.LifetimeCounts
+                .OrderBy(kv => kv.Key)
+                .Select(kv => new HttpErrorCountRow(kv.Key, kv.Value))
+                .ToList(),
+            Entries: snapshot.Recent.Select(e =>
+            {
+                var c = Humans.Infrastructure.Services.UserAgentClassifier.Classify(e.UserAgent);
+                var label = c.BotName
+                    ?? (c is { Browser: "Unknown", Os: "Unknown" } ? "Unknown" : $"{c.Browser} · {c.Os}");
+                return new HttpErrorRow(
+                    e.Timestamp, e.StatusCode, e.Method, e.Url, e.IpAddress, e.UserId, label, e.UserAgent);
+            }).ToList());
+
+        return View(vm);
+    }
+
     [HttpGet("Maintenance")]
     public IActionResult Maintenance() => View();
 

--- a/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
+++ b/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Humans.Application.Interfaces;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http.Extensions;
+using NodaTime;
 
 namespace Humans.Web.Middleware;
 
@@ -11,7 +12,9 @@ namespace Humans.Web.Middleware;
 /// count, so static assets, JSON APIs, health/metrics probes and the beacon
 /// endpoint are naturally excluded. Feeds the <c>/Admin/ClientStats</c> screen.
 /// Also records every error response (status &gt; 399, plus aborted requests as
-/// 499) into the tracker's rolling buffer for <c>/Debug/HttpErrors</c>.
+/// 499) into the tracker's rolling buffer for <c>/Debug/HttpErrors</c>. 429s are
+/// recorded by the rate limiter's OnRejected callback instead — its rejection
+/// short-circuits before this middleware runs.
 /// </summary>
 public sealed class ClientStatsMiddleware(RequestDelegate next, IClientStatsTracker tracker)
 {
@@ -62,6 +65,18 @@ public sealed class ClientStatsMiddleware(RequestDelegate next, IClientStatsTrac
         if (context.Features.Get<IStatusCodeReExecuteFeature>() is not null)
             return;
 
+        tracker.RecordError(BuildEntry(
+            context,
+            aborted ? ClientClosedRequest : context.Response.StatusCode));
+    }
+
+    /// <summary>
+    /// Builds a buffer entry from the request. Shared with the rate limiter's
+    /// OnRejected callback in <c>Program.cs</c>, which records 429s this
+    /// middleware never sees.
+    /// </summary>
+    internal static ClientErrorEntry BuildEntry(HttpContext context, int statusCode)
+    {
         Guid? userId = null;
         if (context.User.FindFirst(ClaimTypes.NameIdentifier) is { } claim
             && Guid.TryParse(claim.Value, out var id))
@@ -69,13 +84,19 @@ public sealed class ClientStatsMiddleware(RequestDelegate next, IClientStatsTrac
             userId = id;
         }
 
-        tracker.RecordError(new ClientErrorEntry(
-            Timestamp: DateTimeOffset.UtcNow,
-            StatusCode: aborted ? ClientClosedRequest : context.Response.StatusCode,
+        // Unhandled exceptions are recorded during UseExceptionHandler's re-execute
+        // at /Home/Error; the feature carries the failing request's real path.
+        var url = context.Features.Get<IExceptionHandlerPathFeature>() is { } exceptionFeature
+            ? exceptionFeature.Path
+            : context.Request.GetEncodedPathAndQuery();
+
+        return new ClientErrorEntry(
+            Timestamp: SystemClock.Instance.GetCurrentInstant(),
+            StatusCode: statusCode,
             Method: context.Request.Method,
-            Url: context.Request.GetEncodedPathAndQuery(),
+            Url: url,
             IpAddress: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
             UserId: userId,
-            UserAgent: context.Request.Headers.UserAgent.ToString()));
+            UserAgent: context.Request.Headers.UserAgent.ToString());
     }
 }

--- a/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
+++ b/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
@@ -1,4 +1,7 @@
+using System.Security.Claims;
 using Humans.Application.Interfaces;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace Humans.Web.Middleware;
 
@@ -7,12 +10,29 @@ namespace Humans.Web.Middleware;
 /// classifying the client by its User-Agent. Only <c>text/html</c> responses
 /// count, so static assets, JSON APIs, health/metrics probes and the beacon
 /// endpoint are naturally excluded. Feeds the <c>/Admin/ClientStats</c> screen.
+/// Also records every error response (status &gt; 399, plus aborted requests as
+/// 499) into the tracker's rolling buffer for <c>/Debug/HttpErrors</c>.
 /// </summary>
 public sealed class ClientStatsMiddleware(RequestDelegate next, IClientStatsTracker tracker)
 {
+    // Non-standard nginx code for "client closed request"; ASP.NET Core's request
+    // metric reports aborted requests the same way, so the buffer stays comparable
+    // to the ClientStats status-code tally.
+    private const int ClientClosedRequest = 499;
+
     public async Task InvokeAsync(HttpContext context)
     {
-        await next(context);
+        try
+        {
+            await next(context);
+        }
+        catch when (context.RequestAborted.IsCancellationRequested)
+        {
+            // A client abort often surfaces downstream as a cancellation exception;
+            // the request still ended, so record it before letting it propagate.
+            MaybeRecordError(context);
+            throw;
+        }
 
         // Count only successful GET navigations that render HTML. This excludes
         // non-GET requests (e.g. a failed POST re-rendering a form) and re-executed
@@ -26,5 +46,36 @@ public sealed class ClientStatsMiddleware(RequestDelegate next, IClientStatsTrac
         {
             tracker.RecordPageView(context.Request.Headers.UserAgent.ToString());
         }
+
+        MaybeRecordError(context);
+    }
+
+    private void MaybeRecordError(HttpContext context)
+    {
+        var aborted = context.RequestAborted.IsCancellationRequested;
+        if (context.Response.StatusCode <= 399 && !aborted)
+            return;
+
+        // UseStatusCodePagesWithReExecute re-runs the pipeline (and this middleware)
+        // to render the error page; only the original pass records, or every 404
+        // would appear twice — and with the error page's path instead of the real one.
+        if (context.Features.Get<IStatusCodeReExecuteFeature>() is not null)
+            return;
+
+        Guid? userId = null;
+        if (context.User.FindFirst(ClaimTypes.NameIdentifier) is { } claim
+            && Guid.TryParse(claim.Value, out var id))
+        {
+            userId = id;
+        }
+
+        tracker.RecordError(new ClientErrorEntry(
+            Timestamp: DateTimeOffset.UtcNow,
+            StatusCode: aborted ? ClientClosedRequest : context.Response.StatusCode,
+            Method: context.Request.Method,
+            Url: context.Request.GetEncodedPathAndQuery(),
+            IpAddress: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            UserId: userId,
+            UserAgent: context.Request.Headers.UserAgent.ToString()));
     }
 }

--- a/src/Humans.Web/Models/HttpErrorsViewModel.cs
+++ b/src/Humans.Web/Models/HttpErrorsViewModel.cs
@@ -1,0 +1,26 @@
+namespace Humans.Web.Models;
+
+/// <summary>
+/// View model for the <c>/Debug/HttpErrors</c> screen: the rolling buffer of
+/// recent error responses (newest first) plus lifetime per-code counts that
+/// survive buffer eviction.
+/// </summary>
+public sealed record HttpErrorsViewModel(
+    long TotalErrors,
+    IReadOnlyList<HttpErrorCountRow> LifetimeCounts,
+    IReadOnlyList<HttpErrorRow> Entries);
+
+/// <summary>Lifetime count for one status code since process start.</summary>
+public sealed record HttpErrorCountRow(int StatusCode, long Count);
+
+/// <summary>One buffered error response. <paramref name="ClientLabel"/> is the
+/// classified short form of <paramref name="UserAgent"/> (bot name, or browser · OS).</summary>
+public sealed record HttpErrorRow(
+    DateTimeOffset Timestamp,
+    int StatusCode,
+    string Method,
+    string Url,
+    string IpAddress,
+    Guid? UserId,
+    string ClientLabel,
+    string UserAgent);

--- a/src/Humans.Web/Models/HttpErrorsViewModel.cs
+++ b/src/Humans.Web/Models/HttpErrorsViewModel.cs
@@ -14,9 +14,10 @@ public sealed record HttpErrorsViewModel(
 public sealed record HttpErrorCountRow(int StatusCode, long Count);
 
 /// <summary>One buffered error response. <paramref name="ClientLabel"/> is the
-/// classified short form of <paramref name="UserAgent"/> (bot name, or browser · OS).</summary>
+/// classified short form of <paramref name="UserAgent"/> (bot name, or browser · OS).
+/// <paramref name="Timestamp"/> is UTC.</summary>
 public sealed record HttpErrorRow(
-    DateTimeOffset Timestamp,
+    DateTime Timestamp,
     int StatusCode,
     string Method,
     string Url,

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -344,6 +344,12 @@ builder.Services.AddRateLimiter(options =>
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
     options.OnRejected = async (context, cancellationToken) =>
     {
+        // The rejection short-circuits before ClientStatsMiddleware, so record the
+        // 429 in the /Debug/HttpErrors buffer here.
+        context.HttpContext.RequestServices.GetRequiredService<IClientStatsTracker>()
+            .RecordError(ClientStatsMiddleware.BuildEntry(
+                context.HttpContext, StatusCodes.Status429TooManyRequests));
+
         var logger = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
             .CreateLogger("RateLimiting");
         var remoteIp = context.HttpContext.Connection.RemoteIpAddress?.ToString();

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -123,6 +123,7 @@ public static class AdminNavTree
         ]),
         new("Diagnostics", System: true, Items: [
             new("Logs",            "Debug", "Logs",          null, null, "fa-solid fa-triangle-exclamation", PolicyNames.AdminOnly),
+            new("HTTP errors",     "Debug", "HttpErrors",    null, null, "fa-solid fa-circle-exclamation",  PolicyNames.AdminOnly),
             new("DB stats",        "Debug", "DbStats",       null, null, "fa-solid fa-database",            PolicyNames.AdminOnly),
             new("Cache stats",     "Debug", "CacheStats",    null, null, "fa-solid fa-bolt",                PolicyNames.AdminOnly),
             new("Client stats",    "Debug", "ClientStats",   null, null, "fa-solid fa-display",             PolicyNames.AdminOnly),

--- a/src/Humans.Web/Views/Debug/ClientStats.cshtml
+++ b/src/Humans.Web/Views/Debug/ClientStats.cshtml
@@ -46,6 +46,8 @@
 <p class="text-muted small">
     @Model.TotalResponses.ToString("N0") responses since startup, across <em>all</em> traffic
     (pages, assets, API, probes) — observed from ASP.NET Core's request metric.
+    Per-request detail for the error responses is on
+    <a asp-action="HttpErrors">HTTP errors</a>.
 </p>
 
 @if (Model.StatusCodes.Count == 0)

--- a/src/Humans.Web/Views/Debug/HttpErrors.cshtml
+++ b/src/Humans.Web/Views/Debug/HttpErrors.cshtml
@@ -1,0 +1,116 @@
+@model HttpErrorsViewModel
+@{
+    ViewData["Title"] = "HTTP Errors";
+}
+
+<div class="container-fluid px-4">
+    <nav aria-label="breadcrumb" class="mt-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+            <li class="breadcrumb-item active" aria-current="page">HTTP Errors</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1>HTTP Errors</h1>
+        <div class="text-muted text-end">
+            <div>Showing @Model.Entries.Count of last 1000 (in-memory buffer)</div>
+            <div><small>@Model.TotalErrors.ToString("#,##0") error responses since app start</small></div>
+        </div>
+    </div>
+
+    <div class="alert alert-info">
+        <i class="fa-solid fa-circle-info me-1"></i>
+        Every response with status &gt; 399 across <em>all</em> traffic (pages, assets, API, probes);
+        aborted requests are recorded as <strong>499</strong>. In-memory — resets on every
+        restart/redeploy. Requests Kestrel rejects before the pipeline (malformed HTTP) are not
+        captured here, so these counts can run slightly below the
+        <a asp-action="ClientStats">ClientStats</a> status-code tally.
+    </div>
+
+    @if (Model.LifetimeCounts.Count > 0)
+    {
+        <div class="d-flex gap-2 mb-3 flex-wrap align-items-center">
+            @foreach (var c in Model.LifetimeCounts)
+            {
+                var btnClass = c.StatusCode >= 500 ? "btn-danger" : "btn-warning";
+                <button type="button" class="btn btn-sm status-toggle @btnClass" data-status="@c.StatusCode" aria-pressed="true">@c.StatusCode: @c.Count.ToString("#,##0")</button>
+            }
+            <small class="text-muted align-self-center">(lifetime counts since app start — click to hide/show rows)</small>
+        </div>
+    }
+
+    @if (Model.Entries.Count == 0)
+    {
+        <div class="alert alert-success">
+            <i class="fa-solid fa-check-circle"></i> No error responses in the buffer.
+        </div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-sm table-hover font-monospace" style="font-size: 0.8rem;">
+                <thead>
+                    <tr>
+                        <th style="width: 160px;">Timestamp (UTC)</th>
+                        <th style="width: 60px;">Code</th>
+                        <th style="width: 70px;">Method</th>
+                        <th>URL</th>
+                        <th style="width: 130px;">IP</th>
+                        <th style="width: 160px;">User</th>
+                        <th style="width: 180px;">Client</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var e in Model.Entries)
+                    {
+                        var rowClass = e.StatusCode >= 500 ? "table-danger" : "table-warning";
+                        <tr class="@rowClass" data-status="@e.StatusCode">
+                            <td class="text-nowrap">@e.Timestamp.UtcDateTime.ToInvariantTimestamp()</td>
+                            <td>@e.StatusCode</td>
+                            <td>@e.Method</td>
+                            <td class="text-break">@e.Url</td>
+                            <td>@e.IpAddress</td>
+                            <td>
+                                @if (e.UserId.HasValue)
+                                {
+                                    <vc:human user-id="@e.UserId.Value" />
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
+                                }
+                            </td>
+                            <td><span title="@e.UserAgent">@e.ClientLabel</span></td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>
+
+@section Styles {
+    <style>
+        .status-toggle.status-off {
+            opacity: 0.45;
+            text-decoration: line-through;
+        }
+    </style>
+}
+
+@section Scripts {
+    <script>
+        document.querySelectorAll('.status-toggle').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var status = btn.getAttribute('data-status');
+                var hide = !btn.classList.contains('status-off');
+                btn.classList.toggle('status-off', hide);
+                btn.setAttribute('aria-pressed', (!hide).toString());
+                document.querySelectorAll('tbody tr[data-status="' + status + '"]').forEach(function (row) {
+                    row.classList.toggle('d-none', hide);
+                });
+            });
+        });
+    </script>
+}

--- a/src/Humans.Web/Views/Debug/HttpErrors.cshtml
+++ b/src/Humans.Web/Views/Debug/HttpErrors.cshtml
@@ -66,7 +66,7 @@
                     {
                         var rowClass = e.StatusCode >= 500 ? "table-danger" : "table-warning";
                         <tr class="@rowClass" data-status="@e.StatusCode">
-                            <td class="text-nowrap">@e.Timestamp.UtcDateTime.ToInvariantTimestamp()</td>
+                            <td class="text-nowrap">@e.Timestamp.ToInvariantTimestamp()</td>
                             <td>@e.StatusCode</td>
                             <td>@e.Method</td>
                             <td class="text-break">@e.Url</td>

--- a/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
@@ -1,7 +1,9 @@
 using AwesomeAssertions;
 using Humans.Infrastructure.Services;
 using Humans.Web.Middleware;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
+using Xunit;
 
 namespace Humans.Web.Tests.Services;
 
@@ -9,7 +11,11 @@ public class ClientStatsMiddlewareTests
 {
     private const string WinChrome = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
-    private static async Task<long> RunAsync(string method, int status, string? contentType)
+    private static async Task<ClientStatsTracker> RunAsync(
+        string method,
+        int status,
+        string? contentType,
+        Action<HttpContext>? configure = null)
     {
         var tracker = new ClientStatsTracker();
         var middleware = new ClientStatsMiddleware(ctx =>
@@ -21,26 +27,101 @@ public class ClientStatsMiddlewareTests
 
         var context = new DefaultHttpContext();
         context.Request.Method = method;
+        context.Request.Path = "/some/path";
         context.Request.Headers.UserAgent = WinChrome;
+        configure?.Invoke(context);
 
         await middleware.InvokeAsync(context);
 
-        return tracker.GetSnapshot().TotalPageViews;
+        return tracker;
     }
+
+    private static async Task<long> PageViewsAsync(string method, int status, string? contentType)
+        => (await RunAsync(method, status, contentType)).GetSnapshot().TotalPageViews;
 
     [HumansFact]
     public async Task SuccessfulGetHtml_IsCounted()
-        => (await RunAsync(HttpMethods.Get, 200, "text/html; charset=utf-8")).Should().Be(1);
+        => (await PageViewsAsync(HttpMethods.Get, 200, "text/html; charset=utf-8")).Should().Be(1);
 
     [HumansFact]
     public async Task PostHtml_IsNotCounted()
-        => (await RunAsync(HttpMethods.Post, 200, "text/html; charset=utf-8")).Should().Be(0);
+        => (await PageViewsAsync(HttpMethods.Post, 200, "text/html; charset=utf-8")).Should().Be(0);
 
     [HumansFact]
     public async Task GetErrorPage_IsNotCounted()
-        => (await RunAsync(HttpMethods.Get, 404, "text/html; charset=utf-8")).Should().Be(0);
+        => (await PageViewsAsync(HttpMethods.Get, 404, "text/html; charset=utf-8")).Should().Be(0);
 
     [HumansFact]
     public async Task GetJson_IsNotCounted()
-        => (await RunAsync(HttpMethods.Get, 200, "application/json")).Should().Be(0);
+        => (await PageViewsAsync(HttpMethods.Get, 200, "application/json")).Should().Be(0);
+
+    [HumansFact]
+    public async Task ErrorResponse_IsRecordedWithRequestDetails()
+    {
+        var tracker = await RunAsync(HttpMethods.Post, 404, null,
+            ctx => ctx.Request.QueryString = new QueryString("?q=1"));
+
+        var snap = tracker.GetErrorsSnapshot(10);
+        var entry = snap.Recent.Should().ContainSingle().Subject;
+        entry.StatusCode.Should().Be(404);
+        entry.Method.Should().Be(HttpMethods.Post);
+        entry.Url.Should().Be("/some/path?q=1");
+        entry.UserAgent.Should().Be(WinChrome);
+        snap.LifetimeCounts[404].Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task ServerError_IsRecorded()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 500, null);
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.StatusCode.Should().Be(500);
+    }
+
+    [HumansFact]
+    public async Task SuccessResponse_IsNotRecorded()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "text/html");
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task AbortedRequest_IsRecordedAs499()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "text/html",
+            ctx => ctx.RequestAborted = new CancellationToken(canceled: true));
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.StatusCode.Should().Be(499);
+    }
+
+    [HumansFact]
+    public async Task StatusCodeReExecutePass_IsNotRecorded()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 404, "text/html",
+            ctx => ctx.Features.Set<IStatusCodeReExecuteFeature>(
+                new StatusCodeReExecuteFeature { OriginalPath = "/missing" }));
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task AbortedRequest_ThrowingCancellation_IsRecordedAndRethrown()
+    {
+        var tracker = new ClientStatsTracker();
+        var middleware = new ClientStatsMiddleware(
+            _ => throw new OperationCanceledException(), tracker);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = "/slow";
+        context.RequestAborted = new CancellationToken(canceled: true);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => middleware.InvokeAsync(context));
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.StatusCode.Should().Be(499);
+    }
 }

--- a/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
@@ -98,6 +98,17 @@ public class ClientStatsMiddlewareTests
     }
 
     [HumansFact]
+    public async Task ExceptionHandlerReExecute_RecordsOriginalPath()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 500, "text/html",
+            ctx => ctx.Features.Set<IExceptionHandlerPathFeature>(
+                new ExceptionHandlerFeature { Path = "/teams/broken", Error = new InvalidOperationException() }));
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.Url.Should().Be("/teams/broken");
+    }
+
+    [HumansFact]
     public async Task StatusCodeReExecutePass_IsNotRecorded()
     {
         var tracker = await RunAsync(HttpMethods.Get, 404, "text/html",

--- a/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
@@ -84,6 +84,53 @@ public class ClientStatsTrackerTests
         snap.Resolutions.Should().BeEmpty();
     }
 
+    private static Humans.Application.Interfaces.ClientErrorEntry Error(
+        int status = 404, string url = "/missing", string ua = WinChrome)
+        => new(DateTimeOffset.UtcNow, status, "GET", url, "203.0.113.7", null, ua);
+
+    [HumansFact]
+    public void RecordError_KeepsNewestThousand_AndLifetimeCountsSurviveEviction()
+    {
+        var tracker = new ClientStatsTracker();
+
+        for (var i = 0; i < 1050; i++)
+            tracker.RecordError(Error(url: $"/missing/{i}"));
+
+        var snap = tracker.GetErrorsSnapshot(1000);
+        snap.TotalErrors.Should().Be(1050);
+        snap.LifetimeCounts[404].Should().Be(1050);
+        snap.Recent.Should().HaveCount(1000);
+        // Newest first; the 50 oldest entries were evicted.
+        snap.Recent[0].Url.Should().Be("/missing/1049");
+        snap.Recent[^1].Url.Should().Be("/missing/50");
+    }
+
+    [HumansFact]
+    public void GetErrorsSnapshot_RespectsCount()
+    {
+        var tracker = new ClientStatsTracker();
+
+        for (var i = 0; i < 10; i++)
+            tracker.RecordError(Error(url: $"/missing/{i}"));
+
+        var snap = tracker.GetErrorsSnapshot(3);
+        snap.Recent.Should().HaveCount(3);
+        snap.Recent[0].Url.Should().Be("/missing/9");
+        snap.TotalErrors.Should().Be(10);
+    }
+
+    [HumansFact]
+    public void RecordError_TruncatesUrlAndUserAgent()
+    {
+        var tracker = new ClientStatsTracker();
+
+        tracker.RecordError(Error(url: new string('u', 500), ua: new string('a', 500)));
+
+        var entry = tracker.GetErrorsSnapshot(1).Recent[0];
+        entry.Url.Should().HaveLength(200);
+        entry.UserAgent.Should().HaveLength(150);
+    }
+
     [HumansFact]
     public void RecordResolution_BeyondCap_FoldsIntoOther()
     {

--- a/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
@@ -86,7 +86,7 @@ public class ClientStatsTrackerTests
 
     private static Humans.Application.Interfaces.ClientErrorEntry Error(
         int status = 404, string url = "/missing", string ua = WinChrome)
-        => new(DateTimeOffset.UtcNow, status, "GET", url, "203.0.113.7", null, ua);
+        => new(NodaTime.SystemClock.Instance.GetCurrentInstant(), status, "GET", url, "203.0.113.7", null, ua);
 
     [HumansFact]
     public void RecordError_KeepsNewestThousand_AndLifetimeCountsSurviveEviction()
@@ -129,6 +129,20 @@ public class ClientStatsTrackerTests
         var entry = tracker.GetErrorsSnapshot(1).Recent[0];
         entry.Url.Should().HaveLength(200);
         entry.UserAgent.Should().HaveLength(150);
+    }
+
+    [HumansFact]
+    public void RecordError_DerivesClientLabel()
+    {
+        var tracker = new ClientStatsTracker();
+
+        tracker.RecordError(Error(ua: WinChrome));
+        tracker.RecordError(Error(ua: Googlebot));
+
+        var snap = tracker.GetErrorsSnapshot(2);
+        snap.Recent[1].ClientLabel.Should().Be("Chrome · Windows");
+        // Bots get the crawler name, not the collapsed "Bot" bucket.
+        snap.Recent[0].ClientLabel.Should().NotBeEmpty().And.NotBe("Bot · Bot");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Why

`/Debug/ClientStats` shows ~1000 client errors (400/404/405/499) but the tally comes from a `MeterListener` that only sees `(status code, count)` — no URL, IP, or UA is captured anywhere, so the errors can't be explained.

## What

- **Capture** — `ClientStatsMiddleware` now records every response with **status > 399** after `await next()`. Aborted requests are recorded as **499** (matching the request metric's convention), including aborts that surface as cancellation exceptions. The `UseStatusCodePagesWithReExecute` re-executed pass is skipped so each error records once, with the real request path.
- **Storage** — ring buffer (capacity 1000) on the existing `ClientStatsTracker`, same enqueue-then-trim-under-lock pattern as `InMemoryLogSink`. Entry: UTC time, code, method, URL (truncated 200), IP, authenticated user id, UA (truncated 150) — under 1 MB total. Lifetime per-code counts survive eviction.
- **Page** — `/Debug/HttpErrors`, same setup as `/Debug/Logs`: newest first, `?count=` clamped 1..1000, per-code lifetime-count toggles to hide/show rows, 4xx warning / 5xx danger row coloring, UA shown as classified label (`UserAgentClassifier`) with raw string in tooltip, `<vc:human>` for authenticated users. Linked from the admin nav (Diagnostics) and from the ClientStats status panel.

## Known gap (noted on the page)

Requests Kestrel rejects before the pipeline (malformed HTTP) never reach middleware, so buffer counts can run slightly below the ClientStats meter tally.

## Reuse notes

Extended the existing `IClientStatsTracker` / `ClientStatsTracker` / `ClientStatsMiddleware` vertical instead of adding a new tracker interface + middleware; rejected logging 4xx into `InMemoryLogSink` (bot 404s would evict real warnings).

## Tests

7 new tests: buffer eviction at 1000 + lifetime counts surviving, count clamp, URL/UA truncation, 404 recorded with details, 500 recorded, 200 not recorded, aborted→499 (both paths), re-execute pass skipped. Full suite: 4,568 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)