### PR TITLE
Remove "Scanning as" operator label from gate terminal

### DIFF
--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -42,16 +42,11 @@ public sealed class GateController(
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken ct)
     {
-        // No claim step: the terminal scans as its authenticated gate account (never a per-staffer
-        // PIN). The attribution id is taken from the principal — never the request body.
-        if (GetCurrentUserId() is not { } scanner)
-            return Unauthorized();
-
-        var info = await UserService.GetUserInfoAsync(scanner, ct);
+        // No claim step and no per-scanner identity shown: the terminal simply scans as its
+        // authenticated gate account (attribution is taken from the principal on Decision).
         var settings = await gate.GetSettingsAsync(ct);
         var asOf = InstantPattern.ExtendedIso.Format(clock.GetCurrentInstant());
-        return View(new GateIndexViewModel(
-            info?.BurnerName ?? "Gate staff", DataStale: false, asOf, settings.CutoffConfigured, []));
+        return View(new GateIndexViewModel(DataStale: false, asOf, settings.CutoffConfigured, []));
     }
 
     [HttpGet("Evaluate")]

--- a/src/Humans.Web/Models/Gate/GateViewModels.cs
+++ b/src/Humans.Web/Models/Gate/GateViewModels.cs
@@ -94,7 +94,7 @@ public sealed record GateScanCardViewModel(
 /// warning banner: while the general-entry cutoff is unset, every scan fails safe to
 /// AMBER, so the terminal tells staff to have an admin set it before doors.</summary>
 public sealed record GateIndexViewModel(
-    string ScannerName, bool DataStale, string DataAsOf, bool CutoffConfigured,
+    bool DataStale, string DataAsOf, bool CutoffConfigured,
     IReadOnlyList<GateSupervisorOption> Supervisors);
 
 /// <summary>One enrolled supervisor offered as a tap-pick on the override panel (kiosk has no free-text search).</summary>

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -12,7 +12,6 @@
 
 <div class="gate-shell">
     <div class="gate-topbar">
-        <span>Scanning as <strong>@Model.ScannerName</strong></span>
         <span class="gate-asof" data-asof="@Model.DataAsOf"
               title="Tap to reload">loaded…</span>
         <a asp-action="Leaderboard" class="gate-topbar-link">Leaderboard</a>


### PR DESCRIPTION
## What

Minimal, last-minute change: removes the last visible "who's doing the scanning" remnant from the gate terminal — the topbar **"Scanning as {gate account}"** label.

The terminal already scans as its authenticated gate account with no claim step and no PIN (from the earlier bypass PR). This drops the now-pointless label and its per-load user lookup, so `/Gate` is simply the gate login.

## Scope

Deliberately minimal — 3 files, no DB/service/test changes:
- `Index.cshtml` — remove the `Scanning as …` span.
- `GateController.Index` — drop the unused `GetUserInfoAsync` name lookup.
- `GateIndexViewModel` — drop the now-unused `ScannerName`.

All the (already-unreachable) PIN/claim plumbing is left untouched.

## Verification

- `dotnet build Humans.slnx` — 0 errors.
- Gate tests — 122 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)