### PR TITLE
test(google-sync): end-to-end reconciliation rig for soft-delete revocation paths

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IGoogleResourceRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IGoogleResourceRepository.cs
@@ -69,6 +69,23 @@ public interface IGoogleResourceRepository : IRepository
     Task<IReadOnlyList<GoogleResource>> GetActiveDriveFoldersAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Returns every active resource matching the exact <paramref name="resourceType"/>
+    /// across all teams. Read-only.
+    /// </summary>
+    /// <remarks>
+    /// nobodies-collective/Humans#508 — <c>GoogleWorkspaceSyncService.SyncResourcesByTypeAsync</c>
+    /// used to call <see cref="GetActiveDriveFoldersAsync"/> for every resource type
+    /// (including <see cref="GoogleResourceType.DriveFile"/>), but that method hard-filters
+    /// to <see cref="GoogleResourceType.DriveFolder"/> at the DB level, so the DriveFile
+    /// reconciliation pass silently loaded zero rows. This method fetches by the exact
+    /// type the caller asked for instead of overfetching a fixed type and filtering
+    /// in memory.
+    /// </remarks>
+    Task<IReadOnlyList<GoogleResource>> GetActiveByResourceTypeAsync(
+        GoogleResourceType resourceType,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Returns the total number of resource rows (including inactive). Used by
     /// the observable metrics gauge. Read-only.
     /// </summary>

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -405,10 +405,8 @@ public sealed class GoogleWorkspaceSyncService(
         // (including soft-deleted) through the Teams service so we never touch
         // the team graph directly — the resource's Team nav is hydrated via
         // ITeamService.GetTeamByIdAsync / GetByIdsWithParentsAsync.
-        var allActive = await resourceRepository.GetActiveDriveFoldersAsync(cancellationToken);
-        IReadOnlyList<GoogleResource> resources = allActive
-            .Where(r => r.ResourceType == resourceType && r.IsActive)
-            .ToList();
+        IReadOnlyList<GoogleResource> resources =
+            await resourceRepository.GetActiveByResourceTypeAsync(resourceType, cancellationToken);
 
         if (resources.Count == 0)
         {

--- a/src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleResourceRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/GoogleIntegration/GoogleResourceRepository.cs
@@ -99,6 +99,17 @@ internal sealed class GoogleResourceRepository(IDbContextFactory<HumansDbContext
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<GoogleResource>> GetActiveByResourceTypeAsync(
+        GoogleResourceType resourceType,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.GoogleResources
+            .AsNoTracking()
+            .Where(r => r.IsActive && r.ResourceType == resourceType)
+            .ToListAsync(ct);
+    }
+
     public async Task<int> GetCountAsync(CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceReconciliationTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceReconciliationTests.cs
@@ -1,0 +1,336 @@
+using AwesomeAssertions;
+using Humans.Application.Configuration;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.GoogleIntegration;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Repositories.GoogleIntegration;
+using Humans.Infrastructure.Services.GoogleWorkspace;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.GoogleIntegration;
+
+/// <summary>
+/// End-to-end regression coverage for the soft-deleted-team revocation path in
+/// <see cref="GoogleWorkspaceSyncService.SyncResourcesByTypeAsync"/>, per
+/// nobodies-collective/Humans#508. PR #227 (sprint/20260415/batch-3) layered
+/// several fixes onto this flow and every bug was caught by review rather
+/// than by a failing test — this file seeds a real (InMemory) <c>HumansDbContext</c>
+/// through the real <see cref="GoogleResourceRepository"/> and a real
+/// <see cref="TeamResourceService"/> (resolved via the service-locator seam
+/// exactly as production does), and drives Drive reconciliation against the
+/// existing dev/test <see cref="StubGoogleDrivePermissionsClient"/> fake — no
+/// new fake Google layer was needed; reuse-first applies to test
+/// infrastructure too (memory/process/reuse-first-change-discipline.md).
+///
+/// <para>
+/// Scope note: <see cref="GoogleResourceType.Group"/> is out of scope here —
+/// <c>SyncResourcesByTypeAsync</c> throws for <c>Group</c> and delegates all
+/// Group membership reconciliation to <c>IGoogleGroupSync</c> (see
+/// <c>RequestGoogleGroupSyncAsync</c> / <c>ReconcileGroupResourceAsync</c> /
+/// <c>EnsureTeamGroupAsync</c> — none of which run inside
+/// <c>SyncResourcesByTypeAsync</c>). That path is already pinned by
+/// <c>GoogleGroupSyncServiceTests</c>. Building an unused fake
+/// CloudIdentityService for a code path this method never calls would be
+/// speculative test infra the actual method can't exercise.
+/// </para>
+/// </summary>
+public sealed class GoogleWorkspaceSyncServiceReconciliationTests : ServiceTestHarness
+{
+    private readonly StubGoogleDrivePermissionsClient _drivePermissions =
+        new(NullLogger<StubGoogleDrivePermissionsClient>.Instance);
+
+    private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
+    private readonly ISyncSettingsService _syncSettingsService = Substitute.For<ISyncSettingsService>();
+    private readonly IGoogleRemovalNotificationService _removalNotifications = Substitute.For<IGoogleRemovalNotificationService>();
+    private readonly ITeamResourceGoogleClient _teamResourceClient = Substitute.For<ITeamResourceGoogleClient>();
+
+    private readonly GoogleWorkspaceSyncService _syncService;
+
+    public GoogleWorkspaceSyncServiceReconciliationTests()
+        : base(Instant.FromUtc(2026, 8, 2, 9, 0))
+    {
+        _teamResourceClient.GetServiceAccountEmailAsync(Arg.Any<CancellationToken>())
+            .Returns("sa@nobodies.team");
+
+        // No expected members and no non-member permissions in most scenarios,
+        // so these two are only exercised by the "extra permission" cases —
+        // safe defaults keep every scenario from needing to restub them.
+        _userEmailService.MatchByEmailsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _userEmailService.GetEntitiesByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, IReadOnlyList<UserEmailRowSnapshot>>());
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, UserInfo>());
+
+        // Default: full Drive reconciliation (add + remove) enabled.
+        _syncSettingsService.GetModeAsync(SyncServiceType.GoogleDrive, Arg.Any<CancellationToken>())
+            .Returns(SyncMode.AddAndRemove);
+
+        IGoogleResourceRepository repository = new GoogleResourceRepository(DbFactory);
+
+        // Real TeamResourceService, resolved through the same service-locator seam
+        // GoogleWorkspaceSyncService uses in production
+        // (serviceProvider.GetRequiredService<ITeamResourceService>()), backed by
+        // the same in-memory DbContext as the resource repository above — so
+        // deactivation writes land in the same table the test asserts against.
+        var teamResourceService = new TeamResourceService(
+            repository,
+            googleClient: Substitute.For<ITeamResourceGoogleClient>(),
+            drivePermissions: _drivePermissions,
+            teamService: Substitute.For<ITeamService>(),
+            serviceProvider: new ServiceLocatorBuilder().Build(),
+            auditLogService: AuditLog,
+            resourceOptions: new TeamResourceManagementOptions(),
+            clock: Clock,
+            logger: NullLogger<TeamResourceService>.Instance);
+
+        var serviceProvider = new ServiceLocatorBuilder()
+            .With<ITeamResourceService>(teamResourceService)
+            .Build();
+
+        var options = Options.Create(new GoogleWorkspaceOptions { Domain = "nobodies.team" });
+
+        _syncService = new GoogleWorkspaceSyncService(
+            Substitute.For<IGoogleGroupProvisioningClient>(),
+            _drivePermissions,
+            Substitute.For<IGoogleDirectoryClient>(),
+            _teamResourceClient,
+            repository,
+            Substitute.For<IGoogleSyncOutboxRepository>(),
+            _teamService,
+            _userService,
+            _userEmailService,
+            Substitute.For<IGoogleGroupSync>(),
+            AuditLog,
+            _syncSettingsService,
+            _removalNotifications,
+            options,
+            Clock,
+            serviceProvider,
+            NullLogger<GoogleWorkspaceSyncService>.Instance);
+    }
+
+    // ==========================================================================
+    // 1. Soft-deleted team revocation
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SyncResourcesByTypeAsync_SoftDeletedTeamWithExtraPermission_RevokesAccessAndDeactivatesResource()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var teamId = Guid.NewGuid();
+        var googleId = await CreateGoogleFolderAsync("Doomed Folder");
+        const string extraEmail = "ex-member@nobodies.team";
+
+        // Simulate a permission that survived from when the team had members.
+        await _drivePermissions.CreatePermissionAsync(googleId, extraEmail, "writer", ct);
+
+        var resourceId = SeedDriveResource(teamId, googleId, "Doomed Folder");
+        await Db.SaveChangesAsync(ct);
+
+        // Team.IsActive = false + no active members (every TeamMember.LeftAt set).
+        StubTeams((teamId, IsActive: false, Members: []));
+
+        var result = await _syncService.SyncResourcesByTypeAsync(
+            GoogleResourceType.DriveFolder, SyncAction.Execute, ct);
+
+        result.Diffs.Should().ContainSingle(d => d.ErrorMessage == null);
+
+        var permissions = await _drivePermissions.ListPermissionsAsync(googleId, ct);
+        permissions.Permissions.Should().BeEmpty("the extra permission should have been revoked");
+
+        var row = await Db.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == resourceId, ct);
+        row.IsActive.Should().BeFalse("the soft-deleted team's Drive resource should be deactivated for this type");
+
+        await _removalNotifications.Received(1).NotifyRemovalAsync(
+            extraEmail, GoogleResourceType.DriveFolder, "Doomed Folder", Arg.Any<string?>(),
+            Arg.Any<SyncRemovalReason>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // 2. Shared-GoogleId Drive groups: whole-group error blocks every row
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SyncResourcesByTypeAsync_SharedGoogleIdGroupErrors_NoRowInGroupIsDeactivated()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var teamId1 = Guid.NewGuid();
+        var teamId2 = Guid.NewGuid();
+
+        // Both teams' rows point at the same GoogleId, which is never
+        // registered with the Drive stub — ListPermissionsAsync returns a
+        // 404 GoogleClientError, exactly like a deleted/mistyped Drive item.
+        const string sharedGoogleId = "unregistered-shared-drive-id";
+        var resourceId1 = SeedDriveResource(teamId1, sharedGoogleId, "Shared Folder (Team 1)");
+        var resourceId2 = SeedDriveResource(teamId2, sharedGoogleId, "Shared Folder (Team 2)");
+        await Db.SaveChangesAsync(ct);
+
+        StubTeams(
+            (teamId1, IsActive: false, Members: []),
+            (teamId2, IsActive: false, Members: []));
+
+        var result = await _syncService.SyncResourcesByTypeAsync(
+            GoogleResourceType.DriveFolder, SyncAction.Execute, ct);
+
+        result.Diffs.Should().ContainSingle(d => d.ErrorMessage != null);
+
+        var rows = await Db.GoogleResources.AsNoTracking()
+            .Where(r => r.Id == resourceId1 || r.Id == resourceId2)
+            .ToListAsync(ct);
+        rows.Should().OnlyContain(r => r.IsActive, "no row in an errored GoogleId group may be deactivated");
+        rows.Should().OnlyContain(r => r.ErrorMessage != null);
+    }
+
+    // ==========================================================================
+    // 3. Partial error within one team: neither row for that team deactivates
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SyncResourcesByTypeAsync_PartialErrorWithinTeam_DefersDeactivationForBothRows()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var teamId = Guid.NewGuid();
+
+        var cleanGoogleId = await CreateGoogleFolderAsync("Clean Folder");
+        const string erroredGoogleId = "unregistered-errored-folder-id";
+
+        var cleanResourceId = SeedDriveResource(teamId, cleanGoogleId, "Clean Folder");
+        var erroredResourceId = SeedDriveResource(teamId, erroredGoogleId, "Errored Folder");
+        await Db.SaveChangesAsync(ct);
+
+        StubTeams((teamId, IsActive: false, Members: []));
+
+        await _syncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, ct);
+
+        var rows = await Db.GoogleResources.AsNoTracking()
+            .Where(r => r.Id == cleanResourceId || r.Id == erroredResourceId)
+            .ToListAsync(ct);
+        rows.Should().OnlyContain(r => r.IsActive,
+            "DeactivateResourcesForTeamAsync(team, type) is all-or-nothing; one errored resource must block the clean one too");
+    }
+
+    // ==========================================================================
+    // 4. Type ordering: DriveFolder pass leaves Group/DriveFile rows alone
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SyncResourcesByTypeAsync_DriveFolderPass_DoesNotDeactivateGroupOrDriveFileRowsForSameTeam()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var teamId = Guid.NewGuid();
+
+        var googleId = await CreateGoogleFolderAsync("Folder");
+        var folderResourceId = SeedDriveResource(teamId, googleId, "Folder", GoogleResourceType.DriveFolder);
+        var groupResourceId = SeedDriveResource(teamId, "group-id", "Group", GoogleResourceType.Group);
+        var driveFileResourceId = SeedDriveResource(teamId, "file-id", "File", GoogleResourceType.DriveFile);
+        await Db.SaveChangesAsync(ct);
+
+        StubTeams((teamId, IsActive: false, Members: []));
+
+        await _syncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, ct);
+
+        var folderRow = await Db.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == folderResourceId, ct);
+        folderRow.IsActive.Should().BeFalse("the DriveFolder row for the soft-deleted team should be deactivated");
+
+        var groupRow = await Db.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == groupResourceId, ct);
+        groupRow.IsActive.Should().BeTrue("the Group row must not be flipped by the DriveFolder pass");
+
+        var fileRow = await Db.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == driveFileResourceId, ct);
+        fileRow.IsActive.Should().BeTrue("the DriveFile row must not be flipped by the DriveFolder pass");
+    }
+
+    // ==========================================================================
+    // 5. Sync-mode gating: AddOnly / None never deactivate
+    // ==========================================================================
+
+    [HumansTheory]
+    [InlineData(SyncMode.AddOnly)]
+    [InlineData(SyncMode.None)]
+    public async Task SyncResourcesByTypeAsync_WhenNotAddAndRemove_DoesNotDeactivateOrRevoke(SyncMode mode)
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        _syncSettingsService.GetModeAsync(SyncServiceType.GoogleDrive, Arg.Any<CancellationToken>())
+            .Returns(mode);
+
+        var teamId = Guid.NewGuid();
+        var googleId = await CreateGoogleFolderAsync("Doomed Folder");
+        const string extraEmail = "ex-member@nobodies.team";
+        await _drivePermissions.CreatePermissionAsync(googleId, extraEmail, "writer", ct);
+
+        var resourceId = SeedDriveResource(teamId, googleId, "Doomed Folder");
+        await Db.SaveChangesAsync(ct);
+
+        StubTeams((teamId, IsActive: false, Members: []));
+
+        await _syncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, ct);
+
+        var row = await Db.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == resourceId, ct);
+        row.IsActive.Should().BeTrue("deactivation only happens when sync mode is AddAndRemove");
+
+        var permissions = await _drivePermissions.ListPermissionsAsync(googleId, ct);
+        permissions.Permissions.Should().ContainSingle(p => p.EmailAddress == extraEmail,
+            "the extra permission must not be revoked outside AddAndRemove mode");
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private async Task<string> CreateGoogleFolderAsync(string name)
+    {
+        var result = await _drivePermissions.CreateFolderAsync(name, parentFolderId: null, CancellationToken.None);
+        result.Folder.Should().NotBeNull();
+        return result.Folder!.Id!;
+    }
+
+    private Guid SeedDriveResource(
+        Guid teamId,
+        string googleId,
+        string name,
+        GoogleResourceType resourceType = GoogleResourceType.DriveFolder)
+    {
+        var id = Guid.NewGuid();
+        Db.GoogleResources.Add(new GoogleResource
+        {
+            Id = id,
+            TeamId = teamId,
+            ResourceType = resourceType,
+            GoogleId = googleId,
+            Name = name,
+            DrivePermissionLevel = DrivePermissionLevel.Contributor,
+            ProvisionedAt = Clock.GetCurrentInstant(),
+            IsActive = true
+        });
+        return id;
+    }
+
+    private void StubTeams(params (Guid TeamId, bool IsActive, List<TeamMemberInfo> Members)[] teams)
+    {
+        var dict = teams.ToDictionary(
+            t => t.TeamId,
+            t => new TeamInfo(
+                t.TeamId, $"Team {t.TeamId}", null, $"team-{t.TeamId:N}",
+                IsActive: t.IsActive, IsSystemTeam: false, SystemTeamType: SystemTeamType.None,
+                RequiresApproval: false, IsPublicPage: false, IsHidden: false,
+                IsPromotedToDirectory: false, CreatedAt: Instant.MinValue,
+                Members: t.Members));
+
+        _teamService.GetTeamsAsync(Arg.Any<CancellationToken>()).Returns(dict);
+    }
+}

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceReconciliationTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceReconciliationTests.cs
@@ -256,7 +256,48 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : ServiceTestH
     }
 
     // ==========================================================================
-    // 5. Sync-mode gating: AddOnly / None never deactivate
+    // 5. DriveFile pass reconciles its own rows (nobodies-collective/Humans#508
+    //    follow-up — flagged by PR #1149 review comment 3700252152)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SyncResourcesByTypeAsync_DriveFilePass_RevokesAccessAndDeactivatesResource()
+    {
+        // Regression for a live bug the type-ordering scenario above didn't
+        // catch: SyncResourcesByTypeAsync(DriveFile, ...) used to call
+        // IGoogleResourceRepository.GetActiveDriveFoldersAsync(), which
+        // hard-filters to ResourceType == DriveFolder at the DB level — so the
+        // DriveFile pass always loaded zero rows and silently no-opped.
+        // GoogleResourceReconciliationJob runs exactly this pass every tick,
+        // so soft-deleted teams' linked Drive *files* never had their Google
+        // permissions revoked. Fixed by GetActiveByResourceTypeAsync (fetch by
+        // the exact requested type instead of overfetching DriveFolder rows).
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var teamId = Guid.NewGuid();
+        var googleId = await CreateGoogleFolderAsync("Doomed File");
+        const string extraEmail = "ex-member@nobodies.team";
+
+        await _drivePermissions.CreatePermissionAsync(googleId, extraEmail, "writer", ct);
+
+        var resourceId = SeedDriveResource(teamId, googleId, "Doomed File", GoogleResourceType.DriveFile);
+        await Db.SaveChangesAsync(ct);
+
+        StubTeams((teamId, IsActive: false, Members: []));
+
+        var result = await _syncService.SyncResourcesByTypeAsync(
+            GoogleResourceType.DriveFile, SyncAction.Execute, ct);
+
+        result.Diffs.Should().ContainSingle(d => d.ErrorMessage == null);
+
+        var permissions = await _drivePermissions.ListPermissionsAsync(googleId, ct);
+        permissions.Permissions.Should().BeEmpty("the extra permission on the DriveFile should have been revoked");
+
+        var row = await Db.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == resourceId, ct);
+        row.IsActive.Should().BeFalse("the soft-deleted team's DriveFile resource should be deactivated for this type");
+    }
+
+    // ==========================================================================
+    // 6. Sync-mode gating: AddOnly / None never deactivate
     // ==========================================================================
 
     [HumansTheory]


### PR DESCRIPTION
## Summary

Adds `GoogleWorkspaceSyncServiceReconciliationTests` — an end-to-end test rig that seeds a real (InMemory) `HumansDbContext` through the real `GoogleResourceRepository` and `TeamResourceService`, and drives `GoogleWorkspaceSyncService.SyncResourcesByTypeAsync` end-to-end against the existing dev/test `StubGoogleDrivePermissionsClient` fake.

PR #227 layered several fixes onto the soft-deleted-team Google revocation flow, but every bug was caught by review (Codex) rather than by a failing test. This closes that verification gap for the scenarios called out in the issue.

## Bug found and fixed — DriveFile reconciliation was a silent no-op

`claude[bot]` [flagged](https://github.com/peterdrier/Humans/pull/1149#discussion_r3700252152) that the original 5-scenario rig only ever called `SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, ...)`, and never exercised the symmetric `DriveFile` pass that `GoogleResourceReconciliationJob` actually runs every tick. Doing so exposed a real production bug:

`GoogleWorkspaceSyncService.SyncResourcesByTypeAsync` loaded rows via `IGoogleResourceRepository.GetActiveDriveFoldersAsync()`, which hard-filters to `ResourceType == DriveFolder` **at the DB level**. The subsequent in-memory `.Where(r => r.ResourceType == resourceType)` filter was therefore dead code whenever `resourceType` was `DriveFile` — the method always returned zero rows and silently no-opped. `GoogleResourceReconciliationJob` calls exactly this path for `DriveFile` every reconciliation run, with a comment claiming the intent was covered. In practice: **soft-deleted teams' linked Drive files never had their Google permissions revoked.**

### Interface surface change — needs Peter's approval

Added `IGoogleResourceRepository.GetActiveByResourceTypeAsync(GoogleResourceType resourceType, ...)` — fetches active resources by the exact requested type, instead of overfetching a hardcoded `DriveFolder` query and filtering in memory. `SyncResourcesByTypeAsync` now calls it directly (the redundant in-memory `.Where` is gone).

**Alternatives considered and rejected:**
- **Rename/broaden `GetActiveDriveFoldersAsync` to return `DriveFolder` + `DriveFile` ("Drive-permission-bearing" resources).** Audited every caller first: `GoogleResourceRepository.GetActiveDriveFoldersAsync` is used at 4 sites in `GoogleWorkspaceSyncService` (not just the buggy one) plus `TeamResourceService.GetActiveDriveFoldersAsync` → `DriveActivityMonitorService`. Two call sites already re-filter to `DriveFolder` explicitly (safe to broaden), but `DriveActivityMonitorService.CheckForAnomalousActivityAsync` genuinely intends folder-only Drive Activity API monitoring (its own log message says "Drive folder resources"). Broadening the shared method would have silently started feeding `DriveFile` rows into an unrelated anomaly-detection feature — an untested, unrequested behavior change. Also, `GoogleResourceType` has a third non-Group value (`SharedDrive`, reserved for future use) that a hardcoded "folder-or-file" broadening wouldn't have covered anyway.
- **A type-parametrized method (`GetActiveByResourceTypeAsync`) was the smallest change that is also correct**: it exactly matches what the one buggy call site needs, doesn't touch the other three `GetActiveDriveFoldersAsync` call sites' behavior, and generalizes cleanly to any future `GoogleResourceType` without further changes.

Left `GetActiveDriveFoldersAsync` and its existing callers untouched.

## Scenarios covered (now 6)

1. **Soft-deleted team revocation** — `Team.IsActive = false` + no active members → existing Drive permissions are revoked and the resource row is deactivated for the reconciled type.
2. **Shared-GoogleId Drive groups** — two teams' rows share one GoogleId; if that group errors, *neither* row is deactivated.
3. **Partial errors** — a team with one errored and one clean Drive resource has *neither* deactivated (`DeactivateResourcesForTeamAsync` is all-or-nothing per team+type).
4. **Type ordering** — a `DriveFolder` pass deactivates only the `DriveFolder` row, leaving `Group`/`DriveFile` rows for the same team untouched.
5. **DriveFile pass reconciles its own rows** *(new)* — `SyncResourcesByTypeAsync(GoogleResourceType.DriveFile, ...)` against a soft-deleted team's `DriveFile` resource revokes the extra permission and deactivates the row. Fails without the `GetActiveByResourceTypeAsync` fix (verified locally by temporarily reverting it), passes with it.
6. **Sync-mode gating** — `AddOnly` / `None` never trigger deactivation or revocation (parametrized `[HumansTheory]`).

## Reuse-first note

Per the issue's own instruction to check existing fakes before inventing new ones: this rig reuses the existing `Humans.Infrastructure.Services.GoogleWorkspace.StubGoogleDrivePermissionsClient` (already the dev/QA Drive fake) and the existing `GoogleResourceRepository` / `TeamResourceService` / `ServiceTestHarness` / `ServiceLocatorBuilder` test infrastructure instead of building a parallel fake layer inside `tests/`.

**Scope decision:** `GoogleResourceType.Group` is out of scope. `SyncResourcesByTypeAsync` throws for `Group` and delegates all Group membership reconciliation to `IGoogleGroupSync` via a different call path (`RequestGoogleGroupSyncAsync` / `ReconcileGroupResourceAsync` / `EnsureTeamGroupAsync`) — none of which execute inside the method under test. That path is already pinned by `GoogleGroupSyncServiceTests`. Building an unused fake `CloudIdentityService` for a code path this method can't reach would be speculative test infra, so it was skipped. This is documented in the test file's class-level doc comment.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] New rig: 7/7 passing (`--filter FullyQualifiedName~GoogleWorkspaceSyncServiceReconciliationTests`)
- [x] Google-sync + reconciliation-repository suites: 234/234 passing
- [x] Full `Humans.Application.Tests`: 3895/3895 passing
- [x] Verified the new DriveFile scenario fails without the fix (reverted locally, confirmed red, restored)

Fixes nobodies-collective/Humans#508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
