### PR TITLE
fix(web): stop recording authenticated profile-picture aborts as 499s

### DIFF
--- a/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
+++ b/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
@@ -12,7 +12,9 @@ namespace Humans.Web.Middleware;
 /// count, so static assets, JSON APIs, health/metrics probes and the beacon
 /// endpoint are naturally excluded. Feeds the <c>/Admin/ClientStats</c> screen.
 /// Also records every error response (status &gt; 399, plus aborted requests as
-/// 499) into the tracker's rolling buffer for <c>/Debug/HttpErrors</c>. 429s are
+/// 499 — except authenticated profile-picture loads, see
+/// <see cref="MaybeRecordError"/>) into the tracker's rolling buffer for
+/// <c>/Debug/HttpErrors</c>. 429s are
 /// recorded by the rate limiter's OnRejected callback instead — its rejection
 /// short-circuits before this middleware runs.
 /// </summary>
@@ -57,6 +59,15 @@ public sealed class ClientStatsMiddleware(RequestDelegate next, IClientStatsTrac
     {
         var aborted = context.RequestAborted.IsCancellationRequested;
         if (context.Response.StatusCode <= 399 && !aborted)
+            return;
+
+        // List pages load ~30 profile pictures at once; navigating away aborts
+        // whatever is still in flight. For a logged-in user that's routine browsing,
+        // not an error — recording it floods /Debug/HttpErrors with 499s. Anonymous
+        // aborts still record: a 499 flood without a session is a scrape signal.
+        if (aborted
+            && context.User.Identity?.IsAuthenticated == true
+            && context.Request.Path.StartsWithSegments("/Profile/Picture", StringComparison.OrdinalIgnoreCase))
             return;
 
         // UseStatusCodePagesWithReExecute re-runs the pipeline (and this middleware)

--- a/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
@@ -98,6 +98,52 @@ public class ClientStatsMiddlewareTests
     }
 
     [HumansFact]
+    public async Task AbortedProfilePicture_AuthenticatedUser_IsNotRecorded()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "image/webp", ctx =>
+        {
+            ctx.Request.Path = "/Profile/Picture";
+            ctx.Request.QueryString = new QueryString("?id=abc&v=1");
+            ctx.RequestAborted = new CancellationToken(canceled: true);
+            ctx.User = AuthenticatedUser();
+        });
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task AbortedProfilePicture_AnonymousUser_IsRecordedAs499()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "image/webp", ctx =>
+        {
+            ctx.Request.Path = "/Profile/Picture";
+            ctx.RequestAborted = new CancellationToken(canceled: true);
+        });
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.StatusCode.Should().Be(499);
+    }
+
+    [HumansFact]
+    public async Task AbortedNonPicturePath_AuthenticatedUser_IsStillRecorded()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "text/html", ctx =>
+        {
+            ctx.RequestAborted = new CancellationToken(canceled: true);
+            ctx.User = AuthenticatedUser();
+        });
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.StatusCode.Should().Be(499);
+    }
+
+    private static System.Security.Claims.ClaimsPrincipal AuthenticatedUser()
+        => new(new System.Security.Claims.ClaimsIdentity(
+            [new System.Security.Claims.Claim(
+                System.Security.Claims.ClaimTypes.NameIdentifier, Guid.NewGuid().ToString())],
+            authenticationType: "Test"));
+
+    [HumansFact]
     public async Task ExceptionHandlerReExecute_RecordsOriginalPath()
     {
         var tracker = await RunAsync(HttpMethods.Get, 500, "text/html",


### PR DESCRIPTION
## Problem

`/Profile/Picture?id=...&v=...` was generating a lot of 499 entries in `/Debug/HttpErrors`.

Investigation: these are **not rate-limit rejections**. `/Profile/Picture` is already fully exempt from the rate limiter (`Program.cs` — "List pages legitimately load ~30 profile images at once"). The 499s come from `ClientStatsMiddleware`, which records any client-aborted request as a 499 ("Client Closed Request", nginx convention). List pages request ~30 pictures at once; navigating away before they finish aborts the in-flight loads, and each abort landed in the error buffer.

## Fix

`ClientStatsMiddleware.MaybeRecordError` now skips recording an aborted request when:
- the user is authenticated, **and**
- the path is `/Profile/Picture`

Anonymous aborts on the same path still record — a 499 flood without a session is a scrape signal worth keeping.

## Tests

- `AbortedProfilePicture_AuthenticatedUser_IsNotRecorded` (new, red before fix)
- `AbortedProfilePicture_AnonymousUser_IsRecordedAs499` (new)
- `AbortedNonPicturePath_AuthenticatedUser_IsStillRecorded` (new)
- Full suite green locally except `Humans.Integration.Tests` (Docker not running on this machine — Testcontainers; unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)