### PR TITLE
fix(ops): pin pg_dump to Postgres 18 so the pre-migration snapshot works in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,26 @@ WORKDIR /app
 
 # Install native dependencies for SkiaSharp + curl for healthcheck
 # (libheif native binaries are provided by the LibHeif.Native NuGet package)
-# postgresql-client-16 matches the postgres:16 server and provides the pg_dump the
-# pre-migration snapshot shells out to (nobodies-collective/Humans#845).
+# postgresql-client-18 provides the pg_dump the pre-migration snapshot shells out to
+# (nobodies-collective/Humans#845). The client major must be >= the *server* major:
+# pg_dump refuses outright to dump a server newer than itself, and production runs
+# Postgres 18. It reads older servers fine, so this one client covers the postgres:16
+# in docker-compose.yml too — pin it to production's major, never to compose's.
+# Noble's own archive stops at 16, so the client comes from PGDG.
 # Swap to nl.archive.ubuntu.com — geographically closer and avoids archive.ubuntu.com flakiness
 RUN sed -i 's|archive\.ubuntu\.com|nl.archive.ubuntu.com|g; s|security\.ubuntu\.com|nl.archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources \
     && apt-get update && apt-get install -y --no-install-recommends \
         libfontconfig1 \
         curl \
-        postgresql-client-16 \
+        ca-certificates \
+        gnupg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        postgresql-client-18 \
+    && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and give it ownership of the app directory.

--- a/docs/database-restore-runbook.md
+++ b/docs/database-restore-runbook.md
@@ -315,8 +315,16 @@ Implemented in `src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs`
 - **If the dump fails, startup aborts and the migration does not run.** This is on purpose:
   the schema is left exactly as the previous release left it, so rolling the image back is a
   complete recovery. Fix the cause (usually the volume mount or a missing `pg_dump`) and
-  redeploy — do not work around it. `postgresql-client-16` is installed in the runtime image by
+  redeploy — do not work around it. `postgresql-client-18` is installed in the runtime image by
   the `Dockerfile`; the volume is declared in `docker-compose.yml`.
+- **The client major tracks production's server, not `docker-compose.yml`'s.** `pg_dump` refuses
+  to dump a server newer than itself but reads older ones fine, so the pinned client must be
+  `>=` the production server's major. Production runs Postgres 18; `docker-compose.yml` runs 16
+  for QA and local, and one client 18 covers both. Pinning it to the compose file instead is what
+  broke the first schema-changing production deploy after this feature shipped
+  (nobodies-collective/Humans#1187): the snapshot only runs when a deploy has pending migrations,
+  so the mismatch sat unexercised through every deploy that did not touch the schema, and QA —
+  on 16, where a client 16 works — could not reproduce it.
 
 > **Owner action — Coolify.** QA gets the `db_snapshots` volume from `docker-compose.yml`.
 > Production is deployed through Coolify, whose volume configuration is not in this repo, so it


### PR DESCRIPTION
## Problem

Production runs Postgres 18. `Dockerfile` pinned `postgresql-client-16` — taken from `docker-compose.yml`'s `postgres:16` rather than from the real server — and `pg_dump` refuses outright to dump a server newer than itself:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 18.2; pg_dump version: 16.14 (Ubuntu 16.14-0ubuntu0.24.04.1)
```

The pre-migration snapshot (nobodies-collective/Humans#845, shipped in #1187) runs only on a deploy that has pending migrations, so the mismatch sat unexercised through every deploy that did not touch the schema. The first schema-changing production deploy after #1187 hit it and failed twice (`ba2323f15`, `ec7cdf019`), aborting before migrating and leaving production on `deee89ba1` for ~4h. QA, on 16 with a client 16, dumps fine and reported nothing.

The abort itself worked as designed: the schema is untouched and production stayed serving on the previous image.

## Change

- `Dockerfile` — `postgresql-client-18` from PGDG (noble's own archive stops at 16). Comment now states the rule: the pinned client major tracks **production's server**, never the compose file, because a newer client reads older servers but never a newer one.
- `docs/database-restore-runbook.md` — same rule written down, with this failure as the worked example, replacing the stale `postgresql-client-16` reference.

QA and local stay on `postgres:16`. A newer client covers them, and bumping the compose image is not a one-liner — Postgres 18 refuses to start on a 16 data directory. Tracked separately.

## Verification

CI does not build the Docker image, so this was checked by hand:

| Check | Result |
|---|---|
| Full `Dockerfile` build | succeeds |
| `pg_dump --version` in the built image, as `appuser` | `18.4 (Ubuntu 18.4-1.pgdg24.04+1)` |
| `curl` still present after the `gnupg` purge (healthcheck) | `8.5.0` |
| Client 18.4 → live server 18.4 | dumps |
| Client 18.4 → live server 16.11 | dumps |
| Client 16.11 → live server 18.4 (negative control) | reproduces the production error verbatim |

Needs promoting to `upstream/main` to actually unblock production — nobodies-collective/Humans#994's Holded contact fix is queued behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
