### PR TITLE
feat(gate): one-off vendor check-in backfill page (temp)

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -227,6 +227,9 @@ inbox:
   # sweep scope entirely); PasswordGenerator CSPRNG (explicitly deferred by
   # Peter, 2026-04-24); BudgetRepository ResponsibleTeam .Include (covered by
   # grandfathered-hum0024-nav-strip).
+  - added: 2026-07-02
+    what: "GateService.EvaluateAsync CheckedInAtVendor uses Status==CheckedIn, but the /check_ins sync stamps CheckedInAt and leaves Status Valid — the 'already checked in at vendor' dedupe signal on the gate card never fires; switch to CheckedInAt (found via Codex on peterdrier/Humans#1080)"
+    review: per-item
   - added: 2026-06-12
     what: "UsersAdminController.Audience direct DbContext reads — route through IAdminDatabaseDiagnosticsService"
     review: panel

--- a/src/Humans.Application/Interfaces/Gate/IGateService.cs
+++ b/src/Humans.Application/Interfaces/Gate/IGateService.cs
@@ -39,6 +39,13 @@ public interface IGateService : IApplicationService
     Task<int> PurgeScansBeforeAsync(Instant cutoff, CancellationToken ct = default);
 
     /// <summary>
+    /// Diff of local admits (<c>gate_scan_events</c>) against the vendor's check-in status
+    /// as of the last ticket sync, for the one-off vendor check-in backfill page — recovers
+    /// admits the fire-and-forget mirror (<c>GateVendorCheckInJob</c>) never delivered.
+    /// </summary>
+    Task<GateVendorBackfillSnapshot> GetVendorCheckInBackfillAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// The de-duplicated volunteers signed up for gate shifts on <paramref name="rosterTeamId"/>
     /// whose shift starts within ±2 hours of now (event-local time) — the people likely working
     /// the gate around shift change. Used to pre-fill the claim screen. Empty when there's no
@@ -164,3 +171,22 @@ public sealed record GateLeaderboard(int TotalAdmitted, int TotalScanned, IReadO
 /// </summary>
 public sealed record GateSettingsDto(
     Instant GeneralEntryOpensAt, int MinorAgeThresholdYears, bool CutoffConfigured = false);
+
+/// <summary>
+/// One local admit in the vendor check-in backfill diff. <paramref name="VendorTicketId"/>
+/// is non-null for mirrorable rows and null for unmirrorable ones (no matched attendee
+/// or the attendee row carries no vendor ticket id).
+/// </summary>
+public sealed record GateVendorBackfillRow(
+    string Barcode, string? AttendeeName, Instant AdmittedAt, string? VendorTicketId);
+
+/// <summary>
+/// Local admits diffed against the vendor's check-in status (as of the last ticket sync).
+/// <paramref name="Pending"/> can be mirrored via <c>GateVendorCheckInJob</c>;
+/// <paramref name="Unmirrorable"/> can only be fixed on the vendor dashboard.
+/// </summary>
+public sealed record GateVendorBackfillSnapshot(
+    int AdmitCount,
+    int AlreadyCheckedInCount,
+    IReadOnlyList<GateVendorBackfillRow> Pending,
+    IReadOnlyList<GateVendorBackfillRow> Unmirrorable);

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -181,7 +181,9 @@ public sealed class GateService(
             if (attendee is null || string.IsNullOrEmpty(attendee.VendorTicketId))
                 unmirrorable.Add(new GateVendorBackfillRow(
                     admit.Barcode, attendee?.AttendeeName, admit.OccurredAt, VendorTicketId: null));
-            else if (attendee.Status == TicketAttendeeStatus.CheckedIn)
+            // CheckedInAt is the vendor check-in signal — a checked-in issued ticket keeps
+            // Status Valid, so testing Status alone would re-post every synced check-in.
+            else if (attendee.CheckedInAt is not null || attendee.Status == TicketAttendeeStatus.CheckedIn)
                 alreadyCheckedIn++;
             else
                 pending.Add(new GateVendorBackfillRow(

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -160,6 +160,37 @@ public sealed class GateService(
     public Task<int> PurgeScansBeforeAsync(Instant cutoff, CancellationToken ct = default) =>
         repository.PurgeScansBeforeAsync(cutoff, ct);
 
+    public async Task<GateVendorBackfillSnapshot> GetVendorCheckInBackfillAsync(CancellationToken ct = default)
+    {
+        var scans = await repository.GetScansSinceAsync(Instant.MinValue, ct);
+        var admits = scans.Where(s => IsAdmit(s.Verdict)).ToList();
+
+        var orders = await tickets.GetTicketOrdersAsync(ct);
+        var attendees = orders
+            .Where(o => o.IsCurrentEvent)
+            .SelectMany(o => o.Attendees)
+            .ToDictionary(a => a.Id);
+
+        List<GateVendorBackfillRow> pending = [];
+        List<GateVendorBackfillRow> unmirrorable = [];
+        var alreadyCheckedIn = 0;
+
+        foreach (var admit in admits)
+        {
+            var attendee = admit.TicketAttendeeId is { } id ? attendees.GetValueOrDefault(id) : null;
+            if (attendee is null || string.IsNullOrEmpty(attendee.VendorTicketId))
+                unmirrorable.Add(new GateVendorBackfillRow(
+                    admit.Barcode, attendee?.AttendeeName, admit.OccurredAt, VendorTicketId: null));
+            else if (attendee.Status == TicketAttendeeStatus.CheckedIn)
+                alreadyCheckedIn++;
+            else
+                pending.Add(new GateVendorBackfillRow(
+                    admit.Barcode, attendee.AttendeeName, admit.OccurredAt, attendee.VendorTicketId));
+        }
+
+        return new GateVendorBackfillSnapshot(admits.Count, alreadyCheckedIn, pending, unmirrorable);
+    }
+
     public async Task<IReadOnlyList<GateRosterEntry>> GetShiftRosterAsync(
         Guid rosterTeamId, CancellationToken ct = default)
     {

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -795,7 +795,8 @@ public sealed class TicketQueryService(
                 MatchedUserId: a.MatchedUserId,
                 Barcode: a.Barcode,
                 TransferredToName: hasTransfer ? tr!.ReceiverLegalName : null,
-                TransferredAt: hasTransfer ? tr!.DecidedAt : null);
+                TransferredAt: hasTransfer ? tr!.DecidedAt : null,
+                CheckedInAt: a.CheckedInAt);
         }).ToList(),
         StripeFee: o.StripeFee,
         ApplicationFee: o.ApplicationFee);

--- a/src/Humans.Application/TicketOrderInfo.cs
+++ b/src/Humans.Application/TicketOrderInfo.cs
@@ -6,6 +6,9 @@ namespace Humans.Application;
 /// <summary>
 /// Compact projection of a <see cref="Humans.Domain.Entities.TicketAttendee"/>
 /// row carried inside <see cref="TicketOrderInfo"/>. One per issued ticket.
+/// <paramref name="CheckedInAt"/> is the vendor check-in signal (from the
+/// <c>/check_ins</c> sync) — the issued ticket's <paramref name="Status"/> stays
+/// <c>Valid</c> when checked in, so consumers must test <paramref name="CheckedInAt"/>.
 /// </summary>
 public sealed record TicketAttendeeInfo(
     Guid Id,
@@ -18,7 +21,8 @@ public sealed record TicketAttendeeInfo(
     Guid? MatchedUserId,
     string? Barcode = null,
     string? TransferredToName = null,
-    Instant? TransferredAt = null);
+    Instant? TransferredAt = null,
+    Instant? CheckedInAt = null);
 
 /// <summary>
 /// Compact projection of a <see cref="Humans.Domain.Entities.TicketOrder"/>

--- a/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Gate;
 using Humans.Application.Interfaces.Users;
 using Humans.Infrastructure.Jobs;
 using Humans.Web.Authorization;
+using Humans.Web.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,24 +12,27 @@ namespace Humans.Web.Controllers;
 // One-off vendor check-in backfill (temp page, remove after use). Recovers gate admits that
 // GateVendorCheckInJob never mirrored to TicketTailor while Gate:VendorMirrorEnabled was unset:
 // shows the diff of local admits vs the vendor's check-in status (last ticket sync), lets an
-// admin send a single test check-in first, then the whole pending set. Both POSTs recompute
-// the diff server-side — a client-supplied id is never enqueued blindly (TicketTailor
-// check-ins double-record, so rows already checked in at the vendor must drop out).
+// admin send a single test check-in first, then the whole pending set. TicketTailor check-ins
+// double-record on repeat, so two guards apply: both POSTs recompute the diff server-side (a
+// client-supplied id is never enqueued blindly), and GateVendorMirrorLedger keeps every
+// already-enqueued id out of both send paths until the ticket sync confirms it.
 [Authorize(Policy = PolicyNames.AdminOnly)]
 [Route("Gate/Admin/VendorCheckInBackfill")]
 public sealed class GateVendorBackfillAdminController(
     IUserServiceRead users,
     IGateService gate,
-    IConfiguration configuration) : HumansControllerBase(users)
+    IConfiguration configuration,
+    GateVendorMirrorLedger ledger,
+    IBackgroundJobClient backgroundJobs) : HumansControllerBase(users)
 {
     private const string MirrorEnabledKey = "Gate:VendorMirrorEnabled";
 
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken ct)
     {
-        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
+        var (snapshot, pending, sent) = await GetPendingSplitAsync(ct);
         return View(new GateVendorBackfillViewModel(
-            snapshot, MirrorEnabled: configuration.GetValue<bool>(MirrorEnabledKey)));
+            snapshot, pending, sent, MirrorEnabled: configuration.GetValue<bool>(MirrorEnabledKey)));
     }
 
     // Send ONE pending check-in so the result can be verified on the vendor dashboard
@@ -40,16 +44,16 @@ public sealed class GateVendorBackfillAdminController(
         if (MirrorDisabledError() is { } error)
             return error;
 
-        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
-        var row = snapshot.Pending.FirstOrDefault(r =>
+        var (_, pending, _) = await GetPendingSplitAsync(ct);
+        var row = pending.FirstOrDefault(r =>
             string.Equals(r.VendorTicketId, vendorTicketId, StringComparison.Ordinal));
         if (row is null)
         {
-            SetError("That ticket is no longer pending — already checked in at the vendor, or unknown.");
+            SetError("That ticket is no longer pending — already sent, checked in at the vendor, or unknown.");
             return RedirectToAction(nameof(Index));
         }
 
-        BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(row.VendorTicketId!, CancellationToken.None));
+        Enqueue(row.VendorTicketId!);
         SetSuccess($"Test check-in enqueued for {row.AttendeeName ?? row.Barcode} ({row.VendorTicketId}). " +
                    "Verify it on the TicketTailor dashboard, then send the rest.");
         return RedirectToAction(nameof(Index));
@@ -62,13 +66,30 @@ public sealed class GateVendorBackfillAdminController(
         if (MirrorDisabledError() is { } error)
             return error;
 
-        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
-        foreach (var row in snapshot.Pending)
-            BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(row.VendorTicketId!, CancellationToken.None));
+        var (_, pending, _) = await GetPendingSplitAsync(ct);
+        foreach (var row in pending)
+            Enqueue(row.VendorTicketId!);
 
-        SetSuccess($"Enqueued {snapshot.Pending.Count} vendor check-in(s). " +
-                   "Counts on this page update after the next ticket sync — do not re-run before it completes.");
+        SetSuccess($"Enqueued {pending.Count} vendor check-in(s). " +
+                   "Sent rows are excluded from re-sending; counts update after the next ticket sync.");
         return RedirectToAction(nameof(Index));
+    }
+
+    // Pending split into not-yet-sent vs sent-awaiting-sync (the ledger remembers enqueued
+    // ids until the vendor's check-in flows back through the ticket sync).
+    private async Task<(GateVendorBackfillSnapshot Snapshot, IReadOnlyList<GateVendorBackfillRow> Pending, IReadOnlyList<GateVendorBackfillRow> Sent)>
+        GetPendingSplitAsync(CancellationToken ct)
+    {
+        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
+        var pending = snapshot.Pending.Where(r => !ledger.WasSent(r.VendorTicketId!)).ToList();
+        var sent = snapshot.Pending.Where(r => ledger.WasSent(r.VendorTicketId!)).ToList();
+        return (snapshot, pending, sent);
+    }
+
+    private void Enqueue(string vendorTicketId)
+    {
+        backgroundJobs.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
+        ledger.MarkSent(vendorTicketId);
     }
 
     private IActionResult? MirrorDisabledError()
@@ -80,4 +101,8 @@ public sealed class GateVendorBackfillAdminController(
     }
 }
 
-public sealed record GateVendorBackfillViewModel(GateVendorBackfillSnapshot Snapshot, bool MirrorEnabled);
+public sealed record GateVendorBackfillViewModel(
+    GateVendorBackfillSnapshot Snapshot,
+    IReadOnlyList<GateVendorBackfillRow> Pending,
+    IReadOnlyList<GateVendorBackfillRow> SentAwaitingSync,
+    bool MirrorEnabled);

--- a/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
@@ -1,0 +1,83 @@
+using Hangfire;
+using Humans.Application.Interfaces.Gate;
+using Humans.Application.Interfaces.Users;
+using Humans.Infrastructure.Jobs;
+using Humans.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+// One-off vendor check-in backfill (temp page, remove after use). Recovers gate admits that
+// GateVendorCheckInJob never mirrored to TicketTailor while Gate:VendorMirrorEnabled was unset:
+// shows the diff of local admits vs the vendor's check-in status (last ticket sync), lets an
+// admin send a single test check-in first, then the whole pending set. Both POSTs recompute
+// the diff server-side — a client-supplied id is never enqueued blindly (TicketTailor
+// check-ins double-record, so rows already checked in at the vendor must drop out).
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Gate/Admin/VendorCheckInBackfill")]
+public sealed class GateVendorBackfillAdminController(
+    IUserServiceRead users,
+    IGateService gate,
+    IConfiguration configuration) : HumansControllerBase(users)
+{
+    private const string MirrorEnabledKey = "Gate:VendorMirrorEnabled";
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken ct)
+    {
+        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
+        return View(new GateVendorBackfillViewModel(
+            snapshot, MirrorEnabled: configuration.GetValue<bool>(MirrorEnabledKey)));
+    }
+
+    // Send ONE pending check-in so the result can be verified on the vendor dashboard
+    // before the bulk run.
+    [HttpPost("RunOne")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RunOne(string vendorTicketId, CancellationToken ct)
+    {
+        if (MirrorDisabledError() is { } error)
+            return error;
+
+        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
+        var row = snapshot.Pending.FirstOrDefault(r =>
+            string.Equals(r.VendorTicketId, vendorTicketId, StringComparison.Ordinal));
+        if (row is null)
+        {
+            SetError("That ticket is no longer pending — already checked in at the vendor, or unknown.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(row.VendorTicketId!, CancellationToken.None));
+        SetSuccess($"Test check-in enqueued for {row.AttendeeName ?? row.Barcode} ({row.VendorTicketId}). " +
+                   "Verify it on the TicketTailor dashboard, then send the rest.");
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("Run")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Run(CancellationToken ct)
+    {
+        if (MirrorDisabledError() is { } error)
+            return error;
+
+        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
+        foreach (var row in snapshot.Pending)
+            BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(row.VendorTicketId!, CancellationToken.None));
+
+        SetSuccess($"Enqueued {snapshot.Pending.Count} vendor check-in(s). " +
+                   "Counts on this page update after the next ticket sync — do not re-run before it completes.");
+        return RedirectToAction(nameof(Index));
+    }
+
+    private IActionResult? MirrorDisabledError()
+    {
+        if (configuration.GetValue<bool>(MirrorEnabledKey))
+            return null;
+        SetError("Gate:VendorMirrorEnabled is off — enqueued jobs would silently skip. Set it in the environment first.");
+        return RedirectToAction(nameof(Index));
+    }
+}
+
+public sealed record GateVendorBackfillViewModel(GateVendorBackfillSnapshot Snapshot, bool MirrorEnabled);

--- a/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
+++ b/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Humans.Web.Infrastructure;
+
+/// <summary>
+/// Remembers which vendor ticket ids the check-in backfill page has already enqueued,
+/// so neither the single-row test nor the bulk send can re-post one while the vendor's
+/// check-in hasn't flowed back through the ticket sync yet (TicketTailor check-ins
+/// double-record on repeat). Single-server in-memory state, like
+/// <see cref="GatePinThrottle"/>; entries expire after <see cref="Retention"/> — by
+/// then the sync has long since moved the row out of pending (or the app restarted,
+/// in which case the page's "wait for the sync" copy is the guard).
+/// </summary>
+public sealed class GateVendorMirrorLedger(IMemoryCache cache)
+{
+    /// <summary>How long a sent id stays remembered — generously past any sync cadence.</summary>
+    public static readonly TimeSpan Retention = TimeSpan.FromHours(24);
+
+    private static string Key(string vendorTicketId) => $"GateVendorMirrorSent:{vendorTicketId}";
+
+    public void MarkSent(string vendorTicketId) =>
+        cache.Set(Key(vendorTicketId), true, Retention);
+
+    public bool WasSent(string vendorTicketId) =>
+        cache.TryGetValue(Key(vendorTicketId), out _);
+}

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -86,6 +86,7 @@ if (!builder.Environment.IsProduction())
 builder.Services.AddScoped<GateTerminalAccountSeeder>();
 builder.Services.AddSingleton<GateLoginThrottle>();
 builder.Services.AddSingleton<GatePinThrottle>();
+builder.Services.AddSingleton<GateVendorMirrorLedger>();
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -149,7 +149,8 @@ public static class AdminNavTree
         ]),
         new("Temp", System: true, Items: [
             new("Picture migration",          "ProfilePictureMigrationAdmin", "Index", null, null, "fa-solid fa-image",     PolicyNames.AdminOnly),
-            new("Stub profile backfill",      "ProfileBackfillAdmin", "Index",          null, null, "fa-solid fa-user-plus", PolicyNames.AdminOnly)
+            new("Stub profile backfill",      "ProfileBackfillAdmin", "Index",          null, null, "fa-solid fa-user-plus", PolicyNames.AdminOnly),
+            new("Vendor check-in backfill",   "GateVendorBackfillAdmin", "Index",       null, null, "fa-solid fa-cloud-arrow-up", PolicyNames.AdminOnly)
         ])
     ];
 }

--- a/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
@@ -1,0 +1,162 @@
+@using Humans.Application.Extensions
+@model Humans.Web.Controllers.GateVendorBackfillViewModel
+@{
+    ViewData["Title"] = "Vendor check-in backfill";
+    Layout = "_AdminLayout";
+    var snapshot = Model.Snapshot;
+    var pending = snapshot.Pending.OrderBy(r => r.AdmittedAt).ToList();
+    var unmirrorable = snapshot.Unmirrorable.OrderBy(r => r.AdmittedAt).ToList();
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Vendor check-in backfill</h1>
+    <small class="text-muted">Temp page — remove after use</small>
+</div>
+
+<p class="text-muted">
+    Gate admits recorded locally in <code>gate_scan_events</code> but not yet checked in at
+    TicketTailor (as of the last ticket sync). Sending a row enqueues the existing
+    <code>GateVendorCheckInJob</code> mirror. TicketTailor check-ins <strong>double-record on
+    repeat</strong>: send once, let the ticket sync catch up, and only re-run rows still listed here.
+</p>
+
+@if (!Model.MirrorEnabled)
+{
+    <div class="alert alert-danger">
+        <i class="fa-solid fa-triangle-exclamation me-1" aria-hidden="true"></i>
+        <strong><code>Gate:VendorMirrorEnabled</code> is off.</strong> Every enqueued job will
+        silently skip — set the environment variable before sending anything.
+    </div>
+}
+
+<div class="row g-3 mb-4">
+    <div class="col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Local admits</h6>
+                <p class="h2 mb-0">@snapshot.AdmitCount</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Already at vendor</h6>
+                <p class="h2 mb-0 text-success">@snapshot.AlreadyCheckedInCount</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Pending mirror</h6>
+                <p class="h2 mb-0 @(pending.Count == 0 ? "text-success" : "text-warning")">@pending.Count</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Unmirrorable</h6>
+                <p class="h2 mb-0 @(unmirrorable.Count == 0 ? "text-success" : "text-danger")">@unmirrorable.Count</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (pending.Count == 0)
+{
+    <div class="card mb-4">
+        <div class="card-body">
+            <p class="mb-0">Nothing pending — every mirrorable admit is checked in at the vendor.</p>
+        </div>
+    </div>
+}
+else
+{
+    <div class="card mb-4">
+        <div class="card-body">
+            <p>
+                <strong>@pending.Count</strong> admit@(pending.Count == 1 ? "" : "s") to send.
+                Test one first (the <em>Send</em> button on a row — pick yourself if you're listed),
+                confirm it lands on the TicketTailor dashboard, then send the rest.
+            </p>
+            <form method="post" asp-action="Run">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-primary">
+                    <i class="fa-solid fa-cloud-arrow-up me-1" aria-hidden="true"></i>
+                    Send all @pending.Count pending check-in@(pending.Count == 1 ? "" : "s") to TicketTailor
+                </button>
+            </form>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">Pending check-ins</div>
+        <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th>Attendee</th>
+                        <th>Barcode</th>
+                        <th>Vendor ticket</th>
+                        <th>Admitted (UTC)</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in pending)
+                    {
+                        <tr>
+                            <td>@(row.AttendeeName ?? "—")</td>
+                            <td><code>@row.Barcode</code></td>
+                            <td><code>@row.VendorTicketId</code></td>
+                            <td>@row.AdmittedAt.ToInvariantTimestamp()</td>
+                            <td class="text-end">
+                                <form method="post" asp-action="RunOne" class="d-inline">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="vendorTicketId" value="@row.VendorTicketId" />
+                                    <button type="submit" class="btn btn-sm btn-outline-primary">Send</button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@if (unmirrorable.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">Unmirrorable — fix on the TicketTailor dashboard by hand</div>
+        <div class="card-body pb-0">
+            <p class="text-muted">
+                These admits have no matched attendee / vendor ticket id (name-search or
+                unmatched-barcode overrides), so the API can't check them in.
+            </p>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-sm mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th>Attendee</th>
+                        <th>Barcode</th>
+                        <th>Admitted (UTC)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in unmirrorable)
+                    {
+                        <tr>
+                            <td>@(row.AttendeeName ?? "—")</td>
+                            <td><code>@row.Barcode</code></td>
+                            <td>@row.AdmittedAt.ToInvariantTimestamp()</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}

--- a/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
@@ -4,7 +4,8 @@
     ViewData["Title"] = "Vendor check-in backfill";
     Layout = "_AdminLayout";
     var snapshot = Model.Snapshot;
-    var pending = snapshot.Pending.OrderBy(r => r.AdmittedAt).ToList();
+    var pending = Model.Pending.OrderBy(r => r.AdmittedAt).ToList();
+    var sent = Model.SentAwaitingSync.OrderBy(r => r.AdmittedAt).ToList();
     var unmirrorable = snapshot.Unmirrorable.OrderBy(r => r.AdmittedAt).ToList();
 }
 
@@ -17,7 +18,8 @@
     Gate admits recorded locally in <code>gate_scan_events</code> but not yet checked in at
     TicketTailor (as of the last ticket sync). Sending a row enqueues the existing
     <code>GateVendorCheckInJob</code> mirror. TicketTailor check-ins <strong>double-record on
-    repeat</strong>: send once, let the ticket sync catch up, and only re-run rows still listed here.
+    repeat</strong>, so already-sent rows are excluded from both send buttons until the next
+    ticket sync confirms them.
 </p>
 
 @if (!Model.MirrorEnabled)
@@ -30,7 +32,7 @@
 }
 
 <div class="row g-3 mb-4">
-    <div class="col-md-3">
+    <div class="col-md">
         <div class="card h-100">
             <div class="card-body">
                 <h6 class="card-subtitle text-muted mb-2">Local admits</h6>
@@ -38,7 +40,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md">
         <div class="card h-100">
             <div class="card-body">
                 <h6 class="card-subtitle text-muted mb-2">Already at vendor</h6>
@@ -46,7 +48,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md">
         <div class="card h-100">
             <div class="card-body">
                 <h6 class="card-subtitle text-muted mb-2">Pending mirror</h6>
@@ -54,7 +56,15 @@
             </div>
         </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Sent — awaiting sync</h6>
+                <p class="h2 mb-0 text-info">@sent.Count</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md">
         <div class="card h-100">
             <div class="card-body">
                 <h6 class="card-subtitle text-muted mb-2">Unmirrorable</h6>
@@ -68,7 +78,12 @@
 {
     <div class="card mb-4">
         <div class="card-body">
-            <p class="mb-0">Nothing pending — every mirrorable admit is checked in at the vendor.</p>
+            <p class="mb-0">
+                Nothing pending —
+                @(sent.Count > 0
+                    ? $"{sent.Count} sent check-in(s) awaiting the next ticket sync."
+                    : "every mirrorable admit is checked in at the vendor.")
+            </p>
         </div>
     </div>
 }
@@ -119,6 +134,42 @@ else
                                     <button type="submit" class="btn btn-sm btn-outline-primary">Send</button>
                                 </form>
                             </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@if (sent.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">Sent — awaiting the next ticket sync</div>
+        <div class="card-body pb-0">
+            <p class="text-muted">
+                Already enqueued; excluded from re-sending. They disappear from this page once the
+                ticket sync confirms the vendor-side check-in.
+            </p>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-sm mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th>Attendee</th>
+                        <th>Barcode</th>
+                        <th>Vendor ticket</th>
+                        <th>Admitted (UTC)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in sent)
+                    {
+                        <tr>
+                            <td>@(row.AttendeeName ?? "—")</td>
+                            <td><code>@row.Barcode</code></td>
+                            <td><code>@row.VendorTicketId</code></td>
+                            <td>@row.AdmittedAt.ToInvariantTimestamp()</td>
                         </tr>
                     }
                 </tbody>

--- a/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
@@ -1,0 +1,138 @@
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Humans.Application.Interfaces.Gate;
+using Humans.Application.Interfaces.Users;
+using Humans.Web.Controllers;
+using Humans.Web.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Controllers;
+
+/// <summary>
+/// The vendor check-in backfill page's double-post guards: a just-sent ticket is
+/// excluded from both the single test send and the bulk send until the ticket sync
+/// confirms it (TicketTailor check-ins double-record on repeat), and nothing is
+/// enqueued while <c>Gate:VendorMirrorEnabled</c> is off.
+/// </summary>
+public class GateVendorBackfillControllerTests
+{
+    private static readonly GateVendorBackfillRow RowA =
+        new("TIX-A", "Ada", Instant.FromUtc(2026, 7, 2, 9, 0), "vt-A");
+
+    private static readonly GateVendorBackfillRow RowB =
+        new("TIX-B", "Ben", Instant.FromUtc(2026, 7, 2, 9, 5), "vt-B");
+
+    private readonly IGateService _gate = Substitute.For<IGateService>();
+    private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
+    private readonly IBackgroundJobClient _jobs = Substitute.For<IBackgroundJobClient>();
+    private readonly GateVendorMirrorLedger _ledger = new(new MemoryCache(new MemoryCacheOptions()));
+
+    public GateVendorBackfillControllerTests()
+    {
+        _gate.GetVendorCheckInBackfillAsync(Arg.Any<CancellationToken>())
+            .Returns(new GateVendorBackfillSnapshot(2, 0, [RowA, RowB], []));
+    }
+
+    private GateVendorBackfillAdminController BuildController(bool mirrorEnabled = true)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Gate:VendorMirrorEnabled"] = mirrorEnabled ? "true" : null,
+            }).Build();
+        var controller = new GateVendorBackfillAdminController(_users, _gate, config, _ledger, _jobs);
+
+        // SetError resolves ILoggerFactory from RequestServices and reads the action
+        // descriptor; RedirectToAction lazily resolves Url — stub all three.
+        var http = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider(),
+        };
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = http,
+            ActionDescriptor = new ControllerActionDescriptor(),
+        };
+        controller.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        controller.Url = Substitute.For<IUrlHelper>();
+        return controller;
+    }
+
+    private string[] EnqueuedVendorIds() =>
+        _jobs.ReceivedCalls()
+            .Where(c => string.Equals(c.GetMethodInfo().Name, nameof(IBackgroundJobClient.Create), StringComparison.Ordinal))
+            .Select(c => (string)((Job)c.GetArguments()[0]!).Args[0]!)
+            .ToArray();
+
+    [HumansFact]
+    public async Task RunOne_EnqueuesThatTicket_AndMarksItSent()
+    {
+        var controller = BuildController();
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        Assert.Equal(["vt-A"], EnqueuedVendorIds());
+        Assert.True(_ledger.WasSent("vt-A"));
+        Assert.False(_ledger.WasSent("vt-B"));
+    }
+
+    [HumansFact]
+    public async Task Run_AfterRunOne_ExcludesTheTestTicket()
+    {
+        var controller = BuildController();
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        // The vendor record now exists but the local sync hasn't run — RowA is still in
+        // the service's Pending. The bulk send must not re-post it.
+        await controller.Run(TestContext.Current.CancellationToken);
+
+        Assert.Equal(["vt-A", "vt-B"], EnqueuedVendorIds());
+    }
+
+    [HumansFact]
+    public async Task RunOne_ForAnAlreadySentTicket_IsRefused()
+    {
+        var controller = BuildController();
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        Assert.Equal(["vt-A"], EnqueuedVendorIds()); // second attempt enqueued nothing
+    }
+
+    [HumansFact]
+    public async Task MirrorDisabled_NothingIsEnqueued()
+    {
+        var controller = BuildController(mirrorEnabled: false);
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+        await controller.Run(TestContext.Current.CancellationToken);
+
+        Assert.Empty(EnqueuedVendorIds());
+        Assert.False(_ledger.WasSent("vt-A"));
+    }
+
+    [HumansFact]
+    public async Task Index_SplitsPendingFromSentAwaitingSync()
+    {
+        var controller = BuildController();
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        var model = Assert.IsType<GateVendorBackfillViewModel>(
+            Assert.IsType<ViewResult>(await controller.Index(TestContext.Current.CancellationToken)).Model);
+
+        Assert.Equal(["vt-B"], model.Pending.Select(r => r.VendorTicketId));
+        Assert.Equal(["vt-A"], model.SentAwaitingSync.Select(r => r.VendorTicketId));
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -65,7 +65,8 @@ public class GateServiceTests : ServiceTestHarness
         TicketAttendeeStatus status = TicketAttendeeStatus.Valid,
         Guid? matchedUserId = null,
         string barcode = Barcode,
-        Guid? attendeeId = null)
+        Guid? attendeeId = null,
+        Instant? checkedInAt = null)
     {
         var attendee = new TicketAttendeeInfo(
             Id: attendeeId ?? Guid.NewGuid(),
@@ -76,7 +77,8 @@ public class GateServiceTests : ServiceTestHarness
             Price: 100m,
             Status: status,
             MatchedUserId: matchedUserId,
-            Barcode: barcode);
+            Barcode: barcode,
+            CheckedInAt: checkedInAt);
 
         var order = new TicketOrderInfo(
             Id: Guid.NewGuid(),
@@ -532,8 +534,9 @@ public class GateServiceTests : ServiceTestHarness
         var attendeeId = Guid.NewGuid();
         StubTicket(attendeeId: attendeeId);
         await Record(idConfirmed: true);
-        // The next ticket sync reports the vendor already has this check-in — drops out of pending.
-        StubTicket(status: TicketAttendeeStatus.CheckedIn, attendeeId: attendeeId);
+        // The next /check_ins sync stamps CheckedInAt — the issued ticket's Status stays
+        // Valid (vendor semantics), so CheckedInAt alone must drop the row out of pending.
+        StubTicket(attendeeId: attendeeId, checkedInAt: Clock.GetCurrentInstant());
 
         var snapshot = await _svc.GetVendorCheckInBackfillAsync();
 
@@ -541,6 +544,20 @@ public class GateServiceTests : ServiceTestHarness
         snapshot.AlreadyCheckedInCount.Should().Be(1);
         snapshot.Pending.Should().BeEmpty();
         snapshot.Unmirrorable.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_CheckedInStatusWithoutTimestamp_AlsoNotPending()
+    {
+        var attendeeId = Guid.NewGuid();
+        StubTicket(attendeeId: attendeeId);
+        await Record(idConfirmed: true);
+        StubTicket(status: TicketAttendeeStatus.CheckedIn, attendeeId: attendeeId);
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AlreadyCheckedInCount.Should().Be(1);
+        snapshot.Pending.Should().BeEmpty();
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -64,10 +64,11 @@ public class GateServiceTests : ServiceTestHarness
     private void StubTicket(
         TicketAttendeeStatus status = TicketAttendeeStatus.Valid,
         Guid? matchedUserId = null,
-        string barcode = Barcode)
+        string barcode = Barcode,
+        Guid? attendeeId = null)
     {
         var attendee = new TicketAttendeeInfo(
-            Id: Guid.NewGuid(),
+            Id: attendeeId ?? Guid.NewGuid(),
             VendorTicketId: "v1",
             AttendeeName: "Jane Donovan",
             AttendeeEmail: "jane@example.com",
@@ -507,5 +508,66 @@ public class GateServiceTests : ServiceTestHarness
 
         // Only the admin-enrolled supervisor is offered in the override picker.
         ids.Should().ContainSingle().Which.Should().Be(enrolled);
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_AdmitNotCheckedInAtVendor_IsPending()
+    {
+        StubTicket();
+        await Record(idConfirmed: true);
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(1);
+        snapshot.AlreadyCheckedInCount.Should().Be(0);
+        snapshot.Unmirrorable.Should().BeEmpty();
+        var row = snapshot.Pending.Should().ContainSingle().Subject;
+        row.VendorTicketId.Should().Be("v1");
+        row.AttendeeName.Should().Be("Jane Donovan");
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_VendorAlreadyCheckedIn_IsNotPending()
+    {
+        var attendeeId = Guid.NewGuid();
+        StubTicket(attendeeId: attendeeId);
+        await Record(idConfirmed: true);
+        // The next ticket sync reports the vendor already has this check-in — drops out of pending.
+        StubTicket(status: TicketAttendeeStatus.CheckedIn, attendeeId: attendeeId);
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(1);
+        snapshot.AlreadyCheckedInCount.Should().Be(1);
+        snapshot.Pending.Should().BeEmpty();
+        snapshot.Unmirrorable.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_AttendeeNoLongerInOrders_IsUnmirrorable()
+    {
+        StubTicket();
+        await Record(idConfirmed: true);
+        _tickets.GetTicketOrdersAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<TicketOrderInfo>());
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.Pending.Should().BeEmpty();
+        var row = snapshot.Unmirrorable.Should().ContainSingle().Subject;
+        row.VendorTicketId.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_RejectedScansAreNotCounted()
+    {
+        StubTicket();
+        await Record(idConfirmed: false); // ID says no → rejected, nothing to mirror
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(0);
+        snapshot.Pending.Should().BeEmpty();
+        snapshot.Unmirrorable.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## What

One-off **temp** admin page at `/Gate/Admin/VendorCheckInBackfill` (AdminOnly, nav under the existing **Temp** group) to recover the ~100 gate admits that never mirrored to TicketTailor while `Gate:VendorMirrorEnabled` was unset.

## How

- **Status first:** the page diffs local admits (`gate_scan_events`, the admit authority) against the vendor's check-in status from the last ticket sync. Cards show: total local admits · already checked in at vendor · **pending mirror** · unmirrorable.
- **Test one, then all:** each pending row has a *Send* button (single test check-in, verify on the TT dashboard), plus one *Send all pending* button for the bulk run.
- **Double-record safety:** TicketTailor check-in POSTs are not idempotent, so both POSTs recompute the diff server-side before enqueueing — a client-supplied id is never enqueued blindly, and rows the vendor already has (as of the latest sync) drop out. The page says plainly: send once, let the sync catch up, only re-run rows still listed.
- **Fail loudly:** both POSTs refuse (with an error banner) while `Gate:VendorMirrorEnabled` is off, since the job would silently skip every enqueue.
- **Unmirrorable admits** (no matched attendee / vendor ticket id — name-search or unmatched-barcode overrides) are listed separately for manual TT-dashboard fix-up.

## New surface (approved by Peter in conversation)

- `IGateService.GetVendorCheckInBackfillAsync` + `GateVendorBackfillSnapshot`/`GateVendorBackfillRow` DTOs.
- `GateVendorBackfillAdminController` + view (modeled on `ProfilePictureMigrationAdminController`).

Reused unchanged: `IGateRepository.GetScansSinceAsync`, `ITicketServiceRead.GetTicketOrdersAsync`, `GateVendorCheckInJob` (enqueue pattern identical to `GateController.Decision`). Rejected: a new repository method (existing scan query suffices) and touching the job/flag semantics (separate decision — the durable reconciliation feature should get its own issue).

## Prerequisites to actually run it

1. `Gate__VendorMirrorEnabled=true` in the prod environment (page refuses otherwise).
2. TicketTailor API key with **Event-manager or Admin** scope (Order-manager 403s on `/v1/check_ins`).

## Checklist

- [x] No EF migrations, no DB changes.
- [x] Build clean, `dotnet format` clean.
- [x] Tests: Application 3840/3840 (4 new backfill tests), Web 340/340.
- [x] Nav link added (Temp group) — no orphan page.
- [x] Issue refs qualified; no upstream issue exists for this (live-ops incident, tracked in conversation).
- [ ] **Remove this page after the backlog is cleared** (it's under the Temp nav group with the other one-offs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)