### PR TITLE
feat(shifts): reframe onboarding critical-shift alert; early-entry-aware CTA

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Benvingut/da — comencem pel teu nom</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Crític</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'esdeveniment només té un {0}% dels torns "crítics" coberts. Si no s'omplen, l'esdeveniment podria cancel·lar-se, ja que no seria viable ni segur tirar-lo endavant.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si en pots omplir alguns, o pots venir abans de l'esdeveniment o quedar-te al desmuntatge, prioritza'ls a l'hora de triar els teus torns.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Només està cobert el {0}% dels torns "crítics". Ajuda'ns a fer possible l'esdeveniment cobrint-ne alguns quan puguis.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si pots venir abans per al muntatge o quedar-te al desmuntatge, aquests són els torns més difícils de cobrir — si us plau, prioritza'ls a l'hora de triar els teus torns.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Les inscripcions de muntatge estan tancades — ja som al lloc. Si us plau, centra't en els torns de l'esdeveniment i de desmuntatge.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Et necessitem!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>També hi ha {0} torns "importants" oberts.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hi ha {0} torns "importants" oberts. Si pots venir abans de l'esdeveniment o quedar-te al desmuntatge, prioritza'ls.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hi ha {0} torns "importants" oberts. Si pots venir abans per al muntatge o quedar-te al desmuntatge, si us plau, prioritza'ls.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Hi ha {0} torns "importants" oberts — si us plau, centra't en els torns de l'esdeveniment i de desmuntatge.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Ara mateix no hi ha cap esdeveniment actiu. Pots acabar la incorporació sense triar cap torn.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>De moment no hi ha torns crítics oberts — prova amb Importants o Tots.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>De moment no hi ha torns importants oberts — prova amb Tots.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Willkommen — fangen wir mit deinem Namen an</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Kritisch</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Wichtig</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Bei der Veranstaltung sind nur {0}% der „kritischen“ Schichten besetzt. Wenn diese nicht besetzt werden, könnte die Veranstaltung abgesagt werden, da es nicht möglich oder sicher wäre, sie durchzuführen.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Wenn du einige davon übernehmen kannst oder vor der Veranstaltung kommen bzw. zum Abbau bleiben kannst, priorisiere diese bitte bei der Auswahl deiner Schichten.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>WICHTIG:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Nur {0}% der „kritischen“ Schichten sind besetzt. Hilf uns, die Veranstaltung möglich zu machen, indem du ein paar übernimmst, wo du kannst.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Wenn du früh zum Aufbau kommen oder zum Abbau bleiben kannst, sind das die am schwersten zu besetzenden Schichten — bitte priorisiere sie bei der Auswahl deiner Schichten.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Aufbau-Anmeldungen sind geschlossen — wir sind bereits vor Ort. Bitte konzentriere dich auf Schichten während der Veranstaltung und beim Abbau.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Wir brauchen dich!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Es sind außerdem {0} „wichtige“ Schichten offen.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Es sind {0} „wichtige“ Schichten offen. Wenn du vor der Veranstaltung kommen oder zum Abbau bleiben kannst, priorisiere diese bitte.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Es sind {0} „wichtige“ Schichten offen. Wenn du früh zum Aufbau kommen oder zum Abbau bleiben kannst, priorisiere diese bitte.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Es sind {0} „wichtige“ Schichten offen — bitte konzentriere dich auf Schichten während der Veranstaltung und beim Abbau.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Derzeit keine aktive Veranstaltung. Du kannst das Onboarding abschließen, ohne eine Schicht auszuwählen.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Derzeit keine kritischen Schichten offen — probiere Wichtig oder Alle.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Derzeit keine wichtigen Schichten offen — probiere Alle.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -6539,11 +6539,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Bienvenido — empecemos por tu nombre</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Crítico</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Importante</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>El evento solo tiene cubierto el {0}% de los turnos "críticos". Si no se cubren, el evento podría cancelarse, ya que no sería viable ni seguro llevarlo a cabo.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si puedes cubrir alguno de esos, o puedes venir antes del evento o quedarte al desmontaje, por favor priorízalos al elegir tus turnos.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANTE:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Solo está cubierto el {0}% de los turnos "críticos". Ayúdanos a hacer posible el evento cubriendo algunos cuando puedas.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si puedes venir antes para el montaje o quedarte al desmontaje, esos son los turnos más difíciles de cubrir — por favor, priorízalos al elegir tus turnos.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Las inscripciones de montaje están cerradas — ya estamos en el sitio. Por favor, céntrate en los turnos del evento y de desmontaje.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>¡Te necesitamos!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>También hay {0} turnos "importantes" abiertos.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hay {0} turnos "importantes" abiertos. Si puedes venir antes del evento o quedarte al desmontaje, por favor priorízalos.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hay {0} turnos "importantes" abiertos. Si puedes venir antes para el montaje o quedarte al desmontaje, por favor, priorízalos.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Hay {0} turnos "importantes" abiertos — por favor, céntrate en los turnos del evento y de desmontaje.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>No hay ningún evento activo ahora mismo. Puedes terminar la incorporación sin elegir un turno.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No hay turnos críticos abiertos en este momento — prueba con Importantes o Todos.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No hay turnos importantes abiertos en este momento — prueba con Todos.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Bienvenue — commençons par votre nom</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critique</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'événement n'a que {0} % des quarts « critiques » pourvus. S'ils ne sont pas pourvus, l'événement pourrait être annulé car il ne serait pas viable ni sûr de l'organiser.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si vous pouvez en pourvoir certains, ou si vous pouvez venir avant l'événement ou rester pour le démontage, veuillez les prioriser lors du choix de vos quarts.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT :</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Seuls {0} % des quarts « critiques » sont pourvus. Aidez-nous à rendre l'événement possible en en prenant quelques-uns si vous le pouvez.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si vous pouvez venir tôt pour le montage ou rester pour le démontage, ce sont les quarts les plus difficiles à pourvoir — veuillez les prioriser lors du choix de vos quarts.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Les inscriptions au montage sont closes — nous sommes déjà sur place. Veuillez vous concentrer sur les quarts pendant l'événement et de démontage.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Nous avons besoin de vous !</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Il y a également {0} quarts « importants » à pourvoir.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Il y a {0} quarts « importants » à pourvoir. Si vous pouvez venir avant l'événement ou rester pour le démontage, veuillez les prioriser.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Il y a {0} quarts « importants » à pourvoir. Si vous pouvez venir tôt pour le montage ou rester pour le démontage, veuillez les prioriser.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Il y a {0} quarts « importants » à pourvoir — veuillez vous concentrer sur les quarts pendant l'événement et de démontage.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Aucun événement actif pour le moment. Vous pouvez terminer l'intégration sans choisir de quart.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Aucun quart critique à pourvoir pour le moment — essayez Important ou Tous.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Aucun quart important à pourvoir pour le moment — essayez Tous.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Benvenuto — iniziamo dal tuo nome</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critico</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Importante</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'evento ha riempito solo il {0}% dei turni "critici". Se non vengono riempiti, l'evento potrebbe essere annullato perché non sarebbe sostenibile o sicuro organizzarlo.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Se riesci a riempirne alcuni, o se puoi venire prima dell'evento o restare per lo smontaggio, dai priorità a questi quando scegli i tuoi turni.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANTE:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>È coperto solo il {0}% dei turni "critici". Aiutaci a rendere possibile l'evento coprendone alcuni quando puoi.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Se puoi venire prima per il montaggio o restare per lo smontaggio, sono i turni più difficili da coprire — dai loro priorità quando scegli i tuoi turni.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Le iscrizioni al montaggio sono chiuse — siamo già sul posto. Concentrati sui turni durante l'evento e di smontaggio.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Abbiamo bisogno di te!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Ci sono anche {0} turni "importanti" aperti.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Ci sono {0} turni "importanti" aperti. Se puoi venire prima dell'evento o restare per lo smontaggio, dai priorità a questi.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Ci sono {0} turni "importanti" aperti. Se puoi venire prima per il montaggio o restare per lo smontaggio, dai loro priorità.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Ci sono {0} turni "importanti" aperti — concentrati sui turni durante l'evento e di smontaggio.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Nessun evento attivo al momento. Puoi completare l'onboarding senza scegliere un turno.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Nessun turno critico aperto al momento — prova Importanti o Tutti.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Nessun turno importante aperto al momento — prova Tutti.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2934,11 +2934,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Welcome — let's start with your name</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critical</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>The event has only {0}% of the "critical" shifts filled. If these are not filled, the event might be cancelled as it would not be viable or safe to run it.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>If you're able to fill some of those, or you're able to come pre-event or stay for strike, please prioritize those when picking your shifts.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Only {0}% of the "critical" shifts are filled. Please help us make the event happen by picking up a few where you can.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>If you can come early for set-up or stay for strike, those slots are the hardest to fill — please prioritise them when picking your shifts.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Set-up sign-ups are closed — we're already on site. Please focus on event-time and strike shifts.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>We need you!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>There are also {0} "important" shifts open.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>There are {0} "important" shifts open. If you're able to come pre-event or stay for strike, please prioritize those.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>There are {0} "important" shifts open. If you can come early for set-up or stay for strike, please prioritise those.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>There are {0} "important" shifts open — please focus on event-time and strike shifts.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>No active event right now. You can finish onboarding without picking a shift.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No critical shifts open at the moment — try Important or All.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No important shifts open at the moment — try All.</value></data>

--- a/src/Humans.Web/Views/OnboardingWidget/Shifts.cshtml
+++ b/src/Humans.Web/Views/OnboardingWidget/Shifts.cshtml
@@ -22,13 +22,17 @@
                     {
                         <div class="mt-2 mb-0">@Localizer["Onboarding_ShiftsImportantAlsoOpen", Model.ImportantOpenCount]</div>
                     }
-                    <div class="mt-2 mb-0">@Localizer["Onboarding_ShiftsCriticalCta"]</div>
+                    <div class="mt-2 mb-0">@(browse.EarlyEntrySignupsClosed
+                        ? Localizer["Onboarding_ShiftsCriticalCtaSetupClosed"]
+                        : Localizer["Onboarding_ShiftsCriticalCta"])</div>
                 </div>
             }
             else if (Model.HasAnyImportant)
             {
                 <div class="alert alert-warning" role="alert">
-                    @Localizer["Onboarding_ShiftsImportantBody", Model.ImportantOpenCount]
+                    @(browse.EarlyEntrySignupsClosed
+                        ? Localizer["Onboarding_ShiftsImportantBodySetupClosed", Model.ImportantOpenCount]
+                        : Localizer["Onboarding_ShiftsImportantBody", Model.ImportantOpenCount])
                 </div>
             }
 


### PR DESCRIPTION
## What & why

The onboarding **"Pick a shift"** critical/important alert threatened that the event *"might be cancelled … not viable or safe to run it"* and told humans to *"come pre-event"*. But after early-entry close the set-up sign-up buttons are now disabled ("Set-up closed"), so the message was **self-contradictory and needlessly alarming** — it told people to do the one thing the lockout blocks.

This reframes the copy to be warm ("please help us make it happen") and makes the CTA **early-entry-aware**.

## Behaviour

Both the critical (danger) and important-only (warning) alerts now branch on the existing `browse.EarlyEntrySignupsClosed` flag:

- **Early entry OPEN** — warm ask, still invites set-up + strike sign-ups.
- **Early entry CLOSED** — drops "pre-event"; points humans at *event-time and strike shifts*.

No controller/model changes — the view reads the flag already threaded into `OnboardingShiftsBrowseModelBuilder` (`OnboardingWidgetController.Shifts` computes `es.IsEarlyEntryClosed(now)`).

## Strings

- Reworded `Onboarding_ShiftsCriticalBody` / `…CriticalCta` / `…CriticalHeading` / `…ImportantBody`.
- Added `Onboarding_ShiftsCriticalCtaSetupClosed` and `Onboarding_ShiftsImportantBodySetupClosed`.
- All **six locales** (en/ca/de/es/fr/it), reusing established vocab (montaje/desmuntatge/montage/montaggio/Aufbau, and the existing "we're already on site" phrasing).

## Verification

`dotnet build` clean. Exercised locally in Chrome as a non-privileged volunteer across all four states (critical/important × open/closed) plus Spanish — copy, the open/closed CTA switch, and `{0}` substitution all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)