### PR TITLE
Add legal-name column to Early Entry roster

### DIFF
--- a/src/Humans.Web/Controllers/EarlyEntryRosterController.cs
+++ b/src/Humans.Web/Controllers/EarlyEntryRosterController.cs
@@ -18,14 +18,22 @@ public sealed class EarlyEntryRosterController(
     {
         var rows = await earlyEntryService.GetRosterAsync(ct);
 
-        // Names are resolved at render via <vc:human>; the VM carries UserId only
-        // (no DisplayName field — see memory/code/no-new-displayname-fields.md).
+        // Burner name is resolved at render via <vc:human>; the VM carries UserId for that
+        // (no DisplayName field — see memory/code/no-new-displayname-fields.md). Legal name is
+        // a separate concept resolved here from the canonical read-model.
         var ordered = rows
             .OrderBy(r => r.EarliestEntryDate)
             .ThenBy(r => r.UserId)
-            .Select(r => new EarlyEntryRosterRowVm(r.UserId, r.EarliestEntryDate, r.Sources, r.HasMultiple))
             .ToList();
 
-        return View(new EarlyEntryRosterViewModel(ordered));
+        var vms = new List<EarlyEntryRosterRowVm>(ordered.Count);
+        foreach (var r in ordered)
+        {
+            var info = await FindUserInfoByIdAsync(r.UserId, ct);
+            var legalName = info?.Profile?.FullName ?? string.Empty;
+            vms.Add(new EarlyEntryRosterRowVm(r.UserId, legalName, r.EarliestEntryDate, r.Sources, r.HasMultiple));
+        }
+
+        return View(new EarlyEntryRosterViewModel(vms));
     }
 }

--- a/src/Humans.Web/Models/EarlyEntry/EarlyEntryRosterViewModel.cs
+++ b/src/Humans.Web/Models/EarlyEntry/EarlyEntryRosterViewModel.cs
@@ -6,6 +6,7 @@ public sealed record EarlyEntryRosterViewModel(IReadOnlyList<EarlyEntryRosterRow
 
 public sealed record EarlyEntryRosterRowVm(
     Guid UserId,
+    string LegalName,
     LocalDate EarliestEntryDate,
     IReadOnlyList<string> Sources,
     bool HasMultiple);

--- a/src/Humans.Web/Views/EarlyEntryRoster/Index.cshtml
+++ b/src/Humans.Web/Views/EarlyEntryRoster/Index.cshtml
@@ -20,6 +20,7 @@ else
         .RowCss(x => x.Row.HasMultiple ? "table-warning" : null)
         .Column("#", x => x.Num, c => c.End())
         .Template("Human", @<text><vc:human user-id="@item.Row.UserId" layout="AvatarName" size="32" /></text>)
+        .Column("Legal name", x => x.Row.LegalName)
         .Column("Enters", x => x.Row.EarliestEntryDate.ToWeekdayDayMonth())
         .Column("Source(s)", x => string.Join(", ", x.Row.Sources))
         .Template("", @<text>@if (item.Row.HasMultiple) { <span class="badge bg-warning text-dark">multiple</span> }</text>, c => c.NoSort())

--- a/tests/Humans.Web.Tests/Controllers/EarlyEntryRosterControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EarlyEntryRosterControllerTests.cs
@@ -1,7 +1,10 @@
 using System.Security.Claims;
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Controllers;
 using Humans.Web.Models.EarlyEntry;
 using Microsoft.AspNetCore.Http;
@@ -71,4 +74,46 @@ public class EarlyEntryRosterControllerTests
         model.Rows[0].HasMultiple.Should().BeTrue();
         model.Rows[0].Sources.Should().HaveCount(2);
     }
+
+    [HumansFact]
+    public async Task Index_PopulatesLegalNameFromProfile()
+    {
+        var userId = Guid.NewGuid();
+
+        _earlyEntryService.GetRosterAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<EarlyEntryRosterRow>
+            {
+                new(userId, new LocalDate(2026, 8, 25), ["Camp Alpha"], HasMultiple: false),
+            });
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(MakeUserInfo(userId, burner: "Spark", first: "Jean", last: "Dupont"));
+
+        var ctrl = BuildSut();
+        var result = await ctrl.Index(Xunit.TestContext.Current.CancellationToken);
+
+        var view = result.Should().BeOfType<ViewResult>().Subject;
+        var model = view.Model.Should().BeOfType<EarlyEntryRosterViewModel>().Subject;
+        model.Rows[0].LegalName.Should().Be("Jean Dupont");
+    }
+
+    private static UserInfo MakeUserInfo(Guid userId, string burner, string first, string last) =>
+        UserInfo.Create(
+            user: new User { Id = userId, DisplayName = burner, PreferredLanguage = "en", CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0) },
+            userEmails: [],
+            eventParticipations: [],
+            externalLogins: [],
+            profile: new Profile
+            {
+                UserId = userId,
+                BurnerName = burner,
+                FirstName = first,
+                LastName = last,
+                State = ProfileState.Active,
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            },
+            contactFields: [],
+            profileLanguages: [],
+            volunteerHistory: [],
+            communicationPreferences: []);
 }


### PR DESCRIPTION
Adds a **Legal name** column to `/Shifts/Admin/EarlyEntry`, between the Human and Enters columns.

## What
- `EarlyEntryRosterRowVm` gains a `LegalName` field (concept-specific name, per the no-`DisplayName` rule).
- Controller resolves it from the canonical `UserInfo` read-model (`Profile.FullName`) via the base controller's existing `FindUserInfoByIdAsync` helper.
- View adds one `.Column("Legal name", …)` to the table builder.
- New test `Index_PopulatesLegalNameFromProfile` asserts the column is populated from the profile.

## Authorization
No new exposure: the page is gated by `ShiftDashboardAccess` (Admin / NoInfoAdmin / VolunteerCoordinator) — the same privileged tier that already sees legal names via the ProfileCard Admin view. Users without a profile render a blank cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)