### PR TITLE
fix: stop stashing the caller's tree in generate-stats.sh / generate-reforge-history.sh

### DIFF
--- a/docs/scripts/generate-reforge-history.sh
+++ b/docs/scripts/generate-reforge-history.sh
@@ -140,7 +140,14 @@ for COMMIT in $COMMITS; do
     FAIL=$((FAIL+1))
     continue
   fi
-  if reforge snapshot --solution "$SNAPSHOT_WORKTREE/$SOLUTION" --append "$SNAP" >/dev/null 2>&1 && [ -s "$SNAP" ]; then
+  # Run reforge from INSIDE the throwaway worktree. reforge relays any command
+  # to a running hot server when it finds a `.reforge-port` file — first next to
+  # `--solution`, then by searching upward from the CWD. The throwaway worktree
+  # has no port file, but the caller's repo does whenever `reforge serve` is
+  # running there, so invoking from the caller's cwd would relay `snapshot` to a
+  # server holding the caller's checkout and silently record rows for the wrong
+  # commit. The subshell keeps the caller's cwd unchanged for the merge below.
+  if ( cd "$SNAPSHOT_WORKTREE" && reforge snapshot --solution "$SNAPSHOT_WORKTREE/$SOLUTION" --append "$SNAP" >/dev/null 2>&1 ) && [ -s "$SNAP" ]; then
     # Strip header (first line); append the data row to the gap accumulator.
     tail -n +2 "$SNAP" >> "$GAP_ROWS"
     OK=$((OK+1))

--- a/docs/scripts/generate-reforge-history.sh
+++ b/docs/scripts/generate-reforge-history.sh
@@ -13,14 +13,25 @@
 # Requirements:
 #   - reforge CLI on PATH (install via `dotnet tool install -g Reforge`)
 #   - bash 4+
-#   - working tree may be dirty (script stashes and restores) but the
-#     `docs/reforge-history.csv` file specifically is reset between
-#     iterations to keep `git checkout COMMIT` clean.
+#   - working tree may be dirty — historical per-day snapshots are computed
+#     in a throwaway `git worktree add --detach` checkout, so the caller's
+#     tree is never stashed, checked out, or otherwise touched (see
+#     nobodies-collective/Humans#971: this used to stash the caller's tree
+#     and leave it checked out at whatever commit the loop last visited on
+#     interrupt — silently reverting concurrent edits from other processes
+#     sharing this worktree, e.g. /freshness-sweep's drift-fix subagents).
 #
 # Implementation notes:
+#   - Historical per-day snapshots are computed in a throwaway
+#     `git worktree add --detach` checkout (SNAPSHOT_WORKTREE below). Every
+#     `git checkout <commit>` and `reforge snapshot` in the loop is scoped to
+#     that throwaway worktree, so the caller's HEAD and tracked files are
+#     never touched — including on interrupt, since there's nothing to
+#     restore in the caller's tree in the first place.
 #   - Snapshots are written to per-iteration temp files OUTSIDE the worktree,
 #     then concatenated into the CSV at the end. This avoids dirtying the
-#     tracked CSV during the loop (which would block subsequent `git checkout`).
+#     tracked CSV during the loop (which would block subsequent `git checkout`
+#     inside the throwaway worktree).
 #   - We avoid setting any shell variable named `TMP` / `TEMP` / `TMPDIR`,
 #     because on Windows those names overlap with the env vars MSBuild uses
 #     for its temp directory; clobbering them makes Roslyn's project loader
@@ -37,29 +48,19 @@ if [ "${1:-}" = "--full" ]; then
   FULL=true
 fi
 
-# Stash any dirty state so checkout iteration is safe.
 ORIG_REF=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
-NEEDS_STASH=false
-if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-  git stash --quiet
-  NEEDS_STASH=true
-fi
 
 # Use the system temp dir but DO NOT name our variables TMP/TEMP/TMPDIR.
 WORK_DIR="${TMPDIR:-/tmp}/reforge-history-$$"
 mkdir -p "$WORK_DIR"
 GAP_ROWS="$WORK_DIR/gap-rows.csv"
+SNAPSHOT_WORKTREE="$WORK_DIR/checkout"
 > "$GAP_ROWS"
 
 cleanup() {
-  # Restore branch FIRST so any subsequent file ops act on the right ref.
-  # Do NOT `git checkout HEAD -- $CSV` here — that step is for the
-  # mid-loop reset between historical checkouts (line below). On EXIT,
-  # the script has already rewritten $CSV with the merged final state,
-  # and a HEAD-restore would silently undo that write.
-  git checkout --quiet "$ORIG_REF" 2>/dev/null || true
-  if [ "$NEEDS_STASH" = "true" ]; then
-    git stash pop --quiet 2>/dev/null || true
+  if [ -d "$SNAPSHOT_WORKTREE" ]; then
+    git worktree remove --force "$SNAPSHOT_WORKTREE" 2>/dev/null \
+      || { rm -rf -- "$SNAPSHOT_WORKTREE" 2>/dev/null || true; git worktree prune --quiet 2>/dev/null || true; }
   fi
   if [ -d "$WORK_DIR" ]; then
     rm -- "$WORK_DIR"/* 2>/dev/null || true
@@ -121,6 +122,10 @@ if [ -z "$COMMITS" ]; then
   exit 0
 fi
 
+# Create the throwaway worktree that historical checkouts happen in. This
+# never touches the caller's tree (see the header comment).
+git worktree add --quiet --detach "$SNAPSHOT_WORKTREE" "$ORIG_REF"
+
 TOTAL=$(echo "$COMMITS" | wc -l)
 N=0
 OK=0
@@ -130,12 +135,12 @@ for COMMIT in $COMMITS; do
   N=$((N+1))
   SNAP="$WORK_DIR/snap-${COMMIT:0:8}.csv"
   > "$SNAP"
-  if ! git checkout --quiet "$COMMIT" 2>/dev/null; then
+  if ! git -C "$SNAPSHOT_WORKTREE" checkout --quiet "$COMMIT" 2>/dev/null; then
     echo "[$N/$TOTAL] $COMMIT — checkout FAILED"
     FAIL=$((FAIL+1))
     continue
   fi
-  if reforge snapshot --solution "$SOLUTION" --append "$SNAP" >/dev/null 2>&1 && [ -s "$SNAP" ]; then
+  if reforge snapshot --solution "$SNAPSHOT_WORKTREE/$SOLUTION" --append "$SNAP" >/dev/null 2>&1 && [ -s "$SNAP" ]; then
     # Strip header (first line); append the data row to the gap accumulator.
     tail -n +2 "$SNAP" >> "$GAP_ROWS"
     OK=$((OK+1))
@@ -143,17 +148,14 @@ for COMMIT in $COMMITS; do
     echo "[$N/$TOTAL] $COMMIT — reforge snapshot FAILED"
     FAIL=$((FAIL+1))
   fi
-  # Reset the tracked CSV in the working tree before next checkout (otherwise
-  # git checkout aborts on the dirty file).
-  git checkout --quiet HEAD -- "$CSV" 2>/dev/null || true
+  # Reset the tracked CSV in the throwaway worktree before next checkout
+  # (otherwise `git checkout` there aborts on the dirty file).
+  git -C "$SNAPSHOT_WORKTREE" checkout --quiet HEAD -- "$CSV" 2>/dev/null || true
 done
 
-# Restore branch (cleanup() will also try, but doing it here lets us write the
-# final CSV from the right ref).
-git checkout --quiet "$ORIG_REF"
-
 # Merge: existing CSV (or empty if --full) + gap rows. Dedup by date column
-# (latest timestamp wins). Sort by timestamp ascending.
+# (latest timestamp wins). Sort by timestamp ascending. The caller's tree was
+# never touched, so $CSV is read/written here directly.
 HEADER=""
 if [ -f "$CSV" ]; then
   HEADER=$(head -1 "$CSV")

--- a/docs/scripts/generate-stats.sh
+++ b/docs/scripts/generate-stats.sh
@@ -13,7 +13,12 @@
 # Requirements:
 #   - bash 4+ (associative arrays)
 #   - GNU sed (for the comma-grouping regex; ships with Git Bash on Windows)
-#   - working tree may be dirty (script stashes everything and restores after)
+#   - working tree may be dirty — historical per-day snapshots are computed in
+#     a throwaway `git worktree add --detach` checkout, so the caller's tree
+#     is never stashed, checked out, or otherwise touched (see
+#     nobodies-collective/Humans#971: stashing used to silently revert
+#     concurrent edits from other processes sharing this worktree, e.g.
+#     /freshness-sweep's drift-fix subagents).
 #   - docs/reforge-history.csv populated by docs/scripts/generate-reforge-history.sh
 #     (used as a join source for semantic class/interface counts; missing dates
 #     fall back to the legacy regex)
@@ -58,13 +63,17 @@
 #   - The Codebase Growth table MUST be the last section in the file. Sections
 #     above (Quick Summary, Language Breakdown, Highlights, Column Key) are
 #     manually maintained and not touched by this script.
-#   - The script never writes to docs/development-stats.md during the
-#     iteration loop (writing to a tracked file makes the next `git checkout
-#     <commit>` abort with "Your local changes would be overwritten"). The
-#     table rows are accumulated in a temp file outside the worktree, then
-#     concatenated onto the doc after we restore the original ref.
-#   - The reforge CSV is loaded ONCE upfront, before any checkouts, so we don't
-#     have to keep it consistent across historical commits.
+#   - Historical per-day snapshots are computed in a throwaway
+#     `git worktree add --detach` checkout (SNAPSHOT_WORKTREE below), not in
+#     the caller's working tree. Every `git checkout <commit>` in the loop is
+#     scoped to that throwaway worktree via `git -C`, so the caller's tracked
+#     files are never touched and the caller's HEAD never moves — this is
+#     what makes the script safe to run concurrently with other processes
+#     (subagents, editors) working in this same worktree.
+#   - The table rows are accumulated in a temp file outside the worktree, then
+#     concatenated onto the doc once at the end, after the loop completes.
+#   - The reforge CSV is loaded ONCE upfront, before any checkouts, from the
+#     caller's tree (it's never touched, so this is safe at any point).
 #
 # Pitfalls — do not regress:
 #   - Never name a shell variable TMP/TEMP/TMPDIR. On Windows, those names
@@ -78,6 +87,9 @@
 #   - The awk regex matching the markdown table separator must accept colons
 #     used for column alignment (e.g. `|----:|`). Use `^\|.*---`, not
 #     `^[|+ -]+$`.
+#   - Do not stash or checkout the caller's tree. Other processes may be
+#     editing files in this worktree concurrently (nobodies-collective/Humans#971);
+#     all historical checkouts MUST stay confined to SNAPSHOT_WORKTREE.
 
 set -euo pipefail
 
@@ -108,7 +120,6 @@ if [ "${1:-}" = "--full" ]; then
 fi
 
 ORIG_REF=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
-NEEDS_STASH=false
 
 # Capture the doc's manually-maintained content (everything down to and
 # including the table separator row) BEFORE we touch the working tree. The
@@ -119,6 +130,7 @@ mkdir -p "$WORK_DIR"
 PREAMBLE="$WORK_DIR/preamble.md"
 EXISTING_ROWS="$WORK_DIR/existing-rows.md"
 NEW_ROWS="$WORK_DIR/new-rows.md"
+SNAPSHOT_WORKTREE="$WORK_DIR/checkout"
 > "$EXISTING_ROWS"
 > "$NEW_ROWS"
 
@@ -156,9 +168,9 @@ else
 fi
 
 cleanup() {
-  git checkout --quiet "$ORIG_REF" 2>/dev/null || true
-  if [ "$NEEDS_STASH" = "true" ]; then
-    git stash pop --quiet 2>/dev/null || true
+  if [ -d "$SNAPSHOT_WORKTREE" ]; then
+    git worktree remove --force "$SNAPSHOT_WORKTREE" 2>/dev/null \
+      || { rm -rf -- "$SNAPSHOT_WORKTREE" 2>/dev/null || true; git worktree prune --quiet 2>/dev/null || true; }
   fi
   if [ -d "$WORK_DIR" ]; then
     rm -- "$WORK_DIR"/*.md 2>/dev/null || true
@@ -183,12 +195,6 @@ if [ -f "$REFORGE_CSV" ]; then
   echo "Loaded reforge classes/interfaces for ${#reforge_classes[@]} days from $REFORGE_CSV."
 else
   echo "Warning: $REFORGE_CSV not found — classes/interfaces will use the legacy regex (less accurate)." >&2
-fi
-
-# Stash anything dirty so checkouts run cleanly.
-if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-  git stash --quiet --include-untracked
-  NEEDS_STASH=true
 fi
 
 # Format helpers.
@@ -232,6 +238,10 @@ done < <(
   '
 )
 
+# Create the throwaway worktree that historical checkouts happen in. This
+# never touches the caller's tree (see the header comment).
+git worktree add --quiet --detach "$SNAPSHOT_WORKTREE" "$ORIG_REF"
+
 N=0
 TOTAL=$(echo "$DAY_COMMITS" | wc -l)
 REFORGE_HITS=0
@@ -240,17 +250,17 @@ REFORGE_MISSES=0
 while IFS=' ' read -r day commit; do
   [ -z "$day" ] && continue
   N=$((N+1))
-  git checkout --quiet "$commit"
+  git -C "$SNAPSHOT_WORKTREE" checkout --quiet "$commit"
 
   # Pipe through `cat` to wc, NOT `xargs -0 wc -l -c | tail -1`. When the file
   # list exceeds the OS command-line limit (~8 KB on Windows), xargs splits
   # into multiple wc invocations and each emits its own "total" line; `tail
   # -1` then only sees the last batch's count. `cat` merges content into a
   # single stream so wc sees the true total.
-  cs_data=$(find src -type f -name '*.cs' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
-  cshtml_data=$(find src -type f -name '*.cshtml' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
-  resx_data=$(find src -type f -name '*.resx' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
-  js_data=$(find src -type f -name '*.js' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
+  cs_data=$(find "$SNAPSHOT_WORKTREE/src" -type f -name '*.cs' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
+  cshtml_data=$(find "$SNAPSHOT_WORKTREE/src" -type f -name '*.cshtml' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
+  resx_data=$(find "$SNAPSHOT_WORKTREE/src" -type f -name '*.resx' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
+  js_data=$(find "$SNAPSHOT_WORKTREE/src" -type f -name '*.js' ! -path '*/Migrations/*' ! -path '*Tests*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
 
   cs_lines=$(echo "$cs_data" | awk '{print $1+0}')
   cshtml_lines=$(echo "$cshtml_data" | awk '{print $1+0}')
@@ -260,7 +270,7 @@ while IFS=' ' read -r day commit; do
   app_lines=$((cs_lines + cshtml_lines + resx_lines + js_lines))
   app_bytes=$(( $(echo "$cs_data" | awk '{print $2+0}') + $(echo "$cshtml_data" | awk '{print $2+0}') + $(echo "$resx_data" | awk '{print $2+0}') + $(echo "$js_data" | awk '{print $2+0}') ))
 
-  test_data=$(find . -type f -name '*.cs' -path '*Tests*' ! -path '*/Migrations/*' ! -path '*/.worktrees/*' ! -path '*/.claude/worktrees/*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
+  test_data=$(find "$SNAPSHOT_WORKTREE" -type f -name '*.cs' -path '*Tests*' ! -path '*/Migrations/*' ! -path '*/.worktrees/*' ! -path '*/.claude/worktrees/*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l -c)
   test_lines=$(echo "$test_data" | awk '{print $1+0}')
   test_bytes=$(echo "$test_data" | awk '{print $2+0}')
 
@@ -268,8 +278,8 @@ while IFS=' ' read -r day commit; do
   app_kb=$(to_kb "$app_bytes")
   test_kb=$(to_kb "$test_bytes")
 
-  app_files=$(( $(find src -type f \( -name '*.cs' -o -name '*.cshtml' -o -name '*.resx' -o -name '*.js' \) ! -path '*/Migrations/*' ! -path '*Tests*' 2>/dev/null | wc -l) ))
-  test_files=$(find . -type f -name '*.cs' -path '*Tests*' ! -path '*/Migrations/*' ! -path '*/.worktrees/*' ! -path '*/.claude/worktrees/*' 2>/dev/null | wc -l)
+  app_files=$(( $(find "$SNAPSHOT_WORKTREE/src" -type f \( -name '*.cs' -o -name '*.cshtml' -o -name '*.resx' -o -name '*.js' \) ! -path '*/Migrations/*' ! -path '*Tests*' 2>/dev/null | wc -l) ))
+  test_files=$(find "$SNAPSHOT_WORKTREE" -type f -name '*.cs' -path '*Tests*' ! -path '*/Migrations/*' ! -path '*/.worktrees/*' ! -path '*/.claude/worktrees/*' 2>/dev/null | wc -l)
   files=$((app_files + test_files))
 
   # Prefer reforge-derived (semantic) counts; fall back to regex if reforge
@@ -280,21 +290,21 @@ while IFS=' ' read -r day commit; do
     interfaces=${reforge_interfaces[$day]}
     REFORGE_HITS=$((REFORGE_HITS+1))
   else
-    classes=$(grep -rE '^\s*(public|internal)\s+(sealed |abstract |static |partial )*(class|record) ' --include='*.cs' src/ 2>/dev/null | grep -v '/Migrations/' | grep -v 'Tests' | wc -l || echo 0)
-    interfaces=$(grep -rE '^\s*public\s+interface\s' --include='*.cs' src/ 2>/dev/null | grep -v '/Migrations/' | grep -v 'Tests' | wc -l || echo 0)
+    classes=$(grep -rE '^\s*(public|internal)\s+(sealed |abstract |static |partial )*(class|record) ' --include='*.cs' "$SNAPSHOT_WORKTREE/src/" 2>/dev/null | grep -v '/Migrations/' | grep -v 'Tests' | wc -l || echo 0)
+    interfaces=$(grep -rE '^\s*public\s+interface\s' --include='*.cs' "$SNAPSHOT_WORKTREE/src/" 2>/dev/null | grep -v '/Migrations/' | grep -v 'Tests' | wc -l || echo 0)
     REFORGE_MISSES=$((REFORGE_MISSES+1))
   fi
 
-  controllers=$(find src -name '*Controller.cs' ! -path '*/Migrations/*' 2>/dev/null | wc -l)
-  views=$(find src -name '*.cshtml' 2>/dev/null | wc -l)
-  entities=$(find src -path '*/Entities/*.cs' 2>/dev/null | wc -l)
-  resx_keys=$(grep -c '<data ' src/Humans.Web/Resources/SharedResource.resx 2>/dev/null || echo 0)
+  controllers=$(find "$SNAPSHOT_WORKTREE/src" -name '*Controller.cs' ! -path '*/Migrations/*' 2>/dev/null | wc -l)
+  views=$(find "$SNAPSHOT_WORKTREE/src" -name '*.cshtml' 2>/dev/null | wc -l)
+  entities=$(find "$SNAPSHOT_WORKTREE/src" -path '*/Entities/*.cs' 2>/dev/null | wc -l)
+  resx_keys=$(grep -c '<data ' "$SNAPSHOT_WORKTREE/src/Humans.Web/Resources/SharedResource.resx" 2>/dev/null || echo 0)
 
   # Semantic C# code/comment split via cloc. Same scope as cs_lines above
   # (src/ minus Migrations; tests live in tests/ at the root, not in src/).
   # cloc CSV: files,language,blank,comment,code  — we read the C# row.
-  if [ -d src ]; then
-    cloc_csv=$("$CLOC" --quiet --csv --include-lang=C# --exclude-dir=Migrations src 2>/dev/null || true)
+  if [ -d "$SNAPSHOT_WORKTREE/src" ]; then
+    cloc_csv=$("$CLOC" --quiet --csv --include-lang=C# --exclude-dir=Migrations "$SNAPSHOT_WORKTREE/src" 2>/dev/null || true)
     cs_code=$(echo "$cloc_csv" | awk -F, '$2=="C#" { print $5+0; exit }')
     cs_comment=$(echo "$cloc_csv" | awk -F, '$2=="C#" { print $4+0; exit }')
     cs_code=${cs_code:-0}
@@ -308,7 +318,7 @@ while IFS=' ' read -r day commit; do
   # Excludes vendored/tooling dirs and any sibling worktree the developer may
   # have created. Defensive — `.worktrees/` is gitignored so it shouldn't show
   # up in a clean checkout, but we exclude it anyway.
-  md_data=$(find . -type f -name '*.md' \
+  md_data=$(find "$SNAPSHOT_WORKTREE" -type f -name '*.md' \
     -not -path '*/.git/*' -not -path '*/node_modules/*' \
     -not -path '*/.worktrees/*' -not -path '*/.claude/worktrees/*' \
     -not -path '*/bin/*' -not -path '*/obj/*' \
@@ -318,7 +328,7 @@ while IFS=' ' read -r day commit; do
   # Migration lines — currently excluded from every other metric. Tracked
   # separately so the cost of accumulated EF migrations is visible (and we
   # know when they need consolidating).
-  migration_data=$(find src -type f -name '*.cs' -path '*/Migrations/*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l)
+  migration_data=$(find "$SNAPSHOT_WORKTREE/src" -type f -name '*.cs' -path '*/Migrations/*' -print0 2>/dev/null | xargs -0 cat 2>/dev/null | wc -l)
   migration_lines=$(echo "$migration_data" | awk '{print $1+0}')
 
   commits="${cum_commits[$day]:-0}"
@@ -339,11 +349,8 @@ while IFS=' ' read -r day commit; do
   echo "[$N/$TOTAL] $day $commit"
 done <<< "$DAY_COMMITS"
 
-# Restore branch BEFORE writing back to the doc, so the file we modify is the
-# one on the original ref (not a historical commit's version of it).
-git checkout --quiet "$ORIG_REF"
-
-# Stitch: preamble + existing rows + new rows.
+# Stitch: preamble + existing rows + new rows. The caller's tree was never
+# touched, so $DOC is written in place with no ref restore needed first.
 {
   cat "$PREAMBLE"
   cat "$EXISTING_ROWS"


### PR DESCRIPTION
## Summary

Fixes nobodies-collective/Humans#971

`docs/scripts/generate-stats.sh` and `docs/scripts/generate-reforge-history.sh` used to `git stash` the whole working tree, loop `git checkout` over historical commits **in the caller's own tree**, then restore the stash on exit. Any uncommitted edit to a tracked file made by another process while the loop was running (e.g. a `/freshness-sweep` drift-fix subagent editing the same worktree concurrently) was silently reverted when the stash was popped. `generate-reforge-history.sh` had the extra bug of leaving the tree checked out at whatever commit the loop last visited if it was interrupted, instead of restoring the original ref.

This implements suggested-fix option 2 from the issue: both scripts now do every historical per-day checkout inside a **throwaway `git worktree add --detach` checkout**, created under the system temp dir and torn down in the `EXIT` trap. The caller's HEAD and tracked files are never touched — no stash, no checkout, no restore in the caller's tree — so there is nothing to revert on interrupt and nothing to race with concurrent edits.

- `generate-stats.sh`: every `find`/`grep`/`cloc` path in the per-day loop is now scoped to the throwaway worktree instead of the caller's `src/`/`docs/`. Removed the stash/`NEEDS_STASH` machinery and the end-of-run `git checkout $ORIG_REF` (no longer needed — the caller's ref never moved).
- `generate-reforge-history.sh`: `git checkout` and `reforge snapshot --solution` in the loop are scoped to the throwaway worktree via `git -C`/an absolute solution path. Removed the stash machinery and the end-of-run ref restore for the same reason.

## Test plan

- [x] `bash -n` syntax-checked both scripts
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors (shell-only change, sanity check only)
- [x] Ran `generate-stats.sh` for real against this worktree (2 new days, `2026-08-04`/`2026-08-05`) with an uncommitted edit sitting in `docs/README.md` the whole time — the edit survived untouched, `git worktree list` shows no leftover throwaway worktree, and the branch/HEAD never moved off `sprint/2026-08-05/issue-971`
- [x] Ran `generate-reforge-history.sh` for real the same way (2 new days) with a fresh uncommitted edit in `docs/README.md` — same result: edit survived, no leftover worktree, HEAD unchanged
- [x] Reverted the test-only doc/CSV output from those two manual runs before committing, so this PR only contains the script fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)