### PR TITLE
feat(agent): add Older/Newer paging to /Agent/Conversations admin view (nobodies-collective/Humans#930)

### DIFF
--- a/src/Humans.Web/Controllers/AgentController.cs
+++ b/src/Humans.Web/Controllers/AgentController.cs
@@ -79,10 +79,11 @@ public class AgentController(
         if (missing is not null) return missing;
 
         var isAdmin = User.IsInRole(RoleNames.Admin);
-        var rows = await LoadConversationsAsync(
+        var (rows, hasNext) = await LoadConversationsAsync(
             isAdmin, currentUser.Id, refusalsOnly, userId, page, cancellationToken);
         var listRows = await StitchListRowsAsync(rows, isAdmin, cancellationToken);
-        return View(new AgentConversationsViewModel(listRows, IsAdminView: isAdmin));
+        return View(new AgentConversationsViewModel(
+            listRows, IsAdminView: isAdmin, Page: page < 0 ? 0 : page, HasNext: hasNext));
     }
 
     [HttpGet("Conversation/{id:guid}")]
@@ -114,7 +115,7 @@ public class AgentController(
         return View(new AgentConversationDetailViewModel(conv, displayName, IsAdminView: isAdmin));
     }
 
-    private async Task<IReadOnlyList<AgentConversationListSnapshot>> LoadConversationsAsync(
+    private async Task<(IReadOnlyList<AgentConversationListSnapshot> Rows, bool HasNext)> LoadConversationsAsync(
         bool isAdmin, Guid currentUserId,
         bool refusalsOnly, Guid? userId, int page,
         CancellationToken ct)
@@ -124,10 +125,14 @@ public class AgentController(
         // otherwise crash the EF paging call with a 500.
         var safePage = page < 0 ? 0 : page;
         if (!isAdmin)
-            return await agent.GetHistoryAsync(currentUserId, take: 50, ct);
+            return (await agent.GetHistoryAsync(currentUserId, take: 50, ct), false);
 
-        return await agent.ListAllConversationsForAdminAsync(
-            refusalsOnly, userId, adminPageSize, safePage * adminPageSize, ct);
+        // Fetch one extra row so the view knows whether an older page exists.
+        var rows = await agent.ListAllConversationsForAdminAsync(
+            refusalsOnly, userId, adminPageSize + 1, safePage * adminPageSize, ct);
+        return rows.Count > adminPageSize
+            ? (rows.Take(adminPageSize).ToList(), true)
+            : (rows, false);
     }
 
     private async Task<List<AgentConversationRow>> StitchListRowsAsync(
@@ -178,10 +183,15 @@ public class AgentController(
 }
 
 /// <summary>List of conversations + an admin flag the view uses to decide whether
-/// to surface admin-only chrome (Human column, refusal filters).</summary>
+/// to surface admin-only chrome (Human column, refusal filters). Paging applies to
+/// the admin view only (the non-admin history is a fixed most-recent window):
+/// <see cref="Page"/> is zero-based and <see cref="HasNext"/> means an older page
+/// exists (detected by over-fetching one row).</summary>
 public sealed record AgentConversationsViewModel(
     IReadOnlyList<AgentConversationRow> Rows,
-    bool IsAdminView);
+    bool IsAdminView,
+    int Page = 0,
+    bool HasNext = false);
 
 /// <summary>One row in the conversations list. <see cref="DisplayName"/> is null
 /// for non-admin views (the column is hidden) and stitched in from

--- a/src/Humans.Web/Views/Agent/Conversations.cshtml
+++ b/src/Humans.Web/Views/Agent/Conversations.cshtml
@@ -63,3 +63,33 @@ else
         .Build();
     <partial name="_Table" model="table" />
 }
+
+@if (Model.IsAdminView && (Model.Page > 0 || Model.HasNext))
+{
+    // Older/Newer paging, preserving the filter query params (refusalsOnly, userId).
+    var baseRoute = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    foreach (var pair in Context.Request.Query)
+    {
+        if (string.Equals(pair.Key, "page", StringComparison.OrdinalIgnoreCase)) { continue; }
+        baseRoute[pair.Key] = pair.Value.ToString();
+    }
+
+    Dictionary<string, string?> RouteFor(int page)
+    {
+        return new Dictionary<string, string?>(baseRoute, StringComparer.OrdinalIgnoreCase)
+        {
+            ["page"] = page.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+    }
+
+    <nav aria-label="Pagination">
+        <ul class="pagination justify-content-center">
+            <li class="page-item @(Model.Page <= 0 ? "disabled" : "")">
+                <a class="page-link" asp-action="Conversations" asp-all-route-data="@RouteFor(Model.Page - 1)">Newer</a>
+            </li>
+            <li class="page-item @(Model.HasNext ? "" : "disabled")">
+                <a class="page-link" asp-action="Conversations" asp-all-route-data="@RouteFor(Model.Page + 1)">Older</a>
+            </li>
+        </ul>
+    </nav>
+}


### PR DESCRIPTION
Fixes nobodies-collective/Humans#930.

## Change
- `AgentController.LoadConversationsAsync` over-fetches one row (`adminPageSize + 1`) so the view knows whether an older page exists; returns `(Rows, HasNext)`.
- `AgentConversationsViewModel` gains `Page` (zero-based) and `HasNext`.
- `Views/Agent/Conversations.cshtml` renders Newer/Older links (admin-only chrome), preserving all filter query params (`refusalsOnly`, `userId`) via the same query-copy approach `_Pager.cshtml` uses.

## Notes
- The shared `_Pager`/`PagerViewModel` (numbered pages) was considered but requires a total count; no count method exists on `IAgentService`, and the issue explicitly proposed has-next via pageSize+1 to avoid growing the Application interface surface.
- Non-admin history remains a fixed most-recent-50 window — `GetHistoryAsync` has no skip parameter, and paging there would be a service-surface change.

## Acceptance criteria
- ✅ /Agent/Conversations can page back through the full conversation history (admin view, where paging exists server-side)
- ✅ Filter query params survive page navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)