### PR TITLE
Show shift signup counts on camp members

### DIFF
--- a/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
+++ b/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
@@ -35,6 +35,15 @@ public sealed record ShiftUserView(
         s.Status is SignupStatus.Pending or SignupStatus.Confirmed);
 
     /// <summary>
+    /// Number of active-state signups (<see cref="SignupStatus.Pending"/> or
+    /// <see cref="SignupStatus.Confirmed"/>) the user holds in the active event.
+    /// Refused / Bailed / Cancelled / NoShow signups don't count. Same
+    /// "active commitment" rule as <see cref="HasShift"/>, expressed as a count.
+    /// </summary>
+    public int ActiveSignupCount => Signups.Count(s =>
+        s.Status is SignupStatus.Pending or SignupStatus.Confirmed);
+
+    /// <summary>
     /// True when the user has at least one active signup (Pending/Confirmed) on
     /// a shift classified into the given <paramref name="period"/>. Each shift's
     /// period is derived from its <see cref="Shift.DayOffset"/> against the

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -437,13 +437,11 @@ public class CampController(
             .ToList();
         if (memberUserIds.Count > 0)
         {
-            var activeMemberUserIds = viewModel.ActiveMembers.Select(m => m.UserId).Distinct().ToList();
-            var shiftViews = await shiftView.GetUsersAsync(activeMemberUserIds, ct);
+            var shiftViews = await shiftView.GetUsersAsync(
+                viewModel.ActiveMembers.Select(m => m.UserId), ct);
             foreach (var member in viewModel.ActiveMembers)
             {
-                member.EventShiftSignupCount = shiftViews.TryGetValue(member.UserId, out var userShiftView)
-                    ? userShiftView.Signups.Count(s => s.Status is SignupStatus.Pending or SignupStatus.Confirmed)
-                    : 0;
+                member.EventShiftSignupCount = shiftViews[member.UserId].ActiveSignupCount;
             }
 
             var memberUsers = await _userService.GetUserInfosAsync(memberUserIds, ct);

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -10,6 +10,7 @@ using NodaTime;
 using Humans.Application;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.CityPlanning;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Camps;
 using Humans.Web.Models.Camp;
@@ -23,6 +24,7 @@ public class CampController(
     ICampContactService campContactService,
     ICampRoleService campRoleService,
     ICityPlanningServiceRead cityPlanningService,
+    IShiftView shiftView,
     IUserServiceRead userService,
     IAuthorizationService authorizationService,
     IClock clock,
@@ -435,6 +437,15 @@ public class CampController(
             .ToList();
         if (memberUserIds.Count > 0)
         {
+            var activeMemberUserIds = viewModel.ActiveMembers.Select(m => m.UserId).Distinct().ToList();
+            var shiftViews = await shiftView.GetUsersAsync(activeMemberUserIds, ct);
+            foreach (var member in viewModel.ActiveMembers)
+            {
+                member.EventShiftSignupCount = shiftViews.TryGetValue(member.UserId, out var userShiftView)
+                    ? userShiftView.Signups.Count(s => s.Status is SignupStatus.Pending or SignupStatus.Confirmed)
+                    : 0;
+            }
+
             var memberUsers = await _userService.GetUserInfosAsync(memberUserIds, ct);
             string MemberName(CampMemberRowViewModel m) =>
                 memberUsers.TryGetValue(m.UserId, out var u) ? u.BurnerName : "";

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -190,7 +190,22 @@ public class CampMemberRowViewModel
     public NodaTime.Instant RequestedAt { get; set; }
     public NodaTime.Instant? ConfirmedAt { get; set; }
     public bool HasEarlyEntry { get; set; }
+    public int EventShiftSignupCount { get; set; }
     public CampMemberStatus Status { get; set; }
+
+    public string EventShiftSignupDisplay => EventShiftSignupCount >= 5
+        ? "5+"
+        : EventShiftSignupCount.ToString(CultureInfo.InvariantCulture);
+
+    public string EventShiftSignupBadgeClass => EventShiftSignupCount switch
+    {
+        <= 0 => "bg-danger",
+        1 => "bg-success-subtle text-success-emphasis border border-success-subtle",
+        2 => "bg-success bg-opacity-25 text-success-emphasis border border-success-subtle",
+        3 => "bg-success bg-opacity-50 text-dark border border-success",
+        4 => "bg-success bg-opacity-75 text-white border border-success",
+        _ => "bg-success text-white"
+    };
 }
 
 public class CampImageViewModel

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Admin de barris</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Inscripcions a torns actives per a l'esdeveniment actual (pendents o confirmades)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} inscripcions a torns actives</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Aquest camp s’ha anomenat mai "Swiss Camp"?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Aktive Schichtanmeldungen für das aktuelle Event (ausstehend oder bestätigt)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} aktive Schichtanmeldungen</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Wurde dieses Camp jemals "Swiss Camp" genannt?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -3079,6 +3079,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Inscripciones a turnos activas para el evento actual (pendientes o confirmadas)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} inscripciones a turnos activas</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>¿Este camp se ha llamado alguna vez "Swiss Camp"?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Inscriptions aux créneaux actives pour l'événement en cours (en attente ou confirmées)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} inscriptions aux créneaux actives</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Ce camp a-t-il déjà été appelé "Swiss Camp" ?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Iscrizioni ai turni attive per l'evento corrente (in attesa o confermate)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} iscrizioni ai turni attive</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Questo camp è mai stato chiamato "Swiss Camp"?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1306,6 +1306,8 @@
   <data name="Camp_Singular" xml:space="preserve"><value>Barrio</value></data>
   <data name="Camp_Plural" xml:space="preserve"><value>Barrios</value></data>
   <data name="Camp_AdminTitle" xml:space="preserve"><value>Barrios Admin</value></data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Active shift signups for the current event (pending or confirmed)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} active shift signups</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Has this camp ever been called "Swiss Camp"</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Barrio Info</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Barrio Name</value></data>

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -204,8 +204,13 @@
                         @foreach (var active in Model.ActiveMembers)
                         {
                             <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
-                                <div class="d-flex align-items-center gap-2">
+                                <div class="d-flex align-items-center gap-2 flex-wrap">
                                     <vc:human user-id="@active.UserId" />
+                                    <span class="badge rounded-pill @active.EventShiftSignupBadgeClass"
+                                          title="Active shift signups for the current event (pending or confirmed)"
+                                          aria-label="@active.EventShiftSignupCount active shift signups">
+                                        @active.EventShiftSignupDisplay
+                                    </span>
                                 </div>
                                 <div class="d-flex gap-2 align-items-center">
                                     @{

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -207,8 +207,8 @@
                                 <div class="d-flex align-items-center gap-2 flex-wrap">
                                     <vc:human user-id="@active.UserId" />
                                     <span class="badge rounded-pill @active.EventShiftSignupBadgeClass"
-                                          title="Active shift signups for the current event (pending or confirmed)"
-                                          aria-label="@active.EventShiftSignupCount active shift signups">
+                                          title="@Localizer["Camp_ShiftSignupBadgeTitle"]"
+                                          aria-label="@Localizer["Camp_ShiftSignupBadgeAriaLabel", active.EventShiftSignupCount]">
                                         @active.EventShiftSignupDisplay
                                     </span>
                                 </div>

--- a/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
@@ -1,8 +1,11 @@
 using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Application;
+using Humans.Application.Services.Camps;
+using Humans.Application.DTOs.Shifts;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.CityPlanning;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -27,6 +30,7 @@ public class CampControllerTests
     private readonly ICampContactService _contacts = Substitute.For<ICampContactService>();
     private readonly ICampRoleService _roles = Substitute.For<ICampRoleService>();
     private readonly ICityPlanningService _cityPlanning = Substitute.For<ICityPlanningService>();
+    private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
     private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
     private readonly IAuthorizationService _authorization = Substitute.For<IAuthorizationService>();
     private readonly IClock _clock = Substitute.For<IClock>();
@@ -90,6 +94,67 @@ public class CampControllerTests
         vm.Camps.Select(c => c.Id).Should().Equal(leadCamp.Id, alphabeticalFirst.Id);
     }
 
+    [HumansFact]
+    public async Task Members_Shows_Active_Event_Shift_Counts_From_Shift_View()
+    {
+        var leadUserId = Guid.NewGuid();
+        var zeroShiftMemberId = Guid.NewGuid();
+        var oneShiftMemberId = Guid.NewGuid();
+        var fivePlusShiftMemberId = Guid.NewGuid();
+
+        var members = new[]
+        {
+            MakeSeasonMember(zeroShiftMemberId),
+            MakeSeasonMember(oneShiftMemberId),
+            MakeSeasonMember(fivePlusShiftMemberId),
+        };
+        var camp = MakeCamp("garden-of-joy", "Garden of Joy", CampSeasonStatus.Active, leadUserId, members: members);
+        var season = camp.Seasons.Single();
+
+        _camps.GetCampBySlugAsync(camp.Slug, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CampInfo?>(camp));
+        _camps.GetCampEditDataAsync(camp.Id, null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CampEditData?>(MakeEditData(camp, season)));
+        _users.GetUserInfoAsync(leadUserId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(MakeUserInfo(leadUserId)));
+        _users.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(call => new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                call.ArgAt<IReadOnlyCollection<Guid>>(0).ToDictionary(id => id, MakeUserInfo)));
+        _authorization.AuthorizeAsync(
+                Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<object?>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Success());
+        _roles.BuildPanelAsync(season.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new CampRolesPanelData(season.Id, [])));
+        _shiftView.GetUsersAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, ShiftUserView>>(
+                new Dictionary<Guid, ShiftUserView>
+                {
+                    [zeroShiftMemberId] = MakeShiftUserView(zeroShiftMemberId),
+                    [oneShiftMemberId] = MakeShiftUserView(oneShiftMemberId, SignupStatus.Confirmed),
+                    [fivePlusShiftMemberId] = MakeShiftUserView(
+                        fivePlusShiftMemberId,
+                        SignupStatus.Confirmed,
+                        SignupStatus.Pending,
+                        SignupStatus.Confirmed,
+                        SignupStatus.Pending,
+                        SignupStatus.Confirmed,
+                        SignupStatus.Bailed),
+                }));
+
+        var controller = BuildController(leadUserId);
+
+        var result = await controller.Members(camp.Slug, null, Xunit.TestContext.Current.CancellationToken);
+
+        var vm = result.Should().BeOfType<ViewResult>().Subject
+            .Model.Should().BeOfType<CampEditViewModel>().Subject;
+        vm.ActiveMembers.Single(m => m.UserId == zeroShiftMemberId).EventShiftSignupCount.Should().Be(0);
+        vm.ActiveMembers.Single(m => m.UserId == oneShiftMemberId).EventShiftSignupCount.Should().Be(1);
+        vm.ActiveMembers.Single(m => m.UserId == fivePlusShiftMemberId).EventShiftSignupCount.Should().Be(5);
+        vm.ActiveMembers.Single(m => m.UserId == fivePlusShiftMemberId).EventShiftSignupDisplay.Should().Be("5+");
+    }
+
     private void StubCampReadModel(IReadOnlyList<CampInfo> camps)
     {
         _camps.GetSettingsAsync(Arg.Any<CancellationToken>())
@@ -105,6 +170,7 @@ public class CampControllerTests
             _contacts,
             _roles,
             _cityPlanning,
+            _shiftView,
             _users,
             _authorization,
             _clock,
@@ -136,7 +202,8 @@ public class CampControllerTests
         string name,
         CampSeasonStatus status,
         Guid? leadUserId = null,
-        YesNoMaybe kidsWelcome = YesNoMaybe.Yes)
+        YesNoMaybe kidsWelcome = YesNoMaybe.Yes,
+        IReadOnlyList<CampSeasonMemberInfo>? members = null)
     {
         var campId = Guid.NewGuid();
         var season = new CampSeasonInfo(
@@ -161,7 +228,8 @@ public class CampControllerTests
             EeGrantedCount: 0,
             JoinedMemberCount: 0)
         {
-            LeadUserIds = leadUserId.HasValue ? [leadUserId.Value] : []
+            LeadUserIds = leadUserId.HasValue ? [leadUserId.Value] : [],
+            Members = members ?? []
         };
 
         return new CampInfo(
@@ -173,6 +241,64 @@ public class CampControllerTests
             TimesAtNowhere: 1,
             Seasons: [season]);
     }
+
+    private static CampSeasonMemberInfo MakeSeasonMember(Guid userId) =>
+        new(
+            Guid.NewGuid(),
+            userId,
+            CampMemberStatus.Active,
+            SystemClock.Instance.GetCurrentInstant(),
+            SystemClock.Instance.GetCurrentInstant(),
+            HasEarlyEntry: false);
+
+    private static CampEditData MakeEditData(CampInfo camp, CampSeasonInfo season) =>
+        new(
+            camp.Id,
+            camp.Slug,
+            season.Id,
+            season.Year,
+            IsNameLocked: false,
+            season.Name,
+            camp.ContactEmail,
+            camp.ContactPhone,
+            Links: [],
+            camp.IsSwissCamp,
+            camp.HideHistoricalNames,
+            camp.TimesAtNowhere,
+            season.BlurbLong,
+            season.BlurbShort,
+            season.Languages,
+            season.AcceptingMembers,
+            season.KidsWelcome,
+            season.KidsVisiting,
+            season.KidsAreaDescription,
+            season.HasPerformanceSpace,
+            season.PerformanceTypes,
+            season.Vibes,
+            season.AdultPlayspace,
+            season.MemberCount,
+            season.SpaceRequirement,
+            season.SoundZone,
+            season.ElectricalGrid,
+            Images: [],
+            HistoricalNames: []);
+
+    private static ShiftUserView MakeShiftUserView(Guid userId, params SignupStatus[] statuses) =>
+        new(
+            userId,
+            Profile: null,
+            Availability: null,
+            BuildStatus: null,
+            TagPreferences: [],
+            Signups: statuses.Select(status => new ShiftSignup
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ShiftId = Guid.NewGuid(),
+                Status = status,
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
+                UpdatedAt = SystemClock.Instance.GetCurrentInstant(),
+            }).ToList());
 
     private static UserInfo MakeUserInfo(Guid userId) =>
         UserInfo.Create(


### PR DESCRIPTION
## Summary
- adds a shift-signup count pill to the Active Humans list on camp member management pages
- counts pending + confirmed active-event shift signups via the cached `IShiftView`
- colors the pill from red `0` through progressively stronger greens, displaying `5+` for five or more signups

## Tests
- `dotnet test tests/Humans.Web.Tests/Humans.Web.Tests.csproj -v quiet -p:CustomBeforeMicrosoftCSharpTargets=/tmp/no-humans-analyzer.targets` (341 passed)
- `dotnet test tests/Humans.Web.Tests/Humans.Web.Tests.csproj -v quiet --filter "FullyQualifiedName~CampControllerTests" -p:CustomBeforeMicrosoftCSharpTargets=/tmp/no-humans-analyzer.targets` (4 passed)

Note: the unmodified local test command currently fails before this change is compiled because this machine has .NET SDK 10.0.107/Roslyn 5.0.0 but the in-repo analyzer references Microsoft.CodeAnalysis 5.3.0 (`CS9057`). The temporary targets file only removes the in-repo Humans analyzer for local verification; no repo files were changed for that workaround.