### PR TITLE
fix(google): strip Gmail +tag when syncing group members

### DIFF
--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -549,7 +549,12 @@ public sealed class GoogleGroupSyncService(
 
             var displayName = user.BurnerName;
 
-            result[user.Id] = new ExpectedMember(user.Id, email, displayName, user.ProfilePictureUrl);
+            // Google's Directory API rejects a Gmail "+tag" address (HTTP 404),
+            // and Google stores/returns the canonical form — so we canonicalize
+            // here for both the add and the membership match. Other domains pass
+            // through untouched.
+            result[user.Id] = new ExpectedMember(
+                user.Id, EmailNormalization.CanonicalizeGmail(email), displayName, user.ProfilePictureUrl);
         }
 
         return result;

--- a/src/Humans.Domain/Helpers/EmailNormalization.cs
+++ b/src/Humans.Domain/Helpers/EmailNormalization.cs
@@ -24,6 +24,33 @@ public static class EmailNormalization
     }
 
     /// <summary>
+    /// Canonicalizes a Gmail address to the form Google itself resolves it to:
+    /// builds on <see cref="NormalizeForComparison"/> (lowercase, @googlemail.com → @gmail.com)
+    /// then strips the "+tag" sub-address from the local part
+    /// (peter+travel@gmail.com → peter@gmail.com). Non-Gmail addresses are returned
+    /// unchanged — plus-addressing is not a universal alias outside Gmail.
+    /// Used at the Google Workspace boundary, where the raw "+tag" form is rejected
+    /// (HTTP 404) and would otherwise be re-added on every sync pass.
+    /// </summary>
+    public static string CanonicalizeGmail(string email)
+    {
+        if (string.IsNullOrEmpty(email))
+            return email;
+
+        const string gmailSuffix = "@gmail.com";
+        var normalized = NormalizeForComparison(email);
+        if (!normalized.EndsWith(gmailSuffix, StringComparison.Ordinal))
+            return email;
+
+        var localPart = normalized[..^gmailSuffix.Length];
+        var plusIndex = localPart.IndexOf('+');
+        if (plusIndex < 0)
+            return normalized;
+
+        return string.Concat(localPart.AsSpan(0, plusIndex), gmailSuffix);
+    }
+
+    /// <summary>
     /// Compares two email addresses for equivalence, treating @googlemail.com and @gmail.com as the same domain.
     /// </summary>
     public static bool EmailsMatch(string? a, string? b)

--- a/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
@@ -76,6 +76,48 @@ public sealed class GoogleGroupSyncServiceTests
     }
 
     [HumansFact]
+    public async Task ReconcileOneAsync_GmailPlusTagMember_AddsCanonicalAddress()
+    {
+        // Google's Directory API rejects the "+tag" form of a Gmail address
+        // (HTTP 404). The expected member email is canonicalized to the form
+        // Google resolves it to before the add.
+        var userId = Guid.NewGuid();
+        var service = CreateService(new StaticSource("team@nobodies.team", userId));
+        StubUsers((userId, "Alice", "alice+travel@gmail.com"));
+        StubGroup("team@nobodies.team", "group-1");
+        _membershipClient.CreateMembershipAsync("group-1", "alice@gmail.com", Arg.Any<CancellationToken>())
+            .Returns(new GroupMembershipMutationResult(GroupMembershipMutationOutcome.Added, null));
+
+        var diff = await service.ReconcileOneAsync("team@nobodies.team", SyncAction.Execute, Xunit.TestContext.Current.CancellationToken);
+
+        diff.MembersToAdd.Should().ContainSingle().Which.Should().Be("alice@gmail.com");
+        await _membershipClient.Received(1)
+            .CreateMembershipAsync("group-1", "alice@gmail.com", Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task ReconcileOneAsync_GmailPlusTagMember_AlreadyPresentAsCanonical_NotReAdded()
+    {
+        // The member is already in the group under its canonical address while
+        // the stored email keeps its "+tag". Matching must treat them as the
+        // same member so the sync doesn't re-add (and re-remove) every pass.
+        var userId = Guid.NewGuid();
+        var service = CreateService(new StaticSource("team@nobodies.team", userId));
+        StubUsers((userId, "Alice", "alice+travel@gmail.com"));
+        StubGroup("team@nobodies.team", "group-1",
+            new GroupMembership("alice@gmail.com", "groups/group-1/memberships/alice"));
+
+        var diff = await service.ReconcileOneAsync("team@nobodies.team", SyncAction.Execute, Xunit.TestContext.Current.CancellationToken);
+
+        diff.MembersToAdd.Should().BeEmpty();
+        diff.MembersToRemove.Should().BeEmpty();
+        await _membershipClient.DidNotReceiveWithAnyArgs()
+            .CreateMembershipAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _membershipClient.DidNotReceiveWithAnyArgs()
+            .DeleteMembershipAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task ReconcileOneAsync_GoogleFailure_SchedulesScopedRetry()
     {
         var userId = Guid.NewGuid();

--- a/tests/Humans.Domain.Tests/Helpers/EmailNormalizationTests.cs
+++ b/tests/Humans.Domain.Tests/Helpers/EmailNormalizationTests.cs
@@ -31,4 +31,32 @@ public class EmailNormalizationTests
     {
         EmailNormalization.NormalizeForComparison(input!).Should().Be(input);
     }
+
+    [HumansTheory]
+    [InlineData("peter+foo@gmail.com", "peter@gmail.com")]
+    [InlineData("peter+travel+more@gmail.com", "peter@gmail.com")]
+    [InlineData("Peter+Travel@Gmail.COM", "peter@gmail.com")]
+    [InlineData("peter+foo@googlemail.com", "peter@gmail.com")]
+    public void CanonicalizeGmail_StripsPlusTag(string input, string expected)
+    {
+        EmailNormalization.CanonicalizeGmail(input).Should().Be(expected);
+    }
+
+    [HumansTheory]
+    [InlineData("peter@gmail.com", "peter@gmail.com")]
+    [InlineData("pet.er+foo@gmail.com", "pet.er@gmail.com")]
+    [InlineData("peter+foo@outlook.com", "peter+foo@outlook.com")]
+    [InlineData("user@nobodies.team", "user@nobodies.team")]
+    public void CanonicalizeGmail_NonGmailOrNoTag_LeavesTagIntact(string input, string expected)
+    {
+        EmailNormalization.CanonicalizeGmail(input).Should().Be(expected);
+    }
+
+    [HumansTheory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CanonicalizeGmail_NullOrEmpty_ReturnsInput(string? input)
+    {
+        EmailNormalization.CanonicalizeGmail(input!).Should().Be(input);
+    }
 }


### PR DESCRIPTION
## Problem

Adding a member with a Gmail `+tag` sub-address to a Google Group fails in production:

```
Google API error adding "le***@gmail.com" to group "034g0dwd3ykdeyv":
Code=404 Message="Resource Not Found: lechauxtom+travel@gmail.com"
```

Google's Directory API won't resolve the `+tag` form to the underlying account, so the add 404s — and because the stored email (`...+travel@`) never matches what the group reconcile expects, the failed add recurs on **every** sync pass.

## Fix

- **`EmailNormalization.CanonicalizeGmail`** (Domain) — builds on the existing `NormalizeForComparison` (lowercase + `googlemail.com`→`gmail.com`), then strips the `+tag` from the local part **for `@gmail.com` only**. Non-Gmail addresses pass through untouched (plus-addressing isn't a universal alias).
- **`GoogleGroupSyncService.HydrateExpectedMembersByUserIdAsync`** — canonicalizes the expected member email at its single source. The same canonical form now feeds both:
  - the **add** → sends `lechauxtom@gmail.com`, no 404; and
  - the **membership match** → Google stores/returns the canonical address, so the member compares equal and is no longer re-added each pass.

Scoped to the Google-group sync path only (that hydration method is private to the service). Stored `UserEmail` rows keep their `+tag`; only the Google boundary uses the stripped form. `NormalizingEmailComparer` is unchanged, so ticket/workspace sync are unaffected.

Per the request, this handles **`+tags` only** — Gmail dot-equivalence is intentionally out of scope (dots don't cause the 404).

## Tests

- `EmailNormalizationTests` — `CanonicalizeGmail` strips `+tags` for gmail/googlemail, leaves dots and non-Gmail addresses intact, handles null/empty.
- `GoogleGroupSyncServiceTests` — the add uses the canonical address; a member already present under its canonical form (while stored with a `+tag`) is not re-added or removed.

All Domain (262) and Application (3754) tests pass; full solution builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)