### PR TITLE
refactor(store): drop auth threading (isPrivilegedReader param + CanOpenStore VM bool)

### DIFF
--- a/src/Humans.Application/Interfaces/Store/IStoreService.cs
+++ b/src/Humans.Application/Interfaces/Store/IStoreService.cs
@@ -6,7 +6,20 @@ namespace Humans.Application.Interfaces.Store;
 public interface IStoreService : IApplicationService
 {
     // Catalog (read)
-    Task<StoreIndexData> GetIndexDataAsync(Guid userId, bool isPrivilegedReader, CancellationToken ct = default);
+    /// <summary>
+    /// Builds the Store index for <paramref name="userId"/>: the camp they lead (if any) and the
+    /// top-level departments they coordinate. See <see cref="GetAllCounterpartiesIndexDataAsync"/>
+    /// for the privileged (every counterparty) variant. Authorization — who may see all
+    /// counterparties vs. only their own — is the controller's concern.
+    /// </summary>
+    Task<StoreIndexData> GetIndexDataAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Builds the Store index listing every camp and department counterparty for the active
+    /// event year, regardless of who leads or coordinates them. Reserved for privileged readers
+    /// (Store admins, TeamsAdmins) — the controller's concern.
+    /// </summary>
+    Task<StoreIndexData> GetAllCounterpartiesIndexDataAsync(CancellationToken ct = default);
     Task<IReadOnlyList<ProductDto>> GetActiveCatalogAsync(int year, CancellationToken ct = default);
     Task<IReadOnlyList<ProductDto>> GetAllProductsForYearAsync(int year, CancellationToken ct = default);
     Task<ProductDto?> GetProductAsync(Guid productId, CancellationToken ct = default);

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -24,10 +24,16 @@ public class StoreService(
     IStripeService stripeService,
     ILogger<StoreService> logger) : IStoreService
 {
-    public async Task<StoreIndexData> GetIndexDataAsync(
+    public Task<StoreIndexData> GetIndexDataAsync(Guid userId, CancellationToken ct = default) =>
+        BuildIndexDataAsync(userId, allCounterparties: false, ct);
+
+    public Task<StoreIndexData> GetAllCounterpartiesIndexDataAsync(CancellationToken ct = default) =>
+        BuildIndexDataAsync(userId: Guid.Empty, allCounterparties: true, ct);
+
+    private async Task<StoreIndexData> BuildIndexDataAsync(
         Guid userId,
-        bool isPrivilegedReader,
-        CancellationToken ct = default)
+        bool allCounterparties,
+        CancellationToken ct)
     {
         var activeEvent = await shifts.GetActiveAsync();
         var year = activeEvent?.Year > 0 ? activeEvent.Year : clock.GetCurrentInstant().InUtc().Year;
@@ -42,7 +48,7 @@ public class StoreService(
         var campSeasons = new List<CampSeasonInfo>();
         foreach (var camp in await campService.GetCampsForYearAsync(year, ct))
         {
-            if (isPrivilegedReader)
+            if (allCounterparties)
             {
                 var season = camp.GetSeasonForYear(year);
                 if (season is not null) campSeasons.Add(season);
@@ -80,7 +86,7 @@ public class StoreService(
         var teamOrderPrices = await LoadCurrentPricesAsync(ct);
         foreach (var team in teams.Values
             .Where(t => t.ParentTeamId is null
-                        && (isPrivilegedReader
+                        && (allCounterparties
                             || (t.ManagementRoleHolderUserIds is not null
                                 && t.ManagementRoleHolderUserIds.Contains(userId)))))
         {
@@ -108,7 +114,7 @@ public class StoreService(
             year,
             catalog,
             counterparties,
-            counterparties.Count == 0 && !isPrivilegedReader);
+            counterparties.Count == 0 && !allCounterparties);
     }
 
     public async Task<IReadOnlyList<ProductDto>> GetActiveCatalogAsync(int year, CancellationToken ct = default)

--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -72,6 +72,9 @@ public static class AuthorizationPolicyExtensions
             options.AddPolicy(PolicyNames.TeamsAdminBoardOrAdmin, policy =>
                 policy.RequireRole(RoleNames.TeamsAdmin, RoleNames.Board, RoleNames.Admin));
 
+            options.AddPolicy(PolicyNames.TeamsAdminOrAdmin, policy =>
+                policy.RequireRole(RoleNames.TeamsAdmin, RoleNames.Admin));
+
             options.AddPolicy(PolicyNames.CampAdminOrAdmin, policy =>
                 policy.RequireRole(RoleNames.CampAdmin, RoleNames.Admin));
 

--- a/src/Humans.Web/Authorization/PolicyNames.cs
+++ b/src/Humans.Web/Authorization/PolicyNames.cs
@@ -13,6 +13,13 @@ public static class PolicyNames
     public const string HumanAdminBoardOrAdmin = nameof(HumanAdminBoardOrAdmin);
     public const string HumanAdminOrAdmin = nameof(HumanAdminOrAdmin);
     public const string TeamsAdminBoardOrAdmin = nameof(TeamsAdminBoardOrAdmin);
+
+    /// <summary>
+    /// TeamsAdmin or Admin — deliberately narrower than <see cref="TeamsAdminBoardOrAdmin"/>
+    /// (Board is not included) for gates where Board access would dead-end the viewer
+    /// (e.g. the Team page's "Open store" link, which Board members can't otherwise use).
+    /// </summary>
+    public const string TeamsAdminOrAdmin = nameof(TeamsAdminOrAdmin);
     public const string CampAdminOrAdmin = nameof(CampAdminOrAdmin);
     public const string TicketAdminBoardOrAdmin = nameof(TicketAdminBoardOrAdmin);
     public const string TicketAdminOrAdmin = nameof(TicketAdminOrAdmin);

--- a/src/Humans.Web/Controllers/StoreController.cs
+++ b/src/Humans.Web/Controllers/StoreController.cs
@@ -32,7 +32,9 @@ public class StoreController(
         // can edit team orders but only view camp orders, so per-row affordances
         // are resolved against the order authorization handler below.
         var isPrivilegedReader = RoleChecks.CanAdministerStore(User) || RoleChecks.IsTeamsAdmin(User);
-        var pageData = await storeService.GetIndexDataAsync(user.Id, isPrivilegedReader, ct);
+        var pageData = isPrivilegedReader
+            ? await storeService.GetAllCounterpartiesIndexDataAsync(ct)
+            : await storeService.GetIndexDataAsync(user.Id, ct);
         if (pageData.ShowNoOrdersMessage)
         {
             SetInfo("You don't lead any camps or coordinate any departments this year, so there are no Store orders to manage.");

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -157,9 +157,6 @@ public class TeamController(
             CurrentUserPendingRequestId = teamPage.CurrentUserPendingRequestId,
             PendingRequestCount = teamPage.PendingRequestCount,
             ShiftsSummary = MapShiftsSummary(teamPage.ShiftsSummary, slug),
-            CanOpenStore = (teamPage.IsCurrentUserCoordinator && team.ParentTeam is null && team.IsActive)
-                || RoleChecks.IsAdmin(User)
-                || RoleChecks.IsTeamsAdmin(User),
         };
 
         // Surface the per-team Early Entry link when EE is enabled and the viewer can

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -95,12 +95,6 @@ public class TeamDetailViewModel
     public ShiftsSummaryCardViewModel? ShiftsSummary { get; set; }
 
     /// <summary>
-    /// Whether to surface the "Open store" link: a coordinator of this active top-level department,
-    /// or an Admin / TeamsAdmin (who reach the Store regardless of coordinator status).
-    /// </summary>
-    public bool CanOpenStore { get; set; }
-
-    /// <summary>
     /// Coordinators/leads from child teams. Only populated for departments with child team coordinators.
     /// </summary>
     public List<ChildTeamMemberViewModel> SubteamLeads { get; set; } = [];

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -1,4 +1,6 @@
 @using Humans.Web.Authorization
+@using Microsoft.AspNetCore.Authorization
+@inject IAuthorizationService AuthService
 @model Humans.Web.Models.TeamDetailViewModel
 @{
     ViewData["Title"] = Model.Name;
@@ -306,7 +308,13 @@
                         Team calendar
                     </a>
 
-                    @if (Model.CanOpenStore)
+                    @{
+                        // "Open store": a coordinator of this active top-level department, or an
+                        // Admin / TeamsAdmin (who reach the Store regardless of coordinator status).
+                        var canOpenStore = (Model.IsCurrentUserCoordinator && Model.ParentTeam is null && Model.IsActive)
+                            || (await AuthService.AuthorizeAsync(User, PolicyNames.TeamsAdminOrAdmin)).Succeeded;
+                    }
+                    @if (canOpenStore)
                     {
                         <a asp-controller="Store" asp-action="Index" class="btn btn-outline-primary w-100 mt-2">
                             <i class="fa-solid fa-cart-shopping me-1"></i> Open store

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTeamOrdersTests.cs
@@ -212,7 +212,7 @@ public class StoreServiceTeamOrdersTests
         _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
             .Returns(new List<StoreProduct>());
 
-        var data = await _service.GetIndexDataAsync(userId, isPrivilegedReader: false, ct: TestContext.Current.CancellationToken);
+        var data = await _service.GetIndexDataAsync(userId, ct: TestContext.Current.CancellationToken);
 
         data.Counterparties.Should().HaveCount(1);
         data.Counterparties[0].CounterpartyType.Should().Be(StoreOrderCounterpartyType.Team);
@@ -234,7 +234,7 @@ public class StoreServiceTeamOrdersTests
         _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
             .Returns(new List<StoreProduct>());
 
-        var data = await _service.GetIndexDataAsync(userId, isPrivilegedReader: false, ct: TestContext.Current.CancellationToken);
+        var data = await _service.GetIndexDataAsync(userId, ct: TestContext.Current.CancellationToken);
 
         data.Counterparties.Should().BeEmpty();
         data.ShowNoOrdersMessage.Should().BeTrue();
@@ -254,7 +254,7 @@ public class StoreServiceTeamOrdersTests
         _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
             .Returns(new List<StoreProduct>());
 
-        var data = await _service.GetIndexDataAsync(viewerId, isPrivilegedReader: true, ct: TestContext.Current.CancellationToken);
+        var data = await _service.GetAllCounterpartiesIndexDataAsync(ct: TestContext.Current.CancellationToken);
 
         data.Counterparties.Should().ContainSingle(c =>
             c.CounterpartyType == StoreOrderCounterpartyType.Team && c.CounterpartyId == otherDeptId);

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
@@ -56,7 +56,7 @@ public class StoreServiceTests
                 MakeProduct(name: "Blanket")
             ]);
 
-        var result = await _service.GetIndexDataAsync(Guid.NewGuid(), isPrivilegedReader: false, ct: TestContext.Current.CancellationToken);
+        var result = await _service.GetIndexDataAsync(Guid.NewGuid(), ct: TestContext.Current.CancellationToken);
 
         result.Year.Should().Be(2026);
         result.Catalog.Select(p => p.Name).Should().Equal("Blanket", "Tent");
@@ -80,7 +80,7 @@ public class StoreServiceTests
         _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
             .Returns(new List<StoreProduct>());
 
-        var result = await _service.GetIndexDataAsync(userId, isPrivilegedReader: false, ct: TestContext.Current.CancellationToken);
+        var result = await _service.GetIndexDataAsync(userId, ct: TestContext.Current.CancellationToken);
 
         result.Counterparties.Should().ContainSingle().Which.Should().Match<StoreCounterpartyOrders>(counterparty =>
             counterparty.CounterpartyType == StoreOrderCounterpartyType.Camp &&


### PR DESCRIPTION
Implements nobodies-collective/Humans#815 (both surface additions are pre-approved in the issue).

## Fix 1 — `IStoreService` is now auth-free
- `GetIndexDataAsync(userId, bool isPrivilegedReader)` → split into `GetIndexDataAsync(userId)` (own counterparties) + `GetAllCounterpartiesIndexDataAsync()` (all).
- Both delegate to one private builder, so behavior is byte-identical; the private flag was renamed `allCounterparties` so no auth vocabulary remains in the service.
- `StoreController` (the auth boundary) picks the variant via `CanAdministerStore || IsTeamsAdmin` — same predicate as before.

## Fix 2 — `CanOpenStore` bool removed from `TeamDetailViewModel`
- `Team/Details.cshtml` self-resolves per `auth-in-views-self-resolving`: coordinator-of-active-top-level-department check stays on the model's data, the role half goes through `@inject IAuthorizationService` with **new** `PolicyNames.TeamsAdminOrAdmin` (Admin or TeamsAdmin — deliberately not `TeamsAdminBoardOrAdmin`; Board would dead-end at the Store, rationale doc'd on the constant).

## Surface additions (issue-approved)
- `IStoreService.GetAllCounterpartiesIndexDataAsync` (replaces the bool overloading; net service surface +1 method, −1 bool param).
- `PolicyNames.TeamsAdminOrAdmin` + registration in `AuthorizationPolicyExtensions`.

## Verification
- Full build 0 errors; Domain/Application/Web/Analyzers suites green (3912/371/271/228). Store-scoped Application tests 172/172.
- Integration suite showed shifting, non-reproducible failures locally (Testcontainers under heavy parallel-agent machine load; store-scoped integration tests pass 22/22 in isolation) — deferring to CI as arbiter.

Part of the overnight Q3 G1 burndown run; autonomous — flagging the `allCounterparties` rename as the only call Peter didn't explicitly spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)