### PR TITLE
Analyzer message wording + per-section boot migration breadcrumbs

### DIFF
--- a/docs/architecture/code-analysis.md
+++ b/docs/architecture/code-analysis.md
@@ -106,8 +106,6 @@ reaches `Microsoft.EntityFrameworkCore.DbContext`. Since the per-section split
 `<Section>DbContext`. Neither namespace nor assembly is pinned, so moving the
 contexts cannot silently switch these rules off; production-only scoping comes
 from each analyzer's `AssemblyScope` guard, not from where the context lives.
-The diagnostic titles and messages still name `HumansDbContext` — read them as
-"the application DbContext you injected".
 
 ### How it ships
 

--- a/src/Humans.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Humans.Analyzers/AnalyzerReleases.Unshipped.md
@@ -9,8 +9,8 @@ HUM0004 | Humans.Architecture   | Error    | Profile.IsSuspended written outside
 HUM0005 | Humans.Architecture   | Error    | IUserEmailService.UpdateEmailAsync called from outside AccountController
 HUM0006 | Humans.Architecture   | Error    | IUserRepository.ApplyUserEmailReconcilePlanAsync called from outside approved user-email services
 HUM0007 | Humans.Architecture   | Error    | Concurrency token metadata is forbidden in live source
-HUM0008 | Humans.Architecture   | Error    | Controller constructor injects HumansDbContext
-HUM0009 | Humans.Architecture   | Error    | Class uses HumansDbContext but does not implement IRepository (downgrades to Warning for classes carrying [Grandfathered("HUM0009", ...)])
+HUM0008 | Humans.Architecture   | Error    | Controller constructor injects an application DbContext
+HUM0009 | Humans.Architecture   | Error    | Class uses an application DbContext but does not implement IRepository (downgrades to Warning for classes carrying [Grandfathered("HUM0009", ...)])
 HUM0010 | Humans.Architecture   | Warning  | Reference to symbol decorated with [ExpiresOn(date)] (escalates to Error on/after the date)
 HUM0011 | Humans.Architecture   | Warning  | Declaration decorated with [ExpiresOn(date)] is past its date (escalates to Error after the graceDays window)
 HUM0012 | Humans.Architecture   | Error    | Application service (IApplicationService implementer) declared outside Humans.Application.Services.* namespace
@@ -25,7 +25,7 @@ HUM0020 | Humans.Architecture   | Error    | Caching decorator references a repo
 HUM0021 | Humans.Architecture   | Warning  | Read of obsolete cross-domain navigation property from Application, Web, or Infrastructure
 HUM0024 | Humans.Architecture   | Error    | EF configuration creates a navigation join across section boundaries (downgrades to Warning for classes carrying [Grandfathered("HUM0024", ...)])
 HUM0025 | Humans.Architecture   | Error    | A DbSet table is referenced (read or written) by more than one repository — a table must belong to exactly one repository (downgrades to Warning for repos carrying [Grandfathered("HUM0025", ..., scope: "<DbSet>")])
-HUM0026 | Humans.Architecture   | Error    | IOrchestrator implementer injects an I*Repository, HumansDbContext, or IDbContextFactory<HumansDbContext>
+HUM0026 | Humans.Architecture   | Error    | IOrchestrator implementer injects an I*Repository, an application DbContext, or IDbContextFactory<TContext> parameterized on one
 HUM0027 | Humans.Architecture   | Error    | Type implements both IApplicationService and IOrchestrator — the role axis is exclusive
 HUM0028 | Humans.Architecture   | Error    | Interface extends IInvalidator (downgrades to Warning for interfaces carrying [Grandfathered("HUM0028", ...)])
 HUM0029 | Humans.Architecture   | Error    | Cross-section read interface (I*Read) exposes EF entity, Microsoft.EntityFrameworkCore type, or System.Linq.IQueryable in a method signature (downgrades to Warning for interfaces carrying [Grandfathered("HUM0029", ...)])

--- a/src/Humans.Analyzers/ApplicationServiceDbContextInjectionAnalyzer.cs
+++ b/src/Humans.Analyzers/ApplicationServiceDbContextInjectionAnalyzer.cs
@@ -28,10 +28,10 @@ public sealed class ApplicationServiceDbContextInjectionAnalyzer : DiagnosticAna
     public const string DiagnosticId = "HUM0009";
 
     private static readonly LocalizableString Title =
-        "Non-repository class uses HumansDbContext";
+        "Non-repository class uses an application DbContext";
 
     private static readonly LocalizableString MessageFormat =
-        "'{0}' uses HumansDbContext but does not implement IRepository. Route the DB access through a repository or service.";
+        "'{0}' uses '{1}' but does not implement IRepository. Route the DB access through a repository or service.";
 
     public static readonly DiagnosticDescriptor Rule = new(
         id: DiagnosticId,
@@ -41,11 +41,11 @@ public sealed class ApplicationServiceDbContextInjectionAnalyzer : DiagnosticAna
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description:
-            "HumansDbContext is the persistence boundary; only repositories may touch it. " +
-            "Classes outside the repository layer that need persisted state must call a service " +
-            "or repository. Existing violators may carry [Grandfathered(\"HUM0009\", …)] which " +
-            "downgrades this diagnostic to a warning for the tagged class only — the attribute " +
-            "is a TODO for migration, not a permanent exemption.");
+            "An application DbContext (HumansDbContext or any per-section context) is the persistence " +
+            "boundary; only repositories may touch it. Classes outside the repository layer that need " +
+            "persisted state must call a service or repository. Existing violators may carry " +
+            "[Grandfathered(\"HUM0009\", …)] which downgrades this diagnostic to a warning for the tagged " +
+            "class only — the attribute is a TODO for migration, not a permanent exemption.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
@@ -126,19 +126,19 @@ public sealed class ApplicationServiceDbContextInjectionAnalyzer : DiagnosticAna
         if (ImplementsRepositoryMarker(type, repositoryMarker))
             return;
 
-        var location = FindFirstDbContextReference(type, efDbContext);
-        if (location is null)
+        var reference = FindFirstDbContextReference(type, efDbContext);
+        if (reference is not { } found)
             return;
 
         var severity = GrandfatheredCheck.EffectiveSeverity(type, grandfatheredAttr, DiagnosticId);
 
         context.ReportDiagnostic(Diagnostic.Create(
             descriptor: Rule,
-            location: location,
+            location: found.Location,
             effectiveSeverity: severity,
             additionalLocations: null,
             properties: null,
-            messageArgs: type.Name));
+            messageArgs: [type.Name, found.ContextType.Name]));
     }
 
     private static bool ImplementsRepositoryMarker(INamedTypeSymbol type, INamedTypeSymbol repositoryMarker)
@@ -185,38 +185,47 @@ public sealed class ApplicationServiceDbContextInjectionAnalyzer : DiagnosticAna
     /// Finds the first structural reference to a Humans persistence context on
     /// the type — base type, implemented interface, field, property, or method
     /// (parameter or return type). Recurses through generic type arguments
-    /// so <c>UserStore&lt;…, HumansDbContext, …&gt;</c> also matches.
-    /// Returns null if the type does not use a context structurally.
+    /// so <c>UserStore&lt;…, HumansDbContext, …&gt;</c> also matches. Returns
+    /// both the location and the actual context type that matched (e.g.
+    /// <c>ContainersDbContext</c>), so the diagnostic can name it instead of a
+    /// generic "HumansDbContext". Returns null if the type does not use a
+    /// context structurally.
     /// </summary>
-    private static Location? FindFirstDbContextReference(INamedTypeSymbol type, INamedTypeSymbol efDbContext)
+    private static (Location Location, INamedTypeSymbol ContextType)? FindFirstDbContextReference(
+        INamedTypeSymbol type, INamedTypeSymbol efDbContext)
     {
-        if (type.BaseType is { } baseType && SectionDbContexts.ReferencesSectionDbContext(baseType, efDbContext))
-            return PreferFirstSyntax(type);
+        if (type.BaseType is { } baseType &&
+            SectionDbContexts.FindReferencedSectionDbContext(baseType, efDbContext) is { } baseContext)
+        {
+            return PreferFirstSyntax(type) is { } loc ? (loc, baseContext) : null;
+        }
 
         foreach (var iface in type.Interfaces)
         {
-            if (SectionDbContexts.ReferencesSectionDbContext(iface, efDbContext))
-                return PreferFirstSyntax(type);
+            if (SectionDbContexts.FindReferencedSectionDbContext(iface, efDbContext) is { } ifaceContext)
+                return PreferFirstSyntax(type) is { } loc ? (loc, ifaceContext) : null;
         }
 
         foreach (var member in type.GetMembers())
         {
             switch (member)
             {
-                case IFieldSymbol field when SectionDbContexts.ReferencesSectionDbContext(field.Type, efDbContext):
-                    return PreferFirst(field.Locations);
+                case IFieldSymbol field
+                    when SectionDbContexts.FindReferencedSectionDbContext(field.Type, efDbContext) is { } fieldContext:
+                    return PreferFirst(field.Locations) is { } floc ? (floc, fieldContext) : null;
 
-                case IPropertySymbol prop when SectionDbContexts.ReferencesSectionDbContext(prop.Type, efDbContext):
-                    return PreferFirst(prop.Locations);
+                case IPropertySymbol prop
+                    when SectionDbContexts.FindReferencedSectionDbContext(prop.Type, efDbContext) is { } propContext:
+                    return PreferFirst(prop.Locations) is { } ploc ? (ploc, propContext) : null;
 
                 case IMethodSymbol method:
-                    if (SectionDbContexts.ReferencesSectionDbContext(method.ReturnType, efDbContext))
-                        return PreferFirst(method.Locations);
+                    if (SectionDbContexts.FindReferencedSectionDbContext(method.ReturnType, efDbContext) is { } retContext)
+                        return PreferFirst(method.Locations) is { } rloc ? (rloc, retContext) : null;
 
                     foreach (var parameter in method.Parameters)
                     {
-                        if (SectionDbContexts.ReferencesSectionDbContext(parameter.Type, efDbContext))
-                            return PreferFirst(parameter.Locations);
+                        if (SectionDbContexts.FindReferencedSectionDbContext(parameter.Type, efDbContext) is { } paramContext)
+                            return PreferFirst(parameter.Locations) is { } paramLoc ? (paramLoc, paramContext) : null;
                     }
                     break;
             }

--- a/src/Humans.Analyzers/ControllerDbContextInjectionAnalyzer.cs
+++ b/src/Humans.Analyzers/ControllerDbContextInjectionAnalyzer.cs
@@ -11,10 +11,10 @@ public sealed class ControllerDbContextInjectionAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "HUM0008";
 
     private static readonly LocalizableString Title =
-        "Controllers may not inject HumansDbContext";
+        "Controllers may not inject an application DbContext";
 
     private static readonly LocalizableString MessageFormat =
-        "Controller '{0}' must not inject HumansDbContext. Controllers should call services; services go through repositories or infrastructure-owned database services.";
+        "Controller '{0}' must not inject '{1}'. Controllers should call services; services go through repositories or infrastructure-owned database services.";
 
     public static readonly DiagnosticDescriptor Rule = new(
         id: DiagnosticId,
@@ -24,8 +24,9 @@ public sealed class ControllerDbContextInjectionAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description:
-            "Controllers reaching directly for HumansDbContext bypass the service and repository layers. " +
-            "Keep database access behind an application or infrastructure service and inject that service instead.");
+            "Controllers reaching directly for an application DbContext (HumansDbContext or any per-section " +
+            "context) bypass the service and repository layers. Keep database access behind an application or " +
+            "infrastructure service and inject that service instead.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
@@ -70,7 +71,8 @@ public sealed class ControllerDbContextInjectionAnalyzer : DiagnosticAnalyzer
                 context.ReportDiagnostic(Diagnostic.Create(
                     Rule,
                     parameter.Locations.Length > 0 ? parameter.Locations[0] : ctor.Locations[0],
-                    type.Name));
+                    type.Name,
+                    parameter.Type.Name));
             }
         }
     }

--- a/src/Humans.Analyzers/Internal/SectionDbContexts.cs
+++ b/src/Humans.Analyzers/Internal/SectionDbContexts.cs
@@ -58,27 +58,37 @@ internal static class SectionDbContexts
     /// <c>IDbContextFactory&lt;TContext&gt;</c>, <c>UserStore&lt;…, HumansDbContext, …&gt;</c>,
     /// and arbitrarily-nested constructions.
     /// </summary>
-    public static bool ReferencesSectionDbContext(ITypeSymbol? candidate, INamedTypeSymbol efDbContext)
+    public static bool ReferencesSectionDbContext(ITypeSymbol? candidate, INamedTypeSymbol efDbContext) =>
+        FindReferencedSectionDbContext(candidate, efDbContext) is not null;
+
+    /// <summary>
+    /// Same walk as <see cref="ReferencesSectionDbContext"/>, but returns the
+    /// specific context type that matched (e.g. <c>ContainersDbContext</c>)
+    /// instead of a bool, so callers can name the actual context in a
+    /// diagnostic message rather than a generic "HumansDbContext".
+    /// </summary>
+    public static INamedTypeSymbol? FindReferencedSectionDbContext(ITypeSymbol? candidate, INamedTypeSymbol efDbContext)
     {
         if (candidate is null)
-            return false;
+            return null;
 
         if (IsSectionDbContext(candidate, efDbContext))
-            return true;
+            return (INamedTypeSymbol)candidate;
 
         if (candidate is INamedTypeSymbol named)
         {
             foreach (var typeArg in named.TypeArguments)
             {
-                if (ReferencesSectionDbContext(typeArg, efDbContext))
-                    return true;
+                var found = FindReferencedSectionDbContext(typeArg, efDbContext);
+                if (found is not null)
+                    return found;
             }
         }
 
-        if (candidate is IArrayTypeSymbol arr && ReferencesSectionDbContext(arr.ElementType, efDbContext))
-            return true;
+        if (candidate is IArrayTypeSymbol arr)
+            return FindReferencedSectionDbContext(arr.ElementType, efDbContext);
 
-        return false;
+        return null;
     }
 
     /// <summary>

--- a/src/Humans.Analyzers/OrchestratorRepositoryInjectionAnalyzer.cs
+++ b/src/Humans.Analyzers/OrchestratorRepositoryInjectionAnalyzer.cs
@@ -10,8 +10,8 @@ namespace Humans.Analyzers;
 /// <see cref="Humans.Application.Interfaces.IOrchestrator"/>.
 /// <list type="bullet">
 /// <item><b>HUM0026</b> — an <c>IOrchestrator</c> implementer must not inject
-/// any <c>I*Repository</c>, <c>HumansDbContext</c>, or
-/// <c>IDbContextFactory&lt;HumansDbContext&gt;</c>. Orchestrators own no lane.</item>
+/// any <c>I*Repository</c>, an application DbContext, or
+/// <c>IDbContextFactory&lt;TContext&gt;</c> parameterized on one. Orchestrators own no lane.</item>
 /// <item><b>HUM0027</b> — a type must implement <c>IOrchestrator</c> XOR
 /// <c>IApplicationService</c>, never both. The role axis is exclusive.</item>
 /// </list>
@@ -57,8 +57,8 @@ public sealed class OrchestratorRepositoryInjectionAnalyzer : DiagnosticAnalyzer
         description:
             "An IOrchestrator coordinates ≥2 sections through their public service interfaces " +
             "and owns no tables — by definition it must not inject any I*Repository, " +
-            "HumansDbContext, or IDbContextFactory<HumansDbContext>. A type that needs that " +
-            "access is a Section, not an orchestrator: relocate the access into the owning " +
+            "an application DbContext, or IDbContextFactory<TContext> parameterized on one. " +
+            "A type that needs that access is a Section, not an orchestrator: relocate the access into the owning " +
             "section's Section service. No grandfather machinery — a violation here means " +
             "the role marker is wrong, not that the rule is wrong.");
 
@@ -139,7 +139,7 @@ public sealed class OrchestratorRepositoryInjectionAnalyzer : DiagnosticAnalyzer
                 messageArgs: type.Name));
         }
 
-        // HUM0026 — no repository / DbContext / DbContextFactory<HumansDbContext> injection.
+        // HUM0026 — no repository / DbContext / DbContextFactory<application DbContext> injection.
         foreach (var ctor in type.InstanceConstructors)
         {
             foreach (var parameter in ctor.Parameters)

--- a/src/Humans.Analyzers/SingleRepositoryPerTableAnalyzer.cs
+++ b/src/Humans.Analyzers/SingleRepositoryPerTableAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Humans.Analyzers;
 /// Enforces two of Peter's hard rules at once (<c>peters-hard-rules.md</c>):
 /// "only the repository writes its section's tables" and "a table must only
 /// exist in one repository." Ownership is <b>emergent</b>, not declared: the
-/// single repository that references a <c>HumansDbContext</c> <c>DbSet</c> is
+/// single repository that references an application DbContext's <c>DbSet</c> is
 /// its owner. When more than one repository references the same DbSet, there is
 /// no single owner — the table is shared across the repository (and usually
 /// section) boundary, which bypasses the owning section's service and its §15
@@ -27,7 +27,7 @@ namespace Humans.Analyzers;
 /// </para>
 /// <para>
 /// Mechanism: across the <c>Humans.Infrastructure</c> compilation, collect every
-/// reference (read or write) to a <c>HumansDbContext</c> DbSet from inside a type
+/// reference (read or write) to an application DbContext's DbSet from inside a type
 /// implementing <see cref="Humans.Application.Interfaces.Repositories.IRepository"/>,
 /// then build <c>DbSet → {referencing repository types}</c>. A table referenced by
 /// N&gt;1 repositories produces a diagnostic at each access site. Phase 1 detects
@@ -48,8 +48,8 @@ namespace Humans.Analyzers;
 /// Counting unit is top-level types implementing <c>IRepository</c>. Framework
 /// stores (ASP.NET Identity <c>UserStore</c> etc.) are not repositories and do not
 /// count — their DbContext access is governed by HUM0009. Runs in
-/// <c>Humans.Infrastructure</c> only, the one compilation where
-/// <c>HumansDbContext</c> and every repository implementation are visible.
+/// <c>Humans.Infrastructure</c> only, the one compilation where every
+/// application DbContext and repository implementation are visible.
 /// </para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -75,7 +75,7 @@ public sealed class SingleRepositoryPerTableAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description:
             "Each section owns its tables and a table must exist in exactly one repository (peters-hard-rules.md). " +
-            "When more than one repository references a HumansDbContext DbSet — read or write — the table is shared " +
+            "When more than one repository references an application DbContext's DbSet — read or write — the table is shared " +
             "across the repository (and usually the section) boundary, bypassing the owning section's service and its " +
             "§15 cache. Route foreign access through the owning section's IRepository / application service. Existing " +
             "shared tables carry [Grandfathered(\"HUM0025\", …, scope: \"<DbSet>\")] on each participating repository, " +

--- a/src/Humans.Infrastructure/Hosting/SectionMigrationRunner.cs
+++ b/src/Humans.Infrastructure/Hosting/SectionMigrationRunner.cs
@@ -52,9 +52,18 @@ internal static class SectionMigrationRunner
                     "{Context}: tables exist but history is empty - recording baseline {Baseline} as applied without executing",
                     contextName, baselineId);
                 await RecordBaselineAsAppliedAsync(db, baselineId, ct);
+                applied = (await db.Database.GetAppliedMigrationsAsync(ct)).ToList();
             }
 
             var pending = (await db.Database.GetPendingMigrationsAsync(ct)).ToList();
+
+            // Warning level so the per-boot migration breadcrumb survives production's
+            // default log filtering, matching HumansDbContext's breadcrumb in
+            // DatabaseMigrationHostedService.MigrateAsync (nobodies-collective/Humans#960).
+            logger.LogWarning(
+                "{Context}: {AppliedCount} applied migrations, {PendingCount} pending",
+                contextName, applied.Count, pending.Count);
+
             if (pending.Count > 0)
             {
                 foreach (var migration in pending)
@@ -63,10 +72,11 @@ internal static class SectionMigrationRunner
                 }
 
                 await db.Database.MigrateAsync(ct);
-            }
-            else
-            {
-                logger.LogInformation("{Context}: schema is up to date", contextName);
+
+                var nowApplied = (await db.Database.GetAppliedMigrationsAsync(ct)).ToList();
+                logger.LogWarning(
+                    "{Context}: migrations complete - {AppliedCount} total applied",
+                    contextName, nowApplied.Count);
             }
         }
         catch (Exception ex)

--- a/tests/Humans.Analyzers.Tests/ApplicationServiceDbContextInjectionAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/ApplicationServiceDbContextInjectionAnalyzerTests.cs
@@ -338,6 +338,34 @@ public class ApplicationServiceDbContextInjectionAnalyzerTests
     }
 
     [HumansFact]
+    public async Task Message_names_the_actual_DbContext_type_used()
+    {
+        // Detection is structural (any DbContext-derived type), so the message
+        // must name the actual context used rather than a hardcoded
+        // "HumansDbContext" (nobodies-collective/Humans#960).
+        var source = Stubs + """
+
+            namespace Humans.Infrastructure.Jobs
+            {
+                public sealed class SomeJob
+                {
+                    public SomeJob(Humans.Infrastructure.Data.SystemSettingsDbContext dbContext)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new ApplicationServiceDbContextInjectionAnalyzer(),
+            "Humans.Infrastructure",
+            source);
+
+        diagnostics.Should().ContainSingle(d =>
+            IsHum0009(d) && d.GetMessage().Contains("SystemSettingsDbContext", StringComparison.Ordinal));
+    }
+
+    [HumansFact]
     public async Task Does_not_fire_outside_Infrastructure_assembly()
     {
         var source = Stubs + """

--- a/tests/Humans.Analyzers.Tests/ControllerDbContextInjectionAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/ControllerDbContextInjectionAnalyzerTests.cs
@@ -209,6 +209,34 @@ public class ControllerDbContextInjectionAnalyzerTests
     }
 
     [HumansFact]
+    public async Task Message_names_the_actual_injected_DbContext_type()
+    {
+        // Detection is structural (any DbContext-derived type), so the message
+        // must name the actual context injected rather than a hardcoded
+        // "HumansDbContext" (nobodies-collective/Humans#960).
+        var source = Stubs + """
+
+            namespace Humans.Web.Controllers
+            {
+                public sealed class SettingsController : Microsoft.AspNetCore.Mvc.Controller
+                {
+                    public SettingsController(Humans.Infrastructure.Data.SystemSettingsDbContext dbContext)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new ControllerDbContextInjectionAnalyzer(),
+            "Humans.Web",
+            source);
+
+        diagnostics.Should().ContainSingle(d =>
+            IsHum0008(d) && d.GetMessage().Contains("SystemSettingsDbContext", StringComparison.Ordinal));
+    }
+
+    [HumansFact]
     public async Task Does_not_fire_outside_Web_assembly()
     {
         var source = Stubs + """


### PR DESCRIPTION
## Summary

Two polish items from the DbContext split (nobodies-collective/Humans#858), tracked as nobodies-collective/Humans#960.

**1. Analyzer message wording (HUM0008/0009/0025/0026)**

Detection for these rules became structural (any DbContext-derived type) in peterdrier/Humans#1140, but HUM0008/HUM0009's `Title`/`MessageFormat` still hardcoded `HumansDbContext` — so HUM0008 firing on a `ContainersDbContext` parameter read "must not inject HumansDbContext". Both now interpolate the actual injected/used context type name into the message. HUM0025/HUM0026's titles and messages were already parameterized/generic; only their long `Description` text (and the `AnalyzerReleases.Unshipped.md` notes) still said "HumansDbContext" — reworded to "an application DbContext". Removed the now-stale caveat in `docs/architecture/code-analysis.md`.

Added a `SectionDbContexts.FindReferencedSectionDbContext` helper (the existing `ReferencesSectionDbContext` bool now delegates to it) so HUM0009 can report the specific matched context type, not just whether one was found.

Added message-text assertions to the HUM0008/HUM0009 analyzer tests proving the actual type name (not "HumansDbContext") now appears in the diagnostic.

**2. Per-section boot migration breadcrumb**

`DatabaseMigrationHostedService.MigrateAsync` logs `Database "humans": N applied migrations, 0 pending` at **Warning** (deliberately, so it survives production's default log filtering) — but only for `HumansDbContext`. `SectionMigrationRunner`'s healthy path logged at **Information**, which production filtering drops, so prod boot logs only showed the migration picture for 1 of 8 contexts.

`SectionMigrationRunner.MigrateAsync` now mirrors `DatabaseMigrationHostedService.MigrateAsync`'s structure: an unconditional Warning breadcrumb (`{Context}: {AppliedCount} applied migrations, {PendingCount} pending`) right after computing state, plus a "migrations complete" Warning summary after applying pending migrations (parity with the HumansDbContext path, which section contexts previously lacked). The existing mark-applied-baseline and per-pending-migration warnings are unchanged.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test tests/Humans.Analyzers.Tests` — 231/231 passed (229 existing + 2 new message-text assertions)
- [x] `dotnet test tests/Humans.Integration.Tests --filter FullyQualifiedName~SectionMigrationRunnerTests` — 3/3 passed against real Postgres (Testcontainers), confirming the boot-breadcrumb rewrite doesn't change baseline-recording/seed/idempotency behavior

Fixes nobodies-collective/Humans#960