### PR TITLE
Gate PIN (D3): decouple claim PIN from override authority (AdminEnrolled) — stacked on #1071

### DIFF
--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -52,9 +52,15 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
 - **Personal staff PINs (`gate_staff_pins`)** — each staffer sets a 4-digit PIN the first time they
   claim the gate (`SetOwnPinAsync`, hashed via Identity's `IPasswordHasher`), reused across shifts.
   Claiming the scanner becomes a PIN entry (`/Gate/ClaimPin`), so the leaderboard attribution is a
-  real per-person claim rather than honour-system. **Supervisors** (Admin/Board/TicketAdmin) cannot
-  self-enrol at the anonymous kiosk — their PIN carries override authority, so an admin enrols it out
-  of band (`/Gate/Admin`); the override path is verify-only and rejects un-enrolled supervisors.
+  real per-person claim rather than honour-system. **Claim vs override are decoupled by the
+  `AdminEnrolled` flag on the PIN.** _Everyone_ — supervisors included — may self-enrol a **claim**
+  PIN at the kiosk (`SetOwnPinAsync`, `AdminEnrolled = false`); it attributes scans only. **Override
+  authority** is conferred solely by an **admin enrolment** (`/Gate/Admin` → `AdminSetPinAsync`,
+  `AdminEnrolled = true`). `AuthorizeOverrideAsync` requires all three, server-checked: an
+  admin-enrolled PIN, the correct PIN, AND a currently-held supervisor role — so an attacker
+  cold-setting a supervisor's PIN at the anonymous kiosk gains attribution spoofing only (already
+  possible for any staffer), never override power. The enrolled-supervisor override picker
+  (`GetEnrolledSupervisorIdsAsync`) lists only admin-enrolled supervisors.
   **First-time set** has two guards (claim-only, never on verify): an "is this you?" confirm before a
   PIN is minted in someone's name, and a double-entry (enter twice, must match) so a mis-typed PIN
   can't silently lock a volunteer out (there is no self-service reset — an admin clears it). Every

--- a/src/Humans.Application/Interfaces/Gate/IGateService.cs
+++ b/src/Humans.Application/Interfaces/Gate/IGateService.cs
@@ -100,9 +100,6 @@ public enum GatePinSetResult
 
     /// <summary>The PIN is not exactly four digits or is too easily guessed (e.g. 0000, 1234, repeats).</summary>
     InvalidPin,
-
-    /// <summary>The user holds a supervisor role — supervisor PINs must be set by an admin, not self-enrolled at the kiosk.</summary>
-    SupervisorMustBeAdminEnrolled,
 }
 
 /// <summary>Write-free result of evaluating a scan, before the agent's ID decision.</summary>

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -204,14 +204,14 @@ public sealed class GateService(
     {
         if (!IsValidPin(pin))
             return GatePinSetResult.InvalidPin;
-        // A supervisor's PIN carries override authority — never let it be minted from the
-        // anonymous kiosk (an attacker could cold-enrol a supervisor and impersonate them).
-        if (await IsSupervisorAsync(userId, ct))
-            return GatePinSetResult.SupervisorMustBeAdminEnrolled;
-        await StorePinAsync(userId, pin, ct);
+        // Everyone — supervisors included — may self-enrol a CLAIM PIN (attribution only). It carries
+        // NO override authority: AdminEnrolled stays false and AuthorizeOverrideAsync requires it true.
+        // So an attacker cold-setting a supervisor's PIN at the anonymous kiosk gains attribution
+        // spoofing (already possible for any staffer), never override power — which stays admin-enrolled.
+        await StorePinAsync(userId, pin, adminEnrolled: false, ct);
         // Self-enrol at the kiosk: actor == the claimed staffer (no PIN value is ever logged).
         await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
-            "Staffer self-enrolled their gate PIN at the kiosk", userId);
+            "Staffer self-enrolled their gate claim PIN at the kiosk", userId);
         return GatePinSetResult.Ok;
     }
 
@@ -219,9 +219,10 @@ public sealed class GateService(
     {
         if (!IsValidPin(pin))
             return false;
-        await StorePinAsync(userId, pin, ct);
+        // Admin enrolment is the only path that confers supervisor-override authority (AdminEnrolled = true).
+        await StorePinAsync(userId, pin, adminEnrolled: true, ct);
         await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
-            "Admin set a staffer's gate PIN", actorUserId);
+            "Admin set a staffer's gate PIN (override-enrolled)", actorUserId);
         return true;
     }
 
@@ -236,8 +237,13 @@ public sealed class GateService(
 
     public async Task<bool> AuthorizeOverrideAsync(Guid supervisorUserId, string pin, CancellationToken ct = default)
     {
-        // Verify-only: enrolled + correct PIN + currently holds a supervisor role. Never enrol here.
-        if (!await VerifyPinAsync(supervisorUserId, pin, ct))
+        // Verify-only, never enrol here. Requires all three, server-checked: an ADMIN-ENROLLED PIN
+        // (a self-set claim PIN — AdminEnrolled=false — can never authorize an override), the correct
+        // PIN, AND a currently-held supervisor role.
+        var row = await repository.GetStaffPinAsync(supervisorUserId, ct);
+        if (row is not { AdminEnrolled: true })
+            return false;
+        if (pinHasher.VerifyHashedPassword(row, row.PinHash, pin) == PasswordVerificationResult.Failed)
             return false;
         return await IsSupervisorAsync(supervisorUserId, ct);
     }
@@ -251,8 +257,8 @@ public sealed class GateService(
 
     public async Task<IReadOnlyList<Guid>> GetEnrolledSupervisorIdsAsync(CancellationToken ct = default)
     {
-        // Union the supervisor-role holders, then keep only those with a PIN — an un-enrolled
-        // supervisor can't override anyway, so listing them would just offer dead picks.
+        // Union the supervisor-role holders, then keep only those with an ADMIN-ENROLLED PIN — a
+        // self-set claim PIN can't authorize an override, so listing those would offer dead picks.
         var supervisors = new HashSet<Guid>();
         foreach (var role in SupervisorRoles)
             foreach (var id in await roles.GetActiveUserIdsInRoleAsync(role, ct))
@@ -260,7 +266,7 @@ public sealed class GateService(
 
         var enrolled = new List<Guid>();
         foreach (var id in supervisors)
-            if (await repository.GetStaffPinAsync(id, ct) is not null)
+            if (await repository.GetStaffPinAsync(id, ct) is { AdminEnrolled: true })
                 enrolled.Add(id);
         return enrolled;
     }
@@ -273,10 +279,10 @@ public sealed class GateService(
         return false;
     }
 
-    private async Task StorePinAsync(Guid userId, string pin, CancellationToken ct)
+    private async Task StorePinAsync(Guid userId, string pin, bool adminEnrolled, CancellationToken ct)
     {
         var now = clock.GetCurrentInstant();
-        var entity = new GateStaffPin { UserId = userId, CreatedAt = now, UpdatedAt = now };
+        var entity = new GateStaffPin { UserId = userId, CreatedAt = now, UpdatedAt = now, AdminEnrolled = adminEnrolled };
         entity.PinHash = pinHasher.HashPassword(entity, pin);
         await repository.UpsertStaffPinAsync(entity, ct);
     }

--- a/src/Humans.Domain/Entities/GateStaffPin.cs
+++ b/src/Humans.Domain/Entities/GateStaffPin.cs
@@ -23,4 +23,13 @@ public class GateStaffPin
 
     /// <summary>When the PIN was last set/reset.</summary>
     public Instant UpdatedAt { get; set; }
+
+    /// <summary>
+    /// True only when an admin set this PIN out of band (<c>/Gate/Admin</c>) — the enrolment that
+    /// confers <b>supervisor-override</b> authority. A staffer who self-enrols at the kiosk gets
+    /// <c>false</c>: their PIN attributes scans (claim) but can never authorize an override, so an
+    /// attacker cold-setting a supervisor's PIN at the anonymous kiosk gains attribution only, never
+    /// override power. The override authorization path requires this true.
+    /// </summary>
+    public bool AdminEnrolled { get; set; }
 }

--- a/src/Humans.Infrastructure/Data/Configurations/Gate/GateStaffPinConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Gate/GateStaffPinConfiguration.cs
@@ -20,5 +20,10 @@ public sealed class GateStaffPinConfiguration : IEntityTypeConfiguration<GateSta
 
         builder.Property(x => x.CreatedAt).IsRequired();
         builder.Property(x => x.UpdatedAt).IsRequired();
+
+        // Override-authority flag. Plain IsRequired (no HasDefaultValue — that bool-sentinel makes EF
+        // omit a `false` from writes). The migration's AddColumn supplies the one-time backfill default
+        // for existing rows; every write sets the value explicitly from the entity.
+        builder.Property(x => x.AdminEnrolled).IsRequired();
     }
 }

--- a/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701005052_AddGateStaffPinAdminEnrolled")]
+    partial class AddGateStaffPinAdminEnrolled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.cs
+++ b/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGateStaffPinAdminEnrolled : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AdminEnrolled",
+                table: "gate_staff_pins",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdminEnrolled",
+                table: "gate_staff_pins");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Gate/GateRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Gate/GateRepository.cs
@@ -99,6 +99,7 @@ internal sealed class GateRepository(IDbContextFactory<HumansDbContext> factory)
                     PinHash = fromPin.PinHash,
                     CreatedAt = fromPin.CreatedAt,
                     UpdatedAt = fromPin.UpdatedAt,
+                    AdminEnrolled = fromPin.AdminEnrolled, // keep the survivor's override authority
                 });
             }
             ctx.Set<GateStaffPin>().Remove(fromPin);
@@ -173,6 +174,7 @@ internal sealed class GateRepository(IDbContextFactory<HumansDbContext> factory)
         {
             existing.PinHash = pin.PinHash;
             existing.UpdatedAt = pin.UpdatedAt;
+            existing.AdminEnrolled = pin.AdminEnrolled;
         }
 
         await ctx.SaveChangesAsync(ct);

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -121,7 +121,7 @@ public sealed class GateController(
             return RedirectToAction(nameof(Claim));
 
         // Don't stamp the session yet — resolve the staffer's PIN status and hand off to the
-        // keypad (set a new PIN, verify the existing one, or block an un-enrolled supervisor).
+        // keypad (set a new PIN, or verify the existing one).
         var status = await gate.GetPinStatusAsync(userId, ct);
         return View("Pin", GatePinViewModel.ForClaim(userId, info.BurnerName, status));
     }
@@ -140,10 +140,6 @@ public sealed class GateController(
         // Re-derive the mode from the server (never trust a client-supplied set/verify hint).
         var status = await gate.GetPinStatusAsync(userId, ct);
         var name = info.BurnerName;
-
-        // A supervisor with no PIN can't self-enrol at the anonymous kiosk — re-show the block.
-        if (status is { HasPin: false, IsSupervisor: true })
-            return View("Pin", GatePinViewModel.ForClaim(userId, name, status));
 
         return status.HasPin
             ? await VerifyClaimAsync(userId, name, status, pin, ct)
@@ -278,10 +274,9 @@ public sealed class GateController(
         await gate.SetOwnPinAsync(userId, pin ?? string.Empty, ct) switch
         {
             GatePinSetResult.Ok => StampAndScan(userId),
-            GatePinSetResult.InvalidPin => View("Pin", GatePinViewModel.ForClaim(
+            // InvalidPin (or any non-Ok) → re-show the keypad with the "pick a better PIN" hint.
+            _ => View("Pin", GatePinViewModel.ForClaim(
                 userId, name, status, "Pick a less obvious PIN — not 1234, 0000, or repeats")),
-            // Role changed to supervisor between the GET and this POST — show the admin-enrol block.
-            _ => View("Pin", new GatePinViewModel(userId, name, GatePinMode.BlockedSupervisor, null)),
         };
 
     private IActionResult StampAndScan(Guid userId)

--- a/src/Humans.Web/Models/Gate/GateViewModels.cs
+++ b/src/Humans.Web/Models/Gate/GateViewModels.cs
@@ -130,9 +130,6 @@ public enum GatePinMode
 
     /// <summary>Returning — enter the existing PIN to take over the scanner.</summary>
     Verify,
-
-    /// <summary>A supervisor with no PIN — they can't self-enrol; an admin must set it up.</summary>
-    BlockedSupervisor,
 }
 
 /// <summary>The full-screen PIN keypad shown after a name is picked on the claim screen.</summary>
@@ -140,12 +137,9 @@ public sealed record GatePinViewModel(Guid UserId, string DisplayName, GatePinMo
 {
     /// <summary>
     /// Resolve the keypad mode from the server-derived PIN status (never a client-supplied hint):
-    /// has a PIN → Verify; no PIN but a supervisor → Blocked (admin must enrol them); otherwise Set.
+    /// has a PIN → Verify; otherwise Set. Everyone — supervisors included — may self-enrol a claim
+    /// PIN; it attributes scans only, never authorizes an override (that stays admin-enrolled).
     /// </summary>
     public static GatePinViewModel ForClaim(Guid userId, string displayName, GatePinStatus status, string? error = null) =>
-        new(userId, displayName,
-            status.HasPin ? GatePinMode.Verify
-            : status.IsSupervisor ? GatePinMode.BlockedSupervisor
-            : GatePinMode.Set,
-            error);
+        new(userId, displayName, status.HasPin ? GatePinMode.Verify : GatePinMode.Set, error);
 }

--- a/src/Humans.Web/Views/Gate/Pin.cshtml
+++ b/src/Humans.Web/Views/Gate/Pin.cshtml
@@ -9,77 +9,59 @@
 }
 
 <div class="gate-pin-screen">
-    @if (Model.Mode == GatePinMode.BlockedSupervisor)
-    {
-        <div class="gate-pin-blocked" role="alert">
-            <div class="gate-pin-icon" aria-hidden="true"><i class="fa-solid fa-user-shield"></i></div>
-            <div class="gate-pin-name">@Model.DisplayName</div>
-            <p class="gate-pin-blocked-text">
-                Supervisor PINs carry override authority, so they're set up ahead of time — not here at
-                the gate. <strong>Ask the gate lead to set up your PIN</strong>, then come back and tap your name.
-            </p>
-            <a asp-action="Claim" class="gate-pin-back">&larr; Back to names</a>
-        </div>
-    }
-    else
-    {
-        <div class="gate-pin-head">
-            <div class="gate-pin-name">@Model.DisplayName</div>
-            <div class="gate-pin-prompt" data-gate-prompt>@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
-            @if (Model.Mode == GatePinMode.Set)
-            {
-                <div class="gate-pin-sub">You'll reuse this each shift to claim the gate.</div>
-            }
-            @if (!string.IsNullOrEmpty(Model.Error))
-            {
-                <div class="gate-pin-error" role="alert">@Model.Error</div>
-            }
-            @* Client-side message for a double-entry mismatch (set mode) — filled by gate-pin.js. *@
-            <div class="gate-pin-error d-none" role="alert" data-gate-error></div>
-        </div>
-
-        @* First-time set only: confirm the staffer is the person they picked before minting a PIN in
-           their name (every scan is attributed to them). The keypad stays hidden until they confirm. *@
+    <div class="gate-pin-head">
+        <div class="gate-pin-name">@Model.DisplayName</div>
+        <div class="gate-pin-prompt" data-gate-prompt>@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
         @if (Model.Mode == GatePinMode.Set)
         {
-            <div class="gate-pin-confirm" data-gate-confirm>
-                <div class="gate-pin-confirm-q">Is this you?</div>
-                <p class="gate-pin-confirm-note">Every ticket you scan will be recorded as <strong>@Model.DisplayName</strong>.</p>
-                <button type="button" class="gate-pin-confirm-yes" data-gate-confirm-yes>Yes — that's me</button>
-            </div>
+            <div class="gate-pin-sub">You'll reuse this each shift to claim the gate.</div>
         }
+        @if (!string.IsNullOrEmpty(Model.Error))
+        {
+            <div class="gate-pin-error" role="alert">@Model.Error</div>
+        }
+        @* Client-side message for a double-entry mismatch (set mode) — filled by gate-pin.js. *@
+        <div class="gate-pin-error d-none" role="alert" data-gate-error></div>
+    </div>
 
-        <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off"
-              class="@(Model.Mode == GatePinMode.Set ? "d-none" : "")">
-            <input type="hidden" name="userId" value="@Model.UserId" />
-            <input type="hidden" name="pin" id="gate-pin-value" />
-            <partial name="_PinPad" />
-        </form>
-
-        <a asp-action="Claim" class="gate-pin-back">&larr; Not you? Pick a different name</a>
+    @* First-time set only: confirm the staffer is the person they picked before minting a PIN in
+       their name (every scan is attributed to them). The keypad stays hidden until they confirm. *@
+    @if (Model.Mode == GatePinMode.Set)
+    {
+        <div class="gate-pin-confirm" data-gate-confirm>
+            <div class="gate-pin-confirm-q">Is this you?</div>
+            <p class="gate-pin-confirm-note">Every ticket you scan will be recorded as <strong>@Model.DisplayName</strong>.</p>
+            <button type="button" class="gate-pin-confirm-yes" data-gate-confirm-yes>Yes — that's me</button>
+        </div>
     }
+
+    <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off"
+          class="@(Model.Mode == GatePinMode.Set ? "d-none" : "")">
+        <input type="hidden" name="userId" value="@Model.UserId" />
+        <input type="hidden" name="pin" id="gate-pin-value" />
+        <partial name="_PinPad" />
+    </form>
+
+    <a asp-action="Claim" class="gate-pin-back">&larr; Not you? Pick a different name</a>
 </div>
 
-@if (Model.Mode != GatePinMode.BlockedSupervisor)
-{
-    @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
-    @section Scripts {
-        @* The keypad itself is a cache-busted classic script (no module import to go stale); the
-           page module wires it to the claim form. *@
-        <script src="@Url.Content("~/js/gate/gate-keypad.js")" asp-append-version="true"
-                nonce="@Context.Items["CspNonce"]"></script>
-        <script nonce="@Context.Items["CspNonce"]" type="module">
-            import { initClaimPin } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/gate/gate-pin.js"))';
-            initClaimPin({
-                container: document.querySelector('[data-gate-keypad]'),
-                form: document.getElementById('gate-pin-form'),
-                valueInput: document.getElementById('gate-pin-value'),
-                confirmTwice: @(Model.Mode == GatePinMode.Set ? "true" : "false"),
-                confirmEl: document.querySelector('[data-gate-confirm]'),
-                confirmYes: document.querySelector('[data-gate-confirm-yes]'),
-                promptEl: document.querySelector('[data-gate-prompt]'),
-                errorEl: document.querySelector('[data-gate-error]')
-            });
-        </script>
-    }
+@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
+@section Scripts {
+    @* The keypad itself is a cache-busted classic script (no module import to go stale); the
+       page module wires it to the claim form. *@
+    <script src="@Url.Content("~/js/gate/gate-keypad.js")" asp-append-version="true"
+            nonce="@Context.Items["CspNonce"]"></script>
+    <script nonce="@Context.Items["CspNonce"]" type="module">
+        import { initClaimPin } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/gate/gate-pin.js"))';
+        initClaimPin({
+            container: document.querySelector('[data-gate-keypad]'),
+            form: document.getElementById('gate-pin-form'),
+            valueInput: document.getElementById('gate-pin-value'),
+            confirmTwice: @(Model.Mode == GatePinMode.Set ? "true" : "false"),
+            confirmEl: document.querySelector('[data-gate-confirm]'),
+            confirmYes: document.querySelector('[data-gate-confirm-yes]'),
+            promptEl: document.querySelector('[data-gate-prompt]'),
+            errorEl: document.querySelector('[data-gate-error]')
+        });
+    </script>
 }

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -132,9 +132,6 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
     border: none; border-radius: 14px; padding: 1.1rem; min-height: 78px; cursor: pointer;
 }
 .gate-pin-confirm-yes:active { background: #095e24; }
-.gate-pin-blocked { max-width: 460px; margin: 2rem auto 0; text-align: center; color: #1e2a33; }
-.gate-pin-icon { font-size: 3.2rem; color: #B26A00; }
-.gate-pin-blocked-text { font-size: 1.2rem; line-height: 1.5; margin-top: .75rem; color: #2b3440; }
 
 /* ── Supervisor-override panel (Index.cshtml) ───────────────────────────────
    Full-viewport scrim so the supervisor's name + PIN entry is the only focus. */

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -426,16 +426,20 @@ public class GateServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
-    public async Task SetOwnPin_Supervisor_Blocked_ButAdminCanEnrol()
+    public async Task SetOwnPin_Supervisor_SelfSetsClaimPin_ButItCannotOverride()
     {
         var sup = Guid.NewGuid();
         _roles.HasActiveRoleAsync(sup, RoleNames.TicketAdmin, Arg.Any<CancellationToken>()).Returns(true);
 
-        (await _svc.SetOwnPinAsync(sup, "2580")).Should().Be(GatePinSetResult.SupervisorMustBeAdminEnrolled);
-        (await _svc.GetPinStatusAsync(sup)).Should().Be(new GatePinStatus(HasPin: false, IsSupervisor: true));
+        // A supervisor may now self-enrol a CLAIM PIN (attribution — everyone can)...
+        (await _svc.SetOwnPinAsync(sup, "2580")).Should().Be(GatePinSetResult.Ok);
+        (await _svc.VerifyPinAsync(sup, "2580")).Should().BeTrue();          // can claim the scanner
+        // ...but a self-set PIN never carries override authority (AdminEnrolled = false).
+        (await _svc.AuthorizeOverrideAsync(sup, "2580")).Should().BeFalse();
 
-        (await _svc.AdminSetPinAsync(sup, "2580", Guid.NewGuid())).Should().BeTrue();
-        (await _svc.VerifyPinAsync(sup, "2580")).Should().BeTrue();
+        // Admin enrolment (AdminEnrolled = true) is the only thing that confers override.
+        (await _svc.AdminSetPinAsync(sup, "1357", Guid.NewGuid())).Should().BeTrue();
+        (await _svc.AuthorizeOverrideAsync(sup, "1357")).Should().BeTrue();
     }
 
     [HumansFact]
@@ -455,22 +459,29 @@ public class GateServiceTests : ServiceTestHarness
         var unenrolledSup = Guid.NewGuid();                                            // supervisor, no PIN
         _roles.HasActiveRoleAsync(unenrolledSup, RoleNames.Admin, Arg.Any<CancellationToken>()).Returns(true);
         (await _svc.AuthorizeOverrideAsync(unenrolledSup, "2580")).Should().BeFalse();
+
+        var selfSetSup = Guid.NewGuid();                                               // supervisor who SELF-set a claim PIN
+        _roles.HasActiveRoleAsync(selfSetSup, RoleNames.Admin, Arg.Any<CancellationToken>()).Returns(true);
+        await _svc.SetOwnPinAsync(selfSetSup, "2580");                                 // AdminEnrolled = false
+        (await _svc.AuthorizeOverrideAsync(selfSetSup, "2580")).Should().BeFalse();    // correct PIN + role, but not admin-enrolled
     }
 
     [HumansFact]
-    public async Task GetEnrolledSupervisorIds_ReturnsOnlySupervisorsWithAPin()
+    public async Task GetEnrolledSupervisorIds_ReturnsOnlySupervisorsWithAnAdminEnrolledPin()
     {
-        Guid enrolled = Guid.NewGuid(), notEnrolled = Guid.NewGuid();
+        Guid enrolled = Guid.NewGuid(), selfSetOnly = Guid.NewGuid();
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.Board, Arg.Any<CancellationToken>())
             .Returns(new[] { enrolled });
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.Admin, Arg.Any<CancellationToken>())
-            .Returns(new[] { notEnrolled });
+            .Returns(new[] { selfSetOnly });
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.TicketAdmin, Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Guid>());
-        await _svc.AdminSetPinAsync(enrolled, "2580", Guid.NewGuid());
+        await _svc.AdminSetPinAsync(enrolled, "2580", Guid.NewGuid());   // admin-enrolled → override-capable
+        await _svc.SetOwnPinAsync(selfSetOnly, "1357");                  // self-set claim PIN → NOT override-capable
 
         var ids = await _svc.GetEnrolledSupervisorIdsAsync();
 
+        // Only the admin-enrolled supervisor is offered in the override picker.
         ids.Should().ContainSingle().Which.Should().Be(enrolled);
     }
 }


### PR DESCRIPTION
**Phase D3** of the gate PIN rework — **stacked on #1071** (contains its commit until that merges). Fixes the "everyone should be able to set a PIN" block (Peter Drier, as an Admin, couldn't self-enrol) — nobodies-collective#909-adjacent.

## The decouple
One `GateStaffPin` row now has an **`AdminEnrolled`** bool that splits the two jobs a PIN used to do:
- **Claim PIN** — _everyone_, supervisors included, may self-enrol one at the kiosk (`AdminEnrolled=false`). It attributes scans. The old supervisor self-enrol block is gone.
- **Override authority** — conferred **only** by an admin enrolment (`/Gate/Admin` → `AdminEnrolled=true`). `AuthorizeOverrideAsync` now requires `AdminEnrolled=true` **and** the correct PIN **and** a live supervisor role.

So an attacker cold-setting a supervisor's PIN at the anonymous kiosk gains attribution spoofing only (already possible for any staffer) — **never override power**. This closes the hole the old block existed for, while unblocking self-enrolment for all. (A peer reviewer initially argued the decouple was unnecessary; I disagreed and a security review confirmed the decouple is what actually closes the hole.)

## ⚠️ DEPLOY RUNBOOK STEP — required before doors open
The migration backfills all existing rows to `AdminEnrolled=false` (fail-safe — no one silently keeps override). **This means every already-enrolled supervisor loses override authority on deploy until an admin re-enrols them.** A blanket backfill to `true` was rejected by both reviews (fail-open — it would re-grant override to any pre-existing self-set PIN, defeating the feature) and a targeted backfill can't run (the supervisor set lives in another section — a cross-section reach forbidden in a migration).

**→ After deploying this, an admin must re-set each gate lead's PIN via `/Gate/Admin` before the gate opens, or overrides will not work.** (This is the same action needed to set up gate leads anyway.)

## Reviews
- **Security review: sound, no blocker** — flag checked before/independently of PIN+role; persists on insert/update/merge; no self-set PIN can reach override; tests prove both directions.
- **EF migration review:** fixed a `HasDefaultValue(false)` bool-sentinel (this repo's known anti-pattern); migration regenerated clean (`AddColumn defaultValue:false` backfill, clean `Down`, snapshot consistent).

## Verification
Build clean · **122 gate + 4 web tests green** · `dotnet format` clean. **Live-verified** on the tablet: a supervisor (Dev Admin) now reaches the normal Set flow instead of the old "blocked" screen; the migration applied cleanly to a real Postgres.

Needs your sign-off, Peter (new auth surface + migration). Not for merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
