### PR TITLE
test(mailer): make the clamped-Retry-After test ordering-driven, not timed

### DIFF
--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
@@ -58,10 +58,12 @@ public class MailerLiteClientRetryTests
         handler.EnqueueJson(HttpStatusCode.OK, HumansGroupPage);
         handler.Enqueue429(retryAfterSeconds: 86400); // a day — clock skew / malformed header
         var logger = new CapturingLogger<MailerLiteClient>();
-        var client = NewClient(handler, logger);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(
             Xunit.TestContext.Current.CancellationToken);
-        cts.CancelAfter(TimeSpan.FromMilliseconds(250)); // don't sit out the (clamped) delay
+        // Cancel the instant the retry warning is written, so the client reaches its
+        // clamped 90s Task.Delay with an already-cancelled token. Ordering, not wall
+        // clock: a loaded runner can no longer cancel before the warning exists.
+        var client = NewClient(handler, new CancelOnRetryWarningLogger(logger, cts));
 
         var act = async () => await client.AssignSubscriberToGroupAsync("sub-1", "42", cts.Token);
 
@@ -75,6 +77,32 @@ public class MailerLiteClientRetryTests
         new(new StubHttpClientFactory(handler),
             NodaTime.SystemClock.Instance,
             logger ?? NullLogger<MailerLiteClient>.Instance);
+
+    // Forwards everything to the capturing logger, then cancels once the 429 retry
+    // warning has been recorded — the deterministic trigger the timed budget was
+    // standing in for.
+    private sealed class CancelOnRetryWarningLogger(
+        CapturingLogger<MailerLiteClient> inner, CancellationTokenSource cts)
+        : ILogger<MailerLiteClient>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            => inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => inner.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            inner.Log(logLevel, eventId, state, exception, formatter);
+            if (logLevel == LogLevel.Warning
+                && formatter(state, exception).Contains("retrying in", StringComparison.Ordinal))
+                cts.Cancel();
+        }
+    }
 
     private sealed class ScriptedHandler : HttpMessageHandler
     {


### PR DESCRIPTION
Fixes nobodies-collective/Humans#982

`MailerLiteClientRetryTests.AssignSubscriberToGroupAsync_ClampsAbsurdRetryAfter_ToCeiling` armed `cts.CancelAfter(250ms)` up front, but the client must complete three handler round-trips (two cache-populate calls, then the 429) before it logs `retrying in 90s`. On a loaded runner those exceed 250 ms, the token cancels first, and the test fails with "the collection is empty" — green and red on identical code (runs `31019573457` vs `31020027058`).

## Change

The cancel trigger moves from a wall-clock timer to the log write itself. A test-local `CancelOnRetryWarningLogger` forwards to the existing `CapturingLogger<T>` and cancels once it sees the retry warning. The client then hits `await Task.Delay(retryAfter, ct)` with an already-cancelled token and throws immediately.

Both assertions keep their original meaning: the `OperationCanceledException` still proves the clamped delay was still pending, and the log entry still proves 86400s clamped to 90s.

## Why not the alternatives

- **Raising the 250 ms budget** — makes the race rarer, not impossible, and leaves the confusing failure mode. `peters-hard-rules.md` rules out that kind of surgical fix.
- **Cancelling from `ScriptedHandler` when it serves the 429** (the issue's first suggestion) — the client wraps `http.SendAsync` in `catch (TaskCanceledException) when (!ct.IsCancellationRequested)`, so if `HttpClient` observes the cancellation on the way out of the handler the call throws *before* line 287 logs, reproducing the original failure by a different route. Triggering off the log removes that dependency on `HttpClient` internals.
- **Injecting `TimeProvider`** — introduces a second time abstraction alongside the NodaTime `IClock` the client already takes. The issue flags it as a conscious decision, not a default; not needed here.

## Reuse-first

`CapturingLogger<T>` is reused as-is and not modified — it is shared with `AuditLogServiceTests`. The decorator is a private nested class in the one test file that needs it: no new file, no new public or internal surface.

The two sibling tests in the file use `retryAfterSeconds: 0` and no timer, so they do not have this shape.

## Verification

`dotnet test --filter MailerLiteClientRetryTests` — 3 passed, 5 consecutive runs, ~94 ms each (was >250 ms for the one test alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)