### PR TITLE
feat(mailer): Push All button to sync every audience sequentially

### DIFF
--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -188,6 +188,35 @@ public sealed class MailerAdminController(
         return RedirectToAction(nameof(Index));
     }
 
+    [HttpPost("SyncAll")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SyncAll(CancellationToken ct)
+    {
+        try
+        {
+            var actor = await GetCurrentUserInfoAsync();
+            var results = await audienceSync.SyncAllAsync(actor?.Id, ct);
+
+            var created = results.Sum(r => r.Created);
+            var assigned = results.Sum(r => r.Assigned);
+            var unassigned = results.Sum(r => r.Unassigned);
+            var errors = results.Sum(r => r.Errors);
+            var failed = _audiences.Count - results.Count;
+
+            var banner = $"Push All: {results.Count}/{_audiences.Count} audiences synced — " +
+                $"{created} created, {assigned} newly assigned, {unassigned} unassigned, {errors} errors.";
+            if (failed > 0) banner += $" {failed} audience(s) failed — see logs.";
+            TempData["Banner"] = banner;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // HttpClient timeout surfaces as TaskCanceledException when caller didn't cancel.
+            logger.LogWarning("Push All timed out");
+            TempData["Banner"] = "Push All timed out. Some audiences may have synced; try again shortly.";
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
     [HttpPost("Refresh")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Refresh(CancellationToken ct)

--- a/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
@@ -6,7 +6,7 @@
         @if (Model.Count > 0)
         {
             <form asp-action="SyncAll" method="post" class="m-0"
-                  onsubmit="return confirm('Push all @Model.Count audiences to MailerLite sequentially?');">
+                  data-confirm="Push all @Model.Count audiences to MailerLite sequentially?">
                 @Html.AntiForgeryToken()
                 <button type="submit" class="btn btn-sm btn-primary">
                     <i class="fa-solid fa-bolt me-1"></i>Push All
@@ -50,3 +50,14 @@
         }
     </div>
 </section>
+
+<script>
+    (function () {
+        document.querySelectorAll('form[data-confirm]').forEach(function (form) {
+            form.addEventListener('submit', function (ev) {
+                var msg = form.getAttribute('data-confirm');
+                if (msg && !window.confirm(msg)) ev.preventDefault();
+            });
+        });
+    })();
+</script>

--- a/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
@@ -1,8 +1,18 @@
 @model IReadOnlyList<Humans.Web.Models.Mailer.AudienceCardRow>
 
 <section class="card mb-4">
-    <header class="card-header">
+    <header class="card-header d-flex justify-content-between align-items-center">
         <h2 class="h5 mb-0">Audiences</h2>
+        @if (Model.Count > 0)
+        {
+            <form asp-action="SyncAll" method="post" class="m-0"
+                  onsubmit="return confirm('Push all @Model.Count audiences to MailerLite sequentially?');">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-sm btn-primary">
+                    <i class="fa-solid fa-bolt me-1"></i>Push All
+                </button>
+            </form>
+        }
     </header>
     <div class="card-body">
         @if (Model.Count == 0)


### PR DESCRIPTION
## What

Adds a **Push All** button to the Mailer Admin dashboard (`/Mailer/Admin`) that pushes every registered audience to MailerLite sequentially, then shows an aggregate result banner.

## Why

The per-audience **Push Now** button (`_AudiencesCard.cshtml`) and the debug page's **Apply N adds, N removes** button (`Debug.cshtml`) post to the *same* action — `POST Mailer/Admin/Audiences/{key}/Sync` → `SyncAudience` → `IMailerAudienceSyncService.SyncAsync`. After debugging all 10 audiences individually, the natural next step is one button that runs them all.

## How

- **Reuse, no new service surface.** The orchestrator already exists: `IMailerAudienceSyncService.SyncAllAsync(actorUserId, ct)` loops every audience calling `SyncAsync`, catching per-audience failures. It's the same method the daily `MailerAudienceSyncJob` runs. The button just gives it a UI trigger.
- New `[HttpPost("SyncAll")]` controller action aggregates the per-audience results (`created` / `assigned` / `unassigned` / `errors`) into a banner, and notes how many audiences failed (the orchestrator swallows + logs per-audience exceptions, returning only successful results).
- Button lives in the **Audiences** card header with a confirm prompt; hidden when no audiences are registered.

## Notes

- Human-triggered, so the actor's id flows to the audit log (vs. `null` for the scheduled job).
- Build clean (0 errors); new action is well under the HUM0031 controller-complexity limit.
- Manual smoke test against the running site still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)