### PR TITLE
refactor(809): migrate the ShiftBrowse, ShiftAdmin and VolunteerTracking groups to BurnSettingsInfo (slice 5)

### DIFF
--- a/src/Humans.Web/Controllers/OnboardingWidgetController.cs
+++ b/src/Humans.Web/Controllers/OnboardingWidgetController.cs
@@ -29,6 +29,7 @@ public class OnboardingWidgetController(
     IProfileEditorService profileEditorService,
     IShiftSignupService signupService,
     IShiftManagementService shiftMgmt,
+    IBurnSettingsService burnSettings,
     IShiftView shiftView,
     IConsentService consents,
     IOnboardingService onboardingService,
@@ -126,7 +127,7 @@ public class OnboardingWidgetController(
     [HttpGet]
     public async Task<IActionResult> Shifts(string? priority = null, CancellationToken ct = default)
     {
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(ct);
         if (es is null)
             return View(OnboardingShiftsBrowseModelBuilder.BuildEmpty(priority ?? string.Empty));
 

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -22,6 +22,7 @@ namespace Humans.Web.Controllers;
 public class ShiftAdminController(
     ITeamServiceRead teamService,
     IShiftManagementService shiftMgmt,
+    IBurnSettingsService burnSettings,
     IShiftSignupService signupService,
     IShiftView shiftView,
     IUserServiceRead userService,
@@ -46,7 +47,7 @@ public class ShiftAdminController(
 
         var canManage = await CanManageDepartmentAsync(user, team);
         var canApprove = await CanApproveDepartmentAsync(user, team);
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
         if (es is null)
         {
             SetError("No active event settings configured.");
@@ -75,7 +76,7 @@ public class ShiftAdminController(
         var (teamError, _, team) = await ResolveDepartmentManagementAsync(slug);
         if (teamError is not null) return teamError;
 
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
         if (es is null) return BadRequest("No active event.");
 
         if (!ModelState.IsValid)

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -51,7 +51,7 @@ public class ShiftsController(
 
         if (RedirectIfNameMissing(user) is { } nameGate) return nameGate;
 
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
         if (es is null) return View("NoActiveEvent");
 
         var isPrivileged = ShiftRoleChecks.IsPrivilegedSignupApprover(User) ||
@@ -175,7 +175,7 @@ public class ShiftsController(
             return RedirectHeader(Url.Action(
                 nameof(OnboardingWidgetController.Index), "OnboardingWidget"));
 
-        var es = await shiftMgmt.GetActiveAsync()
+        var es = await burnSettings.GetActiveAsync(ct)
             ?? throw new InvalidOperationException("ToggleDay requires an active event.");
 
         // Narrow flag drives SignUpAsync's auto-confirm path (admin/approver only); also
@@ -402,7 +402,7 @@ public class ShiftsController(
             return currentUserNotFound;
         }
 
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
         if (es is null) return BadRequest("No active event.");
 
         await volunteerTrackingService.SetAvailabilityAsync(user.Id, es.Id, dayOffsets ?? []);

--- a/src/Humans.Web/Controllers/VolunteerTrackingController.cs
+++ b/src/Humans.Web/Controllers/VolunteerTrackingController.cs
@@ -28,6 +28,7 @@ namespace Humans.Web.Controllers;
 public sealed class VolunteerTrackingController(
     IVolunteerTrackingService service,
     IShiftManagementService shiftManagementService,
+    IBurnSettingsService burnSettings,
     IVolunteerTrackingExportService exportService,
     VolunteerTrackingXlsxBuilder xlsxBuilder,
     IUserServiceRead userService,
@@ -82,7 +83,7 @@ public sealed class VolunteerTrackingController(
         // already know HasActiveEvent is true here), so the result is non-null
         // in practice; defensive fall-back keeps the page renderable if a race
         // empties EventSettings between the two calls.
-        var activeEvent = await shiftManagementService.GetActiveAsync();
+        var activeEvent = await burnSettings.GetActiveAsync(ct);
         var departments = activeEvent is null
             ? []
             : await shiftManagementService.GetDepartmentsWithRotasAsync(activeEvent.Id);
@@ -120,7 +121,7 @@ public sealed class VolunteerTrackingController(
         BuildSubPeriod? subPeriod = null,
         CancellationToken ct = default)
     {
-        var eventSettings = await shiftManagementService.GetActiveAsync();
+        var eventSettings = await burnSettings.GetActiveAsync(ct);
         if (eventSettings is null)
         {
             SetError(localizer["VolTrack_NoActiveEvent"]);
@@ -348,7 +349,7 @@ public sealed class VolunteerTrackingController(
     public async Task<IActionResult> SetAvailabilityDay(
         Guid userId, int dayOffset, string? returnUrl, CancellationToken ct)
     {
-        var es = await shiftManagementService.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(ct);
         if (es is null) { SetError(localizer["VolTrack_Err_BadRequest"]); return RedirectBack(returnUrl); }
 
         var current = await GetCurrentUserInfoAsync();
@@ -376,7 +377,7 @@ public sealed class VolunteerTrackingController(
     public async Task<IActionResult> ClearAvailabilityDay(
         Guid userId, int dayOffset, string? returnUrl, CancellationToken ct)
     {
-        var es = await shiftManagementService.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(ct);
         if (es is null) { SetError(localizer["VolTrack_Err_BadRequest"]); return RedirectBack(returnUrl); }
 
         var current = await GetCurrentUserInfoAsync();

--- a/src/Humans.Web/Models/OnboardingWidget/OnboardingShiftsBrowseModelBuilder.cs
+++ b/src/Humans.Web/Models/OnboardingWidget/OnboardingShiftsBrowseModelBuilder.cs
@@ -23,7 +23,7 @@ public static class OnboardingShiftsBrowseModelBuilder
     public const string PriorityAll = "all";
 
     public static ShiftsStepViewModel Build(
-        EventSettings eventSettings,
+        BurnSettingsInfo eventSettings,
         IReadOnlyList<UrgentShift> allShifts,
         HashSet<Guid> userSignupShiftIds,
         Dictionary<Guid, SignupStatus> userSignupStatuses,

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -172,7 +172,7 @@ public class TimeSlotEntry
 
 public class ShiftBrowseViewModel
 {
-    public EventSettings? EventSettings { get; set; }
+    public BurnSettingsInfo? EventSettings { get; set; }
     public List<DepartmentShiftGroup> Departments { get; set; } = [];
     public List<DepartmentOption> AllDepartments { get; set; } = [];
     public Guid? FilterDepartmentId { get; set; }
@@ -200,7 +200,7 @@ public class ShiftBrowseViewModel
 
     /// <summary>
     /// True when early-entry (build) signups have closed
-    /// (<see cref="EventSettings.EarlyEntryClose"/> passed) and the viewer is not
+    /// (<see cref="IBurnSettingsInfo.EarlyEntryClose"/> passed) and the viewer is not
     /// privileged. Row partials combine this with <see cref="Shift.IsEarlyEntry"/>
     /// so only build shifts lock; mirrors the server gate in ShiftSignupService.
     /// </summary>
@@ -686,7 +686,15 @@ public record ShiftWindow(Instant AbsoluteStart, Instant AbsoluteEnd);
 public class BuildStrikeRotaTableViewModel
 {
     public RotaShiftGroup RotaGroup { get; set; } = null!;
-    public EventSettings EventSettings { get; set; } = null!;
+
+    /// <summary>
+    /// Typed as the interface, not <see cref="BurnSettingsInfo"/>: this partial is
+    /// shared between the migrated browse/onboarding pages (which hold the DTO) and
+    /// the widget gallery (which still holds the EF entity, scope unresolved — #809).
+    /// Both implement <see cref="IBurnSettingsInfo"/> and the partial reads nothing
+    /// beyond it.
+    /// </summary>
+    public IBurnSettingsInfo EventSettings { get; set; } = null!;
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
     public bool ShowSignups { get; set; }
@@ -724,7 +732,9 @@ public class BuildStrikeRotaTableViewModel
 public class EventRotaTableViewModel
 {
     public List<ShiftDisplayItem> Shifts { get; set; } = [];
-    public EventSettings EventSettings { get; set; } = null!;
+
+    /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
+    public IBurnSettingsInfo EventSettings { get; set; } = null!;
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
     public bool ShowSignups { get; set; }
@@ -774,7 +784,9 @@ public class NoShowHistoryItem
 public class BuildStrikeRotaRowViewModel
 {
     public ShiftDisplayItem Item { get; set; } = null!;
-    public EventSettings Es { get; set; } = null!;
+
+    /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
+    public IBurnSettingsInfo Es { get; set; } = null!;
     public bool IsSignedUp { get; set; }
     public SignupStatus? SignupStatus { get; set; }
     public bool SignupsBlockedByMissingDietary { get; set; }
@@ -800,7 +812,7 @@ public class ShiftToggleButtonModel
 
     /// <summary>
     /// True when this is an early-entry (build) shift, early-entry signups have
-    /// closed (<see cref="EventSettings.EarlyEntryClose"/> passed) and the viewer
+    /// closed (<see cref="IBurnSettingsInfo.EarlyEntryClose"/> passed) and the viewer
     /// is not privileged. The button is rendered as a disabled "set-up closed"
     /// state; the server-side gate in ShiftSignupService still enforces it.
     /// </summary>
@@ -811,7 +823,9 @@ public class ShiftToggleButtonModel
 public class EventRotaRowViewModel
 {
     public ShiftDisplayItem Item { get; set; } = null!;
-    public EventSettings Es { get; set; } = null!;
+
+    /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
+    public IBurnSettingsInfo Es { get; set; } = null!;
     public bool IsSignedUp { get; set; }
     public SignupStatus? SignupStatus { get; set; }
     public bool SignupsBlockedByMissingDietary { get; set; }

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -342,7 +342,7 @@ public class MySignupItem
 public class ShiftAdminViewModel
 {
     public TeamInfo Department { get; set; } = null!;
-    public EventSettings EventSettings { get; set; } = null!;
+    public BurnSettingsInfo EventSettings { get; set; } = null!;
     public List<Rota> Rotas { get; set; } = [];
     public List<ShiftSignup> PendingSignups { get; set; } = [];
     public int TotalSlots { get; set; }

--- a/src/Humans.Web/Models/Shifts/ShiftAdminPageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftAdminPageBuilder.cs
@@ -12,7 +12,7 @@ namespace Humans.Web.Models.Shifts;
 
 public sealed record ShiftAdminPageRequest(
     TeamInfo Department,
-    EventSettings EventSettings,
+    BurnSettingsInfo EventSettings,
     bool CanManage,
     bool CanApprove,
     bool CanViewMedical,

--- a/src/Humans.Web/Models/Shifts/ShiftBrowseMapper.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowseMapper.cs
@@ -8,7 +8,7 @@ namespace Humans.Web.Models.Shifts;
 /// (<c>ShiftsController.Index</c>) and the onboarding widget step-2 view
 /// (<see cref="OnboardingWidget.OnboardingShiftsBrowseModelBuilder"/>).
 ///
-/// Pure mapping over <see cref="UrgentShift"/> + <see cref="EventSettings"/> —
+/// Pure mapping over <see cref="UrgentShift"/> + <see cref="BurnSettingsInfo"/> —
 /// no service dependencies. Time/period resolution delegates to the
 /// <see cref="Shift"/> entity helpers (<see cref="Shift.GetAbsoluteStart"/>,
 /// <see cref="Shift.GetAbsoluteEnd"/>, <see cref="Shift.GetShiftPeriod"/>).
@@ -18,7 +18,7 @@ internal static class ShiftBrowseMapper
     /// <summary>
     /// Maps a single <see cref="UrgentShift"/> to a <see cref="ShiftDisplayItem"/>.
     /// </summary>
-    internal static ShiftDisplayItem MapToDisplayItem(UrgentShift u, EventSettings eventSettings)
+    internal static ShiftDisplayItem MapToDisplayItem(UrgentShift u, BurnSettingsInfo eventSettings)
     {
         return new ShiftDisplayItem
         {
@@ -42,7 +42,7 @@ internal static class ShiftBrowseMapper
     /// </summary>
     internal static RotaShiftGroup BuildRotaGroup(
         IGrouping<Guid, UrgentShift> rotaGroup,
-        EventSettings eventSettings,
+        BurnSettingsInfo eventSettings,
         string? departmentName = null,
         string? departmentSlug = null)
     {

--- a/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
@@ -15,7 +15,7 @@ namespace Humans.Web.Models.Shifts;
 /// id set on the view model.
 /// </summary>
 public sealed record ShiftBrowsePageRequest(
-    EventSettings EventSettings,
+    BurnSettingsInfo EventSettings,
     Guid UserId,
     IReadOnlyList<ShiftSignup> UserSignups,
     IReadOnlyList<VolunteerTagPreference> UserTagPreferences,
@@ -30,7 +30,10 @@ public sealed record ShiftBrowsePageRequest(
     IReadOnlyList<string>? Periods,
     bool IsPrivileged);
 
-public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManagement, ITeamServiceRead teamService)
+public sealed class ShiftBrowsePageBuilder(
+    IShiftManagementService shiftManagement,
+    IBurnSettingsService burnSettings,
+    ITeamServiceRead teamService)
 {
     public async Task<ShiftBrowseViewModel> BuildAsync(ShiftBrowsePageRequest request, CancellationToken ct = default)
     {
@@ -50,7 +53,7 @@ public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManageme
         {
             if (activePeriods.Count == 1)
             {
-                var (periodFrom, periodTo) = GetPeriodDateRange(es, activePeriods[0]);
+                var (periodFrom, periodTo) = ShiftFilterResolver.ResolvePeriodRange(activePeriods[0], es);
                 filterFromDate ??= periodFrom;
                 filterToDate ??= periodTo;
             }
@@ -138,8 +141,8 @@ public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManageme
     public async Task<(ShiftDisplayItem Item, bool IsSignedUp, SignupStatus? Status)?> BuildRowAsync(
         Guid shiftId, IReadOnlyList<ShiftSignup> userSignups, bool isPrivileged, CancellationToken ct)
     {
-        // GetActiveAsync() is EventSettings? — guard for nullable + TreatWarningsAsErrors.
-        var es = await shiftManagement.GetActiveAsync()
+        // GetActiveAsync() is BurnSettingsInfo? — guard for nullable + TreatWarningsAsErrors.
+        var es = await burnSettings.GetActiveAsync(ct)
             ?? throw new InvalidOperationException("BuildRowAsync requires an active event.");
 
         var flags = ShiftBrowseQueryFlags.IncludeSignups;
@@ -161,7 +164,7 @@ public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManageme
 
     private async Task<List<DepartmentShiftGroup>> BuildDepartmentGroupsAsync(
         IReadOnlyList<UrgentShift> shifts,
-        EventSettings eventSettings)
+        BurnSettingsInfo eventSettings)
     {
         var teamsById = await teamService.GetTeamsAsync();
 
@@ -249,23 +252,4 @@ public sealed class ShiftBrowsePageBuilder(IShiftManagementService shiftManageme
             .ThenBy(p => p.IsSubTeam ? 1 : 0)
             .ThenBy(p => p.TeamName, StringComparer.Ordinal)
             .ToList();
-
-    private static (LocalDate From, LocalDate To) GetPeriodDateRange(EventSettings es, ShiftPeriod period)
-    {
-        return period switch
-        {
-            ShiftPeriod.Build => (
-                es.GateOpeningDate.PlusDays(es.BuildStartOffset),
-                es.GateOpeningDate.PlusDays(-1)),
-            ShiftPeriod.Event => (
-                es.GateOpeningDate,
-                es.GateOpeningDate.PlusDays(es.EventEndOffset)),
-            ShiftPeriod.Strike => (
-                es.GateOpeningDate.PlusDays(es.EventEndOffset + 1),
-                es.GateOpeningDate.PlusDays(es.StrikeEndOffset)),
-            _ => (
-                es.GateOpeningDate.PlusDays(es.BuildStartOffset),
-                es.GateOpeningDate.PlusDays(es.StrikeEndOffset))
-        };
-    }
 }

--- a/src/Humans.Web/Models/Shifts/ShiftFilterResolver.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftFilterResolver.cs
@@ -1,4 +1,4 @@
-using Humans.Domain.Entities;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Domain.Enums;
 using NodaTime;
 
@@ -26,7 +26,7 @@ public static class ShiftFilterResolver
     /// and <c>ShiftsController.GetPeriodDateRange</c> (consolidating those into this single
     /// home is intentional — see CLAUDE.md DRY rule).
     /// </summary>
-    public static (LocalDate From, LocalDate To) ResolvePeriodRange(ShiftPeriod period, EventSettings es) =>
+    public static (LocalDate From, LocalDate To) ResolvePeriodRange(ShiftPeriod period, BurnSettingsInfo es) =>
         period switch
         {
             ShiftPeriod.Build => (

--- a/src/Humans.Web/Views/Shared/_EventRotaRow.cshtml
+++ b/src/Humans.Web/Views/Shared/_EventRotaRow.cshtml
@@ -1,9 +1,10 @@
 @model Humans.Web.Models.EventRotaRowViewModel
+@using Humans.Application.Interfaces.Shifts
 @using Humans.UI.Extensions
 @using NodaTime
 
 @functions {
-    string GetPhase(Shift shift, EventSettings es)
+    string GetPhase(Shift shift, IBurnSettingsInfo es)
     {
         return shift.GetShiftPeriod(es) switch
         {
@@ -14,7 +15,7 @@
         };
     }
 
-    string GetPhaseBadge(Shift shift, EventSettings es)
+    string GetPhaseBadge(Shift shift, IBurnSettingsInfo es)
     {
         return shift.GetShiftPeriod(es) switch
         {

--- a/tests/Humans.Application.Tests/Controllers/ShiftsControllerDietaryGateTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ShiftsControllerDietaryGateTests.cs
@@ -63,11 +63,12 @@ public class ShiftsControllerDietaryGateTests
         _shiftView.GetUserAsync(_user.Id, Arg.Any<CancellationToken>())
             .Returns(new ShiftUserView(_user.Id, null, null, null, [], []));
 
-        var builder = new ShiftBrowsePageBuilder(_shiftMgmt, _teamService);
+        var burnSettings = Substitute.For<IBurnSettingsService>();
+        var builder = new ShiftBrowsePageBuilder(_shiftMgmt, burnSettings, _teamService);
 
         _controller = new ShiftsController(
             _shiftMgmt,
-            Substitute.For<IBurnSettingsService>(),
+            burnSettings,
             _signupService,
             _volunteerTrackingService,
             _shiftView,

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
@@ -39,6 +39,7 @@ public class OnboardingWidgetControllerConsentsTests
     private readonly IProfileEditorService _profileEditor = Substitute.For<IProfileEditorService>();
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
     private readonly IOnboardingService _onboardingService = Substitute.For<IOnboardingService>();
@@ -70,7 +71,7 @@ public class OnboardingWidgetControllerConsentsTests
         // doesn't divert tests that exercise the consent flow itself.
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(isStub ? StubUserInfo(userId) : NonStubUserInfo(userId));
-        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
+        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _burnSettings, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = _http,

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerDispatcherTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerDispatcherTests.cs
@@ -29,6 +29,7 @@ public class OnboardingWidgetControllerDispatcherTests
     private readonly IProfileEditorService _profileEditor = Substitute.For<IProfileEditorService>();
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
     private readonly IOnboardingService _onboardingService = Substitute.For<IOnboardingService>();
@@ -49,7 +50,7 @@ public class OnboardingWidgetControllerDispatcherTests
     {
         var user = new User { Id = userId };
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
-        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, NodaTime.SystemClock.Instance, _localizer);
+        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _burnSettings, _shiftView, _consents, _onboardingService, NodaTime.SystemClock.Instance, _localizer);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId.ToString())],

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
@@ -28,6 +28,7 @@ public class OnboardingWidgetControllerNamesTests
     private readonly IProfileEditorService _profileEditor = Substitute.For<IProfileEditorService>();
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
     private readonly IOnboardingService _onboardingService = Substitute.For<IOnboardingService>();
@@ -49,7 +50,7 @@ public class OnboardingWidgetControllerNamesTests
         var user = new User { Id = userId };
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
         _state.GetCurrentStepAsync(userId, Arg.Any<CancellationToken>()).Returns(currentStep);
-        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
+        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _burnSettings, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId.ToString())],
@@ -70,7 +71,7 @@ public class OnboardingWidgetControllerNamesTests
         // never the claims.
         var userId = Guid.NewGuid();
         var ctrl = new OnboardingWidgetController(
-            _userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
+            _userService, _state, _profileEditor, _signups, _shiftMgmt, _burnSettings, _shiftView, _consents, _onboardingService, SystemClock.Instance, _localizer);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity(

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
@@ -34,6 +34,7 @@ public class OnboardingWidgetControllerShiftsTests
     private readonly IProfileEditorService _profileEditor = Substitute.For<IProfileEditorService>();
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
     private readonly IOnboardingService _onboardingService = Substitute.For<IOnboardingService>();
@@ -62,7 +63,7 @@ public class OnboardingWidgetControllerShiftsTests
         var services = new ServiceCollection();
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         _http.RequestServices = services.BuildServiceProvider();
-        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, NodaTime.SystemClock.Instance, _localizer);
+        var ctrl = new OnboardingWidgetController(_userService, _state, _profileEditor, _signups, _shiftMgmt, _burnSettings, _shiftView, _consents, _onboardingService, NodaTime.SystemClock.Instance, _localizer);
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = _http,

--- a/tests/Humans.Web.Tests/Controllers/ShiftsControllerNameGateTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ShiftsControllerNameGateTests.cs
@@ -39,6 +39,7 @@ public class ShiftsControllerNameGateTests
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IStringLocalizer<SharedResource> _localizer = Substitute.For<IStringLocalizer<SharedResource>>();
     private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly ShiftBrowsePageBuilder _builder;
     private readonly ILogger<ShiftsController> _logger = NullLogger<ShiftsController>.Instance;
 
@@ -46,14 +47,14 @@ public class ShiftsControllerNameGateTests
     {
         _localizer[Arg.Any<string>()].Returns(ci =>
             new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
-        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, _teamService);
+        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, _burnSettings, _teamService);
     }
 
     private ShiftsController BuildSut(Guid userId, UserInfo userInfo)
     {
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>()).Returns(userInfo);
         var ctrl = new ShiftsController(
-            _shiftMgmt, Substitute.For<IBurnSettingsService>(), _signupService, _volunteerTrackingService, _shiftView, _teamService,
+            _shiftMgmt, _burnSettings, _signupService, _volunteerTrackingService, _shiftView, _teamService,
             _auditLogService, _userService, _localizer, _clock, _builder, _logger);
         var http = new DefaultHttpContext
         {
@@ -111,7 +112,7 @@ public class ShiftsControllerNameGateTests
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal(nameof(OnboardingWidgetController.Index), redirect.ActionName);
         Assert.Equal("OnboardingWidget", redirect.ControllerName);
-        await _shiftMgmt.DidNotReceiveWithAnyArgs().GetActiveAsync();
+        await _burnSettings.DidNotReceiveWithAnyArgs().GetActiveAsync();
     }
 
     [HumansFact]
@@ -122,7 +123,7 @@ public class ShiftsControllerNameGateTests
         // gate let the request through.
         var userId = Guid.NewGuid();
         var ctrl = BuildSut(userId, MakeUserInfo(userId, burner: "B", first: "F", last: "L"));
-        _shiftMgmt.GetActiveAsync().Returns((EventSettings?)null);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
 
         var result = await ctrl.Index(
             departmentId: null, fromDate: null, toDate: null, period: null);

--- a/tests/Humans.Web.Tests/Controllers/ShiftsControllerSummaryTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ShiftsControllerSummaryTests.cs
@@ -57,7 +57,7 @@ public class ShiftsControllerSummaryTests
     {
         _localizer[Arg.Any<string>()].Returns(ci =>
             new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
-        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, _teamService);
+        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, Substitute.For<IBurnSettingsService>(), _teamService);
     }
 
     // Authorization is declarative: [Authorize(Policy = ShiftDepartmentManager)] on

--- a/tests/Humans.Web.Tests/Controllers/ShiftsControllerToggleDayTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ShiftsControllerToggleDayTests.cs
@@ -48,32 +48,38 @@ public class ShiftsControllerToggleDayTests
     private readonly ShiftBrowsePageBuilder _builder;
     private readonly ILogger<ShiftsController> _logger = NullLogger<ShiftsController>.Instance;
 
-    private static readonly EventSettings Event = new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = "Test Event 2026",
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = new LocalDate(2026, 7, 1),
-        BuildStartOffset = -14,
-        EventEndOffset = 6,
-        StrikeEndOffset = 9,
-        IsActive = true,
-        CreatedAt = TestNow,
-        UpdatedAt = TestNow
-    };
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
+
+    private static readonly BurnSettingsInfo Event = new(
+        Id: Guid.NewGuid(),
+        EventName: "Test Event 2026",
+        Year: 2026,
+        TimeZoneId: "Europe/Madrid",
+        GateOpeningDate: new LocalDate(2026, 7, 1),
+        BuildStartOffset: -14,
+        EventEndOffset: 6,
+        StrikeEndOffset: 9,
+        FirstCrewStartOffset: -14,
+        SetupWeekStartOffset: -10,
+        PreEventWeekStartOffset: -7,
+        FinishingWeekendStartOffset: -3,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null,
+        IsShiftBrowsingOpen: true);
 
     public ShiftsControllerToggleDayTests()
     {
         _localizer[Arg.Any<string>()].Returns(ci =>
             new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
-        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, _teamService);
+        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, _burnSettings, _teamService);
     }
 
     private ShiftsController BuildSut(Guid userId, UserInfo userInfo)
     {
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>()).Returns(userInfo);
         var ctrl = new ShiftsController(
-            _shiftMgmt, Substitute.For<IBurnSettingsService>(), _signupService, _volunteerTrackingService, _shiftView, _teamService,
+            _shiftMgmt, _burnSettings, _signupService, _volunteerTrackingService, _shiftView, _teamService,
             _auditLogService, _userService, _localizer, _clock, _builder, _logger);
         var http = new DefaultHttpContext
         {
@@ -153,7 +159,7 @@ public class ShiftsControllerToggleDayTests
             DepartmentName: "Test Department",
             Signups: signups);
 
-        _shiftMgmt.GetActiveAsync().Returns(Event);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(Event);
         _shiftMgmt.GetBrowseShiftsAsync(Arg.Any<ShiftBrowseQuery>())
             .Returns(new List<UrgentShift> { urgent });
     }
@@ -262,7 +268,7 @@ public class ShiftsControllerToggleDayTests
         StubToggleOutcome(new ToggleDaySignupOutcome(false, SignupResult.Ok(created), true, false, [created]));
         // Active event present, but the toggled shift isn't in the browse set → BuildRowAsync
         // returns null; the controller must resync (204) instead of throwing.
-        _shiftMgmt.GetActiveAsync().Returns(Event);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(Event);
         _shiftMgmt.GetBrowseShiftsAsync(Arg.Any<ShiftBrowseQuery>()).Returns(new List<UrgentShift>());
 
         var result = await ctrl.ToggleDay(shiftId, Xunit.TestContext.Current.CancellationToken);
@@ -279,7 +285,7 @@ public class ShiftsControllerToggleDayTests
         // Named (passes name gate) but no dietary preference recorded.
         var ctrl = BuildSut(userId, MakeUserInfo(userId, "B", "F", "L", dietary: null));
 
-        _shiftMgmt.GetActiveAsync().Returns(Event);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(Event);
         StubToggleOutcome(ToggleDaySignupOutcome.DietaryRequired());
 
         var result = await ctrl.ToggleDay(shiftId, Xunit.TestContext.Current.CancellationToken);

--- a/tests/Humans.Web.Tests/Controllers/VolunteerTrackingControllerExportXlsxTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/VolunteerTrackingControllerExportXlsxTests.cs
@@ -144,19 +144,31 @@ public sealed class VolunteerTrackingControllerExportXlsxTests
                 volunteerHistory: [],
                 communicationPreferences: [])));
 
-        var activeEvent = new EventSettings
-        {
-            Id = Guid.NewGuid(),
-            TimeZoneId = "Europe/Madrid",
-            GateOpeningDate = new LocalDate(2026, 7, 9),
-            BuildStartOffset = -7,
-            EventEndOffset = 4,
-            StrikeEndOffset = 6,
-        };
-        shiftMgmt.GetActiveAsync().Returns(activeEvent);
+        // Sub-period offsets mirror the EventSettings entity defaults
+        // (FirstCrew=-25, SetupWeek=-16, PreEventWeek=-9, FinishingWeekend=-4),
+        // which the SetupWeek bounds assertion above depends on.
+        var activeEvent = new BurnSettingsInfo(
+            Id: Guid.NewGuid(),
+            EventName: "Test Burn",
+            Year: 2026,
+            TimeZoneId: "Europe/Madrid",
+            GateOpeningDate: new LocalDate(2026, 7, 9),
+            BuildStartOffset: -7,
+            EventEndOffset: 4,
+            StrikeEndOffset: 6,
+            FirstCrewStartOffset: -25,
+            SetupWeekStartOffset: -16,
+            PreEventWeekStartOffset: -9,
+            FinishingWeekendStartOffset: -4,
+            EarlyEntryCapacity: new Dictionary<int, int>(),
+            BarriosEarlyEntryAllocation: null,
+            EarlyEntryClose: null,
+            IsShiftBrowsingOpen: false);
+        var burnSettings = Substitute.For<IBurnSettingsService>();
+        burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(activeEvent);
 
         var ctrl = new VolunteerTrackingController(
-            service, shiftMgmt, exportService, xlsxBuilder,
+            service, shiftMgmt, burnSettings, exportService, xlsxBuilder,
             userService, auditLog, localizer)
         {
             ControllerContext = BuildControllerContext(currentUserId),

--- a/tests/Humans.Web.Tests/Controllers/VolunteerTrackingControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/VolunteerTrackingControllerTests.cs
@@ -50,6 +50,7 @@ public class VolunteerTrackingControllerTests
     private readonly UserManager<User> _userManager;
     private readonly IVolunteerTrackingService _service = Substitute.For<IVolunteerTrackingService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly IVolunteerTrackingExportService _exportService =
         Substitute.For<IVolunteerTrackingExportService>();
     private readonly Humans.Web.Models.VolunteerTracking.VolunteerTrackingXlsxBuilder _xlsxBuilder = new();
@@ -86,7 +87,7 @@ public class VolunteerTrackingControllerTests
         }
 
         var ctrl = new VolunteerTrackingController(
-            _service, _shiftMgmt, _exportService, _xlsxBuilder,
+            _service, _shiftMgmt, _burnSettings, _exportService, _xlsxBuilder,
             _userService, _auditLog, _localizer);
 
         var http = new DefaultHttpContext();
@@ -619,8 +620,8 @@ public class VolunteerTrackingControllerTests
         var current = new User { Id = Guid.NewGuid() };
         var target = Guid.NewGuid();
         var esId = Guid.NewGuid();
-        var es = new EventSettings { Id = esId };
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        var es = MakeBurn(esId);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
         _service
             .SetDayAvailabilityAsync(target, esId, -2, true, Arg.Any<CancellationToken>())
             .Returns(true);
@@ -645,8 +646,8 @@ public class VolunteerTrackingControllerTests
     {
         var current = new User { Id = Guid.NewGuid() };
         var target = Guid.NewGuid();
-        var es = new EventSettings { Id = Guid.NewGuid() };
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        var es = MakeBurn(Guid.NewGuid());
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
         // Default: SetDayAvailabilityAsync returns false → no audit row (service short-circuited).
         var ctrl = BuildSut(current);
 
@@ -666,8 +667,8 @@ public class VolunteerTrackingControllerTests
         var current = new User { Id = Guid.NewGuid() };
         var target = Guid.NewGuid();
         var esId = Guid.NewGuid();
-        var es = new EventSettings { Id = esId };
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        var es = MakeBurn(esId);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
         _service
             .SetDayAvailabilityAsync(target, esId, -3, false, Arg.Any<CancellationToken>())
             .Returns(true);
@@ -692,8 +693,8 @@ public class VolunteerTrackingControllerTests
     {
         var current = new User { Id = Guid.NewGuid() };
         var target = Guid.NewGuid();
-        var es = new EventSettings { Id = Guid.NewGuid() };
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        var es = MakeBurn(Guid.NewGuid());
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
         // Default: SetDayAvailabilityAsync returns false → no audit row.
         var ctrl = BuildSut(current);
 
@@ -711,8 +712,8 @@ public class VolunteerTrackingControllerTests
     public async Task SetAvailabilityDay_LocalReturnUrl_RedirectsToReturnUrl()
     {
         var current = new User { Id = Guid.NewGuid() };
-        var es = new EventSettings { Id = Guid.NewGuid() };
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        var es = MakeBurn(Guid.NewGuid());
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
         var ctrl = BuildSut(current);
         var localUrl = $"/Profile/{Guid.NewGuid()}";
         ctrl.Url.IsLocalUrl(localUrl).Returns(true);
@@ -727,8 +728,8 @@ public class VolunteerTrackingControllerTests
     public async Task SetAvailabilityDay_ExternalReturnUrl_RedirectsToIndex()
     {
         var current = new User { Id = Guid.NewGuid() };
-        var es = new EventSettings { Id = Guid.NewGuid() };
-        _shiftMgmt.GetActiveAsync().Returns(es);
+        var es = MakeBurn(Guid.NewGuid());
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(es);
         var ctrl = BuildSut(current);
         const string externalUrl = "https://evil.test/steal";
         ctrl.Url.IsLocalUrl(externalUrl).Returns(false);
@@ -743,7 +744,7 @@ public class VolunteerTrackingControllerTests
     public async Task SetAvailabilityDay_NoActiveEvent_RedirectsWithError()
     {
         var current = new User { Id = Guid.NewGuid() };
-        _shiftMgmt.GetActiveAsync().Returns((EventSettings?)null);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
         var ctrl = BuildSut(current);
 
         await ctrl.SetAvailabilityDay(Guid.NewGuid(), -1, returnUrl: null, TestContext.Current.CancellationToken);
@@ -789,4 +790,25 @@ public class VolunteerTrackingControllerTests
             volunteerHistory: [],
             communicationPreferences: []);
     }
+
+    // These tests only care about the burn's Id (it is what gets forwarded to
+    // SetDayAvailabilityAsync); the rest are inert defaults.
+    private static BurnSettingsInfo MakeBurn(Guid id) =>
+        new(
+            Id: id,
+            EventName: "Test Burn",
+            Year: 2026,
+            TimeZoneId: "Europe/Madrid",
+            GateOpeningDate: new LocalDate(2026, 7, 9),
+            BuildStartOffset: -7,
+            EventEndOffset: 4,
+            StrikeEndOffset: 6,
+            FirstCrewStartOffset: -7,
+            SetupWeekStartOffset: -5,
+            PreEventWeekStartOffset: -3,
+            FinishingWeekendStartOffset: -2,
+            EarlyEntryCapacity: new Dictionary<int, int>(),
+            BarriosEarlyEntryAllocation: null,
+            EarlyEntryClose: null,
+            IsShiftBrowsingOpen: false);
 }

--- a/tests/Humans.Web.Tests/Models/Shifts/ShiftAdminPageBuilderTests.cs
+++ b/tests/Humans.Web.Tests/Models/Shifts/ShiftAdminPageBuilderTests.cs
@@ -40,19 +40,23 @@ public sealed class ShiftAdminPageBuilderTests
         IsPublicPage: true, IsHidden: false, IsPromotedToDirectory: false,
         CreatedAt: TestNow, Members: []);
 
-    private static readonly EventSettings Event = new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = "Test Event 2026",
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = new LocalDate(2026, 7, 1),
-        BuildStartOffset = -14,
-        EventEndOffset = 6,
-        StrikeEndOffset = 9,
-        IsActive = true,
-        CreatedAt = TestNow,
-        UpdatedAt = TestNow
-    };
+    private static readonly BurnSettingsInfo Event = new(
+        Id: Guid.NewGuid(),
+        EventName: "Test Event 2026",
+        Year: 2026,
+        TimeZoneId: "Europe/Madrid",
+        GateOpeningDate: new LocalDate(2026, 7, 1),
+        BuildStartOffset: -14,
+        EventEndOffset: 6,
+        StrikeEndOffset: 9,
+        FirstCrewStartOffset: -14,
+        SetupWeekStartOffset: -10,
+        PreEventWeekStartOffset: -7,
+        FinishingWeekendStartOffset: -3,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null,
+        IsShiftBrowsingOpen: true);
 
     public ShiftAdminPageBuilderTests()
     {

--- a/tests/Humans.Web.Tests/Models/Shifts/ShiftFilterResolverTests.cs
+++ b/tests/Humans.Web.Tests/Models/Shifts/ShiftFilterResolverTests.cs
@@ -1,5 +1,5 @@
 using AwesomeAssertions;
-using Humans.Domain.Entities;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Domain.Enums;
 using Humans.Web.Models.Shifts;
 using NodaTime;
@@ -73,16 +73,24 @@ public sealed class ShiftFilterResolverTests
         to.Should().Be(new LocalDate(2026, 7, 15));
     }
 
-    // EventSettings is a plain property-bag entity (see Humans.Domain.Entities.EventSettings) —
-    // existing tests use the object-initializer pattern, e.g.
-    //   tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs:346
-    // We mirror that here.
-    private static EventSettings MakeEventSettings(LocalDate gate, int buildStart, int eventEnd, int strikeEnd) =>
-        new()
-        {
-            GateOpeningDate = gate,
-            BuildStartOffset = buildStart,
-            EventEndOffset = eventEnd,
-            StrikeEndOffset = strikeEnd
-        };
+    // Only the four calendar scalars ResolvePeriodRange reads are meaningful here;
+    // the rest are filled with inert defaults.
+    private static BurnSettingsInfo MakeEventSettings(LocalDate gate, int buildStart, int eventEnd, int strikeEnd) =>
+        new(
+            Id: Guid.NewGuid(),
+            EventName: "Test Burn",
+            Year: gate.Year,
+            TimeZoneId: "Europe/Madrid",
+            GateOpeningDate: gate,
+            BuildStartOffset: buildStart,
+            EventEndOffset: eventEnd,
+            StrikeEndOffset: strikeEnd,
+            FirstCrewStartOffset: buildStart,
+            SetupWeekStartOffset: buildStart,
+            PreEventWeekStartOffset: buildStart,
+            FinishingWeekendStartOffset: buildStart,
+            EarlyEntryCapacity: new Dictionary<int, int>(),
+            BarriosEarlyEntryAllocation: null,
+            EarlyEntryClose: null,
+            IsShiftBrowsingOpen: false);
 }

--- a/tests/Humans.Web.Tests/Shifts/ShiftBrowsePageBuilderRowTests.cs
+++ b/tests/Humans.Web.Tests/Shifts/ShiftBrowsePageBuilderRowTests.cs
@@ -19,21 +19,26 @@ public class ShiftBrowsePageBuilderRowTests
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
     private readonly IShiftManagementService _shiftManagement = Substitute.For<IShiftManagementService>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
 
-    private static readonly EventSettings Event = new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = "Test Event 2026",
-        TimeZoneId = "Europe/Madrid",
-        GateOpeningDate = new LocalDate(2026, 7, 1),
-        BuildStartOffset = -14,
-        EventEndOffset = 6,
-        StrikeEndOffset = 9,
-        IsActive = true,
-        CreatedAt = TestNow,
-        UpdatedAt = TestNow
-    };
+    private static readonly BurnSettingsInfo Event = new(
+        Id: Guid.NewGuid(),
+        EventName: "Test Event 2026",
+        Year: 2026,
+        TimeZoneId: "Europe/Madrid",
+        GateOpeningDate: new LocalDate(2026, 7, 1),
+        BuildStartOffset: -14,
+        EventEndOffset: 6,
+        StrikeEndOffset: 9,
+        FirstCrewStartOffset: -14,
+        SetupWeekStartOffset: -10,
+        PreEventWeekStartOffset: -7,
+        FinishingWeekendStartOffset: -3,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null,
+        IsShiftBrowsingOpen: true);
 
     [HumansFact]
     public async Task BuildRowAsync_ReturnsMappedItem_AndCallerSignupStatus()
@@ -62,7 +67,7 @@ public class ShiftBrowsePageBuilderRowTests
             DepartmentName: "Test Department",
             Signups: [(userId, "Tester", SignupStatus.Confirmed)]);
 
-        _shiftManagement.GetActiveAsync().Returns(Event);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(Event);
         _shiftManagement.GetBrowseShiftsAsync(Arg.Any<ShiftBrowseQuery>())
             .Returns(new List<UrgentShift> { urgent });
 
@@ -79,7 +84,7 @@ public class ShiftBrowsePageBuilderRowTests
             }
         };
 
-        var builder = new ShiftBrowsePageBuilder(_shiftManagement, _teamService);
+        var builder = new ShiftBrowsePageBuilder(_shiftManagement, _burnSettings, _teamService);
 
         var result = await builder.BuildRowAsync(
             shiftId, userSignups, isPrivileged: false, Xunit.TestContext.Current.CancellationToken);


### PR DESCRIPTION
Slice 5 of nobodies-collective/Humans#809 (tracker stays open).

## ⚠️ Stacked on PR #1227 — merge that first

This branch is cut from `sprint/2026-08-07/issue-809-iface` (slice 4, PR #1227), not from `main`. It **contains #1227's five commits** and will show them in the diff until #1227 merges. My own work is the top three commits:

- `2c168ec` ShiftFilterResolver + VolunteerTracking
- `8a2fae9` ShiftBrowse group
- `4477040` ShiftAdmin group

**File overlap:** none with #1227's own edits beyond consuming `IBurnSettingsInfo`. `ShiftDashboardPageBuilder` / `ShiftViewModels.cs:583` belong to **PR #1226** and are deliberately untouched here — but `ShiftViewModels.cs` is edited by both, so expect a small conflict on that file whichever lands second.

## Groups migrated

| Group | What moved to the DTO |
|---|---|
| `ShiftFilterResolver` | `ResolvePeriodRange(ShiftPeriod, BurnSettingsInfo)` |
| VolunteerTracking | `VolunteerTrackingController` — all four `GetActiveAsync` calls now go through `IBurnSettingsService` |
| ShiftBrowse | `ShiftBrowseViewModel`, `ShiftBrowsePageRequest`/`Builder`, `ShiftBrowseMapper`, `OnboardingShiftsBrowseModelBuilder`, `ShiftsController` (Index / ToggleDay / SaveAvailability), `OnboardingWidgetController.Shifts`, `_EventRotaRow.cshtml` |
| ShiftAdmin | `ShiftAdminViewModel`, `ShiftAdminPageRequest`/`Builder`, `ShiftAdminController` (Index + CreateRota) |

Also folded `ShiftBrowsePageBuilder.GetPeriodDateRange` — a private duplicate — into `ShiftFilterResolver.ResolvePeriodRange`, which its own xmldoc already said was the intended single home.

## Correction: the `ShiftFilterResolver` "trap" was stale

The prior audit marked `ResolvePeriodRange` untouchable because "both callers are blocked (`VolunteerTrackingController.cs:147`, `ShiftBrowsePageBuilder.cs:253`)". `ShiftBrowsePageBuilder.cs:253` was never a caller — it was a *private copy* of the same switch. `ResolvePeriodRange` has exactly one production caller, so retyping it cost one line plus the caller I was migrating anyway.

## The shared rota partials are typed `IBurnSettingsInfo`, not `BurnSettingsInfo`

`BuildStrikeRotaTableViewModel.EventSettings`, `EventRotaTableViewModel.EventSettings`, `BuildStrikeRotaRowViewModel.Es` and `EventRotaRowViewModel.Es` are typed as the **interface**.

Reason: `_EventRotaTable` / `_BuildStrikeRotaTable` are shared between the migrated browse + onboarding pages (which hold the DTO) and `Views/WidgetGallery/Index.cshtml:768`, which feeds them `WidgetGalleryViewModel.SampleEventSettings` — still the EF entity, and out of scope (below). Both types implement `IBurnSettingsInfo`, and these partials read nothing beyond `GateOpeningDate`, `TimeZoneId` and `Shift.GetShiftPeriod`. So the entity type name leaves the view models (the spec's acceptance criterion) without forcing a WidgetGallery decision. Tightening these four to `BurnSettingsInfo` is a one-word change each once WidgetGallery is ruled on.

## ❓ Open scope question for Peter — `WidgetGalleryController`

`WidgetGalleryController.cs:53,195,213,237` holds `EventSettings` (`SampleEventSettings`, the private `MapToDisplayItem`, the `ShiftsSamples` record). The spec's item-7 list never names it, so whether it is in scope is genuinely unresolved — **I did not migrate it.** It is mechanically trivial (swap the `GetActiveAsync` source + three type names), and it is the *only* thing standing between the four view models above and a full `BurnSettingsInfo` typing. Your call.

## Verification

- Build: **0 errors, 90 warnings** — unchanged from the slice-4 baseline.
- **HUM0015 / HUM0016 / HUM0025: 0 before, 0 after.** (Present codes: HUM0024 ×108, HUM0028, HUM_USER_DISPLAYNAME — all pre-existing.)
- Tests: **5166 passed, 0 failed** (Domain 274, Analyzers 237, Web 388, Application 4141, Integration 126).
- **No EF migration.** `dotnet ef migrations has-pending-model-changes` reports "No changes have been made to the model since the last migration" for both `HumansDbContext` and `StoreDbContext`.
- No `[Grandfathered]` added. No new public/interface surface, no new DTO field, no new file, no new DI registration — every controller/builder change reuses the already-registered `IBurnSettingsService`.

## Handoff — what still holds the entity

| Site | Why it did not move |
|---|---|
| `ShiftsController.cs:125` (`RenderSummaryAsync`) | **Blocked on new surface.** `IShiftManagementService.BuildSummaryAsync(EventSettings activeEvent, …)` takes the entity; retyping it is an interface-surface change and needs owner approval. |
| `ShiftsController.cs:519-524` (`LoadUserActiveSignupsForUiAsync`) | Reads the EF nav `s.Shift.Rota.EventSettings` per signup — needs the navigation graph, not the calendar. The DTO cannot serve it. |
| `ShiftsController.cs:448-507` (`Settings` GET/POST) | Write path — explicitly out of scope (`EventSettingsFormMapper`). |
| `ShiftVolunteerSearchBuilder.cs:58,73,74` | Same as above — resolves `shift.Rota.EventSettings` off the aggregate; needs the nav graph. |
| `WidgetGalleryController.cs:53,195,213,237` | Scope unresolved — see the question above. |
| `DevelopmentDashboardSeeder.cs:96` | Write path / seeding — out of scope. |
| `ShiftDashboardPageBuilder.cs` + `ShiftViewModels.cs:583` | Owned by PR #1226. |

### Needs new interface surface — owner approval required

1. `IShiftManagementService.BuildSummaryAsync` — would have to accept `BurnSettingsInfo` (or the burn's `Guid`) instead of `EventSettings` to unblock `ShiftsController.RenderSummaryAsync`. This is the only remaining Web-layer read path blocked purely on a signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
