### PR TITLE
fix(cantina): migrate cross-section EventSettings usage to BurnSettingsInfo

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -240,6 +240,7 @@ inbox:
   - added: 2026-08-07
     what: "Shifts section's own Web layer (ShiftAdminController, ShiftsController, VolunteerTrackingController, ShiftViewModels.cs, ShiftAdminPageBuilder, ShiftBrowsePageBuilder, ShiftDashboardPageBuilder, ShiftBrowseMapper, ShiftFilterResolver, ShiftSignupBucketer, ShiftVolunteerSearchBuilder, DevelopmentDashboardSeeder, ShiftSignupsViewComponent) carries the EF EventSettings entity as a view-model/builder field on read-only display paths — should be BurnSettingsInfo per nobodies-collective/Humans#809's acceptance criteria. Distinct from the write/edit path (EventSettingsFormMapper), which legitimately keeps the entity. ~10 interconnected files forming one section's own display pipeline — warrants its own dedicated section-scoped PR rather than folding into #809's cross-section batch (found while working nobodies-collective/Humans#809)"
     review: panel
+  - added: 2026-08-05
     what: "Extend [ExternalWrite] marking to the Holded surface (ExpenseReportService transitions reaching holdedClient.CreatePurchaseDocumentAsync / UpdatePurchaseDocumentTagsAsync / UploadAttachmentAsync via RunMutationAsync; HoldedFinanceService.EnsureCreditorContactAsync, CreateExpenseAccountAsync) so HUM0033 guards it. No defect exists today — ExpensesController and FinanceController declare no CancellationToken parameter — so this is future-proofing per memory/architecture/cancellation-token-propagation.md (found while auditing nobodies-collective/Humans#950)"
     review: panel
   - added: 2026-08-05

--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -234,7 +234,12 @@ inbox:
   # sweep scope entirely); PasswordGenerator CSPRNG (explicitly deferred by
   # Peter, 2026-04-24); BudgetRepository ResponsibleTeam .Include (covered by
   # grandfathered-hum0024-nav-strip).
-  - added: 2026-08-05
+  - added: 2026-08-07
+    what: "DashboardService.GetMemberDashboardAsync (src/Humans.Application/Services/Dashboard/DashboardService.cs) reads the EF EventSettings entity via IShiftManagementService.GetActiveAsync() instead of IBurnSettingsService/BurnSettingsInfo (nobodies-collective/Humans#809). Blocked on two Shifts-internal gaps: (1) activeEvent.IsShiftBrowsingOpen has no BurnSettingsInfo equivalent — it's explicitly Shifts-internal per IBurnSettingsService's xmldoc; (2) Shift.GetAbsoluteStart/GetAbsoluteEnd take the EF EventSettings entity, not a lighter DTO. Needs either a new IShiftManagementService method exposing IsShiftBrowsingOpen as a scalar, or a Shift.GetAbsoluteStart/End overload accepting (LocalDate gateOpeningDate, string timeZoneId) — both are new interface/domain surface requiring Peter's approval (found while working nobodies-collective/Humans#809)"
+    review: panel
+  - added: 2026-08-07
+    what: "Shifts section's own Web layer (ShiftAdminController, ShiftsController, VolunteerTrackingController, ShiftViewModels.cs, ShiftAdminPageBuilder, ShiftBrowsePageBuilder, ShiftDashboardPageBuilder, ShiftBrowseMapper, ShiftFilterResolver, ShiftSignupBucketer, ShiftVolunteerSearchBuilder, DevelopmentDashboardSeeder, ShiftSignupsViewComponent) carries the EF EventSettings entity as a view-model/builder field on read-only display paths — should be BurnSettingsInfo per nobodies-collective/Humans#809's acceptance criteria. Distinct from the write/edit path (EventSettingsFormMapper), which legitimately keeps the entity. ~10 interconnected files forming one section's own display pipeline — warrants its own dedicated section-scoped PR rather than folding into #809's cross-section batch (found while working nobodies-collective/Humans#809)"
+    review: panel
     what: "Extend [ExternalWrite] marking to the Holded surface (ExpenseReportService transitions reaching holdedClient.CreatePurchaseDocumentAsync / UpdatePurchaseDocumentTagsAsync / UploadAttachmentAsync via RunMutationAsync; HoldedFinanceService.EnsureCreditorContactAsync, CreateExpenseAccountAsync) so HUM0033 guards it. No defect exists today — ExpensesController and FinanceController declare no CancellationToken parameter — so this is future-proofing per memory/architecture/cancellation-token-propagation.md (found while auditing nobodies-collective/Humans#950)"
     review: panel
   - added: 2026-08-05

--- a/src/Humans.Application/Interfaces/Cantina/ICantinaRosterService.cs
+++ b/src/Humans.Application/Interfaces/Cantina/ICantinaRosterService.cs
@@ -1,5 +1,5 @@
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Services.Cantina.Dtos;
-using Humans.Domain.Entities;
 using NodaTime;
 
 namespace Humans.Application.Interfaces.Cantina;
@@ -36,11 +36,11 @@ public interface ICantinaRosterService : IApplicationService
     /// Computes the <c>weekStartOffset</c> of the week containing
     /// <paramref name="now"/> in the active event's timezone. Returns the
     /// day-offset of that week's Monday relative to
-    /// <c>EventSettings.GateOpeningDate</c>. The controller calls this to
-    /// resolve a default when no explicit <c>weekStartOffset</c> is on the
-    /// URL.
+    /// <see cref="BurnSettingsInfo.GateOpeningDate"/>. The controller calls
+    /// this to resolve a default when no explicit <c>weekStartOffset</c> is
+    /// on the URL.
     /// </summary>
-    int GetCurrentWeekStartOffsetForActiveEvent(EventSettings eventSettings, Instant now);
+    int GetCurrentWeekStartOffsetForActiveEvent(BurnSettingsInfo burn, Instant now);
 
     /// <summary>
     /// Builds the per-day matrix payload for the Cantina Daily Matrix page
@@ -56,9 +56,9 @@ public interface ICantinaRosterService : IApplicationService
 
     /// <summary>
     /// Computes the day-offset of "today" in the active event's timezone,
-    /// relative to <c>EventSettings.GateOpeningDate</c>. The controller
-    /// calls this to resolve a default when no explicit <c>dayOffset</c>
-    /// is on the URL.
+    /// relative to <see cref="BurnSettingsInfo.GateOpeningDate"/>. The
+    /// controller calls this to resolve a default when no explicit
+    /// <c>dayOffset</c> is on the URL.
     /// </summary>
-    int GetCurrentDayOffsetForActiveEvent(EventSettings eventSettings, Instant now);
+    int GetCurrentDayOffsetForActiveEvent(BurnSettingsInfo burn, Instant now);
 }

--- a/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
+++ b/src/Humans.Application/Services/Cantina/CantinaRosterService.cs
@@ -3,7 +3,6 @@ using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Cantina.Dtos;
 using Humans.Domain.Constants;
-using Humans.Domain.Entities;
 using NodaTime;
 
 namespace Humans.Application.Services.Cantina;
@@ -180,25 +179,25 @@ public sealed class CantinaRosterService : ICantinaRosterService
             EventTodayDate: eventTodayDate);
     }
 
-    public int GetCurrentWeekStartOffsetForActiveEvent(EventSettings eventSettings, Instant now)
+    public int GetCurrentWeekStartOffsetForActiveEvent(BurnSettingsInfo burn, Instant now)
     {
-        ArgumentNullException.ThrowIfNull(eventSettings);
-        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId)
+        ArgumentNullException.ThrowIfNull(burn);
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(burn.TimeZoneId)
             ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
         var todayLocal = now.InZone(zone).Date;
         // NodaTime: IsoDayOfWeek.Monday = 1; LocalDate.DayOfWeek is an IsoDayOfWeek.
         var daysSinceMonday = ((int)todayLocal.DayOfWeek - 1 + DaysPerWeek) % DaysPerWeek;
         var monday = todayLocal.PlusDays(-daysSinceMonday);
-        return Period.Between(eventSettings.GateOpeningDate, monday, PeriodUnits.Days).Days;
+        return Period.Between(burn.GateOpeningDate, monday, PeriodUnits.Days).Days;
     }
 
-    public int GetCurrentDayOffsetForActiveEvent(EventSettings eventSettings, Instant now)
+    public int GetCurrentDayOffsetForActiveEvent(BurnSettingsInfo burn, Instant now)
     {
-        ArgumentNullException.ThrowIfNull(eventSettings);
-        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId)
+        ArgumentNullException.ThrowIfNull(burn);
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(burn.TimeZoneId)
             ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
         var todayLocal = now.InZone(zone).Date;
-        return Period.Between(eventSettings.GateOpeningDate, todayLocal, PeriodUnits.Days).Days;
+        return Period.Between(burn.GateOpeningDate, todayLocal, PeriodUnits.Days).Days;
     }
 
     public async Task<DailyMatrixDto> GetDailyRosterAsync(int dayOffset, CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/CantinaController.cs
+++ b/src/Humans.Web/Controllers/CantinaController.cs
@@ -23,19 +23,19 @@ namespace Humans.Web.Controllers;
 public sealed class CantinaController : HumansControllerBase
 {
     private readonly ICantinaRosterService _roster;
-    private readonly IShiftManagementService _shiftMgmt;
+    private readonly IBurnSettingsService _burnSettings;
     private readonly IClock _clock;
     private readonly ILogger<CantinaController> _logger;
 
     public CantinaController(
         ICantinaRosterService roster,
-        IShiftManagementService shiftMgmt,
+        IBurnSettingsService burnSettings,
         IClock clock,
         ILogger<CantinaController> logger,
         IUserServiceRead userService) : base(userService)
     {
         _roster = roster;
-        _shiftMgmt = shiftMgmt;
+        _burnSettings = burnSettings;
         _clock = clock;
         _logger = logger;
     }
@@ -111,10 +111,10 @@ public sealed class CantinaController : HumansControllerBase
     /// </summary>
     private async Task<int> ComputeDefaultWeekStartOffsetAsync()
     {
-        var es = await _shiftMgmt.GetActiveAsync().ConfigureAwait(false);
-        if (es is null)
+        var burn = await _burnSettings.GetActiveAsync().ConfigureAwait(false);
+        if (burn is null)
             return 0;
-        return _roster.GetCurrentWeekStartOffsetForActiveEvent(es, _clock.GetCurrentInstant());
+        return _roster.GetCurrentWeekStartOffsetForActiveEvent(burn, _clock.GetCurrentInstant());
     }
 
     /// <summary>
@@ -124,9 +124,9 @@ public sealed class CantinaController : HumansControllerBase
     /// </summary>
     private async Task<int> ComputeDefaultDayOffsetAsync()
     {
-        var es = await _shiftMgmt.GetActiveAsync().ConfigureAwait(false);
-        if (es is null)
+        var burn = await _burnSettings.GetActiveAsync().ConfigureAwait(false);
+        if (burn is null)
             return 0;
-        return _roster.GetCurrentDayOffsetForActiveEvent(es, _clock.GetCurrentInstant());
+        return _roster.GetCurrentDayOffsetForActiveEvent(burn, _clock.GetCurrentInstant());
     }
 }


### PR DESCRIPTION
## Summary

First batch of nobodies-collective/Humans#809 — migrating cross-section EF `EventSettings` usage to the `BurnSettingsInfo` DTO / `IBurnSettingsService` boundary.

**The pattern (for the ~30 other sections that will copy this):** a cross-section caller that needs burn/event-cycle data injects `IBurnSettingsService` and reads `BurnSettingsInfo`, never the full write-capable `I<Section>Service` returning the EF entity.

## Audit results (grep for `EventSettings` in `src/`, 174 hits)

Went through every cluster named in the issue body:

| Area | Status |
|---|---|
| Events section (`IEventService.GetEventSettingsByIdAsync`, `CachingEventService`) | **Already compliant** — returns `BurnSettingsInfo?`, no entity materialized. No change needed. |
| Cantina (`ICantinaRosterService`, `CantinaController`) | **Fixed here.** `GetCurrentWeekStartOffsetForActiveEvent`/`GetCurrentDayOffsetForActiveEvent` took the EF `EventSettings` entity; `CantinaController` sourced it via `IShiftManagementService.GetActiveAsync()` (the full write-capable Shifts service). Both now take/resolve `BurnSettingsInfo` via `IBurnSettingsService`. |
| Mailer (`TicketNoShiftsAudience`) | **Already compliant** — reads via `IShiftView`, only a doc-comment prose reference to "EventSettings" remained. |
| Agent (`AgentToolDispatcher`) | **Already compliant** — uses `IBurnSettingsService`/`BurnSettingsInfo` throughout. |
| Workload (`WorkloadService`, `WorkloadReport`) | **Already compliant** — `WorkloadReport` carries only `Guid EventSettingsId` / `int EventYear` (scalars), no entity. Internal EF entity use inside `WorkloadService` is same-section (`Services.Shifts.Workload`), allowed per the issue's item 6. |
| Events controllers/views (`EventsAdminController`, `EventsApiController`, `EventsController`, `EventsModerationController`, `EventsDashboardController`, `EventsExportController`) | **Already compliant** — no `EventSettings` entity references; `EventSettingsOptionViewModel` carries scalar fields only. |
| Dashboard (`DashboardService`) | **Not migrated — genuinely blocked**, see below. |
| Shifts section's own Web layer (`ShiftAdminController`, `ShiftsController`, `ShiftViewModels.cs`, page-builders, mappers, etc.) | **Not migrated**, see below. |

### Reuse-first rejections

- Did not add a new `IBurnSettingsService` method or `BurnSettingsInfo` field — every migrated call site was already covered by `GetActiveAsync`/`GetByIdAsync` and the existing DTO fields (`TimeZoneId`, `GateOpeningDate`).
- Did not introduce an `ICantinaRosterServiceRead` split — the interface has no write methods to separate from.

## Needs new interface surface — owner approval required

**`DashboardService.GetMemberDashboardAsync`** (member dashboard) still reads the EF entity via `IShiftManagementService.GetActiveAsync()`. It's genuinely blocked, not just unmigrated:
- `activeEvent.IsShiftBrowsingOpen` has no `BurnSettingsInfo` equivalent — the issue text and `IBurnSettingsService`'s own xmldoc call this out as Shifts-internal by design.
- `Shift.GetAbsoluteStart(EventSettings)` / `GetAbsoluteEnd(EventSettings)` take the entity, not a lighter type.

Fixing this needs either a new `IShiftManagementService` method exposing the flag as a scalar, or a `Shift.GetAbsoluteStart/End` overload taking `(LocalDate gateOpeningDate, string timeZoneId)` — both are new interface/domain surface. Logged as an inbox item in `docs/architecture/debt-ledger.yml` rather than added unilaterally.

## Out of scope, logged separately

The **Shifts section's own Web layer** (~10 interconnected files: `ShiftAdminController`, `ShiftsController`, `VolunteerTrackingController`, `ShiftViewModels.cs`, `ShiftAdminPageBuilder`, `ShiftBrowsePageBuilder`, `ShiftDashboardPageBuilder`, `ShiftBrowseMapper`, `ShiftFilterResolver`, `ShiftSignupBucketer`, `ShiftVolunteerSearchBuilder`, `DevelopmentDashboardSeeder`, `ShiftSignupsViewComponent`) still carries the EF entity through its own read-only display pipeline. This is distinct from the legitimate write/edit path (`EventSettingsFormMapper`, kept per the issue's explicit allowlist). It's a cohesive, single-section batch that deserves its own dedicated PR per the issue's own "migrate one section's consumers in one PR" guidance, rather than folding into this cross-section batch. Also logged in the debt ledger.

## Acceptance criteria

- [x] Cross-section files (Cantina, Mailer, Agent, Events controllers/views, Workload) no longer reference the EF `EventSettings` type directly.
- [ ] Dashboard — blocked, see above.
- [ ] Web view models in `Humans.Web/Models/**` carry `BurnSettingsInfo` — Shifts' own web layer still doesn't; logged, separate PR.
- [x] `IBurnSettingsService` unchanged — no fields added pre-emptively.
- [x] HUM0025 count for Shifts buckets unaffected (no EF model/config touched).
- [x] No `[Grandfathered]` added.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors (91 pre-existing warnings, unrelated).
- [x] `dotnet test Humans.slnx -v quiet` — full suite green (Domain 274/274, Analyzers 245/245, Web 377/377, Application 3981/3981, Integration 122/122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)