### PR TITLE
fix(infra): give the pre-migration snapshot marker a deploy identity

### DIFF
--- a/src/Humans.Infrastructure/Hosting/DatabaseMigrationHostedService.cs
+++ b/src/Humans.Infrastructure/Hosting/DatabaseMigrationHostedService.cs
@@ -34,15 +34,31 @@ internal sealed class DatabaseMigrationHostedService(
         using var scope = scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
         var dbName = dbContext.Database.GetDbConnection().Database;
+        var sectionContextInstances = sectionContexts
+            .Select(section => (
+                section, Context: (DbContext)scope.ServiceProvider.GetRequiredService(section.ContextType)))
+            .ToList();
         var snapshot = CreateSnapshot();
-        Func<CancellationToken, Task> beforeSchemaChange =
-            snapshot is null ? static _ => Task.CompletedTask : snapshot.EnsureCapturedAsync;
+
+        Func<CancellationToken, Task> beforeSchemaChange;
+        if (snapshot is null)
+        {
+            beforeSchemaChange = static _ => Task.CompletedTask;
+        }
+        else
+        {
+            // Collected once, before any context has applied anything, so the marker records the
+            // frontier the whole deploy needs to clear - not just whichever context happens to
+            // trigger the dump (nobodies-collective/Humans#989).
+            var pendingFrontier = await CollectPendingFrontierAsync(
+                dbContext, sectionContextInstances.Select(instance => instance.Context), cancellationToken);
+            beforeSchemaChange = ct => snapshot.EnsureCapturedAsync(pendingFrontier, ct);
+        }
 
         await MigrateAsync(dbContext, dbName, beforeSchemaChange, cancellationToken);
 
-        foreach (var section in sectionContexts)
+        foreach (var (section, sectionContext) in sectionContextInstances)
         {
-            var sectionContext = (DbContext)scope.ServiceProvider.GetRequiredService(section.ContextType);
             await SectionMigrationRunner.MigrateAsync(
                 sectionContext, section.SentinelTable, _logger, beforeSchemaChange, cancellationToken);
         }
@@ -50,6 +66,26 @@ internal sealed class DatabaseMigrationHostedService(
         // Reached only if every context migrated, so this is what tells the next boot that the
         // snapshot above is history rather than the rollback point for an unfinished deploy.
         snapshot?.MarkMigrationsComplete();
+    }
+
+    /// <summary>
+    /// Every migration pending across <paramref name="dbContext"/> and every section context,
+    /// qualified by context type so identically-timestamped IDs from different contexts can never
+    /// collide. A dry read via <c>GetPendingMigrationsAsync</c> per context - nothing here applies
+    /// anything (nobodies-collective/Humans#989).
+    /// </summary>
+    private static async Task<List<string>> CollectPendingFrontierAsync(
+        HumansDbContext dbContext, IEnumerable<DbContext> sectionContexts, CancellationToken cancellationToken)
+    {
+        var frontier = new List<string>();
+        foreach (var context in sectionContexts.Prepend((DbContext)dbContext))
+        {
+            var contextName = context.GetType().Name;
+            var pending = await context.Database.GetPendingMigrationsAsync(cancellationToken);
+            frontier.AddRange(pending.Select(migration => $"{contextName}:{migration}"));
+        }
+
+        return frontier;
     }
 
     public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
+++ b/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
@@ -145,12 +145,29 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
                 // deploy's rollback point predate the deploy before it. Retire it as history,
                 // same as MarkMigrationsComplete does for a marker that clears normally, and
                 // fall through to take this deploy's own dump.
-                var retired = Retire(carried);
-                logger.LogWarning(
-                    "Retired stale pre-migration snapshot {Path} as {Retired}: none of its recorded " +
-                    "migrations are still pending, so the deploy that took it already finished. See " +
-                    "nobodies-collective/Humans#989",
-                    carried, retired);
+                //
+                // Best-effort, unlike the dump itself: retiring a marker is bookkeeping, and this
+                // deploy gets its own rollback point below either way. A rename that fails must
+                // not be what stops the boot - the marker stays and a later boot retires it, the
+                // same tolerance MarkMigrationsComplete already gives the identical call.
+                try
+                {
+                    var retired = Retire(carried);
+                    logger.LogWarning(
+                        "Retired stale pre-migration snapshot {Path} as {Retired}: none of its recorded " +
+                        "migrations are still pending, so the deploy that took it already finished. See " +
+                        "nobodies-collective/Humans#989",
+                        carried, retired);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    logger.LogError(
+                        ex,
+                        "Could not retire stale pre-migration snapshot {Path}. This deploy still takes its " +
+                        "own snapshot, so it has a rollback point; the stale marker stays until a boot " +
+                        "clears it. See docs/database-restore-runbook.md §5",
+                        carried);
+                }
             }
 
             DiscardAbandonedWrites(SnapshotDirectory, database);
@@ -161,7 +178,25 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
             // deploy's rollback point - and then migrates on the strength of it.
             await RunPgDumpAsync(_connection, dump + WritingSuffix, cancellationToken);
             File.Move(dump + WritingSuffix, path, overwrite: true);
-            WriteFrontier(path, pendingMigrations);
+
+            // Outside the abort contract above, deliberately: the dump - the thing this deploy
+            // must not migrate without - already exists. A sidecar that fails to write leaves the
+            // marker with no recorded frontier, which FrontierStillPending reads as "still
+            // pending": the unconditional carry-forward this had before #989, not a lost rollback
+            // point. Not a reason to refuse the deploy.
+            try
+            {
+                WriteFrontier(path, pendingMigrations);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogError(
+                    ex,
+                    "Could not record the migration frontier for pre-migration snapshot {Path}. The dump " +
+                    "itself is intact; without the sidecar a later deploy carries this marker forward " +
+                    "unconditionally instead of retiring it once stale. See nobodies-collective/Humans#989",
+                    path);
+            }
         }
         catch (Exception ex)
         {

--- a/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
+++ b/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
@@ -50,8 +50,10 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
 
     /// <summary>
     /// Marks a snapshot whose deploy has not finished migrating. Dropped by
-    /// <see cref="MarkMigrationsComplete"/>; while it is there the file is this deploy's
-    /// rollback point and is neither overwritten nor pruned.
+    /// <see cref="MarkMigrationsComplete"/> when that deploy finishes, or by
+    /// <see cref="EnsureCapturedAsync"/> if a later deploy finds it stale
+    /// (nobodies-collective/Humans#989); while it is there the file is this deploy's rollback
+    /// point and is neither overwritten nor pruned.
     /// </summary>
     internal const string UnfinishedSuffix = ".unfinished";
 
@@ -62,6 +64,14 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
     /// point. Nothing reads these; the next dump attempt deletes whatever it finds.
     /// </summary>
     private const string WritingSuffix = ".writing";
+
+    /// <summary>
+    /// Sidecar recording the migrations that were pending, across every context, at the moment
+    /// an <see cref="UnfinishedSuffix"/> snapshot was taken — its deploy identity
+    /// (nobodies-collective/Humans#989). Read by <see cref="FrontierStillPending"/> to tell a
+    /// marker a crash-loop is still carrying forward from one a completed deploy left behind.
+    /// </summary>
+    private const string FrontierSuffix = ".migrations";
 
     /// <summary>
     /// Newest snapshots kept; older ones are deleted after a successful dump. Bounds disk use
@@ -79,10 +89,19 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
     /// unfinished snapshot, which is carried forward instead. Later calls in the same boot are
     /// no-ops, so a deploy that migrates several contexts still snapshots exactly once.
     /// </summary>
+    /// <param name="pendingMigrations">
+    /// Every migration pending across every migrated context, collected once before any of them
+    /// applies anything (nobodies-collective/Humans#989). Recorded alongside a fresh dump as its
+    /// deploy identity, and compared against a carried-forward marker to tell a genuine
+    /// crash-loop retry (some of it still pending) from a marker a completed deploy left behind
+    /// (none of it still pending) — the marker's own migrations having finished is what makes it
+    /// safe to retire instead of carrying it forward as a stale rollback point.
+    /// </param>
     /// <exception cref="InvalidOperationException">
     /// The dump could not be taken. Thrown so the caller aborts before migrating.
     /// </exception>
-    public async Task EnsureCapturedAsync(CancellationToken cancellationToken)
+    public async Task EnsureCapturedAsync(
+        IReadOnlyCollection<string> pendingMigrations, CancellationToken cancellationToken)
     {
         if (_attempted)
         {
@@ -107,19 +126,31 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
             var carried = FindUnfinishedSnapshot(SnapshotDirectory, database);
             if (carried is not null)
             {
-                // Warning level for the same reason as the "written" line below: in a crash loop
-                // this is the line that tells you which file is the real rollback point. The age
-                // is what separates the case this exists for - a restart minutes after the
-                // failed deploy - from a marker left behind by an older one, which would make
-                // this deploy's rollback point far older than it should be.
+                if (FrontierStillPending(carried, pendingMigrations))
+                {
+                    // Warning level for the same reason as the "written" line below: in a crash
+                    // loop this is the line that tells you which file is the real rollback
+                    // point.
+                    logger.LogWarning(
+                        "Reusing pre-migration snapshot {Path}, taken {AgeHours:F1}h ago: an earlier boot of " +
+                        "this deploy took it and did not finish migrating, so it - not the current schema - " +
+                        "is the rollback point. See docs/database-restore-runbook.md §5",
+                        carried,
+                        (DateTime.UtcNow - File.GetLastWriteTimeUtc(carried)).TotalHours);
+                    return;
+                }
+
+                // None of its recorded migrations are still pending, so the deploy that took it
+                // finished (nobodies-collective/Humans#989) - reusing it now would make this
+                // deploy's rollback point predate the deploy before it. Retire it as history,
+                // same as MarkMigrationsComplete does for a marker that clears normally, and
+                // fall through to take this deploy's own dump.
+                var retired = Retire(carried);
                 logger.LogWarning(
-                    "Reusing pre-migration snapshot {Path}, taken {AgeHours:F1}h ago: an earlier boot of " +
-                    "this deploy took it and did not finish migrating, so it - not the current schema - " +
-                    "is the rollback point. An age beyond this deploy means a stale marker; see " +
-                    "docs/database-restore-runbook.md §5",
-                    carried,
-                    (DateTime.UtcNow - File.GetLastWriteTimeUtc(carried)).TotalHours);
-                return;
+                    "Retired stale pre-migration snapshot {Path} as {Retired}: none of its recorded " +
+                    "migrations are still pending, so the deploy that took it already finished. See " +
+                    "nobodies-collective/Humans#989",
+                    carried, retired);
             }
 
             DiscardAbandonedWrites(SnapshotDirectory, database);
@@ -130,6 +161,7 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
             // deploy's rollback point - and then migrates on the strength of it.
             await RunPgDumpAsync(_connection, dump + WritingSuffix, cancellationToken);
             File.Move(dump + WritingSuffix, path, overwrite: true);
+            WriteFrontier(path, pendingMigrations);
         }
         catch (Exception ex)
         {
@@ -164,11 +196,12 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
     /// </para>
     /// <para>
     /// A failure is logged at Error because of what it costs later: the marker stays, and the
-    /// next schema-changing deploy carries this snapshot forward instead of dumping, leaving its
-    /// rollback point older than the deploy it is meant to undo. It mostly self-heals — this runs
-    /// on every boot, pending migrations or not, so any later restart retires the marker — but a
-    /// deploy landing first would inherit it. Making that impossible needs the snapshot to record
-    /// which deploy took it: nobodies-collective/Humans#989.
+    /// next schema-changing deploy finds it. It self-heals either way now
+    /// (nobodies-collective/Humans#989) — a restart before that deploy retires the marker here,
+    /// and the deploy itself retires it via <see cref="FrontierStillPending"/> in
+    /// <see cref="EnsureCapturedAsync"/> once it sees none of the marker's recorded migrations
+    /// are still pending. Logging stays at Error because between those two points the deploy's
+    /// own rollback point is missing its dump.
     /// </para>
     /// </remarks>
     public void MarkMigrationsComplete()
@@ -196,8 +229,10 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
             ex,
             "Could not retire the unfinished pre-migration snapshot in {Directory}. This deploy's " +
             "migrations succeeded, but until the marker clears the next schema-changing deploy will " +
-            "reuse that snapshot instead of taking its own. Rename it to drop the '{Suffix}' suffix, " +
-            "or restart the app once - see docs/database-restore-runbook.md §5",
+            "find it. It self-heals - a restart retries this, or that deploy retires it itself once " +
+            "none of its recorded migrations are still pending - but rename it to drop the " +
+            "'{Suffix}' suffix, or restart the app once, to clear it sooner. See " +
+            "docs/database-restore-runbook.md §5",
             SnapshotDirectory,
             UnfinishedSuffix);
 
@@ -213,23 +248,55 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
     /// Renames every unfinished snapshot of the database to its final name and returns the new
     /// paths.
     /// </summary>
-    internal static List<string> PromoteUnfinishedSnapshots(string directory, string database)
-    {
-        var promoted = new List<string>();
-        foreach (var unfinished in UnfinishedSnapshots(directory, database))
-        {
-            var completed = unfinished[..^UnfinishedSuffix.Length];
-            File.Move(unfinished, completed, overwrite: true);
-            promoted.Add(completed);
-        }
+    internal static List<string> PromoteUnfinishedSnapshots(string directory, string database) =>
+        [.. UnfinishedSnapshots(directory, database).Select(Retire)];
 
-        return promoted;
+    /// <summary>
+    /// Renames one unfinished snapshot to its final name, retiring it from "this deploy's
+    /// rollback point" to plain history, and drops its now-unneeded
+    /// <see cref="FrontierSuffix"/> sidecar (nobodies-collective/Humans#989).
+    /// </summary>
+    private static string Retire(string unfinishedPath)
+    {
+        var completed = unfinishedPath[..^UnfinishedSuffix.Length];
+        File.Move(unfinishedPath, completed, overwrite: true);
+        File.Delete(unfinishedPath + FrontierSuffix);
+        return completed;
     }
 
     private static List<string> UnfinishedSnapshots(string directory, string database) =>
         [.. Directory
             .GetFiles(directory, database + "-*.dump" + UnfinishedSuffix)
             .OrderBy(Path.GetFileName, StringComparer.Ordinal)];
+
+    /// <summary>
+    /// Records the migrations pending, across every context, when <paramref name="unfinishedPath"/>
+    /// was taken — its deploy identity (nobodies-collective/Humans#989). One migration ID per
+    /// line; nothing but <see cref="FrontierStillPending"/> reads it.
+    /// </summary>
+    internal static void WriteFrontier(string unfinishedPath, IEnumerable<string> pendingMigrations) =>
+        File.WriteAllLines(unfinishedPath + FrontierSuffix, pendingMigrations);
+
+    /// <summary>
+    /// Whether any migration recorded as pending when <paramref name="unfinishedPath"/> was taken
+    /// is still pending now. True carries the marker forward (a genuine crash-loop retry); false
+    /// means the deploy that took it finished, so the marker is stale and safe to retire
+    /// (nobodies-collective/Humans#989). A missing <see cref="FrontierSuffix"/> sidecar — a
+    /// snapshot taken before this fix shipped — fails safe as "still pending", the same
+    /// unconditional carry-forward this had before the sidecar existed.
+    /// </summary>
+    internal static bool FrontierStillPending(
+        string unfinishedPath, IReadOnlyCollection<string> currentlyPendingMigrations)
+    {
+        var frontierPath = unfinishedPath + FrontierSuffix;
+        if (!File.Exists(frontierPath))
+        {
+            return true;
+        }
+
+        var frontier = File.ReadAllLines(frontierPath);
+        return frontier.Any(currentlyPendingMigrations.Contains);
+    }
 
     /// <summary>
     /// Deletes the output of any dump that did not finish. Nothing can be mid-dump here — this

--- a/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
+++ b/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
@@ -124,51 +124,18 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
         {
             Directory.CreateDirectory(SnapshotDirectory);
 
-            var carried = FindUnfinishedSnapshot(SnapshotDirectory, database);
+            var carried = CarryForwardMarker(SnapshotDirectory, database, pendingMigrations);
             if (carried is not null)
             {
-                if (FrontierStillPending(carried, pendingMigrations, logger))
-                {
-                    // Warning level for the same reason as the "written" line below: in a crash
-                    // loop this is the line that tells you which file is the real rollback
-                    // point.
-                    logger.LogWarning(
-                        "Reusing pre-migration snapshot {Path}, taken {AgeHours:F1}h ago: an earlier boot of " +
-                        "this deploy took it and did not finish migrating, so it - not the current schema - " +
-                        "is the rollback point. See docs/database-restore-runbook.md §5",
-                        carried,
-                        (DateTime.UtcNow - File.GetLastWriteTimeUtc(carried)).TotalHours);
-                    return;
-                }
-
-                // None of its recorded migrations are still pending, so the deploy that took it
-                // finished (nobodies-collective/Humans#989) - reusing it now would make this
-                // deploy's rollback point predate the deploy before it. Retire it as history,
-                // same as MarkMigrationsComplete does for a marker that clears normally, and
-                // fall through to take this deploy's own dump.
-                //
-                // Best-effort, unlike the dump itself: retiring a marker is bookkeeping, and this
-                // deploy gets its own rollback point below either way. A rename that fails must
-                // not be what stops the boot - the marker stays and a later boot retires it, the
-                // same tolerance MarkMigrationsComplete already gives the identical call.
-                try
-                {
-                    var retired = Retire(carried);
-                    logger.LogWarning(
-                        "Retired stale pre-migration snapshot {Path} as {Retired}: none of its recorded " +
-                        "migrations are still pending, so the deploy that took it already finished. See " +
-                        "nobodies-collective/Humans#989",
-                        carried, retired);
-                }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                {
-                    logger.LogError(
-                        ex,
-                        "Could not retire stale pre-migration snapshot {Path}. This deploy still takes its " +
-                        "own snapshot, so it has a rollback point; the stale marker stays until a boot " +
-                        "clears it. See docs/database-restore-runbook.md §5",
-                        carried);
-                }
+                // Warning level for the same reason as the "written" line below: in a crash loop
+                // this is the line that tells you which file is the real rollback point.
+                logger.LogWarning(
+                    "Reusing pre-migration snapshot {Path}, taken {AgeHours:F1}h ago: an earlier boot of " +
+                    "this deploy took it and did not finish migrating, so it - not the current schema - " +
+                    "is the rollback point. See docs/database-restore-runbook.md §5",
+                    carried,
+                    (DateTime.UtcNow - File.GetLastWriteTimeUtc(carried)).TotalHours);
+                return;
             }
 
             DiscardAbandonedWrites(SnapshotDirectory, database);
@@ -273,12 +240,71 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
             UnfinishedSuffix);
 
     /// <summary>
-    /// The snapshot an earlier boot of this deploy left behind, or <see langword="null"/> if the
-    /// last deploy finished. Oldest first: if several ever pile up, the earliest is the one that
-    /// predates the most.
+    /// The snapshot an earlier boot of this deploy left behind and this boot must reuse instead of
+    /// dumping, or <see langword="null"/> if there is none and this boot takes its own dump.
+    /// Retires every stale marker it steps over on the way (nobodies-collective/Humans#989).
     /// </summary>
-    internal static string? FindUnfinishedSnapshot(string directory, string database) =>
-        UnfinishedSnapshots(directory, database).FirstOrDefault();
+    /// <remarks>
+    /// Walks all the markers, oldest first, rather than judging the oldest alone. Retiring a stale
+    /// marker is best-effort, so a rename that failed leaves that marker sitting in front of one
+    /// that is still live — and this boot's own marker is created behind it. Judging only the
+    /// oldest would then retire the stale one, see nothing else, and dump the half-migrated schema
+    /// as this deploy's rollback point, over a crash loop whose real rollback point was the marker
+    /// it never looked at. Worse, a later boot promotes every marker, so that damaged dump becomes
+    /// the newest completed snapshot — the one <c>docs/database-restore-runbook.md</c> restores.
+    /// Oldest first is still what picks the winner among live markers: the earliest predates the
+    /// most.
+    /// </remarks>
+    internal string? CarryForwardMarker(
+        string directory, string database, IReadOnlyCollection<string> pendingMigrations)
+    {
+        foreach (var marker in UnfinishedSnapshots(directory, database))
+        {
+            if (FrontierStillPending(marker, pendingMigrations, logger))
+            {
+                return marker;
+            }
+
+            RetireStaleMarker(marker);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Retires a marker none of whose recorded migrations are still pending: the deploy that took
+    /// it finished (nobodies-collective/Humans#989), so reusing it would make this deploy's
+    /// rollback point predate the deploy before it. The same rename
+    /// <see cref="MarkMigrationsComplete"/> does for a marker that clears normally.
+    /// </summary>
+    /// <remarks>
+    /// Best-effort, unlike the dump itself: retiring a marker is bookkeeping, and the boot ends up
+    /// with a rollback point either way. A rename that fails must not be what stops the boot — the
+    /// marker stays, <see cref="CarryForwardMarker"/> steps over it next time, and a later boot
+    /// retires it, the same tolerance <see cref="MarkMigrationsComplete"/> already gives the
+    /// identical call.
+    /// </remarks>
+    private void RetireStaleMarker(string marker)
+    {
+        try
+        {
+            var retired = Retire(marker);
+            logger.LogWarning(
+                "Retired stale pre-migration snapshot {Path} as {Retired}: none of its recorded " +
+                "migrations are still pending, so the deploy that took it already finished. See " +
+                "nobodies-collective/Humans#989",
+                marker, retired);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogError(
+                ex,
+                "Could not retire stale pre-migration snapshot {Path}. The boot still gets a rollback " +
+                "point - a live marker behind this one, or its own dump; the stale marker stays until a " +
+                "boot clears it. See docs/database-restore-runbook.md §5",
+                marker);
+        }
+    }
 
     /// <summary>
     /// Renames every unfinished snapshot of the database to its final name and returns the new
@@ -300,7 +326,10 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
         return completed;
     }
 
-    private static List<string> UnfinishedSnapshots(string directory, string database) =>
+    /// <summary>
+    /// Every snapshot of the database whose deploy has not finished migrating, oldest first.
+    /// </summary>
+    internal static List<string> UnfinishedSnapshots(string directory, string database) =>
         [.. Directory
             .GetFiles(directory, database + "-*.dump" + UnfinishedSuffix)
             .OrderBy(Path.GetFileName, StringComparer.Ordinal)];

--- a/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
+++ b/src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs
@@ -58,10 +58,11 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
     internal const string UnfinishedSuffix = ".unfinished";
 
     /// <summary>
-    /// Marks the file <c>pg_dump</c> is writing into. A dump only earns
-    /// <see cref="UnfinishedSuffix"/> once the process has exited successfully, so a failed or
-    /// killed dump can never leave a truncated file that a later boot mistakes for a rollback
-    /// point. Nothing reads these; the next dump attempt deletes whatever it finds.
+    /// Marks a file still being written — <c>pg_dump</c>'s output, or the
+    /// <see cref="FrontierSuffix"/> sidecar in <see cref="WriteFrontier"/>. Neither earns the name
+    /// a later boot looks for until its write has finished, so a write that failed or was killed
+    /// half-way can never leave a truncated file that boot reads as authoritative. Nothing reads
+    /// these; <see cref="DiscardAbandonedWrites"/> deletes whatever it finds.
     /// </summary>
     private const string WritingSuffix = ".writing";
 
@@ -126,7 +127,7 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
             var carried = FindUnfinishedSnapshot(SnapshotDirectory, database);
             if (carried is not null)
             {
-                if (FrontierStillPending(carried, pendingMigrations))
+                if (FrontierStillPending(carried, pendingMigrations, logger))
                 {
                     // Warning level for the same reason as the "written" line below: in a crash
                     // loop this is the line that tells you which file is the real rollback
@@ -309,19 +310,36 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
     /// was taken — its deploy identity (nobodies-collective/Humans#989). One migration ID per
     /// line; nothing but <see cref="FrontierStillPending"/> reads it.
     /// </summary>
-    internal static void WriteFrontier(string unfinishedPath, IEnumerable<string> pendingMigrations) =>
-        File.WriteAllLines(unfinishedPath + FrontierSuffix, pendingMigrations);
+    /// <remarks>
+    /// Published by rename, for the same reason the dump is: <see cref="File.WriteAllLines(string,
+    /// IEnumerable{string})"/> truncates first, so a write that fails half-way — the snapshot
+    /// volume filling up is the likely way — or a process killed mid-write would leave a
+    /// <em>short</em> frontier. A frontier missing the migration that is in fact still pending is
+    /// exactly what makes <see cref="FrontierStillPending"/> retire a marker it should have
+    /// carried forward, so a partial sidecar is worse than none: readers must see the whole
+    /// frontier or no file at all.
+    /// </remarks>
+    internal static void WriteFrontier(string unfinishedPath, IEnumerable<string> pendingMigrations)
+    {
+        var frontierPath = unfinishedPath + FrontierSuffix;
+        File.WriteAllLines(frontierPath + WritingSuffix, pendingMigrations);
+        File.Move(frontierPath + WritingSuffix, frontierPath, overwrite: true);
+    }
 
     /// <summary>
     /// Whether any migration recorded as pending when <paramref name="unfinishedPath"/> was taken
     /// is still pending now. True carries the marker forward (a genuine crash-loop retry); false
     /// means the deploy that took it finished, so the marker is stale and safe to retire
-    /// (nobodies-collective/Humans#989). A missing <see cref="FrontierSuffix"/> sidecar — a
-    /// snapshot taken before this fix shipped — fails safe as "still pending", the same
-    /// unconditional carry-forward this had before the sidecar existed.
+    /// (nobodies-collective/Humans#989). A <see cref="FrontierSuffix"/> sidecar this cannot read —
+    /// missing, because the snapshot was taken before this fix shipped, or unreadable through an
+    /// IO or permission fault — fails safe as "still pending", the same unconditional
+    /// carry-forward this had before the sidecar existed. Retiring a marker needs proof it is
+    /// stale, and "I could not tell" is not proof; nor may a sidecar read be what aborts a boot,
+    /// which is the one failure the deploy cannot recover from
+    /// (<c>memory/architecture/no-startup-guards.md</c>).
     /// </summary>
     internal static bool FrontierStillPending(
-        string unfinishedPath, IReadOnlyCollection<string> currentlyPendingMigrations)
+        string unfinishedPath, IReadOnlyCollection<string> currentlyPendingMigrations, ILogger logger)
     {
         var frontierPath = unfinishedPath + FrontierSuffix;
         if (!File.Exists(frontierPath))
@@ -329,18 +347,36 @@ internal sealed class PreMigrationSnapshot(string connectionString, ILogger logg
             return true;
         }
 
-        var frontier = File.ReadAllLines(frontierPath);
+        string[] frontier;
+        try
+        {
+            frontier = File.ReadAllLines(frontierPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Logged at Error, unlike the expected missing-sidecar case above: the file is there
+            // and the volume would not give it up, which is the same volume the dump writes to.
+            logger.LogError(
+                ex,
+                "Could not read the recorded migration frontier {Path}. Carrying its snapshot forward as " +
+                "this deploy's rollback point rather than retiring a marker that may still be live. See " +
+                "docs/database-restore-runbook.md §5",
+                frontierPath);
+            return true;
+        }
+
         return frontier.Any(currentlyPendingMigrations.Contains);
     }
 
     /// <summary>
-    /// Deletes the output of any dump that did not finish. Nothing can be mid-dump here — this
-    /// runs at startup on the single instance, before this boot's own dump — so anything still
-    /// carrying <see cref="WritingSuffix"/> is the wreckage of an earlier attempt.
+    /// Deletes the output of any dump or frontier-sidecar write that did not finish. Nothing can
+    /// be mid-write here — this runs at startup on the single instance, before this boot's own
+    /// dump — so anything still carrying <see cref="WritingSuffix"/> is the wreckage of an earlier
+    /// attempt.
     /// </summary>
     private static void DiscardAbandonedWrites(string directory, string database)
     {
-        foreach (var abandoned in Directory.GetFiles(directory, database + "-*.dump" + WritingSuffix))
+        foreach (var abandoned in Directory.GetFiles(directory, database + "-*" + WritingSuffix))
         {
             File.Delete(abandoned);
         }

--- a/tests/Humans.Application.Tests/Hosting/PreMigrationSnapshotTests.cs
+++ b/tests/Humans.Application.Tests/Hosting/PreMigrationSnapshotTests.cs
@@ -113,6 +113,79 @@ public sealed class PreMigrationSnapshotTests : IDisposable
         PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, "humans_pr_42").Should().NotBeNull();
     }
 
+    /// <summary>
+    /// The gap nobodies-collective/Humans#989 closes: a genuine crash-loop retry, where the
+    /// deploy that took the marker still has not finished, keeps carrying its snapshot forward.
+    /// </summary>
+    [HumansFact]
+    public void A_marker_with_migrations_still_pending_is_not_stale()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(unfinished, ["HumansDbContext:20260805100000_AddFoo"]);
+
+        PreMigrationSnapshot.FrontierStillPending(
+            unfinished, ["HumansDbContext:20260805100000_AddFoo"]).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A partial application (migration 3 of 5 fails) must still carry forward: the test is "any
+    /// recorded migration still pending", not "all".
+    /// </summary>
+    [HumansFact]
+    public void A_marker_with_only_some_of_its_migrations_still_pending_is_not_stale()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(
+            unfinished,
+            ["HumansDbContext:20260805100000_AddFoo", "HumansDbContext:20260805100001_AddBar"]);
+
+        PreMigrationSnapshot.FrontierStillPending(
+            unfinished, ["HumansDbContext:20260805100001_AddBar"]).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The actual fix: when every migration recorded on the marker has since been applied, the
+    /// deploy that took it finished, so it is stale rather than a rollback point worth reusing.
+    /// </summary>
+    [HumansFact]
+    public void A_marker_whose_migrations_have_all_been_applied_is_stale()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(unfinished, ["HumansDbContext:20260805100000_AddFoo"]);
+
+        PreMigrationSnapshot.FrontierStillPending(
+            unfinished, ["HumansDbContext:20260805200000_AddLaterMigration"]).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A marker taken before nobodies-collective/Humans#989 shipped has no frontier sidecar.
+    /// Unable to tell whether it is stale, it fails safe as the old unconditional carry-forward
+    /// rather than risk losing a real rollback point.
+    /// </summary>
+    [HumansFact]
+    public void A_marker_with_no_recorded_frontier_is_not_stale()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+
+        PreMigrationSnapshot.FrontierStillPending(unfinished, []).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Promoting a marker drops its now-unneeded frontier sidecar along with the
+    /// <see cref="PreMigrationSnapshot.UnfinishedSuffix"/> rename, so it does not linger as an
+    /// orphan file next to the completed snapshot.
+    /// </summary>
+    [HumansFact]
+    public void Promoting_a_marker_drops_its_frontier_sidecar()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(unfinished, ["HumansDbContext:20260805100000_AddFoo"]);
+
+        PreMigrationSnapshot.PromoteUnfinishedSnapshots(_directory, Database);
+
+        File.Exists(unfinished + ".migrations").Should().BeFalse();
+    }
+
     private string Snapshot(string fileName)
     {
         var path = Path.Combine(_directory, fileName);

--- a/tests/Humans.Application.Tests/Hosting/PreMigrationSnapshotTests.cs
+++ b/tests/Humans.Application.Tests/Hosting/PreMigrationSnapshotTests.cs
@@ -23,7 +23,7 @@ public sealed class PreMigrationSnapshotTests : IDisposable
     [HumansFact]
     public void No_snapshots_means_nothing_to_carry_forward()
     {
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().BeNull();
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().BeEmpty();
     }
 
     [HumansFact]
@@ -31,7 +31,7 @@ public sealed class PreMigrationSnapshotTests : IDisposable
     {
         Snapshot("humans-20260805T120000Z.dump");
 
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().BeNull();
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().BeEmpty();
     }
 
     [HumansFact]
@@ -39,20 +39,21 @@ public sealed class PreMigrationSnapshotTests : IDisposable
     {
         var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
 
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().Be(unfinished);
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().Equal(unfinished);
     }
 
     /// <summary>
     /// The crash-loop case: restart two carries forward restart one's file instead of dumping a
-    /// database whose schema the failed migration has already part-changed.
+    /// database whose schema the failed migration has already part-changed. Oldest first, because
+    /// among live markers the earliest is the one that predates the most.
     /// </summary>
     [HumansFact]
-    public void Earliest_unfinished_snapshot_wins()
+    public void Unfinished_snapshots_come_back_oldest_first()
     {
         var first = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
-        Snapshot("humans-20260805T130000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        var second = Snapshot("humans-20260805T130000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
 
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().Be(first);
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().Equal(first, second);
     }
 
     /// <summary>
@@ -65,7 +66,7 @@ public sealed class PreMigrationSnapshotTests : IDisposable
     {
         Snapshot("humans-20260805T120000Z.dump.writing");
 
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().BeNull();
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().BeEmpty();
     }
 
     [HumansFact]
@@ -82,7 +83,7 @@ public sealed class PreMigrationSnapshotTests : IDisposable
     {
         Snapshot("humans_pr_42-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
 
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().BeNull();
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().BeEmpty();
     }
 
     [HumansFact]
@@ -95,7 +96,7 @@ public sealed class PreMigrationSnapshotTests : IDisposable
         promoted.Should().ContainSingle()
             .Which.Should().Be(Path.Combine(_directory, "humans-20260805T120000Z.dump"));
         File.Exists(promoted[0]).Should().BeTrue();
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().BeNull();
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().BeEmpty();
     }
 
     /// <summary>
@@ -110,8 +111,8 @@ public sealed class PreMigrationSnapshotTests : IDisposable
 
         PreMigrationSnapshot.PromoteUnfinishedSnapshots(_directory, Database);
 
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, Database).Should().BeNull();
-        PreMigrationSnapshot.FindUnfinishedSnapshot(_directory, "humans_pr_42").Should().NotBeNull();
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, Database).Should().BeEmpty();
+        PreMigrationSnapshot.UnfinishedSnapshots(_directory, "humans_pr_42").Should().NotBeEmpty();
     }
 
     /// <summary>
@@ -236,6 +237,64 @@ public sealed class PreMigrationSnapshotTests : IDisposable
 
         File.Exists(unfinished + ".migrations").Should().BeFalse();
     }
+
+    /// <summary>
+    /// A single live marker is what a crash-loop retry carries forward, and it is not retired.
+    /// </summary>
+    [HumansFact]
+    public void A_live_marker_is_carried_forward()
+    {
+        var live = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(live, ["HumansDbContext:20260805100000_AddFoo"]);
+
+        Sut().CarryForwardMarker(_directory, Database, ["HumansDbContext:20260805100000_AddFoo"])
+            .Should().Be(live);
+        File.Exists(live).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Every marker being stale is the ordinary "last deploy finished" case: all of them retire
+    /// and the boot goes on to take its own dump.
+    /// </summary>
+    [HumansFact]
+    public void All_markers_stale_means_this_boot_takes_its_own_dump()
+    {
+        var stale = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(stale, ["HumansDbContext:20260805100000_AddFoo"]);
+
+        Sut().CarryForwardMarker(_directory, Database, ["HumansDbContext:20260805200000_AddLater"])
+            .Should().BeNull();
+        File.Exists(stale).Should().BeFalse();
+        File.Exists(Path.Combine(_directory, "humans-20260805T120000Z.dump")).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A retirement that fails leaves its stale marker in front of the marker that is actually
+    /// live, so judging the oldest marker alone would retire the stale one, see nothing else, and
+    /// dump the half-migrated schema over the crash loop's real rollback point — which a later
+    /// boot then promotes as the newest completed snapshot. The scan steps past the stale marker
+    /// and finds the live one.
+    /// </summary>
+    [HumansFact]
+    public void A_stale_marker_in_front_of_a_live_one_is_stepped_over()
+    {
+        var stale = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(stale, ["HumansDbContext:20260805100000_AddFoo"]);
+        var live = Snapshot("humans-20260805T130000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(live, ["HumansDbContext:20260805200000_AddBar"]);
+
+        Sut().CarryForwardMarker(_directory, Database, ["HumansDbContext:20260805200000_AddBar"])
+            .Should().Be(live);
+        File.Exists(stale).Should().BeFalse();
+        File.Exists(live).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Connection string is never opened — <see cref="PreMigrationSnapshot"/> only parses it for
+    /// the database name, and everything under test here is filesystem bookkeeping.
+    /// </summary>
+    private static PreMigrationSnapshot Sut() =>
+        new($"Host=localhost;Database={Database};Username=humans", NullLogger.Instance);
 
     private string Snapshot(string fileName)
     {

--- a/tests/Humans.Application.Tests/Hosting/PreMigrationSnapshotTests.cs
+++ b/tests/Humans.Application.Tests/Hosting/PreMigrationSnapshotTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Humans.Infrastructure.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Humans.Application.Tests.Hosting;
 
@@ -124,7 +125,7 @@ public sealed class PreMigrationSnapshotTests : IDisposable
         PreMigrationSnapshot.WriteFrontier(unfinished, ["HumansDbContext:20260805100000_AddFoo"]);
 
         PreMigrationSnapshot.FrontierStillPending(
-            unfinished, ["HumansDbContext:20260805100000_AddFoo"]).Should().BeTrue();
+            unfinished, ["HumansDbContext:20260805100000_AddFoo"], NullLogger.Instance).Should().BeTrue();
     }
 
     /// <summary>
@@ -140,7 +141,7 @@ public sealed class PreMigrationSnapshotTests : IDisposable
             ["HumansDbContext:20260805100000_AddFoo", "HumansDbContext:20260805100001_AddBar"]);
 
         PreMigrationSnapshot.FrontierStillPending(
-            unfinished, ["HumansDbContext:20260805100001_AddBar"]).Should().BeTrue();
+            unfinished, ["HumansDbContext:20260805100001_AddBar"], NullLogger.Instance).Should().BeTrue();
     }
 
     /// <summary>
@@ -154,7 +155,9 @@ public sealed class PreMigrationSnapshotTests : IDisposable
         PreMigrationSnapshot.WriteFrontier(unfinished, ["HumansDbContext:20260805100000_AddFoo"]);
 
         PreMigrationSnapshot.FrontierStillPending(
-            unfinished, ["HumansDbContext:20260805200000_AddLaterMigration"]).Should().BeFalse();
+            unfinished,
+            ["HumansDbContext:20260805200000_AddLaterMigration"],
+            NullLogger.Instance).Should().BeFalse();
     }
 
     /// <summary>
@@ -167,7 +170,55 @@ public sealed class PreMigrationSnapshotTests : IDisposable
     {
         var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
 
-        PreMigrationSnapshot.FrontierStillPending(unfinished, []).Should().BeTrue();
+        PreMigrationSnapshot.FrontierStillPending(unfinished, [], NullLogger.Instance).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The sidecar is published by rename, so the name readers look for never exists half-written:
+    /// a write killed part-way through leaves only the temporary file, which nothing reads. A
+    /// short frontier read as authoritative is the damaging case — it can omit the migration that
+    /// is still pending and retire a marker that is this deploy's live rollback point.
+    /// </summary>
+    [HumansFact]
+    public void A_frontier_write_killed_half_way_is_never_read_as_the_frontier()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        File.WriteAllText(unfinished + ".migrations.writing", "HumansDbContext:2026080510");
+
+        PreMigrationSnapshot.FrontierStillPending(unfinished, [], NullLogger.Instance).Should().BeTrue();
+        File.Exists(unfinished + ".migrations").Should().BeFalse();
+    }
+
+    [HumansFact]
+    public void Publishing_a_frontier_leaves_no_temporary_file_behind()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+
+        PreMigrationSnapshot.WriteFrontier(unfinished, ["HumansDbContext:20260805100000_AddFoo"]);
+
+        File.Exists(unfinished + ".migrations.writing").Should().BeFalse();
+        File.ReadAllLines(unfinished + ".migrations")
+            .Should().Equal("HumansDbContext:20260805100000_AddFoo");
+    }
+
+    /// <summary>
+    /// A sidecar the volume will not give up must not abort the boot — the one failure a deploy
+    /// cannot recover from (<c>memory/architecture/no-startup-guards.md</c>). Unable to tell
+    /// whether the marker is stale, it carries forward like a marker with no sidecar at all.
+    /// </summary>
+    [HumansFact]
+    public void A_marker_whose_frontier_cannot_be_read_is_not_stale()
+    {
+        var unfinished = Snapshot("humans-20260805T120000Z.dump" + PreMigrationSnapshot.UnfinishedSuffix);
+        PreMigrationSnapshot.WriteFrontier(unfinished, ["HumansDbContext:20260805100000_AddFoo"]);
+
+        using var exclusive = new FileStream(
+            unfinished + ".migrations", FileMode.Open, FileAccess.Read, FileShare.None);
+
+        PreMigrationSnapshot.FrontierStillPending(
+            unfinished,
+            ["HumansDbContext:20260805200000_AddLaterMigration"],
+            NullLogger.Instance).Should().BeTrue();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes the gap left open in nobodies-collective/Humans#845 (shipped via peterdrier/Humans#1187): the `.unfinished` pre-migration snapshot marker recorded *that* a deploy hadn't finished migrating, but not *which* deploy. If `MarkMigrationsComplete()`'s rename failed (logged at Error but swallowed by design, since it must not fail a boot whose migrations already succeeded) and no restart happened before the next schema-changing deploy, that deploy would carry the stale marker forward and skip its own dump — leaving its rollback point older than the deploy it was meant to undo.

Refs nobodies-collective/Humans#989.

## What changed

- `DatabaseMigrationHostedService.StartingAsync` now collects the **frontier** — every migration pending across `HumansDbContext` and every section context, qualified by context type name — once, before any context applies anything. This is the part the issue calls out as "more than a one-liner": the snapshot is taken by whichever context migrates first, but the frontier has to span all of them.
- `PreMigrationSnapshot.EnsureCapturedAsync` now takes that frontier. When it finds a carried-forward `.unfinished` marker, it checks `FrontierStillPending`: if any of the marker's recorded migrations are still pending, it's a genuine crash-loop retry and gets carried forward exactly as before (the #845 guarantee, unregressed). If none are still pending, the deploy that took it finished — the marker is retired (renamed to drop the suffix, same as `MarkMigrationsComplete` does for the normal case) and a fresh dump is taken recording this deploy's own frontier.
- The frontier is persisted as a plain-text sidecar (`<dump>.unfinished.migrations`, one migration ID per line) next to the `.unfinished` dump, and cleaned up on promotion/retirement. A marker with no sidecar (taken before this fix shipped) fails safe as "still pending" — the same unconditional carry-forward the marker had before this existed.
- "Any recorded migration still pending" (not "all") — a partial application (migration 3 of 5 failing) still counts as unfinished. Covered by test.

## Reuse-first

No new files, interfaces, DTOs, or DI registrations. Extended the existing `PreMigrationSnapshot`/`DatabaseMigrationHostedService` pair from #845/#1187 in place:
- Extracted the rename+delete logic already used by `PromoteUnfinishedSnapshots` into a shared `Retire` helper, reused by both the normal completion path and the new stale-retirement path, instead of duplicating rename logic.
- No new interface method or service surface — this is internal hosting bookkeeping, not a section.

No EF migration — this issue is pure filesystem/hosting bookkeeping, no schema change.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx -v quiet` — full suite green (Domain 274, Analyzers 245, Web 377, Application 3976 incl. 7 new `PreMigrationSnapshotTests`, Integration 122 — 0 failures)
- New tests in `tests/Humans.Application.Tests/Hosting/PreMigrationSnapshotTests.cs`:
  - `A_marker_with_migrations_still_pending_is_not_stale` — crash-loop retry still carries forward
  - `A_marker_with_only_some_of_its_migrations_still_pending_is_not_stale` — partial application still counts as unfinished
  - `A_marker_whose_migrations_have_all_been_applied_is_stale` — the actual fix: all-applied → stale → retire
  - `A_marker_with_no_recorded_frontier_is_not_stale` — pre-#989 marker fails safe
  - `Promoting_a_marker_drops_its_frontier_sidecar` — no orphan sidecar files after promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)