### PR TITLE
Name the human in the remove-from-shift confirm dialog

### DIFF
--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -586,13 +586,14 @@
                                                                     <vc:human user-id="@signup.UserId" />
                                                                     @{
                                                                         var manageProfile = Model.VolunteerProfiles.GetValueOrDefault(signup.UserId);
+                                                                        var manageName = Model.Users.GetValueOrDefault(signup.UserId)?.BurnerName ?? "this human";
                                                                     }
                                                                     @await Html.PartialAsync("_VolunteerProfileBadges", manageProfile)
                                                                 </div>
                                                                 <form asp-action="RemoveSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
                                                                     @Html.AntiForgeryToken()
                                                                     <button type="submit" class="btn btn-sm btn-outline-secondary"
-                                                                            data-confirm="Remove this human from the shift?">Remove</button>
+                                                                            data-confirm="Remove @manageName from the shift?">Remove</button>
                                                                 </form>
                                                             </div>
                                                         }
@@ -622,6 +623,7 @@
                                                                 <vc:human user-id="@signup.UserId" />
                                                                 @{
                                                                     var signupProfile = Model.VolunteerProfiles.GetValueOrDefault(signup.UserId);
+                                                                    var signupName = Model.Users.GetValueOrDefault(signup.UserId)?.BurnerName ?? "this human";
                                                                 }
                                                                 @await Html.PartialAsync("_VolunteerProfileBadges", signupProfile)
                                                                 @if (signup.Status == SignupStatus.NoShow)
@@ -639,7 +641,7 @@
                                                                     <form asp-action="RemoveSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
                                                                         @Html.AntiForgeryToken()
                                                                         <button type="submit" class="btn btn-sm btn-outline-secondary"
-                                                                                data-confirm="Remove this human from the shift?">Remove</button>
+                                                                                data-confirm="Remove @signupName from the shift?">Remove</button>
                                                                     </form>
                                                                     <form asp-action="MarkNoShow" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
                                                                         @Html.AntiForgeryToken()


### PR DESCRIPTION
## What

The "Remove" buttons on the **ShiftAdmin** page previously popped a confirm dialog reading **"Remove this human from the shift?"** — with no indication of *which* human, so an admin couldn't verify they'd selected the right row.

Both confirm prompts now name the person:

> Remove **Alice** from the shift?

## How

In `src/Humans.Web/Views/ShiftAdmin/Index.cshtml`, both occurrences (manage active-shift signups + past-shift signups) now interpolate the signup's `BurnerName` — the same profile name already shown next to each row, via `Model.Users.GetValueOrDefault(signup.UserId)?.BurnerName` — into the `data-confirm` text, falling back to `"this human"` when the user isn't in the lookup.

Razor HTML-encodes the interpolated value, so names containing quotes won't break the `data-confirm` attribute. The confirmation mechanism is unchanged (native `confirm()` wired via `site.js`); only the message text changed.

## Verification

- `dotnet build src/Humans.Web` → **0 errors** (pre-existing analyzer warnings only).
- Not yet exercised in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)