### PR TITLE
Strip 16 dead cross-section EF navs across 8 sections

### DIFF
--- a/src/Humans.Domain/Entities/AuditLogEntry.cs
+++ b/src/Humans.Domain/Entities/AuditLogEntry.cs
@@ -63,12 +63,6 @@ public class AuditLogEntry
     public Guid? ResourceId { get; init; }
 
     /// <summary>
-    /// Navigation property to the Google resource.
-    /// Uses set (not init) as required by EF Core for navigation properties.
-    /// </summary>
-    public GoogleResource? Resource { get; set; }
-
-    /// <summary>
     /// Whether the Google API call succeeded. Null for non-Google entries.
     /// </summary>
     public bool? Success { get; init; }

--- a/src/Humans.Domain/Entities/BudgetAuditLog.cs
+++ b/src/Humans.Domain/Entities/BudgetAuditLog.cs
@@ -18,14 +18,5 @@ public class BudgetAuditLog
     public string Description { get; init; } = string.Empty;
     public Guid ActorUserId { get; init; }
 
-    /// <summary>
-    /// Cross-domain navigation to the actor user. Do not use — callers resolve
-    /// display names via <see cref="Humans.Application.Interfaces.IUserService"/>
-    /// or <c>&lt;vc:human user-id="@ActorUserId" /&gt;</c>, keyed off <see cref="ActorUserId"/>.
-    /// Retained only so EF's configured relationship keeps the FK constraint.
-    /// </summary>
-    [Obsolete("Cross-domain nav. Use ActorUserId + IUserService to resolve the user.")]
-    public User? ActorUser { get; set; }
-
     public Instant OccurredAt { get; init; }
 }

--- a/src/Humans.Domain/Entities/BudgetCategory.cs
+++ b/src/Humans.Domain/Entities/BudgetCategory.cs
@@ -17,15 +17,6 @@ public class BudgetCategory
     public ExpenditureType ExpenditureType { get; set; } = ExpenditureType.OpEx;
     public Guid? TeamId { get; set; }
 
-    /// <summary>
-    /// Cross-domain navigation to the owning team. Do not use — callers resolve
-    /// team names via <see cref="Humans.Application.Interfaces.ITeamService"/>,
-    /// keyed off <see cref="TeamId"/>. Retained only so EF's configured
-    /// relationship keeps the FK constraint.
-    /// </summary>
-    [Obsolete("Cross-domain nav. Use TeamId + ITeamService to resolve the team.")]
-    public Team? Team { get; set; }
-
     public int SortOrder { get; set; }
     public Instant CreatedAt { get; init; }
     public Instant UpdatedAt { get; set; }

--- a/src/Humans.Domain/Entities/CalendarEvent.cs
+++ b/src/Humans.Domain/Entities/CalendarEvent.cs
@@ -14,15 +14,6 @@ public class CalendarEvent
     public string? LocationUrl { get; set; }
     public Guid OwningTeamId { get; set; }
 
-    /// <summary>
-    /// Cross-domain navigation to the owning <see cref="Team"/>. Kept so that
-    /// the EF configuration can still declare the FK + cascade behavior, but
-    /// the Application-layer <c>CalendarService</c> stitches team display
-    /// names via <see cref="Team"/> lookups through <c>ITeamService</c>
-    /// rather than <c>.Include()</c>-ing this nav (design-rules §6).
-    /// </summary>
-    [Obsolete("Cross-domain nav — resolve via ITeamService.GetByIdsAsync instead of navigating CalendarEvent.OwningTeam. See design-rules §6c.")]
-    public Team OwningTeam { get; set; } = null!;
     public Instant StartUtc { get; set; }
     public Instant? EndUtc { get; set; }
     public bool IsAllDay { get; set; }

--- a/src/Humans.Domain/Entities/CampPolygon.cs
+++ b/src/Humans.Domain/Entities/CampPolygon.cs
@@ -7,7 +7,6 @@ public class CampPolygon
     public Guid Id { get; init; } = Guid.NewGuid();
 
     public Guid CampSeasonId { get; init; }
-    public CampSeason CampSeason { get; set; } = null!;
 
     public string GeoJson { get; set; } = string.Empty;
     public double AreaSqm { get; set; }

--- a/src/Humans.Domain/Entities/CampPolygonHistory.cs
+++ b/src/Humans.Domain/Entities/CampPolygonHistory.cs
@@ -7,7 +7,6 @@ public class CampPolygonHistory
     public Guid Id { get; init; } = Guid.NewGuid();
 
     public Guid CampSeasonId { get; init; }
-    public CampSeason CampSeason { get; set; } = null!;
 
     public string GeoJson { get; init; } = string.Empty;
     public double AreaSqm { get; init; }

--- a/src/Humans.Domain/Entities/Campaign.cs
+++ b/src/Humans.Domain/Entities/Campaign.cs
@@ -19,15 +19,6 @@ public class Campaign
     public Guid CreatedByUserId { get; set; }
 
     // Navigation.
-    /// <summary>
-    /// Cross-domain navigation to the creator user. Do not use — callers
-    /// resolve user display names via <see cref="Humans.Application.Interfaces.IUserService"/>
-    /// keyed off <see cref="CreatedByUserId"/>. Retained only so EF's configured
-    /// relationship keeps the FK constraint.
-    /// </summary>
-    [Obsolete("Cross-domain nav. Use CreatedByUserId + IUserService to resolve the user.")]
-    public User CreatedByUser { get; set; } = null!;
-
     public ICollection<CampaignCode> Codes { get; } = new List<CampaignCode>();
     public ICollection<CampaignGrant> Grants { get; } = new List<CampaignGrant>();
 }

--- a/src/Humans.Domain/Entities/CampaignGrant.cs
+++ b/src/Humans.Domain/Entities/CampaignGrant.cs
@@ -20,14 +20,5 @@ public class CampaignGrant
     public Campaign Campaign { get; set; } = null!;
     public CampaignCode Code { get; set; } = null!;
 
-    /// <summary>
-    /// Cross-domain navigation to the recipient user. Do not use — callers
-    /// resolve user display names via <see cref="Humans.Application.Interfaces.IUserService"/>
-    /// keyed off <see cref="UserId"/>. Retained only so EF's configured
-    /// relationship keeps the FK constraint.
-    /// </summary>
-    [Obsolete("Cross-domain nav. Use UserId + IUserService to resolve the user.")]
-    public User User { get; set; } = null!;
-
     public ICollection<EmailOutboxMessage> OutboxMessages { get; } = new List<EmailOutboxMessage>();
 }

--- a/src/Humans.Domain/Entities/EmailOutboxMessage.cs
+++ b/src/Humans.Domain/Entities/EmailOutboxMessage.cs
@@ -29,10 +29,7 @@ public class EmailOutboxMessage
     /// </summary>
     public Guid? ShiftSignupId { get; set; }
 
-    // Navigation
-    // Note: no User nav (FK-only per design-rules §6c — cross-domain nav
-    // into the Users section would defeat table ownership). Callers resolve
-    // the user via IUserService.GetUserInfoAsync(message.UserId.Value) when needed.
-    public CampaignGrant? CampaignGrant { get; set; }
-    public ShiftSignup? ShiftSignup { get; set; }
+    // Note: no cross-domain nav properties (FK-only per design-rules §6c —
+    // cross-section navs into the Users/Campaigns/Shifts sections would defeat
+    // table ownership). Callers resolve via the owning section's service.
 }

--- a/src/Humans.Domain/Entities/Issue.cs
+++ b/src/Humans.Domain/Entities/Issue.cs
@@ -10,14 +10,6 @@ public class Issue
     public Guid ReporterUserId { get; init; }
 
     /// <summary>
-    /// Cross-domain navigation to the reporter's <see cref="User"/>. Service
-    /// stitches in memory from <c>IUserService.GetByIdsAsync</c>; repositories
-    /// must not <c>.Include()</c> this property (design-rules §6c).
-    /// </summary>
-    [Obsolete("Cross-domain nav — resolve via IUserService instead. See design-rules §6c.")]
-    public User Reporter { get; set; } = null!;
-
-    /// <summary>
     /// Section the issue is about (drives routing). Null = unknown → Admin queue.
     /// One of the <c>IssueSectionRouting</c> known values; stored as string.
     /// </summary>
@@ -42,17 +34,11 @@ public class Issue
 
     public Guid? AssigneeUserId { get; set; }
 
-    [Obsolete("Cross-domain nav — resolve via IUserService instead. See design-rules §6c.")]
-    public User? Assignee { get; set; }
-
     public Instant CreatedAt { get; init; }
     public Instant UpdatedAt { get; set; }
     public Instant? ResolvedAt { get; set; }
 
     public Guid? ResolvedByUserId { get; set; }
-
-    [Obsolete("Cross-domain nav — resolve via IUserService instead. See design-rules §6c.")]
-    public User? ResolvedByUser { get; set; }
 
     public ICollection<IssueComment> Comments { get; set; } = new List<IssueComment>();
 }

--- a/src/Humans.Domain/Entities/IssueComment.cs
+++ b/src/Humans.Domain/Entities/IssueComment.cs
@@ -10,9 +10,6 @@ public class IssueComment
 
     public Guid? SenderUserId { get; init; }
 
-    [Obsolete("Cross-domain nav — resolve via IUserService instead of navigating IssueComment.SenderUser. See design-rules §6c.")]
-    public User? SenderUser { get; set; }
-
     public string Content { get; set; } = string.Empty;
     public Instant CreatedAt { get; init; }
 }

--- a/src/Humans.Domain/Entities/RoleAssignment.cs
+++ b/src/Humans.Domain/Entities/RoleAssignment.cs
@@ -19,17 +19,6 @@ public class RoleAssignment
     public Guid UserId { get; init; }
 
     /// <summary>
-    /// Cross-domain navigation to the assignee's <see cref="User"/>.
-    /// Kept so controllers / views can still read
-    /// <c>ra.User.DisplayName</c> after the service populates the nav in
-    /// memory from <c>IUserService.GetByIdsAsync</c>. Repositories must not
-    /// <c>.Include()</c> this property (design-rules §6). Callers in new
-    /// code should resolve the user via <c>IUserService</c> directly.
-    /// </summary>
-    [Obsolete("Cross-domain nav — resolve via IUserService instead of navigating RoleAssignment.User. See design-rules §6c.")]
-    public User User { get; set; } = null!;
-
-    /// <summary>
     /// The role name being assigned.
     /// </summary>
     public string RoleName { get; set; } = string.Empty;
@@ -58,14 +47,6 @@ public class RoleAssignment
     /// ID of the user who created this assignment.
     /// </summary>
     public Guid CreatedByUserId { get; init; }
-
-    /// <summary>
-    /// Cross-domain navigation to the user who created this assignment.
-    /// Service stitches this in memory when rendering assignments;
-    /// repositories must not <c>.Include()</c> it.
-    /// </summary>
-    [Obsolete("Cross-domain nav — resolve via IUserService instead of navigating RoleAssignment.CreatedByUser. See design-rules §6c.")]
-    public User? CreatedByUser { get; set; }
 
     /// <summary>
     /// Determines if this role assignment is currently active.

--- a/src/Humans.Infrastructure/Data/Configurations/AuditLog/AuditLogEntryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/AuditLog/AuditLogEntryConfiguration.cs
@@ -66,7 +66,7 @@ public class AuditLogEntryConfiguration : IEntityTypeConfiguration<AuditLogEntry
             .HasMaxLength(500);
 
         // FK to GoogleResource with SetNull on delete
-        builder.HasOne(e => e.Resource)
+        builder.HasOne<GoogleResource>()
             .WithMany()
             .HasForeignKey(e => e.ResourceId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Data/Configurations/Auth/RoleAssignmentConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Auth/RoleAssignmentConfiguration.cs
@@ -36,25 +36,20 @@ public class RoleAssignmentConfiguration : IEntityTypeConfiguration<RoleAssignme
         builder.Property(ra => ra.CreatedAt)
             .IsRequired();
 
-        // EF needs the nav ref to configure the cross-section FK relationship.
-        // The nav itself is [Obsolete] for Application callers; this block
-        // owns the DB-level FK + cascade behavior.
-#pragma warning disable CS0618
-        builder.HasOne(ra => ra.CreatedByUser)
+        // Cross-section FK columns only — no nav property (design-rules §6c,
+        // memory/architecture/no-cross-section-ef-joins.md).
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(ra => ra.CreatedByUserId)
             .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
 
         // Issue #635 (§15i): inverse-side FK preservation after the User-side
         // nav (User.RoleAssignments) was stripped. Configures the schema-level
         // FK + cascade-delete that previously lived on UserConfiguration.HasMany.
-#pragma warning disable CS0618 // RoleAssignment.User is Obsolete; kept for EF FK + inverse nav.
-        builder.HasOne(ra => ra.User)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(ra => ra.UserId)
             .OnDelete(DeleteBehavior.Cascade);
-#pragma warning restore CS0618
 
         builder.HasIndex(ra => ra.UserId);
         builder.HasIndex(ra => ra.RoleName);

--- a/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetAuditLogConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetAuditLogConfiguration.cs
@@ -24,9 +24,7 @@ public class BudgetAuditLogConfiguration : IEntityTypeConfiguration<BudgetAuditL
         builder.Property(a => a.Description).HasMaxLength(1000).IsRequired();
         builder.Property(a => a.OccurredAt).IsRequired();
 
-#pragma warning disable CS0618 // Obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasOne(a => a.ActorUser).WithMany().HasForeignKey(a => a.ActorUserId).OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
+        builder.HasOne<User>().WithMany().HasForeignKey(a => a.ActorUserId).OnDelete(DeleteBehavior.Restrict);
 
         builder.HasIndex(a => a.BudgetYearId);
         builder.HasIndex(a => a.OccurredAt);

--- a/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetCategoryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetCategoryConfiguration.cs
@@ -24,9 +24,7 @@ public class BudgetCategoryConfiguration : IEntityTypeConfiguration<BudgetCatego
         builder.Property(c => c.CreatedAt).IsRequired();
         builder.Property(c => c.UpdatedAt).IsRequired();
 
-#pragma warning disable CS0618 // Obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasOne(c => c.Team).WithMany().HasForeignKey(c => c.TeamId).OnDelete(DeleteBehavior.SetNull);
-#pragma warning restore CS0618
+        builder.HasOne<Team>().WithMany().HasForeignKey(c => c.TeamId).OnDelete(DeleteBehavior.SetNull);
         builder.HasMany(c => c.LineItems).WithOne(l => l.BudgetCategory).HasForeignKey(l => l.BudgetCategoryId).OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(c => new { c.BudgetGroupId, c.SortOrder });

--- a/src/Humans.Infrastructure/Data/Configurations/Calendar/CalendarEventConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Calendar/CalendarEventConfiguration.cs
@@ -25,16 +25,12 @@ public class CalendarEventConfiguration : IEntityTypeConfiguration<CalendarEvent
         b.Property(e => e.RecurrenceTimezone).HasMaxLength(100);
         b.Property(e => e.OwningTeamId).IsRequired();
 
-        // EF needs the nav ref to configure the cross-section FK + cascade
-        // behavior. The nav itself is [Obsolete] for the Application layer
-        // (design-rules §6c) — suppress the obsolete warning only for this
-        // wiring block.
-#pragma warning disable CS0618
-        b.HasOne(e => e.OwningTeam)
+        // Cross-section FK column only — no nav property (design-rules §6c,
+        // memory/architecture/no-cross-section-ef-joins.md).
+        b.HasOne<Team>()
          .WithMany()
          .HasForeignKey(e => e.OwningTeamId)
          .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
 
         b.HasMany(e => e.Exceptions)
          .WithOne(x => x.Event)

--- a/src/Humans.Infrastructure/Data/Configurations/Campaigns/CampaignConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Campaigns/CampaignConfiguration.cs
@@ -27,11 +27,9 @@ public class CampaignConfiguration : IEntityTypeConfiguration<Campaign>
             .HasMaxLength(20)
             .IsRequired();
 
-#pragma warning disable CS0618 // Obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasOne(c => c.CreatedByUser)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(c => c.CreatedByUserId)
             .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
     }
 }

--- a/src/Humans.Infrastructure/Data/Configurations/Campaigns/CampaignGrantConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Campaigns/CampaignGrantConfiguration.cs
@@ -36,11 +36,9 @@ public class CampaignGrantConfiguration : IEntityTypeConfiguration<CampaignGrant
             .HasForeignKey<CampaignGrant>(g => g.CampaignCodeId)
             .OnDelete(DeleteBehavior.Restrict);
 
-#pragma warning disable CS0618 // Obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasOne(g => g.User)
+        builder.HasOne<User>()
             .WithMany()
             .HasForeignKey(g => g.UserId)
             .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
     }
 }

--- a/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonConfiguration.cs
@@ -21,7 +21,7 @@ public class CampPolygonConfiguration : IEntityTypeConfiguration<CampPolygon>
 
         builder.Property(p => p.GeoJson).HasColumnType("text").IsRequired();
 
-        builder.HasOne(p => p.CampSeason)
+        builder.HasOne<CampSeason>()
             .WithMany()
             .HasForeignKey(p => p.CampSeasonId)
             .OnDelete(DeleteBehavior.Restrict);

--- a/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonHistoryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/CityPlanning/CampPolygonHistoryConfiguration.cs
@@ -21,7 +21,7 @@ public class CampPolygonHistoryConfiguration : IEntityTypeConfiguration<CampPoly
         builder.Property(h => h.GeoJson).HasColumnType("text").IsRequired();
         builder.Property(h => h.Note).HasMaxLength(512).IsRequired();
 
-        builder.HasOne(h => h.CampSeason)
+        builder.HasOne<CampSeason>()
             .WithMany()
             .HasForeignKey(h => h.CampSeasonId)
             .OnDelete(DeleteBehavior.Restrict);

--- a/src/Humans.Infrastructure/Data/Configurations/Email/EmailOutboxMessageConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Email/EmailOutboxMessageConfiguration.cs
@@ -46,12 +46,12 @@ public class EmailOutboxMessageConfiguration : IEntityTypeConfiguration<EmailOut
             .HasForeignKey(e => e.UserId)
             .OnDelete(DeleteBehavior.SetNull);
 
-        builder.HasOne(e => e.CampaignGrant)
+        builder.HasOne<CampaignGrant>()
             .WithMany(g => g.OutboxMessages)
             .HasForeignKey(e => e.CampaignGrantId)
             .OnDelete(DeleteBehavior.SetNull);
 
-        builder.HasOne(e => e.ShiftSignup)
+        builder.HasOne<ShiftSignup>()
             .WithMany()
             .HasForeignKey(e => e.ShiftSignupId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/src/Humans.Infrastructure/Data/Configurations/Issues/IssueCommentConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Issues/IssueCommentConfiguration.cs
@@ -20,13 +20,10 @@ public class IssueCommentConfiguration : IEntityTypeConfiguration<IssueComment>
         b.Property(x => x.Content).HasMaxLength(5000).IsRequired();
         b.Property(x => x.CreatedAt).IsRequired();
 
-        // EF needs the nav ref to configure the cross-section FK relationship.
-        // The nav itself is [Obsolete] for Application callers; this block
-        // owns the DB-level FK + cascade behavior.
-#pragma warning disable CS0618
-        b.HasOne(x => x.SenderUser).WithMany().HasForeignKey(x => x.SenderUserId)
+        // Cross-section FK column only — no nav property (design-rules §6c,
+        // memory/architecture/no-cross-section-ef-joins.md).
+        b.HasOne<User>().WithMany().HasForeignKey(x => x.SenderUserId)
             .OnDelete(DeleteBehavior.SetNull);
-#pragma warning restore CS0618
 
         b.HasIndex(x => x.IssueId);
         b.HasIndex(x => x.CreatedAt);

--- a/src/Humans.Infrastructure/Data/Configurations/Issues/IssueConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Issues/IssueConfiguration.cs
@@ -35,10 +35,10 @@ public class IssueConfiguration : IEntityTypeConfiguration<Issue>
         b.Property(x => x.CreatedAt).IsRequired();
         b.Property(x => x.UpdatedAt).IsRequired();
 
-        // EF needs the nav refs to configure the cross-section FK relationships.
-        // The nav properties themselves are [Obsolete] for the Application layer,
-        // but the DB-level FK behavior is still owned here — suppress the
-        // obsolete warning only for this wiring block.
+        // Cross-section FK columns only — no nav property (design-rules §6c,
+        // memory/architecture/no-cross-section-ef-joins.md). Resolve display
+        // data via IUserService; repositories must not .Include() across
+        // sections.
         //
         // Reporter FK uses Restrict: account deletion in this codebase
         // anonymizes the User row in place (see IAccountDeletionService) — the
@@ -46,16 +46,14 @@ public class IssueConfiguration : IEntityTypeConfiguration<Issue>
         // anyone ever bypasses the deletion service and tries to Remove() a
         // user, Restrict makes the DB reject it instead of silently wiping
         // every issue the user reported.
-#pragma warning disable CS0618
-        b.HasOne(x => x.Reporter).WithMany().HasForeignKey(x => x.ReporterUserId)
+        b.HasOne<User>().WithMany().HasForeignKey(x => x.ReporterUserId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        b.HasOne(x => x.Assignee).WithMany().HasForeignKey(x => x.AssigneeUserId)
+        b.HasOne<User>().WithMany().HasForeignKey(x => x.AssigneeUserId)
             .OnDelete(DeleteBehavior.SetNull);
 
-        b.HasOne(x => x.ResolvedByUser).WithMany().HasForeignKey(x => x.ResolvedByUserId)
+        b.HasOne<User>().WithMany().HasForeignKey(x => x.ResolvedByUserId)
             .OnDelete(DeleteBehavior.SetNull);
-#pragma warning restore CS0618
 
         b.HasMany(x => x.Comments).WithOne(c => c.Issue).HasForeignKey(c => c.IssueId)
             .OnDelete(DeleteBehavior.Cascade);

--- a/src/Humans.Infrastructure/Migrations/HumansDbContextModelSnapshot.cs
+++ b/src/Humans.Infrastructure/Migrations/HumansDbContextModelSnapshot.cs
@@ -4629,12 +4629,10 @@ namespace Humans.Infrastructure.Migrations
                         .HasForeignKey("ActorUserId")
                         .OnDelete(DeleteBehavior.SetNull);
 
-                    b.HasOne("Humans.Domain.Entities.GoogleResource", "Resource")
+                    b.HasOne("Humans.Domain.Entities.GoogleResource", null)
                         .WithMany()
                         .HasForeignKey("ResourceId")
                         .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("Resource");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.BoardVote", b =>
@@ -4656,7 +4654,7 @@ namespace Humans.Infrastructure.Migrations
 
             modelBuilder.Entity("Humans.Domain.Entities.BudgetAuditLog", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.User", "ActorUser")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("ActorUserId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -4667,8 +4665,6 @@ namespace Humans.Infrastructure.Migrations
                         .HasForeignKey("BudgetYearId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("ActorUser");
 
                     b.Navigation("BudgetYear");
                 });
@@ -4681,14 +4677,12 @@ namespace Humans.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Humans.Domain.Entities.Team", "Team")
+                    b.HasOne("Humans.Domain.Entities.Team", null)
                         .WithMany()
                         .HasForeignKey("TeamId")
                         .OnDelete(DeleteBehavior.SetNull);
 
                     b.Navigation("BudgetGroup");
-
-                    b.Navigation("Team");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.BudgetGroup", b =>
@@ -4720,13 +4714,11 @@ namespace Humans.Infrastructure.Migrations
 
             modelBuilder.Entity("Humans.Domain.Entities.CalendarEvent", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.Team", "OwningTeam")
+                    b.HasOne("Humans.Domain.Entities.Team", null)
                         .WithMany()
                         .HasForeignKey("OwningTeamId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("OwningTeam");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.CalendarEventException", b =>
@@ -4801,7 +4793,7 @@ namespace Humans.Infrastructure.Migrations
 
             modelBuilder.Entity("Humans.Domain.Entities.CampPolygon", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.CampSeason", "CampSeason")
+                    b.HasOne("Humans.Domain.Entities.CampSeason", null)
                         .WithMany()
                         .HasForeignKey("CampSeasonId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -4812,13 +4804,11 @@ namespace Humans.Infrastructure.Migrations
                         .HasForeignKey("LastModifiedByUserId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("CampSeason");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.CampPolygonHistory", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.CampSeason", "CampSeason")
+                    b.HasOne("Humans.Domain.Entities.CampSeason", null)
                         .WithMany()
                         .HasForeignKey("CampSeasonId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -4829,8 +4819,6 @@ namespace Humans.Infrastructure.Migrations
                         .HasForeignKey("ModifiedByUserId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("CampSeason");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.CampRoleAssignment", b =>
@@ -4878,13 +4866,11 @@ namespace Humans.Infrastructure.Migrations
 
             modelBuilder.Entity("Humans.Domain.Entities.Campaign", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.User", "CreatedByUser")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("CreatedByUserId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.Navigation("CreatedByUser");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.CampaignCode", b =>
@@ -4912,7 +4898,7 @@ namespace Humans.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Humans.Domain.Entities.User", "User")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -4921,8 +4907,6 @@ namespace Humans.Infrastructure.Migrations
                     b.Navigation("Campaign");
 
                     b.Navigation("Code");
-
-                    b.Navigation("User");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.CommunicationPreference", b =>
@@ -4975,12 +4959,12 @@ namespace Humans.Infrastructure.Migrations
 
             modelBuilder.Entity("Humans.Domain.Entities.EmailOutboxMessage", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.CampaignGrant", "CampaignGrant")
+                    b.HasOne("Humans.Domain.Entities.CampaignGrant", null)
                         .WithMany("OutboxMessages")
                         .HasForeignKey("CampaignGrantId")
                         .OnDelete(DeleteBehavior.SetNull);
 
-                    b.HasOne("Humans.Domain.Entities.ShiftSignup", "ShiftSignup")
+                    b.HasOne("Humans.Domain.Entities.ShiftSignup", null)
                         .WithMany()
                         .HasForeignKey("ShiftSignupId")
                         .OnDelete(DeleteBehavior.SetNull);
@@ -4989,10 +4973,6 @@ namespace Humans.Infrastructure.Migrations
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("CampaignGrant");
-
-                    b.Navigation("ShiftSignup");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.EventParticipation", b =>
@@ -5097,27 +5077,21 @@ namespace Humans.Infrastructure.Migrations
 
             modelBuilder.Entity("Humans.Domain.Entities.Issue", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.User", "Assignee")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("AssigneeUserId")
                         .OnDelete(DeleteBehavior.SetNull);
 
-                    b.HasOne("Humans.Domain.Entities.User", "Reporter")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("ReporterUserId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Humans.Domain.Entities.User", "ResolvedByUser")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("ResolvedByUserId")
                         .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("Assignee");
-
-                    b.Navigation("Reporter");
-
-                    b.Navigation("ResolvedByUser");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.IssueComment", b =>
@@ -5128,14 +5102,12 @@ namespace Humans.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Humans.Domain.Entities.User", "SenderUser")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("SenderUserId")
                         .OnDelete(DeleteBehavior.SetNull);
 
                     b.Navigation("Issue");
-
-                    b.Navigation("SenderUser");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.LegalDocument", b =>
@@ -5194,21 +5166,17 @@ namespace Humans.Infrastructure.Migrations
 
             modelBuilder.Entity("Humans.Domain.Entities.RoleAssignment", b =>
                 {
-                    b.HasOne("Humans.Domain.Entities.User", "CreatedByUser")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("CreatedByUserId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Humans.Domain.Entities.User", "User")
+                    b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.Navigation("CreatedByUser");
-
-                    b.Navigation("User");
                 });
 
             modelBuilder.Entity("Humans.Domain.Entities.Rota", b =>

--- a/tests/Humans.Application.Tests/Architecture/CalendarArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/CalendarArchitectureTests.cs
@@ -12,8 +12,8 @@ namespace Humans.Application.Tests.Architecture;
 /// cache-migration plan task T-08. Pins the invariants: <c>CalendarService</c>
 /// lives in Application, goes through <see cref="ICalendarRepository"/>,
 /// never injects <c>DbContext</c>, and resolves owning-team display names via
-/// <see cref="ITeamServiceRead"/> rather than the <c>CalendarEvent.OwningTeam</c>
-/// cross-domain nav. The read surface is DTO-only and cache-backed.
+/// <see cref="ITeamServiceRead"/> rather than a cross-domain nav. The read
+/// surface is DTO-only and cache-backed.
 /// </summary>
 public class CalendarArchitectureTests
 {
@@ -97,17 +97,14 @@ public class CalendarArchitectureTests
     // ── CalendarEvent ────────────────────────────────────────────────────────
 
     [HumansFact]
-    public void CalendarEvent_OwningTeamNavIsObsolete()
+    public void CalendarEvent_HasNoOwningTeamNav()
     {
-        var navProperty = typeof(Humans.Domain.Entities.CalendarEvent)
-            .GetProperty("OwningTeam");
-
-        navProperty.Should().NotBeNull(
-            because: "EF configuration still needs the nav reference to declare FK + cascade behavior");
-
-        navProperty.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false)
-            .Should().NotBeEmpty(
-                because: "CalendarEvent.OwningTeam is a cross-domain nav into the Teams section; resolve via ITeamService instead (design-rules §6c)");
+        typeof(Humans.Domain.Entities.CalendarEvent)
+            .GetProperty("OwningTeam")
+            .Should().BeNull(
+                because: "CalendarEvent.OwningTeam was a cross-domain nav into the Teams section; the FK is now " +
+                          "a bare column configured via typed HasOne<Team>() (design-rules §6c, " +
+                          "memory/architecture/no-cross-section-ef-joins.md)");
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/IssuesApiControllerTests.cs
@@ -41,24 +41,13 @@ public class IssuesApiControllerTests
         string? section = "Tickets",
         string title = "Issue title",
         string description = "Issue description",
-        Guid? reporterId = null,
-        string reporterName = "Reporter",
-        string reporterEmail = "reporter@example.com",
-        string reporterLanguage = "en")
+        Guid? reporterId = null)
     {
         var rId = reporterId ?? Guid.NewGuid();
-        var reporter = new User
-        {
-            Id = rId,
-            Email = reporterEmail,
-            DisplayName = reporterName,
-            PreferredLanguage = reporterLanguage
-        };
         return new Issue
         {
             Id = id ?? Guid.NewGuid(),
             ReporterUserId = rId,
-            Reporter = reporter,
             Section = section,
             Category = category,
             Title = title,
@@ -101,9 +90,9 @@ public class IssuesApiControllerTests
         issue.UserAgent,
         issue.AdditionalContext,
         issue.ReporterUserId,
-        issue.Reporter?.DisplayName,
-        issue.Reporter?.Email,
-        issue.Reporter?.PreferredLanguage,
+        ReporterDisplayName: null,
+        ReporterEmail: null,
+        ReporterPreferredLanguage: null,
         issue.CreatedAt,
         issue.UpdatedAt,
         issue.ResolvedAt,
@@ -111,7 +100,7 @@ public class IssuesApiControllerTests
         issue.ScreenshotStoragePath,
         issue.Comments.Count,
         issue.AssigneeUserId,
-        issue.Assignee?.DisplayName,
+        AssigneeDisplayName: null,
         issue.GitHubIssueNumber);
 
     // ==========================================================================

--- a/tests/Humans.Application.Tests/Repositories/CalendarRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/CalendarRepositoryTests.cs
@@ -75,20 +75,6 @@ public sealed class CalendarRepositoryTests : IDisposable
     }
 
     [HumansFact]
-    public async Task GetEventByIdAsync_DoesNotLoadOwningTeamNav()
-    {
-        var ev = BuildEvent();
-        await _repo.AddAsync(ev, Xunit.TestContext.Current.CancellationToken);
-
-        var fetched = await _repo.GetEventByIdAsync(ev.Id, Xunit.TestContext.Current.CancellationToken);
-        fetched.Should().NotBeNull();
-#pragma warning disable CS0618 // accessing the [Obsolete] nav intentionally in the assertion
-        fetched.OwningTeam.Should().BeNull(
-            because: "CalendarRepository must not .Include(OwningTeam) — cross-domain nav resolved via ITeamService (design-rules §6c)");
-#pragma warning restore CS0618
-    }
-
-    [HumansFact]
     public async Task GetEventByIdAsync_HidesSoftDeleted()
     {
         var ev = BuildEvent();


### PR DESCRIPTION
## Summary

Fixes nobodies-collective/Humans#984

Removes 16 dead cross-section EF navigation properties across 8 sections, per `memory/architecture/no-cross-section-ef-joins.md`. Each `HasOne(e => e.Nav)` is rewritten as the typed `HasOne<TargetType>()` form so the FK constraint stays byte-identical, and the nav property is deleted from the entity. `[Grandfathered(HUM0024)]` stays on each config — the analyzer (`CrossSectionEfJoinAnalyzer`) inspects the type argument of `HasOne<T>()` too, not just the nav lambda, so the underlying cross-section FK constraint (not touched by this issue) still trips HUM0024. Only the compile-time nav-property coupling is removed here.

Navs removed, one commit per section (largest first):
- **Issues (4):** `Issue.Reporter`, `Issue.Assignee`, `Issue.ResolvedByUser`, `IssueComment.SenderUser`
- **Auth (2):** `RoleAssignment.User`, `RoleAssignment.CreatedByUser`
- **CityPlanning (2):** `CampPolygon.CampSeason`, `CampPolygonHistory.CampSeason`
- **Budget (2):** `BudgetCategory.Team`, `BudgetAuditLog.ActorUser`
- **Email (2):** `EmailOutboxMessage.CampaignGrant`, `EmailOutboxMessage.ShiftSignup`
- **Campaigns (2):** `Campaign.CreatedByUser`, `CampaignGrant.User`
- **AuditLog (1):** `AuditLogEntry.Resource`
- **Calendar (1):** `CalendarEvent.OwningTeam`

Plus one `chore` commit regenerating `HumansDbContextModelSnapshot.cs` to match — otherwise the next real migration on a descendant branch would pick up a large phantom diff.

**Teams and Feedback were left untouched**, per the issue's explicit scope — their navs still have live writers (`TeamService.StitchMemberUserSlicesAsync` / `StitchRoleAssignmentUserSlicesAsync`, `FeedbackService.StitchCrossDomainNavsAsync`) pending removal in separate PRs.

Each nav was verified dead (no readers/writers outside the EF config itself) before removal. Two test files needed matching updates because they exercised the removed navs as fixture/assertion shape, not because of a live production writer:
- `IssuesApiControllerTests`: test fixture built `Issue.Reporter` for display-name plumbing that was never actually asserted on.
- `CalendarArchitectureTests` / `CalendarRepositoryTests`: one architecture test pinned the nav's *existence* (now flipped to pin its *absence*), one repository test asserted the nav loaded as null post-fetch (now removed — the invariant it checked is structurally guaranteed with no nav to `.Include()`).

## Verification

- `dotnet build Humans.slnx -v quiet` — clean after every commit.
- `dotnet test Humans.slnx -v quiet` — `Humans.Web.Tests` 371/371 and `Humans.Application.Tests` 3943/3943 green. `Humans.Integration.Tests` shows a handful of non-deterministic failures (different subset each run, e.g. `ChainBuiltDatabase_HasNoUndeclaredPhysicalColumnDefaults`, Stripe/payment webhook tests) — each passes individually in isolation, confirming pre-existing Testcontainers/DB parallel-contention flakiness on this machine, not a regression from this change.
- **Empty-migration check (PASS):** `dotnet ef migrations add TempVerify` against `HumansDbContext` produced an empty `Up()`/`Down()`, proving the schema is unchanged. The migration was discarded (files deleted, `ef migrations remove` couldn't reach a local DB in this sandbox so I removed the two generated files directly — neither was ever committed).
- Confirmed via `git diff --stat origin/main...HEAD` that no Teams or Feedback files were touched.

## Test plan

- [x] All 16 navs rewritten as typed `HasOne<T>()` and nav properties deleted
- [x] One commit per section (+ 1 snapshot chore commit)
- [x] `dotnet build Humans.slnx -v quiet` clean after every commit
- [x] `dotnet test Humans.slnx -v quiet` green (unit suites; integration flakiness is pre-existing/environmental, see above)
- [x] No migration generated — empty `Up()`/`Down()` verified, scratch migration discarded
- [x] Teams and Feedback navs left untouched