### PR TITLE
Gate claim search (D2): masked-email disambiguator (name-only search)

### DIFF
--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -1,7 +1,9 @@
 using Hangfire;
+using Humans.Application;
 using Humans.Application.Interfaces.Gate;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
@@ -152,8 +154,9 @@ public sealed class GateController(
 
     // Name-only people search for the claim screen. The route-locked kiosk can't reach
     // /api/profiles/search (that lock is what keeps the supervisor-override picker a tap-list),
-    // so the claim picker points here instead. Burner names only — no email, no broad fields —
-    // and it stays inside the /Gate route-lock.
+    // so the claim picker points here instead. Matching is burner-name only — never by email or
+    // broad fields — but each result shows a *masked* email as a disambiguator (see below), and it
+    // stays inside the /Gate route-lock.
     [HttpGet("Search")]
     public async Task<IActionResult> Search(string? q, CancellationToken ct)
     {
@@ -161,14 +164,49 @@ public sealed class GateController(
         if (query.Length < 2)
             return Json(Array.Empty<HumanLookupSearchResult>());
 
-        // Same typed shape /api/profiles/search returns to this picker (no Detail —
-        // the kiosk search is name-only). memory/code/search-endpoint-response-shape.md.
-        var matches = await UserService.SearchUsersAsync(query, PersonSearchFields.Name, 10, ct);
-        var rows = matches
+        // Name-only search (never email — see the note above). To tell same-name staffers apart
+        // (many volunteers share a first name), each result carries a *masked* primary email as a
+        // disambiguator — enough to recognise your own address, not enough to broadcast it. The
+        // effective email is read per result (cached) and masked here at the presentation layer, so
+        // the search itself and its response shape stay email-free. Mirrors BuildSupervisorOptionsAsync.
+        var matches = (await UserService.SearchUsersAsync(query, PersonSearchFields.Name, 10, ct))
             .OrderByRelevance()
-            .Select(m => new HumanLookupSearchResult(m.UserId, m.BurnerName, ProfilePictureUrl: m.ProfilePictureUrl))
             .ToList();
+        var rows = new List<HumanLookupSearchResult>(matches.Count);
+        foreach (var m in matches)
+        {
+            var info = await UserService.GetUserInfoAsync(m.UserId, ct);
+            rows.Add(new HumanLookupSearchResult(
+                m.UserId, m.BurnerName, Detail: MaskEmail(PublicEmail(info)), ProfilePictureUrl: m.ProfilePictureUrl));
+        }
         return Json(rows);
+    }
+
+    // The one email safe to hint on a shared, role-less kiosk: a verified address the owner set to
+    // org-public (AllActiveProfiles) visibility — never a Board/coordinator/team-scoped address, and
+    // never a merged/GDPR tombstone. Mirrors the Bio-bucket public-email rule; if the person has no
+    // org-public email, the picker simply shows no disambiguator (the photo still helps).
+    private static string? PublicEmail(UserInfo? info) =>
+        info is null || info.IsTombstone
+            ? null
+            : info.UserEmails
+                .Where(e => e.IsVerified && e.Visibility == ContactFieldVisibility.AllActiveProfiles)
+                .OrderByDescending(e => e.IsPrimary)
+                .Select(e => e.Email)
+                .FirstOrDefault();
+
+    // Masks an email for the shared kiosk picker: first char + bullets + last char of the local
+    // part, then the full domain (paul.smith@gmail.com → p•••h@gmail.com). Recognisable to its
+    // owner, minimal to a bystander. Presentation-only — never used for matching.
+    private static string? MaskEmail(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return null;
+        var at = email.IndexOf('@', StringComparison.Ordinal);
+        if (at <= 0 || at == email.Length - 1) return null;
+        var local = email[..at];
+        var domain = email[(at + 1)..];
+        var shown = local.Length <= 2 ? $"{local[0]}•••" : $"{local[0]}•••{local[^1]}";
+        return $"{shown}@{domain}";
     }
 
     [HttpGet("Leaderboard")]


### PR DESCRIPTION
**Phase D2** of the gate claim/PIN UX rework. Fixes nobodies-collective#907 (the "many Pauls" problem): the claim picker matched **burner name only** and showed no disambiguator, so same-named staff were indistinguishable.

## What this does
Each claim-search result now shows a **masked email** as a disambiguator (plus the existing photo). `paul.smith@gmail.com` → `p•••h@gmail.com`.

- **Privacy-safe by default:** only a verified email the owner set to **org-public (`AllActiveProfiles`) visibility** is ever surfaced — never a Board/coordinator/team-scoped address or a GDPR/merge tombstone. So nothing sensitive lands on the shared, role-less `GateTerminal` kiosk. If a person has no org-public email, the picker shows no disambiguator (the photo still helps). This mirrors the codebase's Bio-bucket public-email rule.
- **Search stays name-only** (`PersonSearchFields.Name`) — you can't type an email to search, so there's no email-confirmation oracle.
- The email is read per result (cached `GetUserInfoAsync`) and masked at the **presentation layer**, so the search and its response shape stay email-free. Mirrors the existing `BuildSupervisorOptionsAsync` loop — no new service/DTO surface. The picker view already renders `Detail`.

## Your call, Peter
The org-public restriction is deliberately conservative — it means the email hint only shows for people who made an address org-public, which may be **few**. If you want broader coverage (e.g. show any verified email, masked, accepting a bounded privacy posture on the kiosk), that's a one-line change — your call. Flagging rather than assuming.

## Verification
Build clean · gate tests green · `dotnet format` clean. **Live-verified** on the tablet viewport: a `BoardOnly` dev email correctly showed **no** hint; the same account switched to org-public then rendered `d•••r@localhost`. Peer-reviewed — this PR already folds in the reviewer's privacy fix (visibility filter) and tombstone guard.

Not for merge without your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
