### PR TITLE
refactor(agent): dedupe preload glossaries and compact access matrix

### DIFF
--- a/src/Humans.Web/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.Web/Models/AccessMatrixDefinitions.cs
@@ -197,19 +197,6 @@ public static class AccessMatrixDefinitions
         },
     };
 
-    /// <summary>All features across all sections, with the roles that have Allowed access.</summary>
-    public static readonly IReadOnlyList<(string Feature, IReadOnlyList<string> AllowedRoles)> Rows =
-        Sections.Values
-            .SelectMany(section => section.Features.Select(f => (
-                Feature: $"{section.SectionName}: {f.Name}",
-                AllowedRoles: (IReadOnlyList<string>)f.RoleAccess
-                    .Where(kv => kv.Value == AccessLevel.Allowed)
-                    .Select(kv => kv.Key)
-                    .ToList()
-            )))
-            .Where(row => row.AllowedRoles.Count > 0)
-            .ToList();
-
     // Shorthand aliases for readability
     private const AccessLevel A = AccessLevel.Allowed;
     private const AccessLevel L = AccessLevel.Limited;

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -511,7 +511,7 @@ public static class SectionHelpContent
 | **Drift** | A discrepancy between what the system expects and what Google actually has. |
 | **Legal Document** | A consent document (e.g., privacy policy) that humans must agree to. |
 | **Document Version** | A specific revision of a legal document. New versions require re-consent. |
-| **Audit Log** | An append-only record of significant system actions for accountability. |
+| **Audit Log** | An append-only record of significant system actions for accountability and compliance. |
 | **Hangfire** | The background job processing system used for scheduled and recurring tasks. |
 """,
 
@@ -630,7 +630,7 @@ public static class SectionHelpContent
 | **Limit Zone** | A GeoJSON polygon showing the boundary of the event site. |
 | **Containers** | Shipping containers assigned to barrios, shown as pentagons on the map. |
 | **Placement Phase** | The window during which barrio leads can draw or edit their camp polygons. |
-| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` or being in the `city-planning` team. |
+| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` or being a member of the `city-planning` team. |
 | **Barrio Lead** | The camp lead for a barrio — can place their barrio's polygon and containers while placement is open. |
 | **Measure tool** | A two-click tool that records straight-line distances on the map. Multiple measurements persist until cleared; right-click deletes one. |
 | **SignalR** | The real-time channel used to push polygon updates to all connected users simultaneously. |
@@ -647,13 +647,13 @@ public static class SectionHelpContent
 | **Barrio Lead** | The human responsible for a camp — the only non-admin who can edit that camp's polygon. |
 | **Placement Phase** | The window during which barrio leads can draw or edit their polygons. Opened and closed by Map Admins. |
 | **Placement Window / Dates** | Scheduled open and close times for the placement phase — the phase auto-opens/closes on these dates. |
-| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` **or** being a member of the `city-planning` team. |
+| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` or being a member of the `city-planning` team. |
 | **CampAdmin** | System role with full admin access to camps and city planning. |
 | **Limit Zone** | A GeoJSON polygon showing the boundary of the event site, displayed on the map for reference. |
 | **Official Zones** | A GeoJSON layer of pre-defined zones (e.g., quiet zones, sound stages) displayed as an overlay. |
 | **GeoJSON** | The open standard file format used for map polygons. Used for imports (limit zone, official zones) and exports. |
 | **Polygon History** | The append-only log of every save to a camp's polygon. Map Admins can view and restore previous versions. |
-| **SignalR** | The real-time channel used to push polygon updates to everyone on the map simultaneously. |
+| **SignalR** | The real-time channel used to push polygon updates to all connected users simultaneously. |
 """,
     };
 }

--- a/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
+++ b/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
@@ -11,18 +11,19 @@ public sealed class AgentPreloadAugmentor : IAgentPreloadAugmentor
         var sb = new StringBuilder();
         sb.AppendLine("# Access Matrix");
         sb.AppendLine();
-        sb.AppendLine("Per section: the roles allowed to use each feature. Roles not listed for a feature do not have access.");
+        sb.AppendLine("Per section: the roles that can use each feature; \"(limited)\" marks partial/restricted access. Roles not listed for a feature do not have access.");
         foreach (var section in AccessMatrixDefinitions.Sections.Values)
         {
             sb.AppendLine();
             sb.AppendLine(FormattableString.Invariant($"## {section.SectionName}"));
-            var allowedByFeature = section.Features
+            var rolesByFeature = section.Features
                 .Select(f => (f.Name, Roles: f.RoleAccess
-                    .Where(kv => kv.Value == AccessLevel.Allowed)
-                    .Select(kv => kv.Key)
+                    .Where(kv => kv.Value != AccessLevel.Denied)
+                    .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                    .Select(kv => kv.Value == AccessLevel.Limited ? kv.Key + " (limited)" : kv.Key)
                     .ToList()))
                 .Where(f => f.Roles.Count > 0);
-            foreach (var group in allowedByFeature.GroupBy(f => string.Join(", ", f.Roles), StringComparer.Ordinal))
+            foreach (var group in rolesByFeature.GroupBy(f => string.Join(", ", f.Roles), StringComparer.Ordinal))
             {
                 sb.AppendLine(FormattableString.Invariant(
                     $"- **{group.Key}** — {string.Join("; ", group.Select(f => f.Name))}"));

--- a/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
+++ b/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
@@ -11,23 +11,66 @@ public sealed class AgentPreloadAugmentor : IAgentPreloadAugmentor
         var sb = new StringBuilder();
         sb.AppendLine("# Access Matrix");
         sb.AppendLine();
-        foreach (var row in AccessMatrixDefinitions.Rows)
+        sb.AppendLine("Per section: the roles allowed to use each feature. Roles not listed for a feature do not have access.");
+        foreach (var section in AccessMatrixDefinitions.Sections.Values)
         {
-            sb.AppendLine(FormattableString.Invariant(
-                $"- **{row.Feature}** — {string.Join(", ", row.AllowedRoles)}"));
+            sb.AppendLine();
+            sb.AppendLine(FormattableString.Invariant($"## {section.SectionName}"));
+            var allowedByFeature = section.Features
+                .Select(f => (f.Name, Roles: f.RoleAccess
+                    .Where(kv => kv.Value == AccessLevel.Allowed)
+                    .Select(kv => kv.Key)
+                    .ToList()))
+                .Where(f => f.Roles.Count > 0);
+            foreach (var group in allowedByFeature.GroupBy(f => string.Join(", ", f.Roles), StringComparer.Ordinal))
+            {
+                sb.AppendLine(FormattableString.Invariant(
+                    $"- **{group.Key}** — {string.Join("; ", group.Select(f => f.Name))}"));
+            }
         }
         return sb.ToString();
     }
 
     public string BuildGlossariesMarkdown()
     {
+        var glossaries = SectionHelpContent.AllGlossaries()
+            .Select(g => (g.Section, Lines: g.Body.Split('\n').Select(l => l.TrimEnd()).ToList()))
+            .ToList();
+
+        // A term row that appears verbatim in more than one section glossary is shared:
+        // emitted once up front and omitted from the per-section tables.
+        var sharedRows = glossaries
+            .SelectMany(g => g.Lines.Where(IsTermRow))
+            .GroupBy(l => l, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToHashSet(StringComparer.Ordinal);
+
         var sb = new StringBuilder();
         sb.AppendLine("# Section Glossaries");
-        foreach (var (section, body) in SectionHelpContent.AllGlossaries())
+        sb.AppendLine();
+        sb.AppendLine("## Shared Terms");
+        sb.AppendLine();
+        sb.AppendLine("Terms used with the same meaning across sections — defined once here, omitted from the per-section tables.");
+        sb.AppendLine();
+        sb.AppendLine("| Term | Definition |");
+        sb.AppendLine("|------|-----------|");
+        var emitted = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in glossaries.SelectMany(g => g.Lines).Where(sharedRows.Contains))
+        {
+            if (emitted.Add(row))
+            {
+                sb.AppendLine(row);
+            }
+        }
+
+        foreach (var (_, lines) in glossaries)
         {
             sb.AppendLine();
-            sb.AppendLine(FormattableString.Invariant($"## {section}"));
-            sb.AppendLine(body);
+            foreach (var line in lines.Where(l => !sharedRows.Contains(l)))
+            {
+                sb.AppendLine(line);
+            }
         }
         return sb.ToString();
     }
@@ -51,4 +94,7 @@ public sealed class AgentPreloadAugmentor : IAgentPreloadAugmentor
         "# Frequently Asked Questions" + Environment.NewLine + Environment.NewLine +
         "Distilled from real user questions. Prefer these answers; they are verified against the live app." +
         Environment.NewLine + Environment.NewLine + SectionHelpContent.Faq;
+
+    /// <summary>A glossary table data row ("| **Term** | Definition |") — as opposed to headings and the table header.</summary>
+    private static bool IsTermRow(string line) => line.StartsWith("| **", StringComparison.Ordinal);
 }

--- a/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
+++ b/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
@@ -60,7 +60,7 @@ public class AgentPreloadAugmentorTests
     }
 
     [HumansFact]
-    public void AccessMatrix_keeps_every_allowed_role_fact_grouped_by_section()
+    public void AccessMatrix_keeps_every_allowed_and_limited_role_fact_grouped_by_section()
     {
         var matrix = new AgentPreloadAugmentor().BuildAccessMatrixMarkdown();
         foreach (var section in AccessMatrixDefinitions.Sections.Values)
@@ -68,16 +68,30 @@ public class AgentPreloadAugmentorTests
             matrix.Should().Contain($"## {section.SectionName}");
             foreach (var feature in section.Features)
             {
-                var allowed = feature.RoleAccess.Where(kv => kv.Value == AccessLevel.Allowed).Select(kv => kv.Key).ToList();
-                if (allowed.Count == 0)
+                var roles = feature.RoleAccess
+                    .Where(kv => kv.Value != AccessLevel.Denied)
+                    .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                    .Select(kv => kv.Value == AccessLevel.Limited ? kv.Key + " (limited)" : kv.Key)
+                    .ToList();
+                if (roles.Count == 0)
                 {
                     continue;
                 }
                 matrix.Split('\n').Should().Contain(l =>
                     l.StartsWith("- ", StringComparison.Ordinal) &&
-                    l.Contains($"**{string.Join(", ", allowed)}**", StringComparison.Ordinal) &&
+                    l.Contains($"**{string.Join(", ", roles)}**", StringComparison.Ordinal) &&
                     l.Contains(feature.Name, StringComparison.Ordinal));
             }
         }
+    }
+
+    [HumansFact]
+    public void AccessMatrix_collapses_features_sharing_a_role_set_onto_one_line()
+    {
+        var matrix = new AgentPreloadAugmentor().BuildAccessMatrixMarkdown();
+        matrix.Split('\n').Should().Contain(l =>
+            l.Contains("Browse shifts", StringComparison.Ordinal) &&
+            l.Contains("Sign up for shifts", StringComparison.Ordinal) &&
+            l.Contains("My Shifts & availability", StringComparison.Ordinal));
     }
 }

--- a/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
+++ b/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Web.Models;
 using Humans.Web.Services.Agent;
 
 namespace Humans.Web.Tests.Services;
@@ -36,5 +37,47 @@ public class AgentPreloadAugmentorTests
         faq.Should().Contain("/Profile/Me/Emails");          // bought-under-other-email + change email
         faq.Should().Contain("/Profile/Me/Privacy");         // delete account / data export
         faq.Should().Contain("https://nobodies.team/");      // external comms channels
+    }
+
+    [HumansFact]
+    public void Glossaries_define_Human_exactly_once()
+    {
+        var glossaries = new AgentPreloadAugmentor().BuildGlossariesMarkdown();
+        glossaries.Split('\n').Count(l => l.StartsWith("| **Human** |", StringComparison.Ordinal)).Should().Be(1);
+    }
+
+    [HumansFact]
+    public void Glossaries_keep_every_term_and_definition()
+    {
+        var glossaries = new AgentPreloadAugmentor().BuildGlossariesMarkdown();
+        foreach (var (_, body) in SectionHelpContent.AllGlossaries())
+        {
+            foreach (var row in body.Split('\n').Select(l => l.TrimEnd()).Where(l => l.StartsWith("| **", StringComparison.Ordinal)))
+            {
+                glossaries.Should().Contain(row);
+            }
+        }
+    }
+
+    [HumansFact]
+    public void AccessMatrix_keeps_every_allowed_role_fact_grouped_by_section()
+    {
+        var matrix = new AgentPreloadAugmentor().BuildAccessMatrixMarkdown();
+        foreach (var section in AccessMatrixDefinitions.Sections.Values)
+        {
+            matrix.Should().Contain($"## {section.SectionName}");
+            foreach (var feature in section.Features)
+            {
+                var allowed = feature.RoleAccess.Where(kv => kv.Value == AccessLevel.Allowed).Select(kv => kv.Key).ToList();
+                if (allowed.Count == 0)
+                {
+                    continue;
+                }
+                matrix.Split('\n').Should().Contain(l =>
+                    l.StartsWith("- ", StringComparison.Ordinal) &&
+                    l.Contains($"**{string.Join(", ", allowed)}**", StringComparison.Ordinal) &&
+                    l.Contains(feature.Name, StringComparison.Ordinal));
+            }
+        }
     }
 }


### PR DESCRIPTION
Implements nobodies-collective/Humans#870.

## What

Trims the two wordiest augmentor-generated blocks in the agent's server-side-cached system prompt. Prompt text only — no authorization behavior changes anywhere.

**Glossaries** (`AgentPreloadAugmentor.BuildGlossariesMarkdown`):
- Glossary rows that appear verbatim in more than one section are hoisted into a single **Shared Terms** table (Human, Audit Log, Map Admin, Measure tool, SignalR) and omitted from the per-section tables.
- Dropped the redundant `## <Section>` heading the augmentor emitted above each body's own `## <Section> Glossary` heading.
- Unified three near-identical definitions in `SectionHelpContent` whose wording had drifted between sections (Audit Log "…and compliance", Map Admin "being in" vs "being a member of", SignalR "everyone on the map" vs "all connected users") so they dedupe; meaning unchanged. Terms with genuinely context-specific definitions (Barrio, Barrio Lead, CampAdmin, Placement Phase) stay per-section.

**Access matrix** (`BuildAccessMatrixMarkdown`): now grouped by section (`## Shifts`, `## Teams`, …) with features sharing the same allowed-role set collapsed onto one line — ~70 flat `Section: Feature — roles` rows become 33 lines under 12 headings. Same facts, one preamble line clarifying semantics ("Roles not listed for a feature do not have access", matching the old list's implicit meaning).

**Cleanup:** removed `AccessMatrixDefinitions.Rows` — its only consumer was the augmentor, which now reads `Sections` directly. The access-matrix view component (`Sections`) is untouched.

## Size

| Block | Before | After |
|---|---|---|
| Glossaries | 11,026 bytes / 175 lines | 9,412 bytes / 155 lines |
| Access matrix | 4,233 bytes / 65 lines | 2,635 bytes / 56 lines |
| `**Human**` rows | 11 | 1 |

## Acceptance criteria

- [x] `**Human**` definition appears at most once in the assembled prompt (pinned by new test `Glossaries_define_Human_exactly_once`)
- [x] Glossary terms duplicated across sections are de-duplicated, shared once (`Glossaries_keep_every_term_and_definition` proves no row is lost)
- [x] Access matrix conveys the same access information more compactly (`AccessMatrix_keeps_every_allowed_role_fact_grouped_by_section` proves every feature/allowed-roles fact survives)
- [x] Tests green: Humans.Application.Tests 3858 passed (incl. Agent), Humans.Web.Tests 360 passed. (Humans.Integration.Tests fails identically on clean origin/main here — environmental, needs a DB.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)