### PR TITLE
feat(i18n): wire onboarding wizard DataAnnotations localization + resx parity test

### DIFF
--- a/src/Humans.Web/Controllers/OnboardingWidgetController.cs
+++ b/src/Humans.Web/Controllers/OnboardingWidgetController.cs
@@ -151,7 +151,7 @@ public class OnboardingWidgetController(
         var result = await signupService.SignUpAsync(userId, shiftId, actorUserId: userId);
         if (!result.Success)
         {
-            SetError(result.Error ?? "Could not sign up.");
+            SetError(result.Error ?? localizer["Onboarding_ShiftsSignUpFailed"].Value);
             return RedirectToAction(nameof(Shifts));
         }
         return RedirectToAction(nameof(Consents));
@@ -165,7 +165,7 @@ public class OnboardingWidgetController(
         var result = await signupService.SignUpRangeAsync(CurrentUserId(), rotaId, startDayOffset, endDayOffset);
         if (!result.Success)
         {
-            SetError(result.Error ?? "Could not sign up for date range.");
+            SetError(result.Error ?? localizer["Onboarding_ShiftsSignUpRangeFailed"].Value);
             return RedirectToAction(nameof(Shifts));
         }
         return RedirectToAction(nameof(Consents));

--- a/src/Humans.Web/Models/OnboardingWidget/NamesViewModel.cs
+++ b/src/Humans.Web/Models/OnboardingWidget/NamesViewModel.cs
@@ -6,16 +6,16 @@ public class NamesViewModel
 {
     [Required]
     [StringLength(100)]
-    [Display(Name = "Burner Name")]
+    [Display(Name = "Onboarding_BurnerNameLabel")]
     public string BurnerName { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    [Display(Name = "Legal First Name")]
+    [Display(Name = "Onboarding_LegalFirstNameLabel")]
     public string FirstName { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    [Display(Name = "Legal Last Name(s)")]
+    [Display(Name = "Onboarding_LegalLastNameLabel")]
     public string LastName { get; set; } = string.Empty;
 }

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -463,7 +463,15 @@ var mvcBuilder = builder.Services.AddControllersWithViews(options =>
         options.ModelBinderProviders.Insert(0, new LocalDateTimeModelBinderProvider());
     })
     .AddViewLocalization(LanguageViewLocationExpanderFormat.Suffix)
-    .AddDataAnnotationsLocalization();
+    .AddDataAnnotationsLocalization(options =>
+    {
+        // Route every [Display]/[Required]/[StringLength] lookup through SharedResource
+        // (same resx views/controllers already use) instead of the per-type resource
+        // MVC defaults to (which nothing here provides, so annotations rendered raw
+        // English regardless of culture). A key with no SharedResource match just
+        // falls back to the attribute's own text, so untouched view models are unaffected.
+        options.DataAnnotationLocalizerProvider = (_, factory) => factory.Create(typeof(Humans.Web.SharedResource));
+    });
 
 // DevLoginController depends on DevPersonaSeeder (non-Production only); exclude in Prod so ValidateOnBuild passes and /dev/login/* 404s cleanly.
 if (builder.Environment.IsProduction())

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1242,6 +1242,10 @@
     <value>Revisar: {0}</value>
     <comment>{0} = document name</comment>
   </data>
+  <data name="ConsentReview_Progress" xml:space="preserve">
+    <value>Document {0} de {1}</value>
+    <comment>{0} = current document index, {1} = total required documents</comment>
+  </data>
   <data name="Consent_RequiredDocuments" xml:space="preserve">
     <value>Documents requerits</value>
   </data>
@@ -5522,6 +5526,33 @@
   <data name="VolTrack_Counts_Unbooked" xml:space="preserve">
     <value>Declarats però sense reserva</value>
   </data>
+  <data name="VolTrack_Export_Title" xml:space="preserve">
+    <value>Exportar graella de voluntariat</value>
+  </data>
+  <data name="VolTrack_Export_Department" xml:space="preserve">
+    <value>Departament</value>
+  </data>
+  <data name="VolTrack_Export_AllDepartments" xml:space="preserve">
+    <value>Tots els departaments</value>
+  </data>
+  <data name="VolTrack_Export_Period" xml:space="preserve">
+    <value>Per&#xED;ode</value>
+  </data>
+  <data name="VolTrack_Export_PeriodCustom" xml:space="preserve">
+    <value>Interval personalitzat</value>
+  </data>
+  <data name="VolTrack_Export_From" xml:space="preserve">
+    <value>Des de</value>
+  </data>
+  <data name="VolTrack_Export_To" xml:space="preserve">
+    <value>Fins a</value>
+  </data>
+  <data name="VolTrack_Export_Download" xml:space="preserve">
+    <value>Descarregar XLSX</value>
+  </data>
+  <data name="VolTrack_Export_Methodology" xml:space="preserve">
+    <value>Files = humans amb &#x2265;1 franja confirmada en l'interval. El color de la cel&#xB7;la = l'equip amb qui van treballar m&#xE9;s hores aquell dia. Cel&#xB7;la blanca = dia abans de la seva primera franja confirmada (dia d'arribada). Fila de totals = humans presents aquell dia (utilitzat per als recomptes d'&#xE0;pats). Els noms mostrats s&#xF3;n noms de platja.</value>
+  </data>
   <data name="VolTrack_Filter_HideNoGaps" xml:space="preserve">
     <value>Oculta els voluntaris sense forats</value>
     <comment>TODO: translate</comment>
@@ -5829,6 +5860,81 @@
   <data name="VolTrack_AuditAction_CampSetupCleared" xml:space="preserve">
     <value>Configuració de muntatge del campament esborrada</value>
     <comment>TODO: translate</comment>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Subject" xml:space="preserve">
+    <value>Un missatge sobre les teves franges a {0}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Hola {0},&lt;/p&gt;&lt;p&gt;Un missatge del coordinador de &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Per a la teva informaci&#xF3;, les teves franges en aquest torn s&#xF3;n:&lt;/p&gt;{4}&lt;p&gt;Gr&#xE0;cies,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_NoShifts" xml:space="preserve">
+    <value>(encara no hi ha franges en aquest torn)</value>
+  </data>
+  <data name="EmailRota_Title" xml:space="preserve">
+    <value>Enviar correu al torn: {0}</value>
+  </data>
+  <data name="EmailRota_Breadcrumb" xml:space="preserve">
+    <value>Correu al torn</value>
+  </data>
+  <data name="EmailRota_Heading" xml:space="preserve">
+    <value>Enviar correu a tothom del torn: {0}</value>
+  </data>
+  <data name="EmailRota_RecipientsHeading" xml:space="preserve">
+    <value>Destinataris ({0})</value>
+  </data>
+  <data name="EmailRota_NoRecipients" xml:space="preserve">
+    <value>Encara ning&#xFA; s'ha inscrit en aquest torn.</value>
+  </data>
+  <data name="EmailRota_MessageLabel" xml:space="preserve">
+    <value>El teu missatge</value>
+  </data>
+  <data name="EmailRota_MessageHelp" xml:space="preserve">
+    <value>Nom&#xE9;s text sense format. Cada destinatari veur&#xE0; aquest missatge juntament amb la seva pr&#xF2;pia llista de franges d'aquest torn.</value>
+  </data>
+  <data name="EmailRota_Button" xml:space="preserve">
+    <value>Enviar correu a un torn</value>
+  </data>
+  <data name="EmailRota_Send" xml:space="preserve">
+    <value>Enviar a {0} destinatari(s)</value>
+  </data>
+  <data name="EmailRota_Success" xml:space="preserve">
+    <value>S'han encuat {0} correu(s) per als destinataris del torn '{1}'.</value>
+  </data>
+  <data name="EmailRota_NoActiveSignups" xml:space="preserve">
+    <value>Aquest torn no t&#xE9; inscripcions actives a les quals enviar correu.</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Subject" xml:space="preserve">
+    <value>Un missatge sobre les teves franges amb {0}</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Hola {0},&lt;/p&gt;&lt;p&gt;Un missatge del coordinador de &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Per a la teva informaci&#xF3;, les teves franges en els propers torns de l'equip:&lt;/p&gt;{4}&lt;p&gt;Gr&#xE0;cies,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="EmailTeamRotas_Title" xml:space="preserve">
+    <value>Enviar correu a l'equip: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_Breadcrumb" xml:space="preserve">
+    <value>Correu a l'equip</value>
+  </data>
+  <data name="EmailTeamRotas_Heading" xml:space="preserve">
+    <value>Enviar correu a tothom dels propers torns: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_RecipientsHeading" xml:space="preserve">
+    <value>Destinataris ({0})</value>
+  </data>
+  <data name="EmailTeamRotas_RotaCount" xml:space="preserve">
+    <value>en {0} torn(s)</value>
+  </data>
+  <data name="EmailTeamRotas_NoRecipients" xml:space="preserve">
+    <value>Encara ning&#xFA; s'ha inscrit en els propers torns d'aquest equip.</value>
+  </data>
+  <data name="EmailTeamRotas_MessageLabel" xml:space="preserve">
+    <value>El teu missatge</value>
+  </data>
+  <data name="EmailTeamRotas_MessageHelp" xml:space="preserve">
+    <value>Nom&#xE9;s text sense format. Cada destinatari veur&#xE0; aquest missatge juntament amb la seva pr&#xF2;pia llista de franges en els propers torns de l'equip.</value>
+  </data>
+  <data name="EmailTeamRotas_Send" xml:space="preserve">
+    <value>Enviar a {0} destinatari(s)</value>
   </data>
   <data name="AdminHumans_MissingConsents" xml:space="preserve"><value>Consentiments pendents</value></data>
   <data name="AdminHumans_IncompleteSignup" xml:space="preserve"><value>Registre incomplet</value></data>
@@ -6448,6 +6554,8 @@
   <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>El nom amb què tothom et coneixerà.</value></data>
   <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Nom burner</value></data>
   <data name="Onboarding_Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="Onboarding_LegalFirstNameLabel" xml:space="preserve"><value>Nom legal</value></data>
+  <data name="Onboarding_LegalLastNameLabel" xml:space="preserve"><value>Cognoms legals</value></data>
   <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>no</value></data>
   <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>exportem aquesta informació, i només la divulgaríem si ho exigís la llei o una auditoria formal.</value></data>
   <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Es guarda internament, només visible per als administradors, i s'utilitza només on la llei espanyola ho requereix — per exemple, el nostre registre d'auditoria que vas acceptar l'acord de voluntariat en una data i hora concretes. Explícitament</value></data>
@@ -6468,6 +6576,8 @@
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>De moment no hi ha torns crítics oberts — prova amb Importants o Tots.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>De moment no hi ha torns importants oberts — prova amb Tots.</value></data>
   <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Ara no</value></data>
+  <data name="Onboarding_ShiftsSignUpFailed" xml:space="preserve"><value>No s'ha pogut inscriure.</value></data>
+  <data name="Onboarding_ShiftsSignUpRangeFailed" xml:space="preserve"><value>No s'ha pogut inscriure per a l'interval de dates.</value></data>
   <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Tria un torn</value></data>
   <data name="Outbox_AdminTitle" xml:space="preserve"><value>Correus</value></data>
   <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Torna a Administració</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1242,6 +1242,10 @@
     <value>Prüfung: {0}</value>
     <comment>{0} = document name</comment>
   </data>
+  <data name="ConsentReview_Progress" xml:space="preserve">
+    <value>Dokument {0} von {1}</value>
+    <comment>{0} = current document index, {1} = total required documents</comment>
+  </data>
   <data name="Consent_RequiredDocuments" xml:space="preserve">
     <value>Erforderliche Dokumente</value>
   </data>
@@ -5522,6 +5526,33 @@
   <data name="VolTrack_Counts_Unbooked" xml:space="preserve">
     <value>Gemeldet, aber ungebucht</value>
   </data>
+  <data name="VolTrack_Export_Title" xml:space="preserve">
+    <value>Freiwilligenraster exportieren</value>
+  </data>
+  <data name="VolTrack_Export_Department" xml:space="preserve">
+    <value>Abteilung</value>
+  </data>
+  <data name="VolTrack_Export_AllDepartments" xml:space="preserve">
+    <value>Alle Abteilungen</value>
+  </data>
+  <data name="VolTrack_Export_Period" xml:space="preserve">
+    <value>Zeitraum</value>
+  </data>
+  <data name="VolTrack_Export_PeriodCustom" xml:space="preserve">
+    <value>Benutzerdefinierter Zeitraum</value>
+  </data>
+  <data name="VolTrack_Export_From" xml:space="preserve">
+    <value>Von</value>
+  </data>
+  <data name="VolTrack_Export_To" xml:space="preserve">
+    <value>Bis</value>
+  </data>
+  <data name="VolTrack_Export_Download" xml:space="preserve">
+    <value>XLSX herunterladen</value>
+  </data>
+  <data name="VolTrack_Export_Methodology" xml:space="preserve">
+    <value>Zeilen = humans mit &#x2265;1 best&#xE4;tigter Schicht im Zeitraum. Zellfarbe = das Team, f&#xFC;r das sie an diesem Tag die meisten Stunden gearbeitet haben. Wei&#xDF;e Zelle = Tag vor der ersten best&#xE4;tigten Schicht (Ankunftstag). Summenzeile = an diesem Tag vor Ort befindliche humans (f&#xFC;r Essensz&#xE4;hlungen verwendet). Angezeigte Namen sind Playa-Namen.</value>
+  </data>
   <data name="VolTrack_Filter_HideNoGaps" xml:space="preserve">
     <value>Freiwillige ohne Lücken ausblenden</value>
     <comment>TODO: translate</comment>
@@ -5829,6 +5860,81 @@
   <data name="VolTrack_AuditAction_CampSetupCleared" xml:space="preserve">
     <value>Camp-Aufbaudatum entfernt</value>
     <comment>TODO: translate</comment>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Subject" xml:space="preserve">
+    <value>Eine Nachricht zu deinen Schichten in {0}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Liebe/r {0},&lt;/p&gt;&lt;p&gt;Eine Nachricht vom Koordinator von &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Zur Info, deine Schichten in diesem Dienstplan sind:&lt;/p&gt;{4}&lt;p&gt;Danke,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_NoShifts" xml:space="preserve">
+    <value>(noch keine Schichten in diesem Dienstplan)</value>
+  </data>
+  <data name="EmailRota_Title" xml:space="preserve">
+    <value>E-Mail an Dienstplan senden: {0}</value>
+  </data>
+  <data name="EmailRota_Breadcrumb" xml:space="preserve">
+    <value>E-Mail an Dienstplan</value>
+  </data>
+  <data name="EmailRota_Heading" xml:space="preserve">
+    <value>E-Mail an alle im Dienstplan senden: {0}</value>
+  </data>
+  <data name="EmailRota_RecipientsHeading" xml:space="preserve">
+    <value>Empf&#xE4;nger ({0})</value>
+  </data>
+  <data name="EmailRota_NoRecipients" xml:space="preserve">
+    <value>F&#xFC;r diesen Dienstplan hat sich noch niemand angemeldet.</value>
+  </data>
+  <data name="EmailRota_MessageLabel" xml:space="preserve">
+    <value>Deine Nachricht</value>
+  </data>
+  <data name="EmailRota_MessageHelp" xml:space="preserve">
+    <value>Nur Klartext. Jeder Empf&#xE4;nger sieht diesen Text zusammen mit seiner eigenen Schichtliste f&#xFC;r diesen Dienstplan.</value>
+  </data>
+  <data name="EmailRota_Button" xml:space="preserve">
+    <value>E-Mail an einen Dienstplan senden</value>
+  </data>
+  <data name="EmailRota_Send" xml:space="preserve">
+    <value>An {0} Empf&#xE4;nger senden</value>
+  </data>
+  <data name="EmailRota_Success" xml:space="preserve">
+    <value>{0} E-Mail(s) an Empf&#xE4;nger im Dienstplan '{1}' eingereiht.</value>
+  </data>
+  <data name="EmailRota_NoActiveSignups" xml:space="preserve">
+    <value>Dieser Dienstplan hat keine aktiven Anmeldungen, denen eine E-Mail gesendet werden k&#xF6;nnte.</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Subject" xml:space="preserve">
+    <value>Eine Nachricht zu deinen Schichten bei {0}</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Liebe/r {0},&lt;/p&gt;&lt;p&gt;Eine Nachricht vom Koordinator von &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Zur Info, deine Schichten in den kommenden Dienstpl&#xE4;nen dieses Teams:&lt;/p&gt;{4}&lt;p&gt;Danke,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="EmailTeamRotas_Title" xml:space="preserve">
+    <value>E-Mail an Team senden: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_Breadcrumb" xml:space="preserve">
+    <value>E-Mail an Team</value>
+  </data>
+  <data name="EmailTeamRotas_Heading" xml:space="preserve">
+    <value>E-Mail an alle in den kommenden Dienstpl&#xE4;nen senden: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_RecipientsHeading" xml:space="preserve">
+    <value>Empf&#xE4;nger ({0})</value>
+  </data>
+  <data name="EmailTeamRotas_RotaCount" xml:space="preserve">
+    <value>in {0} Dienstpl&#xE4;nen</value>
+  </data>
+  <data name="EmailTeamRotas_NoRecipients" xml:space="preserve">
+    <value>F&#xFC;r die kommenden Dienstpl&#xE4;ne dieses Teams hat sich noch niemand angemeldet.</value>
+  </data>
+  <data name="EmailTeamRotas_MessageLabel" xml:space="preserve">
+    <value>Deine Nachricht</value>
+  </data>
+  <data name="EmailTeamRotas_MessageHelp" xml:space="preserve">
+    <value>Nur Klartext. Jeder Empf&#xE4;nger sieht diesen Text zusammen mit seiner eigenen Schichtliste &#xFC;ber die kommenden Dienstpl&#xE4;ne des Teams hinweg.</value>
+  </data>
+  <data name="EmailTeamRotas_Send" xml:space="preserve">
+    <value>An {0} Empf&#xE4;nger senden</value>
   </data>
   <data name="AdminHumans_MissingConsents" xml:space="preserve"><value>Fehlende Einwilligungen</value></data>
   <data name="AdminHumans_IncompleteSignup" xml:space="preserve"><value>Registrierung unvollst&#xE4;ndig</value></data>
@@ -6448,6 +6554,8 @@
   <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>Der Name, unter dem dich alle kennen werden.</value></data>
   <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner Name</value></data>
   <data name="Onboarding_Continue" xml:space="preserve"><value>Weiter</value></data>
+  <data name="Onboarding_LegalFirstNameLabel" xml:space="preserve"><value>Bürgerlicher Vorname</value></data>
+  <data name="Onboarding_LegalLastNameLabel" xml:space="preserve"><value>Bürgerlicher Nachname</value></data>
   <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>nicht</value></data>
   <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>und würden sie nur offenlegen, wenn das Gesetz oder eine förmliche Prüfung es erfordert.</value></data>
   <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Wird intern gespeichert, ist nur für Admins sichtbar und wird nur dort verwendet, wo das spanische Recht es verlangt — zum Beispiel für unseren Prüfnachweis, dass du der Volunteer-Vereinbarung zu einem bestimmten Datum und einer bestimmten Uhrzeit zugestimmt hast. Wir exportieren diese Information ausdrücklich</value></data>
@@ -6468,6 +6576,8 @@
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Derzeit keine kritischen Schichten offen — probiere Wichtig oder Alle.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Derzeit keine wichtigen Schichten offen — probiere Alle.</value></data>
   <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Nicht jetzt</value></data>
+  <data name="Onboarding_ShiftsSignUpFailed" xml:space="preserve"><value>Anmeldung fehlgeschlagen.</value></data>
+  <data name="Onboarding_ShiftsSignUpRangeFailed" xml:space="preserve"><value>Anmeldung für den Datumsbereich fehlgeschlagen.</value></data>
   <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Wähle eine Schicht</value></data>
   <data name="Outbox_AdminTitle" xml:space="preserve"><value>E-Mails</value></data>
   <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Zurück zur Administration</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1242,6 +1242,10 @@
     <value>Revisar: {0}</value>
     <comment>{0} = document name</comment>
   </data>
+  <data name="ConsentReview_Progress" xml:space="preserve">
+    <value>Documento {0} de {1}</value>
+    <comment>{0} = current document index, {1} = total required documents</comment>
+  </data>
   <data name="Consent_RequiredDocuments" xml:space="preserve">
     <value>Documentos requeridos</value>
   </data>
@@ -5879,6 +5883,81 @@
     <value>Fecha de montaje de barrio eliminada</value>
     <comment>TODO: translate</comment>
   </data>
+  <data name="Email_CoordinatorRotaMessage_Subject" xml:space="preserve">
+    <value>Un mensaje sobre tus franjas en {0}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Hola {0},&lt;/p&gt;&lt;p&gt;Un mensaje del coordinador de &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Para tu informaci&#xF3;n, tus franjas en este turno son:&lt;/p&gt;{4}&lt;p&gt;Gracias,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_NoShifts" xml:space="preserve">
+    <value>(todav&#xED;a no hay franjas en este turno)</value>
+  </data>
+  <data name="EmailRota_Title" xml:space="preserve">
+    <value>Enviar correo al turno: {0}</value>
+  </data>
+  <data name="EmailRota_Breadcrumb" xml:space="preserve">
+    <value>Correo al turno</value>
+  </data>
+  <data name="EmailRota_Heading" xml:space="preserve">
+    <value>Enviar correo a todos en el turno: {0}</value>
+  </data>
+  <data name="EmailRota_RecipientsHeading" xml:space="preserve">
+    <value>Destinatarios ({0})</value>
+  </data>
+  <data name="EmailRota_NoRecipients" xml:space="preserve">
+    <value>Todav&#xED;a nadie se ha inscrito en este turno.</value>
+  </data>
+  <data name="EmailRota_MessageLabel" xml:space="preserve">
+    <value>Tu mensaje</value>
+  </data>
+  <data name="EmailRota_MessageHelp" xml:space="preserve">
+    <value>Solo texto sin formato. Cada destinatario ver&#xE1; este mensaje junto con su propia lista de franjas de este turno.</value>
+  </data>
+  <data name="EmailRota_Button" xml:space="preserve">
+    <value>Enviar correo a un turno</value>
+  </data>
+  <data name="EmailRota_Send" xml:space="preserve">
+    <value>Enviar a {0} destinatario(s)</value>
+  </data>
+  <data name="EmailRota_Success" xml:space="preserve">
+    <value>Se encolaron {0} correo(s) para los destinatarios del turno '{1}'.</value>
+  </data>
+  <data name="EmailRota_NoActiveSignups" xml:space="preserve">
+    <value>Este turno no tiene inscripciones activas a las que enviar correo.</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Subject" xml:space="preserve">
+    <value>Un mensaje sobre tus franjas con {0}</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Hola {0},&lt;/p&gt;&lt;p&gt;Un mensaje del coordinador de &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Para tu informaci&#xF3;n, tus franjas en los pr&#xF3;ximos turnos del equipo:&lt;/p&gt;{4}&lt;p&gt;Gracias,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="EmailTeamRotas_Title" xml:space="preserve">
+    <value>Enviar correo al equipo: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_Breadcrumb" xml:space="preserve">
+    <value>Correo al equipo</value>
+  </data>
+  <data name="EmailTeamRotas_Heading" xml:space="preserve">
+    <value>Enviar correo a todos en los pr&#xF3;ximos turnos: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_RecipientsHeading" xml:space="preserve">
+    <value>Destinatarios ({0})</value>
+  </data>
+  <data name="EmailTeamRotas_RotaCount" xml:space="preserve">
+    <value>en {0} turno(s)</value>
+  </data>
+  <data name="EmailTeamRotas_NoRecipients" xml:space="preserve">
+    <value>Todav&#xED;a nadie se ha inscrito en los pr&#xF3;ximos turnos de este equipo.</value>
+  </data>
+  <data name="EmailTeamRotas_MessageLabel" xml:space="preserve">
+    <value>Tu mensaje</value>
+  </data>
+  <data name="EmailTeamRotas_MessageHelp" xml:space="preserve">
+    <value>Solo texto sin formato. Cada destinatario ver&#xE1; este mensaje junto con su propia lista de franjas en los pr&#xF3;ximos turnos del equipo.</value>
+  </data>
+  <data name="EmailTeamRotas_Send" xml:space="preserve">
+    <value>Enviar a {0} destinatario(s)</value>
+  </data>
   <data name="AdminHumans_MissingConsents" xml:space="preserve"><value>Consentimientos pendientes</value></data>
   <data name="AdminHumans_IncompleteSignup" xml:space="preserve"><value>Registro incompleto</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importar mi foto de Google</value></data>
@@ -6485,6 +6564,8 @@
   <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>El nombre por el que todos te conocerán.</value></data>
   <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
   <data name="Onboarding_Continue" xml:space="preserve"><value>Continuar</value></data>
+  <data name="Onboarding_LegalFirstNameLabel" xml:space="preserve"><value>Nombre legal</value></data>
+  <data name="Onboarding_LegalLastNameLabel" xml:space="preserve"><value>Apellidos legales</value></data>
   <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>no</value></data>
   <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>exportamos esta información, y solo la revelaríamos si lo exigiera la ley o una auditoría formal.</value></data>
   <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Se guarda internamente, solo es visible para los administradores y se usa únicamente donde la ley española lo exige — por ejemplo, en nuestro registro de auditoría de que aceptaste el Acuerdo de Voluntariado en una fecha y hora concretas. Explícitamente</value></data>
@@ -6505,6 +6586,8 @@
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No hay turnos críticos abiertos en este momento — prueba con Importantes o Todos.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No hay turnos importantes abiertos en este momento — prueba con Todos.</value></data>
   <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Ahora no</value></data>
+  <data name="Onboarding_ShiftsSignUpFailed" xml:space="preserve"><value>No se pudo inscribir.</value></data>
+  <data name="Onboarding_ShiftsSignUpRangeFailed" xml:space="preserve"><value>No se pudo inscribir para el rango de fechas.</value></data>
   <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Elige un turno</value></data>
   <data name="Outbox_AdminTitle" xml:space="preserve"><value>Correos</value></data>
   <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Volver a Administración</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1242,6 +1242,10 @@
     <value>Consulter : {0}</value>
     <comment>{0} = document name</comment>
   </data>
+  <data name="ConsentReview_Progress" xml:space="preserve">
+    <value>Document {0} sur {1}</value>
+    <comment>{0} = current document index, {1} = total required documents</comment>
+  </data>
   <data name="Consent_RequiredDocuments" xml:space="preserve">
     <value>Documents requis</value>
   </data>
@@ -5522,6 +5526,33 @@
   <data name="VolTrack_Counts_Unbooked" xml:space="preserve">
     <value>Déclarés mais non réservés</value>
   </data>
+  <data name="VolTrack_Export_Title" xml:space="preserve">
+    <value>Exporter la grille des b&#xE9;n&#xE9;voles</value>
+  </data>
+  <data name="VolTrack_Export_Department" xml:space="preserve">
+    <value>D&#xE9;partement</value>
+  </data>
+  <data name="VolTrack_Export_AllDepartments" xml:space="preserve">
+    <value>Tous les d&#xE9;partements</value>
+  </data>
+  <data name="VolTrack_Export_Period" xml:space="preserve">
+    <value>P&#xE9;riode</value>
+  </data>
+  <data name="VolTrack_Export_PeriodCustom" xml:space="preserve">
+    <value>Plage personnalis&#xE9;e</value>
+  </data>
+  <data name="VolTrack_Export_From" xml:space="preserve">
+    <value>Du</value>
+  </data>
+  <data name="VolTrack_Export_To" xml:space="preserve">
+    <value>Au</value>
+  </data>
+  <data name="VolTrack_Export_Download" xml:space="preserve">
+    <value>T&#xE9;l&#xE9;charger le XLSX</value>
+  </data>
+  <data name="VolTrack_Export_Methodology" xml:space="preserve">
+    <value>Lignes = humans ayant &#x2265;1 cr&#xE9;neau confirm&#xE9; sur la p&#xE9;riode. Couleur de cellule = l'&#xE9;quipe avec laquelle ils ont travaill&#xE9; le plus d'heures ce jour-l&#xE0;. Cellule blanche = jour pr&#xE9;c&#xE9;dant leur premier cr&#xE9;neau confirm&#xE9; (jour d'arriv&#xE9;e). Ligne des totaux = humans pr&#xE9;sents sur place ce jour-l&#xE0; (utilis&#xE9; pour le d&#xE9;compte des repas). Les noms affich&#xE9;s sont des noms de playa.</value>
+  </data>
   <data name="VolTrack_Filter_HideNoGaps" xml:space="preserve">
     <value>Masquer les bénévoles sans trous</value>
     <comment>TODO: translate</comment>
@@ -5829,6 +5860,81 @@
   <data name="VolTrack_AuditAction_CampSetupCleared" xml:space="preserve">
     <value>Date d'installation du camp effacée</value>
     <comment>TODO: translate</comment>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Subject" xml:space="preserve">
+    <value>Un message concernant vos cr&#xE9;neaux sur {0}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Bonjour {0},&lt;/p&gt;&lt;p&gt;Un message du coordinateur de &lt;strong&gt;{2}&lt;/strong&gt; :&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Pour information, vos cr&#xE9;neaux sur ce roulement sont :&lt;/p&gt;{4}&lt;p&gt;Merci,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_NoShifts" xml:space="preserve">
+    <value>(aucun cr&#xE9;neau sur ce roulement pour l'instant)</value>
+  </data>
+  <data name="EmailRota_Title" xml:space="preserve">
+    <value>Envoyer un e-mail au roulement&#xA0;: {0}</value>
+  </data>
+  <data name="EmailRota_Breadcrumb" xml:space="preserve">
+    <value>E-mail au roulement</value>
+  </data>
+  <data name="EmailRota_Heading" xml:space="preserve">
+    <value>Envoyer un e-mail &#xE0; tout le monde dans le roulement&#xA0;: {0}</value>
+  </data>
+  <data name="EmailRota_RecipientsHeading" xml:space="preserve">
+    <value>Destinataires ({0})</value>
+  </data>
+  <data name="EmailRota_NoRecipients" xml:space="preserve">
+    <value>Personne n'est encore inscrit &#xE0; ce roulement.</value>
+  </data>
+  <data name="EmailRota_MessageLabel" xml:space="preserve">
+    <value>Votre message</value>
+  </data>
+  <data name="EmailRota_MessageHelp" xml:space="preserve">
+    <value>Texte brut uniquement. Chaque destinataire verra ce message ainsi que sa propre liste de cr&#xE9;neaux pour ce roulement.</value>
+  </data>
+  <data name="EmailRota_Button" xml:space="preserve">
+    <value>Envoyer un e-mail &#xE0; un roulement</value>
+  </data>
+  <data name="EmailRota_Send" xml:space="preserve">
+    <value>Envoyer &#xE0; {0} destinataire(s)</value>
+  </data>
+  <data name="EmailRota_Success" xml:space="preserve">
+    <value>{0} e-mail(s) mis en file d'attente pour les destinataires du roulement &#xAB;&#xA0;{1}&#xA0;&#xBB;.</value>
+  </data>
+  <data name="EmailRota_NoActiveSignups" xml:space="preserve">
+    <value>Ce roulement n'a aucune inscription active &#xE0; qui envoyer un e-mail.</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Subject" xml:space="preserve">
+    <value>Un message concernant vos cr&#xE9;neaux avec {0}</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Bonjour {0},&lt;/p&gt;&lt;p&gt;Un message du coordinateur de &lt;strong&gt;{2}&lt;/strong&gt; :&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Pour information, vos cr&#xE9;neaux dans les prochains roulements de cette &#xE9;quipe :&lt;/p&gt;{4}&lt;p&gt;Merci,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="EmailTeamRotas_Title" xml:space="preserve">
+    <value>Envoyer un e-mail &#xE0; l'&#xE9;quipe&#xA0;: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_Breadcrumb" xml:space="preserve">
+    <value>E-mail &#xE0; l'&#xE9;quipe</value>
+  </data>
+  <data name="EmailTeamRotas_Heading" xml:space="preserve">
+    <value>Envoyer un e-mail &#xE0; tout le monde dans les prochains roulements&#xA0;: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_RecipientsHeading" xml:space="preserve">
+    <value>Destinataires ({0})</value>
+  </data>
+  <data name="EmailTeamRotas_RotaCount" xml:space="preserve">
+    <value>sur {0} roulement(s)</value>
+  </data>
+  <data name="EmailTeamRotas_NoRecipients" xml:space="preserve">
+    <value>Personne n'est encore inscrit aux prochains roulements de cette &#xE9;quipe.</value>
+  </data>
+  <data name="EmailTeamRotas_MessageLabel" xml:space="preserve">
+    <value>Votre message</value>
+  </data>
+  <data name="EmailTeamRotas_MessageHelp" xml:space="preserve">
+    <value>Texte brut uniquement. Chaque destinataire verra ce message ainsi que sa propre liste de cr&#xE9;neaux dans les prochains roulements de l'&#xE9;quipe.</value>
+  </data>
+  <data name="EmailTeamRotas_Send" xml:space="preserve">
+    <value>Envoyer &#xE0; {0} destinataire(s)</value>
   </data>
   <data name="AdminHumans_MissingConsents" xml:space="preserve"><value>Consentements manquants</value></data>
   <data name="AdminHumans_IncompleteSignup" xml:space="preserve"><value>Inscription incompl&#xE8;te</value></data>
@@ -6448,6 +6554,8 @@
   <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>Le nom sous lequel tout le monde vous connaîtra.</value></data>
   <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
   <data name="Onboarding_Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="Onboarding_LegalFirstNameLabel" xml:space="preserve"><value>Prénom légal</value></data>
+  <data name="Onboarding_LegalLastNameLabel" xml:space="preserve"><value>Nom de famille légal</value></data>
   <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>pas</value></data>
   <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>cette information, et nous ne la divulguerions que si la loi ou un audit formel l'exigeait.</value></data>
   <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Conservé en interne, visible uniquement par les Admins, et utilisé seulement là où la loi espagnole l'exige — par exemple, notre enregistrement d'audit attestant que vous avez accepté l'Accord de bénévolat à une date et une heure précises. Nous n'exportons explicitement</value></data>
@@ -6468,6 +6576,8 @@
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Aucun quart critique à pourvoir pour le moment — essayez Important ou Tous.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Aucun quart important à pourvoir pour le moment — essayez Tous.</value></data>
   <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Pas maintenant</value></data>
+  <data name="Onboarding_ShiftsSignUpFailed" xml:space="preserve"><value>Inscription impossible.</value></data>
+  <data name="Onboarding_ShiftsSignUpRangeFailed" xml:space="preserve"><value>Inscription impossible pour cette plage de dates.</value></data>
   <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Choisissez un quart</value></data>
   <data name="Outbox_AdminTitle" xml:space="preserve"><value>E-mails</value></data>
   <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Retour à Administration</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1242,6 +1242,10 @@
     <value>Esame: {0}</value>
     <comment>{0} = document name</comment>
   </data>
+  <data name="ConsentReview_Progress" xml:space="preserve">
+    <value>Documento {0} di {1}</value>
+    <comment>{0} = current document index, {1} = total required documents</comment>
+  </data>
   <data name="Consent_RequiredDocuments" xml:space="preserve">
     <value>Documenti richiesti</value>
   </data>
@@ -5522,6 +5526,33 @@
   <data name="VolTrack_Counts_Unbooked" xml:space="preserve">
     <value>Dichiarati ma non prenotati</value>
   </data>
+  <data name="VolTrack_Export_Title" xml:space="preserve">
+    <value>Esporta griglia dei volontari</value>
+  </data>
+  <data name="VolTrack_Export_Department" xml:space="preserve">
+    <value>Reparto</value>
+  </data>
+  <data name="VolTrack_Export_AllDepartments" xml:space="preserve">
+    <value>Tutti i reparti</value>
+  </data>
+  <data name="VolTrack_Export_Period" xml:space="preserve">
+    <value>Periodo</value>
+  </data>
+  <data name="VolTrack_Export_PeriodCustom" xml:space="preserve">
+    <value>Intervallo personalizzato</value>
+  </data>
+  <data name="VolTrack_Export_From" xml:space="preserve">
+    <value>Da</value>
+  </data>
+  <data name="VolTrack_Export_To" xml:space="preserve">
+    <value>A</value>
+  </data>
+  <data name="VolTrack_Export_Download" xml:space="preserve">
+    <value>Scarica XLSX</value>
+  </data>
+  <data name="VolTrack_Export_Methodology" xml:space="preserve">
+    <value>Righe = humans con &#x2265;1 fascia confermata nell'intervallo. Colore della cella = il team con cui hanno lavorato pi&#xF9; ore quel giorno. Cella bianca = giorno prima della loro prima fascia confermata (giorno di arrivo). Riga dei totali = humans presenti quel giorno (usato per il conteggio dei pasti). I nomi mostrati sono nomi playa.</value>
+  </data>
   <data name="VolTrack_Filter_HideNoGaps" xml:space="preserve">
     <value>Nascondi volontari senza buchi</value>
     <comment>TODO: translate</comment>
@@ -5829,6 +5860,81 @@
   <data name="VolTrack_AuditAction_CampSetupCleared" xml:space="preserve">
     <value>Configurazione montaggio camp rimossa</value>
     <comment>TODO: translate</comment>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Subject" xml:space="preserve">
+    <value>Un messaggio sulle tue fasce in {0}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Ciao {0},&lt;/p&gt;&lt;p&gt;Un messaggio dal coordinatore di &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Per tua informazione, le tue fasce in questo turno sono:&lt;/p&gt;{4}&lt;p&gt;Grazie,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="Email_CoordinatorRotaMessage_NoShifts" xml:space="preserve">
+    <value>(ancora nessuna fascia in questo turno)</value>
+  </data>
+  <data name="EmailRota_Title" xml:space="preserve">
+    <value>Invia email al turno: {0}</value>
+  </data>
+  <data name="EmailRota_Breadcrumb" xml:space="preserve">
+    <value>Email al turno</value>
+  </data>
+  <data name="EmailRota_Heading" xml:space="preserve">
+    <value>Invia email a tutti nel turno: {0}</value>
+  </data>
+  <data name="EmailRota_RecipientsHeading" xml:space="preserve">
+    <value>Destinatari ({0})</value>
+  </data>
+  <data name="EmailRota_NoRecipients" xml:space="preserve">
+    <value>Nessuno si &#xE8; ancora iscritto a questo turno.</value>
+  </data>
+  <data name="EmailRota_MessageLabel" xml:space="preserve">
+    <value>Il tuo messaggio</value>
+  </data>
+  <data name="EmailRota_MessageHelp" xml:space="preserve">
+    <value>Solo testo semplice. Ogni destinatario vedr&#xE0; questo messaggio insieme al proprio elenco di fasce di questo turno.</value>
+  </data>
+  <data name="EmailRota_Button" xml:space="preserve">
+    <value>Invia email a un turno</value>
+  </data>
+  <data name="EmailRota_Send" xml:space="preserve">
+    <value>Invia a {0} destinatario/i</value>
+  </data>
+  <data name="EmailRota_Success" xml:space="preserve">
+    <value>Accodate {0} email per i destinatari del turno '{1}'.</value>
+  </data>
+  <data name="EmailRota_NoActiveSignups" xml:space="preserve">
+    <value>Questo turno non ha iscrizioni attive a cui inviare email.</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Subject" xml:space="preserve">
+    <value>Un messaggio sulle tue fasce con {0}</value>
+  </data>
+  <data name="Email_CoordinatorTeamRotasMessage_Body" xml:space="preserve">
+    <value>&lt;p&gt;Ciao {0},&lt;/p&gt;&lt;p&gt;Un messaggio dal coordinatore di &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;Per tua informazione, le tue fasce nei prossimi turni del team:&lt;/p&gt;{4}&lt;p&gt;Grazie,&lt;/p&gt;{5}</value>
+  </data>
+  <data name="EmailTeamRotas_Title" xml:space="preserve">
+    <value>Invia email al team: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_Breadcrumb" xml:space="preserve">
+    <value>Email al team</value>
+  </data>
+  <data name="EmailTeamRotas_Heading" xml:space="preserve">
+    <value>Invia email a tutti nei prossimi turni: {0}</value>
+  </data>
+  <data name="EmailTeamRotas_RecipientsHeading" xml:space="preserve">
+    <value>Destinatari ({0})</value>
+  </data>
+  <data name="EmailTeamRotas_RotaCount" xml:space="preserve">
+    <value>in {0} turno/i</value>
+  </data>
+  <data name="EmailTeamRotas_NoRecipients" xml:space="preserve">
+    <value>Nessuno si &#xE8; ancora iscritto ai prossimi turni di questo team.</value>
+  </data>
+  <data name="EmailTeamRotas_MessageLabel" xml:space="preserve">
+    <value>Il tuo messaggio</value>
+  </data>
+  <data name="EmailTeamRotas_MessageHelp" xml:space="preserve">
+    <value>Solo testo semplice. Ogni destinatario vedr&#xE0; questo messaggio insieme al proprio elenco di fasce nei prossimi turni del team.</value>
+  </data>
+  <data name="EmailTeamRotas_Send" xml:space="preserve">
+    <value>Invia a {0} destinatario/i</value>
   </data>
   <data name="AdminHumans_MissingConsents" xml:space="preserve"><value>Consensi mancanti</value></data>
   <data name="AdminHumans_IncompleteSignup" xml:space="preserve"><value>Registrazione incompleta</value></data>
@@ -6448,6 +6554,8 @@
   <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>Il nome con cui tutti ti conosceranno.</value></data>
   <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
   <data name="Onboarding_Continue" xml:space="preserve"><value>Continua</value></data>
+  <data name="Onboarding_LegalFirstNameLabel" xml:space="preserve"><value>Nome legale</value></data>
+  <data name="Onboarding_LegalLastNameLabel" xml:space="preserve"><value>Cognome legale</value></data>
   <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>non</value></data>
   <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>esportiamo queste informazioni, e le divulgheremmo solo se richiesto dalla legge o da un audit formale.</value></data>
   <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Conservato internamente, visibile solo agli Admin e usato solo dove lo richiede la legge spagnola — per esempio, il nostro registro di audit attestante che hai accettato l'Accordo di volontariato in una data e ora specifiche. Esplicitamente</value></data>
@@ -6468,6 +6576,8 @@
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Nessun turno critico aperto al momento — prova Importanti o Tutti.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Nessun turno importante aperto al momento — prova Tutti.</value></data>
   <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Non adesso</value></data>
+  <data name="Onboarding_ShiftsSignUpFailed" xml:space="preserve"><value>Iscrizione non riuscita.</value></data>
+  <data name="Onboarding_ShiftsSignUpRangeFailed" xml:space="preserve"><value>Iscrizione non riuscita per l'intervallo di date.</value></data>
   <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Scegli un turno</value></data>
   <data name="Outbox_AdminTitle" xml:space="preserve"><value>Email</value></data>
   <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Torna ad Amministrazione</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -500,6 +500,7 @@
   <!-- ======================== -->
   <data name="ConsentIndex_Title" xml:space="preserve"><value>Agreements</value></data>
   <data name="ConsentReview_Title" xml:space="preserve"><value>Review: {0}</value><comment>{0} = document name</comment></data>
+  <data name="ConsentReview_Progress" xml:space="preserve"><value>Document {0} of {1}</value><comment>{0} = current document index, {1} = total required documents</comment></data>
 
   <!-- Consent Index View -->
   <data name="Consent_RequiredDocuments" xml:space="preserve"><value>Required Documents</value></data>
@@ -2911,6 +2912,8 @@
   <data name="Onboarding_BurnerNameHelp" xml:space="preserve"><value>The name everyone will know you by.</value></data>
   <data name="Onboarding_BurnerNameLabel" xml:space="preserve"><value>Burner name</value></data>
   <data name="Onboarding_Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="Onboarding_LegalFirstNameLabel" xml:space="preserve"><value>Legal First Name</value></data>
+  <data name="Onboarding_LegalLastNameLabel" xml:space="preserve"><value>Legal Last Name(s)</value></data>
   <data name="Onboarding_LegalNameExplainerEmphasis" xml:space="preserve"><value>not</value></data>
   <data name="Onboarding_LegalNameExplainerPost" xml:space="preserve"><value>export this information, and would only disclose it if required by law or a formal audit.</value></data>
   <data name="Onboarding_LegalNameExplainerPre" xml:space="preserve"><value>Kept internally, visible only to Admins, and used only where Spanish law requires it — for example, our audit record that you agreed to the Volunteer Agreement on a specific date and time. We explicitly do</value></data>
@@ -2930,6 +2933,8 @@
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No critical shifts open at the moment — try Important or All.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No important shifts open at the moment — try All.</value></data>
   <data name="Onboarding_ShiftsNotNow" xml:space="preserve"><value>Not right now</value></data>
+  <data name="Onboarding_ShiftsSignUpFailed" xml:space="preserve"><value>Could not sign up.</value></data>
+  <data name="Onboarding_ShiftsSignUpRangeFailed" xml:space="preserve"><value>Could not sign up for date range.</value></data>
   <data name="Onboarding_ShiftsTitle" xml:space="preserve"><value>Pick a shift</value></data>
   <data name="Outbox_AdminTitle" xml:space="preserve"><value>Emails</value></data>
   <data name="Outbox_BackToAdmin" xml:space="preserve"><value>Back to Admin</value></data>

--- a/src/Humans.Web/Views/OnboardingWidget/Consents.cshtml
+++ b/src/Humans.Web/Views/OnboardingWidget/Consents.cshtml
@@ -1,9 +1,9 @@
 @model Humans.Web.Models.OnboardingWidget.ConsentsStepViewModel
-@{ ViewData["Title"] = $"{Model.DocumentName} — please review and sign"; }
+@{ ViewData["Title"] = string.Format(Localizer["ConsentReview_Title"].Value, Model.DocumentName); }
 
 <div class="row justify-content-center">
     <div class="col-lg-10">
-        <p class="text-muted small mb-2">Document @Model.CurrentIndex of @Model.TotalRequired</p>
+        <p class="text-muted small mb-2">@Localizer["ConsentReview_Progress", Model.CurrentIndex, Model.TotalRequired]</p>
         <div class="d-flex justify-content-between align-items-center mb-3">
             <div>
                 <h1 class="mb-0">@Model.DocumentName</h1>

--- a/tests/Humans.Web.Tests/Resources/SharedResourceParityTests.cs
+++ b/tests/Humans.Web.Tests/Resources/SharedResourceParityTests.cs
@@ -1,0 +1,49 @@
+using AwesomeAssertions;
+using Humans.Web.Models;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Humans.Web.Tests.Resources;
+
+/// <summary>
+/// Resx parity gate for <see cref="SharedResource"/>: every key defined in the base
+/// (English) resx must exist in every other supported-culture resx file. A missing key
+/// silently falls back to English at runtime instead of failing loudly — this is the
+/// only thing that catches that drift before it ships (nobodies-collective/Humans#848,
+/// following the recurring gaps reported by #873).
+///
+/// Reuses <see cref="TranslationsGalleryModelBuilder"/> — the same key-by-culture
+/// computation that powers <c>/Debug/Translations</c> — instead of re-parsing the .resx
+/// XML, and builds a real <see cref="ResourceManagerStringLocalizerFactory"/> against the
+/// compiled satellite resources so the test exercises exactly what ships, not a
+/// hand-parsed approximation of it.
+/// </summary>
+public class SharedResourceParityTests
+{
+    [HumansFact]
+    public void EveryNonBaseCultureHasEveryBaseKey()
+    {
+        var factory = new ResourceManagerStringLocalizerFactory(
+            Options.Create(new LocalizationOptions()), NullLoggerFactory.Instance);
+        var localizer = new StringLocalizer<SharedResource>(factory);
+
+        var gallery = TranslationsGalleryModelBuilder.Build(localizer);
+
+        var missingByCulture = gallery.Groups
+            .SelectMany(g => g.Rows)
+            .SelectMany(row => gallery.Languages
+                .Where(culture => row.Values[culture] is null)
+                .Select(culture => (Culture: culture, row.Key)))
+            .GroupBy(x => x.Culture, x => x.Key, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(key => key, StringComparer.Ordinal).ToList(),
+                StringComparer.Ordinal);
+
+        missingByCulture.Should().BeEmpty(
+            "every supported culture must translate every SharedResource base key; " +
+            "found gaps: " + string.Join("; ", missingByCulture.Select(
+                kv => $"{kv.Key} missing {kv.Value.Count}: [{string.Join(", ", kv.Value)}]")));
+    }
+}


### PR DESCRIPTION
## Summary

Closes nobodies-collective/Humans#848.

The wizard *views* (`Names.cshtml`, `Shifts.cshtml`) were already fully localized by #987 before this PR started, and the ~4-5 volunteer-facing missing `es` keys the issue called out (`Onboarding_NameRequiredBeforeShifts`, `AccountStatus_*`) were also already translated by that same PR. What was still genuinely broken:

- `AddDataAnnotationsLocalization()` was registered in `Program.cs` with **no provider**, so it silently did nothing — `NamesViewModel`'s `[Display(Name = "Legal First Name")]` etc. rendered raw English in every culture. Fixed by wiring `DataAnnotationLocalizerProvider` to `SharedResource` (the same resx every other localized string uses) and pointing the `[Display]` attributes at resource keys instead of literal English.
- Two `OnboardingWidgetController` flash messages (`SignUp`/`SignUpRange` failure fallbacks) were still hardcoded English — now localized.
- `Consents.cshtml`'s page title and "Document X of Y" progress line were hardcoded English, despite the issue's problem statement believing this view was "already localized." Fixed by reusing `ConsentReview_Title` (the same key `Consent/Review.cshtml` already uses for the identical concept) and adding `ConsentReview_Progress`.
- **5 new keys** added across all 6 resx files for the above.
- Backfilled the **24-33 `Email_Coordinator*Message_*`/`EmailRota_*`/`EmailTeamRotas_*`/`VolTrack_Export_*` keys** that were missing from `ca`/`de`/`es`/`fr`/`it` (the issue explicitly deferred these as "non-event-critical," but a parity test with a known-broken baseline is a test that's born failing — translated them so the gate can be unconditional rather than carved out).
- **New `SharedResourceParityTests`** (`tests/Humans.Web.Tests/Resources/`) asserts every supported culture has every base-resx key, failing with the exact missing-key list per culture. Placed in `Humans.Web.Tests`, not `Humans.Integration.Tests` — `build.yml`'s test filter is `FullyQualifiedName!~Integration`, so a test in the Integration project would never execute in CI at all, only locally. Reuses `TranslationsGalleryModelBuilder` (the `/Debug/Translations` engine) instead of hand-parsing resx XML — a real `ResourceManagerStringLocalizerFactory` against the compiled satellite resources, so it exercises exactly what ships.

All 6 resx files now have identical key sets (2615 keys each), verified by a script diff before committing.

## Reuse rejected

- New `I...Read` interface or repository method for the parity check — not needed, this is a static resx comparison, no runtime service surface.
- Hand-parsing resx XML in the test — rejected in favor of reusing `TranslationsGalleryModelBuilder`, which already computes exactly this (per-culture missing-key sets) for `/Debug/Translations`.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName!~Integration"` — 274+378+245+3756 passed, 0 failed
- [x] New parity test passes; verified it actually fails when a key is removed (manual sanity check, reverted)
- [x] Existing `OnboardingWidgetController*Tests` (33 tests) pass unchanged
- [x] `dotnet format Humans.slnx --verify-no-changes` — clean
- [x] All 6 `SharedResource*.resx` validated as well-formed XML with identical key sets (2615 each)

**Parity test runs in CI: yes** (Humans.Web.Tests, included in the default `dotnet test` filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)