### PR TITLE
Add Host column to event CSV export

### DIFF
--- a/src/Humans.Web/Controllers/EventsExportController.cs
+++ b/src/Humans.Web/Controllers/EventsExportController.cs
@@ -67,6 +67,7 @@ public class EventsExportController(
                     e.PriorityRank,
                     e.Status.ToString(),
                     ToLocalDateTime(e.SubmittedAt, tz).ToInvariantTimestamp(),
+                    e.Host ?? "",
                 ]);
             }
         }
@@ -74,7 +75,7 @@ public class EventsExportController(
         var bytes = HumansCsv.WriteBytes(csv =>
         {
             csv.WriteRow("Id", "Title", "Description", "Category", "CampName", "VenueName", "SubmitterName",
-                "LocationNote", "Date", "StartTime", "DurationMinutes", "IsRecurring", "PriorityRank", "Status", "SubmittedAt");
+                "LocationNote", "Date", "StartTime", "DurationMinutes", "IsRecurring", "PriorityRank", "Status", "SubmittedAt", "Host");
             foreach (var row in rows)
             {
                 csv.WriteRow(row);


### PR DESCRIPTION
Adds a `Host` column to the CSV export at `GET /Events/Export/Csv`. The column is appended at the end to avoid breaking consumers that rely on column position.

The `EventInfo` DTO already exposes `string? Host`, so no other changes were needed. The API JSON (`GET /api/events/events`) already exports `host` — only the CSV was missing it.

This will allow the whatwherewhen app to display the Host, whereas before it was missing.