### PR TITLE
chore(deps): Bump Meziantou.Analyzer to 3.0.138 + fix MA0002 fallout

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,7 +85,7 @@
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <!-- Analyzers -->
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.121" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.138" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <!-- Testing -->
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
+++ b/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Humans.Analyzers.Internal;
 using Microsoft.CodeAnalysis;
@@ -68,6 +69,7 @@ public sealed class EmailMutationPathsAnalyzer : DiagnosticAnalyzer
     private const string AllowedServiceCaller = "Humans.Application.Services.Users.ExternalLoginService";
     private static readonly ImmutableHashSet<string> AllowedRepositoryCallers =
         ImmutableHashSet.Create(
+            StringComparer.Ordinal,
             "Humans.Application.Services.Profiles.UserEmailService",
             "Humans.Application.Services.Users.UserService");
 

--- a/src/Humans.Infrastructure/Repositories/Finance/HoldedRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Finance/HoldedRepository.cs
@@ -33,7 +33,7 @@ internal sealed class HoldedRepository(IDbContextFactory<FinanceDbContext> facto
         await using var ctx = await factory.CreateDbContextAsync(ct);
         var ids = docs.Select(d => d.HoldedDocId).ToList();
         var existing = await ctx.HoldedExpenseDocs
-            .Where(d => ids.Contains(d.HoldedDocId)).ToDictionaryAsync(d => d.HoldedDocId, ct);
+            .Where(d => ids.Contains(d.HoldedDocId)).ToDictionaryAsync(d => d.HoldedDocId, StringComparer.Ordinal, ct);
         foreach (var d in docs)
         {
             if (existing.TryGetValue(d.HoldedDocId, out var cur))

--- a/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
@@ -90,7 +90,7 @@ public class GateControllerClaimTests
         await _controller.ClaimPin(bogus, "1357", ct);
 
         await _gate.DidNotReceive().SetOwnPinAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-        Assert.DoesNotContain(ScannerSessionKey, _session.Keys);
+        Assert.DoesNotContain(ScannerSessionKey, _session.Keys, StringComparer.Ordinal);
     }
 
     // ── F2: kiosk-scoped name search (replaces the route-blocked profile API) ──

--- a/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
@@ -159,7 +159,7 @@ public class GateVendorBackfillControllerTests
         var model = Assert.IsType<GateVendorBackfillViewModel>(
             Assert.IsType<ViewResult>(await controller.Index(TestContext.Current.CancellationToken)).Model);
 
-        Assert.Equal(["vt-B"], model.Pending.Select(r => r.VendorTicketId));
-        Assert.Equal(["vt-A"], model.SentAwaitingSync.Select(r => r.VendorTicketId));
+        Assert.Equal(["vt-B"], model.Pending.Select(r => r.VendorTicketId), StringComparer.Ordinal);
+        Assert.Equal(["vt-A"], model.SentAwaitingSync.Select(r => r.VendorTicketId), StringComparer.Ordinal);
     }
 }


### PR DESCRIPTION
Supersedes #1165 (Dependabot), which fails CI. The bump is bundled with the code fixes it requires rather than pushed onto the Dependabot branch — foreign edits there have closed PRs on this repo before (#1124/#1128). Dependabot should auto-close #1165 once this lands.

## Why #1165 fails

Meziantou 3.0.128 and 3.0.133 widened **MA0002** (*use an overload that has an `IEqualityComparer<string>`*). Under root `TreatWarningsAsErrors=true` this broke the build at 5 sites. The CI log on #1165 only showed 5 because the build died early in `Humans.Analyzers`; a full local build with escalation disabled confirms 5 is the complete set.

## Fixes

| Site | Change |
|---|---|
| `EmailMutationPathsAnalyzer.cs` | `ImmutableHashSet.Create` for the allowed-caller set takes `StringComparer.Ordinal`; added `using System;` (project targets netstandard2.0, no implicit usings) |
| `HoldedRepository.UpsertDocsAsync` | `ToDictionaryAsync` keyed on `HoldedDocId` takes `StringComparer.Ordinal` |
| `GateControllerClaimTests` | session-key `DoesNotContain` takes `StringComparer.Ordinal` |
| `GateVendorBackfillControllerTests` (×2) | vendor-ticket-id `Assert.Equal` takes `StringComparer.Ordinal` |

`Ordinal` throughout: every site is an exact-identifier comparison, and it is the dominant convention here (441 uses vs 208 `OrdinalIgnoreCase`).

## Codex finding — partially declined

Codex's P1 on #1165 correctly predicted MA0002 fallout, but its two cited files were wrong. `RateLimitRejectionAggregator.cs:21` and `TableModel.cs:15` are **empty** `[]` dictionary initializers and do not trip MA0002 at 3.0.138 (3.0.133 narrowed reporting to collection expressions *with elements*). Verified by build — no change made there.

## Verification

- `dotnet build Humans.slnx -v quiet` → **0 errors** (84 warnings are the pre-existing HUM0024 / HUM_USER_DISPLAYNAME baseline, excluded from escalation)
- **4,542 unit tests pass** — Analyzers 229, Web 371, Application 3,942
- Integration tests are nondeterministic on this machine (varying failure sets across runs) and fail the same way on unmodified `origin/main`, so CI is the authority there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
