### PR TITLE
fix(gate): backfill sends original admit time; live mirrors marked in the ledger

### DIFF
--- a/src/Humans.Infrastructure/Jobs/GateVendorCheckInJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GateVendorCheckInJob.cs
@@ -32,7 +32,19 @@ public sealed class GateVendorCheckInJob(
     IConfiguration configuration,
     ILogger<GateVendorCheckInJob> logger)
 {
-    public async Task ExecuteAsync(string vendorTicketId, CancellationToken cancellationToken = default)
+    // Live mirror: the check-in time is "now" (the scan just happened). Hangfire-invoked —
+    // this signature is frozen per memory/code/hangfire-method-signature-stable.md; the
+    // backfill variant below is a SEPARATE method for the same reason.
+    public Task ExecuteAsync(string vendorTicketId, CancellationToken cancellationToken = default) =>
+        ExecuteCoreAsync(vendorTicketId, clock.GetCurrentInstant(), cancellationToken);
+
+    // Backfill mirror: preserves the original gate admit time (unix seconds — a primitive,
+    // so it serializes stably through Hangfire) instead of stamping the admin's click time.
+    // Also Hangfire-invoked: signature frozen once shipped.
+    public Task ExecuteBackfillAsync(string vendorTicketId, long admittedAtUnixSeconds, CancellationToken cancellationToken = default) =>
+        ExecuteCoreAsync(vendorTicketId, Instant.FromUnixTimeSeconds(admittedAtUnixSeconds), cancellationToken);
+
+    private async Task ExecuteCoreAsync(string vendorTicketId, Instant occurredAt, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(vendorTicketId))
             return;
@@ -47,7 +59,7 @@ public sealed class GateVendorCheckInJob(
 
         try
         {
-            await vendor.CreateCheckInAsync(vendorTicketId, clock.GetCurrentInstant(), cancellationToken);
+            await vendor.CreateCheckInAsync(vendorTicketId, occurredAt, cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode is { } status && (int)status is >= 400 and < 500)
         {

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -39,6 +39,7 @@ public sealed class GateController(
     IUserServiceRead users,
     IConfiguration configuration,
     GatePinThrottle pinThrottle,
+    GateVendorMirrorLedger mirrorLedger,
     IClock clock) : HumansControllerBase(users)
 {
     private const string ScannerSessionKey = "GateScannerId";
@@ -92,8 +93,13 @@ public sealed class GateController(
             scanner, ct);
 
         // Best-effort vendor check-in mirror on admit — fire-and-forget so the gate never waits.
+        // Marked in the mirror ledger so the vendor check-in backfill page never re-sends a live
+        // admit that hasn't flowed back through the ticket sync yet (TT check-ins double-record).
         if (decision.VendorTicketId is { Length: > 0 } vendorTicketId)
+        {
             BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
+            mirrorLedger.MarkSent(vendorTicketId);
+        }
 
         return PartialView("_VerdictCard", GateScanCardViewModel.FromDecision(decision, barcode));
     }

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -44,6 +44,7 @@ public sealed class GateController(
 {
     private const string ScannerSessionKey = "GateScannerId";
     private const string SupervisorPinConfigKey = "Gate:SupervisorPin";
+    private const string VendorMirrorEnabledKey = "Gate:VendorMirrorEnabled";
 
     // Throttle bucket for the shared override PIN — one bucket for the terminal, distinct
     // from the per-user claim buckets so a fumbled override can never lock a claim (or vice versa).
@@ -95,10 +96,13 @@ public sealed class GateController(
         // Best-effort vendor check-in mirror on admit — fire-and-forget so the gate never waits.
         // Marked in the mirror ledger so the vendor check-in backfill page never re-sends a live
         // admit that hasn't flowed back through the ticket sync yet (TT check-ins double-record).
+        // Marked ONLY when the mirror flag is on: with it off the job no-ops, and a ledger mark
+        // would hide exactly the rows the backfill page exists to recover.
         if (decision.VendorTicketId is { Length: > 0 } vendorTicketId)
         {
             BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
-            mirrorLedger.MarkSent(vendorTicketId);
+            if (configuration.GetValue<bool>(VendorMirrorEnabledKey))
+                mirrorLedger.MarkSent(vendorTicketId);
         }
 
         return PartialView("_VerdictCard", GateScanCardViewModel.FromDecision(decision, barcode));

--- a/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
@@ -53,7 +53,7 @@ public sealed class GateVendorBackfillAdminController(
             return RedirectToAction(nameof(Index));
         }
 
-        Enqueue(row.VendorTicketId!);
+        Enqueue(row);
         SetSuccess($"Test check-in enqueued for {row.AttendeeName ?? row.Barcode} ({row.VendorTicketId}). " +
                    "Verify it on the TicketTailor dashboard, then send the rest.");
         return RedirectToAction(nameof(Index));
@@ -68,7 +68,7 @@ public sealed class GateVendorBackfillAdminController(
 
         var (_, pending, _) = await GetPendingSplitAsync(ct);
         foreach (var row in pending)
-            Enqueue(row.VendorTicketId!);
+            Enqueue(row);
 
         SetSuccess($"Enqueued {pending.Count} vendor check-in(s). " +
                    "Sent rows are excluded from re-sending; counts update after the next ticket sync.");
@@ -86,9 +86,14 @@ public sealed class GateVendorBackfillAdminController(
         return (snapshot, pending, sent);
     }
 
-    private void Enqueue(string vendorTicketId)
+    // ExecuteBackfillAsync (not the live ExecuteAsync) so TicketTailor records the ORIGINAL
+    // gate admit time as check_in_at, not the moment the admin clicked Send.
+    private void Enqueue(GateVendorBackfillRow row)
     {
-        backgroundJobs.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
+        var vendorTicketId = row.VendorTicketId!;
+        var admittedAtUnixSeconds = row.AdmittedAt.ToUnixTimeSeconds();
+        backgroundJobs.Enqueue<GateVendorCheckInJob>(j =>
+            j.ExecuteBackfillAsync(vendorTicketId, admittedAtUnixSeconds, CancellationToken.None));
         ledger.MarkSent(vendorTicketId);
     }
 

--- a/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
+++ b/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
@@ -3,8 +3,9 @@ using Microsoft.Extensions.Caching.Memory;
 namespace Humans.Web.Infrastructure;
 
 /// <summary>
-/// Remembers which vendor ticket ids the check-in backfill page has already enqueued,
-/// so neither the single-row test nor the bulk send can re-post one while the vendor's
+/// Remembers which vendor ticket ids already have a check-in mirror enqueued — by the
+/// live gate path (<c>GateController.Decision</c>) or by the backfill page — so the
+/// backfill's single-row test and bulk send can never re-post one while the vendor's
 /// check-in hasn't flowed back through the ticket sync yet (TicketTailor check-ins
 /// double-record on repeat). Single-server in-memory state, like
 /// <see cref="GatePinThrottle"/>; entries expire after <see cref="Retention"/> — by

--- a/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
@@ -16,10 +16,11 @@
 
 <p class="text-muted">
     Gate admits recorded locally in <code>gate_scan_events</code> but not yet checked in at
-    TicketTailor (as of the last ticket sync). Sending a row enqueues the existing
-    <code>GateVendorCheckInJob</code> mirror. TicketTailor check-ins <strong>double-record on
-    repeat</strong>, so already-sent rows are excluded from both send buttons until the next
-    ticket sync confirms them.
+    TicketTailor (as of the last ticket sync). Sending a row enqueues the
+    <code>GateVendorCheckInJob</code> mirror with the <strong>original gate admit time</strong>
+    as the vendor check-in time. TicketTailor check-ins <strong>double-record on repeat</strong>,
+    so anything already enqueued — by these buttons or by a live gate scan — is excluded from
+    both send buttons until the next ticket sync confirms it.
 </p>
 
 @if (!Model.MirrorEnabled)

--- a/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
@@ -41,7 +41,8 @@ public class GateControllerClaimTests
     {
         _throttle = new GatePinThrottle(new MemoryCache(new MemoryCacheOptions()), _clock);
         _controller = new GateController(
-            _gate, _users, new ConfigurationBuilder().Build(), _throttle, _clock);
+            _gate, _users, new ConfigurationBuilder().Build(), _throttle,
+            new GateVendorMirrorLedger(new MemoryCache(new MemoryCacheOptions())), _clock);
 
         var http = new DefaultHttpContext { Session = _session };
         _controller.ControllerContext = new ControllerContext { HttpContext = http };

--- a/tests/Humans.Application.Tests/Controllers/GateControllerOverridePinTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateControllerOverridePinTests.cs
@@ -48,7 +48,8 @@ public class GateControllerOverridePinTests
             settings["Gate:SupervisorPin"] = configuredPin;
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         var throttle = new GatePinThrottle(new MemoryCache(new MemoryCacheOptions()), _clock);
-        var controller = new GateController(_gate, _users, config, throttle, _clock);
+        var mirrorLedger = new GateVendorMirrorLedger(new MemoryCache(new MemoryCacheOptions()));
+        var controller = new GateController(_gate, _users, config, throttle, mirrorLedger, _clock);
 
         var http = new DefaultHttpContext
         {

--- a/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
@@ -3,6 +3,7 @@ using Hangfire.Common;
 using Hangfire.States;
 using Humans.Application.Interfaces.Gate;
 using Humans.Application.Interfaces.Users;
+using Humans.Infrastructure.Jobs;
 using Humans.Web.Controllers;
 using Humans.Web.Infrastructure;
 using Microsoft.AspNetCore.Http;
@@ -85,6 +86,22 @@ public class GateVendorBackfillControllerTests
         Assert.Equal(["vt-A"], EnqueuedVendorIds());
         Assert.True(_ledger.WasSent("vt-A"));
         Assert.False(_ledger.WasSent("vt-B"));
+    }
+
+    [HumansFact]
+    public async Task RunOne_PreservesTheOriginalAdmitTime()
+    {
+        var controller = BuildController();
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        // ExecuteBackfillAsync(vendorTicketId, admittedAtUnixSeconds, ct) — the vendor
+        // check-in must carry the gate admit time, not the moment the admin clicked Send.
+        var job = (Job)_jobs.ReceivedCalls().Single(c =>
+            string.Equals(c.GetMethodInfo().Name, nameof(IBackgroundJobClient.Create), StringComparison.Ordinal))
+            .GetArguments()[0]!;
+        Assert.Equal(nameof(GateVendorCheckInJob.ExecuteBackfillAsync), job.Method.Name);
+        Assert.Equal(RowA.AdmittedAt.ToUnixTimeSeconds(), (long)job.Args[1]!);
     }
 
     [HumansFact]


### PR DESCRIPTION
## What

Fixes for the two Codex P2 findings on the prod promotion PR nobodies-collective/Humans#915 — both verified real. Blocks running the backfill page until merged.

1. **Wrong arrival times.** `TicketTailorService.CreateCheckInAsync` sends `check_in_at` from the job's clock, so a backfilled check-in recorded the admin's click time instead of the real gate admit time — corrupting arrival data in TicketTailor (the system of record) and, via the next sync, our own `CheckedInAt`. New `GateVendorCheckInJob.ExecuteBackfillAsync(vendorTicketId, admittedAtUnixSeconds)` preserves the original admit time (unix seconds — a primitive, Hangfire-serialization-safe). The live `ExecuteAsync` signature is untouched per `memory/code/hangfire-method-signature-stable.md`.
2. **Live-scan double-post race.** With `Gate:VendorMirrorEnabled` on and doors scanning, live admits enqueue their own mirror but still show as "pending" on the backfill page until the next ticket sync — *Send all* would have double-posted everyone scanned since the last sync. `GateController.Decision` now marks each live mirror enqueue in `GateVendorMirrorLedger`; both backfill send paths already exclude ledger-marked ids.

## Checklist

- [x] No EF migrations, no DB changes, no new interface surface (one new method on the existing job class + one ctor param on `GateController`).
- [x] Build clean, `dotnet format` clean.
- [x] Tests: Application 3847/3847 (new: `RunOne_PreservesTheOriginalAdmitTime`), Web 340/340.
- [x] Issue refs qualified.

After squash-merge to `main`, promotion PR nobodies-collective/Humans#915 picks this up automatically (its head is `peterdrier:main`) — I'll update its title/body and reply to the Codex threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)