### PR TITLE
fix(ci): surface-report migration gate counts only added files

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -95,6 +95,9 @@
     <PackageVersion Include="NSubstitute" Version="6.1.0" />
     <PackageVersion Include="Stripe.net" Version="51.2.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <!-- Direct pin over Testcontainers' transitive SSH.NET 2025.1.0 (GHSA-q939-rpr3-3284,
+         NU1903 fails restore). Drop when Testcontainers ships against SSH.NET >= 2026.0.0. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <!-- HTML parsing for the localization-coverage sweep; pinned to the version HtmlSanitizer already resolves so the solution-wide graph is unchanged. -->
     <PackageVersion Include="AngleSharp" Version="1.6.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/scripts/pr-surface-report.py
+++ b/scripts/pr-surface-report.py
@@ -84,7 +84,11 @@ def parse_name_status(base: str, head: str) -> tuple[list[str], list[str], list[
         status = parts[0]
         path = normalize(parts[-1])
         changed_files.append(path)
-        if status.startswith("A"):
+        # A = added; C<score> = copy destination, which is equally a new file —
+        # --find-copies can classify a new migration that resembles an existing
+        # one as C, and treating only A as an addition would let it evade the
+        # one-migration-per-PR gate. Deletions and pure renames stay excluded.
+        if status.startswith(("A", "C")):
             added_files.append(path)
             if is_real_migration_file(path):
                 migration_files.append(path)

--- a/scripts/pr-surface-report.py
+++ b/scripts/pr-surface-report.py
@@ -55,14 +55,14 @@ def is_real_migration_file(path: str) -> bool:
 
 
 def max_migrations_per_context(migration_files: list[str]) -> int:
-    """Max real migrations in any one migration directory.
+    """Max real migrations ADDED in any one migration directory.
 
     Since the per-section DbContext split (nobodies-collective/Humans#858) each
-    context owns its own chain in its own directory (Migrations/ for
-    HumansDbContext, Migrations/<Section>/ for a peeled section). The
-    one-migration-per-PR rule applies per chain: a peel PR legitimately carries
-    one snapshot-only migration on the main chain plus one baseline in the new
-    section's directory.
+    context owns its own chain in its own directory (Migrations/<Section>/;
+    the root Migrations/ chain was deleted at #858 peel 15). The
+    one-migration-per-PR rule applies per chain and only to additions —
+    deleting or relocating a chain authors no migration (the peel-15 chain
+    deletion tripped the old changed-files count at 144/1).
     """
     per_dir: dict[str, int] = {}
     for path in migration_files:
@@ -86,8 +86,8 @@ def parse_name_status(base: str, head: str) -> tuple[list[str], list[str], list[
         changed_files.append(path)
         if status.startswith("A"):
             added_files.append(path)
-        if is_real_migration_file(path):
-            migration_files.append(path)
+            if is_real_migration_file(path):
+                migration_files.append(path)
 
     return added_files, changed_files, migration_files
 
@@ -323,7 +323,7 @@ def build_markdown(
     migration_status = "OK" if max_per_context <= 1 else "BLOCK"
     summary = (
         f"{len(changed_files)} changed file(s) | EF migrations: "
-        f"{len(migration_files)} file(s), max {max_per_context}/1 per context"
+        f"{len(migration_files)} added file(s), max {max_per_context}/1 per context"
     )
 
     compared_line = f"Compared `{short_ref(base_label)}`...`{short_ref(head_label)}`."

--- a/tests/Humans.Integration.Tests/Humans.Integration.Tests.csproj
+++ b/tests/Humans.Integration.Tests/Humans.Integration.Tests.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Testcontainers.PostgreSql" />
+    <!-- Vulnerable-transitive override, see Directory.Packages.props -->
+    <PackageReference Include="SSH.NET" />
     <PackageReference Include="AngleSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
The one-migration-per-PR gate in `scripts/pr-surface-report.py` counted every **changed** real migration file. #1273 deletes the 288-file root chain (858 peel 15), which read as "144 migrations per context" and failed the `report` job. Deleting or relocating a chain authors no migration — the counter now considers only added files.

Verified against #1273's diff locally: `migration_count` goes 144 → 1 (the `BaselineUsers` baseline).

Must land **before** #1273's report job can pass: `pr-surface-report.yml` checks out the base branch's scripts (`ref: base.ref`, the fork-PR injection guard), so the identical fix already sitting on that branch never executes. Once this merges, that file's diff in #1273 collapses to empty and I re-run its report job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)