### PR TITLE
fix(shifts): return a failure instead of throwing on repeat no-show

### DIFF
--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -461,6 +461,9 @@ public sealed class ShiftSignupService(
         if (now < shiftEnd)
             return SignupResult.Fail("Cannot mark no-show before the shift ends.");
 
+        if (signup.Status != SignupStatus.Confirmed)
+            return SignupResult.Fail($"Cannot mark no-show for a signup in {signup.Status} state.");
+
         signup.MarkNoShow(reviewerUserId, clock);
 
         await repo.SaveChangesAsync();

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceTests.cs
@@ -16,6 +16,7 @@ using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Infrastructure.Repositories.Shifts;
+using Xunit;
 
 namespace Humans.Application.Tests.Services.Shifts;
 
@@ -496,6 +497,33 @@ public sealed class ShiftSignupServiceTests : ServiceTestHarness
 
         result.Success.Should().BeTrue();
         result.Signup!.Status.Should().Be(SignupStatus.NoShow);
+    }
+
+    [HumansTheory(Timeout = 10000)]
+    [InlineData(SignupStatus.NoShow)]
+    [InlineData(SignupStatus.Bailed)]
+    [InlineData(SignupStatus.Cancelled)]
+    [InlineData(SignupStatus.Pending)]
+    [InlineData(SignupStatus.Refused)]
+    public async Task MarkNoShow_NotConfirmed_ReturnsErrorInsteadOfThrowing(SignupStatus status)
+    {
+        var (es, _, shift) = SeedShiftScenario(SignupPolicy.Public);
+        // Same past-ending shift as MarkNoShow_AfterShiftEnd_SetsNoShow, so the
+        // shift-end guard passes and the status guard is the one under test.
+        es.GateOpeningDate = new LocalDate(2026, 6, 14);
+        shift.DayOffset = 0;
+        shift.StartTime = new LocalTime(8, 0);
+        shift.Duration = Duration.FromHours(2);
+
+        var userId = Guid.NewGuid();
+        var signup = SeedSignup(userId, shift.Id, status);
+        var reviewerId = Guid.NewGuid();
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var result = await _service.MarkNoShowAsync(signup.Id, reviewerId);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain(status.ToString());
     }
 
     // ============================================================


### PR DESCRIPTION
Fixes nobodies-collective/Humans#947

`ShiftSignupService.MarkNoShowAsync` guarded *signup not found* and *shift not yet ended*, but never checked the signup's current status before calling `signup.MarkNoShow()`. The domain entity throws unless the status is `Confirmed`, so a double-click, a browser-back resubmit, or two admins acting on the same row produced an unhandled 500 in production (`Cannot mark no-show for signup in NoShow state`).

## Change

One guard in `MarkNoShowAsync`, mirroring the one `RemoveSignupAsync` already has eight lines below it:

```csharp
if (signup.Status != SignupStatus.Confirmed)
    return SignupResult.Fail($"Cannot mark no-show for a signup in {signup.Status} state.");
```

`ShiftAdminController.MarkNoShow` was already wired to render `result.Error` via `SetError` and redirect, so no controller change was needed.

## Tests

`MarkNoShow_NotConfirmed_ReturnsErrorInsteadOfThrowing` — a theory over `NoShow`, `Bailed`, `Cancelled`, `Pending`, `Refused`, asserting `SignupResult.Fail` rather than a thrown exception. The shift is seeded past its end so the shift-end guard passes and the new guard is the one under test.

`dotnet test --filter ShiftSignupServiceTests.MarkNoShow` → 7 passed, 0 failed.

## Reuse-first

No new files, types, interface methods, DTOs, or DI registrations. The failure-result shape (`SignupResult.Fail`) and the controller's error rendering both already existed; this only fills the missing precondition check.

## Out of scope

The issue notes the exception also escaped the `/Home/Error` handler, so the admin saw a raw failure page. That is a separate defect in the error pipeline and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)