### PR TITLE
fix(finance): re-check creditor binding before write to close the remaining unbind race

### DIFF
--- a/src/Humans.Application/Services/Finance/HoldedFinanceService.cs
+++ b/src/Humans.Application/Services/Finance/HoldedFinanceService.cs
@@ -660,6 +660,41 @@ public sealed class HoldedFinanceService(
             "both now show on /Finance/Creditors and one must be unbound.",
             writePath, userId, holdedContactId, supplierAccountNum, conflict.UserId, conflict.Source);
 
+    /// <summary>True when the member's creditor row is still exactly what <paramref name="asRead"/>
+    /// holds — same row, same content, or still absent when nothing was read.
+    ///
+    /// <para>The automatic write paths carry the contact id, Source and account number straight off the
+    /// binding they opened with, so their write is only safe while that binding is still the one in the
+    /// table; an admin Bind, Unbind or rebind landing in the window turns it into a silent revert, and
+    /// holded_creditor_contacts has no audit trail to reconstruct the loss from. Row identity alone is
+    /// not enough to detect that: UpsertCreditorContactAsync is keyed by UserId and mutates in place, so
+    /// an admin rebinding a member to a different Holded contact keeps the row and its Id and changes
+    /// only the columns being clobbered. Absence is not enough either — a member unbound at the opening
+    /// read who is manually bound during the round-trip has a row to lose too.</para></summary>
+    private async Task<bool> BindingUnchangedAsync(
+        string writePath, Guid userId, HoldedCreditorContact? asRead, CancellationToken ct)
+    {
+        var current = await repo.GetCreditorContactByUserAsync(userId, ct);
+        if (current is null && asRead is null) return true;
+        if (current is not null && asRead is not null
+            && current.Id == asRead.Id
+            && string.Equals(current.HoldedContactId, asRead.HoldedContactId, StringComparison.Ordinal)
+            && current.SupplierAccountNum == asRead.SupplierAccountNum
+            && current.Source == asRead.Source)
+            return true;
+
+        // The admin's action stands and nothing is written, so this line is the only record that a push
+        // was overtaken — worth a Warning so a member whose push "did nothing" can be explained.
+        logger.LogWarning(
+            "Skipped the creditor binding write in {WritePath} for member {UserId}: the binding changed " +
+            "while the push was in flight — was {WasContactId} / {WasAccountNum} ({WasSource}), is now " +
+            "{NowContactId} / {NowAccountNum} ({NowSource}). The newer binding stands.",
+            writePath, userId,
+            asRead?.HoldedContactId, asRead?.SupplierAccountNum, asRead?.Source,
+            current?.HoldedContactId, current?.SupplierAccountNum, current?.Source);
+        return false;
+    }
+
     public async Task<CreditorBindResult> SetCreditorContactAsync(
         Guid userId, int supplierAccountNum, CancellationToken ct = default)
     {
@@ -808,12 +843,13 @@ public sealed class HoldedFinanceService(
             return contactId;
 
         // A binding still missing its account number does write real content, so it cannot be skipped
-        // the way the steady state above is — but it can still lose a concurrent Unbind the same way:
-        // UpsertCreditorContactAsync treats an absent row as first-time and inserts, which would
-        // resurrect the very binding an admin just cleared (nobodies-collective/Humans#995). Re-reading
-        // right before the write shrinks that window from the whole Holded round-trip above to the gap
-        // between this read and the write call, without a version column (no-concurrency-tokens.md).
-        if (binding is not null && await repo.GetCreditorContactByUserAsync(userId, ct) is null)
+        // the way the steady state above is — but it can still lose whatever an admin did during the
+        // Holded round-trip above. UpsertCreditorContactAsync is keyed by UserId, so it inserts over an
+        // Unbind and mutates over a Bind, either way undoing the admin's action from the copy read
+        // before the round-trip (nobodies-collective/Humans#995). Re-reading right before the write
+        // shrinks that window to the gap between this read and the write call, without a version column
+        // (no-concurrency-tokens.md).
+        if (!await BindingUnchangedAsync(nameof(EnsureCreditorContactAsync), userId, binding, ct))
             return contactId;
 
         var now = clock.GetCurrentInstant();
@@ -846,13 +882,13 @@ public sealed class HoldedFinanceService(
                 nameof(SetCreditorAccountNumAsync), userId, binding.HoldedContactId,
                 supplierAccountNum, conflict);
 
-        // Re-check immediately before writing: an Unbind landing between the read above and here must
-        // not be undone the same way EnsureCreditorContactAsync guards against it (Humans#995) — without
-        // this, UpsertCreditorContactAsync would treat the now-absent row as first-time and insert it
-        // back. This runs at the end of a long push with no I/O since the read above, so the remaining
-        // window is sub-millisecond; closing it fully would need a version column, which this
-        // codebase deliberately does not use (no-concurrency-tokens.md).
-        if (await repo.GetCreditorContactByUserAsync(userId, ct) is null) return;
+        // Re-check immediately before writing: an Unbind or a rebind landing between the read above and
+        // here must not be undone the same way EnsureCreditorContactAsync guards against it
+        // (Humans#995) — the row below carries the contact id, Source and CreatedAt of the binding read
+        // above, so writing it over an admin's newer one reverts it wholesale. This runs at the end of a
+        // long push with no I/O since the read above, so the remaining window is sub-millisecond;
+        // closing it fully would need a version column (no-concurrency-tokens.md).
+        if (!await BindingUnchangedAsync(nameof(SetCreditorAccountNumAsync), userId, binding, ct)) return;
 
         var now = clock.GetCurrentInstant();
         await repo.UpsertCreditorContactAsync(new HoldedCreditorContact

--- a/src/Humans.Application/Services/Finance/HoldedFinanceService.cs
+++ b/src/Humans.Application/Services/Finance/HoldedFinanceService.cs
@@ -801,13 +801,19 @@ public sealed class HoldedFinanceService(
         // an admin who hits Unbind during that window would get their success message and then have the
         // binding they just cleared resurrected from that stale copy. Skipping the empty write is what
         // makes Unbind hold against an in-flight push in the steady state — a member already bound, with
-        // their 400000xx already resolved, does no binding write on a push at all. It does not make the
-        // read-modify-write safe in general: a binding still missing its number, and
-        // SetCreditorAccountNumAsync below, both write real content and can still lose a concurrent
-        // delete (nobodies-collective/Humans#995 — closing that needs an update-only repository write).
+        // their 400000xx already resolved, does no binding write on a push at all.
         if (binding is not null
             && string.Equals(binding.HoldedContactId, contactId, StringComparison.Ordinal)
             && accountNum == binding.SupplierAccountNum)
+            return contactId;
+
+        // A binding still missing its account number does write real content, so it cannot be skipped
+        // the way the steady state above is — but it can still lose a concurrent Unbind the same way:
+        // UpsertCreditorContactAsync treats an absent row as first-time and inserts, which would
+        // resurrect the very binding an admin just cleared (nobodies-collective/Humans#995). Re-reading
+        // right before the write shrinks that window from the whole Holded round-trip above to the gap
+        // between this read and the write call, without a version column (no-concurrency-tokens.md).
+        if (binding is not null && await repo.GetCreditorContactByUserAsync(userId, ct) is null)
             return contactId;
 
         var now = clock.GetCurrentInstant();
@@ -839,6 +845,14 @@ public sealed class HoldedFinanceService(
             LogBindingCollision(
                 nameof(SetCreditorAccountNumAsync), userId, binding.HoldedContactId,
                 supplierAccountNum, conflict);
+
+        // Re-check immediately before writing: an Unbind landing between the read above and here must
+        // not be undone the same way EnsureCreditorContactAsync guards against it (Humans#995) — without
+        // this, UpsertCreditorContactAsync would treat the now-absent row as first-time and insert it
+        // back. This runs at the end of a long push with no I/O since the read above, so the remaining
+        // window is sub-millisecond; closing it fully would need a version column, which this
+        // codebase deliberately does not use (no-concurrency-tokens.md).
+        if (await repo.GetCreditorContactByUserAsync(userId, ct) is null) return;
 
         var now = clock.GetCurrentInstant();
         await repo.UpsertCreditorContactAsync(new HoldedCreditorContact

--- a/tests/Humans.Application.Tests/Finance/HoldedFinanceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Finance/HoldedFinanceServiceTests.cs
@@ -711,6 +711,35 @@ public class HoldedFinanceServiceTests
     }
 
     [HumansFact]
+    public async Task EnsureCreditorContact_UnboundDuringHoldedRoundTrip_DoesNotResurrectBinding()
+    {
+        // nobodies-collective/Humans#995: the write below still carries real content (an unresolved
+        // account number), so it cannot be skipped the way the steady state is — but an Unbind landing
+        // during the Holded round trip above must still not come back from the dead.
+        var userId = Guid.NewGuid();
+        _repo.GetCreditorContactByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(
+            new HoldedCreditorContact
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                HoldedContactId = "c1",
+                SupplierAccountNum = null,
+                Source = CreditorContactSource.Auto,
+            },
+            (HoldedCreditorContact?)null); // re-check right before the write: admin unbound mid-push
+        _client.UpsertContactAsync(Arg.Any<HoldedContactInput>(), Arg.Any<CancellationToken>()).Returns("c1");
+
+        var id = await MakeService().EnsureCreditorContactAsync(
+            userId, "Peter Drier", null, null, null, 40000004,
+            Xunit.TestContext.Current.CancellationToken);
+
+        // Holded itself was still updated — only the local binding write is skipped.
+        id.Should().Be("c1");
+        await _repo.DidNotReceive().UpsertCreditorContactAsync(
+            Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task SetCreditorAccountNum_RecordsAssignedAccountOnExistingBinding()
     {
         var userId = Guid.NewGuid();
@@ -734,6 +763,31 @@ public class HoldedFinanceServiceTests
                 c.HoldedContactId == "new-contact" && c.SupplierAccountNum == 40000012 &&
                 c.Source == CreditorContactSource.Auto),
             FixedNow, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SetCreditorAccountNum_UnboundBetweenReadAndWrite_DoesNotResurrectBinding()
+    {
+        // nobodies-collective/Humans#995: this runs at the end of a long push, well after an admin
+        // could have clicked Unbind. The window between the read and the write below has no I/O in it,
+        // but the re-check still must catch a delete that lands there.
+        var userId = Guid.NewGuid();
+        _repo.GetCreditorContactByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(
+            new HoldedCreditorContact
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                HoldedContactId = "new-contact",
+                SupplierAccountNum = null,
+                Source = CreditorContactSource.Auto,
+            },
+            (HoldedCreditorContact?)null); // re-check right before the write: admin unbound in between
+
+        await MakeService().SetCreditorAccountNumAsync(
+            userId, 40000012, Xunit.TestContext.Current.CancellationToken);
+
+        await _repo.DidNotReceive().UpsertCreditorContactAsync(
+            Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
     }
 
     // ─── Creditor account names + manual bind guard ──────────────────────────────

--- a/tests/Humans.Application.Tests/Finance/HoldedFinanceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Finance/HoldedFinanceServiceTests.cs
@@ -740,6 +740,82 @@ public class HoldedFinanceServiceTests
     }
 
     [HumansFact]
+    public async Task EnsureCreditorContact_ReboundDuringHoldedRoundTrip_DoesNotClobberTheNewBinding()
+    {
+        // An admin who unbinds *and* rebinds inside the window leaves a row behind, so mere presence
+        // proves nothing — and a rebind of an already-bound member keeps the row and its Id
+        // (UpsertCreditorContactAsync is keyed by UserId), so Id proves nothing either. Only the
+        // columns this write would overwrite say whether it is still the binding that was read.
+        var userId = Guid.NewGuid();
+        var bindingId = Guid.NewGuid();
+        var logger = new CapturingLogger<HoldedFinanceService>();
+        _repo.GetCreditorContactByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(
+            new HoldedCreditorContact
+            {
+                Id = bindingId,
+                UserId = userId,
+                HoldedContactId = "c1",
+                SupplierAccountNum = null,
+                Source = CreditorContactSource.Auto,
+            },
+            new HoldedCreditorContact                  // re-check: admin rebound to another contact
+            {
+                Id = bindingId,
+                UserId = userId,
+                HoldedContactId = "c2",
+                SupplierAccountNum = 40000009,
+                Source = CreditorContactSource.Manual,
+            });
+        _repo.GetCreditorContactsAsync(Arg.Any<CancellationToken>()).Returns(new List<HoldedCreditorContact>());
+        _client.UpsertContactAsync(Arg.Any<HoldedContactInput>(), Arg.Any<CancellationToken>()).Returns("c1");
+
+        var id = await new HoldedFinanceService(_repo, _client, _budget, _clock, _cache, logger)
+            .EnsureCreditorContactAsync(
+                userId, "Peter Drier", null, null, null, 40000004,
+                Xunit.TestContext.Current.CancellationToken);
+
+        id.Should().Be("c1");
+        await _repo.DidNotReceive().UpsertCreditorContactAsync(
+            Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+        // The table has no audit trail, so the skip is only reconstructible from this line.
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning)
+            .Which.Message.Should().Contain("c2");
+    }
+
+    [HumansFact]
+    public async Task EnsureCreditorContact_BoundByAdminDuringHoldedRoundTrip_DoesNotOverwriteTheManualBind()
+    {
+        // Same window, opposite polarity: nothing was bound at the opening read, so the write below is
+        // a first-time insert — but Upsert is keyed by UserId, and a manual bind landing mid-push turns
+        // that insert into an update that overwrites the admin's contact and drops Source back to Auto.
+        var userId = Guid.NewGuid();
+        var logger = new CapturingLogger<HoldedFinanceService>();
+        _repo.GetCreditorContactByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(
+            (HoldedCreditorContact?)null,
+            new HoldedCreditorContact                  // re-check: admin bound them while we pushed
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                HoldedContactId = "c-admin",
+                SupplierAccountNum = 40000009,
+                Source = CreditorContactSource.Manual,
+            });
+        _repo.GetCreditorContactsAsync(Arg.Any<CancellationToken>()).Returns(new List<HoldedCreditorContact>());
+        _client.UpsertContactAsync(Arg.Any<HoldedContactInput>(), Arg.Any<CancellationToken>()).Returns("c-new");
+
+        var id = await new HoldedFinanceService(_repo, _client, _budget, _clock, _cache, logger)
+            .EnsureCreditorContactAsync(
+                userId, "Peter Drier", null, null, null, null,
+                Xunit.TestContext.Current.CancellationToken);
+
+        id.Should().Be("c-new");
+        await _repo.DidNotReceive().UpsertCreditorContactAsync(
+            Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning)
+            .Which.Message.Should().Contain("c-admin");
+    }
+
+    [HumansFact]
     public async Task SetCreditorAccountNum_RecordsAssignedAccountOnExistingBinding()
     {
         var userId = Guid.NewGuid();
@@ -788,6 +864,41 @@ public class HoldedFinanceServiceTests
 
         await _repo.DidNotReceive().UpsertCreditorContactAsync(
             Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SetCreditorAccountNum_UnboundAndReboundBetweenReadAndWrite_DoesNotClobberTheNewBinding()
+    {
+        // An Unbind followed by a fresh manual bind leaves a row in place, so the write is not blocked
+        // by absence — and it would carry the old binding's contact id and Source over the admin's.
+        var userId = Guid.NewGuid();
+        var logger = new CapturingLogger<HoldedFinanceService>();
+        _repo.GetCreditorContactByUserAsync(userId, Arg.Any<CancellationToken>()).Returns(
+            new HoldedCreditorContact
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                HoldedContactId = "new-contact",
+                SupplierAccountNum = null,
+                Source = CreditorContactSource.Auto,
+            },
+            new HoldedCreditorContact                  // re-check: a different row — deleted, rebound
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                HoldedContactId = "c-admin",
+                SupplierAccountNum = 40000009,
+                Source = CreditorContactSource.Manual,
+            });
+        _repo.GetCreditorContactsAsync(Arg.Any<CancellationToken>()).Returns(new List<HoldedCreditorContact>());
+
+        await new HoldedFinanceService(_repo, _client, _budget, _clock, _cache, logger)
+            .SetCreditorAccountNumAsync(userId, 40000012, Xunit.TestContext.Current.CancellationToken);
+
+        await _repo.DidNotReceive().UpsertCreditorContactAsync(
+            Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning)
+            .Which.Message.Should().Contain("c-admin");
     }
 
     // ─── Creditor account names + manual bind guard ──────────────────────────────


### PR DESCRIPTION
## Summary

PR #1194 closed the wide race window between `EnsureCreditorContactAsync`'s
Holded round-trip and its write by skipping the write entirely in the
steady state. Two paths still write real content and couldn't take that
treatment, so an Unbind landing in their window was still silently undone:

- `EnsureCreditorContactAsync`, binding present but `SupplierAccountNum`
  null — the seed has a number to write, window is the Holded contact PUT.
- `SetCreditorAccountNumAsync` — window is between its own two repo calls,
  sub-millisecond but non-zero, and it runs at the end of a long push.

Both now re-read the binding via the existing
`repo.GetCreditorContactByUserAsync` immediately before the write and skip
the write if the row is gone — `UpsertCreditorContactAsync` treats an
absent row as first-time and would otherwise re-insert the binding an
admin just deleted. This uses only existing repository surface; no new
interface method, no version column, no data migration (per
`memory/architecture/no-concurrency-tokens.md`).

## Test plan

- [x] `EnsureCreditorContact_UnboundDuringHoldedRoundTrip_DoesNotResurrectBinding` — binding present at read, deleted before the final write, no write happens, Holded is still called.
- [x] `SetCreditorAccountNum_UnboundBetweenReadAndWrite_DoesNotResurrectBinding` — same shape for the second path.
- [x] All existing `HoldedFinanceServiceTests` still pass (46/46) — steady-state skip and first-time-submitter paths unaffected.
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors.
- [x] `dotnet test Humans.slnx -v quiet` — full suite green (4138 Application, 388 Web, 245 Analyzers, 126 Integration).

Fixes nobodies-collective/Humans#995

🤖 Generated with [Claude Code](https://claude.com/claude-code)