### PR TITLE
build: remove per-project revision lookup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,8 +91,13 @@
     <NoWarn>$(NoWarn);CS1591;MA0048;MA0016;MA0026;MA0051;VSTHRD200;HUM_USER_NORMALIZEDEMAIL</NoWarn>
   </PropertyGroup>
 
-  <!-- Embed git commit hash into InformationalVersion at build time (skip when already set via -p:SourceRevisionId) -->
-  <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation" Condition="'$(SourceRevisionId)' == ''">
+  <!--
+    Humans.Web is the only assembly that displays the revision at runtime. Resolving it
+    for every class library and test project runs a git process per project and makes
+    no-change solution builds needlessly expensive.
+  -->
+  <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation"
+          Condition="'$(SourceRevisionId)' == '' and '$(MSBuildProjectName)' == 'Humans.Web'">
     <Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardErrorImportance="low">
       <Output TaskParameter="ConsoleOutput" PropertyName="SourceRevisionId" />
     </Exec>


### PR DESCRIPTION
## Summary

Restrict the local `git rev-parse --short HEAD` lookup to `Humans.Web`, the only assembly that exposes the build revision at runtime.

Previously, the target in `Directory.Build.props` ran once for every solution project. With 122 projects, even a no-change build started roughly 122 Git processes and printed the revision repeatedly. The web host still embeds the exact revision in its `AssemblyInformationalVersion`.

## Measured impact

Measurements used `dotnet build Humans.slnx --no-restore --verbosity quiet -clp:ErrorsOnly` from a clean worktree based on `origin/main`, after restore and one settling build.

| Scenario | Five-run mean | Change |
| --- | ---: | ---: |
| Baseline no-change solution build | 10.80s | — |
| With this change | 9.26s | **-1.55s / -14.3%** |

Individual baseline runs: 10.42s, 10.54s, 11.25s, 11.01s, 10.79s.

Individual optimized runs: 9.34s, 9.69s, 9.33s, 9.63s, 8.29s.

## Dependency investigation

The solution has 122 projects and 808 direct `ProjectReference` edges. A no-change build does remain incremental: it does not recompile every section. The major hubs are expected shared foundations (`Humans.Interfaces`: 69 direct dependents; `Humans.Application`: 46; `Humans.UI`: 38; `Humans.Infrastructure`: 33). No cycle or accidental full-rebuild edge was found, so this PR avoids destabilizing the section boundary graph.

## Validation

- `dotnet build Humans.slnx --no-restore --verbosity quiet -clp:ErrorsOnly`
- verified `Humans.Web` continues to emit `AssemblyInformationalVersion` with revision `d237f3cc0`
- `dotnet test Humans.slnx --no-restore --verbosity quiet` — passed; full suite 153.8s
