### PR TITLE
Disable gate PINs; plain no-PIN override button

### DIFF
--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -22,14 +22,11 @@ namespace Humans.Web.Controllers;
 /// this one decides entry and writes the durable <c>gate_scan_events</c> record.
 /// The terminal authenticates via the <see cref="PolicyNames.ScannerAccess"/>
 /// policy (shared gate-terminal account or a ticket admin) for the read actions
-/// (Index/Evaluate/Leaderboard); the write actions (Decision, Claim/ClaimPin POST)
-/// require the dedicated <see cref="PolicyNames.GateAdmit"/> policy so they never
-/// ride on the read-only Scanner gate. A staffer "claims" the session with their
-/// personal PIN so each scan is attributed to a real Human — the attribution id is
-/// read from the session, never the request body. Supervisor overrides (too-early,
-/// child-without-ID) carry the authorizing supervisor's PIN identity, brute-force
-/// throttled on both the target user-id and the source device via
-/// <see cref="GatePinThrottle"/>.
+/// (Index/Evaluate/Leaderboard); the write action (Decision) requires the dedicated
+/// <see cref="PolicyNames.GateAdmit"/> policy so it never rides on the read-only
+/// Scanner gate. Scans are attributed to the authenticated gate account, taken from
+/// the principal (never the request body). Too-early and child-without-ID admits are
+/// a plain operator override — a button tap, no PIN.
 /// </summary>
 [Authorize(Policy = PolicyNames.ScannerAccess)]
 [Route("Gate")]
@@ -45,23 +42,21 @@ public sealed class GateController(
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken ct)
     {
-        if (GetActiveScannerId() is not { } scanner)
-            return RedirectToAction(nameof(Claim));
+        // No claim step: the terminal scans as its authenticated gate account (never a per-staffer
+        // PIN). The attribution id is taken from the principal — never the request body.
+        if (GetCurrentUserId() is not { } scanner)
+            return Unauthorized();
 
         var info = await UserService.GetUserInfoAsync(scanner, ct);
         var settings = await gate.GetSettingsAsync(ct);
-        var supervisors = await BuildSupervisorOptionsAsync(ct);
         var asOf = InstantPattern.ExtendedIso.Format(clock.GetCurrentInstant());
         return View(new GateIndexViewModel(
-            info?.BurnerName ?? "Gate staff", DataStale: false, asOf, settings.CutoffConfigured, supervisors));
+            info?.BurnerName ?? "Gate staff", DataStale: false, asOf, settings.CutoffConfigured, []));
     }
 
     [HttpGet("Evaluate")]
     public async Task<IActionResult> Evaluate(string barcode, CancellationToken ct)
     {
-        if (GetActiveScannerId() is null)
-            return Unauthorized();
-
         var result = await gate.EvaluateAsync(barcode, ct);
         return PartialView("_VerdictCard", GateScanCardViewModel.FromEvaluation(result));
     }
@@ -71,22 +66,14 @@ public sealed class GateController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Decision(
         string barcode, bool idConfirmed, bool childWithAdult, bool overrideEarly,
-        Guid? supervisorUserId, string? supervisorPin, string? laneId, CancellationToken ct)
+        string? laneId, CancellationToken ct)
     {
-        if (GetActiveScannerId() is not { } scanner)
+        if (GetCurrentUserId() is not { } scanner)
             return Unauthorized();
 
-        // Both the too-early override and the child-without-ID waiver require a server-verified
-        // supervisor PIN (an authorizing identity recorded on the event). Verify before recording.
-        Guid? overrideBy = null;
-        if (childWithAdult || overrideEarly)
-        {
-            var (errorCard, authorized) = await AuthorizeSupervisorAsync(
-                supervisorUserId, supervisorPin, barcode, childWithAdult, ct);
-            if (errorCard is not null)
-                return PartialView("_VerdictCard", errorCard);
-            overrideBy = authorized;
-        }
+        // Too-early and child-without-ID admits are a plain no-PIN override now: the operator's tap on
+        // the override button IS the authorization. Record it against the gate account (no supervisor).
+        Guid? overrideBy = childWithAdult || overrideEarly ? scanner : null;
 
         var decision = await gate.RecordDecisionAsync(
             new GateDecisionInput(barcode, idConfirmed, childWithAdult, laneId,
@@ -337,37 +324,6 @@ public sealed class GateController(
         return RedirectToAction(nameof(Index));
     }
 
-    // ── Override authorization ───────────────────────────────────────────────
-    private async Task<(GateScanCardViewModel? ErrorCard, Guid? SupervisorUserId)> AuthorizeSupervisorAsync(
-        Guid? supervisorUserId, string? pin, string barcode, bool childWithAdult, CancellationToken ct)
-    {
-        // No supervisor picked → nothing to authorize, and no per-person bucket to throttle.
-        if (supervisorUserId is not { } supId)
-            return (OverrideErrorCard(barcode, childWithAdult, "Pick the authorizing supervisor, then enter their PIN"), null);
-
-        // Throttle per target supervisor only. A shared device/IP key would let one locked-out
-        // attempt (or a fat-fingered PIN) freeze every claim and override at the terminal.
-        var userKey = UserKey(supId);
-        if (ThrottleWait(userKey) is { } wait)
-            return (OverrideErrorCard(barcode, childWithAdult, $"Too many PIN attempts — wait {wait}s"), null);
-
-        if (await gate.AuthorizeOverrideAsync(supId, pin ?? string.Empty, ct))
-        {
-            ResetPinThrottle(userKey);
-            return (null, supId);
-        }
-
-        RecordPinFailure(userKey);
-        return (OverrideErrorCard(barcode, childWithAdult, "Supervisor PIN not accepted — check the name & PIN"), null);
-    }
-
-    private static GateScanCardViewModel OverrideErrorCard(string barcode, bool childWithAdult, string reason) =>
-        new(GateCardKind.Amber, "Supervisor", null, reason, IsEarly: false, barcode,
-            AllowChildWithAdult: false,
-            // A too-early override can retry inline (the barcode is preserved on the card). The child
-            // waiver lives on the ID-confirm card, so a failed child auth just re-scans.
-            AllowSupervisorOverride: !childWithAdult);
-
     // ── Throttle helpers (keyed on the target user-id only) ──────────────────────
     // Per-target-user, never per shared device/IP: a 4-digit PIN's brute-force ceiling is
     // already capped per user (5 / 15 min), and a shared-device key would let one bad run
@@ -390,20 +346,4 @@ public sealed class GateController(
         return roster.Select(r => new GateRosterMember(r.UserId, r.DisplayName)).ToList();
     }
 
-    private async Task<IReadOnlyList<GateSupervisorOption>> BuildSupervisorOptionsAsync(CancellationToken ct)
-    {
-        var ids = await gate.GetEnrolledSupervisorIdsAsync(ct);
-        var options = new List<GateSupervisorOption>(ids.Count);
-        foreach (var id in ids)
-        {
-            var info = await UserService.GetUserInfoAsync(id, ct);
-            if (info is { IsActive: true })
-                options.Add(new GateSupervisorOption(id, info.BurnerName));
-        }
-
-        return options.OrderBy(o => o.DisplayName, StringComparer.CurrentCultureIgnoreCase).ToList();
-    }
-
-    private Guid? GetActiveScannerId() =>
-        Guid.TryParse(HttpContext.Session.GetString(ScannerSessionKey), out var id) ? id : null;
 }

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -16,11 +16,6 @@
         <span class="gate-asof" data-asof="@Model.DataAsOf"
               title="Tap to reload">loaded…</span>
         <a asp-action="Leaderboard" class="gate-topbar-link">Leaderboard</a>
-        @* "End shift" clears the scanner session (the next person re-claims with their PIN), so it's a
-           deliberate two-tap (gate.js) to stop a mid-queue fat-finger from dumping the operator out. *@
-        <form method="post" asp-action="EndShift" class="gate-endshift-form">
-            <button type="submit" class="gate-endshift-btn" data-confirm-change="Tap again to end shift">End shift</button>
-        </form>
     </div>
 
     @if (!Model.CutoffConfigured)
@@ -48,39 +43,17 @@
         </div>
     </div>
 
-    @* Supervisor-override panel — shown over the card for a too-early override or a child-without-ID
-       waiver. The kiosk account can't reach free-text people search (route-locked to /Gate), so the
-       supervisor is chosen from a tap-list of enrolled supervisors, then enters their PIN. The PIN +
-       role are re-verified server-side by AuthorizeOverrideAsync; this list is only a convenience. *@
+    @* Override panel — shown over the card for a too-early override or a child-without-ID admit.
+       No PIN and no supervisor pick: a single deliberate confirm tap is the authorization. *@
     <div id="gate-override" class="gate-override d-none" aria-hidden="true">
         <div class="gate-override-head">
-            <span class="gate-override-title" data-override-title>Supervisor override</span>
+            <span class="gate-override-title" data-override-title>Override</span>
             <button type="button" class="gate-override-cancel" data-override-cancel>Cancel</button>
         </div>
-        @if (Model.Supervisors.Count == 0)
-        {
-            <p class="gate-override-empty">
-                No supervisor has a PIN enrolled yet. An admin must enrol one in
-                <strong>Gate &#9656; Admin</strong> before overrides can be authorised.
-            </p>
-        }
-        else
-        {
-            <div class="gate-override-step" data-override-pick>
-                <p class="gate-override-prompt">Supervisor — tap your name</p>
-                <div class="gate-supervisor-list">
-                    @foreach (var s in Model.Supervisors)
-                    {
-                        <button type="button" class="gate-supervisor-pick" data-supervisor-id="@s.UserId">@s.DisplayName</button>
-                    }
-                </div>
-            </div>
-            <div class="gate-override-step d-none" data-override-pin>
-                <button type="button" class="gate-override-back" data-override-back>&larr; Wrong person</button>
-                <p class="gate-override-prompt"><span data-supervisor-name></span> — enter your PIN</p>
-                <partial name="_PinPad" />
-            </div>
-        }
+        <div class="gate-override-step">
+            <p class="gate-override-prompt" data-override-prompt>Admit this guest anyway?</p>
+            <button type="button" class="gate-override-confirm" data-override-confirm>Override — admit</button>
+        </div>
     </div>
 
     @* Always-available cheat-sheet for a barely-trained volunteer (native <details> — no JS).
@@ -103,11 +76,8 @@
 
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @section Scripts {
-    @* Shared keypad is a cache-busted classic script (no module import to go stale on the kiosk);
-       the override panel uses it. Cache-bust the gate.js module import too (the tag-helper
-       asp-append-version can't reach an import statement) so a deployed update reaches the kiosk. *@
-    <script src="@Url.Content("~/js/gate/gate-keypad.js")" asp-append-version="true"
-            nonce="@Context.Items["CspNonce"]"></script>
+    @* Cache-bust the gate.js module import (the tag-helper asp-append-version can't reach an import
+       statement) so a deployed update reaches the kiosk. *@
     <script nonce="@Context.Items["CspNonce"]" type="module">
         import { initGate } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/gate/gate.js"))';
         initGate({

--- a/src/Humans.Web/Views/Gate/_VerdictCard.cshtml
+++ b/src/Humans.Web/Views/Gate/_VerdictCard.cshtml
@@ -59,7 +59,7 @@
             @if (Model.AllowChildWithAdult)
             {
                 <button type="button" class="gate-btn gate-child" data-child="true">
-                    Child — with adult (supervisor)
+                    Child — with adult
                 </button>
             }
             @* Scanned the wrong code (caught a neighbouring ticket)? Bail back to Ready and rescan. *@
@@ -69,12 +69,12 @@
         </div>
     }
 
-    @* Too-early scans (and a failed override retry) carry a supervisor-override affordance; tapping
-       it opens the override panel (supervisor taps their name + enters their PIN). *@
+    @* Too-early scans carry an override affordance; tapping it opens the override panel, where a
+       single confirm tap admits (no PIN, no supervisor pick). *@
     @if (Model.AllowSupervisorOverride)
     {
         <button type="button" class="gate-btn gate-override-btn" data-override="early" data-barcode="@Model.Barcode">
-            <i class="fa-solid fa-user-shield" aria-hidden="true"></i> Supervisor override
+            <i class="fa-solid fa-user-shield" aria-hidden="true"></i> Override — admit
         </button>
     }
 </div>

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -164,6 +164,12 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
     width: 100%; max-width: 480px; background: #f4ede1; border-radius: 16px; padding: 1.25rem;
 }
 .gate-override-prompt { font-size: 1.25rem; font-weight: 600; color: #1e2a33; text-align: center; margin: 0 0 1rem; }
+/* No-PIN override: one big green confirm tap admits the too-early / child-without-ID scan. */
+.gate-override-confirm {
+    width: 100%; font-size: 1.5rem; font-weight: 700; color: #fff; background: #0B7A2F;
+    border: none; border-radius: 14px; padding: 1.1rem; min-height: 78px; cursor: pointer;
+}
+.gate-override-confirm:active { background: #095e24; }
 .gate-supervisor-list { display: flex; flex-direction: column; gap: .6rem; max-height: 60vh; overflow-y: auto; }
 .gate-supervisor-pick {
     font-size: 1.35rem; font-weight: 700; padding: 1.1rem 1.25rem; border: none; border-radius: 12px;

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -105,28 +105,9 @@ export function initGate(refs) {
     }
     result.addEventListener('pointerdown', bumpReset, { passive: true });
 
-    // "End shift" clears the scanner session (next person re-claims with their PIN), so require
-    // a deliberate second tap.
-    initChangeConfirm();
     // The freshness line is a reload affordance on the chromeless kiosk (no browser reload button).
     const asofEl = document.querySelector('.gate-asof');
     if (asofEl) asofEl.addEventListener('click', () => location.reload());
-
-    function initChangeConfirm() {
-        const btn = document.querySelector('[data-confirm-change]');
-        if (!btn) return;
-        let armed = false;
-        const original = btn.textContent;
-        const armedLabel = btn.getAttribute('data-confirm-change') || 'Tap again';
-        btn.addEventListener('click', (e) => {
-            if (armed) return; // second tap within the window → allow the submit to proceed
-            e.preventDefault();
-            armed = true;
-            btn.textContent = armedLabel;
-            btn.classList.add('gate-armed');
-            setTimeout(() => { armed = false; btn.textContent = original; btn.classList.remove('gate-armed'); }, 3000);
-        });
-    }
 
     // Render the "loaded HH:mm · N min ago" indicator and redden it once the terminal
     // has been open a while — a nudge to re-open the page so its data view isn't stale.
@@ -270,36 +251,28 @@ export function initGate(refs) {
         }
     }
 
-    // The supervisor-override panel: pick a supervisor (tap-list — the locked-down kiosk can't
-    // reach free-text people search) → enter their PIN on the shared keypad → submit the decision.
+    // The override panel: a single confirm tap admits a too-early or child-without-ID scan. No PIN
+    // and no supervisor pick — the confirm button IS the authorization (recorded against the gate
+    // account server-side). It's a deliberate second tap so a stray tap on the card can't admit.
     function initOverride() {
         if (!override) return { open: () => {} };
 
         const titleEl = override.querySelector('[data-override-title]');
-        const pickStep = override.querySelector('[data-override-pick]');
-        const pinStep = override.querySelector('[data-override-pin]');
-        const nameEl = override.querySelector('[data-supervisor-name]');
-        const keypadEl = override.querySelector('[data-gate-keypad]');
+        const promptEl = override.querySelector('[data-override-prompt]');
         const cancelBtn = override.querySelector('[data-override-cancel]');
-        const backBtn = override.querySelector('[data-override-back]');
+        const confirmBtn = override.querySelector('[data-override-confirm]');
 
         let mode = 'early';
         let barcode = null;
-        let supervisorUserId = null;
-
-        const keypad = keypadEl && window.initGateKeypad
-            ? window.initGateKeypad(keypadEl, (pin) => submit(pin))
-            : { reset: () => {} };
 
         function open(nextMode, nextBarcode) {
-            clearResetTimer(); // hold the auto-return while the supervisor enters their PIN
+            clearResetTimer(); // hold the auto-return while the operator confirms the override
             mode = nextMode;
             barcode = nextBarcode;
-            supervisorUserId = null;
-            if (titleEl) titleEl.textContent = mode === 'child' ? 'Authorise: child without ID' : 'Supervisor override';
-            if (pinStep) pinStep.classList.add('d-none');
-            if (pickStep) pickStep.classList.remove('d-none');
-            keypad.reset();
+            if (titleEl) titleEl.textContent = mode === 'child' ? 'Admit: child without ID' : 'Supervisor override';
+            if (promptEl) promptEl.textContent = mode === 'child'
+                ? 'Admit this child with the accompanying adult?'
+                : 'Admit this guest before general entry?';
             override.classList.remove('d-none');
             override.setAttribute('aria-hidden', 'false');
         }
@@ -307,7 +280,6 @@ export function initGate(refs) {
         function close() {
             override.classList.add('d-none');
             override.setAttribute('aria-hidden', 'true');
-            keypad.reset();
             focusInput();
         }
 
@@ -320,33 +292,14 @@ export function initGate(refs) {
             if (current && current.hasAttribute('data-kind')) armAutoReset(current, current.getAttribute('data-kind'));
         }
 
-        override.querySelectorAll('[data-supervisor-id]').forEach(btn => {
-            btn.addEventListener('click', () => {
-                supervisorUserId = btn.getAttribute('data-supervisor-id');
-                if (nameEl) nameEl.textContent = btn.textContent.trim();
-                if (pickStep) pickStep.classList.add('d-none');
-                if (pinStep) pinStep.classList.remove('d-none');
-                keypad.reset();
-            });
-        });
-
         if (cancelBtn) cancelBtn.addEventListener('click', closeAndReArm);
 
-        // Tapped the wrong supervisor — go back to the name list without closing the whole panel.
-        if (backBtn) backBtn.addEventListener('click', () => {
-            supervisorUserId = null;
-            if (pinStep) pinStep.classList.add('d-none');
-            if (pickStep) pickStep.classList.remove('d-none');
-            keypad.reset();
-        });
-
-        function submit(pin) {
-            if (!supervisorUserId || !barcode) return;
-            const opts = { supervisorUserId, supervisorPin: pin };
-            if (mode === 'child') opts.childWithAdult = true; else opts.overrideEarly = true;
+        if (confirmBtn) confirmBtn.addEventListener('click', () => {
+            if (!barcode) return;
+            const opts = mode === 'child' ? { childWithAdult: true } : { overrideEarly: true };
             close();
             submitDecision(barcode, opts);
-        }
+        });
 
         return { open };
     }


### PR DESCRIPTION
## What

Drops the new gate PIN flow. The terminal no longer requires a per-staffer claim PIN, and supervisor overrides no longer require a PIN.

- **No claim / no PIN.** `/Gate` lands straight on the scan terminal. Scans are attributed to the authenticated gate account (from the principal, never the request body).
- **Override is a plain button.** Too-early and child-without-ID admits open a panel with a single **"Override — admit"** confirm tap — no supervisor pick, no PIN. The tap is the authorization; `OverrideByUserId` is recorded as the gate account (no supervisor identity).
- Removed the End-shift button and the controller/JS pieces those changes orphaned.

## Scope (bypass only — no database changes)

Left in place as dead plumbing per direction: the PIN table/entity/migration/repository, all service PIN methods, the Admin "Staff PINs" page, `GatePinThrottle`, and the `Claim`/`ClaimPin`/`EndShift`/`Search` actions + `Pin.cshtml`/`Claim.cshtml`/`_PinPad.cshtml`/`gate-pin.js` + their tests — all now unreachable but untouched.

## Verification

- `dotnet build Humans.slnx` — 0 errors.
- `dotnet test` Gate filter — 122 passed.

Note: `IGateService.RecordDecisionAsync` XML doc still says the scanner id comes "from the session" — it now comes from the principal (still unforgeable). Left untouched to keep the diff tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)