### PR TITLE
fix(shifts): dedupe volunteer tag preferences to avoid unique-constraint 500

### DIFF
--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
@@ -625,7 +625,7 @@ internal sealed partial class ShiftRepository : IShiftManagementRepository
         ctx.VolunteerTagPreferences.RemoveRange(existing);
 
         // Dedupe: a duplicate id in the posted list would insert two rows for the
-        // same (UserId, ShiftTagId) and violate the unique index (#888).
+        // same (UserId, ShiftTagId) and violate the unique index.
         foreach (var tagId in tagIds.Distinct())
         {
             ctx.VolunteerTagPreferences.Add(new VolunteerTagPreference

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftRepository.Management.cs
@@ -624,7 +624,9 @@ internal sealed partial class ShiftRepository : IShiftManagementRepository
 
         ctx.VolunteerTagPreferences.RemoveRange(existing);
 
-        foreach (var tagId in tagIds)
+        // Dedupe: a duplicate id in the posted list would insert two rows for the
+        // same (UserId, ShiftTagId) and violate the unique index (#888).
+        foreach (var tagId in tagIds.Distinct())
         {
             ctx.VolunteerTagPreferences.Add(new VolunteerTagPreference
             {

--- a/tests/Humans.Application.Tests/Repositories/ShiftRepositoryManagementTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ShiftRepositoryManagementTests.cs
@@ -117,7 +117,7 @@ public sealed class ShiftRepositoryManagementTests : IDisposable
     {
         // A duplicate tag id in the posted list must not insert two rows for the
         // same (UserId, ShiftTagId) — that violates IX_volunteer_tag_preferences_user_tag_unique
-        // in PostgreSQL and 500s the whole profile save. See #888.
+        // in PostgreSQL and 500s the whole profile save.
         var userId = Guid.NewGuid();
         var tag = new ShiftTag { Id = Guid.NewGuid(), Name = "A" };
         _dbContext.ShiftTags.Add(tag);

--- a/tests/Humans.Application.Tests/Repositories/ShiftRepositoryManagementTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ShiftRepositoryManagementTests.cs
@@ -112,6 +112,28 @@ public sealed class ShiftRepositoryManagementTests : IDisposable
         preferences.Should().BeEquivalentTo([tagB.Id, tagC.Id]);
     }
 
+    [HumansFact]
+    public async Task SetVolunteerTagPreferencesAsync_DeduplicatesTagIds()
+    {
+        // A duplicate tag id in the posted list must not insert two rows for the
+        // same (UserId, ShiftTagId) — that violates IX_volunteer_tag_preferences_user_tag_unique
+        // in PostgreSQL and 500s the whole profile save. See #888.
+        var userId = Guid.NewGuid();
+        var tag = new ShiftTag { Id = Guid.NewGuid(), Name = "A" };
+        _dbContext.ShiftTags.Add(tag);
+        await _dbContext.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        await _repo.SetVolunteerTagPreferencesAsync(userId, [tag.Id, tag.Id], Xunit.TestContext.Current.CancellationToken);
+
+        _dbContext.ChangeTracker.Clear();
+        var preferences = await _dbContext.VolunteerTagPreferences
+            .AsNoTracking()
+            .Where(v => v.UserId == userId)
+            .Select(v => v.ShiftTagId)
+            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        preferences.Should().ContainSingle().Which.Should().Be(tag.Id);
+    }
+
     // ─────────────────────────────────────────────────────────
     // helpers
     // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes #888 — `POST /Profile/Me/Edit` returned a 500 (`23505: duplicate key value violates unique constraint "IX_volunteer_tag_preferences_user_tag_unique"`) when the posted shift-tag list contained a duplicate tag id.

`ShiftRepository.SetVolunteerTagPreferencesAsync` deleted the user's existing prefs and then looped the incoming `tagIds`, `Add`-ing one row per id with no dedup. Two ids equal to the same tag became two INSERTs of the same `(UserId, ShiftTagId)` and collided on the unique index, failing the whole profile save. (EF Core correctly orders the delete-then-reinsert of an unchanged key, so this is purely the duplicate-input path, not delete/insert ordering.)

## Fix
- Dedupe at the repository write boundary: `foreach (var tagId in tagIds.Distinct())` in `ShiftRepository.Management.cs`. The repository owns the table invariant, so it's the right layer to defend (controller is presentation per the hard rules).

## Test
- Added `SetVolunteerTagPreferencesAsync_DeduplicatesTagIds` — passes a duplicated id and asserts a single row results. Confirmed it fails on the old code (two rows under the InMemory provider, which mirrors the duplicate INSERT Postgres rejects) and passes with the fix.
- Full `Humans.Application.Tests` green (3730 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)