### PR TITLE
feat(teams): Board/Admin roster page at /Teams/{slug}/Roster

### DIFF
--- a/docs/sections/Teams.md
+++ b/docs/sections/Teams.md
@@ -149,6 +149,7 @@ Three controllers serve this section. `TeamController` (`[Route("Teams")]`) hand
 | `POST /Teams/{slug}/Members/{userId}/Remove` | `RemoveMember` | `TeamAdminController` | `ResolveTeamManagementAsync` |
 | `POST /Teams/{slug}/Members/{userId}/ProvisionEmail` | `ProvisionEmail` | `TeamAdminController` | `ResolveTeamManagementAsync` |
 | `GET /Teams/{slug}/Members/Search` | `SearchUsers` | `TeamAdminController` | `ResolveTeamManagementAsync` — AJAX name search |
+| `GET /Teams/{slug}/Roster` | `Roster` | `TeamAdminController` | `[Authorize(Policy = BoardOrAdmin)]` + `ResolveTeamManagementAsync` — burner name + legal name; policy narrows the coordinator-inclusive resolver to Board/Admin |
 | `POST /Teams/{slug}/Requests/{requestId}/Approve` | `ApproveRequest` | `TeamAdminController` | `ResolveTeamManagementAsync` |
 | `POST /Teams/{slug}/Requests/{requestId}/Reject` | `RejectRequest` | `TeamAdminController` | `ResolveTeamManagementAsync` |
 | `GET /Teams/{slug}/Resources` | `Resources` | `TeamAdminController` | `[Authorize]` + `CanManageResourcesAsync` (Coordinator of dept or TeamsAdmin/Admin) |

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -209,6 +209,39 @@ public class TeamAdminController(
         return View(viewModel);
     }
 
+    /// <summary>
+    /// Board/Admin-only roster: every member's burner name next to their legal name.
+    /// <c>TeamAuthorizationHandler</c> already passes Board and Admin for
+    /// <c>ManageCoordinators</c>, so the policy narrows <see cref="ResolveTeamManagementAsync"/>
+    /// (which also serves coordinators) down to exactly Board-or-Admin.
+    /// </summary>
+    [HttpGet("Roster")]
+    [Authorize(Policy = PolicyNames.BoardOrAdmin)]
+    public async Task<IActionResult> Roster(string slug, CancellationToken ct)
+    {
+        var (teamError, _, team) = await ResolveTeamManagementAsync(slug);
+        if (teamError is not null)
+        {
+            return teamError;
+        }
+
+        var members = team.Members;
+        var infos = await _userService.GetUserInfosAsync(
+            members.Select(m => m.UserId).ToList(), ct);
+
+        // Display sort at controller (memory/architecture/display-sort-in-controllers.md);
+        // the table's headers re-sort client-side from here.
+        var rows = members
+            .Select(m => new TeamRosterRowViewModel(
+                m.UserId,
+                infos.GetValueOrDefault(m.UserId)?.Profile?.FullName ?? string.Empty,
+                m.JoinedAt))
+            .OrderBy(r => r.LegalName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return View(new TeamRosterViewModel(team.Name, team.Slug, rows));
+    }
+
     [HttpPost("Members/{userId}/Remove")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RemoveMember(string slug, Guid userId)

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -8,6 +8,7 @@ using Humans.Application.Interfaces.Teams;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
+using NodaTime;
 
 namespace Humans.Web.Models;
 
@@ -632,3 +633,19 @@ public class TeamResourceLinkViewModel
     public string? Url { get; set; }
     public string IconClass { get; set; } = string.Empty;
 }
+
+/// <summary>
+/// Board/Admin roster for one team: burner name alongside legal name.
+/// Deliberately not <see cref="TeamMemberViewModel"/> — that shape is shared with the
+/// Members and Roles pages, where a legal name would sit permanently unpopulated.
+/// </summary>
+public sealed record TeamRosterViewModel(
+    string TeamName,
+    string TeamSlug,
+    IReadOnlyList<TeamRosterRowViewModel> Rows);
+
+/// <summary>
+/// One roster row. Carries no name for the human — the burner name renders through
+/// <c>&lt;vc:human&gt;</c> from <see cref="UserId"/> (memory/code/no-new-displayname-fields.md).
+/// </summary>
+public sealed record TeamRosterRowViewModel(Guid UserId, string LegalName, Instant JoinedAt);

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -1,3 +1,4 @@
+@using Humans.Web.Authorization
 @model Humans.Web.Models.TeamDetailViewModel
 @{
     ViewData["Title"] = Model.Name;
@@ -371,6 +372,10 @@
                         </a>
                         <a asp-controller="TeamAdmin" asp-action="Roles" asp-route-slug="@Model.Slug" class="list-group-item list-group-item-action">
                             @Localizer["TeamDetail_ManageRoles"]
+                        </a>
+                        <a asp-controller="TeamAdmin" asp-action="Roster" asp-route-slug="@Model.Slug" class="list-group-item list-group-item-action"
+                           authorize-policy="@PolicyNames.BoardOrAdmin">
+                            Roster
                         </a>
                         @if (Model.CanCurrentUserEditTeam)
                         {

--- a/src/Humans.Web/Views/TeamAdmin/Roster.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Roster.cshtml
@@ -1,0 +1,34 @@
+@using Humans.Web.Models.Tables
+@model Humans.Web.Models.TeamRosterViewModel
+@{
+    ViewData["Title"] = $"Roster — {Model.TeamName}";
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Team" asp-action="Index">@Localizer["Teams_Title"]</a></li>
+        <li class="breadcrumb-item"><a asp-controller="Team" asp-action="Details" asp-route-slug="@Model.TeamSlug">@Model.TeamName</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Roster</li>
+    </ol>
+</nav>
+
+<h1>Roster</h1>
+<p class="text-muted">@Model.TeamName — @Model.Rows.Count humans. Sorted by legal name; click any header to re-sort.</p>
+
+@{
+    var rosterTable = TableModel.For(Model.Rows)
+        .Template("Human", @<text><vc:human user-id="@item.UserId" layout="AvatarName" size="32" /></text>)
+        // null (not "") so a profile-less human gets the muted em-dash, not a blank cell.
+        .Column("Legal name", x => string.IsNullOrEmpty(x.LegalName) ? null : x.LegalName)
+        .Column("Joined", x => x.JoinedAt, c => c.Date())
+        .Empty("No humans on this team.")
+        .Build();
+}
+<div class="card">
+    <partial name="_Table" model="rosterTable" />
+</div>
+
+<div class="mt-3">
+    <a asp-controller="Team" asp-action="Details" asp-route-slug="@Model.TeamSlug" class="btn btn-outline-secondary">@Localizer["TeamAdmin_BackToTeam"]</a>
+    <a asp-action="Members" asp-route-slug="@Model.TeamSlug" class="btn btn-outline-secondary">@Localizer["TeamAdmin_ManageMembers"]</a>
+</div>


### PR DESCRIPTION
Adds `GET /Teams/{slug}/Roster` — a read-only roster showing each team member's **burner name**, **legal name**, and **joined** date. Reachable from the *Team Management* card on `/Teams/{slug}`.

Example: https://humans.nobodies.team/Teams/asociados/Roster

### Behaviour

- **Board or Admin only.** The action carries `[Authorize(Policy = BoardOrAdmin)]` on top of the existing `ResolveTeamManagementAsync`, which narrows that coordinator-inclusive resolver down to exactly Board-or-Admin (both already pass `ManageCoordinators` in `TeamAuthorizationHandler`). A team coordinator gets a 403, and the nav link is wrapped in `authorize-policy` so they never see it.
- **Sorted by legal name** by default; every column header re-sorts client-side via the shared `_Table` partial.
- Direct team members only — same set the Members page shows.
- Humans with no profile show a muted em-dash for legal name.

### Notes for review

- **No new service, repository, or interface surface.** The page composes `TeamInfo.Members` with a single `IUserServiceRead.GetUserInfosAsync` batch for `Profile.FullName`.
- The row shape is its own small record in the existing `TeamViewModels.cs` rather than a field added to `TeamMemberViewModel` — that type is shared with the Members and Roles pages, where a legal name would sit permanently unpopulated.
- Burner name is not a view-model field; it renders through `<vc:human>` per `burnername-is-the-display-name` / `no-new-displayname-fields`.
- No new resource keys — `/TeamAdmin/*` is localization-exempt.
- Route table row added to `docs/sections/Teams.md`.
- Heads up on naming: "Roster" now means two things — the shift-slot roster at `/Teams/Roster` and this membership roster. Built as requested; say the word if you want a different noun.

### Verification

`dotnet build` clean; Domain (271), Analyzers (222), Web (365), and Application (3866) suites all pass. Integration tests could not run locally — Docker isn't up on this machine — so CI and the preview deploy are the check on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)