### PR TITLE
fix(flaky): GetCalendarItems_InactiveStatuses_Excluded

### DIFF
--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceCalendarFeedTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceCalendarFeedTests.cs
@@ -191,7 +191,7 @@ public sealed class ShiftSignupServiceCalendarFeedTests : ServiceTestHarness
         items[0].Summary.Should().Be("Test Rota (pending)");
     }
 
-    [HumansTheory]
+    [HumansTheory(Timeout = 10000)]
     [InlineData(SignupStatus.Cancelled)]
     [InlineData(SignupStatus.Bailed)]
     [InlineData(SignupStatus.NoShow)]


### PR DESCRIPTION
## What

Fixes a flaky test found while scanning `Build and Test` CI runs on `main` for the last 7 days: `GetCalendarItems_InactiveStatuses_Excluded(status: Refused)` in `ShiftSignupServiceCalendarFeedTests` timed out once (2026-07-02, run [28588249183](https://github.com/peterdrier/Humans/actions/runs/28588249183/job/84765149262)) with `Test execution timed out after 5000 milliseconds`, while passing on the other 36 `main`-branch runs in the window and on its own sibling `InlineData` cases within the same failing run.

## Why

**Root cause:** the test is a `[HumansTheory]`, which defaults to a 5000ms timeout (`HumansTheoryAttribute.DefaultTimeoutFor`), whereas every sibling `[HumansFact]` in the same file — doing equivalent EF Core InMemory seeding plus one async service call — gets the 30000ms `[HumansFact]` default. The test itself performs no real I/O (in-memory DB, no delays, no network), so a timeout on unrelated code is a scheduling/contention artifact: `Humans.Application.Tests` runs 3648+ tests, many in parallel, and under CI load the continuation for this particular test's `await` chain occasionally gets delayed past a tight 5s budget purely from thread-pool pressure — not a real hang (the CI-wide 2-minute `--blame-hang-timeout` guard exists precisely to catch actual hangs; this isn't one).

**Fix:** bump the timeout to 10000ms, matching the established convention already used throughout `Humans.Application.Tests` for tests prone to the same scheduling noise (`ProfileServiceTests`, `ShiftManagementServiceTests`, `CampServiceTests`, `TicketSyncServiceTests`, and ~20 others all use `Timeout = 10000`). This is the project's documented escape hatch (see the comment on the `RS0030` check in `.github/workflows/build.yml`: "set a higher Timeout on `[HumansFact]`" instead of suppressing the analyzer).

## Existing surface checked

No new surface — one-line change to an existing test attribute, following an existing project-wide convention (`Timeout = 10000` appears in ~30 other files in this test project).

## Verification

CI environment note: this sandbox had no .NET SDK preinstalled and the official Microsoft SDK CDN is blocked by the outbound network policy here, so the SDK was installed via `apt` (`dotnet-sdk-10.0`) instead. Ran locally against that toolchain:

- `GetCalendarItems_InactiveStatuses_Excluded` (all 4 `InlineData` cases) — 5 consecutive runs, all green.
- Full `Humans.Application.Tests` suite (3648 tests, matching CI's count exactly) — 3 consecutive full runs, all green, 0 failures.
- Full non-integration solution suite (`Domain` 271, `Web` 340, `Analyzers` 222, `Application` 3648) — 1 run, all green.

## Checklist

- ~~Section labeled~~ — test-only CI reliability fix, not section-specific product behavior.
- [x] Targeting `main` on `peterdrier/Humans` (the QA fork).
- [x] Branched off `origin/main`.
- ~~Issue refs are qualified~~ — no linked issue; this is a routine flaky-test scan finding.
- ~~EF migrations~~ — none.
- ~~NuGet packages updated~~ — none.
- ~~New project rule~~ — none; this reinforces an existing, already-documented convention.
- [x] Reuse-first checked — no new surface, reused the existing `Timeout =` pattern.
- [x] Build + test pass locally (see Verification above; via apt-installed SDK, see note).
- ~~Nav coverage~~ — no new page.
- ~~No magic strings~~ — n/a.
- ~~Dates/times via NodaTime~~ — n/a, no behavior change.

## Reviewer notes

This is the only flaky test found in the 7-day scan of `main`-branch CI (`Build and Test` + `E2E Tests (QA)`). Two other things worth flagging separately (not fixed here, out of scope for this PR):

1. `E2E Tests (QA)` failed 28/30 runs this week, but it is **not flaky** — the same 34 admin/board/nav tests fail identically every time with `Received string: https://humans.n.burn.camp/User/Status`, i.e. admin-role users are being redirected off their target page. That's a real, consistent regression in the QA environment/app, worth its own investigation.
2. No workflow runs in the window had `run_attempt > 1` (no reruns on `main`), so this fix relies on cross-commit frequency (1 failure in 37 runs, all-else-equal) rather than a literal same-SHA pass+fail pair — flagging that reasoning gap for visibility.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MqFdqpNfZF5PSf8SPcg3o4)_