### PR TITLE
refactor(shifts): migrate cross-section EventSettings consumers to BurnSettingsInfo (batch 1: non-web)

### DIFF
--- a/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
+++ b/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
@@ -23,6 +23,7 @@ public sealed class CantinaRosterService : ICantinaRosterService
     private const int DaysPerWeek = 7;
 
     private readonly IShiftManagementService _shiftMgmt;
+    private readonly IBurnSettingsService _burnSettings;
     private readonly IUserServiceRead _userRead;
     private readonly IClock _clock;
 
@@ -31,32 +32,34 @@ public sealed class CantinaRosterService : ICantinaRosterService
 
     public CantinaRosterService(
         IShiftManagementService shiftMgmt,
+        IBurnSettingsService burnSettings,
         IUserServiceRead userRead,
         IClock clock)
     {
         _shiftMgmt = shiftMgmt;
+        _burnSettings = burnSettings;
         _userRead = userRead;
         _clock = clock;
     }
 
     public async Task<WeeklyRosterDto> GetWeeklyRosterAsync(int weekStartOffset, CancellationToken ct = default)
     {
-        var eventSettings = await _shiftMgmt.GetActiveAsync().ConfigureAwait(false);
-        var weekStartDate = eventSettings is null
+        var burn = await _burnSettings.GetActiveAsync(ct).ConfigureAwait(false);
+        var weekStartDate = burn is null
             ? (LocalDate?)null
-            : eventSettings.GateOpeningDate.PlusDays(weekStartOffset);
+            : burn.GateOpeningDate.PlusDays(weekStartOffset);
         var weekEndDate = weekStartDate?.PlusDays(DaysPerWeek - 1);
-        var eventName = eventSettings?.EventName;
+        var eventName = burn?.EventName;
 
         // "Today" must be computed in the event timezone — the view uses this
         // to highlight the current row in the per-day mini-table. Falling back
         // to view-side DateTime.UtcNow caused a Madrid coordinator to see
         // tomorrow highlighted late in the evening (CET is ahead of UTC).
-        var eventTodayDate = GetEventTodayDate(eventSettings);
+        var eventTodayDate = GetEventTodayDate(burn);
 
         // Per-day cohort: 7 sequential queries for the on-site user ids. At ~500
         // users this is fine (see CLAUDE.md scale notes).
-        var perDay = await LoadWeeklyOnSiteUsersAsync(eventSettings, weekStartOffset, ct).ConfigureAwait(false);
+        var perDay = await LoadWeeklyOnSiteUsersAsync(burn, weekStartOffset, ct).ConfigureAwait(false);
 
         // Build the union of unique on-site user IDs across the week, and
         // map each user id to the set of calendar dates they were on-site.
@@ -69,14 +72,14 @@ public sealed class CantinaRosterService : ICantinaRosterService
         // inside the visible 7 days. This pulls in humans whose only relation to
         // the week is their arrival day (no confirmed shift inside the week).
         // Guarded on an active event — the no-event branch leaves the map empty.
-        if (eventSettings is not null && weekStartDate is { } anchor)
+        if (burn is not null && weekStartDate is { } anchor)
         {
             // Only arrivals landing in [weekStartOffset, weekStartOffset+6] are
             // injected below, so a first confirmed shift past weekStartOffset+7
             // can't produce an in-week arrival — cap the scan there.
             var firstConfirmedOffsetByUser =
                 await BuildFirstConfirmedOffsetByUserAsync(
-                    eventSettings, weekStartOffset + DaysPerWeek, ct).ConfigureAwait(false);
+                    burn, weekStartOffset + DaysPerWeek, ct).ConfigureAwait(false);
             foreach (var (userId, minOffset) in firstConfirmedOffsetByUser)
             {
                 var arrivalOffset = minOffset - 1;
@@ -200,15 +203,15 @@ public sealed class CantinaRosterService : ICantinaRosterService
 
     public async Task<DailyMatrixDto> GetDailyRosterAsync(int dayOffset, CancellationToken ct = default)
     {
-        var eventSettings = await _shiftMgmt.GetActiveAsync().ConfigureAwait(false);
-        var calendarDate = eventSettings is null
+        var burn = await _burnSettings.GetActiveAsync(ct).ConfigureAwait(false);
+        var calendarDate = burn is null
             ? (LocalDate?)null
-            : eventSettings.GateOpeningDate.PlusDays(dayOffset);
-        var eventName = eventSettings?.EventName;
+            : burn.GateOpeningDate.PlusDays(dayOffset);
+        var eventName = burn?.EventName;
 
         // "Today" must be in event timezone (same rationale as the weekly view —
         // a Madrid coordinator late in the evening must not see tomorrow flagged).
-        var eventTodayDate = GetEventTodayDate(eventSettings);
+        var eventTodayDate = GetEventTodayDate(burn);
 
         // Monday-of-week containing this day. With active event use NodaTime
         // day-of-week so the result respects ISO Monday=1. Fallback when no
@@ -229,9 +232,9 @@ public sealed class CantinaRosterService : ICantinaRosterService
             weekStartOffset = dayOffset - ((dayOffset % DaysPerWeek + DaysPerWeek) % DaysPerWeek);
         }
 
-        var shiftUserIds = eventSettings is null
+        var shiftUserIds = burn is null
             ? Array.Empty<Guid>()
-            : await _shiftMgmt.GetOnSiteUserIdsForDayAsync(eventSettings.Id, dayOffset, ct).ConfigureAwait(false);
+            : await _shiftMgmt.GetOnSiteUserIdsForDayAsync(burn.Id, dayOffset, ct).ConfigureAwait(false);
 
         // Arrival-day feeding: a human is fed (present, no shift) the day before
         // their FIRST confirmed shift across the whole event. For day N that
@@ -243,13 +246,13 @@ public sealed class CantinaRosterService : ICantinaRosterService
         // evaluated on the unioned set. Guarded on an active event; the no-event
         // branch leaves the set as the (empty) shift cohort.
         var unionedUserIds = new HashSet<Guid>(shiftUserIds);
-        if (eventSettings is not null)
+        if (burn is not null)
         {
             // Only users whose first confirmed shift is exactly dayOffset+1 are
             // pulled in, so the scan never needs to look past dayOffset+1.
             var firstConfirmedOffsetByUser =
                 await BuildFirstConfirmedOffsetByUserAsync(
-                    eventSettings, dayOffset + 1, ct).ConfigureAwait(false);
+                    burn, dayOffset + 1, ct).ConfigureAwait(false);
             foreach (var (userId, minOffset) in firstConfirmedOffsetByUser)
             {
                 if (minOffset == dayOffset + 1)
@@ -346,7 +349,7 @@ public sealed class CantinaRosterService : ICantinaRosterService
     }
 
     private async Task<List<(int DayOffset, IReadOnlyList<Guid> UserIds)>> LoadWeeklyOnSiteUsersAsync(
-        EventSettings? eventSettings,
+        BurnSettingsInfo? burn,
         int weekStartOffset,
         CancellationToken ct)
     {
@@ -354,9 +357,9 @@ public sealed class CantinaRosterService : ICantinaRosterService
         for (var i = 0; i < DaysPerWeek; i++)
         {
             var dayOffset = weekStartOffset + i;
-            var userIds = eventSettings is null
+            var userIds = burn is null
                 ? Array.Empty<Guid>()
-                : await _shiftMgmt.GetOnSiteUserIdsForDayAsync(eventSettings.Id, dayOffset, ct)
+                : await _shiftMgmt.GetOnSiteUserIdsForDayAsync(burn.Id, dayOffset, ct)
                     .ConfigureAwait(false);
             perDay.Add((dayOffset, userIds));
         }
@@ -376,15 +379,15 @@ public sealed class CantinaRosterService : ICantinaRosterService
     /// which the caller discards anyway, so scanning past it is wasted DB work.
     /// </summary>
     private async Task<Dictionary<Guid, int>> BuildFirstConfirmedOffsetByUserAsync(
-        EventSettings ev,
+        BurnSettingsInfo burn,
         int scanThroughOffset,
         CancellationToken ct)
     {
         var firstOffsetByUser = new Dictionary<Guid, int>();
-        var lastOffset = Math.Min(ev.StrikeEndOffset, scanThroughOffset);
-        for (var offset = ev.BuildStartOffset; offset <= lastOffset; offset++)
+        var lastOffset = Math.Min(burn.StrikeEndOffset, scanThroughOffset);
+        for (var offset = burn.BuildStartOffset; offset <= lastOffset; offset++)
         {
-            var userIds = await _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, offset, ct).ConfigureAwait(false);
+            var userIds = await _shiftMgmt.GetOnSiteUserIdsForDayAsync(burn.Id, offset, ct).ConfigureAwait(false);
             foreach (var id in userIds)
             {
                 if (!firstOffsetByUser.TryGetValue(id, out var existing) || offset < existing)
@@ -527,12 +530,12 @@ public sealed class CantinaRosterService : ICantinaRosterService
         return noShift;
     }
 
-    private LocalDate? GetEventTodayDate(EventSettings? eventSettings)
+    private LocalDate? GetEventTodayDate(BurnSettingsInfo? burn)
     {
-        if (eventSettings is null)
+        if (burn is null)
             return null;
 
-        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId)
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(burn.TimeZoneId)
             ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
         return _clock.GetCurrentInstant().InZone(zone).Date;
     }

--- a/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
@@ -21,7 +21,7 @@ public sealed class AgentToolDispatcher(
     CommunityFaqReader community,
     IAuditViewerService auditViewer,
     IShiftView shiftView,
-    IShiftManagementService shiftManagement,
+    IBurnSettingsService burnSettings,
     ILogger<AgentToolDispatcher> logger) : IAgentToolDispatcher
 {
     internal const int DefaultAuditHistoryLimit = 20;
@@ -148,7 +148,7 @@ public sealed class AgentToolDispatcher(
     private async Task<AnthropicToolResult> DispatchGetShiftDetailsAsync(
         string callId, Guid userId, Guid shiftKey, CancellationToken ct)
     {
-        var activeEvent = await shiftManagement.GetActiveAsync();
+        var activeEvent = await burnSettings.GetActiveAsync(ct);
         if (activeEvent is null)
             return new AnthropicToolResult(callId, "No active event configured.", IsError: true);
 
@@ -181,7 +181,7 @@ public sealed class AgentToolDispatcher(
     }
 
     /// <summary>Renders the get_shift_details blob. All signups passed in must belong to the caller.</summary>
-    private static string RenderShiftDetails(IReadOnlyList<ShiftSignup> signups, EventSettings ev)
+    private static string RenderShiftDetails(IReadOnlyList<ShiftSignup> signups, BurnSettingsInfo ev)
     {
         // Order chronologically so first/last reflect actual span.
         var ordered = signups.OrderBy(s => s.Shift.DayOffset).ToList();

--- a/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
@@ -159,10 +159,10 @@ public class AgentToolDispatcherTests
 
         var shiftView = MakeViewFor(viewer, signups);
 
-        var shiftMgmt = Substitute.For<Interfaces.Shifts.IShiftManagementService>();
-        shiftMgmt.GetActiveAsync().Returns(ev);
+        var burnSettings = Substitute.For<Interfaces.Shifts.IBurnSettingsService>();
+        burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
-        var dispatcher = MakeDispatcher(shiftView: shiftView, shiftManagement: shiftMgmt);
+        var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
 
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
@@ -190,10 +190,10 @@ public class AgentToolDispatcherTests
 
         var shiftView = MakeViewFor(viewer, [signup]);
 
-        var shiftMgmt = Substitute.For<Interfaces.Shifts.IShiftManagementService>();
-        shiftMgmt.GetActiveAsync().Returns(ev);
+        var burnSettings = Substitute.For<Interfaces.Shifts.IBurnSettingsService>();
+        burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
-        var dispatcher = MakeDispatcher(shiftView: shiftView, shiftManagement: shiftMgmt);
+        var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
 
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
@@ -215,10 +215,10 @@ public class AgentToolDispatcherTests
 
         var shiftView = MakeViewFor(viewer, []);
 
-        var shiftMgmt = Substitute.For<Interfaces.Shifts.IShiftManagementService>();
-        shiftMgmt.GetActiveAsync().Returns(ev);
+        var burnSettings = Substitute.For<Interfaces.Shifts.IBurnSettingsService>();
+        burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
-        var dispatcher = MakeDispatcher(shiftView: shiftView, shiftManagement: shiftMgmt);
+        var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
 
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
@@ -243,10 +243,10 @@ public class AgentToolDispatcherTests
         // Viewer has zero signups in their cached view.
         var shiftView = MakeViewFor(viewer, []);
 
-        var shiftMgmt = Substitute.For<Interfaces.Shifts.IShiftManagementService>();
-        shiftMgmt.GetActiveAsync().Returns(ev);
+        var burnSettings = Substitute.For<Interfaces.Shifts.IBurnSettingsService>();
+        burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
-        var dispatcher = MakeDispatcher(shiftView: shiftView, shiftManagement: shiftMgmt);
+        var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
 
         var result = await dispatcher.DispatchAsync(
             new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
@@ -270,18 +270,22 @@ public class AgentToolDispatcherTests
         result.Content.Should().Contain("must be a valid GUID");
     }
 
-    private static Humans.Domain.Entities.EventSettings MakeEventSettings() => new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = "Test",
-        Year = 2026,
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = new NodaTime.LocalDate(2026, 7, 1),
-        BuildStartOffset = -14,
-        EventEndOffset = 6,
-        StrikeEndOffset = 9,
-        IsActive = true
-    };
+    private static Humans.Application.Interfaces.Shifts.BurnSettingsInfo MakeEventSettings() => new(
+        Id: Guid.NewGuid(),
+        EventName: "Test",
+        Year: 2026,
+        TimeZoneId: "Europe/Madrid",
+        GateOpeningDate: new NodaTime.LocalDate(2026, 7, 1),
+        BuildStartOffset: -14,
+        EventEndOffset: 6,
+        StrikeEndOffset: 9,
+        FirstCrewStartOffset: 0,
+        SetupWeekStartOffset: 0,
+        PreEventWeekStartOffset: 0,
+        FinishingWeekendStartOffset: 0,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null);
 
     private static Humans.Domain.Entities.Shift MakeShift(
         Humans.Domain.Entities.Rota rota, int dayOffset, bool isAllDay,
@@ -438,7 +442,7 @@ public class AgentToolDispatcherTests
     private static Humans.Infrastructure.Services.Agent.AgentToolDispatcher MakeDispatcher(
         Humans.Application.Interfaces.AuditLog.IAuditViewerService? auditViewer = null,
         Interfaces.Shifts.IShiftView? shiftView = null,
-        Interfaces.Shifts.IShiftManagementService? shiftManagement = null,
+        Interfaces.Shifts.IBurnSettingsService? burnSettings = null,
         Humans.Application.Interfaces.IGuideContentSource? source = null)
     {
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
@@ -463,7 +467,7 @@ public class AgentToolDispatcherTests
             community,
             auditViewer ?? new StubAuditViewer(),
             shiftView ?? Substitute.For<Interfaces.Shifts.IShiftView>(),
-            shiftManagement ?? Substitute.For<Interfaces.Shifts.IShiftManagementService>(),
+            burnSettings ?? Substitute.For<Interfaces.Shifts.IBurnSettingsService>(),
             logger);
     }
 

--- a/tests/Humans.Application.Tests/Services/Cantina/CantinaDailyRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Cantina/CantinaDailyRosterServiceTests.cs
@@ -21,6 +21,7 @@ namespace Humans.Application.Tests.Services.Cantina;
 public class CantinaDailyRosterServiceTests
 {
     private readonly IShiftManagementService _shiftMgmt;
+    private readonly IBurnSettingsService _burnSettings;
     private readonly IUserServiceRead _userRead;
     private readonly IClock _clock;
     private readonly CantinaRosterService _service;
@@ -31,6 +32,7 @@ public class CantinaDailyRosterServiceTests
     public CantinaDailyRosterServiceTests()
     {
         _shiftMgmt = Substitute.For<IShiftManagementService>();
+        _burnSettings = Substitute.For<IBurnSettingsService>();
         _userRead = Substitute.For<IUserServiceRead>();
         _clock = new FakeClock(Instant.FromUtc(2026, 7, 7, 12, 0));
 
@@ -43,7 +45,7 @@ public class CantinaDailyRosterServiceTests
                 Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Guid>>(Array.Empty<Guid>()));
 
-        _service = new CantinaRosterService(_shiftMgmt, _userRead, _clock);
+        _service = new CantinaRosterService(_shiftMgmt, _burnSettings, _userRead, _clock);
     }
 
     /// <summary>Builds a Profile carrying burner name + dietary (dietary lives on Profile).</summary>
@@ -65,14 +67,22 @@ public class CantinaDailyRosterServiceTests
             IntoleranceOtherText = intoleranceOther,
         };
 
-    private static EventSettings ActiveEvent() => new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = EventName,
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = GateOpening,
-        IsActive = true
-    };
+    private static BurnSettingsInfo ActiveEvent() => new(
+        Id: Guid.NewGuid(),
+        EventName: EventName,
+        Year: GateOpening.Year,
+        TimeZoneId: "Europe/Madrid",
+        GateOpeningDate: GateOpening,
+        BuildStartOffset: 0,
+        EventEndOffset: 0,
+        StrikeEndOffset: 0,
+        FirstCrewStartOffset: 0,
+        SetupWeekStartOffset: 0,
+        PreEventWeekStartOffset: 0,
+        FinishingWeekendStartOffset: 0,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null);
 
     /// <summary>
     /// Active event with an explicit build→strike offset range so the
@@ -80,16 +90,8 @@ public class CantinaDailyRosterServiceTests
     /// days outside the viewed day. The default <see cref="ActiveEvent"/>
     /// leaves both offsets at 0, which would scan only day 0.
     /// </summary>
-    private static EventSettings ActiveEventWithRange(int buildStart, int strikeEnd) => new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = EventName,
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = GateOpening,
-        IsActive = true,
-        BuildStartOffset = buildStart,
-        StrikeEndOffset = strikeEnd,
-    };
+    private static BurnSettingsInfo ActiveEventWithRange(int buildStart, int strikeEnd) =>
+        ActiveEvent() with { BuildStartOffset = buildStart, StrikeEndOffset = strikeEnd };
 
     [HumansFact]
     public async Task GetDailyRoster_IncludesNextDayArrivals()
@@ -99,7 +101,7 @@ public class CantinaDailyRosterServiceTests
         // shift cohort of its own — must still surface them in People and
         // count them in the day's aggregates.
         var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
-        _shiftMgmt.GetActiveAsync().Returns(ev);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var id = Guid.NewGuid();
         SetupDay(2, id); // first (and only) confirmed shift is on day 2
@@ -120,7 +122,7 @@ public class CantinaDailyRosterServiceTests
         // neither work day 0 nor arrive on it (their arrival is day 1), so
         // they must be absent.
         var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
-        _shiftMgmt.GetActiveAsync().Returns(ev);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var id = Guid.NewGuid();
         SetupDay(2, id);
@@ -135,7 +137,7 @@ public class CantinaDailyRosterServiceTests
     [HumansFact]
     public async Task GetDailyRoster_NoActiveEventSettings_ReturnsEmpty()
     {
-        _shiftMgmt.GetActiveAsync().Returns((EventSettings?)null);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
 
         var result = await _service.GetDailyRosterAsync(dayOffset: 3, ct: Xunit.TestContext.Current.CancellationToken);
 
@@ -163,7 +165,7 @@ public class CantinaDailyRosterServiceTests
     public async Task GetDailyRoster_NoOnSiteUsers_ReturnsZeroState()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var result = await _service.GetDailyRosterAsync(dayOffset: 0, ct: Xunit.TestContext.Current.CancellationToken);
 
@@ -181,7 +183,7 @@ public class CantinaDailyRosterServiceTests
     public async Task GetDailyRoster_PopulatedDay_BuildsAggregatesAndPeople()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         // 3-user fixture mixing dietary, allergy, intolerance and "Other"-with-text combinations.
         var a = Guid.NewGuid();
@@ -244,7 +246,7 @@ public class CantinaDailyRosterServiceTests
             "DailyPersonRowDto must not expose MedicalConditions — GDPR Art.9 boundary.");
 
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var userId = Guid.NewGuid();
         SetupDay(0, userId);
@@ -271,7 +273,7 @@ public class CantinaDailyRosterServiceTests
         //   day -3 = Sat 4 Jul   → Monday of week = Mon 29 Jun → offset -8
         //   day +5 = Sun 12 Jul  → Monday of week = Mon 6 Jul → offset -1
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         (await _service.GetDailyRosterAsync(0, Xunit.TestContext.Current.CancellationToken)).WeekStartOffset.Should().Be(-1);
         (await _service.GetDailyRosterAsync(-3, Xunit.TestContext.Current.CancellationToken)).WeekStartOffset.Should().Be(-8);
@@ -285,7 +287,7 @@ public class CantinaDailyRosterServiceTests
         // (memory/architecture/display-sort-in-controllers.md). Hand the service a
         // reverse-alphabetical order; the result must preserve it.
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var c = Guid.NewGuid();
         var b = Guid.NewGuid();
@@ -307,9 +309,9 @@ public class CantinaDailyRosterServiceTests
         // not from UTC. With clock pinned to 23:30 UTC on day 0, Europe/Madrid
         // is already day 1 (CET = UTC+2 in July).
         var fakeClock = new FakeClock(Instant.FromUtc(2026, 7, 7, 23, 30));
-        var service = new CantinaRosterService(_shiftMgmt, _userRead, fakeClock);
+        var service = new CantinaRosterService(_shiftMgmt, _burnSettings, _userRead, fakeClock);
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var result = await service.GetDailyRosterAsync(dayOffset: 0, ct: Xunit.TestContext.Current.CancellationToken);
 

--- a/tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Cantina/CantinaRosterServiceTests.cs
@@ -22,6 +22,7 @@ namespace Humans.Application.Tests.Services.Cantina;
 public class CantinaRosterServiceTests
 {
     private readonly IShiftManagementService _shiftMgmt;
+    private readonly IBurnSettingsService _burnSettings;
     private readonly IUserServiceRead _userRead;
     private readonly IClock _clock;
     private readonly CantinaRosterService _service;
@@ -33,6 +34,7 @@ public class CantinaRosterServiceTests
     public CantinaRosterServiceTests()
     {
         _shiftMgmt = Substitute.For<IShiftManagementService>();
+        _burnSettings = Substitute.For<IBurnSettingsService>();
         _userRead = Substitute.For<IUserServiceRead>();
         // Fixed clock pinned to noon UTC on the gate-opening day; tests that
         // care about EventTodayDate semantics override on a per-test basis.
@@ -49,7 +51,7 @@ public class CantinaRosterServiceTests
                 Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<Guid>>(Array.Empty<Guid>()));
 
-        _service = new CantinaRosterService(_shiftMgmt, _userRead, _clock);
+        _service = new CantinaRosterService(_shiftMgmt, _burnSettings, _userRead, _clock);
     }
 
     /// <summary>Builds a Profile carrying burner name + dietary (dietary now lives on Profile).</summary>
@@ -71,14 +73,22 @@ public class CantinaRosterServiceTests
             IntoleranceOtherText = intoleranceOther,
         };
 
-    private static EventSettings ActiveEvent() => new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = EventName,
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = GateOpening,
-        IsActive = true
-    };
+    private static BurnSettingsInfo ActiveEvent() => new(
+        Id: Guid.NewGuid(),
+        EventName: EventName,
+        Year: GateOpening.Year,
+        TimeZoneId: "Europe/Madrid",
+        GateOpeningDate: GateOpening,
+        BuildStartOffset: 0,
+        EventEndOffset: 0,
+        StrikeEndOffset: 0,
+        FirstCrewStartOffset: 0,
+        SetupWeekStartOffset: 0,
+        PreEventWeekStartOffset: 0,
+        FinishingWeekendStartOffset: 0,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null);
 
     /// <summary>
     /// Active event with an explicit build→strike offset range so the
@@ -86,21 +96,13 @@ public class CantinaRosterServiceTests
     /// days outside the visible week. The default <see cref="ActiveEvent"/>
     /// leaves both offsets at 0, which would scan only day 0.
     /// </summary>
-    private static EventSettings ActiveEventWithRange(int buildStart, int strikeEnd) => new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = EventName,
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = GateOpening,
-        IsActive = true,
-        BuildStartOffset = buildStart,
-        StrikeEndOffset = strikeEnd,
-    };
+    private static BurnSettingsInfo ActiveEventWithRange(int buildStart, int strikeEnd) =>
+        ActiveEvent() with { BuildStartOffset = buildStart, StrikeEndOffset = strikeEnd };
 
     [HumansFact]
     public async Task GetWeeklyRoster_NoActiveEventSettings_ReturnsDtoWithNullDatesAndNoPeople()
     {
-        _shiftMgmt.GetActiveAsync().Returns((EventSettings?)null);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
 
         var result = await _service.GetWeeklyRosterAsync(WeekStartOffset, Xunit.TestContext.Current.CancellationToken);
 
@@ -135,7 +137,7 @@ public class CantinaRosterServiceTests
     public async Task GetWeeklyRoster_NoOnSiteUsers_AnyDay_ReturnsZeroState()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var result = await _service.GetWeeklyRosterAsync(WeekStartOffset, Xunit.TestContext.Current.CancellationToken);
 
@@ -158,7 +160,7 @@ public class CantinaRosterServiceTests
     public async Task GetWeeklyRoster_OneOmnivoreOnOneDay_AggregatesCorrectly()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var userId = Guid.NewGuid();
 
@@ -199,7 +201,7 @@ public class CantinaRosterServiceTests
     public async Task GetWeeklyRoster_OnePersonOnMultipleDays_CountedOnce()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var userId = Guid.NewGuid();
 
@@ -238,7 +240,7 @@ public class CantinaRosterServiceTests
     public async Task GetWeeklyRoster_VolunteerWithoutDietary_CountsAsUnanswered_Once()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var userId = Guid.NewGuid();
 
@@ -275,7 +277,7 @@ public class CantinaRosterServiceTests
     public async Task GetWeeklyRoster_MixedCohort_RollsUpUniqueAcrossWeek()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var a = Guid.NewGuid();
         var b = Guid.NewGuid();
@@ -337,7 +339,7 @@ public class CantinaRosterServiceTests
     public async Task GetWeeklyRoster_OtherTextDeduplicatedAcrossWeek()
     {
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var a = Guid.NewGuid();
         var b = Guid.NewGuid();
@@ -366,7 +368,7 @@ public class CantinaRosterServiceTests
             "RosterPersonDto must not expose MedicalConditions — GDPR Art.9 boundary.");
 
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var userId = Guid.NewGuid();
         SetupDay(WeekStartOffset + 0, userId);
@@ -396,7 +398,7 @@ public class CantinaRosterServiceTests
         // Also verifies the cohort-exclusion invariant: a known human with NO
         // signups all week does NOT appear in People.
         var es = ActiveEvent();
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
 
         var onSiteUserId = Guid.NewGuid();
         var excludedUserId = Guid.NewGuid(); // never appears on any day → must be excluded
@@ -431,7 +433,7 @@ public class CantinaRosterServiceTests
         // arrival day, pulling them into the cohort even though they were not
         // returned for any visible-week load except day 2.
         var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
-        _shiftMgmt.GetActiveAsync().Returns(ev);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var id = Guid.NewGuid();
         _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 2, Arg.Any<CancellationToken>())
@@ -464,7 +466,7 @@ public class CantinaRosterServiceTests
         // this week. They have NO shift in offsets 0..6 — the arrival day alone
         // pulls them into the cohort.
         var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 8);
-        _shiftMgmt.GetActiveAsync().Returns(ev);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var id = Guid.NewGuid();
         _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 7, Arg.Any<CancellationToken>())
@@ -488,7 +490,7 @@ public class CantinaRosterServiceTests
         // the last day of that window (index 6). The pre-event/negative arrival
         // day must NOT be clamped — the human must appear with ArrivesOn at -1.
         var ev = ActiveEventWithRange(buildStart: -7, strikeEnd: 2);
-        _shiftMgmt.GetActiveAsync().Returns(ev);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var id = Guid.NewGuid();
         _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 0, Arg.Any<CancellationToken>())
@@ -512,7 +514,7 @@ public class CantinaRosterServiceTests
         // earliest in-week day is the offset-8 shift, and offset 7 (index 0)
         // must have zero on-site.
         var ev = ActiveEventWithRange(buildStart: -2, strikeEnd: 14);
-        _shiftMgmt.GetActiveAsync().Returns(ev);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var id = Guid.NewGuid();
         _shiftMgmt.GetOnSiteUserIdsForDayAsync(ev.Id, 2, Arg.Any<CancellationToken>())


### PR DESCRIPTION
First batch of nobodies-collective/Humans#809 (the issue explicitly calls for section-scoped multi-PR batches; this covers the non-web cross-section consumers — the Web layer, cluster 7, is the follow-up batch).

## Categorized audit (required by the issue)

| Cluster | Classification | Action |
|---|---|---|
| 1. Events (`EventService`, `CachingEventService`) | Already compliant | Verified: `GetEventSettingsByIdAsync`/`GetEventSettingsOptionsAsync` already return `BurnSettingsInfo`; the caching decorator never materializes the entity. No change. |
| 2. Cantina (`CantinaRosterService`) | **Fixed** | Active-burn reads now via new `IBurnSettingsService` dependency (DTO) instead of `IShiftManagementService.GetActiveAsync()` (entity). `GetOnSiteUserIdsForDayAsync` stays on `IShiftManagementService` (Shifts-internal, no DTO equivalent). |
| 2b. `ICantinaRosterService` offset lookups | Blocked | Take `EventSettings` params fed by `CantinaController` (Web layer — cluster 7). Migrates with the web batch. |
| 3. Dashboard (`DashboardService`) | Blocked | Needs `IsShiftBrowsingOpen` (deliberately not on the DTO) and passes the entity into `Shift.GetAbsoluteStart/End(EventSettings)` domain signatures. Tech-debt issue to file. |
| 4. Workload | Not a violation | `Humans.Application.Services.Shifts.Workload` is Shifts-internal; `WorkloadReport` exposes only Id/Year primitives. |
| 5. Mailer (`TicketNoShiftsAudience`) | Not a violation | Entity appears only in a doc comment. |
| 6. Agent (`AgentToolDispatcher`) | **Fixed** | `IShiftManagementService` → `IBurnSettingsService`; `RenderShiftDetails` takes `BurnSettingsInfo` (only used `GateOpeningDate`). |
| 6b. `AgentUserSnapshotProvider` (found in sweep, not in issue's list) | Blocked | Same `Shift.GetAbsoluteEnd(EventSettings)` blocker as Dashboard. |

- **No `BurnSettingsInfo` fields added** (every migrated site needed only existing fields); no `[Grandfathered]` added; blocked sites left untouched rather than half-migrated, per the issue.
- Follow-ups to file: (a) web-layer batch (clusters 2b + 7), (b) tech-debt issue for the `Shift.GetAbsoluteStart/End(EventSettings)` signature entanglement blocking Dashboard/AgentUserSnapshotProvider.

## Verification
Build 0 errors; Cantina+Agent scoped tests 143/143; full Application suite 3912 green.

Overnight autonomous run — reasonable-call flags: scoping this PR to the non-web batch (issue's own batching rule), and leaving 6b untouched since it shares the Dashboard blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)