### PR TITLE
fix(issues): infer CityPlanning from /CityPlanning, not /City

### DIFF
--- a/src/Sections/Humans.Issues/Models/IssueSectionInference.cs
+++ b/src/Sections/Humans.Issues/Models/IssueSectionInference.cs
@@ -46,7 +46,7 @@ internal static class IssueSectionInference
         "finance" or "budget" => IssueSectionRouting.Budget,
         "board" or "voting" => IssueSectionRouting.Governance,
         "legal" or "consent" => IssueSectionRouting.Legal,
-        "city" => IssueSectionRouting.CityPlanning,
+        "cityplanning" => IssueSectionRouting.CityPlanning,
         "scanner" => IssueSectionRouting.Scanner,
         _ => null
     };

--- a/tests/Humans.Issues.Tests/Models/IssueSectionInferenceTests.cs
+++ b/tests/Humans.Issues.Tests/Models/IssueSectionInferenceTests.cs
@@ -24,7 +24,8 @@ public class IssueSectionInferenceTests
     [InlineData("/Voting", IssueSectionRouting.Governance)]
     [InlineData("/Legal", IssueSectionRouting.Legal)]
     [InlineData("/Consent", IssueSectionRouting.Legal)]
-    [InlineData("/City/zone", IssueSectionRouting.CityPlanning)]
+    [InlineData("/CityPlanning/BarrioMap", IssueSectionRouting.CityPlanning)]
+    [InlineData("/cityplanning", IssueSectionRouting.CityPlanning)]
     [InlineData("/Scanner", IssueSectionRouting.Scanner)]
     [InlineData("/Scanner/Barcode", IssueSectionRouting.Scanner)]
     [InlineData("https://example.com/Camps/abc", IssueSectionRouting.Camps)]
@@ -47,6 +48,9 @@ public class IssueSectionInferenceTests
     [InlineData("   ")]
     [InlineData("/SomeUnknownPage")]
     [InlineData("/Foo/Bar")]
+    // "/City" was the old mapping and matches no route in the app — CityPlanningController
+    // is [Route("CityPlanning")]. It must not resolve, or the outlier comes back.
+    [InlineData("/City/zone")]
     public void FromPath_returns_null_for_unknown_or_empty(string? input)
     {
         IssueSectionInference.FromPath(input).Should().BeNull();


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1033

## Problem

`IssueSectionInference.Map` matched the path segment `"city"`. `CityPlanningController` is `[Route("CityPlanning")]`, and no route in the app has `city` as its first segment — verified by scanning every `[Route("…")]` prefix in `src/`:

```
admin agent api auditlog barrios budget calendar camp campaigns camps cantina
cityplanning colorpalette debug dev email events expenses feedback finance gate
google governance guide holded home issues legal mailer notifications profile
scanner search shifts store survey teams tickets tour user users widgetgallery
```

So an issue filed from any City Planning page inferred a **null** `Section` and fell through to the Admin queue instead of CampAdmin.

## Change

One line: `"city"` → `"cityplanning"`.

**Replaced rather than aliased.** The issue offered "match `cityplanning` (or accept both)". `"city"` resolves to no route — not a redirect, not a legacy path, not an alias (`grep` for `/City` outside `CityPlanning` returns nothing). Keeping it as a second arm would leave dead code in the table whose whole job is to mirror real first path segments, which is the outlier condition the issue is about.

`api/city-planning` on `CityPlanningApiController` is unaffected: `FromPath` reads the first segment, which is `api` there, and the widget captures page URLs rather than API endpoints.

## Tests

`IssueSectionInferenceTests` line 27 previously asserted `/City/zone` → `CityPlanning` — the test locked the bug in. Now:

- `/CityPlanning/BarrioMap` → `CityPlanning` (the case named in the issue)
- `/cityplanning` → `CityPlanning` (case-insensitivity, matching the other entries' coverage)
- `/City/zone` → **null**, moved into the unknown-segment theory with a comment on why, so the outlier cannot come back

`dotnet test tests/Humans.Issues.Tests` — 121 passed, 0 failed.

## Reuse-first

No new files, types, methods, or DI. One switch arm and three test rows.