### PR TITLE
fix(tests): unbreak main — ShiftRepositoryRotaSearchTests onto the HumansTestDatabase fixture

### DIFF
--- a/tests/Humans.Integration.Tests/Repositories/Shifts/ShiftRepositoryRotaSearchTests.cs
+++ b/tests/Humans.Integration.Tests/Repositories/Shifts/ShiftRepositoryRotaSearchTests.cs
@@ -22,8 +22,8 @@ namespace Humans.Integration.Tests.Repositories.Shifts;
 /// <c>ShiftManagementServiceTests.SearchAsync_GuidQuery_ResolvesARotaHiddenFromVolunteers</c>.
 /// </para>
 /// </summary>
-public class ShiftRepositoryRotaSearchTests(HumansWebApplicationFactory factory)
-    : IntegrationTestBase(factory)
+public class ShiftRepositoryRotaSearchTests(HumansTestDatabase database)
+    : IntegrationTestBase(database)
 {
     [HumansFact]
     public async Task SearchVolunteerVisibleRotasAsync_ExcludesRotasHiddenFromVolunteers()


### PR DESCRIPTION
`origin/main` is red at `a8a062193` and every open PR is blocked behind it.

## The skew

Two PRs that were each green alone:

- **#1208** (`5f62ade68`) changed `IntegrationTestBase` to `public abstract class IntegrationTestBase(HumansTestDatabase database)` — per-test database and app host (nobodies-collective/Humans#983).
- **#1198** (`a8a062193`) added `tests/Humans.Integration.Tests/Repositories/Shifts/ShiftRepositoryRotaSearchTests.cs`, written against the previous `HumansWebApplicationFactory` constructor.

They merged in sequence, so neither PR's CI ever compiled the combination:

```
ShiftRepositoryRotaSearchTests.cs(26,27): error CS1503: Argument 1:
cannot convert from 'HumansWebApplicationFactory' to 'HumansTestDatabase'
```

Failing run: https://github.com/peterdrier/Humans/actions/runs/31201722072 (`build` and `code-quality`).

## The fix

The base still exposes `protected HumansWebApplicationFactory Factory`, so the test bodies (`Factory.Services.CreateAsyncScope()`) are unaffected — only the primary constructor parameter changes, matching `VolunteerTrackingRepositoryTests` and the other 25 migrated classes:

```csharp
public class ShiftRepositoryRotaSearchTests(HumansTestDatabase database)
    : IntegrationTestBase(database)
```

## Sweep

Every `: IntegrationTestBase(` in `tests/` was checked — 26 sites, all already on `HumansTestDatabase`; this was the only straggler. Remaining `HumansWebApplicationFactory` references (the base class itself, `MergeFixtureExtensions`, `PseudoLocalization`, the `TestStripeWebhookSecret` constant) are all legitimate uses of the type, not the old fixture contract.

## Verification

- `dotnet build Humans.slnx -v quiet` — **0 errors**, 91 pre-existing warnings.
- `dotnet test --filter "FullyQualifiedName~ShiftRepositoryRotaSearchTests"` — **2 passed**, against a real PostgreSQL container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
