### PR TITLE
Gate: explicit "End shift" button (clears scanner session server-side)

### DIFF
--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -159,8 +159,10 @@ tap-list because the `GateTerminal` account is route-locked to `/Gate` and so ca
   timeout only (it shows a name but the operator is mid-decision); the supervisor-override panel pauses
   the timer while a PIN is being entered.
 - **No dead-ends / minimal-training affordances** (kiosk is chromeless — no browser back). Every screen
-  has a visible way out: Leaderboard has "← Back to scanning"; the PIN keypad has "← Not you?". "Change"
-  (switch operator) is a deliberate two-tap (it abandons the session). The scan screen has an always-on
+  has a visible way out: Leaderboard has "← Back to scanning"; the PIN keypad has "← Not you?". "End shift"
+  (hand over to the next operator) is a deliberate two-tap button that POSTs `GateController.EndShift` to
+  clear the scanner session **server-side**, so a walk-away can't leave the next person's scans attributed
+  to whoever last claimed. The scan screen has an always-on
   "?" help cheat-sheet (green=admit / red=stop / amber=supervisor), STOP cards spell out the action
   ("Do not admit · if disputed, get the gate lead"), the ID-confirm card has a "Wrong ticket — scan
   again" escape and a visible auto-clear countdown, the override panel has "← Wrong person", and the

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -150,6 +150,19 @@ public sealed class GateController(
             : await SetClaimPinAsync(userId, name, status, pin, ct);
     }
 
+    [HttpPost("EndShift")]
+    [Authorize(Policy = PolicyNames.GateAdmit)]
+    [ValidateAntiForgeryToken]
+    public IActionResult EndShift()
+    {
+        // End the current scanner's session so the terminal drops back to "Who is scanning?".
+        // Clearing attribution server-side (not just navigating away) means a walk-away can't
+        // leave the next person's scans recorded against whoever last claimed — the session
+        // otherwise survives ~8h of idle, long past a single staffer's shift.
+        HttpContext.Session.Remove(ScannerSessionKey);
+        return RedirectToAction(nameof(Claim));
+    }
+
     // Name-only people search for the claim screen. The route-locked kiosk can't reach
     // /api/profiles/search (that lock is what keeps the supervisor-override picker a tap-list),
     // so the claim picker points here instead. Burner names only — no email, no broad fields —

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -15,10 +15,12 @@
         <span>Scanning as <strong>@Model.ScannerName</strong></span>
         <span class="gate-asof" data-asof="@Model.DataAsOf"
               title="Tap to reload">loaded…</span>
-        @* "Change" abandons the session (re-enter PIN), so it's a deliberate two-tap (gate.js) to
-           stop a mid-queue fat-finger from dumping the operator back to the roster. *@
-        <a asp-action="Claim" class="gate-topbar-link" data-confirm-change>Change</a>
         <a asp-action="Leaderboard" class="gate-topbar-link">Leaderboard</a>
+        @* "End shift" clears the scanner session (the next person re-claims with their PIN), so it's a
+           deliberate two-tap (gate.js) to stop a mid-queue fat-finger from dumping the operator out. *@
+        <form method="post" asp-action="EndShift" class="gate-endshift-form">
+            <button type="submit" class="gate-endshift-btn" data-confirm-change="Tap again to end shift">End shift</button>
+        </form>
     </div>
 
     @if (!Model.CutoffConfigured)

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -14,7 +14,14 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
     font-size: 1rem; color: #5f6b76; margin-bottom: .75rem;
 }
 .gate-topbar-link { margin-left: auto; font-weight: 600; }
-.gate-topbar-link + .gate-topbar-link { margin-left: .75rem; }
+.gate-topbar-link ~ .gate-endshift-form { margin: 0; }
+/* "End shift" is a button (not a faint link) so the handover to the next scanner is obvious. */
+.gate-endshift-btn {
+    font: inherit; font-weight: 700; cursor: pointer; line-height: 1.2;
+    color: #2b3440; background: transparent;
+    border: 2px solid #2b3440; border-radius: 6px; padding: .35rem .85rem;
+}
+.gate-endshift-btn:hover, .gate-endshift-btn:focus { background: #2b3440; color: #fff; }
 /* Freshness indicator — readable contrast; reddens once the terminal's been open a while. */
 .gate-asof { color: #2b3440; font-weight: 600; }
 .gate-asof-stale { color: #B11217; }
@@ -191,8 +198,8 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
     font-size: 1.05rem; font-weight: 600; cursor: pointer; margin-bottom: .25rem;
 }
 
-/* "Change" link while armed for the confirming second tap. */
-.gate-topbar-link.gate-armed { color: #B11217; font-weight: 700; }
+/* "End shift" button while armed for the confirming second tap. */
+.gate-endshift-btn.gate-armed { color: #fff; background: #B11217; border-color: #B11217; }
 
 /* The freshness line doubles as the reload control on the chromeless kiosk. */
 .gate-asof { cursor: pointer; }

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -105,24 +105,26 @@ export function initGate(refs) {
     }
     result.addEventListener('pointerdown', bumpReset, { passive: true });
 
-    // "Change" abandons the session (re-enter PIN), so require a deliberate second tap.
+    // "End shift" clears the scanner session (next person re-claims with their PIN), so require
+    // a deliberate second tap.
     initChangeConfirm();
     // The freshness line is a reload affordance on the chromeless kiosk (no browser reload button).
     const asofEl = document.querySelector('.gate-asof');
     if (asofEl) asofEl.addEventListener('click', () => location.reload());
 
     function initChangeConfirm() {
-        const link = document.querySelector('[data-confirm-change]');
-        if (!link) return;
+        const btn = document.querySelector('[data-confirm-change]');
+        if (!btn) return;
         let armed = false;
-        link.addEventListener('click', (e) => {
-            if (armed) return; // second tap within the window → allow the link to navigate
+        const original = btn.textContent;
+        const armedLabel = btn.getAttribute('data-confirm-change') || 'Tap again';
+        btn.addEventListener('click', (e) => {
+            if (armed) return; // second tap within the window → allow the submit to proceed
             e.preventDefault();
             armed = true;
-            const original = link.textContent;
-            link.textContent = 'Tap again to switch';
-            link.classList.add('gate-armed');
-            setTimeout(() => { armed = false; link.textContent = original; link.classList.remove('gate-armed'); }, 3000);
+            btn.textContent = armedLabel;
+            btn.classList.add('gate-armed');
+            setTimeout(() => { armed = false; btn.textContent = original; btn.classList.remove('gate-armed'); }, 3000);
         });
     }
 


### PR DESCRIPTION
Replaces the gate scanning screen's faint **"Change"** text-link with an explicit two-tap **"End shift"** button.

## Why
"Change" only navigated to the claim screen — it did **not** clear the per-person scanner session. Since the session lives ~8h, a volunteer who walked away left the next person's scans attributed to whoever last claimed. It also read as "I picked the wrong name", not "I'm done — next person".

## What
- New `GateController.EndShift` (`[HttpPost]`, `GateAdmit`, antiforgery) clears the scanner session **server-side**, then returns to "Who is scanning?".
- The topbar control is now a clear bordered **button** (not a faint link), keeping the deliberate two-tap guard ("Tap again to end shift").
- Fixes a latent bug: after ending, revisiting `/Gate` now correctly lands on the claim screen with no lingering attribution.

## Verification
Build clean · gate tests green · `dotnet format` clean · **live-verified end-to-end** on the tablet viewport (two-tap arm, POST, session cleared, `/Gate` → claim). Peer-reviewed (no blockers). `docs/sections/Gate.md` invariant updated.

Not for merge without your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
