### PR TITLE
fix(legal): consent notification click-through 404s (/Legal/Consent -> /Consent)

### DIFF
--- a/src/Humans.Application/Services/Legal/LegalDocumentSyncService.cs
+++ b/src/Humans.Application/Services/Legal/LegalDocumentSyncService.cs
@@ -382,7 +382,7 @@ public sealed class LegalDocumentSyncService(
                     title,
                     approvedUserIds,
                     body: body,
-                    actionUrl: "/Legal/Consent",
+                    actionUrl: "/Consent",
                     actionLabel: "Review document",
                     cancellationToken: cancellationToken);
             }

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -128,7 +128,7 @@ public class SuspendNonCompliantMembersJob(
                         "Your access has been suspended",
                         [user.Id],
                         body: "Your access has been suspended because required document consent is missing. Please review and sign the required documents to restore access.",
-                        actionUrl: "/Legal/Consent",
+                        actionUrl: "/Consent",
                         actionLabel: "Review documents",
                         cancellationToken: cancellationToken);
                 }

--- a/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
@@ -205,7 +205,7 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
             Arg.Any<string>(),
             Arg.Is<IReadOnlyList<Guid>>(ids => ids.Contains(user.Id)),
             body: Arg.Any<string?>(),
-            actionUrl: "/Legal/Consent",
+            actionUrl: "/Consent",
             actionLabel: Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),


### PR DESCRIPTION
Fixes nobodies-collective/Humans#954

Both consent-notification emitters set `actionUrl: "/Legal/Consent"`, a route that doesn't exist (`LegalController` resolves slugs against configured legal documents and 404s on `Consent`). The consent dashboard lives at `/Consent`.

## Changes
- `LegalDocumentSyncService.cs:385` — consent-update notification now points at `/Consent`
- `SuspendNonCompliantMembersJob.cs:131` — suspension warning now points at `/Consent`
- `SuspendNonCompliantMembersJobTests` — asserts the emitted `ActionUrl` is `/Consent`; `AnonymousAccessTests.ProtectedEndpoint_RedirectsToLogin_WhenAnonymous` already pins `/Consent` as a real route (login redirect, never 404), so emitted-URL + route existence are both test-enforced

Existing notification rows keep the old URL; consent notifications are re-emitted on each document sync and no data migration is authored (per spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)