### PR TITLE
ci(claude-review): skip review job for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,6 +39,10 @@ name: claude-review
 #   On-demand: any OWNER/MEMBER/COLLABORATOR posting a comment starting with
 #              `/review` on the PR triggers a fresh run. The docs-only skip
 #              does NOT apply to comment-triggered runs (explicit ask wins).
+#   Dependabot: PRs opened by dependabot[bot] are skipped (actor guard in the
+#               `if:` below). Dependabot-triggered runs use the isolated
+#               Dependabot secret store, so CLAUDE_CODE_OAUTH_TOKEN is empty
+#               and the action fails fast — a spurious red check on every bump.
 #
 # Concurrency: per-PR group with cancel-in-progress. A new push or `/review`
 # during an in-flight review cancels the stale run instead of stacking.
@@ -91,7 +95,9 @@ jobs:
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
                     github.event.comment.author_association))
       ||
-      (github.event.pull_request.draft == false && (
+      (github.event.pull_request.draft == false
+        && github.actor != 'dependabot[bot]'
+        && (
         (github.event_name == 'pull_request'
           && github.repository == 'peterdrier/Humans'
           && github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
## What & why

The `claude-review` workflow fails on every Dependabot PR (e.g. #1038–#1042), leaving a spurious red **review** check on each dependency bump.

**Root cause:** Dependabot-triggered workflow runs use GitHub's isolated *Dependabot* secret store, so `CLAUDE_CODE_OAUTH_TOKEN` (and the API key) resolve **empty**. The `claude-code-action` step then fails fast (~11s) with no token. Confirmed in the failed job log: `claude_code_oauth_token: ""`, `anthropic_api_key: ""`, `Secret source: Dependabot`.

This never *blocked* merge — branch protection requires no status checks (only 1 approval) — but it's persistent red noise on routine bumps.

## Fix

Add an actor guard `github.actor != 'dependabot[bot]'` to the review job's `if:` so Dependabot PRs skip the review entirely instead of erroring. One-line change to the existing `draft == false` group; paren balance preserved.

- The `/review` comment path is unaffected (Dependabot can't post `/review` comments, and its `author_association` wouldn't pass the OWNER/MEMBER/COLLABORATOR gate anyway).
- Human and trusted-fork PR review behavior is unchanged.
- Documented the skip in the file's run-cadence header block.

## Verification

- `yaml.safe_load` parses the workflow cleanly.
- Comment placement is in the header block (a `#` comment can't live inside the `if: |` literal expression without breaking it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)