### PR TITLE
feat(gate): "logout" typed into the scan field offers a confirmed kiosk sign-out

### DIFF
--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -184,6 +184,11 @@ but are unreachable since peterdrier#1075 — nothing links to them.)
   ("Do not admit · if disputed, get the gate lead"), the ID-confirm card has a "Wrong ticket — scan
   again" escape and a visible auto-clear countdown, the override panel has "← Wrong person", and the
   freshness line taps to reload.
+- **Logout escape hatch** — the route-restriction middleware hides every normal logout affordance from
+  the gate account, so typing `logout` (any case) into the scan field is the only way off it: a local
+  confirm card (client-side only, auto-clears) POSTs the standard `/Account/Logout` on a confirm tap.
+  Confirm arms after the same anti-mistap delay as Yes/No, so a scanned barcode that *encodes* "logout"
+  can never knock the terminal offline by itself.
 
 ## Cross-Section Dependencies
 

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -98,6 +98,7 @@
             override: document.getElementById('gate-override'),
             evaluateUrl: '@Url.Action("Evaluate", "Gate")',
             decisionUrl: '@Url.Action("Decision", "Gate")',
+            logoutUrl: '@Url.Action("Logout", "Account")',
             token: document.querySelector('input[name="__RequestVerificationToken"]').value
         });
     </script>

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -84,6 +84,8 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-btn[disabled] { opacity: .35; }
 .gate-no { background: #B11217; }
 .gate-yes { background: #0B7A2F; }
+/* Neutral Cancel that sits inside the Yes/No flex row (unlike the block-level cancel-scan). */
+.gate-logout-cancel { background: #5a6672; }
 .gate-child {
     display: block; width: 100%; margin-top: 1rem; background: #3a4753;
     font-size: 1.05rem; padding: .8rem;

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -5,9 +5,11 @@
 // Yes/No (or Child) → /Gate/Decision records the decision and returns the final
 // card. Distinct sounds + haptics let the agent keep their eyes on the guest,
 // and the Yes/No buttons arm only after a short delay to defeat autopilot taps.
+// Typing "logout" (any case) instead of a barcode offers a confirm card that ends
+// the kiosk session — the only logout path on the route-restricted gate account.
 
 export function initGate(refs) {
-    const { form, input, result, override, evaluateUrl, decisionUrl, token } = refs;
+    const { form, input, result, override, evaluateUrl, decisionUrl, logoutUrl, token } = refs;
 
     const focusInput = () => { input.value = ''; input.focus(); };
     input.focus();
@@ -176,6 +178,14 @@ export function initGate(refs) {
         clearScanTimer();
         const code = input.value.trim();
         if (!code || busy || overrideOpen()) return; // ignore scans mid-override
+        // Escape hatch for a device stuck on the kiosk account (the route-restriction
+        // middleware hides every normal logout affordance): typing "logout" into the scan
+        // field offers to end the session. Confirm-tap only — a scanned barcode that
+        // *encodes* "logout" must not be able to knock the terminal offline by itself.
+        if (code.toLowerCase() === 'logout') {
+            showLogoutConfirm();
+            return;
+        }
         busy = true;
         flashNeutral(result);
         try {
@@ -211,6 +221,48 @@ export function initGate(refs) {
             '<div class="gate-word">Error</div>' +
             '<div class="gate-reason">Connection problem — scan again</div></div>';
         signal('Stop');
+    }
+
+    // Local confirm card for the "logout" escape hatch — never touches the server until
+    // confirmed. Confirm POSTs the standard /Account/Logout via a real form (the browser
+    // then follows the redirect out of the kiosk); Cancel returns to Ready. The card
+    // auto-clears like any other so an abandoned prompt can't linger on the shared screen.
+    function showLogoutConfirm() {
+        input.value = '';
+        result.innerHTML =
+            '<div class="gate-card gate-idconfirm" data-kind="LogoutConfirm" role="status">' +
+            '<div class="gate-icon" aria-hidden="true"><i class="fa-solid fa-right-from-bracket"></i></div>' +
+            '<div class="gate-word">Log out</div>' +
+            '<div class="gate-reason">Sign this device out of the gate account?</div>' +
+            '<div class="gate-decide"><div class="gate-yesno">' +
+            '<button type="button" class="gate-btn gate-logout-cancel" data-logout-cancel>' +
+            '<i class="fa-solid fa-rotate-left" aria-hidden="true"></i> Cancel</button>' +
+            '<button type="button" class="gate-btn gate-no" data-logout-confirm>' +
+            '<i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i> Log out</button>' +
+            '</div></div></div>';
+
+        const card = result.firstElementChild;
+        card.querySelector('[data-logout-cancel]').addEventListener('click', resetToReady);
+
+        // Same anti-mistap arming as the Yes/No buttons: a wedge-scanned "logout" barcode
+        // auto-submits, so the confirm must never be tappable in the same motion.
+        const confirmBtn = card.querySelector('[data-logout-confirm]');
+        confirmBtn.setAttribute('disabled', 'disabled');
+        setTimeout(() => confirmBtn.removeAttribute('disabled'), 350);
+        confirmBtn.addEventListener('click', () => {
+            const f = document.createElement('form');
+            f.method = 'POST';
+            f.action = logoutUrl;
+            const t = document.createElement('input');
+            t.type = 'hidden';
+            t.name = '__RequestVerificationToken';
+            t.value = token;
+            f.appendChild(t);
+            document.body.appendChild(f);
+            f.submit();
+        });
+
+        armAutoReset(card, 'LogoutConfirm');
     }
 
     function afterRender() {

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -25,7 +25,7 @@ export function initGate(refs) {
     // but the operator is mid-decision). Any tap on the card pushes the deadline back (active use
     // keeps it up); terminal cards also get a "Next ticket" button with a visible countdown.
     const readyCard = result.firstElementChild ? result.firstElementChild.cloneNode(true) : null;
-    const RESET_MS = { Admit: 10000, Stop: 30000, Amber: 30000, IdConfirm: 60000 };
+    const RESET_MS = { Admit: 10000, Stop: 30000, Amber: 30000, IdConfirm: 60000, LogoutConfirm: 60000 };
     let resetTimer = null, resetCountdown = null, resetDeadline = 0, resetMs = 0, resetLabel = null, resetLabelKind = 'next';
 
     function clearResetTimer() {


### PR DESCRIPTION
## Problem

The gate account's route-restriction middleware (defense in depth) hides every normal logout affordance: browsing anywhere bounces back to `/Gate`, and `/Account/Logout` is POST-only so it can't be typed into the address bar. A personal phone that signs into the kiosk account is permanently stuck on it (real case at gate).

## Change

Typing `logout` (any case) into the scan field shows a **local confirm card** (no server round-trip until confirmed):

- **Log out** POSTs the standard `/Account/Logout` via a real form with the page's antiforgery token — the middleware already allowlists that path, so no server changes at all.
- **Cancel** returns to the Ready screen.
- The confirm button arms after the same 350ms anti-mistap delay as the ID Yes/No buttons, so a scanned barcode that *encodes* the string "logout" auto-submitting via the wedge can never knock the terminal offline by itself — it takes a deliberate second tap.
- The card auto-clears like every other card, so an abandoned prompt can't linger on the shared screen.

On a phone: tap the manual-entry (keyboard) toggle, type `logout`, Go, confirm.

Also documents the escape hatch in `docs/sections/Gate.md` under the no-dead-ends invariant.

## Testing

- Build clean; `gate.js` syntax-checked as an ES module.
- Runtime verification on the PR preview deploy (no local Postgres/Docker on this machine) — results to follow as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)