### PR TITLE
fix(events): toggle favourites without reloading the page

### DIFF
--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -553,17 +553,6 @@ public class EventsController(
         return View(model);
     }
 
-    [HttpPost("Browse/Favourite/{eventId:guid}")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> ToggleFavourite(Guid eventId, int? day, [FromQuery(Name = "days")] int[]? days, Guid? categoryId, Guid? venueId, string? q, bool favouritesOnly = false)
-    {
-        var user = await GetCurrentUserInfoAsync();
-        if (user == null) return Challenge();
-
-        await guide.ToggleFavouriteAsync(user.Id, eventId, day);
-        return RedirectToAction(nameof(Browse), null, new { days, categoryId, venueId, q, favouritesOnly }, $"event-{eventId}");
-    }
-
     [HttpPost("Schedule/Unfavourite/{eventId:guid}")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Unfavourite(Guid eventId, int? day)

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -553,34 +553,6 @@ public class EventsController(
         return View(model);
     }
 
-    [HttpPost("Schedule/Unfavourite/{eventId:guid}")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Unfavourite(Guid eventId, int? day)
-    {
-        var user = await GetCurrentUserInfoAsync();
-        if (user == null) return Challenge();
-
-        if (await guide.RemoveFavouriteAsync(user.Id, eventId, day))
-            SetSuccess("Event removed from your schedule.");
-
-        return RedirectToAction(nameof(Schedule));
-    }
-
-    // Favourite toggle for the events card (camp detail page, profile page).
-    // Bounces back to the host page via returnUrl, falling back to Browse when
-    // the URL is missing or not local.
-    [HttpPost("Card/Favourite/{eventId:guid}")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> ToggleCardFavourite(Guid eventId, string? returnUrl)
-    {
-        var user = await GetCurrentUserInfoAsync();
-        if (user == null) return Challenge();
-
-        // The card lists one row per event, so its heart is whole-event.
-        await guide.ToggleFavouriteAsync(user.Id, eventId, null);
-        return Url.IsLocalUrl(returnUrl) ? Redirect(returnUrl!) : RedirectToAction(nameof(Browse));
-    }
-
     private bool IsSubmissionOpen(EventGuideSettingsView? settings) =>
         settings?.IsSubmissionOpenAt(clock.GetCurrentInstant()) ?? false;
 

--- a/src/Humans.Web/Models/Events/EventsCardViewModel.cs
+++ b/src/Humans.Web/Models/Events/EventsCardViewModel.cs
@@ -7,9 +7,6 @@ namespace Humans.Web.Models.Events;
 /// </summary>
 public class EventsCardViewModel
 {
-    /// <summary>Local URL of the host page — the favourite toggle redirects back here.</summary>
-    public string ReturnUrl { get; set; } = string.Empty;
-
     public List<EventsCardRow> Rows { get; set; } = [];
 }
 

--- a/src/Humans.Web/Models/Events/FavouriteButtonModel.cs
+++ b/src/Humans.Web/Models/Events/FavouriteButtonModel.cs
@@ -1,0 +1,27 @@
+namespace Humans.Web.Models.Events;
+
+/// <summary>
+/// Drives the instant favourite heart shared by Browse, the events card, and
+/// My Schedule. Single source of the JS contract rendered by
+/// <c>_FavouriteButton.cshtml</c> and handled by <c>wwwroot/js/site.js</c>:
+/// the button toggles the favourite through the JSON API without reloading the
+/// page, so the user's filters and scroll position survive.
+/// </summary>
+public sealed class FavouriteButtonModel
+{
+    public required Guid EventId { get; init; }
+
+    /// <summary>Day offset the heart toggles; null = whole-event favourite.</summary>
+    public int? DayOffset { get; init; }
+
+    public bool IsFavourited { get; init; }
+
+    /// <summary>
+    /// My Schedule: remove the row on un-favourite (after <see cref="ConfirmMessage"/>)
+    /// instead of flipping the heart in place. Renders the broken-heart icon.
+    /// </summary>
+    public bool RemoveRow { get; init; }
+
+    /// <summary>Optional confirm prompt shown before acting (My Schedule removal).</summary>
+    public string? ConfirmMessage { get; init; }
+}

--- a/src/Humans.Web/ViewComponents/EventsCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/EventsCardViewComponent.cs
@@ -13,8 +13,8 @@ namespace Humans.Web.ViewComponents;
 /// events card) or a user's personal (non-camp) submitted events — their
 /// profile page; camp events they submitted live on the camp's page. Invoked with
 /// ids only — no Event types cross into the host section's views. The favourite
-/// toggle bounces back to the current request's URL. Auth-gated at the call
-/// site (logged-in Humans users); returns empty content when the Events feature
+/// heart toggles in place via the JSON favourites API (no page reload). Auth-gated
+/// at the call site (logged-in Humans users); returns empty content when the Events feature
 /// is disabled or there are no approved events in scope so the card auto-hides.
 /// </summary>
 public class EventsCardViewComponent(
@@ -27,7 +27,7 @@ public class EventsCardViewComponent(
         try
         {
             // Mirror EventsFeatureFilter: when the Event Guide is off, the Events
-            // routes 404 — so the card (and its favourite POST target) must vanish too.
+            // routes 404 — so the card (and its favourite API target) must vanish too.
             if (!configuration.GetValue<bool>("Features:Events"))
                 return Content(string.Empty);
 
@@ -71,10 +71,8 @@ public class EventsCardViewComponent(
                 })
                 .ToList();
 
-            var request = ViewContext.HttpContext.Request;
             return View(new EventsCardViewModel
             {
-                ReturnUrl = request.Path + request.QueryString,
                 Rows = rows
             });
         }

--- a/src/Humans.Web/Views/Events/Browse.cshtml
+++ b/src/Humans.Web/Views/Events/Browse.cshtml
@@ -113,23 +113,12 @@ else
                             <strong>@item.Title</strong>
                             <span class="badge bg-secondary ms-1">@item.CategoryName</span>
                         </div>
-                        @{
-                            var favTitle = item.IsFavourited ? Localizer["Events_RemoveFromFavourites"].Value : Localizer["Events_AddToFavourites"].Value;
-                        }
-                        @* Hearts toggle in place via the JSON API (handler in the Scripts section
-                           below) so the search filters and scroll position survive. A full-page
-                           POST used to reload Browse and reset both on every toggle. *@
-                        <button type="button"
-                                class="btn btn-sm js-favourite-toggle @(item.IsFavourited ? "btn-danger" : "btn-outline-danger")"
-                                data-event-id="@item.EventId"
-                                data-day="@item.FavouriteDayOffset"
-                                data-favourited="@item.IsFavourited.ToString().ToLowerInvariant()"
-                                data-title-add="@Localizer["Events_AddToFavourites"].Value"
-                                data-title-remove="@Localizer["Events_RemoveFromFavourites"].Value"
-                                aria-pressed="@item.IsFavourited.ToString().ToLowerInvariant()"
-                                title="@favTitle" aria-label="@favTitle">
-                            <i class="fa-solid fa-heart" aria-hidden="true"></i>
-                        </button>
+                        @await Html.PartialAsync("_FavouriteButton", new FavouriteButtonModel
+                        {
+                            EventId = item.EventId,
+                            DayOffset = item.FavouriteDayOffset,
+                            IsFavourited = item.IsFavourited
+                        })
                     </div>
                     <div class="mt-1 small text-muted">
                         <i class="fa-solid fa-clock me-1"></i>@item.StartAt.ToTime() — @item.StartAt.AddMinutes(item.DurationMinutes).ToTime()
@@ -169,39 +158,3 @@ else
         <i class="fa-solid fa-list me-1"></i>@Localizer["Events_MySubmissions"]
     </a>
 </div>
-
-@section Scripts {
-    <script>
-        // Favourite heart toggle: hit the JSON favourites API and flip the button
-        // in place, so adding/removing a favourite never reloads Browse and the
-        // user's filters and scroll position are preserved. The API is same-origin
-        // and authenticated by cookie; it carries no antiforgery requirement.
-        (function () {
-            var errorMsg = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Common_Error"].Value));
-            document.addEventListener('click', function (e) {
-                var btn = e.target.closest('.js-favourite-toggle');
-                if (!btn || btn.disabled) return;
-
-                var favourited = btn.getAttribute('data-favourited') === 'true';
-                var url = '/api/events/favourites/' + encodeURIComponent(btn.getAttribute('data-event-id'));
-                var day = btn.getAttribute('data-day');
-                if (day !== null && day !== '') url += '?day=' + encodeURIComponent(day);
-
-                btn.disabled = true;
-                fetch(url, { method: favourited ? 'DELETE' : 'POST' })
-                    .then(function (r) {
-                        if (!r.ok) throw new Error(r.status);
-                        var nowFav = !favourited;
-                        btn.setAttribute('data-favourited', nowFav ? 'true' : 'false');
-                        btn.setAttribute('aria-pressed', nowFav ? 'true' : 'false');
-                        btn.classList.toggle('btn-danger', nowFav);
-                        btn.classList.toggle('btn-outline-danger', !nowFav);
-                        var label = btn.getAttribute(nowFav ? 'data-title-remove' : 'data-title-add');
-                        if (label) { btn.title = label; btn.setAttribute('aria-label', label); }
-                    })
-                    .catch(function () { showToast(errorMsg, 'danger'); })
-                    .finally(function () { btn.disabled = false; });
-            });
-        })();
-    </script>
-}

--- a/src/Humans.Web/Views/Events/Browse.cshtml
+++ b/src/Humans.Web/Views/Events/Browse.cshtml
@@ -113,21 +113,23 @@ else
                             <strong>@item.Title</strong>
                             <span class="badge bg-secondary ms-1">@item.CategoryName</span>
                         </div>
-                        <form method="post" asp-action="ToggleFavourite" asp-route-eventId="@item.EventId"
-                              asp-route-day="@item.FavouriteDayOffset"
-                              asp-route-categoryId="@Model.FilterCategoryId"
-                              asp-route-venueId="@Model.FilterVenueId" asp-route-q="@Model.SearchQuery"
-                              asp-route-favouritesOnly="@Model.FavouritesOnly" class="d-inline">
-                            @Html.AntiForgeryToken()
-                            @foreach (var d in Model.FilterDays)
-                            {
-                                <input type="hidden" name="days" value="@d" />
-                            }
-                            <button type="submit" class="btn btn-sm @(item.IsFavourited ? "btn-danger" : "btn-outline-danger")"
-                                    title="@(item.IsFavourited ? Localizer["Events_RemoveFromFavourites"].Value : Localizer["Events_AddToFavourites"].Value)">
-                                <i class="fa-solid fa-heart"></i>
-                            </button>
-                        </form>
+                        @{
+                            var favTitle = item.IsFavourited ? Localizer["Events_RemoveFromFavourites"].Value : Localizer["Events_AddToFavourites"].Value;
+                        }
+                        @* Hearts toggle in place via the JSON API (handler in the Scripts section
+                           below) so the search filters and scroll position survive. A full-page
+                           POST used to reload Browse and reset both on every toggle. *@
+                        <button type="button"
+                                class="btn btn-sm js-favourite-toggle @(item.IsFavourited ? "btn-danger" : "btn-outline-danger")"
+                                data-event-id="@item.EventId"
+                                data-day="@item.FavouriteDayOffset"
+                                data-favourited="@item.IsFavourited.ToString().ToLowerInvariant()"
+                                data-title-add="@Localizer["Events_AddToFavourites"].Value"
+                                data-title-remove="@Localizer["Events_RemoveFromFavourites"].Value"
+                                aria-pressed="@item.IsFavourited.ToString().ToLowerInvariant()"
+                                title="@favTitle" aria-label="@favTitle">
+                            <i class="fa-solid fa-heart" aria-hidden="true"></i>
+                        </button>
                     </div>
                     <div class="mt-1 small text-muted">
                         <i class="fa-solid fa-clock me-1"></i>@item.StartAt.ToTime() — @item.StartAt.AddMinutes(item.DurationMinutes).ToTime()
@@ -167,3 +169,39 @@ else
         <i class="fa-solid fa-list me-1"></i>@Localizer["Events_MySubmissions"]
     </a>
 </div>
+
+@section Scripts {
+    <script>
+        // Favourite heart toggle: hit the JSON favourites API and flip the button
+        // in place, so adding/removing a favourite never reloads Browse and the
+        // user's filters and scroll position are preserved. The API is same-origin
+        // and authenticated by cookie; it carries no antiforgery requirement.
+        (function () {
+            var errorMsg = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Common_Error"].Value));
+            document.addEventListener('click', function (e) {
+                var btn = e.target.closest('.js-favourite-toggle');
+                if (!btn || btn.disabled) return;
+
+                var favourited = btn.getAttribute('data-favourited') === 'true';
+                var url = '/api/events/favourites/' + encodeURIComponent(btn.getAttribute('data-event-id'));
+                var day = btn.getAttribute('data-day');
+                if (day !== null && day !== '') url += '?day=' + encodeURIComponent(day);
+
+                btn.disabled = true;
+                fetch(url, { method: favourited ? 'DELETE' : 'POST' })
+                    .then(function (r) {
+                        if (!r.ok) throw new Error(r.status);
+                        var nowFav = !favourited;
+                        btn.setAttribute('data-favourited', nowFav ? 'true' : 'false');
+                        btn.setAttribute('aria-pressed', nowFav ? 'true' : 'false');
+                        btn.classList.toggle('btn-danger', nowFav);
+                        btn.classList.toggle('btn-outline-danger', !nowFav);
+                        var label = btn.getAttribute(nowFav ? 'data-title-remove' : 'data-title-add');
+                        if (label) { btn.title = label; btn.setAttribute('aria-label', label); }
+                    })
+                    .catch(function () { showToast(errorMsg, 'danger'); })
+                    .finally(function () { btn.disabled = false; });
+            });
+        })();
+    </script>
+}

--- a/src/Humans.Web/Views/Events/Schedule.cshtml
+++ b/src/Humans.Web/Views/Events/Schedule.cshtml
@@ -39,12 +39,14 @@ else
                             <strong>@item.Title</strong>
                             <span class="badge bg-secondary ms-1">@item.CategoryName</span>
                         </div>
-                        <form method="post" asp-action="Unfavourite" asp-route-eventId="@item.EventId" asp-route-day="@item.FavouriteDayOffset" class="d-inline" data-confirm="@Localizer["Events_RemoveFromScheduleConfirm"].Value">
-                            @Html.AntiForgeryToken()
-                            <button type="submit" class="btn btn-sm btn-outline-danger" title="@Localizer["Events_RemoveFromSchedule"]">
-                                <i class="fa-solid fa-heart-crack"></i>
-                            </button>
-                        </form>
+                        @await Html.PartialAsync("_FavouriteButton", new FavouriteButtonModel
+                        {
+                            EventId = item.EventId,
+                            DayOffset = item.FavouriteDayOffset,
+                            IsFavourited = true,
+                            RemoveRow = true,
+                            ConfirmMessage = Localizer["Events_RemoveFromScheduleConfirm"].Value
+                        })
                     </div>
                     <div class="mt-1 small text-muted">
                         <i class="fa-solid fa-clock me-1"></i>@item.StartAt.ToTime() — @item.StartAt.AddMinutes(item.DurationMinutes).ToTime()

--- a/src/Humans.Web/Views/Shared/Components/EventsCard/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/EventsCard/Default.cshtml
@@ -29,14 +29,13 @@
                             </span>
                         }
                     </div>
-                    <form method="post" asp-controller="Events" asp-action="ToggleCardFavourite"
-                          asp-route-eventId="@row.EventId" asp-route-returnUrl="@Model.ReturnUrl" class="d-inline ms-2">
-                        @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-sm @(row.IsFavourited ? "btn-danger" : "btn-outline-danger")"
-                                title="@(row.IsFavourited ? "Remove from favourites" : "Add to favourites")">
-                            <i class="fa-solid fa-heart"></i>
-                        </button>
-                    </form>
+                    <span class="ms-2">
+                        @await Html.PartialAsync("_FavouriteButton", new FavouriteButtonModel
+                        {
+                            EventId = row.EventId,
+                            IsFavourited = row.IsFavourited
+                        })
+                    </span>
                 </div>
                 <div class="mt-1 small text-muted">
                     <i class="fa-solid fa-clock me-1"></i>@row.StartAt.ToWeekdayDayMonth() &middot;

--- a/src/Humans.Web/Views/Shared/_FavouriteButton.cshtml
+++ b/src/Humans.Web/Views/Shared/_FavouriteButton.cshtml
@@ -1,0 +1,31 @@
+@model Humans.Web.Models.Events.FavouriteButtonModel
+@*
+    Instant favourite heart — single source of truth for the JS contract:
+    .js-favourite-toggle + data-event-id [+ data-day] + data-favourited, handled by
+    wwwroot/js/site.js. Two modes:
+      • toggle (Browse, events card) — flips the heart in place.
+      • remove (My Schedule) — removes the row; sets data-remove-row + data-favourite-confirm.
+*@
+@{
+    var addTitle = Localizer["Events_AddToFavourites"].Value;
+    var removeTitle = Localizer["Events_RemoveFromFavourites"].Value;
+    var title = Model.RemoveRow
+        ? Localizer["Events_RemoveFromSchedule"].Value
+        : (Model.IsFavourited ? removeTitle : addTitle);
+    var stateClass = !Model.RemoveRow && Model.IsFavourited ? "btn-danger" : "btn-outline-danger";
+    var favourited = Model.IsFavourited.ToString().ToLowerInvariant();
+}
+<button type="button"
+        class="btn btn-sm js-favourite-toggle @stateClass"
+        data-event-id="@Model.EventId"
+        data-day="@Model.DayOffset"
+        data-favourited="@favourited"
+        data-title-add="@addTitle"
+        data-title-remove="@removeTitle"
+        data-error="@Localizer["Common_Error"].Value"
+        data-remove-row="@(Model.RemoveRow ? "true" : null)"
+        data-favourite-confirm="@Model.ConfirmMessage"
+        aria-pressed="@(Model.RemoveRow ? null : favourited)"
+        title="@title" aria-label="@title">
+    <i class="fa-solid @(Model.RemoveRow ? "fa-heart-crack" : "fa-heart")" aria-hidden="true"></i>
+</button>

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -584,3 +584,54 @@ function showToast(message, type) {
         });
     });
 })();
+
+// Favourite hearts (Events): toggle the favourite in place — or remove the row
+// on My Schedule — via the JSON favourites API, so the action never reloads the
+// page and the user's filters/scroll survive. The JS contract is rendered by
+// Views/Shared/_FavouriteButton.cshtml. The API is same-origin + cookie-auth and
+// carries no antiforgery requirement.
+(function () {
+    function removeRow(btn) {
+        var row = btn.closest('.list-group-item');
+        if (!row) return;
+        var list = row.closest('.list-group');
+        row.remove();
+        // Drop an emptied day group (its heading + list) so no orphan date header lingers.
+        if (list && !list.querySelector('.list-group-item')) {
+            var heading = list.previousElementSibling;
+            if (heading && heading.tagName === 'H4') heading.remove();
+            list.remove();
+        }
+        // Whole schedule cleared — reload so the canonical empty-state message renders.
+        if (!document.querySelector('.js-favourite-toggle[data-remove-row="true"]')) window.location.reload();
+    }
+
+    document.addEventListener('click', function (e) {
+        var btn = e.target.closest('.js-favourite-toggle');
+        if (!btn || btn.disabled) return;
+
+        var confirmMsg = btn.getAttribute('data-favourite-confirm');
+        if (confirmMsg && !confirm(confirmMsg)) return;
+
+        var favourited = btn.getAttribute('data-favourited') === 'true';
+        var url = '/api/events/favourites/' + encodeURIComponent(btn.getAttribute('data-event-id'));
+        var day = btn.getAttribute('data-day');
+        if (day !== null && day !== '') url += '?day=' + encodeURIComponent(day);
+
+        btn.disabled = true;
+        fetch(url, { method: favourited ? 'DELETE' : 'POST' })
+            .then(function (r) {
+                if (!r.ok) throw new Error(r.status);
+                if (btn.getAttribute('data-remove-row') === 'true') { removeRow(btn); return; }
+                var nowFav = !favourited;
+                btn.setAttribute('data-favourited', nowFav ? 'true' : 'false');
+                btn.setAttribute('aria-pressed', nowFav ? 'true' : 'false');
+                btn.classList.toggle('btn-danger', nowFav);
+                btn.classList.toggle('btn-outline-danger', !nowFav);
+                var label = btn.getAttribute(nowFav ? 'data-title-remove' : 'data-title-add');
+                if (label) { btn.title = label; btn.setAttribute('aria-label', label); }
+            })
+            .catch(function () { showToast(btn.getAttribute('data-error') || 'Something went wrong.', 'danger'); })
+            .finally(function () { btn.disabled = false; });
+    });
+})();

--- a/tests/Humans.Application.Tests/ViewComponents/EventsCardViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/EventsCardViewComponentTests.cs
@@ -21,8 +21,6 @@ namespace Humans.Application.Tests.ViewComponents;
 /// </summary>
 public class EventsCardViewComponentTests
 {
-    private const string RequestPath = "/Barrios/shenanicamp";
-
     private readonly IEventServiceRead _events = Substitute.For<IEventServiceRead>();
 
     private EventsCardViewComponent BuildSut(Guid? viewerId, bool eventsEnabled = true)
@@ -31,7 +29,6 @@ public class EventsCardViewComponentTests
             ? new ClaimsIdentity()
             : new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, viewerId.Value.ToString())], "Test");
         var http = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
-        http.Request.Path = RequestPath;
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal) { ["Features:Events"] = eventsEnabled ? "true" : "false" })
             .Build();
@@ -77,7 +74,6 @@ public class EventsCardViewComponentTests
 
         var view = result.Should().BeOfType<ViewViewComponentResult>().Subject;
         var vm = view.ViewData!.Model.Should().BeOfType<EventsCardViewModel>().Subject;
-        vm.ReturnUrl.Should().Be(RequestPath);
         vm.Rows.Select(r => r.Title).Should().ContainInOrder("Early", "Late");
         vm.Rows[0].IsFavourited.Should().BeTrue();   // Early — favourited
         vm.Rows[1].IsFavourited.Should().BeFalse();  // Late — not favourited

--- a/tests/Humans.Web.Tests/Controllers/EventsControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EventsControllerTests.cs
@@ -107,53 +107,6 @@ public class EventsControllerTests
         result.Should().BeOfType<ForbidResult>();
     }
 
-    [HumansFact]
-    public async Task ToggleCardFavourite_Authenticated_TogglesAndRedirectsToReturnUrl()
-    {
-        var userId = Guid.NewGuid();
-        var eventId = Guid.NewGuid();
-        var controller = BuildController(userId);
-        controller.Url = Substitute.For<IUrlHelper>();
-        controller.Url.IsLocalUrl("/Barrios/shenanicamp").Returns(true);
-
-        var result = await controller.ToggleCardFavourite(eventId, "/Barrios/shenanicamp");
-
-        await _guide.Received(1).ToggleFavouriteAsync(userId, eventId, null, Arg.Any<CancellationToken>());
-        result.Should().BeOfType<RedirectResult>().Which.Url.Should().Be("/Barrios/shenanicamp");
-    }
-
-    [HumansFact]
-    public async Task ToggleCardFavourite_NonLocalReturnUrl_RedirectsToBrowse()
-    {
-        var controller = BuildController(Guid.NewGuid());
-        controller.Url = Substitute.For<IUrlHelper>(); // IsLocalUrl → false by default
-
-        var result = await controller.ToggleCardFavourite(Guid.NewGuid(), "https://evil.example/phish");
-
-        result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("Browse");
-    }
-
-    [HumansFact]
-    public async Task ToggleCardFavourite_Unauthenticated_ReturnsChallenge()
-    {
-        var controller = BuildAnonymousController();
-
-        var result = await controller.ToggleCardFavourite(Guid.NewGuid(), "/Barrios/shenanicamp");
-
-        result.Should().BeOfType<ChallengeResult>();
-        await _guide.DidNotReceive().ToggleFavouriteAsync(
-            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
-    }
-
-    private EventsController BuildAnonymousController() =>
-        new(_guide, _users, _camps, _authz, _clock, NullLogger<EventsController>.Instance)
-        {
-            ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) },
-            },
-        };
-
     private Guid StubEvent(Guid submitterId, Guid? campId, EventStatus status)
     {
         var guideEvent = MakeEvent(campId, submitterId, status);


### PR DESCRIPTION
## Bug

Browsing events and managing favourites was painful: **every favourite action reloaded the whole page**, resetting scroll position and search filters. On Browse the day filter was also lost entirely (its `days` inputs were posted in the form body but the action bound them via `[FromQuery]`).

## Root cause

All three favourite surfaces used full-page `<form method="post">` → controller → redirect:
- **Browse** heart → `ToggleFavourite` → `RedirectToAction(Browse)`
- **Events card** (camp detail / profile) heart → `ToggleCardFavourite` → redirect to host page
- **My Schedule** heart → `Unfavourite` → `RedirectToAction(Schedule)`

A 302 + full reload can't preserve scroll and re-runs all page state.

## Fix

Each heart now toggles **in place** via the existing JSON API (`POST` / `DELETE /api/events/favourites/{id}?day=N`) — no reload, so filters and scroll survive. `AddFavouriteIfAbsentAsync` / `RemoveFavouriteAsync` share the same `MatchingFavourites` rule as the old toggle, so behaviour is identical. Same-origin + cookie-auth; no antiforgery token needed (no global filter — consistent with `/api/timezone`).

- **Shared partial** `_FavouriteButton.cshtml` + `FavouriteButtonModel` is the single source of the JS contract (mirrors `_ShiftToggleButton.cshtml`), used by Browse, the card, and Schedule.
- **Handler lives in `site.js`** (the global delegated-handler home) so it covers the card too, which renders on multiple host pages. Two modes: *toggle in place* (Browse, card) and *remove row* (Schedule, with confirm).
- The card's tooltips are now **localized** (were hardcoded English).
- Removed the now-dead `ToggleFavourite`, `ToggleCardFavourite`, and `Unfavourite` MVC actions; the card's `ReturnUrl` plumbing; and the matching tests.

## Behaviour notes

- **Schedule:** removing drops the row in place; an emptied day group's header is removed; the page reloads only when the schedule becomes completely empty (to show the canonical empty-state message). The confirm prompt is kept.
- **Browse "favourites only" mode:** an un-favourited row stays visible (empty heart) until the next navigation instead of vanishing on reload — the trade-off for not jumping scroll.
- **Recurring event across multiple day rows with a whole-event favourite:** removing from one row flips only that button; siblings refresh on next load. Rare and self-healing.

## Testing

- `dotnet build Humans.slnx` — 0 errors.
- `dotnet test` (Events): Web.Tests 16/16, Application.Tests 98/98 green. (Integration tests need Docker/Testcontainers, unavailable here — pre-existing, unrelated.)
- Live verification pending on the PR preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)