### PR TITLE
refactor(866): carve Humans.Users.Contracts leaf + read boundary (G5 lane 2, PR A)

### DIFF
--- a/Humans.slnx
+++ b/Humans.slnx
@@ -76,6 +76,7 @@
     <Project Path="src/Sections/Humans.Teams/Humans.Teams.csproj" />
     <Project Path="src/Sections/Humans.Teams.Contracts/Humans.Teams.Contracts.csproj" />
     <Project Path="src/Sections/Humans.Tour/Humans.Tour.csproj" />
+    <Project Path="src/Sections/Humans.Users.Contracts/Humans.Users.Contracts.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <File Path="tests/Directory.Build.props" />

--- a/docs/sections/G5-SECTION-TEMPLATE.md
+++ b/docs/sections/G5-SECTION-TEMPLATE.md
@@ -1510,6 +1510,21 @@ Git Bash.)
       — it is not the same grep as `typeof(<Section>` for the row-in-a-table case, and it
       fails silently in the opposite direction (proven: AuditLog).
 
+      **Sixth sighting, and it is the fifth one's other half: the interface that moves onto a
+      leaf *entirely*.** The `GetInterfaces()` fix below rescues the read-split shape, where
+      `I<Section>Service` stays behind and inherits the leaf half — walk its bases and the
+      members come back. It does nothing for an interface with no Base-side deriving type:
+      `ApplicationInterfaceTypes()` enumerated `Humans.Application.Interfaces.*` plus
+      `SectionAssemblies()`, and a contracts leaf is in neither — it carries no
+      `[assembly: Section("…")]`, by design, because it is not an application part. So
+      `IAccountProvisioningService`, whose `FindOrCreateUserByEmailAsync` returns a record
+      wrapping the `User` entity, simply stopped being scanned the moment Users' leaf was
+      carved, and its baseline row read as *fixed*. **Add a third clause enumerating
+      `Humans.*.Contracts` from `DependencyContext` — a leaf cannot be found by `[Section]`,
+      so it needs its own discovery.** Widening it surfaced exactly one row across all
+      twenty-one existing leaves, which is the usual answer and is why nobody had noticed
+      (proven: Users, lane 2 PR A).
+
       **Fifth sighting, and the keying is neither a path nor an assembly — it is
       `Type.GetMethods()` not following interface inheritance.** A read split that leaves
       `I<Section>Service : I<Section>ServiceRead` moves members onto a leaf that carries no

--- a/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
+++ b/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
@@ -62,7 +62,7 @@ public sealed class EmailMutationPathsAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [ServiceCallerRule, RepositoryCallerRule
     ];
 
-    private const string ServiceInterface = "Humans.Application.Interfaces.Profiles.IUserEmailService";
+    private const string ServiceInterface = "Humans.Users.Contracts.IUserEmailService";
     private const string RepositoryInterface = "Humans.Application.Interfaces.Repositories.IUserRepository";
     private const string ServiceMethodName = "ReconcileOAuthIdentityAsync";
     private const string RepositoryMethodName = "ApplyUserEmailReconcilePlanAsync";

--- a/src/Humans.Application/Helpers/ProfileCompletion.cs
+++ b/src/Humans.Application/Helpers/ProfileCompletion.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Entities;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Helpers;
 

--- a/src/Humans.Application/Humans.Application.csproj
+++ b/src/Humans.Application/Humans.Application.csproj
@@ -69,6 +69,15 @@
     -->
     <ProjectReference Include="..\Sections\Humans.Shifts.Contracts\Humans.Shifts.Contracts.csproj" />
     <ProjectReference Include="..\Sections\Humans.GoogleIntegration.Contracts\Humans.GoogleIntegration.Contracts.csproj" />
+    <!--
+      Users + Profiles' contracts leaf, carved ahead of the section move
+      (nobodies-collective/Humans#866, lane 2 PR A). Base is the heaviest consumer there is:
+      UserInfo is the canonical person read model, and the cross-section orchestrators left
+      here — AccountDeletionService, ExternalLoginService, UserParticipationBackfillService,
+      DashboardService, HumanLifecycleService — plus every Infrastructure job read through it.
+      Every other project reaches these types transitively through this reference.
+    -->
+    <ProjectReference Include="..\Sections\Humans.Users.Contracts\Humans.Users.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.Profiles.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.Profiles.cs
@@ -1,6 +1,7 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Interfaces.Repositories;
 

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.UserEmails.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.UserEmails.cs
@@ -1,6 +1,7 @@
 using Humans.Application.DTOs;
 using Humans.Domain.Entities;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Interfaces.Repositories;
 

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -2,6 +2,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using Humans.Domain.Attributes;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Interfaces.Repositories;
 

--- a/src/Humans.Application/Interfaces/Users/IUnsubscribeTokenProvider.cs
+++ b/src/Humans.Application/Interfaces/Users/IUnsubscribeTokenProvider.cs
@@ -1,5 +1,6 @@
 using Humans.Application.Interfaces.Profiles;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Interfaces.Users;
 

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -19,14 +19,6 @@ namespace Humans.Application.Interfaces.Users;
 public interface IUserService : IUserServiceRead, IApplicationService, IUserMerge
 {
     /// <summary>
-    /// Get all participation records for a given year, projected to the slim
-    /// <see cref="UserParticipationRow"/> shape (no EF entity leaves the
-    /// section). Served from the caching decorator's <see cref="UserInfo"/>
-    /// snapshot.
-    /// </summary>
-    Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default);
-
-    /// <summary>
     /// Declare that the user is not attending this year's event. Upserts a
     /// UserDeclared NotAttending row unless the user is already Attended (in
     /// which case the declaration is logged and ignored).
@@ -318,32 +310,12 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     // ---- Methods added for ContactService migration ----
 
     /// <summary>
-    /// Finds the user whose <c>Email</c> or <c>GoogleEmail</c> matches the given
-    /// address (case-insensitive) and returns the cached <see cref="UserInfo"/>
-    /// read-model for them. Also checks the gmail/googlemail alternate when
-    /// applicable, and falls back to the legacy <c>User.GoogleEmail</c> shadow
-    /// column for pre-issue-687 users whose <c>UserEmail.IsGoogle</c> rows are
-    /// unset. Returns null if no match.
-    /// </summary>
-    Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default);
-
-    /// <summary>
     /// Sets <c>User.LastConsentReminderSentAt</c> to <paramref name="sentAt"/>.
     /// No-op if the user does not exist. Used by the re-consent reminder job
     /// so it does not write to the Users table directly (design-rules §2c).
     /// </summary>
     Task SetLastConsentReminderSentAsync(
         Guid userId, Instant sentAt, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the user ids of every account with <c>DeletionScheduledFor</c>
-    /// in the past (or equal to <paramref name="now"/>) and with
-    /// <c>DeletionEligibleAfter</c> either null or already elapsed. Used by
-    /// the account deletion job to enumerate candidates without reading the
-    /// Users table directly (design-rules §2c).
-    /// </summary>
-    Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
-        Instant now, CancellationToken ct = default);
 
     // ---- Methods added for AccountMergeService fold-into-target redesign ----
 
@@ -422,14 +394,3 @@ public record AnonymizedAccountSummary(
     string PreferredLanguage,
     IReadOnlyList<(Guid SignupId, Guid ShiftId)> CancelledSignupIds);
 
-/// <summary>
-/// Slim cross-section projection of an <see cref="EventParticipation"/> row for
-/// a given year, returned by <see cref="IUserService.GetAllParticipationsForYearAsync"/>.
-/// Carries only the facts consumers diff against (status, source, check-in
-/// instant) keyed by user — no EF entity crosses the section boundary.
-/// </summary>
-public sealed record UserParticipationRow(
-    Guid UserId,
-    ParticipationStatus Status,
-    ParticipationSource Source,
-    Instant? CheckedInAt);

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -3,6 +3,7 @@ using Humans.Onboarding.Contracts;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Interfaces.Users;
 
@@ -420,17 +421,6 @@ public record AnonymizedAccountSummary(
     string OriginalDisplayName,
     string PreferredLanguage,
     IReadOnlyList<(Guid SignupId, Guid ShiftId)> CancelledSignupIds);
-
-/// <summary>
-/// Per-user row returned from <see cref="IUserServiceRead.GetOnsiteUsersAsync"/>.
-/// Names of camps / teams / governance roles are not stitched in here; the Web
-/// layer joins them via the owning section services before rendering. Issue
-/// nobodies-collective/Humans#736.
-/// </summary>
-public sealed record OnsiteUserRow(
-    Guid UserId,
-    string DisplayName,
-    Instant? CheckedInAt);
 
 /// <summary>
 /// Slim cross-section projection of an <see cref="EventParticipation"/> row for

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -310,6 +310,16 @@ public interface IUserService : IUserServiceRead, IApplicationService, IUserMerg
     // ---- Methods added for ContactService migration ----
 
     /// <summary>
+    /// Finds the user whose <c>Email</c> or <c>GoogleEmail</c> matches the given
+    /// address (case-insensitive) and returns the cached <see cref="UserInfo"/>
+    /// read-model for them. Also checks the gmail/googlemail alternate when
+    /// applicable, and falls back to the legacy <c>User.GoogleEmail</c> shadow
+    /// column for pre-issue-687 users whose <c>UserEmail.IsGoogle</c> rows are
+    /// unset. Returns null if no match.
+    /// </summary>
+    Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default);
+
+    /// <summary>
     /// Sets <c>User.LastConsentReminderSentAt</c> to <paramref name="sentAt"/>.
     /// No-op if the user does not exist. Used by the re-consent reminder job
     /// so it does not write to the Users table directly (design-rules §2c).

--- a/src/Humans.Application/Interfaces/Users/UserProfileCommands.cs
+++ b/src/Humans.Application/Interfaces/Users/UserProfileCommands.cs
@@ -52,20 +52,6 @@ public sealed record UserProfileSaveCommand(
     List<string>? Allergies = null,
     string? AllergyOtherText = null);
 
-/// <summary>
-/// Focused write for the full dietary + medical set (the DietaryMedical page).
-/// Updates only these six Profile columns; leaves all other profile fields untouched.
-/// MedicalConditions is GDPR Art. 9 — callers must already have verified the
-/// editor is the owner (or an authorized admin).
-/// </summary>
-public sealed record UserProfileDietaryMedicalCommand(
-    string? DietaryPreference,
-    List<string> Allergies,
-    string? AllergyOtherText,
-    List<string> Intolerances,
-    string? IntoleranceOtherText,
-    string? MedicalConditions);
-
 public enum UserProfilePictureMutation
 {
     None,

--- a/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
+++ b/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.AuditLog;
 using Humans.AuditLog.Contracts;
 using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.AuditLog;
 

--- a/src/Humans.Application/Services/Auth/MagicLinkService.cs
+++ b/src/Humans.Application/Services/Auth/MagicLinkService.cs
@@ -6,6 +6,7 @@ using Humans.Email.Contracts;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Auth;
 

--- a/src/Humans.Application/Services/Dashboard/AdminDashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/AdminDashboardService.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Dashboard;
 using Humans.Governance.Contracts;
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Dashboard;
 

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -10,6 +10,7 @@ using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Dashboard;
 

--- a/src/Humans.Application/Services/ICalFeed/ICalFeedService.cs
+++ b/src/Humans.Application/Services/ICalFeed/ICalFeedService.cs
@@ -4,6 +4,7 @@ using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using Microsoft.Extensions.Logging;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.ICalFeed;
 

--- a/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
+++ b/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Profiles;
 

--- a/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
+++ b/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
@@ -6,6 +6,7 @@ using Humans.Domain.Enums;
 using Humans.AuditLog.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Profiles;
 

--- a/src/Humans.Application/Services/Profiles/ContactFieldService.cs
+++ b/src/Humans.Application/Services/Profiles/ContactFieldService.cs
@@ -9,6 +9,7 @@ using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Profiles;
 

--- a/src/Humans.Application/Services/Profiles/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profiles/EmailProblemsService.cs
@@ -2,6 +2,7 @@ using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Profiles;
 

--- a/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
+++ b/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Profiles;
 

--- a/src/Humans.Application/Services/Profiles/ProfileEditorService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileEditorService.cs
@@ -6,6 +6,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Threading;
 using Humans.Domain.Constants;
 using Microsoft.Extensions.Logging;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Profiles;
 

--- a/src/Humans.Application/Services/Profiles/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profiles/UserEmailService.cs
@@ -12,6 +12,7 @@ using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Profiles;
 

--- a/src/Humans.Application/Services/Users/AccountLifecycle/AccountDeletionService.cs
+++ b/src/Humans.Application/Services/Users/AccountLifecycle/AccountDeletionService.cs
@@ -15,6 +15,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users.AccountLifecycle;
 

--- a/src/Humans.Application/Services/Users/AccountMergeService.cs
+++ b/src/Humans.Application/Services/Users/AccountMergeService.cs
@@ -13,6 +13,7 @@ using Humans.Application.Interfaces.Caching;
 using Humans.Consent.Contracts;
 using Humans.Notifications.Contracts;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users;
 

--- a/src/Humans.Application/Services/Users/AccountProvisioningService.cs
+++ b/src/Humans.Application/Services/Users/AccountProvisioningService.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Enums;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users;
 

--- a/src/Humans.Application/Services/Users/DuplicateAccountService.cs
+++ b/src/Humans.Application/Services/Users/DuplicateAccountService.cs
@@ -3,6 +3,7 @@ using Humans.Domain.Helpers;
 using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users;
 

--- a/src/Humans.Application/Services/Users/ExternalLoginService.cs
+++ b/src/Humans.Application/Services/Users/ExternalLoginService.cs
@@ -5,6 +5,7 @@ using Humans.Domain.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users;
 

--- a/src/Humans.Application/Services/Users/UnsubscribeService.cs
+++ b/src/Humans.Application/Services/Users/UnsubscribeService.cs
@@ -5,6 +5,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users;
 

--- a/src/Humans.Application/Services/Users/UserParticipationBackfillService.cs
+++ b/src/Humans.Application/Services/Users/UserParticipationBackfillService.cs
@@ -4,6 +4,7 @@ using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users;
 

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -15,6 +15,7 @@ using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Services.Users;
 

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -5,6 +5,7 @@ using Humans.Application.Interfaces;
 using Humans.AuditLog.Contracts;
 using Humans.Email.Contracts;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 
@@ -28,7 +29,7 @@ namespace Humans.Infrastructure.Jobs;
 /// </remarks>
 [DisableConcurrentExecution(timeoutInSeconds: 300)]
 public class ProcessAccountDeletionsJob(
-    IUserService userService,
+    IUserServiceRead userService,
     IAccountDeletionService accountDeletionService,
     IEmailService emailService,
     IEmailMessageFactory emailMessages,

--- a/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
@@ -8,6 +8,7 @@ using Humans.Governance.Contracts;
 using Humans.Notifications.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -70,7 +71,7 @@ public class TermRenewalReminderJob(
                 .Distinct()
                 .ToList();
             var applicantsById = applicantIds.Count == 0
-                ? new Dictionary<Guid, Application.UserInfo>()
+                ? new Dictionary<Guid, UserInfo>()
                 : (await userService.GetUserInfosAsync(applicantIds, cancellationToken))
                     .ToDictionary(kv => kv.Key, kv => kv.Value);
 

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.Profiles.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.Profiles.cs
@@ -5,6 +5,7 @@ using Humans.Domain;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Repositories.Users;
 

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.UserEmails.cs
@@ -4,6 +4,7 @@ using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Repositories.Users;
 

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -7,6 +7,7 @@ using Humans.Domain;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Repositories.Users;
 

--- a/src/Humans.Infrastructure/Services/AdminDatabaseDiagnosticsService.cs
+++ b/src/Humans.Infrastructure/Services/AdminDatabaseDiagnosticsService.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Repositories;
 using Humans.Tickets.Contracts;
 using Humans.Application.Interfaces.Users;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Services;
 

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -12,6 +12,7 @@ using Humans.Application.Interfaces.Auth;
 using Humans.Consent.Contracts;
 using Humans.Teams.Contracts;
 using Humans.Governance.Contracts;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Services;
 

--- a/src/Humans.Infrastructure/Services/Profiles/UnsubscribeTokenProvider.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/UnsubscribeTokenProvider.cs
@@ -7,6 +7,7 @@ using Humans.Infrastructure.Configuration;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Services.Profiles;
 

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -11,6 +11,7 @@ using Humans.Application.Services.Profiles;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
+using Humans.Users.Contracts;
 
 namespace Humans.Infrastructure.Services.Users;
 

--- a/src/Humans.UI/Controllers/ApiControllerBase.cs
+++ b/src/Humans.UI/Controllers/ApiControllerBase.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Humans.Application;
 using Humans.Application.Interfaces.Users;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.UI.Controllers;
 

--- a/src/Humans.UI/Controllers/HumansControllerBase.cs
+++ b/src/Humans.UI/Controllers/HumansControllerBase.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.UI.Constants;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.UI.Controllers;
 

--- a/src/Humans.UI/Extensions/PersonSearchOrderingExtensions.cs
+++ b/src/Humans.UI/Extensions/PersonSearchOrderingExtensions.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using Humans.Users.Contracts;
 
 namespace Humans.UI.Extensions;
 

--- a/src/Humans.UI/Extensions/SearchResultMappingExtensions.cs
+++ b/src/Humans.UI/Extensions/SearchResultMappingExtensions.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.UI.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.UI.Extensions;
 

--- a/src/Humans.UI/Hubs/CityPlanningHub.cs
+++ b/src/Humans.UI/Hubs/CityPlanningHub.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.SignalR;
+using Humans.Users.Contracts;
 
 namespace Humans.UI.Hubs;
 

--- a/src/Humans.UI/ViewComponents/HumanSearchViewComponent.cs
+++ b/src/Humans.UI/ViewComponents/HumanSearchViewComponent.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Models;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.UI.ViewComponents;
 

--- a/src/Humans.UI/ViewComponents/HumanViewComponent.cs
+++ b/src/Humans.UI/ViewComponents/HumanViewComponent.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces.Users;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Humans.Users.Contracts;
 
 namespace Humans.UI.ViewComponents;
 

--- a/src/Humans.UI/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.UI/Views/Shared/_LoginPartial.cshtml
@@ -6,7 +6,7 @@
 
 @if (SignInManager.IsSignedIn(User))
 {
-    Humans.Application.UserInfo? currentUser = null;
+    Humans.Users.Contracts.UserInfo? currentUser = null;
     if (Guid.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var currentUserId))
     {
         currentUser = await UserService.GetUserInfoAsync(currentUserId);

--- a/src/Humans.UI/Views/_ViewImports.cshtml
+++ b/src/Humans.UI/Views/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using Humans.Application.Extensions
+@using Humans.Users.Contracts
 @using Humans.Domain.Entities
 @using Humans.Domain.Enums
 @using Humans.UI

--- a/src/Humans.Web/Authorization/HumansUserClaimsPrincipalFactory.cs
+++ b/src/Humans.Web/Authorization/HumansUserClaimsPrincipalFactory.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Authorization;
 

--- a/src/Humans.Web/Authorization/NameRequiredFilter.cs
+++ b/src/Humans.Web/Authorization/NameRequiredFilter.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Authorization;
 

--- a/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
+++ b/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Enums;
 using Humans.UI.Authorization;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Caching.Memory;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Authorization;
 

--- a/src/Humans.Web/Controllers/AboutController.cs
+++ b/src/Humans.Web/Controllers/AboutController.cs
@@ -6,6 +6,7 @@ using NodaTime;
 using Humans.Web.Models;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 // Obsolete RoleAssignment nav props (User, CreatedByUser) stitched in-memory by RoleAssignmentService; see design-rules §15i.
 #pragma warning disable CS0618

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -11,6 +11,7 @@ using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Users;
 using Humans.UI;
 using Humans.Web.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -14,6 +14,7 @@ using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/Api/ICalFeedApiController.cs
+++ b/src/Humans.Web/Controllers/Api/ICalFeedApiController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using Humans.UI.Controllers;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers.Api;
 

--- a/src/Humans.Web/Controllers/EarlyEntryRosterController.cs
+++ b/src/Humans.Web/Controllers/EarlyEntryRosterController.cs
@@ -5,6 +5,7 @@ using Humans.UI.Controllers;
 using Humans.Web.Models.EarlyEntry;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -11,6 +11,7 @@ using Humans.Web.Models;
 using NodaTime;
 using Humans.Tickets.Contracts;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -8,6 +8,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.UI.Authorization;
 using Humans.Web.Models.EmailProblems;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using Humans.UI.Controllers;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -40,6 +40,7 @@ using Humans.Application.Models;
 using Humans.Application.Services.Profiles;
 using Humans.UI;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 // RoleAssignment nav props are [Obsolete]; service stitches them in memory. Nav-strip tracked in §15i.
 #pragma warning disable CS0618

--- a/src/Humans.Web/Controllers/ProfilePictureMigrationAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfilePictureMigrationAdminController.cs
@@ -5,6 +5,7 @@ using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/TicketsGateAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsGateAdminController.cs
@@ -4,6 +4,7 @@ using Humans.UI.Controllers;
 using Humans.Web.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/UserController.cs
+++ b/src/Humans.Web/Controllers/UserController.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Enums;
 using Humans.UI;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/UsersAdminAccountMergesController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminAccountMergesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Humans.Web.Models;
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/UsersAdminController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminController.cs
@@ -24,6 +24,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/UsersAdminDebugController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminDebugController.cs
@@ -5,6 +5,7 @@ using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -12,6 +12,7 @@ using NodaTime;
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
 using Humans.UI.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Humans.Web.Extensions.Infrastructure;
 using Humans.Web.Extensions.Sections;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Extensions;
 

--- a/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
@@ -13,6 +13,7 @@ using UsersUserEmailProviderBackfillService = Humans.Application.Services.Users.
 using UsersUnsubscribeService = Humans.Application.Services.Users.UnsubscribeService;
 using Humans.Application.Interfaces.Users;
 using Humans.Infrastructure.Repositories.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Extensions.Sections;
 

--- a/src/Humans.Web/Extensions/Sections/UsersSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/UsersSectionExtensions.cs
@@ -12,6 +12,7 @@ using DashboardDashboardService = Humans.Application.Services.Dashboard.Dashboar
 using UsersUserService = Humans.Application.Services.Users.UserService;
 using UsersAccountMergeService = Humans.Application.Services.Users.AccountMergeService;
 using UsersDuplicateAccountService = Humans.Application.Services.Users.DuplicateAccountService;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Extensions.Sections;
 

--- a/src/Humans.Web/Infrastructure/GateTerminalAccountSeeder.cs
+++ b/src/Humans.Web/Infrastructure/GateTerminalAccountSeeder.cs
@@ -9,6 +9,7 @@ using Humans.Domain.Enums;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Infrastructure;
 

--- a/src/Humans.Web/Models/AdminHumanDetailViewModelBuilder.cs
+++ b/src/Humans.Web/Models/AdminHumanDetailViewModelBuilder.cs
@@ -7,6 +7,7 @@ using Humans.Campaigns.Contracts;
 using Humans.Governance.Contracts;
 using Humans.Application.Interfaces.Profiles;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models;
 

--- a/src/Humans.Web/Models/DietaryMedicalViewModel.cs
+++ b/src/Humans.Web/Models/DietaryMedicalViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using Humans.Application;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models;
 

--- a/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
+++ b/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
@@ -1,6 +1,7 @@
 using Humans.Application.DTOs.EmailProblems;
 using Humans.Application;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models.EmailProblems;
 

--- a/src/Humans.Web/Models/EmailsViewModel.cs
+++ b/src/Humans.Web/Models/EmailsViewModel.cs
@@ -3,6 +3,7 @@ using Humans.Application;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Domain.Enums;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models;
 

--- a/src/Humans.Web/Models/FacilitatedMessageRequestBuilder.cs
+++ b/src/Humans.Web/Models/FacilitatedMessageRequestBuilder.cs
@@ -1,4 +1,5 @@
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models;
 

--- a/src/Humans.Web/Models/ProfileEditViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileEditViewModelBuilder.cs
@@ -3,6 +3,7 @@ using Humans.Governance.Contracts;
 using Humans.Shifts.Contracts;
 using Humans.Application.Extensions;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models;
 

--- a/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
@@ -2,6 +2,7 @@ using Humans.Teams.Contracts;
 using Humans.Application;
 using Humans.Camps.Contracts;
 using Humans.Application.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models;
 

--- a/src/Humans.Web/Models/UsersDebugViewModel.cs
+++ b/src/Humans.Web/Models/UsersDebugViewModel.cs
@@ -1,6 +1,7 @@
 using Humans.Application;
 using Humans.Domain.Enums;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Models;
 

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -37,6 +37,7 @@ using Humans.UI.Extensions;
 using Serilog;
 using Serilog.Events;
 using Humans.Web.Infrastructure;
+using Humans.Users.Contracts;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Enums;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.ViewComponents;
 

--- a/src/Humans.Web/ViewComponents/DietaryMissingBannerViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/DietaryMissingBannerViewComponent.cs
@@ -1,6 +1,7 @@
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.ViewComponents;
 

--- a/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
@@ -5,6 +5,7 @@ using Humans.Web.Controllers;
 using Humans.Web.Helpers;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.ViewComponents;
 

--- a/src/Humans.Web/ViewComponents/NobodiesEmailBadgeViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NobodiesEmailBadgeViewComponent.cs
@@ -1,5 +1,6 @@
 using Humans.Application.Interfaces.Users;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.ViewComponents;
 

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -11,6 +11,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Governance.Contracts;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.ViewComponents;
 

--- a/src/Humans.Web/ViewComponents/ThingsToDoViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ThingsToDoViewComponent.cs
@@ -8,6 +8,7 @@ using Humans.Shifts.Contracts;
 using Humans.Governance.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.UI;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.ViewComponents;
 

--- a/src/Humans.Web/ViewComponents/UserCalendarViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/UserCalendarViewComponent.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces.ICalFeed;
 using Humans.Application.Interfaces.Users;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.ViewComponents;
 

--- a/src/Humans.Web/Views/_ViewImports.cshtml
+++ b/src/Humans.Web/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 @using Humans.Web
 @using Humans.Application.Extensions
+@using Humans.Users.Contracts
 @using Humans.Web.Extensions
 @using Humans.Web.Extensions.Sections
 @using Humans.Web.Helpers

--- a/src/Sections/Humans.Agent/Controllers/AdminAgentController.cs
+++ b/src/Sections/Humans.Agent/Controllers/AdminAgentController.cs
@@ -6,6 +6,7 @@ using Humans.Agent.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Agent.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Agent.Controllers;
 

--- a/src/Sections/Humans.Agent/Controllers/AgentApiController.cs
+++ b/src/Sections/Humans.Agent/Controllers/AgentApiController.cs
@@ -7,6 +7,7 @@ using Humans.Agent.Filters;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Agent.Domain;
 using Humans.Agent.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Agent.Controllers;
 

--- a/src/Sections/Humans.Agent/Controllers/AgentController.cs
+++ b/src/Sections/Humans.Agent/Controllers/AgentController.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime.Serialization.SystemTextJson;
 using Humans.Agent.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Agent.Controllers;
 

--- a/src/Sections/Humans.Agent/Services/AgentUserSnapshotProvider.cs
+++ b/src/Sections/Humans.Agent/Services/AgentUserSnapshotProvider.cs
@@ -12,6 +12,7 @@ using Humans.Application.Models;
 using Humans.Domain.Enums;
 using NodaTime;
 using Humans.Agent.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Agent.Services;
 

--- a/src/Sections/Humans.AuditLog/Controllers/AuditLogController.cs
+++ b/src/Sections/Humans.AuditLog/Controllers/AuditLogController.cs
@@ -5,6 +5,7 @@ using Humans.Application.Interfaces.AuditLog;
 using Humans.AuditLog.Models;
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.AuditLog.Controllers;
 

--- a/src/Sections/Humans.AuditLog/Services/AuditLogService.cs
+++ b/src/Sections/Humans.AuditLog/Services/AuditLogService.cs
@@ -8,6 +8,7 @@ using Humans.AuditLog.Domain;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.AuditLog.Services;
 

--- a/src/Sections/Humans.Auth/Section.cs
+++ b/src/Sections/Humans.Auth/Section.cs
@@ -10,6 +10,7 @@ using Humans.Infrastructure.Hosting;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Auth;
 

--- a/src/Sections/Humans.Auth/Services/RoleAssignmentService.cs
+++ b/src/Sections/Humans.Auth/Services/RoleAssignmentService.cs
@@ -17,6 +17,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Notifications.Contracts;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Auth;
+using Humans.Users.Contracts;
 
 namespace Humans.Auth.Services;
 

--- a/src/Sections/Humans.Budget/Controllers/BudgetAdminController.cs
+++ b/src/Sections/Humans.Budget/Controllers/BudgetAdminController.cs
@@ -13,6 +13,7 @@ using NodaTime;
 
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Budget.Controllers;
 

--- a/src/Sections/Humans.Budget/Controllers/BudgetController.cs
+++ b/src/Sections/Humans.Budget/Controllers/BudgetController.cs
@@ -8,6 +8,7 @@ using Humans.Budget.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Budget.Controllers;
 

--- a/src/Sections/Humans.Budget/Services/BudgetService.cs
+++ b/src/Sections/Humans.Budget/Services/BudgetService.cs
@@ -10,6 +10,7 @@ using Humans.Budget.Domain;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Budget.Services;
 

--- a/src/Sections/Humans.Calendar/Controllers/CalendarController.cs
+++ b/src/Sections/Humans.Calendar/Controllers/CalendarController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Calendar.Controllers;
 

--- a/src/Sections/Humans.Campaigns/Controllers/CampaignController.cs
+++ b/src/Sections/Humans.Campaigns/Controllers/CampaignController.cs
@@ -5,6 +5,7 @@ using Humans.UI.Authorization;
 using Humans.UI.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Campaigns.Controllers;
 

--- a/src/Sections/Humans.Campaigns/Section.cs
+++ b/src/Sections/Humans.Campaigns/Section.cs
@@ -9,6 +9,7 @@ using Humans.Infrastructure.Hosting;
 using Humans.UI.Models.Tables;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Campaigns;
 

--- a/src/Sections/Humans.Campaigns/Services/CampaignService.cs
+++ b/src/Sections/Humans.Campaigns/Services/CampaignService.cs
@@ -16,6 +16,7 @@ using Humans.Campaigns.Services.Dtos;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Campaigns.Services;
 

--- a/src/Sections/Humans.Camps/Contracts/HumansCampControllerBase.cs
+++ b/src/Sections/Humans.Camps/Contracts/HumansCampControllerBase.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Contracts;
 

--- a/src/Sections/Humans.Camps/Controllers/CampAdminController.cs
+++ b/src/Sections/Humans.Camps/Controllers/CampAdminController.cs
@@ -9,6 +9,7 @@ using NodaTime;
 
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Controllers;
 

--- a/src/Sections/Humans.Camps/Controllers/CampComplianceController.cs
+++ b/src/Sections/Humans.Camps/Controllers/CampComplianceController.cs
@@ -5,6 +5,7 @@ using Humans.UI.Controllers;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Controllers;
 

--- a/src/Sections/Humans.Camps/Controllers/CampController.cs
+++ b/src/Sections/Humans.Camps/Controllers/CampController.cs
@@ -17,6 +17,7 @@ using Humans.UI;
 
 
 using Humans.UI.Controllers;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Controllers;
 

--- a/src/Sections/Humans.Camps/Models/CampAdmin/CampCsvExportBuilder.cs
+++ b/src/Sections/Humans.Camps/Models/CampAdmin/CampCsvExportBuilder.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Csv;
 using Humans.Camps.Contracts;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Models;
 

--- a/src/Sections/Humans.Camps/Section.cs
+++ b/src/Sections/Humans.Camps/Section.cs
@@ -14,6 +14,7 @@ using Humans.Infrastructure.Hosting;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps;
 

--- a/src/Sections/Humans.Camps/Services/CachingCampService.cs
+++ b/src/Sections/Humans.Camps/Services/CachingCampService.cs
@@ -11,6 +11,7 @@ using Humans.Camps.Services;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Services;
 

--- a/src/Sections/Humans.Camps/Services/CampRoleService.cs
+++ b/src/Sections/Humans.Camps/Services/CampRoleService.cs
@@ -11,6 +11,7 @@ using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Services;
 

--- a/src/Sections/Humans.Camps/Services/CampService.cs
+++ b/src/Sections/Humans.Camps/Services/CampService.cs
@@ -18,6 +18,7 @@ using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Services;
 

--- a/src/Sections/Humans.Cantina/Controllers/CantinaController.cs
+++ b/src/Sections/Humans.Cantina/Controllers/CantinaController.cs
@@ -8,6 +8,7 @@ using Humans.Cantina.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Cantina.Controllers;
 

--- a/src/Sections/Humans.Cantina/Services/CantinaRosterService.cs
+++ b/src/Sections/Humans.Cantina/Services/CantinaRosterService.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Cantina.Services.Dtos;
 using Humans.Domain.Constants;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Cantina.Services;
 

--- a/src/Sections/Humans.CityPlanning/Controllers/CityPlanningController.cs
+++ b/src/Sections/Humans.CityPlanning/Controllers/CityPlanningController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 
 using Humans.Application;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.CityPlanning.Controllers;
 

--- a/src/Sections/Humans.CityPlanning/Services/CityPlanningService.cs
+++ b/src/Sections/Humans.CityPlanning/Services/CityPlanningService.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Text;
 using System.Text.Json;
+using Humans.Users.Contracts;
 
 namespace Humans.CityPlanning.Services;
 

--- a/src/Sections/Humans.Consent/Controllers/AdminLegalDocumentsController.cs
+++ b/src/Sections/Humans.Consent/Controllers/AdminLegalDocumentsController.cs
@@ -9,6 +9,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
 using Humans.Consent.Models;
 using Humans.Consent.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Controllers;
 

--- a/src/Sections/Humans.Consent/Controllers/ConsentController.cs
+++ b/src/Sections/Humans.Consent/Controllers/ConsentController.cs
@@ -8,6 +8,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.UI;
 using Humans.Consent.Models;
 using Humans.Consent.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Controllers;
 

--- a/src/Sections/Humans.Consent/Services/CachingConsentService.cs
+++ b/src/Sections/Humans.Consent/Services/CachingConsentService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Consent.Domain;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Services;
 

--- a/src/Sections/Humans.Consent/Services/ConsentService.cs
+++ b/src/Sections/Humans.Consent/Services/ConsentService.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Consent.Data;
 using Humans.Consent.Domain;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Services;
 

--- a/src/Sections/Humans.Consent/Services/LegalDocumentSyncRunner.cs
+++ b/src/Sections/Humans.Consent/Services/LegalDocumentSyncRunner.cs
@@ -5,6 +5,7 @@ using Humans.Consent.Data;
 using Humans.Consent.Domain;
 using Humans.Email.Contracts;
 using Microsoft.Extensions.Logging;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Services;
 

--- a/src/Sections/Humans.Consent/Services/LegalDocumentSyncService.cs
+++ b/src/Sections/Humans.Consent/Services/LegalDocumentSyncService.cs
@@ -13,6 +13,7 @@ using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Consent.Data;
 using Humans.Consent.Domain;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Services;
 

--- a/src/Sections/Humans.Containers/Controllers/ContainerController.cs
+++ b/src/Sections/Humans.Containers/Controllers/ContainerController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Containers.Controllers;
 

--- a/src/Sections/Humans.Debug/Controllers/DebugController.cs
+++ b/src/Sections/Humans.Debug/Controllers/DebugController.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using Serilog.Events;
+using Humans.Users.Contracts;
 
 namespace Humans.Debug.Controllers;
 

--- a/src/Sections/Humans.Development/Controllers/DevLoginController.cs
+++ b/src/Sections/Humans.Development/Controllers/DevLoginController.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Development.Controllers;
 

--- a/src/Sections/Humans.Development/Controllers/DevSeedController.cs
+++ b/src/Sections/Humans.Development/Controllers/DevSeedController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Development.Controllers;
 

--- a/src/Sections/Humans.Development/Services/DevPersonaSeeder.cs
+++ b/src/Sections/Humans.Development/Services/DevPersonaSeeder.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Development.Services;
 

--- a/src/Sections/Humans.Development/Services/DevelopmentDashboardSeeder.cs
+++ b/src/Sections/Humans.Development/Services/DevelopmentDashboardSeeder.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.AspNetCore.Identity;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Development.Services;
 

--- a/src/Sections/Humans.Email/Controllers/EmailController.cs
+++ b/src/Sections/Humans.Email/Controllers/EmailController.cs
@@ -9,6 +9,7 @@ using Humans.Email.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Humans.Users.Contracts;
 
 namespace Humans.Email.Controllers;
 

--- a/src/Sections/Humans.Email/Services/OutboxEmailService.cs
+++ b/src/Sections/Humans.Email/Services/OutboxEmailService.cs
@@ -7,6 +7,7 @@ using Humans.Email.Domain;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Email.Services;
 

--- a/src/Sections/Humans.Events/Controllers/EventsAdminController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsAdminController.cs
@@ -10,6 +10,7 @@ using static Humans.Events.Helpers.EventsTimeHelpers;
 
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Controllers;
 

--- a/src/Sections/Humans.Events/Controllers/EventsApiController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsApiController.cs
@@ -14,6 +14,7 @@ using NodaTime.Text;
 using Humans.Events.Contracts;
 using Humans.Events.Services.Dtos;
 using Humans.UI.Controllers;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Controllers;
 

--- a/src/Sections/Humans.Events/Controllers/EventsController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsController.cs
@@ -15,6 +15,7 @@ using static Humans.Events.Helpers.EventsLookupHelpers;
 using static Humans.Events.Helpers.EventsTimeHelpers;
 using Humans.Events.Contracts;
 using Humans.UI.Controllers;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Controllers;
 

--- a/src/Sections/Humans.Events/Controllers/EventsDashboardController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsDashboardController.cs
@@ -13,6 +13,7 @@ using static Humans.Events.Helpers.EventsLookupHelpers;
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
 using Humans.Events.Contracts;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Controllers;
 

--- a/src/Sections/Humans.Events/Controllers/EventsExportController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsExportController.cs
@@ -12,6 +12,7 @@ using NodaTime;
 using static Humans.Events.Helpers.EventsLookupHelpers;
 using static Humans.Events.Helpers.EventsTimeHelpers;
 using Humans.Events.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Controllers;
 

--- a/src/Sections/Humans.Events/Controllers/EventsModerationController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsModerationController.cs
@@ -15,6 +15,7 @@ using static Humans.Events.Helpers.EventsLookupHelpers;
 using static Humans.Events.Helpers.EventsTimeHelpers;
 using Humans.Events.Contracts;
 using Humans.Events.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Controllers;
 

--- a/src/Sections/Humans.Events/Helpers/EventsLookupHelpers.cs
+++ b/src/Sections/Humans.Events/Helpers/EventsLookupHelpers.cs
@@ -5,6 +5,7 @@ using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Events.Models;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Helpers;
 

--- a/src/Sections/Humans.Events/Services/Service.cs
+++ b/src/Sections/Humans.Events/Services/Service.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Events.Contracts;
 using Humans.Events.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Services;
 

--- a/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
+++ b/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
@@ -13,6 +13,7 @@ using Humans.Expenses.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Expenses.Controllers;
 

--- a/src/Sections/Humans.Feedback/Controllers/FeedbackController.cs
+++ b/src/Sections/Humans.Feedback/Controllers/FeedbackController.cs
@@ -9,6 +9,7 @@ using Humans.UI.Models;
 using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Feedback.Controllers;
 

--- a/src/Sections/Humans.Feedback/Section.cs
+++ b/src/Sections/Humans.Feedback/Section.cs
@@ -8,6 +8,7 @@ using Humans.Feedback.Services;
 using Humans.Infrastructure.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Feedback;
 

--- a/src/Sections/Humans.Feedback/Services/FeedbackService.cs
+++ b/src/Sections/Humans.Feedback/Services/FeedbackService.cs
@@ -16,6 +16,7 @@ using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Notifications.Contracts;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Feedback.Services;
 

--- a/src/Sections/Humans.Finance/Controllers/FinanceController.cs
+++ b/src/Sections/Humans.Finance/Controllers/FinanceController.cs
@@ -5,6 +5,7 @@ using Humans.UI.Authorization;
 using Humans.UI.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Finance.Controllers;
 

--- a/src/Sections/Humans.Gate/Controllers/GateController.cs
+++ b/src/Sections/Humans.Gate/Controllers/GateController.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using NodaTime.Text;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate.Controllers;
 

--- a/src/Sections/Humans.Gate/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Sections/Humans.Gate/Controllers/GateVendorBackfillAdminController.cs
@@ -8,6 +8,7 @@ using Humans.UI.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate.Controllers;
 

--- a/src/Sections/Humans.Gate/Section.cs
+++ b/src/Sections/Humans.Gate/Section.cs
@@ -10,6 +10,7 @@ using Humans.Infrastructure.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate;
 

--- a/src/Sections/Humans.Gate/Services/GateService.cs
+++ b/src/Sections/Humans.Gate/Services/GateService.cs
@@ -17,6 +17,7 @@ using Humans.Gate.Domain;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate.Services;
 

--- a/src/Sections/Humans.GoogleIntegration/Controllers/GoogleController.cs
+++ b/src/Sections/Humans.GoogleIntegration/Controllers/GoogleController.cs
@@ -15,6 +15,7 @@ using Humans.UI.Authorization;
 using Humans.UI.Constants;
 using Humans.GoogleIntegration.Services;
 using Humans.GoogleIntegration.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Controllers;
 

--- a/src/Sections/Humans.GoogleIntegration/Services/EmailProvisioningService.cs
+++ b/src/Sections/Humans.GoogleIntegration/Services/EmailProvisioningService.cs
@@ -13,6 +13,7 @@ using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces;
 using Humans.GoogleIntegration.Data;
 using Humans.GoogleIntegration.Services.Workspace;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Services;
 

--- a/src/Sections/Humans.GoogleIntegration/Services/GoogleAdminService.cs
+++ b/src/Sections/Humans.GoogleIntegration/Services/GoogleAdminService.cs
@@ -11,6 +11,7 @@ using Humans.Application.Interfaces;
 using Humans.GoogleIntegration.Data;
 using Humans.GoogleIntegration.Services.Workspace;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Services;
 

--- a/src/Sections/Humans.GoogleIntegration/Services/GoogleGroupSyncService.cs
+++ b/src/Sections/Humans.GoogleIntegration/Services/GoogleGroupSyncService.cs
@@ -16,6 +16,7 @@ using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.GoogleIntegration.Data;
 using Humans.GoogleIntegration.Services.Workspace;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Services;
 

--- a/src/Sections/Humans.GoogleIntegration/Services/GoogleRemovalNotificationService.cs
+++ b/src/Sections/Humans.GoogleIntegration/Services/GoogleRemovalNotificationService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Humans.Application.Interfaces;
 using Humans.GoogleIntegration.Data;
 using Humans.GoogleIntegration.Services.Workspace;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Services;
 

--- a/src/Sections/Humans.GoogleIntegration/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Sections/Humans.GoogleIntegration/Services/GoogleWorkspaceSyncService.cs
@@ -19,6 +19,7 @@ using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.GoogleIntegration.Data;
 using Humans.GoogleIntegration.Services.Workspace;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Services;
 

--- a/src/Sections/Humans.GoogleIntegration/Views/_ViewImports.cshtml
+++ b/src/Sections/Humans.GoogleIntegration/Views/_ViewImports.cshtml
@@ -11,6 +11,7 @@
    pins that no type here binds a different set. *@
 @using Humans.Application.DTOs
 @using Humans.Application.Extensions
+@using Humans.Users.Contracts
 @using Humans.Application.Interfaces.Profiles
 @using Humans.Domain.Entities
 @using Humans.Domain.Enums

--- a/src/Sections/Humans.Governance/Controllers/GovernanceApplicationsController.cs
+++ b/src/Sections/Humans.Governance/Controllers/GovernanceApplicationsController.cs
@@ -12,6 +12,7 @@ using Humans.UI;
 using Humans.UI.Authorization;
 using Humans.UI.Extensions;
 using Humans.Governance.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Controllers;
 

--- a/src/Sections/Humans.Governance/Controllers/GovernanceBoardVotingController.cs
+++ b/src/Sections/Humans.Governance/Controllers/GovernanceBoardVotingController.cs
@@ -12,6 +12,7 @@ using Humans.Domain.Enums;
 using Humans.UI;
 using Humans.UI.Authorization;
 using Humans.Governance.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Controllers;
 

--- a/src/Sections/Humans.Governance/Controllers/GovernanceController.cs
+++ b/src/Sections/Humans.Governance/Controllers/GovernanceController.cs
@@ -7,6 +7,7 @@ using Humans.Governance.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Extensions;
 using Humans.Governance.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Controllers;
 

--- a/src/Sections/Humans.Governance/Section.cs
+++ b/src/Sections/Humans.Governance/Section.cs
@@ -10,6 +10,7 @@ using Humans.Infrastructure.Hosting;
 using Humans.UI.Models.Tables;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance;
 

--- a/src/Sections/Humans.Governance/Services/ApplicationDecisionService.cs
+++ b/src/Sections/Humans.Governance/Services/ApplicationDecisionService.cs
@@ -24,6 +24,7 @@ using Humans.Notifications.Contracts;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Services;
 

--- a/src/Sections/Humans.Governance/Services/GovernanceIndexService.cs
+++ b/src/Sections/Humans.Governance/Services/GovernanceIndexService.cs
@@ -2,6 +2,7 @@ using Humans.Governance.Contracts;
 using Humans.Consent.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Services;
 

--- a/src/Sections/Humans.Governance/Services/MembershipCalculator.cs
+++ b/src/Sections/Humans.Governance/Services/MembershipCalculator.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Enums;
 using Humans.Consent.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Governance.Contracts;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Services;
 

--- a/src/Sections/Humans.Holded/Controllers/HoldedController.cs
+++ b/src/Sections/Humans.Holded/Controllers/HoldedController.cs
@@ -7,6 +7,7 @@ using Humans.UI.Authorization;
 using Humans.UI.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Holded.Controllers;
 

--- a/src/Sections/Humans.Issues/Controllers/IssuesApiController.cs
+++ b/src/Sections/Humans.Issues/Controllers/IssuesApiController.cs
@@ -10,6 +10,7 @@ using Humans.Issues.Filters;
 using Humans.Issues.Models;
 using Humans.Issues.Services;
 using Humans.Issues.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Issues.Controllers;
 

--- a/src/Sections/Humans.Issues/Controllers/IssuesController.cs
+++ b/src/Sections/Humans.Issues/Controllers/IssuesController.cs
@@ -12,6 +12,7 @@ using Humans.Issues.Models;
 using Humans.Issues.Services;
 using Humans.Issues.Services.Dtos;
 using Humans.UI.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Issues.Controllers;
 

--- a/src/Sections/Humans.Issues/Services/IssuesService.cs
+++ b/src/Sections/Humans.Issues/Services/IssuesService.cs
@@ -20,6 +20,7 @@ using Humans.Issues.Contracts;
 using Humans.Issues.Data;
 using Humans.Issues.Domain;
 using Humans.Issues.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Issues.Services;
 

--- a/src/Sections/Humans.Mailer/Controllers/MailerAdminController.cs
+++ b/src/Sections/Humans.Mailer/Controllers/MailerAdminController.cs
@@ -11,6 +11,7 @@ using Humans.UI.Authorization;
 using Humans.Mailer.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Controllers;
 

--- a/src/Sections/Humans.Mailer/Models/MailerAudienceDebugSnapshotBuilder.cs
+++ b/src/Sections/Humans.Mailer/Models/MailerAudienceDebugSnapshotBuilder.cs
@@ -4,6 +4,7 @@ using Humans.Mailer.Services;
 using Humans.Mailer.Services.Dtos;
 using Humans.Application.Interfaces.Users;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Models;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/HasShiftAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/HasShiftAudience.cs
@@ -1,5 +1,6 @@
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/HasShiftEventAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/HasShiftEventAudience.cs
@@ -1,6 +1,7 @@
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/HasShiftInPeriodAudienceBase.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/HasShiftInPeriodAudienceBase.cs
@@ -1,6 +1,7 @@
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/HasShiftSetupAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/HasShiftSetupAudience.cs
@@ -1,6 +1,7 @@
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/HasShiftStrikeAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/HasShiftStrikeAudience.cs
@@ -1,6 +1,7 @@
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/HasTicketAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/HasTicketAudience.cs
@@ -1,6 +1,7 @@
 using Humans.Tickets.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/MailerAudienceBase.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/MailerAudienceBase.cs
@@ -1,5 +1,6 @@
 using Humans.Mailer.Services;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/MarketingAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/MarketingAudience.cs
@@ -1,4 +1,5 @@
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/MarketingNoTicketAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/MarketingNoTicketAudience.cs
@@ -1,6 +1,7 @@
 using Humans.Tickets.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/Audiences/TicketNoShiftsAudience.cs
+++ b/src/Sections/Humans.Mailer/Services/Audiences/TicketNoShiftsAudience.cs
@@ -2,6 +2,7 @@ using Humans.Shifts.Contracts;
 using Humans.Tickets.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services.Audiences;
 

--- a/src/Sections/Humans.Mailer/Services/MailerAudienceSyncService.cs
+++ b/src/Sections/Humans.Mailer/Services/MailerAudienceSyncService.cs
@@ -5,6 +5,7 @@ using Humans.Mailer.Services.Dtos;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services;
 

--- a/src/Sections/Humans.Mailer/Services/MailerImportService.cs
+++ b/src/Sections/Humans.Mailer/Services/MailerImportService.cs
@@ -6,6 +6,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Services;
 

--- a/src/Sections/Humans.Monitor/Controllers/MonitorController.cs
+++ b/src/Sections/Humans.Monitor/Controllers/MonitorController.cs
@@ -9,6 +9,7 @@ using Humans.UI.Authorization;
 using Humans.UI.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Monitor.Controllers;
 

--- a/src/Sections/Humans.Monitor/Services/DriveActivityMonitorService.cs
+++ b/src/Sections/Humans.Monitor/Services/DriveActivityMonitorService.cs
@@ -9,6 +9,7 @@ using Humans.SystemSettings.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Monitor.Services;
 

--- a/src/Sections/Humans.Notifications/Controllers/NotificationsController.cs
+++ b/src/Sections/Humans.Notifications/Controllers/NotificationsController.cs
@@ -6,6 +6,7 @@ using Humans.Notifications.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Controllers;
 

--- a/src/Sections/Humans.Notifications/Section.cs
+++ b/src/Sections/Humans.Notifications/Section.cs
@@ -8,6 +8,7 @@ using Humans.Notifications.Data;
 using Humans.Notifications.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications;
 

--- a/src/Sections/Humans.Notifications/Services/NotificationEmitter.cs
+++ b/src/Sections/Humans.Notifications/Services/NotificationEmitter.cs
@@ -9,6 +9,7 @@ using NodaTime;
 using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Services;
 

--- a/src/Sections/Humans.Notifications/Services/NotificationInboxService.cs
+++ b/src/Sections/Humans.Notifications/Services/NotificationInboxService.cs
@@ -7,6 +7,7 @@ using Humans.Notifications.Domain;
 using Humans.Notifications.Contracts;
 using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Services;
 

--- a/src/Sections/Humans.Notifications/Services/NotificationMeterProvider.cs
+++ b/src/Sections/Humans.Notifications/Services/NotificationMeterProvider.cs
@@ -14,6 +14,7 @@ using Humans.Notifications.Contracts;
 using Humans.Tickets.Contracts;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Services;
 

--- a/src/Sections/Humans.Notifications/Services/NotificationService.cs
+++ b/src/Sections/Humans.Notifications/Services/NotificationService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Services;
 

--- a/src/Sections/Humans.Onboarding/Controllers/OnboardingReviewController.cs
+++ b/src/Sections/Humans.Onboarding/Controllers/OnboardingReviewController.cs
@@ -10,6 +10,7 @@ using Humans.Onboarding.Contracts;
 using Humans.Onboarding.Services;
 using Humans.UI;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Controllers;
 

--- a/src/Sections/Humans.Onboarding/Controllers/OnboardingWidgetController.cs
+++ b/src/Sections/Humans.Onboarding/Controllers/OnboardingWidgetController.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Controllers;
 

--- a/src/Sections/Humans.Onboarding/Services/OnboardingWidgetState.cs
+++ b/src/Sections/Humans.Onboarding/Services/OnboardingWidgetState.cs
@@ -4,6 +4,7 @@ using Humans.Onboarding.Contracts;
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Services;
 

--- a/src/Sections/Humans.Onboarding/Services/ReviewQueueData.cs
+++ b/src/Sections/Humans.Onboarding/Services/ReviewQueueData.cs
@@ -1,4 +1,5 @@
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Services;
 

--- a/src/Sections/Humans.Scanner/Controllers/ScannerController.cs
+++ b/src/Sections/Humans.Scanner/Controllers/ScannerController.cs
@@ -12,6 +12,7 @@ using Humans.Scanner.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Scanner.Controllers;
 

--- a/src/Sections/Humans.Search/Controllers/SearchController.cs
+++ b/src/Sections/Humans.Search/Controllers/SearchController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Search.Controllers;
 

--- a/src/Sections/Humans.Search/Services/Dtos/GlobalSearchResults.cs
+++ b/src/Sections/Humans.Search/Services/Dtos/GlobalSearchResults.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using Humans.Users.Contracts;
 
 namespace Humans.Search.Services.Dtos;
 

--- a/src/Sections/Humans.Search/Services/SearchService.cs
+++ b/src/Sections/Humans.Search/Services/SearchService.cs
@@ -7,6 +7,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
 using Humans.Search.Services.Dtos;
 using Microsoft.Extensions.Configuration;
+using Humans.Users.Contracts;
 
 namespace Humans.Search.Services;
 

--- a/src/Sections/Humans.Shifts/Contracts/VolunteerBuildStripViewComponent.cs
+++ b/src/Sections/Humans.Shifts/Contracts/VolunteerBuildStripViewComponent.cs
@@ -2,6 +2,7 @@ using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Shifts.Models;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Contracts;
 

--- a/src/Sections/Humans.Shifts/Controllers/ShiftAdminController.cs
+++ b/src/Sections/Humans.Shifts/Controllers/ShiftAdminController.cs
@@ -13,6 +13,7 @@ using NodaTime;
 using Humans.Application.Interfaces.Users;
 using Humans.Application;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Controllers;
 

--- a/src/Sections/Humans.Shifts/Controllers/ShiftDashboardController.cs
+++ b/src/Sections/Humans.Shifts/Controllers/ShiftDashboardController.cs
@@ -12,6 +12,7 @@ using NodaTime.Text;
 
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Controllers;
 

--- a/src/Sections/Humans.Shifts/Controllers/ShiftProfileController.cs
+++ b/src/Sections/Humans.Shifts/Controllers/ShiftProfileController.cs
@@ -6,6 +6,7 @@ using Humans.UI.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Controllers;
 
@@ -24,7 +25,7 @@ namespace Humans.Shifts.Controllers;
 [Route("Profile")]
 internal sealed class ShiftProfileController(
     IShiftManagementService shiftMgmt,
-    IUserService userService,
+    IUserServiceRead userService,
     // SharedResource, not ShiftsResource: the one string this controller resolves is
     // Profile_Updated, which belongs to Shell's profile vocabulary and stayed there. The
     // page's own 13 ShiftInfo_ keys are the view's, and the view reads ShiftsResource

--- a/src/Sections/Humans.Shifts/Controllers/ShiftWorkloadAdminController.cs
+++ b/src/Sections/Humans.Shifts/Controllers/ShiftWorkloadAdminController.cs
@@ -4,6 +4,7 @@ using Humans.UI.Authorization;
 using Humans.UI.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Controllers;
 

--- a/src/Sections/Humans.Shifts/Controllers/ShiftsController.cs
+++ b/src/Sections/Humans.Shifts/Controllers/ShiftsController.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Localization;
 using NodaTime;
 using NodaTime.Text;
 using Humans.Shifts.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Controllers;
 

--- a/src/Sections/Humans.Shifts/Controllers/VolunteerTrackingController.cs
+++ b/src/Sections/Humans.Shifts/Controllers/VolunteerTrackingController.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NodaTime;
 using NodaTime.Text;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Controllers;
 

--- a/src/Sections/Humans.Shifts/Helpers/ShiftVolunteerSearchBuilder.cs
+++ b/src/Sections/Humans.Shifts/Helpers/ShiftVolunteerSearchBuilder.cs
@@ -9,6 +9,7 @@ using Humans.UI.Extensions;
 using Humans.Shifts.Models;
 using Humans.Shifts.Services.Dtos;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Helpers;
 

--- a/src/Sections/Humans.Shifts/Models/ShiftAdminPageBuilder.cs
+++ b/src/Sections/Humans.Shifts/Models/ShiftAdminPageBuilder.cs
@@ -10,6 +10,7 @@ using Humans.Shifts.Domain;
 using Humans.Domain.Enums;
 using NodaTime;
 using Humans.UI.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Models;
 

--- a/src/Sections/Humans.Shifts/Models/ShiftViewModels.cs
+++ b/src/Sections/Humans.Shifts/Models/ShiftViewModels.cs
@@ -11,6 +11,7 @@ using Humans.Shifts.Domain;
 using Humans.Domain.Enums;
 using NodaTime;
 using Humans.UI.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Models;
 

--- a/src/Sections/Humans.Shifts/Section.cs
+++ b/src/Sections/Humans.Shifts/Section.cs
@@ -12,6 +12,7 @@ using Humans.Shifts.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Humans.Application.Interfaces;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts;
 

--- a/src/Sections/Humans.Shifts/Services/RotaCoordinatorMessageService.cs
+++ b/src/Sections/Humans.Shifts/Services/RotaCoordinatorMessageService.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Shifts.Data;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Services;
 

--- a/src/Sections/Humans.Shifts/Services/ShiftManagementService.cs
+++ b/src/Sections/Humans.Shifts/Services/ShiftManagementService.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Humans.Shifts.Data;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Services;
 

--- a/src/Sections/Humans.Shifts/Services/ShiftSignupService.cs
+++ b/src/Sections/Humans.Shifts/Services/ShiftSignupService.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Shifts.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Services;
 

--- a/src/Sections/Humans.Shifts/Services/VolunteerTrackingExportService.cs
+++ b/src/Sections/Humans.Shifts/Services/VolunteerTrackingExportService.cs
@@ -8,6 +8,7 @@ using Humans.Application.Interfaces.Users;
 using NodaTime;
 using Humans.Shifts.Data;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Services;
 

--- a/src/Sections/Humans.Shifts/Services/VolunteerTrackingService.cs
+++ b/src/Sections/Humans.Shifts/Services/VolunteerTrackingService.cs
@@ -10,6 +10,7 @@ using NodaTime;
 using Humans.Shifts.Data;
 using Humans.Shifts.Services.Dtos;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Services;
 

--- a/src/Sections/Humans.Shifts/Services/WorkloadService.cs
+++ b/src/Sections/Humans.Shifts/Services/WorkloadService.cs
@@ -9,6 +9,7 @@ using Humans.Shifts.Domain;
 using Humans.Domain.Enums;
 using NodaTime;
 using Humans.Shifts.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Services;
 

--- a/src/Sections/Humans.Store/Controllers/StoreAdminController.cs
+++ b/src/Sections/Humans.Store/Controllers/StoreAdminController.cs
@@ -10,6 +10,7 @@ using NodaTime.Text;
 
 using Humans.Application.Interfaces.Users;
 using Humans.UI.Authorization;
+using Humans.Users.Contracts;
 
 namespace Humans.Store.Controllers;
 

--- a/src/Sections/Humans.Store/Controllers/StoreController.cs
+++ b/src/Sections/Humans.Store/Controllers/StoreController.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Store.Controllers;
 

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -13,6 +13,7 @@ using Humans.Surveys.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Controllers;
 

--- a/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Controllers;
 

--- a/src/Sections/Humans.Surveys/Controllers/SurveysApiController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveysApiController.cs
@@ -11,6 +11,7 @@ using NodaTime;
 using NodaTime.Text;
 
 using Humans.UI.Controllers;
+using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Controllers;
 

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -15,6 +15,7 @@ using Humans.Domain.Enums;
 using Humans.Surveys.Domain;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Services;
 

--- a/src/Sections/Humans.Teams/Contracts/HumansTeamControllerBase.cs
+++ b/src/Sections/Humans.Teams/Contracts/HumansTeamControllerBase.cs
@@ -6,6 +6,7 @@ using Humans.UI.Controllers;
 using Humans.Teams.Authorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Contracts;
 

--- a/src/Sections/Humans.Teams/Controllers/TeamAdminController.cs
+++ b/src/Sections/Humans.Teams/Controllers/TeamAdminController.cs
@@ -19,6 +19,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
 using Humans.UI.Authorization;
 using NodaTime.Text;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Controllers;
 

--- a/src/Sections/Humans.Teams/Controllers/TeamController.cs
+++ b/src/Sections/Humans.Teams/Controllers/TeamController.cs
@@ -19,6 +19,7 @@ using Humans.UI;
 using Humans.UI.Authorization;
 using Humans.UI.Extensions;
 using Humans.UI.Models;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Controllers;
 

--- a/src/Sections/Humans.Teams/Section.cs
+++ b/src/Sections/Humans.Teams/Section.cs
@@ -12,6 +12,7 @@ using Humans.Teams.Data;
 using Humans.Teams.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams;
 

--- a/src/Sections/Humans.Teams/Services/CachingTeamService.cs
+++ b/src/Sections/Humans.Teams/Services/CachingTeamService.cs
@@ -12,6 +12,7 @@ using Humans.Domain.Enums;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Services;
 

--- a/src/Sections/Humans.Teams/Services/TeamPageService.cs
+++ b/src/Sections/Humans.Teams/Services/TeamPageService.cs
@@ -3,6 +3,7 @@ using Humans.Shifts.Contracts;
 using Humans.Teams.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Services;
 

--- a/src/Sections/Humans.Teams/Services/TeamService.cs
+++ b/src/Sections/Humans.Teams/Services/TeamService.cs
@@ -58,8 +58,8 @@ internal sealed class TeamService(
     private ISystemTeamSync SystemTeamSync
         => serviceProvider.GetRequiredService<ISystemTeamSync>();
 
-    private IUserService UserService
-        => serviceProvider.GetRequiredService<IUserService>();
+    private IUserServiceRead UserService
+        => serviceProvider.GetRequiredService<IUserServiceRead>();
 
     private IGoogleSyncOutboxService GoogleSyncOutboxService
         => serviceProvider.GetRequiredService<IGoogleSyncOutboxService>();

--- a/src/Sections/Humans.Teams/Services/TeamService.cs
+++ b/src/Sections/Humans.Teams/Services/TeamService.cs
@@ -25,6 +25,7 @@ using Humans.Domain.Entities;
 using Humans.Teams.Domain;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Services;
 

--- a/src/Sections/Humans.Tickets/Controllers/TicketController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketController.cs
@@ -11,6 +11,7 @@ using Humans.UI.Extensions;
 using Humans.Tickets.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Controllers;
 

--- a/src/Sections/Humans.Tickets/Controllers/TicketTransferAdminController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketTransferAdminController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Controllers;
 

--- a/src/Sections/Humans.Tickets/Controllers/TicketTransferController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketTransferController.cs
@@ -8,6 +8,7 @@ using Humans.Tickets.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Tickets.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Controllers;
 

--- a/src/Sections/Humans.Tickets/Controllers/TicketsContactsAdminController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketsContactsAdminController.cs
@@ -7,6 +7,7 @@ using Humans.UI.Controllers;
 using Humans.Tickets.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Controllers;
 

--- a/src/Sections/Humans.Tickets/Controllers/TicketsOnsiteAdminController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketsOnsiteAdminController.cs
@@ -7,6 +7,7 @@ using Humans.UI.Controllers;
 using Humans.Tickets.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Controllers;
 

--- a/src/Sections/Humans.Tickets/Section.cs
+++ b/src/Sections/Humans.Tickets/Section.cs
@@ -11,6 +11,7 @@ using Humans.Tickets.Services.Stores;
 using Humans.UI.Models.Tables;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets;
 

--- a/src/Sections/Humans.Tickets/Services/AttendeeContactImportService.cs
+++ b/src/Sections/Humans.Tickets/Services/AttendeeContactImportService.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Tickets.Data;
 using Humans.Tickets.Domain;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Services;
 

--- a/src/Sections/Humans.Tickets/Services/OnsiteRosterService.cs
+++ b/src/Sections/Humans.Tickets/Services/OnsiteRosterService.cs
@@ -5,6 +5,7 @@ using Humans.Teams.Contracts;
 using Humans.Tickets.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Services;
 

--- a/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
@@ -19,6 +19,7 @@ using Humans.Tickets.Domain;
 using Humans.Tickets.Models;
 using Humans.Tickets.Services.Dtos;
 using Humans.Tickets.Services.Stores;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Services;
 

--- a/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
@@ -31,7 +31,7 @@ internal sealed class TicketQueryService(
     ITicketTransferRepository ticketTransferRepository,
     IBudgetServiceRead budgetService,
     ICampaignServiceRead campaignService,
-    IUserService userService,
+    IUserServiceRead userService,
     IUserEmailService userEmailService,
     ITeamServiceRead teamService,
     IBurnSettingsService burnSettings,

--- a/src/Sections/Humans.Tickets/Services/TicketSyncService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketSyncService.cs
@@ -16,6 +16,7 @@ using NodaTime;
 using Humans.Application.Interfaces.TicketVendor;
 using Humans.Tickets.Data;
 using Humans.Tickets.Domain;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Services;
 

--- a/src/Sections/Humans.Tickets/Services/TicketTransferService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketTransferService.cs
@@ -14,6 +14,7 @@ using Humans.Application.Interfaces.TicketVendor;
 using Humans.Tickets.Data;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Services.Dtos;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Services;
 

--- a/src/Sections/Humans.Users.Contracts/CVEntry.cs
+++ b/src/Sections/Humans.Users.Contracts/CVEntry.cs
@@ -1,6 +1,6 @@
 using NodaTime;
 
-namespace Humans.Application;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Slim projection of a volunteer-history entry passed to

--- a/src/Sections/Humans.Users.Contracts/ContactFieldDto.cs
+++ b/src/Sections/Humans.Users.Contracts/ContactFieldDto.cs
@@ -1,6 +1,6 @@
 using Humans.Domain.Enums;
 
-namespace Humans.Application.DTOs;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Contact field data for display purposes.

--- a/src/Sections/Humans.Users.Contracts/HumanSearchResult.cs
+++ b/src/Sections/Humans.Users.Contracts/HumanSearchResult.cs
@@ -1,4 +1,4 @@
-namespace Humans.Application.DTOs;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Single canonical person-search result. Returned by

--- a/src/Sections/Humans.Users.Contracts/Humans.Users.Contracts.csproj
+++ b/src/Sections/Humans.Users.Contracts/Humans.Users.Contracts.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Users + Profiles' cross-section surface, carved into its own leaf project ahead of the
+    section move (nobodies-collective/Humans#866, G5 lane 2, PR A).
+
+    A Contracts/ *folder* inside Humans.Users was never an option here. UserInfo is the
+    canonical "everything-about-a-person" read model and IUserServiceRead is injected by
+    HumansControllerBase, so between them they are named by more than twenty section
+    projects, by Humans.UI, and — decisively — by Humans.Application and
+    Humans.Infrastructure, which the section itself will reference. A folder would cycle at
+    the assembly level in both directions (design §15 step 5b,
+    memory/architecture/section-project-cycle-fix.md).
+
+    It holds exactly what lives outside the section: the UserInfo read model and the eight
+    projections it nests, the cross-section read interface and its result shapes, and the
+    eight service interfaces something outside Humans.Application injects. The section's own
+    write surface — IUserService, IAccountDeletionService, IAccountMergeService,
+    IDuplicateAccountService, IExternalLoginService, IUnsubscribeService,
+    IEmailProblemsService, IProfilePictureService, the six repository interfaces — has no
+    out-of-section production consumer and stays internal to the section.
+
+    Two absences are load-bearing.
+
+    The four Users/Profiles enums (UserState, ProfileState, ContactFieldType,
+    ContactFieldVisibility) are NOT here, contrary to the Camps/Budget "the leaf's own
+    records name them" rule. Humans.Domain's User, Profile, UserEmail and ContactField
+    entities declare columns of those types and Humans.Domain cannot reference this leaf, so
+    moving them now would be a project cycle. They move here in PR B, in the same commit
+    that moves the entities into the section — see the leaf's Users.md notes.
+
+    UserInfo.Create is still here for the same reason: it takes the eight EF entities, which
+    are still Humans.Domain types. PR B splits it into a section-internal factory and leaves
+    the record behind.
+
+    References Humans.Interfaces (IApplicationService, IInvalidator, SurfaceBudgetAttribute,
+    GrandfatheredAttribute) and Humans.Domain (the entities UserInfo.Create consumes and the
+    shared enums its projections name), the same pair Humans.Camps.Contracts and
+    Humans.GoogleIntegration.Contracts take. Acyclic: Humans.Domain names only
+    Humans.Interfaces.
+  -->
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Humans.Interfaces\Humans.Interfaces.csproj" />
+    <ProjectReference Include="..\..\Humans.Domain\Humans.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NodaTime" />
+  </ItemGroup>
+
+</Project>

--- a/src/Sections/Humans.Users.Contracts/IAccountProvisioningService.cs
+++ b/src/Sections/Humans.Users.Contracts/IAccountProvisioningService.cs
@@ -1,7 +1,8 @@
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 
-namespace Humans.Application.Interfaces.Users;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Provides idempotent account creation for import jobs (ticket import, MailerLite import).

--- a/src/Sections/Humans.Users.Contracts/ICommunicationPreferenceService.cs
+++ b/src/Sections/Humans.Users.Contracts/ICommunicationPreferenceService.cs
@@ -1,8 +1,8 @@
-using Humans.Application.Interfaces.Users;
+using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 using NodaTime;
 
-namespace Humans.Application.Interfaces.Profiles;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Status of a CommunicationPreference token validation attempt.

--- a/src/Sections/Humans.Users.Contracts/IContactFieldService.cs
+++ b/src/Sections/Humans.Users.Contracts/IContactFieldService.cs
@@ -1,7 +1,7 @@
-using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 
-namespace Humans.Application.Interfaces.Profiles;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Service for managing contact fields with visibility controls.

--- a/src/Sections/Humans.Users.Contracts/IProfileEditorService.cs
+++ b/src/Sections/Humans.Users.Contracts/IProfileEditorService.cs
@@ -1,7 +1,6 @@
-using Humans.Application.DTOs;
-using Humans.Application.Interfaces.Users;
+using Humans.Application.Interfaces;
 
-namespace Humans.Application.Interfaces.Profiles;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Coordinates profile edit form saves around the Users-owned storage mutation.

--- a/src/Sections/Humans.Users.Contracts/IUserEmailService.cs
+++ b/src/Sections/Humans.Users.Contracts/IUserEmailService.cs
@@ -1,10 +1,9 @@
-using Humans.Application.DTOs;
-using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 
-namespace Humans.Application.Interfaces.Profiles;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Service for managing user email addresses.

--- a/src/Sections/Humans.Users.Contracts/IUserInfoInvalidator.cs
+++ b/src/Sections/Humans.Users.Contracts/IUserInfoInvalidator.cs
@@ -1,8 +1,9 @@
+using Humans.Application.Interfaces;
 using Humans.Application.Architecture;
 
 using System.Runtime.CompilerServices;
 
-namespace Humans.Application.Interfaces.Users;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// One-way cache-staleness signal for <see cref="UserInfo"/>. Implemented by

--- a/src/Sections/Humans.Users.Contracts/IUserMerge.cs
+++ b/src/Sections/Humans.Users.Contracts/IUserMerge.cs
@@ -1,6 +1,6 @@
 using NodaTime;
 
-namespace Humans.Application.Interfaces.Users;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Sections implement this to participate in account merge. Each impl re-FKs

--- a/src/Sections/Humans.Users.Contracts/IUserParticipationBackfillService.cs
+++ b/src/Sections/Humans.Users.Contracts/IUserParticipationBackfillService.cs
@@ -1,4 +1,5 @@
-namespace Humans.Application.Interfaces.Users;
+using Humans.Application.Interfaces;
+namespace Humans.Users.Contracts;
 
 public interface IUserParticipationBackfillService : IApplicationService
 {

--- a/src/Sections/Humans.Users.Contracts/IUserServiceRead.cs
+++ b/src/Sections/Humans.Users.Contracts/IUserServiceRead.cs
@@ -10,7 +10,7 @@ namespace Humans.Users.Contracts;
 /// projections and the merge-chain-follow primitive — no EF entities, no writes,
 /// no cache hooks. See memory/architecture/section-read-write-split.md.
 /// </summary>
-[SurfaceBudget(9)]
+[SurfaceBudget(8)]
 public interface IUserServiceRead
 {
     /// <summary>
@@ -97,16 +97,6 @@ public interface IUserServiceRead
     /// </summary>
     Task<IReadOnlySet<Guid>> GetMergedSourceIdsAsync(
         Guid targetUserId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Finds the user whose <c>Email</c> or <c>GoogleEmail</c> matches the given
-    /// address (case-insensitive) and returns the cached <see cref="UserInfo"/>
-    /// read-model for them. Also checks the gmail/googlemail alternate when
-    /// applicable, and falls back to the legacy <c>User.GoogleEmail</c> shadow
-    /// column for pre-issue-687 users whose <c>UserEmail.IsGoogle</c> rows are
-    /// unset. Returns null if no match.
-    /// </summary>
-    Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default);
 
     /// <summary>
     /// Get all participation records for a given year, projected to the slim

--- a/src/Sections/Humans.Users.Contracts/IUserServiceRead.cs
+++ b/src/Sections/Humans.Users.Contracts/IUserServiceRead.cs
@@ -1,8 +1,7 @@
+using NodaTime;
 using Humans.Application.Architecture;
-using Humans.Application.DTOs;
-using Humans.Application.Services.Profiles;
 
-namespace Humans.Application.Interfaces.Users;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Cross-section read surface for the Users section. External sections inject
@@ -98,3 +97,14 @@ public interface IUserServiceRead
     Task<IReadOnlySet<Guid>> GetMergedSourceIdsAsync(
         Guid targetUserId, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Per-user row returned from <see cref="IUserServiceRead.GetOnsiteUsersAsync"/>.
+/// Names of camps / teams / governance roles are not stitched in here; the Web
+/// layer joins them via the owning section services before rendering. Issue
+/// nobodies-collective/Humans#736.
+/// </summary>
+public sealed record OnsiteUserRow(
+    Guid UserId,
+    string DisplayName,
+    Instant? CheckedInAt);

--- a/src/Sections/Humans.Users.Contracts/IUserServiceRead.cs
+++ b/src/Sections/Humans.Users.Contracts/IUserServiceRead.cs
@@ -1,4 +1,5 @@
 using NodaTime;
+using Humans.Domain.Enums;
 using Humans.Application.Architecture;
 
 namespace Humans.Users.Contracts;
@@ -9,7 +10,7 @@ namespace Humans.Users.Contracts;
 /// projections and the merge-chain-follow primitive — no EF entities, no writes,
 /// no cache hooks. See memory/architecture/section-read-write-split.md.
 /// </summary>
-[SurfaceBudget(6)]
+[SurfaceBudget(9)]
 public interface IUserServiceRead
 {
     /// <summary>
@@ -96,7 +97,48 @@ public interface IUserServiceRead
     /// </summary>
     Task<IReadOnlySet<Guid>> GetMergedSourceIdsAsync(
         Guid targetUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds the user whose <c>Email</c> or <c>GoogleEmail</c> matches the given
+    /// address (case-insensitive) and returns the cached <see cref="UserInfo"/>
+    /// read-model for them. Also checks the gmail/googlemail alternate when
+    /// applicable, and falls back to the legacy <c>User.GoogleEmail</c> shadow
+    /// column for pre-issue-687 users whose <c>UserEmail.IsGoogle</c> rows are
+    /// unset. Returns null if no match.
+    /// </summary>
+    Task<UserInfo?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get all participation records for a given year, projected to the slim
+    /// <see cref="UserParticipationRow"/> shape (no EF entity leaves the
+    /// section). Served from the caching decorator's <see cref="UserInfo"/>
+    /// snapshot.
+    /// </summary>
+    Task<IReadOnlyList<UserParticipationRow>> GetAllParticipationsForYearAsync(
+        int year, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the user ids of every account with <c>DeletionScheduledFor</c>
+    /// in the past (or equal to <paramref name="now"/>) and with
+    /// <c>DeletionEligibleAfter</c> either null or already elapsed. Used by
+    /// the account deletion job to enumerate candidates without reading the
+    /// Users table directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
+        Instant now, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Slim cross-section projection of an <c>EventParticipation</c> row for a given
+/// year, returned by <see cref="IUserServiceRead.GetAllParticipationsForYearAsync"/>.
+/// Carries only the facts consumers diff against (status, source, check-in
+/// instant) keyed by user — no EF entity crosses the section boundary.
+/// </summary>
+public sealed record UserParticipationRow(
+    Guid UserId,
+    ParticipationStatus Status,
+    ParticipationSource Source,
+    Instant? CheckedInAt);
 
 /// <summary>
 /// Per-user row returned from <see cref="IUserServiceRead.GetOnsiteUsersAsync"/>.

--- a/src/Sections/Humans.Users.Contracts/PersonSearchFields.cs
+++ b/src/Sections/Humans.Users.Contracts/PersonSearchFields.cs
@@ -1,4 +1,4 @@
-namespace Humans.Application.Services.Profiles;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// Bit-flags scoping a person-search to specific Profile/User field buckets.

--- a/src/Sections/Humans.Users.Contracts/ProfileSaveRequest.cs
+++ b/src/Sections/Humans.Users.Contracts/ProfileSaveRequest.cs
@@ -1,4 +1,4 @@
-namespace Humans.Application.DTOs;
+namespace Humans.Users.Contracts;
 
 public record ProfileSaveRequest(
     string BurnerName, string FirstName, string LastName,

--- a/src/Sections/Humans.Users.Contracts/UserEmailDto.cs
+++ b/src/Sections/Humans.Users.Contracts/UserEmailDto.cs
@@ -1,6 +1,6 @@
 using Humans.Domain.Enums;
 
-namespace Humans.Application.DTOs;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// User email data for display purposes.
@@ -37,7 +37,7 @@ public record UserEmailEditDto(
 /// <param name="EmailId">The new <see cref="Domain.Entities.UserEmail"/> row's
 /// Id. The verification token is bound to this Id via the token's purpose
 /// suffix, so the verification URL must round-trip this Id back to
-/// <see cref="Humans.Application.Interfaces.Profiles.IUserEmailService.VerifyEmailAsync"/>
+/// <see cref="Humans.Users.Contracts.IUserEmailService.VerifyEmailAsync"/>
 /// to disambiguate when the same user has multiple pending plain rows
 /// (issue nobodies-collective/Humans#611).</param>
 /// <param name="Token">Verification token for building the confirmation URL.</param>

--- a/src/Sections/Humans.Users.Contracts/UserInfo.cs
+++ b/src/Sections/Humans.Users.Contracts/UserInfo.cs
@@ -1,9 +1,8 @@
-using Humans.Domain;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 
-namespace Humans.Application;
+namespace Humans.Users.Contracts;
 
 /// <summary>Compact projection of <see cref="UserEmail"/> carried inside <see cref="UserInfo"/>.</summary>
 public sealed record UserEmailInfo(

--- a/src/Sections/Humans.Users.Contracts/UserProfileDietaryMedicalCommand.cs
+++ b/src/Sections/Humans.Users.Contracts/UserProfileDietaryMedicalCommand.cs
@@ -1,0 +1,21 @@
+namespace Humans.Users.Contracts;
+
+/// <summary>
+/// Focused write for the full dietary + medical set (the DietaryMedical page).
+/// Updates only these six Profile columns; leaves all other profile fields untouched.
+/// MedicalConditions is GDPR Art. 9 — callers must already have verified the
+/// editor is the owner (or an authorized admin).
+/// </summary>
+/// <remarks>
+/// Lives on the leaf rather than beside the rest of <c>UserProfileCommands</c> because
+/// <see cref="IProfileEditorService.SaveDietaryMedicalAsync"/> names it and Onboarding
+/// injects that interface. The sibling commands are <c>IUserService</c>'s surface and stay
+/// with the section (nobodies-collective/Humans#866, lane 2 PR A).
+/// </remarks>
+public sealed record UserProfileDietaryMedicalCommand(
+    string? DietaryPreference,
+    List<string> Allergies,
+    string? AllergyOtherText,
+    List<string> Intolerances,
+    string? IntoleranceOtherText,
+    string? MedicalConditions);

--- a/src/Sections/Humans.Users.Contracts/UserStateClassifier.cs
+++ b/src/Sections/Humans.Users.Contracts/UserStateClassifier.cs
@@ -1,7 +1,7 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 
-namespace Humans.Domain;
+namespace Humans.Users.Contracts;
 
 /// <summary>
 /// The single precedence definition for <see cref="UserState"/>. Every write-site mutates the

--- a/tests/Humans.Agent.Tests/AgentArchitectureTests.cs
+++ b/tests/Humans.Agent.Tests/AgentArchitectureTests.cs
@@ -7,6 +7,7 @@ using Humans.Gdpr.Contracts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Agent.Tests;
 

--- a/tests/Humans.Agent.Tests/AgentUserSnapshotProviderTests.cs
+++ b/tests/Humans.Agent.Tests/AgentUserSnapshotProviderTests.cs
@@ -15,6 +15,7 @@ using Humans.Agent.Services;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Agent.Tests;
 

--- a/tests/Humans.Analyzers.Tests/EmailMutationPathsAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/EmailMutationPathsAnalyzerTests.cs
@@ -38,7 +38,7 @@ public class EmailMutationPathsAnalyzerTests
                 public class SomeOtherController
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Profiles.IUserEmailService svc)
+                        Humans.Users.Contracts.IUserEmailService svc)
                     {
                         await svc.ReconcileOAuthIdentityAsync(System.Guid.Empty, "p", "k", "e@x", true);
                     }
@@ -64,7 +64,7 @@ public class EmailMutationPathsAnalyzerTests
                 public class ExternalLoginService
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Profiles.IUserEmailService svc)
+                        Humans.Users.Contracts.IUserEmailService svc)
                     {
                         await svc.ReconcileOAuthIdentityAsync(System.Guid.Empty, "p", "k", "e@x", true);
                     }
@@ -94,7 +94,7 @@ public class EmailMutationPathsAnalyzerTests
                 public class AccountController
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Profiles.IUserEmailService svc)
+                        Humans.Users.Contracts.IUserEmailService svc)
                     {
                         await svc.ReconcileOAuthIdentityAsync(System.Guid.Empty, "p", "k", "e@x", true);
                     }
@@ -198,7 +198,7 @@ public class EmailMutationPathsAnalyzerTests
 
             namespace Humans.Application.Services.Profiles
             {
-                public class UserEmailService : Humans.Application.Interfaces.Profiles.IUserEmailService
+                public class UserEmailService : Humans.Users.Contracts.IUserEmailService
                 {
                     public async System.Threading.Tasks.Task<int> ReconcileOAuthIdentityAsync(
                         System.Guid userId, string provider, string providerKey, string email, bool emailVerified)
@@ -282,7 +282,7 @@ public class EmailMutationPathsAnalyzerTests
                 public class SomeBackgroundJob
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Profiles.IUserEmailService svc)
+                        Humans.Users.Contracts.IUserEmailService svc)
                     {
                         await svc.ReconcileOAuthIdentityAsync(System.Guid.Empty, "p", "k", "e@x", true);
                     }
@@ -338,7 +338,7 @@ public class EmailMutationPathsAnalyzerTests
                 public class Caller
                 {
                     public async System.Threading.Tasks.Task Run(
-                        Humans.Application.Interfaces.Profiles.IUserEmailService svc)
+                        Humans.Users.Contracts.IUserEmailService svc)
                     {
                         await svc.ReconcileOAuthIdentityAsync(System.Guid.Empty, "p", "k", "e@x", true);
                     }

--- a/tests/Humans.Analyzers.Tests/EmailMutationPathsAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/EmailMutationPathsAnalyzerTests.cs
@@ -5,7 +5,7 @@ namespace Humans.Analyzers.Tests;
 public class EmailMutationPathsAnalyzerTests
 {
     private const string InterfaceStubs = """
-        namespace Humans.Application.Interfaces.Profiles
+        namespace Humans.Users.Contracts
         {
             public interface IUserEmailService
             {

--- a/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
@@ -18,7 +18,7 @@ Humans.Teams.Services.ITeamManagementService.GetByIdsWithParentsAsync:Humans.Tea
 Humans.Teams.Services.ITeamManagementService.GetTeamByIdAsync:Humans.Teams.Domain.Team
 Humans.Teams.Services.ITeamManagementService.GetTeamEntityBySlugAsync:Humans.Teams.Domain.Team
 Humans.Teams.Services.ITeamManagementService.GetUserTeamsAsync:Humans.Teams.Domain.TeamMember
-Humans.Application.Interfaces.Users.IAccountProvisioningService.FindOrCreateUserByEmailAsync:Humans.Domain.Entities.User
+Humans.Users.Contracts.IAccountProvisioningService.FindOrCreateUserByEmailAsync:Humans.Domain.Entities.User
 Humans.Events.Services.IEventService.GetCampEventAsync:Humans.Events.Domain.Event
 Humans.Events.Services.IEventService.GetEventForModerationAsync:Humans.Events.Domain.Event
 Humans.Events.Services.IEventService.GetUserEventAsync:Humans.Events.Domain.Event

--- a/tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Teams.Contracts;
 using ProfileService = Humans.Application.Services.Profiles.ProfileService;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Architecture;
 

--- a/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
@@ -1,4 +1,5 @@
 using Humans.Teams.Data;
+using Microsoft.Extensions.DependencyModel;
 using System.Reflection;
 using AwesomeAssertions;
 using Humans.Application.Interfaces;
@@ -171,11 +172,22 @@ public class ServiceBoundaryArchitectureTests
     // interfaces are internal and live under Humans.<Section>.*, so a namespace filter
     // anchored on Humans.Application.Interfaces alone would stop seeing a section the
     // moment it moves, quietly shrinking every ratchet built on this.
+    // …and the contracts leaves, which carry neither the namespace nor the [Section]
+    // attribute the two clauses above key on. A service interface that lives *entirely* on
+    // a leaf — with no Base-side interface deriving from it — leaves this sweep the moment
+    // it is carved, and its baseline rows read as fixed on byte-identical code. The
+    // GetInterfaces() walk in EntityReturnReadMembers only rescues the read-split shape
+    // (I<Section>Service : I<Section>ServiceRead, where the deriving half stays behind);
+    // Users' IAccountProvisioningService is the whole-interface case and is what surfaced
+    // this (nobodies-collective/Humans#866, lane 2 PR A).
     private static IEnumerable<Type> ApplicationInterfaceTypes() =>
         typeof(IUserRepository).Assembly.GetTypes()
             .Where(t => t.IsInterface)
             .Where(t => t.Namespace?.StartsWith("Humans.Application.Interfaces", StringComparison.Ordinal) == true)
             .Concat(SectionAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .Where(t => t.IsInterface))
+            .Concat(SectionContractsAssemblies()
                 .SelectMany(a => a.GetTypes())
                 .Where(t => t.IsInterface));
 
@@ -185,6 +197,29 @@ public class ServiceBoundaryArchitectureTests
     /// </summary>
     private static IEnumerable<Assembly> SectionAssemblies() =>
         Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies();
+
+    /// <summary>
+    /// Every G5 contracts leaf. Discovered from the dependency graph by name rather than by
+    /// <c>[Section]</c> — a leaf deliberately carries no section marker, because it is not
+    /// an MVC application part and registers no services.
+    /// </summary>
+    private static IEnumerable<Assembly> SectionContractsAssemblies() =>
+        DependencyContext.Default?.RuntimeLibraries
+            .Where(l => l.Name.StartsWith("Humans.", StringComparison.Ordinal)
+                        && l.Name.EndsWith(".Contracts", StringComparison.Ordinal))
+            .Select(l =>
+            {
+                try
+                {
+                    return Assembly.Load(new AssemblyName(l.Name));
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException)
+                {
+                    return null;
+                }
+            })
+            .OfType<Assembly>()
+        ?? [];
 
     private static IEnumerable<Type> RepositoryInterfaceTypes() =>
         ApplicationInterfaceTypes()

--- a/tests/Humans.Application.Tests/Architecture/UserArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/UserArchitectureTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using UserService = Humans.Application.Services.Users.UserService;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Architecture;
 

--- a/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
+++ b/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
@@ -9,6 +9,7 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.AuditLog;
 

--- a/tests/Humans.Application.Tests/Controllers/AccountControllerGateLoginTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/AccountControllerGateLoginTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 

--- a/tests/Humans.Application.Tests/Controllers/AccountControllerOAuthReconcileTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/AccountControllerOAuthReconcileTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 

--- a/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerDietaryMedicalReplayTests.cs
@@ -33,6 +33,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -35,6 +35,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
@@ -34,6 +34,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 
@@ -307,7 +308,7 @@ public class ProfileControllerEmailGridTests
         _userManager.FindByIdAsync(targetUserId.ToString())
             .Returns(new User { Id = targetUserId, DisplayName = "Target User", PreferredLanguage = "en" });
         _userEmailService.AddEmailAsync(targetUserId, newEmail, Arg.Any<CancellationToken>())
-            .Returns(new DTOs.AddEmailResult(Guid.NewGuid(), "token", IsConflict: false));
+            .Returns(new AddEmailResult(Guid.NewGuid(), "token", IsConflict: false));
 
         var result = await _controller.AdminAddEmail(targetUserId, newEmail, Xunit.TestContext.Current.CancellationToken);
 
@@ -325,7 +326,7 @@ public class ProfileControllerEmailGridTests
         _userManager.FindByIdAsync(targetUserId.ToString())
             .Returns(new User { Id = targetUserId, DisplayName = "Target User", PreferredLanguage = "en" });
         _userEmailService.AddEmailAsync(targetUserId, newEmail, Arg.Any<CancellationToken>())
-            .Returns(new DTOs.AddEmailResult(Guid.NewGuid(), "token", IsConflict: false));
+            .Returns(new AddEmailResult(Guid.NewGuid(), "token", IsConflict: false));
 
         var result = await _controller.AdminAddEmail(targetUserId, newEmail, Xunit.TestContext.Current.CancellationToken);
 
@@ -366,7 +367,7 @@ public class ProfileControllerEmailGridTests
         _userService.GetUserInfoAsync(targetUserId, Arg.Any<CancellationToken>())
             .Returns(targetUser.ToUserInfo());
         _userEmailService.AddEmailAsync(targetUserId, newEmail, Arg.Any<CancellationToken>())
-            .Returns(new DTOs.AddEmailResult(Guid.NewGuid(), token, IsConflict: false));
+            .Returns(new AddEmailResult(Guid.NewGuid(), token, IsConflict: false));
 
         var result = await _controller.AdminAddEmail(targetUserId, newEmail, Xunit.TestContext.Current.CancellationToken);
 

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
@@ -33,6 +33,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 

--- a/tests/Humans.Application.Tests/Controllers/UsersAdminAccountMergesControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/UsersAdminAccountMergesControllerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Controllers;
 

--- a/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -3,6 +3,7 @@ using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Infrastructure;
 

--- a/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
@@ -17,6 +17,7 @@ using Humans.Governance.Contracts;
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Tests.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Jobs;
 

--- a/tests/Humans.Application.Tests/Repositories/ProfileRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ProfileRepositoryTests.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Repositories;
 

--- a/tests/Humans.Application.Tests/Services/AccountDeletionServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountDeletionServiceTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/AccountMergeServiceMergeTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountMergeServiceMergeTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Services.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using CommunicationPreferenceService = Humans.Application.Services.Profiles.CommunicationPreferenceService;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/ContactFieldServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ContactFieldServiceTests.cs
@@ -14,6 +14,7 @@ using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Users;
 using Humans.Infrastructure.Repositories.Users;
 using Microsoft.Extensions.Logging.Abstractions;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/Dashboard/AdminDashboardServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Dashboard/AdminDashboardServiceTests.cs
@@ -9,6 +9,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services.Dashboard;
 

--- a/tests/Humans.Application.Tests/Services/DuplicateAccountServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/DuplicateAccountServiceTests.cs
@@ -7,6 +7,7 @@ using Humans.Application.Services.Users;
 using Humans.Domain.Entities;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -7,6 +7,7 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/HumanLifecycle/HumanLifecycleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/HumanLifecycle/HumanLifecycleServiceTests.cs
@@ -10,6 +10,7 @@ using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services.HumanLifecycle;
 

--- a/tests/Humans.Application.Tests/Services/ICalFeed/ICalFeedServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ICalFeed/ICalFeedServiceTests.cs
@@ -6,6 +6,7 @@ using Humans.Domain.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services.ICalFeed;
 

--- a/tests/Humans.Application.Tests/Services/MagicLinkServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/MagicLinkServiceTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using MagicLinkService = Humans.Application.Services.Auth.MagicLinkService;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -15,6 +15,7 @@ using Humans.Application.Tests.Infrastructure;
 using Humans.Infrastructure.Repositories.Users;
 using ProfileEditorService = Humans.Application.Services.Profiles.ProfileEditorService;
 using ProfilePictureStorageKeys = Humans.Application.Services.Profiles.ProfilePictureStorageKeys;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/Profiles/AdminHumanListAssemblerTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profiles/AdminHumanListAssemblerTests.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services.Profiles;
 

--- a/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
+++ b/tests/Humans.Application.Tests/Services/Profiles/PersonSearchMatcherTests.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services.Profiles;
 

--- a/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
+++ b/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/UnsubscribeServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UnsubscribeServiceTests.cs
@@ -8,6 +8,7 @@ using Humans.Domain.Enums;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceReconcileOAuthTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceReconcileOAuthTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
@@ -13,6 +13,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Interfaces.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services;
 

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -10,6 +10,7 @@ using Humans.Application.Services.Profiles;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Services.Users;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services.Users;
 

--- a/tests/Humans.Application.Tests/Services/Users/UserStateClassifierTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/UserStateClassifierTests.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.Services.Users;
 

--- a/tests/Humans.Application.Tests/UserInfoTests.cs
+++ b/tests/Humans.Application.Tests/UserInfoTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests;
 

--- a/tests/Humans.Application.Tests/ViewComponents/CommunicationPreferencesPanelViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/CommunicationPreferencesPanelViewComponentTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.ViewComponents;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.ViewComponents;
 

--- a/tests/Humans.Application.Tests/ViewComponents/DietaryMissingBannerViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/DietaryMissingBannerViewComponentTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.ViewComponents;
 

--- a/tests/Humans.Application.Tests/ViewComponents/ThingsToDoViewComponentDietaryGateTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/ThingsToDoViewComponentDietaryGateTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Application.Tests.ViewComponents;
 

--- a/tests/Humans.AuditLog.Tests/Architecture/AuditLogArchitectureTests.cs
+++ b/tests/Humans.AuditLog.Tests/Architecture/AuditLogArchitectureTests.cs
@@ -120,8 +120,15 @@ public class AuditLogArchitectureTests
             .OrderBy(n => n, StringComparer.Ordinal)
             .ToList();
 
+        // Humans.Users.Contracts is the second entry, and it is not new coupling: AuditLogService
+        // has injected IUserServiceRead all along, under the [CrossSectionException] on that class
+        // ("Audit (crosscut) reads merged-account source IDs via IUserServiceRead"). The reference
+        // only became visible here when the interface left Humans.Application for Users' contracts
+        // leaf (nobodies-collective/Humans#866, lane 2 PR A). #866 names User/UserInfo as sanctioned
+        // shared contracts; where they finally live — this leaf or the Base floor — is the lane 4
+        // "what is Base" question. Deleting the injection is the only thing that removes this row.
         sectionRefs.Should().BeEquivalentTo(
-            ["Humans.Gdpr.Contracts"],
-            because: "a horizontal section may reference only Base and other horizontals");
+            ["Humans.Gdpr.Contracts", "Humans.Users.Contracts"],
+            because: "a horizontal section may reference only Base, other horizontals, and the sanctioned User/UserInfo contracts");
     }
 }

--- a/tests/Humans.Auth.Tests/Architecture/AuthArchitectureTests.cs
+++ b/tests/Humans.Auth.Tests/Architecture/AuthArchitectureTests.cs
@@ -98,9 +98,16 @@ public class AuthArchitectureTests
             .OrderBy(n => n, StringComparer.Ordinal)
             .ToList();
 
+        // The fourth name, Humans.Users.Contracts, is the exception RoleAssignmentService already
+        // carries in source: "Auth (crosscut) references vertical sections — IUserServiceRead for
+        // assignee/creator display stitching". Nothing about that coupling changed here; the
+        // interface simply left Humans.Application for Users' contracts leaf
+        // (nobodies-collective/Humans#866, lane 2 PR A), which is the first time it shows up as an
+        // assembly reference. #866 names User/UserInfo as sanctioned shared contracts; lane 4
+        // decides whether they end up on the Base floor instead, which would drop this row.
         sectionRefs.Should().BeEquivalentTo(
-            ["Humans.AuditLog.Contracts", "Humans.Gdpr.Contracts", "Humans.Notifications.Contracts"],
-            because: "a horizontal section may reference only Base and other horizontals");
+            ["Humans.AuditLog.Contracts", "Humans.Gdpr.Contracts", "Humans.Notifications.Contracts", "Humans.Users.Contracts"],
+            because: "a horizontal section may reference only Base, other horizontals, and the sanctioned User/UserInfo contracts");
     }
 
     [HumansFact]

--- a/tests/Humans.Auth.Tests/Infrastructure/AuthTestHarness.cs
+++ b/tests/Humans.Auth.Tests/Infrastructure/AuthTestHarness.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Auth.Tests.Infrastructure;
 

--- a/tests/Humans.Auth.Tests/Services/RoleAssignmentServiceTests.cs
+++ b/tests/Humans.Auth.Tests/Services/RoleAssignmentServiceTests.cs
@@ -15,6 +15,7 @@ using Humans.Domain.Constants;
 using NSubstitute;
 
 using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Users.Contracts;
 
 
 namespace Humans.Auth.Tests.Services;

--- a/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
@@ -19,6 +19,7 @@ using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
 using CampaignServiceImpl = Humans.Campaigns.Services.CampaignService;
+using Humans.Users.Contracts;
 
 namespace Humans.Campaigns.Tests.Services;
 

--- a/tests/Humans.Camps.Tests/Controllers/CampControllerTests.cs
+++ b/tests/Humans.Camps.Tests/Controllers/CampControllerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Tests.Controllers;
 

--- a/tests/Humans.Camps.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Camps.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Tests.Infrastructure;
 

--- a/tests/Humans.Camps.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampRoleServiceTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Tests.Services;
 

--- a/tests/Humans.Camps.Tests/Services/CampServiceEarlyEntryTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampServiceEarlyEntryTests.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Tests.Services;
 

--- a/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Camps.Tests.Services;
 

--- a/tests/Humans.Cantina.Tests/CantinaArchitectureTests.cs
+++ b/tests/Humans.Cantina.Tests/CantinaArchitectureTests.cs
@@ -3,6 +3,7 @@ using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Cantina.Services;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Cantina.Tests;
 

--- a/tests/Humans.Cantina.Tests/Services/CantinaDailyRosterServiceTests.cs
+++ b/tests/Humans.Cantina.Tests/Services/CantinaDailyRosterServiceTests.cs
@@ -9,6 +9,7 @@ using Humans.Domain.Entities;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Cantina.Tests.Services;
 

--- a/tests/Humans.Cantina.Tests/Services/CantinaRosterServiceTests.cs
+++ b/tests/Humans.Cantina.Tests/Services/CantinaRosterServiceTests.cs
@@ -9,6 +9,7 @@ using Humans.Domain.Entities;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Cantina.Tests.Services;
 

--- a/tests/Humans.CityPlanning.Tests/CityPlanningServiceTests.cs
+++ b/tests/Humans.CityPlanning.Tests/CityPlanningServiceTests.cs
@@ -15,6 +15,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.CityPlanning.Tests;
 

--- a/tests/Humans.Consent.Tests/Controllers/ConsentControllerTests.cs
+++ b/tests/Humans.Consent.Tests/Controllers/ConsentControllerTests.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Tests.Controllers;
 

--- a/tests/Humans.Consent.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Consent.Tests/Services/ConsentServiceTests.cs
@@ -18,6 +18,7 @@ using Humans.Application.Interfaces.HumanLifecycle;
 using Humans.Domain.Enums;
 using Humans.Application.Interfaces.Users;
 using Humans.Consent.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Tests.Services;
 

--- a/tests/Humans.Consent.Tests/Services/LegalDocumentSyncServiceTests.cs
+++ b/tests/Humans.Consent.Tests/Services/LegalDocumentSyncServiceTests.cs
@@ -17,6 +17,7 @@ using Humans.Domain.Entities;
 using Humans.Consent.Domain;
 using Humans.Domain.Enums;
 using Humans.Consent.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Consent.Tests.Services;
 

--- a/tests/Humans.Development.Tests/DevPersonaSeederTests.cs
+++ b/tests/Humans.Development.Tests/DevPersonaSeederTests.cs
@@ -25,6 +25,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Development.Tests;
 

--- a/tests/Humans.Email.Tests/EmailArchitectureTests.cs
+++ b/tests/Humans.Email.Tests/EmailArchitectureTests.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Profiles;
 using Humans.Email.Data;
 using Humans.Email.Services;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Email.Tests;
 

--- a/tests/Humans.Email.Tests/Services/EmailDependencyCycleTests.cs
+++ b/tests/Humans.Email.Tests/Services/EmailDependencyCycleTests.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Email.Tests.Services;
 

--- a/tests/Humans.Email.Tests/Services/OutboxEmailServiceTests.cs
+++ b/tests/Humans.Email.Tests/Services/OutboxEmailServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Email.Tests.Services;
 

--- a/tests/Humans.Events.Tests/Controllers/EventsApiControllerTests.cs
+++ b/tests/Humans.Events.Tests/Controllers/EventsApiControllerTests.cs
@@ -13,6 +13,7 @@ using NodaTime;
 using NSubstitute;
 using Humans.Events.Contracts;
 using Humans.Domain.Entities;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Tests;
 

--- a/tests/Humans.Events.Tests/Controllers/EventsControllerTests.cs
+++ b/tests/Humans.Events.Tests/Controllers/EventsControllerTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Humans.Domain.Entities;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Tests;
 

--- a/tests/Humans.Events.Tests/Services/ServiceCalendarFeedTests.cs
+++ b/tests/Humans.Events.Tests/Services/ServiceCalendarFeedTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Tests;
 

--- a/tests/Humans.Events.Tests/Services/ServiceTests.cs
+++ b/tests/Humans.Events.Tests/Services/ServiceTests.cs
@@ -17,6 +17,7 @@ using NSubstitute;
 using Xunit;
 using Humans.Domain.Entities;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Events.Tests;
 

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceGdprTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceGdprTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Expenses.Tests.Services;
 

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Expenses.Tests.Services;
 

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
@@ -23,6 +23,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using Humans.Users.Contracts;
 
 namespace Humans.Expenses.Tests.Services;
 

--- a/tests/Humans.Feedback.Tests/Architecture/FeedbackArchitectureTests.cs
+++ b/tests/Humans.Feedback.Tests/Architecture/FeedbackArchitectureTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using FeedbackService = Humans.Feedback.Services.FeedbackService;
+using Humans.Users.Contracts;
 
 namespace Humans.Feedback.Tests.Architecture;
 

--- a/tests/Humans.Feedback.Tests/Services/FeedbackServiceTests.cs
+++ b/tests/Humans.Feedback.Tests/Services/FeedbackServiceTests.cs
@@ -19,6 +19,7 @@ using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
 using FeedbackServiceImpl = Humans.Feedback.Services.FeedbackService;
+using Humans.Users.Contracts;
 
 namespace Humans.Feedback.Tests.Services;
 

--- a/tests/Humans.Gate.Tests/GateArchitectureTests.cs
+++ b/tests/Humans.Gate.Tests/GateArchitectureTests.cs
@@ -10,6 +10,7 @@ using Humans.Gate.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate.Tests;
 

--- a/tests/Humans.Gate.Tests/GateControllerClaimTests.cs
+++ b/tests/Humans.Gate.Tests/GateControllerClaimTests.cs
@@ -18,6 +18,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate.Tests;
 

--- a/tests/Humans.Gate.Tests/GateControllerOverridePinTests.cs
+++ b/tests/Humans.Gate.Tests/GateControllerOverridePinTests.cs
@@ -14,6 +14,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate.Tests;
 

--- a/tests/Humans.Gate.Tests/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Gate.Tests/GateVendorBackfillControllerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Gate.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/Architecture/GoogleWorkspaceSyncBridgeArchitectureTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/Architecture/GoogleWorkspaceSyncBridgeArchitectureTests.cs
@@ -95,16 +95,16 @@ public class GoogleWorkspaceSyncBridgeArchitectureTests
         // (transitively) reference any Google.Apis.* assembly. Without this,
         // the whole point of the bridge collapses — a service could grab
         // an SDK type anyway.
-        // Anchored on UserInfo, not on a connector interface: the connectors moved into the
-        // section at G5, so this sweep would otherwise have relocated wholesale onto
-        // Humans.GoogleIntegration - which does reference the SDK - and either failed or,
+        // Loaded by name rather than anchored on a typeof: the connectors moved into the
+        // section at G5, so a type anchor would otherwise have relocated this sweep wholesale
+        // onto Humans.GoogleIntegration - which does reference the SDK - and either failed or,
         // written as a "does not contain", passed while covering nothing
-        // (G5-SECTION-TEMPLATE.md step 11). UserInfo is the cross-section read model every
-        // section binds, so it cannot leave Base; the guard below says so if it ever does.
-        var applicationAssembly = typeof(UserInfo).Assembly;
-        applicationAssembly.GetName().Name
-            .Should().Be("Humans.Application",
-                because: "this sweep is only meaningful while its anchor type still lives in Humans.Application");
+        // (G5-SECTION-TEMPLATE.md step 11). The previous anchor was UserInfo, on the reasoning
+        // that the cross-section read model could not leave Base; it left for
+        // Humans.Users.Contracts at lane 2 (nobodies-collective/Humans#866) and the guard below
+        // caught it. Naming the assembly directly retires the whole anchor-drift failure mode:
+        // there is no type left to follow somewhere else.
+        var applicationAssembly = Assembly.Load(new AssemblyName("Humans.Application"));
 
         var referenced = applicationAssembly.GetReferencedAssemblies();
 

--- a/tests/Humans.GoogleIntegration.Tests/Architecture/GoogleWorkspaceSyncBridgeArchitectureTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/Architecture/GoogleWorkspaceSyncBridgeArchitectureTests.cs
@@ -6,7 +6,6 @@ using Humans.GoogleIntegration.Services;
 using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.GoogleIntegration.Tests.Infrastructure;
-using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests.Architecture;
 

--- a/tests/Humans.GoogleIntegration.Tests/Architecture/GoogleWorkspaceSyncBridgeArchitectureTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/Architecture/GoogleWorkspaceSyncBridgeArchitectureTests.cs
@@ -6,6 +6,7 @@ using Humans.GoogleIntegration.Services;
 using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.GoogleIntegration.Tests.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests.Architecture;
 

--- a/tests/Humans.GoogleIntegration.Tests/EmailProvisioningServiceTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/EmailProvisioningServiceTests.cs
@@ -17,6 +17,7 @@ using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.Application;
 using Humans.GoogleIntegration.Tests.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleAdminServiceTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleAdminServiceTests.cs
@@ -17,6 +17,7 @@ using Humans.GoogleIntegration.Services;
 using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleControllerSyncCancellationTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleControllerSyncCancellationTests.cs
@@ -16,6 +16,7 @@ using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.Application;
 using Humans.GoogleIntegration.Tests.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleGroupSyncServiceTests.cs
@@ -17,6 +17,7 @@ using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.Application;
 using Humans.GoogleIntegration.Tests.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleRemovalNotificationServiceTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleRemovalNotificationServiceTests.cs
@@ -10,6 +10,7 @@ using NSubstitute;
 using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleSyncOutboxProcessorTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleSyncOutboxProcessorTests.cs
@@ -16,6 +16,7 @@ using Humans.GoogleIntegration.Services;
 using Humans.GoogleIntegration.Services.Workspace;
 using Humans.Application;
 using Humans.GoogleIntegration.Tests.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleSyncRemovalNotificationIntegrationTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleSyncRemovalNotificationIntegrationTests.cs
@@ -17,6 +17,7 @@ using NSubstitute;
 using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleWorkspaceSyncServiceReconciliationTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleWorkspaceSyncServiceReconciliationTests.cs
@@ -19,6 +19,7 @@ using NSubstitute;
 using Xunit;
 using Humans.Application;
 using Humans.GoogleIntegration.Tests.Infrastructure;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests;
 

--- a/tests/Humans.GoogleIntegration.Tests/GoogleWorkspaceSyncServiceTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleWorkspaceSyncServiceTests.cs
@@ -21,6 +21,7 @@ using Humans.GoogleIntegration.Services.Workspace;
 using Humans.GoogleIntegration.Data;
 using Humans.Application;
 using Humans.GoogleIntegration.Tests.Infrastructure;
+using Humans.Users.Contracts;
 // UserEmailMatch lives in the Profiles interface namespace, not DTOs.
 
 namespace Humans.GoogleIntegration.Tests;

--- a/tests/Humans.GoogleIntegration.Tests/Infrastructure/UserInfoProjection.cs
+++ b/tests/Humans.GoogleIntegration.Tests/Infrastructure/UserInfoProjection.cs
@@ -1,5 +1,6 @@
 using Humans.Application;
 using Humans.Domain.Entities;
+using Humans.Users.Contracts;
 
 namespace Humans.GoogleIntegration.Tests.Infrastructure;
 

--- a/tests/Humans.Governance.Tests/Infrastructure/UserInfoFixtures.cs
+++ b/tests/Humans.Governance.Tests/Infrastructure/UserInfoFixtures.cs
@@ -1,5 +1,6 @@
 using Humans.Application;
 using Humans.Domain.Entities;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Tests.Infrastructure;
 

--- a/tests/Humans.Governance.Tests/Services/ApplicationDecisionServiceTests.cs
+++ b/tests/Humans.Governance.Tests/Services/ApplicationDecisionServiceTests.cs
@@ -27,6 +27,7 @@ using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Governance.Tests.Infrastructure;
 using Humans.Governance.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Tests.Services;
 

--- a/tests/Humans.Governance.Tests/Services/MembershipCalculatorTests.cs
+++ b/tests/Humans.Governance.Tests/Services/MembershipCalculatorTests.cs
@@ -10,6 +10,7 @@ using Humans.Domain.Enums;
 using Humans.Consent.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Governance.Contracts;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Tests.Services;
 

--- a/tests/Humans.Governance.Tests/Services/MembershipPartitionTests.cs
+++ b/tests/Humans.Governance.Tests/Services/MembershipPartitionTests.cs
@@ -11,6 +11,7 @@ using Humans.Consent.Contracts;
 using Humans.Application.Interfaces.Users;
 using Humans.Governance.Contracts;
 using Humans.Domain.Enums;
+using Humans.Users.Contracts;
 
 namespace Humans.Governance.Tests.Services;
 

--- a/tests/Humans.Integration.Tests/BarriosQueryTests.cs
+++ b/tests/Humans.Integration.Tests/BarriosQueryTests.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Users;
 using Humans.Infrastructure.Data;
 using Humans.Integration.Tests.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Humans.Users.Contracts;
 
 namespace Humans.Integration.Tests;
 

--- a/tests/Humans.Integration.Tests/Controllers/EmailGridFlowTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/EmailGridFlowTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Integration.Tests.Controllers;
 

--- a/tests/Humans.Integration.Tests/Controllers/UnsubscribeFlowTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/UnsubscribeFlowTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Integration.Tests.Controllers;
 

--- a/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
@@ -25,6 +25,7 @@ using Humans.Email.Contracts;
 using Humans.Mailer.Services;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Infrastructure.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Integration.Tests.Infrastructure;
 

--- a/tests/Humans.Issues.Tests/Architecture/IssuesArchitectureTests.cs
+++ b/tests/Humans.Issues.Tests/Architecture/IssuesArchitectureTests.cs
@@ -9,6 +9,7 @@ using Humans.Issues.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using IssuesService = Humans.Issues.Services.IssuesService;
+using Humans.Users.Contracts;
 
 namespace Humans.Issues.Tests.Architecture;
 

--- a/tests/Humans.Issues.Tests/Controllers/IssuesApiControllerTests.cs
+++ b/tests/Humans.Issues.Tests/Controllers/IssuesApiControllerTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 #pragma warning disable CS0618 // Cross-domain navs are intentional in test fixtures.
 

--- a/tests/Humans.Issues.Tests/Services/IssuesServiceTests.cs
+++ b/tests/Humans.Issues.Tests/Services/IssuesServiceTests.cs
@@ -26,6 +26,7 @@ using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
 using IssuesApplicationService = Humans.Issues.Services.IssuesService;
+using Humans.Users.Contracts;
 
 #pragma warning disable CS0618 // User.DisplayName is the seeder's only way to name a person.
 

--- a/tests/Humans.Mailer.Tests/Audiences/HasTicketAudienceTests.cs
+++ b/tests/Humans.Mailer.Tests/Audiences/HasTicketAudienceTests.cs
@@ -6,6 +6,7 @@ using Humans.Mailer.Services.Audiences;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Audiences;
 

--- a/tests/Humans.Mailer.Tests/Audiences/MailerAudienceBaseTests.cs
+++ b/tests/Humans.Mailer.Tests/Audiences/MailerAudienceBaseTests.cs
@@ -6,6 +6,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Audiences;
 

--- a/tests/Humans.Mailer.Tests/Audiences/MarketingAudienceTests.cs
+++ b/tests/Humans.Mailer.Tests/Audiences/MarketingAudienceTests.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Audiences;
 

--- a/tests/Humans.Mailer.Tests/Audiences/MarketingNoTicketAudienceTests.cs
+++ b/tests/Humans.Mailer.Tests/Audiences/MarketingNoTicketAudienceTests.cs
@@ -8,6 +8,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Audiences;
 

--- a/tests/Humans.Mailer.Tests/Audiences/TicketNoShiftsAudienceTests.cs
+++ b/tests/Humans.Mailer.Tests/Audiences/TicketNoShiftsAudienceTests.cs
@@ -8,6 +8,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Audiences;
 

--- a/tests/Humans.Mailer.Tests/Controllers/MailerAdminControllerAudienceSyncTests.cs
+++ b/tests/Humans.Mailer.Tests/Controllers/MailerAdminControllerAudienceSyncTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Controllers;
 

--- a/tests/Humans.Mailer.Tests/Controllers/MailerAdminControllerTests.cs
+++ b/tests/Humans.Mailer.Tests/Controllers/MailerAdminControllerTests.cs
@@ -19,6 +19,7 @@ using NodaTime;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Controllers;
 

--- a/tests/Humans.Mailer.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Mailer.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -2,6 +2,7 @@ using Humans.Application;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Infrastructure;
 

--- a/tests/Humans.Mailer.Tests/Models/MailerAudienceDebugSnapshotBuilderTests.cs
+++ b/tests/Humans.Mailer.Tests/Models/MailerAudienceDebugSnapshotBuilderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Models;
 

--- a/tests/Humans.Mailer.Tests/Services/MailerAudienceSyncServiceTests.cs
+++ b/tests/Humans.Mailer.Tests/Services/MailerAudienceSyncServiceTests.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Services;
 

--- a/tests/Humans.Mailer.Tests/Services/MailerImportServiceClassifierTests.cs
+++ b/tests/Humans.Mailer.Tests/Services/MailerImportServiceClassifierTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Services;
 

--- a/tests/Humans.Mailer.Tests/Services/MailerImportServiceConflictRuleTests.cs
+++ b/tests/Humans.Mailer.Tests/Services/MailerImportServiceConflictRuleTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Services;
 

--- a/tests/Humans.Mailer.Tests/Services/MailerImportServiceIdempotencyTests.cs
+++ b/tests/Humans.Mailer.Tests/Services/MailerImportServiceIdempotencyTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Services;
 

--- a/tests/Humans.Mailer.Tests/Services/MailerImportServiceThrottleTests.cs
+++ b/tests/Humans.Mailer.Tests/Services/MailerImportServiceThrottleTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Services;
 

--- a/tests/Humans.Mailer.Tests/Services/MailerImportServiceWebsiteScopeTests.cs
+++ b/tests/Humans.Mailer.Tests/Services/MailerImportServiceWebsiteScopeTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Mailer.Tests.Services;
 

--- a/tests/Humans.Monitor.Tests/Architecture/MonitorArchitectureTests.cs
+++ b/tests/Humans.Monitor.Tests/Architecture/MonitorArchitectureTests.cs
@@ -45,9 +45,15 @@ public class MonitorArchitectureTests
                 "Humans.AuditLog.Contracts",
                 "Humans.GoogleIntegration.Contracts",
                 "Humans.SystemSettings.Contracts",
+                // Not a fourth coupling — MonitorController and DriveActivityMonitorService have
+                // always read IUserServiceRead/UserInfo; the types simply left Humans.Application
+                // for Users' contracts leaf (nobodies-collective/Humans#866, lane 2 PR A), which is
+                // the first time the dependency shows up as an assembly reference. #866 names
+                // User/UserInfo as sanctioned shared contracts and lane 4 settles where they live.
+                "Humans.Users.Contracts",
             ],
             because: "Monitor consumes AuditLog, GoogleIntegration and SystemSettings through "
-                     + "their leaves, and nothing else");
+                     + "their leaves, plus the sanctioned User/UserInfo contracts, and nothing else");
     }
 
     [HumansFact]

--- a/tests/Humans.Monitor.Tests/DriveActivityMonitorServiceTests.cs
+++ b/tests/Humans.Monitor.Tests/DriveActivityMonitorServiceTests.cs
@@ -12,6 +12,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Monitor.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Monitor.Tests;
 

--- a/tests/Humans.Notifications.Tests/NotificationsArchitectureTests.cs
+++ b/tests/Humans.Notifications.Tests/NotificationsArchitectureTests.cs
@@ -5,6 +5,7 @@ using Humans.Notifications.Data;
 using Humans.Notifications.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Tests;
 

--- a/tests/Humans.Notifications.Tests/Services/NotificationEmitterTests.cs
+++ b/tests/Humans.Notifications.Tests/Services/NotificationEmitterTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 
 namespace Humans.Notifications.Tests.Services;

--- a/tests/Humans.Notifications.Tests/Services/NotificationInboxServiceTests.cs
+++ b/tests/Humans.Notifications.Tests/Services/NotificationInboxServiceTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 
 namespace Humans.Notifications.Tests.Services;

--- a/tests/Humans.Notifications.Tests/Services/NotificationMeterProviderTests.cs
+++ b/tests/Humans.Notifications.Tests/Services/NotificationMeterProviderTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Tests.Services;
 

--- a/tests/Humans.Notifications.Tests/Services/NotificationRetentionTests.cs
+++ b/tests/Humans.Notifications.Tests/Services/NotificationRetentionTests.cs
@@ -9,6 +9,7 @@ using Humans.Application.Interfaces.Users;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Tests.Services;
 

--- a/tests/Humans.Notifications.Tests/Services/NotificationServiceTests.cs
+++ b/tests/Humans.Notifications.Tests/Services/NotificationServiceTests.cs
@@ -17,6 +17,7 @@ using NSubstitute;
 
 
 using Humans.Application.Interfaces.Profiles;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Tests.Services;
 

--- a/tests/Humans.Notifications.Tests/TestInfrastructure.cs
+++ b/tests/Humans.Notifications.Tests/TestInfrastructure.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Entities;
 using Humans.Application;
 using Humans.Domain.Enums;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Notifications.Tests;
 

--- a/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
+++ b/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Tests.Controllers;
 

--- a/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerDispatcherTests.cs
+++ b/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerDispatcherTests.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Tests.Controllers;
 

--- a/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
+++ b/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Localization;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Tests.Controllers;
 

--- a/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
+++ b/tests/Humans.Onboarding.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Tests.Controllers;
 

--- a/tests/Humans.Onboarding.Tests/Services/OnboardingServiceTests.cs
+++ b/tests/Humans.Onboarding.Tests/Services/OnboardingServiceTests.cs
@@ -17,6 +17,7 @@ using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Tests.Services.Onboarding;
 

--- a/tests/Humans.Onboarding.Tests/Services/OnboardingWidgetStateTests.cs
+++ b/tests/Humans.Onboarding.Tests/Services/OnboardingWidgetStateTests.cs
@@ -11,6 +11,7 @@ using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Tests.Services.Onboarding;
 

--- a/tests/Humans.Onboarding.Tests/Services/UserInfoStubs.cs
+++ b/tests/Humans.Onboarding.Tests/Services/UserInfoStubs.cs
@@ -1,6 +1,7 @@
 using Humans.Application;
 using Humans.Domain.Entities;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Onboarding.Tests.Services;
 

--- a/tests/Humans.Scanner.Tests/Controllers/ScannerControllerTests.cs
+++ b/tests/Humans.Scanner.Tests/Controllers/ScannerControllerTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Scanner.Tests.Controllers;
 

--- a/tests/Humans.Search.Tests/Controllers/SearchControllerTests.cs
+++ b/tests/Humans.Search.Tests/Controllers/SearchControllerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Search.Tests.Controllers;
 

--- a/tests/Humans.Search.Tests/Services/SearchServiceTests.cs
+++ b/tests/Humans.Search.Tests/Services/SearchServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Search.Tests.Services;
 

--- a/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerDietaryGateTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerDietaryGateTests.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Controllers;
 

--- a/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerNameGateTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerNameGateTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Controllers;
 

--- a/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerSummaryTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerSummaryTests.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Controllers;
 

--- a/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerToggleDayTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerToggleDayTests.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Controllers;
 

--- a/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerUserActiveSignupsTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerUserActiveSignupsTests.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Controllers;
 

--- a/tests/Humans.Shifts.Tests/Controllers/VolunteerTrackingControllerExportXlsxTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/VolunteerTrackingControllerExportXlsxTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Controllers;
 

--- a/tests/Humans.Shifts.Tests/Controllers/VolunteerTrackingControllerTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/VolunteerTrackingControllerTests.cs
@@ -29,6 +29,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Controllers;
 

--- a/tests/Humans.Shifts.Tests/Infrastructure/ShiftsTestHarness.cs
+++ b/tests/Humans.Shifts.Tests/Infrastructure/ShiftsTestHarness.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Infrastructure;
 

--- a/tests/Humans.Shifts.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Shifts.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -5,6 +5,7 @@ using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Infrastructure;
 

--- a/tests/Humans.Shifts.Tests/Models/ShiftAdminPageBuilderTests.cs
+++ b/tests/Humans.Shifts.Tests/Models/ShiftAdminPageBuilderTests.cs
@@ -12,6 +12,7 @@ using Humans.Domain.Enums;
 using Humans.Shifts.Models;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Models;
 

--- a/tests/Humans.Shifts.Tests/Models/ShiftVolunteerSearchBuilderTests.cs
+++ b/tests/Humans.Shifts.Tests/Models/ShiftVolunteerSearchBuilderTests.cs
@@ -12,6 +12,7 @@ using Humans.Shifts.Helpers;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Models;
 

--- a/tests/Humans.Shifts.Tests/Services/RotaCoordinatorMessageServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/RotaCoordinatorMessageServiceTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 

--- a/tests/Humans.Shifts.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -22,6 +22,7 @@ using Humans.Shifts.Data;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 
@@ -1147,7 +1148,7 @@ public sealed class ShiftDashboardMetricsTests : ShiftsTestHarness
         }
 
         public Task<IReadOnlyList<HumanSearchResult>> SearchUsersAsync(
-            string query, Humans.Application.Services.Profiles.PersonSearchFields fields,
+            string query, Humans.Users.Contracts.PersonSearchFields fields,
             int limit = 10, CancellationToken ct = default) => throw new NotSupportedException();
 
         public async ValueTask<IReadOnlyDictionary<Guid, UserInfo>> GetUserInfosAsync(

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementReadMathTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementReadMathTests.cs
@@ -15,6 +15,7 @@ using Humans.Shifts.Data;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementServiceTests.cs
@@ -19,6 +19,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementWriteGuardTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementWriteGuardTests.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 

--- a/tests/Humans.Shifts.Tests/Services/ShiftSummaryServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSummaryServiceTests.cs
@@ -15,6 +15,7 @@ using Humans.Domain.Enums;
 using Humans.Shifts.Data;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 

--- a/tests/Humans.Shifts.Tests/Services/VolunteerTrackingExportServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/VolunteerTrackingExportServiceTests.cs
@@ -11,6 +11,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 

--- a/tests/Humans.Shifts.Tests/Services/VolunteerTrackingServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/VolunteerTrackingServiceTests.cs
@@ -12,6 +12,7 @@ using Humans.Domain.Enums;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Shifts.Tests.Services;
 

--- a/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
+++ b/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Tests.Controllers;
 

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -19,6 +19,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Tests.Services;
 

--- a/tests/Humans.Surveys.Tests/SurveysArchitectureTests.cs
+++ b/tests/Humans.Surveys.Tests/SurveysArchitectureTests.cs
@@ -7,6 +7,7 @@ using Humans.Surveys.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Tests;
 

--- a/tests/Humans.Teams.Tests/Controllers/TeamAdminControllerTicketLookupTests.cs
+++ b/tests/Humans.Teams.Tests/Controllers/TeamAdminControllerTicketLookupTests.cs
@@ -6,6 +6,7 @@ using Humans.Teams.Domain;
 using Humans.Domain.Enums;
 using Humans.Teams.Controllers;
 using NodaTime;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Tests;
 

--- a/tests/Humans.Teams.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Teams.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -4,6 +4,7 @@ using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Tests.Infrastructure;
 

--- a/tests/Humans.Teams.Tests/Services/CachingTeamServiceGetTeamDetailTests.cs
+++ b/tests/Humans.Teams.Tests/Services/CachingTeamServiceGetTeamDetailTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Tests;
 

--- a/tests/Humans.Teams.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/CachingTeamServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Tests;
 

--- a/tests/Humans.Teams.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamRoleServiceTests.cs
@@ -28,6 +28,7 @@ using Humans.Application.Interfaces.Auth;
 
 using Humans.GoogleIntegration.Data;
 using Humans.Shifts.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Tests;
 
@@ -63,6 +64,7 @@ public sealed class TeamRoleServiceTests : TeamsTestHarness
             .With<IGoogleSyncOutboxService>(googleOutboxService)
             .With(teamResourceService)
             .With(userService)
+            .With<IUserServiceRead>(userService)
             .Build();
         var shiftManagementService = new ShiftManagementService(
             new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock),

--- a/tests/Humans.Teams.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamServiceTests.cs
@@ -41,6 +41,7 @@ using Humans.Application.Interfaces.Auth;
 
 using Humans.GoogleIntegration.Data;
 using Humans.Shifts.Data;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Tests;
 
@@ -85,6 +86,7 @@ public sealed class TeamServiceTests : TeamsTestHarness
             .With<IGoogleSyncOutboxService>(googleOutboxService)
             .With(_teamResourceService)
             .With(userService)
+            .With<IUserServiceRead>(userService)
             .Build();
         var shiftManagementService = new ShiftManagementService(
             new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock),

--- a/tests/Humans.Teams.Tests/Services/TeamsDependencyCycleTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamsDependencyCycleTests.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Teams.Tests;
 

--- a/tests/Humans.Tickets.Tests/Controllers/TicketsContactsAdminControllerTests.cs
+++ b/tests/Humans.Tickets.Tests/Controllers/TicketsContactsAdminControllerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using NSubstitute;
 using Humans.Tickets.Services;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Controllers;
 

--- a/tests/Humans.Tickets.Tests/Services/AttendeeContactImportServiceApplyTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/AttendeeContactImportServiceApplyTests.cs
@@ -15,6 +15,7 @@ using NodaTime.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Humans.Tickets.Domain;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/AttendeeContactImportServicePlanTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/AttendeeContactImportServicePlanTests.cs
@@ -15,6 +15,7 @@ using NodaTime.Testing;
 using NSubstitute;
 using Humans.Tickets.Domain;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/AttendeeContactImportServiceSquatterTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/AttendeeContactImportServiceSquatterTests.cs
@@ -6,6 +6,7 @@ using Humans.Domain.Enums;
 using NSubstitute;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Contracts;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/OnsiteRosterServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/OnsiteRosterServiceTests.cs
@@ -8,6 +8,7 @@ using Humans.Tickets.Services;
 using Humans.Domain.Enums;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
@@ -15,6 +15,7 @@ using NSubstitute;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Contracts;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/TicketQueryService_HoldingsTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketQueryService_HoldingsTests.cs
@@ -13,6 +13,7 @@ using NodaTime;
 using NSubstitute;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Contracts;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketSyncServiceTests.cs
@@ -18,6 +18,7 @@ using NodaTime;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Humans.Tickets.Domain;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/TicketSyncService_ReassignCacheTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketSyncService_ReassignCacheTests.cs
@@ -13,6 +13,7 @@ using NodaTime.Testing;
 using NSubstitute;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Services.Stores;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/TicketTransferServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketTransferServiceTests.cs
@@ -18,6 +18,7 @@ using NSubstitute.ExceptionExtensions;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Services.Dtos;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/Services/TicketTransferService_OnwardTransferTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketTransferService_OnwardTransferTests.cs
@@ -17,6 +17,7 @@ using NSubstitute;
 using Humans.Tickets.Domain;
 using Humans.Tickets.Services.Dtos;
 using Humans.Application;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests.Services;
 

--- a/tests/Humans.Tickets.Tests/TicketsTestHarness.cs
+++ b/tests/Humans.Tickets.Tests/TicketsTestHarness.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests;
 

--- a/tests/Humans.Tickets.Tests/UserInfoProjection.cs
+++ b/tests/Humans.Tickets.Tests/UserInfoProjection.cs
@@ -1,5 +1,6 @@
 using Humans.Application;
 using Humans.Domain.Entities;
+using Humans.Users.Contracts;
 
 namespace Humans.Tickets.Tests;
 

--- a/tests/Humans.Web.Tests/Authorization/NameRequiredFilterTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/NameRequiredFilterTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Authorization;
 

--- a/tests/Humans.Web.Tests/Authorization/RoleAssignmentClaimsTransformationTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/RoleAssignmentClaimsTransformationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Authorization;
 

--- a/tests/Humans.Web.Tests/Controllers/EarlyEntryRosterControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EarlyEntryRosterControllerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Controllers;
 

--- a/tests/Humans.Web.Tests/Controllers/GuestControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/GuestControllerTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Controllers;
 

--- a/tests/Humans.Web.Tests/Controllers/HomeControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/HomeControllerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Controllers;
 

--- a/tests/Humans.Web.Tests/Controllers/ICalFeedApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ICalFeedApiControllerTests.cs
@@ -5,6 +5,7 @@ using Humans.Web.Controllers.Api;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Controllers;
 

--- a/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Controllers;
 

--- a/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
@@ -8,6 +8,7 @@ using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using NSubstitute;
+using Humans.Users.Contracts;
 
 namespace Humans.Web.Tests.Controllers;
 


### PR DESCRIPTION
Phase 1 of nobodies-collective/Humans#866 (G5) lane 2 — Users + Profiles. PR B (the project move) follows; one G5 lane in flight at a time.

## What landed

**1. `src/Sections/Humans.Users.Contracts`** — 18 files holding the cross-section surface:

- `UserInfo` and the eight projections it nests, plus `UserStateClassifier`
- `IUserServiceRead` (+ `OnsiteUserRow`, `UserParticipationRow`), `IUserMerge`, `IUserInfoInvalidator`
- `IUserEmailService`, `ICommunicationPreferenceService`, `IProfileEditorService`, `IAccountProvisioningService`, `IContactFieldService`, `IUserParticipationBackfillService`
- the DTO closure those signatures name: `HumanSearchResult`, `PersonSearchFields`, `ContactFieldDto`/`EditDto`, `ProfileSaveRequest`, `CVEntry`, the `UserEmail*` DTOs, `UserProfileDietaryMedicalCommand`

References `Humans.Interfaces` + `Humans.Domain` + NodaTime only — the same shape as `Humans.Camps.Contracts` and `Humans.GoogleIntegration.Contracts`. `Humans.Application` takes the `ProjectReference`; everything else reaches the types transitively, so no other csproj changes. That also dissolves the recon's "`Humans.UI` needs its first section-leaf reference" question: `ProjectReference` is transitive, and only two projects in the whole tree name `Humans.Camps.Contracts` for the same reason.

`IUserService` is **not** in the leaf and is not going there. Per Peter's ruling it becomes public on the `Humans.Users` assembly at PR B, and the sections that write through it take a `ProjectReference` on `Humans.Users` directly — a sanctioned reference. No write-verb interfaces were built.

**2. Read boundary.** Five consumers whose entire call set is reads are demoted to `IUserServiceRead`: `Shifts/ShiftProfileController`, `Teams/TeamService`, `Tickets/TicketQueryService`, and Infrastructure's `TermRenewalReminderJob` and `ProcessAccountDeletionsJob`.

Three read members move up from `IUserService` to `IUserServiceRead`, and `[SurfaceBudget(6)]` → `(9)`. Two were the one thing blocking a demotion — `GetAllParticipationsForYearAsync` (Tickets/`TicketQueryService`, whose other two calls were already on the read interface) and `GetAccountsDueForAnonymizationAsync` (`ProcessAccountDeletionsJob`, whose sole call it is). The third, `GetByEmailOrAlternateAsync`, unblocks nothing today — all three of its callers are GoogleIntegration services that also write — but it returns `UserInfo` and nothing else, so it belongs on the read surface on its own merits.

The remaining 16 consumers genuinely write and keep `IUserService` exactly where it is today. PR B repoints them at `Humans.Users`; the full file-and-member list is in the lane manifest so Phase 2 does not re-measure.

**3. Five reflection- and namespace-anchored guards repaired**, each of which the carve silently changed the meaning of:

| Guard | What broke |
|---|---|
| `ServiceBoundaryArchitectureTests.ApplicationInterfaceTypes` | Enumerated `Humans.Application.Interfaces.*` + `SectionAssemblies()`. A contracts leaf is in neither, so `IAccountProvisioningService` — which lives entirely on the leaf, with no Base-side interface deriving from it — left the sweep and its baseline row read as *fixed*. Now enumerates `Humans.*.Contracts` from `DependencyContext` as a third clause. Widening surfaced exactly one row across all 21 existing leaves. |
| `GoogleWorkspaceSyncBridgeArchitectureTests` | Reached `Humans.Application` through `typeof(UserInfo).Assembly` and asserted the anchor had not moved. It had. Now loads the assembly by name, retiring the anchor-drift failure mode instead of repointing it at the next type that might move. |
| Auth / AuditLog / Monitor `SectionReferences*` | Each gains `Humans.Users.Contracts`. Not new coupling: `RoleAssignmentService` and `AuditLogService` already carry `[CrossSectionException]`s naming `IUserServiceRead`; the reference only became visible when the interface left Base. |
| `EmailMutationPathsAnalyzer` + its tests | Hard-coded `Humans.Application.Interfaces.Profiles.IUserEmailService`; string-matched, so it would have built green and enforced nothing. The three *implementation* names it also pins move in PR B. |

**4. `G5-SECTION-TEMPLATE.md` step 11** gains a sixth sighting for the leaf-only-interface shape — the fifth sighting's `GetInterfaces()` fix only rescues the read-split case, where the deriving interface stays behind.

## Two things PR B has to handle

- **The four Users/Profiles enums cannot move to the leaf until the entities do.** `Humans.Domain`'s `User.State`, `Profile.State`, `ContactField.FieldType` and `UserEmail.Visibility` are declared with those types and `Humans.Domain` cannot reference the leaf, so moving them first is a project cycle. They travel in the same commit as the entities.
- **`UserInfo.Create` takes the eight EF entities**, so it must split into a section-internal factory once those go internal. The record itself stays on the leaf.

## Verification

- `dotnet build Humans.slnx -v quiet` — clean, zero warnings (`TreatWarningsAsErrors` is on).
- `dotnet test Humans.slnx -v quiet` — **5,478 passed, 0 failed, 5 skipped**.
- `dotnet ef migrations has-pending-model-changes --context UsersDbContext` — *No changes have been made to the model since the last migration.*
- No schema changes: no migration or snapshot file is touched, and the only `Humans.Domain` change is `UserStateClassifier.cs` moving out (it is not an entity and nothing in `Humans.Domain` used it).

Refs nobodies-collective/Humans#866


