### PR TITLE
fix(camps): use section localizer for contact feedback

### DIFF
--- a/src/Sections/Humans.Camps/Controllers/CampController.cs
+++ b/src/Sections/Humans.Camps/Controllers/CampController.cs
@@ -10,6 +10,7 @@ using Humans.Application;
 using Humans.CityPlanning.Contracts;
 using Humans.Shifts.Contracts;
 using Humans.Application.Interfaces.Users;
+using Humans.Camps.Resources;
 using Humans.Camps.Services;
 using Humans.UI;
 
@@ -31,7 +32,8 @@ internal sealed class CampController(
     IAuthorizationService authorizationService,
     IClock clock,
     ILogger<CampController> logger,
-    IStringLocalizer<SharedResource> localizer)
+    IStringLocalizer<CampsResource> campsLocalizer,
+    IStringLocalizer<SharedResource> sharedLocalizer)
     : HumansCampControllerBase(userService, campService, authorizationService)
 {
     private readonly ICampService _campService = campService;
@@ -311,16 +313,16 @@ internal sealed class CampController(
 
             if (result.RateLimited)
             {
-                SetError(localizer["Camp_Contact_RateLimited"].Value);
+                SetError(campsLocalizer["Camp_Contact_RateLimited"].Value);
                 return RedirectToAction(nameof(Details), new { slug });
             }
-            SetSuccess(string.Format(localizer["Camp_Contact_Success"].Value, campDisplayName));
+            SetSuccess(string.Format(campsLocalizer["Camp_Contact_Success"].Value, campDisplayName));
             return RedirectToAction(nameof(Details), new { slug });
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to send facilitated message to camp {Slug}", slug);
-            SetError(localizer["Common_Error"].Value);
+            SetError(sharedLocalizer["Common_Error"].Value);
             return RedirectToAction(nameof(Details), new { slug });
         }
     }
@@ -1314,7 +1316,7 @@ internal sealed class CampController(
         if (!string.IsNullOrWhiteSpace(phone) && !phone.TrimStart().StartsWith("+", StringComparison.Ordinal))
         {
             ModelState.AddModelError(fieldName,
-                localizer["Validation_PhoneE164", "Contact Phone"].Value);
+                sharedLocalizer["Validation_PhoneE164", "Contact Phone"].Value);
         }
     }
 

--- a/tests/Humans.Camps.Tests/Controllers/CampControllerTests.cs
+++ b/tests/Humans.Camps.Tests/Controllers/CampControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Application;
+using Humans.Camps.Resources;
 using Humans.Camps.Services;
 using Humans.CityPlanning.Contracts;
 using Humans.Shifts.Contracts;
@@ -31,7 +32,8 @@ public class CampControllerTests
     private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
     private readonly IAuthorizationService _authorization = Substitute.For<IAuthorizationService>();
     private readonly IClock _clock = Substitute.For<IClock>();
-    private readonly IStringLocalizer<SharedResource> _localizer = Substitute.For<IStringLocalizer<SharedResource>>();
+    private readonly IStringLocalizer<CampsResource> _campsLocalizer = Substitute.For<IStringLocalizer<CampsResource>>();
+    private readonly IStringLocalizer<SharedResource> _sharedLocalizer = Substitute.For<IStringLocalizer<SharedResource>>();
 
     [HumansFact]
     public async Task Index_BuildsPublicDirectory_FromCachedCampInfoRead()
@@ -214,7 +216,8 @@ public class CampControllerTests
             _authorization,
             _clock,
             NullLogger<CampController>.Instance,
-            _localizer);
+            _campsLocalizer,
+            _sharedLocalizer);
 
         var services = new ServiceCollection();
         services.AddLogging();


### PR DESCRIPTION
## What changed

- resolve `Camp_Contact_Success` and `Camp_Contact_RateLimited` through `CampsResource`
- retain `SharedResource` for `Common_Error` and `Validation_PhoneE164`
- update the existing controller test fixture for the two explicit localizers

## Why

The camp contact keys moved into the Camps section resource set, but `CampController` continued looking them up through `SharedResource`. Missing localized strings therefore rendered as raw resource keys after successful or rate-limited contact attempts.

## Impact

Camp contact feedback now renders the translated message for the active culture. Contact delivery and rate-limiting behavior are unchanged.

## Validation

- `dotnet test tests/Humans.Camps.Tests/Humans.Camps.Tests.csproj --no-restore --verbosity quiet` (212 passed, 1 pre-existing skip)
- `dotnet format Humans.slnx --verify-no-changes --verbosity diagnostic --exclude src/Humans.Infrastructure/Migrations/`
