### PR TITLE
fix(web): bind NodaTime LocalDateTime from seconds-less datetime-local posts (nobodies-collective/Humans#932)

### DIFF
--- a/src/Humans.Web/Infrastructure/LocalDateTimeModelBinder.cs
+++ b/src/Humans.Web/Infrastructure/LocalDateTimeModelBinder.cs
@@ -1,0 +1,85 @@
+using Humans.Application.Extensions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using NodaTime;
+using NodaTime.Text;
+
+namespace Humans.Web.Infrastructure;
+
+/// <summary>
+/// Binds NodaTime <see cref="LocalDateTime"/> (and <c>LocalDateTime?</c>) from
+/// <c>&lt;input type="datetime-local"&gt;</c> form posts. Browsers post the wire value
+/// WITHOUT seconds (<c>2026-07-14T10:30</c>) unless the user's picker happens to include
+/// them, while NodaTime's built-in <c>TypeConverter</c> (used by MVC's
+/// <c>SimpleTypeModelBinder</c>) requires seconds — so without this binder every
+/// non-empty datetime-local submit fails model binding (nobodies-collective/Humans#932).
+/// Accepts both <c>yyyy-MM-ddTHH:mm</c> and ISO with seconds/fractions.
+/// <c>LocalDate</c> is untouched: its TypeConverter parses <c>yyyy-MM-dd</c> fine.
+/// </summary>
+public sealed class LocalDateTimeModelBinder : IModelBinder
+{
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        ArgumentNullException.ThrowIfNull(bindingContext);
+
+        var valueResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+        if (valueResult == ValueProviderResult.None)
+            return Task.CompletedTask;
+
+        bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueResult);
+
+        var value = valueResult.FirstValue;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            // Mirror SimpleTypeModelBinder: empty binds to null for nullable models,
+            // and is a model error for non-nullable ones.
+            if (bindingContext.ModelMetadata.IsReferenceOrNullableType)
+            {
+                bindingContext.Result = ModelBindingResult.Success(null);
+            }
+            else
+            {
+                bindingContext.ModelState.TryAddModelError(
+                    bindingContext.ModelName,
+                    bindingContext.ModelMetadata.ModelBindingMessageProvider
+                        .ValueMustNotBeNullAccessor(valueResult.ToString()));
+            }
+            return Task.CompletedTask;
+        }
+
+        // No-seconds wire format first (what browsers actually post), then ISO with
+        // seconds (and optional fractions) for pickers/browsers that include them.
+        var parsed = DateFormattingExtensions.PlacementDateTimePattern.Parse(value);
+        if (!parsed.Success)
+            parsed = LocalDateTimePattern.ExtendedIso.Parse(value);
+
+        if (parsed.Success)
+        {
+            bindingContext.Result = ModelBindingResult.Success(parsed.Value);
+        }
+        else
+        {
+            bindingContext.ModelState.TryAddModelError(
+                bindingContext.ModelName,
+                bindingContext.ModelMetadata.ModelBindingMessageProvider
+                    .AttemptedValueIsInvalidAccessor(
+                        value,
+                        bindingContext.ModelMetadata.DisplayName ?? bindingContext.ModelName));
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Serves <see cref="LocalDateTimeModelBinder"/> for <c>LocalDateTime</c> and
+/// <c>LocalDateTime?</c> models. Registered ahead of the default providers in Program.cs.</summary>
+public sealed class LocalDateTimeModelBinderProvider : IModelBinderProvider
+{
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var modelType = context.Metadata.ModelType;
+        var underlying = Nullable.GetUnderlyingType(modelType) ?? modelType;
+        return underlying == typeof(LocalDateTime) ? new LocalDateTimeModelBinder() : null;
+    }
+}

--- a/src/Humans.Web/Models/SetCampSetupForm.cs
+++ b/src/Humans.Web/Models/SetCampSetupForm.cs
@@ -4,11 +4,13 @@ namespace Humans.Web.Models;
 
 /// <summary>
 /// Form binding for <c>POST /Shifts/Dashboard/VolunteerTracking/SetCampSetup</c>.
-/// <see cref="Date"/> is a wire-format ISO 8601 calendar date (yyyy-MM-dd) —
-/// NodaTime <c>LocalDate</c> cannot bind directly from form input
-/// (the project does not register an MVC <c>LocalDate</c> model binder).
-/// The controller parses the string with <c>LocalDatePattern.Iso.Parse</c>
-/// after the regex passes.
+/// <see cref="Date"/> is a wire-format ISO 8601 calendar date (yyyy-MM-dd),
+/// kept as a string with an explicit regex; the controller parses it with
+/// <c>LocalDatePattern.Iso.Parse</c> after the regex passes. Note: NodaTime
+/// <c>LocalDate</c> binds fine from form input via its TypeConverter (NodaTime ≥ 3.1)
+/// — the string field is a legacy workaround, not a necessity. The real form-binding
+/// hazard was <c>LocalDateTime</c> posted without seconds, now handled by
+/// <see cref="Infrastructure.LocalDateTimeModelBinder"/>.
 /// </summary>
 public sealed class SetCampSetupForm
 {

--- a/src/Humans.Web/Models/TeamEarlyEntryViewModels.cs
+++ b/src/Humans.Web/Models/TeamEarlyEntryViewModels.cs
@@ -9,7 +9,8 @@ namespace Humans.Web.Models;
 /// has its own page; multiple teams may have early entry enabled at once. The page
 /// lists this team's grants and offers add/edit/remove. <see cref="LocalDate"/> on
 /// rows is display-only; form POSTs use the string fields on the input models below
-/// — there is no MVC LocalDate binder.
+/// — a legacy workaround (NodaTime <c>LocalDate</c> binds fine from form input via
+/// its TypeConverter; NodaTime ≥ 3.1).
 /// </summary>
 public sealed class TeamEarlyEntryPageViewModel
 {
@@ -32,7 +33,8 @@ public sealed class TeamEarlyEntryRowViewModel
 
 /// <summary>Add-grant form input. The target team is resolved from the route slug,
 /// so no team field is bound. EntryDate is a string (yyyy-MM-dd) parsed in the
-/// controller via LocalDatePattern.Iso — LocalDate does not bind from form POST.
+/// controller via LocalDatePattern.Iso — a legacy workaround kept for its explicit
+/// validation (LocalDate itself binds fine from form POST via its TypeConverter).
 /// The empty-GUID guard for UserId lives at the service boundary.</summary>
 public sealed class AddTeamEarlyEntryInput
 {

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -451,7 +451,8 @@ var mvcBuilder = builder.Services.AddControllersWithViews(options =>
         options.Filters.Add<Humans.Web.Filters.AuthorizationPillFilter>();
 
         // datetime-local inputs post without seconds; NodaTime's LocalDateTime
-        // TypeConverter requires them. See LocalDateTimeModelBinder (#932).
+        // TypeConverter requires them. See LocalDateTimeModelBinder
+        // (nobodies-collective/Humans#932).
         options.ModelBinderProviders.Insert(0, new LocalDateTimeModelBinderProvider());
     })
     .AddViewLocalization(LanguageViewLocationExpanderFormat.Suffix)

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -449,6 +449,10 @@ var mvcBuilder = builder.Services.AddControllersWithViews(options =>
         options.Filters.Add<NameRequiredFilter>();
         options.Filters.Add<MembershipRequiredFilter>();
         options.Filters.Add<Humans.Web.Filters.AuthorizationPillFilter>();
+
+        // datetime-local inputs post without seconds; NodaTime's LocalDateTime
+        // TypeConverter requires them. See LocalDateTimeModelBinder (#932).
+        options.ModelBinderProviders.Insert(0, new LocalDateTimeModelBinderProvider());
     })
     .AddViewLocalization(LanguageViewLocationExpanderFormat.Suffix)
     .AddDataAnnotationsLocalization();

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Humans.Infrastructure.Data;
+using Humans.Integration.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+
+namespace Humans.Integration.Tests.Controllers;
+
+/// <summary>
+/// Real form-POST coverage for the survey builder's datetime-local fields
+/// (nobodies-collective/Humans#932): browsers post OpensAt/ClosesAt WITHOUT
+/// seconds, which the default NodaTime TypeConverter rejects. These tests
+/// exercise the full MVC model-binding path via LocalDateTimeModelBinder.
+/// </summary>
+public class SurveyAdminControllerTests(HumansWebApplicationFactory factory) : IntegrationTestBase(factory)
+{
+    private static readonly DateTimeZone Madrid = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+
+    [HumansFact(Timeout = 60000)]
+    public async Task Save_binds_OpensAt_and_ClosesAt_from_datetime_local_wire_formats()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+
+        // GET the builder to seed the antiforgery token + cookie.
+        var createResp = await Client.GetAsync("/Survey/Admin/Create", Xunit.TestContext.Current.CancellationToken);
+        createResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var token = ExtractAntiForgeryToken(await createResp.Content.ReadAsStringAsync(Xunit.TestContext.Current.CancellationToken));
+        token.Should().NotBeNullOrEmpty();
+
+        // OpensAt uses the browser's seconds-less wire format; ClosesAt includes
+        // seconds (some pickers do). Both must bind.
+        var saveResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", token!),
+            ("Title[en]", $"Integration test survey {Guid.NewGuid():N}"),
+            ("OpensAt", "2026-07-14T10:30"),
+            ("ClosesAt", "2026-08-01T18:45:30")), Xunit.TestContext.Current.CancellationToken);
+
+        // A model-binding failure re-renders the builder as 200; success redirects to Edit/{id}.
+        ((int)saveResp.StatusCode).Should().BeOneOf(
+            (int)HttpStatusCode.Found, (int)HttpStatusCode.Redirect);
+        var location = saveResp.Headers.Location!.ToString();
+        var idMatch = Regex.Match(location, "/Survey/Admin/Edit/(?<id>[0-9a-fA-F-]{36})",
+            RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(2));
+        idMatch.Success.Should().BeTrue($"expected redirect to Edit/{{id}}, got '{location}'");
+        var surveyId = Guid.Parse(idMatch.Groups["id"].Value);
+
+        // Persisted instants must round-trip the posted local times in Europe/Madrid.
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var survey = await db.Surveys.AsNoTracking()
+            .FirstAsync(s => s.Id == surveyId, Xunit.TestContext.Current.CancellationToken);
+
+        survey.OpensAt.Should().Be(
+            new LocalDateTime(2026, 7, 14, 10, 30).InZoneLeniently(Madrid).ToInstant());
+        survey.ClosesAt.Should().Be(
+            new LocalDateTime(2026, 8, 1, 18, 45, 30).InZoneLeniently(Madrid).ToInstant());
+    }
+
+    private static string? ExtractAntiForgeryToken(string html)
+    {
+        var match = Regex.Match(
+            html,
+            "name=\"__RequestVerificationToken\"[^>]{0,200}value=\"(?<token>[^\"]+)\"",
+            RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
+            TimeSpan.FromSeconds(2));
+        return match.Success ? match.Groups["token"].Value : null;
+    }
+
+    private static FormUrlEncodedContent BuildForm(params (string Key, string Value)[] fields)
+    {
+        return new FormUrlEncodedContent(fields.Select(f =>
+            new KeyValuePair<string, string>(f.Key, f.Value)));
+    }
+}

--- a/tests/Humans.Web.Tests/Infrastructure/LocalDateTimeModelBinderTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/LocalDateTimeModelBinderTests.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+using AwesomeAssertions;
+using Humans.Web.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Web.Tests.Infrastructure;
+
+/// <summary>
+/// MVC model-binding coverage for datetime-local wire values
+/// (nobodies-collective/Humans#932). Runs the real binder against a form value
+/// provider; the full form-POST path is covered by
+/// Humans.Integration.Tests SurveyAdminControllerTests (Docker required).
+/// </summary>
+public class LocalDateTimeModelBinderTests
+{
+    [HumansTheory]
+    [InlineData("2026-07-14T10:30", 2026, 7, 14, 10, 30, 0)]      // browser datetime-local: no seconds
+    [InlineData("2026-07-14T10:30:45", 2026, 7, 14, 10, 30, 45)]  // some pickers include seconds
+    public async Task Binds_datetime_local_wire_formats(
+        string wireValue, int year, int month, int day, int hour, int minute, int second)
+    {
+        var context = CreateContext(typeof(LocalDateTime?), wireValue);
+
+        await new LocalDateTimeModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeTrue();
+        context.Result.Model.Should().Be(new LocalDateTime(year, month, day, hour, minute, second));
+        context.ModelState.ErrorCount.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task Empty_value_binds_to_null_for_nullable()
+    {
+        var context = CreateContext(typeof(LocalDateTime?), "");
+
+        await new LocalDateTimeModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeTrue();
+        context.Result.Model.Should().BeNull();
+        context.ModelState.ErrorCount.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task Unparsable_value_adds_model_error()
+    {
+        var context = CreateContext(typeof(LocalDateTime?), "not-a-date");
+
+        await new LocalDateTimeModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeFalse();
+        context.ModelState["OpensAt"]!.Errors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Contain("not-a-date");
+    }
+
+    [HumansTheory]
+    [InlineData(typeof(LocalDateTime))]
+    [InlineData(typeof(LocalDateTime?))]
+    public void Provider_serves_LocalDateTime_models(Type modelType)
+    {
+        GetBinderFor(modelType).Should().BeOfType<LocalDateTimeModelBinder>();
+    }
+
+    [HumansFact]
+    public void Provider_leaves_LocalDate_to_its_TypeConverter()
+    {
+        GetBinderFor(typeof(LocalDate?)).Should().BeNull();
+    }
+
+    private static IModelBinder? GetBinderFor(Type modelType)
+    {
+        var metadata = new EmptyModelMetadataProvider().GetMetadataForType(modelType);
+        return new LocalDateTimeModelBinderProvider().GetBinder(new TestModelBinderProviderContext(metadata));
+    }
+
+    private static DefaultModelBindingContext CreateContext(Type modelType, string wireValue)
+    {
+        var form = new FormCollection(new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["OpensAt"] = wireValue,
+        });
+
+        return (DefaultModelBindingContext)DefaultModelBindingContext.CreateBindingContext(
+            new ActionContext { HttpContext = new DefaultHttpContext() },
+            new FormValueProvider(BindingSource.Form, form, CultureInfo.InvariantCulture),
+            new EmptyModelMetadataProvider().GetMetadataForType(modelType),
+            bindingInfo: null,
+            modelName: "OpensAt");
+    }
+
+    private sealed class TestModelBinderProviderContext(ModelMetadata metadata) : ModelBinderProviderContext
+    {
+        public override BindingInfo BindingInfo { get; } = new();
+        public override ModelMetadata Metadata { get; } = metadata;
+        public override IModelMetadataProvider MetadataProvider { get; } = new EmptyModelMetadataProvider();
+        public override IModelBinder CreateBinder(ModelMetadata metadata) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Fixes nobodies-collective/Humans#932.

## Problem

`Builder.cshtml` posts `<input type="datetime-local" name="OpensAt">` into `SurveyBuilderViewModel.OpensAt` (`LocalDateTime?`). Browsers post datetime-local **without seconds** (`2026-07-14T10:30`); NodaTime's `LocalDateTime` TypeConverter (used by MVC's `SimpleTypeModelBinder` — no custom binder was registered) requires seconds, so every non-empty Opens/Closes submit failed model binding with "The value '…' is not valid for OpensAt."

## Fix — convention-level, not per-form

- **`src/Humans.Web/Infrastructure/LocalDateTimeModelBinder.cs`** — a project-wide MVC `IModelBinder` + `IModelBinderProvider` for `LocalDateTime` / `LocalDateTime?`, registered ahead of the default providers in `Program.cs`'s `AddControllersWithViews` options. Accepts the seconds-less wire format (reusing the existing `DateFormattingExtensions.PlacementDateTimePattern`, `yyyy-MM-ddTHH:mm` — the HUM0030 sanctioned format home; no new format literals) and falls back to `LocalDateTimePattern.ExtendedIso` for pickers that include seconds/fractions. Empty → null for nullable models; unparsable → the standard `AttemptedValueIsInvalid` model error. This also fixes the identical latent bug on `ContainerViewModels.PlacementOpensAt/ClosesAt`.
- **`LocalDate` is untouched** — the provider returns null for it, so its already-working TypeConverter binding (`yyyy-MM-dd`) is unchanged.

Rejected alternatives: a string wire field + lenient parse (the `SetCampSetupForm` pattern) fixes only this one form and spreads the workaround; rendering/accepting seconds (`step="1"` + `:ss`) is insufficient because some browsers still drop seconds (per the issue).

## Stale comment corrections (part 2 of the issue)

- `src/Humans.Web/Models/SetCampSetupForm.cs`
- `src/Humans.Web/Models/TeamEarlyEntryViewModels.cs`

Both claimed NodaTime `LocalDate` cannot model-bind from form input. It can (NodaTime ≥ 3.1 ships TypeConverters); the real hazard was `LocalDateTime` without seconds. Comments corrected only — the string-field workaround itself is left as-is per the issue.

## Tests

- `tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs` — real form POST to `/Survey/Admin/Save` (admin persona, antiforgery token) with `OpensAt=2026-07-14T10:30` (no seconds) and `ClosesAt=2026-08-01T18:45:30` (with seconds); asserts the redirect to Edit/{id} and the persisted Europe/Madrid instants. Note: the standard CI test job excludes `~Integration` (Docker/Testcontainers); this runs with the rest of the integration suite.
- `tests/Humans.Web.Tests/Infrastructure/LocalDateTimeModelBinderTests.cs` — CI-run MVC binding tests: both wire formats, empty→null, unparsable→model error, and provider scope (serves `LocalDateTime`/`LocalDateTime?`, leaves `LocalDate` alone).

`dotnet build` clean; full test suite (excluding Docker-dependent integration tests, matching CI's filter) green: 222 + 357 + 3651 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)