### PR TITLE
fix(flaky): SearchAsync_TextQuery_ExcludesNonPublicSeasonStatuses

### DIFF
--- a/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingCampServiceTests.cs
@@ -368,7 +368,13 @@ public sealed class CachingCampServiceTests : ServiceTestHarness
             Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
-    [HumansTheory]
+    // Timeout raised from the 5s HumansTheory default: this is the third of three
+    // sequential inline cases, each paying full ServiceTestHarness + EF InMemory
+    // setup, and flaked under CI load with "Test execution timed out after 5000
+    // milliseconds" on the Withdrawn case (never Pending/Rejected) — 4 times in
+    // one week, twice confirmed passing on retry against the identical commit.
+    // 10s matches the codebase's standard bump for CI-load-sensitive tests.
+    [HumansTheory(Timeout = 10000)]
     [InlineData(CampSeasonStatus.Pending)]
     [InlineData(CampSeasonStatus.Rejected)]
     [InlineData(CampSeasonStatus.Withdrawn)]


### PR DESCRIPTION
## What

Fixes flaky test `CachingCampServiceTests.SearchAsync_TextQuery_ExcludesNonPublicSeasonStatuses(status: Withdrawn)` by raising its timeout from the 5s `HumansTheory` default to 10s.

## Why — root-cause analysis

This is a weekly-flaky-test sweep (scheduled routine, scanning `Build and Test` CI runs on `peterdrier/Humans` over the past 7 days). Scanned 346 workflow runs across all branches; the test above was the single flakiest test found.

**Evidence — 4 failures this week, identical signature every time:**

| Run | Branch | Commit | Result |
|---|---|---|---|
| [31314827012](https://github.com/peterdrier/Humans/actions/runs/31314827012) | `track-b-2` | `c579ce7f` | Failed, no retry in window |
| [31339884044](https://github.com/peterdrier/Humans/actions/runs/31339884044) | `no-db-check-constraints` | `42bced1f` | Failed, no retry in window |
| [31340952334](https://github.com/peterdrier/Humans/actions/runs/31340952334) attempt 1 | `track-b-3` | `00fa9be0` | **Failed** |
| [31340952334](https://github.com/peterdrier/Humans/actions/runs/31340952334) attempt 2 | `track-b-3` | `00fa9be0` (same commit) | **Passed** |
| [31404725711](https://github.com/peterdrier/Humans/actions/runs/31404725711) attempt 1 | `sprint/2026-08-10/issue-1013` | `c4ea4fc1` | **Failed** |
| [31404725711](https://github.com/peterdrier/Humans/actions/runs/31404725711) attempt 2 | `sprint/2026-08-10/issue-1013` | `c4ea4fc1` (same commit) | **Passed** |

Every failure carries the exact same error: `Test execution timed out after 5000 milliseconds`, always on the third (`Withdrawn`) inline case — never `Pending` or `Rejected`, the two cases that run before it. None of the four PRs touched camps/search code, ruling out a real logic regression.

**Root cause:** `[HumansTheory]` defaults to a 5000ms timeout outside `Humans.Integration.Tests` (`tests/Humans.Testing/HumansTheoryAttribute.cs:45-48`). This theory's third case pays full `ServiceTestHarness` + EF Core InMemory provider setup after two prior cases already ran in the same test run, and under CI load (concurrent test assemblies contending for the thread pool) that setup occasionally pushes past the 5s ceiling — the cleanup-failure stack trace shows the `CancellationToken` firing mid-`SingleAsync` inside `SeedSettingsAsync`, i.e. the timeout firing during ordinary EF InMemory query scheduling, not a hang in application logic.

**Fix:** `[HumansTheory(Timeout = 10000)]` on this test only. 10s is not an arbitrary number — it's the codebase's existing convention for CI-load-sensitive tests (`grep -rn "HumansFact(Timeout = 10000)\|HumansTheory(Timeout = 10000)"` turns up ~20 other tests already using it). The `build.yml` `code-quality` job's `Forbid RS0030 suppressions in test code` step explicitly names this as the sanctioned fix: *"set a higher Timeout on \[HumansFact\] instead"* of suppressing the bare-attribute analyzer.

## Existing surface checked

No new surface — single-attribute change on an existing test, following an established repo-wide convention (no new helper, no new attribute, no new test).

## Verification

⚠️ Could not run `dotnet test` locally — this sandbox has no .NET SDK installed. The change is a single-parameter timeout bump (no logic touched), matching an existing pattern used ~20 other places in the same test project, so I'm relying on CI to confirm. Flagging this explicitly per the "don't claim success you can't verify" rule — please treat CI green as the actual verification here.

## Checklist

- [x] Section labeled — Camps
- [x] Targeting `main` on `peterdrier/Humans`
- [x] Branched off `origin/main`
- ~~Issue refs are qualified~~ — no linked issue, this is a routine-generated fix
- ~~EF migrations~~ — none
- ~~NuGet packages updated~~ — none
- ~~New project rule~~ — none
- [x] Reuse-first checked — no new surface, reused existing `[HumansTheory(Timeout = N)]` convention
- [ ] Build + test pass locally — **could not run, see Verification above**
- ~~Nav coverage~~ — no UI change
- ~~No magic strings~~ — n/a
- ~~Dates/times via NodaTime~~ — n/a

## Reviewer notes

Two of the four failures happened on the same commit with a clean pass on the immediate retry (zero code changes between attempts), which is about as strong a same-code pass+fail signal as CI evidence gets. The other two failures (different commits, unrelated diffs, identical error message) support the same conclusion without needing a retry to prove it.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Gneh6Ex5ey4jiTkvz9Hm4)_