### PR TITLE
fix(expenses): log user-input rejections at Warning, not Error

### DIFF
--- a/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
@@ -194,11 +194,11 @@ internal sealed class ExpenseReportService(
         CancellationToken ct = default)
     {
         var existing = await repo.GetByIdAsync(reportId, ct)
-            ?? throw new InvalidOperationException("Report not found.");
+            ?? throw new ExpenseValidationException("Report not found.");
         if (existing.SubmitterUserId != submitterUserId)
             throw new UnauthorizedAccessException("Only the submitter can update a draft.");
         if (existing.Status != ExpenseReportStatus.Draft)
-            throw new InvalidOperationException("Only Draft reports can be updated.");
+            throw new ExpenseValidationException("Only Draft reports can be updated.");
 
         var year = await budgetService.GetActiveYearAsync()
             ?? throw new InvalidOperationException("No active budget year.");
@@ -309,7 +309,7 @@ internal sealed class ExpenseReportService(
         // submitter claim an arbitrary unreceipted amount on a Mileage/PerDiem line. To change one,
         // remove it and re-add so the amount is always recomputed from its inputs.
         if (existing.LineType != ExpenseLineType.Receipt)
-            throw new InvalidOperationException(
+            throw new ExpenseValidationException(
                 "Travel lines are computed from their inputs and cannot be edited. Remove the line and add it again to change it.");
 
         var line = new ExpenseLine
@@ -384,13 +384,13 @@ internal sealed class ExpenseReportService(
         Stream content, CancellationToken ct = default)
     {
         if (content is null || content.Length == 0)
-            throw new InvalidOperationException("Please select a file.");
+            throw new ExpenseValidationException("Please select a file.");
         if (content.Length > AttachmentMaxBytes)
-            throw new InvalidOperationException($"File too large. Maximum size is {AttachmentMaxBytes / (1024 * 1024)} MB.");
+            throw new ExpenseValidationException($"File too large. Maximum size is {AttachmentMaxBytes / (1024 * 1024)} MB.");
 
         var extension = Path.GetExtension(originalFileName).ToLowerInvariant();
         if (!AllowedContentTypes.Contains(contentType) || !AllowedExtensions.Contains(extension))
-            throw new InvalidOperationException("Unsupported file type. Upload PDF, JPEG, PNG, or HEIC.");
+            throw new ExpenseValidationException("Unsupported file type. Upload PDF, JPEG, PNG, or HEIC.");
 
         var report = await RequireEditableReportAsync(reportId, submitterUserId, ct);
 
@@ -1004,12 +1004,12 @@ internal sealed class ExpenseReportService(
         Guid reportId, Guid submitterUserId, CancellationToken ct)
     {
         var report = await repo.GetByIdAsync(reportId, ct)
-            ?? throw new InvalidOperationException("Report not found.");
+            ?? throw new ExpenseValidationException("Report not found.");
         if (report.SubmitterUserId != submitterUserId)
             throw new UnauthorizedAccessException("Only the submitter can edit lines.");
         // Line mutations are Draft-only — submitted reports are frozen for review.
         if (report.Status is not ExpenseReportStatus.Draft)
-            throw new InvalidOperationException(
+            throw new ExpenseValidationException(
                 $"Lines cannot be edited when the report is in status {report.Status}.");
         return report;
     }

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
@@ -440,6 +440,75 @@ public sealed class ExpenseReportServiceTests
         result.ErrorMessage.Should().Contain("Unsupported file type");
     }
 
+    [HumansTheory]
+    [Xunit.InlineData("receipt.exe", "application/octet-stream", 3, "Unsupported file type")]
+    [Xunit.InlineData("receipt.pdf", "application/pdf", 0, "Please select a file")]
+    [Xunit.InlineData("receipt.pdf", "application/pdf", 21 * 1024 * 1024, "File too large")] // AttachmentMaxBytes is 20 MB
+    public async Task AttachFileToLineWithResultAsync_LogsWarning_NoStackTrace_ForUserInputRejection(
+        string fileName, string contentType, int byteCount, string expectedMessage)
+    {
+        var logger = new CapturingLogger<ExpenseReportService>();
+        var sut = new ExpenseReportService(
+            _expenseRepo, _fileStorage, _budgetService, _teamService, _userService,
+            AuditLog, _holdedClient, _holdedFinance, Clock, logger,
+            Options.Create(new TravelReimbursementConfig()));
+
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        var lineId = await sut.AddLineAsync(id, submitter, "Item", 10m, ct: Xunit.TestContext.Current.CancellationToken);
+
+        await using var stream = new MemoryStream(new byte[byteCount]);
+        var result = await sut.AttachFileToLineWithResultAsync(
+            id, submitter, lineId, fileName, contentType, stream, Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeFalse();
+        result.ErrorMessage.Should().Contain(expectedMessage,
+            because: "the user-facing message is unchanged by the log-level reclassification");
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning);
+        var warning = logger.Entries.Single(e => e.Level == LogLevel.Warning);
+        warning.Exception.Should().BeNull("a rejected upload is user input, not a system failure");
+        warning.Message.Should().Contain(expectedMessage,
+            because: "RunMutationAsync appends the rejection as the {Reason} property");
+        warning.Message.Should().Contain(lineId.ToString(),
+            because: "the caller's structured identifiers must survive into the warning");
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Error);
+    }
+
+    [HumansFact]
+    public async Task AddLineWithResultAsync_LogsError_WithStackTrace_WhenRepositoryReportsFailure()
+    {
+        var logger = new CapturingLogger<ExpenseReportService>();
+
+        // A repository returning false is a genuine persistence fault, not user input — it must
+        // keep its Error level and stack trace. Only GetByIdAsync is delegated to the real
+        // in-memory repository so the draft-editable guard passes and the failure lands on AddLine.
+        var failingRepo = Substitute.For<IExpenseRepository>();
+        failingRepo.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(call => _expenseRepo.GetByIdAsync(call.Arg<Guid>(), call.Arg<CancellationToken>()));
+        failingRepo.AddLineAsync(Arg.Any<Guid>(), Arg.Any<ExpenseLine>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var sut = new ExpenseReportService(
+            failingRepo, _fileStorage, _budgetService, _teamService, _userService,
+            AuditLog, _holdedClient, _holdedFinance, Clock, logger,
+            Options.Create(new TravelReimbursementConfig()));
+
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+
+        var result = await sut.AddLineWithResultAsync(
+            id, submitter, "Supplies", 25m, Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeFalse();
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Error);
+        var error = logger.Entries.Single(e => e.Level == LogLevel.Error);
+        error.Exception.Should().BeOfType<InvalidOperationException>()
+            .Which.Message.Should().Be("Failed to add line.");
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
+    }
+
     [HumansFact]
     public async Task TryReadAttachmentAsync_ReadsAttachmentFileFromStorage()
     {


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1037

## Problem

A user uploading a disallowed file type to an expense line was rejected correctly and shown the right message — but the rejection logged at **Error** with a full stack trace, reading as a system failure in the production log viewer.

`RunMutationAsync` already has the correct branch: it catches `ExpenseValidationException` and logs at Warning with no exception object, keeping the structured identifiers plus `{Reason}`. The attachment guards threw plain `InvalidOperationException`, so they fell through to `catch (Exception ex)` → `logger.LogError(ex, ...)`.

## Change

Seven user-driven guards in `ExpenseReportService` converted to `ExpenseValidationException`:

- the three attachment guards — empty file, oversized, unsupported type
- `"Report not found."` and `"Only Draft reports can be updated."` in `UpdateDraftAsync`
- the travel-line edit guard (`UpdateLineAsync`)
- both guards in `RequireEditableReportAsync` — `"Report not found."` and the report-state guard

`RequireEditableReportAsync`'s `"Report not found."` is not named line-by-line in the issue, but it is the same user-driven condition as `UpdateDraftAsync`'s, which the issue does list for conversion, and the issue's fourth acceptance criterion is a blanket "no Error-level events for user-input rejections." Converting one and not the other would have left the criterion unmet on the attachment path, which routes through this method.

**Left as `InvalidOperationException`**, exactly as the issue specifies — these are genuine system failures and keep Error with the stack trace:

- `"Failed to add/update/remove line."` — repository returned false
- missing active budget year / category — a configuration problem, not user input
- `"Budget category not found."` and the two Holded guards

Nothing user-facing changes: `RunMutationAsync` returns `ExpenseMutationResult.Failure(ex.Message)` on both branches.

## Reuse-first

No new files, types, interfaces, DTOs, helpers or DI registrations. `ExpenseValidationException` already existed as a private nested type with a doc comment describing exactly this distinction; every throw site is inside the same class, so the change is `new InvalidOperationException` → `new ExpenseValidationException` and nothing else. The alternative considered and rejected was a new exception type per guard family — unnecessary, since `RunMutationAsync` branches on one type.

## Tests

- `AttachFileToLineWithResultAsync_LogsWarning_NoStackTrace_ForUserInputRejection` — theory over all three attachment guards (unsupported type / empty / oversized). Asserts exactly one Warning, `Exception` null, `{Reason}` and the line ID present in the message, the same failure message still returned to the user, and no Error entry.
- `AddLineWithResultAsync_LogsError_WithStackTrace_WhenRepositoryReportsFailure` — a substituted repository returning `false` from `AddLineAsync` (with `GetByIdAsync` delegated to the real in-memory repo so the editable guard passes). Asserts Error with the `InvalidOperationException` attached and no Warning.

Both use the existing `CapturingLogger<T>` pattern already established by `SubmitWithResultAsync_LogsWarning_...` / `_LogsError_...` in the same file.

`dotnet test tests/Humans.Expenses.Tests` — 165 passed, 0 failed. Full solution build: 0 errors.