### PR TITLE
fix(agent): make 9 more sections reachable + FAQ for profile messaging

### DIFF
--- a/docs/superpowers/specs/2026-07-30-faq-proposals-production.md
+++ b/docs/superpowers/specs/2026-07-30-faq-proposals-production.md
@@ -1,0 +1,104 @@
+# Agent FAQ proposals — production, 2026-07-30
+
+Source: `/triage agent` against production. All 142 agent conversations (2026-05-03 → 2026-07-28)
+were fetched and read, not just the ones the API filters flag.
+
+## How this run differed from the last one
+
+The `refusalsOnly=true` filter returned **zero** results. That filter is not a knowledge-gap
+signal — `RefusalReason` is only written for rate-limiting and abuse flags
+(`AgentService.cs:75,82`), never for "I don't know". `handoffsOnly=true` returned 7 legacy rows;
+`HandedOffToFeedbackId` is hardcoded `null` on every new message (`AgentService.cs:236`), so it
+only ever surfaces pre-Issues-migration data. Neither filter is usable for KB triage as things
+stand. Reading the transcripts is the only reliable method today.
+
+The `SectionHelpContent.Faq` block added by the 2026-05-23 audit did its job: ticket transfer,
+early entry, shift bail and profile completion were all failing before it and answer cleanly
+after. The proposals below cover what is still failing in June–July.
+
+## Outcome of this run
+
+Most of what looked like FAQ gaps turned out to be plumbing, and was filed as bugs rather than
+drafted as FAQ text:
+
+| Issue | What |
+|---|---|
+| nobodies-collective#949 | `fetch_section_guide` dead-ends on an unknown key; two disjoint key namespaces |
+| nobodies-collective#951 | Whitelist covers 14 of 35 `docs/sections/*.md` — Events, Store, Scanner, Calendar unreachable |
+| nobodies-collective#952 | Turn can end with an empty reply — 8% of production conversations got nothing back |
+| nobodies-collective#953 | Profile messaging rejects a 1985-character body against a 2000-character limit |
+
+Clusters covering Expenses, Store, Events/WWW Guide, CityPlanning/barrio zones, Scanner and
+Calendar are **not** drafted as FAQ text here. Their content already exists in `docs/sections/`
+and is simply unreachable; hand-writing FAQ entries would duplicate it and create a second copy
+to keep in sync. Fixing #949 and #951 closes them at the source.
+
+Expenses specifically is held until **2026-08-03** — the expenses flow is still being worked out,
+and documenting it now would bake in a procedure that is about to change.
+
+`Gate` was added alongside `Scanner` beyond the eight listed in nobodies-collective#951: the one
+observed operator conversation ("how do I register people after scanning the ticket at the gate?")
+spans both docs, and answering it from `Scanner.md` alone would land the reader on a cross-
+reference to a doc the agent still could not fetch. Note also that the whitelist gap was measured
+against a `pr-1059` checkout with 35 section docs; `origin/main` has 36 (`Gate.md` landed since),
+so the pre-fix ratio is 14 of 36 rather than 14 of 35.
+
+## FAQ entry — private messaging *(shipped in this PR)*
+
+The only cluster that needed new prose. Added to `SectionHelpContent.Faq` in
+`src/Humans.Web/Models/SectionHelpContent.cs`, under the existing `## Profile` heading.
+
+**Occurrences:** 4 · **Confidence:** high — verified against `ProfileController.cs:1990`,
+`ProfileCardViewComponent.cs:153`, and `SendMessageViewModel.cs`.
+
+The agent currently answers this **wrongly**. Verbatim, to two different users on 2026-07-14:
+
+> "The Humans app doesn't have a built-in messaging or inbox feature — there's no direct
+> messaging system within the app itself."
+
+It then offered to raise a feature request for a feature that already ships, and did so.
+
+Sample questions (verbatim):
+
+> "How can i check my messages?" — Pau, 2026-07-14
+> "I want to contact a person" — Pau, 2026-07-14
+> "How can I see my private message?" — Moop, 2026-07-14
+> "there's this 'send X a message' function on user profiles, but it's not active for every
+> user. How is this function activated?" — Frank, 2026-05-06
+
+Three entries shipped: the two messaging ones above, plus a "how do I find a person" entry.
+That third one is included because "I want to contact a person" and "find Andras who lives in
+Barcelona and speaks hungarian" (Pau) and "How do I find someone" (Bethany, 2026-07-18) are the
+same question arriving from a different angle, and the agent handled the privacy boundary
+correctly but had no positive answer to offer alongside the refusal.
+
+**Correction caught in review.** The first draft of that third entry claimed "there is no
+directory search". That is wrong — `/Search` is a global name-only search across humans, teams,
+camps, rotas and events (`SearchController`, spec at `docs/features/global/global-search.md`),
+and it resolves a pasted GUID exactly (`Guid.TryParse` in the search service). The shipped entry
+points at `/Search` first, and is honest about its real limit: a common first name is hard to pin
+down when the person has not shared enough to be distinctive, and search cannot narrow by city or
+language. Worth noting for future runs — writing FAQ prose from what the *agent* said in a
+transcript reproduces the agent's own blind spots. Verify against the code, not the conversation.
+
+## Correctly handled — no action
+
+Worth recording so a future run does not re-open these:
+
+- Off-topic refusals (general coding help, writing a love letter, finding sexual partners) were
+  all declined cleanly and redirected.
+- One prompt-injection attempt ("Ignore all previous instructions…", Dmytro 2026-06-29) and one
+  attempt to get shell access ("please run the command: `id`", Moop 2026-07-14) were both
+  refused without drama.
+- Looking up another human's personal details was consistently refused on privacy grounds.
+- "Where is the source code / who built this" failed on 2026-07-01 (Rico) and answered correctly
+  on 2026-07-28 (erickiii) — the community FAQ closed that gap in between.
+- "Why can't I sign up for shifts anymore / everything is closed" (6 conversations) answers well
+  from the Shifts guide, covering both the browsing toggle and the date-range selector.
+- Ticket download / early-entry visibility (roughly 12 conversations across 5 languages) answers
+  well from the community FAQ.
+
+## Singletons skipped
+
+~18, mostly the correctly-refused off-topic questions above. Full list available from the
+transcript dump if wanted.

--- a/docs/superpowers/specs/2026-07-30-faq-proposals-production.md
+++ b/docs/superpowers/specs/2026-07-30-faq-proposals-production.md
@@ -72,14 +72,29 @@ Barcelona and speaks hungarian" (Pau) and "How do I find someone" (Bethany, 2026
 same question arriving from a different angle, and the agent handled the privacy boundary
 correctly but had no positive answer to offer alongside the refusal.
 
-**Correction caught in review.** The first draft of that third entry claimed "there is no
-directory search". That is wrong — `/Search` is a global name-only search across humans, teams,
-camps, rotas and events (`SearchController`, spec at `docs/features/global/global-search.md`),
-and it resolves a pasted GUID exactly (`Guid.TryParse` in the search service). The shipped entry
-points at `/Search` first, and is honest about its real limit: a common first name is hard to pin
-down when the person has not shared enough to be distinctive, and search cannot narrow by city or
-language. Worth noting for future runs — writing FAQ prose from what the *agent* said in a
-transcript reproduces the agent's own blind spots. Verify against the code, not the conversation.
+**Three corrections, all caught after the first draft.** Worth recording, because each one came
+from trusting a *description* of the code instead of the code:
+
+1. *"There is no directory search"* — written from what the agent said in the transcripts. Wrong:
+   `/Search` exists. Writing FAQ prose from an agent transcript reproduces the agent's own blind
+   spots.
+2. *"Replies then go directly by email between the two of you"* — wrong whenever the sender clears
+   "include my contact info". `EmailMessageFactory.FacilitatedMessage` sets
+   `replyTo = includeContactInfo ? senderEmail : null`, and the rendered body omits the address
+   too, so the recipient has no way to write back. Caught by Codex on the PR.
+3. *"Search matches names only… cannot narrow by city"* and *"pasting the GUID into /Search finds
+   them exactly"* — both wrong, and both came from reading the prose rather than the enum.
+   `SearchController`'s summary comment and `docs/features/global/global-search.md` describe the
+   feature as "name-only", but `SearchHumansAsync` passes `PersonSearchFields.PublicAll`, and
+   `PersonSearchFields.Bio` covers "Bio, city, contribution-interests, CV, pronouns,
+   AllActiveProfiles-visible ContactFields, and publicly-exposed emails". City **is** searchable;
+   languages are not. And the `Guid.TryParse` fast-path exists only in `SearchTeamsAsync` /
+   `SearchCampsAsync` / `SearchShiftsAsync` — the human bucket has none, so a person's id finds
+   nothing in `/Search`. `/Profile/{id}` is the route that works. Codex caught the field list; the
+   GUID error was found while verifying it.
+
+The stale "name-only" wording in `SearchController`'s summary and in `global-search.md` is real
+doc drift, surfaced separately rather than fixed here.
 
 ## Correctly handled — no action
 

--- a/src/Humans.Infrastructure/Services/Preload/AgentPreloadCorpusBuilder.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentPreloadCorpusBuilder.cs
@@ -14,9 +14,12 @@ public sealed class AgentPreloadCorpusBuilder(
     private static readonly IReadOnlyList<string> Tier1Sections =
         ["Onboarding", "Teams", "LegalAndConsent", "Governance", "Shifts", "Tickets", "Profiles", "Auth"];
 
+    // Keep in step with AgentSectionDocReader.Whitelist — a section the reader can serve but
+    // that never appears in this index is one the agent has no reason to ask for.
     private static readonly IReadOnlyList<string> Tier2Sections =
         ["Onboarding", "Teams", "LegalAndConsent", "Governance", "Shifts", "Tickets", "Profiles", "Auth",
-         "Budget", "Camps", "CityPlanning", "Campaigns", "Feedback", "GoogleIntegration"];
+         "Budget", "Camps", "CityPlanning", "Campaigns", "Feedback", "GoogleIntegration",
+         "Events", "Guide", "Store", "Scanner", "Gate", "Calendar", "Cantina", "Containers", "Issues"];
 
     private static readonly MemoryCacheEntryOptions HoldForever =
         new() { Priority = CacheItemPriority.NeverRemove };

--- a/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
+++ b/src/Humans.Infrastructure/Services/Preload/AgentSectionDocReader.cs
@@ -20,12 +20,19 @@ public sealed class AgentSectionDocReader(
     internal const string FolderPath = "docs/sections";
     private const string CacheKeyPrefix = "agent:section:";
 
+    // Every user-facing section. A section left off this list is unreachable: the agent
+    // either refuses the question outright or answers it from the community Discord FAQ
+    // with an "unofficial, may be outdated" disclaimer — even for a first-party feature.
+    // Operator/internal-only sections (Finance, Holded, Email, Mailer, AuditLog, Debug,
+    // admin-shell) stay off deliberately; add one when triage shows users asking about it.
     private static readonly HashSet<string> Whitelist =
         new(StringComparer.OrdinalIgnoreCase)
         {
             "Onboarding", "Teams", "LegalAndConsent", "Governance", "Shifts",
             "Tickets", "Profiles", "Auth", "Budget", "Camps",
-            "CityPlanning", "Campaigns", "Feedback", "GoogleIntegration"
+            "CityPlanning", "Campaigns", "Feedback", "GoogleIntegration",
+            "Events", "Guide", "Store", "Scanner", "Gate",
+            "Calendar", "Cantina", "Containers", "Issues"
         };
 
     // No expiration + NeverRemove: GitHub-backed content that only changes at release.

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -89,6 +89,28 @@ public static class SectionHelpContent
         then set it as your primary. Your sign-in is tied to your Google login / magic-link, which is
         separate from the addresses listed here.
 
+        **Q: How do I read messages sent to me / where is my inbox?**
+        There is no in-app inbox. When someone uses the "Send <name> a message" button on your
+        profile, the message is relayed to your registered email address — check the inbox for the
+        address listed at /Profile/Me/Emails. Replies then go directly by email between the two of
+        you.
+
+        **Q: Why does the "Send <name> a message" button appear on some profiles but not others?**
+        It shows only when all three are true: it is not your own profile; the person has no email
+        address set to "all active profiles" visibility (if their address is already visible to you,
+        you can just email them directly); and they have not switched off facilitated messages in
+        their communication preferences. Messages are capped at 2000 characters.
+
+        **Q: How do I find a specific person?**
+        Use the magnifying glass in the top nav, or go to /Search, and type their name (two
+        characters minimum). Search matches names only — humans, teams, camps, rotas, and events —
+        and only across what each person has chosen to make publicly visible. A common first name
+        is hard to pin down: if someone has not shared enough to make them distinctive, you may get
+        several matches or none, and narrowing by city or language is not something search can do.
+        If you have their profile id, pasting the GUID into /Search finds them exactly. Failing
+        that, /Team shows people you share a team with, and the community channels linked in the
+        footer at https://nobodies.team/ are the way to reach someone you have no other handle on.
+
         ## Account & privacy
 
         **Q: How do I delete my account / download my data?**

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -92,8 +92,9 @@ public static class SectionHelpContent
         **Q: How do I read messages sent to me / where is my inbox?**
         There is no in-app inbox. When someone uses the "Send <name> a message" button on your
         profile, the message is relayed to your registered email address — check the inbox for the
-        address listed at /Profile/Me/Emails. Replies then go directly by email between the two of
-        you.
+        address listed at /Profile/Me/Emails. Whether you can reply is the sender's choice: they
+        tick "include my contact info" when writing, and only then does the email carry their
+        address as the reply-to. Without it the message arrives with no way to write back.
 
         **Q: Why does the "Send <name> a message" button appear on some profiles but not others?**
         It shows only when all three are true: it is not your own profile; the person has no email
@@ -102,14 +103,15 @@ public static class SectionHelpContent
         their communication preferences. Messages are capped at 2000 characters.
 
         **Q: How do I find a specific person?**
-        Use the magnifying glass in the top nav, or go to /Search, and type their name (two
-        characters minimum). Search matches names only — humans, teams, camps, rotas, and events —
-        and only across what each person has chosen to make publicly visible. A common first name
-        is hard to pin down: if someone has not shared enough to make them distinctive, you may get
-        several matches or none, and narrowing by city or language is not something search can do.
-        If you have their profile id, pasting the GUID into /Search finds them exactly. Failing
-        that, /Team shows people you share a team with, and the community channels linked in the
-        footer at https://nobodies.team/ are the way to reach someone you have no other handle on.
+        Use the magnifying glass in the top nav, or go to /Search, and type at least two characters.
+        For people it matches the display name plus whatever they have chosen to make public — city,
+        bio, what they'd like to contribute, pronouns, and contact details set to "all active
+        profiles" visibility — so a city name does work as a search term. It does not search
+        languages, and it never matches anything someone has kept private. A common first name is
+        still hard to pin down: if the person has shared little, you may get many matches or none.
+        Search does not look people up by id — if you have their profile id, go straight to
+        /Profile/<id> instead. /Team lists people you share a team with, and the community channels
+        linked in the footer at https://nobodies.team/ are the way to reach someone otherwise.
 
         ## Account & privacy
 

--- a/tests/Humans.Application.Tests/Agent/AgentPreloadCorpusBuilderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentPreloadCorpusBuilderTests.cs
@@ -28,16 +28,23 @@ public class AgentPreloadCorpusBuilderTests
         text.Should().NotContain("**CityPlanning**");
     }
 
+    /// <summary>
+    /// A section the reader can serve but that never appears in the Tier2 index is one the
+    /// agent has no reason to ask for — the index is the only place it learns the key set.
+    /// Asserting against <c>KnownSections</c> rather than a hand-listed set keeps the two
+    /// lists from drifting apart the way they did before nobodies-collective#951.
+    /// </summary>
     [HumansFact]
-    public async Task Tier2_index_lists_all_fourteen_sections()
+    public async Task Tier2_index_lists_every_section_the_reader_can_serve()
     {
         var builder = MakeBuilder();
         var text = await builder.BuildAsync(AgentPreloadConfig.Tier2, Xunit.TestContext.Current.CancellationToken);
 
-        text.Should().Contain("**Budget**");
-        text.Should().Contain("**Camps**");
-        text.Should().Contain("**CityPlanning**");
-        text.Should().Contain("**Campaigns**");
+        var reader = new AgentSectionDocReader(
+            new StubSource(), new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<AgentSectionDocReader>.Instance);
+
+        text.Should().ContainAll(reader.KnownSections.Select(s => $"**{s}**"));
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Agent/AgentSectionDocReaderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentSectionDocReaderTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces;
+using Humans.Application.Tests.Architecture.Ratchet;
 using Humans.Infrastructure.Services.Preload;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -30,6 +31,25 @@ public class AgentSectionDocReaderTests
         content.Should().NotBeNullOrEmpty();
         source.LastFolder.Should().Be(AgentSectionDocReader.FolderPath);
         source.LastStem.Should().Be("Shifts", "the reader must canonicalize the key, not pass caller casing");
+    }
+
+    /// <summary>
+    /// A whitelisted key with no matching file is unreachable at runtime and fails silently —
+    /// <see cref="AgentSectionDocReader"/> swallows the GitHub 404 and returns null, and the
+    /// docs health check only probes Shifts, so a typo would never surface. The repo is the
+    /// source these docs are served from, so the local folder is the authority.
+    /// </summary>
+    [HumansFact]
+    public void Every_whitelisted_section_has_a_matching_doc_file()
+    {
+        var folder = Path.Combine(RatchetTestRunner.LocateRepoRoot(), "docs", "sections");
+        var stems = Directory.GetFiles(folder, "*.md").Select(Path.GetFileNameWithoutExtension).ToHashSet(StringComparer.Ordinal);
+
+        // Ordinal, not OrdinalIgnoreCase: GitHub paths are case-sensitive, and the reader
+        // fetches "{canonicalKey}.md" verbatim.
+        MakeReader(new FakeSource()).KnownSections.Should().OnlyContain(
+            key => stems.Contains(key),
+            "every whitelisted key is fetched as docs/sections/{key}.md with exact casing");
     }
 
     [HumansFact]


### PR DESCRIPTION
Implements nobodies-collective#951, plus the FAQ deliverable from the `/triage agent` run on production (2026-07-30, all 142 conversations read).

## What was broken

`AgentSectionDocReader.Whitelist` allowed **14 of the 36** `docs/sections/*.md` files. A section left off that list is unreachable: the agent either refuses the question outright or answers it from the community Discord FAQ with an "unofficial, may be outdated" disclaimer — for features that live in this app.

Real production examples:

```
2026-06-08  Belo (es)      "cómo pago con tarjeta"
   -> "pagos con tarjeta no son parte del sistema Humans de Nobodies Collective."   (Store exists)

2026-06-08  Inge           "Could I change the name of the organiser to 'team Nomade'?"
   -> "That's outside the scope of what I can help with here"                        (Events exists)

2026-06-25  Gate Terminal  "how do I register people after scanning the ticket at the gate?"
   -> answered entirely from the Discord FAQ, hedged as unofficial                   (Scanner + Gate exist)

2026-07-05  Axel           "How to export this selection in ics file?"
   -> "there's a shift calendar export feature in the app; I can look into how that
       works" — and then didn't, because it has no key for it                        (Calendar exists)
```

Separately, the agent told two users on 2026-07-14 that *"The Humans app doesn't have a built-in messaging or inbox feature"* and raised a feature request for it. The feature ships — `ProfileController.SendMessage`, gated in `ProfileCardViewComponent`.

## What this changes

**Reachability.** Adds `Events`, `Guide`, `Store`, `Scanner`, `Gate`, `Calendar`, `Cantina`, `Containers`, `Issues` to the whitelist and to `AgentPreloadCorpusBuilder.Tier2Sections` — a key the reader can serve but that never appears in the index is one the agent has no reason to ask for.

`Gate` is beyond the eight listed in the issue: the one observed operator conversation spans Scanner *and* Gate, and `Scanner.md` cross-references `Gate.md`, so whitelisting one without the other lands the reader on a doc the agent still cannot fetch.

`Expenses` is **deliberately held until 2026-08-03** — that flow is still being settled, and documenting it now would have the agent confidently describe a procedure that is about to change. Operator-only sections (Finance, Holded, Email, Mailer, AuditLog, Debug, admin-shell) stay off; the whitelist now carries a comment saying why, so the next person adding one knows the criterion.

Each newly whitelisted doc was read first and scanned for anything unsafe to surface to a volunteer. Store and Gate mention config-variable *names* (`STRIPE_STORE_WEBHOOK_SECRET`) but no values, at the same level of internal detail as the already-whitelisted Shifts and Tickets docs.

**FAQ.** Three entries under `## Profile` in `SectionHelpContent.Faq`: where messages arrive (email relay, no in-app inbox), what gates the "Send *name* a message" button, and how to find a person.

## Tests

- `Every_whitelisted_section_has_a_matching_doc_file` — checks the whitelist against the local `docs/sections` folder with **ordinal** casing. GitHub paths are case-sensitive and the reader swallows the 404 and returns null, so a typo'd key is unreachable *and silent*; `AgentDocsHealthCheck` only probes `Shifts`, so it would not catch it either.
- `Tier2_index_lists_every_section_the_reader_can_serve` — replaces a test that named four sections and was already misnamed ("all fourteen"). Asserts against `KnownSections`, so the whitelist and the index cannot drift apart again.

`dotnet build` clean, `Humans.Application.Tests` 3866/3866 green. Integration tests could not run locally — Docker is not running on this machine (`DockerUnavailableException` from the Testcontainers fixture), so all 113 failures are environmental and CI is the real check.

## Correction worth flagging

The first draft of the "how do I find a person" FAQ entry said *"there is no directory search"*, written from what the agent said in the transcripts. That is wrong — `/Search` is a global name-only search across humans/teams/camps/rotas/events and resolves a pasted GUID exactly. Caught in review; the shipped entry points at `/Search` first and is honest about its real limit (a common first name is hard to pin down when the person has not shared enough to be distinctive). Writing FAQ prose from an agent transcript reproduces the agent's own blind spots — verify against the code.

## Still open from the same triage run

- nobodies-collective#949 — `fetch_section_guide` dead-ends on an unknown key; the fix is to return the valid key list so the agent self-corrects. This PR makes the key set bigger, which makes discoverability matter more, not less.
- nobodies-collective#952 — a turn can end with an empty reply (8% of production conversations).
- nobodies-collective#953 — profile messaging rejects a 1985-character body against a 2000-character limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)