### PR TITLE
fix(e2e): persona seeding restores UserState.Active; auth setup fails loudly (nobodies-collective#867)

### DIFF
--- a/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
@@ -5,7 +5,10 @@ using Humans.Application.Extensions;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.HumanLifecycle;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
@@ -47,6 +50,9 @@ public sealed class DevPersonaSeeder(
     IAuditLogService auditLogService,
     ICampService campService,
     ICampRoleService campRoleService,
+    IConsentService consentService,
+    IMembershipCalculatorRead membershipCalculator,
+    IHumanLifecycleService humanLifecycleService,
     IClock clock,
     IMemoryCache cache,
     IOptions<CityPlanningOptions> cityPlanningOptions,
@@ -60,7 +66,10 @@ public sealed class DevPersonaSeeder(
     {
         var existing = await userManager.FindByIdAsync(id.ToString());
         if (existing is not null)
+        {
+            await EnsureActiveAsync(existing.Id);
             return existing.Id;
+        }
 
         var email = $"dev-{slug}@localhost";
 
@@ -69,6 +78,7 @@ public sealed class DevPersonaSeeder(
         if (byEmailUserId is not null)
         {
             logger.LogInformation("DEV: found legacy persona {Email} ({OldId}), reusing", email, byEmailUserId.Value);
+            await EnsureActiveAsync(byEmailUserId.Value);
             return byEmailUserId.Value;
         }
 
@@ -188,6 +198,11 @@ public sealed class DevPersonaSeeder(
             await EnsureSeededRoleAsync(id, role, id);
         }
 
+        // Sign the required legal documents up front — role-holding personas without
+        // them are suspended by the nightly SuspendNonCompliantMembersJob once a
+        // document's grace period lapses (#867).
+        await EnsureActiveAsync(id);
+
         cache.InvalidateUserAccess(id);
         await userInfoInvalidator.InvalidateAsync(id);
 
@@ -197,6 +212,57 @@ public sealed class DevPersonaSeeder(
             string.Join(", ", roles));
 
         return id;
+    }
+
+    /// <summary>
+    /// Restores a persona to <see cref="UserState.Active"/> on every dev sign-in. Personas
+    /// hold governance roles but historically never signed the required legal documents, so
+    /// the nightly <c>SuspendNonCompliantMembersJob</c> suspended them once a document's
+    /// grace period lapsed, and the create-only seeder could never bring them back (#867).
+    /// Submits any missing required consents through the canonical consent path (whose
+    /// completion also lifts a consent suspension), then lifts any remaining consent
+    /// suspension for the no-longer-missing-anything case. Idempotent.
+    /// </summary>
+    public async Task EnsureActiveAsync(Guid userId)
+    {
+        var info = await userService.GetUserInfoAsync(userId);
+
+        // Guest/no-name personas: no profile or blanked legal names. They cannot consent
+        // (SubmitConsentAsync's Stub gate refuses) and hold no governance roles, so the
+        // suspend job never targets them — nothing to repair.
+        if (info is null || !info.HasRequiredNameFields)
+            return;
+
+        var snapshot = await membershipCalculator.GetMembershipSnapshotAsync(userId);
+        foreach (var versionId in snapshot.MissingConsentVersionIds)
+        {
+            var result = await consentService.SubmitConsentAsync(
+                userId, versionId, explicitConsent: true,
+                ipAddress: "127.0.0.1", userAgent: nameof(DevPersonaSeeder));
+
+            if (result.Success)
+            {
+                logger.LogInformation(
+                    "DEV: seeded consent for persona {UserId} on document version {VersionId}",
+                    userId, versionId);
+            }
+            else if (!string.Equals(result.ErrorKey, "AlreadyConsented", StringComparison.Ordinal))
+            {
+                logger.LogWarning(
+                    "DEV: consent seed failed for persona {UserId} on document version {VersionId}: {ErrorKey}",
+                    userId, versionId, result.ErrorKey);
+            }
+        }
+
+        // Covers a persona left Suspended with nothing missing (the required-document set
+        // can shrink after the suspension). No-ops unless the stored state is Suspended.
+        var restore = await humanLifecycleService.RestoreConsentSuspensionAsync(userId);
+        if (!restore.Success)
+        {
+            logger.LogWarning(
+                "DEV: consent-suspension restore failed for persona {UserId}: {ErrorKey}",
+                userId, restore.ErrorKey);
+        }
     }
 
     /// <summary>

--- a/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
@@ -233,6 +233,9 @@ public sealed class DevPersonaSeeder(
         if (info is null || !info.HasRequiredNameFields)
             return;
 
+        var wasSuspended = info.State == UserState.Suspended;
+        var submittedAny = false;
+
         var snapshot = await membershipCalculator.GetMembershipSnapshotAsync(userId);
         foreach (var versionId in snapshot.MissingConsentVersionIds)
         {
@@ -242,6 +245,7 @@ public sealed class DevPersonaSeeder(
 
             if (result.Success)
             {
+                submittedAny = true;
                 logger.LogInformation(
                     "DEV: seeded consent for persona {UserId} on document version {VersionId}",
                     userId, versionId);
@@ -262,6 +266,18 @@ public sealed class DevPersonaSeeder(
             logger.LogWarning(
                 "DEV: consent-suspension restore failed for persona {UserId}: {ErrorKey}",
                 userId, restore.ErrorKey);
+        }
+
+        // Volunteers admission is name + consents (SyncVolunteersMembershipForUserAsync),
+        // and SubmitConsentAsync deliberately does not provision system-team membership —
+        // without this re-sync a persona repaired here (or created in an environment that
+        // already has required documents, where the creation-path sync ran pre-consent)
+        // stays out of Volunteers until the nightly SystemTeamSyncJob. Skipped when the
+        // restore failed: the user would still be suspended, and a single-user sync also
+        // REMOVES ineligible members.
+        if ((submittedAny || wasSuspended) && restore.Success)
+        {
+            await systemTeamSync.SyncMembershipForUserAsync(userId, SystemTeamType.Volunteers);
         }
     }
 

--- a/tests/Humans.Web.Tests/Infrastructure/DevPersonaSeederTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/DevPersonaSeederTests.cs
@@ -1,0 +1,192 @@
+using AwesomeAssertions;
+using Humans.Application;
+using Humans.Application.Configuration;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.HumanLifecycle;
+using Humans.Application.Interfaces.Onboarding;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Infrastructure;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Web.Tests.Infrastructure;
+
+/// <summary>
+/// Covers the #867 persona repair: dev personas hold governance roles but never signed
+/// the required legal documents, so the nightly SuspendNonCompliantMembersJob suspended
+/// them once a document's grace period lapsed, and the create-only seeder could never
+/// bring them back. EnsureActiveAsync must submit missing consents through the canonical
+/// consent path and lift a consent suspension, on every dev sign-in, idempotently.
+/// </summary>
+public class DevPersonaSeederTests
+{
+    private readonly UserManager<User> _userManager = Substitute.For<UserManager<User>>(
+        Substitute.For<IUserStore<User>>(), null, null, null, null, null, null, null, null);
+    private readonly IProfileEditorService _profileEditor = Substitute.For<IProfileEditorService>();
+    private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
+    private readonly IContactFieldService _contactFields = Substitute.For<IContactFieldService>();
+    private readonly IRoleAssignmentService _roleAssignments = Substitute.For<IRoleAssignmentService>();
+    private readonly IUserInfoInvalidator _userInfoInvalidator = Substitute.For<IUserInfoInvalidator>();
+    private readonly ITeamService _teams = Substitute.For<ITeamService>();
+    private readonly ISystemTeamSync _systemTeamSync = Substitute.For<ISystemTeamSync>();
+    private readonly IUserService _users = Substitute.For<IUserService>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+    private readonly ICampService _camps = Substitute.For<ICampService>();
+    private readonly ICampRoleService _campRoles = Substitute.For<ICampRoleService>();
+    private readonly IConsentService _consents = Substitute.For<IConsentService>();
+    private readonly IMembershipCalculatorRead _membershipCalculator = Substitute.For<IMembershipCalculatorRead>();
+    private readonly IHumanLifecycleService _humanLifecycle = Substitute.For<IHumanLifecycleService>();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 7, 13, 12, 0));
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    private DevPersonaSeeder BuildSut() => new(
+        _userManager,
+        _profileEditor,
+        _userEmails,
+        _contactFields,
+        _roleAssignments,
+        _userInfoInvalidator,
+        _teams,
+        _systemTeamSync,
+        _users,
+        _audit,
+        _camps,
+        _campRoles,
+        _consents,
+        _membershipCalculator,
+        _humanLifecycle,
+        _clock,
+        _cache,
+        Options.Create(new CityPlanningOptions()),
+        NullLogger<DevPersonaSeeder>.Instance);
+
+    private static UserInfo NamedUserInfo(Guid userId, UserState state) =>
+        UserInfo.Create(
+            new User { Id = userId, DisplayName = "Dev Board", State = state },
+            [], [], [],
+            profile: new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                BurnerName = "Dev Board",
+                FirstName = "Dev",
+                LastName = "Board",
+                State = state == UserState.Suspended ? ProfileState.Suspended : ProfileState.Active,
+                IsSuspended = state == UserState.Suspended,
+                IsApproved = true,
+            },
+            [], [], [], []);
+
+    private static MembershipSnapshot Snapshot(params Guid[] missingVersionIds) => new(
+        MembershipStatus.Active,
+        IsVolunteerMember: true,
+        RequiredConsentCount: missingVersionIds.Length,
+        PendingConsentCount: missingVersionIds.Length,
+        MissingConsentVersionIds: missingVersionIds);
+
+    [HumansFact]
+    public async Task EnsureActiveAsync_MissingConsents_SubmitsEachThroughConsentServiceAndRestores()
+    {
+        var userId = Guid.NewGuid();
+        var v1 = Guid.NewGuid();
+        var v2 = Guid.NewGuid();
+        _users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(NamedUserInfo(userId, UserState.Suspended)));
+        _membershipCalculator.GetMembershipSnapshotAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Snapshot(v1, v2));
+        _consents.SubmitConsentAsync(userId, Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ConsentSubmitResult(true));
+        _humanLifecycle.RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+
+        await BuildSut().EnsureActiveAsync(userId);
+
+        await _consents.Received(1).SubmitConsentAsync(
+            userId, v1, true, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _consents.Received(1).SubmitConsentAsync(
+            userId, v2, true, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _humanLifecycle.Received(1).RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task EnsureActiveAsync_NothingMissing_StillLiftsConsentSuspension()
+    {
+        // The required-document set can shrink after a suspension: nothing is missing
+        // anymore, but the profile is still Suspended. The repair must not depend on a
+        // consent submit to trigger the restore.
+        var userId = Guid.NewGuid();
+        _users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(NamedUserInfo(userId, UserState.Suspended)));
+        _membershipCalculator.GetMembershipSnapshotAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Snapshot());
+        _humanLifecycle.RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+
+        await BuildSut().EnsureActiveAsync(userId);
+
+        await _consents.DidNotReceive().SubmitConsentAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _humanLifecycle.Received(1).RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task EnsureActiveAsync_ProfilelessOrBlankNames_SkipsRepair()
+    {
+        // Guest personas have no profile; the No-Name persona has blanked legal names.
+        // Neither can consent (Stub gate in SubmitConsentAsync) and neither holds a
+        // governance role, so the suspend job never targets them — skip entirely.
+        var profileless = Guid.NewGuid();
+        _users.GetUserInfoAsync(profileless, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(UserInfo.Create(
+                new User { Id = profileless, DisplayName = "Dev Guest" },
+                [], [], [], profile: null, [], [], [], [])));
+
+        await BuildSut().EnsureActiveAsync(profileless);
+
+        await _membershipCalculator.DidNotReceive().GetMembershipSnapshotAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _consents.DidNotReceive().SubmitConsentAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _humanLifecycle.DidNotReceive().RestoreConsentSuspensionAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task EnsurePersonaAsync_ExistingPersona_RunsActiveRepair()
+    {
+        // The pre-#867 seeder early-returned for existing personas, so a persona that
+        // drifted non-Active could never recover. The existing-persona path must repair.
+        var userId = DevPersonaSeeder.PersonaGuid("board");
+        _userManager.FindByIdAsync(userId.ToString())
+            .Returns(new User { Id = userId, DisplayName = "Dev Board" });
+        _users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(NamedUserInfo(userId, UserState.Suspended)));
+        _membershipCalculator.GetMembershipSnapshotAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Snapshot(Guid.NewGuid()));
+        _consents.SubmitConsentAsync(userId, Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ConsentSubmitResult(true));
+        _humanLifecycle.RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+
+        var resolved = await BuildSut().EnsurePersonaAsync("board", "Board", userId);
+
+        resolved.Should().Be(userId);
+        await _userManager.DidNotReceive().CreateAsync(Arg.Any<User>());
+        await _consents.Received(1).SubmitConsentAsync(
+            userId, Arg.Any<Guid>(), true, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _humanLifecycle.Received(1).RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Humans.Web.Tests/Infrastructure/DevPersonaSeederTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/DevPersonaSeederTests.cs
@@ -121,6 +121,10 @@ public class DevPersonaSeederTests
         await _consents.Received(1).SubmitConsentAsync(
             userId, v2, true, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         await _humanLifecycle.Received(1).RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>());
+        // Volunteers admission is name + consents and SubmitConsentAsync does not provision
+        // membership — the repair must re-sync or the persona stays out until the nightly job.
+        await _systemTeamSync.Received(1).SyncMembershipForUserAsync(
+            userId, SystemTeamType.Volunteers, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -142,6 +146,46 @@ public class DevPersonaSeederTests
         await _consents.DidNotReceive().SubmitConsentAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         await _humanLifecycle.Received(1).RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>());
+        // Was suspended → the (nightly) suspension flow removed Volunteers membership; re-sync.
+        await _systemTeamSync.Received(1).SyncMembershipForUserAsync(
+            userId, SystemTeamType.Volunteers, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task EnsureActiveAsync_AlreadyActiveNothingMissing_DoesNotResyncVolunteers()
+    {
+        // The steady-state login (persona healthy) must not churn team sync on every hit.
+        var userId = Guid.NewGuid();
+        _users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(NamedUserInfo(userId, UserState.Active)));
+        _membershipCalculator.GetMembershipSnapshotAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Snapshot());
+        _humanLifecycle.RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+
+        await BuildSut().EnsureActiveAsync(userId);
+
+        await _systemTeamSync.DidNotReceive().SyncMembershipForUserAsync(
+            Arg.Any<Guid>(), Arg.Any<SystemTeamType>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task EnsureActiveAsync_RestoreFails_DoesNotResyncVolunteers()
+    {
+        // A still-suspended user is ineligible, and a single-user Volunteers sync REMOVES
+        // ineligible members — never sync when the restore did not succeed.
+        var userId = Guid.NewGuid();
+        _users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(NamedUserInfo(userId, UserState.Suspended)));
+        _membershipCalculator.GetMembershipSnapshotAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Snapshot());
+        _humanLifecycle.RestoreConsentSuspensionAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(false, "NotFound"));
+
+        await BuildSut().EnsureActiveAsync(userId);
+
+        await _systemTeamSync.DidNotReceive().SyncMembershipForUserAsync(
+            Arg.Any<Guid>(), Arg.Any<SystemTeamType>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -49,6 +49,13 @@ export async function liveLoginAndSave(context: BrowserContext, slug: string): P
   // persona occasionally push the response past 60 s, causing a flaky setup failure
   // that Playwright then heals on retry. The extra headroom eliminates the retry.
   await page.waitForSelector(NAV_SELECTOR, { timeout: 90_000 });
+  // A non-Active persona still logs in and still renders the nav — it just lands on
+  // the account-status wall (or the onboarding name gate) instead of the app. Fail the
+  // run HERE with the persona named, instead of ~30 scattered /User/Status redirects
+  // in the feature specs (#867).
+  if (/\/User\/Status|\/OnboardingWidget/.test(page.url())) {
+    throw new Error(`persona ${slug} is not Active — landed on ${page.url()}`);
+  }
   await context.storageState({ path: authFile(slug) });
   await page.close();
 }


### PR DESCRIPTION
Fixes the E2E QA suite red since 2026-06-11 (nobodies-collective/Humans#867).

## Root cause (evidence-based)

- Dev personas hold governance roles but **never signed the required legal documents** — the seeder only clears the consent-*check* gate, which is a different thing.
- The nightly `SuspendNonCompliantMembersJob` therefore suspended every role-holding persona once a required document's grace period lapsed. The QA audit log (`/AuditLog?filter=MemberSuspended`) shows the 11-persona batches on 2026-04-03…06 at 04:30, plus singles as newer personas (events/store/cantina/e-e-team admin) were created — exactly the persona set behind the ~34 failing tests. `volunteer`/`coordinator`/`city-planning`/`barrio-1-lead` hold no governance role, matching the ~87 passing.
- The suite stayed green until the UserState access refactor (peterdrier/Humans#881, `bf42fd0d`, 2026-06-07) made the stored non-Active state wall off every app page via `MembershipRequiredFilter` → suspended personas started bouncing to `/User/Status`.
- `EnsurePersonaAsync` early-returned for existing personas, so seeding could never repair them.

## cc159bd7 lead ruled out at source

The UnlinkAsync verified-floor guard only ever **throws before mutating** (it blocks an unlink); nothing in that path writes `User.State` or profile lifecycle fields, and state classification doesn't depend on emails. Timing also excludes it: the first broadly-failing run was 2026-06-12T19:30, the commit was authored 2026-06-13 18:52. **No real user can be driven non-Active by it.**

## Fix (canonical service paths only — no QA state edits)

- `DevPersonaSeeder.EnsureActiveAsync` runs on every dev sign-in and at creation: submits missing required consents via `IConsentService.SubmitConsentAsync` (whose completion already lifts a consent suspension via `RestoreConsentSuspensionAsync`), then calls `IHumanLifecycleService.RestoreConsentSuspensionAsync` for the required-set-shrank-but-still-Suspended case. Idempotent; guest/no-name personas are skipped (no profile / blanked names — cannot consent, hold no roles).
- Seeding consents at creation means a brand-new persona is no longer suspended at the next 04:30 run (the May/June single-suspension pattern).
- `tests/e2e/helpers/auth.ts`: `liveLoginAndSave` now throws with the persona named when login lands on `/User/Status` or `/OnboardingWidget`; the aggregate assert in `auth.setup.ts` fails the setup project, so the feature suite is skipped instead of producing ~30 scattered redirect failures.
- The `admin-shell` "Overview in Google" assertion needs no change — expected to pass once the admin persona is Active with full role claims (issue ask 3).

## Verification

- 4 new unit tests (`DevPersonaSeederTests`): missing-consents submit + restore, nothing-missing-still-suspended restore, profileless/blank-name skip, existing-persona path runs the repair.
- Full suite: Domain 271 ✅, Web 344 ✅ (incl. new), Analyzers 222 ✅, Application 3854 ✅. Integration tests need Docker (not running locally) — CI covers them.
- First E2E run against QA after this deploys should repair all personas on `auth.setup`'s logins and go green; follow-up nobodies-collective/Humans#767 (quarantine discipline) is the guard against a silent month-red recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)