### PR TITLE
fix: controller audit tier 2 — one-fix-many-sites (A1, T1–T3, E1–E5, E12–E13)

### DIFF
--- a/src/Humans.Application/Events/EventConflictDetector.cs
+++ b/src/Humans.Application/Events/EventConflictDetector.cs
@@ -1,0 +1,44 @@
+using NodaTime;
+
+namespace Humans.Application.Events;
+
+/// <summary>
+/// Single owner of the "two events overlap in time" rule (audit E12/E13):
+/// half-open [start, start + duration) interval intersection. Used by the
+/// personal-schedule conflict flags and the moderation duplicate-candidate scan.
+/// </summary>
+public static class EventConflictDetector
+{
+    public static bool Overlaps(
+        Instant aStartAt, int aDurationMinutes,
+        Instant bStartAt, int bDurationMinutes) =>
+        aStartAt < bStartAt.Plus(Duration.FromMinutes(bDurationMinutes))
+        && bStartAt < aStartAt.Plus(Duration.FromMinutes(aDurationMinutes));
+
+    /// <summary>
+    /// Indexes of every item that overlaps at least one other item.
+    /// O(n²) — input sets are small (one user's schedule, one camp's events).
+    /// </summary>
+    public static IReadOnlySet<int> FindConflictingIndexes<T>(
+        IReadOnlyList<T> items,
+        Func<T, Instant> startAt,
+        Func<T, int> durationMinutes)
+    {
+        var conflicted = new HashSet<int>();
+        for (var i = 0; i < items.Count; i++)
+        {
+            for (var j = i + 1; j < items.Count; j++)
+            {
+                if (Overlaps(
+                        startAt(items[i]), durationMinutes(items[i]),
+                        startAt(items[j]), durationMinutes(items[j])))
+                {
+                    conflicted.Add(i);
+                    conflicted.Add(j);
+                }
+            }
+        }
+
+        return conflicted;
+    }
+}

--- a/src/Humans.Application/Interfaces/Events/EventInfo.cs
+++ b/src/Humans.Application/Interfaces/Events/EventInfo.cs
@@ -211,6 +211,18 @@ public sealed record EventInfo(
     IReadOnlyList<EventModerationHistoryInfo> ModerationHistory)
 {
     /// <summary>
+    /// Whether the submitter may edit/resubmit this event — single source:
+    /// <see cref="Event.IsEditableBySubmitter"/> (camp events have no Draft stage).
+    /// </summary>
+    public bool CanEdit => Event.IsEditableBySubmitter(Status, CampId is not null);
+
+    /// <summary>
+    /// Whether the submitter may withdraw this event — single source:
+    /// <see cref="Event.IsWithdrawableBySubmitter"/>.
+    /// </summary>
+    public bool CanWithdraw => Event.IsWithdrawableBySubmitter(Status, CampId is not null);
+
+    /// <summary>
     /// Expands this event into concrete occurrence instants. A non-null
     /// <paramref name="dayOffset"/> narrows a recurring event to the single
     /// occurrence on that day offset (non-recurring events ignore it).

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -86,6 +86,11 @@ public partial interface IUserRepository : IRepository
     Task<bool> SetICalTokenAsync(Guid userId, Guid token, CancellationToken ct = default);
 
     /// <summary>
+    /// Stamps <c>User.LastLoginAt</c>. Returns false if the user does not exist.
+    /// </summary>
+    Task<bool> SetLastLoginAsync(Guid userId, Instant at, CancellationToken ct = default);
+
+    /// <summary>
     /// Sets <c>User.GoogleEmail</c> if and only if it is currently null.
     /// No-op if the user already has a GoogleEmail set or the user does not
     /// exist. Returns true if the GoogleEmail was set.

--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -380,9 +380,11 @@ public interface ITeamService : ITeamServiceRead, IApplicationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Removes a member from a team (admin action).
+    /// Removes a member from a team (admin action). When the removed member was a
+    /// coordinator, reconciles their Coordinators system-team membership as part of
+    /// the mutation.
     /// </summary>
-    Task<bool> RemoveMemberAsync(
+    Task RemoveMemberAsync(
         Guid teamId,
         Guid userId,
         Guid actorUserId,
@@ -514,14 +516,17 @@ public interface ITeamService : ITeamServiceRead, IApplicationService
     // ==========================================================================
 
     /// <summary>
-    /// Assigns a team member to the next available slot in a role definition.
+    /// Assigns a team member to the next available slot in a role definition,
+    /// then reconciles the target's Coordinators system-team membership
+    /// (management roles promote).
     /// </summary>
     Task<TeamRoleAssignment> AssignToRoleAsync(
         Guid roleDefinitionId, Guid targetUserId, Guid actorUserId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Removes a team member's assignment from a role definition.
+    /// Removes a team member's assignment from a role definition, then
+    /// reconciles the target's Coordinators system-team membership.
     /// </summary>
     Task UnassignFromRoleAsync(
         Guid roleDefinitionId, Guid teamMemberId, Guid actorUserId,

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -137,6 +137,14 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     Task SetICalTokenAsync(Guid userId, Guid token, CancellationToken ct = default);
 
     /// <summary>
+    /// Stamps <c>User.LastLoginAt = now</c> after a successful sign-in (any
+    /// method: OAuth, magic link, gate terminal) and refreshes the cached
+    /// UserInfo. The single owner of the login-stamp rule — sign-in flows must
+    /// not write <c>LastLoginAt</c> directly. No-op if the user does not exist.
+    /// </summary>
+    Task RecordLoginAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
     /// Sets the deletion-pending fields on a user (<c>DeletionRequestedAt</c>,
     /// <c>DeletionScheduledFor</c>, optional <c>DeletionEligibleAfter</c>).
     /// <paramref name="eligibleAfter"/> is the post-event hold date when the

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -1092,7 +1092,7 @@ public sealed class TeamService(
         return TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, teamId, userId);
     }
 
-    public async Task<bool> RemoveMemberAsync(
+    public async Task RemoveMemberAsync(
         Guid teamId,
         Guid userId,
         Guid actorUserId,
@@ -1144,7 +1144,10 @@ public sealed class TeamService(
             logger.LogError(ex, "Failed to dispatch TeamMemberRemoved notification for user {UserId} team {TeamId}", userId, teamId);
         }
 
-        return wasCoordinator;
+        // Removing a coordinator changes their Coordinators system-team eligibility —
+        // reconcile as part of the mutation, not as a caller-remembered follow-up.
+        if (wasCoordinator)
+            await SystemTeamSync.SyncMembershipForUserAsync(userId, SystemTeamType.Coordinators, cancellationToken);
     }
 
     public async Task<TeamMember> AddMemberToTeamAsync(
@@ -1635,6 +1638,10 @@ public sealed class TeamService(
 
         InvalidateShiftAuthorizationIfNeeded(definition, targetUserId);
 
+        // Role assignment can change Coordinators system-team eligibility (management
+        // roles promote) — reconcile as part of the mutation.
+        await SystemTeamSync.SyncMembershipForUserAsync(targetUserId, SystemTeamType.Coordinators, cancellationToken);
+
         return assignment;
     }
 
@@ -1661,6 +1668,9 @@ public sealed class TeamService(
 
         InvalidateShiftAuthorizationIfNeeded(definition, targetUserId);
 
+        // Losing a (possibly management) role can change Coordinators system-team
+        // eligibility — reconcile as part of the mutation.
+        await SystemTeamSync.SyncMembershipForUserAsync(targetUserId, SystemTeamType.Coordinators, cancellationToken);
     }
 
     public Task<IReadOnlyList<Guid>> GetUserCoordinatedTeamIdsAsync(

--- a/src/Humans.Application/Services/Users/AccountProvisioningService.cs
+++ b/src/Humans.Application/Services/Users/AccountProvisioningService.cs
@@ -123,8 +123,7 @@ public sealed class AccountProvisioningService(
                     User: null);
             }
 
-            existingUser.LastLoginAt = clock.GetCurrentInstant();
-            await userManager.UpdateAsync(existingUser);
+            await userService.RecordLoginAsync(existingUser.Id, ct);
             return new MagicLinkSignupCompletionResult(
                 MagicLinkSignupCompletionOutcome.ExistingUser,
                 existingUser);

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -265,6 +265,11 @@ public sealed class UserService(
         await repo.SetICalTokenAsync(userId, token, ct);
     }
 
+    public async Task RecordLoginAsync(Guid userId, CancellationToken ct = default)
+    {
+        await repo.SetLastLoginAsync(userId, clock.GetCurrentInstant(), ct);
+    }
+
     public async Task<bool> SetDeletionPendingAsync(
         Guid userId, Instant requestedAt, Instant scheduledFor, Instant? eligibleAfter,
         CancellationToken ct = default)

--- a/src/Humans.Domain/Entities/Event.cs
+++ b/src/Humans.Domain/Entities/Event.cs
@@ -127,6 +127,46 @@ public class Event
     /// </summary>
     public ICollection<EventFavourite> EventFavourites { get; } = new List<EventFavourite>();
 
+    // Schedule encoding
+
+    /// <summary>All-day events are stored as a midnight start + 1440-minute duration.</summary>
+    public const int AllDayDurationMinutes = 1440;
+
+    /// <summary>
+    /// Resolves the form-level "all day" flag into the stored schedule encoding:
+    /// all-day ⇒ midnight start + <see cref="AllDayDurationMinutes"/>.
+    /// </summary>
+    public static (TimeSpan StartTime, int DurationMinutes) ResolveAllDaySchedule(
+        bool isAllDay, TimeSpan startTime, int durationMinutes) =>
+        isAllDay ? (TimeSpan.Zero, AllDayDurationMinutes) : (startTime, durationMinutes);
+
+    /// <summary>True when the stored duration carries the all-day encoding.</summary>
+    public bool IsAllDay => DurationMinutes == AllDayDurationMinutes;
+
+    // Submitter eligibility predicates
+
+    /// <summary>
+    /// Statuses the submitter may edit/resubmit from. Camp (barrio) events have
+    /// no Draft stage; individual events may also be edited while Draft.
+    /// </summary>
+    public static bool IsEditableBySubmitter(EventStatus status, bool isCampEvent) =>
+        status is EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested
+        || (!isCampEvent && status is EventStatus.Draft);
+
+    /// <summary>
+    /// Statuses the submitter may withdraw from. Camp (barrio) events have no
+    /// Draft stage.
+    /// </summary>
+    public static bool IsWithdrawableBySubmitter(EventStatus status, bool isCampEvent) =>
+        status is EventStatus.Pending or EventStatus.Approved
+        || (!isCampEvent && status is EventStatus.Draft);
+
+    /// <inheritdoc cref="IsEditableBySubmitter(EventStatus, bool)"/>
+    public bool CanBeEditedBySubmitter => IsEditableBySubmitter(Status, CampId is not null);
+
+    /// <inheritdoc cref="IsWithdrawableBySubmitter(EventStatus, bool)"/>
+    public bool CanBeWithdrawnBySubmitter => IsWithdrawableBySubmitter(Status, CampId is not null);
+
     // State transition methods
 
     /// <summary>
@@ -144,11 +184,12 @@ public class Event
     }
 
     /// <summary>
-    /// Withdraw the submission. Available from Draft, Pending, or Approved.
+    /// Withdraw the submission. Available from Pending or Approved — plus Draft
+    /// for individual events (camp events have no Draft stage).
     /// </summary>
     public void Withdraw(IClock clock)
     {
-        if (Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Approved))
+        if (!CanBeWithdrawnBySubmitter)
             throw new InvalidOperationException($"Cannot withdraw event in {Status} state");
         Status = EventStatus.Withdrawn;
         LastUpdatedAt = clock.GetCurrentInstant();

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -343,8 +343,16 @@ public class SystemTeamSyncJob(
     public Task SyncMembershipForUserAsync(
         Guid userId,
         SystemTeamType teamType,
-        CancellationToken cancellationToken = default) =>
-        teamType switch
+        CancellationToken cancellationToken = default)
+    {
+        // Several callers invoke this from inside their own mutation — e.g.
+        // TeamService.AssignToRoleAsync runs within CachingTeamService's delegate,
+        // before the decorator invalidates — so the cached team set still shows
+        // pre-mutation roles. The mutation is already committed; drop the cache so
+        // the eligibility reads below see the post-mutation state.
+        teamService.InvalidateActiveTeamsCache();
+
+        return teamType switch
         {
             SystemTeamType.Volunteers => SyncVolunteersMembershipForUserAsync(userId, cancellationToken),
             SystemTeamType.Coordinators => SyncCoordinatorsMembershipForUserAsync(userId, cancellationToken),
@@ -355,6 +363,7 @@ public class SystemTeamSyncJob(
             SystemTeamType.BarrioLeads => SyncBarrioLeadsMembershipForUserAsync(userId, cancellationToken),
             _ => throw new ArgumentOutOfRangeException(nameof(teamType), teamType, "System team does not support per-user sync.")
         };
+    }
 
     /// <summary>
     /// Syncs Volunteers team membership for a single user. Call this after approving

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -154,6 +154,19 @@ internal sealed partial class UserRepository : IUserRepository
         return true;
     }
 
+    public async Task<bool> SetLastLoginAsync(
+        Guid userId, Instant at, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var user = await ctx.Users.FindAsync([userId], ct);
+        if (user is null)
+            return false;
+
+        user.LastLoginAt = at;
+        await ctx.SaveChangesAsync(ct);
+        return true;
+    }
+
     public async Task<bool> TrySetGoogleEmailAsync(
         Guid userId, string email, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
+++ b/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
@@ -593,16 +593,15 @@ public sealed class CachingTeamService(
         return TeamCoordinatorAccess.IsCoordinatorOfActiveTeam(teamsById, teamId, userId);
     }
 
-    public async Task<bool> RemoveMemberAsync(
+    public async Task RemoveMemberAsync(
         Guid teamId,
         Guid userId,
         Guid actorUserId,
         CancellationToken cancellationToken = default)
     {
-        var result = await WithInner(inner => inner.RemoveMemberAsync(
+        await WithInner(inner => inner.RemoveMemberAsync(
             teamId, userId, actorUserId, cancellationToken));
         InvalidateTeamsCache();
-        return result;
     }
 
     public async Task<IReadOnlyDictionary<Guid, string>> GetManagementRoleNamesByTeamIdsAsync(

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -547,6 +547,12 @@ public sealed class CachingUserService(
         await RefreshEntryAsync(userId, ct);
     }
 
+    public async Task RecordLoginAsync(Guid userId, CancellationToken ct = default)
+    {
+        await WithInnerAsync(inner => inner.RecordLoginAsync(userId, ct));
+        await RefreshEntryAsync(userId, ct);
+    }
+
     public async Task<bool> SetDeletionPendingAsync(
         Guid userId, Instant requestedAt, Instant scheduledFor, Instant? eligibleAfter,
         CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -111,8 +111,7 @@ public class AccountController(
         var existingUser = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
         if (existingUser is not null)
         {
-            existingUser.LastLoginAt = clock.GetCurrentInstant();
-            await userManager.UpdateAsync(existingUser);
+            await userService.RecordLoginAsync(existingUser.Id);
             await TryReconcileOAuthIdentityAsync(existingUser.Id, info);
         }
 
@@ -135,8 +134,7 @@ public class AccountController(
         var addLinkResult = await userManager.AddLoginAsync(currentUser, info);
         if (addLinkResult.Succeeded)
         {
-            currentUser.LastLoginAt = clock.GetCurrentInstant();
-            await userManager.UpdateAsync(currentUser);
+            await userService.RecordLoginAsync(currentUser.Id);
 
             if (!string.IsNullOrEmpty(email))
                 await TryReconcileOAuthIdentityAsync(currentUser.Id, info);
@@ -196,8 +194,7 @@ public class AccountController(
                 return null;
             }
 
-            activeTarget.LastLoginAt = clock.GetCurrentInstant();
-            await userManager.UpdateAsync(activeTarget);
+            await userService.RecordLoginAsync(activeTarget.Id);
             await signInManager.SignInAsync(activeTarget, isPersistent: false);
             await TryReconcileOAuthIdentityAsync(activeTarget.Id, info);
 
@@ -231,8 +228,7 @@ public class AccountController(
             var linkResult = await userManager.AddLoginAsync(existingByEmail, info);
             if (linkResult.Succeeded)
             {
-                existingByEmail.LastLoginAt = clock.GetCurrentInstant();
-                await userManager.UpdateAsync(existingByEmail);
+                await userService.RecordLoginAsync(existingByEmail.Id);
                 await TryReconcileOAuthIdentityAsync(existingByEmail.Id, info);
 
                 await signInManager.SignInAsync(existingByEmail, isPersistent: false);
@@ -470,8 +466,7 @@ public class AccountController(
             return View("MagicLinkError");
         }
 
-        user.LastLoginAt = clock.GetCurrentInstant();
-        await userManager.UpdateAsync(user);
+        await userService.RecordLoginAsync(user.Id);
 
         await signInManager.SignInAsync(user, isPersistent: false);
         logger.LogInformation("User {UserId} logged in via magic link", user.Id);
@@ -595,8 +590,7 @@ public class AccountController(
 
         gateThrottle.Reset(source);
 
-        user.LastLoginAt = clock.GetCurrentInstant();
-        await userManager.UpdateAsync(user);
+        await userService.RecordLoginAsync(user.Id);
 
         await signInManager.SignInAsync(user, isPersistent: true);
         logger.LogInformation("Gate terminal signed in");

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -85,8 +85,8 @@ public class EventsController(
                     DurationMinutes = e.DurationMinutes,
                     Status = e.Status,
                     PriorityRank = e.PriorityRank,
-                    CanEdit = e.Status is EventStatus.Rejected or EventStatus.ResubmitRequested or EventStatus.Pending,
-                    CanWithdraw = e.Status is EventStatus.Pending or EventStatus.Approved
+                    CanEdit = e.CanEdit,
+                    CanWithdraw = e.CanWithdraw
                 }).ToList()
             });
         }
@@ -118,8 +118,8 @@ public class EventsController(
                     StartAt = ToLocalDateTime(e.StartAt, tz),
                     DurationMinutes = e.DurationMinutes,
                     Status = e.Status,
-                    CanEdit = e.Status is EventStatus.Draft or EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested,
-                    CanWithdraw = e.Status is EventStatus.Draft or EventStatus.Pending or EventStatus.Approved
+                    CanEdit = e.CanEdit,
+                    CanWithdraw = e.CanWithdraw
                 }).ToList()
             },
             Barrios = barrioBlocks
@@ -168,8 +168,8 @@ public class EventsController(
         }
 
         var tz = GetTimeZone(eventSettings);
-        var durationMinutes = model.IsAllDay ? 1440 : model.DurationMinutes;
-        var startTime = model.IsAllDay ? TimeSpan.Zero : model.StartTime;
+        var (startTime, durationMinutes) = Event.ResolveAllDaySchedule(
+            model.IsAllDay, model.StartTime, model.DurationMinutes);
 
         var guideEvent = new Event
         {
@@ -223,7 +223,7 @@ public class EventsController(
         if (guideEvent.SubmitterUserId != user.Id && !RoleChecks.IsEventsAdmin(User))
             return Forbid();
 
-        if (guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
+        if (!guideEvent.CanBeEditedBySubmitter)
         {
             SetError("This event cannot be edited in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -249,7 +249,7 @@ public class EventsController(
         model.VenueId = guideEvent.GuideSharedVenueId ?? Guid.Empty;
         model.StartDate = localStart.Date;
         model.StartTime = localStart.TimeOfDay;
-        model.IsAllDay = guideEvent.DurationMinutes == 1440;
+        model.IsAllDay = guideEvent.IsAllDay;
         model.DurationMinutes = guideEvent.DurationMinutes;
         model.LocationNote = guideEvent.LocationNote;
         model.Host = guideEvent.Host;
@@ -277,7 +277,7 @@ public class EventsController(
         if (guideEvent.SubmitterUserId != user.Id && !RoleChecks.IsEventsAdmin(User))
             return Forbid();
 
-        if (guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
+        if (!guideEvent.CanBeEditedBySubmitter)
         {
             SetError("This event cannot be edited in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -301,8 +301,8 @@ public class EventsController(
         }
 
         var tz = GetTimeZone(eventSettings);
-        var durationMinutes = model.IsAllDay ? 1440 : model.DurationMinutes;
-        var startTime = model.IsAllDay ? TimeSpan.Zero : model.StartTime;
+        var (startTime, durationMinutes) = Event.ResolveAllDaySchedule(
+            model.IsAllDay, model.StartTime, model.DurationMinutes);
 
         guideEvent.Title = model.Title;
         guideEvent.Description = model.Description;
@@ -343,7 +343,7 @@ public class EventsController(
         var guideEvent = await guide.GetUserEventAsync(eventId, user.Id);
         if (guideEvent == null) return NotFound();
 
-        if (guideEvent.Status is not (EventStatus.Draft or EventStatus.Pending or EventStatus.Approved))
+        if (!guideEvent.CanBeWithdrawnBySubmitter)
         {
             SetError("This event cannot be withdrawn in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -750,7 +750,7 @@ public class EventsController(
         var guideEvent = await guide.GetCampEventAsync(eventId, camp.Id);
         if (guideEvent == null) return NotFound();
 
-        if (guideEvent.Status is not (EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
+        if (!guideEvent.CanBeEditedBySubmitter)
         {
             SetError("This event cannot be edited in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -796,7 +796,7 @@ public class EventsController(
         var guideEvent = await guide.GetCampEventAsync(eventId, camp.Id);
         if (guideEvent == null) return NotFound();
 
-        if (guideEvent.Status is not (EventStatus.Pending or EventStatus.Rejected or EventStatus.ResubmitRequested))
+        if (!guideEvent.CanBeEditedBySubmitter)
         {
             SetError("This event cannot be edited in its current state.");
             return RedirectToAction(nameof(MySubmissions));
@@ -860,7 +860,7 @@ public class EventsController(
         var guideEvent = await guide.GetCampEventAsync(eventId, camp.Id);
         if (guideEvent == null) return NotFound();
 
-        if (guideEvent.Status is not (EventStatus.Pending or EventStatus.Approved))
+        if (!guideEvent.CanBeWithdrawnBySubmitter)
         {
             SetError("This event cannot be withdrawn in its current state.");
             return RedirectToAction(nameof(MySubmissions));

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -419,20 +419,10 @@ public class EventsController(
         }).OrderBy(i => i.StartInstant).ToList();
 
         // Detect time conflicts
-        for (var i = 0; i < scheduleItems.Count; i++)
+        foreach (var index in EventConflictDetector.FindConflictingIndexes(
+                     scheduleItems, i => i.StartInstant, i => i.DurationMinutes))
         {
-            for (var j = i + 1; j < scheduleItems.Count; j++)
-            {
-                var a = scheduleItems[i];
-                var b = scheduleItems[j];
-                var aEnd = a.StartInstant.Plus(Duration.FromMinutes(a.DurationMinutes));
-                var bEnd = b.StartInstant.Plus(Duration.FromMinutes(b.DurationMinutes));
-                if (a.StartInstant < bEnd && b.StartInstant < aEnd)
-                {
-                    a.HasConflict = true;
-                    b.HasConflict = true;
-                }
-            }
+            scheduleItems[index].HasConflict = true;
         }
 
         var model = new ScheduleViewModel

--- a/src/Humans.Web/Controllers/EventsModerationController.cs
+++ b/src/Humans.Web/Controllers/EventsModerationController.cs
@@ -180,7 +180,7 @@ public class EventsModerationController(
             VenueId = guideEvent.GuideSharedVenueId,
             StartDate = localStart.Date,
             StartTime = localStart.TimeOfDay,
-            IsAllDay = guideEvent.DurationMinutes == 1440,
+            IsAllDay = guideEvent.IsAllDay,
             DurationMinutes = guideEvent.DurationMinutes,
             LocationNote = guideEvent.LocationNote,
             Host = guideEvent.Host,
@@ -306,12 +306,13 @@ public class EventsModerationController(
     // rank; individual events carry a venue and the all-day flag.
     private void ApplyFormToEvent(Event guideEvent, AdminEventFormViewModel model, bool isCampEvent, DateTimeZone? tz)
     {
-        var isAllDay = !isCampEvent && model.IsAllDay;
+        var (startTime, durationMinutes) = Event.ResolveAllDaySchedule(
+            !isCampEvent && model.IsAllDay, model.StartTime, model.DurationMinutes);
         guideEvent.Title = model.Title;
         guideEvent.Description = model.Description;
         guideEvent.CategoryId = model.CategoryId;
-        guideEvent.StartAt = ToInstant(model.StartDate.Add(isAllDay ? TimeSpan.Zero : model.StartTime), tz);
-        guideEvent.DurationMinutes = isAllDay ? 1440 : model.DurationMinutes;
+        guideEvent.StartAt = ToInstant(model.StartDate.Add(startTime), tz);
+        guideEvent.DurationMinutes = durationMinutes;
         guideEvent.LocationNote = model.LocationNote;
         guideEvent.Host = model.Host;
         guideEvent.IsRecurring = model.IsRecurring;

--- a/src/Humans.Web/Controllers/EventsModerationController.cs
+++ b/src/Humans.Web/Controllers/EventsModerationController.cs
@@ -1,4 +1,5 @@
 using Humans.Application;
+using Humans.Application.Events;
 using Humans.Application.Architecture;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Email;
@@ -74,12 +75,12 @@ public class EventsModerationController(
                 var evt = campEvents.FirstOrDefault(e => e.Id == row.Id);
                 if (evt?.CampId == null) continue;
 
-                var endAt = evt.StartAt.Plus(Duration.FromMinutes(evt.DurationMinutes));
                 row.DuplicateCandidates = allCampEvents
                     .Where(other => other.Id != evt.Id
                                  && other.CampId == evt.CampId
-                                 && other.StartAt < endAt
-                                 && evt.StartAt < other.StartAt.Plus(Duration.FromMinutes(other.DurationMinutes)))
+                                 && EventConflictDetector.Overlaps(
+                                     other.StartAt, other.DurationMinutes,
+                                     evt.StartAt, evt.DurationMinutes))
                     .Select(other => new DuplicateCandidateViewModel
                     {
                         Id = other.Id,

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -29,7 +29,6 @@ public class TeamAdminController(
     IUserServiceRead userService,
     IEmailProvisioningService emailProvisioningService,
     IAuthorizationService authorizationService,
-    ISystemTeamSync systemTeamSyncJob,
     ILogger<TeamAdminController> logger,
     IStringLocalizer<SharedResource> localizer,
     ITicketServiceRead tickets)
@@ -222,11 +221,7 @@ public class TeamAdminController(
 
         try
         {
-            var wasCoordinator = await _teamService.RemoveMemberAsync(team.Id, userId, user.Id);
-            if (wasCoordinator)
-            {
-                await systemTeamSyncJob.SyncMembershipForUserAsync(userId, SystemTeamType.Coordinators);
-            }
+            await _teamService.RemoveMemberAsync(team.Id, userId, user.Id);
             SetSuccess(localizer["TeamAdmin_MemberRemoved"].Value);
         }
         catch (InvalidOperationException ex)
@@ -824,7 +819,6 @@ public class TeamAdminController(
         try
         {
             await _teamService.AssignToRoleAsync(roleId, model.UserId, user.Id);
-            await systemTeamSyncJob.SyncMembershipForUserAsync(model.UserId, SystemTeamType.Coordinators);
             SetSuccess("Member assigned to role.");
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
@@ -848,17 +842,7 @@ public class TeamAdminController(
 
         try
         {
-            var teamInfo = await _teamService.GetTeamAsync(team.Id);
-            var member = teamInfo?.Members.FirstOrDefault(m => m.TeamMemberId == memberId);
-            var userId = member?.UserId;
-
             await _teamService.UnassignFromRoleAsync(roleId, memberId, user.Id);
-
-            if (userId.HasValue)
-            {
-                await systemTeamSyncJob.SyncMembershipForUserAsync(userId.Value, SystemTeamType.Coordinators);
-            }
-
             SetSuccess("Member unassigned from role.");
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)

--- a/tests/Humans.Application.Tests/Controllers/AccountControllerGateLoginTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/AccountControllerGateLoginTests.cs
@@ -35,6 +35,7 @@ public class AccountControllerGateLoginTests
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 6, 10, 12, 0));
     private readonly UserManager<User> _userManager;
     private readonly SignInManager<User> _signInManager;
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly GateLoginThrottle _throttle;
     private readonly AccountController _controller;
 
@@ -68,7 +69,7 @@ public class AccountControllerGateLoginTests
 
         _controller = new AccountController(
             _signInManager,
-            Substitute.For<IUserService>(),
+            _userService,
             _userManager,
             _clock,
             NullLogger<AccountController>.Instance,
@@ -228,8 +229,8 @@ public class AccountControllerGateLoginTests
 
         // Persistent session so the laptop survives restarts without an admin.
         await _signInManager.Received(1).SignInAsync(_gateUser, true, Arg.Any<string?>());
-        _gateUser.LastLoginAt.Should().Be(_clock.GetCurrentInstant());
-        await _userManager.Received(1).UpdateAsync(_gateUser);
+        // Login stamp goes through the single owner of the rule (A1).
+        await _userService.Received(1).RecordLoginAsync(_gateUser.Id, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Events/EventConflictDetectorTests.cs
+++ b/tests/Humans.Application.Tests/Events/EventConflictDetectorTests.cs
@@ -1,0 +1,44 @@
+using AwesomeAssertions;
+using Humans.Application.Events;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests.Events;
+
+public sealed class EventConflictDetectorTests
+{
+    private static readonly Instant T0 = Instant.FromUtc(2026, 7, 1, 10, 0);
+
+    [HumansTheory]
+    [InlineData(0, 60, 30, 60, true)]    // partial overlap
+    [InlineData(0, 60, 0, 30, true)]     // containment
+    [InlineData(0, 60, 60, 60, false)]   // back-to-back: half-open, no conflict
+    [InlineData(0, 60, 90, 60, false)]   // disjoint
+    public void Overlaps_HalfOpenIntervalSemantics(
+        int aOffsetMinutes, int aDuration, int bOffsetMinutes, int bDuration, bool expected)
+    {
+        var a = T0.Plus(Duration.FromMinutes(aOffsetMinutes));
+        var b = T0.Plus(Duration.FromMinutes(bOffsetMinutes));
+
+        EventConflictDetector.Overlaps(a, aDuration, b, bDuration).Should().Be(expected);
+        // Symmetric.
+        EventConflictDetector.Overlaps(b, bDuration, a, aDuration).Should().Be(expected);
+    }
+
+    [HumansFact]
+    public void FindConflictingIndexes_FlagsBothSidesOfEachOverlap_AndNothingElse()
+    {
+        // [0] 10:00-11:00 overlaps [1] 10:30-11:30; [2] 12:00-13:00 is clear.
+        var items = new[]
+        {
+            (StartAt: T0, Minutes: 60),
+            (StartAt: T0.Plus(Duration.FromMinutes(30)), Minutes: 60),
+            (StartAt: T0.Plus(Duration.FromMinutes(120)), Minutes: 60),
+        };
+
+        var conflicted = EventConflictDetector.FindConflictingIndexes(
+            items, i => i.StartAt, i => i.Minutes);
+
+        conflicted.Should().BeEquivalentTo([0, 1]);
+    }
+}

--- a/tests/Humans.Application.Tests/Repositories/UserRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/UserRepositoryTests.cs
@@ -58,6 +58,33 @@ public sealed class UserRepositoryTests : IDisposable
     }
 
     // ==========================================================================
+    // SetLastLoginAsync (A1 — single owner of the login stamp)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SetLastLoginAsync_StampsLastLoginAt_AndReturnsTrue()
+    {
+        var user = await SeedUserAsync();
+        var at = _clock.GetCurrentInstant();
+
+        var result = await _repo.SetLastLoginAsync(user.Id, at, Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeTrue();
+        _dbContext.ChangeTracker.Clear();
+        var reloaded = await _dbContext.Users.SingleAsync(u => u.Id == user.Id, Xunit.TestContext.Current.CancellationToken);
+        reloaded.LastLoginAt.Should().Be(at);
+    }
+
+    [HumansFact]
+    public async Task SetLastLoginAsync_ReturnsFalse_WhenUserDoesNotExist()
+    {
+        var result = await _repo.SetLastLoginAsync(
+            Guid.NewGuid(), _clock.GetCurrentInstant(), Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    // ==========================================================================
     // TrySetGoogleEmailAsync
     // ==========================================================================
 

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -140,6 +140,8 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<bool> SetICalTokenAsync(Guid userId, Guid token, CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task<bool> SetLastLoginAsync(Guid userId, Instant at, CancellationToken ct = default) =>
+            throw new NotSupportedException();
         public Task<bool> TrySetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<bool> SetDeletionPendingAsync(
@@ -853,8 +855,8 @@ public class AccountProvisioningServiceTests
 
         result.Outcome.Should().Be(MagicLinkSignupCompletionOutcome.ExistingUser);
         result.User.Should().BeSameAs(user);
-        user.LastLoginAt.Should().Be(_clock.GetCurrentInstant());
-        await _userManager.Received(1).UpdateAsync(user);
+        // Login stamp goes through the single owner of the rule (A1).
+        await _userService.Received(1).RecordLoginAsync(user.Id, Arg.Any<CancellationToken>());
         await _userManager.DidNotReceive().CreateAsync(Arg.Any<User>());
     }
 

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1033,6 +1033,7 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task<bool> TrySetGoogleEmailStatusFromSyncAsync(Guid userId, GoogleEmailStatus status, CancellationToken ct = default) => throw new NotSupportedException();
         public Task SetPreferredLanguageAsync(Guid userId, string preferredLanguage, CancellationToken ct = default) => throw new NotSupportedException();
         public Task SetICalTokenAsync(Guid userId, Guid token, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task RecordLoginAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetDeletionPendingAsync(Guid userId, Instant requestedAt, Instant scheduledFor, Instant? eligibleAfter, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> ClearDeletionAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> EnsureStubProfileAsync(Guid userId, string? burnerName = null, string? firstName = null, string? lastName = null, CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1135,7 +1135,7 @@ public sealed class ShiftDashboardMetricsTests : ServiceTestHarness
         public Task<IReadOnlyList<TeamJoinRequestSnapshot>> GetPendingRequestsForTeamAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<TeamJoinRequestSnapshot?> GetUserPendingRequestAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<bool> IsUserCoordinatorOfTeamAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-        public Task<bool> RemoveMemberAsync(Guid teamId, Guid userId, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task RemoveMemberAsync(Guid teamId, Guid userId, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyDictionary<Guid, string>> GetManagementRoleNamesByTeamIdsAsync(IEnumerable<Guid> teamIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<(bool Updated, string? PreviousPrefix)> SetGoogleGroupPrefixAsync(Guid teamId, string? prefix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<AdminTeamListResult> GetAdminTeamListAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
+++ b/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
@@ -160,4 +160,26 @@ public class SystemTeamSyncJobBarrioLeadsTests
             Arg.Any<Instant>(),
             Arg.Any<CancellationToken>());
     }
+
+    [HumansFact]
+    public async Task SyncMembershipForUserAsync_InvalidatesTeamCacheBeforeReading()
+    {
+        // Several services call the per-user sync from inside their own mutation,
+        // before CachingTeamService has invalidated — the job must drop the cache
+        // first or its eligibility reads see the pre-mutation team set.
+        var userId = Guid.NewGuid();
+        StubBarrioLeadsTeam();
+        _campRepository.IsLeadAnywhereAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var job = CreateJob();
+
+        await job.SyncMembershipForUserAsync(userId, SystemTeamType.BarrioLeads, Xunit.TestContext.Current.CancellationToken);
+
+        Received.InOrder(() =>
+        {
+            _teamService.InvalidateActiveTeamsCache();
+            _ = _teamService.GetTeamsAsync(Arg.Any<CancellationToken>());
+        });
+    }
 }

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -38,6 +38,7 @@ public sealed class TeamServiceTests : ServiceTestHarness
     private readonly TeamService _service;
     private readonly RoleAssignmentService _roleAssignmentService;
     private readonly ITeamResourceService _teamResourceService;
+    private readonly ISystemTeamSync _systemTeamSync = Substitute.For<ISystemTeamSync>();
 
     public TeamServiceTests()
     {
@@ -67,7 +68,7 @@ public sealed class TeamServiceTests : ServiceTestHarness
             .With<ITeamService>()
             .With<IRoleAssignmentService>(_roleAssignmentService)
             .With<IEmailService>()
-            .With<ISystemTeamSync>()
+            .With(_systemTeamSync)
             .With<IGoogleSyncOutboxService>(googleOutboxService)
             .With(_teamResourceService)
             .With(userService)
@@ -957,7 +958,7 @@ public sealed class TeamServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
-    public async Task RemoveMemberAsync_RegularMember_SetsLeftAtAndReturnsFalse()
+    public async Task RemoveMemberAsync_RegularMember_SetsLeftAt_WithoutCoordinatorSync()
     {
         var actor = SeedUser(displayName: "Actor");
         var target = SeedUser(displayName: "Target");
@@ -966,16 +967,17 @@ public sealed class TeamServiceTests : ServiceTestHarness
         var member = SeedTeamMember(team.Id, target.Id);
         await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
-        var wasCoordinator = await _service.RemoveMemberAsync(team.Id, target.Id, actor.Id, Xunit.TestContext.Current.CancellationToken);
+        await _service.RemoveMemberAsync(team.Id, target.Id, actor.Id, Xunit.TestContext.Current.CancellationToken);
 
-        wasCoordinator.Should().BeFalse();
         Db.ChangeTracker.Clear();
         var reloaded = await Db.TeamMembers.AsNoTracking().SingleAsync(tm => tm.Id == member.Id, Xunit.TestContext.Current.CancellationToken);
         reloaded.LeftAt.Should().Be(Clock.GetCurrentInstant());
+        await _systemTeamSync.DidNotReceive().SyncMembershipForUserAsync(
+            Arg.Any<Guid>(), Arg.Any<SystemTeamType>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
-    public async Task RemoveMemberAsync_Coordinator_ReturnsTrue()
+    public async Task RemoveMemberAsync_Coordinator_SyncsCoordinatorsSystemTeam()
     {
         var actor = SeedUser(displayName: "Actor");
         SeedRoleAssignment(actor.Id, RoleNames.Admin,
@@ -985,9 +987,11 @@ public sealed class TeamServiceTests : ServiceTestHarness
         SeedTeamMember(team.Id, target.Id, TeamMemberRole.Coordinator);
         await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
-        var wasCoordinator = await _service.RemoveMemberAsync(team.Id, target.Id, actor.Id, Xunit.TestContext.Current.CancellationToken);
+        await _service.RemoveMemberAsync(team.Id, target.Id, actor.Id, Xunit.TestContext.Current.CancellationToken);
 
-        wasCoordinator.Should().BeTrue();
+        // The coordinator-eligibility reconcile is part of the mutation (T1).
+        await _systemTeamSync.Received(1).SyncMembershipForUserAsync(
+            target.Id, SystemTeamType.Coordinators, Arg.Any<CancellationToken>());
     }
 
     // ==========================================================================

--- a/tests/Humans.Domain.Tests/Entities/EventTests.cs
+++ b/tests/Humans.Domain.Tests/Entities/EventTests.cs
@@ -78,6 +78,65 @@ public class EventTests
             .WithMessage($"Cannot withdraw event in {source} state");
     }
 
+    [HumansFact]
+    public void Withdraw_CampEventInDraft_Throws()
+    {
+        // Camp (barrio) events have no Draft stage — the asymmetry the
+        // controllers used to encode is now owned by the entity (E2-E4).
+        var guideEvent = CreateEvent(EventStatus.Draft);
+        guideEvent.CampId = Guid.NewGuid();
+
+        var action = () => guideEvent.Withdraw(_clock);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("Cannot withdraw event in Draft state");
+    }
+
+    [HumansTheory]
+    [InlineData(EventStatus.Draft, false, true)]
+    [InlineData(EventStatus.Draft, true, false)]   // camp events have no Draft stage
+    [InlineData(EventStatus.Pending, false, true)]
+    [InlineData(EventStatus.Pending, true, true)]
+    [InlineData(EventStatus.Rejected, false, true)]
+    [InlineData(EventStatus.Rejected, true, true)]
+    [InlineData(EventStatus.ResubmitRequested, false, true)]
+    [InlineData(EventStatus.ResubmitRequested, true, true)]
+    [InlineData(EventStatus.Approved, false, false)]
+    [InlineData(EventStatus.Withdrawn, false, false)]
+    public void IsEditableBySubmitter_CoversStatusAndCampAsymmetry(
+        EventStatus status, bool isCampEvent, bool expected)
+    {
+        Event.IsEditableBySubmitter(status, isCampEvent).Should().Be(expected);
+    }
+
+    [HumansTheory]
+    [InlineData(EventStatus.Draft, false, true)]
+    [InlineData(EventStatus.Draft, true, false)]   // camp events have no Draft stage
+    [InlineData(EventStatus.Pending, false, true)]
+    [InlineData(EventStatus.Pending, true, true)]
+    [InlineData(EventStatus.Approved, false, true)]
+    [InlineData(EventStatus.Approved, true, true)]
+    [InlineData(EventStatus.Rejected, false, false)]
+    [InlineData(EventStatus.Withdrawn, false, false)]
+    public void IsWithdrawableBySubmitter_CoversStatusAndCampAsymmetry(
+        EventStatus status, bool isCampEvent, bool expected)
+    {
+        Event.IsWithdrawableBySubmitter(status, isCampEvent).Should().Be(expected);
+    }
+
+    [HumansTheory]
+    [InlineData(true, 90, 1440)]
+    [InlineData(false, 90, 90)]
+    public void ResolveAllDaySchedule_AllDayMeansMidnightStartFullDay(
+        bool isAllDay, int requestedMinutes, int expectedMinutes)
+    {
+        var (startTime, durationMinutes) = Event.ResolveAllDaySchedule(
+            isAllDay, new TimeSpan(14, 30, 0), requestedMinutes);
+
+        durationMinutes.Should().Be(expectedMinutes);
+        startTime.Should().Be(isAllDay ? TimeSpan.Zero : new TimeSpan(14, 30, 0));
+    }
+
     [HumansTheory]
     [InlineData(EventModerationActionType.Approved, EventStatus.Approved)]
     [InlineData(EventModerationActionType.Rejected, EventStatus.Rejected)]


### PR DESCRIPTION
## Summary

Tier 2 (one-fix-many-sites) of the controller-intent-audit fixes, per `docs/debt/controller-intent-audit-2026-06-12.md` (#992). Tier 1 is #994. One commit per cluster.

| Finding | Fix |
|---|---|
| **A1** — `LastLoginAt` stamped at 7 AccountController sites (+1 service-side copy), each via entity mutation + `UserManager.UpdateAsync`, bypassing the UserInfo cache | `IUserService.RecordLoginAsync` is the single owner (repo stamp + cache refresh via `CachingUserService`); all post-login sites delegated. The new-user creation-time initializer stays — that chain moves with A3 in tier 3 |
| **T1–T3** — coordinator-sync trio: three TeamAdminController actions decided when the Coordinators system team needed reconciling (returned-bool inspection, unconditional sync, lookup→mutate→sync) | `ITeamService` owns the reconcile inside `RemoveMemberAsync` / `AssignToRoleAsync` / `UnassignFromRoleAsync` via the existing lazy `ISystemTeamSync`; the `wasCoordinator` bool is off the public surface; controller drops its `ISystemTeamSync` dependency |
| **E1–E4** — `CanEdit`/`CanWithdraw` status sets re-derived at 8 sites with an undocumented barrio-vs-individual asymmetry (`Event.Withdraw()` allowed Draft for camp events) | predicates live once on the `Event` entity (`IsEditableBySubmitter`/`IsWithdrawableBySubmitter` + instance properties; computed `CanEdit`/`CanWithdraw` on `EventInfo`); `Withdraw()` now enforces the camp asymmetry; all sites consume the shared predicate |
| **E5** — all-day ⇒ midnight start + 1440 min applied at 3 form-mapping sites | `Event.ResolveAllDaySchedule` / `Event.IsAllDay` own the encoding |
| **E12–E13** — interval-overlap algorithm written twice (schedule conflicts, moderation duplicate candidates) | shared `Humans.Application.Events.EventConflictDetector` |

## Test plan

- New tests: repo login stamp, coordinator sync presence/absence on member removal, full predicate truth tables incl. the camp-Draft asymmetry (now-throwing `Withdraw`), all-day resolution, half-open overlap semantics
- Full suite: 4,598 passed, 0 failed

Tier 3 (workflow moves) and tier 4 (DTO enrichment) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)