### PR TITLE
fix(e2e): root-cause and fix the 14 residual QA failures (#936)

### DIFF
--- a/tests/e2e/tests/admin-shell.spec.ts
+++ b/tests/e2e/tests/admin-shell.spec.ts
@@ -143,10 +143,18 @@ test.describe('Admin shell — sidebar visibility matrix', () => {
         await expect(section, `${role.name} should see group '${group.label}'`).toBeVisible();
 
         for (const item of group.items) {
-          // toBeAttached, not toBeVisible: system groups start collapsed on
-          // desktop, so their links render display:none until expanded.
+          // System groups start collapsed on desktop, so their links are
+          // display:none until expanded — hence toBeAttached rather than
+          // toBeVisible. Match on DOM text rather than getByRole: role locators
+          // resolve against the accessibility tree, which omits hidden elements,
+          // so on a collapsed group they find nothing and toBeAttached can never
+          // pass. (getByRole with includeHidden is not the fix — it also pulls
+          // icon glyph text into the accessible name, which breaks the anchor.)
+          // \s* absorbs whitespace contributed by each item's leading icon.
           await expect(
-            section.getByRole('link', { name: new RegExp(`^${escapeRegex(item)}\\b`) }),
+            section.locator('a').filter({
+              hasText: new RegExp(`^\\s*${escapeRegex(item)}\\b`),
+            }),
             `${role.name} should see item '${item}' in '${group.label}'`,
           ).toBeAttached();
         }
@@ -278,14 +286,16 @@ test.describe('Admin shell — chrome', () => {
     await expect(page.locator('body.admin-shell')).toHaveCount(0);
   });
 
-  test('dashboard tiles render: active humans, shift coverage, open feedback, recent activity', async ({ page }) => {
+  test('dashboard tiles render: active profiles, shift coverage, open feedback, recent activity', async ({ page }) => {
     await loginAsAdmin(page);
     await page.goto('/Admin');
 
-    // Tiles from _DashboardStats (active humans, shifts staffed, open feedback)
+    // Tiles from _DashboardStats. The "Active humans" tile was renamed to
+    // "Active (has profile)" by #546 (UserInfo-driven stats); the test was never
+    // updated, so this assertion had been failing against a label that no longer exists.
     const stats = page.locator('.stats');
     await expect(stats).toBeVisible();
-    await expect(stats.locator('.stat .label', { hasText: 'Active humans' })).toBeVisible();
+    await expect(stats.locator('.stat .label', { hasText: 'Active (has profile)' })).toBeVisible();
     await expect(stats.locator('.stat .label', { hasText: /Shifts staffed/ })).toBeVisible();
     await expect(stats.locator('.stat .label', { hasText: 'Open feedback' })).toBeVisible();
 

--- a/tests/e2e/tests/board.spec.ts
+++ b/tests/e2e/tests/board.spec.ts
@@ -11,7 +11,12 @@ test.describe('Board (09-administration + 18-board-voting)', () => {
     await loginAsBoard(page);
     await page.goto('/Admin');
 
-    await expect(page.locator('h1, h2').first()).toBeVisible();
+    // Assert a dashboard-specific element, not just a heading: the app uses
+    // UseStatusCodePagesWithReExecute("/Home/Error/{0}"), which renders
+    // Views/Home/Error.cshtml *at the original URL*. That view has its own
+    // h1 + h2, so `h1, h2` visible + `url contains /Admin` would still pass if
+    // board lost AnyAdminRole or /Admin returned any 4xx/5xx.
+    await expect(page.locator('.stats')).toBeVisible();
     expect(page.url()).toContain('/Admin');
   });
 

--- a/tests/e2e/tests/board.spec.ts
+++ b/tests/e2e/tests/board.spec.ts
@@ -2,12 +2,17 @@ import { test, expect } from '@playwright/test';
 import { loginAsBoard, loginAsVolunteer, expectBlocked } from '../helpers/auth';
 
 test.describe('Board (09-administration + 18-board-voting)', () => {
+  // NOTE: there is no /Board route (no BoardController; GET /Board is 404 even
+  // anonymously). Board functionality lives at /Admin (board satisfies
+  // AnyAdminRole) and /Governance/BoardVoting. The previous tests pointed at
+  // /Board and passed vacuously: the 404 page has a heading, so `h1, h2` was
+  // visible, and expectBlocked() treats "Page Not Found" as blocked.
   test('US-9.1: board dashboard loads with quick actions', async ({ page }) => {
     await loginAsBoard(page);
-    await page.goto('/Board');
+    await page.goto('/Admin');
 
     await expect(page.locator('h1, h2').first()).toBeVisible();
-    expect(page.url()).toContain('/Board');
+    expect(page.url()).toContain('/Admin');
   });
 
   test('US-9.2: humans list loads at /Users/Admin', async ({ page }) => {
@@ -27,17 +32,28 @@ test.describe('Board (09-administration + 18-board-voting)', () => {
     expect(page.url()).not.toContain('/Error');
   });
 
-  test('nav: board sees Board link, not Admin link', async ({ page }) => {
+  test('nav: board sees the Admin link', async ({ page }) => {
     await loginAsBoard(page);
     await page.goto('/');
 
+    // The layout has no "Board" nav entry — the Admin link is gated on
+    // AnyAdminRole, which board satisfies. The old assertion ("sees Board, not
+    // Admin") described a nav that no longer exists and had been failing.
     const nav = page.locator('nav');
-    await expect(nav.getByRole('link', { name: 'Board' })).toBeVisible();
-    await expect(nav.getByRole('link', { name: 'Admin' })).not.toBeVisible();
+    await expect(nav.getByRole('link', { name: 'Admin' })).toBeVisible();
   });
 
-  test('boundary: volunteer cannot access /Board', async ({ page }) => {
+  test('nav: volunteer does not see the Admin link', async ({ page }) => {
     await loginAsVolunteer(page);
-    await expectBlocked(page, '/Board');
+    await page.goto('/');
+
+    await expect(page.locator('nav').getByRole('link', { name: 'Admin' })).toHaveCount(0);
+  });
+
+  test('boundary: volunteer cannot access board voting', async ({ page }) => {
+    await loginAsVolunteer(page);
+    // /Board does not exist, so the old target passed on a 404 without ever
+    // exercising authorization. /Governance/BoardVoting is the real BoardOrAdmin route.
+    await expectBlocked(page, '/Governance/BoardVoting');
   });
 });

--- a/tests/e2e/tests/calendar.spec.ts
+++ b/tests/e2e/tests/calendar.spec.ts
@@ -15,8 +15,12 @@ test.describe('Community calendar', () => {
     await page.goto('/Calendar/Event/Create');
 
     await expect(page.getByRole('heading', { name: 'New event' })).toBeVisible();
-    await expect(page.locator('input[name="Title"]')).toBeVisible();
-    await expect(page.locator('select[name="OwningTeamId"]')).toBeVisible();
+    // Scope to <main>: the global "file an issue" widget lives outside it in the
+    // layout and also renders an input[name="Title"], which makes the bare
+    // selector a strict-mode violation.
+    const form = page.locator('main');
+    await expect(form.locator('input[name="Title"]')).toBeVisible();
+    await expect(form.locator('select[name="OwningTeamId"]')).toBeVisible();
   });
 
   test('agenda view renders', async ({ page }) => {

--- a/tests/e2e/tests/city-planning.spec.ts
+++ b/tests/e2e/tests/city-planning.spec.ts
@@ -20,32 +20,32 @@ test.describe('City Planning (38-city-planning)', () => {
   });
 
   test.describe('admin access — positive', () => {
-    test('camp-admin can access /CityPlanning/Admin', async ({ page }) => {
+    test('camp-admin can access /CityPlanning/BarrioMap/Admin', async ({ page }) => {
       await loginAsCampAdmin(page);
-      await page.goto('/CityPlanning/Admin');
+      await page.goto('/CityPlanning/BarrioMap/Admin');
 
-      expect(page.url()).toContain('/CityPlanning/Admin');
+      expect(page.url()).toContain('/CityPlanning/BarrioMap/Admin');
       await expect(page.locator('h1, h2').first()).toBeVisible();
     });
 
-    test('city-planning team member can access /CityPlanning/Admin', async ({ page }) => {
+    test('city-planning team member can access /CityPlanning/BarrioMap/Admin', async ({ page }) => {
       await loginAsCityPlanning(page);
-      await page.goto('/CityPlanning/Admin');
+      await page.goto('/CityPlanning/BarrioMap/Admin');
 
-      expect(page.url()).toContain('/CityPlanning/Admin');
+      expect(page.url()).toContain('/CityPlanning/BarrioMap/Admin');
       await expect(page.locator('h1, h2').first()).toBeVisible();
     });
   });
 
   test.describe('admin access — boundary', () => {
-    test('volunteer cannot access /CityPlanning/Admin', async ({ page }) => {
+    test('volunteer cannot access /CityPlanning/BarrioMap/Admin', async ({ page }) => {
       await loginAsVolunteer(page);
-      await expectBlocked(page, '/CityPlanning/Admin');
+      await expectBlocked(page, '/CityPlanning/BarrioMap/Admin');
     });
 
-    test('board member cannot access /CityPlanning/Admin', async ({ page }) => {
+    test('board member cannot access /CityPlanning/BarrioMap/Admin', async ({ page }) => {
       await loginAsBoard(page);
-      await expectBlocked(page, '/CityPlanning/Admin');
+      await expectBlocked(page, '/CityPlanning/BarrioMap/Admin');
     });
   });
 
@@ -53,40 +53,40 @@ test.describe('City Planning (38-city-planning)', () => {
     test('volunteer cannot POST OpenPlacement', async ({ page }) => {
       await loginAsVolunteer(page);
       await page.goto('/CityPlanning');
-      const response = await postWithCsrf(page, '/CityPlanning/Admin/OpenPlacement', '');
+      const response = await postWithCsrf(page, '/CityPlanning/BarrioMap/Admin/OpenPlacement', '');
       expect([302, 403]).toContain(response.status());
       // If 302, it should NOT redirect to the admin page (should be access denied or home)
       if (response.status() === 302) {
         const location = response.headers()['location'] ?? '';
-        expect(location).not.toContain('/CityPlanning/Admin');
+        expect(location).not.toContain('/CityPlanning/BarrioMap/Admin');
       }
     });
 
     test('volunteer cannot POST ClosePlacement', async ({ page }) => {
       await loginAsVolunteer(page);
       await page.goto('/CityPlanning');
-      const response = await postWithCsrf(page, '/CityPlanning/Admin/ClosePlacement', '');
+      const response = await postWithCsrf(page, '/CityPlanning/BarrioMap/Admin/ClosePlacement', '');
       expect([302, 403]).toContain(response.status());
     });
 
     test('volunteer cannot POST UploadLimitZone', async ({ page }) => {
       await loginAsVolunteer(page);
       await page.goto('/CityPlanning');
-      const response = await postWithCsrf(page, '/CityPlanning/Admin/UploadLimitZone', '');
+      const response = await postWithCsrf(page, '/CityPlanning/BarrioMap/Admin/UploadLimitZone', '');
       expect([302, 403]).toContain(response.status());
     });
 
     test('volunteer cannot POST UploadOfficialZones', async ({ page }) => {
       await loginAsVolunteer(page);
       await page.goto('/CityPlanning');
-      const response = await postWithCsrf(page, '/CityPlanning/Admin/UploadOfficialZones', '');
+      const response = await postWithCsrf(page, '/CityPlanning/BarrioMap/Admin/UploadOfficialZones', '');
       expect([302, 403]).toContain(response.status());
     });
 
     test('board member cannot POST OpenPlacement', async ({ page }) => {
       await loginAsBoard(page);
       await page.goto('/CityPlanning');
-      const response = await postWithCsrf(page, '/CityPlanning/Admin/OpenPlacement', '');
+      const response = await postWithCsrf(page, '/CityPlanning/BarrioMap/Admin/OpenPlacement', '');
       expect([302, 403]).toContain(response.status());
     });
   });

--- a/tests/e2e/tests/city-planning.spec.ts
+++ b/tests/e2e/tests/city-planning.spec.ts
@@ -20,12 +20,20 @@ test.describe('City Planning (38-city-planning)', () => {
   });
 
   test.describe('admin access — positive', () => {
+    // Assert an admin-page-specific control, not just a heading. The app uses
+    // UseStatusCodePagesWithReExecute("/Home/Error/{0}"), which renders
+    // Views/Home/Error.cshtml *at the original URL* — and that view has its own
+    // h1 + h2. So `url contains ...` + `h1, h2` visible would still pass on a
+    // 403/404/500, which is exactly the vacuous behaviour the route correction
+    // was meant to remove. The admin forms only exist on the real admin page.
+    const adminForm = 'form[action*="/CityPlanning/BarrioMap/Admin/"]';
+
     test('camp-admin can access /CityPlanning/BarrioMap/Admin', async ({ page }) => {
       await loginAsCampAdmin(page);
       await page.goto('/CityPlanning/BarrioMap/Admin');
 
       expect(page.url()).toContain('/CityPlanning/BarrioMap/Admin');
-      await expect(page.locator('h1, h2').first()).toBeVisible();
+      await expect(page.locator(adminForm).first()).toBeVisible();
     });
 
     test('city-planning team member can access /CityPlanning/BarrioMap/Admin', async ({ page }) => {
@@ -33,7 +41,7 @@ test.describe('City Planning (38-city-planning)', () => {
       await page.goto('/CityPlanning/BarrioMap/Admin');
 
       expect(page.url()).toContain('/CityPlanning/BarrioMap/Admin');
-      await expect(page.locator('h1, h2').first()).toBeVisible();
+      await expect(page.locator(adminForm).first()).toBeVisible();
     });
   });
 

--- a/tests/e2e/tests/profile.spec.ts
+++ b/tests/e2e/tests/profile.spec.ts
@@ -20,8 +20,12 @@ test.describe('Profile (02-profiles)', () => {
     await expect(burnerNameInput).toBeVisible();
     await expect(burnerNameInput).toBeEditable();
 
-    // Bio textarea
-    await expect(page.locator('textarea[name="Bio"]')).toBeVisible();
+    // Bio field. MarkdownEditorTagHelper upgrades it to an EasyMDE editor, which
+    // hides the underlying <textarea> and renders its own editing surface — so
+    // assert both: the field that actually posts still exists, and the editor the
+    // user types into is visible.
+    await expect(page.locator('textarea[name="Bio"]')).toBeAttached();
+    await expect(page.locator('.EasyMDEContainer .CodeMirror')).toBeVisible();
 
     // Private section (legal name)
     await expect(page.locator('input[name="FirstName"]')).toBeVisible();

--- a/tests/e2e/tests/scanner.spec.ts
+++ b/tests/e2e/tests/scanner.spec.ts
@@ -3,12 +3,20 @@ import { loginAsTicketAdmin, loginAsVolunteer, expectBlocked } from '../helpers/
 
 test.describe('Scanner', () => {
   test('ticket admin can decode locally and stop the camera stream', async ({ page }) => {
+    // Global, once-per-session telemetry every page fires on load: screen size
+    // (client-metrics.js) and browser timezone (site.js). Neither is triggered by
+    // the scanner nor carries the decoded value, so they are not evidence of the
+    // scan leaving the browser.
+    const GLOBAL_TELEMETRY = ['/api/client-metrics', '/api/timezone'];
+
     const appPosts: string[] = [];
+    const postedBodies: string[] = [];
     page.on('request', request => {
       const url = new URL(request.url());
-      if (request.method() === 'POST' && url.origin === new URL(page.url()).origin) {
-        appPosts.push(url.pathname);
-      }
+      if (request.method() !== 'POST' || url.origin !== new URL(page.url()).origin) return;
+      postedBodies.push(request.postData() ?? '');
+      if (GLOBAL_TELEMETRY.includes(url.pathname)) return;
+      appPosts.push(url.pathname);
     });
 
     await page.addInitScript(() => {
@@ -56,6 +64,9 @@ test.describe('Scanner', () => {
 
     await expect(page.locator('#scanner-results')).toContainText('https://tickets.example.test/stub/123');
     expect(appPosts).toEqual([]);
+    // The point of the test: decoding is local, so the scanned value must never be
+    // sent to the server — checked against every POST body, telemetry included.
+    expect(postedBodies.filter(body => body.includes('tickets.example.test'))).toEqual([]);
 
     await page.getByRole('button', { name: /stop|detener|stopp|atura|arrêter|ferma/i }).click();
 

--- a/tests/e2e/tests/shifts.spec.ts
+++ b/tests/e2e/tests/shifts.spec.ts
@@ -6,8 +6,14 @@ test.describe('Shifts (25-shift-management)', () => {
     await loginAsVolunteer(page);
     await page.goto('/Shifts');
 
-    // Page loads — may show shifts or "browsing closed" info alert
-    await expect(page.locator('h1, h2').first()).toBeVisible();
+    // Page loads — may show shifts or "browsing closed" info alert.
+    // Both Shifts pages are tab-based and render no visible h1/h2: the only h2 in
+    // the DOM is inside the collapsed help panel (SectionHelpContent "How Shifts
+    // Work"), which is hidden, so `locator('h1, h2').first()` could never pass.
+    // Assert the tab that identifies the page instead.
+    const browseTab = page.getByRole('tab', { name: 'Browse Volunteer Options' });
+    await expect(browseTab).toBeVisible();
+    await expect(browseTab).toHaveAttribute('aria-selected', 'true');
     expect(page.url()).not.toContain('/Error');
   });
 
@@ -15,7 +21,10 @@ test.describe('Shifts (25-shift-management)', () => {
     await loginAsVolunteer(page);
     await page.goto('/Shifts/Mine');
 
-    await expect(page.locator('h1, h2').first()).toBeVisible();
+    // See above — assert the selected tab, not a heading.
+    const mineTab = page.getByRole('tab', { name: /^My Shifts\b/ });
+    await expect(mineTab).toBeVisible();
+    await expect(mineTab).toHaveAttribute('aria-selected', 'true');
   });
 
   test('US-25.1: shift settings page loads for admin', async ({ page }) => {


### PR DESCRIPTION
Closes nobodies-collective/Humans#936.

**All 14 are test-vs-app drift — no app bugs.** Verified against QA at the deployed commit: **122 passed / 0 failed**, three consecutive runs (baseline: 107 passed / 14 failed).

## The two hypotheses in the issue were both wrong

The issue suspected a **stale deploy** (Ask 1) or **role claims** behind the admin-shell cluster. Neither holds:

- The version gate confirmed correctly on the run I analysed (`Deploy confirmed after ~155s`) and tests ran against the right build.
- The real cause is Playwright locator semantics. System nav groups start **collapsed**, so their links are `display:none`. The spec correctly used `toBeAttached()` for that — but paired it with `getByRole()`, which resolves against the **accessibility tree**, and hidden elements are absent from it. So the locator matched nothing regardless of the assertion.

That also resolves the issue's central puzzle — *"ARIA snapshots show every System group heading-only with zero items, yet a fresh probe shows all items present"*. ARIA snapshots exclude hidden elements. The groups were never empty.

> `includeHidden` is **not** the fix — it folds icon glyph text into the accessible name and breaks the `^name` anchor. I tried it; it turned 2 failures into 7. Matching on DOM text is correct.

## Fixes

| Area | Failures | Root cause |
|---|---:|---|
| city-planning | 5 | Admin routes moved under `BarrioMap` in #389; spec still posts to `/CityPlanning/Admin/*` → 404 |
| admin-shell matrix | 2 | `getByRole` can't match hidden links in collapsed groups |
| admin-shell tiles | 1 | "Active humans" tile renamed "Active (has profile)" by #546 |
| board | 1 | `/Board` route does not exist; nav has no Board entry |
| shifts | 2 | Pages are tab-based with no visible `h1/h2`; only h2 is in the hidden help panel |
| profile | 1 | EasyMDE hides the underlying `Bio` textarea |
| calendar | 1 | Global "file an issue" widget also has `input[name="Title"]` → strict-mode violation |
| scanner | 1 | Assertion caught unrelated page-load telemetry POSTs |

## ⚠️ The more serious finding: tests that were *passing* while asserting nothing

`expectBlocked()` treats a **404 as "blocked"**, and the positive tests asserted only that the URL was unchanged and *some* `h1/h2` rendered — both true of a 404 page. So tests pointed at dead routes went green while exercising no authorization at all.

This fix removes **6** such tests:
- **city-planning ×4** — the entire `/CityPlanning/Admin` surface (2 positive + 2 boundary) had no real coverage. Now genuinely exercises the routes; the app correctly returns 403.
- **board ×2** — `/Board` 404s, so "board dashboard loads" was asserting a 404 page renders, and "volunteer cannot access /Board" was asserting a 404 is a 404.

Scanner was also **strengthened** beyond its original intent: it now asserts the decoded value never appears in any POST body, telemetry included — the actual privacy property.

## Two more vacuous tests found, deliberately left alone

I temporarily hardened `expectBlocked` to reject 404s and re-ran the suite. It surfaced two more currently-green boundary tests aimed at routes that don't exist:

- `volunteer cannot access /Admin/Feedback` — no such route; the feedback admin surface is `/Feedback` itself, policy-gated by content (relates to nobodies-collective/Humans#832, matrix not wired to enforcement)
- `volunteer cannot access /Teams/Sync` — no such route

I reverted that diagnostic rather than ship it. Hardening `expectBlocked` is the right systemic guard for Ask 4, but it turns those two green tests red and choosing their replacement targets is a judgement call — worth its own PR with your input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)