### PR TITLE
fix(web): cache-bust all local static assets + always-revalidate static file policy

### DIFF
--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -572,7 +572,15 @@ app.Use(async (context, next) =>
     await next();
 });
 
-app.UseStaticFiles();
+// "no-cache" = cache but always revalidate (cheap 304s at this scale). Without an explicit policy,
+// browsers heuristically cache static files (~10% of time since Last-Modified) with NO request at
+// all, so after a release some long-running kiosk tablets kept serving week-old CSS/JS while others
+// didn't. Fingerprinted URLs (asp-append-version / FileVersionProvider) change per release, but
+// unfingerprinted paths — and nested JS module imports, which no tag helper can reach — need this.
+app.UseStaticFiles(new StaticFileOptions
+{
+    OnPrepareResponse = ctx => ctx.Context.Response.Headers.CacheControl = "no-cache",
+});
 
 // Serve .well-known directory (blocked by default since it starts with a dot)
 if (app.Environment.IsDevelopment())

--- a/src/Humans.Web/Views/CityPlanning/Admin.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Admin.cshtml
@@ -272,5 +272,5 @@
 
 @section Scripts {
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
-    <script src="~/js/city-planning/barrio-map/admin-import.js"></script>
+    <script src="~/js/city-planning/barrio-map/admin-import.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/CityPlanning/BarrioMap.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/BarrioMap.cshtml
@@ -124,5 +124,5 @@
     <script src="https://unpkg.com/&#64;mapbox/mapbox-gl-draw@1.5.1/dist/mapbox-gl-draw.js"></script>
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/&#64;microsoft/signalr@8.0.7/dist/browser/signalr.min.js"></script>
-    <script type="module" src="~/js/city-planning/barrio-map/main.js"></script>
+    <script type="module" src="~/js/city-planning/barrio-map/main.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/CityPlanning/ContainerMap.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/ContainerMap.cshtml
@@ -149,5 +149,5 @@
 @section Scripts {
     <script src="https://unpkg.com/maplibre-gl@5.20.1/dist/maplibre-gl.js"></script>
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
-    <script type="module" src="~/js/city-planning/container-map/main.js"></script>
+    <script type="module" src="~/js/city-planning/container-map/main.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -55,5 +55,5 @@
 @section Scripts {
     <script src="https://unpkg.com/maplibre-gl@5.20.1/dist/maplibre-gl.js"></script>
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
-    <script type="module" src="~/js/city-planning/main.js"></script>
+    <script type="module" src="~/js/city-planning/main.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/Scanner/Barcode.cshtml
+++ b/src/Humans.Web/Views/Scanner/Barcode.cshtml
@@ -62,9 +62,12 @@
     </div>
 </div>
 
+@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @section Scripts {
+    @* Cache-bust the module import (the tag-helper asp-append-version can't reach an import
+       statement) so a deployed update reaches long-cached tablets. Mirrors Gate/Index. *@
     <script nonce="@Context.Items["CspNonce"]" type="module">
-        import { initBarcodeScanner } from '@Url.Content("~/js/scanner/barcode.js")';
+        import { initBarcodeScanner } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/scanner/barcode.js"))';
 
         initBarcodeScanner({
             startButton: document.getElementById('scanner-start'),

--- a/src/Humans.Web/Views/Scanner/Tickets.cshtml
+++ b/src/Humans.Web/Views/Scanner/Tickets.cshtml
@@ -63,9 +63,12 @@
     </div>
 </div>
 
+@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @section Scripts {
+    @* Cache-bust the module import (the tag-helper asp-append-version can't reach an import
+       statement) so a deployed update reaches long-cached tablets. Mirrors Gate/Index. *@
     <script nonce="@Context.Items["CspNonce"]" type="module">
-        import { initTicketScanner } from '@Url.Content("~/js/scanner/tickets.js")';
+        import { initTicketScanner } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/scanner/tickets.js"))';
 
         initTicketScanner({
             startButton: document.getElementById('scanner-start'),

--- a/src/Humans.Web/Views/Shared/_AdminLayout.cshtml
+++ b/src/Humans.Web/Views/Shared/_AdminLayout.cshtml
@@ -22,9 +22,9 @@
     <link rel="icon" href="~/img/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="~/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="512x512" href="~/icon-512.png">
-    <link rel="stylesheet" href="~/css/tokens.css" />
-    <link rel="stylesheet" href="~/css/site.css" />
-    <link rel="stylesheet" href="~/css/admin-shell.css" />
+    <link rel="stylesheet" href="~/css/tokens.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/admin-shell.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="admin-shell">

--- a/src/Humans.Web/Views/Shared/_GateLayout.cshtml
+++ b/src/Humans.Web/Views/Shared/_GateLayout.cshtml
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Source+Sans+3:wght@400;500;600;700&display=swap">
     <link rel="icon" href="~/favicon.ico" sizes="any">
     <link rel="icon" href="~/img/favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="~/css/tokens.css" />
-    <link rel="stylesheet" href="~/css/site.css" />
+    <link rel="stylesheet" href="~/css/tokens.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="gate-kiosk">

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -28,8 +28,8 @@
     <link rel="icon" href="~/img/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="~/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="512x512" href="~/icon-512.png">
-    <link rel="stylesheet" href="~/css/tokens.css" />
-    <link rel="stylesheet" href="~/css/site.css" />
+    <link rel="stylesheet" href="~/css/tokens.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="@(ViewData["BodyClass"])">


### PR DESCRIPTION
## Problem

One scanner tablet behaved differently from the others and nobody could figure out why: it was running **stale CSS/JS from before a release**. Two gaps allowed that:

1. **Unfingerprinted asset URLs.** `tokens.css`/`site.css`/`admin-shell.css` in all shared layouts (including `_GateLayout`), the four CityPlanning `<script>` tags, and the Scanner section's two JS module imports had no `?v=` content hash — a release changing them didn't change their URL.
2. **No `Cache-Control` on static files.** Bare `app.UseStaticFiles()` sends no caching header, so browsers use *heuristic* caching (~10% of time since `Last-Modified`) and serve from cache with **no request at all**. Expiry depends on when each device first fetched the file — hence one tablet stale, the others fine.

## Fix

- `asp-append-version="true"` on every remaining unfingerprinted local stylesheet/script tag.
- `FileVersionProvider.AddFileVersionToPath` on the Scanner module imports (`Barcode.cshtml`, `Tickets.cshtml`) — same pattern `Gate/Index.cshtml` already uses, since the tag helper can't reach an `import` statement.
- `OnPrepareResponse` on `UseStaticFiles` setting `Cache-Control: no-cache` (= cache but always revalidate; cheap 304s at ~500 users). This also covers the city-planning JS's *nested* relative module imports, which no tag helper can reach, and anything unfingerprinted we add in the future.

## Testing

- `dotnet build Humans.slnx -v quiet` — clean.
- Local runtime check not possible (no local Postgres); **verify on the preview deploy**: `curl -sI https://<pr>.n.burn.camp/css/site.css` should show `Cache-Control: no-cache`, and the login page HTML should reference `site.css?v=…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)