### PR TITLE
feat(cantina): feed humans the day before their first confirmed shift

### DIFF
--- a/docs/sections/Cantina.md
+++ b/docs/sections/Cantina.md
@@ -17,7 +17,8 @@ Read-only weekly roster surface for the food-service team — who is on site eac
 ## Concepts
 
 - The **Cantina** is the food-service team. It plans meals around who is on site for the week, not who is medically vulnerable.
-- A human is **on site for a day** when they hold a Pending or Confirmed `ShiftSignup` on a Shift whose `DayOffset` matches that calendar day (relative to `EventSettings.GateOpeningDate`). All-day shifts cover one day each.
+- A human is **on site for a day** when they hold a Confirmed `ShiftSignup` on a Shift whose `DayOffset` matches that calendar day (relative to `EventSettings.GateOpeningDate`). All-day shifts cover one day each.
+- **Arrival-day rule:** a human is also counted as on site (fed) on the day before their first confirmed shift: `arrivalDay = firstConfirmedShiftDay − 1`. This arrival day is stored as `ArrivesOn` on the roster person. The rule applies to the weekly roster, the per-day summary, the daily drill-down, and the CSV export.
 - The **Weekly Roster** is the page payload: the cohort of unique humans on site at any point in the Mon–Sun window, their `ArrivesOn` date, their `NoShift` dates (days within the week with no on-site signup), and their non-medical dietary fields (preference, allergies, intolerances, "Other" free-text). Aggregates (dietary preference roll-up, allergy/intolerance counts) are computed over **unique humans** for the week — never summed per day.
 - The **Daily Mini-Summary** lists the same per-day cohort counts as a sanity check; same uniqueness rule applies within the day.
 
@@ -25,7 +26,7 @@ Read-only weekly roster surface for the food-service team — who is on site eac
 
 None — Cantina owns no tables. The section is a pure read/aggregate composition over:
 
-- `shift_signups` — owned by **Shifts** ([`Shifts.md`](Shifts.md)). Filtered to `Status ∈ {Pending, Confirmed}` joined to `shifts` by `DayOffset`. Read **through `IShiftManagementService`** (`GetOnSiteUserIdsForDayAsync`), never the Shifts repository directly.
+- `shift_signups` — owned by **Shifts** ([`Shifts.md`](Shifts.md)). Filtered to `Status = Confirmed` joined to `shifts` by `DayOffset`. Read **through `IShiftManagementService`** (`GetOnSiteUserIdsForDayAsync`), never the Shifts repository directly.
 - Dietary (`DietaryPreference`, `Allergies`, `AllergyOtherText`, `Intolerances`, `IntoleranceOtherText`) — `Profile` fields owned by **Users/Identity**, read through the cached **`IUserServiceRead.GetUserInfosAsync`** (`UserInfo.Profile`). **`MedicalConditions` is never read by the cantina** — the cantina DTOs have no such field.
 - `profiles` / `users` — owned by **Users/Identity**. Burner names are read via the cross-section **`IUserServiceRead.GetUserInfosAsync`** (cached `UserInfo`); no entity reads, no new surface.
 
@@ -53,11 +54,11 @@ None — Cantina owns no tables. The section is a pure read/aggregate compositio
 ## Invariants
 
 - **`MedicalConditions` is never surfaced via this section, regardless of viewer role.** The Cantina plans around food, not medical history (GDPR Article 9 boundary). `MedicalConditions` lives on the cached `UserInfo`/`ProfileInfo`, but `CantinaRosterService` simply never reads it, and the output DTOs (`RosterPersonDto`, `DailyPersonRowDto`) have no `MedicalConditions` property. Medical data continues to flow only through the `_VolunteerProfileBadges` partial with `ShowMedical=true`, gated to NoInfoAdmin / Admin — not through Cantina.
-- "On site" is strictly defined as a Pending or Confirmed `ShiftSignup` on a Shift with matching `DayOffset`. Refused, Bailed, Cancelled, and NoShow signups do not count. All-day shifts are single-day (one row per signup per day per shift, per Shifts §all-day-window).
+- "On site" is strictly defined as a Confirmed `ShiftSignup` on a Shift with matching `DayOffset`, **plus the arrival day** (`arrivalDay = firstConfirmedShiftDay − 1`). Refused, Bailed, Cancelled, NoShow, and Pending signups do not count. All-day shifts are single-day (one row per signup per day per shift, per Shifts §all-day-window).
 - Weekly aggregates (dietary preference roll-up, allergy / intolerance counters, total head count) are computed over **unique humans** for the week, not summed day-by-day. A human on site Mon + Wed counts once.
 - The section is **read-only** — no writes to any table, no audit entries, no notifications.
 - The roster is rendered live on every request — no cached aggregates. CSV exports the same in-memory aggregate produced for the HTML view.
-- Every `RosterPersonDto` in the cohort has at least one on-site day in the window by construction; `ArrivesOn` is therefore non-nullable.
+- Every `RosterPersonDto` in the cohort has at least one on-site day in the window by construction; `ArrivesOn` is therefore non-nullable. The arrival day is a real on-site day, so the `ArrivesOn`-is-non-nullable invariant holds for all roster humans including arrival-day humans.
 - Burner-name stitching reads `UserInfo.BurnerName` (from `IUserServiceRead`), falling through to `"(unknown)"` when absent. `UserInfo.BurnerName` itself derives from `Profile.BurnerName` with the legacy `DisplayName` fallback handled inside the Users section.
 
 ## Negative Access Rules

--- a/docs/superpowers/plans/2026-06-24-cantina-arrival-and-fodmap.md
+++ b/docs/superpowers/plans/2026-06-24-cantina-arrival-and-fodmap.md
@@ -1,0 +1,284 @@
+# Cantina arrival-day feeding + remove FODMAP — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the FODMAP intolerance option, and make the Cantina roster feed each human on the day before their first *confirmed* shift.
+
+**Architecture:** Two independent features → **two branches, two PRs** off `origin/main`. Feature 1 is a deletion across the canonical option list + locale files. Feature 2 flips one hardcoded scope constant in the Shifts service (cantina is its sole caller) and adds an inline "earliest confirmed day" scan in `CantinaRosterService` to derive each human's arrival day (`firstConfirmedOffset − 1`).
+
+**Tech Stack:** .NET (C#), EF Core, NodaTime, xUnit (`[HumansFact]`), NSubstitute, AwesomeAssertions.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md`
+
+**Build/test (from repo root):** `dotnet build Humans.slnx -v quiet` · `dotnet test Humans.slnx -v quiet` (the `-v quiet` is mandatory).
+
+---
+
+## Chunk 1: PR #1 — Remove FODMAP intolerance
+
+Branch: `chore/remove-fodmap-intolerance` (worktree `.worktrees/fodmap-removal`), off `origin/main`.
+This is a near-mechanical deletion; one test changes. No migration (existing data left inert, per spec).
+
+### Task 1.1: Drop FODMAP from the canonical list (red via existing test)
+
+**Files:**
+- Modify: `src/Humans.Domain/Constants/DietaryOptions.cs:38`
+- Modify (test): `tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs:307`
+
+- [ ] **Step 1: Update the existing rollup test to the new expectation (it should fail first).**
+  In `CantinaRosterServiceTests.cs` remove the now-invalid assertion line:
+  ```csharp
+  intolerance["FODMAP"].Should().Be(0);
+  ```
+  Removing it is required because, once FODMAP leaves `IntoleranceOptions`, the rollup dictionary
+  no longer contains a `"FODMAP"` key and that line would throw `KeyNotFoundException`.
+
+- [ ] **Step 2: Run the affected test BEFORE the domain change to confirm current green baseline.**
+  Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CantinaRosterServiceTests"`
+  Expected: PASS (baseline, FODMAP still present).
+
+- [ ] **Step 3: Remove `"FODMAP"` from `IntoleranceOptions`.**
+  `DietaryOptions.cs:38`:
+  ```csharp
+  // before
+  public static readonly IReadOnlyList<string> IntoleranceOptions =
+      ["Lactose", "Gluten", "Histamine", "FODMAP", OtherOption];
+  // after
+  public static readonly IReadOnlyList<string> IntoleranceOptions =
+      ["Lactose", "Gluten", "Histamine", OtherOption];
+  ```
+
+- [ ] **Step 4: Run the cantina tests again.**
+  Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CantinaRosterServiceTests"`
+  Expected: PASS (rollup no longer has FODMAP; assertion removed).
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git add src/Humans.Domain/Constants/DietaryOptions.cs \
+          tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
+  git commit -m "feat(profile): remove FODMAP from intolerance options"
+  ```
+
+### Task 1.2: Delete the FODMAP localization entries
+
+**Files (modify all six):**
+`src/Humans.Web/Resources/SharedResource.resx`, `.es.resx`, `.de.resx`, `.ca.resx`, `.fr.resx`, `.it.resx`
+
+- [ ] **Step 1: Delete the `Profile_DietaryMedical_Intolerance_FODMAP` `<data>` element from each file.**
+  Each file has exactly one line of the form:
+  ```xml
+  <data name="Profile_DietaryMedical_Intolerance_FODMAP" xml:space="preserve"><value>FODMAP</value></data>
+  ```
+  Remove that single line in all six files. One-liner per file:
+  ```bash
+  for f in SharedResource SharedResource.es SharedResource.de SharedResource.ca SharedResource.fr SharedResource.it; do
+    sed -i '/name="Profile_DietaryMedical_Intolerance_FODMAP"/d' "src/Humans.Web/Resources/$f.resx"
+  done
+  ```
+
+- [ ] **Step 2: Verify no FODMAP references remain anywhere.**
+  Run: `grep -rni "FODMAP" src/ tests/`
+  Expected: no output.
+
+- [ ] **Step 3: Build to confirm resx still well-formed and nothing references the dropped key.**
+  Run: `dotnet build Humans.slnx -v quiet`
+  Expected: 0 errors.
+
+- [ ] **Step 4: Full test run.**
+  Run: `dotnet test Humans.slnx -v quiet`
+  Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git add src/Humans.Web/Resources/SharedResource*.resx
+  git commit -m "chore(i18n): drop FODMAP intolerance label from all locales"
+  ```
+
+### Task 1.3: Open PR #1
+- [ ] Push branch to `origin` and open a PR to `origin/main` titled
+  `feat(profile): remove FODMAP from intolerances`. Body: link the spec; note existing stored
+  `"FODMAP"` values are left inert (no migration) and self-heal on next profile save.
+
+---
+
+## Chunk 2: PR #2 — Cantina arrival-day feeding
+
+Branch: `feat/cantina-arrival-day` (this worktree; carries the spec + plan docs), off `origin/main`.
+Confirmed-only scope change + inline arrival-day computation. TDD against `CantinaRosterService`.
+
+> **Mock note:** `CantinaRosterServiceTests` stub `IShiftManagementService.GetOnSiteUserIdsForDayAsync`
+> at the interface (which has no scope parameter). So the §(a) scope-constant change is invisible to
+> these unit tests — they assert on whatever the stub returns. Arrival-day tests must therefore stub
+> the *range* of offsets the helper scans, which means setting event offsets on the fixture (next note).
+
+> **Fixture note:** `ActiveEvent()` currently sets no `BuildStartOffset`/`StrikeEndOffset` (both default
+> 0), so the (b) range scan would cover only day 0. Arrival-day tests must build an event with explicit
+> offsets wide enough to cover the days they stub, e.g. `BuildStartOffset = -2, StrikeEndOffset = 8`.
+
+### Task 2.1: Confirmed-only scope + doc comments (no cantina-test impact)
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Shifts/ShiftManagementService.cs:1979`
+- Modify (doc): `src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs:354`
+
+- [ ] **Step 1: Flip the scope constant.**
+  `ShiftManagementService.cs:1979`: `ShiftDayUserStatusScope.PendingOrConfirmed` → `ShiftDayUserStatusScope.ConfirmedOnly`.
+
+- [ ] **Step 2: Fix the now-stale XML doc on the interface method** (`IShiftManagementService.cs:354`):
+  change wording "Pending/Confirmed signup" → "Confirmed signup". (The stale wording lives only here
+  and in `Cantina.md` — there is no prose comment at the impl site 1974-1980, so don't go hunting.)
+
+- [ ] **Step 3: Build + run shifts/cantina tests (should stay green — cantina mocks this method).**
+  Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Cantina|FullyQualifiedName~ShiftManagement"`
+  Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+  ```bash
+  git add src/Humans.Application/Services/Shifts/ShiftManagementService.cs \
+          src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+  git commit -m "feat(cantina): count only confirmed shifts for on-site cohort"
+  ```
+
+### Task 2.2: Earliest-confirmed-day helper + weekly arrival day (TDD)
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Cantina/CantinaRosterService.cs`
+- Test: `tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs`
+
+- [ ] **Step 1: Write the failing test — first shift Wed ⇒ appears Tue as arrival.**
+  Build an event with offsets covering the days, stub confirmed cohorts so a human's earliest day is
+  Wednesday (offset 2), and assert they now show on Tuesday (offset 1) with `ArrivesOn` = Tue and Tue
+  in `NoShift`. Sketch:
+  ```csharp
+  [HumansFact]
+  public async Task GetWeeklyRoster_FeedsHumanDayBeforeFirstConfirmedShift()
+  {
+      var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8); // helper sets offsets
+      _shiftMgmt.GetActiveAsync().Returns(ev);
+      var id = Guid.NewGuid();
+      // First (and only) confirmed shift on Wednesday = offset 2.
+      _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 2, Arg.Any<CancellationToken>())
+          .Returns(Task.FromResult<IReadOnlyList<Guid>>(new[] { id }));
+      SetupHumans(Human(id, "Ash"));
+
+      var result = await _service.GetWeeklyRosterAsync(0, TestContext.Current.CancellationToken);
+
+      var person = result.People.Single(p => p.UserId == id);
+      person.ArrivesOn.Should().Be(GateOpening.PlusDays(1));        // Tuesday
+      person.NoShift.Should().Contain(GateOpening.PlusDays(1));      // present, no shift
+      result.Days[1].TotalOnSite.Should().Be(1);                    // Tuesday cohort includes them
+  }
+  ```
+  Add a small `ActiveEventWithRange(...)` fixture helper (mirrors `ActiveEvent()` + sets
+  `BuildStartOffset`/`StrikeEndOffset`/`EventEndOffset`). Reuse the existing `SetupHumans`/`Human` helpers.
+
+- [ ] **Step 2: Run it — expect FAIL** (person absent Tuesday today).
+  Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~FeedsHumanDayBeforeFirstConfirmedShift"`
+  Expected: FAIL.
+
+- [ ] **Step 3: Implement.**
+  In `CantinaRosterService`:
+  - Add `private async Task<Dictionary<Guid,int>> BuildFirstConfirmedOffsetByUserAsync(EventSettings ev, CancellationToken ct)`
+    looping `offset = ev.BuildStartOffset; offset <= ev.StrikeEndOffset; offset++`, calling
+    `_shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, offset, ct)`, recording min offset per user.
+  - In `GetWeeklyRosterAsync`, after `BuildDaysOnSiteByUserId(...)`, call the helper and for each
+    `(user, minOffset)` compute `arrivalOffset = minOffset - 1`; if `weekStartDate.PlusDays(arrivalOffset - weekStartOffset)`
+    falls within `weekDays`, add that date to the user's list in `daysOnSiteByUserId` (creating the
+    entry if absent), then recompute `uniqueUserIds = daysOnSiteByUserId.Keys`. Existing downstream
+    code (`ArrivesOn = daysList[0]` after sort, `NoShift`, aggregates over `uniqueUserIds`) then needs
+    no further change.
+
+- [ ] **Step 4: Run the test — expect PASS.**
+  Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~FeedsHumanDayBeforeFirstConfirmedShift"`
+  Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git add src/Humans.Application/Services/Cantina/CantinaRosterService.cs \
+          tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
+  git commit -m "feat(cantina): feed humans the day before their first confirmed shift (weekly)"
+  ```
+
+### Task 2.3: Weekly edge cases (TDD, one test each)
+
+For each, write the failing test, run (some may already pass given 2.2's impl — if so, keep as
+regression guards), then commit. Add per behavior:
+
+- [ ] **Arrival-only human pulled into the week.** First confirmed shift = Monday of next week
+  (offset 7); assert they appear on this week's Sunday (offset 6) even with no in-week shift, counted
+  once in `TotalUniqueOnSite`/dietary/rollups.
+- [ ] **No clamp.** Render the *previous* week (`GetWeeklyRosterAsync(weekStartOffset: -7)`) with an
+  event whose `BuildStartOffset` ≤ −1; stub a human's first confirmed shift on offset 0; assert their
+  arrival day (offset −1, the Sunday of week −7's window) is present and equals `ArrivesOn`, proving
+  the negative/pre-event arrival day is not clamped away.
+- [ ] **Global-minimum guard.** Human has a confirmed shift in a *prior* week and again this week;
+  assert NO spurious arrival day is added this week (their min offset is in the earlier week).
+- [ ] **Commit** the edge-case tests:
+  ```bash
+  git commit -am "test(cantina): weekly arrival-day edge cases (arrival-only, no-clamp, global-min)"
+  ```
+
+### Task 2.4: Daily drill-down arrival day (TDD)
+
+**Files:** `CantinaRosterService.cs` (`GetDailyRosterAsync`), `CantinaDailyRosterServiceTests.cs`
+
+- [ ] **Step 1: Failing test** — day N includes humans whose first confirmed shift is N+1, and
+  excludes pending-only (mock returns confirmed cohort only). Assert such a human appears in the
+  day-N `People` and counts in that day's aggregates.
+
+- [ ] **Step 2: Run — expect FAIL.**
+  Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CantinaDailyRosterServiceTests"`
+  Expected: FAIL (arrival human absent on day N).
+
+- [ ] **Step 3: Implement.** In `GetDailyRosterAsync(dayOffset = N)`, after fetching the day-N cohort,
+  call `BuildFirstConfirmedOffsetByUserAsync` and union in users whose `minOffset == N + 1`. Add them
+  to the `userIds` set before building people/aggregates (dedup via set semantics).
+
+- [ ] **Step 4: Run — expect PASS.**
+  Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CantinaDailyRosterServiceTests"`
+  Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git commit -am "feat(cantina): include next-day arrivals in daily drill-down"
+  ```
+
+### Task 2.5: CSV parity check + full suite + docs
+
+- [ ] **Step 1:** Confirm the CSV needs no separate change — `CantinaRosterCsvWriter` iterates
+  `roster.People` (line 66) from the same `WeeklyRosterDto`, so arrival-day humans flow through
+  automatically. Extend the existing `tests/Humans.Web.Tests/Cantina/CantinaCsvWritersTests.cs` with
+  a case asserting an arrival-day human (built into a `WeeklyRosterDto`) appears as a CSV row with
+  `ArrivesOn` = their arrival day.
+- [ ] **Step 2: Full build + test.**
+  Run: `dotnet build Humans.slnx -v quiet && dotnet test Humans.slnx -v quiet`
+  Expected: 0 errors, all tests PASS.
+- [ ] **Step 3: Update the Cantina section invariant doc** (`docs/sections/Cantina.md`). The
+  Pending/Confirmed "on-site" definition is repeated in **multiple places (≈ lines 20, 28, 56 plus the
+  cross-section dependency note)** — update ALL of them to **Confirmed** or the doc self-contradicts.
+  Also add the new arrival-day rule (fed on `firstConfirmedDay − 1`). Keep it terse, per the section
+  template. Note: the `ArrivesOn` non-nullable invariant (≈ line 60) still holds — arrival-day humans
+  get the arrival date as a real on-site day, so `daysList[0]` is valid.
+- [ ] **Step 4: Commit docs.**
+  ```bash
+  git add docs/sections/Cantina.md
+  git commit -m "docs(cantina): confirmed-only on-site + arrival-day feeding rule"
+  ```
+
+### Task 2.6: Open PR #2
+- [ ] Push branch to `origin`, open PR to `origin/main` titled
+  `feat(cantina): feed humans the day before their first confirmed shift`. Body: link the spec;
+  **call out the two behavior changes for Peter's sign-off** — (1) cantina on-site is now
+  confirmed-only (pending-only humans drop off), (2) `GetOnSiteUserIdsForDayAsync` semantics changed.
+  Also note: **no new interface/repo/service surface was added** (reuse-first satisfied, no approval
+  gate), and the per-render DB round-trips rise to ~40-60 sequential `GetOnSiteUserIdsForDayAsync`
+  calls — a conscious trade documented in the spec (Peter will likely ask).
+
+---
+
+## Manual verification (after both PRs, per CLAUDE.md "exercise the change")
+- Launch the app (`dotnet run --project src/Humans.Web`, dev login) and open the Cantina roster:
+  - Confirm a human whose first confirmed shift is e.g. Wednesday now shows on Tuesday (no shift).
+  - Confirm a pending-only human is absent.
+  - Confirm the CSV export includes the arrival-day row.
+  - Confirm the FODMAP checkbox is gone from Profile → Dietary/Medical and the intolerance rollup.

--- a/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
@@ -1,7 +1,7 @@
 # Design: Cantina arrival-day feeding + remove FODMAP intolerance
 
 Date: 2026-06-24
-Status: Approved (brainstorm) — pending spec review
+Status: Spec-reviewed ✅ — pending user review
 Branch: `feat/cantina-arrival-and-fodmap`
 
 Two small, independent changes bundled in one branch (two commits, possibly two PRs at merge time).
@@ -78,6 +78,10 @@ method exists to feed the cantina, so changing its on-site definition to confirm
 correct fix, not a surgical patch — and it stays inside the existing method (no interface change, no
 new parameter, so no new public surface needing approval). Note for review: this *does* change the
 semantics of a Shifts-service method, recorded here explicitly for Peter's sign-off at PR.
+
+Also update the now-stale doc comments that say "Pending/Confirmed": the XML summary on
+`IShiftManagementService.GetOnSiteUserIdsForDayAsync` (`IShiftManagementService.cs:354`) and any
+parallel comment near the implementation → "Confirmed signup" (fix-it-right, no misleading comment).
 
 **(b) Earliest-confirmed-day map (inline, computed from a single range scan).**
 Inside `CantinaRosterService`, scan the **full event day range**, inclusive of both ends:

--- a/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
@@ -1,0 +1,128 @@
+# Design: Cantina arrival-day feeding + remove FODMAP intolerance
+
+Date: 2026-06-24
+Status: Approved (brainstorm) — pending spec review
+Branch: `feat/cantina-arrival-and-fodmap`
+
+Two small, independent changes bundled in one branch (two commits, possibly two PRs at merge time).
+
+---
+
+## Feature 1 — Remove FODMAP from intolerances
+
+### Problem
+"FODMAP" is no longer wanted as a selectable intolerance.
+
+### Design
+Intolerance options have a single canonical source: `DietaryOptions.IntoleranceOptions`
+(`src/Humans.Domain/Constants/DietaryOptions.cs:38`). Removing the string removes the checkbox,
+the cantina rollup row, and validation acceptance everywhere, because all consumers read that list.
+
+Changes:
+1. `DietaryOptions.cs:38` — drop `"FODMAP"`:
+   `["Lactose", "Gluten", "Histamine", "FODMAP", OtherOption]` → `["Lactose", "Gluten", "Histamine", OtherOption]`.
+2. Delete the `Profile_DietaryMedical_Intolerance_FODMAP` entry from all six locale files:
+   `SharedResource.resx`, `.es`, `.de`, `.ca`, `.fr`, `.it`.
+3. `tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs:307` — remove the
+   `intolerance["FODMAP"].Should().Be(0)` assertion (the key no longer exists in the rollup).
+
+### Existing data — leave inert (decided)
+Intolerances persist as a JSON array on `profiles.Intolerances` (not a bitmask), so stored
+`"FODMAP"` values are harmless:
+- `BuildRollup` only counts canonical labels → FODMAP never appears in cantina rollups.
+- The edit view filters unknown values via `IsKnownIntolerance()` → it's dropped on the next profile save.
+
+No migration. No flag. Data self-heals as humans re-save.
+
+---
+
+## Feature 2 — Cantina: feed people the day before their first shift
+
+### Problem
+The cantina cohort for a given day is exactly "humans with a shift that day"
+(`ShiftRepository.Signups.cs:106`, via `IShiftManagementService.GetOnSiteUserIdsForDayAsync`).
+There is no concept of a continuous on-site stay. So a human whose first shift is Wednesday is
+**absent from the cantina on Tuesday** — the day they actually arrive and need feeding.
+
+### Decisions (from brainstorm)
+- **Confirmed-only.** The cantina currently counts `PendingOrConfirmed`. Switch to `ConfirmedOnly`.
+  Consequence (intended): humans whose shifts are all still pending no longer appear in the cantina
+  roster until a shift is confirmed.
+- **Arrival day = (first confirmed shift day − 1).** Mirrors the already-blessed pattern in
+  `ShiftEarlyEntryProjection.FirstShiftDayByUser` / `VolunteerTrackingExportService`
+  (`arrivalDay = firstShiftDay − 1`). That code is confirmed-only too, which now aligns.
+- **No clamp.** If the arrival day falls before the event (negative offset), show it anyway.
+- **Scope:** weekly roster (drives both the on-screen roster and the CSV export — they share
+  `WeeklyRosterDto`) **and** the per-day drill-down matrix, so the two views agree.
+- **Inline, no new interface methods.** Compute first-confirmed-day inside `CantinaRosterService`
+  using the existing `GetOnSiteUserIdsForDayAsync`. (Reuse-first; avoids new interface surface that
+  would need Peter's approval.)
+
+### Design
+
+All logic lives in `src/Humans.Application/Services/Cantina/CantinaRosterService.cs`.
+
+**(a) Flip the scope.** Both `GetOnSiteUserIdsForDayAsync(...)` calls (lines 200, 299) pass
+`ShiftDayUserStatusScope.ConfirmedOnly` instead of the current `PendingOrConfirmed`.
+(Confirm the current default is passed implicitly; make it explicit.)
+
+**(b) Earliest-confirmed-day map (inline helper).**
+`firstConfirmedDayOffsetByUser(eventSettings, ct)` scans the **full event day range**
+`[eventSettings.BuildStartOffset … eventSettings.StrikeEndOffset]`, calling the existing
+`GetOnSiteUserIdsForDayAsync(eventId, offset, ConfirmedOnly)` per offset, and records the minimum
+offset seen per user id. At ~500 humans and a bounded day count this is in-memory-cheap
+(CLAUDE.md scale notes: prefer in-memory over query tuning). Returns `Dictionary<Guid,int>`.
+
+Scanning the whole event range — not just the visible week — is required so that "first shift" is
+the human's *true* earliest confirmed shift, not merely their first appearance within the current
+week window (which would wrongly grant an arrival day to multi-week attendees).
+
+**(c) Weekly view (`GetWeeklyRosterAsync`).**
+After building `daysOnSiteByUserId` from the week's confirmed cohorts, for each user compute
+`arrivalOffset = firstConfirmedDayOffset[user] − 1`. If `arrivalOffset` maps to a date inside the
+visible week window, add that date to the user's on-site day set — pulling the user into the cohort
+even if they have no shift in this week (e.g. first shift is the Monday of next week → arrival is
+the Sunday shown this week). Downstream this means:
+- `ArrivesOn` (`daysList[0]`) becomes the true arrival day.
+- The arrival day appears in `NoShift` (present, no shift) — existing treatment, no new field.
+- Dietary breakdown, allergy/intolerance rollups, totals and unanswered counts include arrival-only
+  humans automatically, because they join `uniqueUserIds`.
+
+**(d) Daily drill-down (`GetDailyRosterAsync(dayOffset = N)`).**
+Cohort = confirmed users on day N **∪** users whose `firstConfirmedDayOffset == N + 1`. The added
+arrival-day humans flow through the same per-day people list and aggregates.
+
+### Edge cases
+- First confirmed shift on the event's first possible day → arrival offset is one earlier
+  (possibly negative). Shown anyway (no clamp).
+- A human with confirmed shifts on consecutive days starting day N: arrival = N−1; days N, N+1…
+  already covered by their shifts; set semantics prevent double counting.
+- A human with only pending shifts: excluded entirely (confirmed-only) — no arrival day either.
+- No active event: unchanged (empty roster path).
+
+### Out of scope (YAGNI)
+- Filling *all* gaps between arrival and departure (only the single arrival day is added, matching
+  the request and the existing EE pattern).
+- Any visual "arriving / setup" badge — the existing `NoShift` rendering is sufficient.
+- Departure-day / day-after-last-shift feeding.
+
+---
+
+## Testing
+
+Feature 1:
+- Adjust the existing cantina rollup test (drop FODMAP assertion).
+- (Existing edit/validation tests already cover that unknown intolerances are filtered.)
+
+Feature 2 (TDD — `CantinaRosterServiceTests` / `CantinaDailyRosterServiceTests`,
+`Substitute`-mocked `IShiftManagementService`):
+- Weekly: human with first confirmed shift on Wed → appears Tue (arrival), `ArrivesOn` = Tue,
+  Tue ∈ `NoShift`.
+- Weekly: pending-only human → absent (confirmed-only).
+- Weekly: arrival day falling before the visible week is not shown this week; arrival day on the
+  last day of the previous-relative window pulls a no-shift human into the week.
+- Weekly: arrival-only human counts once in totals / dietary / rollups.
+- Daily(N): includes humans whose first confirmed shift is N+1; excludes pending-only.
+- No-clamp: first shift on day 0 → arrival day −1 still produced.
+- Earliest-day map uses the *global* minimum (a human with a shift in a prior week is not granted a
+  spurious arrival day in a later week).

--- a/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
@@ -60,26 +60,50 @@ There is no concept of a continuous on-site stay. So a human whose first shift i
 
 ### Design
 
-All logic lives in `src/Humans.Application/Services/Cantina/CantinaRosterService.cs`.
+The arrival-day logic lives in `src/Humans.Application/Services/Cantina/CantinaRosterService.cs`.
+The scope change is one line in the Shifts service (see (a)). **No new interface, repository, or
+service methods are added.**
 
-**(a) Flip the scope.** Both `GetOnSiteUserIdsForDayAsync(...)` calls (lines 200, 299) pass
-`ShiftDayUserStatusScope.ConfirmedOnly` instead of the current `PendingOrConfirmed`.
-(Confirm the current default is passed implicitly; make it explicit.)
+**(a) Confirmed-only — change the scope inside the existing Shifts method.**
+The scope is *not* a caller argument: `IShiftManagementService.GetOnSiteUserIdsForDayAsync`
+(`IShiftManagementService.cs:358`) takes only `(eventSettingsId, dayOffset, ct)`, and the
+implementation (`ShiftManagementService.cs:1974-1980`) hardcodes
+`ShiftDayUserStatusScope.PendingOrConfirmed` when calling the repo. The fix is to change that one
+constant on **line 1979** to `ShiftDayUserStatusScope.ConfirmedOnly` (a real enum value already used
+by `ShiftSignupService.cs:1076`).
 
-**(b) Earliest-confirmed-day map (inline helper).**
-`firstConfirmedDayOffsetByUser(eventSettings, ct)` scans the **full event day range**
-`[eventSettings.BuildStartOffset … eventSettings.StrikeEndOffset]`, calling the existing
-`GetOnSiteUserIdsForDayAsync(eventId, offset, ConfirmedOnly)` per offset, and records the minimum
-offset seen per user id. At ~500 humans and a bounded day count this is in-memory-cheap
-(CLAUDE.md scale notes: prefer in-memory over query tuning). Returns `Dictionary<Guid,int>`.
+Blast radius — verified safe: `GetOnSiteUserIdsForDayAsync` has exactly one production caller,
+`CantinaRosterService` (calls at lines 200, 299; `grep` across `src/` finds no other consumer). The
+method exists to feed the cantina, so changing its on-site definition to confirmed-only is the
+correct fix, not a surgical patch — and it stays inside the existing method (no interface change, no
+new parameter, so no new public surface needing approval). Note for review: this *does* change the
+semantics of a Shifts-service method, recorded here explicitly for Peter's sign-off at PR.
+
+**(b) Earliest-confirmed-day map (inline, computed from a single range scan).**
+Inside `CantinaRosterService`, scan the **full event day range**, inclusive of both ends:
+`for (offset = eventSettings.BuildStartOffset; offset <= eventSettings.StrikeEndOffset; offset++)`,
+calling the existing (now confirmed-only) `GetOnSiteUserIdsForDayAsync(eventId, offset, ct)` per
+offset. From that single pass build both:
+  - `confirmedByOffset`: `Dictionary<int, IReadOnlyList<Guid>>` — the per-day cohorts, and
+  - `firstConfirmedOffsetByUser`: `Dictionary<Guid,int>` — the minimum offset seen per user.
 
 Scanning the whole event range — not just the visible week — is required so that "first shift" is
 the human's *true* earliest confirmed shift, not merely their first appearance within the current
 week window (which would wrongly grant an arrival day to multi-week attendees).
 
+NOTE (conscious trade): this is one DB round-trip per event-day (`BuildStartOffset` can be ≈ −25
+through `StrikeEndOffset`, so ~40-60 sequential queries) per roster render, where the weekly view
+previously issued 7. Result sets are tiny (id lists at ~500 humans) — the cost is round-trip count,
+not data volume. Accepted under CLAUDE.md "prefer in-memory over query tuning / don't over-engineer
+for scale," and because the cheaper alternative (a single `MIN(DayOffset) GROUP BY UserId` repo
+query) would require a new repository + interface method, which this design deliberately avoids. The
+weekly view derives its 7-day slice from `confirmedByOffset` (no separate 7 calls), so it is not
+more expensive than the scan itself.
+
 **(c) Weekly view (`GetWeeklyRosterAsync`).**
-After building `daysOnSiteByUserId` from the week's confirmed cohorts, for each user compute
-`arrivalOffset = firstConfirmedDayOffset[user] − 1`. If `arrivalOffset` maps to a date inside the
+After building `daysOnSiteByUserId` from the week's confirmed cohorts (the 7-day slice of
+`confirmedByOffset`), for each user compute `arrivalOffset = firstConfirmedOffsetByUser[user] − 1`.
+If `arrivalOffset` maps to a date inside the
 visible week window, add that date to the user's on-site day set — pulling the user into the cohort
 even if they have no shift in this week (e.g. first shift is the Monday of next week → arrival is
 the Sunday shown this week). Downstream this means:
@@ -89,8 +113,10 @@ the Sunday shown this week). Downstream this means:
   humans automatically, because they join `uniqueUserIds`.
 
 **(d) Daily drill-down (`GetDailyRosterAsync(dayOffset = N)`).**
-Cohort = confirmed users on day N **∪** users whose `firstConfirmedDayOffset == N + 1`. The added
-arrival-day humans flow through the same per-day people list and aggregates.
+Cohort = confirmed users on day N **∪** users whose `firstConfirmedOffsetByUser == N + 1`. The added
+arrival-day humans flow through the same per-day people list and aggregates. (This path also runs the
+range scan from (b) to obtain `firstConfirmedOffsetByUser`, since a single day cannot reveal whether
+a human's first confirmed shift is N+1.)
 
 ### Edge cases
 - First confirmed shift on the event's first possible day → arrival offset is one earlier

--- a/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
@@ -83,31 +83,36 @@ Also update the now-stale doc comments that say "Pending/Confirmed": the XML sum
 `IShiftManagementService.GetOnSiteUserIdsForDayAsync` (`IShiftManagementService.cs:354`) and any
 parallel comment near the implementation → "Confirmed signup" (fix-it-right, no misleading comment).
 
-**(b) Earliest-confirmed-day map (inline, computed from a single range scan).**
-Inside `CantinaRosterService`, scan the **full event day range**, inclusive of both ends:
+**(b) Earliest-confirmed-day map (inline helper).**
+Add a private helper in `CantinaRosterService`:
+`BuildFirstConfirmedOffsetByUserAsync(eventSettings, ct)` that scans the **full event day range**,
+inclusive of both ends:
 `for (offset = eventSettings.BuildStartOffset; offset <= eventSettings.StrikeEndOffset; offset++)`,
 calling the existing (now confirmed-only) `GetOnSiteUserIdsForDayAsync(eventId, offset, ct)` per
-offset. From that single pass build both:
-  - `confirmedByOffset`: `Dictionary<int, IReadOnlyList<Guid>>` — the per-day cohorts, and
-  - `firstConfirmedOffsetByUser`: `Dictionary<Guid,int>` — the minimum offset seen per user.
+offset, recording the minimum offset seen per user id. Returns `Dictionary<Guid,int>`.
 
 Scanning the whole event range — not just the visible week — is required so that "first shift" is
 the human's *true* earliest confirmed shift, not merely their first appearance within the current
 week window (which would wrongly grant an arrival day to multi-week attendees).
 
-NOTE (conscious trade): this is one DB round-trip per event-day (`BuildStartOffset` can be ≈ −25
-through `StrikeEndOffset`, so ~40-60 sequential queries) per roster render, where the weekly view
-previously issued 7. Result sets are tiny (id lists at ~500 humans) — the cost is round-trip count,
-not data volume. Accepted under CLAUDE.md "prefer in-memory over query tuning / don't over-engineer
-for scale," and because the cheaper alternative (a single `MIN(DayOffset) GROUP BY UserId` repo
-query) would require a new repository + interface method, which this design deliberately avoids. The
-weekly view derives its 7-day slice from `confirmedByOffset` (no separate 7 calls), so it is not
-more expensive than the scan itself.
+**This helper is kept SEPARATE from the visible-week / single-day cohort load** (it does not replace
+them). The weekly view continues to scan its 7 requested days via the existing
+`LoadWeeklyOnSiteUsersAsync`, and the daily view its one day, exactly as today — so the *displayed*
+window stays decoupled from the event bounds and existing cohort behavior/tests are unchanged. The
+min-day helper runs in addition, purely to drive arrival-day computation.
+
+NOTE (conscious trade): the helper adds one DB round-trip per event-day (`BuildStartOffset` ≈ −25
+through `StrikeEndOffset`, so ~40-60 sequential queries) per roster render, on top of the existing
+7 (weekly) / 1 (daily). Result sets are tiny (id lists at ~500 humans) — the cost is round-trip
+count, not data volume. Accepted under CLAUDE.md "prefer in-memory over query tuning / don't
+over-engineer for scale"; the cheaper alternative (a single `MIN(DayOffset) GROUP BY UserId` repo
+query) is deliberately rejected because it would require a new repository + interface method.
 
 **(c) Weekly view (`GetWeeklyRosterAsync`).**
-After building `daysOnSiteByUserId` from the week's confirmed cohorts (the 7-day slice of
-`confirmedByOffset`), for each user compute `arrivalOffset = firstConfirmedOffsetByUser[user] − 1`.
-If `arrivalOffset` maps to a date inside the
+After building `daysOnSiteByUserId` from the week's confirmed cohorts (unchanged
+`LoadWeeklyOnSiteUsersAsync`), call the (b) helper for `firstConfirmedOffsetByUser`. For each user in
+that map compute `arrivalOffset = firstConfirmedOffsetByUser[user] − 1`. If `arrivalOffset` maps to a
+date inside the
 visible week window, add that date to the user's on-site day set — pulling the user into the cohort
 even if they have no shift in this week (e.g. first shift is the Monday of next week → arrival is
 the Sunday shown this week). Downstream this means:

--- a/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
+++ b/docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md
@@ -116,10 +116,18 @@ date inside the
 visible week window, add that date to the user's on-site day set — pulling the user into the cohort
 even if they have no shift in this week (e.g. first shift is the Monday of next week → arrival is
 the Sunday shown this week). Downstream this means:
-- `ArrivesOn` (`daysList[0]`) becomes the true arrival day.
-- The arrival day appears in `NoShift` (present, no shift) — existing treatment, no new field.
-- Dietary breakdown, allergy/intolerance rollups, totals and unanswered counts include arrival-only
-  humans automatically, because they join `uniqueUserIds`.
+- `ArrivesOn` (`daysList[0]`) becomes the true arrival day (the arrival date is now the user's
+  earliest on-site day).
+- The arrival day is an **on-site day**, so it is NOT in `NoShift` (which is the week-complement of
+  on-site days). It surfaces as `ArrivesOn`. (The original spec draft said "appears in NoShift" —
+  that was wrong and is corrected here.)
+- Weekly-level aggregates (`TotalUniqueOnSite`, dietary breakdown, allergy/intolerance rollups,
+  unanswered) include arrival-only humans automatically, because they join `uniqueUserIds`.
+- The **per-day `Days` summary** (the clickable day-strip that links into the daily drill-down) must
+  ALSO count arrivals on their arrival day, so the weekly strip count matches the drill-down. This
+  requires `BuildDaySummaries` to derive each day's `TotalOnSite`/`UnansweredOnDay` from the
+  post-injection `daysOnSiteByUserId` (+ profiles) rather than from the raw visible-week load. Counts
+  are identical to today on every non-arrival day.
 
 **(d) Daily drill-down (`GetDailyRosterAsync(dayOffset = N)`).**
 Cohort = confirmed users on day N **∪** users whose `firstConfirmedOffsetByUser == N + 1`. The added

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -351,7 +351,7 @@ public interface IShiftManagementService : IApplicationService
 
     /// <summary>
     /// Returns the distinct user ids of volunteers on-site for the given event
-    /// day — those with a Pending/Confirmed signup on a <see cref="Shift"/> whose
+    /// day — those with a Confirmed signup on a <see cref="Shift"/> whose
     /// <see cref="Shift.DayOffset"/> matches. Service-layer read for the Cantina
     /// roster (feature #36) so it never reaches into the Shifts repository.
     /// </summary>

--- a/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
+++ b/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
@@ -225,9 +225,32 @@ public sealed class CantinaRosterService : ICantinaRosterService
             weekStartOffset = dayOffset - ((dayOffset % DaysPerWeek + DaysPerWeek) % DaysPerWeek);
         }
 
-        var userIds = eventSettings is null
+        var shiftUserIds = eventSettings is null
             ? Array.Empty<Guid>()
             : await _shiftMgmt.GetOnSiteUserIdsForDayAsync(eventSettings.Id, dayOffset, ct).ConfigureAwait(false);
+
+        // Arrival-day feeding: a human is fed (present, no shift) the day before
+        // their FIRST confirmed shift across the whole event. For day N that
+        // means anyone whose first confirmed shift offset == N+1 arrives today.
+        // Union them with the day-N shift cohort so the drill-down stays
+        // consistent with the weekly strip (which injects the same arrival day).
+        // CRITICAL: compute the union BEFORE the empty-check — a day can have
+        // zero shifts but still have arrivals, so the early-return must be
+        // evaluated on the unioned set. Guarded on an active event; the no-event
+        // branch leaves the set as the (empty) shift cohort.
+        var unionedUserIds = new HashSet<Guid>(shiftUserIds);
+        if (eventSettings is not null)
+        {
+            var firstConfirmedOffsetByUser =
+                await BuildFirstConfirmedOffsetByUserAsync(eventSettings, ct).ConfigureAwait(false);
+            foreach (var (userId, minOffset) in firstConfirmedOffsetByUser)
+            {
+                if (minOffset == dayOffset + 1)
+                    unionedUserIds.Add(userId);
+            }
+        }
+
+        var userIds = unionedUserIds.ToList();
 
         if (userIds.Count == 0)
         {

--- a/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
+++ b/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
@@ -71,8 +71,12 @@ public sealed class CantinaRosterService : ICantinaRosterService
         // Guarded on an active event — the no-event branch leaves the map empty.
         if (eventSettings is not null && weekStartDate is { } anchor)
         {
+            // Only arrivals landing in [weekStartOffset, weekStartOffset+6] are
+            // injected below, so a first confirmed shift past weekStartOffset+7
+            // can't produce an in-week arrival — cap the scan there.
             var firstConfirmedOffsetByUser =
-                await BuildFirstConfirmedOffsetByUserAsync(eventSettings, ct).ConfigureAwait(false);
+                await BuildFirstConfirmedOffsetByUserAsync(
+                    eventSettings, weekStartOffset + DaysPerWeek, ct).ConfigureAwait(false);
             foreach (var (userId, minOffset) in firstConfirmedOffsetByUser)
             {
                 var arrivalOffset = minOffset - 1;
@@ -241,8 +245,11 @@ public sealed class CantinaRosterService : ICantinaRosterService
         var unionedUserIds = new HashSet<Guid>(shiftUserIds);
         if (eventSettings is not null)
         {
+            // Only users whose first confirmed shift is exactly dayOffset+1 are
+            // pulled in, so the scan never needs to look past dayOffset+1.
             var firstConfirmedOffsetByUser =
-                await BuildFirstConfirmedOffsetByUserAsync(eventSettings, ct).ConfigureAwait(false);
+                await BuildFirstConfirmedOffsetByUserAsync(
+                    eventSettings, dayOffset + 1, ct).ConfigureAwait(false);
             foreach (var (userId, minOffset) in firstConfirmedOffsetByUser)
             {
                 if (minOffset == dayOffset + 1)
@@ -358,19 +365,24 @@ public sealed class CantinaRosterService : ICantinaRosterService
     }
 
     /// <summary>
-    /// Scans the full event span (build start through strike end, inclusive)
-    /// and records, per human, the earliest day offset on which they have a
-    /// confirmed on-site signup. Used to feed each human the day before their
-    /// first confirmed shift. Kept separate from
+    /// Scans from build start up through <paramref name="scanThroughOffset"/>
+    /// (clamped to strike end, inclusive) and records, per human, the earliest
+    /// day offset on which they have a confirmed on-site signup. Used to feed
+    /// each human the day before their first confirmed shift. Kept separate from
     /// <see cref="LoadWeeklyOnSiteUsersAsync"/> — that load stays scoped to the
-    /// visible week; this one needs the whole span to find a true first day.
+    /// visible week; this one scans from the start of the event so a true first
+    /// day is never missed. The upper bound is the caller's window end: a first
+    /// confirmed shift later than that yields an arrival day outside the window,
+    /// which the caller discards anyway, so scanning past it is wasted DB work.
     /// </summary>
     private async Task<Dictionary<Guid, int>> BuildFirstConfirmedOffsetByUserAsync(
         EventSettings ev,
+        int scanThroughOffset,
         CancellationToken ct)
     {
         var firstOffsetByUser = new Dictionary<Guid, int>();
-        for (var offset = ev.BuildStartOffset; offset <= ev.StrikeEndOffset; offset++)
+        var lastOffset = Math.Min(ev.StrikeEndOffset, scanThroughOffset);
+        for (var offset = ev.BuildStartOffset; offset <= lastOffset; offset++)
         {
             var userIds = await _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, offset, ct).ConfigureAwait(false);
             foreach (var id in userIds)

--- a/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
+++ b/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
@@ -62,6 +62,34 @@ public sealed class CantinaRosterService : ICantinaRosterService
         // map each user id to the set of calendar dates they were on-site.
         var daysOnSiteByUserId = BuildDaysOnSiteByUserId(perDay, weekStartOffset, weekStartDate);
 
+        // Arrival-day feeding: each human is fed (present, but with no shift)
+        // the day before their FIRST confirmed shift across the whole event,
+        // not just this week. Scan the full build→strike range once, then inject
+        // the day-before-first-shift into this week's on-site set when it lands
+        // inside the visible 7 days. This pulls in humans whose only relation to
+        // the week is their arrival day (no confirmed shift inside the week).
+        // Guarded on an active event — the no-event branch leaves the map empty.
+        if (eventSettings is not null && weekStartDate is { } anchor)
+        {
+            var firstConfirmedOffsetByUser =
+                await BuildFirstConfirmedOffsetByUserAsync(eventSettings, ct).ConfigureAwait(false);
+            foreach (var (userId, minOffset) in firstConfirmedOffsetByUser)
+            {
+                var arrivalOffset = minOffset - 1;
+                if (arrivalOffset < weekStartOffset || arrivalOffset > weekStartOffset + DaysPerWeek - 1)
+                    continue;
+
+                var arrivalDate = anchor.PlusDays(arrivalOffset - weekStartOffset);
+                if (!daysOnSiteByUserId.TryGetValue(userId, out var list))
+                {
+                    list = new List<LocalDate>(capacity: DaysPerWeek);
+                    daysOnSiteByUserId[userId] = list;
+                }
+
+                list.Add(arrivalDate);
+            }
+        }
+
         var uniqueUserIds = daysOnSiteByUserId.Keys.ToList();
 
         // Dietary lives on Profile — read it from the cached UserInfo for the whole
@@ -71,9 +99,11 @@ public sealed class CantinaRosterService : ICantinaRosterService
             ? new Dictionary<Guid, ProfileInfo>()
             : BuildProfileMap(await _userRead.GetUserInfosAsync(uniqueUserIds, ct).ConfigureAwait(false));
 
-        // Build per-day summaries (counts only). Dietary is per-user, so a day's
-        // "unanswered" count is over that day's user ids.
-        var days = BuildDaySummaries(perDay, weekStartDate, profileByUserId);
+        // Build per-day summaries (counts only) from the POST-injection on-site
+        // map so arrival-day people are counted on their arrival date — keeping
+        // the weekly strip consistent with the daily drill-down. Dietary is
+        // per-user, so a day's "unanswered" count is over that day's user ids.
+        var days = BuildDaySummaries(daysOnSiteByUserId, weekStartOffset, weekStartDate, profileByUserId);
 
         if (uniqueUserIds.Count == 0)
         {
@@ -304,6 +334,32 @@ public sealed class CantinaRosterService : ICantinaRosterService
         return perDay;
     }
 
+    /// <summary>
+    /// Scans the full event span (build start through strike end, inclusive)
+    /// and records, per human, the earliest day offset on which they have a
+    /// confirmed on-site signup. Used to feed each human the day before their
+    /// first confirmed shift. Kept separate from
+    /// <see cref="LoadWeeklyOnSiteUsersAsync"/> — that load stays scoped to the
+    /// visible week; this one needs the whole span to find a true first day.
+    /// </summary>
+    private async Task<Dictionary<Guid, int>> BuildFirstConfirmedOffsetByUserAsync(
+        EventSettings ev,
+        CancellationToken ct)
+    {
+        var firstOffsetByUser = new Dictionary<Guid, int>();
+        for (var offset = ev.BuildStartOffset; offset <= ev.StrikeEndOffset; offset++)
+        {
+            var userIds = await _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, offset, ct).ConfigureAwait(false);
+            foreach (var id in userIds)
+            {
+                if (!firstOffsetByUser.TryGetValue(id, out var existing) || offset < existing)
+                    firstOffsetByUser[id] = offset;
+            }
+        }
+
+        return firstOffsetByUser;
+    }
+
     private static Dictionary<Guid, List<LocalDate>> BuildDaysOnSiteByUserId(
         IReadOnlyList<(int DayOffset, IReadOnlyList<Guid> UserIds)> perDay,
         int weekStartOffset,
@@ -330,26 +386,39 @@ public sealed class CantinaRosterService : ICantinaRosterService
     }
 
     private static List<DayRosterSummaryDto> BuildDaySummaries(
-        IReadOnlyList<(int DayOffset, IReadOnlyList<Guid> UserIds)> perDay,
+        IReadOnlyDictionary<Guid, List<LocalDate>> daysOnSiteByUserId,
+        int weekStartOffset,
         LocalDate? weekStartDate,
         IReadOnlyDictionary<Guid, ProfileInfo> profileByUserId)
     {
         var days = new List<DayRosterSummaryDto>(DaysPerWeek);
         for (var i = 0; i < DaysPerWeek; i++)
         {
-            var (dayOffset, userIds) = perDay[i];
+            var calendarDate = weekStartDate?.PlusDays(i);
+
+            // Count users on-site this calendar date from the post-injection map
+            // (includes arrival-day people). Without an anchor date the map holds
+            // no dates, so every day is correctly zero.
+            var total = 0;
             var unanswered = 0;
-            foreach (var id in userIds)
+            if (calendarDate is { } day)
             {
-                if (!profileByUserId.TryGetValue(id, out var profile)
-                    || string.IsNullOrEmpty(profile.DietaryPreference))
-                    unanswered++;
+                foreach (var (id, dates) in daysOnSiteByUserId)
+                {
+                    if (!dates.Contains(day))
+                        continue;
+
+                    total++;
+                    if (!profileByUserId.TryGetValue(id, out var profile)
+                        || string.IsNullOrEmpty(profile.DietaryPreference))
+                        unanswered++;
+                }
             }
 
             days.Add(new DayRosterSummaryDto(
-                DayOffset: dayOffset,
-                CalendarDate: weekStartDate?.PlusDays(i),
-                TotalOnSite: userIds.Count,
+                DayOffset: weekStartOffset + i,
+                CalendarDate: calendarDate,
+                TotalOnSite: total,
                 UnansweredOnDay: unanswered));
         }
 

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -1976,7 +1976,7 @@ public sealed class ShiftManagementService(
         repo.GetUserIdsForDayAsync(
             eventSettingsId,
             dayOffset,
-            ShiftDayUserStatusScope.PendingOrConfirmed,
+            ShiftDayUserStatusScope.ConfirmedOnly,
             ct);
 
     public async Task<int> DeleteShiftProfilesForUserAsync(

--- a/tests/Humans.Application.Tests/Services/Cantina/CantinaDailyRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Cantina/CantinaDailyRosterServiceTests.cs
@@ -74,6 +74,64 @@ public class CantinaDailyRosterServiceTests
         IsActive = true
     };
 
+    /// <summary>
+    /// Active event with an explicit build→strike offset range so the
+    /// arrival-day scan (<c>BuildFirstConfirmedOffsetByUserAsync</c>) covers
+    /// days outside the viewed day. The default <see cref="ActiveEvent"/>
+    /// leaves both offsets at 0, which would scan only day 0.
+    /// </summary>
+    private static EventSettings ActiveEventWithRange(int buildStart, int strikeEnd) => new()
+    {
+        Id = Guid.NewGuid(),
+        EventName = EventName,
+        TimeZoneId = "Europe/Madrid",
+        GateOpeningDate = GateOpening,
+        IsActive = true,
+        BuildStartOffset = buildStart,
+        StrikeEndOffset = strikeEnd,
+    };
+
+    [HumansFact]
+    public async Task GetDailyRoster_IncludesNextDayArrivals()
+    {
+        // A human whose only confirmed shift is offset 2 arrives on day 1
+        // (the day before their first shift). Viewing day 1 — which has no
+        // shift cohort of its own — must still surface them in People and
+        // count them in the day's aggregates.
+        var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
+        _shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var id = Guid.NewGuid();
+        SetupDay(2, id); // first (and only) confirmed shift is on day 2
+        SetupHumans(Human(id, "Arriver", "Vegan"));
+
+        var result = await _service.GetDailyRosterAsync(dayOffset: 1, ct: Xunit.TestContext.Current.CancellationToken);
+
+        result.People.Should().ContainSingle(p => p.UserId == id);
+        result.TotalOnSite.Should().Be(1);
+        result.DietaryBreakdown["Vegan"].Should().Be(1);
+        result.UnansweredCount.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task GetDailyRoster_DoesNotIncludeArrivalsTwoDaysOut()
+    {
+        // Same human, first confirmed shift on day 2. Viewing day 0: they
+        // neither work day 0 nor arrive on it (their arrival is day 1), so
+        // they must be absent.
+        var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
+        _shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var id = Guid.NewGuid();
+        SetupDay(2, id);
+        SetupHumans(Human(id, "Arriver", "Vegan"));
+
+        var result = await _service.GetDailyRosterAsync(dayOffset: 0, ct: Xunit.TestContext.Current.CancellationToken);
+
+        result.People.Should().BeEmpty();
+        result.TotalOnSite.Should().Be(0);
+    }
+
     [HumansFact]
     public async Task GetDailyRoster_NoActiveEventSettings_ReturnsEmpty()
     {

--- a/tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
@@ -457,6 +457,80 @@ public class CantinaRosterServiceTests
         result.Days[1].TotalOnSite.Should().Be(1);
     }
 
+    [HumansFact]
+    public async Task GetWeeklyRoster_ArrivalOnlyHuman_PulledIntoWeek()
+    {
+        // Human's ONLY confirmed shift is offset 7 (next week's first day).
+        // Viewing week 0 (offsets 0..6), their arrival = offset 6, which IS in
+        // this week. They have NO shift in offsets 0..6 — the arrival day alone
+        // pulls them into the cohort.
+        var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
+        _shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var id = Guid.NewGuid();
+        _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 7, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>(new[] { id }));
+        SetupHumans(Human(id, "Bo"));
+
+        var result = await _service.GetWeeklyRosterAsync(0, Xunit.TestContext.Current.CancellationToken);
+
+        result.People.Should().ContainSingle(p => p.UserId == id);
+        var person = result.People.Single(p => p.UserId == id);
+        person.ArrivesOn.Should().Be(GateOpening.PlusDays(6));
+        result.TotalUniqueOnSite.Should().Be(1);
+        result.Days[6].TotalOnSite.Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task GetWeeklyRoster_ArrivalDayBeforeEvent_NotClamped()
+    {
+        // Human's first confirmed shift is offset 0 (gate opening). Arrival =
+        // offset -1. Viewing the PREVIOUS week (offsets -7..-1); offset -1 is
+        // the last day of that window (index 6). The pre-event/negative arrival
+        // day must NOT be clamped — the human must appear with ArrivesOn at -1.
+        var ev = ActiveEventWithRange(buildStart: -7, strikeEnd: 2);
+        _shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var id = Guid.NewGuid();
+        _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 0, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>(new[] { id }));
+        SetupHumans(Human(id, "Cy"));
+
+        var result = await _service.GetWeeklyRosterAsync(-7, Xunit.TestContext.Current.CancellationToken);
+
+        var person = result.People.Single(p => p.UserId == id);
+        person.ArrivesOn.Should().Be(GateOpening.PlusDays(-1));
+        result.Days[6].TotalOnSite.Should().Be(1); // offset -1 is index 6 of the -7..-1 window
+    }
+
+    [HumansFact]
+    public async Task GetWeeklyRoster_FirstShiftInPriorWeek_NoSpuriousArrivalInLaterWeek()
+    {
+        // Guards the GLOBAL-minimum logic. Human has confirmed shifts on offset
+        // 2 (a prior week) AND offset 8 (the viewed week, offsets 7..13).
+        // Their global min is 2 → arrival offset 1, which is NOT in the viewed
+        // week. So viewing week 7, no arrival day must be injected — their
+        // earliest in-week day is the offset-8 shift, and offset 7 (index 0)
+        // must have zero on-site.
+        var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 14);
+        _shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var id = Guid.NewGuid();
+        _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 2, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>(new[] { id }));
+        _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 8, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>(new[] { id }));
+        SetupHumans(Human(id, "Di"));
+
+        var result = await _service.GetWeeklyRosterAsync(7, Xunit.TestContext.Current.CancellationToken);
+
+        var person = result.People.Single(p => p.UserId == id);
+        // ArrivesOn must be the first shift IN this week, not a spurious arrival
+        // day derived from the prior-week global minimum.
+        person.ArrivesOn.Should().Be(GateOpening.PlusDays(8));
+        result.Days[0].TotalOnSite.Should().Be(0); // offset 7 — no shift and no arrival
+    }
+
     // ---- helpers ----
 
     /// <summary>Stubs the on-site cohort for a single day (dietary comes from SetupHumans).</summary>

--- a/tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
@@ -80,6 +80,23 @@ public class CantinaRosterServiceTests
         IsActive = true
     };
 
+    /// <summary>
+    /// Active event with an explicit build→strike offset range so the
+    /// arrival-day scan (<c>BuildFirstConfirmedOffsetByUserAsync</c>) covers
+    /// days outside the visible week. The default <see cref="ActiveEvent"/>
+    /// leaves both offsets at 0, which would scan only day 0.
+    /// </summary>
+    private static EventSettings ActiveEventWithRange(int buildStart, int strikeEnd) => new()
+    {
+        Id = Guid.NewGuid(),
+        EventName = EventName,
+        TimeZoneId = "Europe/Madrid",
+        GateOpeningDate = GateOpening,
+        IsActive = true,
+        BuildStartOffset = buildStart,
+        StrikeEndOffset = strikeEnd,
+    };
+
     [HumansFact]
     public async Task GetWeeklyRoster_NoActiveEventSettings_ReturnsDtoWithNullDatesAndNoPeople()
     {
@@ -404,6 +421,40 @@ public class CantinaRosterServiceTests
             GateOpening.PlusDays(3), // Thu
             GateOpening.PlusDays(4), // Fri
             GateOpening.PlusDays(6)); // Sun
+    }
+
+    [HumansFact]
+    public async Task GetWeeklyRoster_FeedsHumanDayBeforeFirstConfirmedShift()
+    {
+        // Human's only confirmed shift is Wednesday (offset 2). They have no
+        // signup on any visible-week day other than via that shift, so the
+        // roster must feed them the day before — Tuesday (offset 1) — as their
+        // arrival day, pulling them into the cohort even though they were not
+        // returned for any visible-week load except day 2.
+        var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
+        _shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var id = Guid.NewGuid();
+        _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 2, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>(new[] { id }));
+        SetupHumans(Human(id, "Ash"));
+
+        var result = await _service.GetWeeklyRosterAsync(0, Xunit.TestContext.Current.CancellationToken);
+
+        var person = result.People.Single(p => p.UserId == id);
+        // Arrival = day before the first confirmed shift (offset 2 → offset 1).
+        person.ArrivesOn.Should().Be(GateOpening.PlusDays(1));
+        // The arrival day is fed in as a real on-site day, so it is NOT in
+        // NoShift (NoShift is the complement of on-site days). The human is
+        // "present, no shift" on the arrival day in the sense that they have no
+        // confirmed signup there — but the day still counts as on-site for the
+        // cohort, which is what pulls an otherwise arrival-only human into the
+        // roster. Their only confirmed-shift day (offset 2) is likewise on-site.
+        person.NoShift.Should().NotContain(GateOpening.PlusDays(1)); // arrival is on-site
+        person.NoShift.Should().NotContain(GateOpening.PlusDays(2)); // confirmed shift is on-site
+        // The weekly per-day strip counts the arrival person on Tuesday (offset 1),
+        // matching what the daily drill-down will show (Task 2.4).
+        result.Days[1].TotalOnSite.Should().Be(1);
     }
 
     // ---- helpers ----

--- a/tests/Humans.Web.Tests/Cantina/CantinaCsvWritersTests.cs
+++ b/tests/Humans.Web.Tests/Cantina/CantinaCsvWritersTests.cs
@@ -95,7 +95,7 @@ public sealed class CantinaCsvWritersTests
         // Arrange: human arrives on 2026-07-12 (day 5 of week), shifts only on 2026-07-13 (day 6).
         // NoShift covers the first 5 days of the week (Mon–Sat with no signup).
         var arrivalDay = WeekStart.PlusDays(5); // 2026-07-12
-        var shiftDay   = WeekStart.PlusDays(6); // 2026-07-13
+        var shiftDay = WeekStart.PlusDays(6); // 2026-07-13
 
         var noShiftDays = Enumerable.Range(0, 5)
             .Select(i => WeekStart.PlusDays(i))

--- a/tests/Humans.Web.Tests/Cantina/CantinaCsvWritersTests.cs
+++ b/tests/Humans.Web.Tests/Cantina/CantinaCsvWritersTests.cs
@@ -83,6 +83,59 @@ public sealed class CantinaCsvWritersTests
         personRow.Should().Contain("'@lookup");
     }
 
+    /// <summary>
+    /// Regression guard: a human whose arrival day is the day before their first
+    /// confirmed shift (arrivalDay = firstConfirmedShiftDay − 1) must still appear
+    /// in the CSV with the correct ArrivesOn date. ArrivesOn is a non-nullable
+    /// column; this test pins that it is emitted correctly for arrival-day humans.
+    /// </summary>
+    [HumansFact]
+    public void WeeklyRoster_ArrivalDayHuman_AppearsInCsvWithArrivalDate()
+    {
+        // Arrange: human arrives on 2026-07-12 (day 5 of week), shifts only on 2026-07-13 (day 6).
+        // NoShift covers the first 5 days of the week (Mon–Sat with no signup).
+        var arrivalDay = WeekStart.PlusDays(5); // 2026-07-12
+        var shiftDay   = WeekStart.PlusDays(6); // 2026-07-13
+
+        var noShiftDays = Enumerable.Range(0, 5)
+            .Select(i => WeekStart.PlusDays(i))
+            .ToArray<LocalDate>();
+
+        var person = new RosterPersonDto(
+            UserId: Guid.NewGuid(),
+            BurnerName: "Arrival",
+            ArrivesOn: arrivalDay,
+            NoShift: noShiftDays,
+            DietaryPreference: "Vegan",
+            Allergies: Array.Empty<string>(),
+            AllergyOtherText: null,
+            Intolerances: Array.Empty<string>(),
+            IntoleranceOtherText: null);
+
+        var roster = new WeeklyRosterDto(
+            WeekStartOffset: 0,
+            WeekStartDate: WeekStart,
+            WeekEndDate: WeekStart.PlusDays(6),
+            EventName: "Test Event",
+            TotalUniqueOnSite: 1,
+            UnansweredCount: 0,
+            DietaryBreakdown: new Dictionary<string, int>(StringComparer.Ordinal),
+            AllergyRollup: [],
+            AllergyOtherEntries: [],
+            IntoleranceRollup: [],
+            IntoleranceOtherEntries: [],
+            Days: [new DayRosterSummaryDto(5, arrivalDay, 1, 0)],
+            People: [person],
+            EventTodayDate: null);
+
+        // Act
+        var lines = RosterLines(roster);
+
+        // Assert: person row exists and ArrivesOn column is the arrival date.
+        var personRow = lines[5];
+        personRow.Should().StartWith("Arrival,2026-07-12");
+    }
+
     [HumansFact]
     public void DailyMatrix_WritesHeaderPeopleAndTotals()
     {


### PR DESCRIPTION
Feeds each human in the Cantina roster on the day **before their first confirmed shift** — their expected arrival day — since they're on-site and need feeding before they start working.

## ⚠️ Two behavior changes for your sign-off, Peter
1. **Cantina on-site is now CONFIRMED-only** (was Pending *or* Confirmed). Consequence: humans whose shifts are all still pending no longer appear in the cantina roster until a shift is confirmed. Implemented by flipping the hardcoded scope inside `ShiftManagementService.GetOnSiteUserIdsForDayAsync` — **`CantinaRosterService` is the sole production caller** of that method (verified), so the blast radius is the cantina only.
2. That flip **changes the semantics of `GetOnSiteUserIdsForDayAsync`** (its doc comment was updated to match).

## What changed
- **Arrival day = `firstConfirmedShiftOffset − 1`**, mirroring the existing blessed pattern (`ShiftEarlyEntryProjection` / volunteer-tracking export). Computed inline in `CantinaRosterService` via a private helper that scans the event day range — **no new interface/repo/service surface** (reuse-first; no approval gate triggered).
- Applied consistently across the **weekly roster**, the **per-day day-strip summary**, the **daily drill-down**, and the **CSV export** (the day-strip count and the drill-down now agree for the same day).
- The arrival day becomes the human's `ArrivesOn`; no clamp (a pre-event/negative arrival day still shows).
- `docs/sections/Cantina.md` updated (confirmed-only + arrival rule). Spec & plan included under `docs/superpowers/`.

## Perf note (conscious trade)
The inline approach adds ~40–60 sequential `GetOnSiteUserIdsForDayAsync` calls per roster render (one per event-day) on top of the existing 7/1. Result sets are tiny (id lists at ~500 humans); accepted under the repo's "prefer in-memory / don't over-engineer for scale" doctrine. The cheaper `MIN(DayOffset) GROUP BY UserId` alternative was deliberately rejected because it needs a new repo+interface method.

## Verification
- `dotnet build Humans.slnx -v quiet` → 0 errors
- `dotnet test Humans.slnx -v quiet` → **4,682 passed / 0 failed / 4 skipped**
- Cantina suite: 38 passed. New tests cover: feeds-day-before, arrival-only-pulled-into-week, no-clamp (negative offset), **global-min guard** (no spurious arrival for prior-week attendees), daily includes N+1 / excludes 2-days-out, CSV emits ArrivesOn.

Spec: `docs/superpowers/specs/2026-06-24-cantina-arrival-and-fodmap-design.md` (Feature 2). FODMAP removal (Feature 1) ships as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)