### PR TITLE
docs: sweep the G5 sections' in-project docs

### DIFF
--- a/docs/architecture/freshness-catalog.yml
+++ b/docs/architecture/freshness-catalog.yml
@@ -213,6 +213,9 @@ editorial_trees:
   - docs/sections/
   - docs/features/
   - docs/guide/
+  # Sections that moved into their own project (nobodies-collective/Humans#866, G5)
+  # carry their invariants + feature docs in-project rather than in docs/sections/.
+  - src/Sections/
   - docs/architecture/coding-rules.md
   - docs/architecture/design-rules.md
   - docs/architecture/roslyn-analysis.md
@@ -234,3 +237,7 @@ ignore:
   - docs/guide/README.md
   - docs/guide/GettingStarted.md
   - docs/guide/Glossary.md
+  # G5 in-project docs: sweep the living invariants/feature docs, not the dated
+  # design records (historical, same genre as docs/superpowers/specs/).
+  - src/Sections/*/Docs/20*.md
+  - src/Sections/*/Contracts/README.md

--- a/src/Sections/Humans.Events/Docs/Events-feature.md
+++ b/src/Sections/Humans.Events/Docs/Events-feature.md
@@ -1,5 +1,6 @@
 <!-- freshness:triggers
   src/Sections/Humans.Events/**
+  src/Sections/Humans.Events.Contracts/**
 -->
 <!-- freshness:flag-on-change
   Submission/moderation workflow, GuideEvent state machine, bulk CSV upload rules, public /api/events surface, and email triggers. Review when Event Guide controllers, service, or entities change.

--- a/src/Sections/Humans.Events/Docs/Events-feature.md
+++ b/src/Sections/Humans.Events/Docs/Events-feature.md
@@ -1,19 +1,5 @@
 <!-- freshness:triggers
-  src/Humans.Web/Controllers/EventsController.cs
-  src/Humans.Web/Controllers/EventsAdminController.cs
-  src/Humans.Web/Controllers/EventsModerationController.cs
-  src/Humans.Web/Controllers/EventsExportController.cs
-  src/Humans.Web/Views/Events/**
-  src/Humans.Web/Views/EventsAdmin/**
-  src/Humans.Web/Views/EventsModeration/**
-  src/Humans.Web/Views/EventsExport/**
-  src/Humans.Application/Services/Events/EventService.cs
-  src/Humans.Application/Interfaces/Events/**
-  src/Humans.Domain/Entities/Event.cs
-  src/Humans.Domain/Entities/EventCategory.cs
-  src/Humans.Domain/Entities/EventVenue.cs
-  src/Humans.Domain/Entities/EventGuideSettings.cs
-  src/Humans.Domain/Entities/EventModerationAction.cs
+  src/Sections/Humans.Events/**
 -->
 <!-- freshness:flag-on-change
   Submission/moderation workflow, GuideEvent state machine, bulk CSV upload rules, public /api/events surface, and email triggers. Review when Event Guide controllers, service, or entities change.

--- a/src/Sections/Humans.Events/Docs/Events.md
+++ b/src/Sections/Humans.Events/Docs/Events.md
@@ -1,5 +1,6 @@
 <!-- freshness:triggers
   src/Sections/Humans.Events/**
+  src/Sections/Humans.Events.Contracts/**
 -->
 <!-- freshness:flag-on-change
   Event submission/moderation lifecycle, guide settings window, public API surface, favourites/preferences, and the IEventServiceRead cross-section read surface — review when Events services/entities/controllers/view component change.


### PR DESCRIPTION
## Summary

The six sections moved into their own projects (nobodies-collective/Humans#866, G5) carry their invariants and feature docs at `src/Sections/Humans.<X>/Docs/`. The freshness catalog's `editorial_trees` only listed `docs/sections/`, `docs/features/` and `docs/guide/`, so those seven docs sat **outside `/freshness-sweep` entirely** — even though they already carry `freshness:triggers` + `flag-on-change` markers. Found while running the 2026-08-10 sweep (#1256).

- Add `src/Sections/` to `editorial_trees`.
- Ignore the dated in-project design records (`src/Sections/*/Docs/20*.md`) and `src/Sections/*/Contracts/README.md` — historical/meta, same genre as `docs/superpowers/specs/`.
- Repoint `Events-feature.md`'s triggers at `src/Sections/Humans.Events/**`. All 15 of its globs still named pre-G5 paths (`src/Humans.Web/Controllers/EventsController.cs`, `src/Humans.Domain/Entities/Event.cs`, …), so it would not have fired even once the tree was added.

Verified selection under the sweep's Phase 3 walk semantics:

**Now swept (7):** `Containers.md`, `Events.md`, `Events-feature.md`, `Expenses.md`, `Finance.md`, `Store.md`, `Store-feature.md`
**Excluded by `ignore` (7):** the five dated design records, `Store/Contracts/README.md`

Editorial doc count 131 → 138. `docs/scripts/freshness-checks/diff-mode.sh` passes 6/6.

## Follow-up (not in this PR)

`diff-mode.sh` won't validate this change — its editorial walk is hardcoded to the three `docs/` trees rather than read from the catalog, and its `N_TREES` counter reports `0` (a pre-existing awk range bug, same on `origin/main`). Both noted on nobodies-collective/Humans#1021, which already covers extending that script to editorial docs.

## Test plan
- [ ] Confirm the seven in-project docs are the right set to sweep, and the dated design records the right set to skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)