### PR TITLE
[THROWAWAY] probe: does a non-main-based PR get built?

### DIFF
--- a/docs/architecture/maintenance-log.md
+++ b/docs/architecture/maintenance-log.md
@@ -93,3 +93,5 @@ for the 2026-05-24→06-01 wave, so the 2026-06-11 snapshot is everyone's baseli
 | Cantina | 304 | — | — | never served |
 | Search | 132 | — | 2026-06-07 | #906 relevance-ranked, cache-only search rewrite |
 | Gdpr | 81 | — | — | never served |
+
+<!-- CI trigger verification probe — this branch is a throwaway. -->


### PR DESCRIPTION
Temporary verification probe for the `build.yml` trigger change. Base is `fix/ci-build-all-pr-bases`, **not** `main` — so under the old `branches: [ main ]` filter this PR would receive only `check-migrations` + `report`.

If `build` / `code-quality` / `detect-migration-changes` appear here, the fix works.

Will be closed without merging.