### PR TITLE
fix(flaky): authenticate all personas

### DIFF
--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -5,7 +5,10 @@ import { PERSONAS, liveLoginAndSave } from './helpers/auth';
 // Single test = single worker = no login herd during seeding. Failures are
 // collected so one broken persona doesn't hide the others.
 setup('authenticate all personas', async ({ browser, baseURL }) => {
-  setup.setTimeout(PERSONAS.length * 90_000);
+  // Worst-case: 2 attempts × 90 s + 5 s inter-attempt pause per persona,
+  // so the test always reaches the aggregate "personas failed" message rather
+  // than timing out mid-list when multiple personas are slow.
+  setup.setTimeout(PERSONAS.length * (90_000 * 2 + 5_000));
   const failures: string[] = [];
   for (const slug of PERSONAS) {
     // Try each persona up to twice. QA cold-start or SeedLock contention on the

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -8,15 +8,27 @@ setup('authenticate all personas', async ({ browser, baseURL }) => {
   setup.setTimeout(PERSONAS.length * 90_000);
   const failures: string[] = [];
   for (const slug of PERSONAS) {
-    // baseURL isn't applied to ad-hoc contexts (only test page/context fixtures
-    // get use.* options), so pass it through for liveLoginAndSave's relative goto.
-    const context = await browser.newContext({ baseURL });
-    try {
-      await liveLoginAndSave(context, slug);
-    } catch (e) {
-      failures.push(`${slug}: ${(e as Error).message.split('\n')[0]}`);
-    } finally {
-      await context.close();
+    // Try each persona up to twice. QA cold-start or SeedLock contention on the
+    // first persona can push the response past the waitForSelector ceiling; a 5 s
+    // pause then a second attempt recovers without forcing Playwright to retry all
+    // 19 personas from scratch (baseURL isn't applied to ad-hoc contexts — only
+    // test page/context fixtures get use.* options — so pass it through here).
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt <= 1; attempt++) {
+      if (attempt > 0) await new Promise(r => setTimeout(r, 5_000));
+      const context = await browser.newContext({ baseURL });
+      try {
+        await liveLoginAndSave(context, slug);
+        lastError = null;
+        break;
+      } catch (e) {
+        lastError = e as Error;
+      } finally {
+        await context.close();
+      }
+    }
+    if (lastError !== null) {
+      failures.push(`${slug}: ${lastError.message.split('\n')[0]}`);
     }
   }
   expect(failures, `personas failed to seed/login:\n${failures.join('\n')}`).toEqual([]);


### PR DESCRIPTION
## Flaky test identified

**Test:** `[setup] › auth.setup.ts:7:6 › authenticate all personas`
**File:** `tests/e2e/auth.setup.ts`
**Observed flake:** Run [27616495140](https://github.com/peterdrier/Humans/actions/runs/27616495140) (SHA f37b3c07, 2026-06-16 12:10 UTC) — Playwright explicitly reports `1 flaky` for this test. It failed on attempt 1 and succeeded on Playwright's test-level retry.

## Root cause

The setup test loops serially over 19 personas, calling `/dev/login/{slug}` and waiting for the authenticated nav element (90 s ceiling per persona). When a QA cold-start or SeedLock contention pushes the **first** persona's response past the ceiling, Playwright's test-level retry (`retries: 2`) kicks in — but that reruns **all 19 personas** from scratch, wasting ~4 minutes.

The 90 s window (bumped from 60 s in a previous fix) was intended to eliminate the retry, but was still insufficient in ~1/18 runs observed over the last week.

## Fix

Add a per-persona inner retry loop (2 total attempts, 5 s pause between). When a single persona times out, only that persona is retried rather than the entire 19-persona seeding sequence. The outer Playwright retry remains as a last resort.

**Before:** 1 persona slow → whole 19-persona setup retried (all SHAs from Jun 15–17 show this)
**After:** 1 persona slow → only that persona retried, other 18 are unaffected

## Scan summary (21 runs × 2 workflows, 2026-06-15 to 2026-06-17)

| Workflow | Runs | Outcomes |
|---|---|---|
| Build and Test | 21 | 21 success — no flakiness |
| E2E Tests (QA) | 21 | 18 actual test runs (all failed); 3 "success" (tests skipped — QA deploy superseded) |

The 34 consistently-failing E2E tests (redirected to `/User/Status`) are a separate QA DB state issue, not flakiness — they fail deterministically on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nnha5EkfVp77rr6LfrN2No

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nnha5EkfVp77rr6LfrN2No)_