### PR TITLE
feat(tickets): sales totals by ticket type/price

### DIFF
--- a/src/Sections/Humans.Tickets/Controllers/TicketController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketController.cs
@@ -248,6 +248,13 @@ internal sealed class TicketController(
                 VatAmount = q.VatAmount,
                 VipDonations = q.VipDonations,
             }).ToList(),
+            ByTicketType = aggregates.ByTicketType.Select(t => new TicketTypeSalesRow
+            {
+                TicketTypeName = t.TicketTypeName,
+                Price = t.Price,
+                TicketsSold = t.TicketsSold,
+                GrossRevenue = t.GrossRevenue,
+            }).ToList(),
         };
 
         return View(model);

--- a/src/Sections/Humans.Tickets/Controllers/TicketController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketController.cs
@@ -253,7 +253,7 @@ internal sealed class TicketController(
                 TicketTypeName = t.TicketTypeName,
                 Price = t.Price,
                 TicketsSold = t.TicketsSold,
-                GrossRevenue = t.GrossRevenue,
+                FaceValue = t.FaceValue,
             }).ToList(),
         };
 

--- a/src/Sections/Humans.Tickets/Data/ITicketRepository.cs
+++ b/src/Sections/Humans.Tickets/Data/ITicketRepository.cs
@@ -251,6 +251,8 @@ internal interface ITicketRepository : IRepository
 
     Task<IReadOnlyList<PaidOrderSalesRow>> GetPaidOrderSalesRowsAsync(CancellationToken ct = default);
 
+    Task<IReadOnlyList<PaidAttendeeTypePriceRow>> GetPaidAttendeeTypePriceRowsAsync(CancellationToken ct = default);
+
     Task<IReadOnlyList<DiscountCodeOrderRow>> GetOrdersWithDiscountCodesAsync(CancellationToken ct = default);
 
     Task<(IReadOnlyList<OrderRow> Rows, int TotalCount)> GetOrdersPageAsync(

--- a/src/Sections/Humans.Tickets/Data/TicketRepository.cs
+++ b/src/Sections/Humans.Tickets/Data/TicketRepository.cs
@@ -589,6 +589,23 @@ internal sealed class TicketRepository(IDbContextFactory<TicketsDbContext> facto
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<PaidAttendeeTypePriceRow>> GetPaidAttendeeTypePriceRowsAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.TicketAttendees
+            .AsNoTracking()
+            .Where(a =>
+                a.TicketOrder.PaymentStatus == TicketPaymentStatus.Paid &&
+                (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn))
+            .Select(a => new PaidAttendeeTypePriceRow
+            {
+                TicketTypeName = a.TicketTypeName,
+                Price = a.Price,
+            })
+            .ToListAsync(ct);
+    }
+
     public async Task<IReadOnlyList<DiscountCodeOrderRow>> GetOrdersWithDiscountCodesAsync(
         CancellationToken ct = default)
     {

--- a/src/Sections/Humans.Tickets/Models/TicketViewModels.cs
+++ b/src/Sections/Humans.Tickets/Models/TicketViewModels.cs
@@ -174,7 +174,16 @@ internal sealed class TicketSalesAggregatesViewModel
 {
     public List<WeeklySalesRow> WeeklySales { get; set; } = [];
     public List<QuarterlySalesRow> QuarterlySales { get; set; } = [];
+    public List<TicketTypeSalesRow> ByTicketType { get; set; } = [];
     public string Currency { get; set; } = "EUR";
+}
+
+internal sealed class TicketTypeSalesRow
+{
+    public string TicketTypeName { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public int TicketsSold { get; set; }
+    public decimal GrossRevenue { get; set; }
 }
 
 internal sealed class WeeklySalesRow

--- a/src/Sections/Humans.Tickets/Models/TicketViewModels.cs
+++ b/src/Sections/Humans.Tickets/Models/TicketViewModels.cs
@@ -183,7 +183,7 @@ internal sealed class TicketTypeSalesRow
     public string TicketTypeName { get; set; } = string.Empty;
     public decimal Price { get; set; }
     public int TicketsSold { get; set; }
-    public decimal GrossRevenue { get; set; }
+    public decimal FaceValue { get; set; }
 }
 
 internal sealed class WeeklySalesRow

--- a/src/Sections/Humans.Tickets/Services/Dtos/TicketDashboardDtos.cs
+++ b/src/Sections/Humans.Tickets/Services/Dtos/TicketDashboardDtos.cs
@@ -67,6 +67,7 @@ internal sealed class TicketSalesAggregates
 {
     public List<WeeklySalesAggregate> WeeklySales { get; init; } = [];
     public List<QuarterlySalesAggregate> QuarterlySales { get; init; } = [];
+    public List<TicketTypeSalesAggregate> ByTicketType { get; init; } = [];
 }
 
 internal sealed class WeeklySalesAggregate
@@ -91,6 +92,14 @@ internal sealed class QuarterlySalesAggregate
     public decimal Donations { get; init; }
     public decimal VatAmount { get; init; }
     public decimal VipDonations { get; init; }
+}
+
+internal sealed class TicketTypeSalesAggregate
+{
+    public string TicketTypeName { get; init; } = string.Empty;
+    public decimal Price { get; init; }
+    public int TicketsSold { get; init; }
+    public decimal GrossRevenue { get; init; }
 }
 
 /// <summary>Aggregated code tracking data: campaign summaries + individual code details.</summary>
@@ -268,6 +277,16 @@ internal sealed class PaidOrderSalesRow
     public decimal VatAmount { get; init; }
     public int AttendeeCount { get; init; }
     public decimal VipDonations { get; init; }
+}
+
+/// <summary>
+/// Narrow per-attendee projection used to aggregate sales by ticket type and
+/// price. One row per Valid/CheckedIn attendee on a paid order.
+/// </summary>
+internal sealed class PaidAttendeeTypePriceRow
+{
+    public string TicketTypeName { get; init; } = string.Empty;
+    public decimal Price { get; init; }
 }
 
 /// <summary>

--- a/src/Sections/Humans.Tickets/Services/Dtos/TicketDashboardDtos.cs
+++ b/src/Sections/Humans.Tickets/Services/Dtos/TicketDashboardDtos.cs
@@ -99,7 +99,11 @@ internal sealed class TicketTypeSalesAggregate
     public string TicketTypeName { get; init; } = string.Empty;
     public decimal Price { get; init; }
     public int TicketsSold { get; init; }
-    public decimal GrossRevenue { get; init; }
+
+    /// <summary>Sum of listed ticket prices — not order revenue (order-level
+    /// discounts and donations are excluded), so it won't reconcile with
+    /// the weekly/quarterly GrossRevenue figures.</summary>
+    public decimal FaceValue { get; init; }
 }
 
 /// <summary>Aggregated code tracking data: campaign summaries + individual code details.</summary>

--- a/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
@@ -368,9 +368,9 @@ internal sealed class TicketQueryService(
                 TicketTypeName = g.Key.TicketTypeName,
                 Price = g.Key.Price,
                 TicketsSold = g.Count(),
-                GrossRevenue = g.Sum(a => a.Price),
+                FaceValue = g.Sum(a => a.Price),
             })
-            .OrderByDescending(t => t.GrossRevenue)
+            .OrderByDescending(t => t.FaceValue)
             .ToList();
 
         return new TicketSalesAggregates

--- a/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
@@ -359,10 +359,25 @@ internal sealed class TicketQueryService(
             })
             .ToList();
 
+        var attendees = await ticketRepository.GetPaidAttendeeTypePriceRowsAsync();
+
+        var byTicketType = attendees
+            .GroupBy(a => (a.TicketTypeName, a.Price))
+            .Select(g => new TicketTypeSalesAggregate
+            {
+                TicketTypeName = g.Key.TicketTypeName,
+                Price = g.Key.Price,
+                TicketsSold = g.Count(),
+                GrossRevenue = g.Sum(a => a.Price),
+            })
+            .OrderByDescending(t => t.GrossRevenue)
+            .ToList();
+
         return new TicketSalesAggregates
         {
             WeeklySales = weeklySales,
             QuarterlySales = quarterlySales,
+            ByTicketType = byTicketType,
         };
     }
 

--- a/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
+++ b/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
@@ -160,7 +160,7 @@
                             <th>Ticket Type</th>
                             <th class="text-end">Price</th>
                             <th class="text-end">Tickets</th>
-                            <th class="text-end">Gross Revenue</th>
+                            <th class="text-end">Face Value</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -170,7 +170,7 @@
                                 <td>@type.TicketTypeName</td>
                                 <td class="text-end">@Model.Currency @type.Price.ToString("N2")</td>
                                 <td class="text-end">@type.TicketsSold.ToString("N0")</td>
-                                <td class="text-end">@Model.Currency @type.GrossRevenue.ToString("N2")</td>
+                                <td class="text-end">@Model.Currency @type.FaceValue.ToString("N2")</td>
                             </tr>
                         }
                     </tbody>
@@ -179,10 +179,17 @@
                             <td>Total</td>
                             <td></td>
                             <td class="text-end">@Model.ByTicketType.Sum(t => t.TicketsSold).ToString("N0")</td>
-                            <td class="text-end">@Model.Currency @Model.ByTicketType.Sum(t => t.GrossRevenue).ToString("N2")</td>
+                            <td class="text-end">@Model.Currency @Model.ByTicketType.Sum(t => t.FaceValue).ToString("N2")</td>
                         </tr>
                     </tfoot>
                 </table>
+                <div class="px-3 py-2">
+                    <small class="text-muted">
+                        <i class="fa-solid fa-circle-info"></i>
+                        Face value is the listed ticket price — order-level discounts and donations are excluded,
+                        so totals here won't match Gross Revenue in the tables above.
+                    </small>
+                </div>
             }
             else
             {

--- a/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
+++ b/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
@@ -146,4 +146,48 @@
             }
         </div>
     </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <i class="fa-solid fa-ticket"></i> By Ticket Type
+        </div>
+        <div class="card-body p-0">
+            @if (Model.ByTicketType.Count > 0)
+            {
+                <table class="table table-sm table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Ticket Type</th>
+                            <th class="text-end">Price</th>
+                            <th class="text-end">Tickets</th>
+                            <th class="text-end">Gross Revenue</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var type in Model.ByTicketType)
+                        {
+                            <tr>
+                                <td>@type.TicketTypeName</td>
+                                <td class="text-end">@Model.Currency @type.Price.ToString("N2")</td>
+                                <td class="text-end">@type.TicketsSold.ToString("N0")</td>
+                                <td class="text-end">@Model.Currency @type.GrossRevenue.ToString("N2")</td>
+                            </tr>
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr class="fw-bold">
+                            <td>Total</td>
+                            <td></td>
+                            <td class="text-end">@Model.ByTicketType.Sum(t => t.TicketsSold).ToString("N0")</td>
+                            <td class="text-end">@Model.Currency @Model.ByTicketType.Sum(t => t.GrossRevenue).ToString("N2")</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            }
+            else
+            {
+                <div class="text-muted text-center py-3">No paid orders yet.</div>
+            }
+        </div>
+    </div>
 </div>

--- a/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
@@ -159,6 +159,117 @@ public sealed class TicketQueryServiceTests : TicketsTestHarness
     }
 
     [HumansFact]
+    public async Task GetSalesAggregatesAsync_GroupsByTicketTypeAndPrice()
+    {
+        var orderId = Guid.NewGuid();
+        TicketsDb.TicketOrders.Add(new TicketOrder
+        {
+            Id = orderId,
+            VendorOrderId = "ord_by_type",
+            BuyerName = "Buyer",
+            BuyerEmail = "buyer@example.com",
+            TotalAmount = 700m,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
+            VendorEventId = "ev_test",
+            PurchasedAt = Instant.FromUtc(2026, 3, 2, 10, 0),
+            SyncedAt = Instant.FromUtc(2026, 3, 2, 10, 0),
+            Attendees =
+            [
+                MakePricedAttendee(orderId, "tkt_fw_1", "Full Week", 100m, TicketAttendeeStatus.Valid),
+                MakePricedAttendee(orderId, "tkt_fw_2", "Full Week", 100m, TicketAttendeeStatus.CheckedIn),
+                MakePricedAttendee(orderId, "tkt_fw_early", "Full Week", 80m, TicketAttendeeStatus.Valid),
+                MakePricedAttendee(orderId, "tkt_vip", "VIP", 420m, TicketAttendeeStatus.Valid)
+            ]
+        });
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var result = await _service.GetSalesAggregatesAsync();
+
+        result.ByTicketType.Should().HaveCount(3);
+
+        // Ordered by gross revenue descending.
+        var vip = result.ByTicketType[0];
+        vip.TicketTypeName.Should().Be("VIP");
+        vip.Price.Should().Be(420m);
+        vip.TicketsSold.Should().Be(1);
+        vip.GrossRevenue.Should().Be(420m);
+
+        var fullWeek = result.ByTicketType[1];
+        fullWeek.TicketTypeName.Should().Be("Full Week");
+        fullWeek.Price.Should().Be(100m);
+        fullWeek.TicketsSold.Should().Be(2);
+        fullWeek.GrossRevenue.Should().Be(200m);
+
+        var earlyBird = result.ByTicketType[2];
+        earlyBird.TicketTypeName.Should().Be("Full Week");
+        earlyBird.Price.Should().Be(80m);
+        earlyBird.TicketsSold.Should().Be(1);
+        earlyBird.GrossRevenue.Should().Be(80m);
+    }
+
+    [HumansFact]
+    public async Task GetSalesAggregatesAsync_ByTicketType_ExcludesUnpaidOrdersAndVoidAttendees()
+    {
+        var paidOrderId = Guid.NewGuid();
+        TicketsDb.TicketOrders.Add(new TicketOrder
+        {
+            Id = paidOrderId,
+            VendorOrderId = "ord_paid",
+            BuyerName = "Buyer",
+            BuyerEmail = "buyer@example.com",
+            TotalAmount = 200m,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
+            VendorEventId = "ev_test",
+            PurchasedAt = Instant.FromUtc(2026, 3, 2, 10, 0),
+            SyncedAt = Instant.FromUtc(2026, 3, 2, 10, 0),
+            Attendees =
+            [
+                MakePricedAttendee(paidOrderId, "tkt_valid", "Full Week", 100m, TicketAttendeeStatus.Valid),
+                MakePricedAttendee(paidOrderId, "tkt_void", "Full Week", 100m, TicketAttendeeStatus.Void)
+            ]
+        });
+
+        var refundedOrderId = Guid.NewGuid();
+        TicketsDb.TicketOrders.Add(new TicketOrder
+        {
+            Id = refundedOrderId,
+            VendorOrderId = "ord_refunded",
+            BuyerName = "Buyer",
+            BuyerEmail = "buyer@example.com",
+            TotalAmount = 400m,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Refunded,
+            VendorEventId = "ev_test",
+            PurchasedAt = Instant.FromUtc(2026, 3, 2, 12, 0),
+            SyncedAt = Instant.FromUtc(2026, 3, 2, 12, 0),
+            Attendees =
+            [
+                MakePricedAttendee(refundedOrderId, "tkt_refunded", "VIP", 400m, TicketAttendeeStatus.Valid)
+            ]
+        });
+
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var result = await _service.GetSalesAggregatesAsync();
+
+        var row = result.ByTicketType.Should().ContainSingle().Subject;
+        row.TicketTypeName.Should().Be("Full Week");
+        row.Price.Should().Be(100m);
+        row.TicketsSold.Should().Be(1);
+        row.GrossRevenue.Should().Be(100m);
+    }
+
+    [HumansFact]
+    public async Task GetSalesAggregatesAsync_ByTicketType_IsEmptyWithoutData()
+    {
+        var result = await _service.GetSalesAggregatesAsync();
+
+        result.ByTicketType.Should().BeEmpty();
+    }
+
+    [HumansFact]
     public async Task GetAvailableTicketTypesAsync_ReturnsDistinctTypes()
     {
         var orderId = Guid.NewGuid();
@@ -698,6 +809,23 @@ public sealed class TicketQueryServiceTests : TicketsTestHarness
             Status = TicketAttendeeStatus.Valid,
             VendorEventId = "ev_test",
             SyncedAt = Instant.FromUtc(2026, 3, 1, 10, 0),
+        };
+
+    private static TicketAttendee MakePricedAttendee(
+        Guid orderId, string vendorTicketId, string ticketTypeName,
+        decimal price, TicketAttendeeStatus status) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = vendorTicketId,
+            TicketOrderId = orderId,
+            TicketOrder = null!,
+            AttendeeName = vendorTicketId,
+            TicketTypeName = ticketTypeName,
+            Price = price,
+            Status = status,
+            VendorEventId = "ev_test",
+            SyncedAt = Instant.FromUtc(2026, 3, 2, 10, 0),
         };
 
     private static TeamInfo VolunteersTeam(IEnumerable<Guid> userIds) =>

--- a/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
@@ -188,24 +188,24 @@ public sealed class TicketQueryServiceTests : TicketsTestHarness
 
         result.ByTicketType.Should().HaveCount(3);
 
-        // Ordered by gross revenue descending.
+        // Ordered by face value descending.
         var vip = result.ByTicketType[0];
         vip.TicketTypeName.Should().Be("VIP");
         vip.Price.Should().Be(420m);
         vip.TicketsSold.Should().Be(1);
-        vip.GrossRevenue.Should().Be(420m);
+        vip.FaceValue.Should().Be(420m);
 
         var fullWeek = result.ByTicketType[1];
         fullWeek.TicketTypeName.Should().Be("Full Week");
         fullWeek.Price.Should().Be(100m);
         fullWeek.TicketsSold.Should().Be(2);
-        fullWeek.GrossRevenue.Should().Be(200m);
+        fullWeek.FaceValue.Should().Be(200m);
 
         var earlyBird = result.ByTicketType[2];
         earlyBird.TicketTypeName.Should().Be("Full Week");
         earlyBird.Price.Should().Be(80m);
         earlyBird.TicketsSold.Should().Be(1);
-        earlyBird.GrossRevenue.Should().Be(80m);
+        earlyBird.FaceValue.Should().Be(80m);
     }
 
     [HumansFact]
@@ -258,7 +258,7 @@ public sealed class TicketQueryServiceTests : TicketsTestHarness
         row.TicketTypeName.Should().Be("Full Week");
         row.Price.Should().Be(100m);
         row.TicketsSold.Should().Be(1);
-        row.GrossRevenue.Should().Be(100m);
+        row.FaceValue.Should().Be(100m);
     }
 
     [HumansFact]


### PR DESCRIPTION
Adds a **By Ticket Type** aggregate card to the Tickets Sales Aggregates page. The page previously showed weekly and quarterly totals but had no view of totals by ticket type/price.

- **Repository** — `GetPaidAttendeeTypePriceRowsAsync` on `ITicketRepository`/`TicketRepository`: narrow, DB-filtered projection returning one row per Valid/CheckedIn attendee on a `Paid` order (same filter as `GetPaidOrderSalesRowsAsync`). AsNoTracking, factory-created context.
- **DTOs** — `PaidAttendeeTypePriceRow` (repo projection) and `TicketTypeSalesAggregate` (`TicketTypeName`, `Price`, `TicketsSold`, `GrossRevenue`); `TicketSalesAggregates.ByTicketType` added.
- **Service** — `TicketQueryService.GetSalesAggregatesAsync` groups by `(TicketTypeName, Price)`, counts tickets, sums gross, orders by gross revenue descending. `CachingTicketQueryService` already wraps this method, unchanged.
- **View model / controller** — `TicketSalesAggregatesViewModel.ByTicketType` (`TicketTypeSalesRow`), mapped in `TicketController.SalesAggregates()`.
- **View** — third card after Quarterly, matching the existing card/table markup: Ticket Type, Price, Tickets, Gross Revenue, with a bold totals footer and the shared "No paid orders yet." empty state.
- **Tests** — three cases in `TicketQueryServiceTests`: grouping by type+price, exclusion of non-Paid orders and Void attendees, and empty data yielding an empty list.

No schema change, so no EF migration.

Build and full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
