### PR TITLE
ci: fail loud when slnx or SECTION_DB_CONTEXTS misses a project/context

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,6 +267,13 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    - name: Verify Humans.slnx and SECTION_DB_CONTEXTS are complete
+      # Two hand-maintained lists that silently skip a new section if
+      # forgotten — a project missing from Humans.slnx gets no build/test/
+      # format, and a DbContext missing from SECTION_DB_CONTEXTS gets no
+      # migration check. This makes both fail loud instead.
+      run: bash scripts/check-ci-completeness.sh
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:

--- a/scripts/check-ci-completeness.sh
+++ b/scripts/check-ci-completeness.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Guardrail: two hand-maintained lists that silently skip a new section if
+# forgotten. Both used to fail quiet — this makes them fail loud.
+#
+# 1. slnx completeness: every *.csproj under src/ and tests/ must be listed
+#    in Humans.slnx. A project missing from the slnx gets no build, no test,
+#    no format check in CI, and no error.
+# 2. SECTION_DB_CONTEXTS completeness: build.yml's MAIN_DB_CONTEXT +
+#    SECTION_DB_CONTEXTS env pairs must list every DbContext-derived class in
+#    the codebase's own Data folders. Discovery is a filename heuristic keyed
+#    to the *DbContext.cs naming convention (real class declarations here use
+#    primary constructors with the base type — e.g. IdentityDbContext<...> —
+#    on a separate line, so a reliable declaration-based grep isn't
+#    practical). Kept discovery-driven on purpose: when HumansDbContext is
+#    deleted (nobodies-collective/Humans#866), this check needs no edit.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+FAIL=0
+
+# --- Check 1: every src/ and tests/ csproj is listed in Humans.slnx ---
+
+MISSING_PROJECTS=()
+while IFS= read -r -d '' csproj; do
+  rel="${csproj#./}"
+  rel="${rel//\\//}"
+  if ! grep -qi "Path=\"${rel}\"" Humans.slnx; then
+    MISSING_PROJECTS+=("$rel")
+  fi
+done < <(find src tests -name '*.csproj' -print0 | sort -z)
+
+if [[ ${#MISSING_PROJECTS[@]} -gt 0 ]]; then
+  echo "::error::Project(s) on disk missing from Humans.slnx (no build/test/format in CI):" >&2
+  printf '  %s\n' "${MISSING_PROJECTS[@]}" >&2
+  FAIL=1
+else
+  echo "ok: every src/ and tests/ csproj is listed in Humans.slnx."
+fi
+
+# --- Check 2: SECTION_DB_CONTEXTS (+ MAIN_DB_CONTEXT) lists every DbContext ---
+
+BUILD_YML=".github/workflows/build.yml"
+
+DISCOVERED_CONTEXTS=$(find src/Sections/*/Data src/Humans.Infrastructure/Data -maxdepth 1 -name '*DbContext.cs' 2>/dev/null \
+  | xargs -n1 basename | sed 's/\.cs$//' | sort -u)
+
+# Context names appear as `FooDbContext:<project-path>` tokens inside the env
+# block only (between `env:` and `jobs:`), both in MAIN_DB_CONTEXT's single
+# pair and in SECTION_DB_CONTEXTS' multi-line list.
+LISTED_CONTEXTS=$(awk '/^env:/{p=1} /^jobs:/{p=0} p' "$BUILD_YML" \
+  | grep -oE '[A-Za-z][A-Za-z0-9]*DbContext:' | tr -d ':' | sort -u)
+
+MISSING_CONTEXTS=()
+while IFS= read -r ctx; do
+  [[ -z "$ctx" ]] && continue
+  if ! grep -qx "$ctx" <<< "$LISTED_CONTEXTS"; then
+    MISSING_CONTEXTS+=("$ctx")
+  fi
+done <<< "$DISCOVERED_CONTEXTS"
+
+if [[ ${#MISSING_CONTEXTS[@]} -gt 0 ]]; then
+  echo "::error::DbContext(s) found in Data/ but missing from MAIN_DB_CONTEXT/SECTION_DB_CONTEXTS in $BUILD_YML:" >&2
+  printf '  %s\n' "${MISSING_CONTEXTS[@]}" >&2
+  FAIL=1
+else
+  echo "ok: every discovered DbContext is listed in MAIN_DB_CONTEXT/SECTION_DB_CONTEXTS."
+fi
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Two hand-maintained lists in `.github/workflows/build.yml` silently skip a new section when someone forgets to add it:

1. **Humans.slnx** — a `*.csproj` under `src/` or `tests/` that isn't listed as a `<Project Path=...>` gets no build, no test, and no `dotnet format` in CI, with no error.
2. **`SECTION_DB_CONTEXTS`** — a `DbContext`-derived class that isn't in the `MAIN_DB_CONTEXT`/`SECTION_DB_CONTEXTS` env list gets no `has-pending-model-changes` check, with no error.

Adds `scripts/check-ci-completeness.sh`, run as the first step of the `code-quality` job (before restore, so it fails fast and cheap), converting both silent-skip modes into a named CI failure.

Check 2 is discovery-driven on purpose: it scans `src/Sections/*/Data/` and `src/Humans.Infrastructure/Data/` for `*DbContext.cs` files rather than hardcoding a list, so it stays correct with no edit when `HumansDbContext` is deleted (nobodies-collective/Humans#866).

## Verification

Both checks pass against current `main` with zero missing entries:

```
$ bash scripts/check-ci-completeness.sh
ok: every src/ and tests/ csproj is listed in Humans.slnx.
ok: every discovered DbContext is listed in MAIN_DB_CONTEXT/SECTION_DB_CONTEXTS.
```

Negative-tested each check against scratch copies (not committed) with one entry removed:

- Removed `src/Sections/Humans.Store/Humans.Store.csproj` from a scratch `Humans.slnx` → check correctly reported it missing:
  ```
  NEGATIVE TEST 1 (slnx) - detected missing:
    src/Sections/Humans.Store/Humans.Store.csproj
  ```
- Removed the `StoreDbContext:src/Sections/Humans.Store` pair from a scratch `build.yml`'s `SECTION_DB_CONTEXTS` → check correctly reported it missing:
  ```
  NEGATIVE TEST 2 (db contexts) - detected missing:
    StoreDbContext
  ```

Also confirmed `build.yml` still parses as valid YAML after the edit:
```
$ python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/build.yml'))"
YAML OK
```

## Test plan

- [x] `bash scripts/check-ci-completeness.sh` passes clean on current `main`
- [x] Negative test: missing slnx entry is detected and named
- [x] Negative test: missing SECTION_DB_CONTEXTS entry is detected and named
- [x] `build.yml` remains valid YAML
- [ ] CI green on this PR (new step runs as part of `code-quality`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)