### PR TITLE
fix(agent): recover truncated tool calls and persist a trace on turn exceptions

### DIFF
--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -125,19 +125,22 @@ public sealed class AgentService : IAgentService
         // below because something threw between the two writes). `await foreach` forbids
         // `yield` inside its implicit try/finally, so drive the inner enumerator manually —
         // that lets MoveNextAsync be wrapped in try/catch while still streaming tokens live.
-        var turn = RunTurnAsync(request, conversation, settings, priorTurns, today, hour, cancellationToken);
+        // Shared with RunTurnAsync so the failure path below can still bill a turn that broke
+        // partway: the running totals live inside the iterator, out of reach of this method.
+        var turnUsage = new TurnUsage();
+        var turn = RunTurnAsync(request, conversation, settings, priorTurns, today, hour, turnUsage, cancellationToken);
         await using var enumerator = turn.GetAsyncEnumerator(cancellationToken);
         // False until the assistant message for this turn is on disk — written either by
         // RunTurnAsync itself (it yields its finalizer only after AppendMessageAsync) or by
-        // the failure path below. While it's false the persisted user message still owes the
-        // user a reply, so both the catch and the finally below write one.
+        // the finally below. While it's false the persisted user message still owes the user
+        // a reply, and the turn is still unbilled.
         var assistantPersisted = false;
+        Exception? turnFailure = null;
         try
         {
             while (true)
             {
                 AgentTurnToken? current = null;
-                Exception? caught = null;
                 try
                 {
                     if (!await enumerator.MoveNextAsync())
@@ -148,37 +151,34 @@ public sealed class AgentService : IAgentService
                 {
                     // `yield` isn't allowed inside a catch block, so stash the exception and
                     // handle/yield below.
-                    caught = ex;
+                    turnFailure = ex;
                 }
 
-                if (caught is not null)
+                if (turnFailure is not null)
                 {
-                    if (caught is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                    if (turnFailure is OperationCanceledException && cancellationToken.IsCancellationRequested)
                     {
-                        // Expected (client disconnect), not a bug — Warning, not Error. Still
-                        // persist the trace below: #952's log evidence showed conversations with
-                        // no assistant message at all, and a disconnect is one plausible cause.
+                        // Expected (client disconnect), not a bug — Warning, not Error. The
+                        // finally still persists the trace: #952's log evidence showed
+                        // conversations with no assistant message at all, and a disconnect is
+                        // one plausible cause.
                         _logger.LogWarning(
                             "Agent turn cancelled (likely client disconnect) before completion for conversation {ConversationId}",
                             conversation.Id);
                     }
                     else
                     {
-                        _logger.LogError(caught,
+                        _logger.LogError(turnFailure,
                             "Agent turn failed before completion for conversation {ConversationId}", conversation.Id);
                     }
-                    // CancellationToken.None: the turn may be failing BECAUSE cancellationToken
-                    // fired (client disconnect), and the whole point is to still leave a trace.
-                    await AppendFailureMessage(conversation.Id, "error", settings.Model, CancellationToken.None);
-                    assistantPersisted = true;
                     yield return new AgentTurnToken(null, null,
                         new AgentTurnFinalizer(0, 0, 0, 0, settings.Model, "error", conversation.Id));
                     yield break;
                 }
 
-                // RunTurnAsync yields its finalizer last, after AppendMessageAsync — seeing one
-                // means the turn is fully persisted, so a disconnect while writing that very
-                // frame must not add a spurious failure trace on top of it.
+                // RunTurnAsync yields its finalizer last, after AppendMessageAsync and its own
+                // _rateLimit.Record — seeing one means the turn is fully persisted and billed,
+                // so a disconnect while writing that very frame must not double up on either.
                 if (current!.Finalizer is not null)
                     assistantPersisted = true;
                 yield return current;
@@ -186,19 +186,40 @@ public sealed class AgentService : IAgentService
         }
         finally
         {
-            // Not every abandoned turn throws into the catch above: AgentController awaits
-            // WriteSse OUTSIDE this method, so a browser that disconnects while a token is
-            // being written tears the turn down by disposing the iterator at a `yield return`,
-            // which resumes here rather than at MoveNextAsync. Without this the disconnect
-            // case #963 set out to fix still leaves a user message with no assistant reply.
+            // Reached by `yield break` above and also by disposal: not every abandoned turn
+            // throws into the catch, because AgentController awaits WriteSse OUTSIDE this
+            // method — a browser that disconnects while a token is being written tears the turn
+            // down by disposing the iterator at a `yield return`, which resumes here rather
+            // than at MoveNextAsync. Without that the disconnect case #963 set out to fix still
+            // leaves a user message with no assistant reply.
             if (!assistantPersisted)
             {
-                _logger.LogWarning(
-                    "Agent turn abandoned mid-stream (likely client disconnect) for conversation {ConversationId}",
-                    conversation.Id);
+                if (turnFailure is null)
+                    _logger.LogWarning(
+                        "Agent turn abandoned mid-stream (likely client disconnect) for conversation {ConversationId}",
+                        conversation.Id);
+                // CancellationToken.None: the turn may be failing BECAUSE cancellationToken
+                // fired (client disconnect), and the whole point is to still leave a trace.
                 await AppendFailureMessage(conversation.Id, "error", settings.Model, CancellationToken.None);
+                // Bill it. The provider already charged us for whatever the turn consumed
+                // before it broke, so leaving those tokens out understates admin spend and the
+                // DailyTokenCap; and a turn that fails deterministically must still cost a
+                // message, or a repeatable backend error becomes an unmetered send loop.
+                _rateLimit.Record(request.UserId, today, hour,
+                    messagesDelta: 1, tokensDelta: turnUsage.PromptTokens + turnUsage.OutputTokens);
             }
         }
+    }
+
+    /// <summary>Provider usage accumulated by <see cref="RunTurnAsync"/> as its tool loop runs.
+    /// Mutable and passed in by <see cref="AskAsync"/> rather than kept as iterator locals so a
+    /// turn that dies partway can still be billed for the tokens already spent on it.</summary>
+    private sealed class TurnUsage
+    {
+        public int PromptTokens;
+        public int OutputTokens;
+        public int CacheReadTokens;
+        public int CacheCreationTokens;
     }
 
     /// <summary>The tool-call loop and finalizer for one turn, run after the user message is
@@ -212,6 +233,7 @@ public sealed class AgentService : IAgentService
         List<AgentMessage> priorTurns,
         LocalDate today,
         int hour,
+        TurnUsage usage,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var snapshot = await _snapshots.LoadAsync(request.UserId, cancellationToken);
@@ -243,11 +265,8 @@ public sealed class AgentService : IAgentService
         // Each loop iteration is a separate provider request with its own usage.
         // Accumulate across all of them — recording only the last finalizer would
         // drop tool-loop (and cap-hit synthesis) requests from admin spend and
-        // the DailyTokenCap accounting.
-        var promptTokensTotal = 0;
-        var outputTokensTotal = 0;
-        var cacheReadTokensTotal = 0;
-        var cacheCreationTokensTotal = 0;
+        // the DailyTokenCap accounting. The totals live on the caller-supplied
+        // `usage` so a turn that throws mid-loop can still be billed for them.
         // Wall-clock turn duration (streaming + tool loop) for the admin status latency panel.
         var turnStart = _clock.GetCurrentInstant();
 
@@ -279,10 +298,10 @@ public sealed class AgentService : IAgentService
                 else if (token.Finalizer is { } f)
                 {
                     finalFinalizer = f;
-                    promptTokensTotal += f.InputTokens;
-                    outputTokensTotal += f.OutputTokens;
-                    cacheReadTokensTotal += f.CacheReadTokens;
-                    cacheCreationTokensTotal += f.CacheCreationTokens;
+                    usage.PromptTokens += f.InputTokens;
+                    usage.OutputTokens += f.OutputTokens;
+                    usage.CacheReadTokens += f.CacheReadTokens;
+                    usage.CacheCreationTokens += f.CacheCreationTokens;
                 }
             }
 
@@ -405,9 +424,9 @@ public sealed class AgentService : IAgentService
             Role = AgentRole.Assistant,
             Content = assistantText,
             CreatedAt = turnEnd,
-            PromptTokens = promptTokensTotal,
-            OutputTokens = outputTokensTotal,
-            CachedTokens = cacheReadTokensTotal,
+            PromptTokens = usage.PromptTokens,
+            OutputTokens = usage.OutputTokens,
+            CachedTokens = usage.CacheReadTokens,
             Model = settings.Model,
             DurationMs = durationMs,
             FetchedDocs = fetchedDocs.ToArray(),
@@ -425,10 +444,10 @@ public sealed class AgentService : IAgentService
         yield return new AgentTurnToken(null, null, fallbackFinalizer with
         {
             ConversationId = conversation.Id,
-            InputTokens = promptTokensTotal,
-            OutputTokens = outputTokensTotal,
-            CacheReadTokens = cacheReadTokensTotal,
-            CacheCreationTokens = cacheCreationTokensTotal
+            InputTokens = usage.PromptTokens,
+            OutputTokens = usage.OutputTokens,
+            CacheReadTokens = usage.CacheReadTokens,
+            CacheCreationTokens = usage.CacheCreationTokens
         });
     }
 

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -200,7 +200,7 @@ public sealed class AgentService : IAgentService
                         conversation.Id);
                 // CancellationToken.None: the turn may be failing BECAUSE cancellationToken
                 // fired (client disconnect), and the whole point is to still leave a trace.
-                await AppendFailureMessage(conversation.Id, "error", settings.Model, CancellationToken.None);
+                await AppendFailureMessage(conversation.Id, "error", settings.Model, turnUsage, CancellationToken.None);
                 // Bill it. The provider already charged us for whatever the turn consumed
                 // before it broke, so leaving those tokens out understates admin spend and the
                 // DailyTokenCap; and a turn that fails deterministically must still cost a
@@ -772,7 +772,8 @@ public sealed class AgentService : IAgentService
                 : await _repo.CreateConversationAsync(req.UserId, req.Locale, ct);
         }
 
-        await AppendFailureMessage(conv.Id, reason, _settings.Current.Model, ct);
+        // usage: null — a refused turn is rejected before any provider call, so it cost nothing.
+        await AppendFailureMessage(conv.Id, reason, _settings.Current.Model, usage: null, ct);
     }
 
     /// <summary>Appends an empty-content assistant message carrying a machine-readable
@@ -780,7 +781,14 @@ public sealed class AgentService : IAgentService
     /// already writes for rate-limit/abuse turns (Agent.md invariant 6). Reused for the
     /// turn-exception path (nobodies-collective/Humans#963) so a failed turn shows up through the
     /// same admin refusals filter and "top refusal reasons" panel instead of a new surface.</summary>
-    private async Task AppendFailureMessage(Guid conversationId, string reason, string model, CancellationToken ct)
+    /// <param name="usage">Provider usage to stamp on the row, or null for a turn that never
+    /// reached the provider (rate_limited / abuse_flag). A turn that failed mid-flight did spend
+    /// tokens, and <see cref="AgentAdminStatusService"/> prices spend straight off
+    /// <see cref="AgentMessage.PromptTokens"/>/<see cref="AgentMessage.OutputTokens"/> — leaving
+    /// zeros here would hide billable turns from the admin panel even though the rate-limit
+    /// store counted them.</param>
+    private async Task AppendFailureMessage(
+        Guid conversationId, string reason, string model, TurnUsage? usage, CancellationToken ct)
     {
         await _repo.AppendMessageAsync(new AgentMessage
         {
@@ -789,6 +797,9 @@ public sealed class AgentService : IAgentService
             Role = AgentRole.Assistant,
             Content = "",
             CreatedAt = _clock.GetCurrentInstant(),
+            PromptTokens = usage?.PromptTokens ?? 0,
+            OutputTokens = usage?.OutputTokens ?? 0,
+            CachedTokens = usage?.CacheReadTokens ?? 0,
             Model = model,
             RefusalReason = reason
         }, ct);

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -269,10 +269,13 @@ public sealed class AgentService : IAgentService
             if (withholdTools || pendingToolCalls.Count == 0 || !continuesToolLoop)
                 break;
 
+            // Replay the calls with unparseable arguments neutralised — see
+            // ReplayableToolCalls. Dispatch below still uses the raw pendingToolCalls
+            // so the dispatcher sees (and reports) the malformed payload as it is.
             sdkMessages.Add(new AnthropicMessage(
                 Role: "assistant",
                 Text: iterationAssistantText.Length > 0 ? iterationAssistantText.ToString() : null,
-                ToolCalls: pendingToolCalls,
+                ToolCalls: ReplayableToolCalls(pendingToolCalls),
                 ToolResults: null));
 
             var results = new List<AnthropicToolResult>();
@@ -607,6 +610,43 @@ public sealed class AgentService : IAgentService
     /// non-doc tools we drop the JSON args entirely — different shift ids /
     /// audit limits would otherwise split the bucket per invocation.
     /// </summary>
+    /// <summary>
+    /// Returns the tool calls as they can safely be replayed to the provider.
+    /// </summary>
+    /// <remarks>
+    /// A max_tokens cutoff mid tool-call JSON yields a truncated arguments payload
+    /// (nobodies-collective/Humans#963). Every following request replays the whole
+    /// assistant message, and <c>AnthropicClient.MapMessages</c> deserializes each
+    /// replayed <c>tool_use</c> block's arguments into a
+    /// <c>Dictionary&lt;string, JsonElement&gt;</c> — so replaying the raw truncated
+    /// payload throws while building the request, killing the very recovery
+    /// iteration this is supposed to enable.
+    /// <para>
+    /// Unparseable arguments are therefore swapped for an empty object. The block
+    /// still pairs with its <c>tool_result</c> (the API rejects an unmatched
+    /// <c>tool_use</c>), and that result carries <c>IsError</c>, so the model is
+    /// told the call failed and can reissue it rather than silently seeing a
+    /// well-formed no-arg call.
+    /// </para>
+    /// </remarks>
+    private static List<AnthropicToolCall> ReplayableToolCalls(List<AnthropicToolCall> calls) =>
+        [.. calls.Select(c => IsReplayableArguments(c.JsonArguments) ? c : c with { JsonArguments = "{}" })];
+
+    private static bool IsReplayableArguments(string jsonArguments)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(jsonArguments);
+            // MapMessages deserializes into a dictionary, so a valid non-object
+            // (array, bare string) would throw there just like malformed JSON does.
+            return doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return false;
+        }
+    }
+
     private static string NormalizeFetchedDocSlug(string toolName, string jsonArguments, ILogger<AgentService> logger)
     {
         switch (toolName)

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -305,9 +305,13 @@ public sealed class AgentService : IAgentService
                         fetchedDocs.Add(NormalizeFetchedDocSlug(call.Name, call.JsonArguments, _logger));
                     }
                 }
-                else
+                else if (!result.IsError)
                 {
                     // Normalize slug so admin "Top fetched docs" groups by document, not tool-name+args.
+                    // Only successful dispatches count: now that max_tokens-truncated calls are
+                    // dispatched rather than discarded, a malformed-JSON call would otherwise be
+                    // recorded under its bare tool name (NormalizeFetchedDocSlug's parse fallback)
+                    // and inflate the admin panel with lookups that never returned a document.
                     fetchedDocs.Add(NormalizeFetchedDocSlug(call.Name, call.JsonArguments, _logger));
                 }
             }

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -127,48 +127,77 @@ public sealed class AgentService : IAgentService
         // that lets MoveNextAsync be wrapped in try/catch while still streaming tokens live.
         var turn = RunTurnAsync(request, conversation, settings, priorTurns, today, hour, cancellationToken);
         await using var enumerator = turn.GetAsyncEnumerator(cancellationToken);
-        while (true)
+        // False until the assistant message for this turn is on disk — written either by
+        // RunTurnAsync itself (it yields its finalizer only after AppendMessageAsync) or by
+        // the failure path below. While it's false the persisted user message still owes the
+        // user a reply, so both the catch and the finally below write one.
+        var assistantPersisted = false;
+        try
         {
-            AgentTurnToken? current = null;
-            Exception? caught = null;
-            try
+            while (true)
             {
-                if (!await enumerator.MoveNextAsync())
+                AgentTurnToken? current = null;
+                Exception? caught = null;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync())
+                        yield break;
+                    current = enumerator.Current;
+                }
+                catch (Exception ex)
+                {
+                    // `yield` isn't allowed inside a catch block, so stash the exception and
+                    // handle/yield below.
+                    caught = ex;
+                }
+
+                if (caught is not null)
+                {
+                    if (caught is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                    {
+                        // Expected (client disconnect), not a bug — Warning, not Error. Still
+                        // persist the trace below: #952's log evidence showed conversations with
+                        // no assistant message at all, and a disconnect is one plausible cause.
+                        _logger.LogWarning(
+                            "Agent turn cancelled (likely client disconnect) before completion for conversation {ConversationId}",
+                            conversation.Id);
+                    }
+                    else
+                    {
+                        _logger.LogError(caught,
+                            "Agent turn failed before completion for conversation {ConversationId}", conversation.Id);
+                    }
+                    // CancellationToken.None: the turn may be failing BECAUSE cancellationToken
+                    // fired (client disconnect), and the whole point is to still leave a trace.
+                    await AppendFailureMessage(conversation.Id, "error", settings.Model, CancellationToken.None);
+                    assistantPersisted = true;
+                    yield return new AgentTurnToken(null, null,
+                        new AgentTurnFinalizer(0, 0, 0, 0, settings.Model, "error", conversation.Id));
                     yield break;
-                current = enumerator.Current;
-            }
-            catch (Exception ex)
-            {
-                // `yield` isn't allowed inside a catch block, so stash the exception and
-                // handle/yield below.
-                caught = ex;
-            }
+                }
 
-            if (caught is not null)
+                // RunTurnAsync yields its finalizer last, after AppendMessageAsync — seeing one
+                // means the turn is fully persisted, so a disconnect while writing that very
+                // frame must not add a spurious failure trace on top of it.
+                if (current!.Finalizer is not null)
+                    assistantPersisted = true;
+                yield return current;
+            }
+        }
+        finally
+        {
+            // Not every abandoned turn throws into the catch above: AgentController awaits
+            // WriteSse OUTSIDE this method, so a browser that disconnects while a token is
+            // being written tears the turn down by disposing the iterator at a `yield return`,
+            // which resumes here rather than at MoveNextAsync. Without this the disconnect
+            // case #963 set out to fix still leaves a user message with no assistant reply.
+            if (!assistantPersisted)
             {
-                if (caught is OperationCanceledException && cancellationToken.IsCancellationRequested)
-                {
-                    // Expected (client disconnect), not a bug — Warning, not Error. Still
-                    // persist the trace below: #952's log evidence showed conversations with
-                    // no assistant message at all, and a disconnect is one plausible cause.
-                    _logger.LogWarning(
-                        "Agent turn cancelled (likely client disconnect) before completion for conversation {ConversationId}",
-                        conversation.Id);
-                }
-                else
-                {
-                    _logger.LogError(caught,
-                        "Agent turn failed before completion for conversation {ConversationId}", conversation.Id);
-                }
-                // CancellationToken.None: the turn may be failing BECAUSE cancellationToken
-                // fired (client disconnect), and the whole point is to still leave a trace.
+                _logger.LogWarning(
+                    "Agent turn abandoned mid-stream (likely client disconnect) for conversation {ConversationId}",
+                    conversation.Id);
                 await AppendFailureMessage(conversation.Id, "error", settings.Model, CancellationToken.None);
-                yield return new AgentTurnToken(null, null,
-                    new AgentTurnFinalizer(0, 0, 0, 0, settings.Model, "error", conversation.Id));
-                yield break;
             }
-
-            yield return current!;
         }
     }
 

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -146,8 +146,20 @@ public sealed class AgentService : IAgentService
 
             if (caught is not null)
             {
-                _logger.LogError(caught,
-                    "Agent turn failed before completion for conversation {ConversationId}", conversation.Id);
+                if (caught is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                {
+                    // Expected (client disconnect), not a bug — Warning, not Error. Still
+                    // persist the trace below: #952's log evidence showed conversations with
+                    // no assistant message at all, and a disconnect is one plausible cause.
+                    _logger.LogWarning(
+                        "Agent turn cancelled (likely client disconnect) before completion for conversation {ConversationId}",
+                        conversation.Id);
+                }
+                else
+                {
+                    _logger.LogError(caught,
+                        "Agent turn failed before completion for conversation {ConversationId}", conversation.Id);
+                }
                 // CancellationToken.None: the turn may be failing BECAUSE cancellationToken
                 // fired (client disconnect), and the whole point is to still leave a trace.
                 await AppendFailureMessage(conversation.Id, "error", settings.Model, CancellationToken.None);

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -119,6 +119,60 @@ public sealed class AgentService : IAgentService
             Model = settings.Model
         }, cancellationToken);
 
+        // From here on, a thrown exception (or client disconnect) would otherwise leave the
+        // user message above with no matching assistant reply (nobodies-collective/Humans#963:
+        // 4 of 11 conversations in #952's log evidence never reached the AppendMessageAsync
+        // below because something threw between the two writes). `await foreach` forbids
+        // `yield` inside its implicit try/finally, so drive the inner enumerator manually —
+        // that lets MoveNextAsync be wrapped in try/catch while still streaming tokens live.
+        var turn = RunTurnAsync(request, conversation, settings, priorTurns, today, hour, cancellationToken);
+        await using var enumerator = turn.GetAsyncEnumerator(cancellationToken);
+        while (true)
+        {
+            AgentTurnToken? current = null;
+            Exception? caught = null;
+            try
+            {
+                if (!await enumerator.MoveNextAsync())
+                    yield break;
+                current = enumerator.Current;
+            }
+            catch (Exception ex)
+            {
+                // `yield` isn't allowed inside a catch block, so stash the exception and
+                // handle/yield below.
+                caught = ex;
+            }
+
+            if (caught is not null)
+            {
+                _logger.LogError(caught,
+                    "Agent turn failed before completion for conversation {ConversationId}", conversation.Id);
+                // CancellationToken.None: the turn may be failing BECAUSE cancellationToken
+                // fired (client disconnect), and the whole point is to still leave a trace.
+                await AppendFailureMessage(conversation.Id, "error", settings.Model, CancellationToken.None);
+                yield return new AgentTurnToken(null, null,
+                    new AgentTurnFinalizer(0, 0, 0, 0, settings.Model, "error", conversation.Id));
+                yield break;
+            }
+
+            yield return current!;
+        }
+    }
+
+    /// <summary>The tool-call loop and finalizer for one turn, run after the user message is
+    /// already persisted. Split out of <see cref="AskAsync"/> so the caller can wrap iteration
+    /// in try/catch (nobodies-collective/Humans#963) — a `yield`-containing method can't have a
+    /// `catch` in its own body around the `yield`.</summary>
+    private async IAsyncEnumerable<AgentTurnToken> RunTurnAsync(
+        AgentTurnRequest request,
+        AgentConversation conversation,
+        AgentSettingsDto settings,
+        List<AgentMessage> priorTurns,
+        LocalDate today,
+        int hour,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
         var snapshot = await _snapshots.LoadAsync(request.UserId, cancellationToken);
         var preloadText = await _preload.BuildAsync(settings.PreloadConfig, cancellationToken);
         var systemPrompt = _assembler.BuildSystemPrompt(preloadText);
@@ -167,8 +221,8 @@ public sealed class AgentService : IAgentService
             var pendingToolCalls = new List<AnthropicToolCall>();
 
             await foreach (var token in _client.StreamAsync(
-                new AnthropicRequest(settings.Model, systemPrompt, sdkMessages, tools, MaxOutputTokens: 1024,
-                    DisallowToolUse: withholdTools),
+                new AnthropicRequest(settings.Model, systemPrompt, sdkMessages, tools,
+                    MaxOutputTokens: MaxOutputTokensPerIteration, DisallowToolUse: withholdTools),
                 cancellationToken))
             {
                 if (token.TextDelta is { Length: > 0 } delta)
@@ -191,7 +245,16 @@ public sealed class AgentService : IAgentService
                 }
             }
 
-            if (withholdTools || pendingToolCalls.Count == 0 || !string.Equals(finalFinalizer?.StopReason, "tool_use", StringComparison.Ordinal))
+            // A max_tokens cutoff mid tool-call JSON still yields a (possibly truncated)
+            // AnthropicToolCall — AnthropicClient closes the current content block before the
+            // stream ends regardless of stop reason (nobodies-collective/Humans#963). Treat it
+            // like tool_use so the call is dispatched instead of silently discarded: the
+            // dispatcher already handles malformed JSON gracefully, and MaxToolCallsPerTurn
+            // still bounds the loop if the model keeps truncating.
+            var stopReason = finalFinalizer?.StopReason;
+            var continuesToolLoop = string.Equals(stopReason, "tool_use", StringComparison.Ordinal)
+                || string.Equals(stopReason, "max_tokens", StringComparison.Ordinal);
+            if (withholdTools || pendingToolCalls.Count == 0 || !continuesToolLoop)
                 break;
 
             sdkMessages.Add(new AnthropicMessage(
@@ -323,6 +386,13 @@ public sealed class AgentService : IAgentService
 
     /// <summary>How many prior user/assistant turns to replay (bounded for context budget).</summary>
     private const int HistoryReplayLimit = 20;
+
+    /// <summary>Per-iteration output cap sent to the provider. 1024 (the prior value) was tight
+    /// for a turn that also emits tool-call JSON, truncating mid-JSON often enough to matter
+    /// (nobodies-collective/Humans#963). Raised alongside the max_tokens loop-continuation fix
+    /// above — the two are complementary, not alternatives: the higher cap avoids most
+    /// truncation outright, and the loop fix handles what it doesn't.</summary>
+    private const int MaxOutputTokensPerIteration = 4096;
 
     /// <summary>Shown when a turn ends with no assistant prose (exhausted/truncated tool loop).
     /// Localized here because the Application layer has no resx access and the text is both
@@ -598,14 +668,24 @@ public sealed class AgentService : IAgentService
                 : await _repo.CreateConversationAsync(req.UserId, req.Locale, ct);
         }
 
+        await AppendFailureMessage(conv.Id, reason, _settings.Current.Model, ct);
+    }
+
+    /// <summary>Appends an empty-content assistant message carrying a machine-readable
+    /// <c>RefusalReason</c> — the same "no real answer, here's why" shape <see cref="PersistRefusal"/>
+    /// already writes for rate-limit/abuse turns (Agent.md invariant 6). Reused for the
+    /// turn-exception path (nobodies-collective/Humans#963) so a failed turn shows up through the
+    /// same admin refusals filter and "top refusal reasons" panel instead of a new surface.</summary>
+    private async Task AppendFailureMessage(Guid conversationId, string reason, string model, CancellationToken ct)
+    {
         await _repo.AppendMessageAsync(new AgentMessage
         {
             Id = Guid.NewGuid(),
-            ConversationId = conv.Id,
+            ConversationId = conversationId,
             Role = AgentRole.Assistant,
             Content = "",
             CreatedAt = _clock.GetCurrentInstant(),
-            Model = _settings.Current.Model,
+            Model = model,
             RefusalReason = reason
         }, ct);
     }

--- a/src/Humans.Infrastructure/Repositories/AgentRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/AgentRepository.cs
@@ -52,13 +52,28 @@ internal sealed class AgentRepository(AgentDbContext db, IClock clock) : IAgentR
 
     public async Task AppendMessageAsync(AgentMessage message, CancellationToken cancellationToken)
     {
-        db.AgentMessages.Add(message);
+        try
+        {
+            db.AgentMessages.Add(message);
 
-        var conv = await db.AgentConversations.FirstAsync(c => c.Id == message.ConversationId, cancellationToken);
-        conv.MessageCount += 1;
-        conv.LastMessageAt = message.CreatedAt;
+            var conv = await db.AgentConversations.FirstAsync(c => c.Id == message.ConversationId, cancellationToken);
+            conv.MessageCount += 1;
+            conv.LastMessageAt = message.CreatedAt;
 
-        await db.SaveChangesAsync(cancellationToken);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch
+        {
+            // A failed append leaves the message Added (and any MessageCount bump Modified) on
+            // this scoped context, so the NEXT save through it would flush this half-written
+            // append on top of its own work. AgentService answers a failed turn by appending an
+            // "error" trace (nobodies-collective/Humans#963) — without this the transcript would
+            // get both the original assistant reply and the trace, plus a double MessageCount
+            // increment. Cancellation is the likely trigger: it can land on either the
+            // conversation read or SaveChangesAsync, so both are inside the try.
+            db.ChangeTracker.Clear();
+            throw;
+        }
     }
 
     public async Task<IReadOnlyList<AgentConversation>> ListConversationsForUserAsync(Guid userId, int take, CancellationToken cancellationToken) =>

--- a/src/Humans.Web/wwwroot/css/agent.css
+++ b/src/Humans.Web/wwwroot/css/agent.css
@@ -80,6 +80,14 @@
     padding-top: 0.4rem;
     color: #444;
 }
+/* Appended under a partial answer when the turn failed after streaming some of it,
+   so the text the user already read stays put but doesn't read as a finished reply. */
+.agent-error-note {
+    border-top: 1px dotted #ccc;
+    margin-top: 0.4rem;
+    padding-top: 0.4rem;
+    color: #a33;
+}
 .agent-tool-calls summary {
     cursor: pointer;
 }

--- a/src/Humans.Web/wwwroot/js/agent/widget.js
+++ b/src/Humans.Web/wwwroot/js/agent/widget.js
@@ -164,16 +164,23 @@
             if (reason === 'rate_limited') bubble.textContent = '(Daily limit reached — try again tomorrow.)';
             // A turn that threw mid-stream now finishes as a well-formed 200/SSE
             // 'error' finalizer instead of a broken connection, so neither the
-            // !resp.ok branch nor the catch below fires — without this the user is
-            // left staring at an empty bubble. Only fill a bubble that is still
-            // empty: the exception can land after a partial answer was streamed
-            // (rawMarkdown), or after the propose branch wrote the handoff line as
-            // plain text with no rawMarkdown — both beat a generic error, and the
-            // proposal modal is open and usable regardless. The bubble starts as
-            // appendMessage('assistant', ''), so textContent is only non-empty when
-            // one of those branches filled it.
-            if (reason === 'error' && !bubble.dataset.rawMarkdown.trim() && !bubble.textContent.trim()) {
-                bubble.textContent = '(Something went wrong answering that. Please try again.)';
+            // !resp.ok branch nor the catch below fires — the user must be told
+            // here or not at all. Replace an empty bubble; append to one that
+            // already has content so a partial answer, or the propose branch's
+            // handoff line, survives while the user still learns the turn didn't
+            // finish. The bubble starts as appendMessage('assistant', ''), so
+            // textContent is only non-empty once one of those branches filled it.
+            if (reason === 'error') {
+                const errorText = '(Something went wrong answering that. Please try again.)';
+                if (!bubble.dataset.rawMarkdown.trim() && !bubble.textContent.trim()) {
+                    bubble.textContent = errorText;
+                } else {
+                    const note = document.createElement('div');
+                    note.className = 'agent-error-note';
+                    note.textContent = errorText;
+                    bubble.appendChild(note);
+                }
+                messagesEl.scrollTop = messagesEl.scrollHeight;
             }
             // Capture the conversation id from the first successful turn so the
             // next send continues the same conversation server-side. Bail-out

--- a/src/Humans.Web/wwwroot/js/agent/widget.js
+++ b/src/Humans.Web/wwwroot/js/agent/widget.js
@@ -165,10 +165,14 @@
             // A turn that threw mid-stream now finishes as a well-formed 200/SSE
             // 'error' finalizer instead of a broken connection, so neither the
             // !resp.ok branch nor the catch below fires — without this the user is
-            // left staring at an empty bubble. Only fill an empty bubble: the
-            // exception can land after a partial answer was already streamed, and
-            // that text is worth keeping.
-            if (reason === 'error' && !bubble.dataset.rawMarkdown.trim()) {
+            // left staring at an empty bubble. Only fill a bubble that is still
+            // empty: the exception can land after a partial answer was streamed
+            // (rawMarkdown), or after the propose branch wrote the handoff line as
+            // plain text with no rawMarkdown — both beat a generic error, and the
+            // proposal modal is open and usable regardless. The bubble starts as
+            // appendMessage('assistant', ''), so textContent is only non-empty when
+            // one of those branches filled it.
+            if (reason === 'error' && !bubble.dataset.rawMarkdown.trim() && !bubble.textContent.trim()) {
                 bubble.textContent = '(Something went wrong answering that. Please try again.)';
             }
             // Capture the conversation id from the first successful turn so the

--- a/src/Humans.Web/wwwroot/js/agent/widget.js
+++ b/src/Humans.Web/wwwroot/js/agent/widget.js
@@ -162,6 +162,15 @@
             // Final-frame placeholders are trusted strings — render as plain text.
             if (reason === 'disabled') bubble.textContent = '(The agent is currently disabled.)';
             if (reason === 'rate_limited') bubble.textContent = '(Daily limit reached — try again tomorrow.)';
+            // A turn that threw mid-stream now finishes as a well-formed 200/SSE
+            // 'error' finalizer instead of a broken connection, so neither the
+            // !resp.ok branch nor the catch below fires — without this the user is
+            // left staring at an empty bubble. Only fill an empty bubble: the
+            // exception can land after a partial answer was already streamed, and
+            // that text is worth keeping.
+            if (reason === 'error' && !bubble.dataset.rawMarkdown.trim()) {
+                bubble.textContent = '(Something went wrong answering that. Please try again.)';
+            }
             // Capture the conversation id from the first successful turn so the
             // next send continues the same conversation server-side. Bail-out
             // finalizers (disabled, rate_limited) carry an empty Guid; ignore

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -595,6 +595,75 @@ public class AgentServiceTests
     }
 
     [HumansFact]
+    public async Task Ask_persists_an_assistant_message_when_the_stream_is_abandoned_mid_turn()
+    {
+        // nobodies-collective/Humans#963 — AgentController awaits WriteSse OUTSIDE AskAsync, so
+        // a browser that goes away while a token is being written never throws into AskAsync's
+        // catch: it abandons the enumeration, which disposes the iterator at a `yield return`.
+        // That is the likeliest disconnect timing, and it must still leave the already-persisted
+        // user message with a matching assistant trace.
+        var userId = Guid.NewGuid();
+        var (svc, client) = await BuildService(s => s.Enabled = true);
+
+        client.EnqueueTurn(
+            new AgentTurnToken("Teams are groups of ", null, null),
+            new AgentTurnToken("volunteers.", null, null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(40, 10, 0, 0, "claude-sonnet-4-6", "end_turn")));
+
+        // `break` disposes the async enumerator — exactly what the controller's `await foreach`
+        // does when the response write throws on a dead connection.
+        await foreach (var t in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "What are teams?", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+            if (t.TextDelta is not null)
+                break;
+        }
+
+        var rows = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: false, handoffsOnly: false, userId: userId, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+        var messages = rows.SelectMany(r => r.Messages).ToList();
+        messages.Should().Contain(m => m.Role == AgentRole.User,
+            "the user message is persisted before the turn starts streaming");
+        var failure = messages.Should().ContainSingle(m => m.Role == AgentRole.Assistant,
+            "an abandoned turn must leave exactly one assistant trace — no reply, and no duplicate")
+            .Subject;
+        failure.RefusalReason.Should().Be("error",
+            "the trace surfaces through the existing admin refusals filter");
+    }
+
+    [HumansFact]
+    public async Task Ask_does_not_add_a_failure_trace_when_the_consumer_stops_after_the_finalizer()
+    {
+        // The disconnect guard above must not fire on a turn that completed: RunTurnAsync yields
+        // its finalizer only after AppendMessageAsync, so a disconnect while writing that last
+        // frame would otherwise stack a bogus "error" trace on top of a perfectly good answer.
+        var userId = Guid.NewGuid();
+        var (svc, client) = await BuildService(s => s.Enabled = true);
+
+        client.EnqueueTurn(
+            new AgentTurnToken("Teams are groups of volunteers.", null, null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(40, 10, 0, 0, "claude-sonnet-4-6", "end_turn")));
+
+        await foreach (var t in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "What are teams?", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+            if (t.Finalizer is not null)
+                break;
+        }
+
+        var rows = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: false, handoffsOnly: false, userId: userId, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+        var assistant = rows.SelectMany(r => r.Messages).Should()
+            .ContainSingle(m => m.Role == AgentRole.Assistant).Subject;
+        assistant.Content.Should().Be("Teams are groups of volunteers.");
+        assistant.RefusalReason.Should().BeNull();
+    }
+
+    [HumansFact]
     public async Task Refused_conversations_are_surfaced_by_the_admin_refusals_filter()
     {
         var userId = Guid.NewGuid();

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -496,6 +496,96 @@ public class AgentServiceTests
     }
 
     [HumansFact]
+    public async Task Ask_continues_the_tool_loop_when_a_tool_call_is_truncated_by_max_tokens()
+    {
+        // nobodies-collective/Humans#963 — a max_tokens cutoff mid tool-call JSON used to
+        // discard the call outright: the loop only ever continued on StopReason=="tool_use".
+        // AnthropicClient still closes the current content block before the stream ends, so a
+        // (possibly malformed) AnthropicToolCall reaches AgentService even on a max_tokens stop.
+        var userId = Guid.NewGuid();
+        var dispatcher = Substitute.For<IAgentToolDispatcher>();
+        dispatcher.DispatchAsync(Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(new AnthropicToolResult(
+                call.Arg<AnthropicToolCall>().Id, "Malformed tool arguments (expected JSON object).", IsError: true)));
+        var (svc, client) = await BuildService(s => s.Enabled = true, toolDispatcher: dispatcher);
+
+        // Iteration 1: max_tokens hits mid tool-call JSON.
+        client.EnqueueTurn(
+            new AgentTurnToken("Let me check that. ", null, null),
+            new AgentTurnToken(null, new AnthropicToolCall("t1", "fetch_section_guide", """{"section":"tea"""), null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(100, 20, 0, 0, "claude-sonnet-4-6", "max_tokens")));
+
+        // Iteration 2: the follow-up call recovers and answers normally.
+        client.EnqueueTurn(
+            new AgentTurnToken("Teams are groups of volunteers.", null, null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(40, 10, 0, 0, "claude-sonnet-4-6", "end_turn")));
+
+        var tokens = new List<AgentTurnToken>();
+        await foreach (var t in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "What are teams?", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+            tokens.Add(t);
+        }
+
+        await dispatcher.Received(1).DispatchAsync(
+            Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+
+        var streamedText = string.Concat(tokens.Where(t => t.TextDelta != null).Select(t => t.TextDelta));
+        streamedText.Should().Contain("Teams are groups of volunteers",
+            "a max_tokens cutoff mid tool-call must not dead-end the turn — the loop retries and the model finishes its answer");
+
+        tokens.Last().Finalizer!.StopReason.Should().Be("end_turn");
+    }
+
+    [HumansFact]
+    public async Task Ask_persists_an_assistant_message_when_an_exception_escapes_the_turn()
+    {
+        // nobodies-collective/Humans#963 — 4 of 11 conversations in #952's log evidence never
+        // reached AppendMessageAsync for the assistant turn because an exception escaped the
+        // stream between the user message being written and the assistant message being
+        // written. A failed turn must still leave a trace in the transcript.
+        var userId = Guid.NewGuid();
+        var dispatcher = Substitute.For<IAgentToolDispatcher>();
+        dispatcher.DispatchAsync(Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns<Task<AnthropicToolResult>>(_ => throw new InvalidOperationException("simulated dispatch failure"));
+        var logger = Substitute.For<ILogger<AgentService>>();
+        var (svc, client) = await BuildService(s => s.Enabled = true, toolDispatcher: dispatcher, logger: logger);
+
+        client.EnqueueTurn(
+            new AgentTurnToken(null, new AnthropicToolCall("t1", "fetch_section_guide", """{"section":"teams"}"""), null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(100, 20, 0, 0, "claude-sonnet-4-6", "tool_use")));
+
+        var tokens = new List<AgentTurnToken>();
+        await foreach (var t in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "What are teams?", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+            tokens.Add(t);
+        }
+
+        var finalizer = tokens.Last().Finalizer;
+        finalizer.Should().NotBeNull();
+        finalizer!.StopReason.Should().Be("error");
+        finalizer.ConversationId.Should().NotBe(Guid.Empty,
+            "the client must be able to continue the same conversation after a failed turn");
+
+        var transcript = await svc.GetConversationForUserAsync(
+            userId, finalizer.ConversationId, Xunit.TestContext.Current.CancellationToken);
+        transcript.Should().NotBeNull();
+        var failureMessage = transcript!.Messages.Should().ContainSingle(m => m.Role == AgentRole.Assistant,
+            "a turn that throws mid-stream must still leave an assistant message in the transcript").Subject;
+        failureMessage.RefusalReason.Should().Be("error");
+
+        logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Is<Exception>(e => e is InvalidOperationException),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [HumansFact]
     public async Task Refused_conversations_are_surfaced_by_the_admin_refusals_filter()
     {
         var userId = Guid.NewGuid();

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -536,6 +536,15 @@ public class AgentServiceTests
             "a max_tokens cutoff mid tool-call must not dead-end the turn — the loop retries and the model finishes its answer");
 
         tokens.Last().Finalizer!.StopReason.Should().Be("end_turn");
+
+        // Dispatching the truncated call must not inflate the admin "Top fetched docs" panel:
+        // NormalizeFetchedDocSlug can't parse the truncated args, so it would fall back to the
+        // bare tool name and record a lookup that never returned a document.
+        var rows = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: false, handoffsOnly: false, userId: userId, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+        rows.SelectMany(r => r.Messages).SelectMany(m => m.FetchedDocs)
+            .Should().BeEmpty("a failed tool dispatch is not a fetched doc");
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -587,6 +587,10 @@ public class AgentServiceTests
         var failureMessage = transcript!.Messages.Should().ContainSingle(m => m.Role == AgentRole.Assistant,
             "a turn that throws mid-stream must still leave an assistant message in the transcript").Subject;
         failureMessage.RefusalReason.Should().Be("error");
+        // AgentAdminStatusService prices spend straight off these fields, so a zeroed trace
+        // would hide a turn the provider actually billed us for.
+        failureMessage.PromptTokens.Should().Be(100);
+        failureMessage.OutputTokens.Should().Be(20);
 
         logger.Received(1).Log(
             LogLevel.Error,

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -559,7 +559,9 @@ public class AgentServiceTests
         dispatcher.DispatchAsync(Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns<Task<AnthropicToolResult>>(_ => throw new InvalidOperationException("simulated dispatch failure"));
         var logger = Substitute.For<ILogger<AgentService>>();
-        var (svc, client) = await BuildService(s => s.Enabled = true, toolDispatcher: dispatcher, logger: logger);
+        var store = new AgentRateLimitStore();
+        var (svc, client) = await BuildService(s => s.Enabled = true, rateLimitStore: store,
+            toolDispatcher: dispatcher, logger: logger);
 
         client.EnqueueTurn(
             new AgentTurnToken(null, new AnthropicToolCall("t1", "fetch_section_guide", """{"section":"teams"}"""), null),
@@ -592,6 +594,66 @@ public class AgentServiceTests
             Arg.Any<object>(),
             Arg.Is<Exception>(e => e is InvalidOperationException),
             Arg.Any<Func<object, Exception?, string>>());
+
+        // A failed turn is still a billed turn: the provider charged us for the 100/20 the
+        // first request consumed before the dispatcher threw, and leaving the message cap
+        // untouched would make a deterministic backend error an unmetered send loop.
+        var usage = store.Get(userId, new LocalDate(2026, 4, 21), hour: 12);
+        usage.MessagesToday.Should().Be(1);
+        usage.MessagesThisHour.Should().Be(1);
+        usage.TokensToday.Should().Be(120,
+            "tokens the provider already billed before the failure must reach DailyTokenCap and admin spend");
+    }
+
+    [HumansFact]
+    public async Task Ask_writes_one_trace_when_the_assistant_append_itself_is_cancelled()
+    {
+        // AgentRepository shares one scoped AgentDbContext across the turn. A cancellation that
+        // lands inside the final AppendMessageAsync leaves the assistant message tracked as
+        // Added, so the failure trace's save would flush BOTH — a real reply plus an "error"
+        // refusal for the same turn, and a double MessageCount bump. The repository discards the
+        // half-written append on failure so the turn ends with exactly one trace.
+        var userId = Guid.NewGuid();
+        using var cts = new CancellationTokenSource();
+
+        // route_to_issue is the one turn shape that reaches the final append with no further
+        // provider call in between (the proposal frame is terminal), so cancelling from the
+        // dispatcher lands the cancellation inside AppendMessageAsync itself rather than in
+        // the streaming loop — which is the ordering the duplicate-write hazard needs.
+        var dispatcher = Substitute.For<IAgentToolDispatcher>();
+        dispatcher.DispatchAsync(Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                await cts.CancelAsync();
+                return new AnthropicToolResult(
+                    call.Arg<AnthropicToolCall>().Id, "Proposal queued.", IsError: false);
+            });
+        var (svc, client) = await BuildService(s => s.Enabled = true, toolDispatcher: dispatcher);
+
+        client.EnqueueTurn(
+            new AgentTurnToken(null, new AnthropicToolCall(
+                "tc1", AgentToolNames.RouteToIssue,
+                """{"title":"Broken link","category":"Bug","description":"The camps page 404s."}"""), null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(40, 10, 0, 0, "claude-sonnet-4-6", "tool_use")));
+
+        await foreach (var _ in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "the camps page is broken", Locale: "es"),
+            cts.Token))
+        {
+            // Drain; the assertions below read the persisted transcript.
+        }
+
+        var rows = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: false, handoffsOnly: false, userId: userId, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+        var conversation = rows.Should().ContainSingle().Subject;
+        var assistant = conversation.Messages.Should()
+            .ContainSingle(m => m.Role == AgentRole.Assistant,
+                "the cancelled append must not be flushed alongside the failure trace")
+            .Subject;
+        assistant.RefusalReason.Should().Be("error");
+        assistant.Content.Should().BeEmpty();
+        conversation.MessageCount.Should().Be(2, "one user message and one assistant trace");
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
@@ -331,6 +331,29 @@ public class AgentToolDispatcherTests
     }
 
     [HumansFact]
+    public async Task RouteToIssue_reports_an_error_when_max_tokens_truncated_its_arguments()
+    {
+        // nobodies-collective/Humans#963 dispatches max_tokens-truncated tool calls instead of
+        // discarding them, which raised the question of whether route_to_issue — the one tool
+        // whose result is a canned success string — could tell the model "Proposal queued" for
+        // a payload AgentService then drops, leaving the user with no issue form. It can't:
+        // DispatchAsync parses the arguments once, up front, for every tool, so a truncated
+        // payload fails before the per-tool switch is ever reached. Pinning that ordering here
+        // because the canned success sits below it and would be wrong if the parse ever moved.
+        var dispatcher = MakeDispatcher();
+
+        var result = await dispatcher.DispatchAsync(
+            new AnthropicToolCall("t1", AgentToolNames.RouteToIssue,
+                """{"title":"Calendar feature","category":"Feature","description":"User asked ab"""),
+            userId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Xunit.TestContext.Current.CancellationToken);
+
+        result.IsError.Should().BeTrue(
+            "the model must learn the proposal failed so it can retry, not be told it was queued");
+        result.Content.Should().NotContain("Proposal queued");
+    }
+
+    [HumansFact]
     public async Task FetchCommunityFaq_returns_wrapped_body_for_known_topic()
     {
         var dispatcher = MakeDispatcher();

--- a/tests/Humans.Application.Tests/Agent/AnthropicClientFake.cs
+++ b/tests/Humans.Application.Tests/Agent/AnthropicClientFake.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Humans.Application.Interfaces;
 using Humans.Application.Models;
 
@@ -26,6 +27,7 @@ internal sealed class AnthropicClientFake : IAnthropicClient
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         LastRequest = request;
+        RejectUnmappableToolCalls(request);
         if (_scripted.Count == 0)
             throw new InvalidOperationException("AnthropicClientFake has no scripted turn left.");
         foreach (var token in _scripted.Dequeue())
@@ -33,6 +35,29 @@ internal sealed class AnthropicClientFake : IAnthropicClient
             cancellationToken.ThrowIfCancellationRequested();
             yield return token;
             await Task.Yield();
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the one way the real client can reject a request the fake would
+    /// otherwise wave through: <c>AnthropicClient.MapMessages</c> deserializes every
+    /// replayed <c>tool_use</c> block's arguments into
+    /// <c>Dictionary&lt;string, JsonElement&gt;</c>, so a malformed or non-object
+    /// payload throws while the request is being built.
+    /// </summary>
+    /// <remarks>
+    /// Without this, a test can replay a truncated tool call (as a max_tokens cutoff
+    /// produces — nobodies-collective/Humans#963) and pass green while the same path
+    /// would throw in production. Keep the fake's contract as strict as the client's.
+    /// </remarks>
+    private static void RejectUnmappableToolCalls(AnthropicRequest request)
+    {
+        foreach (var call in request.Messages.SelectMany(m => m.ToolCalls ?? []))
+        {
+            var input = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(call.JsonArguments);
+            if (input is null)
+                throw new JsonException(
+                    $"Tool call '{call.Name}' has null arguments; the real client cannot map it.");
         }
     }
 }


### PR DESCRIPTION
## Summary

Two defects in `AgentService`'s per-turn loop, split off nobodies-collective/Humans#952 as tracked here.

**1. max_tokens truncation was discarded.** The per-iteration `MaxOutputTokens` cap (1024) was tight for a turn that also emits tool-call JSON. `AnthropicClient` closes the current content block on *any* stop reason (including `max_tokens`), so a (possibly truncated) `AnthropicToolCall` was reaching `AgentService` — but the loop only continued when `StopReason == "tool_use"`, so it was thrown away. Fixed both ways the issue allowed:
- Raised the cap 1024 → 4096 (`MaxOutputTokensPerIteration`), which avoids most truncation outright.
- Widened the loop-continuation condition to also cover `max_tokens` with pending tool calls, so a truncated call still gets dispatched. `AgentToolDispatcher` already handles malformed JSON gracefully (catches `JsonException`, returns `IsError`), and `MaxToolCallsPerTurn` still bounds the loop if the model keeps truncating.

**2. No-message-at-all turns weren't exception-safe.** 4 of 11 conversations in #952's log evidence never reached `AppendMessageAsync` for the assistant turn — an exception (or client disconnect) escaped between the user message being written and the assistant message being written. `AskAsync`'s body after the user-message append is now a separate `RunTurnAsync` iterator, driven manually from `AskAsync` (`await foreach` forbids `yield` inside its implicit try/finally, so `MoveNextAsync` is wrapped in try/catch instead). On failure, an empty assistant message with `RefusalReason = "error"` is persisted via a new `AppendFailureMessage` helper — shared with `PersistRefusal` rather than duplicating the `AgentMessage` construction — so failed turns surface through the existing admin refusals filter / "top refusal reasons" panel instead of a new surface. Cancellation caused by the caller's own token (client disconnect) is logged at Warning, not Error, matching the existing distinction in `AnthropicClient.cs`; the trace is still persisted either way.

## Reuse-first notes
- Rejected calling `PersistRefusal` directly from the catch block — it re-resolves/creates a *new* conversation from `request.ConversationId`, which would diverge from the already-established `conversation` in scope. Instead extracted the shared "append an empty-content assistant message with `RefusalReason`" shape into `AppendFailureMessage`, called by both `PersistRefusal` and the new catch path.
- No new DTOs, interfaces, or config surface added — reused `RefusalReason` (existing field) and `AgentTurnFinalizer` (existing record).

## Test plan
- [x] `dotnet build Humans.slnx -v quiet`
- [x] `dotnet test Humans.slnx -v quiet` — Domain/Analyzers/Web/Application all green; `Humans.Integration.Tests` has 17 pre-existing failures unrelated to Agent (Stripe webhooks, CSP nonce, DB baseline, health endpoint) — confirmed identical failures on `main` via `git stash`.
- [x] New test: `Ask_continues_the_tool_loop_when_a_tool_call_is_truncated_by_max_tokens` — a `max_tokens` stop mid tool-call JSON still dispatches the call and the follow-up iteration recovers with a normal answer.
- [x] New test: `Ask_persists_an_assistant_message_when_an_exception_escapes_the_turn` — a dispatcher exception still yields a persisted assistant message with `RefusalReason = "error"` and an `"error"` finalizer carrying the conversation id.

Fixes nobodies-collective/Humans#963