### PR TITLE
Holded: split the chart of accounts by group, drop the duplicate department table

### DIFF
--- a/src/Sections/Humans.Holded/Docs/Holded.md
+++ b/src/Sections/Humans.Holded/Docs/Holded.md
@@ -35,8 +35,9 @@ mirror tables runs before this baseline recreates them.
 
 - `/Holded` — admin screen: usage meter (API's number displayed; budget = config
   `Holded:MonthlyCallBudget`, default 2000), calls-by-month, per-kind sync states plus
-  Finance's doc-sync row, Sync now / Full sync buttons, 629 department actuals, full account
-  list with reconciliation flags.
+  Finance's doc-sync row, Sync now / Full sync buttons, and the chart of accounts with
+  reconciliation flags — split by PGC group (named in English from the account number's leading
+  digit, not Holded's Spanish `group` string), accounts with no cached lines hidden by default.
 - `/Holded/Accounts/{number}` — the general-ledger page for ANY account (departments, banks,
   creditors), native Holded sign, header + all cached journal lines.
 

--- a/src/Sections/Humans.Holded/Models/HoldedAdminModels.cs
+++ b/src/Sections/Humans.Holded/Models/HoldedAdminModels.cs
@@ -38,9 +38,13 @@ internal sealed record HoldedSyncStateRow(
 /// corriente"). The number is the authority: it is what the group means.</param>
 /// <param name="LocalBalance">Null when the mirror holds no line for the account — distinct
 /// from a cached zero, which reconciles a zero Holded balance.</param>
+/// <param name="HoldedHasPostings">Holded's own debit or credit total is non-zero. Not derivable
+/// from <paramref name="HoldedBalance"/>: an account with equal debits and credits — a clearing
+/// account, a bank drained to nothing — nets to zero while having been posted to all year.</param>
 internal sealed record HoldedAccountRow(
     int Number, string Name, string? Group,
-    decimal HoldedBalance, decimal? LocalBalance, int LocalLineCount, bool Reconciled);
+    decimal HoldedBalance, decimal? LocalBalance, int LocalLineCount, bool Reconciled,
+    bool HoldedHasPostings);
 
 /// <summary>
 /// One general-ledger account and every cached line on it, in Holded's own sign convention

--- a/src/Sections/Humans.Holded/Models/HoldedAdminModels.cs
+++ b/src/Sections/Humans.Holded/Models/HoldedAdminModels.cs
@@ -23,7 +23,6 @@ internal sealed record HoldedAdminOverview(
     IReadOnlyList<HoldedMonthlyCalls> CallsByMonth,
     IReadOnlyList<HoldedSyncStateRow> SyncStates,
     IReadOnlyList<HoldedAccountRow> Accounts,
-    IReadOnlyList<HoldedAccountRow> DepartmentActuals,
     int LedgerLineCount);
 
 /// <summary>Metered API calls for one Madrid-zone month.</summary>
@@ -34,6 +33,9 @@ internal sealed record HoldedSyncStateRow(
     string Kind, string Status, Instant? LastSyncAt, string? LastError, int LastCount);
 
 /// <summary>One chart account on the /Holded reconciliation table.</summary>
+/// <param name="Group">The PGC group's English name, derived from the account number's leading
+/// digit — not Holded's own <c>group</c> string, which is Spanish ("Existencias", "Activo no
+/// corriente"). The number is the authority: it is what the group means.</param>
 /// <param name="LocalBalance">Null when the mirror holds no line for the account — distinct
 /// from a cached zero, which reconciles a zero Holded balance.</param>
 internal sealed record HoldedAccountRow(

--- a/src/Sections/Humans.Holded/Services/Service.cs
+++ b/src/Sections/Humans.Holded/Services/Service.cs
@@ -192,7 +192,8 @@ internal sealed class Service(
                 decimal? localBalance = hasLines ? cached.Balance : null;
                 return new HoldedAccountRow(
                     a.Number, a.Name, GroupName(a.Number), a.Balance, localBalance,
-                    hasLines ? cached.Count : 0, a.Balance == (localBalance ?? 0m));
+                    hasLines ? cached.Count : 0, a.Balance == (localBalance ?? 0m),
+                    a.Debit != 0m || a.Credit != 0m);
             })
             .ToList();
 
@@ -222,7 +223,8 @@ internal sealed class Service(
         return new HoldedAccountStatement(
             new HoldedAccountRow(
                 number, account?.Name ?? "", GroupName(number), holdedBalance,
-                localBalance, lines.Count, holdedBalance == (localBalance ?? 0m)),
+                localBalance, lines.Count, holdedBalance == (localBalance ?? 0m),
+                account is { } a && (a.Debit != 0m || a.Credit != 0m)),
             lines
                 .OrderBy(l => l.Date)
                 .ThenBy(l => l.EntryNumber)

--- a/src/Sections/Humans.Holded/Services/Service.cs
+++ b/src/Sections/Humans.Holded/Services/Service.cs
@@ -191,7 +191,7 @@ internal sealed class Service(
                 var hasLines = local.TryGetValue(a.Number, out var cached);
                 decimal? localBalance = hasLines ? cached.Balance : null;
                 return new HoldedAccountRow(
-                    a.Number, a.Name, a.Group, a.Balance, localBalance,
+                    a.Number, a.Name, GroupName(a.Number), a.Balance, localBalance,
                     hasLines ? cached.Count : 0, a.Balance == (localBalance ?? 0m));
             })
             .ToList();
@@ -203,10 +203,6 @@ internal sealed class Service(
             CallsByMonth: callsByMonth,
             SyncStates: syncStates,
             Accounts: accounts,
-            DepartmentActuals: accounts
-                .Where(a => a.Number is >= 62900000 and <= 62999999)
-                .OrderByDescending(a => a.HoldedBalance)
-                .ToList(),
             LedgerLineCount: lines.Count);
     }
 
@@ -225,7 +221,7 @@ internal sealed class Service(
 
         return new HoldedAccountStatement(
             new HoldedAccountRow(
-                number, account?.Name ?? "", account?.Group, holdedBalance,
+                number, account?.Name ?? "", GroupName(number), holdedBalance,
                 localBalance, lines.Count, holdedBalance == (localBalance ?? 0m)),
             lines
                 .OrderBy(l => l.Date)
@@ -327,6 +323,32 @@ internal sealed class Service(
     /// would fail the save and report a completed refresh as an error.</summary>
     private static string TruncateForState(string message) =>
         message.Length <= 2000 ? message : message[..1997] + "…";
+
+    /// <summary>
+    /// The Spanish PGC group an account belongs to, in English. Read from the account number's
+    /// leading digit rather than Holded's own <c>group</c> field, which returns Spanish
+    /// ("Financiación básica", "Acreedores y deudores operaciones de la actividad") and is
+    /// free text we would be translating by string match. The digit is the definition.
+    /// </summary>
+    private static string GroupName(int number)
+    {
+        var leading = Math.Abs(number);
+        while (leading >= 10) leading /= 10;
+
+        return leading switch
+        {
+            1 => "Equity and long-term financing",
+            2 => "Non-current assets",
+            3 => "Inventory",
+            4 => "Receivables and payables",
+            5 => "Financial accounts",
+            6 => "Purchases and expenses",
+            7 => "Sales and income",
+            8 => "Expenses charged to equity",
+            9 => "Income charged to equity",
+            _ => "Unclassified",
+        };
+    }
 
     private static Instant ToWindowStart(LocalDate from) =>
         from.AtStartOfDayInZone(MadridZone).ToInstant();

--- a/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
@@ -184,7 +184,8 @@
             <div class="form-check form-switch mb-0">
                 <input class="form-check-input" type="checkbox" role="switch"
                        id="hide-empty-accounts" checked>
-                <label class="form-check-label small" for="hide-empty-accounts">
+                <label class="form-check-label small" for="hide-empty-accounts"
+                       title="An account with no lines but a Holded balance is a hole in the mirror, not an unused account — those stay visible.">
                     Hide accounts with no lines
                 </label>
             </div>
@@ -215,7 +216,8 @@
                         </tr>
                         @foreach (var a in group)
                         {
-                            <tr class="js-account-row" data-lines="@a.LocalLineCount">
+                            <tr class="js-account-row" data-lines="@a.LocalLineCount"
+                                data-reconciled="@(a.Reconciled ? "1" : "0")">
                                 <td class="text-nowrap"><a asp-action="Account" asp-route-number="@a.Number"><code>@a.Number</code></a></td>
                                 <td>@a.Name</td>
                                 <td class="text-end">@a.HoldedBalance.ToEuro()</td>
@@ -241,7 +243,8 @@
             Archived accounts are hidden. Groups are the Spanish chart's own, named from the
             account number's leading digit. <strong>Local</strong> is Σdebit − Σcredit over the
             cached lines; a ✗ means the nightly reconciliation still sees drift after its targeted
-            re-pull. Total cached lines: @o.LedgerLineCount.ToString("N0", CultureInfo.InvariantCulture).
+            re-pull, and a ✗ account stays listed even with no lines. Total cached lines:
+            @o.LedgerLineCount.ToString("N0", CultureInfo.InvariantCulture).
         </div>
     }
 </div>
@@ -249,6 +252,11 @@
 <script>
     // Most of the 267-account chart has never carried a line; hiding those is the default view.
     // A group whose every account is hidden goes with them, header and all.
+    //
+    // "No lines" alone is not the test: an account Holded gives a balance for but the mirror has
+    // no line for reconciles ✗ with zero lines, and that is a missing-ledger-data alarm. Hiding it
+    // by default would hide the one thing this table exists to surface, so only a zero-line account
+    // that also reconciles counts as unused.
     (function () {
         var toggle = document.getElementById('hide-empty-accounts');
         var count = document.getElementById('account-count');
@@ -260,8 +268,8 @@
             document.querySelectorAll('.js-account-group').forEach(function (group) {
                 var shown = 0;
                 group.querySelectorAll('.js-account-row').forEach(function (row) {
-                    var empty = row.dataset.lines === '0';
-                    row.hidden = hide && empty;
+                    var unused = row.dataset.lines === '0' && row.dataset.reconciled === '1';
+                    row.hidden = hide && unused;
                     if (!row.hidden) shown++;
                 });
                 group.hidden = shown === 0;

--- a/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
@@ -185,7 +185,7 @@
                 <input class="form-check-input" type="checkbox" role="switch"
                        id="hide-empty-accounts" checked>
                 <label class="form-check-label small" for="hide-empty-accounts"
-                       title="An account with no lines but a Holded balance is a hole in the mirror, not an unused account — those stay visible.">
+                       title="Only accounts Holded has never posted to either. Anything Holded shows activity for stays visible, balance or no balance.">
                     Hide accounts with no lines
                 </label>
             </div>
@@ -217,7 +217,8 @@
                         @foreach (var a in group)
                         {
                             <tr class="js-account-row" data-lines="@a.LocalLineCount"
-                                data-reconciled="@(a.Reconciled ? "1" : "0")">
+                                data-reconciled="@(a.Reconciled ? "1" : "0")"
+                                data-holded-postings="@(a.HoldedHasPostings ? "1" : "0")">
                                 <td class="text-nowrap"><a asp-action="Account" asp-route-number="@a.Number"><code>@a.Number</code></a></td>
                                 <td>@a.Name</td>
                                 <td class="text-end">@a.HoldedBalance.ToEuro()</td>
@@ -243,7 +244,8 @@
             Archived accounts are hidden. Groups are the Spanish chart's own, named from the
             account number's leading digit. <strong>Local</strong> is Σdebit − Σcredit over the
             cached lines; a ✗ means the nightly reconciliation still sees drift after its targeted
-            re-pull, and a ✗ account stays listed even with no lines. Total cached lines:
+            re-pull. An account Holded has posted to stays listed even when the mirror has no line
+            for it — that gap is the point. Total cached lines:
             @o.LedgerLineCount.ToString("N0", CultureInfo.InvariantCulture).
         </div>
     }
@@ -253,10 +255,11 @@
     // Most of the 267-account chart has never carried a line; hiding those is the default view.
     // A group whose every account is hidden goes with them, header and all.
     //
-    // "No lines" alone is not the test: an account Holded gives a balance for but the mirror has
-    // no line for reconciles ✗ with zero lines, and that is a missing-ledger-data alarm. Hiding it
-    // by default would hide the one thing this table exists to surface, so only a zero-line account
-    // that also reconciles counts as unused.
+    // "No lines" alone is not the test — twice over. An account Holded gives a balance for but the
+    // mirror has no line for reconciles ✗ with zero lines. And an account whose debits and credits
+    // cancel nets to zero, so it reconciles ✓ against an empty mirror while Holded shows a year of
+    // postings. Both are missing-ledger-data alarms, which is the one thing this table exists to
+    // raise. Unused means all three: nothing locally, nothing at Holded, and no disagreement.
     (function () {
         var toggle = document.getElementById('hide-empty-accounts');
         var count = document.getElementById('account-count');
@@ -268,7 +271,9 @@
             document.querySelectorAll('.js-account-group').forEach(function (group) {
                 var shown = 0;
                 group.querySelectorAll('.js-account-row').forEach(function (row) {
-                    var unused = row.dataset.lines === '0' && row.dataset.reconciled === '1';
+                    var unused = row.dataset.lines === '0'
+                        && row.dataset.holdedPostings === '0'
+                        && row.dataset.reconciled === '1';
                     row.hidden = hide && unused;
                     if (!row.hidden) shown++;
                 });

--- a/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
@@ -177,52 +177,19 @@
     }
 </div>
 
-<div class="card mb-4">
-    <div class="card-header d-flex justify-content-between align-items-center">
-        <span><i class="fa-solid fa-chart-simple me-1"></i>Department actuals</span>
-        <span class="badge bg-secondary">629xxxxx</span>
-    </div>
-    @if (o.DepartmentActuals.Count == 0)
-    {
-        <div class="card-body"><p class="mb-0 text-muted">No department accounts cached — run a sync.</p></div>
-    }
-    else
-    {
-        <div class="table-responsive">
-            <table class="table table-sm align-middle mb-0">
-                <thead>
-                    <tr><th>Account</th><th>Name</th><th class="text-end">Spent</th><th class="text-end">Lines</th><th class="text-center">OK</th></tr>
-                </thead>
-                <tbody>
-                    @foreach (var a in o.DepartmentActuals)
-                    {
-                        <tr>
-                            <td class="text-nowrap"><a asp-action="Account" asp-route-number="@a.Number"><code>@a.Number</code></a></td>
-                            <td>@a.Name</td>
-                            <td class="text-end">@a.HoldedBalance.ToEuro()</td>
-                            <td class="text-end">@a.LocalLineCount</td>
-                            <td class="text-center">
-                                @if (a.Reconciled)
-                                {
-                                    <i class="fa-solid fa-check text-success" title="Local ledger sum matches Holded"></i>
-                                }
-                                else
-                                {
-                                    <i class="fa-solid fa-xmark text-danger" title="Local @a.LocalBalance.ToEuro() vs Holded @a.HoldedBalance.ToEuro()"></i>
-                                }
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        </div>
-    }
-</div>
-
 <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
         <span><i class="fa-solid fa-list me-1"></i>Chart of accounts</span>
-        <span class="badge bg-secondary">@o.Accounts.Count accounts</span>
+        <div class="d-flex align-items-center gap-3">
+            <div class="form-check form-switch mb-0">
+                <input class="form-check-input" type="checkbox" role="switch"
+                       id="hide-empty-accounts" checked>
+                <label class="form-check-label small" for="hide-empty-accounts">
+                    Hide accounts with no lines
+                </label>
+            </div>
+            <span class="badge bg-secondary" id="account-count">@o.Accounts.Count accounts</span>
+        </div>
     </div>
     @if (o.Accounts.Count == 0)
     {
@@ -231,48 +198,82 @@
     else
     {
         <div class="table-responsive">
-            <table class="table table-sm table-striped align-middle mb-0">
+            <table class="table table-sm table-striped align-middle mb-0" id="chart-of-accounts">
                 <thead>
                     <tr>
-                        <th>Account</th><th>Name</th><th>Group</th>
+                        <th>Account</th><th>Name</th>
                         <th class="text-end">Holded</th><th class="text-end">Local</th>
                         <th class="text-end">Lines</th><th class="text-center">OK</th>
                     </tr>
                 </thead>
-                <tbody>
-                    @foreach (var a in o.Accounts)
-                    {
-                        <tr>
-                            <td class="text-nowrap"><a asp-action="Account" asp-route-number="@a.Number"><code>@a.Number</code></a></td>
-                            <td>@a.Name</td>
-                            <td class="small text-muted">@a.Group</td>
-                            <td class="text-end">@a.HoldedBalance.ToEuro()</td>
-                            <td class="text-end">@(a.LocalBalance is null ? "—" : a.LocalBalance.ToEuro())</td>
-                            <td class="text-end">@a.LocalLineCount</td>
-                            <td class="text-center">
-                                @if (a.Reconciled)
-                                {
-                                    <i class="fa-solid fa-check text-success"></i>
-                                }
-                                else
-                                {
-                                    <i class="fa-solid fa-xmark text-danger"></i>
-                                }
-                            </td>
+                @* Accounts arrive ordered by number, so grouping keeps the PGC groups in 1..9 order. *@
+                @foreach (var group in o.Accounts.GroupBy(a => a.Group))
+                {
+                    <tbody class="js-account-group">
+                        <tr class="table-light">
+                            <th colspan="6" class="fw-semibold">@group.Key</th>
                         </tr>
-                    }
-                </tbody>
+                        @foreach (var a in group)
+                        {
+                            <tr class="js-account-row" data-lines="@a.LocalLineCount">
+                                <td class="text-nowrap"><a asp-action="Account" asp-route-number="@a.Number"><code>@a.Number</code></a></td>
+                                <td>@a.Name</td>
+                                <td class="text-end">@a.HoldedBalance.ToEuro()</td>
+                                <td class="text-end">@(a.LocalBalance is null ? "—" : a.LocalBalance.ToEuro())</td>
+                                <td class="text-end">@a.LocalLineCount</td>
+                                <td class="text-center">
+                                    @if (a.Reconciled)
+                                    {
+                                        <i class="fa-solid fa-check text-success"></i>
+                                    }
+                                    else
+                                    {
+                                        <i class="fa-solid fa-xmark text-danger"></i>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                }
             </table>
         </div>
         <div class="card-footer text-muted small">
-            Archived accounts are hidden. <strong>Local</strong> is Σdebit − Σcredit over the cached
-            lines; a ✗ means the nightly reconciliation still sees drift after its targeted re-pull.
-            Total cached lines: @o.LedgerLineCount.ToString("N0", CultureInfo.InvariantCulture).
+            Archived accounts are hidden. Groups are the Spanish chart's own, named from the
+            account number's leading digit. <strong>Local</strong> is Σdebit − Σcredit over the
+            cached lines; a ✗ means the nightly reconciliation still sees drift after its targeted
+            re-pull. Total cached lines: @o.LedgerLineCount.ToString("N0", CultureInfo.InvariantCulture).
         </div>
     }
 </div>
 
 <script>
+    // Most of the 267-account chart has never carried a line; hiding those is the default view.
+    // A group whose every account is hidden goes with them, header and all.
+    (function () {
+        var toggle = document.getElementById('hide-empty-accounts');
+        var count = document.getElementById('account-count');
+        if (!toggle) return;
+
+        function apply() {
+            var hide = toggle.checked;
+            var visible = 0;
+            document.querySelectorAll('.js-account-group').forEach(function (group) {
+                var shown = 0;
+                group.querySelectorAll('.js-account-row').forEach(function (row) {
+                    var empty = row.dataset.lines === '0';
+                    row.hidden = hide && empty;
+                    if (!row.hidden) shown++;
+                });
+                group.hidden = shown === 0;
+                visible += shown;
+            });
+            count.textContent = visible + ' accounts';
+        }
+
+        toggle.addEventListener('change', apply);
+        apply();
+    })();
+
     // A sweep can take a while and a second submit only earns a "skipped" toast; disable on click.
     document.querySelectorAll('.js-sync-form').forEach(function (form) {
         form.addEventListener('submit', function () {

--- a/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
+++ b/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
@@ -48,14 +48,18 @@ public sealed class HoldedAdminOverviewTests
         StatusCode = 200,
     };
 
-    private static HoldedAccount Account(int number, decimal balance, bool archived = false) => new()
+    private static HoldedAccount Account(
+        int number, decimal balance, bool archived = false,
+        decimal? debit = null, decimal? credit = null) => new()
     {
         Number = number,
         HoldedId = $"id-{number}",
         Name = $"acct {number}",
         Group = "Gastos",
-        Debit = balance > 0 ? balance : 0m,
-        Credit = balance < 0 ? -balance : 0m,
+        // Overridable together for the accounts whose debits and credits cancel: balance alone
+        // cannot tell "never posted to" from "posted to all year and back to zero".
+        Debit = debit ?? (balance > 0 ? balance : 0m),
+        Credit = credit ?? (balance < 0 ? -balance : 0m),
         Balance = balance,
         Archived = archived,
         SyncedAt = FixedNow,
@@ -123,6 +127,31 @@ public sealed class HoldedAdminOverviewTests
         var overview = await _service.GetOverviewAsync(ct);
 
         overview.Accounts.Select(a => a.Number).Should().Equal(40000004, 62900000, 62900128);
+    }
+
+    [HumansFact]
+    public async Task Holded_postings_are_reported_even_when_debits_and_credits_cancel()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await _repo.UpsertAccountsAsync(
+        [
+            Account(55500001, 0m, debit: 5_000m, credit: 5_000m),   // posted to, back to zero
+            Account(62900140, 0m),                                  // never posted to
+            Account(62900141, 10m),                                 // posted to, drifted
+        ], FixedNow, ct);
+
+        var overview = await _service.GetOverviewAsync(ct);
+        var byNumber = overview.Accounts.ToDictionary(a => a.Number);
+
+        // The cancelling account reconciles against an empty mirror, so Reconciled cannot carry
+        // this and HoldedBalance cannot either — both read exactly like the untouched account.
+        byNumber[55500001].Reconciled.Should().BeTrue();
+        byNumber[55500001].HoldedBalance.Should().Be(0m);
+        byNumber[55500001].LocalLineCount.Should().Be(0);
+        byNumber[55500001].HoldedHasPostings.Should().BeTrue();
+
+        byNumber[62900140].HoldedHasPostings.Should().BeFalse();
+        byNumber[62900141].HoldedHasPostings.Should().BeTrue();
     }
 
     [HumansFact]

--- a/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
+++ b/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
@@ -109,7 +109,7 @@ public sealed class HoldedAdminOverviewTests
     }
 
     [HumansFact]
-    public async Task Department_actuals_are_the_629_slice_ordered_by_balance_desc()
+    public async Task Archived_accounts_are_dropped_and_the_chart_is_ordered_by_number()
     {
         var ct = Xunit.TestContext.Current.CancellationToken;
         await _repo.UpsertAccountsAsync(
@@ -122,9 +122,29 @@ public sealed class HoldedAdminOverviewTests
 
         var overview = await _service.GetOverviewAsync(ct);
 
-        overview.DepartmentActuals.Select(a => a.Number).Should().Equal(62900000, 62900128);
-        // Archived accounts are gone from both lists; the full list is by number.
         overview.Accounts.Select(a => a.Number).Should().Equal(40000004, 62900000, 62900128);
+    }
+
+    [HumansFact]
+    public async Task Accounts_carry_the_english_pgc_group_not_holdeds_spanish_one()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await _repo.UpsertAccountsAsync(
+        [
+            Account(40000004, -53_203.00m),
+            Account(57200001, 418_840.54m),
+            Account(62900000, 133_416.45m),
+            Account(75900001, -5_000.00m),
+        ], FixedNow, ct);
+
+        var overview = await _service.GetOverviewAsync(ct);
+
+        // Number order is group order, which is what lets the view group without sorting again.
+        overview.Accounts.Select(a => a.Group).Should().Equal(
+            "Receivables and payables",
+            "Financial accounts",
+            "Purchases and expenses",
+            "Sales and income");
     }
 
     [HumansFact]
@@ -177,7 +197,6 @@ public sealed class HoldedAdminOverviewTests
         overview.ApiReachable.Should().BeFalse();
         overview.MonthlyCallBudget.Should().Be(2000);
         overview.Accounts.Should().ContainSingle();
-        overview.DepartmentActuals.Should().ContainSingle();
         overview.LedgerLineCount.Should().Be(1);
     }
 
@@ -242,7 +261,8 @@ public sealed class HoldedAdminOverviewTests
 
         statement.Should().NotBeNull();
         statement.Account.Name.Should().Be("acct 62900128");
-        statement.Account.Group.Should().Be("Gastos");
+        // Derived from the 6 in 62900128, not the "Gastos" the chart cache carries.
+        statement.Account.Group.Should().Be("Purchases and expenses");
         statement.Account.HoldedBalance.Should().Be(121_684.00m);
         statement.Account.LocalBalance.Should().Be(121_784.00m);
         statement.Account.LocalLineCount.Should().Be(3);

--- a/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
+++ b/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
@@ -51,19 +51,19 @@ public sealed class HoldedAdminOverviewTests
     private static HoldedAccount Account(
         int number, decimal balance, bool archived = false,
         decimal? debit = null, decimal? credit = null) => new()
-    {
-        Number = number,
-        HoldedId = $"id-{number}",
-        Name = $"acct {number}",
-        Group = "Gastos",
-        // Overridable together for the accounts whose debits and credits cancel: balance alone
-        // cannot tell "never posted to" from "posted to all year and back to zero".
-        Debit = debit ?? (balance > 0 ? balance : 0m),
-        Credit = credit ?? (balance < 0 ? -balance : 0m),
-        Balance = balance,
-        Archived = archived,
-        SyncedAt = FixedNow,
-    };
+        {
+            Number = number,
+            HoldedId = $"id-{number}",
+            Name = $"acct {number}",
+            Group = "Gastos",
+            // Overridable together for the accounts whose debits and credits cancel: balance alone
+            // cannot tell "never posted to" from "posted to all year and back to zero".
+            Debit = debit ?? (balance > 0 ? balance : 0m),
+            Credit = credit ?? (balance < 0 ? -balance : 0m),
+            Balance = balance,
+            Archived = archived,
+            SyncedAt = FixedNow,
+        };
 
     private static HoldedLedgerLine Line(int entry, int account, decimal debit = 0m, decimal credit = 0m,
         int line = 1, Instant? date = null) => new()


### PR DESCRIPTION
## What

`/Holded` showed the same accounts twice: the **Department actuals** card was `accounts.Where(a => a.Number is >= 62900000 and <= 62999999)` — the 629xxxxx slice of the chart of accounts table rendered directly beneath it, with the same balances and the same reconciliation flags. That card and the `DepartmentActuals` projection feeding it are gone.

The chart of accounts is now split into PGC groups, and the groups are named in English.

## Why the group name comes from the number, not from Holded

Holded returns a Spanish `group` string per account — "Financiación básica", "Activo no corriente", "Existencias", "Acreedores y deudores operaciones de la actividad". Translating those would mean matching on free text we do not control.

The account number already carries the answer: the leading digit *is* the PGC group. `GroupName(int number)` in the Holded service maps it, and the stored `HoldedAccount.Group` is simply no longer displayed (still mirrored, unchanged).

| Digit | Shown as |
|---|---|
| 1 | Equity and long-term financing |
| 2 | Non-current assets |
| 3 | Inventory |
| 4 | Receivables and payables |
| 5 | Financial accounts |
| 6 | Purchases and expenses |
| 7 | Sales and income |
| 8 / 9 | Expenses / Income charged to equity |

Because the chart already arrives ordered by number, grouping keeps the sections in 1..9 order without a second sort.

## Hide accounts with no lines

A switch in the card header, **on by default** — most of the 267-account chart has never been posted to. It filters client-side on `data-lines`, hides any group whose accounts all disappear, and keeps the header badge counting what is actually visible.

## Notes

- The `Group` column is dropped from the table body; it is the section header now.
- `/Holded/Accounts/{number}` gets the English group in its header too, via the same helper.
- No schema change, no new interface method, no new repository method.
- Sign convention on these tables is untouched here — that is nobodies-collective/Humans#1028.

Refs nobodies-collective/Humans#1028

## Test

`dotnet test Humans.slnx -v quiet` — green. Holded suite 28/28.

- Replaced the department-slice test with one covering archived exclusion and number ordering.
- Added a test that four accounts seeded with `Group = "Gastos"` come back as Receivables and payables / Financial accounts / Purchases and expenses / Sales and income — proving the Spanish value is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
