### PR TITLE
fix(surveys): exclude status-walled accounts from LoggedInSince audience

### DIFF
--- a/src/Humans.Application/Services/Surveys/SurveyService.cs
+++ b/src/Humans.Application/Services/Surveys/SurveyService.cs
@@ -1023,12 +1023,14 @@ public sealed class SurveyService(
                     // "Logged in on or after the cutoff" = LastLoginAt >= cutoff; null LastLoginAt never
                     // matches (predates tracking). Deliberately no IsApproved filter — mid-onboarding
                     // users belong in this audience (nobodies-collective/Humans#894) — but tombstones
-                    // (GDPR-anonymized/merged) and deletion-pending users are never invited.
+                    // (GDPR-anonymized/merged), deletion-pending users, and accounts walled off by
+                    // state (rejected/suspended — they can't reach the survey) are never invited.
                     if (loggedInSince is null) return new HashSet<Guid>();
                     var users = await userService.GetAllUserInfosAsync(ct);
                     return users
                         .Where(u => u.LastLoginAt is { } lastLogin && lastLogin >= loggedInSince.Value)
                         .Where(u => !u.IsGdprAnonymized && !u.IsDeletionPending && !u.IsMerged)
+                        .Where(u => u.State is not (UserState.Rejected or UserState.Suspended or UserState.AdminSuspended))
                         .Select(u => u.Id)
                         .ToHashSet();
                 }

--- a/tests/Humans.Application.Tests/Surveys/SurveyServiceTests.cs
+++ b/tests/Humans.Application.Tests/Surveys/SurveyServiceTests.cs
@@ -241,9 +241,9 @@ public class SurveyServiceTests
         AudienceLoggedInSince = loggedInSince,
     };
 
-    private static UserInfo UserWithLastLogin(Guid id, Instant? lastLogin) =>
+    private static UserInfo UserWithLastLogin(Guid id, Instant? lastLogin, UserState? state = null) =>
         UserInfo.Create(
-            new User { Id = id, PreferredLanguage = "en", LastLoginAt = lastLogin },
+            new User { Id = id, PreferredLanguage = "en", LastLoginAt = lastLogin, State = state },
             [], [], [], null, [], [], [], []);
 
     private static TeamInfo TeamWith(Guid teamId, params Guid[] memberUserIds) => new(
@@ -285,6 +285,28 @@ public class SurveyServiceTests
         var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
 
         count.Should().Be(2);
+    }
+
+    [HumansFact]
+    public async Task PreviewAudienceCountAsync_loggedInSince_excludes_status_walled_accounts()
+    {
+        var cutoff = Instant.FromUtc(2026, 1, 1, 0, 0);
+        var recentLogin = cutoff + Duration.FromDays(3);
+        var survey = SurveyWith(SurveyStatus.Draft, SurveyAudienceType.LoggedInSince, null, cutoff);
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _userService.GetAllUserInfosAsync(Arg.Any<CancellationToken>()).Returns(new List<UserInfo>
+        {
+            UserWithLastLogin(Guid.NewGuid(), recentLogin, UserState.Active),         // included
+            UserWithLastLogin(Guid.NewGuid(), recentLogin, UserState.Bare),           // mid-onboarding → included
+            UserWithLastLogin(Guid.NewGuid(), recentLogin),                           // legacy null state → included
+            UserWithLastLogin(Guid.NewGuid(), recentLogin, UserState.Rejected),       // status wall → excluded
+            UserWithLastLogin(Guid.NewGuid(), recentLogin, UserState.Suspended),      // status wall → excluded
+            UserWithLastLogin(Guid.NewGuid(), recentLogin, UserState.AdminSuspended), // status wall → excluded
+        });
+
+        var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
+
+        count.Should().Be(3);
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

Fixes the Codex P2 finding on the prod promotion PR (nobodies-collective/Humans#934, review comment on `SurveyService.cs`): the `LoggedInSince` audience (nobodies-collective/Humans#894) included `Rejected` / `Suspended` / `AdminSuspended` accounts whose `LastLoginAt` is past the cutoff — `SendInvitesAsync` would create invitations and email survey links to accounts that can only see the account-status wall.

## Changes

- `SurveyService.ResolveRecipientIdsAsync` (`LoggedInSince` branch): additionally exclude `UserState.Rejected`, `Suspended`, and `AdminSuspended` via the existing `UserInfo.State`. Mid-onboarding (`Bare`) and legacy null-state users stay in the audience per the nobodies-collective/Humans#894 intent; GDPR/merged/deletion-pending tombstone filtering is unchanged.
- Test: `PreviewAudienceCountAsync_loggedInSince_excludes_status_walled_accounts` covers all six states through the audience path (66/66 survey tests green).

Intended to be merged to fork main and ride the open prod promotion PR nobodies-collective/Humans#934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)