### PR TITLE
fix(web): remove Expenses from top nav, add Expenses button to budget page

### DIFF
--- a/src/Humans.Web/Views/Budget/Index.cshtml
+++ b/src/Humans.Web/Views/Budget/Index.cshtml
@@ -25,12 +25,17 @@
         <h1 class="mb-0">@Model.Year.Name</h1>
         <span class="badge bg-success fs-6">@Model.Year.Status</span>
     </div>
-    @if (Model.IsFinanceAdmin)
-    {
-        <a asp-controller="Finance" asp-action="Index" class="btn btn-outline-primary">
-            <i class="fa-solid fa-gear me-1"></i>Finance Admin <i class="fa-solid fa-lock auth-lock-icon"></i>
+    <div class="d-flex gap-2">
+        <a asp-controller="Expenses" asp-action="Index" class="btn btn-outline-primary">
+            <i class="fa-solid fa-receipt me-1"></i>Expenses
         </a>
-    }
+        @if (Model.IsFinanceAdmin)
+        {
+            <a asp-controller="Finance" asp-action="Index" class="btn btn-outline-primary">
+                <i class="fa-solid fa-gear me-1"></i>Finance Admin <i class="fa-solid fa-lock auth-lock-icon"></i>
+            </a>
+        }
+    </div>
 </div>
 
 

--- a/src/Humans.Web/Views/Budget/Summary.cshtml
+++ b/src/Humans.Web/Views/Budget/Summary.cshtml
@@ -12,12 +12,17 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="mb-0">@Localizer["Budget_OverviewTitle"]</h1>
-    @if (Model.IsCoordinator)
-    {
-        <a asp-action="Index" class="btn btn-outline-primary">
-            <i class="fa-solid fa-list me-1"></i>@Localizer["Budget_DepartmentDetail"]
+    <div class="d-flex gap-2">
+        <a asp-controller="Expenses" asp-action="Index" class="btn btn-outline-primary">
+            <i class="fa-solid fa-receipt me-1"></i>Expenses
         </a>
-    }
+        @if (Model.IsCoordinator)
+        {
+            <a asp-action="Index" class="btn btn-outline-primary">
+                <i class="fa-solid fa-list me-1"></i>@Localizer["Budget_DepartmentDetail"]
+            </a>
+        }
+    </div>
 </div>
 
 

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -137,9 +137,6 @@
                         <li class="nav-item" authorize-policy="AppAccess">
                             <a class="nav-link" asp-area="" asp-controller="Budget" asp-action="Summary">Budget</a>
                         </li>
-                        <li class="nav-item" authorize-policy="AppAccess">
-                            <a class="nav-link" asp-area="" asp-controller="Expenses" asp-action="Index">Expenses</a>
-                        </li>
                         <li class="nav-item" authorize-policy="AnyAdminRole">
                             <a class="nav-link nav-restricted" asp-area="" asp-controller="Admin" asp-action="Index">@Localizer["Nav_Admin"]</a>
                         </li>


### PR DESCRIPTION
## What

1. **Remove the `Expenses` link from the top nav bar.** It had been removed before but was re-introduced by the section-true nav redesign (#960). Top-nav space is precious.
2. **Add an `Expenses` button to the budget page header** so the page stays reachable. Added to both budget views (`Summary`, which all members land on, and the coordinator/finance-admin `Index`), matching the existing `btn btn-outline-primary` + Font Awesome icon convention already used by the Department Detail / Finance Admin buttons.

## Scope

View-only changes — `_Layout.cshtml`, `Budget/Summary.cshtml`, `Budget/Index.cshtml`. No controller, route, or behaviour changes; `/Expenses` is unchanged and still directly reachable.

## Not in this PR (discussed separately with Peter)

- The `SepaSent` status semantics (status flips at SEPA-XML-generation time, not at actual send/bank-confirmation).
- Surfacing the Holded creditor balance / ledger on the Expenses page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)