### PR TITLE
fix(access-matrix): drop "Member data export" — feature won't be built

### DIFF
--- a/src/Humans.Web/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.Web/Models/AccessMatrixDefinitions.cs
@@ -104,7 +104,6 @@ public static class AccessMatrixDefinitions
             [
                 Feature("Dashboard & stats", "Board", A),
                 Feature("Audit log", "Board", A),
-                Feature("Member data export", "Board", A),
             ]
         },
 

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -326,7 +326,6 @@ public static class SectionHelpContent
 
             - **Dashboard & stats** — membership counts, recent activity, growth trends
             - **Audit log** — chronological record of all significant system actions
-            - **Member data export** — GDPR-compliant data export for individual humans
 
             ### What Happens Automatically
 


### PR DESCRIPTION
The access matrix and the Board Dashboard help both advertised a board-level **"Member data export"** tool that does not exist in code — there is no export action in `AdminController`/`UsersAdminController`; the only member-data export in the app is the self-service GDPR `ProfileController.DownloadData`, scoped to the caller's own data.

Per Peter, a bulk/board member export **won't be built** — too much PII to put in a single file. Removing the false advertisement:

- `AccessMatrixDefinitions.cs` — drop the Board `Member data export` `Feature` row.
- `SectionHelpContent.cs` — drop the matching Board Dashboard "Available Tools" bullet.

2 deletions, no behavior change. `Humans.Web` builds clean (0 errors).

_Surfaced by the 2026-06-13 access-matrix verification maintenance sweep._

🤖 Generated with [Claude Code](https://claude.com/claude-code)