### PR TITLE
fix(debug): per-section migration history in /Debug/DbVersion + section failure logging

### DIFF
--- a/src/Humans.Application/Interfaces/Admin/AdminDatabaseDiagnostics.cs
+++ b/src/Humans.Application/Interfaces/Admin/AdminDatabaseDiagnostics.cs
@@ -13,7 +13,18 @@ public sealed record DatabaseMigrationStatus(
     string? LastApplied,
     int AppliedCount,
     int PendingCount,
-    IReadOnlyList<string> Applied);
+    IReadOnlyList<string> Applied,
+    IReadOnlyList<SectionMigrationStatus> Sections);
+
+/// <summary>
+/// Migration state of one per-section DbContext (nobodies-collective/Humans#858),
+/// so QA/prod rollouts can confirm each section's baseline was recorded.
+/// </summary>
+public sealed record SectionMigrationStatus(
+    string Context,
+    string? LastApplied,
+    int AppliedCount,
+    int PendingCount);
 
 public sealed record AudienceSegmentation(
     int TotalAccounts,

--- a/src/Humans.Infrastructure/Hosting/SectionMigrationRunner.cs
+++ b/src/Humans.Infrastructure/Hosting/SectionMigrationRunner.cs
@@ -41,30 +41,40 @@ internal static class SectionMigrationRunner
     public static async Task MigrateAsync(DbContext db, string sentinelTable, ILogger logger, CancellationToken ct)
     {
         var contextName = db.GetType().Name;
-        var applied = (await db.Database.GetAppliedMigrationsAsync(ct)).ToList();
-
-        if (applied.Count == 0 && await SentinelTableExistsAsync(db, sentinelTable, ct))
+        try
         {
-            var baselineId = db.Database.GetMigrations().First();
-            logger.LogWarning(
-                "{Context}: tables exist but history is empty - recording baseline {Baseline} as applied without executing",
-                contextName, baselineId);
-            await RecordBaselineAsAppliedAsync(db, baselineId, ct);
-        }
+            var applied = (await db.Database.GetAppliedMigrationsAsync(ct)).ToList();
 
-        var pending = (await db.Database.GetPendingMigrationsAsync(ct)).ToList();
-        if (pending.Count > 0)
-        {
-            foreach (var migration in pending)
+            if (applied.Count == 0 && await SentinelTableExistsAsync(db, sentinelTable, ct))
             {
-                logger.LogWarning("{Context}: applying pending migration: {Migration}", contextName, migration);
+                var baselineId = db.Database.GetMigrations().First();
+                logger.LogWarning(
+                    "{Context}: tables exist but history is empty - recording baseline {Baseline} as applied without executing",
+                    contextName, baselineId);
+                await RecordBaselineAsAppliedAsync(db, baselineId, ct);
             }
 
-            await db.Database.MigrateAsync(ct);
+            var pending = (await db.Database.GetPendingMigrationsAsync(ct)).ToList();
+            if (pending.Count > 0)
+            {
+                foreach (var migration in pending)
+                {
+                    logger.LogWarning("{Context}: applying pending migration: {Migration}", contextName, migration);
+                }
+
+                await db.Database.MigrateAsync(ct);
+            }
+            else
+            {
+                logger.LogInformation("{Context}: schema is up to date", contextName);
+            }
         }
-        else
+        catch (Exception ex)
         {
-            logger.LogInformation("{Context}: schema is up to date", contextName);
+            logger.LogError(ex,
+                "Section migration failed for {Context}. The application may not function correctly",
+                contextName);
+            throw;
         }
     }
 

--- a/src/Humans.Infrastructure/Repositories/Admin/AdminDatabaseDiagnosticsRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Admin/AdminDatabaseDiagnosticsRepository.cs
@@ -1,11 +1,16 @@
 using Humans.Application.Interfaces.Admin;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Hosting;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Humans.Infrastructure.Repositories.Admin;
 
-internal sealed class AdminDatabaseDiagnosticsRepository(IDbContextFactory<HumansDbContext> factory)
+internal sealed class AdminDatabaseDiagnosticsRepository(
+    IDbContextFactory<HumansDbContext> factory,
+    IServiceScopeFactory scopeFactory,
+    IEnumerable<SectionDbContextRegistration> sectionContexts)
     : IAdminDatabaseDiagnosticsRepository
 {
     public async Task<DatabaseMigrationStatus> GetMigrationStatusAsync(CancellationToken ct = default)
@@ -14,11 +19,28 @@ internal sealed class AdminDatabaseDiagnosticsRepository(IDbContextFactory<Human
         var applied = (await db.Database.GetAppliedMigrationsAsync(ct)).ToList();
         var pending = await db.Database.GetPendingMigrationsAsync(ct);
 
+        // Section contexts are scoped (registered via AddSectionDbContext), so
+        // resolve them through a scope — same pattern as DatabaseMigrationHostedService.
+        var sections = new List<SectionMigrationStatus>();
+        using var scope = scopeFactory.CreateScope();
+        foreach (var section in sectionContexts)
+        {
+            var sectionDb = (DbContext)scope.ServiceProvider.GetRequiredService(section.ContextType);
+            var sectionApplied = (await sectionDb.Database.GetAppliedMigrationsAsync(ct)).ToList();
+            var sectionPending = await sectionDb.Database.GetPendingMigrationsAsync(ct);
+            sections.Add(new SectionMigrationStatus(
+                Context: section.ContextType.Name,
+                LastApplied: sectionApplied.LastOrDefault(),
+                AppliedCount: sectionApplied.Count,
+                PendingCount: sectionPending.Count()));
+        }
+
         return new DatabaseMigrationStatus(
             LastApplied: applied.LastOrDefault(),
             AppliedCount: applied.Count,
             PendingCount: pending.Count(),
-            Applied: applied);
+            Applied: applied,
+            Sections: sections);
     }
 
     public async Task<int> ClearHangfireLocksAsync(CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/DebugController.cs
+++ b/src/Humans.Web/Controllers/DebugController.cs
@@ -147,7 +147,8 @@ public class DebugController(
             lastApplied = status.LastApplied,
             appliedCount = status.AppliedCount,
             pendingCount = status.PendingCount,
-            recentApplied = status.Applied.TakeLast(20).Reverse().ToList()
+            recentApplied = status.Applied.TakeLast(20).Reverse().ToList(),
+            sections = status.Sections
         });
     }
 


### PR DESCRIPTION
## Summary

Operational guards for the in-flight nobodies-collective/Humans#858 rollout — partial delivery of nobodies-collective/Humans#959 (the two items that are useful *during* the peel merges and live in files the remaining stack PRs don't touch):

- **`/Debug/DbVersion` now reports section contexts.** Adds a `sections` array (context name, last applied, applied/pending counts) so each peel merge can be verified on QA with a browser hit: `SystemSettingsDbContext` showing `appliedCount: 1, pendingCount: 0` means the mark-applied baseline fired. Lights up automatically as each remaining peel (#1114–#1119) merges — no further changes needed.
- **`SectionMigrationRunner` log-and-rethrow** — a failed section migration at boot now logs "Section migration failed for {Context}" before rethrowing, matching `DatabaseMigrationHostedService`'s main-pile diagnostics.

## Reuse notes

- No new interface surface: enriched the existing `DatabaseMigrationStatus` DTO (+ new `SectionMigrationStatus` record) behind the existing `IAdminDatabaseDiagnosticsService.GetMigrationStatusAsync`.
- Repository resolves section contexts via `IServiceScopeFactory` + `IEnumerable<SectionDbContextRegistration>` — the exact pattern `DatabaseMigrationHostedService` already uses.
- One nobodies-collective/Humans#959 MINOR is **invalid** and intentionally not done: EF's `DatabaseFacade.CloseConnectionAsync()` has no cancellation-token overload.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors (95 pre-existing warnings)
- [x] Architecture + endpoint-authorization suites — 291/291 pass
- [ ] After merge: hit `https://<qa>/Debug/DbVersion`, confirm `sections` shows the peeled contexts with `pendingCount: 0`

Remaining nobodies-collective/Humans#959 items (history-table helper, exactly-one-owner test, pg_constraint equivalence, build.yml list, doc drift) intentionally deferred until the full stack lands — they touch files PRs #1114–#1119 keep rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)