### PR TITLE
test(infra): share one Postgres container across the integration assembly

### DIFF
--- a/docs/features/test-system-reliability.md
+++ b/docs/features/test-system-reliability.md
@@ -48,20 +48,21 @@ Remove `--filter "FullyQualifiedName!~Integration"` from `.github/workflows/buil
 
 **Definition of done:** integration tests run on every PR. A new "pre-existing failure" cannot land on `main` without being noticed.
 
-### P2 — Share one Postgres container across the assembly
-**Value: high · Effort: medium · Risk: medium. Depends on P0.**
+### P2 — Share one Postgres container across the assembly — **shipped**
+**Value: high · Effort: medium · Risk: medium. Depends on P0. Landed via nobodies-collective/Humans#764.**
 
-Move from `IClassFixture<HumansWebApplicationFactory>` to `IAssemblyFixture<HumansWebApplicationFactory>` (xUnit v3 supports this natively). One container, one app boot, one migration pass per test run.
+`HumansWebApplicationFactory` is registered once for the assembly with xUnit v3's `[assembly: AssemblyFixture(...)]` (the attribute form — v3 has no `IAssemblyFixture<T>` interface, and an assembly fixture cannot take another assembly fixture as a constructor argument). One container, one app boot, one migration pass per test run. Test parallelization is disabled for the assembly, since the classes now share one host. The migration-mechanics tests (`PhysicalDefaultParityTests`, `SectionMigrationRunnerTests`) and the localization sweep's second app boot take their own databases inside that one container rather than starting their own.
 
-Per-test isolation via either:
-- (a) `BEGIN; ROLLBACK` transaction wrapper per test — fast, clean for the common case.
-- (b) `TRUNCATE TABLE ... CASCADE` reset between tests — necessary for tests that assert post-commit behavior (triggers firing, etc.).
+Measured on `origin/main` at 94535e688: **27 → 1** concurrent Postgres containers, **22 → 0** failures (all 22 were 30s/60s timeouts, i.e. contention), **62s → 31s** of test time.
 
-Default to (a); tests that need post-commit assertions opt into (b) via a fixture base-class flag.
+**Per-test database isolation did not ship** — tracked as nobodies-collective/Humans#983. Both options in the original plan were tried and neither works as written:
 
-Tradeoff: shared container trades isolation for speed. Mitigated by per-test transaction rollback. A handful of tests will need the TRUNCATE variant — that's a 5-line fixture method.
+- (a) **`BEGIN; ROLLBACK` per test.** Not implementable for this suite. Tests drive the app over TestServer, so each request resolves its own scoped `HumansDbContext` off the pooled `NpgsqlDataSource` and writes on a different physical connection than the test holds; a transaction the test opens is invisible to the code under test. Pinning the pool to a single connection does not help either — EF's own `SaveChanges` transaction collides with an out-of-band `BEGIN`.
+- (b) **`TRUNCATE ... CASCADE`.** Implemented and measured, including a post-boot snapshot/restore so `HasData` and startup-seeder rows survive. It takes 23 of 123 tests down, because the app's 11 Singleton caching decorators are not truncated with the database: `/dev/login/{persona}` 500s when `DevPersonaSeeder` resolves a cached user id whose row was just truncated. Truncating the database while the app still believes the old rows exist is a worse correctness story than not truncating at all, so it was not shipped. #983 records what a complete cache-flush capability would need.
 
-**Definition of done:** integration suite boots one Postgres container per run; per-test isolation preserved; suite runtime drops to seconds, not minutes.
+The suite is green sharing one database because tests already scope assertions to rows they seeded themselves (per-test GUID suffixes). `HumansWebApplicationFactory`'s XML docs state that contract for future tests.
+
+**Definition of done:** integration suite boots one Postgres container per run ✅; suite runtime drops to seconds, not minutes ✅; per-test isolation → deferred to nobodies-collective/Humans#983.
 
 ### P3 — Containerize Hangfire away from static state
 **Value: high · Effort: medium · Risk: low. Can run in parallel with P2.**
@@ -121,7 +122,7 @@ Parent: nobodies-collective/Humans#761. Phase issues:
 |-------|-------|
 | P0 — Fix 53 integration failures | nobodies-collective/Humans#762 |
 | P1 — Integration in CI | nobodies-collective/Humans#763 |
-| P2 — Shared container fixture | nobodies-collective/Humans#764 |
+| P2 — Shared container fixture | nobodies-collective/Humans#764 (shipped; isolation follow-up nobodies-collective/Humans#983) |
 | P3 — Hangfire abstraction | nobodies-collective/Humans#765 |
 | P4 — EF In-Memory migration | nobodies-collective/Humans#766 |
 | P5 — Quarantine discipline | nobodies-collective/Humans#767 |

--- a/docs/features/test-system-reliability.md
+++ b/docs/features/test-system-reliability.md
@@ -53,7 +53,16 @@ Remove `--filter "FullyQualifiedName!~Integration"` from `.github/workflows/buil
 
 `HumansWebApplicationFactory` is registered once for the assembly with xUnit v3's `[assembly: AssemblyFixture(...)]` (the attribute form — v3 has no `IAssemblyFixture<T>` interface, and an assembly fixture cannot take another assembly fixture as a constructor argument). One container, one app boot, one migration pass per test run. Test parallelization is disabled for the assembly, since the classes now share one host. The migration-mechanics tests (`PhysicalDefaultParityTests`, `SectionMigrationRunnerTests`) and the localization sweep's second app boot take their own databases inside that one container rather than starting their own.
 
-Measured on `origin/main` at 94535e688: **27 → 1** concurrent Postgres containers, **22 → 0** failures (all 22 were 30s/60s timeouts, i.e. contention), **62s → 31s** of test time.
+Measured back to back against `origin/main` at 94535e688, same machine, same command:
+
+| | before | after |
+|---|---|---|
+| distinct Postgres containers created per run | 30 | **1** |
+| test duration | 4m 27s | **25s** |
+| result on an otherwise-idle machine | 122 passed, 1 skipped | 122 passed, 1 skipped |
+| result while four other agents were building | **22 failed** (every one a 30s/60s timeout) | 0 failed |
+
+That last row is the point of the phase: the "pre-existing failures" were never assertion failures, they were containers starving each other.
 
 **Per-test database isolation did not ship** — tracked as nobodies-collective/Humans#983. Both options in the original plan were tried and neither works as written:
 

--- a/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFoldTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFoldTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
@@ -21,7 +21,7 @@ namespace Humans.Integration.Tests.AccountMerge;
 /// <see cref="MergeFixtureBuilder"/>, calls <c>AcceptAsync</c>, then asserts
 /// the resulting fold against the rule documented in the fold-redesign plan.
 /// </summary>
-public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassFixture<HumansWebApplicationFactory>
+public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     private async Task<Guid> SeedAdminUserAsync()
     {
@@ -32,7 +32,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         // CanUserApproveRequestsForTeamAsync). Seed an admin User + an active
         // Admin RoleAssignment per test so those FKs resolve and authorization
         // succeeds.
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var now = SystemClock.Instance.GetCurrentInstant();
@@ -79,17 +79,17 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         // doesn't trip when the class fixture's shared DB carries rows from
         // an earlier test in the same run.
         var sharedEmail = $"shared-{Guid.NewGuid():N}@example.com";
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithSourceEmail(sharedEmail, verified: true, isPrimary: false, isGoogle: false);
             b.WithTargetEmail(sharedEmail, verified: false, isPrimary: true, isGoogle: true);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var emailRepo = assertScope.ServiceProvider.GetRequiredService<IUserRepository>();
 
         var targetEmails = await emailRepo.GetUserEmailsByUserIdReadOnlyAsync(targetId, TestContext.Current.CancellationToken);
@@ -112,18 +112,18 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         // OR-combine into a single verified target row.
         var collapseEmail = $"collapse-{Guid.NewGuid():N}@example.com";
         var sourceOnlyEmail = $"source-only-{Guid.NewGuid():N}@example.com";
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithSourceEmail(collapseEmail, verified: true);
             b.WithTargetEmail(collapseEmail, verified: false, isPrimary: true);
             b.WithSourceEmail(sourceOnlyEmail, verified: true);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var emailRepo = assertScope.ServiceProvider.GetRequiredService<IUserRepository>();
 
         var targetEmails = await emailRepo.GetUserEmailsByUserIdReadOnlyAsync(targetId, TestContext.Current.CancellationToken);
@@ -155,18 +155,18 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         var sourceKey2 = $"source-sub-2-{Guid.NewGuid():N}";
         var targetKey = $"target-sub-{Guid.NewGuid():N}";
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithSourceLogin("Google", sourceKey1);
             b.WithSourceLogin("Google", sourceKey2);
             b.WithTargetLogin("Google", targetKey);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetLogins = await db.Set<IdentityUserLogin<Guid>>()
@@ -200,13 +200,13 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_Profile_AnonymizesAndKeepsTombstoneRow()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         // Source profile row still exists (tombstone) but with anonymized scalars.
@@ -234,19 +234,19 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_VolunteerHistory_Move_DedupIdenticalEntries()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithSourceVolunteerHistory(2024, "Nowhere 2024");
             b.WithTargetVolunteerHistory(2024, "Nowhere 2024"); // dup — drop source
             b.WithSourceVolunteerHistory(2023, "Build 2023");   // unique to source — moves
             b.WithTargetVolunteerHistory(2025, "Cleanup 2025"); // unique to target — stays
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetProfileId = await db.Profiles
@@ -281,7 +281,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_Languages_Move_DedupKeepHighestProficiency()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             // Both have "es" — source higher proficiency, target's row should
             // be upgraded.
@@ -294,12 +294,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             // Target-only "de" stays.
             b.WithTargetLanguage("de", LanguageProficiency.Native);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetProfileId = await db.Profiles
@@ -332,7 +332,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         var older = Instant.FromUtc(2025, 1, 1, 0, 0);
         var newer = Instant.FromUtc(2025, 6, 1, 0, 0);
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             // Same category — source is newer, so source's OptedOut value wins
             // and gets copied onto target before the source row is deleted.
@@ -343,12 +343,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             b.WithSourceCommPref(MessageCategory.Marketing, optedOut: false, updatedAt: older);
             b.WithTargetCommPref(MessageCategory.Marketing, optedOut: true, updatedAt: newer);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetPrefs = await db.CommunicationPreferences
@@ -376,7 +376,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_EventParticipation_HighestStatusWins_ByEnumPrecedence()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             // Year 2024 — source Attended (highest precedence) beats target NotAttending.
             b.WithSourceEventParticipation(2024, ParticipationStatus.Attended);
@@ -389,12 +389,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             // Year 2023 — source-only, re-FKs to target.
             b.WithSourceEventParticipation(2023, ParticipationStatus.Attended);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetEvents = await db.EventParticipations
@@ -421,19 +421,19 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_Applications_Move_AllHistorical()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             // Both source and target have applications — every row moves; no dedup.
             b.WithSourceApplication();
             b.WithSourceApplication(MembershipTier.Asociado);
             b.WithTargetApplication();
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetApps = await db.Applications
@@ -456,18 +456,18 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_FeedbackReportsAndMessages_Move()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithSourceFeedbackReport("Source bug A");
             b.WithSourceFeedbackReport("Source bug B");
             b.WithTargetFeedbackReport("Target bug C");
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetReports = await db.FeedbackReports
@@ -497,16 +497,16 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         // seeded by other tests in the same shared-DB class fixture.
         var description = $"audit-source-action-{Guid.NewGuid():N}";
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithSourceAuditLogEntry(AuditAction.AccountAnonymized, description);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         // The seeded audit row MUST still be attached to the source user id —
@@ -527,13 +527,13 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_TombstonesSourceWithMergedToUserId()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var sourceUser = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == sourceId, TestContext.Current.CancellationToken);
@@ -549,13 +549,13 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_PreventsSourceLogin()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var sourceUser = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == sourceId, TestContext.Current.CancellationToken);
@@ -573,19 +573,19 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact(Timeout = 30_000)]
     public async Task AcceptAsync_ContactFields_Move_DedupOnTypeValue()
     {
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithTargetContactField(ContactFieldType.Phone, "+34 600 100 200");
             b.WithSourceContactField(ContactFieldType.Phone, "+34 600 100 200"); // dup — drop source
             b.WithSourceContactField(ContactFieldType.Telegram, "@source-handle"); // unique to source — moves
             b.WithTargetContactField(ContactFieldType.Telegram, "@target-handle"); // unique to target — stays
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetProfileId = await db.Profiles
@@ -631,7 +631,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         var sharedRole = $"shared-role-{Guid.NewGuid():N}";
         var sourceOnlyRole = $"source-only-role-{Guid.NewGuid():N}";
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             // Both have an active assignment for sharedRole — drop source's row.
             b.WithSourceRoleAssignment(sharedRole);
@@ -640,12 +640,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             // Source-only — re-FK to target.
             b.WithSourceRoleAssignment(sourceOnlyRole);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetRows = await db.RoleAssignments
@@ -675,7 +675,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     {
         Guid sharedTeamId = Guid.Empty, sourceOnlyTeamId = Guid.Empty;
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             sharedTeamId = b.SeedTeamNow($"Shared-{Guid.NewGuid():N}");
             sourceOnlyTeamId = b.SeedTeamNow($"SourceOnly-{Guid.NewGuid():N}");
@@ -687,12 +687,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             // Only source belongs to sourceOnlyTeam — target gets added, source removed.
             b.WithSourceTeamMember(sourceOnlyTeamId);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         // Target should have ACTIVE memberships (LeftAt == null) on both teams.
@@ -723,7 +723,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     {
         Guid contestedTeamId = Guid.Empty, sourceOnlyTeamId = Guid.Empty;
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             contestedTeamId = b.SeedTeamNow($"Contested-{Guid.NewGuid():N}");
             sourceOnlyTeamId = b.SeedTeamNow($"SourceOnlyTJR-{Guid.NewGuid():N}");
@@ -735,12 +735,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             // Source pending on sourceOnly — re-FK to target.
             b.WithSourceTeamJoinRequest(sourceOnlyTeamId);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetRequests = await db.TeamJoinRequests
@@ -771,7 +771,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     {
         Guid sharedNotificationId = Guid.Empty, sourceOnlyNotificationId = Guid.Empty;
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             sharedNotificationId = b.SeedNotificationNow($"shared-{Guid.NewGuid():N}");
             sourceOnlyNotificationId = b.SeedNotificationNow($"source-only-{Guid.NewGuid():N}");
@@ -780,12 +780,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             b.WithTargetNotificationRecipient(sharedNotificationId);
             b.WithSourceNotificationRecipient(sourceOnlyNotificationId);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetRecipients = await db.NotificationRecipients
@@ -815,13 +815,13 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     {
         Guid contestedCampaignId, sourceOnlyCampaignId;
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
 
         // Need a real user to satisfy Campaign.CreatedByUserId FK; use the
         // source as creator (fold doesn't touch Campaigns).
         var creatorId = sourceId;
 
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var builder = new MergeFixtureBuilder(scope, sourceId, targetId);
             contestedCampaignId = builder.SeedCampaignNow($"Contested-{Guid.NewGuid():N}", creatorId);
@@ -834,12 +834,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
 
             await builder.SaveAllAsync();
         }
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db2 = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         var targetGrants = await db2.CampaignGrants
@@ -870,9 +870,9 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         var sourceContent = $"source-msg-{Guid.NewGuid():N}";
         var targetContent = $"target-msg-{Guid.NewGuid():N}";
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
 
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var builder = new MergeFixtureBuilder(scope, sourceId, targetId);
             // FeedbackMessages.SenderUserId references either user; the
@@ -887,12 +887,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
 
             await builder.SaveAllAsync();
         }
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         // Both messages should now be attributed to target.
@@ -920,9 +920,9 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
     {
         var description = $"budget-source-action-{Guid.NewGuid():N}";
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
 
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var builder = new MergeFixtureBuilder(scope, sourceId, targetId);
             var budgetYearId = builder.SeedBudgetYearNow($"BY-{Guid.NewGuid():N}".Substring(0, 6));
@@ -930,12 +930,12 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
             await builder.SaveAllAsync();
         }
 
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         // Audit row must still point at the source user — fold doesn't
@@ -959,16 +959,16 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
         // The request is created Target=<new account>, Source=<primary>. The admin flips it,
         // keeping the Source — the request's stored direction must be overridden.
         var (requestId, requestTargetId, requestSourceId) =
-            await factory.SeedPendingMergeRequestAsync($"shared-{Guid.NewGuid():N}@example.com");
+            await Factory.SeedPendingMergeRequestAsync($"shared-{Guid.NewGuid():N}@example.com");
 
         var adminId = await SeedAdminUserAsync();
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var sut = scope.ServiceProvider.GetRequiredService<IAccountMergeService>();
             await sut.AcceptAsync(requestId, adminId, survivorUserId: requestSourceId, ct: TestContext.Current.CancellationToken); // flip: keep the Source
         }
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
         (await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == requestSourceId, TestContext.Current.CancellationToken))!.MergedToUserId
             .Should().BeNull("the admin-chosen survivor is never tombstoned");
@@ -984,7 +984,7 @@ public class AcceptAsyncFoldTests(HumansWebApplicationFactory factory) : IClassF
 
     private async Task AcceptAsync(Guid requestId, Guid adminUserId)
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var mergeService = scope.ServiceProvider.GetRequiredService<IAccountMergeService>();
         // These fold tests assert source→target (target survives); pick the request target.
         var request = await mergeService.GetByIdAsync(requestId, TestContext.Current.CancellationToken)

--- a/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFoldTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFoldTests.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;

--- a/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFullFixtureTest.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFullFixtureTest.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;

--- a/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFullFixtureTest.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFullFixtureTest.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -36,7 +36,7 @@ namespace Humans.Integration.Tests.AccountMerge;
 /// </para>
 /// </summary>
 public class AcceptAsyncFullFixtureTest(HumansWebApplicationFactory factory)
-    : IClassFixture<HumansWebApplicationFactory>
+    : IntegrationTestBase(factory)
 {
     [HumansFact(Timeout = 60_000)]
     public async Task AcceptAsync_FullFixture_FoldsAllSectionsAndTombstonesSource()
@@ -68,7 +68,7 @@ public class AcceptAsyncFullFixtureTest(HumansWebApplicationFactory factory)
         // that does NOT need an ad-hoc parent (UserEmails, ContactFields,
         // VolunteerHistory, ProfileLanguages, CommPrefs, IdentityUserLogins,
         // EventParticipations, Applications, AuditLogEntries, RoleAssignments).
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             // UserEmail — shared (collapse) + source-only (re-FK).
             b.WithSourceEmail(sharedEmail, verified: true);
@@ -112,7 +112,7 @@ public class AcceptAsyncFullFixtureTest(HumansWebApplicationFactory factory)
         // (Teams, Notifications, Campaigns, FeedbackMessages, BudgetAuditLog,
         // ConsentRecord). Mirrors the patterns in AcceptAsyncFoldTests for
         // each section.
-        await using (var seedScope = factory.Services.CreateAsyncScope())
+        await using (var seedScope = Factory.Services.CreateAsyncScope())
         {
             var builder = new MergeFixtureBuilder(seedScope, sourceId, targetId);
 
@@ -158,18 +158,18 @@ public class AcceptAsyncFullFixtureTest(HumansWebApplicationFactory factory)
             await builder.SaveAllAsync();
         }
 
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         // Act — accept the merge.
         var adminId = await SeedAdminUserAsync();
-        await using (var actScope = factory.Services.CreateAsyncScope())
+        await using (var actScope = Factory.Services.CreateAsyncScope())
         {
             var mergeService = actScope.ServiceProvider.GetRequiredService<IAccountMergeService>();
             await mergeService.AcceptAsync(requestId, adminId, survivorUserId: targetId, ct: TestContext.Current.CancellationToken);
         }
 
         // Assert — comprehensive post-merge state.
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         // ----------------------------------------------------------------
@@ -362,7 +362,7 @@ public class AcceptAsyncFullFixtureTest(HumansWebApplicationFactory factory)
 
     private async Task<Guid> SeedAdminUserAsync()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var now = SystemClock.Instance.GetCurrentInstant();

--- a/tests/Humans.Integration.Tests/AccountMerge/ChainFollowReadTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/ChainFollowReadTests.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Budget;
 using Humans.Application.Interfaces.Consent;

--- a/tests/Humans.Integration.Tests/AccountMerge/ChainFollowReadTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/ChainFollowReadTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Budget;
 using Humans.Application.Interfaces.Consent;
@@ -28,7 +28,7 @@ namespace Humans.Integration.Tests.AccountMerge;
 /// <c>IUserService.AnonymizeForMergeAsync</c>), then queries the read path
 /// for the target and asserts the source-attributed row surfaces.
 /// </summary>
-public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassFixture<HumansWebApplicationFactory>
+public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     // ==================================================================
     // AuditLog — chain-follow GetByUserAsync (Phase 4.1)
@@ -41,18 +41,18 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
         // seeded by other tests in the same shared-DB class fixture.
         var description = $"chain-follow-audit-{Guid.NewGuid():N}";
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithSourceAuditLogEntry(AuditAction.AccountAnonymized, description);
         });
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
 
         // Act: query the AuditLog read path for the TARGET — chain-follow
         // should union the source-tombstone id and surface source's row.
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var auditService = assertScope.ServiceProvider.GetRequiredService<IAuditLogService>();
         var entries = await auditService.GetByUserAsync(targetId, count: 100, ct: TestContext.Current.CancellationToken);
 
@@ -72,9 +72,9 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
     {
         Guid versionId;
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
 
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var builder = new MergeFixtureBuilder(scope, sourceId, targetId);
             versionId = builder.SeedDocumentVersionNow($"ChainFollowDoc-{Guid.NewGuid():N}".Substring(0, 24));
@@ -82,7 +82,7 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
             await builder.SaveAllAsync();
         }
 
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
@@ -93,7 +93,7 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
         // chain-follow read; the uniquely-seeded version id is consented to
         // by the source only, so a History match under a target read proves
         // the source-tombstone id was unioned in.
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var consentService = assertScope.ServiceProvider.GetRequiredService<IConsentService>();
         var dashboard = await consentService.GetConsentDashboardAsync(targetId, TestContext.Current.CancellationToken);
 
@@ -114,9 +114,9 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
     {
         var description = $"chain-follow-budget-{Guid.NewGuid():N}";
 
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync();
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync();
 
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var builder = new MergeFixtureBuilder(scope, sourceId, targetId);
             var budgetYearId = builder.SeedBudgetYearNow($"BY-{Guid.NewGuid():N}".Substring(0, 6));
@@ -124,7 +124,7 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
             await builder.SaveAllAsync();
         }
 
-        var requestId = await factory.SeedMergeRequestAsync(sourceId, targetId);
+        var requestId = await Factory.SeedMergeRequestAsync(sourceId, targetId);
 
         var adminId = await SeedAdminUserAsync();
         await AcceptAsync(requestId, adminId);
@@ -134,7 +134,7 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
         // both IBudgetService and IUserDataContributor; resolve the former
         // (single DI registration to that ID) and cast for the contributor
         // method.
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var budgetService = assertScope.ServiceProvider.GetRequiredService<IBudgetService>();
         var contributor = (IUserDataContributor)budgetService;
         var slices = await contributor.ContributeForUserAsync(targetId, TestContext.Current.CancellationToken);
@@ -164,7 +164,7 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
         // and ActorUserId = adminUserId on the audit row, both FK'd to AspNetUsers.
         // It also calls TeamService.RemoveMemberAsync for non-system team folds,
         // which requires the actor to be Admin / Board / TeamsAdmin.
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var now = SystemClock.Instance.GetCurrentInstant();
@@ -202,7 +202,7 @@ public class ChainFollowReadTests(HumansWebApplicationFactory factory) : IClassF
 
     private async Task AcceptAsync(Guid requestId, Guid adminUserId)
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var mergeService = scope.ServiceProvider.GetRequiredService<IAccountMergeService>();
         // Chain-follow tests assert source→target (target survives); pick the request target.
         var request = await mergeService.GetByIdAsync(requestId, TestContext.Current.CancellationToken)

--- a/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncFullFixtureTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncFullFixtureTests.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;

--- a/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncFullFixtureTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncFullFixtureTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -18,7 +18,7 @@ namespace Humans.Integration.Tests.AccountMerge;
 /// seeds a full two-user fixture, invokes a direct admin fold (no
 /// AccountMergeRequest), and asserts all six post-conditions.
 /// </summary>
-public class MergeAsyncFullFixtureTests(HumansWebApplicationFactory factory) : IClassFixture<HumansWebApplicationFactory>
+public class MergeAsyncFullFixtureTests(HumansWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     [HumansFact(Timeout = 60_000)]
     public async Task MergeAsync_FullFixture_AllPostConditionsHold()
@@ -33,7 +33,7 @@ public class MergeAsyncFullFixtureTests(HumansWebApplicationFactory factory) : I
 
         // Stage 1 — seed source/target user pair with their primary verified
         // emails, a login, and a role assignment.
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             // Source: primary verified email.
             b.WithSourceEmail(sourceEmail, verified: true, isPrimary: true);
@@ -50,7 +50,7 @@ public class MergeAsyncFullFixtureTests(HumansWebApplicationFactory factory) : I
         });
 
         // Stage 2 — seed a source-only team membership (requires ad-hoc Team row).
-        await using (var seedScope = factory.Services.CreateAsyncScope())
+        await using (var seedScope = Factory.Services.CreateAsyncScope())
         {
             var builder = new MergeFixtureBuilder(seedScope, sourceId, targetId);
             sourceOnlyTeamId = builder.SeedTeamNow($"SrcOnly-{runTag}".Substring(0, 12));
@@ -60,14 +60,14 @@ public class MergeAsyncFullFixtureTests(HumansWebApplicationFactory factory) : I
 
         // Act — direct admin fold (no AccountMergeRequest): survivor = target, archived = source.
         var adminId = await SeedAdminUserAsync();
-        await using (var actScope = factory.Services.CreateAsyncScope())
+        await using (var actScope = Factory.Services.CreateAsyncScope())
         {
             var mergeService = actScope.ServiceProvider.GetRequiredService<IAccountMergeService>();
             await mergeService.MergeAsync(targetId, sourceId, adminId, ct: TestContext.Current.CancellationToken);
         }
 
         // Assert — all six post-conditions from the EmailProblems spec case 5.
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
         // ----------------------------------------------------------------
@@ -154,7 +154,7 @@ public class MergeAsyncFullFixtureTests(HumansWebApplicationFactory factory) : I
 
     private async Task<Guid> SeedAdminUserAsync()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var now = SystemClock.Instance.GetCurrentInstant();

--- a/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncOrderedTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncOrderedTests.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;

--- a/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncOrderedTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/MergeAsyncOrderedTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -19,7 +19,7 @@ namespace Humans.Integration.Tests.AccountMerge;
 /// No cross-section transaction — the tombstone is the commit point and source of truth.
 /// </summary>
 public class MergeAsyncOrderedTests(HumansWebApplicationFactory factory)
-    : IClassFixture<HumansWebApplicationFactory>
+    : IntegrationTestBase(factory)
 {
     [HumansFact(Timeout = 60_000)]
     public async Task MergeAsync_FoldsArchivedIntoSurvivor_AndTombstonesArchivedOnly()
@@ -30,7 +30,7 @@ public class MergeAsyncOrderedTests(HumansWebApplicationFactory factory)
         // class fixture shares one Postgres DB and the verified-email uniqueness
         // index would otherwise trip across tests.
         var runTag = Guid.NewGuid().ToString("N");
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithTargetEmail($"keep-{runTag}@example.com", verified: true, isPrimary: true);   // survivor
             b.WithSourceEmail($"dupe-{runTag}@example.com", verified: true, isPrimary: true);   // archived
@@ -40,13 +40,13 @@ public class MergeAsyncOrderedTests(HumansWebApplicationFactory factory)
         var archivedId = sourceId;
 
         var adminId = await SeedAdminUserAsync();
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var sut = scope.ServiceProvider.GetRequiredService<IAccountMergeService>();
             await sut.MergeAsync(survivorId, archivedId, adminId, ct: TestContext.Current.CancellationToken);
         }
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var survivor = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == survivorId, TestContext.Current.CancellationToken);
         var archived = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == archivedId, TestContext.Current.CancellationToken);
@@ -59,7 +59,7 @@ public class MergeAsyncOrderedTests(HumansWebApplicationFactory factory)
     public async Task MergeAsync_WithAlreadyGonePendingEmail_CompletesWithoutThrowing()
     {
         var runTag = Guid.NewGuid().ToString("N");
-        var (sourceId, targetId) = await factory.SeedMergeFixtureAsync(b =>
+        var (sourceId, targetId) = await Factory.SeedMergeFixtureAsync(b =>
         {
             b.WithTargetEmail($"keep-{runTag}@example.com", verified: true, isPrimary: true);
             b.WithSourceEmail($"dupe-{runTag}@example.com", verified: true, isPrimary: true);
@@ -68,7 +68,7 @@ public class MergeAsyncOrderedTests(HumansWebApplicationFactory factory)
         var archivedId = sourceId;
 
         var adminId = await SeedAdminUserAsync();
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var sut = scope.ServiceProvider.GetRequiredService<IAccountMergeService>();
 
         // A pending-email id that no longer exists must NOT throw — a gone email is the
@@ -78,7 +78,7 @@ public class MergeAsyncOrderedTests(HumansWebApplicationFactory factory)
 
         await act.Should().NotThrowAsync();
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
         (await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == archivedId, TestContext.Current.CancellationToken))!.MergedToUserId
             .Should().Be(survivorId, "the tombstone must still be written when the pending email is gone");
@@ -94,7 +94,7 @@ public class MergeAsyncOrderedTests(HumansWebApplicationFactory factory)
         // AspNetUsers) and the IUserMerge fan-out hits TeamService authorization,
         // which requires an active Admin role. Seed both per call so those FKs
         // resolve and authorization succeeds.
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var now = SystemClock.Instance.GetCurrentInstant();

--- a/tests/Humans.Integration.Tests/AccountMerge/ReconcileOrphanTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/ReconcileOrphanTests.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;

--- a/tests/Humans.Integration.Tests/AccountMerge/ReconcileOrphanTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/ReconcileOrphanTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -20,23 +20,23 @@ namespace Humans.Integration.Tests.AccountMerge;
 /// flow never leaves orphaned Pending rows behind.
 /// </summary>
 public class ReconcileOrphanTests(HumansWebApplicationFactory factory)
-    : IClassFixture<HumansWebApplicationFactory>
+    : IntegrationTestBase(factory)
 {
     [HumansFact(Timeout = 60_000)]
     public async Task MergeAsync_ClosesPendingRequestForThePair()
     {
         var adminId = await SeedAdminUserAsync();
         var (requestId, targetId, sourceId) =
-            await factory.SeedPendingMergeRequestAsync($"shared-{Guid.NewGuid():N}@example.com");
+            await Factory.SeedPendingMergeRequestAsync($"shared-{Guid.NewGuid():N}@example.com");
 
         // Merge the pair through the engine (survivor = target, archived = source).
-        await using (var scope = factory.Services.CreateAsyncScope())
+        await using (var scope = Factory.Services.CreateAsyncScope())
         {
             var sut = scope.ServiceProvider.GetRequiredService<IAccountMergeService>();
             await sut.MergeAsync(targetId, sourceId, adminId, ct: TestContext.Current.CancellationToken);
         }
 
-        await using var assertScope = factory.Services.CreateAsyncScope();
+        await using var assertScope = Factory.Services.CreateAsyncScope();
         var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
         (await db.AccountMergeRequests.AsNoTracking().FirstOrDefaultAsync(r => r.Id == requestId, TestContext.Current.CancellationToken))!.Status
             .Should().Be(AccountMergeRequestStatus.Accepted,
@@ -49,7 +49,7 @@ public class ReconcileOrphanTests(HumansWebApplicationFactory factory)
 
     private async Task<Guid> SeedAdminUserAsync()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var now = SystemClock.Instance.GetCurrentInstant();

--- a/tests/Humans.Integration.Tests/DependencyInjection/DiResolutionSmokeTests.cs
+++ b/tests/Humans.Integration.Tests/DependencyInjection/DiResolutionSmokeTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Humans.Application.Interfaces.Email;
 using Humans.Integration.Tests.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Humans.Integration.Tests.DependencyInjection;
 
-public class DiResolutionSmokeTests(HumansWebApplicationFactory factory) : IClassFixture<HumansWebApplicationFactory>
+public class DiResolutionSmokeTests(HumansWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     private static readonly HashSet<Type> RuntimeBootstrappedServiceTypes =
     [
@@ -16,11 +16,11 @@ public class DiResolutionSmokeTests(HumansWebApplicationFactory factory) : IClas
     [HumansFact(Timeout = 60000)]
     public async Task All_application_registrations_resolve_from_a_real_app_scope()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
 
         var failures = new List<string>();
 
-        foreach (var group in factory.RegisteredServices
+        foreach (var group in Factory.RegisteredServices
                      .Where(IsResolvableApplicationRegistration)
                      .GroupBy(d => d.ServiceType)
                      .OrderBy(g => g.Key.FullName, StringComparer.Ordinal))

--- a/tests/Humans.Integration.Tests/DependencyInjection/DiResolutionSmokeTests.cs
+++ b/tests/Humans.Integration.Tests/DependencyInjection/DiResolutionSmokeTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Humans.Application.Interfaces.Email;
 using Humans.Integration.Tests.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Humans.Integration.Tests/Infrastructure/AssemblyFixtures.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/AssemblyFixtures.cs
@@ -1,0 +1,16 @@
+using Humans.Integration.Tests.Infrastructure;
+using Xunit;
+
+// One Postgres container, one app boot and one migration pass for the whole
+// assembly (nobodies-collective/Humans#764). Before this, each test class owned
+// an IClassFixture<HumansWebApplicationFactory>, so a run booted ~26 concurrent
+// Testcontainers Postgres instances and ran the full migration chain in each —
+// the resource contention behind the timeout-shaped "pre-existing failures".
+[assembly: AssemblyFixture(typeof(HumansWebApplicationFactory))]
+
+// The assembly fixture is shared mutable state: one database, one set of
+// Singleton caches and one set of NSubstitute stubs behind one app host. Test
+// classes therefore must not run concurrently — IntegrationTestBase resets those
+// stubs per test, and a sibling class running in parallel would observe the
+// reset mid-assertion.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Humans.Integration.Tests/Infrastructure/AssemblyFixtures.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/AssemblyFixtures.cs
@@ -3,9 +3,9 @@ using Xunit;
 
 // One Postgres container, one app boot and one migration pass for the whole
 // assembly (nobodies-collective/Humans#764). Before this, each test class owned
-// an IClassFixture<HumansWebApplicationFactory>, so a run booted ~26 concurrent
-// Testcontainers Postgres instances and ran the full migration chain in each —
-// the resource contention behind the timeout-shaped "pre-existing failures".
+// an IClassFixture<HumansWebApplicationFactory>, so a run started 30 Testcontainers
+// Postgres instances and ran the full migration chain in every one of them — the
+// resource contention behind the timeout-shaped "pre-existing failures".
 [assembly: AssemblyFixture(typeof(HumansWebApplicationFactory))]
 
 // The assembly fixture is shared mutable state: one database, one set of

--- a/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using Hangfire;
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
+using Npgsql;
 using NSubstitute;
 using NSubstitute.ClearExtensions;
 using Testcontainers.PostgreSql;
@@ -25,6 +26,26 @@ using Humans.Infrastructure.Services;
 
 namespace Humans.Integration.Tests.Infrastructure;
 
+/// <summary>
+/// The integration suite's app host, registered once for the whole assembly
+/// (see AssemblyFixtures.cs): one Postgres container, one app boot, one migration
+/// pass per <c>dotnet test</c> run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Test classes take it as a constructor parameter — an assembly fixture needs no
+/// <c>IClassFixture</c> declaration. Classes deriving from
+/// <see cref="IntegrationTestBase"/> additionally get the shared NSubstitute stubs
+/// reset per test.
+/// </para>
+/// <para>
+/// One database is shared by every test, so a test must not assume an empty table:
+/// scope assertions to rows it seeded itself (a per-test GUID suffix is the
+/// established pattern here). Per-test database rollback is not available — see
+/// the P2 notes in <c>docs/features/test-system-reliability.md</c> for why, and
+/// nobodies-collective/Humans#983 for what it would take.
+/// </para>
+/// </remarks>
 public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
     /// <summary>Test-only Stripe Store webhook signing secret. Used by webhook integration tests to compute valid Stripe-Signature headers.</summary>
@@ -41,8 +62,10 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
     /// </summary>
     public IBackgroundJobClient BackgroundJobClientStub { get; } = Substitute.For<IBackgroundJobClient>();
 
-    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16-alpine")
-        .Build();
+    /// <summary>Null until <see cref="StartDatabaseAsync"/> starts one; a derived factory that borrows an existing database never creates a container.</summary>
+    private PostgreSqlContainer? _postgres;
+
+    private string _connectionString = string.Empty;
 
     public IReadOnlyList<ServiceDescriptor> RegisteredServices { get; private set; } = [];
 
@@ -57,7 +80,7 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
             // NpgsqlDataSource and DbContext, so overriding here is sufficient.
             config.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
             {
-                ["ConnectionStrings:DefaultConnection"] = _postgres.GetConnectionString(),
+                ["ConnectionStrings:DefaultConnection"] = _connectionString,
                 ["DevAuth:Enabled"] = "true",
                 ["Authentication:Google:ClientId"] = "test-client-id",
                 ["Authentication:Google:ClientSecret"] = "test-client-secret",
@@ -121,10 +144,9 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
     /// <summary>
     /// Resets the shared single-instance NSubstitute stubs so no state leaks between
     /// tests. <see cref="StripeServiceStub"/> and <see cref="BackgroundJobClientStub"/>
-    /// are singletons reused across every test in a class; xUnit runs tests within a
-    /// class sequentially so within-class is safe today, but the contract is fragile —
-    /// any future move to method-level parallelism would silently corrupt assertions.
-    /// Called per test from <see cref="IntegrationTestBase"/>'s constructor.
+    /// are singletons reused by every test in the assembly, so this is what keeps
+    /// received-call assertions honest. Called per test from
+    /// <see cref="IntegrationTestBase"/>'s constructor.
     /// </summary>
     public void ResetSharedSubstitutes()
     {
@@ -164,13 +186,53 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
     // Testcontainers Postgres container.
     public async ValueTask InitializeAsync()
     {
-        await _postgres.StartAsync(TestContext.Current.CancellationToken);
+        var ct = TestContext.Current.CancellationToken;
+
+        _connectionString = await StartDatabaseAsync(ct);
+
+        // Force the host to build now: that runs DatabaseMigrationHostedService
+        // (the whole migration chain) and warms every Singleton cache. Paying it
+        // here rather than inside whichever test first calls CreateClient keeps a
+        // slow boot from eating that test's 30s timeout.
+        _ = Services;
+    }
+
+    /// <summary>
+    /// Provisions the database this factory's app runs against and returns its
+    /// connection string. The assembly fixture starts the run's single Postgres
+    /// container here; a derived factory that needs its own app boot overrides
+    /// this to borrow a database from the already-running container instead of
+    /// starting a second one.
+    /// </summary>
+    protected virtual async ValueTask<string> StartDatabaseAsync(CancellationToken ct)
+    {
+        _postgres = new PostgreSqlBuilder("postgres:16-alpine").Build();
+        await _postgres.StartAsync(ct);
+        return _postgres.GetConnectionString();
     }
 
     public override async ValueTask DisposeAsync()
     {
-        await _postgres.DisposeAsync();
         await base.DisposeAsync();
+        if (_postgres is not null)
+            await _postgres.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Creates an additional database in this factory's Postgres container and
+    /// returns its connection string. Lets the migration-mechanics tests — which
+    /// need pristine databases to migrate from scratch — share the assembly's one
+    /// container instead of each starting their own.
+    /// </summary>
+    public async Task<string> CreateDatabaseAsync(string name, CancellationToken ct)
+    {
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(ct);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"CREATE DATABASE {name}";
+        await command.ExecuteNonQueryAsync(ct);
+
+        return new NpgsqlConnectionStringBuilder(_connectionString) { Database = name }.ConnectionString;
     }
 
     /// <summary>

--- a/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using Hangfire;

--- a/tests/Humans.Integration.Tests/Infrastructure/IntegrationTestBase.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/IntegrationTestBase.cs
@@ -15,8 +15,6 @@ public abstract class IntegrationTestBase
 
     protected IntegrationTestBase(HumansWebApplicationFactory factory)
     {
-        ArgumentNullException.ThrowIfNull(factory);
-
         // The factory (and its single-instance NSubstitute stubs) is shared by
         // every test in the assembly. This constructor runs once per test, so
         // reset the shared substitutes here to guarantee no mutation leaks

--- a/tests/Humans.Integration.Tests/Infrastructure/IntegrationTestBase.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/IntegrationTestBase.cs
@@ -2,17 +2,25 @@ using Xunit;
 
 namespace Humans.Integration.Tests.Infrastructure;
 
-public abstract class IntegrationTestBase : IClassFixture<HumansWebApplicationFactory>
+/// <summary>
+/// Base for every integration test class. <see cref="HumansWebApplicationFactory"/>
+/// is an assembly fixture — one container, one app boot, one set of Singleton
+/// stubs for the whole run — so returning those stubs to a pristine state before
+/// each test is this type's job.
+/// </summary>
+public abstract class IntegrationTestBase
 {
     protected readonly HttpClient Client;
     protected readonly HumansWebApplicationFactory Factory;
 
     protected IntegrationTestBase(HumansWebApplicationFactory factory)
     {
-        // The factory (and its single-instance NSubstitute stubs) is shared across
-        // every test in the class via IClassFixture. This constructor runs once per
-        // test, so reset the shared substitutes here to guarantee no mutation leaks
-        // between tests — keeping the suite correct even under per-method parallelism.
+        ArgumentNullException.ThrowIfNull(factory);
+
+        // The factory (and its single-instance NSubstitute stubs) is shared by
+        // every test in the assembly. This constructor runs once per test, so
+        // reset the shared substitutes here to guarantee no mutation leaks
+        // between tests — the P7 precondition that makes sharing safe.
         factory.ResetSharedSubstitutes();
 
         Client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions

--- a/tests/Humans.Integration.Tests/Infrastructure/PhysicalDefaultParityTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/PhysicalDefaultParityTests.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Humans.Integration.Tests.Infrastructure;

--- a/tests/Humans.Integration.Tests/Infrastructure/PhysicalDefaultParityTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/PhysicalDefaultParityTests.cs
@@ -42,21 +42,8 @@ namespace Humans.Integration.Tests.Infrastructure;
 /// migration dropping the scaffolded default — never leave the two disagreeing.
 /// </para>
 /// </remarks>
-public sealed class PhysicalDefaultParityTests : IAsyncLifetime
+public sealed class PhysicalDefaultParityTests(HumansWebApplicationFactory factory)
 {
-    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16-alpine")
-        .Build();
-
-    public async ValueTask InitializeAsync()
-    {
-        await _postgres.StartAsync(TestContext.Current.CancellationToken);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _postgres.DisposeAsync();
-    }
-
     [HumansFact]
     public async Task ChainBuiltDatabase_HasNoUndeclaredPhysicalColumnDefaults()
     {
@@ -168,17 +155,10 @@ public sealed class PhysicalDefaultParityTests : IAsyncLifetime
         return (DbContext)Activator.CreateInstance(contextType, optionsBuilder.Options)!;
     }
 
-    private async Task<string> CreateDatabaseAsync(string name)
-    {
-        var admin = new NpgsqlConnectionStringBuilder(_postgres.GetConnectionString());
-        await using (var connection = new NpgsqlConnection(admin.ConnectionString))
-        {
-            await connection.OpenAsync(TestContext.Current.CancellationToken);
-            await using var command = connection.CreateCommand();
-            command.CommandText = $"CREATE DATABASE {name}";
-            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
-        }
-
-        return new NpgsqlConnectionStringBuilder(admin.ConnectionString) { Database = name }.ConnectionString;
-    }
+    /// <summary>
+    /// A pristine database in the assembly's shared Postgres container — this test
+    /// migrates from scratch, so it needs its own database, not the app's.
+    /// </summary>
+    private Task<string> CreateDatabaseAsync(string name) =>
+        factory.CreateDatabaseAsync(name, TestContext.Current.CancellationToken);
 }

--- a/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
@@ -4,7 +4,6 @@ using Humans.Infrastructure.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Humans.Integration.Tests.Infrastructure;

--- a/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
@@ -30,7 +30,7 @@ namespace Humans.Integration.Tests.Infrastructure;
 /// from the context model, not a literal list, so a table added to a section
 /// context is covered without touching this file.
 /// </summary>
-public sealed class SectionMigrationRunnerTests : IAsyncLifetime
+public sealed class SectionMigrationRunnerTests(HumansWebApplicationFactory factory)
 {
     private sealed record SectionCase(
         string Name,
@@ -77,19 +77,6 @@ public sealed class SectionMigrationRunnerTests : IAsyncLifetime
             CreateSectionContext<EventGuideDbContext>,
             """SELECT count(*) FROM event_categories WHERE "Slug" = 'workshop'"""),
     ];
-
-    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16-alpine")
-        .Build();
-
-    public async ValueTask InitializeAsync()
-    {
-        await _postgres.StartAsync(TestContext.Current.CancellationToken);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _postgres.DisposeAsync();
-    }
 
     [HumansFact]
     public async Task FreshDatabase_BaselineExecutes_TablesSeedAndHistoryAppear()
@@ -211,19 +198,13 @@ public sealed class SectionMigrationRunnerTests : IAsyncLifetime
             .Order(StringComparer.Ordinal)
             .ToList();
 
-    private async Task<string> CreateDatabaseAsync(string name)
-    {
-        var admin = new NpgsqlConnectionStringBuilder(_postgres.GetConnectionString());
-        await using (var connection = new NpgsqlConnection(admin.ConnectionString))
-        {
-            await connection.OpenAsync(TestContext.Current.CancellationToken);
-            await using var command = connection.CreateCommand();
-            command.CommandText = $"CREATE DATABASE {name}";
-            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
-        }
-
-        return new NpgsqlConnectionStringBuilder(admin.ConnectionString) { Database = name }.ConnectionString;
-    }
+    /// <summary>
+    /// A pristine database in the assembly's shared Postgres container — these tests
+    /// drive the migration runner from scratch, so they need their own databases,
+    /// not the app's.
+    /// </summary>
+    private Task<string> CreateDatabaseAsync(string name) =>
+        factory.CreateDatabaseAsync(name, TestContext.Current.CancellationToken);
 
     private static async Task MigrateOldChainAsync(string connectionString)
     {

--- a/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
+++ b/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
@@ -21,8 +21,8 @@ namespace Humans.Integration.Tests.Localization;
 /// intended cadence is a bi-weekly maintenance sweep, not a per-build blocker.
 /// </summary>
 public sealed class LocalizationCoverageSweep(
-    PseudoLocalizationWebApplicationFactory factory,
-    ITestOutputHelper output) : IClassFixture<PseudoLocalizationWebApplicationFactory>
+    HumansWebApplicationFactory sharedFactory,
+    ITestOutputHelper output)
 {
     /// <summary>
     /// Gates the sweep out of normal CI runs (it boots a Postgres container and crawls every
@@ -38,12 +38,17 @@ public sealed class LocalizationCoverageSweep(
         SkipUnless = nameof(SweepEnabled))]
     public async Task Public_pages_are_localized_and_admin_pages_are_not()
     {
+        // Built here rather than injected as a fixture: the sweep is skipped on
+        // normal runs, and a fixture would pay for the second app boot anyway.
+        await using var factory = new PseudoLocalizationWebApplicationFactory(sharedFactory);
+        await factory.InitializeAsync();
+
         var catalog = SweepRouteCatalog.Build(factory.Services);
 
-        var publicClient = CreateClient();
+        var publicClient = CreateClient(factory);
         await factory.SignInAsFullyOnboardedAsync(publicClient, DevPersona.Volunteer);
 
-        var adminClient = CreateClient();
+        var adminClient = CreateClient(factory);
         await factory.SignInAsFullyOnboardedAsync(adminClient, DevPersona.Admin);
 
         var results = new List<RouteScanResult>(catalog.Crawlable.Count);
@@ -62,7 +67,7 @@ public sealed class LocalizationCoverageSweep(
         results.Should().NotBeEmpty("the sweep must crawl at least one page");
     }
 
-    private HttpClient CreateClient() =>
+    private static HttpClient CreateClient(PseudoLocalizationWebApplicationFactory factory) =>
         factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
     private static string? LocationOf(HttpResponseMessage response)

--- a/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
+++ b/tests/Humans.Integration.Tests/Localization/LocalizationCoverageSweep.cs
@@ -25,7 +25,7 @@ public sealed class LocalizationCoverageSweep(
     ITestOutputHelper output)
 {
     /// <summary>
-    /// Gates the sweep out of normal CI runs (it boots a Postgres container and crawls every
+    /// Gates the sweep out of normal CI runs (it boots a second app host and crawls every
     /// page, ~20s). Set <c>RUN_LOCALIZATION_SWEEP=1</c> to run it — e.g. from the bi-weekly
     /// maintenance job. How (and whether) it should gate on findings is decided separately.
     /// </summary>

--- a/tests/Humans.Integration.Tests/Localization/PseudoLocalization.cs
+++ b/tests/Humans.Integration.Tests/Localization/PseudoLocalization.cs
@@ -71,8 +71,18 @@ internal sealed class PseudoStringLocalizer : IStringLocalizer
 /// which the framework builds on top of <see cref="IStringLocalizerFactory"/>. Isolated to the
 /// sweep fixture — all other integration tests keep the real localizer.
 /// </summary>
-public sealed class PseudoLocalizationWebApplicationFactory : HumansWebApplicationFactory
+/// <remarks>
+/// The sweep needs a second app boot (a different DI graph), but not a second
+/// Postgres container: it takes its own database inside the shared one. The sweep
+/// constructs this itself rather than declaring it as a fixture, so the second
+/// boot costs nothing on the runs where the sweep is skipped.
+/// </remarks>
+public sealed class PseudoLocalizationWebApplicationFactory(HumansWebApplicationFactory shared)
+    : HumansWebApplicationFactory
 {
+    protected override ValueTask<string> StartDatabaseAsync(CancellationToken ct) =>
+        new(shared.CreateDatabaseAsync("pseudo_localization", ct));
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         base.ConfigureWebHost(builder);

--- a/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryConfirmedShiftsTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryConfirmedShiftsTests.cs
@@ -13,25 +13,18 @@ namespace Humans.Integration.Tests.Repositories.Shifts;
 /// <summary>
 /// Integration tests for
 /// <see cref="IShiftManagementRepository.GetConfirmedShiftsInRangeAsync"/>.
-/// Mirrors the existing <c>VolunteerTrackingRepositoryTests</c> style: container-
-/// backed factory via <see cref="IClassFixture{T}"/>, scope per test, real
-/// PostgreSQL. Seeding helpers are inlined here (rather than shared) because the
-/// existing class keeps them <c>private</c>.
+/// Mirrors the existing <c>VolunteerTrackingRepositoryTests</c> style: the
+/// assembly-shared container-backed factory, scope per test, real PostgreSQL.
+/// Seeding helpers are inlined here (rather than shared) because the existing
+/// class keeps them <c>private</c>.
 /// </summary>
-public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
-    : IClassFixture<HumansWebApplicationFactory>
+public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests(HumansWebApplicationFactory factory)
+    : IntegrationTestBase(factory)
 {
-    private readonly HumansWebApplicationFactory _factory;
-
-    public VolunteerTrackingRepositoryConfirmedShiftsTests(HumansWebApplicationFactory factory)
-    {
-        _factory = factory;
-    }
-
     [HumansFact]
     public async Task ReturnsOnlyConfirmedSignups()
     {
-        await using var scope = _factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
@@ -51,7 +44,7 @@ public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
     [HumansFact]
     public async Task ExcludesShiftsOutsideRange()
     {
-        await using var scope = _factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
@@ -71,7 +64,7 @@ public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
     [HumansFact]
     public async Task DepartmentFilter_ExcludesOtherTeams()
     {
-        await using var scope = _factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 
@@ -90,7 +83,7 @@ public sealed class VolunteerTrackingRepositoryConfirmedShiftsTests
     [HumansFact]
     public async Task ShiftThatOverlapsStartBoundary_IsIncluded()
     {
-        await using var scope = _factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var repo = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
 

--- a/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;

--- a/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
@@ -12,15 +12,12 @@ using Xunit;
 namespace Humans.Integration.Tests.Repositories.Shifts;
 
 /// <summary>
-/// Integration tests for <see cref="VolunteerTrackingRepository"/>. Mirrors the
-/// repo's established service-test shape (e.g. <c>CalendarServiceTests</c>):
-/// uses <see cref="IClassFixture{T}"/> for the test-container-backed factory,
-/// resolves the Scoped <see cref="HumansDbContext"/> per test through a DI
-/// scope, and exercises the repository against a real PostgreSQL container.
-///
-/// <see cref="IntegrationTestBase"/> is HttpClient-only, so it doesn't fit
-/// repository tests; we use the factory directly per the
-/// <c>CalendarServiceTests</c> pattern.
+/// Integration tests for <see cref="VolunteerTrackingRepository"/>. Takes the
+/// assembly-shared <see cref="HumansWebApplicationFactory"/> through
+/// <see cref="IntegrationTestBase"/>, resolves the Scoped
+/// <see cref="HumansDbContext"/> per test through a DI scope off
+/// <see cref="IntegrationTestBase.Factory"/>, and exercises the repository
+/// against the run's single PostgreSQL container.
 /// </summary>
 public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factory)
     : IntegrationTestBase(factory)

--- a/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/VolunteerTrackingRepositoryTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -23,12 +23,12 @@ namespace Humans.Integration.Tests.Repositories.Shifts;
 /// <c>CalendarServiceTests</c> pattern.
 /// </summary>
 public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factory)
-    : IClassFixture<HumansWebApplicationFactory>
+    : IntegrationTestBase(factory)
 {
     [HumansFact]
     public async Task GetBuildStatusesForEventAsync_returns_empty_when_no_row_exists()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var sut = new VolunteerTrackingRepository(db);
         var userId = Guid.NewGuid();
@@ -41,7 +41,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact]
     public async Task UpsertCampSetupAsync_inserts_when_no_row_exists()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);
         var userId = Guid.NewGuid();
@@ -67,7 +67,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact]
     public async Task GetBuildStatusesForEventAsync_returns_only_rows_for_requested_event()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es1 = await SeedActiveEventAsync(db);
         var es2 = await SeedActiveEventAsync(db);
@@ -92,7 +92,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact]
     public async Task GetEligibleBuildSignupsAsync_returns_only_build_period_active_signups_in_event()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);   // BuildStartOffset = -10
         var sut = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
@@ -140,7 +140,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact(Timeout = 30000)]
     public async Task UpsertDayOffAsync_inserts_first_entry_and_creates_row_if_absent()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);
         var userId = Guid.NewGuid();
@@ -164,7 +164,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact(Timeout = 30000)]
     public async Task UpsertDayOffAsync_replaces_entry_for_same_day_offset()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);
         var userId = Guid.NewGuid();
@@ -191,7 +191,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact(Timeout = 30000)]
     public async Task UpsertDayOffAsync_appends_entries_for_distinct_days_sorted_by_offset()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);
         var userId = Guid.NewGuid();
@@ -212,7 +212,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact(Timeout = 30000)]
     public async Task RemoveDayOffAsync_drops_only_the_specified_day()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);
         var userId = Guid.NewGuid();
@@ -235,7 +235,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact(Timeout = 30000)]
     public async Task RemoveDayOffAsync_returns_false_when_entry_absent()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);
         var userId = Guid.NewGuid();
@@ -254,7 +254,7 @@ public class VolunteerTrackingRepositoryTests(HumansWebApplicationFactory factor
     [HumansFact(Timeout = 30000)]
     public async Task UpsertCampSetupAsync_does_not_disturb_existing_DayOffs()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var es = await SeedActiveEventAsync(db);
         var userId = Guid.NewGuid();

--- a/tests/Humans.Integration.Tests/SecurityHeaderTests.cs
+++ b/tests/Humans.Integration.Tests/SecurityHeaderTests.cs
@@ -67,10 +67,10 @@ public class SecurityHeaderTests(HumansWebApplicationFactory factory) : Integrat
     }
 
     // The auth-cookie policy from nobodies-collective#925 lives here rather than in its own
-    // class: every test class owns an IClassFixture<HumansWebApplicationFactory>, and each
-    // factory starts its own Testcontainers Postgres. Reusing this class's fixture keeps the
-    // suite at 14 parallel containers instead of 15 — worth doing for two assertions, since
-    // several tests already run 26-29s against HumansFact's 30s default timeout.
+    // class simply because it asserts on response headers like the rest of this class. The
+    // original reason — one Testcontainers Postgres per test class, so co-locating saved a
+    // container — no longer applies: the factory is an assembly fixture and the whole run
+    // shares a single container.
 
     [HumansFact]
     public async Task SignIn_IssuesPersistentCookie_NotSessionCookie()

--- a/tests/Humans.Integration.Tests/Services/CachingEventServiceTests.cs
+++ b/tests/Humans.Integration.Tests/Services/CachingEventServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using AwesomeAssertions;
+using AwesomeAssertions;
 using Humans.Application.Interfaces.Events;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;

--- a/tests/Humans.Integration.Tests/Services/CachingEventServiceTests.cs
+++ b/tests/Humans.Integration.Tests/Services/CachingEventServiceTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Humans.Application.Interfaces.Events;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -18,12 +18,12 @@ namespace Humans.Integration.Tests.Services;
 /// Singleton decorator, reads come back through the same decorator, and the
 /// assertion is that the cached projection reflects the write.
 /// </summary>
-public class CachingEventServiceTests(HumansWebApplicationFactory factory) : IClassFixture<HumansWebApplicationFactory>
+public class CachingEventServiceTests(HumansWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     [HumansFact]
     public async Task CreateCategoryAsync_through_decorator_is_visible_to_next_read()
     {
-        var svc = factory.Services.GetRequiredService<IEventService>();
+        var svc = Factory.Services.GetRequiredService<IEventService>();
         svc.Should().BeOfType<CachingEventService>(
             "the unkeyed IEventService registration must resolve to the Singleton decorator");
 
@@ -54,7 +54,7 @@ public class CachingEventServiceTests(HumansWebApplicationFactory factory) : ICl
     [HumansFact]
     public async Task UpdateCategoryAsync_through_decorator_updates_cached_projection()
     {
-        var svc = factory.Services.GetRequiredService<IEventService>();
+        var svc = Factory.Services.GetRequiredService<IEventService>();
         await ((CachingEventService)svc).WarmAllAsync(TestContext.Current.CancellationToken);
 
         var slug = $"itest-rename-{Guid.NewGuid():N}";
@@ -87,7 +87,7 @@ public class CachingEventServiceTests(HumansWebApplicationFactory factory) : ICl
         // Codex P1 (PR #582): GetCategoryAsync served from an active-only
         // snapshot, breaking EditCategory for inactive rows. Snapshot must
         // hold all rows; IsActive filter belongs in GetActive*Async.
-        var svc = factory.Services.GetRequiredService<IEventService>();
+        var svc = Factory.Services.GetRequiredService<IEventService>();
         await ((CachingEventService)svc).WarmAllAsync(TestContext.Current.CancellationToken);
 
         var slug = $"itest-inactive-cat-{Guid.NewGuid():N}";
@@ -116,7 +116,7 @@ public class CachingEventServiceTests(HumansWebApplicationFactory factory) : ICl
     public async Task GetVenueAsync_returns_inactive_venue_for_admin_edit()
     {
         // Codex P1 (PR #582): same regression on venues — EditVenue 404s.
-        var svc = factory.Services.GetRequiredService<IEventService>();
+        var svc = Factory.Services.GetRequiredService<IEventService>();
         await ((CachingEventService)svc).WarmAllAsync(TestContext.Current.CancellationToken);
 
         var name = $"itest-inactive-venue-{Guid.NewGuid():N}";
@@ -144,7 +144,7 @@ public class CachingEventServiceTests(HumansWebApplicationFactory factory) : ICl
         // §15g-bis for the admin in-place edit path: an Approved event edited
         // via AdminUpdateAsync stays approved (status preserved) and the cached
         // approved-events projection must reflect the new field values.
-        var svc = factory.Services.GetRequiredService<IEventService>();
+        var svc = Factory.Services.GetRequiredService<IEventService>();
         await ((CachingEventService)svc).WarmAllAsync(TestContext.Current.CancellationToken);
 
         var category = new EventCategory
@@ -204,7 +204,7 @@ public class CachingEventServiceTests(HumansWebApplicationFactory factory) : ICl
         // Codex P1 (PR #582): DB unique index covers active+inactive rows;
         // the cache check must match or INSERT will throw DbUpdateException
         // instead of producing a friendly ModelState message.
-        var svc = factory.Services.GetRequiredService<IEventService>();
+        var svc = Factory.Services.GetRequiredService<IEventService>();
         await ((CachingEventService)svc).WarmAllAsync(TestContext.Current.CancellationToken);
 
         var slug = $"itest-slug-collide-{Guid.NewGuid():N}";

--- a/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
+++ b/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using AwesomeAssertions;
 using Humans.Application.DTOs.Calendar;
 using Humans.Application.Interfaces.Calendar;

--- a/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
+++ b/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using AwesomeAssertions;
 using Humans.Application.DTOs.Calendar;
 using Humans.Application.Interfaces.Calendar;
@@ -12,12 +12,12 @@ using Xunit;
 
 namespace Humans.Integration.Tests.Services;
 
-public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassFixture<HumansWebApplicationFactory>
+public class CalendarServiceTests(HumansWebApplicationFactory factory) : IntegrationTestBase(factory)
 {
     [HumansFact]
     public async Task CreateEventAsync_persists_and_GetEventById_returns_it()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -54,7 +54,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task GetOccurrencesInWindow_returns_single_event_when_overlapping()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -86,7 +86,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task GetOccurrencesInWindow_filters_by_team()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -116,7 +116,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task Soft_deleted_events_do_not_appear_in_window()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -141,7 +141,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task Recurring_weekly_event_stays_at_local_time_across_Madrid_DST()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -179,7 +179,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task Recurring_bounded_event_is_skipped_when_until_before_window()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -205,7 +205,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task Cancelled_exception_removes_that_occurrence()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -236,7 +236,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task Override_changes_title_and_moves_occurrence()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -277,7 +277,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task UpdateEvent_changes_fields_and_preserves_id()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -304,7 +304,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task CreateEvent_rejects_malformed_rrule()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -326,7 +326,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task UpdateEvent_rejects_malformed_rrule()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
@@ -353,7 +353,7 @@ public class CalendarServiceTests(HumansWebApplicationFactory factory) : IClassF
     [HumansFact]
     public async Task DeleteEvent_soft_deletes_and_hides_from_queries()
     {
-        await using var scope = factory.Services.CreateAsyncScope();
+        await using var scope = Factory.Services.CreateAsyncScope();
         var svc = scope.ServiceProvider.GetRequiredService<ICalendarService>();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 


### PR DESCRIPTION
Fixes nobodies-collective/Humans#764 (P2 of nobodies-collective/Humans#761)

## What changed

`HumansWebApplicationFactory` is now registered once for the whole assembly via xUnit v3's `[assembly: AssemblyFixture(...)]`, instead of one `IClassFixture<HumansWebApplicationFactory>` per test class. A `dotnet test` run boots **one** Postgres container, **one** app host and runs the migration chain **once**.

- Test parallelization is disabled for the assembly — the classes now share a host, so they must not run concurrently.
- `PhysicalDefaultParityTests` and `SectionMigrationRunnerTests` genuinely need pristine databases (they drive the migration runner from scratch). They now take their own databases *inside* the shared container via a new `CreateDatabaseAsync` on the factory, rather than each starting a container.
- The localization sweep needs a second app boot (different DI graph) but not a second container: `PseudoLocalizationWebApplicationFactory` overrides `StartDatabaseAsync` to take its own database in the shared container, and the sweep constructs it inside the test method so the boot costs nothing on the runs where the sweep is skipped.
- Every integration test class now derives from `IntegrationTestBase`, so the shared NSubstitute stubs get reset per test. That was the P7 (nobodies-collective/Humans#769) precondition for sharing the factory; before this, the eleven classes that used `IClassFixture` directly had their own factory instance and never needed it.
- The migration/cache warmup is forced in the fixture's `InitializeAsync` rather than lazily on the first `CreateClient`, so a slow boot cannot eat the first test's 30s timeout.

No production code changed.

## Measurements

Back to back on the same machine, same command, against `origin/main` at 94535e688. Container count is the number of **distinct** Postgres containers observed during the run, diffed against a pre-run snapshot (the machine runs other agents' suites concurrently).

| | before | after |
|---|---|---|
| distinct Postgres containers created per run | **30** | **1** |
| test duration | **4m 27s** | **25s** |
| result, idle machine | 122 passed, 1 skipped | 122 passed, 1 skipped |
| result, while four other agents were building | **22 failed** | **0 failed** |

Every one of those 22 failures was a 30s or 60s `Test execution timed out` — not a single assertion failure. That is the phase's thesis confirmed: the "pre-existing failures" people have been merging around were containers starving each other, and they disappear when there is one container.

Full solution suite green: Domain 274, Web 371, Analyzers 229, Application 3944, Integration 122 (+1 skipped).

## Per-test database isolation did NOT ship — nobodies-collective/Humans#983

The issue asked for per-test isolation via (a) a `BEGIN; ROLLBACK` wrapper by default and (b) an opt-in `TRUNCATE ... CASCADE`. Both were implemented or attempted and neither works against a shared host. Rather than ship something that looks isolated and isn't, this PR ships the container/runtime win and files nobodies-collective/Humans#983 for the rest.

**(a) `BEGIN; ROLLBACK` is not implementable for this suite.** Tests drive the app over TestServer. Each request resolves its own scoped `HumansDbContext` off the pooled `NpgsqlDataSource` and writes on a different physical connection than the test holds, so a transaction the test opens is invisible to the code under test. Pinning the pool to one connection does not rescue it either — EF's own `SaveChanges` transaction collides with an out-of-band `BEGIN` on that connection.

**(b) `TRUNCATE ... CASCADE` was built and measured, and it fails.** The implementation discovered the table list from `pg_tables`, snapshotted the post-boot rows into a schema so `HasData` and startup-seeder rows survived, and replayed truncate+restore under `session_replication_role = replica`. It takes **23 of 123 tests** down, because the app's eleven Singleton caching decorators are not truncated along with the database. Reproduced deterministically: sign in, reset, sign in again → `/dev/login/{persona}` 500s, because `DevPersonaSeeder` resolves the persona through `IUserEmailService`, gets a cached user id whose row was just truncated, takes the "legacy persona, reusing" branch, and `userManager.FindByIdAsync` then returns null.

Truncating the database while the app still believes the old rows exist is a worse correctness story than not truncating, so that code is not in this PR. nobodies-collective/Humans#983 records what a complete fix needs — chiefly a `Clear()` on `ICacheStats` (every implementer already has it) plus a real flush for `CachingEventService`, whose `_categories`/`_venues`/`_settings`/`_isLoaded` live outside the `TrackedCache` its `ICacheStats` registration exposes. That is production surface added for a test need on a public Application interface, so it wants Peter's call on the shape before anyone writes it.

The suite is green sharing one database because tests already scope assertions to rows they seeded themselves (per-test GUID suffixes on emails, slugs and names). `HumansWebApplicationFactory`'s XML docs now state that contract for future tests, and the P2 section of `docs/features/test-system-reliability.md` carries the evidence.

## Options considered and rejected

- **`IAssemblyFixture<T>` as an interface on each test class**, as the issue describes. xUnit v3.2.2 has no such interface — assembly fixtures are declared with `[assembly: AssemblyFixture(typeof(T))]` and injected into test-class constructors with no interface declaration. Verified by spike.
- **A separate `PostgresFixture` owning the container, with `HumansWebApplicationFactory` taking it as a constructor argument.** Cleaner separation, but xUnit v3 cannot resolve one assembly fixture from another: *"Assembly fixture type 'X' had one or more unresolved constructor arguments"*. Verified by spike. Container ownership therefore stays on the factory, which already had it.
- **A new shared `CreateDatabaseAsync` helper class** for the two migration-mechanics tests. They each had a private copy; rather than add a third home, the one surviving copy moved onto the factory that owns the container.
- **Keeping the eleven non-`IntegrationTestBase` classes as they were** (just deleting their `IClassFixture` declaration) — a much smaller diff, but they would then be the only classes not resetting the now-assembly-wide NSubstitute stubs.
- **Dropping `PseudoLocalizationWebApplicationFactory` onto the shared database** instead of giving it its own. Rejected: a second app host warms its own caches, and pointing it at the shared database would make the two hosts' caches disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)