### PR TITLE
fix(camps): fixed-height barrio carousel slides, drop autoplay

### DIFF
--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -19,12 +19,11 @@
         {
             if (Model.ImageUrls.Count == 1)
             {
-                <img src="@Model.ImageUrls[0]" class="img-fluid rounded mb-4" alt="@Model.Name"
-                     style="width: 100%; max-height: 400px; object-fit: cover;" />
+                <img src="@Model.ImageUrls[0]" class="w-100 rounded mb-4 camp-carousel-img" alt="@Model.Name" />
             }
             else
             {
-                <div id="campCarousel" class="carousel slide mb-4" data-bs-ride="carousel">
+                <div id="campCarousel" class="carousel slide mb-4">
                     <div class="carousel-indicators">
                         @for (var i = 0; i < Model.ImageUrls.Count; i++)
                         {
@@ -36,8 +35,7 @@
                         @for (var i = 0; i < Model.ImageUrls.Count; i++)
                         {
                             <div class="carousel-item @(i == 0 ? "active" : "")">
-                                <img src="@Model.ImageUrls[i]" class="d-block w-100 rounded" alt="@Model.Name"
-                                     style="max-height: 400px; object-fit: cover;" />
+                                <img src="@Model.ImageUrls[i]" class="d-block w-100 rounded camp-carousel-img" alt="@Model.Name" />
                             </div>
                         }
                     </div>

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -2097,3 +2097,19 @@ body.city-map-fullscreen main {
     font-weight: 600;
     color: var(--h-aged-ink); /* #3d2b1f — high contrast on parchment card */
 }
+
+/* ── Barrio image carousel (issue #956) ─────────────────────────────────
+   Fixed slide height so mixed-aspect images don't reflow the page as the
+   carousel advances; object-fit crops instead of the box auto-sizing. */
+.camp-carousel-img {
+    width: 100%;
+    height: 400px;
+    display: block;
+    object-fit: cover;
+}
+
+@media (max-width: 575.98px) {
+    .camp-carousel-img {
+        height: 220px;
+    }
+}


### PR DESCRIPTION
## Summary
- Barrio carousel slides (`src/Humans.Web/Views/Camp/Details.cshtml`) were only `max-height` capped, so each image rendered at its own intrinsic aspect height. On a barrio with mixed-aspect images, the carousel box changed height per slide, reflowing everything below it.
- Added a fixed-height `.camp-carousel-img` class in `site.css` (400px desktop, 220px at the `575.98px` mobile breakpoint) so `object-fit: cover` actually crops into a stable box. Applied to both the single-image branch and the multi-image carousel branch so they present consistently.
- Removed `data-bs-ride="carousel"` so the slideshow no longer auto-advances — users navigate via the existing prev/next controls. This is the smaller fix from the two options in the issue and fully removes the "cannot be paused" complaint.

## Acceptance criteria
- [x] Content below the carousel does not shift as slides advance — slide box height is now fixed, not content-driven
- [x] Slides are consistently sized on mobile and desktop — `.camp-carousel-img` + mobile media query
- [x] The user can stop the slideshow (it no longer auto-advances)
- [ ] Reporter notification (`iss:22c88666`) — out of scope for this code change, handled by the in-app issue/triage flow

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] No existing unit/integration tests reference `Camp/Details.cshtml` or the carousel markup
- [ ] Manual check on `/Barrios/curious-creatures` (mixed-aspect images) recommended in QA preview deploy

Fixes nobodies-collective/Humans#956