### PR TITLE
chore(deps): bump Hangfire.Core + Hangfire.AspNetCore to 1.8.24 in lockstep

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,9 +31,12 @@
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
     <!-- State Machine -->
     <PackageVersion Include="Stateless" Version="5.20.1" />
-    <!-- Background Jobs -->
-    <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
-    <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.23" />
+    <!-- Background Jobs.
+         Hangfire.Core and Hangfire.AspNetCore must move in lockstep: AspNetCore
+         pulls Hangfire.NetCore, which constrains Hangfire.Core to an *exact*
+         version. Bumping Core alone fails restore with NU1608. -->
+    <PackageVersion Include="Hangfire.Core" Version="1.8.24" />
+    <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.24" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.21.1" />
     <!-- Email -->
     <PackageVersion Include="MailKit" Version="4.17.0" />


### PR DESCRIPTION
## Why #1126 can't merge

Dependabot bumped `Hangfire.Core` 1.8.23 → 1.8.24 **alone**. That fails restore in every project:

```
error NU1608: Detected package version outside of dependency constraint:
Hangfire.NetCore 1.8.23 requires Hangfire.Core (= 1.8.23)
but version Hangfire.Core 1.8.24 was resolved.
```

`Hangfire.AspNetCore` pulls `Hangfire.NetCore`, which constrains `Hangfire.Core` to an **exact** version. The two must move together.

This is the same shape as the `HtmlSanitizer` / `AngleSharp` exact-pin pair in #1130 — Dependabot treats companion packages independently and produces a PR that cannot build. I added a comment above the pins so the constraint is visible where someone edits it, not only in a failed CI log.

**Supersedes #1126** (close it).

## Verification

- `dotnet restore` — clean, no NU1608
- `dotnet build Humans.slnx` — **0 errors**
- **4,517 non-Docker tests green** — Domain 271, Analyzers 222, Web 365, Application 3659

🤖 Generated with [Claude Code](https://claude.com/claude-code)