### PR TITLE
fix(tickets): block transfer of gate-checked-in tickets (respect CheckedInAt)

### DIFF
--- a/src/Humans.Application/DTOs/TicketTransferDtos.cs
+++ b/src/Humans.Application/DTOs/TicketTransferDtos.cs
@@ -23,6 +23,7 @@ public sealed record TicketTransferRowDto(
     string OriginalAttendeeName,
     string TicketTypeName,
     TicketAttendeeStatus OriginalAttendeeStatus,
+    Instant? OriginalAttendeeCheckedInAt,
     Guid SenderUserId,
     string SenderDisplayName,
     Guid ReceiverUserId,

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -58,7 +58,7 @@ public sealed class TicketTransferService(
                     TicketTypeName: a.TicketTypeName,
                     Status: a.Status,
                     IsCurrentOwner: owner,
-                    CanSendTransfer: a.Status == TicketAttendeeStatus.Valid && owner && !pending,
+                    CanSendTransfer: a.Status == TicketAttendeeStatus.Valid && a.CheckedInAt is null && owner && !pending,
                     HasPendingOutgoingTransfer: pending,
                     PendingTransferRequestId: pending ? transferId : null);
             })
@@ -73,6 +73,7 @@ public sealed class TicketTransferService(
         var attendee = await ticketRepo.GetAttendeeByIdAsync(attendeeId, ct);
         if (attendee is null
             || attendee.Status != TicketAttendeeStatus.Valid
+            || attendee.CheckedInAt is not null
             || !TicketAttendeeOwnership.IsCurrentOwner(attendee, senderUserId))
         {
             return null;
@@ -106,6 +107,12 @@ public sealed class TicketTransferService(
 
         if (attendee.Status != TicketAttendeeStatus.Valid)
             throw new InvalidOperationException("Only Valid tickets can be transferred.");
+
+        // A gate scan keeps Status = Valid and records the scan in CheckedInAt
+        // (nobodies-collective/Humans#736), so the Valid check above no longer
+        // catches an already-used ticket — guard on CheckedInAt explicitly.
+        if (attendee.CheckedInAt is not null)
+            throw new InvalidOperationException("Checked-in tickets cannot be transferred.");
 
         var receiverInfo = await userService.GetUserInfoAsync(dto.ReceiverUserId, ct)
             ?? throw new InvalidOperationException("Receiver user not found.");
@@ -721,6 +728,7 @@ public sealed class TicketTransferService(
             OriginalAttendeeName: attendee.AttendeeName,
             TicketTypeName: attendee.TicketTypeName,
             OriginalAttendeeStatus: attendee.Status,
+            OriginalAttendeeCheckedInAt: attendee.CheckedInAt,
             SenderUserId: r.SenderUserId,
             SenderDisplayName: sender?.BurnerName ?? "(unknown)",
             ReceiverUserId: r.ReceiverUserId,

--- a/src/Humans.Web/Views/TicketTransferAdmin/Detail.cshtml
+++ b/src/Humans.Web/Views/TicketTransferAdmin/Detail.cshtml
@@ -142,7 +142,7 @@ else if (row.Status == TicketTransferStatus.Pending)
         </div>
     </div>
 
-    @if (row.OriginalAttendeeStatus == TicketAttendeeStatus.CheckedIn)
+    @if (row.OriginalAttendeeStatus == TicketAttendeeStatus.CheckedIn || row.OriginalAttendeeCheckedInAt is not null)
     {
         <div class="alert alert-warning">
             This ticket has already been checked in — confirm with the Sender before processing.

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
@@ -120,6 +120,16 @@ public sealed class TicketTransferServiceTests
         confirm.Should().BeNull();
     }
 
+    [HumansFact]
+    public async Task GetConfirmation_Null_WhenCheckedIn()
+    {
+        // A gate scan keeps Status = Valid but records CheckedInAt — a used ticket
+        // must not be transferable. nobodies-collective/Humans#736.
+        StubAttendee(TicketAttendeeStatus.Valid, _senderId, checkedInAt: _now);
+        var confirm = await _service.GetConfirmationAsync(_attendeeId, _receiverId, _senderId, Xunit.TestContext.Current.CancellationToken);
+        confirm.Should().BeNull();
+    }
+
     // ── CreateRequestAsync ──────────────────────────────────────────────────────
 
     [HumansFact]
@@ -189,6 +199,18 @@ public sealed class TicketTransferServiceTests
         var act = () => _service.CreateRequestAsync(
             new TicketTransferRequestDto(_attendeeId, _receiverId, "x"), _senderId, Xunit.TestContext.Current.CancellationToken);
         await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [HumansFact]
+    public async Task CreateRequest_Throws_WhenCheckedIn()
+    {
+        // Status stays Valid after a gate scan (nobodies-collective/Humans#736);
+        // the CheckedInAt guard must still block the transfer of a used ticket.
+        StubAttendee(TicketAttendeeStatus.Valid, _senderId, checkedInAt: _now);
+        var act = () => _service.CreateRequestAsync(
+            new TicketTransferRequestDto(_attendeeId, _receiverId, "x"), _senderId, Xunit.TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Checked-in tickets cannot be transferred.");
     }
 
     [HumansFact]
@@ -588,10 +610,11 @@ public sealed class TicketTransferServiceTests
             _clock,
             NullLogger<TicketTransferService>.Instance);
 
-    private void StubAttendee(TicketAttendeeStatus status, Guid attendeeMatchedUserId)
+    private void StubAttendee(
+        TicketAttendeeStatus status, Guid attendeeMatchedUserId, Instant? checkedInAt = null)
     {
         _ticketRepo.GetAttendeeByIdAsync(_attendeeId, Arg.Any<CancellationToken>())
-            .Returns(MakeAttendee(_attendeeId, _orderId, attendeeMatchedUserId, status));
+            .Returns(MakeAttendee(_attendeeId, _orderId, attendeeMatchedUserId, status, checkedInAt));
     }
 
     private static User MakeUser(Guid id, string displayName) => new()
@@ -616,7 +639,8 @@ public sealed class TicketTransferServiceTests
         communicationPreferences: []);
 
     private static TicketAttendee MakeAttendee(
-        Guid id, Guid orderId, Guid attendeeMatchedUserId, TicketAttendeeStatus status)
+        Guid id, Guid orderId, Guid attendeeMatchedUserId, TicketAttendeeStatus status,
+        Instant? checkedInAt = null)
     {
         // Buyer-fallback removed in nobodies-collective/Humans#856.
         // Ownership is determined by TicketAttendee.MatchedUserId only.
@@ -646,6 +670,7 @@ public sealed class TicketTransferServiceTests
             TicketTypeName = "Full Week",
             Price = 200m,
             Status = status,
+            CheckedInAt = checkedInAt,
             VendorEventId = "ev_test",
             SyncedAt = Instant.FromUtc(2026, 3, 1, 10, 0),
             MatchedUserId = attendeeMatchedUserId,

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
@@ -80,6 +80,32 @@ public sealed class TicketTransferService_OnwardTransferTests
     }
 
     [HumansFact]
+    public async Task GetMyAttendees_DeniesTransfer_WhenCheckedIn()
+    {
+        // A gate scan keeps Status = Valid and records CheckedInAt
+        // (nobodies-collective/Humans#736); the owner must not be able to send a
+        // ticket they've already used at the door.
+        var attendee = new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            Status = TicketAttendeeStatus.Valid,
+            CheckedInAt = Now,
+            MatchedUserId = UserB,
+            TicketOrder = new TicketOrder { Id = OrderId, MatchedUserId = UserB },
+        };
+        _ticketRepo.GetAttendeesVisibleToUserAsync(UserB, Arg.Any<CancellationToken>())
+            .Returns([attendee]);
+        _transferRepo.GetBySenderAsync(UserB, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var rows = await _service.GetMyAttendeesAsync(UserB, Xunit.TestContext.Current.CancellationToken);
+
+        rows.Should().HaveCount(1);
+        rows[0].IsCurrentOwner.Should().BeTrue();
+        rows[0].CanSendTransfer.Should().BeFalse();
+    }
+
+    [HumansFact]
     public async Task GetMyAttendees_DeniesTransfer_WhenAttendeeMatchedToSomeoneElse_EvenIfCallerIsBuyer()
     {
         var attendee = new TicketAttendee


### PR DESCRIPTION
## Problem

The `/check_ins` sync (peterdrier/Humans#1059, issue nobodies-collective/Humans#736) records a gate scan on the new `TicketAttendee.CheckedInAt` column and **deliberately keeps `Status = Valid`**. The ticket-transfer flow gated eligibility purely on `Status == Valid`, so after a real gate scan:

- a **used ticket became transferable again** (the sender could initiate, confirm, and the admin could process a void+reissue of a ticket already scanned at the door), and
- the admin Detail **"already checked in" warning** — keyed on `Status == CheckedIn` — no longer fired.

Before #1059, a checked-in ticket had `Status = CheckedIn`, which blocked all three sender gates and showed the warning. #1059 silently removed that guard. Caught by Codex on the QA→prod promotion (nobodies-collective/Humans#902).

## Fix

Restore the guard using the canonical `CheckedInAt` signal at every eligibility gate:

- **`CanSendTransfer`** — dashboard Send button hidden for checked-in tickets
- **`GetConfirmationAsync`** — sender confirm screen returns null
- **`CreateRequestAsync`** — the mutation throws `"Checked-in tickets cannot be transferred."`
- **admin Detail warning** — now also fires on `CheckedInAt`, plumbed via new `TicketTransferRowDto.OriginalAttendeeCheckedInAt`

`Status == CheckedIn` is retained alongside `CheckedInAt` for read-compat with non-prod DBs that still hold legacy `"CheckedIn"` strings.

## Tests

- `GetMyAttendees_DeniesTransfer_WhenCheckedIn` (CanSendTransfer false)
- `GetConfirmation_Null_WhenCheckedIn`
- `CreateRequest_Throws_WhenCheckedIn` (asserts the message)

`Application` suite green (3771). Build green.

Refs nobodies-collective/Humans#736