### PR TITLE
fix(profile): normalise CRLF before message length validation

### DIFF
--- a/src/Humans.Web/Models/SendMessageViewModel.cs
+++ b/src/Humans.Web/Models/SendMessageViewModel.cs
@@ -18,7 +18,7 @@ public class SendMessageViewModel
     public string Message
     {
         get => _message;
-        set => _message = value?.Replace("\r\n", "\n") ?? string.Empty;
+        set => _message = value?.Replace("\r\n", "\n", StringComparison.Ordinal) ?? string.Empty;
     }
 
     public bool IncludeContactInfo { get; set; } = true;

--- a/src/Humans.Web/Models/SendMessageViewModel.cs
+++ b/src/Humans.Web/Models/SendMessageViewModel.cs
@@ -4,12 +4,22 @@ namespace Humans.Web.Models;
 
 public class SendMessageViewModel
 {
+    private string _message = string.Empty;
+
     public Guid RecipientId { get; set; }
     public string RecipientDisplayName { get; set; } = string.Empty;
 
+    // Browsers submit textarea line breaks as \r\n regardless of how the user (or a
+    // client-side character counter) perceives them, which would otherwise inflate the
+    // bound string past what the user counted. Normalise on bind so the length check
+    // below — and the stored/relayed message — agree with what the user sees.
     [Required]
     [StringLength(2000, MinimumLength = 1)]
-    public string Message { get; set; } = string.Empty;
+    public string Message
+    {
+        get => _message;
+        set => _message = value?.Replace("\r\n", "\n") ?? string.Empty;
+    }
 
     public bool IncludeContactInfo { get; set; } = true;
 

--- a/tests/Humans.Web.Tests/Controllers/SendMessageViewModelTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/SendMessageViewModelTests.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel.DataAnnotations;
+using AwesomeAssertions;
+using Humans.Web.Models;
+
+namespace Humans.Web.Tests.Controllers;
+
+/// <summary>
+/// Validation coverage for <see cref="SendMessageViewModel"/>. Browsers submit
+/// textarea line breaks as \r\n, which — uncorrected — inflates the bound string
+/// past what the user counted and pushed a 1985-character message with line
+/// breaks over the 2000-char limit (nobodies-collective/Humans#953). The
+/// property normalises \r\n to \n on bind so the length check agrees with the
+/// user's count.
+/// </summary>
+public sealed class SendMessageViewModelTests
+{
+    [HumansFact]
+    public void Message_CrLfNormalized_OnSet()
+    {
+        var vm = new SendMessageViewModel { Message = "line one\r\nline two" };
+
+        vm.Message.Should().Be("line one\nline two");
+    }
+
+    [HumansFact]
+    public void Message_1985CharsWithCrLfLineBreaks_PassesValidation()
+    {
+        // Build the message as the user (and a client-side char counter reading a
+        // textarea's .value) would see it: exactly 1985 chars, one line break every
+        // 100 chars (~19 line breaks total).
+        var chars = new char[1985];
+        Array.Fill(chars, 'x');
+        for (var i = 99; i < chars.Length; i += 100)
+            chars[i] = '\n';
+        var userPerceived = new string(chars);
+        var lineBreakCount = userPerceived.Count(c => c == '\n');
+
+        // The browser submits textarea line breaks as \r\n, so this is what actually
+        // hits the server-bound property — 1985 + lineBreakCount chars
+        // pre-normalisation, which pushes it past the 2000-char StringLength check
+        // without the fix.
+        var rawSubmitted = userPerceived.Replace("\n", "\r\n", StringComparison.Ordinal);
+        rawSubmitted.Length.Should().Be(1985 + lineBreakCount);
+        rawSubmitted.Length.Should().BeGreaterThan(2000);
+
+        var vm = new SendMessageViewModel { Message = rawSubmitted };
+
+        vm.Message.Length.Should().Be(1985);
+        Validate(vm).Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void Message_TooLong_AfterNormalization_FailsValidation()
+    {
+        var vm = new SendMessageViewModel { Message = new string('x', 2001) };
+
+        Validate(vm).Should().Contain(r => r.MemberNames.Contains(nameof(SendMessageViewModel.Message), StringComparer.Ordinal));
+    }
+
+    [HumansFact]
+    public void Message_Empty_FailsValidation()
+    {
+        var vm = new SendMessageViewModel { Message = string.Empty };
+
+        Validate(vm).Should().Contain(r => r.MemberNames.Contains(nameof(SendMessageViewModel.Message), StringComparer.Ordinal));
+    }
+
+    private static IReadOnlyList<ValidationResult> Validate(SendMessageViewModel vm)
+    {
+        var context = new ValidationContext(vm);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(vm, context, results, validateAllProperties: true);
+        return results;
+    }
+}


### PR DESCRIPTION
## Summary

Browsers submit `<textarea>` line breaks as `\r\n` on form submission, even though the textarea's JS `.value` (and thus any client-side character count) normalises them to `\n`. This inflated the server-bound `SendMessageViewModel.Message` length past what the user counted, so a 1985-character message with line breaks could be rejected against the 2000-char `StringLength` limit.

## Fix

`SendMessageViewModel.Message` now normalises `\r\n` → `\n` in its setter. Since ASP.NET Core model binding sets the property before `[StringLength]` validation runs, the length that gets validated is the normalised one — matching what the user perceives. This also fixes a latent cosmetic bug in `EmailRenderer`, which replaces `\n` with `<br />` for the facilitated-message email body; a stray `\r` before each `<br />` no longer survives.

## Acceptance criteria

- [x] A 1985-character message containing line breaks submits successfully — `Message_1985CharsWithCrLfLineBreaks_PassesValidation`
- [x] A message genuinely over 2000 characters after normalisation is still rejected — `Message_TooLong_AfterNormalization_FailsValidation`
- [x] A test covers a body whose `\r\n` count is what pushes it over the limit — same test, constructs the raw submitted string and asserts `rawSubmitted.Length > 2000` pre-normalisation
- [ ] Reporter notification (agent conversation `f65cfa90`, user Yoris) — out of scope for this code fix; flagging for manual follow-up.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Humans.Web.Tests"` — 371 passed, 0 failed

Fixes nobodies-collective/Humans#953