### PR TITLE
Gate PIN UX (Phase 1): set/reset audit + first-time confirm & double-entry

### DIFF
--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -55,6 +55,11 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
   real per-person claim rather than honour-system. **Supervisors** (Admin/Board/TicketAdmin) cannot
   self-enrol at the anonymous kiosk — their PIN carries override authority, so an admin enrols it out
   of band (`/Gate/Admin`); the override path is verify-only and rejects un-enrolled supervisors.
+  **First-time set** has two guards (claim-only, never on verify): an "is this you?" confirm before a
+  PIN is minted in someone's name, and a double-entry (enter twice, must match) so a mis-typed PIN
+  can't silently lock a volunteer out (there is no self-service reset — an admin clears it). Every
+  PIN **set/reset is audited** (`GateStaffPinSet`/`GateStaffPinReset` with the acting user — the
+  staffer on self-enrol, the admin on admin-set/reset); PIN values are never logged.
 - **Supervisor override** — a too-early scan (e.g. a Friday Early-Entry ticket scanned on Wednesday)
   STOPs with a precise reason (the holder's EE date vs today, or "no early entry · general entry
   opens …" — date only, never the EE source) and offers a **supervisor override**: the supervisor

--- a/src/Humans.Application/Interfaces/Gate/IGateService.cs
+++ b/src/Humans.Application/Interfaces/Gate/IGateService.cs
@@ -60,8 +60,8 @@ public interface IGateService : IApplicationService
     /// </summary>
     Task<GatePinSetResult> SetOwnPinAsync(Guid userId, string pin, CancellationToken ct = default);
 
-    /// <summary>Admin sets/initialises any user's PIN (incl. supervisors), from the gate admin page. Returns false if the PIN is invalid.</summary>
-    Task<bool> AdminSetPinAsync(Guid userId, string pin, CancellationToken ct = default);
+    /// <summary>Admin sets/initialises any user's PIN (incl. supervisors), from the gate admin page. <paramref name="actorUserId"/> is the acting admin (audit). Returns false if the PIN is invalid.</summary>
+    Task<bool> AdminSetPinAsync(Guid userId, string pin, Guid actorUserId, CancellationToken ct = default);
 
     /// <summary>Verify a staffer's PIN for claiming the scanner. Timing-safe. False if no PIN set or mismatch.</summary>
     Task<bool> VerifyPinAsync(Guid userId, string pin, CancellationToken ct = default);
@@ -73,8 +73,8 @@ public interface IGateService : IApplicationService
     /// </summary>
     Task<bool> AuthorizeOverrideAsync(Guid supervisorUserId, string pin, CancellationToken ct = default);
 
-    /// <summary>Clear a user's PIN (admin reset). They re-enrol on next claim.</summary>
-    Task ClearPinAsync(Guid userId, CancellationToken ct = default);
+    /// <summary>Clear a user's PIN (admin reset). <paramref name="actorUserId"/> is the acting admin (audit). They re-enrol on next claim.</summary>
+    Task ClearPinAsync(Guid userId, Guid actorUserId, CancellationToken ct = default);
 
     /// <summary>
     /// The user-ids of every gate-supervisor (Admin/Board/TicketAdmin) who has a PIN enrolled —

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -1,5 +1,6 @@
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Gate;
@@ -32,6 +33,7 @@ public sealed class GateService(
     IShiftManagementService shifts,
     IRoleAssignmentService roles,
     IPasswordHasher<GateStaffPin> pinHasher,
+    IAuditLogService auditLog,
     IClock clock) : IGateService, IUserMerge, IUserDataContributor
 {
     /// <summary>How far either side of "now" a gate shift may start to count as current.</summary>
@@ -207,14 +209,19 @@ public sealed class GateService(
         if (await IsSupervisorAsync(userId, ct))
             return GatePinSetResult.SupervisorMustBeAdminEnrolled;
         await StorePinAsync(userId, pin, ct);
+        // Self-enrol at the kiosk: actor == the claimed staffer (no PIN value is ever logged).
+        await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
+            "Staffer self-enrolled their gate PIN at the kiosk", userId);
         return GatePinSetResult.Ok;
     }
 
-    public async Task<bool> AdminSetPinAsync(Guid userId, string pin, CancellationToken ct = default)
+    public async Task<bool> AdminSetPinAsync(Guid userId, string pin, Guid actorUserId, CancellationToken ct = default)
     {
         if (!IsValidPin(pin))
             return false;
         await StorePinAsync(userId, pin, ct);
+        await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
+            "Admin set a staffer's gate PIN", actorUserId);
         return true;
     }
 
@@ -235,8 +242,12 @@ public sealed class GateService(
         return await IsSupervisorAsync(supervisorUserId, ct);
     }
 
-    public Task ClearPinAsync(Guid userId, CancellationToken ct = default) =>
-        repository.DeleteStaffPinAsync(userId, ct);
+    public async Task ClearPinAsync(Guid userId, Guid actorUserId, CancellationToken ct = default)
+    {
+        await repository.DeleteStaffPinAsync(userId, ct);
+        await auditLog.LogAsync(AuditAction.GateStaffPinReset, nameof(GateStaffPin), userId,
+            "Admin reset a staffer's gate PIN", actorUserId);
+    }
 
     public async Task<IReadOnlyList<Guid>> GetEnrolledSupervisorIdsAsync(CancellationToken ct = default)
     {

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -191,6 +191,9 @@ public enum AuditAction
     EarlyEntryRevoked,
     StorePaymentsReconciled,
     GateTerminalPasswordSet,
+    // Gate personal-PIN lifecycle: who set (self-enrol or admin) or reset a staffer's claim PIN.
+    GateStaffPinSet,
+    GateStaffPinReset,
     SurveyCreated,
     SurveyUpdated,
     SurveyOpened,

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -224,9 +224,11 @@ public sealed class GateController(
     [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> SetStaffPin(Guid userId, string? pin, CancellationToken ct)
     {
+        if (GetCurrentUserId() is not { } actor)
+            return Unauthorized();
         if (userId == Guid.Empty)
             SetError("Pick a person before setting a PIN.");
-        else if (await gate.AdminSetPinAsync(userId, pin ?? string.Empty, ct))
+        else if (await gate.AdminSetPinAsync(userId, pin ?? string.Empty, actor, ct))
             SetSuccess("PIN set.");
         else
             SetError("PIN must be 4 digits and not trivially guessable (no 1234, 0000, or repeats).");
@@ -240,11 +242,13 @@ public sealed class GateController(
     [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> ResetStaffPin(Guid userId, CancellationToken ct)
     {
+        if (GetCurrentUserId() is not { } actor)
+            return Unauthorized();
         if (userId == Guid.Empty)
             SetError("Pick a person before resetting a PIN.");
         else
         {
-            await gate.ClearPinAsync(userId, ct);
+            await gate.ClearPinAsync(userId, actor, ct);
             SetSuccess("PIN reset — they'll set a new one on their next claim.");
         }
 

--- a/src/Humans.Web/Views/Gate/Pin.cshtml
+++ b/src/Humans.Web/Views/Gate/Pin.cshtml
@@ -25,7 +25,7 @@
     {
         <div class="gate-pin-head">
             <div class="gate-pin-name">@Model.DisplayName</div>
-            <div class="gate-pin-prompt">@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
+            <div class="gate-pin-prompt" data-gate-prompt>@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
             @if (Model.Mode == GatePinMode.Set)
             {
                 <div class="gate-pin-sub">You'll reuse this each shift to claim the gate.</div>
@@ -34,9 +34,23 @@
             {
                 <div class="gate-pin-error" role="alert">@Model.Error</div>
             }
+            @* Client-side message for a double-entry mismatch (set mode) — filled by gate-pin.js. *@
+            <div class="gate-pin-error d-none" role="alert" data-gate-error></div>
         </div>
 
-        <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off">
+        @* First-time set only: confirm the staffer is the person they picked before minting a PIN in
+           their name (every scan is attributed to them). The keypad stays hidden until they confirm. *@
+        @if (Model.Mode == GatePinMode.Set)
+        {
+            <div class="gate-pin-confirm" data-gate-confirm>
+                <div class="gate-pin-confirm-q">Is this you?</div>
+                <p class="gate-pin-confirm-note">Every ticket you scan will be recorded as <strong>@Model.DisplayName</strong>.</p>
+                <button type="button" class="gate-pin-confirm-yes" data-gate-confirm-yes>Yes — that's me</button>
+            </div>
+        }
+
+        <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off"
+              class="@(Model.Mode == GatePinMode.Set ? "d-none" : "")">
             <input type="hidden" name="userId" value="@Model.UserId" />
             <input type="hidden" name="pin" id="gate-pin-value" />
             <partial name="_PinPad" />
@@ -59,7 +73,12 @@
             initClaimPin({
                 container: document.querySelector('[data-gate-keypad]'),
                 form: document.getElementById('gate-pin-form'),
-                valueInput: document.getElementById('gate-pin-value')
+                valueInput: document.getElementById('gate-pin-value'),
+                confirmTwice: @(Model.Mode == GatePinMode.Set ? "true" : "false"),
+                confirmEl: document.querySelector('[data-gate-confirm]'),
+                confirmYes: document.querySelector('[data-gate-confirm-yes]'),
+                promptEl: document.querySelector('[data-gate-prompt]'),
+                errorEl: document.querySelector('[data-gate-error]')
             });
         </script>
     }

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -111,6 +111,9 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-pin-head { margin-bottom: 1.25rem; }
 .gate-pin-name { font-size: 2.1rem; font-weight: 700; color: #1e2a33; line-height: 1.1; }
 .gate-pin-prompt { font-size: 1.4rem; color: #2b3440; margin-top: .35rem; }
+/* Re-enter (confirm) step of a first-time set — stands out from the neutral "set" prompt so the
+   volunteer notices the keypad is asking a second time, not repeating itself. */
+.gate-pin-prompt-confirm { color: #0B7A2F; font-weight: 700; }
 .gate-pin-sub { font-size: 1.05rem; color: #5f6b76; margin-top: .25rem; }
 .gate-pin-error {
     margin-top: .9rem; padding: .6rem 1rem; border-radius: 10px;
@@ -119,6 +122,16 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-pin-back {
     display: inline-block; margin-top: 1.5rem; font-size: 1.1rem; font-weight: 600; color: #5f6b76;
 }
+/* "Is this you?" confirm before a first-time PIN set — big, unmissable, glove-friendly. */
+.gate-pin-confirm { max-width: 440px; margin: 0 auto; }
+.gate-pin-confirm-q { font-size: 1.6rem; font-weight: 700; color: #1e2a33; }
+.gate-pin-confirm-note { font-size: 1.2rem; color: #2b3440; line-height: 1.45; margin: .5rem 0 1.5rem; }
+.gate-pin-confirm-note strong { color: #1e2a33; }
+.gate-pin-confirm-yes {
+    width: 100%; font-size: 1.6rem; font-weight: 700; color: #fff; background: #0B7A2F;
+    border: none; border-radius: 14px; padding: 1.1rem; min-height: 78px; cursor: pointer;
+}
+.gate-pin-confirm-yes:active { background: #095e24; }
 .gate-pin-blocked { max-width: 460px; margin: 2rem auto 0; text-align: center; color: #1e2a33; }
 .gate-pin-icon { font-size: 3.2rem; color: #B26A00; }
 .gate-pin-blocked-text { font-size: 1.2rem; line-height: 1.5; margin-top: .75rem; color: #2b3440; }

--- a/src/Humans.Web/wwwroot/js/gate/gate-pin.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate-pin.js
@@ -5,13 +5,51 @@
 // this page with an error and an empty keypad (state resets naturally on reload), so there's no
 // AJAX or error-merging to get wrong. The keypad itself comes from window.initGateKeypad, a
 // cache-busted classic script, so this module has no import to go stale on the kiosk.
+//
+// Two guards apply on *first-time set* only (confirmTwice), never on verify (which stays a single
+// snappy entry): (1) an "is this you?" step keeps the keypad hidden until the staffer confirms the
+// name they picked — a PIN is attributed to them; (2) the PIN must be entered twice and match, so
+// a mis-typed PIN can't silently lock a volunteer out (there's no self-service reset). All of this
+// lives here, in the claim-only module — the shared keypad and the override panel are untouched.
 export function initClaimPin(refs) {
-    const { container, form, valueInput } = refs;
+    const { container, form, valueInput, confirmTwice, confirmEl, confirmYes, promptEl, errorEl } = refs;
     if (!container || !form || !valueInput || !window.initGateKeypad) return;
 
+    const setPrompt = (text, isConfirmStep) => {
+        if (!promptEl) return;
+        promptEl.textContent = text;
+        promptEl.classList.toggle('gate-pin-prompt-confirm', !!isConfirmStep);
+    };
+    const showError = (text) => { if (errorEl) { errorEl.textContent = text; errorEl.classList.toggle('d-none', !text); } };
+
+    // "Is this you?" gate (set only): reveal the keypad only once the staffer confirms.
+    if (confirmEl && confirmYes) {
+        confirmYes.addEventListener('click', () => {
+            confirmEl.classList.add('d-none');
+            form.classList.remove('d-none');
+        });
+    }
+
     let submitted = false;
-    window.initGateKeypad(container, (pin) => {
+    let firstPin = null; // holds the first entry while we wait for the confirming re-entry (set mode)
+    const pad = window.initGateKeypad(container, (pin) => {
         if (submitted) return;
+
+        if (confirmTwice && firstPin === null) {
+            firstPin = pin; // first entry captured — ask for a confirming re-entry
+            setPrompt('Re-enter your PIN to confirm', true);
+            showError('');
+            pad.reset();
+            return;
+        }
+        if (confirmTwice && pin !== firstPin) {
+            firstPin = null; // mismatch — start the pair over from a clean "set" prompt
+            setPrompt('Set a 4-digit PIN', false);
+            showError("PINs didn't match — start over");
+            pad.reset();
+            return;
+        }
+
         submitted = true; // one submit per page load — a double-tap can't double-post
         valueInput.value = pin;
         form.submit();

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Gate;
 using Humans.Application.Interfaces.Gdpr;
@@ -36,6 +37,7 @@ public class GateServiceTests : ServiceTestHarness
     private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
     private readonly IRoleAssignmentService _roles = Substitute.For<IRoleAssignmentService>();
     private readonly IPasswordHasher<GateStaffPin> _pinHasher = new PasswordHasher<GateStaffPin>();
+    private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
     private readonly GateService _svc;
 
     public GateServiceTests()
@@ -43,7 +45,7 @@ public class GateServiceTests : ServiceTestHarness
         _burn.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
         _earlyEntry.GetForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((UserEarlyEntry?)null);
-        _svc = new GateService(new GateRepository(DbFactory), _tickets, _earlyEntry, _burn, _shifts, _roles, _pinHasher, Clock);
+        _svc = new GateService(new GateRepository(DbFactory), _tickets, _earlyEntry, _burn, _shifts, _roles, _pinHasher, _auditLog, Clock);
 
         // Baseline: an admin has set the cutoff in the past, so general entry is open.
         // Seeded directly (sync) since the ctor can't await; Db shares the in-memory
@@ -397,6 +399,25 @@ public class GateServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task PinSetAndReset_AreAudited_WithTheActingUser()
+    {
+        var user = Guid.NewGuid();
+        var admin = Guid.NewGuid();
+
+        await _svc.SetOwnPinAsync(user, "2580");                 // self-enrol: actor == the staffer
+        await _auditLog.Received(1).LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), user,
+            Arg.Any<string>(), user);
+
+        await _svc.AdminSetPinAsync(user, "1357", admin);        // admin set: actor == the admin
+        await _auditLog.Received(1).LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), user,
+            Arg.Any<string>(), admin);
+
+        await _svc.ClearPinAsync(user, admin);                   // admin reset: actor == the admin
+        await _auditLog.Received(1).LogAsync(AuditAction.GateStaffPinReset, nameof(GateStaffPin), user,
+            Arg.Any<string>(), admin);
+    }
+
+    [HumansFact]
     public async Task SetOwnPin_RejectsTrivialOrMalformedPins()
     {
         var user = Guid.NewGuid();
@@ -413,7 +434,7 @@ public class GateServiceTests : ServiceTestHarness
         (await _svc.SetOwnPinAsync(sup, "2580")).Should().Be(GatePinSetResult.SupervisorMustBeAdminEnrolled);
         (await _svc.GetPinStatusAsync(sup)).Should().Be(new GatePinStatus(HasPin: false, IsSupervisor: true));
 
-        (await _svc.AdminSetPinAsync(sup, "2580")).Should().BeTrue();
+        (await _svc.AdminSetPinAsync(sup, "2580", Guid.NewGuid())).Should().BeTrue();
         (await _svc.VerifyPinAsync(sup, "2580")).Should().BeTrue();
     }
 
@@ -422,7 +443,7 @@ public class GateServiceTests : ServiceTestHarness
     {
         var sup = Guid.NewGuid();
         _roles.HasActiveRoleAsync(sup, RoleNames.Board, Arg.Any<CancellationToken>()).Returns(true);
-        await _svc.AdminSetPinAsync(sup, "2580");
+        await _svc.AdminSetPinAsync(sup, "2580", Guid.NewGuid());
 
         (await _svc.AuthorizeOverrideAsync(sup, "2580")).Should().BeTrue();
         (await _svc.AuthorizeOverrideAsync(sup, "1357")).Should().BeFalse();          // wrong PIN
@@ -446,7 +467,7 @@ public class GateServiceTests : ServiceTestHarness
             .Returns(new[] { notEnrolled });
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.TicketAdmin, Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Guid>());
-        await _svc.AdminSetPinAsync(enrolled, "2580");
+        await _svc.AdminSetPinAsync(enrolled, "2580", Guid.NewGuid());
 
         var ids = await _svc.GetEnrolledSupervisorIdsAsync();
 


### PR DESCRIPTION
**Phase 1** of the gate claim/PIN UX rework (from an investigation into three pathways: check-in source of truth, PIN/login ambiguity, and the supervisor PIN block). This PR is the safe, decision-independent slice; D2/D3/D1 follow separately.

## What this does
1. **PIN set/reset audit.** Every gate PIN set/reset now writes an audit entry via the existing `IAuditLogService` — new `AuditAction.GateStaffPinSet`/`GateStaffPinReset` (string-enum, **no migration**). Records the acting user: the staffer on self-enrol, the admin on admin set/reset. **PIN values are never logged.**
2. **"Is this you, {name}?" confirm** before a first-time PIN is minted in someone's name (attribution guard). Set mode only.
3. **Double-entry on set** (enter twice, must match) so a mis-typed PIN can't silently lock a volunteer out — there is no self-service reset. Mismatch resets to a clean "Set a 4-digit PIN" with a distinct error. Verify mode stays a single snappy entry.

Parts 2–3 are confined to the claim-only `gate-pin.js` + `Pin.cshtml`; the **shared `gate-keypad.js` and the supervisor-override panel are untouched**.

## ⚠️ Needs your sign-off, Peter
- **`IGateService` interface change:** `AdminSetPinAsync`/`ClearPinAsync` gained a `Guid actorUserId` param, threaded from the Web layer's `GetCurrentUserId()` (the service can't discover the acting admin itself). Per reuse-first discipline this public-surface change needs your OK. Only one implementor, no caching decorator — fully contained.

## Verification
- Build clean · **122 gate tests green** (incl. a new audit-actor test) · `dotnet format` clean.
- **Live-verified** on the rugged-tablet viewport: the confirm step, double-entry happy path, and the mismatch-restart all drive correctly end-to-end; audit fires on self-enrol.
- Peer-reviewed (two UX tweaks from the review applied: mismatch-restart copy + emphasised re-enter prompt).

## Related
Part of the gate rework tracked in nobodies-collective#906 (check-in divergence), nobodies-collective#907 (claim search), nobodies-collective#909 (gate-lead role). Not for merge without your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
