### PR TITLE
refactor(1056): move AccessMatrixViewComponent + registries into Humans.UI

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -12,7 +12,7 @@ Five phases run in priority order:
 2. **Close phase** — find open issues whose fixes shipped to production, close them, notify reporters
 3. **Feedback phase** — triage new feedback reports into GitHub issues (legacy; feedback is being retired in favor of in-app Issues)
 4. **Issues phase** — triage non-terminal in-app Issues (`/api/issues`) — the going-forward replacement for feedback
-5. **Agent phase** — pull the full agent conversation history (`/api/agent/conversations`), cluster repeated user questions, propose FAQ entries to plug gaps in `src/Humans.Web/Models/SectionHelpContent.cs` (the hardcoded knowledge base the agent reads via the `fetch_section_guide` tool)
+5. **Agent phase** — pull the full agent conversation history (`/api/agent/conversations`), cluster repeated user questions, propose FAQ entries to plug gaps in `src/Humans.UI/Models/SectionHelpContent.cs` (the hardcoded knowledge base the agent reads via the `fetch_section_guide` tool)
 
 ## Arguments
 
@@ -687,7 +687,7 @@ Issues phase complete: {total} in-app issues ({environment})
 
 Skip if any of `logs`/`close`/`open`/`issues` is specified without `agent`.
 
-The agent (chat assistant) reads hardcoded markdown from `src/Humans.Web/Models/SectionHelpContent.cs` via the `fetch_section_guide` tool. When the user's question isn't covered, the agent refuses, hands off to the issues queue, or answers from weaker sources (e.g. the unofficial community FAQ, with a "not official" disclaimer). All of these point at gaps in the hardcoded KB. **The goal of this phase is to propose new FAQ entries to plug those gaps, not to "process" individual conversations.** The KB is small and hand-edited for now; an editing UI may come later.
+The agent (chat assistant) reads hardcoded markdown from `src/Humans.UI/Models/SectionHelpContent.cs` via the `fetch_section_guide` tool. When the user's question isn't covered, the agent refuses, hands off to the issues queue, or answers from weaker sources (e.g. the unofficial community FAQ, with a "not official" disclaimer). All of these point at gaps in the hardcoded KB. **The goal of this phase is to propose new FAQ entries to plug those gaps, not to "process" individual conversations.** The KB is small and hand-edited for now; an editing UI may come later.
 
 Review the **full conversation list**, not a refusal filter — see the dead-counters note in Step 5.1.
 

--- a/reforge.surface-score.json
+++ b/reforge.surface-score.json
@@ -747,13 +747,13 @@
         "src/Humans.Web/Health/GitHubHealthCheck.cs",
         "src/Humans.Web/Infrastructure/**",
         "src/Humans.Web/Middleware/**",
-        "src/Humans.Web/Models/AccessMatrixDefinitions.cs",
+        "src/Humans.UI/Models/AccessMatrixDefinitions.cs",
         "src/Humans.Web/Models/ClientStatsViewModel.cs",
         "src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs",
         "src/Humans.Web/Models/PagedListViewModel.cs",
         "src/Humans.UI/Models/PagerViewModel.cs",
         "src/Humans.Web/Models/PublicPopoverViewModel.cs",
-        "src/Humans.Web/Models/SectionHelpViewModel.cs",
+        "src/Humans.UI/Models/SectionHelpViewModel.cs",
         "src/Humans.Web/Models/StaffViewModels.cs"
       ],
       "symbols": [

--- a/src/Humans.UI/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.UI/Models/AccessMatrixDefinitions.cs
@@ -1,4 +1,4 @@
-namespace Humans.Web.Models;
+namespace Humans.UI.Models;
 
 public enum AccessLevel
 {

--- a/src/Humans.UI/Models/SectionHelpContent.cs
+++ b/src/Humans.UI/Models/SectionHelpContent.cs
@@ -1,4 +1,4 @@
-namespace Humans.Web.Models;
+namespace Humans.UI.Models;
 
 /// <summary>
 /// Hardcoded markdown content for section help pages (Guide, Glossary).

--- a/src/Humans.UI/Models/SectionHelpViewModel.cs
+++ b/src/Humans.UI/Models/SectionHelpViewModel.cs
@@ -1,4 +1,4 @@
-namespace Humans.Web.Models;
+namespace Humans.UI.Models;
 
 public class SectionHelpViewModel
 {

--- a/src/Humans.UI/ViewComponents/AccessMatrixViewComponent.cs
+++ b/src/Humans.UI/ViewComponents/AccessMatrixViewComponent.cs
@@ -1,7 +1,7 @@
-using Humans.Web.Models;
+using Humans.UI.Models;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Humans.Web.ViewComponents;
+namespace Humans.UI.ViewComponents;
 
 public class AccessMatrixViewComponent : ViewComponent
 {

--- a/src/Humans.UI/Views/Shared/Components/AccessMatrix/Default.cshtml
+++ b/src/Humans.UI/Views/Shared/Components/AccessMatrix/Default.cshtml
@@ -1,5 +1,5 @@
 @using Humans.UI.Extensions
-@model Humans.Web.Models.SectionHelpViewModel
+@model Humans.UI.Models.SectionHelpViewModel
 
 @{
     var modalId = "sectionHelp-" + Model.SectionKey.Replace(" ", "");

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -110,8 +110,8 @@ public static class InfrastructureServiceCollectionExtensions
 
         // Shell-resident collaborators of sections that have already moved out. AgentPreloadAugmentor
         // builds the access matrix, glossaries, route map and FAQ blocks of the agent's preload
-        // corpus from Shell-owned help content (AccessMatrixDefinitions, SectionHelpContent), so it
-        // cannot move into Humans.Agent; the section consumes it through the contracts leaf.
+        // corpus from the shared help registries (Humans.UI's AccessMatrixDefinitions and
+        // SectionHelpContent); the section consumes it through the contracts leaf.
         services.AddSingleton<IAgentPreloadAugmentor, Humans.Web.Services.Agent.AgentPreloadAugmentor>();
 
         // Users' CSV participation backfill. Its registration sat in the Tickets section file

--- a/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
+++ b/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
@@ -1,6 +1,6 @@
 using System.Text;
 using Humans.Agent.Contracts;
-using Humans.Web.Models;
+using Humans.UI.Models;
 
 namespace Humans.Web.Services.Agent;
 

--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -834,7 +834,7 @@
                             <span class="wg-card-name">&lt;vc:access-matrix&gt;</span>
                             <span class="wg-card-kind kind-vc">ViewComponent</span>
                         </div>
-                        <span class="wg-card-path">src/Humans.Web/ViewComponents/AccessMatrixViewComponent.cs</span>
+                        <span class="wg-card-path">src/Humans.UI/ViewComponents/AccessMatrixViewComponent.cs</span>
                     </div>
                     <div class="wg-card-note">Section-help bundle: guide markdown + glossary + access matrix. Renders nothing for sections with no help content registered.</div>
                     @ParamsBlock(

--- a/src/Sections/Humans.Auth/Docs/Auth.md
+++ b/src/Sections/Humans.Auth/Docs/Auth.md
@@ -10,8 +10,8 @@
   src/Humans.UI/Authorization/PolicyNames.cs
   src/Humans.UI/Authorization/RoleChecks.cs
   src/Humans.Web/Authorization/Requirements/**
-  src/Humans.Web/Models/AccessMatrixDefinitions.cs
-  src/Humans.Web/ViewComponents/AccessMatrixViewComponent.cs
+  src/Humans.UI/Models/AccessMatrixDefinitions.cs
+  src/Humans.UI/ViewComponents/AccessMatrixViewComponent.cs
 -->
 <!-- freshness:flag-on-change
   Role-assignment temporal invariants, magic-link rate-limit/replay rules, role-name constants, and the access-matrix mechanism (§"Access Matrix UI" — AccessMatrixViewComponent over static AccessMatrixDefinitions data, no DB table) — review when Auth services, role constants, claims transformation, or the access-matrix component/source change.
@@ -146,7 +146,7 @@ The auth surface is mid-transition per `docs/plans/2026-04-03-first-class-author
 ## Access Matrix UI (per-section)
 
 
-Each section's landing page exposes an info-icon button (`AccessMatrixViewComponent`, invoked as `<vc:access-matrix section="…" />`) that opens a modal showing which roles can do what in that section. Definitions live in `src/Humans.Web/Models/AccessMatrixDefinitions.cs` as **static data, not DB-driven** — there is intentionally no `access_matrix` table.
+Each section's landing page exposes an info-icon button (`AccessMatrixViewComponent`, invoked as `<vc:access-matrix section="…" />`) that opens a modal showing which roles can do what in that section. Definitions live in `src/Humans.UI/Models/AccessMatrixDefinitions.cs` as **static data, not DB-driven** — there is intentionally no `access_matrix` table.
 
 - **Admin is excluded from every matrix.** Admin can do everything everywhere; including the column would be visual noise.
 - **"Volunteer" is the baseline, not a formal role.** It means "any active member" — the absence of an elevated role, not an entry in `role_assignments`.

--- a/src/Sections/Humans.Camps/Views/Camp/Index.cshtml
+++ b/src/Sections/Humans.Camps/Views/Camp/Index.cshtml
@@ -8,12 +8,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>@SharedLocalizer["Camp_Plural"] @Model.Year</h1>
     <div class="d-flex gap-2">
-        @* AccessMatrixViewComponent reads AccessMatrixDefinitions and SectionHelpContent — ~900 lines
-   of every section's roles, routes and FAQ, which Shell's agent preloader reads too. Dragging
-   that into Humans.UI to satisfy one section is the registry inversion (design §15 step 5b), so
-   the component stays in Shell and resolves by name across application parts. Its only argument
-   is a string, so Governance's parameter-nameability rider is satisfied. *@
-                @await Component.InvokeAsync("AccessMatrix", new { section = "Camps" })
+        <vc:access-matrix section="Camps" />
         <a asp-controller="CampAdmin" asp-action="Index" class="btn btn-outline-secondary" authorize-policy="CampAdminOrAdmin">
             <i class="fa-solid fa-shield-halved me-1"></i> @Localizer["Camp_AdminTitle"]
             @if (pendingCount > 0)

--- a/src/Sections/Humans.CityPlanning/Views/CityPlanning/Admin.cshtml
+++ b/src/Sections/Humans.CityPlanning/Views/CityPlanning/Admin.cshtml
@@ -1,9 +1,3 @@
-@* <vc:access-matrix> is unavailable here: AccessMatrixViewComponent lives in
-   Humans.Web (it reads AccessMatrixDefinitions and SectionHelpContent, two Shell-owned
-   registries that name every section), and a section _ViewImports cannot
-   @addTagHelper Humans.Web — the element would render as inert literal markup.
-   Component.InvokeAsync resolves the component by NAME across application parts, so
-   the widget stays where it belongs and this view still gets it. *@
 @{
     ViewData["Title"] = Localizer["CityPlanning_Admin_Title"].Value;
     var settings = (CityPlanningSettingsDto)ViewBag.Settings;
@@ -15,7 +9,7 @@
         <a asp-action="BarrioMap" class="btn btn-outline-secondary btn-sm">
             <i class="fa-solid fa-map"></i> @Localizer["CityPlanning_Admin_ViewMap"]
         </a>
-        @await Component.InvokeAsync("AccessMatrix", new { section = "CityPlanningBarrioMap" })
+        <vc:access-matrix section="CityPlanningBarrioMap" />
     </div>
 
     <div class="row g-4">

--- a/src/Sections/Humans.CityPlanning/Views/CityPlanning/_MeasurePanel.cshtml
+++ b/src/Sections/Humans.CityPlanning/Views/CityPlanning/_MeasurePanel.cshtml
@@ -1,9 +1,3 @@
-@* <vc:access-matrix> is unavailable here: AccessMatrixViewComponent lives in
-   Humans.Web (it reads AccessMatrixDefinitions and SectionHelpContent, two Shell-owned
-   registries that name every section), and a section _ViewImports cannot
-   @addTagHelper Humans.Web — the element would render as inert literal markup.
-   Component.InvokeAsync resolves the component by NAME across application parts, so
-   the widget stays where it belongs and this view still gets it. *@
 @model CityPlanningMeasurePanelViewModel
 @{
     var clearMeasurementsLabel = Localizer["CityPlanning_ClearMeasurementsButton"];
@@ -11,7 +5,7 @@
 
 <div class="card shadow-sm">
     <div class="card-body py-2 px-3 d-flex flex-column gap-1">
-        @await Component.InvokeAsync("AccessMatrix", new { section = Model.AccessMatrixSection })
+        <vc:access-matrix section="@Model.AccessMatrixSection" />
         <div class="d-flex gap-1">
             <button type="button" id="measure-btn" class="btn btn-outline-secondary btn-sm flex-grow-1" title="@Localizer["CityPlanning_MeasureButton"]" aria-pressed="false">
                 <i class="fa-solid fa-ruler me-1"></i> @Localizer["CityPlanning_MeasureButton"]

--- a/src/Sections/Humans.GoogleIntegration/Views/Google/Index.cshtml
+++ b/src/Sections/Humans.GoogleIntegration/Views/Google/Index.cshtml
@@ -4,12 +4,10 @@
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Google Integration</h1>
-    @* Invoked by name: AccessMatrixViewComponent reads Shell's AccessMatrixDefinitions and
-       SectionHelpContent — a cross-section registry that cannot move to Humans.UI — so the
-       compile-time <vc:> tag helper cannot see it from a section and would ship as inert
-       literal markup (G5-SECTION-TEMPLATE.md step 6, CityPlanning's case). An unresolvable
-       InvokeAsync throws, so the render test catches a rename. *@
-    @await Component.InvokeAsync("AccessMatrix", new { section = "Google" })
+    @* Renders nothing today: AccessMatrixDefinitions.Sections and SectionHelpContent have no
+       "Google" key, so the component short-circuits to empty content. That is a content gap
+       (nobodies-collective/Humans#1056 finding), not a wiring problem. *@
+    <vc:access-matrix section="Google" />
 </div>
 
 

--- a/src/Sections/Humans.Governance/Views/Governance/Index.cshtml
+++ b/src/Sections/Humans.Governance/Views/Governance/Index.cshtml
@@ -19,11 +19,7 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="mb-0">@Localizer["Governance_Title"]</h1>
-    @* AccessMatrixViewComponent stays in Shell — it reads AccessMatrixDefinitions and
-       SectionHelpContent, ~900 lines naming every section's roles, routes and FAQ, which
-       Shell's agent preloader reads too. A section _ViewImports cannot @addTagHelper
-       Humans.Web, so the widget is invoked by name across application parts (§15 step 6). *@
-    @await Component.InvokeAsync("AccessMatrix", new { section = "Governance" })
+    <vc:access-matrix section="Governance" />
 </div>
 
 <div class="row mb-4">

--- a/src/Sections/Humans.Onboarding/Models/ShiftsStepViewModel.cs
+++ b/src/Sections/Humans.Onboarding/Models/ShiftsStepViewModel.cs
@@ -14,8 +14,8 @@ namespace Humans.Onboarding.Models;
 /// <c>ShiftBrowseViewModel</c>, <c>RotaShiftGroup</c>, <c>ShiftBrowseMapper</c> and the
 /// <c>_BuildStrikeRotaTable</c>/<c>_EventRotaTable</c> partials all live in Shell and
 /// Shifts has not moved — so the view hands this model's Base-typed contents to Shell's
-/// <c>OnboardingShiftsList</c> view component and invokes it by name (design §15 step 6,
-/// CityPlanning's <c>&lt;vc:access-matrix&gt;</c> case). Everything on this record is a
+/// <c>OnboardingShiftsList</c> view component and invokes it by name (design §15 step 6).
+/// Everything on this record is a
 /// <c>Humans.Domain</c> or <c>Humans.Application</c> type, which is what makes that
 /// invocation compile from a section.
 /// </remarks>

--- a/src/Sections/Humans.Onboarding/Views/OnboardingReview/Index.cshtml
+++ b/src/Sections/Humans.Onboarding/Views/OnboardingReview/Index.cshtml
@@ -8,7 +8,7 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="mb-0">@Localizer["OnboardingReview_Title"]</h1>
-    @await Component.InvokeAsync("AccessMatrix", new { section = "OnboardingReview" })
+    <vc:access-matrix section="OnboardingReview" />
 </div>
 
 

--- a/src/Sections/Humans.Onboarding/Views/_ViewImports.cshtml
+++ b/src/Sections/Humans.Onboarding/Views/_ViewImports.cshtml
@@ -8,10 +8,10 @@
    DataAnnotationLocalizerProvider resolves; and the widget's Consents step renders
    Consent's copy through Consent's own _ConsentReviewBody partial.
 
-   The review pages' three <vc:> elements resolve as follows: <vc:human> is already in
-   Humans.UI, while <vc:profile-card> and <vc:access-matrix> read Shell-owned registries
-   and stay there — both are invoked by name instead (design §15 step 6, CityPlanning's
-   and Governance's cases). Guarded by OnboardingPageRenderTests (step 12). *@
+   The review pages' three <vc:> elements resolve as follows: <vc:human> and
+   <vc:access-matrix> are both in Humans.UI and bind through the @addTagHelper below;
+   <vc:profile-card> still reads a Shell-owned registry and stays there, invoked by name
+   (design §15 step 6). Guarded by OnboardingPageRenderTests (step 12). *@
 @using Humans.Application.DTOs
 @using Humans.Application.Extensions
 @using Humans.Consent

--- a/src/Sections/Humans.Shifts/ViewComponents/OnboardingShiftsListViewComponent.cs
+++ b/src/Sections/Humans.Shifts/ViewComponents/OnboardingShiftsListViewComponent.cs
@@ -12,8 +12,7 @@ namespace Humans.Shifts.ViewComponents;
 /// </summary>
 /// <remarks>
 /// Stays in Shell and is invoked by name from <c>Humans.Onboarding</c>'s
-/// <c>Views/OnboardingWidget/Shifts.cshtml</c>, the same call CityPlanning makes for
-/// <c>&lt;vc:access-matrix&gt;</c>: everything below the first line of this method is
+/// <c>Views/OnboardingWidget/Shifts.cshtml</c>: everything below the first line of this method is
 /// Shifts' presentation — <see cref="ShiftBrowseMapper"/> (internal to Shell),
 /// <see cref="ShiftBrowseViewModel"/>, <see cref="RotaShiftGroup"/> and the
 /// <c>_BuildStrikeRotaTable</c>/<c>_EventRotaTable</c> partials — and Shifts has not gone

--- a/src/Sections/Humans.Shifts/Views/Shifts/Index.cshtml
+++ b/src/Sections/Humans.Shifts/Views/Shifts/Index.cshtml
@@ -64,12 +64,7 @@
         </ul>
         <div class="d-flex gap-2">
             @* Hide the info button but keep the modal in the DOM for the "Learn more" button *@
-            @* <vc:access-matrix> is unavailable here: AccessMatrixViewComponent reads Shell-owned
-   registries naming every section, so it stays in Humans.Web and the section cannot
-   bind its tag helper. Resolved by name across application parts instead — it throws
-   rather than degrading, so ShiftsPageRenderTests asserting a 200 is the proof
-   (design §15 step 6, CityPlanning's rule). *@
-            <span class="shifts-hidden-info-btn">@await Component.InvokeAsync("AccessMatrix", new { section = "Shifts" })</span>
+            <span class="shifts-hidden-info-btn"><vc:access-matrix section="Shifts" /></span>
             <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning btn-sm" authorize-policy="ShiftDepartmentManager"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard <i class="fa-solid fa-lock auth-lock-icon"></i></a>
             <a asp-action="Settings" class="btn btn-outline-secondary btn-sm" authorize-policy="AdminOnly"><i class="fa-solid fa-gear me-1"></i>Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
         </div>

--- a/src/Sections/Humans.Teams/Views/Team/Index.cshtml
+++ b/src/Sections/Humans.Teams/Views/Team/Index.cshtml
@@ -12,7 +12,7 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1>@SharedLocalizer["Teams_Title"]</h1>
         <div class="d-flex gap-2">
-            @await Component.InvokeAsync("AccessMatrix", new { section = "Teams" })
+            <vc:access-matrix section="Teams" />
             <a asp-action="MyTeams" class="btn btn-outline-secondary">@Localizer["MyTeams_Title"]</a>
             <a asp-controller="Profile" asp-action="Search" class="btn btn-outline-secondary"><i class="fa-solid fa-search"></i></a>
             <a asp-action="Roster" class="btn btn-outline-secondary">@SharedLocalizer["Nav_Roster"]</a>

--- a/src/Sections/Humans.Tickets/Views/Ticket/Index.cshtml
+++ b/src/Sections/Humans.Tickets/Views/Ticket/Index.cshtml
@@ -6,7 +6,7 @@
 <div class="container-fluid px-4">
     <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
         <h1 class="mb-0">Tickets</h1>
-        @await Component.InvokeAsync("AccessMatrix", new { section = "Tickets" })
+        <vc:access-matrix section="Tickets" />
     </div>
 
     <partial name="_TicketNav" />

--- a/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
+++ b/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
@@ -6,7 +6,7 @@
 <div class="container-fluid px-4">
     <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
         <h1 class="mb-0">Tickets</h1>
-        @await Component.InvokeAsync("AccessMatrix", new { section = "Tickets" })
+        <vc:access-matrix section="Tickets" />
     </div>
 
     <partial name="_TicketNav" />

--- a/src/Sections/Humans.Tickets/Views/_ViewImports.cshtml
+++ b/src/Sections/Humans.Tickets/Views/_ViewImports.cshtml
@@ -24,7 +24,7 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @* <vc:ticket-stub> is this section's own component, public under Contracts/ so MVC's
    default provider discovers it and the tag helper is generated (step 6). Everything else
-   the views open — <vc:human>, <vc:human-search>, <vc:audit-log> — is Humans.UI's.
-   <vc:access-matrix> and <vc:human-summary> are Shell's and are invoked by name. *@
+   the views open — <vc:human>, <vc:human-search>, <vc:audit-log>, <vc:access-matrix> —
+   is Humans.UI's. <vc:human-summary> is still Shell's and is invoked by name. *@
 @addTagHelper *, Humans.UI
 @addTagHelper *, Humans.Tickets

--- a/src/Sections/Humans.Users/Views/Profile/Index.cshtml
+++ b/src/Sections/Humans.Users/Views/Profile/Index.cshtml
@@ -15,8 +15,7 @@
         <div class="d-flex justify-content-between align-items-center">
             <h1>@(Model.IsOwnProfile ? Localizer["Profile_Title"] : Model.DisplayName)</h1>
             <div class="d-flex gap-2">
-                @* AccessMatrix is Shell-owned; a section RCL cannot @addTagHelper *, Humans.Web, so invoke by name. *@
-                @await Component.InvokeAsync("AccessMatrix", new { section = "Profile" })
+                <vc:access-matrix section="Profile" />
                 <a asp-controller="UsersAdmin" asp-action="AdminDetail" asp-route-id="@Model.UserId" class="btn btn-sm btn-outline-secondary" authorize-policy="HumanAdminBoardOrAdmin">
                     <i class="fa-solid fa-user-shield"></i> @Localizer["Common_Admin"] <i class="fa-solid fa-lock auth-lock-icon"></i>
                 </a>

--- a/src/Sections/Humans.Users/Views/Profile/_ViewImports.cshtml
+++ b/src/Sections/Humans.Users/Views/Profile/_ViewImports.cshtml
@@ -37,10 +37,9 @@
 @addTagHelper *, Humans.Shifts
 @* <vc:my-camps> is Humans.Camps'. *@
 @addTagHelper *, Humans.Camps
-@* No @addTagHelper for Humans.Web — a section RCL cannot reference the Shell. The four
-   Shell-owned components this page renders (AccessMatrix, EventsCard, TicketHoldings,
-   CommunicationPreferencesPanel) are therefore invoked by name until they move to an
-   assembly a section can reference — tracked with the per-component blocker in
-   nobodies-collective/Humans#1056. A <vc:> element
+@* No @addTagHelper for Humans.Web — a section RCL cannot reference the Shell. AccessMatrix
+   moved to Humans.UI (nobodies-collective/Humans#1056) and now binds as <vc:access-matrix>;
+   the three still-Shell-owned components this page renders (EventsCard, TicketHoldings,
+   CommunicationPreferencesPanel) stay invoked by name until they move too. A <vc:> element
    for an unimported assembly renders as inert markup with a green build and no runtime
    error, so never add one without its @addTagHelper. *@

--- a/tests/Humans.Integration.Tests/Controllers/CampsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CampsPageRenderTests.cs
@@ -108,6 +108,12 @@ public class CampsPageRenderTests(HumansTestDatabase database) : IntegrationTest
             because: "Camp_Index_BarrioGuide resolves through IStringLocalizer<CampsResource>");
         html.Should().Contain("Filter",
             because: "Camp_Index_FilterButton is on the section's own filter bar");
+        // <vc:access-matrix> binds through @addTagHelper *, Humans.UI since the component
+        // moved out of Shell (nobodies-collective/Humans#1056). An unbound <vc:> ships as
+        // inert literal markup with a green build, so assert the emitted modal id, not just
+        // the absence of "<vc:" above.
+        html.Should().Contain("sectionHelp-Camps",
+            because: "<vc:access-matrix section=\"Camps\" /> must bind and emit its modal");
     }
 
     /// <summary>

--- a/tests/Humans.Integration.Tests/Controllers/CityPlanningPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CityPlanningPageRenderTests.cs
@@ -77,11 +77,12 @@ public class CityPlanningPageRenderTests(HumansTestDatabase database) : Integrat
     }
 
     [HumansFact(Timeout = 120000)]
-    public async Task The_admin_page_renders_the_shell_resident_access_matrix_widget()
+    public async Task The_admin_page_renders_the_access_matrix_widget()
     {
-        // <vc:access-matrix> cannot be used from a section view (AccessMatrixViewComponent is in
-        // Humans.Web and a section _ViewImports cannot @addTagHelper it). Component.InvokeAsync
-        // resolves it by name across application parts instead — this pins that it still lands.
+        // AccessMatrixViewComponent moved into Humans.UI (nobodies-collective/Humans#1056), so
+        // <vc:access-matrix section="CityPlanningBarrioMap" /> binds through the section's
+        // @addTagHelper *, Humans.UI. An unbound <vc:> ships inert with a green build, so the
+        // emitted modal id is what proves it bound.
         var ct = Xunit.TestContext.Current.CancellationToken;
         await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
 

--- a/tests/Humans.Integration.Tests/Controllers/GoogleIntegrationPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/GoogleIntegrationPageRenderTests.cs
@@ -22,11 +22,14 @@ namespace Humans.Integration.Tests.Controllers;
 /// <para>
 /// Three failure modes are silent and get an assertion each. A <c>&lt;vc:&gt;</c> whose
 /// component is not visible from the section renders as inert literal markup rather than
-/// throwing — <c>&lt;vc:access-matrix&gt;</c> was rewritten to
-/// <c>Component.InvokeAsync</c> for exactly that reason, because its component reads a
-/// Shell-owned registry. A key the resx carve missed renders as its own name. And the
-/// section's <c>_ViewImports</c> is what binds every tag helper, so a missing line there
-/// ships broken HTML with a green build.
+/// throwing — <c>&lt;vc:access-matrix&gt;</c> is back on the tag-helper form since the
+/// component moved to <c>Humans.UI</c> (nobodies-collective/Humans#1056), and it binds
+/// through the section's <c>@@addTagHelper *, Humans.UI</c>. Note it renders <b>empty</b> on
+/// <c>/Google</c>: neither <c>AccessMatrixDefinitions.Sections</c> nor <c>SectionHelpContent</c>
+/// has a "Google" key, a content gap tracked separately — so there is no modal id to assert
+/// here, only the absence of literal markup. A key the resx carve missed renders as its own
+/// name. And the section's <c>_ViewImports</c> is what binds every tag helper, so a missing
+/// line there ships broken HTML with a green build.
 /// </para>
 /// </remarks>
 public class GoogleIntegrationPageRenderTests(HumansTestDatabase database) : IntegrationTestBase(database)

--- a/tests/Humans.Integration.Tests/Controllers/GovernancePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/GovernancePageRenderTests.cs
@@ -127,12 +127,13 @@ public class GovernancePageRenderTests(HumansTestDatabase database) : Integratio
         AssertRenderedCleanly(html, "GET /Governance");
 
         html.Should().Contain("Who Should Apply?");            // Governance_WhoShouldApply
-        // <vc:access-matrix> cannot bind from a section view — the component reads Shell-owned
-        // registries and is invoked by name. An unresolvable invocation throws, so a 200 here
-        // is the assertion; the modal id proves it ran with the section argument.
+        // AccessMatrixViewComponent moved into Humans.UI (nobodies-collective/Humans#1056), so
+        // <vc:access-matrix section="Governance" /> binds through @addTagHelper *, Humans.UI.
+        // An unbound <vc:> ships as inert literal markup with a green build and no log line, so
+        // the emitted modal id is the proof — the 200 alone is not.
         html.Should().Contain("sectionHelp-Governance",
             because: "the access-matrix component renders a modal id built from the section key; "
-                   + "a component that failed to resolve throws rather than degrading");
+                   + "an unbound tag helper renders nothing at all");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/OnboardingPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/OnboardingPageRenderTests.cs
@@ -24,10 +24,10 @@ namespace Humans.Integration.Tests.Controllers;
 /// now).
 /// </description></item>
 /// <item><description>
-/// The review pages' <c>&lt;vc:access-matrix&gt;</c> and <c>&lt;vc:profile-card&gt;</c> became
-/// <c>Component.InvokeAsync</c> calls, because both components read Shell-owned registries. An
-/// unresolvable invocation throws; a stray <c>&lt;vc:&gt;</c> renders as inert markup and only the
-/// <c>NotContain</c> assertion catches it.
+/// The review pages' <c>&lt;vc:access-matrix&gt;</c> binds through <c>@@addTagHelper *, Humans.UI</c>
+/// since the component moved there; <c>&lt;vc:profile-card&gt;</c> still reads a Shell-owned registry
+/// and is a <c>Component.InvokeAsync</c> call. An unresolvable invocation throws; a stray
+/// <c>&lt;vc:&gt;</c> renders as inert markup and only the <c>NotContain</c> assertion catches it.
 /// </description></item>
 /// <item><description>
 /// The progress banner moved <i>into</i> the section, so it is an <c>internal</c> view component
@@ -67,9 +67,12 @@ public class OnboardingPageRenderTests(HumansTestDatabase database) : Integratio
 
         html.Should().Contain("Onboarding Review Queue");           // OnboardingReview_Title
         html.Should().Contain("No humans are waiting for review.");  // OnboardingReview_NoPending
-        // AccessMatrix stayed in Shell and is invoked by name; the modal id it emits is built
-        // from the section key, so its presence proves the cross-application-part lookup.
-        html.Should().Contain("OnboardingReview", "the access-matrix modal keys off the section name");
+        // AccessMatrix moved into Humans.UI (nobodies-collective/Humans#1056), so the call site
+        // is <vc:access-matrix section="OnboardingReview" />. An unbound <vc:> ships as inert
+        // literal markup with a green build, so assert the modal id the component emits — the
+        // bare section key would also match the page title and prove nothing.
+        html.Should().Contain("sectionHelp-OnboardingReview",
+            "<vc:access-matrix> must bind through @addTagHelper *, Humans.UI");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/ShiftsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/ShiftsPageRenderTests.cs
@@ -142,6 +142,30 @@ public class ShiftsPageRenderTests(HumansTestDatabase database) : IntegrationTes
         }
     }
 
+    /// <summary>
+    /// AccessMatrixViewComponent moved into <c>Humans.UI</c> (nobodies-collective/Humans#1056),
+    /// so <c>/Shifts</c> carries <c>&lt;vc:access-matrix section="Shifts" /&gt;</c> bound through
+    /// <c>@@addTagHelper *, Humans.UI</c>. The blanket <c>NotContain("&lt;vc:")</c> above cannot
+    /// see a Razor comment being stripped instead of a tag binding, and the page also hard-codes
+    /// <c>data-bs-target="#sectionHelp-Shifts"</c> on its "Learn more" button — so the proof has
+    /// to be the <c>id=</c> attribute only the component emits.
+    /// </summary>
+    [HumansFact(Timeout = 120000)]
+    public async Task The_browse_page_renders_the_access_matrix_widget()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await SeedActiveBurnAsync();
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+
+        var response = await Client.GetAsync("/Shifts", ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var html = await response.Content.ReadAsStringAsync(ct);
+        html.Should().NotContain("<vc:", "GET /Shifts left a view-component tag unrendered");
+        html.Should().Contain("id=\"sectionHelp-Shifts\"",
+            "the access-matrix modal is what the page's Learn-more button targets");
+    }
+
     [HumansFact(Timeout = 120000)]
     public async Task Shifts_pages_render_spanish_from_the_sections_own_satellite_assemblies()
     {

--- a/tests/Humans.Integration.Tests/Controllers/TeamsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/TeamsPageRenderTests.cs
@@ -19,9 +19,8 @@ namespace Humans.Integration.Tests.Controllers;
 /// A section RCL does not inherit the host's <c>Views/_ViewImports.cshtml</c> — a missing
 /// <c>@@using</c> or <c>@@addTagHelper</c> ships literal markup with a green build, and an
 /// unrendered <c>&lt;vc:…&gt;</c> element is inert text the browser simply drops. The section's
-/// views open with four of them (<c>human</c>, <c>human-search</c>, <c>audit-log</c>, and the
-/// Shell-owned <c>access-matrix</c>, which is invoked by name and <b>throws</b> when it fails
-/// to resolve rather than degrading).
+/// views open with four of them (<c>human</c>, <c>human-search</c>, <c>audit-log</c> and
+/// <c>access-matrix</c>), all four bound through <c>@@addTagHelper *, Humans.UI</c>.
 /// </description></item>
 /// <item><description>
 /// The resx carve moved 193 keys across thirteen prefixes out of <c>SharedResource</c>. A key
@@ -97,19 +96,18 @@ public class TeamsPageRenderTests(HumansTestDatabase database) : IntegrationTest
     }
 
     [HumansFact(Timeout = 120000)]
-    public async Task The_directory_renders_the_shell_owned_access_matrix_invoked_by_name()
+    public async Task The_directory_renders_the_access_matrix_tag_helper()
     {
-        // <vc:access-matrix> could not survive the move: AccessMatrixViewComponent reads
-        // Shell-owned registries naming every section, so the call site became
-        // Component.InvokeAsync("AccessMatrix", …). That throws when it fails to resolve
-        // rather than degrading, so a 200 with the modal id on it is the whole proof
-        // (CityPlanning's rule).
+        // AccessMatrixViewComponent moved into Humans.UI (nobodies-collective/Humans#1056),
+        // so the call site is <vc:access-matrix section="Teams" /> bound through
+        // @addTagHelper *, Humans.UI. An unbound <vc:> ships as inert literal markup with a
+        // green build and no log line, so the emitted modal id is the proof — not the 200.
         var ct = Xunit.TestContext.Current.CancellationToken;
         await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
 
         var html = await (await Client.GetAsync("/Teams", ct)).Content.ReadAsStringAsync(ct);
 
-        html.Should().Contain("sectionHelp-Teams", "the Shell access-matrix widget must render from a section view");
+        html.Should().Contain("sectionHelp-Teams", "the access-matrix widget must bind and render from a section view");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/TicketsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/TicketsPageRenderTests.cs
@@ -20,9 +20,9 @@ namespace Humans.Integration.Tests.Controllers;
 /// <c>@@using</c> or <c>@@addTagHelper</c> ships literal markup with a green build, and an
 /// unrendered <c>&lt;vc:…&gt;</c> element is inert text the browser simply drops. Tickets is
 /// the first section to ship a <c>&lt;vc:&gt;</c> component of its <em>own</em> (the ticket
-/// stub, public under <c>Contracts/</c>), alongside two Shell components it now invokes by
-/// name — <c>AccessMatrix</c> and <c>HumanSummary</c>, both of which <b>throw</b> when they
-/// fail to resolve rather than degrading.
+/// stub, public under <c>Contracts/</c>), alongside <c>&lt;vc:access-matrix&gt;</c> bound
+/// through <c>@@addTagHelper *, Humans.UI</c> and <c>HumanSummary</c>, still Shell's and
+/// invoked by name — the latter <b>throws</b> when it fails to resolve rather than degrading.
 /// </description></item>
 /// <item><description>
 /// The resx carve moved the 25 <c>TicketTransfer_*</c> keys out of <c>SharedResource</c>. A
@@ -95,19 +95,18 @@ public class TicketsPageRenderTests(HumansTestDatabase database) : IntegrationTe
     }
 
     [HumansFact(Timeout = 120000)]
-    public async Task The_dashboard_renders_the_shell_owned_access_matrix_invoked_by_name()
+    public async Task The_dashboard_renders_the_access_matrix_tag_helper()
     {
-        // <vc:access-matrix> could not survive the move: AccessMatrixViewComponent reads
-        // Shell-owned registries naming every section, so the call site became
-        // Component.InvokeAsync("AccessMatrix", …). That throws when it fails to resolve
-        // rather than degrading, so a 200 with the modal id on it is the whole proof
-        // (CityPlanning's rule).
+        // AccessMatrixViewComponent moved into Humans.UI (nobodies-collective/Humans#1056),
+        // so the call site is <vc:access-matrix section="Tickets" /> bound through
+        // @addTagHelper *, Humans.UI. An unbound <vc:> ships as inert literal markup with a
+        // green build and no log line, so the emitted modal id is the proof — not the 200.
         var ct = Xunit.TestContext.Current.CancellationToken;
         await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
 
         var html = await (await Client.GetAsync("/Tickets", ct)).Content.ReadAsStringAsync(ct);
 
-        html.Should().Contain("sectionHelp-Tickets", "the Shell access-matrix widget must render from a section view");
+        html.Should().Contain("sectionHelp-Tickets", "the access-matrix widget must bind and render from a section view");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/UsersPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/UsersPageRenderTests.cs
@@ -92,7 +92,8 @@ public class UsersPageRenderTests(HumansTestDatabase database) : IntegrationTest
         // The page's own chrome, and the two cards that render regardless of data.
         html.Should().Contain("My Profile", "the page must render its own title");
         html.Should().Contain("sectionHelp-Profile",
-            "the access-matrix widget is invoked by name and must resolve");
+            "<vc:access-matrix section=\"Profile\" /> must bind through @addTagHelper *, Humans.UI " +
+            "(nobodies-collective/Humans#1056) — an unbound <vc:> ships inert with a green build");
         html.Should().Contain("Profile Information", "the profile-card must render");
         html.Should().Contain("Quick Actions", "the quick-actions panel must render");
 

--- a/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
+++ b/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
@@ -1,7 +1,7 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces;
 using Humans.Agent.Contracts;
-using Humans.Web.Models;
+using Humans.UI.Models;
 using Humans.Web.Services.Agent;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tools/agent-spike/run.py
+++ b/tools/agent-spike/run.py
@@ -105,7 +105,7 @@ def load_corpus() -> str:
         if p.exists():
             add("SECTION INVARIANT", p)
 
-    matrix = REPO_ROOT / "src" / "Humans.Web" / "Models" / "AccessMatrixDefinitions.cs"
+    matrix = REPO_ROOT / "src" / "Humans.UI" / "Models" / "AccessMatrixDefinitions.cs"
     if matrix.exists():
         add("ACCESS MATRIX", matrix)
 


### PR DESCRIPTION
G5 batch #4, lane 4b-1. Closes nobodies-collective/Humans#1056; part of nobodies-collective/Humans#866.

## What moved

`src/Humans.Web` → `src/Humans.UI`:

| File | New home |
|---|---|
| `ViewComponents/AccessMatrixViewComponent.cs` | `src/Humans.UI/ViewComponents/` |
| `Models/AccessMatrixDefinitions.cs` | `src/Humans.UI/Models/` |
| `Models/SectionHelpContent.cs` | `src/Humans.UI/Models/` |
| `Models/SectionHelpViewModel.cs` | `src/Humans.UI/Models/` |
| `Views/Shared/Components/AccessMatrix/Default.cshtml` | `src/Humans.UI/Views/Shared/Components/AccessMatrix/` |

All four types are static content registries with no vertical-section dependency, so the move does not cross a section boundary. Namespaces `Humans.Web.Models` → `Humans.UI.Models` and `Humans.Web.ViewComponents` → `Humans.UI.ViewComponents`. The component stays `public` — HUM0034 exempts view components, and an `internal` one would ship its `<vc:>` tag as inert literal markup with a green build.

## `<vc:access-matrix>` restored

Every section already references `Humans.UI` and already carries `@addTagHelper *, Humans.UI`, so no `_ViewImports` needed a new line. Eleven call sites that had been rewritten to `Component.InvokeAsync("AccessMatrix", …)` purely because the component was stranded in Shell go back to the tag form:

- `Humans.Camps/Views/Camp/Index.cshtml`
- `Humans.CityPlanning/Views/CityPlanning/Admin.cshtml`
- `Humans.CityPlanning/Views/CityPlanning/_MeasurePanel.cshtml` (dynamic `section="@Model.AccessMatrixSection"`)
- `Humans.GoogleIntegration/Views/Google/Index.cshtml`
- `Humans.Governance/Views/Governance/Index.cshtml`
- `Humans.Onboarding/Views/OnboardingReview/Index.cshtml`
- `Humans.Shifts/Views/Shifts/Index.cshtml`
- `Humans.Teams/Views/Team/Index.cshtml`
- `Humans.Tickets/Views/Ticket/Index.cshtml`
- `Humans.Tickets/Views/Ticket/SalesAggregates.cshtml`
- `Humans.Users/Views/Profile/Index.cshtml`

The `_ViewImports` complaints in Users/Profile, Onboarding and Tickets are rewritten to say what is actually true now. `Humans.Web/Views/WidgetGallery/Index.cshtml` already used the tag; only its displayed source path changed.

## Proof the tags render

A green build proves nothing here — an unbound `<vc:>` ships as inert literal markup with no error and no log line. Each affected page asserts the modal id the component emits (`sectionHelp-<key>`), not just the blanket `NotContain("<vc:")`:

- **Camps** — `sectionHelp-Camps` added to the index render test
- **Shifts** — new `The_browse_page_renders_the_access_matrix_widget`, asserting `id="sectionHelp-Shifts"`. The page hard-codes `data-bs-target="#sectionHelp-Shifts"` on its Learn-more button, so the bare key would be a false positive; the `id=` attribute is the only thing the component itself emits. Needs `SeedActiveBurnAsync()` — without an active burn `/Shifts` renders an empty state.
- **Onboarding** — tightened from `Contain("OnboardingReview")`, which also matched the page title, to `sectionHelp-OnboardingReview`
- **Teams, Tickets, Users, Governance, CityPlanning** — already asserted their modal ids; their stale "invoked by name / could not survive the move" comments are corrected

## Deliberately not fixed

`/Google` renders **nothing**. `AccessMatrixDefinitions.Sections` has no `"Google"` key and `SectionHelpContent` has no Google guide or glossary, so the component short-circuits to `Content(string.Empty)` and the section-help button there has been dead since it was added. That is a content gap, not a wiring problem, and out of scope for this move — recorded as a comment at the call site and in the lane findings.

## Verification

`dotnet build Humans.slnx -v quiet` — green, 0 errors.
`dotnet test Humans.slnx -v quiet` — **5,486 passed / 0 failed / 5 skipped**.

No schema changes, no migrations, no analyzer or arch-test coverage reduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
