### PR TITLE
docs: reuse-first calibration + Store flake ledger entry

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -249,6 +249,9 @@ themes:
     notes: Each inbox entry carries its own review tier; drained entries are deleted from the list.
 inbox:
   # Seeded from the open items in docs/architecture/tech-debt-2026-04-23.md.
+  - added: 2026-08-13
+    what: "StorePayActionTests.Pay_with_amount_over_balance_redirects_back_to_order_without_calling_Stripe fails under full parallel-suite runs but passes in isolation — races something shared; surfaced twice during PR peterdrier/Humans#1272's full-suite runs"
+    review: light
   - added: 2026-08-11
     what: "TeamConfiguration's six system-team HasData rows declare RequiresApproval = false, but false is the CLR default so EF omits the column from the INSERT and the DB default (true) applies — model believes false, database holds true, on both chain-built and baseline-built schema. Long-standing (Initial did the same); surfaced by the EF migration review of the Teams peel (peel 14, nobodies-collective/Humans#858)"
     review: light

--- a/memory/process/reuse-first-change-discipline.md
+++ b/memory/process/reuse-first-change-discipline.md
@@ -16,6 +16,8 @@ New durable surface is technical debt until proven otherwise. Before adding any 
 5. If new surface is still necessary, state which existing options were rejected and why.
 6. Stop and ask Peter before adding public/interface surface, or before adding a parallel service/repository/helper where an owner already exists.
 
+**Approval-required is not default-deny.** The gate exists to make surface growth deliberate, not impossible — surface has a cost, but there is a reasonableness argument, and a read-only stats/aggregate view is the canonical reasonable case. When a task needs surface that requires approval, propose the minimal reasonable version and ask; never silently drop the feature and narrate the descope as "needed approval" afterward — that converts the gate into a veto Peter never issued (Peter, 2026-08-12, PR peterdrier/Humans#1272: a spec'd dashboard tile was dropped because the section had no public read surface; the right move was proposing the read-leaf promotion, which he approved on sight).
+
 **Examples:**
 
 - Prefer `GetAllAsync()` + `.Where(...).FirstOrDefault()` at one call site over `GetSpecialCaseAsync()` on an interface.


### PR DESCRIPTION
Follow-ups from PR #1272, kept out of the feature PR:

- **`memory/process/reuse-first-change-discipline.md`** — the calibration Peter dictated during the expenses/store tile reversal: approval-required public surface means *propose the minimal reasonable version and ask*, never silently descope. Read-only stats/aggregate views are the canonical reasonable case.
- **`docs/architecture/debt-ledger.yml`** — inbox entry for the `StorePayActionTests` flake (fails under full parallel-suite runs, passes in isolation; seen twice during #1272's verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)