### PR TITLE
fix(analyzers): HUM0024 silently skipped root-namespace EF configs

### DIFF
--- a/docs/architecture/code-analysis.md
+++ b/docs/architecture/code-analysis.md
@@ -84,7 +84,7 @@ HUM0018 | Section-aware analyzer cannot determine a type's section (missing `[Se
 HUM0019 | Read of an Identity-derived User column (Email/NormalizedEmail/UserName/NormalizedUserName) from Application or Web | Warning
 HUM0020 | Caching decorator references a repository directly instead of the keyed inner service | Error
 HUM0021 | Read of an obsolete cross-domain navigation property from Application, Web, or Infrastructure | Warning
-HUM0024 | EF configuration creates a navigation join across section boundaries (`[Grandfathered("HUM0024")]` downgrades to Warning) | Error
+HUM0024 | EF configuration creates a navigation join across section boundaries — a configuration's section is its namespace segment under `Data.Configurations`; one sitting in the `Configurations` root declares no section and is reported as `(unsectioned)` rather than skipped (`[Grandfathered("HUM0024")]` downgrades to Warning) | Error
 HUM0025 | A DbSet table is referenced by more than one repository (`[Grandfathered("HUM0025", scope: "<DbSet>")]` downgrades to Warning) | Error
 HUM0026 | IOrchestrator implementer injects an `I*Repository`, an application DbContext, or `IDbContextFactory<TContext>` for one | Error
 HUM0027 | Type implements both IApplicationService and IOrchestrator (the role axis is exclusive) | Error

--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -17,8 +17,13 @@ themes:
     detect: "build:HUM0024"
     review: panel
     last_swept: 2026-06-12
-    remaining: 34
+    remaining: 56
     notes: >-
+      Count re-measured 2026-08-05 (nobodies-collective/Humans#978): 47 -> 56.
+      The +9 are not new joins, they are joins HUM0024 could not see until the
+      analyzer stopped silently skipping configurations that sit in the
+      `Configurations` root namespace. 55 carry markers; the 56th
+      (GoogleResourceConfiguration) is marked by #1178.
       SCHEMA-BLOCKED (verified empirically, sweep 2026-06-12): dropping any
       HasOne config fires `dotnet ef migrations has-pending-model-changes` —
       the config blocks own the DB-level FK + cascade behavior, so every fix

--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -17,13 +17,15 @@ themes:
     detect: "build:HUM0024"
     review: panel
     last_swept: 2026-06-12
-    remaining: 56
+    remaining: 55
     notes: >-
-      Count re-measured 2026-08-05 (nobodies-collective/Humans#978): 47 -> 56.
-      The +9 are not new joins, they are joins HUM0024 could not see until the
-      analyzer stopped silently skipping configurations that sit in the
-      `Configurations` root namespace. 55 carry markers; the 56th
-      (GoogleResourceConfiguration) is marked by #1178.
+      Count re-measured 2026-08-05 (nobodies-collective/Humans#978): 47 -> 55,
+      all carrying markers. These are not new joins; they are joins HUM0024
+      could not see. +1 net from #1178's relocations (GoogleResource gained a
+      section, EventParticipation moved under Users and folded to an
+      intra-section nav that correctly stopped firing), then +7 from #978,
+      which stopped the analyzer silently skipping configurations that sit in
+      the `Configurations` root namespace. Six configs remain in that root.
       SCHEMA-BLOCKED (verified empirically, sweep 2026-06-12): dropping any
       HasOne config fires `dotnet ef migrations has-pending-model-changes` —
       the config blocks own the DB-level FK + cascade behavior, so every fix

--- a/src/Humans.Analyzers/CrossSectionEfJoinAnalyzer.cs
+++ b/src/Humans.Analyzers/CrossSectionEfJoinAnalyzer.cs
@@ -20,6 +20,15 @@ public sealed class CrossSectionEfJoinAnalyzer : DiagnosticAnalyzer
     private const string EntityTypeConfigurationFullName = "Microsoft.EntityFrameworkCore.IEntityTypeConfiguration`1";
     private const string EfBuilderNamespacePrefix = "Microsoft.EntityFrameworkCore";
 
+    /// <summary>
+    /// Section identity for a configuration that sits directly in the
+    /// <c>Configurations</c> root namespace, where no folder segment names an
+    /// owning section. Such configurations form a single bucket that is never
+    /// equal to a named section, so their joins to (and from) sectioned
+    /// entities are reported instead of silently passing.
+    /// </summary>
+    private const string UnsectionedSection = "(unsectioned)";
+
     private static readonly ImmutableHashSet<string> RelationshipMethods =
         ImmutableHashSet.Create(StringComparer.Ordinal, "HasOne", "HasMany");
 
@@ -38,8 +47,11 @@ public sealed class CrossSectionEfJoinAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description:
             "A section's EF model must not configure HasOne/HasMany navigation joins to entities owned by " +
-            "another section. Existing violators carry [Grandfathered(\"HUM0024\", ...)] until their joins " +
-            "are migrated to bare FK columns and service-level stitching.");
+            "another section. A configuration's owning section is the folder/namespace segment directly under " +
+            "Data/Configurations; one that sits in the Configurations root declares no section and is reported " +
+            "as '(unsectioned)' -- move it under Configurations/<Section>/ so its owner is stated. Existing " +
+            "violators carry [Grandfathered(\"HUM0024\", ...)] until their joins are migrated to bare FK " +
+            "columns and service-level stitching.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
@@ -156,6 +168,14 @@ public sealed class CrossSectionEfJoinAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    /// <summary>
+    /// Resolves the section that owns a configuration class from the namespace
+    /// segment directly beneath <c>…Data.Configurations</c>. Returns
+    /// <c>null</c> only when the type is not under that namespace at all (so it
+    /// is not an EF configuration this rule governs); a configuration that sits
+    /// in the <c>Configurations</c> root namespace resolves to
+    /// <see cref="UnsectionedSection"/> rather than to <c>null</c>.
+    /// </summary>
     private static string? SectionFromConfigurationNamespace(INamedTypeSymbol type)
     {
         var ns = type.ContainingNamespace?.ToDisplayString();
@@ -163,7 +183,7 @@ public sealed class CrossSectionEfJoinAnalyzer : DiagnosticAnalyzer
             return null;
 
         if (ns.Length == ConfigurationNamespacePrefix.Length)
-            return null;
+            return UnsectionedSection;
 
         if (ns[ConfigurationNamespacePrefix.Length] != '.')
             return null;
@@ -171,7 +191,7 @@ public sealed class CrossSectionEfJoinAnalyzer : DiagnosticAnalyzer
         var start = ConfigurationNamespacePrefix.Length + 1;
         var dot = ns.IndexOf('.', start);
         var raw = dot < 0 ? ns.Substring(start) : ns.Substring(start, dot - start);
-        return FoldSection(raw);
+        return Sections.Fold(raw);
     }
 
     private static INamedTypeSymbol? FindTargetEntity(
@@ -241,13 +261,6 @@ public sealed class CrossSectionEfJoinAnalyzer : DiagnosticAnalyzer
 
     private static string SymbolKey(ITypeSymbol type) =>
         type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-
-    private static string FoldSection(string raw) =>
-        raw switch
-        {
-            "Users" or "Profile" or "Profiles" => "Humans",
-            _ => raw,
-        };
 
     private sealed class OwnershipMap
     {

--- a/src/Humans.Infrastructure/Data/Configurations/ApplicationConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/ApplicationConfiguration.cs
@@ -1,10 +1,16 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
+using Humans.Application.Architecture;
 using MemberApplication = Humans.Domain.Entities.Application;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
+[Grandfathered(
+    ruleId: "HUM0024",
+    justification: "Pre-existing cross-section EF navigation join; migrating to bare FK + service-level stitching.",
+    since: "2026-08-05",
+    issueRef: "docs/architecture/roslyn-analysis.md#hum0024")]
 public class ApplicationConfiguration : IEntityTypeConfiguration<MemberApplication>
 {
     public void Configure(EntityTypeBuilder<MemberApplication> builder)

--- a/src/Humans.Infrastructure/Data/Configurations/ApplicationStateHistoryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/ApplicationStateHistoryConfiguration.cs
@@ -1,9 +1,15 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
+using Humans.Application.Architecture;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
+[Grandfathered(
+    ruleId: "HUM0024",
+    justification: "Pre-existing cross-section EF navigation join; migrating to bare FK + service-level stitching.",
+    since: "2026-08-05",
+    issueRef: "docs/architecture/roslyn-analysis.md#hum0024")]
 public class ApplicationStateHistoryConfiguration : IEntityTypeConfiguration<ApplicationStateHistory>
 {
     public void Configure(EntityTypeBuilder<ApplicationStateHistory> builder)

--- a/src/Humans.Infrastructure/Data/Configurations/BoardVoteConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/BoardVoteConfiguration.cs
@@ -1,9 +1,15 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
+using Humans.Application.Architecture;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
+[Grandfathered(
+    ruleId: "HUM0024",
+    justification: "Pre-existing cross-section EF navigation join; migrating to bare FK + service-level stitching.",
+    since: "2026-08-05",
+    issueRef: "docs/architecture/roslyn-analysis.md#hum0024")]
 public class BoardVoteConfiguration : IEntityTypeConfiguration<BoardVote>
 {
     public void Configure(EntityTypeBuilder<BoardVote> builder)

--- a/src/Humans.Infrastructure/Data/Configurations/GoogleSyncOutboxEventConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/GoogleSyncOutboxEventConfiguration.cs
@@ -1,9 +1,15 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
+using Humans.Application.Architecture;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
+[Grandfathered(
+    ruleId: "HUM0024",
+    justification: "Pre-existing cross-section EF navigation join; migrating to bare FK + service-level stitching.",
+    since: "2026-08-05",
+    issueRef: "docs/architecture/roslyn-analysis.md#hum0024")]
 public class GoogleSyncOutboxEventConfiguration : IEntityTypeConfiguration<GoogleSyncOutboxEvent>
 {
     public void Configure(EntityTypeBuilder<GoogleSyncOutboxEvent> builder)

--- a/src/Humans.Infrastructure/Data/Configurations/SyncServiceSettingsConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/SyncServiceSettingsConfiguration.cs
@@ -3,9 +3,15 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using NodaTime;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Application.Architecture;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
+[Grandfathered(
+    ruleId: "HUM0024",
+    justification: "Pre-existing cross-section EF navigation join; migrating to bare FK + service-level stitching.",
+    since: "2026-08-05",
+    issueRef: "docs/architecture/roslyn-analysis.md#hum0024")]
 public class SyncServiceSettingsConfiguration : IEntityTypeConfiguration<SyncServiceSettings>
 {
     private static readonly Instant SeedTimestamp = Instant.FromUtc(2026, 3, 9, 0, 0, 0);

--- a/tests/Humans.Analyzers.Tests/CrossSectionEfJoinAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/CrossSectionEfJoinAnalyzerTests.cs
@@ -56,6 +56,11 @@ public sealed class CrossSectionEfJoinAnalyzerTests
                 public User User { get; set; } = new();
                 public Team Team { get; set; } = new();
             }
+            public sealed class SyncSettings { }
+            public sealed class SyncLink
+            {
+                public SyncSettings Settings { get; set; } = new();
+            }
         }
 
         namespace Humans.Infrastructure.Data.Configurations.Users
@@ -230,7 +235,7 @@ public sealed class CrossSectionEfJoinAnalyzerTests
     }
 
     [HumansFact]
-    public async Task Does_not_fire_for_root_level_configuration_without_section_namespace()
+    public async Task Fires_for_root_level_configuration_targeting_sectioned_entity()
     {
         var source = Stubs + """
 
@@ -250,7 +255,102 @@ public sealed class CrossSectionEfJoinAnalyzerTests
             "Humans.Infrastructure",
             source);
 
+        var hit = diagnostics.Where(IsHum0024).Should().ContainSingle().Subject;
+        hit.Severity.Should().Be(DiagnosticSeverity.Error);
+        hit.GetMessage().Should().Contain("(unsectioned)");
+    }
+
+    [HumansFact]
+    public async Task Fires_for_sectioned_configuration_targeting_root_level_entity()
+    {
+        var source = Stubs + """
+
+            namespace Humans.Infrastructure.Data.Configurations
+            {
+                public sealed class SyncSettingsConfiguration :
+                    Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<Humans.Domain.Entities.SyncSettings>
+                {
+                    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<Humans.Domain.Entities.SyncSettings> builder) { }
+                }
+            }
+
+            namespace Humans.Infrastructure.Data.Configurations.Teams
+            {
+                public sealed class TeamMemberConfiguration :
+                    Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<Humans.Domain.Entities.TeamMember>
+                {
+                    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<Humans.Domain.Entities.TeamMember> builder) =>
+                        builder.HasOne<Humans.Domain.Entities.SyncSettings>();
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new CrossSectionEfJoinAnalyzer(),
+            "Humans.Infrastructure",
+            source);
+
+        diagnostics.Where(IsHum0024).Should().ContainSingle();
+    }
+
+    [HumansFact]
+    public async Task Does_not_fire_between_two_root_level_configurations()
+    {
+        var source = Stubs + """
+
+            namespace Humans.Infrastructure.Data.Configurations
+            {
+                public sealed class SyncSettingsConfiguration :
+                    Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<Humans.Domain.Entities.SyncSettings>
+                {
+                    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<Humans.Domain.Entities.SyncSettings> builder) { }
+                }
+
+                public sealed class SyncLinkConfiguration :
+                    Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<Humans.Domain.Entities.SyncLink>
+                {
+                    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<Humans.Domain.Entities.SyncLink> builder) =>
+                        builder.HasOne(link => link.Settings);
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new CrossSectionEfJoinAnalyzer(),
+            "Humans.Infrastructure",
+            source);
+
         diagnostics.Where(IsHum0024).Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task Reports_warning_for_grandfathered_root_level_configuration()
+    {
+        var source = Stubs + """
+
+            namespace Humans.Infrastructure.Data.Configurations
+            {
+                [Humans.Application.Architecture.Grandfathered(
+                    ruleId: "HUM0024",
+                    justification: "Pre-existing cross-section EF navigation join.",
+                    since: "2026-08-05",
+                    issueRef: "docs/architecture/roslyn-analysis.md#hum0024")]
+                public sealed class TeamMemberConfiguration :
+                    Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<Humans.Domain.Entities.TeamMember>
+                {
+                    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<Humans.Domain.Entities.TeamMember> builder) =>
+                        builder.HasOne<Humans.Domain.Entities.User>();
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new CrossSectionEfJoinAnalyzer(),
+            "Humans.Infrastructure",
+            source);
+
+        var hit = diagnostics.Where(IsHum0024).Should().ContainSingle().Subject;
+        hit.Severity.Should().Be(DiagnosticSeverity.Warning);
     }
 
     [HumansFact]


### PR DESCRIPTION
Fixes nobodies-collective/Humans#978

> **Updated after merging `origin/main`** (which now carries #1178). The blocker described in the first revision of this body is gone — the build is clean. Counts below are re-measured post-merge and differ from the original numbers; see "Occurrence count".

## Root cause

Not "Governance and GoogleIntegration are special" — **section resolution had a silent fall-through.**

`CrossSectionEfJoinAnalyzer.SectionFromConfigurationNamespace` returned `null` for a configuration class sitting directly in the `Humans.Infrastructure.Data.Configurations` **root** namespace (no folder segment to name a section). `BuildOwnershipMap` skips any type whose section is `null`, which dropped that configuration from **both** halves of the ownership map:

- **As a source** — `AnalyzeInvocation` bails at `ConfigurationSections.TryGetValue(...)`, so the config's own `HasOne`/`HasMany` calls were never checked.
- **As a target** — the entity it configures never entered `EntitySections`, so `FindTargetEntity` returned `null` for *any other section's* navigation pointing at that entity.

The 8 occurrences in the issue are the first case; the second case surfaced an extra one.

The confirming detail from #981/#1178: `GoogleResourceConfiguration` did not fire at the root and started firing the moment its namespace changed. Nothing about the *relationship* changed — only whether the analyzer could name a section for it.

At this branch point the `Governance/` folder still doesn't exist; those 4 occurrences live in root-namespace files (`ApplicationConfiguration`, `ApplicationStateHistoryConfiguration`, `BoardVoteConfiguration`) that a later relocation will move into it. Same files, same bug.

## The fix

A root-namespace configuration now resolves to a distinct `(unsectioned)` bucket instead of `null`:

- **Never equal to a named section** → joins crossing between it and any section are reported. No more silent pass.
- **Equal to itself** → root-to-root relationships (e.g. `BoardVote` → `Application`, both root-configured) don't become false positives. We genuinely cannot tell those apart, and they are in fact same-section.
- **The bucket name lands in the diagnostic message** (`from section '(unsectioned)' to 'Teams'`), so the unresolved section is visible at the call site rather than swallowed. The descriptor's `description` now says to move the file under `Configurations/<Section>/`.

No folder names are special-cased; the change is the removal of one `return null`.

**On reusing HUM0018** ("Section cannot be determined"): that descriptor is owned by `CrossSectionRepositoryInjectionAnalyzer`, and its own code comments establish the precedent that you don't pile on a second indeterminate-section diagnostic when another rule already covers the site. HUM0024 now reports the site itself with `(unsectioned)` named in the message, so a second diagnostic would be noise on the same location.

Also drops the analyzer's private `FoldSection` copy in favour of the shared `Sections.Fold` — that duplication is what let the two resolvers drift apart in the first place.

## Occurrence count

Measured against a forced rebuild of `Humans.Infrastructure` (an incremental build silently emits none — worth knowing if you re-check this).

| | Count |
|---|---|
| Before either PR | 47 |
| After #1178 alone | 48 |
| **After this PR (current)** | **55 — all warnings, 0 errors** |

**7 occurrences are attributable to this fix** — the configurations still sitting in the `Configurations` root, each given a `[Grandfathered(HUM0024)]` marker here:

| File | Direction |
|---|---|
| `ApplicationConfiguration.cs` ×2 | (unsectioned) → Humans (User) |
| `ApplicationStateHistoryConfiguration.cs` | (unsectioned) → Humans (User) |
| `BoardVoteConfiguration.cs` | (unsectioned) → Humans (User) |
| `GoogleSyncOutboxEventConfiguration.cs` ×2 | (unsectioned) → Teams / Humans |
| `SyncServiceSettingsConfiguration.cs` | (unsectioned) → Humans (User) |

Pre-merge this PR surfaced **9**. Two of those are now attributable to #1178 instead of to this fix, because its relocation gave `GoogleResource` a real section name: its own `HasOne<Team>()` (now `GoogleIntegration → Teams`) and `AuditLogEntryConfiguration → GoogleResource` (now `AuditLog → GoogleIntegration`). Both are still detected; they'd now be caught without this fix too.

The merge also **removed** one occurrence, correctly: #1178 moved `EventParticipationConfiguration` from `Shifts` to `Users`, and `Users` folds to the unified `Humans` section, so its `HasOne(User)` became an *intra*-section navigation and rightly stopped firing.

`docs/architecture/debt-ledger.yml` `remaining` updated 34 → 55 (the 34 was stale from the 2026-06-12 sweep). These are not new joins — they are joins the analyzer could not previously see.

**Six EF configurations remain in the `Configurations` root namespace** and are the reason the `(unsectioned)` bucket still has members. Relocating them into section folders is follow-up work in the spirit of #1178, not done here.

## Verification

- `dotnet build Humans.slnx -v quiet` — **clean**, 0 errors.
- `dotnet test Humans.slnx -v quiet` — Domain 277, **Analyzers 234**, Web 371, Application 3944 — all pass.
- 4 new analyzer tests. Verified they fail against the old code: reverting the one-line fix turns **3 of the 4 red** (`Fires_for_root_level_configuration_targeting_sectioned_entity`, `Fires_for_sectioned_configuration_targeting_root_level_entity`, `Reports_warning_for_grandfathered_root_level_configuration`). The 4th, `Does_not_fire_between_two_root_level_configurations`, is green both ways by design — it guards the false positive this fix could have introduced.

**Integration tests are not green on my machine, and it is not this diff.** `Humans.Integration.Tests` failed 15, then 18, then 17 across three consecutive runs with a *differing* failure set each time, spanning unrelated areas (liveness endpoint, CSP header, Stripe webhooks, schema comparison). `LivenessEndpoint_ReturnsOk` passes when run in isolation. This is contention under parallel load — two GitHub Actions runner containers were live on the same box. This diff has no runtime surface: analyzer code is compile-time only, and the 5 added attributes sit on EF *configuration* classes, not entities, so the model is untouched. Flagging it rather than reporting a green I didn't get; CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
