### PR TITLE
test: add EnumStringStabilityTests guards for nine string-persisted enums

### DIFF
--- a/tests/Humans.Campaigns.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Campaigns.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,37 @@
+using AwesomeAssertions;
+using Humans.Campaigns.Domain;
+
+namespace Humans.Campaigns.Tests.Enums;
+
+/// <summary>
+/// Campaigns' string-stored-enum guard. Lives here rather than the central
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> because <see cref="CampaignStatus"/>
+/// is internal to <c>Humans.Campaigns</c> after the section's G5 move
+/// (nobodies-collective/Humans#866), so the central project cannot name it
+/// (nobodies-collective/Humans#1025).
+/// </summary>
+/// <remarks>
+/// Persisted with <c>HasConversion&lt;string&gt;()</c> / <c>HasMaxLength(20)</c>: renaming a
+/// member leaves the OLD string in <c>campaigns.status</c>. A rename needs a migration that
+/// UPDATEs the stored values. A <c>[Fact]</c> rather than a theory: a public test method
+/// cannot take an internal enum type as a parameter (CS0051, Issues' fold).
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansFact]
+    public void StringStoredCampaignsEnums_MemberNames_MustMatchExpected()
+    {
+        AssertNames(typeof(CampaignStatus), ["Draft", "Active", "Completed"]);
+    }
+
+    private static void AssertNames(Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                "If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+}

--- a/tests/Humans.Domain.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Domain.Tests/Enums/EnumStringStabilityTests.cs
@@ -122,6 +122,14 @@ public class EnumStringStabilityTests
                 "System", "EventOperations", "CommunityUpdates", "Marketing", "Governance",
                 "CampaignCodes", "FacilitatedMessages", "Ticketing", "VolunteerUpdates", "TeamUpdates"
             ]
+        },
+        {
+            // Guarded centrally rather than per section: three sections persist this one
+            // public Humans.Domain enum as a string — campaign_grants.LatestEmailStatus
+            // (CampaignGrantConfiguration), survey_invitations.LatestEmailStatus
+            // (SurveyInvitationConfiguration), and the Email outbox's own Status
+            // (EmailOutboxMessageConfiguration). A rename strands the old string in all three.
+            typeof(EmailOutboxStatus), ["Queued", "Sent", "Failed"]
         }
     };
 }

--- a/tests/Humans.Feedback.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Feedback.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using Humans.Feedback.Domain;
+
+namespace Humans.Feedback.Tests.Enums;
+
+/// <summary>
+/// Feedback's string-stored-enum guard. Lives here rather than the central
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> because <see cref="FeedbackCategory"/>,
+/// <see cref="FeedbackStatus"/> and <see cref="FeedbackSource"/> are all internal to
+/// <c>Humans.Feedback</c> after the section's G5 move (nobodies-collective/Humans#866), so the
+/// central project cannot name them (nobodies-collective/Humans#1025).
+/// </summary>
+/// <remarks>
+/// All three are persisted with <c>HasConversion&lt;string&gt;()</c>: renaming a member leaves
+/// the OLD string in <c>feedback_reports.category</c> / <c>.status</c> / <c>.source</c>. A
+/// rename needs a migration that UPDATEs the stored values.
+/// <see cref="FeedbackSource"/> is doubly load-bearing: it also has a DB default of
+/// <c>'UserReport'</c> (<c>HasDefaultValueSql</c>), so renaming that specific member breaks
+/// the default, not just stored history. A <c>[Fact]</c> rather than a theory: a public test
+/// method cannot take an internal enum type as a parameter (CS0051, Issues' fold).
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansFact]
+    public void StringStoredFeedbackEnums_MemberNames_MustMatchExpected()
+    {
+        AssertNames(typeof(FeedbackCategory), ["Bug", "FeatureRequest", "Question"]);
+        AssertNames(typeof(FeedbackStatus), ["Open", "Acknowledged", "Resolved", "WontFix"]);
+
+        // Also the DB default (HasDefaultValueSql("'UserReport'")) — renaming this
+        // member specifically breaks the default, not just stored history.
+        AssertNames(typeof(FeedbackSource), ["UserReport", "AgentUnresolved"]);
+    }
+
+    private static void AssertNames(Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                "If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+}

--- a/tests/Humans.Issues.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Issues.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,48 @@
+using AwesomeAssertions;
+using Humans.Issues.Contracts;
+using Humans.Issues.Domain;
+
+namespace Humans.Issues.Tests.Enums;
+
+/// <summary>
+/// Issues' string-stored-enum guard. Lives here rather than the central
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> because <see cref="IssueStatus"/>
+/// is internal to <c>Humans.Issues</c> and <see cref="IssueCategory"/> sits on Issues'
+/// contracts leaf after the section's G5 move (nobodies-collective/Humans#866), neither of
+/// which the central project can name (nobodies-collective/Humans#1025).
+/// </summary>
+/// <remarks>
+/// Both are persisted with <c>HasConversion&lt;string&gt;()</c>: renaming a member leaves the
+/// OLD string in <c>issues.status</c> / <c>issues.category</c>. A rename needs a migration
+/// that UPDATEs the stored values. <see cref="IssueCategory"/> is doubly load-bearing: it is
+/// also parsed by name across a section boundary via <c>Enum.TryParse&lt;IssueCategory&gt;</c>
+/// in <c>Humans.Agent</c>'s <c>AgentService.ParseIssueProposalArgs</c> — renaming a member
+/// silently breaks that parse (it falls back to <see cref="IssueCategory.Question"/> instead
+/// of erroring), not just stored history. A <c>[Fact]</c> rather than a theory: a public test
+/// method cannot take an internal enum type as a parameter (CS0051).
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansFact]
+    public void StringStoredIssuesEnums_MemberNames_MustMatchExpected()
+    {
+        AssertNames(typeof(IssueStatus),
+            ["Triage", "Open", "InProgress", "Resolved", "WontFix", "Duplicate"]);
+
+        // Also parsed by name across a section boundary (Humans.Agent's
+        // Enum.TryParse<IssueCategory> in AgentService.ParseIssueProposalArgs) — a rename
+        // here silently breaks that cross-section parse, not just stored history.
+        AssertNames(typeof(IssueCategory), ["Bug", "Feature", "Question"]);
+    }
+
+    private static void AssertNames(Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                "If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+}

--- a/tests/Humans.Notifications.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Notifications.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,61 @@
+using AwesomeAssertions;
+using Humans.Notifications.Contracts;
+using Xunit;
+
+namespace Humans.Notifications.Tests.Enums;
+
+/// <summary>
+/// Notifications' string-stored-enum guard. Lives here rather than the central
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> because <see cref="NotificationSource"/>,
+/// <see cref="NotificationClass"/> and <see cref="NotificationPriority"/> all sit on
+/// Notifications' contracts leaf after the section's G5 move (nobodies-collective/Humans#866),
+/// where the central project cannot name them (nobodies-collective/Humans#1025).
+/// </summary>
+/// <remarks>
+/// All three are persisted with <c>HasConversion&lt;string&gt;()</c>: renaming a member leaves
+/// the OLD string in <c>notifications.source</c> / <c>.class</c> / <c>.priority</c>. A rename
+/// needs a migration that UPDATEs the stored values.
+/// <see cref="NotificationSource"/> is doubly load-bearing: it is named by three moved
+/// sections plus eleven Base services through the contracts leaf, so a rename is far more
+/// likely to be silently missed somewhere than for a single-caller enum.
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansTheory]
+    [MemberData(nameof(StringStoredEnumData))]
+    public void StringStoredEnum_MemberNames_MustMatchExpected(
+        Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                $"If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+
+    public static TheoryData<Type, string[]> StringStoredEnumData => new()
+    {
+        {
+            typeof(NotificationSource), [
+                "TeamMemberAdded", "ShiftCoverageGap", "ShiftSignupChange", "ConsentReviewNeeded",
+                "ApplicationSubmitted", "SyncError", "TermRenewalReminder", "ApplicationApproved",
+                "ApplicationRejected", "VolunteerApproved", "ProfileRejected", "AccessSuspended",
+                "ReConsentRequired", "TeamJoinRequestSubmitted", "TeamJoinRequestDecided",
+                "FeedbackResponse", "WorkspaceCredentialsReady", "RoleAssignmentChanged",
+                "CampaignReceived", "TeamMemberRemoved", "ShiftAssigned", "GoogleDriftDetected",
+                "FacilitatedMessageReceived", "LegalDocumentPublished", "CampMembershipApproved",
+                "CampMembershipRejected", "CampMembershipSeasonClosed", "CampRoleAssigned",
+                "IssueComment", "IssueStatusChanged", "IssueAssigned", "IssueSubmitted"
+            ]
+        },
+        {
+            typeof(NotificationClass), ["Informational", "Actionable"]
+        },
+        {
+            typeof(NotificationPriority), ["Normal", "High", "Critical"]
+        }
+    };
+}


### PR DESCRIPTION
## Summary

Adds `EnumStringStabilityTests` guard rows for the nine string-persisted enums identified in #1025:

| Section | Enums | Confirmed EF config |
|---|---|---|
| Campaigns | `CampaignStatus` | `HasConversion<string>()` + `HasMaxLength(20)` — matches issue |
| Feedback | `FeedbackCategory`, `FeedbackStatus`, `FeedbackSource` | All `HasConversion<string>()`; `FeedbackSource` has `HasSentinel((FeedbackSource)(-1))` + `HasDefaultValueSql("'UserReport'")` — matches issue |
| Issues | `IssueStatus`, `IssueCategory` | Both `HasConversion<string>()`; `IssueCategory` is parsed by name in `Humans.Agent`'s `AgentService.ParseIssueProposalArgs` via `Enum.TryParse<IssueCategory>` — matches issue |
| Notifications | `NotificationSource`, `NotificationClass`, `NotificationPriority` | All `HasConversion<string>()`; `NotificationSource` has 32 members — matches issue |

No discrepancies found — every enum listed in the issue was verified against its live `IEntityTypeConfiguration` and matched the issue's description exactly.

## Placement decision

Placed each guard in the owning section's own `tests/Humans.<Section>.Tests/Enums/EnumStringStabilityTests.cs` rather than the central `Humans.Domain.Tests` file. Reasoning: `CampaignStatus`, `FeedbackCategory`/`Status`/`Source`, and `IssueStatus` are `internal` to their section's `Domain/` folder after the G5 move, so the central project physically cannot name them (HUM0034 / internal-by-default); `IssueCategory` and the three `Notification*` enums live on their section's contracts leaf, which the section-project program (#866) treats as owned end-to-end by that section, not the central project. This matches the precedent already set for Tickets, Governance, and Budget's own `EnumStringStabilityTests` files.

Style follows the existing split precedent exactly: sections with any internal enum in the guard (Campaigns, Feedback, Issues) use a `[HumansFact]` + `AssertNames` helper (a public test method can't take an internal enum type as a theory parameter — CS0051, per the Tickets file's own comment); Notifications, where all three enums are public on the contracts leaf, uses the `[HumansTheory]` + `TheoryData<Type, string[]>` pattern matching Domain/Governance/Budget.

## Load-bearing hazards covered

- **`FeedbackSource`**: guard asserts `UserReport` and `AgentUnresolved` by name — a rename of `UserReport` would break the `HasDefaultValueSql("'UserReport'")` DB default, not just stored history.
- **`IssueCategory`**: guard asserts `Bug`, `Feature`, `Question` by name — a rename would silently break `Enum.TryParse<IssueCategory>` in `AgentService.ParseIssueProposalArgs` (falls back to `Question` instead of erroring), not just stored history.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test` on each of the four affected projects, filtered to `EnumStringStabilityTests` — all pass (Campaigns 1/1, Feedback 1/1, Issues 1/1, Notifications 3/3)
- [x] Full `dotnet test Humans.slnx -v quiet` — all green except two pre-existing flaky Integration tests (`Volunteer_GET_Store_returns_200_with_catalog_only`, `AcceptAsync_Languages_Move_DedupKeepHighestProficiency`), unrelated to this change (Store/AccountMerge), confirmed to pass in isolation

Fixes nobodies-collective/Humans#1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)