### PR TITLE
fix(profile): UnlinkAsync lockout guard must run for unverified linked rows

### DIFF
--- a/src/Humans.Application/Services/Profiles/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profiles/UserEmailService.cs
@@ -850,18 +850,22 @@ public sealed class UserEmailService(
             return false;
 
         // Auth-method invariant: at least one verified email must remain after unlink —
-        // otherwise a programmatic unlink locks the user out of sign-in entirely.
-        // Checked before RemoveLoginAsync so a refusal mutates nothing.
-        if (row.IsVerified)
+        // otherwise a programmatic unlink locks the user out of sign-in entirely (magic
+        // link also requires a verified address). This runs regardless of whether the
+        // row being unlinked is itself verified: an unverified row can still carry the
+        // user's only OAuth login — that state is reachable via AddUserEmailAsync with
+        // IsVerified=false and via the provider backfill, which tags existing (possibly
+        // unverified) rows with Provider/ProviderKey — and OAuth sign-in resolves off
+        // the AspNetUserLogins entry, not the row's IsVerified flag. Removing that login
+        // locks the user out just the same. Checked before RemoveLoginAsync so a refusal
+        // mutates nothing.
+        var allEmails = await repository.GetUserEmailsByUserIdForMutationAsync(userId, cancellationToken);
+        var verifiedRemaining = allEmails.Count(e => e.IsVerified && e.Id != userEmailId);
+        if (verifiedRemaining == 0)
         {
-            var allEmails = await repository.GetUserEmailsByUserIdForMutationAsync(userId, cancellationToken);
-            var verifiedRemaining = allEmails.Count(e => e.IsVerified && e.Id != userEmailId);
-            if (verifiedRemaining == 0)
-            {
-                throw new ValidationException(
-                    "Cannot unlink your last verified sign-in method. Add another verified " +
-                    "email first so you can still sign in.");
-            }
+            throw new ValidationException(
+                "Cannot unlink your last verified sign-in method. Add another verified " +
+                "email first so you can still sign in.");
         }
 
         var user = await userManager.FindByIdAsync(userId.ToString());

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
@@ -1218,10 +1218,43 @@ public class UserEmailServiceTests
     }
 
     [HumansFact]
-    public async Task UnlinkAsync_UnverifiedRow_SkipsVerifiedFloorCheck()
+    public async Task UnlinkAsync_UnverifiedRow_NoOtherVerifiedEmail_ThrowsAndMutatesNothing()
     {
-        // An unverified linked row was never a sign-in method — unlinking it can't
-        // lock anyone out, so it succeeds even when no other verified email exists.
+        // An unverified row can still carry the user's only OAuth login (reachable via
+        // AddUserEmailAsync IsVerified=false and the provider backfill). OAuth sign-in
+        // resolves off the AspNetUserLogins entry, not the row's IsVerified flag, so
+        // removing this login with no other verified email locks the user out — the
+        // floor check must apply regardless of the unlinked row's verified state.
+        var userId = Guid.NewGuid();
+        var rowId = Guid.NewGuid();
+        var row = new UserEmail
+        {
+            Id = rowId,
+            UserId = userId,
+            Email = "pending@example.com",
+            Provider = "Google",
+            ProviderKey = "sub-P",
+            IsVerified = false,
+        };
+        _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+            .Returns(row);
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserEmail>>([row]));
+
+        var act = async () => await _service.UnlinkAsync(userId, rowId, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>().WithMessage("*last verified sign-in method*");
+        await _userManager.DidNotReceive().RemoveLoginAsync(
+            Arg.Any<User>(), Arg.Any<string>(), Arg.Any<string>());
+        await _repository.DidNotReceive().RemoveUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task UnlinkAsync_UnverifiedRow_OtherVerifiedEmailRemains_Succeeds()
+    {
+        // The floor check is about what REMAINS, not what's removed: unlinking an
+        // unverified linked row is fine as long as another verified email keeps the
+        // user able to sign in. No over-blocking of the normal case.
         var userId = Guid.NewGuid();
         var rowId = Guid.NewGuid();
         var row = new UserEmail
@@ -1236,14 +1269,17 @@ public class UserEmailServiceTests
         var user = new User { Id = userId };
         _repository.GetUserEmailByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
             .Returns(row);
+        _repository.GetUserEmailsByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserEmail>>([
+                row,
+                new UserEmail { Id = Guid.NewGuid(), UserId = userId, Email = "verified@example.com", IsVerified = true },
+            ]));
         _userManager.FindByIdAsync(userId.ToString()).Returns(user);
         _userManager.RemoveLoginAsync(user, "Google", "sub-P")
             .Returns(IdentityResult.Success);
 
         var result = await _service.UnlinkAsync(userId, rowId, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
 
-        // No verified row remains anywhere, yet the unlink succeeds — the floor
-        // check applies only to verified rows.
         result.Should().BeTrue();
         await _repository.Received(1).RemoveUserEmailAsync(row, Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## What

`IUserEmailService.UnlinkAsync` wrapped its last-verified-sign-in guard in `if (row.IsVerified)`, so unlinking an **unverified but OAuth-linked** `UserEmail` row skipped the check entirely — removing the `AspNetUserLogins` entry and the row, potentially leaving the user with **no sign-in method**.

Flagged by Codex (P2) on the QA→prod promotion **nobodies-collective/Humans#865**. Originating code shipped in **peterdrier/Humans#994** (controller-audit tier 1, P5).

## Why it's a real lockout (the unverified-linked state is reachable)

- `UserService.AddUserEmailAsync` sets `IsVerified = command.IsVerified` alongside `Provider`/`ProviderKey` — linking does **not** force verified.
- `UserEmailProviderBackfillService` tags **existing** (possibly unverified) rows with `Provider`/`ProviderKey` without verifying them.
- OAuth sign-in resolves via the `AspNetUserLogins` entry (`FindByLoginAsync`), independent of the row's `IsVerified` flag. So an unverified-but-linked row **is** a working sign-in method, and removing its login locks the user out the same as a verified one.

## Fix

Run the verified-floor check **unconditionally**: require ≥1 verified email to remain regardless of the unlinked row's own verified state. This blocks an *unlink* (never a sign-in), consistent with the never-block-signin rule, and is about what **remains**, not what's removed.

The pre-existing test `UnlinkAsync_UnverifiedRow_SkipsVerifiedFloorCheck` asserted the old skip behaviour on the now-disproven premise *"an unverified linked row was never a sign-in method."* Replaced with:
- `UnlinkAsync_UnverifiedRow_NoOtherVerifiedEmail_ThrowsAndMutatesNothing` — lockout blocked.
- `UnlinkAsync_UnverifiedRow_OtherVerifiedEmailRemains_Succeeds` — no over-blocking of the normal case.

## Note for review

This **inverts a deliberate, commented test** in auth-critical code, so it deserves a careful look — I'm confident the old premise was factually wrong (evidence above), but flagging it explicitly. Behaviour change is narrow: only unlinking an unverified-linked row when **zero** other verified emails remain now throws instead of succeeding.

## Test plan

- [x] 87 UserEmailService + ProfileControllerEmailGrid tests pass locally
- [ ] CI green
- [ ] Squash-merge → flows into nobodies-collective/Humans#865 (QA→prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)