### PR TITLE
fix(google-sync): log Drive permission failures once

### DIFF
--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDrivePermissionsClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDrivePermissionsClient.cs
@@ -164,7 +164,9 @@ public sealed class GoogleDrivePermissionsClient(
         }
         catch (Google.GoogleApiException ex)
         {
-            logger.LogWarning(ex,
+            // Debug only — GoogleWorkspaceSyncService logs the failure with
+            // resource/role context (nobodies-collective/Humans#893).
+            logger.LogDebug(ex,
                 "Google API error granting {Role} to {Email} on {FileId}: Code={Code} Message={Message}",
                 role, userEmail, fileId, ex.Error?.Code, ex.Error?.Message);
             return new DrivePermissionMutationResult(
@@ -189,7 +191,9 @@ public sealed class GoogleDrivePermissionsClient(
         }
         catch (Google.GoogleApiException ex)
         {
-            logger.LogWarning(ex,
+            // Debug only — GoogleWorkspaceSyncService logs the failure with
+            // resource context (nobodies-collective/Humans#893).
+            logger.LogDebug(ex,
                 "Google API error deleting permission {PermissionId} on {FileId}: Code={Code} Message={Message}",
                 permissionId, fileId, ex.Error?.Code, ex.Error?.Message);
             return new GoogleClientError(ex.Error?.Code ?? 0, ex.Error?.Message);


### PR DESCRIPTION
## What
Drops the `GoogleDrivePermissionsClient` grant/delete failure logs from Warning to Debug, so each Drive permission grant/delete failure is logged exactly once — at the caller (`GoogleWorkspaceSyncService`), which has resource/role context.

## Why
Every Drive grant/delete failure was logged twice: once at the client with exception + stack trace, and again at the caller in HTTP format. Production saw 20 warning events for 10 actual failures over 5 days. The Debug demotion matches the existing `GetFileAsync` / `GetSharedDriveAsync` pattern in the same file, and keeps the full exception available at Debug verbosity when needed.

## Acceptance criteria
- [x] A Drive grant/delete failure produces exactly one warning log entry — client logs are Debug now; caller warnings at `GoogleWorkspaceSyncService.cs` (grant ~line 130, delete ~line 217) are the single Warning.
- [x] The retained log keeps resource id, role/permission id, and Google status code + message — grant: `{Role} {Email} {GoogleId} HTTP {Code}: {Message}`; delete: `{PermissionId} {GoogleId} HTTP {Code}: {Message}`.
- [x] No stack-trace spam — the exception-bearing log entry is now Debug-only; the retained caller warnings carry no exception.

## Not implemented (possible follow-up)
The issue's optional item — skipping delete attempts on **inherited** permissions (Google always rejects them with 403 "limited access must be leveraged") — is a separate behavioral decision and was deliberately not bundled here, per sprint gate review.

## Testing
- `dotnet build Humans.slnx -v quiet` — green
- `dotnet test tests/Humans.Application.Tests --filter FullyQualifiedName~GoogleIntegration` — 206 passed

Fixes nobodies-collective/Humans#893

🤖 Generated with [Claude Code](https://claude.com/claude-code)