### PR TITLE
fix(development): never mint an Admin session from dev login outside a dev host

### DIFF
--- a/src/Sections/Humans.Development/Controllers/DevLoginController.cs
+++ b/src/Sections/Humans.Development/Controllers/DevLoginController.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text;
 using Humans.Application.Configuration;
+using Humans.Auth.Contracts;
 using Humans.Users.Contracts;
 using Humans.Development.Services;
 using Humans.Domain.Constants;
@@ -18,6 +19,7 @@ internal sealed class DevLoginController(
     SignInManager<User> signInManager,
     IUserEmailService userEmailService,
     DevPersonaSeeder personaSeeder,
+    IRoleAssignmentService roleAssignmentService,
     IWebHostEnvironment env,
     IConfiguration config,
     ConfigurationRegistry configRegistry,
@@ -28,6 +30,16 @@ internal sealed class DevLoginController(
     // Shell's view named the type directly; the markup moved instead (step 3b), so the persona
     // list never leaves the section.
     internal static IReadOnlyList<DevPersonaInfo> AllPersonas { get; } = BuildPersonaList();
+
+    /// <summary>
+    /// The personas offered in <paramref name="environment"/>. Admin is dropped outside a dev
+    /// host — see <see cref="AdminSignInAllowed"/>. Used by the panel so the buttons and the
+    /// route agree on one predicate.
+    /// </summary>
+    internal static IEnumerable<DevPersonaInfo> PersonasFor(IWebHostEnvironment environment) =>
+        AdminSignInAllowed(environment)
+            ? AllPersonas
+            : AllPersonas.Where(p => !IsAdminPersona(p));
 
     private static readonly SemaphoreSlim SeedLock = new(1, 1);
 
@@ -40,6 +52,11 @@ internal sealed class DevLoginController(
         var info = AllPersonas.FirstOrDefault(p =>
             string.Equals(p.Slug, persona, StringComparison.OrdinalIgnoreCase));
         if (info is null)
+            return NotFound();
+
+        // Before any seeding: an Admin session must never be minted off an anonymous URL
+        // outside a dev host.
+        if (IsAdminPersona(info) && !AdminSignInAllowed(env))
             return NotFound();
 
         // Guest: fresh profileless user per click so parallel testers don't collide.
@@ -119,6 +136,10 @@ internal sealed class DevLoginController(
         if (user is null)
             return NotFound();
 
+        // Impersonating a real Admin is the same hole as the Admin persona.
+        if (!AdminSignInAllowed(env) && await roleAssignmentService.IsUserAdminAsync(id))
+            return NotFound();
+
         await signInManager.SignInAsync(user, isPersistent: true);
         logger.LogWarning("DEV LOGIN: signed in as user {Id}", user.Id);
 
@@ -158,6 +179,20 @@ internal sealed class DevLoginController(
     }
 
     // --- Static helpers ---
+
+    /// <summary>
+    /// Whether this host may hand out an Admin session through dev login. Deployed hosts run
+    /// Staging (QA, previews) or Production with real Google Workspace data, and QA keeps
+    /// <c>DevAuth:Enabled</c> on — so anonymous Admin there is a live privilege escalation.
+    /// "Testing" is the in-process integration host, the same discriminator Program.cs uses.
+    /// </summary>
+    private static bool AdminSignInAllowed(IWebHostEnvironment environment) =>
+        environment.IsDevelopment() || environment.IsEnvironment("Testing");
+
+    /// <summary>The persona whose seeded governance role is <see cref="RoleNames.Admin"/>.</summary>
+    private static bool IsAdminPersona(DevPersonaInfo persona) =>
+        string.Equals(
+            DevPersonaSeeder.RoleNameFromSlug(persona.Slug), RoleNames.Admin, StringComparison.Ordinal);
 
     private static List<DevPersonaInfo> BuildPersonaList()
     {

--- a/src/Sections/Humans.Development/Docs/Development.md
+++ b/src/Sections/Humans.Development/Docs/Development.md
@@ -24,9 +24,9 @@ This section owns no entities and no tables. Everything it creates belongs to an
 
 | Route | Method | Auth | Purpose |
 |-------|--------|------|---------|
-| `/dev/login/{persona}` | GET | Anonymous | Seed (idempotently) and sign in as a named persona; `guest` mints a fresh profileless account per click |
+| `/dev/login/{persona}` | GET | Anonymous | Seed (idempotently) and sign in as a named persona; `guest` mints a fresh profileless account per click. The `admin` persona 404s outside a dev host |
 | `/dev/login/users` | GET | Anonymous | User chooser - first 100 humans by burner name, ephemeral guests filtered out |
-| `/dev/login/users/{id}` | GET | Anonymous | Sign in as an existing user by id |
+| `/dev/login/users/{id}` | GET | Anonymous | Sign in as an existing user by id; 404s outside a dev host when that human holds an active Admin assignment |
 | `/dev/seed/budget` | POST | `FinanceAdminOrAdmin` | Budget demo data, via `IBudgetDemoSeeder` on Budget's contracts leaf |
 | `/dev/seed/camp-roles` | POST | `CampAdminOrAdmin` | Five system camp-role definitions |
 | `/dev/seed/dashboard` | POST | `ShiftDashboardAccess` | Coordinator-dashboard demo: one event, 8 departments, 5 subteams, ~120 humans, rotas/shifts/signups |
@@ -50,6 +50,7 @@ Every route 404s when the dev-auth gate is closed. `/dev/login/*` additionally d
 - **Nothing in this section is reachable in Production.** Three independent mechanisms, deliberately not one: the seeders are not registered (`Section.Register` returns early), `DevLoginController` is removed from MVC's controller feature by Shell's `DevLoginControllerExclusionProvider`, and both controllers' own `IsDevAuthEnabled()` / `IsDevSeedEnabled()` guards return `NotFound()`.
 - **`Section.Register` fails closed.** `ISection.Register` takes no `IHostEnvironment`, so it reads `HostDefaults.EnvironmentKey` from the configuration Shell hands it. An environment name it cannot read registers *nothing* - the failure lands as dev login 404ing in the test host, not as dev seeders reaching Production. Pinned by `DevelopmentArchitectureTests`.
 - **The dashboard seed is stricter than the rest**: `IsDevelopment()` **and** `DevAuth:Enabled`. QA, preview and production cannot invoke it regardless of role. (`src/Sections/Humans.Shifts/Docs/Shifts.md` states the same invariant from the other side; `DevSeedControllerTests` covers both branches.)
+- **Dev login never yields an Admin session outside a dev host.** A "dev host" is `Development` or the in-process `Testing` integration host - QA and previews run `Staging` with `DevAuth:Enabled` on and real Google Workspace data, so an anonymous URL that mints Admin there is a live privilege escalation. Both doors are shut: the `admin` persona (matched by resolving the slug back through `DevPersonaSeeder.RoleNameFromSlug`, before any seeding runs) and impersonation of any human with an active `RoleNames.Admin` assignment (`IRoleAssignmentService.IsUserAdminAsync`). `_DevLoginPanel` renders `DevLoginController.PersonasFor(env)` so the button and the route share one predicate. Covered by `DevLoginControllerTests`.
 - **Every write goes through the owning section's service.** No `DbContext`, no repository, no cross-section table access - `DevelopmentArchitectureTests.SectionTakesNoDbContextOrRepository` asserts it on the constructors.
 - **Persona seeding is idempotent and repairs.** `EnsurePersonaAsync` returns the existing user when there is one, and `EnsureActiveAsync` runs on *every* sign-in: it submits any missing required consents through the canonical consent path and lifts a consent suspension, because personas hold governance roles and the nightly `SuspendNonCompliantMembersJob` suspends them otherwise (nobodies-collective/Humans#867).
 - **The `no-name` persona is re-blanked on every sign-in** so the onboarding name gate (#812) re-triggers each time.
@@ -60,6 +61,7 @@ Every route 404s when the dev-auth gate is closed. `/dev/login/*` additionally d
 - A non-privileged authenticated human cannot invoke any `/dev/seed/*` action: `302 -> /Account/AccessDenied` (cookie authentication's `AccessDeniedPath`, app-wide - not a bare `403`). Pinned by `DevelopmentPageRenderTests`.
 - No type in the section may take `IStringLocalizer<T>` for **any** `T`. The section carries no resource set, no `Development_*` key and no `Enum_Development*` key: every string is English developer copy. Adding localized copy must start by carving a resource set. Enforced by `DevelopmentArchitectureTests`.
 - The seeders must not be reachable from production code paths. They are `internal` to this assembly and registered only outside Production.
+- No anonymous visitor to a deployed host may reach an Admin session through `/dev/login/*`, with `DevAuth:Enabled` on or off: `GET /dev/login/admin` and `GET /dev/login/users/{id}` for an active Admin both `404`. `Development` and `Testing` are the only environments that allow either.
 
 ## Triggers
 

--- a/src/Sections/Humans.Development/Services/DevPersonaSeeder.cs
+++ b/src/Sections/Humans.Development/Services/DevPersonaSeeder.cs
@@ -696,7 +696,7 @@ internal sealed class DevPersonaSeeder(
     /// <summary>
     /// Resolves a persona slug back to a RoleNames constant, or null for "volunteer".
     /// </summary>
-    private static string? RoleNameFromSlug(string slug)
+    internal static string? RoleNameFromSlug(string slug)
     {
         if (string.Equals(slug, "volunteer", StringComparison.OrdinalIgnoreCase))
             return null;

--- a/src/Sections/Humans.Development/Views/Shared/_DevLoginPanel.cshtml
+++ b/src/Sections/Humans.Development/Views/Shared/_DevLoginPanel.cshtml
@@ -1,7 +1,7 @@
 @inject IWebHostEnvironment HostEnv
 @*
     The dev sign-in panel on Shell's /Account/Login. It lives here rather than in that view
-    because it enumerates DevLoginController.AllPersonas, which is internal to this section
+    because it enumerates DevLoginController.PersonasFor, which is internal to this section
     (step 3b's "move the markup instead of the key" applied to a type instead of a resource
     key). Shell renders it with @await Html.PartialAsync("_DevLoginPanel") — partial lookup
     resolves by name across application parts, the same mechanism as _GateLayout and
@@ -21,7 +21,9 @@
             <div class="card-body py-3 text-center">
                 <p class="text-muted small mb-3">Skip Google OAuth and sign in directly.</p>
                 <div class="d-flex gap-2 justify-content-center flex-wrap mb-3">
-                    @foreach (var persona in DevLoginController.AllPersonas)
+                    @* PersonasFor drops the Admin persona outside a dev host — the button and
+                       the route share one predicate. *@
+                    @foreach (var persona in DevLoginController.PersonasFor(HostEnv))
                     {
                         <a asp-controller="DevLogin" asp-action="SignIn"
                            asp-route-persona="@persona.Slug"

--- a/tests/Humans.Development.Tests/DevLoginControllerTests.cs
+++ b/tests/Humans.Development.Tests/DevLoginControllerTests.cs
@@ -1,0 +1,195 @@
+using AwesomeAssertions;
+using Humans.Application.Configuration;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Users;
+using Humans.AuditLog.Contracts;
+using Humans.Auth.Contracts;
+using Humans.Camps.Contracts;
+using Humans.CityPlanning.Contracts;
+using Humans.Consent.Contracts;
+using Humans.Development.Controllers;
+using Humans.Development.Services;
+using Humans.Governance.Contracts;
+using Humans.Teams.Contracts;
+using Humans.Users.Contracts;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Development.Tests;
+
+/// <summary>
+/// Covers <c>Development.md</c>'s Admin lockdown: dev login may not hand out an Admin
+/// session outside a dev host. QA runs as <c>Staging</c> with <c>DevAuth:Enabled</c> and
+/// real Google Workspace data, so both the <c>admin</c> persona route and impersonation of
+/// a human holding an active Admin assignment must 404 there.
+///
+/// Same shape as <see cref="DevSeedControllerTests"/>: the environment gate runs inside the
+/// action, so both branches are exercised through a substituted
+/// <see cref="IWebHostEnvironment"/>.
+/// </summary>
+public class DevLoginControllerTests
+{
+    private readonly UserManager<User> _userManager = Substitute.For<UserManager<User>>(
+        Substitute.For<IUserStore<User>>(), null, null, null, null, null, null, null, null);
+
+    private readonly SignInManager<User> _signInManager = Substitute.For<SignInManager<User>>(
+        Substitute.For<UserManager<User>>(
+            Substitute.For<IUserStore<User>>(), null, null, null, null, null, null, null, null),
+        Substitute.For<IHttpContextAccessor>(),
+        Substitute.For<IUserClaimsPrincipalFactory<User>>(),
+        null, null, null, null);
+
+    private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
+    private readonly IRoleAssignmentService _roleAssignments = Substitute.For<IRoleAssignmentService>();
+    private readonly IUserService _users = Substitute.For<IUserService>();
+    private readonly IWebHostEnvironment _environment = Substitute.For<IWebHostEnvironment>();
+    private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
+    private readonly ConfigurationRegistry _configRegistry = new();
+
+    [HumansFact]
+    public async Task SignIn_AdminPersona_OutsideDevelopment_ReturnsNotFoundBeforeSeeding()
+    {
+        // QA's exact shape: Staging + DevAuth on. The refusal must land before the seeder
+        // touches anything — an Admin user seeded into QA outlives the request.
+        _environment.EnvironmentName.Returns("Staging");
+        SetDevAuthEnabled(true);
+
+        var result = await BuildSut().SignIn("admin");
+
+        result.Should().BeOfType<NotFoundResult>();
+        await _userManager.DidNotReceive().FindByIdAsync(Arg.Any<string>());
+        await _signInManager.DidNotReceive().SignInAsync(Arg.Any<User>(), Arg.Any<bool>());
+    }
+
+    [HumansFact]
+    public async Task SignIn_AdminPersona_InDevelopment_StillSignsIn()
+    {
+        _environment.EnvironmentName.Returns("Development");
+        SetDevAuthEnabled(true);
+        SeedExistingPersona("admin");
+
+        var result = await BuildSut().SignIn("admin");
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        await _signInManager.Received(1).SignInAsync(Arg.Any<User>(), true);
+    }
+
+    [HumansFact]
+    public async Task SignIn_NonAdminPersona_OutsideDevelopment_StillSignsIn()
+    {
+        // The gate is Admin-only: dev login remains the way into QA for every other persona.
+        _environment.EnvironmentName.Returns("Staging");
+        SetDevAuthEnabled(true);
+        SeedExistingPersona("volunteer");
+
+        var result = await BuildSut().SignIn("volunteer");
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        await _signInManager.Received(1).SignInAsync(Arg.Any<User>(), true);
+    }
+
+    [HumansFact]
+    public async Task SignInAsUser_ActiveAdminAssignment_OutsideDevelopment_ReturnsNotFound()
+    {
+        // The chooser's second hole: any real Admin is reachable by id without the persona route.
+        _environment.EnvironmentName.Returns("Staging");
+        SetDevAuthEnabled(true);
+        var id = Guid.NewGuid();
+        _userManager.FindByIdAsync(id.ToString()).Returns(new User { Id = id });
+        _roleAssignments.IsUserAdminAsync(id, Arg.Any<CancellationToken>()).Returns(true);
+
+        var result = await BuildSut().SignInAsUser(id);
+
+        result.Should().BeOfType<NotFoundResult>();
+        await _signInManager.DidNotReceive().SignInAsync(Arg.Any<User>(), Arg.Any<bool>());
+    }
+
+    [HumansFact]
+    public async Task SignInAsUser_NonAdmin_OutsideDevelopment_StillSignsIn()
+    {
+        _environment.EnvironmentName.Returns("Staging");
+        SetDevAuthEnabled(true);
+        var id = Guid.NewGuid();
+        var user = new User { Id = id };
+        _userManager.FindByIdAsync(id.ToString()).Returns(user);
+        _roleAssignments.IsUserAdminAsync(id, Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await BuildSut().SignInAsUser(id);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        await _signInManager.Received(1).SignInAsync(user, true);
+    }
+
+    /// <summary>
+    /// Makes the persona resolve to an already-seeded user, so <c>EnsurePersonaAsync</c>
+    /// short-circuits to the repair path and the action reaches the sign-in.
+    /// </summary>
+    private void SeedExistingPersona(string slug)
+    {
+        var id = DevPersonaSeeder.PersonaGuid(slug);
+        _userManager.FindByIdAsync(id.ToString()).Returns(new User { Id = id });
+    }
+
+    private void SetDevAuthEnabled(bool enabled)
+    {
+        var section = Substitute.For<IConfigurationSection>();
+        section.Value.Returns(enabled ? "true" : "false");
+        section.Path.Returns("DevAuth:Enabled");
+        section.Key.Returns("Enabled");
+        _configuration.GetSection("DevAuth:Enabled").Returns(section);
+        _configuration["DevAuth:Enabled"].Returns(enabled ? "true" : "false");
+    }
+
+    private DevLoginController BuildSut()
+    {
+        var ctrl = new DevLoginController(
+            _userManager,
+            _signInManager,
+            _userEmails,
+            BuildSeeder(),
+            _roleAssignments,
+            _environment,
+            _configuration,
+            _configRegistry,
+            NullLogger<DevLoginController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+            // RedirectToLocalOrHome consults Url.IsLocalUrl; the substitute answers false,
+            // which is the no-returnUrl branch this suite exercises.
+            Url = Substitute.For<IUrlHelper>(),
+        };
+        return ctrl;
+    }
+
+    private DevPersonaSeeder BuildSeeder() => new(
+        _userManager,
+        Substitute.For<IProfileEditorService>(),
+        _userEmails,
+        Substitute.For<IContactFieldService>(),
+        _roleAssignments,
+        Substitute.For<IUserInfoInvalidator>(),
+        Substitute.For<ITeamService>(),
+        Substitute.For<ITeamSeeding>(),
+        Substitute.For<ISystemTeamSync>(),
+        _users,
+        Substitute.For<IAuditLogService>(),
+        Substitute.For<ICampServiceRead>(),
+        Substitute.For<ICampSeeding>(),
+        Substitute.For<ICampRoleSeeding>(),
+        Substitute.For<IConsentSubmission>(),
+        Substitute.For<IMembershipCalculatorRead>(),
+        Substitute.For<IHumanLifecycleService>(),
+        new FakeClock(Instant.FromUtc(2026, 8, 16, 12, 0)),
+        new MemoryCache(new MemoryCacheOptions()),
+        Options.Create(new CityPlanningOptions()),
+        NullLogger<DevPersonaSeeder>.Instance);
+}


### PR DESCRIPTION
**Section:** Development

## Problem

Dev login could hand an anonymous visitor a full Admin session on a deployed host. QA runs as `Staging` with `DevAuth:Enabled=true` against real Google Workspace data, and the dev-auth gate only excluded `Production` — so both of these worked there:

1. **Admin persona.** `BuildPersonaList()` turns every `RoleNames` constant into a persona, so `GET /dev/login/admin` seeded an Admin user and signed in as it.
2. **Impersonation.** `GET /dev/login/users/{id}` signed in as any user by GUID, including every real Admin (the chooser at `/dev/login/users` lists them by name).

## Fix

A "dev host" is `Development` or the in-process `Testing` integration host — the same `IsEnvironment("Testing")` discriminator `Program.cs` already uses. Everywhere else:

- `SignIn` returns `NotFound()` for the Admin persona **before any seeding runs**. The persona is matched by resolving the slug back through `DevPersonaSeeder.RoleNameFromSlug` and comparing to `RoleNames.Admin` — no hardcoded `"admin"` string, so a rename of the constant carries.
- `SignInAsUser` returns `NotFound()` when the target holds an active Admin assignment, via `IRoleAssignmentService.IsUserAdminAsync`.
- `_DevLoginPanel.cshtml` renders `DevLoginController.PersonasFor(env)` instead of `AllPersonas`, so the button and the route share one predicate rather than drifting.

No new interfaces, DI registrations, config settings, or migrations. `RoleNameFromSlug` went `private` → `internal` (same assembly) so the controller reuses the existing slug→role resolution instead of duplicating the kebab-case logic.

### Deviation from the brief, flagged

The brief specified `IRoleAssignmentService.GetByUserIdAsync` plus a manual `RoleAssignmentSummarySnapshot.IsActive(now)` filter. I used the existing `IsUserAdminAsync` instead: it is `repository.HasActiveRoleAsync(userId, RoleNames.Admin, clock.GetCurrentInstant())`, i.e. identical semantics including the validity window, in one call and with no `IClock` injection. Reuse-first over a hand-rolled equivalent.

The brief also said "NOT Development". A strict `IsDevelopment()`-only gate breaks the integration suite: `HumansWebApplicationFactory` boots as `"Testing"` and `SignInAsFullyOnboardedAsync(client, DevPersona.Admin)` goes through `GET /dev/login/admin`, used across 38 test files. Flipping the test host to `Development` is not viable either — `Program.cs` has four `IsEnvironment("Testing")` carve-outs that would invert. Deployments are only ever `Staging` (`deploy-qa.sh`) or `Production` (`docker-compose.yml`), so allowing `Testing` costs nothing operationally.

## Test coverage

New `tests/Humans.Development.Tests/DevLoginControllerTests.cs`, mirroring `DevSeedControllerTests`' substituted-`IWebHostEnvironment` shape (the gate runs inside the action, so both branches are reachable from a unit test — and only from one, since the integration host is an allowed environment):

- `admin` persona under `Staging` + DevAuth on → 404, asserted **before** the seeder touches anything.
- `admin` persona under `Development` → still signs in.
- `volunteer` persona under `Staging` → still signs in (the gate is Admin-only).
- `/dev/login/users/{id}` for an active Admin under `Staging` → 404.
- `/dev/login/users/{id}` for a non-admin under `Staging` → still signs in.

Full suite green: 46 assemblies, 0 failures, integration 276 passed / 1 pre-existing skip.

## Docs

`src/Sections/Humans.Development/Docs/Development.md` — Routing table, a new Invariant, and a new Negative Access Rule.

## Operational note

The QA database already holds a seeded Dev Admin user from before this fix. This PR deliberately ships **no** code to clean that up — Peter ends its role assignment through the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
