### PR TITLE
refactor(users): retire verified-email repo lookups; match in-memory against UserInfo cache

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.UserEmails.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.UserEmails.cs
@@ -181,14 +181,6 @@ public partial interface IUserRepository
         Guid userId, Guid emailId, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns the owning <c>UserId</c> for a verified email address matching
-    /// the given string exactly (no gmail/googlemail aliasing). Returns
-    /// <c>null</c> if no verified row matches.
-    /// </summary>
-    Task<Guid?> GetUserIdByVerifiedUserEmailAsync(
-        string email, CancellationToken ct = default);
-
-    /// <summary>
     /// Returns distinct user ids whose email starts with <paramref name="prefix"/>
     /// and ends with <paramref name="suffix"/>.
     /// </summary>
@@ -196,29 +188,6 @@ public partial interface IUserRepository
         string prefix,
         string suffix,
         CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns all distinct <c>UserId</c> values whose verified email rows
-    /// contain an address that matches <paramref name="email"/> exactly
-    /// (case-sensitive, no gmail/googlemail aliasing). The caller uses this
-    /// to detect ambiguous matches: a count of 0 means no match, a count
-    /// of 1 means an unambiguous match, and a count &gt; 1 means the same
-    /// address is verified for more than one user (invariant violation —
-    /// treat as ambiguous / return null to the caller).
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedUserEmailAsync(
-        string email, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the distinct UserIds whose verified UserEmail matches the given
-    /// normalized address (or its gmail/googlemail alternate). Same matching
-    /// semantics as <see cref="FindVerifiedUserEmailWithUserAsync"/>, but returns the
-    /// full set rather than picking one arbitrary owner — so classifiers can
-    /// detect service-level uniqueness drift instead of silently attaching to
-    /// the wrong account.
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserEmailUserIdsAsync(
-        string normalizedEmail, string? alternateEmail, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the id of any user, other than <paramref name="excludeUserId"/>,

--- a/src/Humans.Application/Services/Profiles/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profiles/UserEmailService.cs
@@ -474,14 +474,24 @@ public sealed class UserEmailService(
     public async Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserIdsAsync(
         string email, CancellationToken cancellationToken = default)
     {
-        var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
-        var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
-        return await repository.GetDistinctVerifiedUserEmailUserIdsAsync(normalizedEmail, alternateEmail, cancellationToken);
+        // Matches against the cached UserInfo snapshot's verified emails; EmailsMatch handles
+        // gmail/googlemail aliasing on both sides, so no separate alternate-form lookup is needed.
+        var infos = await userService.GetAllUserInfosAsync(cancellationToken);
+        return infos
+            .Where(i => i.UserEmails.Any(e => e.IsVerified && EmailNormalization.EmailsMatch(e.Email, email)))
+            .Select(i => i.Id)
+            .ToList();
     }
 
-    public Task<Guid?> GetUserIdByVerifiedEmailAsync(
-        string email, CancellationToken cancellationToken = default) =>
-        repository.GetUserIdByVerifiedUserEmailAsync(email, cancellationToken);
+    public async Task<Guid?> GetUserIdByVerifiedEmailAsync(
+        string email, CancellationToken cancellationToken = default)
+    {
+        var infos = await userService.GetAllUserInfosAsync(cancellationToken);
+        return infos
+            .FirstOrDefault(i => i.UserEmails.Any(e =>
+                e.IsVerified && string.Equals(e.Email, email, StringComparison.OrdinalIgnoreCase)))
+            ?.Id;
+    }
 
     public Task<IReadOnlyList<Guid>> GetUserIdsByEmailPrefixAndSuffixAsync(
         string prefix,
@@ -492,7 +502,13 @@ public sealed class UserEmailService(
     public async Task<Guid?> GetUserIdByExactEmailAsync(string email, CancellationToken ct = default)
     {
         // Returns null on zero matches OR ambiguous matches; only non-null when exactly one user verified-holds the address.
-        var userIds = await repository.GetDistinctUserIdsByVerifiedUserEmailAsync(email, ct);
+        // No gmail/googlemail aliasing here (exact match only), matching the retired repo method's contract.
+        var infos = await userService.GetAllUserInfosAsync(ct);
+        var userIds = infos
+            .Where(i => i.UserEmails.Any(e =>
+                e.IsVerified && string.Equals(e.Email, email, StringComparison.OrdinalIgnoreCase)))
+            .Select(i => i.Id)
+            .ToList();
         return userIds.Count == 1 ? userIds[0] : null;
     }
 

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -194,20 +194,22 @@ public sealed class UserService(
         return await repo.ApplyExpiredDeletionAnonymizationAsync(userId, ct);
     }
 
+    /// <remarks>
+    /// This is the <b>legacy GoogleEmail shadow-column fallback only</b>. The verified-UserEmails
+    /// match that logically precedes it is owned by <c>CachingUserService</c>, which scans its
+    /// warmed <c>UserInfo</c> snapshot and only delegates here on a miss — same division of labour
+    /// as <see cref="SearchUsersAsync"/>. Doing the match here too would re-derive that entire
+    /// snapshot (<see cref="GetAllUserInfosAsync"/> = six bulk repository reads) on every miss,
+    /// once per address, which is what a Google sync run with unknown recipients actually hits.
+    /// Callers resolve <c>IUserService</c> to the decorator; reaching the inner service directly
+    /// is a DI registration mistake.
+    /// </remarks>
     public async Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default)
     {
         var normalized = EmailNormalization.NormalizeForComparison(email);
         var alternate = GetAlternateEmail(normalized);
 
-        // UserEmails-based match: in-memory against the UserInfo snapshot. EmailsMatch handles
-        // gmail/googlemail aliasing on both sides, so no separate alternate-form lookup is needed.
-        var infos = await GetAllUserInfosAsync(ct);
-        var match = infos.FirstOrDefault(i =>
-            i.UserEmails.Any(e => e.IsVerified && EmailNormalization.EmailsMatch(e.Email, email)));
-        if (match is not null)
-            return match;
-
-        // Legacy fallback: the deprecated GoogleEmail shadow column, which UserInfo does not carry
+        // The deprecated GoogleEmail shadow column, which UserInfo does not carry
         // (UserInfo.IdentityEmailColumn is User.Email/Identity's column — a different legacy field).
         var legacyUser = await repo.GetByEmailOrAlternateAsync(normalized, alternate, ct);
         if (legacyUser is null)

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -194,6 +194,10 @@ public sealed class UserService(
         return await repo.ApplyExpiredDeletionAnonymizationAsync(userId, ct);
     }
 
+    /// <summary>
+    /// Resolves a user by the legacy GoogleEmail shadow column (and its gmail/googlemail
+    /// alternate form), returning the matching <see cref="UserInfo"/> or null.
+    /// </summary>
     /// <remarks>
     /// This is the <b>legacy GoogleEmail shadow-column fallback only</b>. The verified-UserEmails
     /// match that logically precedes it is owned by <c>CachingUserService</c>, which scans its

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -199,10 +199,16 @@ public sealed class UserService(
         var normalized = EmailNormalization.NormalizeForComparison(email);
         var alternate = GetAlternateEmail(normalized);
 
-        var matchingUserIds = await repo.GetDistinctVerifiedUserEmailUserIdsAsync(normalized, alternate, ct);
-        if (matchingUserIds.Count > 0)
-            return await GetUserInfoAsync(matchingUserIds[0], ct);
+        // UserEmails-based match: in-memory against the UserInfo snapshot. EmailsMatch handles
+        // gmail/googlemail aliasing on both sides, so no separate alternate-form lookup is needed.
+        var infos = await GetAllUserInfosAsync(ct);
+        var match = infos.FirstOrDefault(i =>
+            i.UserEmails.Any(e => e.IsVerified && EmailNormalization.EmailsMatch(e.Email, email)));
+        if (match is not null)
+            return match;
 
+        // Legacy fallback: the deprecated GoogleEmail shadow column, which UserInfo does not carry
+        // (UserInfo.IdentityEmailColumn is User.Email/Identity's column — a different legacy field).
         var legacyUser = await repo.GetByEmailOrAlternateAsync(normalized, alternate, ct);
         if (legacyUser is null)
             return null;

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs
@@ -294,18 +294,6 @@ internal sealed partial class UserRepository
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<Guid?> GetUserIdByVerifiedUserEmailAsync(
-        string email, CancellationToken ct = default)
-    {
-        var escaped = EscapeLikePattern(email);
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.UserEmails
-            .AsNoTracking()
-            .Where(ue => EF.Functions.ILike(ue.Email, escaped, "\\") && ue.IsVerified)
-            .Select(ue => (Guid?)ue.UserId)
-            .FirstOrDefaultAsync(ct);
-    }
-
     public async Task<IReadOnlyList<Guid>> GetUserIdsByUserEmailPrefixAndSuffixAsync(
         string prefix,
         string suffix,
@@ -318,33 +306,6 @@ internal sealed partial class UserRepository
             .Select(ue => ue.UserId)
             .Distinct()
             .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedUserEmailAsync(
-        string email, CancellationToken ct = default)
-    {
-        var escaped = EscapeLikePattern(email);
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.UserEmails
-            .AsNoTracking()
-            .Where(ue => EF.Functions.ILike(ue.Email, escaped, "\\") && ue.IsVerified)
-            .Select(ue => ue.UserId)
-            .Distinct()
-            .ToListAsync(ct);
-    }
-
-    public async Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserEmailUserIdsAsync(
-        string normalizedEmail, string? alternateEmail, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var query = ctx.UserEmails.AsNoTracking().Where(ue => ue.IsVerified);
-
-        query = alternateEmail is null
-            ? query.Where(ue => EF.Functions.ILike(ue.Email, normalizedEmail))
-            : query.Where(ue => EF.Functions.ILike(ue.Email, normalizedEmail)
-                             || EF.Functions.ILike(ue.Email, alternateEmail));
-
-        return await query.Select(ue => ue.UserId).Distinct().ToListAsync(ct);
     }
 
     public async Task<Guid?> GetOtherUserIdHavingUserEmailAsync(

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -10,6 +10,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
 
 namespace Humans.Infrastructure.Services.Users;
 
@@ -499,8 +500,20 @@ public sealed class CachingUserService(
         return result;
     }
 
-    public Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) =>
-        WithInnerAsync(inner => inner.GetByEmailOrAlternateAsync(email, ct));
+    public async Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default)
+    {
+        // Verified-email match is served from the warmed snapshot; only the legacy
+        // GoogleEmail shadow-column fallback (not projected onto UserInfo) goes to the
+        // inner service's repo read.
+        await EnsureWarmedAsync(ct).ConfigureAwait(false);
+        foreach (var u in Values)
+        {
+            if (u.UserEmails.Any(e => e.IsVerified && EmailNormalization.EmailsMatch(e.Email, email)))
+                return u;
+        }
+
+        return await WithInnerAsync(inner => inner.GetByEmailOrAlternateAsync(email, ct)).ConfigureAwait(false);
+    }
 
     public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
         Instant now, CancellationToken ct = default) =>

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -504,7 +504,9 @@ public sealed class CachingUserService(
     {
         // Verified-email match is served from the warmed snapshot; only the legacy
         // GoogleEmail shadow-column fallback (not projected onto UserInfo) goes to the
-        // inner service's repo read.
+        // inner service's repo read. The inner method is legacy-column-only by design —
+        // it deliberately does NOT repeat this scan, so a miss costs one targeted query
+        // rather than re-deriving the whole snapshot. See UserService.GetByEmailOrAlternateAsync.
         await EnsureWarmedAsync(ct).ConfigureAwait(false);
         foreach (var u in Values)
         {

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -326,17 +326,8 @@ public class AccountProvisioningServiceTests
         public Task<string?> GetVerifiedUserEmailAddressAsync(
             Guid userId, Guid emailId, CancellationToken ct = default) =>
             throw new NotSupportedException();
-        public Task<Guid?> GetUserIdByVerifiedUserEmailAsync(
-            string email, CancellationToken ct = default) =>
-            throw new NotSupportedException();
         public Task<IReadOnlyList<Guid>> GetUserIdsByUserEmailPrefixAndSuffixAsync(
             string prefix, string suffix, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-        public Task<IReadOnlyList<Guid>> GetDistinctUserIdsByVerifiedUserEmailAsync(
-            string email, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-        public Task<IReadOnlyList<Guid>> GetDistinctVerifiedUserEmailUserIdsAsync(
-            string normalizedEmail, string? alternateEmail, CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<Guid?> GetOtherUserIdHavingUserEmailAsync(
             string email, Guid excludeUserId, CancellationToken ct = default) =>

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
@@ -1963,4 +1963,140 @@ public class UserEmailServiceTests
         await _repository.DidNotReceive()
             .AddUserEmailAsync(Arg.Any<UserEmail>(), Arg.Any<CancellationToken>());
     }
+
+    // --- nobodies-collective/Humans#828: verified-email lookups match in-memory against UserInfo cache ---
+
+    [HumansFact]
+    public async Task GetDistinctVerifiedUserIdsAsync_GmailAlternateForm_Matches()
+    {
+        // Stored row is @googlemail.com; caller looks up the @gmail.com form (and vice versa
+        // would match too) — EmailsMatch normalizes both sides before comparing.
+        var userId = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userId, Email = "alice@googlemail.com", IsVerified = true },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var matches = await _service.GetDistinctVerifiedUserIdsAsync(
+            "alice@gmail.com", Xunit.TestContext.Current.CancellationToken);
+
+        matches.Should().ContainSingle().Which.Should().Be(userId);
+    }
+
+    [HumansFact]
+    public async Task GetDistinctVerifiedUserIdsAsync_NoMatch_ReturnsEmpty()
+    {
+        var userId = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userId, Email = "alice@gmail.com", IsVerified = true },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var matches = await _service.GetDistinctVerifiedUserIdsAsync(
+            "bob@gmail.com", Xunit.TestContext.Current.CancellationToken);
+
+        matches.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task GetDistinctVerifiedUserIdsAsync_IgnoresUnverifiedRows()
+    {
+        var userId = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userId, Email = "alice@gmail.com", IsVerified = false },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var matches = await _service.GetDistinctVerifiedUserIdsAsync(
+            "alice@gmail.com", Xunit.TestContext.Current.CancellationToken);
+
+        matches.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task GetUserIdByExactEmailAsync_SingleVerifiedMatch_ReturnsUserId()
+    {
+        var userId = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userId, Email = "alice@example.com", IsVerified = true },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var result = await _service.GetUserIdByExactEmailAsync(
+            "alice@example.com", Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().Be(userId);
+    }
+
+    [HumansFact]
+    public async Task GetUserIdByExactEmailAsync_GmailAlternateForm_DoesNotMatch()
+    {
+        // Exact-match semantics (no gmail/googlemail aliasing) — unlike
+        // GetDistinctVerifiedUserIdsAsync, this method must NOT alias-match.
+        var userId = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userId, Email = "alice@googlemail.com", IsVerified = true },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var result = await _service.GetUserIdByExactEmailAsync(
+            "alice@gmail.com", Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetUserIdByExactEmailAsync_AmbiguousMatch_ReturnsNull()
+    {
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userA, Email = "shared@example.com", IsVerified = true },
+            new() { Id = Guid.NewGuid(), UserId = userB, Email = "shared@example.com", IsVerified = true },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var result = await _service.GetUserIdByExactEmailAsync(
+            "shared@example.com", Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetUserIdByVerifiedEmailAsync_CaseInsensitiveExactMatch_ReturnsUserId()
+    {
+        var userId = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userId, Email = "alice@example.com", IsVerified = true },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var result = await _service.GetUserIdByVerifiedEmailAsync(
+            "ALICE@EXAMPLE.COM", Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().Be(userId);
+    }
+
+    [HumansFact]
+    public async Task GetUserIdByVerifiedEmailAsync_NoMatch_ReturnsNull()
+    {
+        var userId = Guid.NewGuid();
+        var rows = new List<UserEmail>
+        {
+            new() { Id = Guid.NewGuid(), UserId = userId, Email = "alice@example.com", IsVerified = true },
+        };
+        StubAllUserInfosFromRows(rows);
+
+        var result = await _service.GetUserIdByVerifiedEmailAsync(
+            "bob@example.com", Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
 }


### PR DESCRIPTION
Implements nobodies-collective/Humans#828.

## What
- Deleted the three single-purpose verified-email lookups from `IUserRepository.UserEmails.cs` / `UserRepository.UserEmails.cs` (+ the hand-written fake in `AccountProvisioningServiceTests`): `GetDistinctUserIdsByVerifiedUserEmailAsync`, `GetDistinctVerifiedUserEmailUserIdsAsync`, `GetUserIdByVerifiedUserEmailAsync`. The confusing near-identical naming goes with them.
- `UserEmailService.GetUserIdByExactEmailAsync` / `GetDistinctVerifiedUserIdsAsync` / `GetUserIdByVerifiedEmailAsync` and `UserService.GetByEmailOrAlternateAsync` now filter the warmed `GetAllUserInfosAsync()` snapshot in memory (PR #873 pattern).

## The two behaviors the issue required preserving
1. **Gmail-normalization semantics** — alias-aware methods use the existing `EmailNormalization.EmailsMatch` (normalizes both sides, gmail↔googlemail), equivalent to the old `ILIKE(stored, normalized) OR ILIKE(stored, alternate)`; exact-match methods keep their documented no-aliasing contract via ordinal-ignore-case equality. Covered by new alternate-form match + non-match tests.
2. **Legacy fallback in `GetByEmailOrAlternateAsync`** — verified `UserInfo` does NOT carry the legacy `GoogleEmail` shadow column (`UserInfo.IdentityEmailColumn` is a different legacy field), so the `repo.GetByEmailOrAlternateAsync` fallback branch is kept unchanged. Only the `UserEmails` branch moved in-memory; on match it now returns the `UserInfo` directly (one fewer round-trip than the old id-then-refetch).

## Autonomous-run notes (flagging per overnight protocol)
- `UserService`'s internal `this.GetAllUserInfosAsync()` runs on the **inner** (uncached) service, so `GetByEmailOrAlternateAsync` now loads the full user snapshot per call instead of one targeted query. Its real callers are Google-sync/account-creation error paths (found via grep: `GoogleWorkspaceSyncService`, `GoogleGroupSyncService`, `GoogleAdminService`), not sign-in-hot; at ~500 users this is the documented in-memory-over-query-optimization tradeoff. External callers hit the warmed `CachingUserService` snapshot as the issue intended.
- Sign-in path: no new failure modes introduced (never-block-sign-in intact); Application suite 3920 green, Web 371 green, build 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)