### PR TITLE
chore: remove redundant code flagged by ReSharper InspectCode

### DIFF
--- a/src/Humans.Analyzers/CrossSectionRepositoryInjectionAnalyzer.cs
+++ b/src/Humans.Analyzers/CrossSectionRepositoryInjectionAnalyzer.cs
@@ -27,7 +27,6 @@ public sealed class CrossSectionRepositoryInjectionAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "HUM0017";
     public const string IndeterminateSectionId = "HUM0018";
 
-    private const string ServiceNamespacePrefix = "Humans.Application.Services.";
     private const string ApplicationServiceMarkerFullName = "Humans.Application.Interfaces.IApplicationService";
     private const string RepositoryMarkerFullName = "Humans.Application.Interfaces.Repositories.IRepository";
     private const string SectionAttributeFullName = "Humans.Domain.Attributes.SectionAttribute";

--- a/src/Humans.Application/Services/Events/EventService.cs
+++ b/src/Humans.Application/Services/Events/EventService.cs
@@ -647,7 +647,7 @@ public sealed class EventService(
             {
                 e.Description,
                 string.IsNullOrWhiteSpace(e.Host) ? null : $"Host: {e.Host}",
-                string.IsNullOrWhiteSpace(e.Category?.Name) ? null : $"Category: {e.Category!.Name}",
+                string.IsNullOrWhiteSpace(e.Category?.Name) ? null : $"Category: {e.Category.Name}",
             }.Where(s => !string.IsNullOrWhiteSpace(s)));
 
             foreach (var start in occurrences)

--- a/src/Humans.Application/Services/Finance/HoldedFinanceService.cs
+++ b/src/Humans.Application/Services/Finance/HoldedFinanceService.cs
@@ -569,7 +569,7 @@ public sealed class HoldedFinanceService(
         var binding = await repo.GetCreditorContactByUserAsync(userId, ct);
         // Reuse the bound contact, else lazy-seed from the report's previously-cached contact id.
         var existingContactId = !string.IsNullOrEmpty(binding?.HoldedContactId)
-            ? binding!.HoldedContactId
+            ? binding.HoldedContactId
             : (string.IsNullOrEmpty(seedContactId) ? null : seedContactId);
 
         // Burner goes in tradeName only — and only when it differs from the official legal name.

--- a/src/Humans.Application/Services/GoogleIntegration/SyncSettingsService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/SyncSettingsService.cs
@@ -1,6 +1,5 @@
 using NodaTime;
 using Humans.Application.Interfaces.Repositories;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Application.Interfaces.GoogleIntegration;
 

--- a/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
@@ -190,7 +190,7 @@ public sealed class NotificationInboxService(
             {
                 entry.AbsoluteExpirationRelativeToNow = BadgeCacheDuration;
                 return await repo.GetUnreadBadgeCountsAsync(userId, ct);
-            })!;
+            });
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)
     {

--- a/src/Humans.Application/Services/Surveys/SurveyService.cs
+++ b/src/Humans.Application/Services/Surveys/SurveyService.cs
@@ -753,7 +753,7 @@ public sealed class SurveyService(
             .Distinct()
             .ToList();
         var users = identifiedUserIds.Count == 0
-            ? (IReadOnlyDictionary<Guid, UserInfo>)new Dictionary<Guid, UserInfo>()
+            ? new Dictionary<Guid, UserInfo>()
             : await userService.GetUserInfosAsync(identifiedUserIds, ct);
 
         var rows = responses
@@ -1057,7 +1057,7 @@ public sealed class SurveyService(
                     Order = o.Order,
                     Value = o.Value,
                     Label = o.Label,
-                }).ToList<SurveyQuestionOption>(),
+                }).ToList(),
             };
         }).ToList();
 

--- a/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
+++ b/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
@@ -1,4 +1,3 @@
-using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Teams;

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StorePaymentConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StorePaymentConfiguration.cs
@@ -1,5 +1,4 @@
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -10,7 +10,6 @@ using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.ContactFields.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.ContactFields.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using NodaTime;
 
 namespace Humans.Infrastructure.Repositories.Users;

--- a/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
+++ b/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
@@ -189,9 +189,9 @@ public sealed class CachingCampService(
                     CampName: season.Name,
                     CampSlug: camp.Slug,
                     CampSeasonId: season.Id,
-                    Status: season.Status,
+                    season.Status,
                     TargetMemberCount: season.MemberCount,
-                    JoinedMemberCount: season.JoinedMemberCount)))
+                    season.JoinedMemberCount)))
             .ToList();
     }
 

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleTranslationClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleTranslationClient.cs
@@ -1,4 +1,3 @@
-using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Humans.Application.Extensions;

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -1,5 +1,4 @@
 using Humans.Application.Interfaces.Budget;
-using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -5,7 +5,6 @@ using Humans.Application.DTOs.Events;
 using Humans.Application.Events;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Camps;
-using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;

--- a/src/Humans.Web/Controllers/EventsModerationController.cs
+++ b/src/Humans.Web/Controllers/EventsModerationController.cs
@@ -1,8 +1,6 @@
 using Humans.Application;
 using Humans.Application.Events;
-using Humans.Application.Architecture;
 using Humans.Application.Interfaces.Camps;
-using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -1,4 +1,3 @@
-using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Budget;
 using Humans.Application.Interfaces.Expenses;
 using Humans.Application.Interfaces.Finance;
@@ -12,7 +11,6 @@ using Humans.Web.Authorization.Requirements;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Humans.Web.Controllers;

--- a/src/Humans.Web/Controllers/ScannerController.cs
+++ b/src/Humans.Web/Controllers/ScannerController.cs
@@ -1,4 +1,3 @@
-using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Consent;

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Humans.Application;
 using Humans.Application.Architecture;
 using Humans.Application.Extensions;
-using Humans.Application.DTOs.Shifts;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;

--- a/src/Humans.Web/Controllers/SurveyAdminController.cs
+++ b/src/Humans.Web/Controllers/SurveyAdminController.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 using Humans.Application.Interfaces.Surveys;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
-using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Models;

--- a/src/Humans.Web/Controllers/UsersAdminController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminController.cs
@@ -1,6 +1,5 @@
 // @e2e: board.spec.ts
 // @e2e: profile.spec.ts
-using Humans.Application;
 using Humans.Application.Authorization;
 using Humans.Application.Interfaces.Admin;
 using Humans.Application.Interfaces.AuditLog;

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -1,10 +1,12 @@
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using NodaTime;
 
 using Humans.Application.Interfaces.Users;
 
@@ -106,10 +108,10 @@ public sealed class WidgetGalleryController(
             },
             SampleTableRows =
             [
-                new() { Name = "Sparkle", Amount = 120.50m, JoinedAt = NodaTime.SystemClock.Instance.GetCurrentInstant().Minus(NodaTime.Duration.FromDays(400)), Status = Humans.Domain.Enums.TicketAttendeeStatus.Valid, IsVip = true },
-                new() { Name = "Embers", Amount = 95.00m, JoinedAt = NodaTime.SystemClock.Instance.GetCurrentInstant().Minus(NodaTime.Duration.FromDays(120)), Status = Humans.Domain.Enums.TicketAttendeeStatus.CheckedIn, IsVip = false },
-                new() { Name = "Dusty", Amount = 240.00m, JoinedAt = NodaTime.SystemClock.Instance.GetCurrentInstant().Minus(NodaTime.Duration.FromDays(30)), Status = Humans.Domain.Enums.TicketAttendeeStatus.Void, IsVip = false },
-                new() { Name = "Nova", Amount = 95.00m, JoinedAt = NodaTime.SystemClock.Instance.GetCurrentInstant().Minus(NodaTime.Duration.FromDays(10)), Status = Humans.Domain.Enums.TicketAttendeeStatus.Valid, IsVip = false },
+                new() { Name = "Sparkle", Amount = 120.50m, JoinedAt = SystemClock.Instance.GetCurrentInstant().Minus(Duration.FromDays(400)), Status = TicketAttendeeStatus.Valid, IsVip = true },
+                new() { Name = "Embers", Amount = 95.00m, JoinedAt = SystemClock.Instance.GetCurrentInstant().Minus(Duration.FromDays(120)), Status = TicketAttendeeStatus.CheckedIn, IsVip = false },
+                new() { Name = "Dusty", Amount = 240.00m, JoinedAt = SystemClock.Instance.GetCurrentInstant().Minus(Duration.FromDays(30)), Status = TicketAttendeeStatus.Void, IsVip = false },
+                new() { Name = "Nova", Amount = 95.00m, JoinedAt = SystemClock.Instance.GetCurrentInstant().Minus(Duration.FromDays(10)), Status = TicketAttendeeStatus.Valid, IsVip = false },
             ],
         };
 
@@ -249,6 +251,6 @@ public sealed class TableDemoRow
     public string Name { get; set; } = string.Empty;
     public decimal Amount { get; set; }
     public NodaTime.Instant JoinedAt { get; set; }
-    public Humans.Domain.Enums.TicketAttendeeStatus Status { get; set; }
+    public TicketAttendeeStatus Status { get; set; }
     public bool IsVip { get; set; }
 }

--- a/src/Humans.Web/Extensions/Sections/AgentSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/AgentSectionExtensions.cs
@@ -14,7 +14,6 @@ using Humans.Infrastructure.Stores;
 using Humans.Web.Filters;
 using Humans.Web.Services.Agent;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
 
 namespace Humans.Web.Extensions.Sections;
 

--- a/src/Humans.Web/Extensions/StatusBadgeExtensions.cs
+++ b/src/Humans.Web/Extensions/StatusBadgeExtensions.cs
@@ -41,7 +41,6 @@ public static class StatusBadgeExtensions
             ExpenseReportStatus.Submitted => "bg-primary",
             ExpenseReportStatus.CoordinatorEndorsed => "bg-info text-dark",
             ExpenseReportStatus.Approved => "bg-success",
-            ExpenseReportStatus.Withdrawn => "bg-secondary",
             _ => "bg-secondary"
         };
     }
@@ -55,7 +54,6 @@ public static class StatusBadgeExtensions
         {
             BudgetYearStatus.Draft => "bg-warning text-dark",
             BudgetYearStatus.Active => "bg-success",
-            BudgetYearStatus.Closed => "bg-secondary",
             _ => "bg-secondary"
         };
     }

--- a/src/Humans.Web/Health/AgentDocsHealthCheck.cs
+++ b/src/Humans.Web/Health/AgentDocsHealthCheck.cs
@@ -2,7 +2,6 @@ using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Stores;
 using Humans.Infrastructure.Services.Preload;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Logging;
 
 namespace Humans.Web.Health;
 

--- a/src/Humans.Web/TagHelpers/PageHeaderTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/PageHeaderTagHelper.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Encodings.Web;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Humans.Web.TagHelpers;

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -186,7 +186,7 @@ public class AgentServiceTests
             conversationId, Xunit.TestContext.Current.CancellationToken);
 
         preview.Should().NotBeNull();
-        preview!.SystemPromptTokens.Should().Be(4096);
+        preview.SystemPromptTokens.Should().Be(4096);
     }
 
     [HumansFact]
@@ -202,7 +202,7 @@ public class AgentServiceTests
             conversationId, Xunit.TestContext.Current.CancellationToken);
 
         preview.Should().NotBeNull();
-        preview!.SystemPromptTokens.Should().BeNull(
+        preview.SystemPromptTokens.Should().BeNull(
             "a count_tokens failure must never break the admin prompt-preview page");
     }
 

--- a/tests/Humans.Application.Tests/Architecture/SurveyArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/SurveyArchitectureTests.cs
@@ -3,7 +3,6 @@ using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Surveys;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Repositories.Surveys;
-using Xunit;
 using SurveyService = Humans.Application.Services.Surveys.SurveyService;
 
 namespace Humans.Application.Tests.Architecture;

--- a/tests/Humans.Application.Tests/Extensions/LoggerTimingExtensionsTests.cs
+++ b/tests/Humans.Application.Tests/Extensions/LoggerTimingExtensionsTests.cs
@@ -60,7 +60,7 @@ public class LoggerTimingExtensionsTests
         var snapshot = registry.GetTimings()
             .FirstOrDefault(t => string.Equals(t.Key, "RepeatClass.RepeatOp", StringComparison.Ordinal));
         snapshot.Should().NotBeNull();
-        snapshot!.Count.Should().BeGreaterThanOrEqualTo(2);
+        snapshot.Count.Should().BeGreaterThanOrEqualTo(2);
     }
 
     // ── Eat increments swallowed counter ───────────────────────────────────

--- a/tests/Humans.Application.Tests/Finance/HoldedFinanceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Finance/HoldedFinanceServiceTests.cs
@@ -254,7 +254,7 @@ public class HoldedFinanceServiceTests
 
         // The last saved state must be Error.
         savedState.Should().NotBeNull();
-        savedState!.SyncStatus.Should().Be(HoldedSyncStatus.Error);
+        savedState.SyncStatus.Should().Be(HoldedSyncStatus.Error);
         savedState.LastError.Should().NotBeNullOrEmpty();
     }
 
@@ -399,7 +399,7 @@ public class HoldedFinanceServiceTests
         var ledger = await MakeService().GetCreditorLedgerAsync(40000004, Xunit.TestContext.Current.CancellationToken);
 
         ledger.Should().NotBeNull();
-        ledger!.Balance.Should().Be(-50m);
+        ledger.Balance.Should().Be(-50m);
         ledger.OwedToMember.Should().Be(50m);
         ledger.Lines.Should().ContainSingle();
     }

--- a/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampRoleServiceTests.cs
@@ -480,7 +480,7 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
         await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
         _campAccess.GetCampSeasonsForComplianceAsync(2026, Arg.Any<CancellationToken>())
-            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, season.MemberCount, (int?)null)]);
+            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, season.MemberCount, null)]);
 
         var summaries = await _service.GetDirectoryRoleSummariesAsync(2026, Xunit.TestContext.Current.CancellationToken);
 
@@ -498,7 +498,7 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
         await SeedDefinitionAsync("LNT", slotCount: 1, minimumRequired: 1);
 
         _campAccess.GetCampSeasonsForComplianceAsync(2026, Arg.Any<CancellationToken>())
-            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, season.MemberCount, (int?)null)]);
+            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, season.MemberCount, null)]);
 
         var summaries = await _service.GetDirectoryRoleSummariesAsync(2026, Xunit.TestContext.Current.CancellationToken);
 
@@ -510,7 +510,7 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
     {
         var (camp, season) = await SeedCampWithSeasonAsync(year: 2026);
         // Sort order puts "LNT" before "Consent Lead" regardless of name.
-        var consent = await SeedDefinitionAsync("Consent Lead", slotCount: 2, minimumRequired: 1);
+        var consent = await SeedDefinitionAsync(slotCount: 2, minimumRequired: 1);
         var lnt = await SeedDefinitionAsync("LNT", slotCount: 1, minimumRequired: 1);
         lnt.SortOrder = -5;
         await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
@@ -528,7 +528,7 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
         await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
         _campAccess.GetCampSeasonsForComplianceAsync(2026, Arg.Any<CancellationToken>())
-            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, 25, (int?)7)]);
+            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, 25, 7)]);
 
         var matrix = await _service.BuildComplianceMatrixAsync(2026, Xunit.TestContext.Current.CancellationToken);
 
@@ -553,9 +553,9 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
 
         _campAccess.GetCampSeasonsForComplianceAsync(2026, Arg.Any<CancellationToken>())
             .Returns([
-                (camp.Id, "Active Camp", camp.Slug, season.Id, CampSeasonStatus.Active, 10, (int?)null),
-                (camp.Id, "Full Camp", camp.Slug, Guid.NewGuid(), CampSeasonStatus.Full, 10, (int?)null),
-                (camp.Id, "Pending Camp", camp.Slug, Guid.NewGuid(), CampSeasonStatus.Pending, 10, (int?)null),
+                (camp.Id, "Active Camp", camp.Slug, season.Id, CampSeasonStatus.Active, 10, null),
+                (camp.Id, "Full Camp", camp.Slug, Guid.NewGuid(), CampSeasonStatus.Full, 10, null),
+                (camp.Id, "Pending Camp", camp.Slug, Guid.NewGuid(), CampSeasonStatus.Pending, 10, null),
             ]);
 
         var matrix = await _service.BuildComplianceMatrixAsync(2026, Xunit.TestContext.Current.CancellationToken);
@@ -591,7 +591,7 @@ public sealed class CampRoleServiceTests : ServiceTestHarness
         await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
         _campAccess.GetCampSeasonsForComplianceAsync(2026, Arg.Any<CancellationToken>())
-            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, 10, (int?)null)]);
+            .Returns([(camp.Id, season.Name, camp.Slug, season.Id, season.Status, 10, null)]);
 
         var matrix = await _service.BuildComplianceMatrixAsync(2026, Xunit.TestContext.Current.CancellationToken);
 

--- a/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceEarlyEntryTests.cs
@@ -1,5 +1,4 @@
 using AwesomeAssertions;
-using Humans.Application;
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.EarlyEntry;

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -5,7 +5,6 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
 

--- a/tests/Humans.Application.Tests/Services/Events/EventServiceCalendarFeedTests.cs
+++ b/tests/Humans.Application.Tests/Services/Events/EventServiceCalendarFeedTests.cs
@@ -198,7 +198,7 @@ public class EventServiceCalendarFeedTests
     {
         var userId = Guid.NewGuid();
         _repo.GetFavouritesWithEventsAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<EventFavourite>)[]);
+            .Returns([]);
 
         var items = await _service.GetCalendarItemsForUserAsync(userId, Xunit.TestContext.Current.CancellationToken);
 

--- a/tests/Humans.Application.Tests/Services/Holded/HoldedClientContactTests.cs
+++ b/tests/Humans.Application.Tests/Services/Holded/HoldedClientContactTests.cs
@@ -5,7 +5,6 @@ using Humans.Application.Interfaces.Holded;
 using Humans.Infrastructure.Services.Holded;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using NodaTime;
 
 namespace Humans.Application.Tests.Services.Holded;
 

--- a/tests/Humans.Application.Tests/Services/ICalFeed/ICalFeedServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ICalFeed/ICalFeedServiceTests.cs
@@ -3,7 +3,6 @@ using Humans.Application.Interfaces.ICalFeed;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.ICalFeed;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceCalendarFeedTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceCalendarFeedTests.cs
@@ -8,7 +8,6 @@ using Humans.Application.Services.Shifts;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;

--- a/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
+++ b/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
@@ -5,7 +5,6 @@ using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;

--- a/tests/Humans.Application.Tests/Surveys/LocalizedTextTests.cs
+++ b/tests/Humans.Application.Tests/Surveys/LocalizedTextTests.cs
@@ -1,6 +1,5 @@
 using AwesomeAssertions;
 using Humans.Domain.ValueObjects;
-using Xunit;
 
 namespace Humans.Application.Tests.Surveys;
 

--- a/tests/Humans.Application.Tests/Surveys/SurveyBranchingEvaluatorTests.cs
+++ b/tests/Humans.Application.Tests/Surveys/SurveyBranchingEvaluatorTests.cs
@@ -3,8 +3,6 @@ using Humans.Application.Services.Surveys;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
-using Xunit;
-
 namespace Humans.Application.Tests.Surveys;
 
 public class SurveyBranchingEvaluatorTests
@@ -191,7 +189,7 @@ public class SurveyBranchingEvaluatorTests
         var q1 = Guid.NewGuid();
         var q2 = Guid.NewGuid();
         var q3 = Guid.NewGuid();
-        var ordered = new (Guid, BranchCondition?)[]
+        var ordered = new[]
         {
             (q1, null),
             (q2, Cond(BranchCombine.All, Clause(q1, BranchOperator.Is, "yes"))),

--- a/tests/Humans.Application.Tests/Surveys/SurveyInviteTokenTests.cs
+++ b/tests/Humans.Application.Tests/Surveys/SurveyInviteTokenTests.cs
@@ -1,7 +1,6 @@
 using AwesomeAssertions;
 using Humans.Infrastructure.Services.Surveys;
 using Microsoft.AspNetCore.DataProtection;
-using Xunit;
 
 namespace Humans.Application.Tests.Surveys;
 

--- a/tests/Humans.Application.Tests/Surveys/SurveyServiceTests.cs
+++ b/tests/Humans.Application.Tests/Surveys/SurveyServiceTests.cs
@@ -1,5 +1,4 @@
 using AwesomeAssertions;
-using Humans.Application;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Gdpr;
@@ -272,9 +271,9 @@ public class SurveyServiceTests
         _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
         _teamService.GetTeamAsync(teamId, Arg.Any<CancellationToken>()).Returns(TeamWith(teamId, a, b, c));
         _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlySet<Guid>)new HashSet<Guid> { a });
+            .Returns(new HashSet<Guid> { a });
         _userEmailService.GetNotificationTargetEmailsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>
+            .Returns(new Dictionary<Guid, string>
             {
                 [b] = "b@example.org",
                 [c] = "c@example.org",
@@ -305,9 +304,9 @@ public class SurveyServiceTests
         _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
         _teamService.GetTeamAsync(teamId, Arg.Any<CancellationToken>()).Returns(TeamWith(teamId, b, c));
         _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlySet<Guid>)new HashSet<Guid>());
+            .Returns(new HashSet<Guid>());
         _userEmailService.GetNotificationTargetEmailsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>
+            .Returns(new Dictionary<Guid, string>
             {
                 [b] = "b@example.org",
                 [c] = "c@example.org",
@@ -368,10 +367,10 @@ public class SurveyServiceTests
             LatestEmailStatus = EmailOutboxStatus.Sent,
         };
         _repo.GetInvitationsDueForReminderAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyInvitation>)new List<SurveyInvitation> { inv });
+            .Returns(new List<SurveyInvitation> { inv });
         _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
         _userEmailService.GetNotificationTargetEmailsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string> { [userId] = "u@example.org" });
+            .Returns(new Dictionary<Guid, string> { [userId] = "u@example.org" });
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
                 new Dictionary<Guid, UserInfo> { [userId] = UserInfoWithName(userId, "Sparkle") }));
@@ -391,7 +390,7 @@ public class SurveyServiceTests
     public async Task SendDueRemindersAsync_returns_zero_and_sends_nothing_when_none_due()
     {
         _repo.GetInvitationsDueForReminderAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyInvitation>)new List<SurveyInvitation>());
+            .Returns(new List<SurveyInvitation>());
 
         var count = await CreateService().SendDueRemindersAsync(TestContext.Current.CancellationToken);
 
@@ -414,10 +413,10 @@ public class SurveyServiceTests
             LatestEmailStatus = EmailOutboxStatus.Sent,
         };
         _repo.GetInvitationsDueForReminderAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyInvitation>)new List<SurveyInvitation> { inv });
+            .Returns(new List<SurveyInvitation> { inv });
         _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
         _userEmailService.GetNotificationTargetEmailsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>());
+            .Returns(new Dictionary<Guid, string>());
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
 
@@ -451,10 +450,10 @@ public class SurveyServiceTests
             LatestEmailStatus = EmailOutboxStatus.Sent,
         };
         _repo.GetInvitationsDueForReminderAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyInvitation>)new List<SurveyInvitation> { invA, invB });
+            .Returns(new List<SurveyInvitation> { invA, invB });
         _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
         _userEmailService.GetNotificationTargetEmailsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>
+            .Returns(new Dictionary<Guid, string>
             {
                 [userA] = "a@example.org",
                 [userB] = "b@example.org",
@@ -500,7 +499,7 @@ public class SurveyServiceTests
             LatestEmailStatus = EmailOutboxStatus.Queued,
         };
         _repo.GetInvitationsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyInvitation>)new List<SurveyInvitation> { knownInvite, unknownInvite });
+            .Returns(new List<SurveyInvitation> { knownInvite, unknownInvite });
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
                 new Dictionary<Guid, UserInfo> { [known] = UserInfoWithName(known, "Sparkle") }));
@@ -570,7 +569,7 @@ public class SurveyServiceTests
         var ctx = await CreateService().ResolveAnswerContextAsync("good", TestContext.Current.CancellationToken);
 
         ctx.Should().NotBeNull();
-        ctx!.SurveyId.Should().Be(survey.Id);
+        ctx.SurveyId.Should().Be(survey.Id);
         ctx.InvitationId.Should().Be(invitation.Id);
         ctx.UserId.Should().Be(userId);
         ctx.HasResumableDraft.Should().BeTrue();
@@ -644,7 +643,7 @@ public class SurveyServiceTests
         var ctx = await CreateService().ResolvePublicContextAsync(" Feedback ", TestContext.Current.CancellationToken);
 
         ctx.Should().NotBeNull();
-        ctx!.SurveyId.Should().Be(survey.Id);
+        ctx.SurveyId.Should().Be(survey.Id);
         ctx.Definition.Id.Should().Be(survey.Id);
         ctx.Definition.Status.Should().Be(SurveyStatus.Open);
     }
@@ -1095,7 +1094,7 @@ public class SurveyServiceTests
         Type = type,
         Prompt = L($"Q{order.ToString(System.Globalization.CultureInfo.InvariantCulture)}"),
         Options = opts.Select(o => new SurveyQuestionOption { Id = Guid.NewGuid(), QuestionId = id, Order = o.Order, Value = o.Value, Label = L(o.Label) })
-            .ToList<SurveyQuestionOption>(),
+            .ToList(),
     };
 
     private static SurveyQuestion RatingQuestion(Guid id, Guid surveyId, int order, int min, int max) => new()
@@ -1184,16 +1183,16 @@ public class SurveyServiceTests
                 ChoiceAnswer(choiceId, "no"), RatingAnswer(ratingId, 1), TextAnswer(textId, "")),
         };
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)responses);
+            .Returns(responses);
         _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, int>)new Dictionary<Guid, int> { [surveyId] = 4 });
+            .Returns(new Dictionary<Guid, int> { [surveyId] = 4 });
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
 
         var result = await CreateService().GetResultsAsync(surveyId, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
-        result!.ResponseCount.Should().Be(3);
+        result.ResponseCount.Should().Be(3);
         result.InvitedCount.Should().Be(4);
         result.ResponseRate.Should().BeApproximately(3d / 4d, 0.0001);
 
@@ -1245,9 +1244,9 @@ public class SurveyServiceTests
             SubmittedResponse(surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, now, null),
         };
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)responses);
+            .Returns(responses);
         _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, int>)new Dictionary<Guid, int>());
+            .Returns(new Dictionary<Guid, int>());
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
 
@@ -1284,9 +1283,9 @@ public class SurveyServiceTests
                 ChoiceAnswer(choiceId, "no")),
         };
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)responses);
+            .Returns(responses);
         _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, int>)new Dictionary<Guid, int>());
+            .Returns(new Dictionary<Guid, int>());
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
                 new Dictionary<Guid, UserInfo> { [identifiedUser] = UserInfoWithName(identifiedUser, "Sparkle") }));
@@ -1294,7 +1293,7 @@ public class SurveyServiceTests
         var result = await CreateService().GetResultsAsync(surveyId, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
-        result!.ResponseCount.Should().Be(3);
+        result.ResponseCount.Should().Be(3);
         // All three counted in the aggregate (2 yes, 1 no).
         var choice = result.Questions.Single(q => q.QuestionId == choiceId);
         choice.OptionCounts.Single(o => string.Equals(o.Value, "yes", StringComparison.Ordinal)).Count.Should().Be(2);
@@ -1321,13 +1320,13 @@ public class SurveyServiceTests
 
         var user = Guid.NewGuid();
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)new List<SurveyResponse>
+            .Returns(new List<SurveyResponse>
             {
                 SubmittedResponse(surveyId, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
                     _clock.GetCurrentInstant(), user),
             });
         _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, int>)new Dictionary<Guid, int>());
+            .Returns(new Dictionary<Guid, int>());
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
 
@@ -1356,17 +1355,17 @@ public class SurveyServiceTests
             SubmittedResponse(surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, now, null),
         };
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)responses);
+            .Returns(responses);
         _repo.GetStartedInvitationCountAsync(surveyId, Arg.Any<CancellationToken>()).Returns(7);
         _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyDictionary<Guid, int>)new Dictionary<Guid, int> { [surveyId] = 10 });
+            .Returns(new Dictionary<Guid, int> { [surveyId] = 10 });
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
 
         var result = await CreateService().GetResultsAsync(surveyId, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
-        result!.Funnel.LinkStarted.Should().Be(7);
+        result.Funnel.LinkStarted.Should().Be(7);
         result.Funnel.LinkFinished.Should().Be(2);   // Identified + CompletionTracked via link
         result.Funnel.SlugStarted.Should().Be(9);
         result.Funnel.SlugFinished.Should().Be(2);   // two anonymous slug responses
@@ -1409,7 +1408,7 @@ public class SurveyServiceTests
                 ChoiceAnswer(choiceId, "no")),
         };
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)responses);
+            .Returns(responses);
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
                 new Dictionary<Guid, UserInfo> { [identifiedUser] = UserInfoWithName(identifiedUser, "Sparkle") }));
@@ -1417,7 +1416,7 @@ public class SurveyServiceTests
         var export = await CreateService().GetResponseExportAsync(surveyId, TestContext.Current.CancellationToken);
 
         export.Should().NotBeNull();
-        export!.Rows.Should().HaveCount(3);   // every tier appears so totals reconcile
+        export.Rows.Should().HaveCount(3);   // every tier appears so totals reconcile
 
         var identified = export.Rows.Single(r => r.Anonymity == ResponseAnonymity.Identified);
         identified.UserId.Should().Be(identifiedUser);
@@ -1444,7 +1443,7 @@ public class SurveyServiceTests
 
         var now = _clock.GetCurrentInstant();
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)new List<SurveyResponse>
+            .Returns(new List<SurveyResponse>
             {
                 SubmittedResponse(surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, now, null,
                     ChoiceAnswer(multiId, "a", "b"), TextAnswer(textId, "free")),
@@ -1455,7 +1454,7 @@ public class SurveyServiceTests
         var export = await CreateService().GetResponseExportAsync(surveyId, TestContext.Current.CancellationToken);
 
         export.Should().NotBeNull();
-        export!.Questions.Select(q => q.QuestionId).Should().ContainInOrder(multiId, textId);
+        export.Questions.Select(q => q.QuestionId).Should().ContainInOrder(multiId, textId);
 
         var row = export.Rows.Single();
         var multiAnswer = row.Answers.Single(a => a.QuestionId == multiId);
@@ -1480,7 +1479,7 @@ public class SurveyServiceTests
         var late = SubmittedResponse(surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, t0 + Duration.FromHours(2), null);
         // Provide them out of chronological order.
         _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)new List<SurveyResponse> { late, early });
+            .Returns(new List<SurveyResponse> { late, early });
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
 
@@ -1514,7 +1513,7 @@ public class SurveyServiceTests
             _clock.GetCurrentInstant(), userId,
             ChoiceAnswer(choiceId, "yes"), RatingAnswer(ratingId, 4), TextAnswer(textId, "loved it"));
         _repo.GetIdentifiedResponsesForUserAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)new List<SurveyResponse> { response });
+            .Returns(new List<SurveyResponse> { response });
 
         var slices = await CreateService().ContributeForUserAsync(userId, TestContext.Current.CancellationToken);
 
@@ -1535,7 +1534,7 @@ public class SurveyServiceTests
     {
         var userId = Guid.NewGuid();
         _repo.GetIdentifiedResponsesForUserAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)new List<SurveyResponse>());
+            .Returns(new List<SurveyResponse>());
 
         var slices = await CreateService().ContributeForUserAsync(userId, TestContext.Current.CancellationToken);
 
@@ -1561,7 +1560,7 @@ public class SurveyServiceTests
         var one = SubmittedResponse(surveyId, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
             _clock.GetCurrentInstant(), userId);
         _repo.GetIdentifiedResponsesForUserAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<SurveyResponse>)new List<SurveyResponse> { one });
+            .Returns(new List<SurveyResponse> { one });
 
         var slices = await CreateService().ContributeForUserAsync(userId, TestContext.Current.CancellationToken);
 

--- a/tests/Humans.Application.Tests/Surveys/SurveyWizardFlowTests.cs
+++ b/tests/Humans.Application.Tests/Surveys/SurveyWizardFlowTests.cs
@@ -3,7 +3,6 @@ using Humans.Application.Interfaces.Surveys;
 using Humans.Application.Services.Surveys;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
-using Xunit;
 
 namespace Humans.Application.Tests.Surveys;
 

--- a/tests/Humans.Integration.Tests/Localization/RenderedTextScanner.cs
+++ b/tests/Humans.Integration.Tests/Localization/RenderedTextScanner.cs
@@ -32,7 +32,7 @@ internal static class RenderedTextScanner
     public static IReadOnlyList<string> ExtractTextRuns(string html)
     {
         var document = Parser.ParseDocument(html);
-        var root = document.QuerySelector("main") ?? (IElement?)document.Body;
+        var root = document.QuerySelector("main") ?? document.Body;
         if (root is null)
             return [];
 

--- a/tests/Humans.Integration.Tests/Services/CachingEventServiceTests.cs
+++ b/tests/Humans.Integration.Tests/Services/CachingEventServiceTests.cs
@@ -195,7 +195,7 @@ public class CachingEventServiceTests(HumansWebApplicationFactory factory) : ICl
         loaded.Status.Should().Be(EventStatus.Approved);
         var cached = await svc.GetApprovedEventByIdAsync(ev.Id, TestContext.Current.CancellationToken);
         cached.Should().NotBeNull("an edited Approved event stays approved and in the cache");
-        cached!.Title.Should().Be("Edited title");
+        cached.Title.Should().Be("Edited title");
     }
 
     [HumansFact]

--- a/tests/Humans.Web.Tests/Controllers/EventsApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EventsApiControllerTests.cs
@@ -5,7 +5,6 @@ using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Humans.Web.Controllers.Api;
 using Humans.Web.Models.Events;
 using Microsoft.AspNetCore.Http;

--- a/tests/Humans.Web.Tests/Controllers/EventsControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EventsControllerTests.cs
@@ -2,7 +2,6 @@ using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Application;
 using Humans.Application.Interfaces.Camps;
-using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Events;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
@@ -69,7 +69,7 @@ public class OnboardingWidgetControllerConsentsTests
         // doesn't divert tests that exercise the consent flow itself.
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(isStub ? StubUserInfo(userId) : NonStubUserInfo(userId));
-        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, NodaTime.SystemClock.Instance, _localizer);
+        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = _http,

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
@@ -48,7 +48,7 @@ public class OnboardingWidgetControllerNamesTests
         var user = new User { Id = userId };
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
         _state.GetCurrentStepAsync(userId, Arg.Any<CancellationToken>()).Returns(currentStep);
-        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, NodaTime.SystemClock.Instance, _localizer);
+        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId.ToString())],
@@ -69,7 +69,7 @@ public class OnboardingWidgetControllerNamesTests
         // never the claims.
         var userId = Guid.NewGuid();
         var ctrl = new OnboardingWidgetController(
-            _userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, NodaTime.SystemClock.Instance, _localizer);
+            _userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity(

--- a/tests/Humans.Web.Tests/Controllers/TeamAdminControllerTicketLookupTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/TeamAdminControllerTicketLookupTests.cs
@@ -3,7 +3,6 @@ using Humans.Application;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Controllers;
-using Humans.Web.Models;
 using NodaTime;
 
 namespace Humans.Web.Tests.Controllers;

--- a/tests/Humans.Web.Tests/Infrastructure/InMemoryLogSinkTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/InMemoryLogSinkTests.cs
@@ -1,7 +1,6 @@
 using AwesomeAssertions;
 using Humans.Web.Infrastructure;
 using Serilog.Events;
-using Serilog.Parsing;
 
 namespace Humans.Web.Tests.Infrastructure;
 

--- a/tests/Humans.Web.Tests/Mailer/MailerAudienceDebugSnapshotBuilderTests.cs
+++ b/tests/Humans.Web.Tests/Mailer/MailerAudienceDebugSnapshotBuilderTests.cs
@@ -4,7 +4,6 @@ using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Humans.Web.Models.Mailer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Humans.Web.Tests/Models/Survey/SurveyBuilderViewModelTests.cs
+++ b/tests/Humans.Web.Tests/Models/Survey/SurveyBuilderViewModelTests.cs
@@ -32,7 +32,7 @@ public sealed class SurveyBuilderViewModelTests
         var showIf = vm.ToInput(0).ShowIf;
 
         showIf.Should().NotBeNull();
-        showIf!.Combine.Should().Be(BranchCombine.Any);
+        showIf.Combine.Should().Be(BranchCombine.Any);
         var clause = showIf.Clauses.Should().ContainSingle().Subject;
         clause.QuestionId.Should().Be(gate);
         clause.Operator.Should().Be(BranchOperator.Is);

--- a/tests/Humans.Web.Tests/Models/Tables/TableModelBuilderTests.cs
+++ b/tests/Humans.Web.Tests/Models/Tables/TableModelBuilderTests.cs
@@ -21,7 +21,7 @@ public class TableModelBuilderTests
         var table = TableModel.For(Rows)
             .Column("Name", r => r.Name)
             .Column("Amount", r => r.Amount, c => c.Currency().End())
-            .Template("Actions", r => new HtmlString("<a>x</a>"))
+            .Template("Actions", _ => new HtmlString("<a>x</a>"))
             .Build();
 
         table.Columns.Select(c => c.Header).Should().Equal("Name", "Amount", "Actions");

--- a/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsTrackerTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
 using Humans.Infrastructure.Services;
 using Xunit;
 
@@ -84,7 +85,7 @@ public class ClientStatsTrackerTests
         snap.Resolutions.Should().BeEmpty();
     }
 
-    private static Humans.Application.Interfaces.ClientErrorEntry Error(
+    private static ClientErrorEntry Error(
         int status = 404, string url = "/missing", string ua = WinChrome)
         => new(NodaTime.SystemClock.Instance.GetCurrentInstant(), status, "GET", url, "203.0.113.7", null, ua);
 


### PR DESCRIPTION
Runs ReSharper InspectCode against `Humans.slnx` and applies the **safe, mechanical redundancy fixes** only.

## What changed (54 `.cs` files, +74/−111)
- Unused `using` directives, redundant casts, redundant name qualifiers, redundant null-forgiving (`!`) operators, and a few misc redundant expressions.
- Removed a dead shadowed `ServiceNamespacePrefix` const in `CrossSectionRepositoryInjectionAnalyzer` (the file already uses the canonical `Sections.ServiceNamespacePrefix`).
- Removed an unused lambda parameter (`r` → `_`) in a table test.

## Triage of the higher-priority tiers — nothing to fix
- **23 "Error" findings: all false positives.** MVC actions resolve via `[Route(...)]` attribute routing (view folder ≠ controller name); resource keys exist but are read dynamically via `ResourceManager.GetString`; `.HtmlErrors` are JS string literals inside `<script>`; `.RazorErrors` are valid conditional `<option>` markup.
- **14 "Possible bug" findings: no real defects.** Multiple-enumeration of already-materialized collections, or always-true / redundant-`??` checks that are *correct defensive code* against EF-navigation and model-binding nulls the nullable annotations don't reflect. Removing them would introduce NRE risk.

## Deliberately skipped
- ~600 `UnusedAutoPropertyAccessor` / `NotAccessedPositionalProperty` warnings on DTOs / view-models / EF entities (bound via Razor, JSON serialization, or EF materialization — not actually dead).
- 708 `LambdaExpressionCanBeMadeStatic` and naming/xmldoc/`HUM00xx` noise.

## Razor views reverted (important)
The project uses `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation`, so `.cshtml` changes **cannot be validated by `dotnet build`** and the app can't run here (DB needs Docker). One reverted change also removed a load-bearing `(long)` cast (changed a value's type). All 23 view changes were reverted; only build-and-test-verified `.cs` cleanup remains.

## Verification
- Build: **0 errors**.
- Unit tests: **4560 passing** (Domain 271, Analyzers 222, Web 338, Application 3729); 3 skipped.
- Integration tests need Docker (unavailable in this environment), so they were not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)