### PR TITLE
fix(camps): sort Camp Summary table by camp name on Barrios admin page

### DIFF
--- a/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
@@ -89,6 +89,8 @@ public sealed class CampAdminPageBuilder(
                     }).ToList()
             });
         }
-        return rows;
+        return rows
+            .OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 }


### PR DESCRIPTION
## What

The **Camp Summary** table on `/Barrios/Admin` rendered its rows in whatever order the camps came back from the store (no sort). This sorts the summary rows alphabetically by camp name.

## How

`CampAdminPageBuilder.BuildSummaries` now orders the built rows by `Name` using `StringComparer.OrdinalIgnoreCase` before returning — matching the existing case-insensitive sort pattern already used for camp names in `CampAdminController.RolesDrillDown`.

Sorting lives in the Web layer (the page-builder formatting helper), per Peter's hard rule that controllers/Web are responsible for sorting.

## Scope

One-line behavioural change; no schema, interface, or service-surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)