### PR TITLE
feat(surveys): add LoggedInSince audience with cutoff date (nobodies-collective/Humans#894)

### DIFF
--- a/docs/sections/survey.md
+++ b/docs/sections/survey.md
@@ -45,6 +45,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | OpensAt / ClosesAt | Instant? | optional open/close window |
 | AudienceType | SurveyAudienceType? | string-converted; null = no audience |
 | AudienceTeamId | Guid? | bare FK → Team (when `AudienceType = Team`) — **FK only**, no nav, no cross-section EF FK constraint |
+| AudienceLoggedInSince | Instant? | cutoff (when `AudienceType = LoggedInSince`); users with `LastLoginAt >= cutoff` match, `null` LastLoginAt never matches |
 | PublicSlug | string? | max 80; public answering link; requires `AllowAnonymous`; null = invite-only |
 | PublicStartedCount | int | slug-path "started" funnel counter (no per-person anchor) |
 | CreatedByUserId | Guid | bare FK → User — **FK only**, no nav, resolved via `IUserServiceRead` |
@@ -139,7 +140,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | SurveyQuestionType | SingleChoice, MultiChoice, ShortText, LongText, Rating |
 | ResponseAnonymity | Identified, CompletionTracked, Anonymous |
 | SurveyInputMethod | UserSpecificLink, Slug |
-| SurveyAudienceType | Team, AllActiveMembers, TicketHolders, ShiftParticipants |
+| SurveyAudienceType | Team, AllActiveMembers, TicketHolders, ShiftParticipants, LoggedInSince |
 | BranchCombine | All, Any |
 | BranchOperator | Is, IsNot, Answered, NotAnswered |
 
@@ -201,7 +202,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 
 ## Cross-Section Dependencies
 
-- **Users/Identity:** `IUserServiceRead` — resolve active-member ids for audience, and creator/respondent/recipient display names + preferred languages.
+- **Users/Identity:** `IUserServiceRead` — resolve active-member ids and `LoggedInSince`-audience ids (`UserInfo.LastLoginAt`), and creator/respondent/recipient display names + preferred languages.
 - **Teams:** `ITeamServiceRead` — `Team`-audience member ids and team display data.
 - **Tickets:** `ITicketServiceRead` — `TicketHolders`-audience recipient ids.
 - **Shifts:** `IShiftView` — `ShiftParticipants`-audience recipient ids.

--- a/src/Humans.Application/Interfaces/Surveys/ISurveyService.cs
+++ b/src/Humans.Application/Interfaces/Surveys/ISurveyService.cs
@@ -149,6 +149,7 @@ public sealed record SurveyEditInput(
     Instant? ClosesAt,
     SurveyAudienceType? AudienceType,
     Guid? AudienceTeamId,
+    Instant? AudienceLoggedInSince,
     string? PublicSlug,
     IReadOnlyList<QuestionInput> Questions);
 

--- a/src/Humans.Application/Services/Surveys/SurveyService.cs
+++ b/src/Humans.Application/Services/Surveys/SurveyService.cs
@@ -60,7 +60,7 @@ public sealed class SurveyService(
 
         var input = new SurveyEditInput(
             s.Title, s.Intro, s.ThankYou, s.DefaultCulture, s.AllowAnonymous, s.OpensAt, s.ClosesAt,
-            s.AudienceType, s.AudienceTeamId, s.PublicSlug,
+            s.AudienceType, s.AudienceTeamId, s.AudienceLoggedInSince, s.PublicSlug,
             s.Questions
                 .OrderBy(q => q.PageNumber).ThenBy(q => q.Order)
                 .Select(q => new QuestionInput(
@@ -93,6 +93,7 @@ public sealed class SurveyService(
             ClosesAt = input.ClosesAt,
             AudienceType = input.AudienceType,
             AudienceTeamId = input.AudienceTeamId,
+            AudienceLoggedInSince = input.AudienceLoggedInSince,
             PublicSlug = NormalizeSlug(input.PublicSlug),
             CreatedByUserId = actorUserId,
             CreatedAt = now,
@@ -125,6 +126,7 @@ public sealed class SurveyService(
             ClosesAt = input.ClosesAt,
             AudienceType = input.AudienceType,
             AudienceTeamId = input.AudienceTeamId,
+            AudienceLoggedInSince = input.AudienceLoggedInSince,
             PublicSlug = NormalizeSlug(input.PublicSlug),
             UpdatedAt = now,
             Questions = questions,
@@ -185,7 +187,7 @@ public sealed class SurveyService(
         var input = new SurveyEditInput(
             new LocalizedText(title), new LocalizedText(intro), new LocalizedText(thankYou),
             e.DefaultCulture, e.AllowAnonymous, e.OpensAt, e.ClosesAt,
-            e.AudienceType, e.AudienceTeamId, e.PublicSlug,
+            e.AudienceType, e.AudienceTeamId, e.AudienceLoggedInSince, e.PublicSlug,
             questions.Select(q => q.Question with
             {
                 Prompt = new LocalizedText(q.Prompt),
@@ -232,7 +234,7 @@ public sealed class SurveyService(
         var survey = await repo.GetByIdAsync(surveyId, ct);
         if (survey?.AudienceType is null) return 0;
 
-        var recipients = await ResolveRecipientIdsAsync(survey.AudienceType.Value, survey.AudienceTeamId, ct);
+        var recipients = await ResolveRecipientIdsAsync(survey.AudienceType.Value, survey.AudienceTeamId, survey.AudienceLoggedInSince, ct);
         return recipients.Count;
     }
 
@@ -246,7 +248,7 @@ public sealed class SurveyService(
             throw new InvalidOperationException("Survey has no audience to invite.");
 
         var now = clock.GetCurrentInstant();
-        var target = await ResolveRecipientIdsAsync(survey.AudienceType.Value, survey.AudienceTeamId, ct);
+        var target = await ResolveRecipientIdsAsync(survey.AudienceType.Value, survey.AudienceTeamId, survey.AudienceLoggedInSince, ct);
         var alreadyInvited = await repo.GetInvitedUserIdsAsync(surveyId, ct);
         var netNew = target.Except(alreadyInvited).ToList();
 
@@ -980,7 +982,7 @@ public sealed class SurveyService(
     /// interfaces. No marketing opt-out filter — surveys are System/always-send.
     /// </summary>
     private async Task<IReadOnlySet<Guid>> ResolveRecipientIdsAsync(
-        SurveyAudienceType type, Guid? teamId, CancellationToken ct)
+        SurveyAudienceType type, Guid? teamId, Instant? loggedInSince, CancellationToken ct)
     {
         switch (type)
         {
@@ -1013,6 +1015,21 @@ public sealed class SurveyService(
                     return views
                         .Where(kv => kv.Value.HasShift)
                         .Select(kv => kv.Key)
+                        .ToHashSet();
+                }
+
+            case SurveyAudienceType.LoggedInSince:
+                {
+                    // "Logged in on or after the cutoff" = LastLoginAt >= cutoff; null LastLoginAt never
+                    // matches (predates tracking). Deliberately no IsApproved filter — mid-onboarding
+                    // users belong in this audience (nobodies-collective/Humans#894) — but tombstones
+                    // (GDPR-anonymized/merged) and deletion-pending users are never invited.
+                    if (loggedInSince is null) return new HashSet<Guid>();
+                    var users = await userService.GetAllUserInfosAsync(ct);
+                    return users
+                        .Where(u => u.LastLoginAt is { } lastLogin && lastLogin >= loggedInSince.Value)
+                        .Where(u => !u.IsGdprAnonymized && !u.IsDeletionPending && !u.IsMerged)
+                        .Select(u => u.Id)
                         .ToHashSet();
                 }
 

--- a/src/Humans.Domain/Entities/Survey.cs
+++ b/src/Humans.Domain/Entities/Survey.cs
@@ -17,6 +17,7 @@ public class Survey
     public Instant? ClosesAt { get; set; }
     public SurveyAudienceType? AudienceType { get; set; }
     public Guid? AudienceTeamId { get; set; }                 // bare Guid when AudienceType == Team; no nav, no cross-section FK constraint
+    public Instant? AudienceLoggedInSince { get; set; }       // cutoff when AudienceType == LoggedInSince; users with LastLoginAt >= cutoff match
     public string? PublicSlug { get; set; }                   // public answering link; requires AllowAnonymous; null = invite-only
     public int PublicStartedCount { get; set; }               // slug-path "started" funnel counter (anonymous → no per-person anchor)
     public Guid CreatedByUserId { get; init; }                // bare FK: no nav, no cross-section EF FK constraint; resolve via IUserServiceRead

--- a/src/Humans.Domain/Enums/SurveyAudienceType.cs
+++ b/src/Humans.Domain/Enums/SurveyAudienceType.cs
@@ -10,5 +10,6 @@ public enum SurveyAudienceType
     Team = 0,
     AllActiveMembers = 1,
     TicketHolders = 2,
-    ShiftParticipants = 3
+    ShiftParticipants = 3,
+    LoggedInSince = 4
 }

--- a/src/Humans.Infrastructure/Migrations/20260713192905_AddSurveyAudienceLoggedInSince.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260713192905_AddSurveyAudienceLoggedInSince.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260713192905_AddSurveyAudienceLoggedInSince")]
+    partial class AddSurveyAudienceLoggedInSince
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260713192905_AddSurveyAudienceLoggedInSince.cs
+++ b/src/Humans.Infrastructure/Migrations/20260713192905_AddSurveyAudienceLoggedInSince.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSurveyAudienceLoggedInSince : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Instant>(
+                name: "AudienceLoggedInSince",
+                table: "surveys",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AudienceLoggedInSince",
+                table: "surveys");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Surveys/SurveyRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Surveys/SurveyRepository.cs
@@ -57,6 +57,7 @@ internal sealed partial class SurveyRepository(IDbContextFactory<HumansDbContext
         existing.ClosesAt = survey.ClosesAt;
         existing.AudienceType = survey.AudienceType;
         existing.AudienceTeamId = survey.AudienceTeamId;
+        existing.AudienceLoggedInSince = survey.AudienceLoggedInSince;
         existing.PublicSlug = survey.PublicSlug;
         existing.UpdatedAt = survey.UpdatedAt;
 

--- a/src/Humans.Web/Controllers/SurveyAdminController.cs
+++ b/src/Humans.Web/Controllers/SurveyAdminController.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Humans.Application.Interfaces.Surveys;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
@@ -68,6 +69,12 @@ public class SurveyAdminController(
     {
         var actorId = GetCurrentUserId();
         if (actorId is null) return Forbid();
+
+        if (model.AudienceType == SurveyAudienceType.LoggedInSince && model.AudienceLoggedInSince is null)
+        {
+            ModelState.AddModelError(nameof(model.AudienceLoggedInSince),
+                "A \"Logged in since\" cutoff date is required for the LoggedInSince audience.");
+        }
 
         if (!ModelState.IsValid)
         {

--- a/src/Humans.Web/Models/SurveyViewModels.cs
+++ b/src/Humans.Web/Models/SurveyViewModels.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 using Humans.Web.Extensions;
 using NodaTime;
+using NodaTime.Text;
 
 namespace Humans.Web.Models;
 
@@ -124,6 +125,7 @@ public sealed class SurveyBuilderViewModel
     public LocalDateTime? ClosesAt { get; set; }
     public SurveyAudienceType? AudienceType { get; set; }
     public Guid? AudienceTeamId { get; set; }
+    public LocalDate? AudienceLoggedInSince { get; set; }
     public string? PublicSlug { get; set; }
 
     public List<SurveyQuestionBuilderViewModel> Questions { get; set; } = [];
@@ -137,6 +139,10 @@ public sealed class SurveyBuilderViewModel
     // datetime-local <input> values (empty when unset).
     public string OpensAtInput => FormatLocal(OpensAt);
     public string ClosesAtInput => FormatLocal(ClosesAt);
+
+    // date <input> value (empty when unset).
+    public string AudienceLoggedInSinceInput
+        => AudienceLoggedInSince is null ? string.Empty : LocalDatePattern.Iso.Format(AudienceLoggedInSince.Value);
 
     private static string FormatLocal(LocalDateTime? local)
         => local is null ? string.Empty : DateFormattingExtensions.PlacementDateTimePattern.Format(local.Value);
@@ -152,6 +158,7 @@ public sealed class SurveyBuilderViewModel
         ToInstant(ClosesAt, zone),
         AudienceType,
         AudienceType == SurveyAudienceType.Team ? AudienceTeamId : null,
+        AudienceType == SurveyAudienceType.LoggedInSince ? ToStartOfDayInstant(AudienceLoggedInSince, zone) : null,
         string.IsNullOrWhiteSpace(PublicSlug) ? null : PublicSlug,
         Questions.Select((q, i) => q.ToInput(i)).ToList());
 
@@ -171,6 +178,7 @@ public sealed class SurveyBuilderViewModel
             ClosesAt = FromInstant(e.ClosesAt, zone),
             AudienceType = e.AudienceType,
             AudienceTeamId = e.AudienceTeamId,
+            AudienceLoggedInSince = e.AudienceLoggedInSince?.InZone(zone).Date,
             PublicSlug = e.PublicSlug,
             Questions = e.Questions.Select(SurveyQuestionBuilderViewModel.FromInput).ToList(),
             Teams = teams,
@@ -182,6 +190,9 @@ public sealed class SurveyBuilderViewModel
 
     internal static Instant? ToInstant(LocalDateTime? local, DateTimeZone zone)
         => local?.InZoneLeniently(zone).ToInstant();
+
+    internal static Instant? ToStartOfDayInstant(LocalDate? date, DateTimeZone zone)
+        => date?.AtStartOfDayInZone(zone).ToInstant();
 
     internal static LocalDateTime? FromInstant(Instant? instant, DateTimeZone zone)
         => instant?.InZone(zone).LocalDateTime;

--- a/src/Humans.Web/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Humans.Web/Views/SurveyAdmin/Builder.cshtml
@@ -120,7 +120,7 @@
                         }
                     </select>
                 </div>
-                <div class="col-md-2" id="logged-in-since-field">
+                <div class="col-md-2" id="logged-in-since-field" style="@(Model.AudienceType == SurveyAudienceType.LoggedInSince ? "" : "display:none")">
                     <label class="form-label small">Logged in since</label>
                     <input type="date" name="AudienceLoggedInSince" value="@Model.AudienceLoggedInSinceInput" class="form-control form-control-sm" />
                 </div>

--- a/src/Humans.Web/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Humans.Web/Views/SurveyAdmin/Builder.cshtml
@@ -120,7 +120,11 @@
                         }
                     </select>
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-2" id="logged-in-since-field">
+                    <label class="form-label small">Logged in since</label>
+                    <input type="date" name="AudienceLoggedInSince" value="@Model.AudienceLoggedInSinceInput" class="form-control form-control-sm" />
+                </div>
+                <div class="col-md-4">
                     <label class="form-label small">Public link slug (optional; requires Allow anonymous)</label>
                     <input type="text" asp-for="PublicSlug" class="form-control form-control-sm" placeholder="e.g. feedback-2026" />
                 </div>
@@ -210,6 +214,17 @@
                 applyCulture();
                 updateMissingBadges();
             }));
+
+            // ── audience cutoff visibility ───────────────────────────────────
+            const audienceType = document.querySelector('select[name="AudienceType"]');
+            const loggedInSinceField = document.getElementById('logged-in-since-field');
+
+            function applyAudienceVisibility() {
+                loggedInSinceField.style.display = audienceType.value === 'LoggedInSince' ? '' : 'none';
+            }
+
+            audienceType.addEventListener('change', applyAudienceVisibility);
+            applyAudienceVisibility();
 
             // ── question cards ───────────────────────────────────────────────
             function applyTypeVisibility(card) {

--- a/tests/Humans.Application.Tests/Controllers/SurveysApiControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/SurveysApiControllerTests.cs
@@ -59,7 +59,7 @@ public class SurveysApiControllerTests
         var id = Guid.NewGuid();
         var qId = Guid.NewGuid();
         var editable = new SurveyEditInput(
-            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty, "en", false, null, null, null, null, null,
+            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty, "en", false, null, null, null, null, null, null,
             [
                 new QuestionInput(qId, 1, 0, SurveyQuestionType.SingleChoice, Text("Pick one"), LocalizedText.Empty,
                     true, null, null, LocalizedText.Empty, LocalizedText.Empty, null,

--- a/tests/Humans.Application.Tests/Surveys/SurveyServiceTests.cs
+++ b/tests/Humans.Application.Tests/Surveys/SurveyServiceTests.cs
@@ -50,7 +50,7 @@ public class SurveyServiceTests
         new(null, page, order, type, L(prompt), LocalizedText.Empty, false, null, null, LocalizedText.Empty, LocalizedText.Empty, null, opts.ToList());
 
     private static SurveyEditInput Input(params QuestionInput[] qs) =>
-        new(L("Title"), L("Intro"), L("Thanks"), "en", false, null, null, null, null, null, qs.ToList());
+        new(L("Title"), L("Intro"), L("Thanks"), "en", false, null, null, null, null, null, null, qs.ToList());
 
     [HumansFact]
     public async Task CreateAsync_persists_draft_with_questions_options_and_creator()
@@ -81,7 +81,7 @@ public class SurveyServiceTests
     }
 
     private static SurveyEditInput InputWithSlug(string? slug) =>
-        new(L("Title"), L("Intro"), L("Thanks"), "en", true, null, null, null, null, slug, []);
+        new(L("Title"), L("Intro"), L("Thanks"), "en", true, null, null, null, null, null, slug, []);
 
     [HumansTheory]
     [InlineData("admin")]
@@ -133,7 +133,7 @@ public class SurveyServiceTests
             new List<OptionInput> { Opt("yes", "Yes", 1) });
         var q2 = new QuestionInput(q2Id, 1, 2, SurveyQuestionType.SingleChoice, L("Q2"), LocalizedText.Empty, false, null, null,
             LocalizedText.Empty, LocalizedText.Empty, null, new List<OptionInput> { Opt("yes", "Yes", 1) });
-        var input = new SurveyEditInput(L("T"), L("I"), L("Ty"), "en", false, null, null, null, null, null, new List<QuestionInput> { q1, q2 });
+        var input = new SurveyEditInput(L("T"), L("I"), L("Ty"), "en", false, null, null, null, null, null, null, new List<QuestionInput> { q1, q2 });
 
         var act = async () => await CreateService().UpdateAsync(Guid.NewGuid(), input, Guid.NewGuid(), TestContext.Current.CancellationToken);
 
@@ -230,7 +230,7 @@ public class SurveyServiceTests
 
     // ── Invitations ──────────────────────────────────────────────────────────
 
-    private static Survey SurveyWith(SurveyStatus status, SurveyAudienceType? audience, Guid? teamId) => new()
+    private static Survey SurveyWith(SurveyStatus status, SurveyAudienceType? audience, Guid? teamId, Instant? loggedInSince = null) => new()
     {
         Id = Guid.NewGuid(),
         Title = L("My Survey"),
@@ -238,7 +238,13 @@ public class SurveyServiceTests
         Status = status,
         AudienceType = audience,
         AudienceTeamId = teamId,
+        AudienceLoggedInSince = loggedInSince,
     };
+
+    private static UserInfo UserWithLastLogin(Guid id, Instant? lastLogin) =>
+        UserInfo.Create(
+            new User { Id = id, PreferredLanguage = "en", LastLoginAt = lastLogin },
+            [], [], [], null, [], [], [], []);
 
     private static TeamInfo TeamWith(Guid teamId, params Guid[] memberUserIds) => new(
         teamId, "Team", null, "team",
@@ -260,6 +266,74 @@ public class SurveyServiceTests
         var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
 
         count.Should().Be(3);
+    }
+
+    [HumansFact]
+    public async Task PreviewAudienceCountAsync_loggedInSince_counts_only_users_logged_in_at_or_after_cutoff()
+    {
+        var cutoff = Instant.FromUtc(2026, 1, 1, 0, 0);
+        var survey = SurveyWith(SurveyStatus.Draft, SurveyAudienceType.LoggedInSince, null, cutoff);
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>()).Returns(new List<UserInfo>
+        {
+            UserWithLastLogin(Guid.NewGuid(), cutoff - Duration.FromDays(1)),  // before → excluded
+            UserWithLastLogin(Guid.NewGuid(), cutoff),                         // exactly at → included
+            UserWithLastLogin(Guid.NewGuid(), cutoff + Duration.FromDays(30)), // after → included
+            UserWithLastLogin(Guid.NewGuid(), null),                           // never logged in → excluded
+        });
+
+        var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
+
+        count.Should().Be(2);
+    }
+
+    [HumansFact]
+    public async Task PreviewAudienceCountAsync_loggedInSince_returns_zero_when_cutoff_missing()
+    {
+        var survey = SurveyWith(SurveyStatus.Draft, SurveyAudienceType.LoggedInSince, null);
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UserInfo> { UserWithLastLogin(Guid.NewGuid(), Instant.FromUtc(2026, 6, 1, 0, 0)) });
+
+        var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
+
+        count.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task SendInvitesAsync_loggedInSince_invites_only_matching_users()
+    {
+        var cutoff = Instant.FromUtc(2026, 1, 1, 0, 0);
+        Guid recent = Guid.NewGuid(), stale = Guid.NewGuid(), never = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Open, SurveyAudienceType.LoggedInSince, null, cutoff);
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(new HashSet<Guid>());
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>()).Returns(new List<UserInfo>
+        {
+            UserWithLastLogin(recent, cutoff + Duration.FromDays(3)),
+            UserWithLastLogin(stale, cutoff - Duration.FromDays(3)),
+            UserWithLastLogin(never, null),
+        });
+        _userEmailService.GetNotificationTargetEmailsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string>
+            {
+                [recent] = "recent@example.org",
+                [stale] = "stale@example.org",
+                [never] = "never@example.org",
+            });
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo>()));
+
+        var result = await CreateService().SendInvitesAsync(survey.Id, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.InvitationsCreated.Should().Be(1);
+        result.EmailsQueued.Should().Be(1);
+        await _repo.Received(1).AddInvitationAndSaveAsync(Arg.Is<SurveyInvitation>(i => i.UserId == recent), Arg.Any<CancellationToken>());
+        await _repo.DidNotReceive().AddInvitationAndSaveAsync(Arg.Is<SurveyInvitation>(i => i.UserId == stale), Arg.Any<CancellationToken>());
+        await _repo.DidNotReceive().AddInvitationAndSaveAsync(Arg.Is<SurveyInvitation>(i => i.UserId == never), Arg.Any<CancellationToken>());
+        _tokenProvider.Received(1).Create(Arg.Any<Guid>());
+        await _emailService.Received(1).SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]


### PR DESCRIPTION
Implements nobodies-collective/Humans#894 — a first-class survey audience for "everyone who logged into Humans on or after a cutoff date".

## What changed

- **Domain:** `SurveyAudienceType.LoggedInSince` (new enum value, string-converted column, fits existing max length); `Survey.AudienceLoggedInSince` (`Instant?`) stored alongside the existing `AudienceTeamId` audience param.
- **Application:** `ResolveRecipientIdsAsync` gains a `LoggedInSince` branch — `UserInfo.LastLoginAt >= cutoff`, `null` `LastLoginAt` never matches, read via the existing `IUserServiceRead.GetAllUserInfosAsync` (the `UserInfo` read model already carried `LastLoginAt`, so **no new cross-section interface method** was needed). Deliberately no `IsApproved` filter (mid-onboarding users are in scope per the issue), but GDPR-anonymized / merged / deletion-pending users are excluded — we never email tombstones.
- **Infrastructure:** `SurveyRepository.UpdateAsync` copies the new scalar; EF migration adds the nullable column (no backfill — historical `null`s simply don't match).
- **Web:** Builder shows a date picker when `LoggedInSince` is selected (server-rendered initial visibility + CSP-safe `addEventListener` toggle); `Save` validates the cutoff is required for this audience type; `ToEditInput` clears it for other audience types — mirroring how `AudienceTeamId` is handled. Cutoff is interpreted as start-of-day Europe/Madrid (matches the builder's existing `OpensAt`/`ClosesAt` zone) and round-trips losslessly on edit.
- **Docs:** `docs/sections/survey.md` data model / enum / cross-section tables updated.

## Migration

`20260713192905_AddSurveyAudienceLoggedInSince` — single nullable `AddColumn` on `surveys`, generator-pure (EF migration reviewer ran clean; snapshot delta is exactly the one property).

## Acceptance criteria

- [x] `SurveyAudienceType.LoggedInSince` added; resolver returns only users with `LastLoginAt >= cutoff`, excluding `null` — unit tests cover before/exactly-at/after/null boundary and the null-cutoff → empty case (`SurveyServiceTests`).
- [x] `Survey` stores the cutoff (EF migration); admin UI exposes a date picker for this audience type and validates it server-side as required.
- [x] Sending a `LoggedInSince` survey produces tokenised invitations only for matching users — `SendInvitesAsync_loggedInSince_invites_only_matching_users` asserts one invitation + token + queued email for the matching user only; the Identified/follow-up flow is untouched (shared resolver feeds the existing invite ledger/token/email path).

## New public surface

- `SurveyEditInput` gains one positional param (`Instant? AudienceLoggedInSince`) — enrichment of the existing authoring DTO, all 12 construction sites updated.
- `Survey.AudienceLoggedInSince` entity property + matching `SurveyBuilderViewModel.AudienceLoggedInSince` (`LocalDate?`, binds via the same NodaTime TypeConverter mechanism as the existing `OpensAt`/`ClosesAt` inputs).
- No new interfaces, no new service/repository methods, no new DI registrations.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors, no new warnings.
- `dotnet test Humans.slnx -v quiet` — Application tests 3857/3857 pass. (Integration tests require Docker/Testcontainers, unavailable in this environment — failures there are environmental and pre-existing.)
- Spec-compliance and code-review passes both PASS (no CRITICAL/WARNING findings). Noted for a possible follow-up: `Send.cshtml` shows the audience name but not the cutoff date; pre-existing stale comment in `TeamEarlyEntryViewModels.cs` claims `LocalDate` can't model-bind, which NodaTime 3.x TypeConverters disprove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)