### PR TITLE
fix(gate): suppress touch keyboard on scan field; auto-submit wedge burst without Enter suffix

### DIFF
--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -29,10 +29,17 @@
         </div>
     }
 
+    @* inputmode="none" keeps the tablet's touch keyboard down: the field stays focused for the
+       keyboard-wedge imager (HID input still lands), but a tap never summons the OS keyboard over
+       the verdict card. The keyboard button flips to manual typing for damaged/unreadable codes. *@
     <form id="gate-scan-form" autocomplete="off">
-        <input id="gate-scan-input" type="text" inputmode="text" autocomplete="off"
+        <input id="gate-scan-input" type="text" inputmode="none" autocomplete="off"
                autocapitalize="off" spellcheck="false" placeholder="Scan a ticket"
                aria-label="Scan a ticket" />
+        <button type="button" id="gate-manual-toggle" class="gate-manual-toggle"
+                title="Type a code manually" aria-label="Type a code manually" aria-pressed="false">
+            <i class="fa-solid fa-keyboard" aria-hidden="true"></i>
+        </button>
     </form>
 
     <div id="gate-result">

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -39,11 +39,18 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-config-warning > i { margin-top: .15rem; flex: none; color: #e0962b; }
 .gate-config-warning strong { color: #fff; }
 
+#gate-scan-form { display: flex; gap: .6rem; }
 #gate-scan-input {
     width: 100%; font-size: 1.6rem; padding: .9rem 1.1rem; border-radius: 12px;
     border: 2px solid #c9d2da;
 }
 #gate-scan-input:focus { outline: none; border-color: #1e2a33; box-shadow: 0 0 0 4px rgba(30,42,51,.15); }
+/* Manual-entry toggle — brings the touch keyboard up for typing a damaged/unreadable code. */
+.gate-manual-toggle {
+    flex: none; font-size: 1.4rem; color: #5f6b76; background: transparent; cursor: pointer;
+    border: 2px solid #c9d2da; border-radius: 12px; padding: .5rem .9rem; min-width: 64px;
+}
+.gate-manual-toggle.gate-manual-on { color: #fff; background: #2b3440; border-color: #2b3440; }
 
 .gate-card {
     margin-top: 1rem; border-radius: 18px; padding: 2rem 1.5rem; text-align: center;

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -141,8 +141,39 @@ export function initGate(refs) {
         }
     });
 
+    // Don't depend on the imager's Enter-suffix config to submit: a wedge scan arrives as a fast
+    // burst of characters, so once the field has a plausible barcode and goes quiet for a beat,
+    // submit anyway. An Enter suffix still submits immediately (the form handler clears the timer).
+    // Manual mode turns the quiet-timer off — a human typing pauses far longer than a wedge burst
+    // and presses Enter/Go themselves.
+    const SCAN_QUIET_MS = 300;
+    const SCAN_MIN_LENGTH = 5;
+    let scanTimer = null;
+    let manualMode = false;
+    const clearScanTimer = () => { if (scanTimer) { clearTimeout(scanTimer); scanTimer = null; } };
+    input.addEventListener('input', () => {
+        clearScanTimer();
+        if (manualMode || input.value.trim().length < SCAN_MIN_LENGTH) return;
+        scanTimer = setTimeout(() => form.requestSubmit(), SCAN_QUIET_MS);
+    });
+
+    // Manual-entry toggle: flips inputmode so the touch keyboard comes up (it stays suppressed in
+    // scan mode) for typing a damaged/unreadable code. Blur-then-focus forces the keyboard to
+    // follow the new inputmode while the field keeps receiving wedge input either way.
+    const manualToggle = document.getElementById('gate-manual-toggle');
+    if (manualToggle) manualToggle.addEventListener('click', () => {
+        manualMode = !manualMode;
+        clearScanTimer();
+        input.setAttribute('inputmode', manualMode ? 'text' : 'none');
+        manualToggle.setAttribute('aria-pressed', String(manualMode));
+        manualToggle.classList.toggle('gate-manual-on', manualMode);
+        input.blur();
+        input.focus();
+    });
+
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
+        clearScanTimer();
         const code = input.value.trim();
         if (!code || busy || overrideOpen()) return; // ignore scans mid-override
         busy = true;


### PR DESCRIPTION
## Problem (reported from the gate)

Scanning on the kiosk tablet: the on-screen keyboard pops up over the verdict card, and a scan's ~7 characters land in the field without auto-submitting.

Diagnosis notes:
- **Not a regression from the last 24h of production PRs** — the diff window (`2c3fe2d5..b58303d0`, PRs #1071–#1075) never touched the scan input, the submit handler, or the focus logic. `inputmode="text"` and the tap-anywhere→refocus have shipped since the first gate PR (#1066).
- Keyboard: every tap on the page refocuses the text input *inside a touch gesture*, which makes Edge/Windows raise the touch keyboard.
- No auto-send: submission depended 100% on the imager appending an Enter suffix. If that suffix config isn't active on the device, characters sit in the field and nothing fires.

## Fix

- `inputmode="none"` on the scan field — the touch keyboard stays down; keyboard-wedge (HID) input still lands in the focused field.
- **Quiet-timer auto-submit**: a wedge scan arrives as a fast burst, so 300 ms after the burst goes quiet with ≥ 5 chars in the field, the form submits. An Enter suffix still submits immediately (and cancels the timer), so a correctly-configured imager behaves exactly as before.
- **Manual-entry toggle** (keyboard icon next to the field): flips `inputmode` back to `text` so the touch keyboard comes up for typing a damaged/unreadable code; the quiet-timer is disabled in manual mode so a slow human typist isn't submitted mid-entry.

## Testing

- `dotnet build Humans.slnx -v quiet` — clean (warnings pre-existing).
- No e2e coverage exists for the gate scan input; behavior needs a check on the OneRugged tablet (scan with and without Enter suffix, toggle manual entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)