### PR TITLE
fix(gate): atomic ledger claim (TryMarkSent) + 30-day backfill window

### DIFF
--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -202,9 +202,14 @@ public sealed class GateService(
     public Task<int> PurgeScansBeforeAsync(Instant cutoff, CancellationToken ct = default) =>
         repository.PurgeScansBeforeAsync(cutoff, ct);
 
+    /// <summary>Backfill diff window. Covers the whole event including the Early-Entry run-up,
+    /// while keeping prior editions' scans (retention is 365 days) out of the diff — the
+    /// attendee join is current-event-only, so older admits would only pollute Unmirrorable.</summary>
+    private static readonly Duration VendorBackfillWindow = Duration.FromDays(30);
+
     public async Task<GateVendorBackfillSnapshot> GetVendorCheckInBackfillAsync(CancellationToken ct = default)
     {
-        var scans = await repository.GetScansSinceAsync(Instant.MinValue, ct);
+        var scans = await repository.GetScansSinceAsync(clock.GetCurrentInstant().Minus(VendorBackfillWindow), ct);
         var admits = scans.Where(s => IsAdmit(s.Verdict)).ToList();
 
         var orders = await tickets.GetTicketOrdersAsync(ct);

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -102,7 +102,7 @@ public sealed class GateController(
         {
             BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
             if (configuration.GetValue<bool>(VendorMirrorEnabledKey))
-                mirrorLedger.MarkSent(vendorTicketId);
+                mirrorLedger.TryMarkSent(vendorTicketId);
         }
 
         return PartialView("_VerdictCard", GateScanCardViewModel.FromDecision(decision, barcode));

--- a/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
@@ -47,13 +47,12 @@ public sealed class GateVendorBackfillAdminController(
         var (_, pending, _) = await GetPendingSplitAsync(ct);
         var row = pending.FirstOrDefault(r =>
             string.Equals(r.VendorTicketId, vendorTicketId, StringComparison.Ordinal));
-        if (row is null)
+        if (row is null || !TryEnqueue(row))
         {
             SetError("That ticket is no longer pending — already sent, checked in at the vendor, or unknown.");
             return RedirectToAction(nameof(Index));
         }
 
-        Enqueue(row);
         SetSuccess($"Test check-in enqueued for {row.AttendeeName ?? row.Barcode} ({row.VendorTicketId}). " +
                    "Verify it on the TicketTailor dashboard, then send the rest.");
         return RedirectToAction(nameof(Index));
@@ -67,10 +66,9 @@ public sealed class GateVendorBackfillAdminController(
             return error;
 
         var (_, pending, _) = await GetPendingSplitAsync(ct);
-        foreach (var row in pending)
-            Enqueue(row);
+        var enqueued = pending.Count(TryEnqueue);
 
-        SetSuccess($"Enqueued {pending.Count} vendor check-in(s). " +
+        SetSuccess($"Enqueued {enqueued} vendor check-in(s). " +
                    "Sent rows are excluded from re-sending; counts update after the next ticket sync.");
         return RedirectToAction(nameof(Index));
     }
@@ -87,14 +85,19 @@ public sealed class GateVendorBackfillAdminController(
     }
 
     // ExecuteBackfillAsync (not the live ExecuteAsync) so TicketTailor records the ORIGINAL
-    // gate admit time as check_in_at, not the moment the admin clicked Send.
-    private void Enqueue(GateVendorBackfillRow row)
+    // gate admit time as check_in_at, not the moment the admin clicked Send. The ledger claim
+    // is atomic and happens BEFORE the enqueue: two overlapping requests (double-click, second
+    // admin) must never both enqueue the same non-idempotent vendor check-in.
+    private bool TryEnqueue(GateVendorBackfillRow row)
     {
         var vendorTicketId = row.VendorTicketId!;
+        if (!ledger.TryMarkSent(vendorTicketId))
+            return false;
+
         var admittedAtUnixSeconds = row.AdmittedAt.ToUnixTimeSeconds();
         backgroundJobs.Enqueue<GateVendorCheckInJob>(j =>
             j.ExecuteBackfillAsync(vendorTicketId, admittedAtUnixSeconds, CancellationToken.None));
-        ledger.MarkSent(vendorTicketId);
+        return true;
     }
 
     private IActionResult? MirrorDisabledError()

--- a/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
+++ b/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
@@ -17,10 +17,26 @@ public sealed class GateVendorMirrorLedger(IMemoryCache cache)
     /// <summary>How long a sent id stays remembered — generously past any sync cadence.</summary>
     public static readonly TimeSpan Retention = TimeSpan.FromHours(24);
 
+    private readonly Lock _lock = new();
+
     private static string Key(string vendorTicketId) => $"GateVendorMirrorSent:{vendorTicketId}";
 
-    public void MarkSent(string vendorTicketId) =>
-        cache.Set(Key(vendorTicketId), true, Retention);
+    /// <summary>
+    /// Atomically claim an id: true when THIS call marked it (caller may enqueue), false
+    /// when it was already claimed. Check-then-act under one lock — two overlapping "Send
+    /// all" requests must not both enqueue the same non-idempotent vendor check-in.
+    /// </summary>
+    public bool TryMarkSent(string vendorTicketId)
+    {
+        lock (_lock)
+        {
+            var key = Key(vendorTicketId);
+            if (cache.TryGetValue(key, out _))
+                return false;
+            cache.Set(key, true, Retention);
+            return true;
+        }
+    }
 
     public bool WasSent(string vendorTicketId) =>
         cache.TryGetValue(Key(vendorTicketId), out _);

--- a/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
@@ -141,6 +141,16 @@ public class GateVendorBackfillControllerTests
     }
 
     [HumansFact]
+    public void TryMarkSent_ClaimsAnIdExactlyOnce()
+    {
+        // The atomic claim is the double-post guard: of two overlapping requests
+        // (double-click / second admin), exactly one may enqueue a given ticket.
+        Assert.True(_ledger.TryMarkSent("vt-X"));
+        Assert.False(_ledger.TryMarkSent("vt-X"));
+        Assert.True(_ledger.WasSent("vt-X"));
+    }
+
+    [HumansFact]
     public async Task Index_SplitsPendingFromSentAwaitingSync()
     {
         var controller = BuildController();

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -659,6 +659,21 @@ public class GateServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task VendorBackfill_IgnoresAdmitsOlderThanTheWindow()
+    {
+        StubTicket();
+        await Record(idConfirmed: true);
+        // Prior-edition admits (retention is 365 days) must not pollute the diff.
+        Clock.Advance(Duration.FromDays(31));
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(0);
+        snapshot.Pending.Should().BeEmpty();
+        snapshot.Unmirrorable.Should().BeEmpty();
+    }
+
+    [HumansFact]
     public async Task VendorBackfill_RejectedScansAreNotCounted()
     {
         StubTicket();


### PR DESCRIPTION
## What

Fixes the two confirmed Claude-review findings on the prod promotion PR nobodies-collective/Humans#915:

1. **TOCTOU on the double-post guard.** The `WasSent` check and `MarkSent` write weren't atomic — a double-click on *Send all* (or a second admin mid-run) could double-enqueue every pending row, producing duplicate non-idempotent TicketTailor check-ins. `GateVendorMirrorLedger.TryMarkSent` now claims an id atomically under a lock; the backfill claims **before** enqueueing, and both send paths act only on rows this request claimed. Success message reports the actually-enqueued count.
2. **Unbounded diff window.** `GetVendorCheckInBackfillAsync` scanned since `Instant.MinValue`; with 365-day scan retention, next year's page would count this year's admits as unmirrorable noise. Scoped to a 30-day window (covers the event + Early-Entry run-up).

The third finding on nobodies-collective/Humans#915 (move the orchestration into `GateService`) is refuted in-thread: the pending/sent split is controller-side filtering (hard rules assign filtering to controllers), the enqueue+Web-state shape matches the existing `Decision`/`GatePinThrottle` precedent, and `GateService` (Application) can't reference the Hangfire job type (Infrastructure) without new abstraction surface — for a temp page slated for deletion. Thread left open for Peter to overrule.

## Checklist

- [x] No EF migrations, no new interface surface.
- [x] Build + `dotnet format` clean; Application 3854/3854 (2 new tests), Web 340/340.
- [x] Issue refs qualified.

After squash-merge, nobodies-collective/Humans#915 picks this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)