### PR TITLE
fix(gate): typed search response + correct PIN-throttle doc

### DIFF
--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -6,6 +6,7 @@ using Humans.Infrastructure.Jobs;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Infrastructure;
+using Humans.Web.Models;
 using Humans.Web.Models.Gate;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -158,18 +159,14 @@ public sealed class GateController(
     {
         var query = q?.Trim() ?? string.Empty;
         if (query.Length < 2)
-            return Json(Array.Empty<object>());
+            return Json(Array.Empty<HumanLookupSearchResult>());
 
+        // Same typed shape /api/profiles/search returns to this picker (no Detail —
+        // the kiosk search is name-only). memory/code/search-endpoint-response-shape.md.
         var matches = await UserService.SearchUsersAsync(query, PersonSearchFields.Name, 10, ct);
         var rows = matches
             .OrderByRelevance()
-            .Select(m => new
-            {
-                userId = m.UserId,
-                displayName = m.BurnerName,
-                detail = (string?)null,
-                profilePictureUrl = m.ProfilePictureUrl,
-            })
+            .Select(m => new HumanLookupSearchResult(m.UserId, m.BurnerName, ProfilePictureUrl: m.ProfilePictureUrl))
             .ToList();
         return Json(rows);
     }

--- a/src/Humans.Web/Infrastructure/GatePinThrottle.cs
+++ b/src/Humans.Web/Infrastructure/GatePinThrottle.cs
@@ -9,9 +9,11 @@ namespace Humans.Web.Infrastructure;
 /// secret, so after a few failures the key is locked for a real cooldown that does NOT
 /// reset on its own — only a correct PIN (<see cref="Reset"/>) clears it.
 ///
-/// Callers throttle on BOTH the target user-id AND the source device/IP, so neither a
-/// single supervisor's PIN nor one kiosk can be ground through the ~10k space: check
-/// both keys before verifying, record a failure on both, reset both on success.
+/// Callers throttle per <em>target user-id only</em>. A shared device/IP key was
+/// considered but rejected: in practice the reverse-proxy collapses all kiosk traffic
+/// to one IP, so 5 failures for any one PIN would freeze every claim and override at
+/// the terminal for 15 minutes (gate-wide DoS). The per-user bucket already caps
+/// brute-force at 5 / 15 min across the ~10k PIN space.
 /// </summary>
 public sealed class GatePinThrottle(IMemoryCache cache, IClock clock)
 {

--- a/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
@@ -6,6 +6,7 @@ using Humans.Application.Services.Profiles;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Web.Controllers;
 using Humans.Web.Infrastructure;
+using Humans.Web.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -103,11 +104,10 @@ public class GateControllerClaimTests
         var result = await _controller.Search("ann", ct);
 
         var json = Assert.IsType<JsonResult>(result);
-        var doc = System.Text.Json.JsonSerializer.SerializeToElement(json.Value);
-        Assert.Equal(1, doc.GetArrayLength());
-        var row = doc[0];
-        Assert.Equal(id.ToString(), row.GetProperty("userId").GetString());
-        Assert.Equal("Annie", row.GetProperty("displayName").GetString());
+        var rows = Assert.IsType<List<HumanLookupSearchResult>>(json.Value);
+        var row = Assert.Single(rows);
+        Assert.Equal(id, row.UserId);
+        Assert.Equal("Annie", row.DisplayName);
     }
 
     [HumansFact]


### PR DESCRIPTION
Follow-up to the Gate admissions feature (peterdrier/Humans#1066), addressing two valid automated-review findings raised on the production promotion PR nobodies-collective/Humans#903.

### Fixes
- **`/Gate/Search` returned anonymous objects** → violates `memory/code/search-endpoint-response-shape.md` ("search JSON endpoints use stable typed records; reuse shared models across endpoints feeding the same client"). Now returns the existing **`HumanLookupSearchResult`** record — the exact shape `/api/profiles/search` already feeds the `human-search` picker (Detail omitted; the kiosk search is name-only).
- **`GatePinThrottle` summary was stale** → it still described the removed dual-key (user-id + device/IP) throttle. Updated to the current **per-target-user-only** contract and the reason the device key was dropped (shared reverse-proxy IP would freeze the whole terminal — gate-wide DoS).

### Not changed (deliberately)
- The Codex "throttle by source as well as user" suggestion was **not** applied: re-adding the device key reintroduces the gate-wide DoS the per-user design fixed; per-account brute force is already capped at 5/15 min. (The in-house reviewer's finding above endorses the removal.)
- A separate finding — auto-STOP/AMBER scans not persisted to `gate_scan_events` — is a pre-existing design judgment (record-decisions vs record-every-scan) and is being tracked as a design question, not bundled here.

### Verification
- `dotnet build` clean; `dotnet format --verify-no-changes` clean.
- `GateControllerClaimTests` green (the search test now asserts the typed result directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)