### PR TITLE
fix(notifications): retry MailerLite 429s honoring Retry-After

### DIFF
--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -27,6 +27,10 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
     // ML's rate-limit window is 60s; used when a 429 carries no Retry-After header.
     private static readonly TimeSpan DefaultRetryAfter = TimeSpan.FromSeconds(60);
 
+    // Ceiling on honoring Retry-After (60s window + skew headroom) — a malformed or
+    // far-future header must not block callers for minutes; values above clamp to this.
+    private static readonly TimeSpan MaxRetryAfter = TimeSpan.FromSeconds(90);
+
     private static readonly JsonSerializerOptions Json = BuildJson();
     private readonly TrackedLock _gate = new("MailerLiteClient.Gate");
 
@@ -279,6 +283,7 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
                     _ => DefaultRetryAfter,
                 };
                 if (retryAfter < TimeSpan.Zero) retryAfter = TimeSpan.Zero;
+                if (retryAfter > MaxRetryAfter) retryAfter = MaxRetryAfter;
                 logger.LogWarning(
                     "MailerLite returned 429; retrying in {Delay:0.#}s (attempt {Attempt}/{MaxAttempts}): {Method} {Url}",
                     retryAfter.TotalSeconds, attempt, MaxSendAttempts, method, url);

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -22,6 +22,10 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
 {
     public const string HttpClientName = "mailerlite";
     private const string HumansGroupPrefix = "Humans - ";
+    private const int MaxSendAttempts = 3;
+
+    // ML's rate-limit window is 60s; used when a 429 carries no Retry-After header.
+    private static readonly TimeSpan DefaultRetryAfter = TimeSpan.FromSeconds(60);
 
     private static readonly JsonSerializerOptions Json = BuildJson();
     private readonly TrackedLock _gate = new("MailerLiteClient.Gate");
@@ -246,24 +250,52 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
     {
         using var _ = logger.TimeOperation(operation: caller);
         var http = httpFactory.CreateClient(HttpClientName);
-        using var req = new HttpRequestMessage(method, url);
-        if (content is not null) req.Content = content;
-        HttpResponseMessage resp;
-        try
+        for (var attempt = 1; ; attempt++)
         {
-            resp = await http.SendAsync(req, ct);
+            using var req = new HttpRequestMessage(method, url);
+            if (content is not null) req.Content = content;
+            HttpResponseMessage resp;
+            try
+            {
+                resp = await http.SendAsync(req, ct);
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "MailerLite HTTP call failed: {Method} {Url}", method, url);
+                throw;
+            }
+            catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+            {
+                // HttpClient timeout — surfaces as TaskCanceledException with no token cancel.
+                logger.LogError(ex, "MailerLite HTTP call timed out: {Method} {Url}", method, url);
+                throw;
+            }
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxSendAttempts)
+            {
+                var retryAfter = resp.Headers.RetryAfter switch
+                {
+                    { Delta: { } delta } => delta,
+                    { Date: { } date } => date - clock.GetCurrentInstant().ToDateTimeOffset(),
+                    _ => DefaultRetryAfter,
+                };
+                if (retryAfter < TimeSpan.Zero) retryAfter = TimeSpan.Zero;
+                logger.LogWarning(
+                    "MailerLite returned 429; retrying in {Delay:0.#}s (attempt {Attempt}/{MaxAttempts}): {Method} {Url}",
+                    retryAfter.TotalSeconds, attempt, MaxSendAttempts, method, url);
+                resp.Dispose();
+                // Detach the caller-owned content so disposing this request doesn't dispose it.
+                req.Content = null;
+                await Task.Delay(retryAfter, ct);
+                continue;
+            }
+            return await FinishSendAsync(resp, method, url, ct);
         }
-        catch (HttpRequestException ex)
-        {
-            logger.LogError(ex, "MailerLite HTTP call failed: {Method} {Url}", method, url);
-            throw;
-        }
-        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
-        {
-            // HttpClient timeout — surfaces as TaskCanceledException with no token cancel.
-            logger.LogError(ex, "MailerLite HTTP call timed out: {Method} {Url}", method, url);
-            throw;
-        }
+    }
+
+    // Post-response bookkeeping: proactive rate-limit backoff + non-2xx warning.
+    private async Task<HttpResponseMessage> FinishSendAsync(
+        HttpResponseMessage resp, HttpMethod method, string url, CancellationToken ct)
+    {
         if (resp.Headers.TryGetValues("X-RateLimit-Remaining", out var values)
             && int.TryParse(values.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining))
         {

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http.Headers;
 using AwesomeAssertions;
+using Humans.Application.Tests.AuditLog;
 using Humans.Infrastructure.Services.Mailer;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Humans.Application.Tests.Services.Mailer;
@@ -48,10 +50,31 @@ public class MailerLiteClientRetryTests
             "retries are bounded to 3 attempts, not an infinite loop");
     }
 
-    private static MailerLiteClient NewClient(HttpMessageHandler handler) =>
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_ClampsAbsurdRetryAfter_ToCeiling()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, HumansGroupPage);
+        handler.Enqueue429(retryAfterSeconds: 86400); // a day — clock skew / malformed header
+        var logger = new CapturingLogger<MailerLiteClient>();
+        var client = NewClient(handler, logger);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            Xunit.TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(250)); // don't sit out the (clamped) delay
+
+        var act = async () => await client.AssignSubscriberToGroupAsync("sub-1", "42", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "the clamped 90s delay is still pending when the token cancels");
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning && e.Message.Contains("retrying in 90s"),
+            "an absurd Retry-After must clamp to the 90s ceiling, not be honored verbatim");
+    }
+
+    private static MailerLiteClient NewClient(HttpMessageHandler handler, ILogger<MailerLiteClient>? logger = null) =>
         new(new StubHttpClientFactory(handler),
             NodaTime.SystemClock.Instance,
-            NullLogger<MailerLiteClient>.Instance);
+            logger ?? NullLogger<MailerLiteClient>.Instance);
 
     private sealed class ScriptedHandler : HttpMessageHandler
     {

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using Humans.Infrastructure.Services.Mailer;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Humans.Application.Tests.Services.Mailer;
+
+public class MailerLiteClientRetryTests
+{
+    private const string HumansGroupPage =
+        """{"data":[{"id":"42","name":"Humans - Test","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""";
+
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_RetriesAfter429_AndSucceeds()
+    {
+        var handler = new ScriptedHandler();
+        // Cache pre-populate: empty subscriber page, then a Humans-managed group.
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, HumansGroupPage);
+        handler.Enqueue429(retryAfterSeconds: 0);
+        handler.EnqueueJson(HttpStatusCode.OK, "{}");
+        var client = NewClient(handler);
+        var callsBeforeAssign = 2;
+
+        await client.AssignSubscriberToGroupAsync("sub-1", "42", Xunit.TestContext.Current.CancellationToken);
+
+        handler.Calls.Should().Be(callsBeforeAssign + 2,
+            "the 429 must be retried once and succeed on the second attempt");
+    }
+
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_GivesUpAfterBoundedRetries()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, HumansGroupPage);
+        for (var i = 0; i < 5; i++) handler.Enqueue429(retryAfterSeconds: 0);
+        var client = NewClient(handler);
+        var callsBeforeAssign = 2;
+
+        var act = async () => await client.AssignSubscriberToGroupAsync(
+            "sub-1", "42", Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            "exhausting bounded retries must still surface the failure");
+        handler.Calls.Should().Be(callsBeforeAssign + 3,
+            "retries are bounded to 3 attempts, not an infinite loop");
+    }
+
+    private static MailerLiteClient NewClient(HttpMessageHandler handler) =>
+        new(new StubHttpClientFactory(handler),
+            NodaTime.SystemClock.Instance,
+            NullLogger<MailerLiteClient>.Instance);
+
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public int Calls { get; private set; }
+
+        public void EnqueueJson(HttpStatusCode status, string body)
+            => _responses.Enqueue(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            });
+
+        public void Enqueue429(int retryAfterSeconds)
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Content = new StringContent("""{"message":"Too Many Attempts."}""",
+                    System.Text.Encoding.UTF8, "application/json"),
+            };
+            resp.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(retryAfterSeconds));
+            _responses.Enqueue(resp);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(_responses.Count > 0
+                ? _responses.Dequeue()
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"),
+                });
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.test/") };
+    }
+}


### PR DESCRIPTION
## What
`MailerLiteClient.SendAsync` now retries HTTP 429 responses up to 3 total attempts, honoring the `Retry-After` header (delta-seconds or HTTP-date form; 60s fallback matching MailerLite's rate-limit window) before giving up. The existing proactive `X-RateLimit-Remaining` backoff is unchanged.

## Why
Audience sync was silently dropping subscriber assign/unassign on real 429s — `EnsureSuccessStatusCode()` threw on the first attempt, `MailerAudienceSyncService.SyncAsync` logged a warning, and the operation was lost, causing MailerLite audiences to drift (~13 hard failures over 5 days in production).

## Acceptance criteria
- [x] A 429 from MailerLite triggers a `Retry-After`-honoring retry rather than throwing on the first attempt (`MailerLiteClientRetryTests.AssignSubscriberToGroupAsync_RetriesAfter429_AndSucceeds`)
- [x] Assign/unassign succeeds after a transient 429 — no audience drift (same test; unassign shares the same `SendAsync` path)
- [x] After exhausting bounded retries the failure is still logged — the final 429 flows through the existing non-2xx warning and surfaces to the sync service's existing failure logging (`AssignSubscriberToGroupAsync_GivesUpAfterBoundedRetries` proves 3-attempt bound, no infinite loop)

## Tests
- New `tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs` (reuses the existing ScriptedHandler pattern)
- Full unit suites green (3860 Application + 357 Web); integration tests skipped locally (Docker unavailable)

Fixes nobodies-collective/Humans#892

🤖 Generated with [Claude Code](https://claude.com/claude-code)