### PR TITLE
chore(866): make 6 silently-retargetable arch anchors fail loudly

### DIFF
--- a/tests/Humans.Application.Tests/Architecture/Rules/DisplaySortInControllersRule.cs
+++ b/tests/Humans.Application.Tests/Architecture/Rules/DisplaySortInControllersRule.cs
@@ -80,6 +80,10 @@ public class DisplaySortInControllersRule
     /// </remarks>
     private static IEnumerable<string> RepositoryFiles(string repoRoot)
     {
+        // Base's repository folder is allowed to be absent: G5 drains it section by section and
+        // it legitimately disappears when the last one leaves. src/Sections below is the
+        // opposite — it is the destination, so its absence means the layout moved and the sweep
+        // would otherwise report success by scanning nothing.
         var baseRepos = Path.Combine(repoRoot, "src", "Humans.Infrastructure", "Repositories");
         if (Directory.Exists(baseRepos))
         {
@@ -90,7 +94,14 @@ public class DisplaySortInControllersRule
         }
 
         var sections = Path.Combine(repoRoot, "src", "Sections");
-        if (!Directory.Exists(sections)) yield break;
+        if (!Directory.Exists(sections))
+        {
+            throw new DirectoryNotFoundException(
+                $"DisplaySortInControllers: expected section root '{sections}' does not exist. " +
+                "Every G5 section repository lives under it, so a missing path means the sweep " +
+                "scans nothing and the ratchet reads every baseline row as fixed. Update the " +
+                "path here rather than letting the rule pass vacuously.");
+        }
 
         foreach (var sectionData in Directory.EnumerateDirectories(sections)
                      .Select(d => Path.Combine(d, "Data"))

--- a/tests/Humans.AuditLog.Tests/Architecture/AuditLogArchitectureTests.cs
+++ b/tests/Humans.AuditLog.Tests/Architecture/AuditLogArchitectureTests.cs
@@ -49,7 +49,11 @@ public class AuditLogArchitectureTests
 
     // ── Section boundary (G5, nobodies-collective/Humans#866) ────────────────
 
-    private static System.Reflection.Assembly SectionAssembly => typeof(IAuditLogRepository).Assembly;
+    // Anchored on Section rather than IAuditLogRepository: Section is the ISection registration
+    // and cannot leave Humans.AuditLog, so this anchor is immune by construction. A repository
+    // interface anchor would silently retarget onto Humans.AuditLog.Contracts the day the
+    // interface moves there, after which every sweep below goes near-empty and still passes.
+    private static System.Reflection.Assembly SectionAssembly => typeof(Section).Assembly;
 
     [HumansFact]
     public void SectionTypesTakeNoStringLocalizer()

--- a/tests/Humans.Auth.Tests/Architecture/AuthArchitectureTests.cs
+++ b/tests/Humans.Auth.Tests/Architecture/AuthArchitectureTests.cs
@@ -1,5 +1,4 @@
 using AwesomeAssertions;
-using Humans.Auth.Data;
 using Humans.Auth.Services;
 
 namespace Humans.Auth.Tests.Architecture;
@@ -23,7 +22,11 @@ namespace Humans.Auth.Tests.Architecture;
 /// </remarks>
 public class AuthArchitectureTests
 {
-    private static System.Reflection.Assembly SectionAssembly => typeof(IRoleAssignmentRepository).Assembly;
+    // Anchored on Section rather than IRoleAssignmentRepository: Section is the ISection
+    // registration and cannot leave Humans.Auth, so this anchor is immune by construction. A
+    // repository interface anchor would silently retarget onto Humans.Auth.Contracts the day the
+    // interface moves there, after which every sweep below goes near-empty and still passes.
+    private static System.Reflection.Assembly SectionAssembly => typeof(Section).Assembly;
 
     [HumansFact]
     public void SectionServicesTakeNoDbContextOrStore()

--- a/tests/Humans.Camps.Tests/Architecture/CampsArchitectureTests.cs
+++ b/tests/Humans.Camps.Tests/Architecture/CampsArchitectureTests.cs
@@ -116,15 +116,16 @@ public class CampsArchitectureTests
             "Humans.Camps.Services.CampRoleService",
         };
 
-        var assemblies = new[]
-        {
-            typeof(CampService).Assembly,
-            typeof(CampRepository).Assembly,
-            typeof(CachingCampService).Assembly,
-        };
+        // Anchored on Section, not on the three service/repo types this list used to name:
+        // they were three assemblies before G5 and are one (Humans.Camps) now, so the array was
+        // scanning the same assembly three times. Section is the ISection registration and
+        // cannot leave Humans.Camps; any of the old anchors would have silently retargeted onto
+        // Humans.Camps.Contracts on a move, leaving this tripwire scanning an assembly with no
+        // ICampRepository consumers in it and passing vacuously.
+        var sectionAssembly = typeof(Section).Assembly;
 
-        var consumers = assemblies
-            .SelectMany(a => a.GetTypes())
+        var consumers = sectionAssembly
+            .GetTypes()
             .Where(t => t.GetConstructors()
                 .Any(c => c.GetParameters().Any(p => p.ParameterType == typeof(ICampRepository))))
             .Select(t => t.FullName ?? t.Name)
@@ -147,7 +148,8 @@ public class CampsArchitectureTests
     [HumansFact]
     public void CampInfoSaveChangesInterceptor_IsNotPresent()
     {
-        var found = typeof(CachingCampService).Assembly
+        // Section anchor: immune to CachingCampService relocating (see above).
+        var found = typeof(Section).Assembly
             .GetTypes()
             .FirstOrDefault(t => string.Equals(t.Name, "CampInfoSaveChangesInterceptor", StringComparison.Ordinal));
 
@@ -166,7 +168,8 @@ public class CampsArchitectureTests
     [HumansFact]
     public void CampRoleService_IsTheOnlyCampsSideGoogleGroupMembershipSource()
     {
-        var campsAssembly = typeof(CampService).Assembly;
+        // Section anchor: immune to CampService relocating (see above).
+        var campsAssembly = typeof(Section).Assembly;
         var campsClaimants = campsAssembly
             .GetTypes()
             .Where(t => !t.IsAbstract


### PR DESCRIPTION
Follow-up to #1317 (analyzer refactor-immunity audit). Two halves — only the first is in this diff.

## Half 1 — shipped here

Six guards that could go quiet without failing.

**Five architecture-test anchors** used `typeof(X).Assembly` to *mean* a section's assembly. Each retargets silently onto a `.Contracts` leaf if `X` moves there, after which every sweep over it goes near-empty and still passes. All five now anchor on `typeof(Section)` — the `ISection` registration cannot leave its section project, so the anchor is immune by construction rather than merely guarded (the pattern already used in 6 other files):

| Site | Was |
|---|---|
| `AuditLogArchitectureTests.SectionAssembly` | `typeof(IAuditLogRepository)` |
| `AuthArchitectureTests.SectionAssembly` | `typeof(IRoleAssignmentRepository)` |
| `CampsArchitectureTests.ICampRepository_HasNoUnexpectedConsumers` | 3-element array of `CampService` / `CampRepository` / `CachingCampService` |
| `CampsArchitectureTests.CampInfoSaveChangesInterceptor_IsNotPresent` | `typeof(CachingCampService)` |
| `CampsArchitectureTests.CampRoleService_IsTheOnlyCampsSideGoogleGroupMembershipSource` | `typeof(CampService)` |

The Camps array was three separate assemblies before G5 and is one now, so it was scanning `Humans.Camps` three times over; it collapses to a single `typeof(Section).Assembly`.

**`DisplaySortInControllersRule.RepositoryFiles`** did `yield break` on a missing `src/Sections`. That is the worst possible failure mode for a ratcheted rule: the sweep finds nothing, reports success, and the ratchet reads every abandoned baseline row as *fixed* while the code is byte-identical. It now throws. The sibling guard on Base's `Humans.Infrastructure/Repositories` stays tolerant on purpose — G5 drains that folder and it legitimately disappears.

### Negative probe

A guard never observed failing is indistinguishable from one that cannot fail, so two probes were run against the re-anchored Camps tests and then reverted:

1. Repointed `CampRoleService_IsTheOnlyCampsSideGoogleGroupMembershipSource` at `Humans.GoogleIntegration.Contracts` → **FAIL** (claimant list empty). Confirms the `Section` anchor resolves to `Humans.Camps` and the sweep is sensitive to it.
2. Dropped `Humans.Camps.Services.CampService` from the `ICampRepository` allow-list → **FAIL**, `found at least one item {"Humans.Camps.Services.CampService"}`. Confirms the `Section`-anchored scan really enumerates Camps consumers rather than passing on an empty set.

Assertions only — no tests added or removed. **5508 tests, 0 failed, 5 skipped, before and after. 0 build errors, 26 warnings (unchanged).**

## Half 2 — measured, deliberately not committed

Four further fixes would each switch on enforcement that has never run. Each was applied, built, counted and fully reverted; `git status` is clean of them. Numbers are in the agent report for Peter to decide on — three of the four surface **zero** violations, so they are free to promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
