### PR TITLE
ci: build and test every PR, not only those based on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,15 @@ name: Build and Test
 on:
   push:
     branches: [ main ]
+  # Deliberately NO base-branch filter. `branches: [ main ]` on pull_request
+  # filters on the PR's *base*, so a stacked PR — one targeting another feature
+  # branch rather than main — silently got no build, no tests, no code-quality
+  # and no migration checks. That is how #1113-#1119 (the #858 per-section
+  # DbContext split, ~50k lines across seven PRs) sat for two weeks with
+  # `check-migrations` and `report` as their only checks; those two come from
+  # label-db.yml / pr-surface-report.yml, which never had a base filter.
+  # Preview-DB provisioning stays main-only — see preview-db.yml.
   pull_request:
-    branches: [ main ]
 
 env:
   DOTNET_VERSION: '10.0.x'


### PR DESCRIPTION
## The gap

`build.yml` filtered `pull_request` on `branches: [ main ]`. That filter matches the PR's **base**, so any *stacked* PR — one targeting another feature branch — received **no build, no tests, no code-quality, and no migration checks**.

The failure mode is silent: such a PR still shows green, because the only checks that ran are the ones whose workflows never had a base filter (`check-migrations` from `label-db.yml`, `report` from `pr-surface-report.yml`).

This is not hypothetical. **#1113–#1119** — the #858 per-section DbContext split, ~50k lines across seven PRs — have sat for two weeks with exactly those two checks each, and have **never once been compiled by CI**.

| PR | Base | Checks it got |
|---|---|---|
| #1112 | `main` | build, code-quality, detect-migration-changes, verify-migrations-apply, check-migrations, report |
| #1113–#1119 | `858/*` | check-migrations, report |

## The change

Drop the base filter so every PR builds regardless of base. Scope deliberately kept tight:

- `push` stays `main`-only — branch pushes shouldn't double-run alongside the PR build.
- `preview-db.yml` stays `main`-only — a stacked PR shouldn't provision its own cloned database.

## Verification — proven, not assumed

Opened a throwaway PR (#1131) based on **this branch** rather than `main`. Under the old filter it would have received only `check-migrations` + `report`. It received:

```
build, check-migrations, code-quality, detect-migration-changes, report, review
```

All four previously-missing checks now fire on a non-main base. Probe closed without merging.

## ⚠️ Follow-up for the #858 stack

Merging this does **not** retroactively start building #1113–#1119. For `pull_request` events GitHub resolves the workflow from the PR **merge commit**, so those PRs only pick this up once their base branches are updated from main — `858/00-design` first, then cascading down the chain.

Until that's done, the stack's green checkmarks still mean only "migrations parse", not "it compiles".

🤖 Generated with [Claude Code](https://claude.com/claude-code)