### PR TITLE
build(docker): drop the per-project csproj copy list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,15 @@
 tests/e2e/
+
+# Host build artifacts and VCS/agent metadata — never needed in the image and
+# would bloat the build context now that COPY src/ src/ pulls the whole tree.
+bin/
+obj/
+.vs/
+.git/
+.github/
+.claude/
+.worktrees/
+.codex/
+.superpowers/
+TestResults/
+local/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,12 @@ tests/e2e/
 
 # Host build artifacts and VCS/agent metadata — never needed in the image and
 # would bloat the build context now that COPY src/ src/ pulls the whole tree.
-bin/
-obj/
+# bin/, obj/ and TestResults/ live nested under every project (src/*/bin, not
+# just a top-level bin/), so they need the ** prefix to match recursively —
+# a bare "bin/" only matches a top-level directory named bin.
+**/bin/
+**/obj/
+**/TestResults/
 .vs/
 .git/
 .github/
@@ -11,5 +15,4 @@ obj/
 .worktrees/
 .codex/
 .superpowers/
-TestResults/
 local/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,15 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-# Copy project files for restore
+# Copy the whole source tree, then restore. This trades the restore layer's cache
+# granularity (any source edit now re-runs restore) for a Dockerfile that never
+# needs a per-project COPY line — the project count is heading from 9 to ~40 as
+# G5 (nobodies-collective/Humans#866) peels sections into their own projects.
 COPY .editorconfig Directory.Build.props Directory.Packages.props ./
-COPY src/Humans.Domain/Humans.Domain.csproj src/Humans.Domain/
-COPY src/Humans.Application/Humans.Application.csproj src/Humans.Application/
-COPY src/Humans.Infrastructure/Humans.Infrastructure.csproj src/Humans.Infrastructure/
-COPY src/Humans.UI/Humans.UI.csproj src/Humans.UI/
-COPY src/Humans.Web/Humans.Web.csproj src/Humans.Web/
+COPY src/ src/
 
 # Restore packages
 RUN dotnet restore src/Humans.Web/Humans.Web.csproj
-
-# Copy source code
-COPY src/ src/
 
 # Coolify passes SOURCE_COMMIT and MINVER_VERSION as build args; deploy-qa.sh sets them from the host repo
 ARG SOURCE_COMMIT=""


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1006

## Summary
- The Dockerfile hand-enumerated every project's `.csproj` before `dotnet restore`, and the list was already stale (missing Store and Interfaces).
- Replaced the per-project `COPY` lines with a single `COPY src/ src/` before restore, so adding a project under `src/Sections/` needs no Dockerfile change. This trades restore-layer cache granularity (any source edit now re-runs restore) for a file that never needs touching again — reasonable at this deploy cadence.
- Tightened `.dockerignore` to exclude host/VCS artifacts (`bin/`, `obj/`, `.git/`, `.worktrees/`, `.claude/`, etc.) now that the build context pulls the whole `src/` tree.
- **Follow-up fix:** the first pass used bare `bin/`, `obj/`, `TestResults/` patterns. Docker matches `.dockerignore` entries with `filepath.Match` extended by `**`, so a bare `bin/` only matches a top-level `bin/` — not `src/Humans.Application/bin/`, which is where these artifacts actually live. Switched to `**/bin/`, `**/obj/`, `**/TestResults/` so they match at every depth; the genuinely top-level entries (`.git/`, `.github/`, `.claude/`, `.worktrees/`, `.codex/`, `.superpowers/`, `.vs/`, `local/`) stayed bare since they're correct as-is.

## Test plan
- [x] `docker build --no-cache .` from a clean context, through publish — ran multiple times, all succeeded. `dotnet restore` resolved all 16 csproj files (every `src/Sections/*` project plus `Humans.Interfaces`, `Humans.Analyzers`, etc.) with zero "not found" skips.
- [x] Confirmed the recursive-pattern fix actually bites, measured as **the bytes that actually reach the image** (`COPY . /ctx` + `RUN du -sh /ctx` on a throwaway builder), against a tree with `src/*/bin` and `src/*/obj` populated: bare patterns deliver a **2.1 GB** context, `**/` patterns deliver **60.3 MB**. ~35x, ~2 GB less per build.

  **Correction:** an earlier revision of this section claimed 580.77 MB → 222.62 kB, read off BuildKit's `transferring context:` progress line. That line is not the context size — it reports incremental/metadata transfer and collapses to a few hundred kB once the builder already has the files, so the two figures were taken under different cache states and were never comparable. On this repo it reports 532 B and 312 kB for a context that actually delivers 60.3 MB. The real reduction is the 2.1 GB → 60.3 MB above.
- [ ] QA deploy on merge (Coolify auto-deploys `origin/main`)

