### PR TITLE
feat(ops): staging environment on the prod host — repo half (nobodies-collective/Humans#962)

### DIFF
--- a/.claude/skills/pr-prod/SKILL.md
+++ b/.claude/skills/pr-prod/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "(no args)"
 
 Promotes the batch through staging and opens a single batched PR from `peterdrier/Humans:main` (peter's fork, QA-deployed) to `nobodies-collective/Humans:main` (production). Per `CLAUDE.md`, the upstream merge strategy is **rebase merge** — individual PRs were already squashed on the fork.
 
-The batch goes to `upstream/staging` first, where it deploys against a fresh clone of the production database, and only reaches `upstream/main` once that deploy has been verified — `docs/staging-environment.md` (nobodies-collective/Humans#962). The PR records the verified staging SHA, so `upstream/main` never moves to a commit whose migrations have not already run against real production data.
+The batch goes to `upstream/staging` first, where it deploys against a fresh clone of the production database, and only reaches `upstream/main` once that deploy has been verified — `docs/staging-environment.md` (nobodies-collective/Humans#962). The PR is opened **from the verified commit itself**, on a one-shot `promote/*` branch rather than from the fork's moving `main`, so `upstream/main` never moves to a commit whose migrations have not already run against real production data.
 
 ## The ref-qualification rule (read this first)
 
@@ -36,29 +36,35 @@ git fetch upstream main
 ### 2. Check for an existing open PR
 
 ```bash
-gh pr list --repo nobodies-collective/Humans --state open --head peterdrier:main
+gh pr list --repo nobodies-collective/Humans --state open --base main \
+  --json number,title,headRefName --jq '.[] | "\(.number) \(.headRefName) — \(.title)"'
 ```
 
-If one exists, **edit it** with `gh pr edit <num> --repo nobodies-collective/Humans --body ...` instead of opening a duplicate.
+Don't filter on `--head peterdrier:main` — since step 6 each promotion opens from its own `promote/*` branch, so an exact-head filter matches nothing.
 
-### 3. Enumerate the commits to promote
+If an open promotion is for **this** batch, **edit it** with `gh pr edit <num> --repo nobodies-collective/Humans --body ...` instead of opening a duplicate. If it is for an earlier batch that never merged, stop and ask Peter — two open promotions racing the same base is his call, not a thing to resolve by opening a third.
+
+### 3. Enumerate the commits to promote, and pin the SHA
 
 ```bash
 git log --oneline upstream/main..origin/main
 git diff --stat upstream/main..origin/main | tail -1
+PROMOTE_SHA=$(git rev-parse origin/main)
 ```
 
 If empty: nothing to promote. Tell the user and stop.
 
+`$PROMOTE_SHA` **is** the batch, and every step from here names that commit rather than the `origin/main` branch. The branch moves — feature PRs land on the fork continuously — and a promotion that tracked it would quietly grow past the commit staging verified.
+
 ### 4. Promote to `upstream/staging`
 
 ```bash
-git push upstream origin/main:refs/heads/staging
+git push upstream "$PROMOTE_SHA":refs/heads/staging
 ```
 
 This is the deploy trigger: `.github/workflows/staging-db.yml` rebuilds `humans_staging` from the newest production backup artifact, and Coolify deploys the pushed commit against it.
 
-**If the push is rejected as a non-fast-forward, stop and ask Peter.** It means the previous batch was staged and then abandoned rather than promoted. Recovering needs a force-push, which requires Peter's explicit per-instance approval (`memory/process/no-force-push-without-permission.md`) — never pass `--force` or `--force-with-lease` here on your own initiative.
+**A non-fast-forward rejection here is expected from the second cycle onwards, and does not mean a batch was abandoned.** Upstream merges by rebase, so last cycle's promotion sits on `upstream/main` under rewritten SHAs, and `memory/process/after-prod-merge-reset.md` then resets `origin/main` onto that rewritten history. `upstream/staging` still points at the pre-rebase commit, which is no longer an ancestor of anything on the fork. Realigning it is a forced update, and forced updates need Peter's explicit per-instance approval (`memory/process/no-destructive-actions-without-approval.md`) — **stop and ask; never pass `--force` or `--force-with-lease` here on your own initiative.** See [Open question](#open-question--realigning-upstreamstaging) below.
 
 ### 5. Verify on staging
 
@@ -74,9 +80,20 @@ curl -s https://staging.nobodies.team/api/version     # commit == the SHA you pu
 
 **If anything fails, stop.** The bad commit is on `staging` only; fix it on the fork and re-run from step 1. Do not open the production PR.
 
-Record the verified SHA — step 6 puts it in the PR body.
+`/api/version` must report `$PROMOTE_SHA` itself, not merely "something recent" — that equality is what ties the verification to the commit the next step promotes.
 
-### 6. Build the PR body
+### 6. Publish the promotion head
+
+```bash
+PROMOTE_BRANCH="promote/$(date -u +%Y-%m-%d)-$(git rev-parse --short "$PROMOTE_SHA")"
+git push origin "$PROMOTE_SHA":"refs/heads/$PROMOTE_BRANCH"
+```
+
+A fresh branch per promotion, pointed at the verified commit and written exactly once. **The PR opens from this, never from `peterdrier:main`.** A PR whose head is `main` follows the branch: any feature PR that lands on the fork between staging verification and Peter's merge is carried into production without ever having deployed against the cloned database, while the PR body goes on naming the older SHA as verified. That is the whole guarantee this skill exists to provide, and a branch head silently voids it.
+
+Nothing else writes to `$PROMOTE_BRANCH`, so it is immutable in practice and never needs a force-push. Leave it in place after the merge — it is the record of exactly what was promoted, and deleting branches needs Peter's approval anyway (`memory/process/no-destructive-actions-without-approval.md`).
+
+### 7. Build the PR body
 
 For each commit, transform the subject as follows:
 
@@ -97,20 +114,22 @@ emit this bullet:
 - `8508e353` nobodies-collective/Humans#673: consolidate person-search with PersonSearchFields bit-flag API (peterdrier/Humans#455)
 ```
 
-### 7. Write the PR
+### 8. Write the PR
 
-Use `gh pr create` with `--head peterdrier:main`. Pass the body via heredoc to preserve formatting:
+Use `gh pr create` with `--head peterdrier:$PROMOTE_BRANCH`. Pass the body via heredoc to preserve formatting:
 
 ```bash
 gh pr create --repo nobodies-collective/Humans \
-  --base main --head peterdrier:main \
+  --base main --head "peterdrier:$PROMOTE_BRANCH" \
   --title "Promote QA → production (N commits)" \
   --body "$(cat <<'EOF'
 ## Summary
 
-Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.
+Batched promotion of QA-tested changes from `peterdrier/Humans` to production.
 
 Verified on staging at `<staging sha>` — `https://staging.nobodies.team` deployed this batch against a fresh clone of the production database, migrations applied cleanly, real sign-in works.
+
+**This PR's head is that commit**, not the fork's moving `main`, so what merges is what staging ran.
 
 All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.
 
@@ -128,13 +147,13 @@ EOF
 )"
 ```
 
-Substitute `N` with the actual commit count and `<staging sha>` with the SHA verified in step 5.
+Substitute `N` with the actual commit count and `<staging sha>` with `$PROMOTE_SHA`, the SHA verified in step 5.
 
-### 8. Return the PR URL
+### 9. Return the PR URL
 
-`gh pr create` prints the URL on success — surface it to the user. Don't merge; promotion is Peter's call. Merging fast-forwards `upstream/main` onto the commit staging already ran.
+`gh pr create` prints the URL on success — surface it to the user. Don't merge; promotion is Peter's call. Rebase merge replays these commits onto `upstream/main` under new SHAs — same trees, different history, which is the reason step 4 stops being a fast-forward next cycle.
 
-### 9. Discord release notes
+### 10. Discord release notes
 
 After surfacing the PR URL, draft member-facing release notes for Discord and present them in the conversation as a single copy-paste-ready ```markdown code block (Claude does NOT post to Discord — Peter pastes it).
 
@@ -155,12 +174,32 @@ Rules:
 - [ ] Title is `Promote QA → production (<N> commits)` with the correct count.
 - [ ] No existing open PR was overlooked (step 2).
 - [ ] The batch deployed to staging and passed step 5, and the body names the verified SHA.
-- [ ] Discord release notes drafted (step 9), dated, member-features first, ≤ 2,000 characters.
+- [ ] The PR head is `peterdrier:promote/<date>-<short sha>`, **not** `peterdrier:main`, and `gh pr view <num> --repo nobodies-collective/Humans --json headRefOid` returns `$PROMOTE_SHA`.
+- [ ] Discord release notes drafted (step 10), dated, member-features first, ≤ 2,000 characters.
+
+## Open question — realigning `upstream/staging`
+
+**For Peter. Until it is answered, step 4 stops and asks on every cycle after the first.**
+
+The promotion cycle structurally requires one forced update of `upstream/staging` per cycle. Rebase merge rewrites the batch's SHAs onto `upstream/main`, `after-prod-merge-reset` resets the fork onto that rewritten history, and `upstream/staging` is left holding a commit that is nobody's ancestor. There is no non-forced way out: the branch has to be rewritten because upstream rewrote the commits under it.
+
+The argument for making it standing rather than per-instance: `upstream/staging` is a disposable pointer at "the batch currently under verification". It is never merged anywhere, its database is dropped between cycles by design (`docs/staging-environment.md` §6), and its history carries nothing that could be lost. `--force-with-lease` would still refuse if someone else had moved it.
+
+The argument against: `memory/process/no-destructive-actions-without-approval.md` is a hard rule with exactly one standing exception today (the squash-merge button), and `after-prod-merge-reset`'s `--force-with-lease` on `origin/main` is a documented procedure Peter wrote, not a precedent an agent gets to extend to a second remote on its own.
+
+Recommended: realign as part of the post-merge reset, when the two commits have identical trees and the operation is unambiguous —
+
+```bash
+git push upstream upstream/main:refs/heads/staging --force-with-lease
+```
+
+— added to `memory/process/after-prod-merge-reset.md` so it is Peter's standing instruction rather than an agent's judgement call. **Not made here**, for the reason in the paragraph above.
 
 ## What this skill does NOT do
 
 - Merge the PR. Peter does that manually with rebase merge.
-- Force-push `upstream/staging`, or skip the staging verification because the batch "looks safe". Both need Peter.
+- Force-push `upstream/staging`, or skip the staging verification because the batch "looks safe". Both need Peter — see the open question above.
+- Delete the `promote/*` branch after the merge. It stays as the record of what was promoted.
 - Post to Discord. The release notes are drafted in-conversation for Peter to paste.
 - Update fork main after merge. The `memory/process/after-prod-merge-reset.md` rule covers post-merge.
 - Open or modify per-feature PRs on `peterdrier/Humans`. Those land on the fork before promotion runs.

--- a/.claude/skills/pr-prod/SKILL.md
+++ b/.claude/skills/pr-prod/SKILL.md
@@ -6,7 +6,9 @@ argument-hint: "(no args)"
 
 # Promote QA → production
 
-Opens a single batched PR from `peterdrier/Humans:main` (peter's fork, QA-deployed) to `nobodies-collective/Humans:main` (production). Per `CLAUDE.md`, the upstream merge strategy is **rebase merge** — individual PRs were already squashed on the fork.
+Promotes the batch through staging and opens a single batched PR from `peterdrier/Humans:main` (peter's fork, QA-deployed) to `nobodies-collective/Humans:main` (production). Per `CLAUDE.md`, the upstream merge strategy is **rebase merge** — individual PRs were already squashed on the fork.
+
+The batch goes to `upstream/staging` first, where it deploys against a fresh clone of the production database, and only reaches `upstream/main` once that deploy has been verified — `docs/staging-environment.md` (nobodies-collective/Humans#962). The PR records the verified staging SHA, so `upstream/main` never moves to a commit whose migrations have not already run against real production data.
 
 ## The ref-qualification rule (read this first)
 
@@ -48,7 +50,33 @@ git diff --stat upstream/main..origin/main | tail -1
 
 If empty: nothing to promote. Tell the user and stop.
 
-### 4. Build the PR body
+### 4. Promote to `upstream/staging`
+
+```bash
+git push upstream origin/main:refs/heads/staging
+```
+
+This is the deploy trigger: `.github/workflows/staging-db.yml` rebuilds `humans_staging` from the newest production backup artifact, and Coolify deploys the pushed commit against it.
+
+**If the push is rejected as a non-fast-forward, stop and ask Peter.** It means the previous batch was staged and then abandoned rather than promoted. Recovering needs a force-push, which requires Peter's explicit per-instance approval (`memory/process/no-force-push-without-permission.md`) — never pass `--force` or `--force-with-lease` here on your own initiative.
+
+### 5. Verify on staging
+
+Wait for the refresh workflow and the Coolify deploy, then run the checks in `docs/staging-environment.md` §8. The load-bearing ones:
+
+```bash
+curl -s https://staging.nobodies.team/api/version     # commit == the SHA you pushed
+```
+
+- Migrations applied cleanly to the fresh clone — this is the dress rehearsal, and a migration that would break production breaks here instead.
+- Real Google sign-in works.
+- Whatever this batch changed, exercised against real-shaped data.
+
+**If anything fails, stop.** The bad commit is on `staging` only; fix it on the fork and re-run from step 1. Do not open the production PR.
+
+Record the verified SHA — step 6 puts it in the PR body.
+
+### 6. Build the PR body
 
 For each commit, transform the subject as follows:
 
@@ -69,7 +97,7 @@ emit this bullet:
 - `8508e353` nobodies-collective/Humans#673: consolidate person-search with PersonSearchFields bit-flag API (peterdrier/Humans#455)
 ```
 
-### 5. Write the PR
+### 7. Write the PR
 
 Use `gh pr create` with `--head peterdrier:main`. Pass the body via heredoc to preserve formatting:
 
@@ -82,6 +110,8 @@ gh pr create --repo nobodies-collective/Humans \
 
 Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.
 
+Verified on staging at `<staging sha>` — `https://staging.nobodies.team` deployed this batch against a fresh clone of the production database, migrations applied cleanly, real sign-in works.
+
 All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.
 
 ## Commits
@@ -93,18 +123,18 @@ All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` —
 
 - [ ] Rebase merge (each PR is already squashed)
 - [ ] CI green on production
-- [ ] Verify EF migrations apply cleanly
+- [x] EF migrations verified against a production-data clone on staging
 EOF
 )"
 ```
 
-Substitute `N` with the actual commit count.
+Substitute `N` with the actual commit count and `<staging sha>` with the SHA verified in step 5.
 
-### 6. Return the PR URL
+### 8. Return the PR URL
 
-`gh pr create` prints the URL on success — surface it to the user. Don't merge; promotion is Peter's call.
+`gh pr create` prints the URL on success — surface it to the user. Don't merge; promotion is Peter's call. Merging fast-forwards `upstream/main` onto the commit staging already ran.
 
-### 7. Discord release notes
+### 9. Discord release notes
 
 After surfacing the PR URL, draft member-facing release notes for Discord and present them in the conversation as a single copy-paste-ready ```markdown code block (Claude does NOT post to Discord — Peter pastes it).
 
@@ -124,11 +154,13 @@ Rules:
 - [ ] Every inline `#NNN` reference is qualified (`peterdrier/Humans#NNN` or `nobodies-collective/Humans#NNN`) — no bare refs anywhere in the body.
 - [ ] Title is `Promote QA → production (<N> commits)` with the correct count.
 - [ ] No existing open PR was overlooked (step 2).
-- [ ] Discord release notes drafted (step 7), dated, member-features first, ≤ 2,000 characters.
+- [ ] The batch deployed to staging and passed step 5, and the body names the verified SHA.
+- [ ] Discord release notes drafted (step 9), dated, member-features first, ≤ 2,000 characters.
 
 ## What this skill does NOT do
 
 - Merge the PR. Peter does that manually with rebase merge.
+- Force-push `upstream/staging`, or skip the staging verification because the batch "looks safe". Both need Peter.
 - Post to Discord. The release notes are drafted in-conversation for Peter to paste.
 - Update fork main after merge. The `memory/process/after-prod-merge-reset.md` rule covers post-merge.
 - Open or modify per-feature PRs on `peterdrier/Humans`. Those land on the fork before promotion runs.

--- a/.github/workflows/staging-db.yml
+++ b/.github/workflows/staging-db.yml
@@ -25,7 +25,20 @@ jobs:
   refresh:
     runs-on: [self-hosted, prod]
     steps:
+      # `main`, not the pushed commit. This job runs on the production host with Docker
+      # access, so whatever it executes has effectively root there. Checking out the
+      # candidate would mean any commit staged for review could rewrite the script and run
+      # it as root on production *before* the production PR is looked at. `main` is the
+      # reviewed ref; a change to the refresh script therefore takes effect one promotion
+      # after it lands, which is the right way round for infrastructure.
+      #
+      # This does NOT cover the workflow file itself — for `on: push`, GitHub reads that
+      # from the pushed ref. Push access to `staging` is therefore equivalent to root on
+      # the production host, which is why docs/staging-environment.md §7.8 makes branch
+      # protection on `staging` a required step rather than a suggestion.
       - uses: actions/checkout@v7
+        with:
+          ref: main
 
       - name: Refresh humans_staging
         env:

--- a/.github/workflows/staging-db.yml
+++ b/.github/workflows/staging-db.yml
@@ -1,0 +1,37 @@
+name: Staging Database Refresh
+
+# Rebuilds humans_staging from production on every push to the staging branch, so the
+# staging deploy that follows applies its migrations to a fresh clone of prod data.
+# Runs on the production host — the runner label is `prod`, not `nuc` (that is QA).
+# nobodies-collective/Humans#962 · docs/staging-environment.md
+on:
+  push:
+    branches: [staging]
+  workflow_dispatch:
+    inputs:
+      source:
+        description: "backup = newest Coolify artifact (also tests the restore path); live = pg_dump from prod"
+        type: choice
+        options: [backup, live]
+        default: backup
+
+# Two pushes in quick succession must not race each other into the same DROP DATABASE.
+# Queue rather than cancel: a cancelled refresh leaves a half-restored staging database.
+concurrency:
+  group: staging-db-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: [self-hosted, prod]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Refresh humans_staging
+        env:
+          DB_CONTAINER: ${{ vars.STAGING_DB_CONTAINER || 'humans-db' }}
+          STAGING_APP_CONTAINER: ${{ vars.STAGING_APP_CONTAINER }}
+          COOLIFY_BACKUP_DIR: ${{ vars.COOLIFY_BACKUP_DIR || '/data/coolify/backups' }}
+          PROD_UPLOADS_DIR: ${{ vars.PROD_UPLOADS_DIR }}
+          STAGING_UPLOADS_DIR: ${{ vars.STAGING_UPLOADS_DIR }}
+        run: ./scripts/refresh-staging-db.sh "${{ github.event.inputs.source || 'backup' }}"

--- a/.github/workflows/staging-db.yml
+++ b/.github/workflows/staging-db.yml
@@ -32,6 +32,9 @@ jobs:
           DB_CONTAINER: ${{ vars.STAGING_DB_CONTAINER || 'humans-db' }}
           STAGING_APP_CONTAINER: ${{ vars.STAGING_APP_CONTAINER }}
           COOLIFY_BACKUP_DIR: ${{ vars.COOLIFY_BACKUP_DIR || '/data/coolify/backups' }}
+          # Set to match production's real backup cadence. A stalled backup schedule must
+          # fail the refresh rather than quietly restore a weeks-old artifact.
+          BACKUP_MAX_AGE_HOURS: ${{ vars.BACKUP_MAX_AGE_HOURS }}
           PROD_UPLOADS_DIR: ${{ vars.PROD_UPLOADS_DIR }}
           STAGING_UPLOADS_DIR: ${{ vars.STAGING_UPLOADS_DIR }}
         run: ./scripts/refresh-staging-db.sh "${{ github.event.inputs.source || 'backup' }}"

--- a/.github/workflows/staging-db.yml
+++ b/.github/workflows/staging-db.yml
@@ -44,6 +44,11 @@ jobs:
         env:
           DB_CONTAINER: ${{ vars.STAGING_DB_CONTAINER || 'humans-db' }}
           STAGING_APP_CONTAINER: ${{ vars.STAGING_APP_CONTAINER }}
+          # The restricted role the staging app connects as (docs/staging-environment.md
+          # §7.7). Unset, the script falls back to the production role and says so in the
+          # log — the restored objects would then belong to `humans` and the staging app
+          # would fail on its first query.
+          STAGING_DB_OWNER: ${{ vars.STAGING_DB_OWNER }}
           COOLIFY_BACKUP_DIR: ${{ vars.COOLIFY_BACKUP_DIR || '/data/coolify/backups' }}
           # Set to match production's real backup cadence. A stalled backup schedule must
           # fail the refresh rather than quietly restore a weeks-old artifact.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ dotnet run --project src/Humans.Web
 - **`origin`** = `peterdrier/Humans` (fork — QA auto-deploys from `main` via Coolify)
 - **`upstream`** = `nobodies-collective/Humans` (production)
 
-All changes go on a **feature branch in a worktree** (`.worktrees/<name>`) → PR to `origin/main` (squash if multiple commits). Promote to prod by batching on `origin/main` → PR to `upstream/main` (rebase merge) — use `/pr-prod`. Per-PR preview deploys at `https://{pr_id}.n.burn.camp` (DB `humans_pr_{N}` cloned from QA, dropped on close; dev login enabled). Version check: `GET /api/version`.
+All changes go on a **feature branch in a worktree** (`.worktrees/<name>`) → PR to `origin/main` (squash if multiple commits). Promote to prod by batching on `origin/main` → push to `upstream/staging` → verify at `staging.nobodies.team` (prod host, fresh clone of the prod DB — [`docs/staging-environment.md`](docs/staging-environment.md)) → PR to `upstream/main` (rebase merge) — use `/pr-prod`. Per-PR preview deploys at `https://{pr_id}.n.burn.camp` (DB `humans_pr_{N}` cloned from QA, dropped on close; dev login enabled). Version check: `GET /api/version`.
 
 Rules: [`no-direct-to-main`](memory/process/no-direct-to-main.md) · [`issue-refs-qualified`](memory/process/issue-refs-qualified.md) · [`after-prod-merge-reset`](memory/process/after-prod-merge-reset.md) · [`cross-repo-pr-push-target`](memory/process/cross-repo-pr-push-target.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,6 +163,7 @@ Plain-language pages for the things people ask most.
 | Document | Description |
 |----------|-------------|
 | [Database Restore Runbook](database-restore-runbook.md) | Restoring Postgres from a backup, the automatic pre-deploy snapshot, and the event deploy-freeze policy |
+| [Staging Environment](staging-environment.md) | The promotion gate on the prod host: per-deploy restore of the prod DB, connector safety, GDPR posture, and the host-side setup it needs |
 | [Admin Role Setup](admin-role-setup.md) | Adding initial admin users via SQL |
 | [GUID Reservations](guid-reservations.md) | Reserved deterministic GUID blocks for seeded data |
 | [Seed Data Strategy](seed-data.md) | When to use `HasData`, migration backfills, and dev-only runtime seeders |

--- a/docs/database-restore-runbook.md
+++ b/docs/database-restore-runbook.md
@@ -393,6 +393,24 @@ an outage of unknown length without them, in the middle of the one week the app 
 
 ---
 
+## 8. The staging refresh is this runbook, running continuously
+
+`scripts/refresh-staging-db.sh` rebuilds `humans_staging` on every promotion to production, and
+its default source is **the newest Coolify backup artifact** — restored with the same commands
+§2 and §3 use, with the same stop-on-first-error flags, and verified with the same
+`__EFMigrationsHistory` check. See [`staging-environment.md`](staging-environment.md).
+
+That closes the gap the drill record below names first: the drill could not restore a real
+Coolify-produced backup, so the format assumption in §0 stood on nothing. Once staging is live
+(nobodies-collective/Humans#962), every promotion settles it again.
+
+**So a failed staging refresh is a production backup incident, not a staging one.** If the
+workflow cannot find an artifact, cannot read one, or restores an empty migration history, the
+thing that is broken is the archive you would be reaching for at 3am — investigate it here,
+where nothing is on fire.
+
+---
+
 ## Drill record (2026-08-05)
 
 Executed against a throwaway local `postgres:16` container, schema created by running this

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -97,11 +97,26 @@ fine.
 
 ### What it verifies
 
-After restoring, the script fails the workflow if the restored database has no tables, or if
-**any** `__EFMigrationsHistory*` table came back empty. There is one history table per
-DbContext since the per-section split (nobodies-collective/Humans#858), and an empty one is the
-quiet failure worth catching: the app boots happily and then applies that section's migrations
-from scratch against tables that already exist.
+After restoring, the script fails the workflow if the restored database has no tables, if any
+**expected** `__EFMigrationsHistory*` table is missing, or if any of them came back empty.
+There is one history table per DbContext since the per-section split
+(nobodies-collective/Humans#858), so the expected set is `__EFMigrationsHistory` plus one
+`__EFMigrationsHistory_<Section>` per entry in `SECTION_DB_CONTEXTS` — the same list
+`.github/workflows/build.yml` uses, duplicated in the script's defaults and kept in step with
+it by name.
+
+Missing and empty are different failures and both are quiet. An empty history table has the
+app boot happily and then apply that section's migrations from scratch against tables that
+already exist. A **missing** one cannot be caught by the empty check at all — no row to
+inspect — which is how a selective or pre-split archive would otherwise be reported as
+verified.
+
+**Staleness is the third.** The newest artifact is rejected if it is older than
+`BACKUP_MAX_AGE_HOURS` (default 48). A stalled backup schedule leaves a perfectly restorable
+file behind, so without an age bound every check above passes while staging rehearses
+migrations against weeks-old schema — and the backup outage goes unreported, which is the one
+thing §9 says this workflow is for. Naming `BACKUP_FILE` explicitly bypasses the bound, since
+that is a deliberate reach for an older artifact; `BACKUP_MAX_AGE_HOURS=0` disables it.
 
 ### Uploads
 
@@ -127,7 +142,9 @@ STAGING_APP_CONTAINER=<staging app container> \
 ```
 
 Set `BACKUP_FILE=/path/to/artifact` to restore a specific one — an older backup, or one whose
-filename does not carry the database name — instead of the newest match.
+filename does not carry the database name — instead of the newest match. That also bypasses the
+`BACKUP_MAX_AGE_HOURS` bound, which exists to catch a stalled schedule rather than to stop
+someone deliberately restoring an old artifact.
 
 Nothing in the script writes to production. `backup` never opens the production database at
 all; `live` only reads it; the uploads copy is one-way. The destructive statements target
@@ -291,6 +308,7 @@ repository cannot know; the script fails loudly rather than guessing.
 | `PROD_UPLOADS_DIR` | Host path backing production's `/app/wwwroot/uploads` (Coolify → the production resource → **Storages**) | Yes |
 | `STAGING_UPLOADS_DIR` | Host path for staging's uploads — a **new, separate** directory | Yes |
 | `COOLIFY_BACKUP_DIR` | Where Coolify writes database backup artifacts, if not `/data/coolify/backups` | Only if different |
+| `BACKUP_MAX_AGE_HOURS` | How old the newest artifact may be before the refresh fails as a backup incident. Default 48 — set it to match the real Coolify backup schedule, since a cadence slower than the bound fails every refresh and one much faster than it wastes the signal | Recommended |
 | `STAGING_DB_CONTAINER` | Postgres container name, if not `humans-db` | Only if different |
 | `STAGING_APP_CONTAINER` | Staging app container name, stable across deploys. The script stops the app before dropping its database and restarts it afterwards, and refuses to run if the name is unset or does not resolve — an app left running through the drop reconnects to a half-restored database and stays there | Yes |
 
@@ -409,4 +427,7 @@ restore itself are exercised continuously rather than the once
 nobodies-collective/Humans#845 asked for.
 
 A staging refresh that fails on the restore step is telling you something about **production's
-backups**, not about staging. Treat it as an incident on the backup path.
+backups**, not about staging. Treat it as an incident on the backup path. `BACKUP_MAX_AGE_HOURS`
+extends that to the schedule itself: backups that stopped being written are an incident even
+though the last one still restores perfectly, and without the age bound that is precisely the
+outage this workflow would sail through.

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -12,6 +12,13 @@ also a live test of the restore path that
 > exist until someone with Coolify, Google Cloud console, and shell access to the production
 > host works through [§7 Host-side steps](#7-host-side-steps-owner).
 > nobodies-collective/Humans#962.
+>
+> **`scripts/refresh-staging-db.sh` has not been executed.** Unlike the restore runbook, whose
+> procedure was drilled against a real `postgres:16` container before it was written down, this
+> script is reviewed and syntax-checked only. Its commands are the ones `preview-db.yml` runs
+> today and the ones the runbook's drill proved, but the script as a whole is unproven. **Run
+> §7.3's manual dispatch and read the log before trusting a scheduled refresh** — that run is
+> its first real test.
 
 ---
 
@@ -102,6 +109,9 @@ PROD_UPLOADS_DIR=/path/to/prod/uploads \
 STAGING_UPLOADS_DIR=/path/to/staging/uploads \
 ./scripts/refresh-staging-db.sh backup      # or: live
 ```
+
+Set `BACKUP_FILE=/path/to/artifact` to restore a specific one — an older backup, or one whose
+filename does not carry the database name — instead of the newest match.
 
 Nothing in the script writes to production. `backup` never opens the production database at
 all; `live` only reads it; the uploads copy is one-way. The destructive statements target

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -164,6 +164,8 @@ setting one turns the real connector on:
 |---|---|
 | `GoogleWorkspace__ServiceAccountKeyJson` / `__ServiceAccountKeyPath` | Real Drive/Groups clients. Reconciliation jobs would mutate real Workspace resources from cloned state |
 | `HOLDED_API_KEY` | Real `api.holded.com` client. `HoldedExpenseOutboxJob` runs every minute and would push cloned expense rows into the real accounting system |
+| `MailerLite__ApiKey` **and** `MAILERLITE_API_KEY` | Real `api.mailerlite.com` client. `MailerSectionExtensions.cs` registers `MailerLiteClient` unconditionally, and `IMailerLiteService` writes — `AssignSubscriberToGroupAsync`, `UnassignSubscriberFromGroupAsync`, `BulkImportSubscribersToGroupAsync`. Audience membership is computed from the cloned database, so a sync from here adds and removes real subscribers in the real account. **Two spellings, both live**: the dotted key binds through `MailerLiteOptions`, and the flat one is picked up by an explicit `Environment.GetEnvironmentVariable` fallback. Omitting one and copying the other leaves the connector fully armed |
+| `MailerLite__AudienceSyncCron` | Turns the audience sync from admin-triggered into scheduled. `RecurringJobExtensions.cs` registers `MailerAudienceSyncJob` only when this is non-empty, so a copied production cron makes staging push audiences on a timer with nobody watching |
 | `STRIPE_TICKETS_KEY`, `STRIPE_STORE_KEY`, `STRIPE_STORE_WEBHOOK_SECRET`, `STRIPE_STORE_WEBHOOK_REGISTRAR_KEY` | Live payment calls. The registrar key additionally re-points the Store webhook |
 | `Anthropic__ApiKey` | Billed agent calls from a full copy of production's data |
 | `GITHUB_ACCESS_TOKEN` | Not dangerous — legal-doc sync is a read. Omit anyway; staging does not need the rate limit |
@@ -228,7 +230,10 @@ What makes that defensible under the existing posture:
   is Google OAuth against the cloned database, so the same humans hold the same roles they hold
   in production — staging grants nobody access they do not already have.
 - **No new egress.** Every outbound connector is stubbed (§5), so PII is not forwarded to any
-  third party from here.
+  third party from here. For a few this is enforced by code; for most — Workspace, Holded,
+  MailerLite, Stripe — it rests on the credential simply being absent, so the guarantee holds
+  exactly as long as §4's must-stay-unset list is honoured. That is a configuration promise,
+  not a code one, which is why §8 checks it per deploy instead of assuming it.
 - **Wiped on every refresh.** The database is dropped and recreated, and uploads are re-copied
   with `--delete`. Nothing accumulates: staging holds a snapshot, never a divergent second copy
   of member data with its own history.
@@ -349,6 +354,13 @@ after the restore and verification, and restarts anything running — whether it
 itself or found it started mid-flight. A restart re-runs `DatabaseMigrationHostedService`
 against the finished database, and the log line it prints is what §8.2 reads. The refresh is
 therefore idempotent with respect to deploy timing rather than dependent on it.
+
+**On failure it goes the other way.** A restore, verification, or uploads copy that fails after
+the `DROP` never reaches that hand-back — `set -e` exits first — so the script's `EXIT` trap
+stops the app instead. Otherwise a container that came up mid-flight would be left serving a
+partial clone under the pushed SHA: workflow red, staging apparently healthy, which is exactly
+the wrong way round for a promotion gate. Staging stays down until the next refresh restores
+it, and down is the honest state.
 
 **The durable fix is ordering, not correction.** Turning off Coolify's auto-deploy for the
 staging resource and having `staging-db.yml` trigger the deploy through Coolify's API once the

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -110,10 +110,16 @@ fine.
 After restoring, the script fails the workflow if the restored database has no tables, if any
 **expected** `__EFMigrationsHistory*` table is missing, or if any of them came back empty.
 There is one history table per DbContext since the per-section split
-(nobodies-collective/Humans#858), so the expected set is `__EFMigrationsHistory` plus one
-`__EFMigrationsHistory_<Section>` per entry in `SECTION_DB_CONTEXTS` — the same list
-`.github/workflows/build.yml` uses, duplicated in the script's defaults and kept in step with
-it by name.
+(nobodies-collective/Humans#858).
+
+**The expected set is read from production's catalog, not from the checkout.** A release that
+adds a section arrives at staging with a DbContext whose first migration has not run anywhere
+yet, so production's backup legitimately has no history table for it. Deriving the expected set
+from the candidate's list of contexts would reject that valid backup — making the gate
+impossible to pass for precisely the releases most worth rehearsing. What the backup should
+contain is what production's deployed schema contains, so that is what it is compared against.
+This is the one statement `backup` mode runs against the production database, and it reads
+table names from `information_schema`.
 
 Missing and empty are different failures and both are quiet. An empty history table has the
 app boot happily and then apply that section's migrations from scratch against tables that
@@ -157,8 +163,9 @@ filename does not carry the database name — instead of the newest match. That 
 `BACKUP_MAX_AGE_HOURS` bound, which exists to catch a stalled schedule rather than to stop
 someone deliberately restoring an old artifact.
 
-Nothing in the script writes to production. `backup` never opens the production database at
-all; `live` only reads it; the uploads copy is one-way. The destructive statements target
+Nothing in the script writes to production. `backup` reads only its catalog, to learn which
+migration-history tables the backup is expected to carry; `live` reads its data as well; the
+uploads copy is one-way. The destructive statements target
 `humans_staging`, and the script refuses to start if that name has drifted onto `humans` or a
 `humans_pr_*` preview.
 
@@ -173,7 +180,8 @@ this host** — those are QA's and production's values.
 | Variable | Value | Why it cannot be left to defaults |
 |---|---|---|
 | `ASPNETCORE_ENVIRONMENT` | `Staging` | Selects the connector-stubbing branches in §5 |
-| `ConnectionStrings__DefaultConnection` | `Host=humans-db;Database=humans_staging;Username=humans;Password=<prod DB password>` | Same Postgres server as production, different database |
+| `ConnectionStrings__DefaultConnection` | `Host=humans-db;Database=humans_staging;Username=humans_staging;Password=<staging role password>` | Same Postgres server as production, different database **and different role**. Not `humans` — see §7.7. The database name in a connection string is a choice the application makes at runtime; the role's grants are what actually stop staging reaching production |
+| `POSTGRES_PASSWORD` | the **staging** role's password | Only if the staging resource templates its connection string from it. Never production's |
 | `AllowedHosts` | `staging.nobodies.team;localhost` | `appsettings.Staging.json` sets this to `humans.n.burn.camp;localhost`. Leave it and **every request to staging is rejected** before it reaches a controller |
 | `Email__BaseUrl` | `https://staging.nobodies.team` | Same file points it at QA. Links in anything staging generates would send people to QA |
 | `Email__SmtpHost` | *(empty string — see §5)* | Its default in `appsettings.json` is a real relay. **This is the one that decides whether staging can send mail to real members** |
@@ -181,7 +189,6 @@ this host** — those are QA's and production's values.
 | `Authentication__Google__ClientId` | production's value | Same OAuth client, with the staging redirect URI added |
 | `Authentication__Google__ClientSecret` | production's value | |
 | `GOOGLE_MAPS_API_KEY` | production's value | Read-only autocomplete; safe to share |
-| `POSTGRES_PASSWORD` | production's value | Only if the staging resource templates the connection string from it |
 
 ### Must stay unset
 
@@ -369,7 +376,49 @@ JavaScript origins** if that list is in use.
 
 **Check:** it resolves to the same address as `humans.nobodies.team`.
 
-### 7.7 Confirm the deploy ordering
+### 7.7 Create a restricted database role for staging
+
+**Required.** Staging and production share a Postgres server, and the database named in a
+connection string is a runtime choice, not a boundary. If staging connects as `humans` — the
+role that owns production — then staged code reaches production data by changing one string,
+and an accidental override or a bad candidate release is production-impacting. Every stub in §5
+is irrelevant to this: it is a direct database connection, not a connector.
+
+```sql
+CREATE ROLE humans_staging LOGIN PASSWORD '<a new password, not production''s>';
+REVOKE ALL ON DATABASE humans FROM humans_staging;
+REVOKE CONNECT ON DATABASE humans FROM humans_staging, PUBLIC;
+GRANT ALL ON DATABASE humans_staging TO humans_staging;
+```
+
+`REVOKE ... FROM PUBLIC` matters: without it the implicit `PUBLIC` grant lets any role connect
+to `humans`, and the revoke on the named role achieves nothing.
+
+Then set `STAGING_DB_OWNER=humans_staging` as a repository variable. The refresh script grants
+that role rights on each restored database — the restore itself runs as `humans`, so without the
+grant staging would connect successfully and then fail on the first query. When
+`STAGING_DB_OWNER` is unset the script logs a warning naming this section, because the default
+is the insecure one.
+
+**Check:** `psql -U humans_staging -d humans` is refused, and `psql -U humans_staging -d
+humans_staging` succeeds.
+
+### 7.8 Protect the `staging` branch
+
+**Required, and it is a production-host security control rather than a hygiene one.** The
+refresh workflow runs on the production host with Docker access, which is effectively root
+there. `.github/workflows/staging-db.yml` checks out `main` rather than the pushed commit, so a
+candidate cannot rewrite the *script* it runs — but for `on: push`, GitHub reads the *workflow
+file itself* from the pushed ref. Anyone who can push to `staging` can therefore add a step and
+run it as root on the production host, before the production PR is reviewed.
+
+GitHub → **Settings → Branches → Add rule** for `staging`: restrict who can push to the people
+who run promotions. Do not add required status checks — `/pr-prod` pushes a commit that CI has
+already passed on the fork, and a pending check would stall the promotion.
+
+**Check:** a push to `staging` from an account outside the allow-list is rejected.
+
+### 7.9 Confirm the deploy ordering
 
 Coolify auto-deploys the staging app on push to `staging`, and the refresh workflow starts on
 the same push. **Nothing orders the two.** In practice the refresh (seconds) finishes long

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -328,6 +328,7 @@ repository cannot know; the script fails loudly rather than guessing.
 | `COOLIFY_BACKUP_DIR` | Where Coolify writes database backup artifacts, if not `/data/coolify/backups`. Prefer the **production resource's own** backup directory over the shared root — it removes any chance of selecting another database's artifact | Only if different |
 | `BACKUP_MAX_AGE_HOURS` | How old the newest artifact may be before the refresh fails as a backup incident. Default 48 — set it to match the real Coolify backup schedule, since a cadence slower than the bound fails every refresh and one much faster than it wastes the signal | Recommended |
 | `STAGING_DB_CONTAINER` | Postgres container name, if not `humans-db` | Only if different |
+| `STAGING_DB_OWNER` | The restricted role from §7.7, e.g. `humans_staging`. Unset, the refresh leaves the restored objects owned by production's role and logs a warning | Yes, once §7.7 is done |
 | `STAGING_APP_CONTAINER` | Staging app container name, stable across deploys. The script stops the app before dropping its database and restarts it afterwards, and refuses to run if the name is unset or does not resolve — an app left running through the drop reconnects to a half-restored database and stays there | Yes |
 
 **Check:** run the workflow manually (**Actions → Staging Database Refresh → Run workflow**) and
@@ -389,19 +390,27 @@ CREATE ROLE humans_staging LOGIN PASSWORD '<a new password, not production''s>';
 REVOKE ALL ON DATABASE humans FROM humans_staging;
 REVOKE CONNECT ON DATABASE humans FROM humans_staging, PUBLIC;
 GRANT ALL ON DATABASE humans_staging TO humans_staging;
+GRANT humans_staging TO humans;
 ```
 
-`REVOKE ... FROM PUBLIC` matters: without it the implicit `PUBLIC` grant lets any role connect
-to `humans`, and the revoke on the named role achieves nothing.
+Two of those lines are easy to leave out, and each one silently defeats the step:
 
-Then set `STAGING_DB_OWNER=humans_staging` as a repository variable. The refresh script grants
-that role rights on each restored database — the restore itself runs as `humans`, so without the
-grant staging would connect successfully and then fail on the first query. When
-`STAGING_DB_OWNER` is unset the script logs a warning naming this section, because the default
-is the insecure one.
+- **`REVOKE ... FROM PUBLIC`.** Postgres grants `CONNECT` to `PUBLIC` by default, so revoking
+  it from the named role alone changes nothing — staging would still reach `humans`.
+- **`GRANT humans_staging TO humans`.** Changing an object's owner requires membership of the
+  role receiving it. Without this the refresh script cannot hand the restored objects over and
+  fails at that step, unless `humans` happens to be a superuser — not something to depend on.
 
-**Check:** `psql -U humans_staging -d humans` is refused, and `psql -U humans_staging -d
-humans_staging` succeeds.
+Then set `STAGING_DB_OWNER=humans_staging` as a repository variable (§7.3). The refresh script
+transfers ownership of every restored object to that role — **ownership, not privileges**. The
+restore runs as `humans`, and EF migrations issue `ALTER TABLE` and `DROP TABLE`, which `GRANT`
+does not confer. With grants alone staging would start cleanly and then fail on the first
+schema-changing release, which is the release the rehearsal exists for. When `STAGING_DB_OWNER`
+is unset the script logs a warning naming this section, because the default is the insecure one.
+
+**Check:** `psql -U humans_staging -d humans` is refused; `psql -U humans_staging -d
+humans_staging` succeeds; and after a refresh `\dt` in `humans_staging` shows `humans_staging`
+owning the restored tables.
 
 ### 7.8 Protect the `staging` branch
 

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -87,8 +87,18 @@ restore-source switch and the verification step added.
 
 | Source | What it restores | When |
 |---|---|---|
-| **`backup`** (default) | The newest Coolify backup artifact under `COOLIFY_BACKUP_DIR` | Every push. Doubles as the restore test — a broken backup fails the workflow here rather than during an incident |
+| **`backup`** (default) | The newest Coolify backup artifact **for the `humans` database** under `COOLIFY_BACKUP_DIR` | Every push. Doubles as the restore test — a broken backup fails the workflow here rather than during an incident |
 | **`live`** | `pg_dump` straight from the production database | Manual override via **Actions → Staging Database Refresh → Run workflow → source: live**, when you need data newer than the last backup |
+
+**The database name has to match as a whole token, not as a substring.** `humans_staging`,
+`humans_restore` and `humans_pr_12` all contain `humans`, and all of them restore cleanly and
+satisfy every check below — so a newer artifact for one of those would be promoted as though it
+were production, having verified the release against the wrong snapshot. The selector keeps an
+artifact only when the character after the database name is a digit or a separator (the
+timestamp Coolify appends); a letter, with or without an underscore, means a different database
+whose name merely starts with this one. Pointing `COOLIFY_BACKUP_DIR` at the production
+resource's own backup directory removes the ambiguity at the source and is worth doing if
+Coolify's layout allows it.
 
 Format is detected, not assumed: `.gz` is decompressed, then the `PGDMP` magic bytes select
 `pg_restore --exit-on-error` over `psql -v ON_ERROR_STOP=1`. Both paths carry a
@@ -123,12 +133,13 @@ that is a deliberate reach for an older artifact; `BACKUP_MAX_AGE_HOURS=0` disab
 `rsync -a --delete` from production's uploads directory into staging's. A **copy**, never a
 shared mount — staging writes to its uploads directory, and production's bytes must not be on
 the other end of that. `--delete` is deliberate: staging's own uploads are wiped on every
-refresh, exactly like its database. The script refuses to run if both paths are not set, or if
-they are the same directory, or if either is nested inside the other — the two paths are
-resolved with `realpath` first, so a trailing slash or a symlink cannot disguise any of those.
-Nesting is the one worth spelling out: with staging at `/data` and production at
-`/data/uploads`, `rsync --delete` finds production's directory extraneous at the destination
-and deletes it.
+refresh, exactly like its database. The script refuses to run if both paths are not set, if
+either resolves to `/`, if they are the same directory, or if either is nested inside the
+other — the two paths are resolved with `realpath` first, so a trailing slash or a symlink
+cannot disguise any of those. Nesting is the one worth spelling out: with staging at `/data`
+and production at `/data/uploads`, `rsync --delete` finds production's directory extraneous at
+the destination and deletes it. `/` is rejected separately because it is the only canonical
+path that already ends in a slash, which is exactly the shape the nesting test cannot see.
 
 ### Running it by hand
 
@@ -307,7 +318,7 @@ repository cannot know; the script fails loudly rather than guessing.
 |---|---|---|
 | `PROD_UPLOADS_DIR` | Host path backing production's `/app/wwwroot/uploads` (Coolify → the production resource → **Storages**) | Yes |
 | `STAGING_UPLOADS_DIR` | Host path for staging's uploads — a **new, separate** directory | Yes |
-| `COOLIFY_BACKUP_DIR` | Where Coolify writes database backup artifacts, if not `/data/coolify/backups` | Only if different |
+| `COOLIFY_BACKUP_DIR` | Where Coolify writes database backup artifacts, if not `/data/coolify/backups`. Prefer the **production resource's own** backup directory over the shared root — it removes any chance of selecting another database's artifact | Only if different |
 | `BACKUP_MAX_AGE_HOURS` | How old the newest artifact may be before the refresh fails as a backup incident. Default 48 — set it to match the real Coolify backup schedule, since a cadence slower than the bound fails every refresh and one much faster than it wastes the signal | Recommended |
 | `STAGING_DB_CONTAINER` | Postgres container name, if not `humans-db` | Only if different |
 | `STAGING_APP_CONTAINER` | Staging app container name, stable across deploys. The script stops the app before dropping its database and restarts it afterwards, and refuses to run if the name is unset or does not resolve — an app left running through the drop reconnects to a half-restored database and stays there | Yes |

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -109,7 +109,11 @@ from scratch against tables that already exist.
 shared mount — staging writes to its uploads directory, and production's bytes must not be on
 the other end of that. `--delete` is deliberate: staging's own uploads are wiped on every
 refresh, exactly like its database. The script refuses to run if both paths are not set, or if
-they are the same path.
+they are the same directory, or if either is nested inside the other — the two paths are
+resolved with `realpath` first, so a trailing slash or a symlink cannot disguise any of those.
+Nesting is the one worth spelling out: with staging at `/data` and production at
+`/data/uploads`, `rsync --delete` finds production's directory extraneous at the destination
+and deletes it.
 
 ### Running it by hand
 

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -1,0 +1,357 @@
+# Staging Environment
+
+**Production-candidate code, running against a fresh clone of production data, on the
+production host.** Every promotion to production passes through it first, so the first time a
+migration meets real production data is on staging rather than on production — and because the
+clone is normally restored from the newest Coolify backup artifact, every staging deploy is
+also a live test of the restore path that
+[`database-restore-runbook.md`](database-restore-runbook.md) documents.
+
+> **Not live yet.** The repository half of this — the refresh script, its workflow, this
+> document, and the `/pr-prod` promotion step — is committed. The environment itself does not
+> exist until someone with Coolify, Google Cloud console, and shell access to the production
+> host works through [§7 Host-side steps](#7-host-side-steps-owner).
+> nobodies-collective/Humans#962.
+
+---
+
+## 1. Topology
+
+| Environment | Host | Deploys from | Database | `ASPNETCORE_ENVIRONMENT` |
+|---|---|---|---|---|
+| Production — `humans.nobodies.team` | prod server | `upstream/main` | `humans` | `Production` |
+| **Staging — `staging.nobodies.team`** | **prod server** | **`upstream/staging`** | **`humans_staging`** | **`Staging`** |
+| QA — `humans.n.burn.camp` | NUC | `origin/main` | `humans` (on the NUC) | `Staging` |
+| PR previews — `{pr}.n.burn.camp` | NUC | the PR branch | `humans_pr_{N}` | `Staging` |
+
+Staging and QA share the `Staging` environment name, and therefore share
+`src/Humans.Web/appsettings.Staging.json`. **That file is QA's** — it pins `Email:BaseUrl` and
+`AllowedHosts` to `humans.n.burn.camp`. Everything staging-specific is a Coolify environment
+variable override, which is why §4 is not optional reading.
+
+Production's deploy semantics do not change: it still auto-deploys `upstream/main` on push.
+
+---
+
+## 2. The promotion cycle
+
+```
+origin/main  ──push──▶  upstream/staging  ──▶  refresh humans_staging  ──▶  staging deploy
+                                                                                  │
+                                                                             verify (§8)
+                                                                                  │
+                                             upstream/main ◀── fast-forward ──────┘
+                                                    │
+                                            production deploy
+```
+
+The gate is git-native: `upstream/main` only ever moves to a commit that already deployed and
+was verified on staging. `/pr-prod` (`.claude/skills/pr-prod/SKILL.md`) drives it.
+
+**Sequential promotions stay fast-forwards.** `origin/main` is a superset of `upstream/main`,
+so each cycle's push to `staging` is a fast-forward of the previous one. It stops being one if a
+batch is verified on staging and then abandoned rather than promoted. Recovering from that needs
+a force-push to `upstream/staging`, which needs Peter's explicit per-instance approval
+(`memory/process/no-force-push-without-permission.md`) — so don't abandon a batch quietly.
+
+---
+
+## 3. Database and uploads refresh
+
+`scripts/refresh-staging-db.sh`, run on the production host by
+`.github/workflows/staging-db.yml` on every push to `staging`.
+
+It terminates connections to `humans_staging`, drops and recreates it, restores, verifies, and
+copies uploads. The recipe is the one `preview-db.yml` already uses for PR previews, with the
+restore-source switch and the verification step added.
+
+### Two sources
+
+| Source | What it restores | When |
+|---|---|---|
+| **`backup`** (default) | The newest Coolify backup artifact under `COOLIFY_BACKUP_DIR` | Every push. Doubles as the restore test — a broken backup fails the workflow here rather than during an incident |
+| **`live`** | `pg_dump` straight from the production database | Manual override via **Actions → Staging Database Refresh → Run workflow → source: live**, when you need data newer than the last backup |
+
+Format is detected, not assumed: `.gz` is decompressed, then the `PGDMP` magic bytes select
+`pg_restore --exit-on-error` over `psql -v ON_ERROR_STOP=1`. Both paths carry a
+stop-on-first-error flag, because the failure mode without one is a partial database that looks
+fine.
+
+### What it verifies
+
+After restoring, the script fails the workflow if the restored database has no tables, or if
+**any** `__EFMigrationsHistory*` table came back empty. There is one history table per
+DbContext since the per-section split (nobodies-collective/Humans#858), and an empty one is the
+quiet failure worth catching: the app boots happily and then applies that section's migrations
+from scratch against tables that already exist.
+
+### Uploads
+
+`rsync -a --delete` from production's uploads directory into staging's. A **copy**, never a
+shared mount — staging writes to its uploads directory, and production's bytes must not be on
+the other end of that. `--delete` is deliberate: staging's own uploads are wiped on every
+refresh, exactly like its database. The script refuses to run if both paths are not set, or if
+they are the same path.
+
+### Running it by hand
+
+On the production host, from a checkout:
+
+```bash
+PROD_UPLOADS_DIR=/path/to/prod/uploads \
+STAGING_UPLOADS_DIR=/path/to/staging/uploads \
+./scripts/refresh-staging-db.sh backup      # or: live
+```
+
+Nothing in the script writes to production. `backup` never opens the production database at
+all; `live` only reads it; the uploads copy is one-way. The destructive statements target
+`humans_staging`, and the script refuses to start if that name has drifted onto `humans` or a
+`humans_pr_*` preview.
+
+---
+
+## 4. Configuration
+
+Set on the Coolify staging application. Values in `appsettings.Staging.json` and
+`appsettings.json` are the fallback, and for the first three rows the fallback is **wrong for
+this host** — those are QA's and production's values.
+
+| Variable | Value | Why it cannot be left to defaults |
+|---|---|---|
+| `ASPNETCORE_ENVIRONMENT` | `Staging` | Selects the connector-stubbing branches in §5 |
+| `ConnectionStrings__DefaultConnection` | `Host=humans-db;Database=humans_staging;Username=humans;Password=<prod DB password>` | Same Postgres server as production, different database |
+| `AllowedHosts` | `staging.nobodies.team;localhost` | `appsettings.Staging.json` sets this to `humans.n.burn.camp;localhost`. Leave it and **every request to staging is rejected** before it reaches a controller |
+| `Email__BaseUrl` | `https://staging.nobodies.team` | Same file points it at QA. Links in anything staging generates would send people to QA |
+| `Email__SmtpHost` | *(empty string — see §5)* | Its default in `appsettings.json` is a real relay. **This is the one that decides whether staging can send mail to real members** |
+| `DevAuth__Enabled` | `false` | No dev login, no dev seeding. Sign-in is real Google OAuth only |
+| `Authentication__Google__ClientId` | production's value | Same OAuth client, with the staging redirect URI added |
+| `Authentication__Google__ClientSecret` | production's value | |
+| `GOOGLE_MAPS_API_KEY` | production's value | Read-only autocomplete; safe to share |
+| `POSTGRES_PASSWORD` | production's value | Only if the staging resource templates the connection string from it |
+
+### Must stay unset
+
+Absence is the mechanism. Each of these is checked for presence, not for environment, so
+setting one turns the real connector on:
+
+| Variable | What setting it would do |
+|---|---|
+| `GoogleWorkspace__ServiceAccountKeyJson` / `__ServiceAccountKeyPath` | Real Drive/Groups clients. Reconciliation jobs would mutate real Workspace resources from cloned state |
+| `HOLDED_API_KEY` | Real `api.holded.com` client. `HoldedExpenseOutboxJob` runs every minute and would push cloned expense rows into the real accounting system |
+| `STRIPE_TICKETS_KEY`, `STRIPE_STORE_KEY`, `STRIPE_STORE_WEBHOOK_SECRET`, `STRIPE_STORE_WEBHOOK_REGISTRAR_KEY` | Live payment calls. The registrar key additionally re-points the Store webhook |
+| `Anthropic__ApiKey` | Billed agent calls from a full copy of production's data |
+| `GITHUB_ACCESS_TOKEN` | Not dangerous — legal-doc sync is a read. Omit anyway; staging does not need the rate limit |
+| `TICKET_VENDOR_API_KEY` | Harmless as it happens (§5), but omit it — do not rely on a second gate holding |
+
+---
+
+## 5. Why it is safe, and the one place it is not
+
+The cloned database carries production's live email outbox rows, real member addresses, and
+real Workspace/Holded identifiers. A staging environment labelled `Production` would double-send
+pending mail on its first boot. Stubbing is the safety requirement here, not a backdoor.
+
+**Stubbed by environment** — cannot be turned on from Coolify:
+
+- **TicketTailor.** `TicketVendorInfrastructureExtensions.cs` registers `TicketTailorService`
+  only when `IsProduction()`. Everything else gets `StubTicketVendorService`, whatever
+  `TICKET_VENDOR_API_KEY` says.
+- **Dev login and dev seeding.** `DevLoginController` and `DevSeedController` return `NotFound`
+  unless `DevAuth:Enabled` is true — and it defaults to false. Real Google OAuth is the only way
+  in, and authorization comes from the cloned database, so the same people hold the same roles
+  they hold in production.
+- **Stripe Store webhook registration.** `StoreWebhookRegistrationService` needs both the
+  registrar key and a hostname ending `.n.burn.camp`; `staging.nobodies.team` fails the second
+  test regardless of the first.
+
+**Stubbed by absence of credentials** — Google Workspace, via
+`GoogleWorkspaceInfrastructureExtensions.cs`: credentials present means real clients in any
+environment, absent means stubs everywhere except production (where it throws instead). Leave
+the two variables unset and staging gets `StubGoogleSyncService` and friends.
+
+> ### ⚠️ Email does not stub itself. `Email__SmtpHost` must be set empty.
+>
+> `EmailInfrastructureExtensions.cs` chooses `StubEmailTransport` only when
+> `Email:SmtpHost` is empty — and `appsettings.json` gives it a real default,
+> `smtp-relay.gmail.com`, in every environment. So "no email credentials" does **not** stub
+> email the way it stubs Workspace: staging gets `SmtpEmailTransport` pointed at a real relay
+> unless `Email__SmtpHost` is explicitly overridden to an empty string.
+>
+> This is fail-**open**, and it is the wrong way round for a host whose database is a copy of
+> production's outbox. Setting the variable is required, and confirming it is a §8 verification
+> step rather than something to assume.
+>
+> **Open question for Peter (nobodies-collective/Humans#962).** The durable fix is to make
+> email fail closed — stub unless SMTP is explicitly configured *for this environment*. The
+> obvious change (`"Email": { "SmtpHost": "" }` in `appsettings.Staging.json`) also changes QA,
+> which shares that file and may be sending real mail today on purpose. Not made here for that
+> reason.
+
+---
+
+## 6. GDPR
+
+**Staging holds full member PII** — every profile, email address, emergency contact, and
+consent record that production holds, restored whole.
+
+What makes that defensible under the existing posture:
+
+- **Same host, same operators.** The data does not leave the machine that already holds it, and
+  no new person gains access to it.
+- **Real-login authorization only.** No dev login, no seeded personas, no anonymous path. Sign-in
+  is Google OAuth against the cloned database, so the same humans hold the same roles they hold
+  in production — staging grants nobody access they do not already have.
+- **No new egress.** Every outbound connector is stubbed (§5), so PII is not forwarded to any
+  third party from here.
+- **Wiped on every refresh.** The database is dropped and recreated, and uploads are re-copied
+  with `--delete`. Nothing accumulates: staging holds a snapshot, never a divergent second copy
+  of member data with its own history.
+
+**It still argues for dropping the staging database when idle.** Between promotion cycles,
+staging is a full copy of production's personal data sitting on disk earning nothing. The
+minimising step is to drop it and let the next push restore it:
+
+```bash
+docker exec humans-db psql -U humans -d postgres -c "DROP DATABASE IF EXISTS humans_staging"
+rm -rf <staging uploads dir>/*
+```
+
+The next push to `staging` rebuilds both. Do this after a promotion lands, not before verifying
+it.
+
+---
+
+## 7. Host-side steps (owner)
+
+None of this can be done from the repository — it needs the Coolify console, the Google Cloud
+console, and a shell on the production host. Until every box is ticked, pushing to `staging`
+does nothing useful.
+
+### 7.1 Create the `staging` branch
+
+```bash
+git push upstream upstream/main:refs/heads/staging
+```
+
+**Check:** the branch shows on `nobodies-collective/Humans` at the same SHA as `main`.
+
+### 7.2 Install the self-hosted runner on the production host
+
+GitHub → `nobodies-collective/Humans` → **Settings → Actions → Runners → New self-hosted
+runner → Linux**, and follow the generated commands on the production host. This is the only
+genuinely new infrastructure.
+
+- **Labels: `self-hosted` and `prod`.** `.github/workflows/staging-db.yml` targets
+  `[self-hosted, prod]`. The `nuc` label belongs to QA's runner and must not be added here, or
+  `preview-db.yml` will start running preview clones on the production host.
+- The runner's user needs to run `docker` (in the `docker` group), read the Coolify backup
+  directory, read production's uploads directory, and write staging's.
+- Install it as a service (`./svc.sh install && ./svc.sh start`) so it survives a reboot.
+
+**Check:** the runner shows **Idle** with both labels in the Runners list.
+
+### 7.3 Set the repository variables
+
+GitHub → **Settings → Secrets and variables → Actions → Variables**. These are paths the
+repository cannot know; the script fails loudly rather than guessing.
+
+| Variable | Value | Required |
+|---|---|---|
+| `PROD_UPLOADS_DIR` | Host path backing production's `/app/wwwroot/uploads` (Coolify → the production resource → **Storages**) | Yes |
+| `STAGING_UPLOADS_DIR` | Host path for staging's uploads — a **new, separate** directory | Yes |
+| `COOLIFY_BACKUP_DIR` | Where Coolify writes database backup artifacts, if not `/data/coolify/backups` | Only if different |
+| `STAGING_DB_CONTAINER` | Postgres container name, if not `humans-db` | Only if different |
+| `STAGING_APP_CONTAINER` | Staging app container name. Set it — the script stops the app before dropping its database and starts it again afterwards | Recommended |
+
+**Check:** run the workflow manually (**Actions → Staging Database Refresh → Run workflow**) and
+watch it find a backup artifact, restore it, print a non-empty migration-history table per
+context, and copy uploads.
+
+### 7.4 Create the Coolify staging application
+
+New application on the production server, from `nobodies-collective/Humans`, branch `staging`,
+domain `staging.nobodies.team`.
+
+- Environment variables per §4 — including `Email__SmtpHost` **set and empty**, and the §4
+  "must stay unset" list genuinely absent rather than blank-but-present where the code checks
+  presence.
+- Persistent storage mounted at `/app/wwwroot/uploads`, backed by the same host path as
+  `STAGING_UPLOADS_DIR`.
+- Persistent storage mounted at `/app/db-snapshots`. Staging takes pre-migration snapshots too
+  (`DatabaseMigrationHostedService` runs them for `Production` and `Staging`), and without a
+  volume they die with the container.
+- **No scheduled backups on `humans_staging`.** It is disposable by design, and backing it up
+  would create a second off-host copy of member PII (§6).
+- TLS certificate for `staging.nobodies.team` (Coolify handles Let's Encrypt once DNS resolves).
+
+**Check:** `https://staging.nobodies.team/api/version` returns JSON rather than a certificate
+error or a 400.
+
+### 7.5 Add the staging redirect URI to the OAuth client
+
+Google Cloud console → **APIs & Services → Credentials** → the OAuth 2.0 client whose ID is in
+production's `Authentication__Google__ClientId` → **Authorised redirect URIs** → add exactly:
+
+```
+https://staging.nobodies.team/signin-google
+```
+
+`/signin-google` is the ASP.NET Core Google handler's default callback path; nothing in
+`Program.cs` overrides it. Add the origin `https://staging.nobodies.team` to **Authorised
+JavaScript origins** if that list is in use.
+
+**Check:** signing in at `staging.nobodies.team` completes instead of failing with
+`redirect_uri_mismatch`.
+
+### 7.6 Point DNS at the production host
+
+`staging.nobodies.team` → the production server's address.
+
+**Check:** it resolves to the same address as `humans.nobodies.team`.
+
+### 7.7 Confirm the deploy ordering
+
+Coolify auto-deploys the staging app on push to `staging`, and the refresh workflow starts on
+the same push. In practice the refresh (seconds) finishes long before the image build (minutes),
+and the script stops the app before dropping its database and restarts it afterwards, so either
+order is survivable.
+
+**Check:** after the first real push, the workflow log shows the restore completing, and the
+staging app's log shows migrations applying to the restored database — not to an empty one.
+
+---
+
+## 8. Verifying a staging deploy
+
+Before fast-forwarding `upstream/main`:
+
+1. **The pushed commit is live.** `curl -s https://staging.nobodies.team/api/version` reports
+   the `commit` you pushed.
+2. **Migrations applied to the clone.** The staging app log carries the migration breadcrumb —
+   `Database humans_staging: N applied migrations, 0 pending` — with the release's migrations
+   applied, not re-applied from scratch. Any migration that was going to fail against production
+   data has already failed here.
+3. **Real sign-in works.** Sign in with Google. You land with the roles you hold in production,
+   because that is the database you are looking at.
+4. **Email is stubbed.** `/Debug/Configuration` (Admin only) lists `Email:SmtpHost`; on staging
+   it must show as unset. It is registered as a critical setting, so an empty value shows up as
+   a missing critical one — that is the correct state here, not a problem to fix. This is the §5
+   fail-open, and it is worth one look per deploy rather than one assumption.
+5. **Exercise what the release changed.** Against real data, which is the entire point of the
+   environment.
+
+If any of this fails, the promotion stops. The bad commit is on `staging` only, and the next
+push overwrites it.
+
+---
+
+## 9. Relationship to the restore runbook
+
+[`database-restore-runbook.md`](database-restore-runbook.md) is what you read when production's
+database is wrong. This document is what keeps that runbook honest: the `backup` source restores
+a real Coolify artifact on every promotion, so the archive format, the artifact path, and the
+restore itself are exercised continuously rather than the once
+nobodies-collective/Humans#845 asked for.
+
+A staging refresh that fails on the restore step is telling you something about **production's
+backups**, not about staging. Treat it as an incident on the backup path.

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -214,6 +214,13 @@ The cloned database carries production's live email outbox rows, real member add
 real Workspace/Holded identifiers. A staging environment labelled `Production` would double-send
 pending mail on its first boot. Stubbing is the safety requirement here, not a backdoor.
 
+**Stubbing is only half of it.** Everything in this section governs *connectors* — code paths
+that reach a third party. It says nothing about the database, and staging shares a Postgres
+server with production, so a staging app holding production's role reaches live data directly
+with no connector in the path and no stub able to intervene. That boundary is a role grant, not
+a code branch, and it is §7.7. Read the two together: §5 is why staging cannot talk to the
+outside world, §7.7 is why it cannot talk to production's database.
+
 **Stubbed by environment** — cannot be turned on from Coolify:
 
 - **TicketTailor.** `TicketVendorInfrastructureExtensions.cs` registers `TicketTailorService`
@@ -479,7 +486,19 @@ Before merging the production PR onto `upstream/main`:
    it must show as unset. It is registered as a critical setting, so an empty value shows up as
    a missing critical one — that is the correct state here, not a problem to fix. This is the §5
    fail-open, and it is worth one look per deploy rather than one assumption.
-5. **Exercise what the release changed.** Against real data, which is the entire point of the
+5. **Staging is on its own database role.** Nothing in the app reports this —
+   `/Debug/Configuration` does not carry the connection string — so ask Postgres, on the
+   production host:
+
+   ```bash
+   docker exec humans-db psql -U humans -d postgres \
+     -c "SELECT DISTINCT usename FROM pg_stat_activity WHERE datname = 'humans_staging'"
+   ```
+
+   It must show `humans_staging`, never `humans`. Same reasoning as the check above it: §7.7 is
+   a configuration boundary rather than a code one, so a Coolify edit undoes it silently and
+   nothing goes wrong until staging touches production.
+6. **Exercise what the release changed.** Against real data, which is the entire point of the
    environment.
 
 If any of this fails, the promotion stops. The bad commit is on `staging` only, and the next

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -107,6 +107,7 @@ On the production host, from a checkout:
 ```bash
 PROD_UPLOADS_DIR=/path/to/prod/uploads \
 STAGING_UPLOADS_DIR=/path/to/staging/uploads \
+STAGING_APP_CONTAINER=<staging app container> \
 ./scripts/refresh-staging-db.sh backup      # or: live
 ```
 
@@ -271,7 +272,7 @@ repository cannot know; the script fails loudly rather than guessing.
 | `STAGING_UPLOADS_DIR` | Host path for staging's uploads — a **new, separate** directory | Yes |
 | `COOLIFY_BACKUP_DIR` | Where Coolify writes database backup artifacts, if not `/data/coolify/backups` | Only if different |
 | `STAGING_DB_CONTAINER` | Postgres container name, if not `humans-db` | Only if different |
-| `STAGING_APP_CONTAINER` | Staging app container name. Set it — the script stops the app before dropping its database and starts it again afterwards | Recommended |
+| `STAGING_APP_CONTAINER` | Staging app container name, stable across deploys. The script stops the app before dropping its database and restarts it afterwards, and refuses to run if the name is unset or does not resolve — an app left running through the drop reconnects to a half-restored database and stays there | Yes |
 
 **Check:** run the workflow manually (**Actions → Staging Database Refresh → Run workflow**) and
 watch it find a backup artifact, restore it, print a non-empty migration-history table per
@@ -322,12 +323,29 @@ JavaScript origins** if that list is in use.
 ### 7.7 Confirm the deploy ordering
 
 Coolify auto-deploys the staging app on push to `staging`, and the refresh workflow starts on
-the same push. In practice the refresh (seconds) finishes long before the image build (minutes),
-and the script stops the app before dropping its database and restarts it afterwards, so either
-order is survivable.
+the same push. **Nothing orders the two.** In practice the refresh (seconds) finishes long
+before the image build (minutes), but that is a timing observation, not a guarantee, and the
+case it would leave behind is the quiet one: a container that came up between the `DROP` and
+the end of the restore, migrated a partial clone, and now serves the pushed SHA at
+`/api/version` — passing §8.1 while §8.2 is a lie.
+
+The script closes that by not trusting its own snapshot. It re-reads the container's state
+after the restore and verification, and restarts anything running — whether it stopped it
+itself or found it started mid-flight. A restart re-runs `DatabaseMigrationHostedService`
+against the finished database, and the log line it prints is what §8.2 reads. The refresh is
+therefore idempotent with respect to deploy timing rather than dependent on it.
+
+**The durable fix is ordering, not correction.** Turning off Coolify's auto-deploy for the
+staging resource and having `staging-db.yml` trigger the deploy through Coolify's API once the
+refresh succeeds would remove the window instead of repairing it. That needs a Coolify API
+token in repository secrets and the resource's UUID, so it is a deliberate follow-up rather
+than part of the repository half — and it is worth doing before this environment carries a
+promotion anyone relies on.
 
 **Check:** after the first real push, the workflow log shows the restore completing, and the
-staging app's log shows migrations applying to the restored database — not to an empty one.
+staging app's log shows migrations applying to the restored database — not to an empty one. If
+the workflow log carries `came up during the refresh`, the deploy raced the restore and the
+restart corrected it; that is the signal to do the ordering fix above.
 
 ---
 

--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -43,23 +43,34 @@ Production's deploy semantics do not change: it still auto-deploys `upstream/mai
 ## 2. The promotion cycle
 
 ```
-origin/main  ──push──▶  upstream/staging  ──▶  refresh humans_staging  ──▶  staging deploy
-                                                                                  │
-                                                                             verify (§8)
-                                                                                  │
-                                             upstream/main ◀── fast-forward ──────┘
+origin/main @ SHA  ──push SHA──▶  upstream/staging  ──▶  refresh humans_staging  ──▶  deploy
+                                                                                        │
+                                                                                   verify (§8)
+                                                                                        │
+                                   origin/promote/<date>-<sha> @ SHA  ◀── push SHA ─────┘
                                                     │
-                                            production deploy
+                                          PR ── rebase merge ──▶  upstream/main
+                                                                        │
+                                                                production deploy
 ```
 
 The gate is git-native: `upstream/main` only ever moves to a commit that already deployed and
 was verified on staging. `/pr-prod` (`.claude/skills/pr-prod/SKILL.md`) drives it.
 
-**Sequential promotions stay fast-forwards.** `origin/main` is a superset of `upstream/main`,
-so each cycle's push to `staging` is a fast-forward of the previous one. It stops being one if a
-batch is verified on staging and then abandoned rather than promoted. Recovering from that needs
-a force-push to `upstream/staging`, which needs Peter's explicit per-instance approval
-(`memory/process/no-force-push-without-permission.md`) — so don't abandon a batch quietly.
+**The gate is pinned to a commit, not to a branch.** `/pr-prod` captures the SHA it stages,
+pushes that SHA to `staging`, and opens the production PR from a one-shot `promote/<date>-<sha>`
+branch pointed at it. Opening the PR from `peterdrier:main` instead would let any feature PR
+landing on the fork between verification and merge ride into production unverified, while the
+body still named the older SHA — the branch head follows, the claim does not.
+
+**Pushes to `staging` stop being fast-forwards after the first cycle.** Upstream merges by
+rebase, so a promoted batch lands on `upstream/main` under rewritten SHAs, and
+`memory/process/after-prod-merge-reset.md` resets `origin/main` onto that rewritten history.
+`upstream/staging` is left at the pre-rebase commit, which is then nobody's ancestor. That
+rejection is the normal state of affairs, not evidence of an abandoned batch. Realigning the
+branch is a forced update and needs Peter's approval
+(`memory/process/no-destructive-actions-without-approval.md`); whether that approval should
+become standing is an open question recorded in `.claude/skills/pr-prod/SKILL.md`.
 
 ---
 
@@ -351,7 +362,7 @@ restart corrected it; that is the signal to do the ordering fix above.
 
 ## 8. Verifying a staging deploy
 
-Before fast-forwarding `upstream/main`:
+Before merging the production PR onto `upstream/main`:
 
 1. **The pushed commit is live.** `curl -s https://staging.nobodies.team/api/version` reports
    the `commit` you pushed.

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -76,17 +76,22 @@ if [ "$SOURCE" = "live" ]; then
   RESTORE_KIND="live"
   log "Source: live pg_dump from '$PROD_DB'"
 else
-  [ -d "$COOLIFY_BACKUP_DIR" ] \
-    || die "backup directory '$COOLIFY_BACKUP_DIR' not found — set COOLIFY_BACKUP_DIR to Coolify's backup path, or pass 'live'"
+  # BACKUP_FILE picks a specific artifact — an older one, or one whose filename does not
+  # carry the database name. Unset, the newest matching artifact wins.
+  if [ -z "${BACKUP_FILE:-}" ]; then
+    [ -d "$COOLIFY_BACKUP_DIR" ] \
+      || die "backup directory '$COOLIFY_BACKUP_DIR' not found — set COOLIFY_BACKUP_DIR to Coolify's backup path, or pass 'live'"
 
-  # Coolify writes one file per scheduled backup under a per-resource directory; the
-  # database name is in the filename. Newest wins, whatever the nesting.
-  BACKUP_FILE=$(find "$COOLIFY_BACKUP_DIR" -type f -name "*${PROD_DB}*" \
-    \( -name '*.dump' -o -name '*.dmp' -o -name '*.sql' -o -name '*.backup' -o -name '*.gz' \) \
-    -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2-)
+    # Coolify writes one file per scheduled backup under a per-resource directory; the
+    # database name is in the filename. Newest wins, whatever the nesting.
+    BACKUP_FILE=$(find "$COOLIFY_BACKUP_DIR" -type f -name "*${PROD_DB}*" \
+      \( -name '*.dump' -o -name '*.dmp' -o -name '*.sql' -o -name '*.backup' -o -name '*.gz' \) \
+      -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2-)
 
-  [ -n "$BACKUP_FILE" ] \
-    || die "no backup artifact matching '*${PROD_DB}*' under '$COOLIFY_BACKUP_DIR' — check the path, or pass 'live'"
+    [ -n "$BACKUP_FILE" ] \
+      || die "no backup artifact matching '*${PROD_DB}*' under '$COOLIFY_BACKUP_DIR' — check the path, set BACKUP_FILE to one directly, or pass 'live'"
+  fi
+  [ -f "$BACKUP_FILE" ] || die "backup artifact '$BACKUP_FILE' is not a file"
 
   log "Source: $BACKUP_FILE ($(date -r "$BACKUP_FILE" '+%Y-%m-%d %H:%M:%S %Z'))"
 
@@ -163,6 +168,10 @@ esac
 TABLES=$(psql_staging -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE';" | tr -d '[:space:]')
 [ "${TABLES:-0}" -gt 0 ] || die "restored database has no tables — the archive was empty or the wrong file"
 log "Restored $TABLES tables"
+
+HISTORY_TABLES=$(psql_staging -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name LIKE '\_\_EFMigrationsHistory%';" | tr -d '[:space:]')
+[ "${HISTORY_TABLES:-0}" -gt 0 ] \
+  || die "restored database has no __EFMigrationsHistory table — this is not a Humans database"
 
 log "Migration history:"
 psql_staging -c "

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -8,10 +8,10 @@
 #           from docs/database-restore-runbook.md, run for real on every staging deploy.
 #   live    pg_dump straight out of the production database, for up-to-the-minute data.
 #
-# Nothing here writes to production: `backup` never opens the production database at all,
-# `live` only reads it, and the uploads copy is one-way. The only destructive statements
-# target $STAGING_DB, and the guards below refuse to run if that name has drifted onto
-# something real.
+# Nothing here writes to production: `backup` reads only its catalog, to learn which
+# migration-history tables a backup is expected to carry; `live` reads its data as well; and
+# the uploads copy is one-way. The only destructive statements target $STAGING_DB, and the
+# guards below refuse to run if that name has drifted onto something real.
 #
 # See docs/staging-environment.md for the environment this feeds and the host-side setup
 # it assumes. nobodies-collective/Humans#962.
@@ -32,10 +32,12 @@ STAGING_APP_CONTAINER="${STAGING_APP_CONTAINER:-}"
 # BACKUP_FILE is deliberately reaching for an older one. 0 disables the check.
 BACKUP_MAX_AGE_HOURS="${BACKUP_MAX_AGE_HOURS:-48}"
 
-# Per-section DbContexts, each of which owns a __EFMigrationsHistory_<Section> table since
-# nobodies-collective/Humans#858. Same list, same variable name, as
-# .github/workflows/build.yml — grep SECTION_DB_CONTEXTS to find both; they move together.
-SECTION_DB_CONTEXTS="${SECTION_DB_CONTEXTS:-SystemSettingsDbContext ContainersDbContext AgentDbContext ExpensesDbContext FinanceDbContext SurveysDbContext EventGuideDbContext}"
+# The role the staging application connects as. It must NOT be $DB_USER: that role owns
+# production, so a staging app holding it can simply point its connection string at
+# $PROD_DB and read or write live data — no code change required, no stub in the way.
+# docs/staging-environment.md §7.7 creates it. Defaults to $DB_USER so a first bootstrap
+# run works before the role exists; the script says so loudly when it does.
+STAGING_DB_OWNER="${STAGING_DB_OWNER:-$DB_USER}"
 
 log() { printf '==> %s\n' "$*"; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -230,6 +232,12 @@ psql_postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE d
 psql_postgres -c "DROP DATABASE IF EXISTS ${STAGING_DB};"
 psql_postgres -c "CREATE DATABASE ${STAGING_DB} OWNER ${DB_USER};"
 
+if [ "$STAGING_DB_OWNER" = "$DB_USER" ]; then
+  log "WARNING: staging will connect as '${DB_USER}', the role that owns production."
+  log "         That role can reach '${PROD_DB}' from staging by connection string alone."
+  log "         Create a restricted role and set STAGING_DB_OWNER — docs/staging-environment.md §7.7."
+fi
+
 case "$RESTORE_KIND" in
   live)
     log "Cloning '$PROD_DB' -> '$STAGING_DB'"
@@ -247,6 +255,19 @@ case "$RESTORE_KIND" in
     docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$STAGING_DB" -v ON_ERROR_STOP=1 -f /tmp/staging-restore.sql >/dev/null
     ;;
 esac
+
+# The restore runs as $DB_USER, so every restored object is owned by it. When staging
+# connects as a restricted role instead, that role needs rights on what was just restored —
+# including CREATE on the schema, because the migration service adds tables on boot.
+if [ "$STAGING_DB_OWNER" != "$DB_USER" ]; then
+  log "Granting '$STAGING_DB_OWNER' on '$STAGING_DB'"
+  psql_staging -v ON_ERROR_STOP=1 -c "
+    GRANT ALL ON SCHEMA public TO ${STAGING_DB_OWNER};
+    GRANT ALL ON ALL TABLES IN SCHEMA public TO ${STAGING_DB_OWNER};
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO ${STAGING_DB_OWNER};
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${STAGING_DB_OWNER};
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${STAGING_DB_OWNER};" >/dev/null
+fi
 
 # ---------------------------------------------------------------------------
 # 4. Verify the restore landed
@@ -267,10 +288,22 @@ log "Restored $TABLES tables"
 # unapplied and replay them against tables that already exist.
 RESTORED_HISTORY=$(psql_staging -tAc "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name LIKE '\_\_EFMigrationsHistory%';" | tr -d '\r')
 
-EXPECTED_HISTORY="__EFMigrationsHistory"          # HumansDbContext, the original
-for ctx in $SECTION_DB_CONTEXTS; do
-  EXPECTED_HISTORY="$EXPECTED_HISTORY __EFMigrationsHistory_${ctx%DbContext}"
-done
+# The expected set comes from production's own catalog, not from this checkout's list of
+# DbContexts. A release that ADDS a section arrives here with a context whose first
+# migration has not run anywhere yet, so production's backup legitimately has no history
+# table for it — and a candidate-derived list would reject that valid backup and make the
+# gate impossible to pass for exactly the releases most worth rehearsing. Production's
+# deployed schema is the thing the backup should match.
+#
+# This reads production's catalog. It is the only statement in `backup` mode that touches
+# the production database at all, it selects table names from information_schema, and it
+# is covered by the same read-only posture as `live`.
+EXPECTED_HISTORY=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$PROD_DB" -tAc \
+  "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name LIKE '\_\_EFMigrationsHistory%';" | tr -d '\r') \
+  || die "could not read production's migration-history tables from '$PROD_DB' — this script expects to run on the production host (docs/staging-environment.md §7.2)"
+
+printf '%s\n' "$EXPECTED_HISTORY" | grep -qx -- '__EFMigrationsHistory' \
+  || die "production database '$PROD_DB' has no __EFMigrationsHistory table — refusing to verify a restore against it"
 
 MISSING_HISTORY=""
 for expected in $EXPECTED_HISTORY; do
@@ -278,7 +311,7 @@ for expected in $EXPECTED_HISTORY; do
     || MISSING_HISTORY="$MISSING_HISTORY $expected"
 done
 [ -z "$MISSING_HISTORY" ] \
-  || die "restored database is missing migration-history table(s):$MISSING_HISTORY — either the archive is not a Humans database, or it predates those sections; restoring it would have the app replay their migrations against existing tables"
+  || die "restored database is missing migration-history table(s) that production has:$MISSING_HISTORY — the archive is not a Humans database, or it predates those sections; restoring it would have the app replay their migrations against existing tables. A section added since this backup was taken is the benign case: take a fresh backup, or pass 'live'"
 
 log "Migration history:"
 psql_staging -c "

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -48,6 +48,16 @@ esac
 docker inspect "$DB_CONTAINER" >/dev/null 2>&1 \
   || die "database container '$DB_CONTAINER' not found (set DB_CONTAINER)"
 
+# Required, not optional. An app left running through the drop has its connections
+# terminated, reconnects to a half-restored database, and stays pointed at it — the
+# migration service already ran, so recreating the database underneath it does not make it
+# run again. A stale name is the same failure with a typo in front of it, so an
+# uninspectable container fails here rather than being read as "no app to stop".
+[ -n "$STAGING_APP_CONTAINER" ] \
+  || die "STAGING_APP_CONTAINER must be set — the staging app has to be down while its database is dropped and restored (see docs/staging-environment.md §7.3)"
+docker inspect "$STAGING_APP_CONTAINER" >/dev/null 2>&1 \
+  || die "staging application container '$STAGING_APP_CONTAINER' not found — fix the name in Coolify rather than refreshing the database out from under a running app"
+
 # Checked up front rather than at the copy: by then the database is already dropped and
 # the app is already stopped, and failing there leaves staging down for a missing path.
 [ -n "${PROD_UPLOADS_DIR:-}" ] && [ -n "${STAGING_UPLOADS_DIR:-}" ] \
@@ -118,14 +128,12 @@ fi
 # 2. Take the staging app down
 #
 # Its connections block DROP DATABASE, and a running app must not read a
-# half-restored database. Coolify's deploy for this push brings it back; the
-# restart below only covers a refresh that ran on its own.
+# half-restored database. Stopping it here is only half the job — §6 handles the
+# deploy that lands while the restore is still going.
 # ---------------------------------------------------------------------------
 
-APP_WAS_RUNNING=false
-if [ -n "$STAGING_APP_CONTAINER" ] \
-   && [ "$(docker inspect -f '{{.State.Running}}' "$STAGING_APP_CONTAINER" 2>/dev/null || echo false)" = "true" ]; then
-  APP_WAS_RUNNING=true
+APP_WAS_RUNNING=$(docker inspect -f '{{.State.Running}}' "$STAGING_APP_CONTAINER")
+if [ "$APP_WAS_RUNNING" = "true" ]; then
   log "Stopping '$STAGING_APP_CONTAINER'"
   docker stop "$STAGING_APP_CONTAINER" >/dev/null
 fi
@@ -204,9 +212,22 @@ rsync -a --delete "$PROD_UPLOADS_DIR"/ "$STAGING_UPLOADS_DIR"/
 
 # ---------------------------------------------------------------------------
 # 6. Hand back
+#
+# Coolify deploys the staging app on the same push that starts this refresh, and nothing
+# orders the two. So the check in §2 is a snapshot, not a lock: a container can come up
+# between the DROP and the end of the restore and bind to a partial clone. The state is
+# re-read here rather than assumed, and anything found running is restarted — the database
+# it is looking at now is the finished one, and a restart is what makes the migration
+# service run against it instead of against whatever existed mid-restore.
 # ---------------------------------------------------------------------------
 
-if [ "$APP_WAS_RUNNING" = true ]; then
+APP_IS_RUNNING=$(docker inspect -f '{{.State.Running}}' "$STAGING_APP_CONTAINER")
+if [ "$APP_IS_RUNNING" = "true" ]; then
+  [ "$APP_WAS_RUNNING" = "true" ] \
+    || log "'$STAGING_APP_CONTAINER' came up during the refresh — a deploy landed mid-restore"
+  log "Restarting '$STAGING_APP_CONTAINER'"
+  docker restart "$STAGING_APP_CONTAINER" >/dev/null
+elif [ "$APP_WAS_RUNNING" = "true" ]; then
   log "Starting '$STAGING_APP_CONTAINER'"
   docker start "$STAGING_APP_CONTAINER" >/dev/null
 fi

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -52,6 +52,20 @@ case "$SOURCE" in
   *) die "unknown source '$SOURCE' (expected 'backup' or 'live')" ;;
 esac
 
+# Identifiers first, because every comparison below is a shell string compare and Postgres
+# does not agree with the shell about what two strings are the same. `DROP DATABASE Humans`
+# is unquoted, so Postgres folds it to `humans` — while `[ "Humans" = "humans" ]` is false
+# and `case Humans in humans)` does not match. STAGING_DB=Humans would therefore clear both
+# guards below and drop production. Requiring the already-folded form makes the shell's
+# notion of equality and Postgres's the same one.
+for ident_var in STAGING_DB PROD_DB DB_USER STAGING_DB_OWNER; do
+  eval "ident_val=\$$ident_var"
+  case "$ident_val" in
+    ""|[!a-z_]*|*[!a-z0-9_]*)
+      die "$ident_var is '$ident_val' — it must be a lowercase identifier ([a-z_][a-z0-9_]*). Postgres folds unquoted identifiers to lowercase, so a name that looks different here can still resolve to production's" ;;
+  esac
+done
+
 [ "$STAGING_DB" = "$PROD_DB" ] && die "STAGING_DB and PROD_DB are both '$PROD_DB' — refusing to drop production"
 case "$STAGING_DB" in
   humans|humans_pr_*) die "STAGING_DB is '$STAGING_DB' — that name belongs to production or a PR preview" ;;
@@ -256,17 +270,37 @@ case "$RESTORE_KIND" in
     ;;
 esac
 
-# The restore runs as $DB_USER, so every restored object is owned by it. When staging
-# connects as a restricted role instead, that role needs rights on what was just restored —
-# including CREATE on the schema, because the migration service adds tables on boot.
+# The restore runs as $DB_USER, so every restored object is owned by it. Ownership has to be
+# handed over, not merely granted: privileges do not carry ALTER or DROP, those need
+# ownership, and DatabaseMigrationHostedService applies pending migrations through the
+# application's own connection. An AlterColumn or DropColumn migration — this repository
+# produces them routinely — would fail at staging startup, which is the one release the
+# rehearsal most needs to survive.
+#
+# Object by object rather than REASSIGN OWNED BY: that statement also reassigns shared
+# objects owned by the role, which includes the production database itself.
 if [ "$STAGING_DB_OWNER" != "$DB_USER" ]; then
-  log "Granting '$STAGING_DB_OWNER' on '$STAGING_DB'"
+  log "Transferring '$STAGING_DB' objects to '$STAGING_DB_OWNER'"
   psql_staging -v ON_ERROR_STOP=1 -c "
-    GRANT ALL ON SCHEMA public TO ${STAGING_DB_OWNER};
-    GRANT ALL ON ALL TABLES IN SCHEMA public TO ${STAGING_DB_OWNER};
-    GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO ${STAGING_DB_OWNER};
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${STAGING_DB_OWNER};
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${STAGING_DB_OWNER};" >/dev/null
+    ALTER SCHEMA public OWNER TO ${STAGING_DB_OWNER};
+    DO \$\$
+    DECLARE r record;
+    BEGIN
+      FOR r IN
+        SELECT c.relname, c.relkind
+        FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
+      LOOP
+        EXECUTE format(
+          CASE r.relkind
+            WHEN 'S' THEN 'ALTER SEQUENCE public.%I OWNER TO %I'
+            WHEN 'v' THEN 'ALTER VIEW public.%I OWNER TO %I'
+            WHEN 'm' THEN 'ALTER MATERIALIZED VIEW public.%I OWNER TO %I'
+            ELSE 'ALTER TABLE public.%I OWNER TO %I'
+          END, r.relname, '${STAGING_DB_OWNER}');
+      END LOOP;
+    END
+    \$\$;" >/dev/null
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -80,6 +80,13 @@ docker inspect "$STAGING_APP_CONTAINER" >/dev/null 2>&1 \
 PROD_UPLOADS_DIR=$(realpath -m "$PROD_UPLOADS_DIR")
 STAGING_UPLOADS_DIR=$(realpath -m "$STAGING_UPLOADS_DIR")
 
+# '/' is the one path that breaks the nesting test below: it is the only canonical path
+# ending in a slash, so its ancestry pattern would be '//*' and would match nothing —
+# '/data/uploads' would read as unrelated to '/'. Rejected here rather than papered over in
+# the pattern, because neither variable has any business pointing at the host root.
+[ "$PROD_UPLOADS_DIR" = "/" ] && die "PROD_UPLOADS_DIR resolves to '/' — that is the host root, not an uploads directory"
+[ "$STAGING_UPLOADS_DIR" = "/" ] && die "STAGING_UPLOADS_DIR resolves to '/' — rsync --delete would run against the host root"
+
 # Equality is not the only way `rsync --delete` reaches production. If staging is an
 # ancestor of prod — staging '/data', prod '/data/uploads' — rsync copies the contents of
 # '/data/uploads' into '/data', finds '/data/uploads' extraneous at the destination, and
@@ -142,10 +149,25 @@ else
     # under `pipefail` plus `errexit`, sort dying of SIGPIPE once the listing outgrows the
     # pipe buffer would fail this assignment with status 141 and block every refresh from
     # then on — with a directory full of perfectly good backups. awk drains the stream.
+    # '*humans*' also matches humans_staging, humans_restore and humans_pr_12 — all of
+    # which restore cleanly and satisfy every check below, so a newer one of those would
+    # be promoted as though it were production. The second awk keeps only artifacts where
+    # the database name is a whole token: a letter straight after it (with or without an
+    # underscore) means a different database whose name merely starts with this one, while
+    # a digit or a separator is the timestamp Coolify appends.
     BACKUP_FILE=$(find "$COOLIFY_BACKUP_DIR" -type f -name "*${PROD_DB}*" \
       \( -name '*.dump' -o -name '*.dmp' -o -name '*.sql' -o -name '*.backup' -o -name '*.gz' \) \
       -printf '%T@\t%p\n' 2>/dev/null \
-      | sort -rn | cut -f2- | awk 'NR == 1 { newest = $0 } END { print newest }')
+      | sort -rn | cut -f2- \
+      | awk -v db="$PROD_DB" '
+          {
+            name = $0; sub(/^.*\//, "", name)
+            p = index(name, db)
+            if (p == 0) next
+            if (substr(name, p + length(db)) ~ /^_?[A-Za-z]/) next
+            print
+          }' \
+      | awk 'NR == 1 { newest = $0 } END { print newest }')
 
     [ -n "$BACKUP_FILE" ] \
       || die "no backup artifact matching '*${PROD_DB}*' under '$COOLIFY_BACKUP_DIR' — check the path, set BACKUP_FILE to one directly, or pass 'live'"

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -27,6 +27,16 @@ STAGING_DB="${STAGING_DB:-humans_staging}"
 COOLIFY_BACKUP_DIR="${COOLIFY_BACKUP_DIR:-/data/coolify/backups}"
 STAGING_APP_CONTAINER="${STAGING_APP_CONTAINER:-}"
 
+# How old the newest backup artifact may be before this is a backup incident rather than a
+# refresh. Only applies when the artifact was picked automatically — an operator naming
+# BACKUP_FILE is deliberately reaching for an older one. 0 disables the check.
+BACKUP_MAX_AGE_HOURS="${BACKUP_MAX_AGE_HOURS:-48}"
+
+# Per-section DbContexts, each of which owns a __EFMigrationsHistory_<Section> table since
+# nobodies-collective/Humans#858. Same list, same variable name, as
+# .github/workflows/build.yml — grep SECTION_DB_CONTEXTS to find both; they move together.
+SECTION_DB_CONTEXTS="${SECTION_DB_CONTEXTS:-SystemSettingsDbContext ContainersDbContext AgentDbContext ExpensesDbContext FinanceDbContext SurveysDbContext EventGuideDbContext}"
+
 log() { printf '==> %s\n' "$*"; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
@@ -139,6 +149,17 @@ else
 
     [ -n "$BACKUP_FILE" ] \
       || die "no backup artifact matching '*${PROD_DB}*' under '$COOLIFY_BACKUP_DIR' — check the path, set BACKUP_FILE to one directly, or pass 'live'"
+
+    # A stalled backup schedule leaves a perfectly restorable artifact lying around, so
+    # every check below would pass while staging exercised weeks-old schema and data —
+    # the migration rehearsal would be against the wrong database, and the backup outage
+    # this workflow exists to surface would go unreported. Age is the only thing that
+    # distinguishes the two, so it is checked rather than logged.
+    if [ "$BACKUP_MAX_AGE_HOURS" != "0" ]; then
+      AGE_HOURS=$(( ( $(date +%s) - $(date -r "$BACKUP_FILE" +%s) ) / 3600 ))
+      [ "$AGE_HOURS" -le "$BACKUP_MAX_AGE_HOURS" ] \
+        || die "newest backup artifact is ${AGE_HOURS}h old (limit ${BACKUP_MAX_AGE_HOURS}h): '$BACKUP_FILE' — treat this as an incident on production's backup schedule, not as a staging problem (docs/staging-environment.md §9). Set BACKUP_FILE to restore it anyway, BACKUP_MAX_AGE_HOURS to match the real cadence, or pass 'live'"
+    fi
   fi
   [ -f "$BACKUP_FILE" ] || die "backup artifact '$BACKUP_FILE' is not a file"
 
@@ -217,9 +238,25 @@ TABLES=$(psql_staging -tAc "SELECT count(*) FROM information_schema.tables WHERE
 [ "${TABLES:-0}" -gt 0 ] || die "restored database has no tables — the archive was empty or the wrong file"
 log "Restored $TABLES tables"
 
-HISTORY_TABLES=$(psql_staging -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name LIKE '\_\_EFMigrationsHistory%';" | tr -d '[:space:]')
-[ "${HISTORY_TABLES:-0}" -gt 0 ] \
-  || die "restored database has no __EFMigrationsHistory table — this is not a Humans database"
+# Every expected history table by name, not merely "at least one". A count test passes on an
+# archive holding the main __EFMigrationsHistory and none of the per-section ones — and the
+# empty-table query below cannot see a table that is absent, so such a restore would be
+# reported as verified. The app would then treat that section's post-baseline migrations as
+# unapplied and replay them against tables that already exist.
+RESTORED_HISTORY=$(psql_staging -tAc "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name LIKE '\_\_EFMigrationsHistory%';" | tr -d '\r')
+
+EXPECTED_HISTORY="__EFMigrationsHistory"          # HumansDbContext, the original
+for ctx in $SECTION_DB_CONTEXTS; do
+  EXPECTED_HISTORY="$EXPECTED_HISTORY __EFMigrationsHistory_${ctx%DbContext}"
+done
+
+MISSING_HISTORY=""
+for expected in $EXPECTED_HISTORY; do
+  printf '%s\n' "$RESTORED_HISTORY" | grep -qx -- "$expected" \
+    || MISSING_HISTORY="$MISSING_HISTORY $expected"
+done
+[ -z "$MISSING_HISTORY" ] \
+  || die "restored database is missing migration-history table(s):$MISSING_HISTORY — either the archive is not a Humans database, or it predates those sections; restoring it would have the app replay their migrations against existing tables"
 
 log "Migration history:"
 psql_staging -c "

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -88,9 +88,24 @@ psql_postgres() { docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d postgres "$@
 psql_staging()  { docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$STAGING_DB" "$@"; }
 
 WORKDIR=""
+DB_AT_RISK=false   # armed just before the DROP — see cleanup()
+
 cleanup() {
+  status=$?
   [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"
   docker exec "$DB_CONTAINER" rm -f /tmp/staging-restore.dump /tmp/staging-restore.sql 2>/dev/null || true
+
+  # A failure anywhere after the DROP leaves $STAGING_DB missing or half-restored, and
+  # `set -e` means the hand-back in §6 never runs. Coolify's deploy is still racing this
+  # script, so a container it brought up mid-flight would be left serving a partial clone
+  # under the pushed SHA: workflow red, staging apparently fine, which is the wrong way
+  # round. Leave it stopped — the next refresh restores the database and starts it again.
+  if [ "$status" -ne 0 ] && [ "$DB_AT_RISK" = true ] \
+     && [ "$(docker inspect -f '{{.State.Running}}' "$STAGING_APP_CONTAINER" 2>/dev/null || echo false)" = "true" ]; then
+    printf '==> Refresh failed — stopping %s so it cannot serve a partial database\n' "$STAGING_APP_CONTAINER" >&2
+    docker stop "$STAGING_APP_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  return "$status"
 }
 trap cleanup EXIT
 
@@ -167,6 +182,7 @@ fi
 # ---------------------------------------------------------------------------
 
 log "Recreating '$STAGING_DB'"
+DB_AT_RISK=true   # from here on, any failure leaves the database unusable — cleanup() stops the app
 psql_postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${STAGING_DB}' AND pid <> pg_backend_pid();" >/dev/null || true
 psql_postgres -c "DROP DATABASE IF EXISTS ${STAGING_DB};"
 psql_postgres -c "CREATE DATABASE ${STAGING_DB} OWNER ${DB_USER};"

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Rebuild the staging database from production, on the production host.
+#
+#   ./scripts/refresh-staging-db.sh [backup|live]
+#
+# Two sources, same destination:
+#   backup  (default) restore the newest Coolify backup artifact. This is the restore path
+#           from docs/database-restore-runbook.md, run for real on every staging deploy.
+#   live    pg_dump straight out of the production database, for up-to-the-minute data.
+#
+# Nothing here writes to production: `backup` never opens the production database at all,
+# `live` only reads it, and the uploads copy is one-way. The only destructive statements
+# target $STAGING_DB, and the guards below refuse to run if that name has drifted onto
+# something real.
+#
+# See docs/staging-environment.md for the environment this feeds and the host-side setup
+# it assumes. nobodies-collective/Humans#962.
+
+set -euo pipefail
+
+SOURCE="${1:-${STAGING_REFRESH_SOURCE:-backup}}"
+
+DB_CONTAINER="${DB_CONTAINER:-humans-db}"
+DB_USER="${DB_USER:-humans}"
+PROD_DB="${PROD_DB:-humans}"
+STAGING_DB="${STAGING_DB:-humans_staging}"
+COOLIFY_BACKUP_DIR="${COOLIFY_BACKUP_DIR:-/data/coolify/backups}"
+STAGING_APP_CONTAINER="${STAGING_APP_CONTAINER:-}"
+
+log() { printf '==> %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Guards. Every one of these is a name that could have been mistyped into an
+# environment variable, and every one of them is destructive if it has been.
+# ---------------------------------------------------------------------------
+
+case "$SOURCE" in
+  backup|live) ;;
+  *) die "unknown source '$SOURCE' (expected 'backup' or 'live')" ;;
+esac
+
+[ "$STAGING_DB" = "$PROD_DB" ] && die "STAGING_DB and PROD_DB are both '$PROD_DB' — refusing to drop production"
+case "$STAGING_DB" in
+  humans|humans_pr_*) die "STAGING_DB is '$STAGING_DB' — that name belongs to production or a PR preview" ;;
+esac
+
+docker inspect "$DB_CONTAINER" >/dev/null 2>&1 \
+  || die "database container '$DB_CONTAINER' not found (set DB_CONTAINER)"
+
+# Checked up front rather than at the copy: by then the database is already dropped and
+# the app is already stopped, and failing there leaves staging down for a missing path.
+[ -n "${PROD_UPLOADS_DIR:-}" ] && [ -n "${STAGING_UPLOADS_DIR:-}" ] \
+  || die "PROD_UPLOADS_DIR and STAGING_UPLOADS_DIR must both be set — staging without uploads renders a broken image for every profile picture (see docs/staging-environment.md)"
+[ "$PROD_UPLOADS_DIR" = "$STAGING_UPLOADS_DIR" ] \
+  && die "PROD_UPLOADS_DIR and STAGING_UPLOADS_DIR are the same path — staging would write into production's uploads"
+[ -d "$PROD_UPLOADS_DIR" ] || die "PROD_UPLOADS_DIR '$PROD_UPLOADS_DIR' does not exist"
+
+psql_postgres() { docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d postgres "$@"; }
+psql_staging()  { docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$STAGING_DB" "$@"; }
+
+WORKDIR=""
+cleanup() {
+  [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"
+  docker exec "$DB_CONTAINER" rm -f /tmp/staging-restore.dump /tmp/staging-restore.sql 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Pick the restore source
+# ---------------------------------------------------------------------------
+
+RESTORE_KIND=""   # "custom" | "plain" | "live"
+
+if [ "$SOURCE" = "live" ]; then
+  RESTORE_KIND="live"
+  log "Source: live pg_dump from '$PROD_DB'"
+else
+  [ -d "$COOLIFY_BACKUP_DIR" ] \
+    || die "backup directory '$COOLIFY_BACKUP_DIR' not found — set COOLIFY_BACKUP_DIR to Coolify's backup path, or pass 'live'"
+
+  # Coolify writes one file per scheduled backup under a per-resource directory; the
+  # database name is in the filename. Newest wins, whatever the nesting.
+  BACKUP_FILE=$(find "$COOLIFY_BACKUP_DIR" -type f -name "*${PROD_DB}*" \
+    \( -name '*.dump' -o -name '*.dmp' -o -name '*.sql' -o -name '*.backup' -o -name '*.gz' \) \
+    -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2-)
+
+  [ -n "$BACKUP_FILE" ] \
+    || die "no backup artifact matching '*${PROD_DB}*' under '$COOLIFY_BACKUP_DIR' — check the path, or pass 'live'"
+
+  log "Source: $BACKUP_FILE ($(date -r "$BACKUP_FILE" '+%Y-%m-%d %H:%M:%S %Z'))"
+
+  WORKDIR=$(mktemp -d)
+  CANDIDATE="$WORKDIR/artifact"
+  case "$BACKUP_FILE" in
+    *.gz) gunzip -c "$BACKUP_FILE" > "$CANDIDATE" ;;
+    *)    cp "$BACKUP_FILE" "$CANDIDATE" ;;
+  esac
+
+  # Custom-format archives start with the magic bytes PGDMP; anything else is plain SQL.
+  # Same check the restore runbook tells a human to run.
+  if [ "$(head -c 5 "$CANDIDATE")" = "PGDMP" ]; then
+    RESTORE_KIND="custom"
+    docker cp "$CANDIDATE" "$DB_CONTAINER:/tmp/staging-restore.dump"
+  else
+    RESTORE_KIND="plain"
+    docker cp "$CANDIDATE" "$DB_CONTAINER:/tmp/staging-restore.sql"
+  fi
+  log "Format: $RESTORE_KIND"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Take the staging app down
+#
+# Its connections block DROP DATABASE, and a running app must not read a
+# half-restored database. Coolify's deploy for this push brings it back; the
+# restart below only covers a refresh that ran on its own.
+# ---------------------------------------------------------------------------
+
+APP_WAS_RUNNING=false
+if [ -n "$STAGING_APP_CONTAINER" ] \
+   && [ "$(docker inspect -f '{{.State.Running}}' "$STAGING_APP_CONTAINER" 2>/dev/null || echo false)" = "true" ]; then
+  APP_WAS_RUNNING=true
+  log "Stopping '$STAGING_APP_CONTAINER'"
+  docker stop "$STAGING_APP_CONTAINER" >/dev/null
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Drop and recreate the staging database
+# ---------------------------------------------------------------------------
+
+log "Recreating '$STAGING_DB'"
+psql_postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${STAGING_DB}' AND pid <> pg_backend_pid();" >/dev/null || true
+psql_postgres -c "DROP DATABASE IF EXISTS ${STAGING_DB};"
+psql_postgres -c "CREATE DATABASE ${STAGING_DB} OWNER ${DB_USER};"
+
+case "$RESTORE_KIND" in
+  live)
+    log "Cloning '$PROD_DB' -> '$STAGING_DB'"
+    docker exec "$DB_CONTAINER" bash -c \
+      "set -o pipefail; pg_dump -U ${DB_USER} ${PROD_DB} | psql -U ${DB_USER} -v ON_ERROR_STOP=1 ${STAGING_DB}" >/dev/null
+    ;;
+  custom)
+    log "Restoring custom-format archive"
+    # --exit-on-error: without it pg_restore reports problems, carries on, and leaves a
+    # partial database that looks fine.
+    docker exec "$DB_CONTAINER" pg_restore -U "$DB_USER" -d "$STAGING_DB" --exit-on-error /tmp/staging-restore.dump
+    ;;
+  plain)
+    log "Restoring plain-SQL dump"
+    docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$STAGING_DB" -v ON_ERROR_STOP=1 -f /tmp/staging-restore.sql >/dev/null
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 4. Verify the restore landed
+#
+# This is what makes the refresh a restore *test* rather than a copy. An empty or
+# missing per-section __EFMigrationsHistory table is the failure worth catching: the
+# app boots fine and then re-applies that section's migrations from scratch.
+# ---------------------------------------------------------------------------
+
+TABLES=$(psql_staging -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE';" | tr -d '[:space:]')
+[ "${TABLES:-0}" -gt 0 ] || die "restored database has no tables — the archive was empty or the wrong file"
+log "Restored $TABLES tables"
+
+log "Migration history:"
+psql_staging -c "
+  SELECT table_name,
+         (xpath('/row/cnt/text()', query_to_xml(format('select count(*) as cnt from public.%I', table_name), false, true, '')))[1]::text::bigint AS migrations
+  FROM information_schema.tables
+  WHERE table_schema='public' AND table_name LIKE '\_\_EFMigrationsHistory%'
+  ORDER BY table_name;"
+
+EMPTY_HISTORY=$(psql_staging -tAc "
+  SELECT count(*) FROM (
+    SELECT (xpath('/row/cnt/text()', query_to_xml(format('select count(*) as cnt from public.%I', table_name), false, true, '')))[1]::text::bigint AS migrations
+    FROM information_schema.tables
+    WHERE table_schema='public' AND table_name LIKE '\_\_EFMigrationsHistory%'
+  ) h WHERE h.migrations = 0;" | tr -d '[:space:]')
+[ "${EMPTY_HISTORY:-0}" = "0" ] \
+  || die "$EMPTY_HISTORY migration-history table(s) restored empty — the app would re-apply that section from scratch"
+
+# ---------------------------------------------------------------------------
+# 5. Uploads
+#
+# A copy, never a share: staging writes to its uploads directory, and prod's bind mount
+# must not be on the other end of that. --delete is deliberate — staging's own uploads
+# are wiped on every refresh, same as its database.
+# ---------------------------------------------------------------------------
+
+log "Copying uploads -> $STAGING_UPLOADS_DIR"
+mkdir -p "$STAGING_UPLOADS_DIR"
+rsync -a --delete "$PROD_UPLOADS_DIR"/ "$STAGING_UPLOADS_DIR"/
+
+# ---------------------------------------------------------------------------
+# 6. Hand back
+# ---------------------------------------------------------------------------
+
+if [ "$APP_WAS_RUNNING" = true ]; then
+  log "Starting '$STAGING_APP_CONTAINER'"
+  docker start "$STAGING_APP_CONTAINER" >/dev/null
+fi
+
+log "Done. '$STAGING_DB' rebuilt from $SOURCE."

--- a/scripts/refresh-staging-db.sh
+++ b/scripts/refresh-staging-db.sh
@@ -62,9 +62,27 @@ docker inspect "$STAGING_APP_CONTAINER" >/dev/null 2>&1 \
 # the app is already stopped, and failing there leaves staging down for a missing path.
 [ -n "${PROD_UPLOADS_DIR:-}" ] && [ -n "${STAGING_UPLOADS_DIR:-}" ] \
   || die "PROD_UPLOADS_DIR and STAGING_UPLOADS_DIR must both be set — staging without uploads renders a broken image for every profile picture (see docs/staging-environment.md)"
-[ "$PROD_UPLOADS_DIR" = "$STAGING_UPLOADS_DIR" ] \
-  && die "PROD_UPLOADS_DIR and STAGING_UPLOADS_DIR are the same path — staging would write into production's uploads"
 [ -d "$PROD_UPLOADS_DIR" ] || die "PROD_UPLOADS_DIR '$PROD_UPLOADS_DIR' does not exist"
+
+# Resolved before comparing: '/data/uploads', '/data/uploads/', '/data/./uploads' and a
+# symlink to any of them are the same directory and must not read as three different ones.
+# -m so the staging path is allowed not to exist yet — §5 creates it.
+PROD_UPLOADS_DIR=$(realpath -m "$PROD_UPLOADS_DIR")
+STAGING_UPLOADS_DIR=$(realpath -m "$STAGING_UPLOADS_DIR")
+
+# Equality is not the only way `rsync --delete` reaches production. If staging is an
+# ancestor of prod — staging '/data', prod '/data/uploads' — rsync copies the contents of
+# '/data/uploads' into '/data', finds '/data/uploads' extraneous at the destination, and
+# deletes production's uploads. The reverse nesting has rsync copying a tree into itself.
+# Both are rejected; only two disjoint trees are safe here.
+[ "$PROD_UPLOADS_DIR" = "$STAGING_UPLOADS_DIR" ] \
+  && die "PROD_UPLOADS_DIR and STAGING_UPLOADS_DIR resolve to the same path '$PROD_UPLOADS_DIR' — staging would write into production's uploads"
+case "$STAGING_UPLOADS_DIR/" in
+  "$PROD_UPLOADS_DIR"/*) die "STAGING_UPLOADS_DIR '$STAGING_UPLOADS_DIR' is inside PROD_UPLOADS_DIR '$PROD_UPLOADS_DIR' — the copy would recurse into its own destination" ;;
+esac
+case "$PROD_UPLOADS_DIR/" in
+  "$STAGING_UPLOADS_DIR"/*) die "PROD_UPLOADS_DIR '$PROD_UPLOADS_DIR' is inside STAGING_UPLOADS_DIR '$STAGING_UPLOADS_DIR' — rsync --delete would delete production's uploads as an extraneous destination entry" ;;
+esac
 
 psql_postgres() { docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d postgres "$@"; }
 psql_staging()  { docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$STAGING_DB" "$@"; }
@@ -94,9 +112,15 @@ else
 
     # Coolify writes one file per scheduled backup under a per-resource directory; the
     # database name is in the filename. Newest wins, whatever the nesting.
+    #
+    # awk keeps the first line rather than `head -1`, which would close the pipe early:
+    # under `pipefail` plus `errexit`, sort dying of SIGPIPE once the listing outgrows the
+    # pipe buffer would fail this assignment with status 141 and block every refresh from
+    # then on — with a directory full of perfectly good backups. awk drains the stream.
     BACKUP_FILE=$(find "$COOLIFY_BACKUP_DIR" -type f -name "*${PROD_DB}*" \
       \( -name '*.dump' -o -name '*.dmp' -o -name '*.sql' -o -name '*.backup' -o -name '*.gz' \) \
-      -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2-)
+      -printf '%T@\t%p\n' 2>/dev/null \
+      | sort -rn | cut -f2- | awk 'NR == 1 { newest = $0 } END { print newest }')
 
     [ -n "$BACKUP_FILE" ] \
       || die "no backup artifact matching '*${PROD_DB}*' under '$COOLIFY_BACKUP_DIR' — check the path, set BACKUP_FILE to one directly, or pass 'live'"


### PR DESCRIPTION
**This is the repository half of nobodies-collective/Humans#962. The environment is not live when this merges.** The refresh script, its workflow, the documentation, and the `/pr-prod` promotion step are here; the Coolify staging app, the OAuth redirect URI, the self-hosted runner, and the repository variables are not — they need console and shell access this PR does not have. Nothing takes effect until someone works through **Host-side steps (owner)** below, which is also committed as `docs/staging-environment.md` §7 so it does not live only in a merged PR description.

## What it does

Production auto-deploys `upstream/main` and applies migrations on boot, so today the first time a migration meets production data is on production. This adds a staging environment on the production host that deploys `upstream/staging` against a **fresh restore of the production database** — and because the default restore source is the newest Coolify backup artifact, every promotion also exercises the restore path that nobodies-collective/Humans#845 proved exactly once.

```
origin/main ──▶ upstream/staging ──▶ refresh humans_staging ──▶ deploy ──▶ verify ──▶ upstream/main ──▶ prod
```

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | Coolify staging app live at `staging.nobodies.team`, `ASPNETCORE_ENVIRONMENT=Staging`, pointed at `humans_staging` | **Owner action** — §7.4. Exact env vars specified in `docs/staging-environment.md` §4 |
| 2 | Dev login/seed off (`DevAuth:Enabled=false`); real Google OAuth works (staging redirect URI added) | **Owner action** — §7.5. Code already gates both on `DevAuth:Enabled` + non-Production; the redirect URI is a Google Cloud console change |
| 3 | No outbound side effects: email/Workspace/TicketTailor stubbed; `HOLDED_API_KEY`, Stripe secrets, `Anthropic:ApiKey` unset | **Owner action, with a repo-side correction** — the per-connector analysis and the must-stay-unset list are in `docs/staging-environment.md` §5. **The issue's premise is wrong about email** — see below |
| 4 | Every push to `upstream/staging` refreshes `humans_staging` (default source: latest Coolify backup artifact) and a staging uploads copy, then deploys; `live` available as manual override | **Done in this PR** — `scripts/refresh-staging-db.sh` + `.github/workflows/staging-db.yml`. Needs the runner and repo variables (§7.2, §7.3) before it can run |
| 5 | A deploy verified end-to-end: migrations auto-apply to the fresh clone, real sign-in succeeds, `/api/version` reports the pushed SHA | **Owner action** — out of scope by construction. The checks are written up as `docs/staging-environment.md` §8 and wired into `/pr-prod` step 5 |
| 6 | Restore runbook committed to `docs/`, including the GDPR note | **Done in this PR** — the runbook itself landed with nobodies-collective/Humans#845 (`docs/database-restore-runbook.md`); this adds its §8 tying the staging refresh to it, and the GDPR note as `docs/staging-environment.md` §6 |
| 7 | `/pr-prod` updated: promote to `upstream/staging` → verify → fast-forward `upstream/main` | **Done in this PR** — `.claude/skills/pr-prod/SKILL.md` |

Done in this PR: 4, 6, 7. Owner action: 1, 2, 3, 5.

## The issue's email premise does not hold

The issue says email stubs itself in non-Production when credentials are absent, citing `EmailInfrastructureExtensions.cs:41`. It does not. That branch is reached only when `Email:SmtpHost` is empty — and `appsettings.json` gives it a real default, `smtp-relay.gmail.com`, in every environment. Absence of `EMAIL_USERNAME`/`EMAIL_PASSWORD` does **not** select `StubEmailTransport` the way absence of Workspace credentials selects the Workspace stubs.

So staging must set `Email__SmtpHost` to an **empty string** explicitly, or it boots with `SmtpEmailTransport` against a real relay while holding a clone of production's outbox and every real member address. That is documented as a required variable (§4), as a callout (§5), and as a per-deploy verification step (§8) rather than left as an assumption.

**Not fixed in code here, and it needs your call.** The clean fix is to make email fail closed. The obvious change — `"Email": { "SmtpHost": "" }` in `appsettings.Staging.json` — also changes QA, which shares that file and may be sending real mail on purpose today.

Two other findings in the same family, both handled by the same §4 table: `appsettings.Staging.json` also pins `AllowedHosts` and `Email:BaseUrl` to `humans.n.burn.camp`, so without overrides staging rejects every request at the host filter and points its links at QA.

## The script

`scripts/refresh-staging-db.sh`, run by the workflow on push to `staging`:

- **Sources:** `backup` (default) restores the newest Coolify artifact — `.gz` decompressed, then the `PGDMP` magic bytes pick `pg_restore --exit-on-error` over `psql -v ON_ERROR_STOP=1`. `live` is the `pg_dump | psql` clone, on manual dispatch.
- **Verifies, not just copies:** fails if the restore produced no tables, no `__EFMigrationsHistory` table, or **any** per-section history table that came back empty — the quiet failure where the app boots fine and then re-applies a section's migrations from scratch.
- **Uploads:** `rsync -a --delete` into a separate staging directory. A copy, never a shared mount; `--delete` so staging's own writes are wiped with its database.
- **Guards:** refuses to start if the target name has drifted onto `humans` or a `humans_pr_*` preview, if the two uploads paths are equal, or if either is unset. Nothing writes to production — `backup` never opens the production database, `live` only reads it.

**It has not been executed.** Unlike the nobodies-collective/Humans#845 runbook, whose procedure was drilled against a real `postgres:16` container before being written down, this script is reviewed and syntax-checked only. I started a local drill and stopped when the setup tripped this machine's recursive-delete block; I did not work around it. Its commands are the ones `preview-db.yml` runs today and the ones that drill proved, but the script as a whole is unproven — §7.3's manual dispatch is its first real test, and the doc says so at the top.

## Reuse-first

- **The refresh recipe** is `preview-db.yml`'s existing terminate → drop → create → `pg_dump | psql`, not a new one. Added: the artifact source, format detection, and the verification step.
- **The workflow** mirrors `preview-db.yml`'s shape, on `[self-hosted, prod]` rather than `[self-hosted, nuc]`. Kept separate rather than extended — different trigger, different host, and merging them would put preview-clone jobs one label away from the production host.
- **No new runbook.** nobodies-collective/Humans#845 already landed `docs/database-restore-runbook.md`; a second restore document would compete with it. It gains §8 and a link; the environment-specific material (topology, config, GDPR, owner checklist) is a separate `docs/staging-environment.md` rather than bloating a document you read during an incident.
- **`docker-entrypoint.sh` unchanged.** Its connection-string override only fires for a numeric PR id, and `staging.nobodies.team` does not match the FQDN pattern. Staging takes its connection string from Coolify like production does.
- **No EF migration.** Nothing here touches the model.

## Host-side steps (owner)

Also in `docs/staging-environment.md` §7, with the same per-step checks.

- [ ] **Create the branch.** `git push upstream upstream/main:refs/heads/staging`. *Check:* the branch exists on `nobodies-collective/Humans` at `main`'s SHA.
- [ ] **Install the self-hosted runner** on the production host — GitHub → Settings → Actions → Runners → New self-hosted runner → Linux. Labels **`self-hosted` and `prod`**; do **not** add `nuc`, or `preview-db.yml` starts cloning preview databases onto the production host. The runner user needs the `docker` group, read on the Coolify backup dir and production's uploads, write on staging's. Install as a service (`./svc.sh install && ./svc.sh start`). *Check:* runner shows **Idle** with both labels.
- [ ] **Set repository variables** (Settings → Secrets and variables → Actions → Variables). Required: `PROD_UPLOADS_DIR` (host path behind production's `/app/wwwroot/uploads`, from Coolify → Storages) and `STAGING_UPLOADS_DIR` (a new, separate directory). Optional, only if different: `COOLIFY_BACKUP_DIR` (default `/data/coolify/backups`), `STAGING_DB_CONTAINER` (default `humans-db`). Set `STAGING_APP_CONTAINER` — it lets the script stop the app before dropping its database. *Check:* Actions → Staging Database Refresh → Run workflow finds an artifact, restores it, prints a non-empty migration count per context, copies uploads.
- [ ] **Create the Coolify staging app** on the production server from `nobodies-collective/Humans`, branch `staging`, domain `staging.nobodies.team`. Env vars per §4 — including `Email__SmtpHost` set and **empty**, and the must-stay-unset list genuinely absent. Persistent storage at `/app/wwwroot/uploads` (same host path as `STAGING_UPLOADS_DIR`) and at `/app/db-snapshots`. **No scheduled backups on `humans_staging`** — it is disposable, and backing it up creates a second off-host copy of member PII. *Check:* `https://staging.nobodies.team/api/version` returns JSON.
- [ ] **Add the OAuth redirect URI.** Google Cloud console → APIs & Services → Credentials → the client in production's `Authentication__Google__ClientId` → Authorised redirect URIs → `https://staging.nobodies.team/signin-google` (the handler's default callback path; nothing in `Program.cs` overrides it). *Check:* sign-in completes rather than `redirect_uri_mismatch`.
- [ ] **Point DNS** `staging.nobodies.team` at the production host. *Check:* resolves to the same address as `humans.nobodies.team`.
- [ ] **First real push:** confirm the workflow log shows the restore completing and the staging app log shows migrations applying to the restored database, not an empty one.

## GDPR

Staging holds full member PII. `docs/staging-environment.md` §6 records why that is defensible under the existing posture — same host and operators, real-login authorization only so nobody gains access they do not already have, no new egress because every connector is stubbed, and wiped on every refresh so nothing accumulates — and why it still argues for dropping `humans_staging` when idle between promotion cycles, with the two commands to do it.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 warnings, 0 errors
- [x] `bash -n scripts/refresh-staging-db.sh`
- [ ] `scripts/refresh-staging-db.sh` executed against a real database — **not done**, see above
- [ ] Workflow run — needs the runner (§7.2)

Refs nobodies-collective/Humans#962, nobodies-collective/Humans#845
