### PR TITLE
test(search): cover SearchService/SearchController; move the privacy guarantee onto the destination page

### DIFF
--- a/docs/features/global/global-search.md
+++ b/docs/features/global/global-search.md
@@ -80,11 +80,13 @@ The feature is deliberately scoped to matching **confined to each entity's own p
 **Acceptance Criteria:**
 - The Teams, Camps and Rotas buckets treat a parseable GUID as an id lookup and skip the visibility filters in US-GS.4 — the hit comes back for a hidden team, a non-public camp season, or a rota hidden from volunteers.
 - Humans are unconditionally GUID-resolvable: there are no hidden users.
-- The hit is scored as an exact match and its URL is the entity's normal detail page. Opening that page re-runs the page's own access checks, so a viewer without a stake in it gets an error, not the page.
+- The hit is scored as an exact match and its URL is the entity's normal detail page. Opening that page re-runs the page's own access checks, so a viewer without a stake in it gets an error, not the page — except for `/Camps/{slug}`, which does not yet gate on season status (see Authorization Model).
 
 ## Authorization Model
 
 `/Search` is gated by `[Authorize]` — anonymous viewers can't reach it. Beyond that, **search is not an authorization boundary**: a hit says a URL exists, not that the caller may open it. Visibility is enforced at the destination page (ruling on nobodies-collective/Humans#985, 2026-08-07). Text queries are still filtered to the public surface per US-GS.4; the GUID path in US-GS.5 is deliberately unfiltered, because you can only use it if you already hold the id.
+
+That destination-page guarantee has one known hole: `CampController.Details` (and `SeasonDetails`) has no season-status gate, so a camp whose public-year season is `Pending`, `Rejected` or `Withdrawn` renders its detail page to anyone, signed-out included. Tracked as nobodies-collective/Humans#993; `CampControllerTests.Details_NonPublicSeason_AnonymousViewer_IsRefused` is skipped until that lands.
 
 There is no scope parameter on `ISearchService` and no role check in `SearchController`.
 

--- a/docs/features/global/global-search.md
+++ b/docs/features/global/global-search.md
@@ -81,6 +81,7 @@ The feature is deliberately scoped to matching **confined to each entity's own p
 - The Teams, Camps and Rotas buckets treat a parseable GUID as an id lookup and skip the visibility filters in US-GS.4 — the hit comes back for a hidden team, a non-public camp season, or a rota hidden from volunteers.
 - Humans are the exception: the id path skips only the `PersonSearchFields` mask, not the eligibility gate. `CachingUserService.SearchUsersAsync` requires `Profile is not null && Profile.RejectedAt is null` on the GUID branch exactly as it does per-row on the text branch, so a profile-less or rejected user resolves to nothing either way.
 - The hit is scored as an exact match and its URL is the entity's normal page. Opening it re-runs that page's own access checks — a detail page refuses (`/Teams/{slug}` 404s a hidden team), and a rota's `/Shifts?departmentId={teamId}` listing opens but omits the hidden rota. `/Camps/{slug}` is the one that does not yet hold up its end (see Authorization Model).
+- Rotas carry one further exception, and it is about reach rather than visibility. The GUID branch of `ShiftManagementService.SearchAsync` has no event filter, but `/Shifts` always builds from the active event — so a rota belonging to a **past** event resolves to a link that cannot show it, even when it is volunteer-visible. Tracked as nobodies-collective/Humans#998. The text branch does not have this problem: it is already scoped to the active event.
 
 ## Authorization Model
 

--- a/docs/features/global/global-search.md
+++ b/docs/features/global/global-search.md
@@ -79,12 +79,12 @@ The feature is deliberately scoped to matching **confined to each entity's own p
 
 **Acceptance Criteria:**
 - The Teams, Camps and Rotas buckets treat a parseable GUID as an id lookup and skip the visibility filters in US-GS.4 — the hit comes back for a hidden team, a non-public camp season, or a rota hidden from volunteers.
-- Humans are unconditionally GUID-resolvable: there are no hidden users.
-- The hit is scored as an exact match and its URL is the entity's normal detail page. Opening that page re-runs the page's own access checks, so a viewer without a stake in it gets an error, not the page — except for `/Camps/{slug}`, which does not yet gate on season status (see Authorization Model).
+- Humans are the exception: the id path skips only the `PersonSearchFields` mask, not the eligibility gate. `CachingUserService.SearchUsersAsync` requires `Profile is not null && Profile.RejectedAt is null` on the GUID branch exactly as it does per-row on the text branch, so a profile-less or rejected user resolves to nothing either way.
+- The hit is scored as an exact match and its URL is the entity's normal page. Opening it re-runs that page's own access checks — a detail page refuses (`/Teams/{slug}` 404s a hidden team), and a rota's `/Shifts?departmentId={teamId}` listing opens but omits the hidden rota. `/Camps/{slug}` is the one that does not yet hold up its end (see Authorization Model).
 
 ## Authorization Model
 
-`/Search` is gated by `[Authorize]` — anonymous viewers can't reach it. Beyond that, **search is not an authorization boundary**: a hit says a URL exists, not that the caller may open it. Visibility is enforced at the destination page (ruling on nobodies-collective/Humans#985, 2026-08-07). Text queries are still filtered to the public surface per US-GS.4; the GUID path in US-GS.5 is deliberately unfiltered, because you can only use it if you already hold the id.
+`/Search` is gated by `[Authorize]` — anonymous viewers can't reach it. Beyond that, **search is not an authorization boundary**: a hit says a URL exists, not that the caller may open it. Visibility is enforced at the destination, in whatever shape that destination has — a detail page refuses outright, a listing page renders and omits the row (ruling on nobodies-collective/Humans#985, 2026-08-07). Text queries are still filtered to the public surface per US-GS.4; the GUID path in US-GS.5 is deliberately unfiltered, because you can only use it if you already hold the id.
 
 That destination-page guarantee has one known hole: `CampController.Details` (and `SeasonDetails`) has no season-status gate, so a camp whose public-year season is `Pending`, `Rejected` or `Withdrawn` renders its detail page to anyone, signed-out included. Tracked as nobodies-collective/Humans#993; `CampControllerTests.Details_NonPublicSeason_AnonymousViewer_IsRefused` is skipped until that lands.
 

--- a/docs/features/global/global-search.md
+++ b/docs/features/global/global-search.md
@@ -60,9 +60,9 @@ The feature is deliberately scoped to matching **confined to each entity's own p
 - **Events** match on `Event.Title` or `Event.Description` and are filtered to `Status = Approved` only. Events are the one deliberate exception to matching on the name/title field alone: the orchestrator reuses `IEventServiceRead.GetApprovedEventsAsync` (the same call the public Browse page makes), which filters Title + Description with ILike, because event copy is short and free-form so description text is often the load-bearing name signal users remember. Rows are still scored by Title via the standard exact/prefix/contains rubric; rows that only matched via Description fall through to a contains-tier score so they're still surfaced (just ranked below title hits).
 - Humans, Teams, and Camps match in-memory against the cached snapshots (`CachingUserService` / `CachingTeamService` / `CachingCampService`) — case-insensitive contains, accent-folded for humans; search never hits the DB for these buckets. Shifts and Events still run case-insensitive Postgres `EF.Functions.ILike` at the DB layer per `memory/feedback_ef_ilike_not_toupper.md`.
 
-### US-GS.4: Search surfaces the public-visibility set, never more
+### US-GS.4: A text query surfaces the public-visibility set, never more
 **As an** authenticated viewer (any role)
-**I want** search to surface only what a regular volunteer would see from list pages
+**I want** a name search to surface only what a regular volunteer would see from list pages
 **So that** the search affordance can't be a privilege escalation, and admins never see surprise data through this path
 
 **Acceptance Criteria:**
@@ -72,9 +72,21 @@ The feature is deliberately scoped to matching **confined to each entity's own p
 - Events are filtered to `Status = Approved`; submissions in `Draft`, `Pending`, `Rejected`, `ResubmitRequested`, or `Withdrawn` are never returned, matching the public `/Events/Browse` surface.
 - Admin-only profile fields (verified emails, non-public ContactFields) are never returned through `/Search`, regardless of role. Admins use the existing per-section admin pages (`/Teams` admin, `/Camps` admin, `/Users/Admin`) for privileged views.
 
+### US-GS.5: A GUID query resolves straight to the entity
+**As** someone who already holds an entity id (from a log line, an audit row, a support thread)
+**I want** pasting it into search to find that entity
+**So that** I don't have to know which section's admin page owns it
+
+**Acceptance Criteria:**
+- The Teams, Camps and Rotas buckets treat a parseable GUID as an id lookup and skip the visibility filters in US-GS.4 — the hit comes back for a hidden team, a non-public camp season, or a rota hidden from volunteers.
+- Humans are unconditionally GUID-resolvable: there are no hidden users.
+- The hit is scored as an exact match and its URL is the entity's normal detail page. Opening that page re-runs the page's own access checks, so a viewer without a stake in it gets an error, not the page.
+
 ## Authorization Model
 
-`/Search` is gated by `[Authorize]` — anonymous viewers can't reach it. Beyond that, **every authenticated viewer sees the same public-visibility surface**, regardless of role. There is no scope parameter on `ISearchService` and no role check in `SearchController`.
+`/Search` is gated by `[Authorize]` — anonymous viewers can't reach it. Beyond that, **search is not an authorization boundary**: a hit says a URL exists, not that the caller may open it. Visibility is enforced at the destination page (ruling on nobodies-collective/Humans#985, 2026-08-07). Text queries are still filtered to the public surface per US-GS.4; the GUID path in US-GS.5 is deliberately unfiltered, because you can only use it if you already hold the id.
+
+There is no scope parameter on `ISearchService` and no role check in `SearchController`.
 
 This is a deliberate descope. An earlier draft had a `SearchScope { Public, Admin }` parameter threaded through every search service that promoted `Admin` / `HumanAdmin` / `Board` callers to a wider surface (hidden teams, non-public camp seasons, admin-only profile fields). It was removed because:
 

--- a/src/Humans.Application/Interfaces/Search/ISearchService.cs
+++ b/src/Humans.Application/Interfaces/Search/ISearchService.cs
@@ -23,7 +23,10 @@ namespace Humans.Application.Interfaces.Search;
 /// <b>Search is not an authorization boundary.</b> A hit says a URL exists;
 /// it does not say the caller may open it. Visibility is enforced at the
 /// destination page, which re-runs its own access checks — so search may
-/// legitimately return a row that then 404s for that viewer.
+/// legitimately return a row that then 404s for that viewer. One
+/// destination does not yet hold up its end: <c>/Camps/{slug}</c> has no
+/// season-status gate, so a non-public season still renders
+/// (nobodies-collective/Humans#993).
 /// </para>
 ///
 /// <para>

--- a/src/Humans.Application/Interfaces/Search/ISearchService.cs
+++ b/src/Humans.Application/Interfaces/Search/ISearchService.cs
@@ -4,12 +4,13 @@ namespace Humans.Application.Interfaces.Search;
 
 /// <summary>
 /// Top-level search orchestrator for the global <c>/Search</c> page. Fans
-/// out to per-section service interfaces (<c>IProfileService</c>,
-/// <c>ITeamService</c>, <c>ICampService</c>, <c>IShiftManagementService</c>),
-/// each of which runs its own case-insensitive Postgres ILike query at the
-/// DB layer (<c>memory/feedback_ef_ilike_not_toupper.md</c>). The
-/// orchestrator scores and ranks within each type and returns four
-/// independently-ranked buckets — there is no cross-modal / relational
+/// out to per-section read interfaces (<c>IUserServiceRead</c>,
+/// <c>ITeamServiceRead</c>, <c>ICampServiceRead</c>,
+/// <c>IShiftManagementService</c>, <c>IEventServiceRead</c>), each of which
+/// resolves its own case-insensitive match — from a cached snapshot for
+/// teams/camps/humans, via Postgres ILike at the DB layer for rotas and
+/// events. The orchestrator scores and ranks within each type and returns
+/// five independently-ranked buckets — there is no cross-modal / relational
 /// expansion (see <c>docs/features/global/global-search.md</c>).
 ///
 /// <para>
@@ -19,11 +20,21 @@ namespace Humans.Application.Interfaces.Search;
 /// </para>
 ///
 /// <para>
-/// Every viewer sees the public-visibility surface: hidden teams,
-/// non-public camp seasons, admin-only rotas, and admin-only profile
-/// fields are excluded for everyone, regardless of role. Privileged
-/// search across those surfaces is out of scope for this iteration —
-/// admins use the existing per-section admin pages.
+/// <b>Search is not an authorization boundary.</b> A hit says a URL exists;
+/// it does not say the caller may open it. Visibility is enforced at the
+/// destination page, which re-runs its own access checks — so search may
+/// legitimately return a row that then 404s for that viewer.
+/// </para>
+///
+/// <para>
+/// Text queries match the public surface only: hidden teams, non-public camp
+/// seasons and admin-only rotas never match by name, and humans are matched
+/// with <c>PersonSearchFields.PublicAll</c>, so admin-only profile fields
+/// match for nobody regardless of role. A <b>GUID</b> query is deliberately
+/// different — the Team, Camp and Rota buckets resolve it straight to the
+/// entity with no visibility filter. That is a routing convenience for
+/// someone who already holds the id, not an authorization statement. Humans
+/// are unconditionally GUID-resolvable: there are no hidden users.
 /// </para>
 /// </summary>
 public interface ISearchService : IApplicationService

--- a/src/Humans.Application/Interfaces/Search/ISearchService.cs
+++ b/src/Humans.Application/Interfaces/Search/ISearchService.cs
@@ -27,9 +27,12 @@ namespace Humans.Application.Interfaces.Search;
 /// listing renders and omits the row, since a rota hit links to
 /// <c>/Shifts?departmentId={teamId}</c>, whose default browse query drops
 /// rotas hidden from volunteers. Either way the viewer does not get the
-/// thing. One destination does not yet hold up its end:
-/// <c>/Camps/{slug}</c> has no season-status gate, so a non-public season
-/// still renders (nobodies-collective/Humans#993).
+/// thing. Two destinations fall short. <c>/Camps/{slug}</c> has no
+/// season-status gate, so a non-public season still renders
+/// (nobodies-collective/Humans#993). And a rota from a <i>past</i> event
+/// resolves by id but <c>/Shifts</c> only ever builds the active event, so
+/// that link cannot reach it even when it is volunteer-visible
+/// (nobodies-collective/Humans#998) — a reach problem, not a privacy one.
 /// </para>
 ///
 /// <para>

--- a/src/Humans.Application/Interfaces/Search/ISearchService.cs
+++ b/src/Humans.Application/Interfaces/Search/ISearchService.cs
@@ -21,12 +21,15 @@ namespace Humans.Application.Interfaces.Search;
 ///
 /// <para>
 /// <b>Search is not an authorization boundary.</b> A hit says a URL exists;
-/// it does not say the caller may open it. Visibility is enforced at the
-/// destination page, which re-runs its own access checks — so search may
-/// legitimately return a row that then 404s for that viewer. One
-/// destination does not yet hold up its end: <c>/Camps/{slug}</c> has no
-/// season-status gate, so a non-public season still renders
-/// (nobodies-collective/Humans#993).
+/// it does not say the caller may open it. Enforcement lives at the
+/// destination, in whatever shape that destination has: a detail page
+/// refuses outright — <c>/Teams/{slug}</c> 404s a hidden team — while a
+/// listing renders and omits the row, since a rota hit links to
+/// <c>/Shifts?departmentId={teamId}</c>, whose default browse query drops
+/// rotas hidden from volunteers. Either way the viewer does not get the
+/// thing. One destination does not yet hold up its end:
+/// <c>/Camps/{slug}</c> has no season-status gate, so a non-public season
+/// still renders (nobodies-collective/Humans#993).
 /// </para>
 ///
 /// <para>
@@ -37,7 +40,10 @@ namespace Humans.Application.Interfaces.Search;
 /// different — the Team, Camp and Rota buckets resolve it straight to the
 /// entity with no visibility filter. That is a routing convenience for
 /// someone who already holds the id, not an authorization statement. Humans
-/// are unconditionally GUID-resolvable: there are no hidden users.
+/// are the exception: the id path skips only the field mask, not the
+/// eligibility gate, so a user with no profile or a rejected one resolves
+/// to nothing by id exactly as by name
+/// (<c>CachingUserService.SearchUsersAsync</c>).
 /// </para>
 /// </summary>
 public interface ISearchService : IApplicationService

--- a/src/Humans.Web/Controllers/SearchController.cs
+++ b/src/Humans.Web/Controllers/SearchController.cs
@@ -9,7 +9,7 @@ using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
-/// <summary>Global search: matches each entity's own public fields (for humans: name + bio/city/interests/pronouns/contact) across humans/teams/camps/rotas/events, with no cross-modal traversal. Text queries match the public surface only; a GUID query resolves straight to the entity, and the destination page — not search — enforces visibility (docs/features/global/global-search.md).</summary>
+/// <summary>Global search: matches each entity's own public fields (for humans: name + bio/city/interests/pronouns/contact) across humans/teams/camps/rotas/events, with no cross-modal traversal. Text queries match the public surface only; a GUID query resolves straight to the entity, and the destination page — not search — enforces visibility (one known gap, nobodies-collective/Humans#993; docs/features/global/global-search.md).</summary>
 [Authorize]
 [Route("Search")]
 public sealed class SearchController(

--- a/src/Humans.Web/Controllers/SearchController.cs
+++ b/src/Humans.Web/Controllers/SearchController.cs
@@ -9,7 +9,7 @@ using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
-/// <summary>Global search: matches each entity's own public fields (for humans: name + bio/city/interests/pronouns/contact) across humans/teams/camps/rotas/events, with no cross-modal traversal. Public-visibility surface only (docs/features/global/global-search.md).</summary>
+/// <summary>Global search: matches each entity's own public fields (for humans: name + bio/city/interests/pronouns/contact) across humans/teams/camps/rotas/events, with no cross-modal traversal. Text queries match the public surface only; a GUID query resolves straight to the entity, and the destination page — not search — enforces visibility (docs/features/global/global-search.md).</summary>
 [Authorize]
 [Route("Search")]
 public sealed class SearchController(

--- a/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Xunit;
 
 namespace Humans.Application.Tests.Services;
 
@@ -367,7 +368,39 @@ public sealed class CachingCampServiceTests : ServiceTestHarness
             Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
-    private async Task<(Camp camp, CampSeason season)> SeedCampWithSeasonAsync(int year)
+    [HumansTheory]
+    [InlineData(CampSeasonStatus.Pending)]
+    [InlineData(CampSeasonStatus.Rejected)]
+    [InlineData(CampSeasonStatus.Withdrawn)]
+    public async Task SearchAsync_TextQuery_ExcludesNonPublicSeasonStatuses(CampSeasonStatus status)
+    {
+        // The ruling on nobodies-collective/Humans#985 narrowed the privacy guarantee to
+        // by-GUID lookups only — text queries are unchanged and still see Active/Full alone.
+        await SeedSettingsAsync(publicYear: 2026, openSeasons: [2026]);
+        await SeedCampWithSeasonAsync(year: 2026, status);
+
+        var results = await _service.SearchAsync(
+            "test camp", int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+
+        results.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_ResolvesACampWithANonPublicSeason()
+    {
+        // Routing convenience, not authorization: the caller already holds the camp id and
+        // /Camps/{slug} is where the decision belongs.
+        await SeedSettingsAsync(publicYear: 2026, openSeasons: [2026]);
+        var (camp, _) = await SeedCampWithSeasonAsync(year: 2026, CampSeasonStatus.Pending);
+
+        var results = await _service.SearchAsync(
+            camp.Id.ToString(), int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+
+        results.Should().ContainSingle().Which.Slug.Should().Be(camp.Slug);
+    }
+
+    private async Task<(Camp camp, CampSeason season)> SeedCampWithSeasonAsync(
+        int year, CampSeasonStatus status = CampSeasonStatus.Active)
     {
         var camp = new Camp
         {
@@ -384,7 +417,7 @@ public sealed class CachingCampServiceTests : ServiceTestHarness
             Id = Guid.NewGuid(),
             CampId = camp.Id,
             Year = year,
-            Status = CampSeasonStatus.Active,
+            Status = status,
             Name = "Test Camp",
             EeSlotCount = 5,
             BlurbLong = "A fun camp",

--- a/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
@@ -483,6 +483,73 @@ public sealed class CachingTeamServiceTests : ServiceTestHarness
             Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_ResolvesAHiddenTeam_BecauseTheDestinationPageEnforces()
+    {
+        // Ruling on nobodies-collective/Humans#985 (2026-08-07): a by-GUID hit is a routing
+        // convenience for someone who already holds the id, not an authorization statement.
+        // The pairing test below — GetTeamDetailAsync_HiddenTeam_NonPrivilegedViewer — is what
+        // makes that safe: /Teams/{slug} is where the hidden team is actually refused.
+        var hidden = SeedTeam("Kitchenette");
+        hidden.IsHidden = true;
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var results = await _service.SearchAsync(
+            hidden.Id.ToString(), int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+
+        results.Should().ContainSingle().Which.Name.Should().Be("Kitchenette");
+    }
+
+    [HumansFact]
+    public async Task GetTeamDetailAsync_HiddenTeam_NonPrivilegedViewer_ReturnsNull()
+    {
+        // Destination-page enforcement for the ruling above. TeamController.Details turns this
+        // null into NotFound(), so pasting a hidden team's GUID into /Search buys the caller a
+        // link and a 404 — never the page.
+        var viewer = SeedUser("Plain Human");
+        var hidden = SeedTeam("Kitchenette");
+        hidden.IsHidden = true;
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var detail = await _service.GetTeamDetailAsync(
+            hidden.Slug, viewer.Id, Xunit.TestContext.Current.CancellationToken);
+
+        detail.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetTeamDetailAsync_HiddenTeam_AnonymousViewer_ReturnsNull()
+    {
+        var hidden = SeedTeam("Kitchenette");
+        hidden.IsHidden = true;
+        hidden.IsPublicPage = true;
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var detail = await _service.GetTeamDetailAsync(
+            hidden.Slug, userId: null, Xunit.TestContext.Current.CancellationToken);
+
+        detail.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetTeamDetailAsync_HiddenTeam_TeamsAdmin_ReturnsTheDetail()
+    {
+        var admin = SeedUser("Teams Admin");
+        var hidden = SeedTeam("Kitchenette");
+        hidden.IsHidden = true;
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+        _roleAssignmentService.IsUserTeamsAdminAsync(admin.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+        _innerTeamService.GetPendingRequestsForTeamAsync(hidden.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TeamJoinRequestSnapshot>>([]));
+
+        var detail = await _service.GetTeamDetailAsync(
+            hidden.Slug, admin.Id, Xunit.TestContext.Current.CancellationToken);
+
+        detail.Should().NotBeNull();
+        detail.Team.Name.Should().Be("Kitchenette");
+    }
+
     private void SeedJoinRequest(Guid teamId, Guid userId)
     {
         var request = new TeamJoinRequest

--- a/tests/Humans.Application.Tests/Services/Search/SearchServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Search/SearchServiceTests.cs
@@ -272,8 +272,10 @@ public sealed class SearchServiceTests
     [HumansFact]
     public async Task SearchAsync_GuidQuery_AlsoAsksForPublicFieldsOnly()
     {
-        // There are no hidden users, so humans stay GUID-resolvable — but the id path must
-        // not widen the field mask on the way.
+        // The id path must not widen the field mask on the way. It skips only the mask:
+        // CachingUserService.SearchUsersAsync still requires a non-rejected profile on its
+        // GUID branch, so eligibility is unchanged — that gate is covered where it lives,
+        // not here, since this harness stubs IUserServiceRead.
         await Build().SearchAsync(Guid.NewGuid().ToString(), ct: TestContext.Current.CancellationToken);
 
         await _users.Received(1).SearchUsersAsync(

--- a/tests/Humans.Application.Tests/Services/Search/SearchServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Search/SearchServiceTests.cs
@@ -1,0 +1,409 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Events;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Profiles;
+using Humans.Application.Services.Search;
+using Microsoft.Extensions.Configuration;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Search;
+
+/// <summary>
+/// Orchestration tests for <see cref="SearchService"/> against substitutes for the five
+/// section read interfaces it fans out to. Two things are pinned here that no other test
+/// can see: the field mask the human bucket asks for (<see cref="PersonSearchFields.PublicAll"/>
+/// — the only search-time privacy filter this service owns), and the GUID short-circuit that
+/// scores an id paste as an exact match.
+///
+/// <para>
+/// Per the 2026-08-07 ruling on nobodies-collective/Humans#985, search is not an
+/// authorization boundary: a hit is a routing convenience and the destination page enforces
+/// visibility. The per-section text-query filters that this service depends on are pinned
+/// where they live — <c>CachingTeamServiceTests</c>, <c>CachingCampServiceTests</c>,
+/// <c>ShiftManagementServiceTests</c> and <c>ShiftRepositoryRotaSearchVisibilityTests</c>.
+/// </para>
+/// </summary>
+public sealed class SearchServiceTests
+{
+    private const int ScoreExact = 100;
+    private const int ScorePrefix = 80;
+    private const int ScoreContains = 60;
+
+    private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
+    private readonly ITeamServiceRead _teams = Substitute.For<ITeamServiceRead>();
+    private readonly ICampServiceRead _camps = Substitute.For<ICampServiceRead>();
+    private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
+    private readonly IEventServiceRead _events = Substitute.For<IEventServiceRead>();
+
+    public SearchServiceTests()
+    {
+        StubHumans(MakeHuman("Kitchen Sink"));
+        StubTeams(new TeamSearchHit("Kitchen", "kitchen"));
+        StubCamps(new CampSearchHit("kitchen-camp", "Kitchen"));
+        StubRotas(new RotaSearchHit("Kitchen", Guid.NewGuid(), "Cantina"));
+        StubEvents(MakeEvent("Kitchen Takeover", "Food"));
+    }
+
+    // ==========================================================================
+    // Query-length gate
+    // ==========================================================================
+
+    [HumansTheory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("a")]
+    [InlineData("  k  ")]
+    public async Task SearchAsync_QueryShorterThanTwoCharsAfterTrim_ReturnsEmpty_AndTouchesNoSection(string query)
+    {
+        var results = await Build().SearchAsync(query, ct: TestContext.Current.CancellationToken);
+
+        results.Query.Should().Be(query.Trim());
+        results.Humans.Should().BeEmpty();
+        results.Teams.Should().BeEmpty();
+        results.Camps.Should().BeEmpty();
+        results.Shifts.Should().BeEmpty();
+        results.Events.Should().BeEmpty();
+
+        await _users.DidNotReceive().SearchUsersAsync(
+            Arg.Any<string>(), Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _teams.DidNotReceive().SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _camps.DidNotReceive().SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _shifts.DidNotReceive().SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_TwoCharQuery_IsAtTheGateBoundary_AndFansOut()
+    {
+        await Build().SearchAsync("ki", ct: TestContext.Current.CancellationToken);
+
+        await _teams.Received(1).SearchAsync("ki", Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_TrimsQuery_BeforeFanOut_AndEchoesTheTrimmedForm()
+    {
+        var results = await Build().SearchAsync("  Kitchen  ", ct: TestContext.Current.CancellationToken);
+
+        results.Query.Should().Be("Kitchen");
+        await _teams.Received(1).SearchAsync("Kitchen", Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _camps.Received(1).SearchAsync("Kitchen", Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _shifts.Received(1).SearchAsync("Kitchen", Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // onlyType short-circuit
+    // ==========================================================================
+
+    [HumansTheory]
+    [InlineData(SearchResultType.Human)]
+    [InlineData(SearchResultType.Team)]
+    [InlineData(SearchResultType.Camp)]
+    [InlineData(SearchResultType.Shift)]
+    [InlineData(SearchResultType.Event)]
+    public async Task SearchAsync_OnlyType_QueriesThatSectionAndSkipsTheOtherFour(SearchResultType onlyType)
+    {
+        var results = await Build().SearchAsync("Kitchen", onlyType, TestContext.Current.CancellationToken);
+
+        results.Humans.Should().HaveCount(onlyType == SearchResultType.Human ? 1 : 0);
+        results.Teams.Should().HaveCount(onlyType == SearchResultType.Team ? 1 : 0);
+        results.Camps.Should().HaveCount(onlyType == SearchResultType.Camp ? 1 : 0);
+        results.Shifts.Should().HaveCount(onlyType == SearchResultType.Shift ? 1 : 0);
+        results.Events.Should().HaveCount(onlyType == SearchResultType.Event ? 1 : 0);
+
+        await _users.Received(onlyType == SearchResultType.Human ? 1 : 0).SearchUsersAsync(
+            Arg.Any<string>(), Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _teams.Received(onlyType == SearchResultType.Team ? 1 : 0).SearchAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _camps.Received(onlyType == SearchResultType.Camp ? 1 : 0).SearchAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _shifts.Received(onlyType == SearchResultType.Shift ? 1 : 0).SearchAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _events.Received(onlyType == SearchResultType.Event ? 1 : 0).GetApprovedEventsAsync(
+            Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<string?>(),
+            Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_NoOnlyType_QueriesEverySection()
+    {
+        var results = await Build().SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
+
+        results.Humans.Should().ContainSingle();
+        results.Teams.Should().ContainSingle();
+        results.Camps.Should().ContainSingle();
+        results.Shifts.Should().ContainSingle();
+        results.Events.Should().ContainSingle();
+    }
+
+    // ==========================================================================
+    // Score tiers and their boundaries
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SearchAsync_ScoresTeamNames_ExactThenPrefixThenContains_AndDropsNonMatches()
+    {
+        StubTeams(
+            new TeamSearchHit("Kitchen", "kitchen"),
+            new TeamSearchHit("Kitchen Crew", "kitchen-crew"),
+            new TeamSearchHit("Main Kitchen", "main-kitchen"),
+            new TeamSearchHit("Gate", "gate"));
+
+        var results = await Build().SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
+
+        results.Teams.Should().SatisfyRespectively(
+            exact => exact.Score.Should().Be(ScoreExact),
+            prefix => prefix.Score.Should().Be(ScorePrefix),
+            contains => contains.Score.Should().Be(ScoreContains));
+        results.Teams.Should().NotContain(r => r.Title == "Gate");
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_ScoringIsCaseInsensitive_SoCasingNeverDemotesAnExactMatch()
+    {
+        StubTeams(new TeamSearchHit("KITCHEN", "kitchen"));
+
+        var results = await Build().SearchAsync("kitchen", ct: TestContext.Current.CancellationToken);
+
+        results.Teams.Should().ContainSingle().Which.Score.Should().Be(ScoreExact);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_EmptyName_ScoresZero_AndIsDropped()
+    {
+        StubTeams(new TeamSearchHit(string.Empty, "nameless"));
+
+        var results = await Build().SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
+
+        results.Teams.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_ScoresAndBuildsUrls_ForCampAndRotaBucketsToo()
+    {
+        var teamId = Guid.NewGuid();
+        StubCamps(
+            new CampSearchHit("garden-of-joy", "Garden of Joy"),
+            new CampSearchHit("gate-camp", "Gate"));
+        StubRotas(
+            new RotaSearchHit("Garden", teamId, "Gardening"),
+            new RotaSearchHit("Perimeter", teamId, "Gate"));
+
+        var results = await Build().SearchAsync("Garden", ct: TestContext.Current.CancellationToken);
+
+        var camp = results.Camps.Should().ContainSingle().Subject;
+        camp.Score.Should().Be(ScorePrefix);
+        camp.Url.Should().Be("/Camps/garden-of-joy");
+        camp.Subtitle.Should().Be("garden-of-joy");
+
+        var rota = results.Shifts.Should().ContainSingle().Subject;
+        rota.Score.Should().Be(ScoreExact);
+        rota.Url.Should().Be($"/Shifts?departmentId={teamId}");
+        rota.Subtitle.Should().Be("Gardening");
+    }
+
+    // ==========================================================================
+    // The ruling: a GUID hit is a routing convenience, not an authorization statement
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_ReturnsTheTeamCampAndRotaHits_EvenThoughTheNameCannotMatch()
+    {
+        // Ruling (nobodies-collective/Humans#985, 2026-08-07): by-GUID lookups skip the
+        // visibility filter. The caller already holds the id; the destination page decides
+        // whether they may open it. Nothing here depends on the viewer's role — the service
+        // takes no viewer at all, so the hit comes back for admin and non-admin alike.
+        var id = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        StubTeams(new TeamSearchHit("Hidden Ops", "hidden-ops"));
+        StubCamps(new CampSearchHit("pending-camp", "Pending Camp"));
+        StubRotas(new RotaSearchHit("Admin Only Rota", teamId, "Gate"));
+
+        var results = await Build().SearchAsync(id.ToString(), ct: TestContext.Current.CancellationToken);
+
+        results.Teams.Should().ContainSingle().Which.Score.Should().Be(ScoreExact);
+        results.Camps.Should().ContainSingle().Which.Score.Should().Be(ScoreExact);
+        results.Shifts.Should().ContainSingle().Which.Score.Should().Be(ScoreExact);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_StillReturnsNothing_WhenTheSectionResolvedNoEntity()
+    {
+        StubTeams();
+        StubCamps();
+        StubRotas();
+
+        var results = await Build().SearchAsync(
+            Guid.NewGuid().ToString(), ct: TestContext.Current.CancellationToken);
+
+        results.Teams.Should().BeEmpty();
+        results.Camps.Should().BeEmpty();
+        results.Shifts.Should().BeEmpty();
+    }
+
+    // ==========================================================================
+    // The one search-time privacy filter this service owns
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SearchAsync_HumanBucket_AlwaysAsksForPublicFieldsOnly()
+    {
+        // The only privacy guarantee that survives the ruling at *search* time: admin-only
+        // profile fields (verified emails, non-public contact fields, legal names) are never
+        // matched, for anyone. SearchService takes no viewer, so "regardless of role" is
+        // structural — the mask is a constant, and this asserts the constant.
+        await Build().SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
+
+        await _users.Received(1).SearchUsersAsync(
+            "Kitchen", PersonSearchFields.PublicAll, Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _users.DidNotReceive().SearchUsersAsync(
+            Arg.Any<string>(),
+            Arg.Is<PersonSearchFields>(f =>
+                f.HasFlag(PersonSearchFields.Admin) || f.HasFlag(PersonSearchFields.LegalName)),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_AlsoAsksForPublicFieldsOnly()
+    {
+        // There are no hidden users, so humans stay GUID-resolvable — but the id path must
+        // not widen the field mask on the way.
+        await Build().SearchAsync(Guid.NewGuid().ToString(), ct: TestContext.Current.CancellationToken);
+
+        await _users.Received(1).SearchUsersAsync(
+            Arg.Any<string>(), PersonSearchFields.PublicAll, Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_PassesAnUnboundedCap_ToEverySection()
+    {
+        // No per-type cap at ~500-user scale: capping made people miss matches.
+        await Build().SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
+
+        await _users.Received(1).SearchUsersAsync(
+            Arg.Any<string>(), Arg.Any<PersonSearchFields>(), int.MaxValue, Arg.Any<CancellationToken>());
+        await _teams.Received(1).SearchAsync(Arg.Any<string>(), int.MaxValue, Arg.Any<CancellationToken>());
+        await _camps.Received(1).SearchAsync(Arg.Any<string>(), int.MaxValue, Arg.Any<CancellationToken>());
+        await _shifts.Received(1).SearchAsync(Arg.Any<string>(), int.MaxValue, Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // Features:Events flag
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SearchAsync_EventsFeatureOff_ReturnsNoEvents_AndNeverCallsTheEventsSection()
+    {
+        var results = await Build(eventsEnabled: false)
+            .SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
+
+        results.Events.Should().BeEmpty();
+        await _events.DidNotReceive().GetApprovedEventsAsync(
+            Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<string?>(),
+            Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_EventTitleMisses_FallsBackToTheContainsTier_SoDescriptionMatchesStillSurface()
+    {
+        // The Events bucket is filtered server-side on title OR description; a row that only
+        // matched the description scores 0 on Title and must not be dropped like a team would be.
+        StubEvents(
+            MakeEvent("Sunset Yoga", "Yoga"),
+            MakeEvent("Meditation Circle", "Wellbeing"));
+
+        var results = await Build().SearchAsync("Meditation", ct: TestContext.Current.CancellationToken);
+
+        results.Events.Should().SatisfyRespectively(
+            titleMatch =>
+            {
+                titleMatch.Title.Should().Be("Meditation Circle");
+                titleMatch.Score.Should().Be(ScorePrefix);
+            },
+            descriptionOnly =>
+            {
+                descriptionOnly.Title.Should().Be("Sunset Yoga");
+                descriptionOnly.Score.Should().Be(ScoreContains);
+            });
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_EventBucket_BuildsABrowseUrlEscapedForTheTitle()
+    {
+        StubEvents(MakeEvent("Fire & Ice", "Performance"));
+
+        var results = await Build().SearchAsync("Fire", ct: TestContext.Current.CancellationToken);
+
+        var hit = results.Events.Should().ContainSingle().Subject;
+        hit.Url.Should().Be("/Events/Browse?q=Fire%20%26%20Ice");
+        hit.Subtitle.Should().Be("Performance");
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private SearchService Build(bool eventsEnabled = true) =>
+        new(_users, _teams, _camps, _shifts, _events,
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    ["Features:Events"] = eventsEnabled ? "true" : "false"
+                })
+                .Build());
+
+    private void StubHumans(params HumanSearchResult[] hits) =>
+        _users.SearchUsersAsync(
+                Arg.Any<string>(), Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<HumanSearchResult>>(hits));
+
+    private void StubTeams(params TeamSearchHit[] hits) =>
+        _teams.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TeamSearchHit>>(hits));
+
+    private void StubCamps(params CampSearchHit[] hits) =>
+        _camps.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CampSearchHit>>(hits));
+
+    private void StubRotas(params RotaSearchHit[] hits) =>
+        _shifts.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<RotaSearchHit>>(hits));
+
+    private void StubEvents(params ApprovedEventView[] hits) =>
+        _events.GetApprovedEventsAsync(
+                Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<string?>(),
+                Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ApprovedEventView>>(hits));
+
+    private static HumanSearchResult MakeHuman(string burnerName) =>
+        new(Guid.NewGuid(), Guid.NewGuid(), burnerName, null, "Name", null, null, ScoreExact);
+
+    private static ApprovedEventView MakeEvent(string title, string categoryName) =>
+        new(
+            Guid.NewGuid(),
+            CampId: null,
+            GuideSharedVenueId: null,
+            SubmitterUserId: Guid.NewGuid(),
+            CategoryId: Guid.NewGuid(),
+            CategorySlug: categoryName.ToLowerInvariant(),
+            categoryName,
+            CategoryIsSensitive: false,
+            VenueName: null,
+            title,
+            Description: "Anything at all",
+            LocationNote: null,
+            Host: null,
+            StartAt: Instant.FromUtc(2026, 7, 4, 18, 0),
+            DurationMinutes: 60,
+            IsRecurring: false,
+            RecurrenceDays: null,
+            PriorityRank: 0,
+            SubmittedAt: Instant.FromUtc(2026, 6, 1, 12, 0),
+            LastUpdatedAt: Instant.FromUtc(2026, 6, 1, 12, 0));
+}

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
@@ -835,6 +835,27 @@ public sealed class ShiftManagementServiceTests : ServiceTestHarness
         results.Should().BeEmpty();
     }
 
+    [HumansFact]
+    public async Task GetBrowseShifts_HiddenRota_IsAbsentForAVolunteer_AndPresentForAPrivilegedViewer()
+    {
+        // Destination-page enforcement for the rota half of the nobodies-collective/Humans#985
+        // ruling. A GUID search hit links to /Shifts?departmentId={teamId}; the listing that
+        // page builds is a default ShiftBrowseQuery, which excludes rotas hidden from
+        // volunteers. ShiftBrowsePageBuilder only adds IncludeHidden for a privileged viewer.
+        var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
+        rota.IsVisibleToVolunteers = false;
+        SeedShift(rota, dayOffset: 1);
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var volunteerView = await _service.GetBrowseShiftsAsync(
+            new ShiftBrowseQuery(es.Id, rota.TeamId));
+        var privilegedView = await _service.GetBrowseShiftsAsync(
+            new ShiftBrowseQuery(es.Id, rota.TeamId, Flags: ShiftBrowseQueryFlags.IncludeHidden));
+
+        volunteerView.Should().BeEmpty();
+        privilegedView.Should().ContainSingle().Which.Shift.RotaId.Should().Be(rota.Id);
+    }
+
     private (EventSettings es, Rota rota) SeedRotaScenario(RotaPeriod period)
     {
         var es = new EventSettings

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
@@ -789,6 +789,52 @@ public sealed class ShiftManagementServiceTests : ServiceTestHarness
         Db.ShiftSignups.Add(signup);
     }
 
+    // ============================================================
+    // SearchAsync — global /Search rota bucket
+    // ============================================================
+
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_ResolvesARotaHiddenFromVolunteers()
+    {
+        // Ruling on nobodies-collective/Humans#985 (2026-08-07): the id path skips the
+        // visibility filter on purpose. The rota's destination — /Shifts?departmentId={teamId}
+        // — still builds its listing through the ExcludeHiddenRotas filter, so the hit is a
+        // link, not access. The text-query half of this pair needs Postgres ILike and lives in
+        // Humans.Integration.Tests/Repositories/Shifts/ShiftRepositoryRotaSearchTests.
+        var (_, rota) = SeedRotaScenario(RotaPeriod.Event);
+        rota.IsVisibleToVolunteers = false;
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var results = await _service.SearchAsync(
+            rota.Id.ToString(), int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+
+        var hit = results.Should().ContainSingle().Subject;
+        hit.Name.Should().Be("Test Rota");
+        hit.TeamId.Should().Be(rota.TeamId);
+        hit.TeamName.Should().Be("Test Department");
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_ReturnsNothing_WhenNoRotaHasThatId()
+    {
+        SeedRotaScenario(RotaPeriod.Event);
+        await Db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var results = await _service.SearchAsync(
+            Guid.NewGuid().ToString(), int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+
+        results.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_TextQuery_ReturnsNothing_WhenNoEventIsActive()
+    {
+        var results = await _service.SearchAsync(
+            "rota", int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+
+        results.Should().BeEmpty();
+    }
+
     private (EventSettings es, Rota rota) SeedRotaScenario(RotaPeriod period)
     {
         var es = new EventSettings

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -572,6 +572,7 @@ public class CachingUserServiceTests
         bool isApproved = true,
         bool isSuspended = false,
         bool isRejected = false,
+        bool hasProfile = true,
         IReadOnlyList<(string Email, bool IsVerified, bool IsPrimary)>? emails = null,
         IReadOnlyList<(string EventName, string? Description)>? volunteerHistory = null,
         IReadOnlyList<(ContactFieldType Type, string Value, ContactFieldVisibility Visibility)>? contactFields = null)
@@ -639,7 +640,7 @@ public class CachingUserServiceTests
             user, userEmails,
             eventParticipations: [],
             externalLogins: [],
-            profile, cfRows,
+            hasProfile ? profile : null, cfRows,
             profileLanguages: [],
             volunteerHistory: vhRows,
             communicationPreferences: []);
@@ -804,6 +805,35 @@ public class CachingUserServiceTests
         results.Should().HaveCount(1);
         results[0].UserId.Should().Be(userId);
         results[0].MatchField.Should().Be("User ID");
+    }
+
+    [HumansFact]
+    public async Task SearchUsersAsync_PublicAll_GuidQuery_ExcludesRejected()
+    {
+        // The by-id fast path skips the PersonSearchFields mask, which only governs which
+        // text fields are matched — it does NOT skip the eligibility gate. A rejected
+        // profile is as unresolvable by GUID as it is by name
+        // (SearchUsersAsync_PublicAll_ExcludesRejected), so the global-search ruling on
+        // nobodies-collective/Humans#985 never hands out a rejected human's id.
+        var userId = Guid.NewGuid();
+        var sut = CreateSut();
+        await PrimeAsync(sut, BuildSearchableUserInfo(userId, burnerName: "Alice", isRejected: true));
+
+        var results = await sut.SearchUsersAsync(userId.ToString(), PersonSearchFields.PublicAll, ct: Xunit.TestContext.Current.CancellationToken);
+
+        results.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task SearchUsersAsync_PublicAll_GuidQuery_ExcludesUserWithNoProfile()
+    {
+        var userId = Guid.NewGuid();
+        var sut = CreateSut();
+        await PrimeAsync(sut, BuildSearchableUserInfo(userId, burnerName: "Alice", hasProfile: false));
+
+        var results = await sut.SearchUsersAsync(userId.ToString(), PersonSearchFields.PublicAll, ct: Xunit.TestContext.Current.CancellationToken);
+
+        results.Should().BeEmpty();
     }
 
     [HumansFact]

--- a/tests/Humans.Integration.Tests/Repositories/Shifts/ShiftRepositoryRotaSearchTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/ShiftRepositoryRotaSearchTests.cs
@@ -1,0 +1,125 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Integration.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Integration.Tests.Repositories.Shifts;
+
+/// <summary>
+/// The admin-only-rota half of the global-search privacy guarantee. The filter is a
+/// Postgres <c>ILike</c> predicate, so it cannot be exercised against the in-memory
+/// provider the Application tests use — it needs the run's real PostgreSQL container.
+///
+/// <para>
+/// Per the ruling on nobodies-collective/Humans#985, a text query is still filtered:
+/// a rota with <c>IsVisibleToVolunteers = false</c> must never match by name for anyone.
+/// The by-GUID counterpart (which deliberately skips this filter) is pinned in
+/// <c>ShiftManagementServiceTests.SearchAsync_GuidQuery_ResolvesARotaHiddenFromVolunteers</c>.
+/// </para>
+/// </summary>
+public class ShiftRepositoryRotaSearchTests(HumansWebApplicationFactory factory)
+    : IntegrationTestBase(factory)
+{
+    [HumansFact]
+    public async Task SearchVolunteerVisibleRotasAsync_ExcludesRotasHiddenFromVolunteers()
+    {
+        await using var scope = Factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var sut = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
+
+        var es = await SeedActiveEventAsync(db);
+        var team = await SeedTeamAsync(db);
+        var token = $"Kitchen{Guid.NewGuid():N}";
+        await SeedRotaAsync(db, es, team, $"{token} Prep", visibleToVolunteers: true);
+        await SeedRotaAsync(db, es, team, $"{token} Admin", visibleToVolunteers: false);
+
+        var hits = await sut.SearchVolunteerVisibleRotasAsync(
+            token, es.Id, int.MaxValue, TestContext.Current.CancellationToken);
+
+        hits.Select(r => r.Name).Should().Equal($"{token} Prep");
+    }
+
+    [HumansFact]
+    public async Task SearchVolunteerVisibleRotasAsync_MatchesCaseInsensitively_WithinTheGivenEventOnly()
+    {
+        await using var scope = Factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var sut = scope.ServiceProvider.GetRequiredService<IShiftManagementRepository>();
+
+        var es = await SeedActiveEventAsync(db);
+        var otherEvent = await SeedActiveEventAsync(db);
+        var team = await SeedTeamAsync(db);
+        var token = $"Gate{Guid.NewGuid():N}";
+        await SeedRotaAsync(db, es, team, $"{token} Crew", visibleToVolunteers: true);
+        await SeedRotaAsync(db, otherEvent, team, $"{token} Crew", visibleToVolunteers: true);
+
+        var hits = await sut.SearchVolunteerVisibleRotasAsync(
+            token.ToUpperInvariant(), es.Id, int.MaxValue, TestContext.Current.CancellationToken);
+
+        hits.Should().ContainSingle().Which.EventSettingsId.Should().Be(es.Id);
+    }
+
+    private static async Task<EventSettings> SeedActiveEventAsync(HumansDbContext db)
+    {
+        var now = SystemClock.Instance.GetCurrentInstant();
+        var es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = $"RotaSearch-{Guid.NewGuid():N}",
+            Year = 2026,
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = new LocalDate(2026, 7, 1),
+            BuildStartOffset = -10,
+            EventEndOffset = 6,
+            StrikeEndOffset = 8,
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        db.EventSettings.Add(es);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return es;
+    }
+
+    private static async Task<Team> SeedTeamAsync(HumansDbContext db)
+    {
+        var now = SystemClock.Instance.GetCurrentInstant();
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = $"RotaSearch Team {Guid.NewGuid():N}",
+            Slug = $"rotasearch-{Guid.NewGuid():N}",
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        db.Teams.Add(team);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return team;
+    }
+
+    private static async Task SeedRotaAsync(
+        HumansDbContext db, EventSettings es, Team team, string name, bool visibleToVolunteers)
+    {
+        var now = SystemClock.Instance.GetCurrentInstant();
+        db.Rotas.Add(new Rota
+        {
+            Id = Guid.NewGuid(),
+            EventSettingsId = es.Id,
+            TeamId = team.Id,
+            Name = name,
+            Priority = ShiftPriority.Normal,
+            Policy = SignupPolicy.Public,
+            Period = RotaPeriod.Event,
+            IsVisibleToVolunteers = visibleToVolunteers,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
@@ -176,6 +176,27 @@ public class CampControllerTests
         vm.ActiveMembers.Single(m => m.UserId == fivePlusShiftMemberId).EventShiftSignupDisplay.Should().Be("5+");
     }
 
+    [HumansFact(Skip = "nobodies-collective/Humans#993 — /Camps/{slug} has no season-status gate, so a non-public season renders. Unskip with the fix.")]
+    public async Task Details_NonPublicSeason_AnonymousViewer_IsRefused()
+    {
+        // Destination-page half of the nobodies-collective/Humans#985 ruling: global search
+        // stops offering a camp once its public-year season leaves Active/Full, and the id
+        // path deliberately does not — so /Camps/{slug} has to be the enforcement point.
+        var pending = MakeCamp("pending-camp", "Pending Camp", CampSeasonStatus.Pending);
+        StubCampReadModel([pending]);
+        _camps.GetCampBySlugAsync(pending.Slug, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CampInfo?>(pending));
+        _authorization.AuthorizeAsync(
+                Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<object?>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Failed());
+
+        var result = await BuildController().Details(pending.Slug, Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
     private void StubCampReadModel(IReadOnlyList<CampInfo> camps)
     {
         _camps.GetSettingsAsync(Arg.Any<CancellationToken>())

--- a/tests/Humans.Web.Tests/Controllers/SearchControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/SearchControllerTests.cs
@@ -1,0 +1,186 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Search;
+using Humans.Application.Interfaces.Users;
+using Humans.Web.Controllers;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers;
+
+/// <summary>
+/// <see cref="SearchController"/> owns two things the service deliberately does not:
+/// display ordering (memory/architecture/display-sort-in-controllers.md) and view-model
+/// assembly. Everything else on this page is a pass-through, so that is what is pinned here.
+/// </summary>
+public sealed class SearchControllerTests
+{
+    private readonly ISearchService _search = Substitute.For<ISearchService>();
+    private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
+
+    [HumansTheory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("a")]
+    public async Task Index_QueryShorterThanTwoChars_RendersTheShell_WithoutSearching(string? query)
+    {
+        var vm = await IndexAsync(query, filter: null);
+
+        vm.Query.Should().Be(query);
+        vm.HumanResults.Should().BeEmpty();
+        vm.TeamResults.Should().BeEmpty();
+        vm.CampResults.Should().BeEmpty();
+        vm.ShiftResults.Should().BeEmpty();
+        vm.EventResults.Should().BeEmpty();
+        await _search.DidNotReceive().SearchAsync(
+            Arg.Any<string>(), Arg.Any<SearchResultType?>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Index_TrimsTheQuery_AndForwardsTheFilterToTheService()
+    {
+        StubResults(new GlobalSearchResults("Kitchen", [], [], [], [], []));
+
+        var vm = await IndexAsync("  Kitchen  ", SearchResultType.Team);
+
+        await _search.Received(1).SearchAsync("Kitchen", SearchResultType.Team, Arg.Any<CancellationToken>());
+        vm.Filter.Should().Be(SearchResultType.Team);
+        vm.Query.Should().Be("Kitchen");
+    }
+
+    [HumansFact]
+    public async Task Index_SortsEveryNonHumanBucket_ByScoreDescendingThenTitleAscending()
+    {
+        var teams = new[]
+        {
+            Hit(SearchResultType.Team, "beta", 60),
+            Hit(SearchResultType.Team, "Alpha", 60),
+            Hit(SearchResultType.Team, "Zulu", 100),
+        };
+        StubResults(new GlobalSearchResults(
+            "q", [], teams, Retype(teams, SearchResultType.Camp),
+            Retype(teams, SearchResultType.Shift), Retype(teams, SearchResultType.Event)));
+
+        var vm = await IndexAsync("query", filter: null);
+
+        // Title tiebreak is case-insensitive: "Alpha" must beat "beta" despite the lowercase b.
+        vm.TeamResults.Select(r => r.Title).Should().Equal("Zulu", "Alpha", "beta");
+        vm.CampResults.Select(r => r.Title).Should().Equal("Zulu", "Alpha", "beta");
+        vm.ShiftResults.Select(r => r.Title).Should().Equal("Zulu", "Alpha", "beta");
+        vm.EventResults.Select(r => r.Title).Should().Equal("Zulu", "Alpha", "beta");
+    }
+
+    [HumansFact]
+    public async Task Index_SortsHumans_ByRelevanceThenBurnerName()
+    {
+        StubResults(new GlobalSearchResults(
+            "ian",
+            [
+                Human("Adrian", 60),
+                Human("Brian", 60),
+                Human("Ian", 100),
+            ],
+            [], [], [], []));
+
+        var vm = await IndexAsync("ian", filter: null);
+
+        vm.HumanResults.Select(r => r.BurnerName).Should().Equal("Ian", "Adrian", "Brian");
+    }
+
+    [HumansFact]
+    public async Task Index_ProjectsEveryHumanField_OntoTheSharedPartialsViewModel()
+    {
+        var hit = new HumanSearchResult(
+            UserId: Guid.NewGuid(),
+            ProfileId: Guid.NewGuid(),
+            BurnerName: "Sparkle",
+            ProfilePictureUrl: "/uploads/profiles/sparkle.jpg",
+            MatchField: "Bio",
+            MatchSnippet: "…builds <em>kitchens</em>…",
+            MatchedEmail: null,
+            Score: 60);
+        StubResults(new GlobalSearchResults("kitchen", [hit], [], [], [], []));
+
+        var vm = await IndexAsync("kitchen", filter: null);
+
+        var row = vm.HumanResults.Should().ContainSingle().Subject;
+        row.UserId.Should().Be(hit.UserId);
+        row.BurnerName.Should().Be(hit.BurnerName);
+        row.ProfilePictureUrl.Should().Be(hit.ProfilePictureUrl);
+        row.MatchField.Should().Be(hit.MatchField);
+        row.MatchSnippet.Should().Be(hit.MatchSnippet);
+        row.MatchedEmail.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task Index_SearchThrows_RendersTheShellWithTheQueryPreserved_InsteadOfA500()
+    {
+        _search.SearchAsync(Arg.Any<string>(), Arg.Any<SearchResultType?>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("section down"));
+
+        var vm = await IndexAsync("kitchen", SearchResultType.Camp);
+
+        vm.Query.Should().Be("kitchen");
+        vm.Filter.Should().Be(SearchResultType.Camp);
+        vm.TeamResults.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task Index_RequestCancelled_PropagatesInsteadOfReturningA200Shell()
+    {
+        _search.SearchAsync(Arg.Any<string>(), Arg.Any<SearchResultType?>(), Arg.Any<CancellationToken>())
+            .Throws(new OperationCanceledException());
+
+        var act = async () => await BuildController().Index(
+            "kitchen", null, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private async Task<GlobalSearchViewModel> IndexAsync(string? query, SearchResultType? filter)
+    {
+        var result = await BuildController().Index(query, filter, TestContext.Current.CancellationToken);
+
+        return result.Should().BeOfType<ViewResult>().Subject
+            .Model.Should().BeOfType<GlobalSearchViewModel>().Subject;
+    }
+
+    private void StubResults(GlobalSearchResults results) =>
+        _search.SearchAsync(Arg.Any<string>(), Arg.Any<SearchResultType?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(results));
+
+    private SearchController BuildController()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var http = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        var controller = new SearchController(_search, _users, NullLogger<SearchController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = http }
+        };
+        controller.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        return controller;
+    }
+
+    private static GlobalSearchResult Hit(SearchResultType type, string title, int score) =>
+        new(type, title, $"{title}-subtitle", $"/{type}/{title}", score);
+
+    private static IReadOnlyList<GlobalSearchResult> Retype(
+        IReadOnlyList<GlobalSearchResult> hits, SearchResultType type) =>
+        hits.Select(h => h with { Type = type }).ToList();
+
+    private static HumanSearchResult Human(string burnerName, int score) =>
+        new(Guid.NewGuid(), Guid.NewGuid(), burnerName, null, "Name", null, null, score);
+}


### PR DESCRIPTION
Closes nobodies-collective/Humans#985.

`SearchService` and `SearchController` had zero test coverage, and `ISearchService`'s doc comment promised a privacy guarantee the code stopped making. This adds the coverage and rewrites the comment to match the ruling.

## The ruling

Per Peter's 2026-08-07 ruling on nobodies-collective/Humans#985, **search is not an authorization boundary**. A hit says a URL exists; the destination page decides whether the caller may open it. Text queries stay filtered to the public surface; a GUID query resolves straight to the entity, unfiltered, because you can only use it if you already hold the id. There are no hidden users, so humans are unconditionally GUID-resolvable.

The old comment said hidden teams, non-public camp seasons, admin-only rotas and admin-only profile fields were *"excluded for everyone, regardless of role."* That is now scoped to text queries, and the GUID carve-out is stated explicitly.

## What changed

**Production code — doc comments only.** No new types, interface methods, DTOs, endpoints or DI registrations.

- `ISearchService` — rewritten summary. Also corrected the stale fan-out list (it named `IProfileService`/`ITeamService`/`ICampService` and "four buckets"; it is five read interfaces and five buckets).
- `SearchController` — one-line summary updated to match.
- `docs/features/global/global-search.md` — US-GS.4 scoped to text queries, new US-GS.5 for the GUID path, authorization model reframed.

**New tests**

- `SearchServiceTests` (24 tests) — mocks all five injected read interfaces. Query-length gate and its 2-char boundary, trim-before-fan-out, `onlyType` short-circuit across all five types, exact/prefix/contains score tiers and their zero-score drop, case-insensitivity, camp/rota URL construction, the `Features:Events` flag, the events description-only contains-tier fallback, and the unbounded per-section cap.
- `SearchControllerTests` (10 tests) — per-bucket score-desc-then-title-asc sort (with the case-insensitive tiebreak), human relevance ordering, full view-model projection, the short-query shell, service-throws-renders-shell, and cancellation re-throw.
- `ShiftRepositoryRotaSearchTests` (Integration, Postgres) — the admin-only-rota text filter. It is an `EF.Functions.ILike` predicate, so the in-memory provider cannot run it.

**Ruling locked where the filters actually live**

| Guarantee | Text query excluded | GUID resolves anyway |
|---|---|---|
| Hidden team | `CachingTeamServiceTests` (pre-existing) | `CachingTeamServiceTests` (new) |
| Non-public camp season | `CachingCampServiceTests` (new, all 3 non-public statuses) | `CachingCampServiceTests` (new) |
| Admin-only rota | `ShiftRepositoryRotaSearchTests` (new) | `ShiftManagementServiceTests` (new) |
| Admin-only profile fields | `SearchServiceTests` — the `PersonSearchFields.PublicAll` mask | n/a (mask holds on the id path too) |

On the issue's *"asserted absent for a non-admin AND for an admin"*: none of these code paths take a viewer at all — the mask is a constant and the filters are role-blind by construction. There is no admin variant to write, so "regardless of role" is pinned structurally rather than by a duplicated test.

**Destination pages**

- `/Teams/{slug}` — refuses a hidden team for an anonymous viewer and for a signed-in non-privileged one, and admits a TeamsAdmin. Three new tests on `CachingTeamService.GetTeamDetailAsync`, the enforcement point `TeamController.Details` turns into `NotFound()`.
- `/Shifts?departmentId={teamId}` — a default `ShiftBrowseQuery` (what the page builds for a volunteer) excludes a rota hidden from volunteers; only a privileged viewer's `IncludeHidden` surfaces it.
- `/Camps/{slug}` — **see below.**

## ⚠️ Destination-page leak found: `/Camps/{slug}`

**`CampController.Details` has no season-status gate.** A camp whose public-year season is `Pending`, `Rejected` or `Withdrawn` renders its full detail page — and the action is `[AllowAnonymous]`, so signed-out too. Search excludes those statuses from a text query and the public directory excludes them from the listing, but the page itself lets anyone in who knows the slug — and the slug is the camp's own name. `SeasonDetails` has the same shape.

Filed as **nobodies-collective/Humans#993** and not fixed here, per the issue instructions. `CampControllerTests.Details_NonPublicSeason_AnonymousViewer_IsRefused` is committed with `[HumansFact(Skip = "…#993…")]`; unskipping it fails with `Expected NotFoundResult, but found ViewResult`. Deleting the Skip is the whole verification step once #993 lands.

## Reuse-first rejections

- **A dedicated visibility-test file** — rejected. The filters live in `CachingTeamService`, `CachingCampService` and `ShiftManagementService`, which already have test classes owning their seeding helpers. Extended those instead of adding a fourth file that would have to re-seed everything.
- **`ServiceTestHarness` for `SearchServiceTests`** — rejected. `SearchService` touches no DB, clock or cache, so the harness's entire payload would be dead weight; plain NSubstitute fields match the `CampControllerTests` shape.
- **New seeder on `ServiceTestHarness`** — rejected. Added an optional `status` parameter to the existing test-local `SeedCampWithSeasonAsync` (default unchanged, so all seven existing call sites are untouched).
- **Constructing the internal `ShiftRepository` in the integration test** — rejected. Resolved `IShiftManagementRepository` from the factory's DI, matching how the app wires it.
- **A read-interface or DTO change to make the guarantee testable** — rejected. Everything asserted here was already observable through existing surface.

## Notes

- No EF migration.
- Full suite green: 5042 passed, 5 skipped (1 new — the #993 tracker), 0 failed.
- Two commits, not squashed: squashing means force-pushing a pushed branch, which `memory/process/no-force-push-without-permission.md` gates behind Peter's per-instance approval. The squash-merge button gets the same result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
