### PR TITLE
fix(events,mailer): whole-event unfavourite clears all rows; drop duplicate confirm handler

### DIFF
--- a/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
@@ -50,14 +50,3 @@
         }
     </div>
 </section>
-
-<script>
-    (function () {
-        document.querySelectorAll('form[data-confirm]').forEach(function (form) {
-            form.addEventListener('submit', function (ev) {
-                var msg = form.getAttribute('data-confirm');
-                if (msg && !window.confirm(msg)) ev.preventDefault();
-            });
-        });
-    })();
-</script>

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -592,16 +592,25 @@ function showToast(message, type) {
 // carries no antiforgery requirement.
 (function () {
     function removeRow(btn) {
-        var row = btn.closest('.list-group-item');
-        if (!row) return;
-        var list = row.closest('.list-group');
-        row.remove();
-        // Drop an emptied day group (its heading + list) so no orphan date header lingers.
-        if (list && !list.querySelector('.list-group-item')) {
-            var heading = list.previousElementSibling;
-            if (heading && heading.tagName === 'H4') heading.remove();
-            list.remove();
-        }
+        // A whole-event unfavourite (empty data-day) deletes every occurrence
+        // server-side, so remove every occurrence row for this event; a day-specific
+        // unfavourite removes only the clicked row.
+        var day = btn.getAttribute('data-day');
+        var toggles = (day === null || day === '')
+            ? document.querySelectorAll('.js-favourite-toggle[data-remove-row="true"][data-event-id="' + btn.getAttribute('data-event-id') + '"]')
+            : [btn];
+        Array.prototype.forEach.call(toggles, function (t) {
+            var row = t.closest('.list-group-item');
+            if (!row) return;
+            var list = row.closest('.list-group');
+            row.remove();
+            // Drop an emptied day group (its heading + list) so no orphan date header lingers.
+            if (list && !list.querySelector('.list-group-item')) {
+                var heading = list.previousElementSibling;
+                if (heading && heading.tagName === 'H4') heading.remove();
+                list.remove();
+            }
+        });
         // Whole schedule cleared — reload so the canonical empty-state message renders.
         if (!document.querySelector('.js-favourite-toggle[data-remove-row="true"]')) window.location.reload();
     }


### PR DESCRIPTION
## Summary

Fixes the two review findings raised on the QA→prod promotion PR (nobodies-collective/Humans#887). Both are in code already on `origin/main`, so the fix lands here on the fork and flows up on the next promotion.

### 1. Whole-event unfavourite leaves sibling rows visible (Codex P2)

On `/Events/Schedule`, a whole-event favourite of a recurring event (`DayOffset == null`) expands to one row **per occurrence**, each rendered with an empty `data-day`. The DELETE endpoint removes **every** favourite row for that event when `day` is omitted, but the client `removeRow` stripped only the clicked `.list-group-item`. The other occurrence rows stayed on screen as if still scheduled until the next reload.

Now an empty-`data-day` unfavourite removes every occurrence row for that event id (matching the server's whole-event delete); a day-specific unfavourite still removes only the clicked row. The empty-day-group cleanup and whole-schedule reload-to-empty-state behaviour are preserved.

Origin of the bug: `fix(events): toggle favourites without reloading the page` (peterdrier/Humans#1044).

### 2. Duplicate `form[data-confirm]` handler → double confirm dialog (Claude review WARN)

`site.js` already has a document-level delegated `submit` handler for `form[data-confirm]`. The inline `<script>` in `Mailer/Admin/_AudiencesCard.cshtml` attached a second handler directly to each form, so clicking **Push All** fired two confirm prompts. Removed the redundant inline block; the global handler covers it.

Origin of the bug: `feat(mailer): Push All button to sync every audience sequentially` (peterdrier/Humans#1043).

## Test plan

- [ ] `/Events/Schedule` with a whole-event favourite of a recurring event → unfavourite one occurrence removes all of them without reload
- [ ] `/Events/Schedule` with a day-specific favourite → unfavourite removes only that row
- [ ] Mailer audiences → **Push All** shows exactly one confirm dialog
- [ ] `dotnet build Humans.slnx -v quiet` (0 errors — verified locally)