### PR TITLE
fix(finance): normalize Holded purchase-doc and ledger parse throws; correct the ISearchService doc

### DIFF
--- a/src/Humans.Application/Interfaces/Search/ISearchService.cs
+++ b/src/Humans.Application/Interfaces/Search/ISearchService.cs
@@ -8,8 +8,8 @@ namespace Humans.Application.Interfaces.Search;
 /// <c>ITeamServiceRead</c>, <c>ICampServiceRead</c>,
 /// <c>IShiftManagementService</c>, <c>IEventServiceRead</c>), each of which
 /// resolves its own case-insensitive match — from a cached snapshot for
-/// teams/camps/humans, via Postgres ILike at the DB layer for rotas and
-/// events. The orchestrator scores and ranks within each type and returns
+/// teams/camps/humans/events, via Postgres ILike at the DB layer for rotas
+/// only. The orchestrator scores and ranks within each type and returns
 /// five independently-ranked buckets — there is no cross-modal / relational
 /// expansion (see <c>docs/features/global/global-search.md</c>).
 ///

--- a/src/Humans.Infrastructure/Services/Holded/HoldedClient.cs
+++ b/src/Humans.Infrastructure/Services/Holded/HoldedClient.cs
@@ -157,8 +157,23 @@ public sealed class HoldedClient : IHoldedClient
         AttachAuth(req);
         using var resp = await SendAsync(req, ct);
         await using var stream = await resp.Content.ReadAsStreamAsync(ct);
-        var arr = (await JsonNode.ParseAsync(stream, cancellationToken: ct))?.AsArray() ?? [];
-        return arr.Select(ParsePurchaseDoc).ToList();
+        try
+        {
+            var arr = (await JsonNode.ParseAsync(stream, cancellationToken: ct))?.AsArray() ?? [];
+            return arr.Select(ParsePurchaseDoc).ToList();
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException
+            or FormatException or OverflowException)
+        {
+            // Same normalization as GetContactAsync: a value of an unexpected type belongs to the
+            // stored document, not to this request, so retrying cannot help. Raw parse throws would
+            // escape past IHoldedClient's two typed exceptions and leak an Infrastructure detail into
+            // the Application layer. Unlike the per-contact skip in ListContactsAsync this fails the
+            // page rather than dropping the doc — these totals become budget-category actuals, and a
+            // silently short page is wrong money rather than a missing name.
+            throw new HoldedPermanentException(
+                $"Holded purchase-document page {page} could not be read.", ex);
+        }
     }
 
     public async Task<string> UpsertContactAsync(HoldedContactInput input, CancellationToken ct = default)
@@ -286,6 +301,11 @@ public sealed class HoldedClient : IHoldedClient
     private static JsonNode? Prop(JsonNode? node, string name) =>
         node is JsonObject obj ? obj[name] : null;
 
+    /// <summary>The array at <paramref name="node"/>, or empty when it is absent or of another kind.
+    /// <see cref="JsonNode.AsArray"/> throws on a non-array for the same reason the string indexer
+    /// throws on a non-object, and Holded is equally happy to send an absent collection as a scalar.</summary>
+    private static JsonArray Arr(JsonNode? node) => node as JsonArray ?? [];
+
     public async Task<IReadOnlyList<HoldedLedgerLineDto>> ListDailyLedgerAsync(
         Instant from, Instant to, CancellationToken ct = default)
     {
@@ -301,21 +321,34 @@ public sealed class HoldedClient : IHoldedClient
             AttachAuth(req);
             using var resp = await SendAsync(req, ct);
             await using var stream = await resp.Content.ReadAsStreamAsync(ct);
-            var arr = (await JsonNode.ParseAsync(stream, cancellationToken: ct))?.AsArray() ?? [];
-            foreach (var n in arr)
+            JsonArray arr;
+            try
             {
-                if (n is null) continue;
-                lines.Add(new HoldedLedgerLineDto
+                arr = (await JsonNode.ParseAsync(stream, cancellationToken: ct))?.AsArray() ?? [];
+                foreach (var n in arr)
                 {
-                    EntryNumber = ReadInt(n["entryNumber"]) ?? 0,
-                    Line = ReadInt(n["line"]) ?? 0,
-                    Date = ReadInstant(n["timestamp"]) ?? Instant.FromUnixTimeSeconds(0),
-                    AccountNum = ReadInt(n["account"]) ?? 0,
-                    Debit = ReadDecimal(n["debit"]),
-                    Credit = ReadDecimal(n["credit"]),
-                    Type = n["type"]?.GetValue<string>(),
-                    Description = n["description"]?.GetValue<string>(),
-                });
+                    if (n is null) continue;
+                    lines.Add(new HoldedLedgerLineDto
+                    {
+                        EntryNumber = ReadInt(Prop(n, "entryNumber")) ?? 0,
+                        Line = ReadInt(Prop(n, "line")) ?? 0,
+                        Date = ReadInstant(Prop(n, "timestamp")) ?? Instant.FromUnixTimeSeconds(0),
+                        AccountNum = ReadInt(Prop(n, "account")) ?? 0,
+                        Debit = ReadDecimal(Prop(n, "debit")),
+                        Credit = ReadDecimal(Prop(n, "credit")),
+                        Type = Prop(n, "type")?.GetValue<string>(),
+                        Description = Prop(n, "description")?.GetValue<string>(),
+                    });
+                }
+            }
+            catch (Exception ex) when (ex is JsonException or InvalidOperationException
+                or FormatException or OverflowException)
+            {
+                // As in ListPurchaseDocumentsPageAsync — permanent, and the whole page fails rather
+                // than skipping the line. Creditor balances are summed from these debits and credits,
+                // so a quietly dropped line reads as a settled invoice that was never paid.
+                throw new HoldedPermanentException(
+                    $"Holded daily-ledger page {page} for {from}..{to} could not be read.", ex);
             }
             if (arr.Count < pageSize) return lines;
         }
@@ -325,28 +358,30 @@ public sealed class HoldedClient : IHoldedClient
         return lines;
     }
 
+    /// <summary>Projects one purchase document. Every container read goes through <see cref="Prop"/> /
+    /// <see cref="Arr"/> rather than the raw indexer, for the reason spelled out on those two.</summary>
     private static HoldedPurchaseDocListItemDto ParsePurchaseDoc(JsonNode? n) => new()
     {
-        Id = n!["id"]?.GetValue<string>() ?? "",
-        DocNumber = n["docNumber"]?.GetValue<string>() ?? "",
-        ContactName = n["contactName"]?.GetValue<string>() ?? "",
-        Date = ReadInstant(n["date"]) ?? Instant.FromUnixTimeSeconds(0),
-        Subtotal = ReadDecimal(n["subtotal"]),
-        Tax = ReadDecimal(n["tax"]),
-        Total = ReadDecimal(n["total"]),
-        ApprovedAt = ReadInstant(n["approvedAt"]),
-        Currency = n["currency"]?.GetValue<string>() ?? "eur",
-        Tags = ReadTags(n["tags"]),
-        Lines = (n["products"]?.AsArray() ?? []).Select(p => new HoldedPurchaseLineDto
+        Id = Prop(n, "id")?.GetValue<string>() ?? "",
+        DocNumber = Prop(n, "docNumber")?.GetValue<string>() ?? "",
+        ContactName = Prop(n, "contactName")?.GetValue<string>() ?? "",
+        Date = ReadInstant(Prop(n, "date")) ?? Instant.FromUnixTimeSeconds(0),
+        Subtotal = ReadDecimal(Prop(n, "subtotal")),
+        Tax = ReadDecimal(Prop(n, "tax")),
+        Total = ReadDecimal(Prop(n, "total")),
+        ApprovedAt = ReadInstant(Prop(n, "approvedAt")),
+        Currency = Prop(n, "currency")?.GetValue<string>() ?? "eur",
+        Tags = ReadTags(Prop(n, "tags")),
+        Lines = Arr(Prop(n, "products")).Select(p => new HoldedPurchaseLineDto
         {
-            Amount = ReadDecimal(p!["price"]),
-            AccountId = p["account"]?.GetValue<string>(),
-            Tags = ReadTags(p["tags"]),
+            Amount = ReadDecimal(Prop(p, "price")),
+            AccountId = Prop(p, "account")?.GetValue<string>(),
+            Tags = ReadTags(Prop(p, "tags")),
         }).ToList(),
     };
 
     private static IReadOnlyList<string> ReadTags(JsonNode? node) =>
-        node?.AsArray().Where(t => t is not null).Select(t => t!.GetValue<string>()).ToList() ?? [];
+        Arr(node).Where(t => t is not null).Select(t => t!.GetValue<string>()).ToList();
 
     private void AttachAuth(HttpRequestMessage req) =>
         req.Headers.Add("key", _options.ApiKey);

--- a/tests/Humans.Application.Tests/Services/Holded/HoldedClientReadTests.cs
+++ b/tests/Humans.Application.Tests/Services/Holded/HoldedClientReadTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Holded;
 using Humans.Infrastructure.Services.Holded;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -81,6 +82,49 @@ public class HoldedClientReadTests
 
         capturedQuery.Should().Contain("page=3");
         capturedQuery.Should().Contain("limit=50");
+    }
+
+    [HumansFact]
+    public async Task ListPurchaseDocumentsPage_treats_a_non_array_products_as_no_lines()
+    {
+        // Holded sends an absent sub-record as an empty array (#994) and is equally free to send an
+        // absent collection as something other than an array; AsArray() throws on both.
+        var json = """[{"id":"doc-1","docNumber":"F001","products":{},"tags":""}]""";
+        var client = Make(new StubHandler(_ => Respond(HttpStatusCode.OK, json)));
+
+        var docs = await client.ListPurchaseDocumentsPageAsync(1, 10, Xunit.TestContext.Current.CancellationToken);
+
+        docs.Should().ContainSingle();
+        docs[0].Lines.Should().BeEmpty();
+        docs[0].Tags.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task ListPurchaseDocumentsPage_surfaces_an_unreadable_doc_as_permanent_not_a_raw_parse_throw()
+    {
+        // Callers handle only IHoldedClient's two typed exceptions; a raw parse throw from a bad
+        // stored value would escape the client and leak an Infrastructure detail upward.
+        var client = Make(new StubHandler(_ => Respond(
+            HttpStatusCode.OK, """[{"id":42,"docNumber":"F001"}]""")));
+
+        var act = async () => await client.ListPurchaseDocumentsPageAsync(1, 10, Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HoldedPermanentException>();
+    }
+
+    [HumansFact]
+    public async Task ListDailyLedger_surfaces_an_unreadable_line_as_permanent_not_a_raw_parse_throw()
+    {
+        // ReadInt's GetValue<decimal> throws on a non-numeric account. Fail the page rather than
+        // drop the line: creditor balances are summed from these debits and credits.
+        var client = Make(new StubHandler(_ => Respond(
+            HttpStatusCode.OK, """[{"entryNumber":1,"account":"not-a-number","debit":10.0}]""")));
+
+        var act = async () => await client.ListDailyLedgerAsync(
+            Instant.FromUnixTimeSeconds(0), Instant.FromUnixTimeSeconds(86400),
+            Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HoldedPermanentException>();
     }
 
     [HumansFact]


### PR DESCRIPTION
Two unrelated defects found while reviewing other PRs, both already on `main` and unowned.

## 1. `ISearchService` XML doc claimed events search the DB

The summary said results come "via Postgres ILike at the DB layer for rotas **and events**". Events don't touch the DB:

- `src/Humans.Web/Extensions/Sections/EventsSectionExtensions.cs:48` registers `IEventServiceRead` as the `CachingEventService` singleton.
- `CachingEventService.GetApprovedEventsAsync` (`:295`) filters `_eventCache.Values` through `MatchesQuery` (`:327`), which is `Contains(…, OrdinalIgnoreCase)` on `Title`/`Description` — an in-memory snapshot scan, no round trip and not ILike semantics.
- `SearchService.SearchEventsAsync` (`:138`) is the only caller in the search path, and it goes through that interface.

Rotas (`IShiftManagementService.SearchAsync`) are the only genuinely DB-backed bucket. Comment-only change; nothing else in the summary was touched.

## 2. Malformed-field fragility in `HoldedClient`

Same shape #1201 fixed for `GetContactAsync`. `ParsePurchaseDoc` and `ListDailyLedgerAsync` read every field through the raw `n["x"]` indexer, which throws `InvalidOperationException` on anything but a `JsonObject` (this is exactly how #994 blanked every creditor name in prod — Holded sends an absent sub-record as `[]`). `ReadInt`'s `GetValue<decimal>()` throws `InvalidOperationException`/`FormatException`/`OverflowException` on a non-numeric token. All of those escape past `IHoldedClient`'s two typed exceptions and leak an Infrastructure detail into the Application layer.

Following #1201's precedent:

- Container reads go through `Prop()` (added in #1201) plus a new sibling `Arr()`, so an absent collection sent as a scalar or object costs the field, not the parse. `ReadTags` loses its unguarded `AsArray()` — same defect, same code path, called only from `ParsePurchaseDoc`. That is the one extra instance beyond the two named paths.
- `ListPurchaseDocumentsPageAsync` and `ListDailyLedgerAsync` wrap `JsonException or InvalidOperationException or FormatException or OverflowException` into `HoldedPermanentException`. Permanent, not transient: a bad stored value is a property of the record, so retrying cannot help. `ReadInt` still throws — the wrapper is now its typed home, the same way #1201 left it for `ParseContact`.
- These fail the **page** rather than skipping the row, unlike the per-contact skip in `ListContactsAsync`. A dropped contact costs a name; a dropped ledger line or purchase doc silently understates a creditor balance or a budget-category actual. Wrong money is worse than a loud failure.

**One correction to the framing this was filed under:** the blast radius is the nightly `HoldedSyncJob`, not the outbox drain. `ListPurchaseDocumentsPageAsync` is reached from `HoldedFinanceService.SyncAsync:191` and `ListDailyLedgerAsync` from `:410`/`:434` — both under `HoldedSyncJob`, which the outbox drain does not call. `SyncAsync` already catches `Exception` broadly and records `HoldedSyncStatus.Error`, so today one bad field doesn't wedge a job on every poll; it aborts the whole nightly pull and skips `SyncCreditorLedgerAsync` on the next line. Still worth fixing, and the contract argument (typed exceptions only, no Infrastructure leak) stands on its own.

## Tests

Three added to `HoldedClientReadTests`, in the style of `HoldedClientContactTests.GetContact_surfaces_an_unreadable_contact_as_permanent_not_a_raw_parse_throw`: non-array `products`/`tags` parse to empty, an unreadable purchase doc surfaces as `HoldedPermanentException`, an unreadable ledger line likewise.

All three verified to fail against the current client by re-running them with `HoldedClient.cs` stashed — not assumed:

```
[FAIL] ListPurchaseDocumentsPage_treats_a_non_array_products_as_no_lines
[FAIL] ListDailyLedger_surfaces_an_unreadable_line_as_permanent_not_a_raw_parse_throw
[FAIL] ListPurchaseDocumentsPage_surfaces_an_unreadable_doc_as_permanent_not_a_raw_parse_throw
Failed! - Failed: 3, Passed: 19
```

With the fix: `dotnet build Humans.slnx -v quiet` → 0 errors, and the Holded + Search filters → `Failed: 0, Passed: 124`.

No issue filed for either — too small for the ceremony, per Peter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
