### PR TITLE
fix(agent): stop diluting the latency panel with untimed rows

### DIFF
--- a/src/Humans.Application/Models/AgentAdminStatus.cs
+++ b/src/Humans.Application/Models/AgentAdminStatus.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Enums;
 using NodaTime;
 
 namespace Humans.Application.Models;
@@ -14,6 +15,7 @@ public sealed record AgentStatusMessageRow(
     Guid ConversationId,
     Guid UserId,
     Instant CreatedAt,
+    AgentRole Role,
     int PromptTokens,
     int OutputTokens,
     int CachedTokens,

--- a/src/Humans.Application/Services/Agent/AgentAdminStatusService.cs
+++ b/src/Humans.Application/Services/Agent/AgentAdminStatusService.cs
@@ -116,7 +116,10 @@ public sealed class AgentAdminStatusService(
 
         var cacheBase = prompt + cached;
         var cacheRatio = cacheBase > 0 ? (double)cached / cacheBase : 0.0;
-        var avgMs = messageCount > 0 ? (int)durations.Average() : 0;
+        // Guard on the sample list, not messageCount: a window can hold rows that all fail
+        // the timed-turn filter above (user rows only, or nothing but refusals), leaving
+        // messageCount positive and durations empty — Average() throws on empty.
+        var avgMs = durations.Count > 0 ? (int)durations.Average() : 0;
         var p95Ms = Percentile(durations, 0.95);
 
         return new AgentUsageStats(

--- a/src/Humans.Application/Services/Agent/AgentAdminStatusService.cs
+++ b/src/Humans.Application/Services/Agent/AgentAdminStatusService.cs
@@ -2,6 +2,7 @@ using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Stores;
 using Humans.Application.Models;
+using Humans.Domain.Enums;
 using NodaTime;
 
 namespace Humans.Application.Services.Agent;
@@ -92,6 +93,7 @@ public sealed class AgentAdminStatusService(
     {
         // Rows are CreatedAt-desc; early-stop once outside `since`.
         long prompt = 0, output = 0, cached = 0;
+        var messageCount = 0;
         var durations = new List<int>();
         var uniqueUsers = new HashSet<Guid>();
 
@@ -101,11 +103,17 @@ public sealed class AgentAdminStatusService(
             prompt += r.PromptTokens;
             output += r.OutputTokens;
             cached += r.CachedTokens;
-            durations.Add(r.DurationMs);
+            messageCount++;
+            // Latency panel measures completed turns only. User rows carry no duration at
+            // all, and refusal/error rows (rate_limited, abuse_flag, "error" traces) never
+            // finished a timed provider turn — their DurationMs is a structural 0, not a
+            // real sample. Mixing either into the average/percentile dilutes both toward
+            // roughly half the real figure (nobodies-collective/Humans#990).
+            if (r.Role == AgentRole.Assistant && string.IsNullOrEmpty(r.RefusalReason))
+                durations.Add(r.DurationMs);
             uniqueUsers.Add(r.UserId);
         }
 
-        var messageCount = durations.Count;
         var cacheBase = prompt + cached;
         var cacheRatio = cacheBase > 0 ? (double)cached / cacheBase : 0.0;
         var avgMs = messageCount > 0 ? (int)durations.Average() : 0;

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -171,8 +171,15 @@ public sealed class AgentService : IAgentService
                         _logger.LogError(turnFailure,
                             "Agent turn failed before completion for conversation {ConversationId}", conversation.Id);
                     }
+                    // Bill the failed turn's real usage, not zeros — the same totals
+                    // AppendFailureMessage/_rateLimit.Record use below, so this streamed
+                    // frame agrees with what got persisted and billed instead of telling
+                    // /Agent/Ask consumers the turn cost nothing (nobodies-collective/Humans#990).
                     yield return new AgentTurnToken(null, null,
-                        new AgentTurnFinalizer(0, 0, 0, 0, settings.Model, "error", conversation.Id));
+                        new AgentTurnFinalizer(
+                            turnUsage.PromptTokens, turnUsage.OutputTokens,
+                            turnUsage.CacheReadTokens, turnUsage.CacheCreationTokens,
+                            settings.Model, "error", conversation.Id));
                     yield break;
                 }
 

--- a/src/Humans.Infrastructure/Repositories/AgentRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/AgentRepository.cs
@@ -167,6 +167,7 @@ internal sealed class AgentRepository(AgentDbContext db, IClock clock) : IAgentR
                 m.ConversationId,
                 m.Conversation.UserId,
                 m.CreatedAt,
+                m.Role,
                 m.PromptTokens,
                 m.OutputTokens,
                 m.CachedTokens,

--- a/tests/Humans.Application.Tests/Agent/AgentAdminStatusServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentAdminStatusServiceTests.cs
@@ -108,6 +108,32 @@ public class AgentAdminStatusServiceTests
     }
 
     [HumansFact]
+    public async Task Latency_panel_reports_zero_when_the_window_holds_no_completed_turn()
+    {
+        // Decoupling MessageCount from the duration sample made an empty sample reachable
+        // with a positive message count: a window of nothing but user rows and refusals.
+        // Averaging that empty sample throws, so the guard reads durations, not messages.
+        await using var db = InMemoryDb();
+        var now = Instant.FromUtc(2026, 5, 17, 12, 0);
+        var clock = new FakeClock(now);
+
+        var user1 = Guid.NewGuid();
+        var conv = SeedConversation(db, user1, now);
+
+        SeedMessage(db, conv.Id, now - Duration.FromMinutes(20), prompt: 10, output: 0, cached: 0,
+            role: AgentRole.User, durationMs: 0);
+        SeedMessage(db, conv.Id, now - Duration.FromMinutes(10), prompt: 0, output: 0, cached: 0,
+            role: AgentRole.Assistant, refusalReason: "rate_limited", durationMs: 0);
+        await db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var report = await BuildService(db, clock).GetStatusAsync(Xunit.TestContext.Current.CancellationToken);
+
+        report.Usage24h.MessageCount.Should().Be(2);
+        report.Usage24h.AverageTurnMs.Should().Be(0);
+        report.Usage24h.P95TurnMs.Should().Be(0);
+    }
+
+    [HumansFact]
     public async Task Balance_unavailable_when_admin_key_missing()
     {
         await using var db = InMemoryDb();

--- a/tests/Humans.Application.Tests/Agent/AgentAdminStatusServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentAdminStatusServiceTests.cs
@@ -67,6 +67,47 @@ public class AgentAdminStatusServiceTests
     }
 
     [HumansFact]
+    public async Task Latency_panel_excludes_user_rows_and_zero_duration_refusals()
+    {
+        // nobodies-collective/Humans#990: user rows carry no duration at all, and
+        // refusal/error rows (rate_limited, abuse_flag, "error" traces) are
+        // structural zeros — none of them represent a timed provider turn. Mixing
+        // them into AverageTurnMs/P95TurnMs dilutes both toward roughly half the
+        // real figure. Only completed (non-refused) assistant rows should count.
+        await using var db = InMemoryDb();
+        var now = Instant.FromUtc(2026, 5, 17, 12, 0);
+        var clock = new FakeClock(now);
+
+        var user1 = Guid.NewGuid();
+        var conv = SeedConversation(db, user1, now);
+
+        // Real, completed assistant turns — the only rows that should feed the average/p95.
+        SeedMessage(db, conv.Id, now - Duration.FromMinutes(30), prompt: 10, output: 5, cached: 0,
+            role: AgentRole.Assistant, durationMs: 1000);
+        SeedMessage(db, conv.Id, now - Duration.FromMinutes(20), prompt: 10, output: 5, cached: 0,
+            role: AgentRole.Assistant, durationMs: 2000);
+
+        // Dilution sources: a user row (no duration concept) and refusal/error assistant
+        // rows (DurationMs stamped 0 because the turn never reached/finished the provider).
+        SeedMessage(db, conv.Id, now - Duration.FromMinutes(31), prompt: 10, output: 0, cached: 0,
+            role: AgentRole.User, durationMs: 0);
+        SeedMessage(db, conv.Id, now - Duration.FromMinutes(10), prompt: 0, output: 0, cached: 0,
+            role: AgentRole.Assistant, refusalReason: "rate_limited", durationMs: 0);
+        SeedMessage(db, conv.Id, now - Duration.FromMinutes(5), prompt: 5, output: 3, cached: 0,
+            role: AgentRole.Assistant, refusalReason: "error", durationMs: 0);
+        await db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var report = await BuildService(db, clock).GetStatusAsync(Xunit.TestContext.Current.CancellationToken);
+
+        // Average/p95 computed only over the two real assistant turns (1000ms, 2000ms).
+        report.Usage24h.AverageTurnMs.Should().Be(1500);
+        report.Usage24h.P95TurnMs.Should().Be(2000);
+
+        // MessageCount still counts every row in the window (raw message volume), unaffected.
+        report.Usage24h.MessageCount.Should().Be(5);
+    }
+
+    [HumansFact]
     public async Task Balance_unavailable_when_admin_key_missing()
     {
         await using var db = InMemoryDb();
@@ -149,20 +190,21 @@ public class AgentAdminStatusServiceTests
 
     private static void SeedMessage(AgentDbContext db, Guid conversationId,
         Instant createdAt, int prompt, int output, int cached,
-        string[]? fetched = null, string? refusalReason = null)
+        string[]? fetched = null, string? refusalReason = null,
+        AgentRole role = AgentRole.Assistant, int durationMs = 1200)
     {
         db.AgentMessages.Add(new AgentMessage
         {
             Id = Guid.NewGuid(),
             ConversationId = conversationId,
-            Role = AgentRole.Assistant,
+            Role = role,
             Content = string.Empty,
             CreatedAt = createdAt,
             PromptTokens = prompt,
             OutputTokens = output,
             CachedTokens = cached,
             Model = "claude-sonnet-4-6",
-            DurationMs = 1200,
+            DurationMs = durationMs,
             FetchedDocs = fetched ?? [],
             RefusalReason = refusalReason,
         });

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -580,6 +580,11 @@ public class AgentServiceTests
         finalizer!.StopReason.Should().Be("error");
         finalizer.ConversationId.Should().NotBe(Guid.Empty,
             "the client must be able to continue the same conversation after a failed turn");
+        // nobodies-collective/Humans#990: the streamed error frame must agree with what got
+        // persisted and billed below, not hardcode zeros — that was a contract inconsistency
+        // between three surfaces (SSE finalizer, AgentMessage row, rate-limit billing).
+        finalizer.InputTokens.Should().Be(100);
+        finalizer.OutputTokens.Should().Be(20);
 
         var transcript = await svc.GetConversationForUserAsync(
             userId, finalizer.ConversationId, Xunit.TestContext.Current.CancellationToken);


### PR DESCRIPTION
## Problem

`AgentAdminStatusService.BuildUsage` fed **every** row from `ListMessagesSinceAsync` into `AverageTurnMs`/`P95TurnMs`, with no filter on role or on whether the row represents a completed timed turn. User rows carry no duration concept at all, and refusal/error rows (`rate_limited`, `abuse_flag`, and the `error` trace added by #1179) are structural `DurationMs = 0` — they never reached or finished a provider turn. With one user + one assistant row per normal turn, roughly half the samples were zeros, pulling both figures toward about half the real value.

## Fix

- Added `Role` to `AgentStatusMessageRow` (projected in `AgentRepository.ListMessagesSinceAsync`) and filter the duration sample in `BuildUsage` to `Role == Assistant && RefusalReason is null` — the issue's own "most likely" suggested direction.
- `MessageCount` is left counting every row in the window, unchanged. The admin table column is literally labeled "Messages," and no consumer expects the row-per-turn reading — changing its meaning would be a separate, undiscussed decision. Flagging this explicitly per the issue's ask to confirm before changing it.
- Also fixed the third accounting surface flagged in the issue comments: `AskAsync`'s SSE error finalizer hardcoded `InputTokens`/`OutputTokens`/`CacheReadTokens`/`CacheCreationTokens` to `0`, disagreeing with the `AgentMessage` row and rate-limit billing that already record the real `turnUsage` for the same failed turn. Now populated from that same in-scope accumulator.

## Explicitly out of scope

The issue's "Secondary, latent" item (`AgentToolDispatcher.DispatchAsync` / `AgentService.ParseIssueProposalArgs` catching only `JsonException` when `TryGetProperty` can also throw `InvalidOperationException` on valid-but-non-object JSON) is left alone — the issue itself characterizes it as "not known to be reachable in practice... robustness, not a live bug," and it's an unrelated code path from the latency panel this issue is about.

## Reuse-first

Extended the existing `AgentStatusMessageRow` DTO with one field rather than adding a new projection/interface — same pattern as `read-model-enrichment`. No new files, types, interfaces, or DI registrations.

## Tests

- `Latency_panel_excludes_user_rows_and_zero_duration_refusals` (new) — mixes real assistant turns with a user row and two zero-duration refusal/error rows in the same window; asserts `AverageTurnMs`/`P95TurnMs` reflect only the real turns while `MessageCount` still counts all five.
- Extended `Ask_persists_an_assistant_message_when_an_exception_escapes_the_turn` to assert the SSE error finalizer's `InputTokens`/`OutputTokens` match the billed usage instead of zero.
- Full suite green: `dotnet test Humans.slnx -v quiet` — 4995 passed, 0 failed, 4 skipped.

nobodies-collective/Humans#990