### PR TITLE
refactor(809): close out the read-side migration — BuildSummaryAsync, WidgetGallery, rota view models

### DIFF
--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -120,7 +120,7 @@ public interface IShiftManagementService : IApplicationService
     /// orders for display.
     /// </summary>
     Task<ShiftSummary?> BuildSummaryAsync(
-        EventSettings activeEvent,
+        BurnSettingsInfo activeEvent,
         string? teamSlug = null,
         Guid? rotaId = null,
         CancellationToken ct = default);

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -286,7 +286,7 @@ public sealed class ShiftManagementService(
     }
 
     public async Task<ShiftSummary?> BuildSummaryAsync(
-        EventSettings activeEvent,
+        BurnSettingsInfo activeEvent,
         string? teamSlug = null,
         Guid? rotaId = null,
         CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -123,7 +123,7 @@ public class ShiftsController(
 
     private async Task<IActionResult> RenderSummaryAsync(string? teamSlug, Guid? rotaId)
     {
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
         if (es is null) return View("NoActiveEvent");
 
         var summary = await shiftMgmt.BuildSummaryAsync(es, teamSlug, rotaId, HttpContext.RequestAborted);

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -26,6 +26,7 @@ public sealed class WidgetGalleryController(
     IUserServiceRead userService,
     ITeamServiceRead teamService,
     IShiftManagementService shiftMgmt,
+    IBurnSettingsService burnSettings,
     ILogger<WidgetGalleryController> logger) : HumansControllerBase(userService)
 {
     [HttpGet("")]
@@ -147,7 +148,7 @@ public sealed class WidgetGalleryController(
     {
         try
         {
-            var es = await shiftMgmt.GetActiveAsync();
+            var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
             if (es is null)
                 return ShiftsSamples.Empty;
 
@@ -193,7 +194,7 @@ public sealed class WidgetGalleryController(
         }
     }
 
-    private ShiftDisplayItem MapToDisplayItem(UrgentShift u, EventSettings es)
+    private ShiftDisplayItem MapToDisplayItem(UrgentShift u, BurnSettingsInfo es)
     {
         return new ShiftDisplayItem
         {
@@ -211,7 +212,7 @@ public sealed class WidgetGalleryController(
     }
 
     private sealed record ShiftsSamples(
-        EventSettings? EventSettings,
+        BurnSettingsInfo? EventSettings,
         Rota? Rota,
         IReadOnlyList<DailyStaffingData> StaffingData,
         IReadOnlyList<DailyStaffingHours> StaffingHours,
@@ -235,7 +236,7 @@ public sealed class WidgetGalleryViewModel
     public string? SampleTeamSlug { get; init; }
     public string? SampleTeamName { get; init; }
     public VolunteerEventProfile? SampleVolunteerProfile { get; init; }
-    public EventSettings? SampleEventSettings { get; init; }
+    public BurnSettingsInfo? SampleEventSettings { get; init; }
     public Rota? SampleRota { get; init; }
     public required IReadOnlyList<DailyStaffingData> SampleStaffingData { get; init; }
     public required IReadOnlyList<DailyStaffingHours> SampleStaffingHours { get; init; }

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -688,13 +688,12 @@ public class BuildStrikeRotaTableViewModel
     public RotaShiftGroup RotaGroup { get; set; } = null!;
 
     /// <summary>
-    /// Typed as the interface, not <see cref="BurnSettingsInfo"/>: this partial is
-    /// shared between the migrated browse/onboarding pages (which hold the DTO) and
-    /// the widget gallery (which still holds the EF entity, scope unresolved — #809).
-    /// Both implement <see cref="IBurnSettingsInfo"/> and the partial reads nothing
-    /// beyond it.
+    /// The burn this rota belongs to, as the cross-section read DTO. Every consumer
+    /// of this partial — browse, onboarding, and the widget gallery — resolves the
+    /// active burn through <see cref="IBurnSettingsService"/>, so the EF entity never
+    /// reaches a view model (#809).
     /// </summary>
-    public IBurnSettingsInfo EventSettings { get; set; } = null!;
+    public BurnSettingsInfo EventSettings { get; set; } = null!;
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
     public bool ShowSignups { get; set; }
@@ -734,7 +733,7 @@ public class EventRotaTableViewModel
     public List<ShiftDisplayItem> Shifts { get; set; } = [];
 
     /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
-    public IBurnSettingsInfo EventSettings { get; set; } = null!;
+    public BurnSettingsInfo EventSettings { get; set; } = null!;
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
     public bool ShowSignups { get; set; }
@@ -786,7 +785,7 @@ public class BuildStrikeRotaRowViewModel
     public ShiftDisplayItem Item { get; set; } = null!;
 
     /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
-    public IBurnSettingsInfo Es { get; set; } = null!;
+    public BurnSettingsInfo Es { get; set; } = null!;
     public bool IsSignedUp { get; set; }
     public SignupStatus? SignupStatus { get; set; }
     public bool SignupsBlockedByMissingDietary { get; set; }
@@ -825,7 +824,7 @@ public class EventRotaRowViewModel
     public ShiftDisplayItem Item { get; set; } = null!;
 
     /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
-    public IBurnSettingsInfo Es { get; set; } = null!;
+    public BurnSettingsInfo Es { get; set; } = null!;
     public bool IsSignedUp { get; set; }
     public SignupStatus? SignupStatus { get; set; }
     public bool SignupsBlockedByMissingDietary { get; set; }

--- a/src/Humans.Web/Views/Shared/_EventRotaRow.cshtml
+++ b/src/Humans.Web/Views/Shared/_EventRotaRow.cshtml
@@ -4,7 +4,7 @@
 @using NodaTime
 
 @functions {
-    string GetPhase(Shift shift, IBurnSettingsInfo es)
+    string GetPhase(Shift shift, BurnSettingsInfo es)
     {
         return shift.GetShiftPeriod(es) switch
         {
@@ -15,7 +15,7 @@
         };
     }
 
-    string GetPhaseBadge(Shift shift, IBurnSettingsInfo es)
+    string GetPhaseBadge(Shift shift, BurnSettingsInfo es)
     {
         return shift.GetShiftPeriod(es) switch
         {

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSummaryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSummaryServiceTests.cs
@@ -31,8 +31,10 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
 
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
-    // Scenario ids.
+    // Scenario ids. The entity is what the repository reads; _burn is the
+    // cross-section DTO BuildSummaryAsync now takes (same Id, same calendar).
     private readonly EventSettings _event;
+    private readonly BurnSettingsInfo _burn;
     private readonly Guid _powerId = Guid.NewGuid();
     private readonly Guid _subId = Guid.NewGuid();
     private readonly Guid _waterId = Guid.NewGuid();
@@ -59,6 +61,24 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
             TimeZoneId = "UTC",
             IsActive = true
         };
+
+        _burn = new BurnSettingsInfo(
+            Id: _event.Id,
+            EventName: _event.EventName,
+            Year: 2026,
+            TimeZoneId: _event.TimeZoneId,
+            GateOpeningDate: _event.GateOpeningDate,
+            BuildStartOffset: _event.BuildStartOffset,
+            EventEndOffset: _event.EventEndOffset,
+            StrikeEndOffset: _event.StrikeEndOffset,
+            FirstCrewStartOffset: _event.FirstCrewStartOffset,
+            SetupWeekStartOffset: _event.SetupWeekStartOffset,
+            PreEventWeekStartOffset: _event.PreEventWeekStartOffset,
+            FinishingWeekendStartOffset: _event.FinishingWeekendStartOffset,
+            EarlyEntryCapacity: new Dictionary<int, int>(),
+            BarriosEarlyEntryAllocation: null,
+            EarlyEntryClose: _event.EarlyEntryClose,
+            IsShiftBrowsingOpen: _event.IsShiftBrowsingOpen);
 
         SeedScenario();
 
@@ -121,7 +141,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_Global_FlatTableHasEveryConfirmedHumanWithCamp()
     {
-        var summary = await _service.BuildSummaryAsync(_event, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().NotBeNull();
         summary.Scope.Should().Be(ShiftSummaryScope.Global);
@@ -148,7 +168,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_Global_PivotLeftJoinsRosterWithCamplessBucket()
     {
-        var summary = await _service.BuildSummaryAsync(_event, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, ct: Xunit.TestContext.Current.CancellationToken);
 
         var byCamp = summary!.Camps.ToDictionary(c => c.CampId ?? Guid.Empty);
 
@@ -173,7 +193,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_Global_LinksToEachDepartment()
     {
-        var summary = await _service.BuildSummaryAsync(_event, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, ct: Xunit.TestContext.Current.CancellationToken);
 
         // Non-promoted sub-team "Sub" rolls up into "Power"; departments = Power, Water.
         summary!.TeamLinks.Select(t => t.Slug).Should().BeEquivalentTo(["power", "water"]);
@@ -183,7 +203,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_TeamScope_RestrictsFlatTableToTeamSetButKeepsFullRoster()
     {
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "power", ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "power", ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().NotBeNull();
         summary.Scope.Should().Be(ShiftSummaryScope.Team);
@@ -208,7 +228,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_RotaScope_RestrictsToSingleRota()
     {
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "power", rotaId: _rPower, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "power", rotaId: _rPower, ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().NotBeNull();
         summary.Scope.Should().Be(ShiftSummaryScope.Rota);
@@ -225,7 +245,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     public async Task BuildSummaryAsync_RotaNotInTeamSet_ReturnsNull()
     {
         // rWater belongs to Water, not Power's team-set.
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "power", rotaId: _rWater, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "power", rotaId: _rWater, ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().BeNull();
     }
@@ -233,7 +253,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_UnknownTeamSlug_ReturnsNull()
     {
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "does-not-exist", ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "does-not-exist", ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().BeNull();
     }

--- a/tests/Humans.Web.Tests/Controllers/ShiftsControllerSummaryTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ShiftsControllerSummaryTests.cs
@@ -44,20 +44,31 @@ public class ShiftsControllerSummaryTests
     private readonly ShiftBrowsePageBuilder _builder;
     private readonly ILogger<ShiftsController> _logger = NullLogger<ShiftsController>.Instance;
 
-    private static readonly EventSettings ActiveEvent = new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = "Test Event",
-        GateOpeningDate = new LocalDate(2026, 7, 1),
-        TimeZoneId = "UTC",
-        IsActive = true
-    };
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
+
+    private static readonly BurnSettingsInfo ActiveEvent = new(
+        Id: Guid.NewGuid(),
+        EventName: "Test Event",
+        Year: 2026,
+        TimeZoneId: "UTC",
+        GateOpeningDate: new LocalDate(2026, 7, 1),
+        BuildStartOffset: -14,
+        EventEndOffset: 6,
+        StrikeEndOffset: 9,
+        FirstCrewStartOffset: -14,
+        SetupWeekStartOffset: -10,
+        PreEventWeekStartOffset: -7,
+        FinishingWeekendStartOffset: -3,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null,
+        IsShiftBrowsingOpen: true);
 
     public ShiftsControllerSummaryTests()
     {
         _localizer[Arg.Any<string>()].Returns(ci =>
             new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
-        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, Substitute.For<IBurnSettingsService>(), _teamService);
+        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, _burnSettings, _teamService);
     }
 
     // Authorization is declarative: [Authorize(Policy = ShiftDepartmentManager)] on
@@ -69,7 +80,7 @@ public class ShiftsControllerSummaryTests
     {
         var userId = Guid.NewGuid();
         var ctrl = BuildSut(userId);
-        _shiftMgmt.GetActiveAsync().Returns((EventSettings?)null);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
 
         var result = await ctrl.Summary();
 
@@ -82,7 +93,7 @@ public class ShiftsControllerSummaryTests
     {
         var userId = Guid.NewGuid();
         var ctrl = BuildSut(userId);
-        _shiftMgmt.GetActiveAsync().Returns(ActiveEvent);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ActiveEvent);
         _shiftMgmt.BuildSummaryAsync(ActiveEvent, "ghost", null, Arg.Any<CancellationToken>())
             .Returns((ShiftSummary?)null);
 
@@ -96,7 +107,7 @@ public class ShiftsControllerSummaryTests
     {
         var userId = Guid.NewGuid();
         var ctrl = BuildSut(userId);
-        _shiftMgmt.GetActiveAsync().Returns(ActiveEvent);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ActiveEvent);
 
         var campX = Guid.NewGuid();
         var campY = Guid.NewGuid();
@@ -137,7 +148,7 @@ public class ShiftsControllerSummaryTests
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(MakeUserInfo(userId));
         var ctrl = new ShiftsController(
-            _shiftMgmt, Substitute.For<IBurnSettingsService>(), _signupService, _volunteerTrackingService, _shiftView, _teamService,
+            _shiftMgmt, _burnSettings, _signupService, _volunteerTrackingService, _shiftView, _teamService,
             _auditLogService, _userService, _localizer, _clock, _builder, _logger);
         var http = new DefaultHttpContext
         {


### PR DESCRIPTION
Slice 6 of nobodies-collective/Humans#809 (tracker stays open).

Closes out the three remaining approved items on the read side: the Shift Summary service call, WidgetGallery, and the shared rota partial view models.

## Stacking — this must merge last of the three

```
#1227 (slice 4, IBurnSettingsInfo)
  └── #1229 (slice 5, ShiftBrowse/ShiftAdmin)
        └── this PR (slice 6)
```

This branch is based on `sprint/2026-08-07/issue-809-slice5`, which is based on `sprint/2026-08-07/issue-809-slice4`. Merge #1227, then #1229, then this.

**File overlap with #1226** (`refactor(809): migrate the ShiftDashboard chain to BurnSettingsInfo`): both touch `src/Humans.Web/Models/ShiftViewModels.cs`. #1226 edits the ShiftDashboard view models; this PR edits the four rota table/row view models further down the same file. Different regions — a textual conflict is possible but the resolution is a straight union.

## Item 1 — `BuildSummaryAsync` off the EF entity

`IShiftManagementService.BuildSummaryAsync` took `EventSettings`; `ShiftsController.RenderSummaryAsync` was the one production caller and the last thing forcing that controller path to hold the entity. It now takes `BurnSettingsInfo`, and the controller resolves the active burn through `IBurnSettingsService` exactly like `Index`, `ToggleDay` and `SaveAvailability` already do after slice 5.

Evidence that nothing but the id was ever needed — every use of the parameter in the method body:

```
ShiftManagementService.cs:321   rota.EventSettingsId != activeEvent.Id
ShiftManagementService.cs:334   repo.GetConfirmedUserShiftTotalsAsync(activeEvent.Id, ...)
ShiftManagementService.cs:362   BuildDepartmentLinksAsync(activeEvent.Id, ct)
ShiftManagementService.cs:365   repo.GetRotasAsync(activeEvent.Id, ...)
```

### Deviation from the brief: `BurnSettingsInfo`, not `IBurnSettingsInfo`

The brief asked for `IBurnSettingsInfo` on the grounds that it widens the parameter and stays source-compatible. **That is not achievable.** `IBurnSettingsInfo` is deliberately the burn's *calendar shape* and carries no `Id` — see its own xmldoc and the nine members it declares. Retyping to the interface would have required adding `Guid Id { get; }` to it, which is new interface surface and outside this slice's authority.

`BurnSettingsInfo` was chosen instead because:

- it carries `Id`, so no member has to be invented;
- #809's acceptance criteria name `BurnSettingsInfo` as what web consumers carry;
- slices 4 and 5 moved every other web consumer onto exactly this type.

The cost is that the two test fixtures constructing an `EventSettings` for this call now construct the DTO. `ShiftSummaryServiceTests` keeps its entity for repository seeding and adds a DTO projected off it, so the id and calendar still agree.

## Item 2 — WidgetGallery

`WidgetGalleryViewModel.SampleEventSettings` and the controller's private `ShiftsSamples` record now carry `BurnSettingsInfo`; the active burn comes from `IBurnSettingsService`; `MapToDisplayItem` takes the DTO. `Shift.GetAbsoluteStart/GetAbsoluteEnd/GetShiftPeriod` accept `IBurnSettingsInfo` since slice 4, so the three call sites at `:200-202` needed no other change.

`Views/WidgetGallery/Index.cshtml` needed **no edit**: `:768` hands the sample to `_EventRotaTable`, whose view model accepts it either way, and the only field the page reads off the sample directly is `EventName` (`:221`), which the DTO carries. Verified by build — Razor is source-generated and type-checked at compile time in this solution (probed by deliberately breaking a view and confirming `error CS`).

WidgetGallery has no tests; `AdminNavTree` and `Views/ColorPalette/Index.cshtml` reference only the route.

## Item 3 — tighten the four shared rota view models

`BuildStrikeRotaTableViewModel`, `BuildStrikeRotaRowViewModel`, `EventRotaTableViewModel` and `EventRotaRowViewModel` go from `IBurnSettingsInfo` to `BurnSettingsInfo`, along with the two `@functions` helpers in `_EventRotaRow.cshtml`.

Slice 5 typed these as the interface for one stated reason — WidgetGallery still held the entity and its scope was unresolved. Item 2 removes that reason: every consumer now holds the DTO. The xmldoc that explained the interface choice has been replaced rather than left to rot.

`IBurnSettingsInfo` keeps its real job — letting `Shift`'s helpers and `BuildSubPeriodClassifier` accept either shape from the Domain layer. Its `sealed` default members and the `EventSettings` / `BurnSettingsInfo` forwarders are untouched.

## Verification

| | Before | After |
|---|---|---|
| Warnings | 90 | 90 |
| Errors | 0 | 0 |
| HUM0015 | 0 | 0 |
| HUM0016 | 0 | 0 |
| HUM0025 | 0 | 0 |
| Tests | 5166 pass | 5166 pass |

Full-solution `--no-incremental` build reports only `HUM0024` (108) and `HUM0028` (34), both pre-existing and unchanged.

**No EF migration.** `dotnet ef migrations has-pending-model-changes` reports *"No changes have been made to the model since the last migration"* for **both** contexts (`HumansDbContext` and `StoreDbContext`). The `EventSettings` entity, its table, and the `Shift`/`Rota`/`GeneralAvailability`/`VolunteerBuildStatus` navigations are untouched.

No `[Grandfathered]` added. No new public or interface surface — the only signature change is item 1's parameter type.

## What still holds the EF entity in #809's scope, and why each is deliberate

After this slice the `Humans.Web` layer holds `EventSettings` in exactly four places, all of them intentional:

1. **`ShiftsController.LoadUserActiveSignupsForUiAsync` (`:519-522`)** — reaches the entity through the Shifts-internal `Shift → Rota → EventSettings` navigation. That navigation is *within* the section, so the hard rules permit it; this is not a boundary violation. Migrating it is real behavioural work (collect distinct `EventSettingsId`s, fetch DTOs, join in memory), not a retype. Peter has not ruled on it — its own PR.

2. **`ShiftVolunteerSearchBuilder` (`Web/Helpers`, `:58, :73-74`)** — same same-section navigation, same reasoning, same open question. Left with 1.

3. **The `Settings` write path — `ShiftsController.Settings` (`:449, :452, :481-507`) and `EventSettingsFormMapper`** — this is the admin form that *edits the burn*. A write path legitimately holds the entity it mutates; a read DTO is the wrong type for it. Out of scope for #809, which is about the entity leaking into read/render paths.

4. **`DevelopmentDashboardSeeder` (`:96`)** — constructs the entity to seed it. Same reasoning as 3.

Also outside this slice by design: Shifts-internal read paths (spec item 6), `ShiftSignupService`, and the EF navigations on `Shift` / `Rota` / `GeneralAvailability` / `VolunteerBuildStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
