### PR TITLE
fix(expenses): log validation failures at Warning, not Error with stack trace

### DIFF
--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -472,20 +472,20 @@ public sealed class ExpenseReportService(
         if (report.Status != ExpenseReportStatus.Draft) return false;
 
         if (!report.Lines.Any())
-            throw new InvalidOperationException("Report must have at least one line.");
+            throw new ExpenseValidationException("Report must have at least one line.");
 
         if (report.Lines.Any(l => l.LineType == ExpenseLineType.Receipt && l.AttachmentId is null))
-            throw new InvalidOperationException("Receipt lines must have an attachment before submitting.");
+            throw new ExpenseValidationException("Receipt lines must have an attachment before submitting.");
 
         var profile = (await userService.GetUserInfoAsync(submitterUserId, ct))?.Profile;
         if (profile?.Iban is null)
-            throw new InvalidOperationException("Submitter must have an IBAN set on their profile.");
+            throw new ExpenseValidationException("Submitter must have an IBAN set on their profile.");
 
         // Financial records use legal name (not BurnerName). See memory/architecture/burnername-is-the-display-name.md.
         var legalName = $"{profile.FirstName} {profile.LastName}".Trim();
         if (string.IsNullOrWhiteSpace(legalName))
         {
-            throw new InvalidOperationException("Submitter must have first and last name set on their profile.");
+            throw new ExpenseValidationException("Submitter must have first and last name set on their profile.");
         }
         var payeeIban = profile.Iban;
 
@@ -585,6 +585,21 @@ public sealed class ExpenseReportService(
     private static ExpenseIbanSaveResult IbanFailure(string message, bool isValidationError) =>
         new(Succeeded: false, IsValidationError: isValidationError, Message: message);
 
+    /// <summary>
+    /// Signals an ordinary, user-driven validation rejection (missing attachment, missing IBAN,
+    /// empty report, etc.) as distinct from a genuine dependency/system fault. Only the guard
+    /// clauses for expected, user-correctable conditions should throw this — never wrap an
+    /// arbitrary <see cref="InvalidOperationException"/> surfaced by EF Core, IUserService,
+    /// IFileStorage, or another dependency, since those indicate a real fault that must stay
+    /// visible at Error with its stack trace.
+    /// </summary>
+    private sealed class ExpenseValidationException : InvalidOperationException
+    {
+        public ExpenseValidationException() { }
+        public ExpenseValidationException(string message) : base(message) { }
+        public ExpenseValidationException(string message, Exception inner) : base(message, inner) { }
+    }
+
     private async Task<ExpenseMutationResult> RunMutationAsync(
         Func<Task<ExpenseMutationResult>> mutation,
         string logMessage,
@@ -595,13 +610,12 @@ public sealed class ExpenseReportService(
         {
             return await mutation();
         }
-        catch (InvalidOperationException ex)
+        catch (ExpenseValidationException ex)
         {
-            // InvalidOperationException is this file's established signal for ordinary,
-            // user-driven validation failures (missing attachment, missing IBAN, etc.) —
-            // not a system fault. Log at Warning with no stack trace so it doesn't pollute
-            // the Error log, but keep it structured and visible in the production log viewer.
-            logger.LogWarning("Expense mutation rejected: {Reason}", ex.Message);
+            // Expected, user-driven rejection — log at Warning with no stack trace so it doesn't
+            // pollute the Error log, but keep the caller's structured identifiers (report/line IDs)
+            // plus the reason, so it's still traceable to the affected mutation.
+            logger.LogWarning($"{logMessage}: {{Reason}}", [.. logArgs, ex.Message]);
             return ExpenseMutationResult.Failure(exceptionPrefix is null
                 ? ex.Message
                 : $"{exceptionPrefix}: {ex.Message}");

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -595,6 +595,17 @@ public sealed class ExpenseReportService(
         {
             return await mutation();
         }
+        catch (InvalidOperationException ex)
+        {
+            // InvalidOperationException is this file's established signal for ordinary,
+            // user-driven validation failures (missing attachment, missing IBAN, etc.) —
+            // not a system fault. Log at Warning with no stack trace so it doesn't pollute
+            // the Error log, but keep it structured and visible in the production log viewer.
+            logger.LogWarning("Expense mutation rejected: {Reason}", ex.Message);
+            return ExpenseMutationResult.Failure(exceptionPrefix is null
+                ? ex.Message
+                : $"{exceptionPrefix}: {ex.Message}");
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, logMessage, logArgs);

--- a/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
@@ -9,6 +9,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Expenses;
 using Humans.Application.Services.Expenses.Dtos;
 using Humans.Application.Services.Finance.Dtos;
+using Humans.Application.Tests.AuditLog;
 using Humans.Application.Tests.Infrastructure;
 using Microsoft.Extensions.Options;
 using Humans.Domain.Entities;
@@ -674,9 +675,9 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
-    public async Task SubmitWithResultAsync_LogsWarning_NoException_WhenValidationFails()
+    public async Task SubmitWithResultAsync_LogsWarning_WithReportId_NoException_WhenValidationFails()
     {
-        var logger = Substitute.For<ILogger<ExpenseReportService>>();
+        var logger = new CapturingLogger<ExpenseReportService>();
         var sut = new ExpenseReportService(
             _expenseRepo, _fileStorage, _budgetService, _teamService, _userService,
             AuditLog, _holdedClient, _holdedFinance, Clock, logger,
@@ -691,24 +692,20 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
         var result = await sut.SubmitWithResultAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeFalse();
-        logger.Received().Log(
-            LogLevel.Warning,
-            Arg.Any<EventId>(),
-            Arg.Any<object>(),
-            Arg.Is<Exception?>(e => e == null),
-            Arg.Any<Func<object, Exception?, string>>());
-        logger.DidNotReceive().Log(
-            LogLevel.Error,
-            Arg.Any<EventId>(),
-            Arg.Any<object>(),
-            Arg.Any<Exception?>(),
-            Arg.Any<Func<object, Exception?, string>>());
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning,
+            because: "a validation rejection is an expected, user-driven outcome, not a fault");
+        var warning = logger.Entries.Single(e => e.Level == LogLevel.Warning);
+        warning.Exception.Should().BeNull("no stack trace should be logged for a validation rejection");
+        warning.Message.Should().Contain(id.ToString(),
+            because: "the caller's structured identifiers (report ID) must survive into the warning");
+        warning.Message.Should().Contain("attachment");
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Error);
     }
 
     [HumansFact]
     public async Task SubmitWithResultAsync_LogsError_WithException_ForGenuineFault()
     {
-        var logger = Substitute.For<ILogger<ExpenseReportService>>();
+        var logger = new CapturingLogger<ExpenseReportService>();
         var sut = new ExpenseReportService(
             _expenseRepo, _fileStorage, _budgetService, _teamService, _userService,
             AuditLog, _holdedClient, _holdedFinance, Clock, logger,
@@ -721,19 +718,20 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
         var attachId = await _expenseRepo.AddAttachmentAsync(MakeAttachment(submitter), Xunit.TestContext.Current.CancellationToken);
         await _expenseRepo.SetLineAttachmentAsync(lineId, attachId, Xunit.TestContext.Current.CancellationToken);
 
-        // Not InvalidOperationException — a genuine fault, not a validation rejection.
+        // A dependency throwing plain InvalidOperationException for a genuine runtime fault —
+        // NOT the service's own ExpenseValidationException — must still log at Error with the
+        // exception attached, not be misclassified as a validation rejection.
         _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
-            .Throws(new TimeoutException("db timeout"));
+            .Throws(new InvalidOperationException("IUserService: profile cache not initialized"));
 
         var result = await sut.SubmitWithResultAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeFalse();
-        logger.Received().Log(
-            LogLevel.Error,
-            Arg.Any<EventId>(),
-            Arg.Any<object>(),
-            Arg.Is<Exception?>(e => e is TimeoutException),
-            Arg.Any<Func<object, Exception?, string>>());
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Error,
+            because: "a dependency fault (even one thrown as InvalidOperationException) is not a validation rejection");
+        var error = logger.Entries.Single(e => e.Level == LogLevel.Error);
+        error.Exception.Should().BeOfType<InvalidOperationException>();
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
@@ -16,9 +16,11 @@ using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Expenses;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Humans.Application.Tests.Services.Expenses;
 
@@ -669,6 +671,69 @@ public sealed class ExpenseReportServiceTests : ServiceTestHarness
         var result = await _sut.SubmitWithResultAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task SubmitWithResultAsync_LogsWarning_NoException_WhenValidationFails()
+    {
+        var logger = Substitute.For<ILogger<ExpenseReportService>>();
+        var sut = new ExpenseReportService(
+            _expenseRepo, _fileStorage, _budgetService, _teamService, _userService,
+            AuditLog, _holdedClient, _holdedFinance, Clock, logger,
+            Options.Create(new TravelReimbursementConfig()));
+
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        await sut.AddLineAsync(id, submitter, "No attachment line", 50m, ct: Xunit.TestContext.Current.CancellationToken); // Receipt line, no attachment
+        SetupUserAndProfile(submitter, "Bob", "ES1234");
+
+        var result = await sut.SubmitWithResultAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeFalse();
+        logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Is<Exception?>(e => e == null),
+            Arg.Any<Func<object, Exception?, string>>());
+        logger.DidNotReceive().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [HumansFact]
+    public async Task SubmitWithResultAsync_LogsError_WithException_ForGenuineFault()
+    {
+        var logger = Substitute.For<ILogger<ExpenseReportService>>();
+        var sut = new ExpenseReportService(
+            _expenseRepo, _fileStorage, _budgetService, _teamService, _userService,
+            AuditLog, _holdedClient, _holdedFinance, Clock, logger,
+            Options.Create(new TravelReimbursementConfig()));
+
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        var lineId = await sut.AddLineAsync(id, submitter, "Item", 50m, ct: Xunit.TestContext.Current.CancellationToken);
+        var attachId = await _expenseRepo.AddAttachmentAsync(MakeAttachment(submitter), Xunit.TestContext.Current.CancellationToken);
+        await _expenseRepo.SetLineAttachmentAsync(lineId, attachId, Xunit.TestContext.Current.CancellationToken);
+
+        // Not InvalidOperationException — a genuine fault, not a validation rejection.
+        _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
+            .Throws(new TimeoutException("db timeout"));
+
+        var result = await sut.SubmitWithResultAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeFalse();
+        logger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Is<Exception?>(e => e is TimeoutException),
+            Arg.Any<Func<object, Exception?, string>>());
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

`ExpenseReportService.RunMutationAsync` caught every exception and logged it at `Error` with a full stack trace, including ordinary user-input validation failures (missing attachment, missing IBAN, empty report, missing legal name) thrown as `InvalidOperationException` from `SubmitAsync`. This made routine user mistakes indistinguishable from real faults in the production error log.

## Fix

`RunMutationAsync` now catches `InvalidOperationException` separately and logs it at `Warning` with a structured `{Reason}` property and no exception object — reusing the validation-vs-fault distinction already established in this file (see `ExpenseIbanSaveResult.IsValidationError`). All other exceptions still log at `Error` with the full exception object.

Because the fix lives in the shared `RunMutationAsync` helper, every caller (submit, withdraw, endorse, reject, approve, add/update/remove line, attach file, etc.) gets consistent treatment automatically — not just the one call site from the log evidence.

The user-facing failure message returned via `ExpenseMutationResult.Failure` is unchanged.

## Test plan
- [x] `SubmitWithResultAsync_LogsWarning_NoException_WhenValidationFails` — asserts Warning logged with `Exception == null`, no Error logged, for the missing-attachment case (representative of all four `SubmitAsync` validation checks, which share the same `RunMutationAsync` catch path)
- [x] `SubmitWithResultAsync_LogsError_WithException_ForGenuineFault` — asserts a non-`InvalidOperationException` fault still logs at Error with the exception attached
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet --filter FullyQualifiedName~ExpenseReportServiceTests` — 71/71 passed

Fixes nobodies-collective/Humans#948