### PR TITLE
fix(dashboard): let request-driven cancellation abort instead of logging Error (nobodies-collective/Humans#890)

### DIFF
--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -171,6 +171,10 @@ public class DashboardService(
                 hasTicket = userTicketCount > 0;
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // request aborted — let it abort, don't log as an error
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to load ticket status for user {UserId}", userId);
@@ -186,6 +190,10 @@ public class DashboardService(
                 participationStatus = info?.EventParticipations
                     .FirstOrDefault(p => p.Year == activeEvent.Year)?.Status;
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // request aborted — let it abort, don't log as an error
         }
         catch (OperationCanceledException ex)
         {


### PR DESCRIPTION
Fixes nobodies-collective/Humans#890.

## Change
In `DashboardService.GetMemberDashboardAsync`, added

```csharp
catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
{
    throw; // request aborted — let it abort, don't log as an error
}
```

ahead of the broad catches in the **ticket-holdings** block (the one from the log evidence) and the **participation** block — the two per-section lookups that receive the request token. The participation block's existing `OperationCanceledException` → Warning catch remains for cancellations not driven by the request token. The shift-related blocks don't take the token (their service calls have no `ct` parameter), so they can't see a request-driven OCE.

Existing `LogError` catches are untouched — genuine failures still log at Error with the exception.

## Acceptance criteria
- ✅ Navigating away mid-dashboard-load no longer produces an Error-level log entry (OCE rethrows, request aborts)
- ✅ A real failure in the ticket-holdings lookup still logs at Error with the exception

## Verification
Build green; Dashboard test suite 49/49 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)