### PR TITLE
fix(analyzers): derive architecture-attribute names from the classes

### DIFF
--- a/src/Humans.Analyzers/ExpiresOnAnalyzer.cs
+++ b/src/Humans.Analyzers/ExpiresOnAnalyzer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Threading;
+using Humans.Domain.Architecture;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -31,8 +32,15 @@ public sealed class ExpiresOnAnalyzer : DiagnosticAnalyzer
     public const string UsageDiagnosticId = "HUM0010";
     public const string DeclarationDiagnosticId = "HUM0011";
 
-    private const string ExpiresOnAttributeFullName =
-        "Humans.Domain.Architecture.ExpiresOnAttribute";
+    /// <summary>
+    /// Derived from the attribute class (linked into this project by
+    /// <c>Humans.Analyzers.csproj</c>) rather than spelled as a literal: an
+    /// unresolved lookup makes <see cref="OnCompilationStart"/> register
+    /// nothing, so a stale literal would retire HUM0010/HUM0011 silently.
+    /// See nobodies-collective/Humans#1057.
+    /// </summary>
+    private static readonly string ExpiresOnAttributeFullName =
+        typeof(ExpiresOnAttribute).FullName!;
 
     /// <summary>
     /// Test hook. When non-null, replaces <c>DateTime.UtcNow.Date</c> for

--- a/src/Humans.Analyzers/Humans.Analyzers.csproj
+++ b/src/Humans.Analyzers/Humans.Analyzers.csproj
@@ -26,4 +26,40 @@
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
+  <!--
+    The architecture attributes are linked in as a *name oracle* so each
+    analyzer can say typeof(XAttribute).FullName instead of repeating a
+    metadata-name string literal that drifts silently when the namespace
+    moves (nobodies-collective/Humans#1057). Two of the three consumers
+    early-return on an unresolved lookup, so the drift stopped enforcement
+    with no error, no warning and nothing in the build log.
+
+    A ProjectReference cannot replace this: src/Directory.Build.props gives
+    every project under src/ a ProjectReference on Humans.Analyzers with
+    OutputItemType="Analyzer", so the reverse edge would close a project
+    cycle; and Roslyn loads an analyzer's dependency closure into the
+    compiler process, which is what EnforceExtendedAnalyzerRules exists to
+    prevent. The compiled copies here never enter an analyzed compilation —
+    the reference above carries ReferenceOutputAssembly="false" — so they
+    cannot make the real attribute types ambiguous.
+
+    ImplicitUsings is disabled in this project; the linked sources rely on
+    an implicit `using System;` in their owning project, which the Using
+    item below restores here without editing them.
+  -->
+  <ItemGroup>
+    <Using Include="System" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Humans.Interfaces\Architecture\GrandfatheredAttribute.cs"
+             Link="Architecture\GrandfatheredAttribute.cs" />
+    <Compile Include="..\Humans.Interfaces\Architecture\SurfaceBudgetAttribute.cs"
+             Link="Architecture\SurfaceBudgetAttribute.cs" />
+    <Compile Include="..\Humans.Interfaces\Architecture\ExternalWriteAttribute.cs"
+             Link="Architecture\ExternalWriteAttribute.cs" />
+    <Compile Include="..\Humans.Interfaces\Architecture\ExpiresOnAttribute.cs"
+             Link="Architecture\ExpiresOnAttribute.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Humans.Analyzers/Internal/GrandfatheredCheck.cs
+++ b/src/Humans.Analyzers/Internal/GrandfatheredCheck.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Architecture;
 using Microsoft.CodeAnalysis;
 
 namespace Humans.Analyzers.Internal;
@@ -26,7 +27,13 @@ namespace Humans.Analyzers.Internal;
 /// </remarks>
 internal static class GrandfatheredCheck
 {
-    public const string AttributeFullName = "Humans.Application.Architecture.GrandfatheredAttribute";
+    /// <summary>
+    /// Metadata name the attribute is resolved by, derived from the class
+    /// itself (linked into this project by <c>Humans.Analyzers.csproj</c>) so
+    /// a namespace move carries the constant with it. Never re-inline this as
+    /// a literal — see nobodies-collective/Humans#1057.
+    /// </summary>
+    public static readonly string AttributeFullName = typeof(GrandfatheredAttribute).FullName!;
 
     /// <summary>
     /// Resolves the <see cref="GrandfatheredAttribute"/> symbol from the

--- a/src/Humans.Analyzers/RequestScopedCancellationOnExternalWriteAnalyzer.cs
+++ b/src/Humans.Analyzers/RequestScopedCancellationOnExternalWriteAnalyzer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using Humans.Analyzers.Internal;
+using Humans.Application.Architecture;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -47,8 +48,15 @@ public sealed class RequestScopedCancellationOnExternalWriteAnalyzer : Diagnosti
 {
     public const string DiagnosticId = "HUM0033";
 
-    public const string ExternalWriteAttributeFullName =
-        "Humans.Application.Architecture.ExternalWriteAttribute";
+    /// <summary>
+    /// Derived from the attribute class (linked into this project by
+    /// <c>Humans.Analyzers.csproj</c>) rather than spelled as a literal: an
+    /// unresolved lookup makes <see cref="OnCompilationStart"/> register
+    /// nothing, so a stale literal would retire HUM0033 silently.
+    /// See nobodies-collective/Humans#1057.
+    /// </summary>
+    public static readonly string ExternalWriteAttributeFullName =
+        typeof(ExternalWriteAttribute).FullName!;
 
     private const string MvcNamespace = "Microsoft.AspNetCore.Mvc";
     private const string RequestAbortedPropertyName = "RequestAborted";

--- a/src/Humans.Analyzers/SurfaceBudgetAnalyzer.cs
+++ b/src/Humans.Analyzers/SurfaceBudgetAnalyzer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using Humans.Application.Architecture;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -11,8 +12,15 @@ public sealed class SurfaceBudgetAnalyzer : DiagnosticAnalyzer
     public const string OverBudgetDiagnosticId = "HUM0015";
     public const string SlackDiagnosticId = "HUM0016";
 
-    private const string SurfaceBudgetAttributeFullName =
-        "Humans.Application.Architecture.SurfaceBudgetAttribute";
+    /// <summary>
+    /// Derived from the attribute class (linked into this project by
+    /// <c>Humans.Analyzers.csproj</c>) rather than spelled as a literal: an
+    /// unresolved lookup makes <see cref="OnCompilationStart"/> register
+    /// nothing, so a stale literal would retire HUM0015/HUM0016 silently.
+    /// See nobodies-collective/Humans#1057.
+    /// </summary>
+    private static readonly string SurfaceBudgetAttributeFullName =
+        typeof(SurfaceBudgetAttribute).FullName!;
 
     private static readonly LocalizableString OverBudgetTitle =
         "Type surface exceeds budget";

--- a/tests/Humans.Analyzers.Tests/AnalyzerTestHarness.cs
+++ b/tests/Humans.Analyzers.Tests/AnalyzerTestHarness.cs
@@ -70,14 +70,30 @@ internal static class AnalyzerTestHarness
         return await withAnalyzers.GetAnalyzerDiagnosticsAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// The analyzer assembly must never be a reference of an analyzed
+    /// compilation. It carries linked copies of the architecture attributes
+    /// (its name oracle — see nobodies-collective/Humans#1057), and
+    /// <c>GetTypeByMetadataName</c> returns <c>null</c> when a name is declared
+    /// in more than one place, so leaving it in would make every marker lookup
+    /// ambiguous and quietly disable the rule under test. Production never
+    /// references it either: <c>src/Directory.Build.props</c> attaches it with
+    /// <c>ReferenceOutputAssembly="false"</c>.
+    /// </summary>
     private static ImmutableArray<MetadataReference> BuildBaseReferences()
     {
+        var analyzerAssemblyFileName = Path.GetFileName(typeof(SurfaceBudgetAnalyzer).Assembly.Location);
+
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();
         var trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
         foreach (var path in trustedAssemblies.Split(Path.PathSeparator))
         {
-            if (path.Length > 0)
-                builder.Add(MetadataReference.CreateFromFile(path));
+            if (path.Length == 0)
+                continue;
+            if (string.Equals(Path.GetFileName(path), analyzerAssemblyFileName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            builder.Add(MetadataReference.CreateFromFile(path));
         }
         return builder.ToImmutable();
     }

--- a/tests/Humans.Analyzers.Tests/ArchitectureAttributeIdentityTests.cs
+++ b/tests/Humans.Analyzers.Tests/ArchitectureAttributeIdentityTests.cs
@@ -1,0 +1,245 @@
+using AwesomeAssertions;
+using Humans.Application.Architecture;
+using Humans.Domain.Architecture;
+using Microsoft.CodeAnalysis;
+
+namespace Humans.Analyzers.Tests;
+
+/// <summary>
+/// Alarm for the failure mode behind nobodies-collective/Humans#1057.
+///
+/// <para>
+/// Every analyzer here finds its marker attribute with
+/// <c>Compilation.GetTypeByMetadataName</c> and returns from
+/// <c>OnCompilationStart</c> when the lookup comes back <c>null</c> — no symbol
+/// action registered, no diagnostic, green build. A name that stops matching
+/// therefore retires HUM0015/HUM0016, HUM0033 and HUM0010/HUM0011 in silence.
+/// The names are now derived from the attribute classes themselves (linked into
+/// <c>Humans.Analyzers</c> by its csproj), which removes the drift; these tests
+/// are what makes a regression loud.
+/// </para>
+///
+/// <para>
+/// The other analyzer tests stub their marker attribute inline, so the stub and
+/// the analyzer agree with each other no matter what the real class says. These
+/// tests instead compile the <b>production source file</b>, embedded verbatim
+/// from <c>src/Humans.Interfaces/Architecture/</c> by the test csproj, into the
+/// referenced assembly — the same shape as production, where the attribute lives
+/// outside the assembly under analysis. If the analyzers' compiled copy ever
+/// diverges from that file — the link dropped, a literal re-inlined, a hand-made
+/// duplicate — the attribute stops resolving and these tests go red.
+/// </para>
+///
+/// <para>
+/// Nothing here spells a namespace as a literal: the snippets build their
+/// attribute references from <c>typeof(...).Namespace</c>, so moving the
+/// attributes' namespace needs no edit in the analyzers <i>or</i> here.
+/// </para>
+/// </summary>
+public class ArchitectureAttributeIdentityTests
+{
+    /// <summary>
+    /// Reads a production attribute source file out of this assembly's embedded
+    /// resources. The owning project has <c>ImplicitUsings</c> enabled and these
+    /// snippets are parsed on their own, so the implicit <c>using System;</c> is
+    /// restored — the same thing <c>Humans.Analyzers.csproj</c> does with a
+    /// <c>&lt;Using Include="System" /&gt;</c> item.
+    /// </summary>
+    private static string ProductionSource(string fileName)
+    {
+        var resourceName = "ProductionAttributes." + fileName;
+        using var stream =
+            typeof(ArchitectureAttributeIdentityTests).Assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{resourceName}' is missing. It is declared in " +
+                "Humans.Analyzers.Tests.csproj against src/Humans.Interfaces/Architecture/ — " +
+                "if the attributes moved, move the declaration with them rather than " +
+                "dropping it, or the analyzers lose their only end-to-end check.");
+
+        using var reader = new StreamReader(stream);
+        return "using System;\n" + reader.ReadToEnd();
+    }
+
+    [HumansFact]
+    public async Task Production_SurfaceBudgetAttribute_still_drives_HUM0015()
+    {
+        var ns = typeof(SurfaceBudgetAttribute).Namespace;
+        var source = $$"""
+            namespace Sample
+            {
+                [{{ns}}.SurfaceBudget(1)]
+                public interface ISample
+                {
+                    void M1();
+                    void M2();
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new SurfaceBudgetAnalyzer(),
+            "Humans.Application",
+            source,
+            ProductionSource("SurfaceBudgetAttribute.cs"));
+
+        diagnostics.Should().ContainSingle(d =>
+            string.Equals(d.Id, SurfaceBudgetAnalyzer.OverBudgetDiagnosticId, StringComparison.Ordinal));
+    }
+
+    [HumansFact]
+    public async Task Production_SurfaceBudgetAttribute_still_drives_HUM0016()
+    {
+        var ns = typeof(SurfaceBudgetAttribute).Namespace;
+        var source = $$"""
+            namespace Sample
+            {
+                [{{ns}}.SurfaceBudget(3)]
+                public interface ISample
+                {
+                    void M1();
+                    void M2();
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new SurfaceBudgetAnalyzer(),
+            "Humans.Application",
+            source,
+            ProductionSource("SurfaceBudgetAttribute.cs"));
+
+        diagnostics.Should().ContainSingle(d =>
+            string.Equals(d.Id, SurfaceBudgetAnalyzer.SlackDiagnosticId, StringComparison.Ordinal));
+    }
+
+    [HumansFact]
+    public async Task Production_ExternalWriteAttribute_still_drives_HUM0033()
+    {
+        var ns = typeof(ExternalWriteAttribute).Namespace;
+        var source = $$"""
+            namespace Microsoft.AspNetCore.Http
+            {
+                public abstract class HttpContext
+                {
+                    public System.Threading.CancellationToken RequestAborted { get; }
+                }
+            }
+
+            namespace Microsoft.AspNetCore.Mvc
+            {
+                public abstract class ControllerBase
+                {
+                    public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; } = null!;
+                }
+
+                public sealed class HttpPostAttribute : System.Attribute { }
+            }
+
+            namespace Humans.Application.Interfaces
+            {
+                public interface ISyncService
+                {
+                    [{{ns}}.ExternalWrite]
+                    System.Threading.Tasks.Task SyncAsync(System.Threading.CancellationToken ct);
+                }
+            }
+
+            namespace Humans.Web.Controllers
+            {
+                public sealed class SyncController : Microsoft.AspNetCore.Mvc.ControllerBase
+                {
+                    private readonly Humans.Application.Interfaces.ISyncService _sync = null!;
+
+                    [Microsoft.AspNetCore.Mvc.HttpPost]
+                    public System.Threading.Tasks.Task Execute() =>
+                        _sync.SyncAsync(HttpContext.RequestAborted);
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new RequestScopedCancellationOnExternalWriteAnalyzer(),
+            "Humans.Web",
+            source,
+            ProductionSource("ExternalWriteAttribute.cs"));
+
+        diagnostics.Should().ContainSingle(d =>
+            string.Equals(
+                d.Id,
+                RequestScopedCancellationOnExternalWriteAnalyzer.DiagnosticId,
+                StringComparison.Ordinal));
+    }
+
+    [HumansFact]
+    public async Task Production_ExpiresOnAttribute_still_drives_HUM0010()
+    {
+        var ns = typeof(ExpiresOnAttribute).Namespace;
+        var source = $$"""
+            namespace Sample
+            {
+                public class Container
+                {
+                    [{{ns}}.ExpiresOn("2020-01-01")]
+                    public int Foo { get; set; }
+                }
+
+                public class Caller
+                {
+                    public int Read(Container c) => c.Foo;
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new ExpiresOnAnalyzer(),
+            "Humans.Application",
+            source,
+            ProductionSource("ExpiresOnAttribute.cs"));
+
+        diagnostics.Should().ContainSingle(d =>
+            string.Equals(d.Id, ExpiresOnAnalyzer.UsageDiagnosticId, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// <c>[Grandfathered]</c> is the one marker that already failed loudly — an
+    /// unresolved lookup snaps every grandfathered violation back to
+    /// <see cref="DiagnosticSeverity.Error"/> and the build goes red. This pins
+    /// that behaviour to the real attribute rather than to a stub, so the
+    /// downgrade path is covered by the same end-to-end check as the rest.
+    /// </summary>
+    [HumansFact]
+    public async Task Production_GrandfatheredAttribute_still_downgrades_a_violation()
+    {
+        var ns = typeof(GrandfatheredAttribute).Namespace;
+        var source = $$"""
+            namespace Humans.Application.Interfaces.Repositories
+            {
+                public interface IRepository { }
+                public interface ICampRepository : IRepository { }
+            }
+
+            namespace Humans.Web.Controllers
+            {
+                [{{ns}}.Grandfathered("HUM0014", "test", "2026-05-15", "test")]
+                public sealed class CampsController
+                {
+                    public CampsController(
+                        Humans.Application.Interfaces.Repositories.ICampRepository repo) { }
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.RunAsync(
+            new WebRepositoryInjectionAnalyzer(),
+            "Humans.Web",
+            source,
+            ProductionSource("GrandfatheredAttribute.cs"));
+
+        var hum0014 = diagnostics
+            .Where(d => string.Equals(d.Id, WebRepositoryInjectionAnalyzer.DiagnosticId, StringComparison.Ordinal))
+            .ToArray();
+
+        hum0014.Should().ContainSingle();
+        hum0014[0].Severity.Should().Be(DiagnosticSeverity.Warning);
+    }
+}

--- a/tests/Humans.Analyzers.Tests/Humans.Analyzers.Tests.csproj
+++ b/tests/Humans.Analyzers.Tests/Humans.Analyzers.Tests.csproj
@@ -19,4 +19,24 @@
     <ProjectReference Include="..\..\src\Humans.Analyzers\Humans.Analyzers.csproj" />
   </ItemGroup>
 
+  <!--
+    The production architecture-attribute sources, embedded verbatim so
+    ArchitectureAttributeIdentityTests can drive the *real* attribute through
+    the real analyzer instead of an inline stub that agrees with itself.
+    A stub cannot fail when the analyzer's lookup drifts off the real class —
+    which is how HUM0015/HUM0016 and HUM0033 could have been retired silently
+    (nobodies-collective/Humans#1057). Paths are literal on purpose: if the
+    attributes move, this is a build error, not a quietly-skipped test.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\src\Humans.Interfaces\Architecture\GrandfatheredAttribute.cs"
+                      LogicalName="ProductionAttributes.GrandfatheredAttribute.cs" />
+    <EmbeddedResource Include="..\..\src\Humans.Interfaces\Architecture\SurfaceBudgetAttribute.cs"
+                      LogicalName="ProductionAttributes.SurfaceBudgetAttribute.cs" />
+    <EmbeddedResource Include="..\..\src\Humans.Interfaces\Architecture\ExternalWriteAttribute.cs"
+                      LogicalName="ProductionAttributes.ExternalWriteAttribute.cs" />
+    <EmbeddedResource Include="..\..\src\Humans.Interfaces\Architecture\ExpiresOnAttribute.cs"
+                      LogicalName="ProductionAttributes.ExpiresOnAttribute.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Closes nobodies-collective/Humans#1057. Refs nobodies-collective/Humans#866.

## What was wrong

Four analyzers located their marker attribute with `Compilation.GetTypeByMetadataName` against a hardcoded literal. Three early-return when the lookup returns `null` — no symbol action registered, no diagnostic, green build:

| Constant | Rule(s) | Failure shape |
|---|---|---|
| `SurfaceBudgetAnalyzer` | HUM0015 / HUM0016 | **silent** |
| `RequestScopedCancellationOnExternalWriteAnalyzer` | HUM0033 | **silent** |
| `ExpiresOnAnalyzer` (not in the issue body) | HUM0010 / HUM0011 | **silent** |
| `GrandfatheredCheck` | all grandfathered rules | loud (null ⇒ Error) |

`[SurfaceBudget]` has four live usages, so silent death is real coverage loss.

Correction to the issue's premise: phase 3 preserved every namespace and `GetTypeByMetadataName` resolves by namespace, not assembly — so the `Humans.Interfaces` → `Humans.Base` **assembly** rename would not have broken these, and this is not a prerequisite for it. The justification is the silent failure mode, not the rename.

## What changed

- `Humans.Analyzers.csproj` links the four attribute sources as a name oracle plus `<Using Include="System" />` (the project has `ImplicitUsings=disable`; the `Using` item restores the implicit `using System;` without editing the attribute files, which the issue proposed).
- Each constant is now `typeof(XAttribute).FullName!`.
- No analyzer behaviour, id, severity or message changed.

`ProjectReference` is still impossible and still absent: the reverse edge closes the cycle `src/Directory.Build.props` creates, and Roslyn loads an analyzer's dependency closure into the compiler process. The linked copies never enter an analyzed compilation — that reference carries `ReferenceOutputAssembly="false"`.

## The loud-failure guard

`ArchitectureAttributeIdentityTests` (5 tests) drives the **production attribute source** — embedded verbatim from `src/Humans.Interfaces/Architecture/` by the test csproj — through the real analyzer and asserts the diagnostic still fires. Every other analyzer test stubs its marker inline, so the stub and the analyzer agree with each other no matter what the real class says; that is exactly why this defect class was invisible. Nothing in the new file spells a namespace as a literal — snippets build their attribute references from `typeof(...).Namespace`.

Rejected: (a) a resolution-only assertion against a synthetic compilation — vacuous once both sides derive from the same linked file; (b) matching on the simple name to remove the null path — drops the compile-time link and would match any same-named type; (c) passing the unresolved symbol through as `null` HUM0034-style — the null cannot be acted on without changing a diagnostic, which this PR is not allowed to do; (d) a repo-root walk to read the files at runtime — an embedded resource makes a moved file a build error instead of a test failure.

### Negative probes (all observed)

1. Stale literal re-inlined in `SurfaceBudgetAnalyzer` → 6 tests red.
2. **The historic scenario** — production namespace moved to `Humans.Base.Architecture`, old literal left in place: all 10 pre-existing stub-based SurfaceBudget tests stayed **green**; only the 2 new production-source tests went red.
3. Same rename with the derived constant → the analyzers needed no edit at all and the new tests followed the class automatically.

All three reverted.

## Harness fix

`AnalyzerTestHarness` now drops the analyzer assembly from a synthetic compilation's references. It is on `TRUSTED_PLATFORM_ASSEMBLIES` and now carries the linked attribute copies, and `GetTypeByMetadataName` returns `null` on an ambiguous name — leaving it in silently disabled the rule under test (caught immediately: 6 tests failed on the first run). Production never references it either.

## Verify

- `dotnet build Humans.slnx` — 0 errors, 26 warnings, all pre-existing families (HUM0017 ×2, HUM0028 ×12, HUM_USER_DISPLAYNAME ×38 occurrences).
- `dotnet test Humans.slnx` — 46 projects, **5493 tests, 0 failures** (5488 before; +5 new). `Humans.Analyzers.Tests` 204 → 209.

## Left for the rename lane (not touched — outside this lane's file boundary)

- `src/Humans.Interfaces/Humans.Interfaces.csproj` still carries the comment claiming the namespace is pinned so the analyzer constants stay valid. That constraint is gone; the comment should be deleted.
- `Humans.Domain.Attributes.SectionAttribute` (`src/Humans.Interfaces/Attributes/`) is a fifth hardcoded literal with the same shape, in `CrossSectionRepositoryInjectionAnalyzer` and `CrossSectionFullServiceInjectionAnalyzer` (HUM0017 / HUM0018). Same one-line fix.
- The inline attribute stubs in the other analyzer test files hardcode `Humans.Application.Architecture`, so a namespace rename must update them — mechanically, and loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
