### PR TITLE
refactor(809): migrate the last two Web-layer EventSettings holders to BurnSettingsInfo (slice 7)

### DIFF
--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -120,7 +120,7 @@ public interface IShiftManagementService : IApplicationService
     /// orders for display.
     /// </summary>
     Task<ShiftSummary?> BuildSummaryAsync(
-        EventSettings activeEvent,
+        BurnSettingsInfo activeEvent,
         string? teamSlug = null,
         Guid? rotaId = null,
         CancellationToken ct = default);

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -286,7 +286,7 @@ public sealed class ShiftManagementService(
     }
 
     public async Task<ShiftSummary?> BuildSummaryAsync(
-        EventSettings activeEvent,
+        BurnSettingsInfo activeEvent,
         string? teamSlug = null,
         Guid? rotaId = null,
         CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -123,7 +123,7 @@ public class ShiftsController(
 
     private async Task<IActionResult> RenderSummaryAsync(string? teamSlug, Guid? rotaId)
     {
-        var es = await shiftMgmt.GetActiveAsync();
+        var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
         if (es is null) return View("NoActiveEvent");
 
         var summary = await shiftMgmt.BuildSummaryAsync(es, teamSlug, rotaId, HttpContext.RequestAborted);

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -512,29 +512,48 @@ public class ShiftsController(
         return RedirectToAction(nameof(Settings));
     }
 
+    // A user's signups are not scoped to the active burn — they can span cycles — so
+    // each row is rendered against its OWN rota's burn, never the active one. The
+    // distinct burn ids are resolved once up front and joined in memory; a lookup
+    // inside the projection would be an N+1.
     private async Task<IReadOnlyList<UserSignupConflictItem>> LoadUserActiveSignupsForUiAsync(Guid userId)
     {
-        var allSignups = await signupService.GetByUserAsync(userId);
-        return allSignups
+        var ct = HttpContext.RequestAborted;
+        var active = (await signupService.GetByUserAsync(userId))
             .Where(s => s.Status is SignupStatus.Pending or SignupStatus.Confirmed)
-            .Where(s => s.Shift?.Rota?.EventSettings is not null)
-            .Select(s =>
-            {
-                var sEs = s.Shift.Rota.EventSettings;
-                var absStart = s.Shift.GetAbsoluteStart(sEs);
-                var absEnd = s.Shift.GetAbsoluteEnd(sEs);
-                var tz = DateTimeZoneProviders.Tzdb[sEs.TimeZoneId];
-                var localStart = absStart.InZone(tz).LocalDateTime;
-                var localEnd = absEnd.InZone(tz).LocalDateTime;
-                return new UserSignupConflictItem(
-                    Date: localStart.Date,
-                    RotaName: s.Shift.Rota.Name,
-                    AbsoluteStart: absStart,
-                    AbsoluteEnd: absEnd,
-                    DisplayStart: DateFormattingExtensions.TimeOfDayPattern.Format(localStart.TimeOfDay),
-                    DisplayEnd: DateFormattingExtensions.TimeOfDayPattern.Format(localEnd.TimeOfDay));
-            })
+            .Where(s => s.Shift?.Rota is not null)
             .ToList();
+
+        var burns = new Dictionary<Guid, BurnSettingsInfo>();
+        foreach (var burnId in active.Select(s => s.Shift.Rota.EventSettingsId).Distinct())
+        {
+            if (await burnSettings.GetByIdAsync(burnId, ct) is { } burn)
+                burns[burnId] = burn;
+        }
+
+        var items = new List<UserSignupConflictItem>(active.Count);
+        foreach (var s in active)
+        {
+            // Unresolvable burn → skip, matching the old "no EventSettings on the
+            // graph → drop the row" guard rather than rendering a bogus time.
+            if (!burns.TryGetValue(s.Shift.Rota.EventSettingsId, out var sEs))
+                continue;
+
+            var absStart = s.Shift.GetAbsoluteStart(sEs);
+            var absEnd = s.Shift.GetAbsoluteEnd(sEs);
+            var tz = DateTimeZoneProviders.Tzdb[sEs.TimeZoneId];
+            var localStart = absStart.InZone(tz).LocalDateTime;
+            var localEnd = absEnd.InZone(tz).LocalDateTime;
+            items.Add(new UserSignupConflictItem(
+                Date: localStart.Date,
+                RotaName: s.Shift.Rota.Name,
+                AbsoluteStart: absStart,
+                AbsoluteEnd: absEnd,
+                DisplayStart: DateFormattingExtensions.TimeOfDayPattern.Format(localStart.TimeOfDay),
+                DisplayEnd: DateFormattingExtensions.TimeOfDayPattern.Format(localEnd.TimeOfDay)));
+        }
+
+        return items;
     }
 
     // Admin diagnostic: signups with no Created/Voluntold/Confirmed audit row

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -26,6 +26,7 @@ public sealed class WidgetGalleryController(
     IUserServiceRead userService,
     ITeamServiceRead teamService,
     IShiftManagementService shiftMgmt,
+    IBurnSettingsService burnSettings,
     ILogger<WidgetGalleryController> logger) : HumansControllerBase(userService)
 {
     [HttpGet("")]
@@ -147,7 +148,7 @@ public sealed class WidgetGalleryController(
     {
         try
         {
-            var es = await shiftMgmt.GetActiveAsync();
+            var es = await burnSettings.GetActiveAsync(HttpContext.RequestAborted);
             if (es is null)
                 return ShiftsSamples.Empty;
 
@@ -193,7 +194,7 @@ public sealed class WidgetGalleryController(
         }
     }
 
-    private ShiftDisplayItem MapToDisplayItem(UrgentShift u, EventSettings es)
+    private ShiftDisplayItem MapToDisplayItem(UrgentShift u, BurnSettingsInfo es)
     {
         return new ShiftDisplayItem
         {
@@ -211,7 +212,7 @@ public sealed class WidgetGalleryController(
     }
 
     private sealed record ShiftsSamples(
-        EventSettings? EventSettings,
+        BurnSettingsInfo? EventSettings,
         Rota? Rota,
         IReadOnlyList<DailyStaffingData> StaffingData,
         IReadOnlyList<DailyStaffingHours> StaffingHours,
@@ -235,7 +236,7 @@ public sealed class WidgetGalleryViewModel
     public string? SampleTeamSlug { get; init; }
     public string? SampleTeamName { get; init; }
     public VolunteerEventProfile? SampleVolunteerProfile { get; init; }
-    public EventSettings? SampleEventSettings { get; init; }
+    public BurnSettingsInfo? SampleEventSettings { get; init; }
     public Rota? SampleRota { get; init; }
     public required IReadOnlyList<DailyStaffingData> SampleStaffingData { get; init; }
     public required IReadOnlyList<DailyStaffingHours> SampleStaffingHours { get; init; }

--- a/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
+++ b/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
@@ -37,7 +37,7 @@ public sealed record VolunteerSearchBuildResult(
 }
 
 public sealed class ShiftVolunteerSearchBuilder(
-    IShiftManagementService shiftManagement,
+    IBurnSettingsService burnSettings,
     IUserServiceRead userService,
     IShiftView shiftView,
     IShiftSignupService signupService,
@@ -54,8 +54,17 @@ public sealed class ShiftVolunteerSearchBuilder(
         if (shift is null)
             return VolunteerSearchBuildResult.NotFound;
 
-        var activeEvent = await shiftManagement.GetActiveAsync();
-        var eventSettings = shift.Rota.EventSettings;
+        // Two distinct burns, deliberately not collapsed: the target shift's own
+        // burn (drives its calendar) and the currently active one (decides whether
+        // the cached, active-scoped ShiftUserView.Signups can be reused). Admins
+        // search shifts in past/future cycles, so these differ.
+        var activeEvent = await burnSettings.GetActiveAsync();
+        var eventSettings = activeEvent?.Id == shift.Rota.EventSettingsId
+            ? activeEvent
+            : await burnSettings.GetByIdAsync(shift.Rota.EventSettingsId);
+
+        if (eventSettings is null)
+            return VolunteerSearchBuildResult.NotFound;
 
         var results = await BuildAsync(
             shift,
@@ -70,8 +79,8 @@ public sealed class ShiftVolunteerSearchBuilder(
     private async Task<List<VolunteerSearchResult>> BuildAsync(
         Shift shift,
         string query,
-        EventSettings eventSettings,
-        EventSettings? activeEvent,
+        BurnSettingsInfo eventSettings,
+        BurnSettingsInfo? activeEvent,
         bool canViewMedical)
     {
         var shiftStart = shift.GetAbsoluteStart(eventSettings);

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -688,13 +688,12 @@ public class BuildStrikeRotaTableViewModel
     public RotaShiftGroup RotaGroup { get; set; } = null!;
 
     /// <summary>
-    /// Typed as the interface, not <see cref="BurnSettingsInfo"/>: this partial is
-    /// shared between the migrated browse/onboarding pages (which hold the DTO) and
-    /// the widget gallery (which still holds the EF entity, scope unresolved — #809).
-    /// Both implement <see cref="IBurnSettingsInfo"/> and the partial reads nothing
-    /// beyond it.
+    /// The burn this rota belongs to, as the cross-section read DTO. Every consumer
+    /// of this partial — browse, onboarding, and the widget gallery — resolves the
+    /// active burn through <see cref="IBurnSettingsService"/>, so the EF entity never
+    /// reaches a view model (#809).
     /// </summary>
-    public IBurnSettingsInfo EventSettings { get; set; } = null!;
+    public BurnSettingsInfo EventSettings { get; set; } = null!;
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
     public bool ShowSignups { get; set; }
@@ -734,7 +733,7 @@ public class EventRotaTableViewModel
     public List<ShiftDisplayItem> Shifts { get; set; } = [];
 
     /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
-    public IBurnSettingsInfo EventSettings { get; set; } = null!;
+    public BurnSettingsInfo EventSettings { get; set; } = null!;
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
     public bool ShowSignups { get; set; }
@@ -786,7 +785,7 @@ public class BuildStrikeRotaRowViewModel
     public ShiftDisplayItem Item { get; set; } = null!;
 
     /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
-    public IBurnSettingsInfo Es { get; set; } = null!;
+    public BurnSettingsInfo Es { get; set; } = null!;
     public bool IsSignedUp { get; set; }
     public SignupStatus? SignupStatus { get; set; }
     public bool SignupsBlockedByMissingDietary { get; set; }
@@ -825,7 +824,7 @@ public class EventRotaRowViewModel
     public ShiftDisplayItem Item { get; set; } = null!;
 
     /// <inheritdoc cref="BuildStrikeRotaTableViewModel.EventSettings" />
-    public IBurnSettingsInfo Es { get; set; } = null!;
+    public BurnSettingsInfo Es { get; set; } = null!;
     public bool IsSignedUp { get; set; }
     public SignupStatus? SignupStatus { get; set; }
     public bool SignupsBlockedByMissingDietary { get; set; }

--- a/src/Humans.Web/Views/Shared/_EventRotaRow.cshtml
+++ b/src/Humans.Web/Views/Shared/_EventRotaRow.cshtml
@@ -4,7 +4,7 @@
 @using NodaTime
 
 @functions {
-    string GetPhase(Shift shift, IBurnSettingsInfo es)
+    string GetPhase(Shift shift, BurnSettingsInfo es)
     {
         return shift.GetShiftPeriod(es) switch
         {
@@ -15,7 +15,7 @@
         };
     }
 
-    string GetPhaseBadge(Shift shift, IBurnSettingsInfo es)
+    string GetPhaseBadge(Shift shift, BurnSettingsInfo es)
     {
         return shift.GetShiftPeriod(es) switch
         {

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSummaryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSummaryServiceTests.cs
@@ -31,8 +31,10 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
 
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
 
-    // Scenario ids.
+    // Scenario ids. The entity is what the repository reads; _burn is the
+    // cross-section DTO BuildSummaryAsync now takes (same Id, same calendar).
     private readonly EventSettings _event;
+    private readonly BurnSettingsInfo _burn;
     private readonly Guid _powerId = Guid.NewGuid();
     private readonly Guid _subId = Guid.NewGuid();
     private readonly Guid _waterId = Guid.NewGuid();
@@ -59,6 +61,24 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
             TimeZoneId = "UTC",
             IsActive = true
         };
+
+        _burn = new BurnSettingsInfo(
+            Id: _event.Id,
+            EventName: _event.EventName,
+            Year: 2026,
+            TimeZoneId: _event.TimeZoneId,
+            GateOpeningDate: _event.GateOpeningDate,
+            BuildStartOffset: _event.BuildStartOffset,
+            EventEndOffset: _event.EventEndOffset,
+            StrikeEndOffset: _event.StrikeEndOffset,
+            FirstCrewStartOffset: _event.FirstCrewStartOffset,
+            SetupWeekStartOffset: _event.SetupWeekStartOffset,
+            PreEventWeekStartOffset: _event.PreEventWeekStartOffset,
+            FinishingWeekendStartOffset: _event.FinishingWeekendStartOffset,
+            EarlyEntryCapacity: new Dictionary<int, int>(),
+            BarriosEarlyEntryAllocation: null,
+            EarlyEntryClose: _event.EarlyEntryClose,
+            IsShiftBrowsingOpen: _event.IsShiftBrowsingOpen);
 
         SeedScenario();
 
@@ -121,7 +141,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_Global_FlatTableHasEveryConfirmedHumanWithCamp()
     {
-        var summary = await _service.BuildSummaryAsync(_event, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().NotBeNull();
         summary.Scope.Should().Be(ShiftSummaryScope.Global);
@@ -148,7 +168,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_Global_PivotLeftJoinsRosterWithCamplessBucket()
     {
-        var summary = await _service.BuildSummaryAsync(_event, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, ct: Xunit.TestContext.Current.CancellationToken);
 
         var byCamp = summary!.Camps.ToDictionary(c => c.CampId ?? Guid.Empty);
 
@@ -173,7 +193,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_Global_LinksToEachDepartment()
     {
-        var summary = await _service.BuildSummaryAsync(_event, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, ct: Xunit.TestContext.Current.CancellationToken);
 
         // Non-promoted sub-team "Sub" rolls up into "Power"; departments = Power, Water.
         summary!.TeamLinks.Select(t => t.Slug).Should().BeEquivalentTo(["power", "water"]);
@@ -183,7 +203,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_TeamScope_RestrictsFlatTableToTeamSetButKeepsFullRoster()
     {
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "power", ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "power", ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().NotBeNull();
         summary.Scope.Should().Be(ShiftSummaryScope.Team);
@@ -208,7 +228,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_RotaScope_RestrictsToSingleRota()
     {
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "power", rotaId: _rPower, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "power", rotaId: _rPower, ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().NotBeNull();
         summary.Scope.Should().Be(ShiftSummaryScope.Rota);
@@ -225,7 +245,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     public async Task BuildSummaryAsync_RotaNotInTeamSet_ReturnsNull()
     {
         // rWater belongs to Water, not Power's team-set.
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "power", rotaId: _rWater, ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "power", rotaId: _rWater, ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().BeNull();
     }
@@ -233,7 +253,7 @@ public sealed class ShiftSummaryServiceTests : ServiceTestHarness
     [HumansFact]
     public async Task BuildSummaryAsync_UnknownTeamSlug_ReturnsNull()
     {
-        var summary = await _service.BuildSummaryAsync(_event, teamSlug: "does-not-exist", ct: Xunit.TestContext.Current.CancellationToken);
+        var summary = await _service.BuildSummaryAsync(_burn, teamSlug: "does-not-exist", ct: Xunit.TestContext.Current.CancellationToken);
 
         summary.Should().BeNull();
     }

--- a/tests/Humans.Web.Tests/Controllers/ShiftsControllerSummaryTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ShiftsControllerSummaryTests.cs
@@ -44,20 +44,31 @@ public class ShiftsControllerSummaryTests
     private readonly ShiftBrowsePageBuilder _builder;
     private readonly ILogger<ShiftsController> _logger = NullLogger<ShiftsController>.Instance;
 
-    private static readonly EventSettings ActiveEvent = new()
-    {
-        Id = Guid.NewGuid(),
-        EventName = "Test Event",
-        GateOpeningDate = new LocalDate(2026, 7, 1),
-        TimeZoneId = "UTC",
-        IsActive = true
-    };
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
+
+    private static readonly BurnSettingsInfo ActiveEvent = new(
+        Id: Guid.NewGuid(),
+        EventName: "Test Event",
+        Year: 2026,
+        TimeZoneId: "UTC",
+        GateOpeningDate: new LocalDate(2026, 7, 1),
+        BuildStartOffset: -14,
+        EventEndOffset: 6,
+        StrikeEndOffset: 9,
+        FirstCrewStartOffset: -14,
+        SetupWeekStartOffset: -10,
+        PreEventWeekStartOffset: -7,
+        FinishingWeekendStartOffset: -3,
+        EarlyEntryCapacity: new Dictionary<int, int>(),
+        BarriosEarlyEntryAllocation: null,
+        EarlyEntryClose: null,
+        IsShiftBrowsingOpen: true);
 
     public ShiftsControllerSummaryTests()
     {
         _localizer[Arg.Any<string>()].Returns(ci =>
             new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
-        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, Substitute.For<IBurnSettingsService>(), _teamService);
+        _builder = new ShiftBrowsePageBuilder(_shiftMgmt, _burnSettings, _teamService);
     }
 
     // Authorization is declarative: [Authorize(Policy = ShiftDepartmentManager)] on
@@ -69,7 +80,7 @@ public class ShiftsControllerSummaryTests
     {
         var userId = Guid.NewGuid();
         var ctrl = BuildSut(userId);
-        _shiftMgmt.GetActiveAsync().Returns((EventSettings?)null);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
 
         var result = await ctrl.Summary();
 
@@ -82,7 +93,7 @@ public class ShiftsControllerSummaryTests
     {
         var userId = Guid.NewGuid();
         var ctrl = BuildSut(userId);
-        _shiftMgmt.GetActiveAsync().Returns(ActiveEvent);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ActiveEvent);
         _shiftMgmt.BuildSummaryAsync(ActiveEvent, "ghost", null, Arg.Any<CancellationToken>())
             .Returns((ShiftSummary?)null);
 
@@ -96,7 +107,7 @@ public class ShiftsControllerSummaryTests
     {
         var userId = Guid.NewGuid();
         var ctrl = BuildSut(userId);
-        _shiftMgmt.GetActiveAsync().Returns(ActiveEvent);
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ActiveEvent);
 
         var campX = Guid.NewGuid();
         var campY = Guid.NewGuid();
@@ -137,7 +148,7 @@ public class ShiftsControllerSummaryTests
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(MakeUserInfo(userId));
         var ctrl = new ShiftsController(
-            _shiftMgmt, Substitute.For<IBurnSettingsService>(), _signupService, _volunteerTrackingService, _shiftView, _teamService,
+            _shiftMgmt, _burnSettings, _signupService, _volunteerTrackingService, _shiftView, _teamService,
             _auditLogService, _userService, _localizer, _clock, _builder, _logger);
         var http = new DefaultHttpContext
         {

--- a/tests/Humans.Web.Tests/Controllers/ShiftsControllerUserActiveSignupsTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ShiftsControllerUserActiveSignupsTests.cs
@@ -1,0 +1,244 @@
+using System.Security.Claims;
+using Humans.Application;
+using Humans.Application.DTOs.Shifts;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.UI;
+using Humans.Web.Controllers;
+using Humans.Web.Models;
+using Humans.Web.Models.Shifts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers;
+
+/// <summary>
+/// The browse page's conflict strip (<see cref="ShiftBrowseViewModel.UserActiveSignups"/>)
+/// renders each signup against the burn its own rota belongs to, not the active one.
+/// A user's signup history spans cycles, so a single-burn fixture would pass even if
+/// the controller wrongly resolved every row through <c>GetActiveAsync()</c> — these
+/// tests deliberately straddle two burns in different timezones (issue #809).
+/// </summary>
+public class ShiftsControllerUserActiveSignupsTests
+{
+    private static readonly Guid ActiveBurnId = Guid.NewGuid();
+    private static readonly Guid PastBurnId = Guid.NewGuid();
+
+    // Madrid (UTC+2 in July) vs Auckland (UTC+13 in January). If the wrong burn were
+    // used for a row, both the local time-of-day and the absolute instant would move.
+    private static readonly BurnSettingsInfo ActiveBurn =
+        MakeBurn(ActiveBurnId, "Nowhere 2026", 2026, "Europe/Madrid", new LocalDate(2026, 7, 9));
+
+    private static readonly BurnSettingsInfo PastBurn =
+        MakeBurn(PastBurnId, "Southern 2025", 2025, "Pacific/Auckland", new LocalDate(2025, 1, 15));
+
+    private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
+    private readonly IShiftSignupService _signupService = Substitute.For<IShiftSignupService>();
+    private readonly IVolunteerTrackingService _volunteerTracking = Substitute.For<IVolunteerTrackingService>();
+    private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
+    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IStringLocalizer<SharedResource> _localizer = Substitute.For<IStringLocalizer<SharedResource>>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public ShiftsControllerUserActiveSignupsTests()
+    {
+        _localizer[Arg.Any<string>()].Returns(ci => new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
+        _clock.GetCurrentInstant().Returns(Instant.FromUtc(2026, 6, 1, 0, 0));
+
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ActiveBurn);
+        _burnSettings.GetByIdAsync(ActiveBurnId, Arg.Any<CancellationToken>()).Returns(ActiveBurn);
+        _burnSettings.GetByIdAsync(PastBurnId, Arg.Any<CancellationToken>()).Returns(PastBurn);
+
+        _shiftMgmt.GetCoordinatorTeamIdsAsync(_userId).Returns([]);
+        _shiftMgmt.GetBrowseShiftsAsync(Arg.Any<ShiftBrowseQuery>()).Returns([]);
+        _shiftMgmt.GetTagsAsync().Returns([]);
+        _shiftMgmt.GetDepartmentCoveragePiesAsync(
+            Arg.Any<Guid>(), Arg.Any<LocalDate?>(), Arg.Any<LocalDate?>(), ct: Arg.Any<CancellationToken>())
+            .Returns([]);
+        _shiftMgmt.HasQualifyingCantinaSignupAsync(_userId, Arg.Any<CancellationToken>()).Returns(false);
+        _teamService.GetTeamsAsync().Returns(new Dictionary<Guid, TeamInfo>());
+
+        _shiftView.GetUserAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new ShiftUserView(_userId, null, null, null, [], []));
+    }
+
+    [HumansFact]
+    public async Task Index_SignupsSpanningTwoBurns_ResolvesEachRowAgainstItsOwnBurn()
+    {
+        // Same DayOffset + StartTime in both burns: any difference in the rendered
+        // instants can only come from the burn each row was resolved against.
+        _signupService.GetByUserAsync(_userId).Returns(
+        [
+            MakeSignup(ActiveBurnId, "Gate 2026", dayOffset: 1, new LocalTime(10, 0), SignupStatus.Confirmed),
+            MakeSignup(PastBurnId, "Bar 2025", dayOffset: 1, new LocalTime(10, 0), SignupStatus.Pending),
+        ]);
+
+        var model = await BuildBrowseModelAsync();
+
+        Assert.Equal(2, model.UserActiveSignups.Count);
+
+        var current = model.UserActiveSignups[0];
+        Assert.Equal("Gate 2026", current.RotaName);
+        Assert.Equal(new LocalDate(2026, 7, 10), current.Date);
+        // 2026-07-10 10:00 Europe/Madrid = 08:00Z
+        Assert.Equal(Instant.FromUtc(2026, 7, 10, 8, 0), current.AbsoluteStart);
+
+        var past = model.UserActiveSignups[1];
+        Assert.Equal("Bar 2025", past.RotaName);
+        Assert.Equal(new LocalDate(2025, 1, 16), past.Date);
+        // 2025-01-16 10:00 Pacific/Auckland = 2025-01-15 21:00Z
+        Assert.Equal(Instant.FromUtc(2025, 1, 15, 21, 0), past.AbsoluteStart);
+
+        // Both rows share one burn id each, so the distinct set is resolved once per
+        // burn — never once per row (that would be an N+1).
+        await _burnSettings.Received(1).GetByIdAsync(ActiveBurnId, Arg.Any<CancellationToken>());
+        await _burnSettings.Received(1).GetByIdAsync(PastBurnId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Index_ManyRowsInOneBurn_ResolvesThatBurnOnce()
+    {
+        _signupService.GetByUserAsync(_userId).Returns(
+        [
+            MakeSignup(ActiveBurnId, "A", dayOffset: 0, new LocalTime(9, 0), SignupStatus.Confirmed),
+            MakeSignup(ActiveBurnId, "B", dayOffset: 1, new LocalTime(9, 0), SignupStatus.Confirmed),
+            MakeSignup(ActiveBurnId, "C", dayOffset: 2, new LocalTime(9, 0), SignupStatus.Pending),
+        ]);
+
+        var model = await BuildBrowseModelAsync();
+
+        Assert.Equal(3, model.UserActiveSignups.Count);
+        await _burnSettings.Received(1).GetByIdAsync(ActiveBurnId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Index_InactiveStatusesAndUnresolvableBurns_AreDropped()
+    {
+        var unknownBurnId = Guid.NewGuid();
+        _burnSettings.GetByIdAsync(unknownBurnId, Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
+
+        _signupService.GetByUserAsync(_userId).Returns(
+        [
+            MakeSignup(ActiveBurnId, "Keeper", dayOffset: 0, new LocalTime(9, 0), SignupStatus.Confirmed),
+            MakeSignup(ActiveBurnId, "Bailed", dayOffset: 0, new LocalTime(9, 0), SignupStatus.Bailed),
+            MakeSignup(unknownBurnId, "Orphan", dayOffset: 0, new LocalTime(9, 0), SignupStatus.Confirmed),
+        ]);
+
+        var model = await BuildBrowseModelAsync();
+
+        Assert.Equal("Keeper", Assert.Single(model.UserActiveSignups).RotaName);
+    }
+
+    private async Task<ShiftBrowseViewModel> BuildBrowseModelAsync()
+    {
+        var ctrl = BuildSut();
+        var result = await ctrl.Index(departmentId: null, fromDate: null, toDate: null, period: null);
+        return Assert.IsType<ShiftBrowseViewModel>(Assert.IsType<ViewResult>(result).Model);
+    }
+
+    private ShiftsController BuildSut()
+    {
+        _userService.GetUserInfoAsync(_userId, Arg.Any<CancellationToken>()).Returns(MakeUserInfo(_userId));
+
+        var ctrl = new ShiftsController(
+            _shiftMgmt, _burnSettings, _signupService, _volunteerTracking, _shiftView, _teamService,
+            _auditLog, _userService, _localizer, _clock,
+            new ShiftBrowsePageBuilder(_shiftMgmt, _burnSettings, _teamService),
+            NullLogger<ShiftsController>.Instance);
+
+        var http = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, _userId.ToString())], "test")),
+        };
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        http.RequestServices = services.BuildServiceProvider();
+        ctrl.ControllerContext = new ControllerContext { HttpContext = http };
+        ctrl.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        ctrl.Url = Substitute.For<IUrlHelper>();
+        return ctrl;
+    }
+
+    // Rota carries only EventSettingsId — the EventSettings navigation is deliberately
+    // left unpopulated so a regression back to reading it off the graph fails here.
+    private static ShiftSignup MakeSignup(
+        Guid burnId, string rotaName, int dayOffset, LocalTime start, SignupStatus status) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Status = status,
+            Shift = new Shift
+            {
+                Id = Guid.NewGuid(),
+                DayOffset = dayOffset,
+                StartTime = start,
+                Duration = Duration.FromHours(4),
+                Rota = new Rota { Id = Guid.NewGuid(), EventSettingsId = burnId, Name = rotaName },
+            },
+        };
+
+    private static BurnSettingsInfo MakeBurn(
+        Guid id, string name, int year, string timeZoneId, LocalDate gateOpening) =>
+        new(
+            Id: id,
+            EventName: name,
+            Year: year,
+            TimeZoneId: timeZoneId,
+            GateOpeningDate: gateOpening,
+            BuildStartOffset: -7,
+            EventEndOffset: 4,
+            StrikeEndOffset: 6,
+            FirstCrewStartOffset: -25,
+            SetupWeekStartOffset: -16,
+            PreEventWeekStartOffset: -9,
+            FinishingWeekendStartOffset: -4,
+            EarlyEntryCapacity: new Dictionary<int, int>(),
+            BarriosEarlyEntryAllocation: null,
+            EarlyEntryClose: null,
+            IsShiftBrowsingOpen: true);
+
+    private static UserInfo MakeUserInfo(Guid userId) =>
+        UserInfo.Create(
+            user: new User
+            {
+                Id = userId,
+                DisplayName = "Burner",
+                PreferredLanguage = "en",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            },
+            userEmails: [],
+            eventParticipations: [],
+            externalLogins: [],
+            profile: new Profile
+            {
+                UserId = userId,
+                BurnerName = "Burner",
+                FirstName = "First",
+                LastName = "Last",
+                DietaryPreference = "None",
+                State = ProfileState.Active,
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            },
+            contactFields: [],
+            profileLanguages: [],
+            volunteerHistory: [],
+            communicationPreferences: []);
+}

--- a/tests/Humans.Web.Tests/Shifts/ShiftVolunteerSearchBuilderTests.cs
+++ b/tests/Humans.Web.Tests/Shifts/ShiftVolunteerSearchBuilderTests.cs
@@ -1,0 +1,172 @@
+using Humans.Application;
+using Humans.Application.DTOs;
+using Humans.Application.DTOs.Shifts;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Profiles;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Helpers;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Shifts;
+
+/// <summary>
+/// <see cref="ShiftVolunteerSearchBuilder"/> juggles two burns that are easy to
+/// conflate: the target shift's own burn (drives its absolute times, the pool
+/// lookup and the signup filter) and the currently active burn (decides whether
+/// the active-scoped cached <c>ShiftUserView.Signups</c> can be reused). Admins
+/// search shifts in past/future cycles, so a single-burn fixture would pass even
+/// if the two were collapsed (issue #809).
+/// </summary>
+public class ShiftVolunteerSearchBuilderTests
+{
+    private static readonly Guid ActiveBurnId = Guid.NewGuid();
+    private static readonly Guid PastBurnId = Guid.NewGuid();
+
+    private static readonly BurnSettingsInfo ActiveBurn =
+        MakeBurn(ActiveBurnId, "Europe/Madrid", new LocalDate(2026, 7, 9));
+
+    private static readonly BurnSettingsInfo PastBurn =
+        MakeBurn(PastBurnId, "Europe/Madrid", new LocalDate(2025, 7, 9));
+
+    private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
+    private readonly IUserServiceRead _userService = Substitute.For<IUserServiceRead>();
+    private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
+    private readonly IShiftSignupService _signupService = Substitute.For<IShiftSignupService>();
+    private readonly IVolunteerTrackingService _tracking = Substitute.For<IVolunteerTrackingService>();
+    private readonly Guid _candidateId = Guid.NewGuid();
+
+    public ShiftVolunteerSearchBuilderTests()
+    {
+        _burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ActiveBurn);
+        _burnSettings.GetByIdAsync(ActiveBurnId, Arg.Any<CancellationToken>()).Returns(ActiveBurn);
+        _burnSettings.GetByIdAsync(PastBurnId, Arg.Any<CancellationToken>()).Returns(PastBurn);
+
+        _userService.SearchUsersAsync("ann", Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([new HumanSearchResult(_candidateId, Guid.NewGuid(), "Ann", null, "Name", null, null, 100)]);
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, UserInfo>());
+        _tracking.GetAvailableForDayAsync(Arg.Any<Guid>(), Arg.Any<int>()).Returns([]);
+    }
+
+    private ShiftVolunteerSearchBuilder BuildSut() =>
+        new(_burnSettings, _userService, _shiftView, _signupService, _tracking);
+
+    [HumansFact]
+    public async Task TargetInActiveBurn_ReusesCachedViewAndResolvesTheBurnOnce()
+    {
+        var target = MakeShift(ActiveBurnId, dayOffset: 1, new LocalTime(10, 0), Duration.FromHours(4));
+        // Cached view is active-scoped, so it may be used as-is here.
+        SetCachedSignups(MakeSignup(ActiveBurnId, dayOffset: 1, new LocalTime(12, 0), Duration.FromHours(4)));
+
+        var result = await BuildSut().BuildForShiftAsync(target, "ann", canViewMedical: false);
+
+        var row = Assert.Single(result.Results);
+        Assert.Equal(1, row.BookedShiftCount);
+        Assert.True(row.HasOverlap); // 12:00–16:00 overlaps the 10:00–14:00 target.
+
+        // Active burn already in hand — no extra GetByIdAsync round trip.
+        await _burnSettings.DidNotReceiveWithAnyArgs().GetByIdAsync(default, default);
+        await _signupService.DidNotReceiveWithAnyArgs().GetByUserAsync(default, default);
+        await _tracking.Received(1).GetAvailableForDayAsync(ActiveBurnId, 1);
+    }
+
+    [HumansFact]
+    public async Task TargetInAnotherBurn_UsesThatBurnsCalendarAndRefetchesSignups()
+    {
+        var target = MakeShift(PastBurnId, dayOffset: 1, new LocalTime(10, 0), Duration.FromHours(4));
+
+        // The cached view holds the ACTIVE burn's signups at the same offsets/times.
+        // If the builder reused them (or measured them against the active burn's
+        // calendar) it would report a phantom overlap for a different year.
+        SetCachedSignups(MakeSignup(ActiveBurnId, dayOffset: 1, new LocalTime(10, 0), Duration.FromHours(4)));
+        _signupService.GetByUserAsync(_candidateId, PastBurnId).Returns(
+        [
+            MakeSignup(PastBurnId, dayOffset: 1, new LocalTime(20, 0), Duration.FromHours(2)),
+        ]);
+
+        var result = await BuildSut().BuildForShiftAsync(target, "ann", canViewMedical: false);
+
+        var row = Assert.Single(result.Results);
+        Assert.Equal(1, row.BookedShiftCount);
+        Assert.False(row.HasOverlap); // 20:00–22:00 in the past burn misses 10:00–14:00.
+
+        // Exactly one extra service call for the off-cycle burn — bounded, not per row.
+        await _burnSettings.Received(1).GetByIdAsync(PastBurnId, Arg.Any<CancellationToken>());
+        await _signupService.Received(1).GetByUserAsync(_candidateId, PastBurnId);
+        await _tracking.Received(1).GetAvailableForDayAsync(PastBurnId, 1);
+    }
+
+    [HumansFact]
+    public async Task ShiftFromAnUnresolvableBurn_IsNotFound()
+    {
+        var unknownId = Guid.NewGuid();
+        _burnSettings.GetByIdAsync(unknownId, Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
+
+        var result = await BuildSut().BuildForShiftAsync(
+            MakeShift(unknownId, dayOffset: 0, new LocalTime(9, 0), Duration.FromHours(2)),
+            "ann",
+            canViewMedical: false);
+
+        Assert.Equal(VolunteerSearchBuildStatus.NotFound, result.Status);
+    }
+
+    [HumansFact]
+    public async Task BlankQuery_ShortCircuitsBeforeAnyBurnLookup()
+    {
+        var result = await BuildSut().BuildForShiftAsync(
+            MakeShift(ActiveBurnId, dayOffset: 0, new LocalTime(9, 0), Duration.FromHours(2)),
+            "   ",
+            canViewMedical: false);
+
+        Assert.Equal(VolunteerSearchBuildStatus.EmptyQuery, result.Status);
+        await _burnSettings.DidNotReceiveWithAnyArgs().GetActiveAsync();
+    }
+
+    private void SetCachedSignups(params ShiftSignup[] signups) =>
+        _shiftView.GetUsersAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, ShiftUserView>
+            {
+                [_candidateId] = new(_candidateId, null, null, null, [], signups),
+            });
+
+    private static Shift MakeShift(Guid burnId, int dayOffset, LocalTime start, Duration duration) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            DayOffset = dayOffset,
+            StartTime = start,
+            Duration = duration,
+            Rota = new Rota { Id = Guid.NewGuid(), EventSettingsId = burnId, Name = "Rota" },
+        };
+
+    private static ShiftSignup MakeSignup(Guid burnId, int dayOffset, LocalTime start, Duration duration) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Status = SignupStatus.Confirmed,
+            Shift = MakeShift(burnId, dayOffset, start, duration),
+        };
+
+    private static BurnSettingsInfo MakeBurn(Guid id, string timeZoneId, LocalDate gateOpening) =>
+        new(
+            Id: id,
+            EventName: "Burn",
+            Year: gateOpening.Year,
+            TimeZoneId: timeZoneId,
+            GateOpeningDate: gateOpening,
+            BuildStartOffset: -7,
+            EventEndOffset: 4,
+            StrikeEndOffset: 6,
+            FirstCrewStartOffset: -25,
+            SetupWeekStartOffset: -16,
+            PreEventWeekStartOffset: -9,
+            FinishingWeekendStartOffset: -4,
+            EarlyEntryCapacity: new Dictionary<int, int>(),
+            BarriosEarlyEntryAllocation: null,
+            EarlyEntryClose: null,
+            IsShiftBrowsingOpen: true);
+}


### PR DESCRIPTION
Slice 7 of nobodies-collective/Humans#809 (tracker stays open).

Closes the last two Web-layer sites that held the Shifts EF `EventSettings` entity.

**Stacked**: #1230 (slice 6) → #1229 (slice 5) → #1227 (slice 4). This one merges last.

## Why these two migrate

Both reach the entity through `Shift → Rota → EventSettings`. That is an **intra-section** navigation — all three types are Shifts-owned — and it is entirely legitimate. It is not one of the cross-section navs stripped by #1225, and it is not in #992's FK cut. **No EF navigation property or configuration is touched in this PR.** The change is what the *web layer* holds, not what the model declares: #809 item 7 says a Web-layer type holding `EventSettings` is wrong regardless of how it got there.

## Targets

**1. `ShiftsController.LoadUserActiveSignupsForUiAsync`** — builds the browse page's conflict strip.

The settings here are **per-row, not "the current burn"**: a user's signups span cycles, so each row is still rendered against its *own* rota's burn. The distinct `EventSettingsId`s are collected and resolved once through `IBurnSettingsService`, then joined in memory. A lookup inside the projection would be an N+1 and is not used.

**2. `ShiftVolunteerSearchBuilder`** — the voluntell candidate search.

This one holds **two** burns and they are deliberately **not** collapsed:
- the target shift's own burn — drives its absolute start/end, the availability-pool lookup and the confirmed-signup filter;
- the currently active burn — decides only whether the active-scoped cached `ShiftUserView.Signups` can be reused, or whether per-user signups must be refetched for the target's burn.

Admins search shifts in past/future cycles, so these genuinely differ. Collapsing them would report phantom overlaps against another year's signups.

`ShiftVolunteerSearchBuilder.cs:127` was already an id comparison (`s.Shift?.Rota?.EventSettingsId == eventSettings.Id`) and now works off `BurnSettingsInfo.Id` unchanged.

## Query-count impact

`IBurnSettingsService` has **no cached and no get-all read** — `BurnSettingsService` is explicitly uncached ("single active row, cold path — see #719") and both its methods go straight to `IShiftManagementRepository`. Adding a get-all would be new interface surface, which this slice is not permitted to introduce, so the bounded distinct-id loop is the correct available form.

| Path | Before | After | Delta |
|---|---|---|---|
| `LoadUserActiveSignupsForUiAsync` | 1 (`GetByUserAsync`) | 1 + **D** | +D |
| `ShiftVolunteerSearchBuilder`, target in the active burn | 1 (`IShiftManagementService.GetActiveAsync`) | 1 (`IBurnSettingsService.GetActiveAsync`) | **0** |
| `ShiftVolunteerSearchBuilder`, target in another burn | 1 | 2 | **+1** |

**D** = the number of *distinct burns* the user has Pending/Confirmed signups in — **1** in steady state, **2** across a cycle transition. It is bounded by the number of event cycles a single human has live signups in, not by row count: three signups in one burn cost one lookup, asserted by a test.

The search builder's active-burn case is a genuine wash: `IShiftManagementService.GetActiveAsync()` and `IBurnSettingsService.GetActiveAsync()` both resolve to the same single uncached `ShiftRepository.GetActiveEventSettingsAsync()`. The `+1` only fires when the target shift belongs to a non-active burn — exactly the case the code already treats specially by refetching per-user signups.

## Behaviour

Same rows, same ordering, same overlap/conflict results. Two edge cases are now explicit rather than accidental:
- an unresolvable burn drops the conflict row (was: dropped when the nav wasn't on the graph) — impossible in production, `Rota.EventSettingsId` is a non-nullable FK and the read path Includes the nav;
- a shift whose burn can't be resolved returns `NotFound` from the search builder instead of NREing, which both call sites already map to a 404.

## Tests

7 new tests. Both suites deliberately straddle **two burns** — a single-burn fixture would pass even if the active burn were wrongly used for every row.

- `ShiftsControllerUserActiveSignupsTests` — signups in a Madrid 2026 burn and an Auckland 2025 burn at the same day offset and wall time; asserts each row's absolute instant comes from its own burn, that one burn with three rows is resolved once, and that inactive statuses and unresolvable burns are dropped.
- `ShiftVolunteerSearchBuilderTests` — off-cycle target must not reuse the active-scoped cached signups (the fixture plants an active-burn signup that would produce a phantom overlap if it did), plus the resolve-once / no-extra-call assertions.

Both fixtures build `Rota` with only `EventSettingsId` set and leave the `EventSettings` navigation unpopulated, so a regression back to reading it off the graph fails here.

## Verification

- Build: **90 warnings, 0 errors** — baseline held.
- `HUM0015` / `HUM0016` / `HUM0025`: **0 → 0**.
- Tests: **5173 pass** (5166 baseline + 7 new), 0 failures.
- `dotnet ef migrations has-pending-model-changes --context HumansDbContext`: *"No changes have been made to the model since the last migration."* — **no EF migration**; the diff touches `Humans.Web` and tests only.
- No `[Grandfathered]`, no new public/interface surface, no new DI registration. `ShiftVolunteerSearchBuilder` drops one constructor dependency (`IShiftManagementService`) and gains `IBurnSettingsService`.

## What still holds the entity in #809's scope

Only the sites the spec keeps or defers:

- **Write path** — `ShiftsController.Settings` / `MapEventSettingsToViewModel`, `EventSettingsFormMapper`, `ShiftManagementService` mutations (spec "out of scope").
- **Shifts-internal read paths** — spec item 6, lowest priority.
- `ShiftDashboardPageBuilder` + `ShiftDashboardViewModel` — the one remaining Web-layer holder, owned by the parallel ShiftDashboard slice.
- `DevelopmentDashboardSeeder` — seeds the entity directly; excluded.
- The owning layer itself — `EventSettings`, its configuration, the DbSet, migrations, `ShiftRepository`, `BurnSettingsService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
