### PR TITLE
refactor(auditlog): consume Teams via ITeamServiceRead instead of Team entities

### DIFF
--- a/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
+++ b/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
@@ -9,7 +9,7 @@ namespace Humans.Application.Services.AuditLog;
 public sealed class AuditViewerService(
     IAuditLogService auditLog,
     IUserServiceRead userService,
-    ITeamService teamService,
+    ITeamServiceRead teamService,
     ITeamResourceService teamResourceService) : IAuditViewerService
 {
     public async Task<IReadOnlyList<AuditEvent>> GetRecentAsync(int count, CancellationToken ct = default)
@@ -138,8 +138,12 @@ public sealed class AuditViewerService(
     private async Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(
         IReadOnlyList<Guid> teamIds, CancellationToken ct)
     {
-        var teams = await teamService.GetByIdsWithParentsAsync(teamIds, ct);
-        return teams.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Name, kvp.Value.Slug));
+        // Teams section serves its full (cached) team list; filter to the requested ids here
+        // rather than adding a by-ids method to ITeamServiceRead.
+        var allTeams = await teamService.GetTeamsAsync(ct);
+        return teamIds
+            .Where(allTeams.ContainsKey)
+            .ToDictionary(id => id, id => (allTeams[id].Name, allTeams[id].Slug));
     }
 
     private static (List<Guid> UserIds, List<Guid> TeamIds, List<Guid> ResourceIds) CollectIds(IReadOnlyList<AuditLogEntrySnapshot> entries)

--- a/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
+++ b/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
@@ -38,9 +38,9 @@ public class AuditViewerServiceTests
             (actor, "Frank"),
             (viewer, "Peter"));
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -65,7 +65,7 @@ public class AuditViewerServiceTests
             .Returns([]);
 
         var userService = Substitute.For<IUserService>();
-        var teamService = Substitute.For<ITeamService>();
+        var teamService = Substitute.For<ITeamServiceRead>();
         var teamResourceService = Substitute.For<ITeamResourceService>();
         var service = new AuditViewerService(auditLog, userService, teamService, teamResourceService);
 
@@ -123,9 +123,9 @@ public class AuditViewerServiceTests
 
         var userService = StubUserService();
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -160,9 +160,9 @@ public class AuditViewerServiceTests
 
         var userService = StubUserService((actor, "Frank"));
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -177,7 +177,7 @@ public class AuditViewerServiceTests
         result.Items[0].ActorDisplayName.Should().Be("Frank");
     }
 
-    private static (IAuditLogService, IUserService, ITeamService, ITeamResourceService) MakeServices(
+    private static (IAuditLogService, IUserService, ITeamServiceRead, ITeamResourceService) MakeServices(
         AuditLogEntry entry, Guid actor, Guid viewer, string actorName, string viewerName)
     {
         var auditLog = Substitute.For<IAuditLogService>();
@@ -188,9 +188,9 @@ public class AuditViewerServiceTests
             (actor, actorName),
             (viewer, viewerName));
 
-        var teamService = Substitute.For<ITeamService>();
-        teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Team>());
+        var teamService = Substitute.For<ITeamServiceRead>();
+        teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
 
         var teamResourceService = Substitute.For<ITeamResourceService>();
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())


### PR DESCRIPTION
Stretch lane from the overnight G0 run — fixes the AuditLog audit's headline G1 gap (see PR #1153's `2026-08-03-g0-first-audit/AuditLog.md`): the horizontal AuditLog section held raw `Team` entities via the full `ITeamService.GetByIdsWithParentsAsync`.

- `AuditViewerService` now injects `ITeamServiceRead` (HUM0032-conformant) and reuses the existing cached `GetTeamsAsync` dictionary, filtering to the requested ids in memory (read-model-enrichment pattern; no new interface surface).
- Only `TeamInfo.Name`/`Slug` were ever consumed — the parent eager-load in the old call was dead weight.
- `ITeamResourceService.GetResourceNamesByIdsAsync` untouched (already DTO-shaped, no leak).
- Tests: `AuditViewerServiceTests` mocks swapped to `ITeamServiceRead`.

Verification: build 0 errors; AuditLog-scoped tests 50/50; full Application suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)