### PR TITLE
refactor(809): migrate the ShiftDashboard chain to BurnSettingsInfo

### DIFF
--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -19,6 +19,7 @@ namespace Humans.Web.Controllers;
 [Authorize(Policy = PolicyNames.ShiftDepartmentManager)]
 [Route("Shifts/Dashboard")]
 public class ShiftDashboardController(
+    IBurnSettingsService burnSettings,
     IShiftManagementService shiftMgmt,
     IShiftSignupService signupService,
     IUserServiceRead userService,
@@ -43,7 +44,7 @@ public class ShiftDashboardController(
         ShiftPeriod? period,
         BuildSubPeriod? subPeriod)
     {
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync();
         if (es is null)
         {
             SetError("No active event settings configured.");
@@ -75,7 +76,7 @@ public class ShiftDashboardController(
     [HttpGet("PostEventStats")]
     public async Task<IActionResult> PostEventStats()
     {
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync();
         if (es is null)
         {
             SetError("No active event settings configured.");

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -580,7 +580,7 @@ public class ShiftDashboardViewModel
     public LocalDate? FilterEndDate { get; set; }
     public ShiftPeriod? SelectedPeriod { get; set; }
     public BuildSubPeriod? SelectedSubPeriod { get; set; }
-    public EventSettings EventSettings { get; set; } = null!;
+    public BurnSettingsInfo EventSettings { get; set; } = null!;
     public List<DailyStaffingData> StaffingData { get; set; } = [];
     public List<DailyStaffingHours> StaffingHours { get; set; } = [];
 

--- a/src/Humans.Web/Models/Shifts/ShiftDashboardPageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftDashboardPageBuilder.cs
@@ -1,13 +1,12 @@
 using Humans.Application.Enums;
 using Humans.Application.Interfaces.Shifts;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 
 namespace Humans.Web.Models.Shifts;
 
 public sealed record ShiftDashboardPageRequest(
-    EventSettings EventSettings,
+    BurnSettingsInfo EventSettings,
     Guid? DepartmentId,
     Guid? RotaId,
     string? StartDate,
@@ -75,7 +74,7 @@ public sealed class ShiftDashboardPageBuilder(
         };
     }
 
-    private BuildDayCountdown BuildCountdown(EventSettings eventSettings)
+    private BuildDayCountdown BuildCountdown(BurnSettingsInfo eventSettings)
     {
         var tz = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventSettings.TimeZoneId) ?? DateTimeZone.Utc;
         var todayLocal = clock.GetCurrentInstant().InZone(tz).Date;


### PR DESCRIPTION
Slice 3 of nobodies-collective/Humans#809 (tracker stays open).

Migrates the one call chain in #809 that is completable today with **no new interface surface, no new DTO field, and no owner decision**. Everything else is blocked — see the two sections at the bottom.

## What changed

The ShiftDashboard chain now carries `BurnSettingsInfo` end to end instead of the Shifts-owned `EventSettings` entity:

| File | Change |
|---|---|
| `ShiftDashboardController.cs` | Injects `IBurnSettingsService`; both `GetActiveAsync()` call sites (`Index`, `PostEventStats`) resolve through it. `IShiftManagementService` stays — still needed for `GetPostEventStatsAsync` and `GetShiftByIdAsync`. |
| `ShiftDashboardPageBuilder.cs` | `ShiftDashboardPageRequest.EventSettings` and `BuildCountdown(...)` retype to `BurnSettingsInfo`; the now-unused `using Humans.Domain.Entities` is dropped. |
| `ShiftViewModels.cs` | `ShiftDashboardViewModel.EventSettings` retypes to `BurnSettingsInfo`. (`using Humans.Domain.Entities` stays — nine other view models in that file still hold entities.) |

6 insertions, 6 deletions across 3 files. No behavioural change.

## Evidence the chain is self-contained

Verified by reading each file rather than inferring:

- **Every field consumed already exists on `BurnSettingsInfo`.** Builder: `Id`, `TimeZoneId`, `GateOpeningDate`, `BuildStartOffset`. `Views/ShiftDashboard/Index.cshtml`: `GateOpeningDate` (`:123`, `:288`), `BuildStartOffset`, `EventEndOffset`, `StrikeEndOffset`, and all four sub-period offsets (`:124-130`).
- **The view calls no entity methods** — every reference is a plain property read.
- **The view passes `EventSettings` into no partial.** The partials at `:203-232` and `:365-366` take `Overview`, `StaffingData`, `Trends`, and `CoverageHeatmap`.
- **`PostEventStats` only needs `es.Id`**, which the DTO carries.
- **`ShiftDashboardPageRequest` / `ShiftDashboardViewModel` / `ShiftDashboardPageBuilder` have no other referents** in `src/` or `tests/` beyond the controller, the DI registration, and the view.
- **Behaviourally identical resolution.** `BurnSettingsService.GetActiveAsync` and `ShiftManagementService.GetActiveAsync` both call `repo.GetActiveEventSettingsAsync()` — same row, and neither is cached.

Test exposure, both read in full:
- `ShiftDashboardControllerTests.cs` exercises `ShiftFilterResolver.Resolve` only; it never builds the view model.
- `EndpointAuthorizationTests.cs` (flagged unverified in the prior handoff — now opened) asserts controller/action authorization policies by reflection at `:52-54` and `:158-172`. It never constructs the controller, so the added constructor parameter cannot affect it.

## Verification

| Check | Before | After |
|---|---|---|
| Build warnings | 90 | 90 |
| Build errors | 0 | 0 |
| **HUM0015** | 0 | **0** |
| **HUM0016** | 0 | **0** |
| **HUM0025** | 0 | **0** |

Both runs used `dotnet build <abs>/Humans.slnx -v quiet --no-incremental`.

Tests: `Failed: 0` across all three projects — 4141 Application, 388 Web, 126 Integration.

**No EF migration produced.** `dotnet ef migrations has-pending-model-changes` → *"No changes have been made to the model since the last migration."* This slice is code-only.

## Needs owner decision — blocks the rest of #809

Every remaining call site funnels into six members that take the `EventSettings` **entity**: `EventSettings.IsEarlyEntryClosed`, `EventSettings.IsEarlyEntrySignupsClosedFor`, `Shift.GetAbsoluteStart`, `Shift.GetAbsoluteEnd`, `Shift.GetShiftPeriod`, and `BuildSubPeriodClassifier.Classify`/`BoundsFor`. One ruling unblocks Dashboard, Agent, and the whole Shifts Web layer.

**Dead option, stated so it isn't re-proposed:** overloads on `Shift` / `BuildSubPeriodClassifier` taking `BurnSettingsInfo` are **layer-impossible**. `BurnSettingsInfo` lives in `Humans.Application.Interfaces.Shifts`; `Shift` lives in `Humans.Domain.Entities`. Domain has no external dependencies and Application references Domain, so Domain cannot see the DTO. An earlier audit proposed exactly this — it cannot be built.

**Option 1 (recommended) — a `BurnCalendar` value object in `Humans.Domain`** holding `{ TimeZoneId, GateOpeningDate, BuildStartOffset, EventEndOffset, StrikeEndOffset, FirstCrewStartOffset, SetupWeekStartOffset, PreEventWeekStartOffset, FinishingWeekendStartOffset }`. `EventSettings` exposes it, `BurnSettingsInfo` carries it, and all six members take `BurnCalendar` instead of the entity. Domain stays dependency-free and one new type retires six signature problems. Cost: one new Domain file.

**Option 2 (fallback) — scalar-parameter overloads.** `Shift.GetAbsoluteStart/GetAbsoluteEnd(string timeZoneId, LocalDate gateOpeningDate)`, `Shift.GetShiftPeriod(int eventEndOffset)`, and `BuildSubPeriodClassifier` taking four ints. No new type, but that four-int signature is genuinely bad.

**Separately — `IsShiftBrowsingOpen`.** The one real DTO-field gap, and it is contested. `BurnSettingsInfo`'s own xmldoc (`:8-11`) names it explicitly as a Shifts-internal flag that stays on `IShiftManagementService`, while #809's acceptance criteria say to extend the DTO for genuinely migrated callers. `DashboardService:82,218` needs it. Deliberately **not** added here: adding it completes nothing on its own, because `DashboardService` also calls `GetAbsoluteStart/End` at `:94,141,142` and stays blocked on the ruling above regardless.

Also worth folding into whichever option lands: mirror `IsEarlyEntryClosed` and `IsEarlyEntrySignupsClosedFor` onto the record, following the `GetEarlyEntryCapacityForDay` precedent already in `BurnSettingsInfo.cs:43-63`. Both are one-liners over `EarlyEntryClose`, which the DTO already carries, but `EventSettings.cs:145-149` calls the first "the single home for the early-entry-closed clock rule" and there are five call sites — so mirror it, do not inline it.

## Handoff — remaining blocked call sites

| Entry point | Chain | Blocked on |
|---|---|---|
| `ShiftViewModels.cs:175` `ShiftBrowseViewModel` | `ShiftBrowseMapper.cs:26,27,28`; `ShiftBrowsePageBuilder.cs:75`; `OnboardingShiftsBrowseModelBuilder.cs:26,49` | `GetAbsoluteStart/End`, `GetShiftPeriod` |
| `ShiftViewModels.cs:814` `EventRotaRowViewModel.Es` | `_EventRotaRow.cshtml:8,19`; also `:689` `BuildStrikeRotaTableViewModel`, `:727` `EventRotaTableViewModel`, `:777` `BuildStrikeRotaRowViewModel.Es` | `GetAbsoluteStart/End` |
| `ShiftViewModels.cs:307` `MyShiftsViewModel` | `Views/Shifts/Mine.cshtml:14,26` | `GetAbsoluteStart/End` |
| `ShiftViewModels.cs:345` `ShiftAdminViewModel` | `Views/ShiftAdmin/Index.cshtml:381,402` | `GetAbsoluteStart/End` |
| `ShiftViewModels.cs:655` `ShiftSignupsViewModel` | `ShiftSignupBucketer.cs:48,49` via `ShiftSignupsViewComponent.cs:53` | `GetAbsoluteStart/End` |
| `VolunteerTrackingController.cs:141` | `BuildSubPeriodClassifier.BoundsFor` | classifier signature |
| `DashboardService.cs:82,218` + `:94,141,142` | — | `IsShiftBrowsingOpen` **and** `GetAbsoluteStart/End`; needs both rulings |
| `AgentUserSnapshotProvider.cs:24,79` | `s.Shift.GetAbsoluteEnd(activeEvent)` | `GetAbsoluteEnd` |
| `ShiftsController.cs:64,88,229,240,347,471,522,523` | — | `GetAbsoluteStart/End`, `GetShiftPeriod` |
| `OnboardingWidgetController.cs:141` · `WidgetGalleryController.cs:200-202,237` · `ShiftVolunteerSearchBuilder.cs:77,78,132,133` · `Views/Shifts/Index.cshtml:319` | — | entity-bound |

**Trap for the next slice:** `ShiftFilterResolver.ResolvePeriodRange` (`ShiftFilterResolver.cs:29`) reads only DTO-available fields and *looks* migratable, but both callers are blocked (`VolunteerTrackingController.cs:147`, `ShiftBrowsePageBuilder.cs:253`). Retyping it just breaks them. Leave it.

**Do not inline `GetAbsoluteStart`/`GetAbsoluteEnd` at call sites to dodge the surface question.** They apply the all-day policy (`IsAllDay ? AllDayWindowStart : StartTime`, 08:00→18:00 — `Shift.cs:64,71`), and `Shift.cs:83-91` states that readers must use these methods rather than the raw fields whenever `IsAllDay = true`.

**Verified compliant, no work needed:** Workload (`WorkloadReport.cs:16` carries `Guid EventSettingsId` + `int EventYear`), the Mailer `TicketNoShiftsAudience` (doc-comment prose only), `AgentToolDispatcher` (migrated by #1154), and all six Events controllers (all resolve via `guide.GetEventSettingsByIdAsync` → `BurnSettingsInfo?`).

**Unresolved scope question:** `WidgetGalleryController` holds the entity at `:237` but is not named in the spec's item-7 list; whether it is in scope for #809 was never settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
