### PR TITLE
chore(866): distribute EnumStringStabilityTests rows to owning section test projects

### DIFF
--- a/src/Sections/Humans.Shifts.Contracts/Humans.Shifts.Contracts.csproj
+++ b/src/Sections/Humans.Shifts.Contracts/Humans.Shifts.Contracts.csproj
@@ -30,8 +30,7 @@
     4b-2k: it existed for the section's persisted-string enums (SignupStatus, ShiftPeriod,
     ShiftPriority, RotaPeriod, BuildSubPeriod, SignupPolicy), and those now live here, in
     Humans.Shifts.Contracts, because this leaf's own signatures name them (Budget's rule).
-    Their EnumStringStabilityTests rows still live in tests/Humans.Domain.Tests — that
-    project reaches them through its existing project graph.
+    Their EnumStringStabilityTests rows live in tests/Humans.Shifts.Tests/Enums.
 
     No entity crosses this boundary. Shift / ShiftSignup / Rota / EventSettings /
     VolunteerEventProfile are internal sealed types in Humans.Shifts.Domain, and every

--- a/src/Sections/Humans.Users/Humans.Users.csproj
+++ b/src/Sections/Humans.Users/Humans.Users.csproj
@@ -19,11 +19,6 @@
     <!-- Same shape, same expiry: Shell-level tests over the moved controllers. -->
     <InternalsVisibleTo Include="Humans.Web.Tests" />
     <!--
-      Same shape, same expiry: ContactFieldTests and ProfileTests are two of the 43 test files
-      lane 2 phase 3 moves into tests/Humans.Users.Tests.
-    -->
-    <InternalsVisibleTo Include="Humans.Domain.Tests" />
-    <!--
       Three unmoved sections' harnesses seed this section's rows through an in-memory
       UsersDbContext (Teams' two-way pattern, design §15 step 8). Each drops out at the lane
       that stops its harness building another section's context directly.

--- a/tests/Humans.AuditLog.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.AuditLog.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,59 @@
+using AwesomeAssertions;
+using Humans.AuditLog.Contracts;
+using Xunit;
+
+namespace Humans.AuditLog.Tests.Enums;
+
+/// <summary>
+/// AuditLog's share of the string-stored-enum guard, moved out of
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <see cref="AuditAction"/> lives on <c>Humans.AuditLog.Contracts</c>, so the guard belongs to
+/// the section that owns it (nobodies-collective/Humans#866).
+/// </summary>
+/// <remarks>
+/// <c>AuditAction</c> is persisted with <c>HasConversion&lt;string&gt;()</c> in
+/// <c>audit_log_entries.action</c>: renaming a member leaves the OLD string in the column, and
+/// every historical row keeps it. A rename needs a migration that UPDATEs the stored values.
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansTheory]
+    [MemberData(nameof(StringStoredEnumData))]
+    public void StringStoredEnum_MemberNames_MustMatchExpected(
+        Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                $"If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+
+    public static TheoryData<Type, string[]> StringStoredEnumData => new()
+    {
+        {
+            typeof(AuditAction), [
+                "TeamMemberAdded", "TeamMemberRemoved", "MemberSuspended", "MemberUnsuspended",
+                "AccountAnonymized", "RoleAssigned", "RoleEnded", "VolunteerApproved",
+                "GoogleResourceAccessGranted", "GoogleResourceAccessRevoked", "GoogleResourceProvisioned",
+                "TeamJoinedDirectly", "TeamLeft", "TeamJoinRequestApproved", "TeamJoinRequestRejected",
+                "TeamMemberRoleChanged", "AnomalousPermissionDetected",
+                "MembershipsRevokedOnDeletionRequest", "ConsentCheckCleared", "ConsentCheckFlagged",
+                "SignupRejected", "TierApplicationApproved", "TierApplicationRejected", "TierDowngraded",
+                "GoogleResourceDeactivated", "FacilitatedMessageSent",
+                "TeamRoleDefinitionCreated", "TeamRoleDefinitionUpdated", "TeamRoleDefinitionDeleted",
+                "TeamRoleAssigned", "TeamRoleUnassigned",
+                "CampCreated", "CampUpdated", "CampDeleted",
+                "CampSeasonCreated", "CampSeasonApproved", "CampSeasonRejected",
+                "CampSeasonWithdrawn", "CampSeasonStatusChanged", "CampNameChanged",
+                "CampLeadAdded", "CampLeadRemoved", "CampPrimaryLeadTransferred",
+                "CampImageUploaded", "CampImageDeleted",
+                "ShiftSignupCreated", "ShiftSignupConfirmed", "ShiftSignupRefused", "ShiftSignupVoluntold",
+                "ShiftSignupBailed", "ShiftSignupNoShow", "ShiftSignupCancelled", "ShiftSignupReassigned"
+            ]
+        }
+    };
+}

--- a/tests/Humans.AuditLog.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.AuditLog.Tests/Enums/EnumStringStabilityTests.cs
@@ -6,7 +6,8 @@ namespace Humans.AuditLog.Tests.Enums;
 
 /// <summary>
 /// AuditLog's share of the string-stored-enum guard, moved out of
-/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that orphaned project's rows
+/// were distributed to their owners —
 /// <see cref="AuditAction"/> lives on <c>Humans.AuditLog.Contracts</c>, so the guard belongs to
 /// the section that owns it (nobodies-collective/Humans#866).
 /// </summary>

--- a/tests/Humans.Budget.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Budget.Tests/Enums/EnumStringStabilityTests.cs
@@ -5,8 +5,8 @@ using Xunit;
 namespace Humans.Budget.Tests.Enums;
 
 /// <summary>
-/// Budget's half of the string-stored-enum guard. The rest live in
-/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c>; these two moved out with the
+/// Budget's half of the string-stored-enum guard. The rest live in the test project of the
+/// section that owns each enum; these two moved out with the
 /// section because <see cref="BudgetYearStatus"/> and <see cref="ExpenditureType"/> now sit
 /// on Budget's contracts leaf, where <c>Humans.Domain.Tests</c> cannot name them
 /// (nobodies-collective/Humans#866).

--- a/tests/Humans.Domain.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Domain.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,10 +1,5 @@
-using Humans.GoogleIntegration.Contracts;
 using AwesomeAssertions;
-using Humans.AuditLog.Contracts;
 using Humans.Domain.Enums;
-using Humans.Shifts.Contracts;
-using Humans.Teams.Contracts;
-using Humans.Users.Contracts;
 using Xunit;
 
 namespace Humans.Domain.Tests.Enums;
@@ -15,6 +10,14 @@ namespace Humans.Domain.Tests.Enums;
 /// When a rename IS intentional, update the expected names here AND create a DB migration
 /// to UPDATE the old values.
 /// </summary>
+/// <remarks>
+/// Only the two enums that <c>Humans.Interfaces</c> still owns are left here. Every other row
+/// moved to the test project of the section that owns the enum, one file per section
+/// (nobodies-collective/Humans#866): Teams, Shifts, Users, GoogleIntegration and AuditLog, beside
+/// the Budget/Campaigns/Feedback/Governance/Issues/Notifications/Tickets halves that had already
+/// split out. Neither of these two has a home yet — there is no <c>Humans.Interfaces.Tests</c>,
+/// which is what still blocks retiring this project.
+/// </remarks>
 public class EnumStringStabilityTests
 {
     /// <summary>
@@ -40,122 +43,14 @@ public class EnumStringStabilityTests
         // This catches both renames (old name missing) and deletions
     }
 
-    /// <summary>
-    /// Every enum that uses HasConversion&lt;string&gt;() in EF Core configuration.
-    /// Update this list when adding new string-stored enums.
-    /// </summary>
-    /// <remarks>
-    /// G5 lane 4b-2k moved seven of these enums out of <c>Humans.Domain.Enums</c> and onto their
-    /// owning sections' contracts leaves — <c>TeamMemberRole</c>, <c>TeamJoinRequestStatus</c> and
-    /// <c>RolePeriod</c> to <c>Humans.Teams.Contracts</c>; <c>ShiftPriority</c>,
-    /// <c>SignupPolicy</c>, <c>SignupStatus</c> and <c>RotaPeriod</c> to
-    /// <c>Humans.Shifts.Contracts</c>. The rows stay here rather than splitting into per-section
-    /// test projects (Tickets' shape, above) because every one of them is still public on a leaf
-    /// this project can name, so the guard keeps working unsplit. Member names are unchanged, so
-    /// no persisted string moved.
-    ///
-    /// G5 lane 4b-2l moved an eighth — <c>AuditAction</c> to <c>Humans.AuditLog.Contracts</c> —
-    /// on the same terms.
-    ///
-    /// G5 lane 3b emptied and deleted <c>src/Humans.Domain</c>. Four of the rows below moved with
-    /// it: <c>MembershipTier</c>, <c>ConsentCheckStatus</c> and <c>MessageCategory</c> to
-    /// <c>Humans.Users.Contracts</c>, and <c>SyncAction</c> to
-    /// <c>Humans.GoogleIntegration.Contracts</c> beside its <c>GoogleResourceType</c> and
-    /// <c>DrivePermissionLevel</c> siblings. Member names are unchanged in every case, so no
-    /// persisted string moved and no migration is involved — which is exactly what the rows below
-    /// assert. <c>SystemTeamType</c> and <c>EmailOutboxStatus</c> keep the
-    /// <c>Humans.Domain.Enums</c> namespace and now live in the <c>Humans.Interfaces</c> assembly:
-    /// <c>EmailOutboxStatus</c> because Campaigns' <c>campaign_grants</c> and Surveys'
-    /// <c>survey_invitations</c> persist it alongside Email's own outbox, so it fails the "who
-    /// writes it to a table" test for a single owner (design §15 step 5, Email).
-    /// </remarks>
     public static TheoryData<Type, string[]> StringStoredEnumData => new()
     {
-        {
-            typeof(TeamMemberRole), ["Member", "Coordinator"]
-        },
-        {
-            typeof(TeamJoinRequestStatus), ["Pending", "Approved", "Rejected", "Withdrawn"]
-        },
         {
             typeof(SystemTeamType), ["None", "Volunteers", "Coordinators", "Board", "Asociados", "Colaboradors"]
         },
         {
-            typeof(GoogleResourceType), ["DriveFolder", "SharedDrive", "Group", "DriveFile"]
-        },
-        {
-            typeof(ContactFieldType), ["Email", "Phone", "Signal", "Telegram", "WhatsApp", "Discord", "Other"]
-        },
-        {
-            typeof(ContactFieldVisibility), ["BoardOnly", "CoordinatorsAndBoard", "MyTeams", "AllActiveProfiles"]
-        },
-        {
-            typeof(AuditAction), [
-                "TeamMemberAdded", "TeamMemberRemoved", "MemberSuspended", "MemberUnsuspended",
-                "AccountAnonymized", "RoleAssigned", "RoleEnded", "VolunteerApproved",
-                "GoogleResourceAccessGranted", "GoogleResourceAccessRevoked", "GoogleResourceProvisioned",
-                "TeamJoinedDirectly", "TeamLeft", "TeamJoinRequestApproved", "TeamJoinRequestRejected",
-                "TeamMemberRoleChanged", "AnomalousPermissionDetected",
-                "MembershipsRevokedOnDeletionRequest", "ConsentCheckCleared", "ConsentCheckFlagged",
-                "SignupRejected", "TierApplicationApproved", "TierApplicationRejected", "TierDowngraded",
-                "GoogleResourceDeactivated", "FacilitatedMessageSent",
-                "TeamRoleDefinitionCreated", "TeamRoleDefinitionUpdated", "TeamRoleDefinitionDeleted",
-                "TeamRoleAssigned", "TeamRoleUnassigned",
-                "CampCreated", "CampUpdated", "CampDeleted",
-                "CampSeasonCreated", "CampSeasonApproved", "CampSeasonRejected",
-                "CampSeasonWithdrawn", "CampSeasonStatusChanged", "CampNameChanged",
-                "CampLeadAdded", "CampLeadRemoved", "CampPrimaryLeadTransferred",
-                "CampImageUploaded", "CampImageDeleted",
-                "ShiftSignupCreated", "ShiftSignupConfirmed", "ShiftSignupRefused", "ShiftSignupVoluntold",
-                "ShiftSignupBailed", "ShiftSignupNoShow", "ShiftSignupCancelled", "ShiftSignupReassigned"
-            ]
-        },
-        {
-            typeof(MembershipTier), ["Volunteer", "Colaborador", "Asociado"]
-        },
-        {
-            typeof(ConsentCheckStatus), ["Pending", "Cleared", "Flagged"]
-        },
-        {
-            typeof(SyncMode), ["None", "AddOnly", "AddAndRemove"]
-        },
-        {
-            typeof(SyncServiceType), ["GoogleDrive", "GoogleGroups", "Discord"]
-        },
-        {
-            typeof(SyncAction), ["Preview", "Execute"]
-        },
-        // Tickets' three string-stored enums moved to
-        // tests/Humans.Tickets.Tests/Enums/TicketEnumStringStabilityTests.cs at that
-        // section's G5 move — two are internal to Humans.Tickets and one pair is on its
-        // contracts leaf, so this project can no longer name them (Budget's rule).
-        {
-            typeof(ShiftPriority), ["Normal", "Important", "Essential"]
-        },
-        {
-            typeof(SignupPolicy), ["Public", "RequireApproval"]
-        },
-        {
-            typeof(SignupStatus), ["Pending", "Confirmed", "Refused", "Bailed", "Cancelled", "NoShow"]
-        },
-        {
-            typeof(RotaPeriod), ["Build", "Event", "Strike", "All"]
-        },
-        {
-            typeof(RolePeriod), ["YearRound", "Build", "Event", "Strike"]
-        },
-        {
-            typeof(DrivePermissionLevel), ["None", "Viewer", "Commenter", "Contributor", "ContentManager", "Manager"]
-        },
-        {
-            typeof(MessageCategory), [
-                "System", "EventOperations", "CommunityUpdates", "Marketing", "Governance",
-                "CampaignCodes", "FacilitatedMessages", "Ticketing", "VolunteerUpdates", "TeamUpdates"
-            ]
-        },
-        {
             // Guarded centrally rather than per section: three sections persist this one
-            // public Humans.Domain enum as a string — campaign_grants.LatestEmailStatus
+            // enum as a string — campaign_grants.LatestEmailStatus
             // (CampaignGrantConfiguration), survey_invitations.LatestEmailStatus
             // (SurveyInvitationConfiguration), and the Email outbox's own Status
             // (EmailOutboxMessageConfiguration). A rename strands the old string in all three.

--- a/tests/Humans.Domain.Tests/Humans.Domain.Tests.csproj
+++ b/tests/Humans.Domain.Tests/Humans.Domain.Tests.csproj
@@ -1,38 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    NAME IS STALE. src/Humans.Domain was deleted by G5 lane 3b
-    (nobodies-collective/Humans#866) once its last five enums moved onto owning leaves, so
-    this project no longer tests a project called Humans.Domain. It was left named
-    Humans.Domain.Tests deliberately: renaming it also touches Humans.slnx, the
-    <InternalsVisibleTo Include="Humans.Domain.Tests" /> in Humans.Users.csproj, this
-    directory's stryker-config.json and CI job names, none of which belong in a lane whose
-    job is the dependency graph. Rename it alongside the Humans.Interfaces -> Humans.Base
-    rename in lane 4b-iv, where the same set of files is already open.
+    NAME IS STALE AND THE PROJECT IS AN ORPHAN. src/Humans.Domain was deleted by G5 lane 3b
+    (nobodies-collective/Humans#866), so no production assembly matches this name — which
+    Peter's "a test assembly maps 1-1 to a production assembly" ruling forbids.
 
-    What it actually covers now: the shared vocabulary that lives in Humans.Interfaces
-    (RoleNames, EmailNormalization, IbanFormatter, IbanValidator, SystemTeamType,
-    EmailOutboxStatus), plus EnumStringStabilityTests, which is deliberately central.
+    Everything that could leave has left: every section-owned EnumStringStabilityTests row and
+    MessageCategoryExtensionsTests now live in the test project of the section that owns the
+    type. What is left has no 1-1 home to move to, and is what blocks the delete:
+
+      - Humans.Interfaces' shared vocabulary — RoleNames, EmailNormalization, IbanFormatter,
+        IbanValidator, and the SystemTeamType / EmailOutboxStatus enum rows. Humans.Interfaces
+        exists but has no test project; it is renamed to Humans.Base in lane 4b-iv.
+      - The tests/Humans.Testing shared-source attributes (HumansFact, HumansTheory, BrokenFact,
+        DebuggerOnlyFact) — compiled into every test project by tests/Directory.Build.props, so
+        they belong to no production assembly at all.
   -->
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Humans.Interfaces\Humans.Interfaces.csproj" />
-    <!--
-      EnumStringStabilityTests guards persisted enum strings across every section that has
-      one. The rows stay in one file rather than splitting per section (see the remarks on
-      that class), so this project declares a ProjectReference per destination assembly —
-      explicitly, never transitively, so the guard survives a change to any one of those
-      projects' own reference sets. Lanes 4b-2k and 4b-2l set that pattern; lane 3b adds
-      Humans.Users.Contracts (MembershipTier, ConsentCheckStatus, MessageCategory,
-      ContactFieldType, ContactFieldVisibility) and Humans.GoogleIntegration.Contracts
-      (SyncAction, SyncMode, SyncServiceType, GoogleResourceType, DrivePermissionLevel),
-      both of which previously resolved only by luck through Humans.Users.
-    -->
-    <ProjectReference Include="..\..\src\Sections\Humans.AuditLog.Contracts\Humans.AuditLog.Contracts.csproj" />
-    <ProjectReference Include="..\..\src\Sections\Humans.GoogleIntegration.Contracts\Humans.GoogleIntegration.Contracts.csproj" />
-    <ProjectReference Include="..\..\src\Sections\Humans.Shifts.Contracts\Humans.Shifts.Contracts.csproj" />
-    <ProjectReference Include="..\..\src\Sections\Humans.Teams.Contracts\Humans.Teams.Contracts.csproj" />
-    <ProjectReference Include="..\..\src\Sections\Humans.Users.Contracts\Humans.Users.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Humans.GoogleIntegration.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/Enums/EnumStringStabilityTests.cs
@@ -6,7 +6,8 @@ namespace Humans.GoogleIntegration.Tests.Enums;
 
 /// <summary>
 /// GoogleIntegration's share of the string-stored-enum guard, moved out of
-/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that orphaned project's rows
+/// were distributed to their owners —
 /// <see cref="GoogleResourceType"/>, <see cref="SyncMode"/>, <see cref="SyncServiceType"/>,
 /// <see cref="SyncAction"/> and <see cref="DrivePermissionLevel"/> live on
 /// <c>Humans.GoogleIntegration.Contracts</c>, so the guard belongs to the section that owns them

--- a/tests/Humans.GoogleIntegration.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,54 @@
+using AwesomeAssertions;
+using Humans.GoogleIntegration.Contracts;
+using Xunit;
+
+namespace Humans.GoogleIntegration.Tests.Enums;
+
+/// <summary>
+/// GoogleIntegration's share of the string-stored-enum guard, moved out of
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <see cref="GoogleResourceType"/>, <see cref="SyncMode"/>, <see cref="SyncServiceType"/>,
+/// <see cref="SyncAction"/> and <see cref="DrivePermissionLevel"/> live on
+/// <c>Humans.GoogleIntegration.Contracts</c>, so the guard belongs to the section that owns them
+/// (nobodies-collective/Humans#866).
+/// </summary>
+/// <remarks>
+/// All five are persisted with <c>HasConversion&lt;string&gt;()</c>: renaming a member leaves
+/// the OLD string in the column. A rename needs a migration that UPDATEs the stored values.
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansTheory]
+    [MemberData(nameof(StringStoredEnumData))]
+    public void StringStoredEnum_MemberNames_MustMatchExpected(
+        Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                $"If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+
+    public static TheoryData<Type, string[]> StringStoredEnumData => new()
+    {
+        {
+            typeof(GoogleResourceType), ["DriveFolder", "SharedDrive", "Group", "DriveFile"]
+        },
+        {
+            typeof(SyncMode), ["None", "AddOnly", "AddAndRemove"]
+        },
+        {
+            typeof(SyncServiceType), ["GoogleDrive", "GoogleGroups", "Discord"]
+        },
+        {
+            typeof(SyncAction), ["Preview", "Execute"]
+        },
+        {
+            typeof(DrivePermissionLevel), ["None", "Viewer", "Commenter", "Contributor", "ContentManager", "Manager"]
+        }
+    };
+}

--- a/tests/Humans.Governance.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Governance.Tests/Enums/EnumStringStabilityTests.cs
@@ -6,8 +6,8 @@ using Xunit;
 namespace Humans.Governance.Tests.Enums;
 
 /// <summary>
-/// Governance's half of the string-stored-enum guard. The rest live in
-/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c>; these two moved out with the
+/// Governance's half of the string-stored-enum guard. The rest live in the test project of the
+/// section that owns each enum; these two moved out with the
 /// section because <c>ApplicationStatus</c> now sits on Governance's contracts leaf and
 /// <c>VoteChoice</c> turned internal in the section, neither of which
 /// <c>Humans.Domain.Tests</c> can name (nobodies-collective/Humans#866).

--- a/tests/Humans.Shifts.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Shifts.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,50 @@
+using AwesomeAssertions;
+using Humans.Shifts.Contracts;
+using Xunit;
+
+namespace Humans.Shifts.Tests.Enums;
+
+/// <summary>
+/// Shifts' share of the string-stored-enum guard, moved out of
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <see cref="ShiftPriority"/>, <see cref="SignupPolicy"/>, <see cref="SignupStatus"/> and
+/// <see cref="RotaPeriod"/> live on <c>Humans.Shifts.Contracts</c>, so the guard belongs to the
+/// section that owns them (nobodies-collective/Humans#866).
+/// </summary>
+/// <remarks>
+/// All four are persisted with <c>HasConversion&lt;string&gt;()</c>: renaming a member leaves
+/// the OLD string in the column. A rename needs a migration that UPDATEs the stored values.
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansTheory]
+    [MemberData(nameof(StringStoredEnumData))]
+    public void StringStoredEnum_MemberNames_MustMatchExpected(
+        Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                $"If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+
+    public static TheoryData<Type, string[]> StringStoredEnumData => new()
+    {
+        {
+            typeof(ShiftPriority), ["Normal", "Important", "Essential"]
+        },
+        {
+            typeof(SignupPolicy), ["Public", "RequireApproval"]
+        },
+        {
+            typeof(SignupStatus), ["Pending", "Confirmed", "Refused", "Bailed", "Cancelled", "NoShow"]
+        },
+        {
+            typeof(RotaPeriod), ["Build", "Event", "Strike", "All"]
+        }
+    };
+}

--- a/tests/Humans.Shifts.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Shifts.Tests/Enums/EnumStringStabilityTests.cs
@@ -6,7 +6,8 @@ namespace Humans.Shifts.Tests.Enums;
 
 /// <summary>
 /// Shifts' share of the string-stored-enum guard, moved out of
-/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that orphaned project's rows
+/// were distributed to their owners —
 /// <see cref="ShiftPriority"/>, <see cref="SignupPolicy"/>, <see cref="SignupStatus"/> and
 /// <see cref="RotaPeriod"/> live on <c>Humans.Shifts.Contracts</c>, so the guard belongs to the
 /// section that owns them (nobodies-collective/Humans#866).

--- a/tests/Humans.Teams.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Teams.Tests/Enums/EnumStringStabilityTests.cs
@@ -6,7 +6,8 @@ namespace Humans.Teams.Tests.Enums;
 
 /// <summary>
 /// Teams' share of the string-stored-enum guard, moved out of
-/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that orphaned project's rows
+/// were distributed to their owners —
 /// <see cref="TeamMemberRole"/>, <see cref="TeamJoinRequestStatus"/> and
 /// <see cref="RolePeriod"/> live on <c>Humans.Teams.Contracts</c>, so the guard belongs to the
 /// section that owns them (nobodies-collective/Humans#866).

--- a/tests/Humans.Teams.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Teams.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using Humans.Teams.Contracts;
+using Xunit;
+
+namespace Humans.Teams.Tests.Enums;
+
+/// <summary>
+/// Teams' share of the string-stored-enum guard, moved out of
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <see cref="TeamMemberRole"/>, <see cref="TeamJoinRequestStatus"/> and
+/// <see cref="RolePeriod"/> live on <c>Humans.Teams.Contracts</c>, so the guard belongs to the
+/// section that owns them (nobodies-collective/Humans#866).
+/// </summary>
+/// <remarks>
+/// All three are persisted with <c>HasConversion&lt;string&gt;()</c>: renaming a member leaves
+/// the OLD string in the column. A rename needs a migration that UPDATEs the stored values.
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansTheory]
+    [MemberData(nameof(StringStoredEnumData))]
+    public void StringStoredEnum_MemberNames_MustMatchExpected(
+        Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                $"If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+
+    public static TheoryData<Type, string[]> StringStoredEnumData => new()
+    {
+        {
+            typeof(TeamMemberRole), ["Member", "Coordinator"]
+        },
+        {
+            typeof(TeamJoinRequestStatus), ["Pending", "Approved", "Rejected", "Withdrawn"]
+        },
+        {
+            typeof(RolePeriod), ["YearRound", "Build", "Event", "Strike"]
+        }
+    };
+}

--- a/tests/Humans.Users.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Users.Tests/Enums/EnumStringStabilityTests.cs
@@ -6,7 +6,8 @@ namespace Humans.Users.Tests.Enums;
 
 /// <summary>
 /// Users' share of the string-stored-enum guard, moved out of
-/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that orphaned project's rows
+/// were distributed to their owners —
 /// <see cref="MembershipTier"/>, <see cref="ConsentCheckStatus"/>, <see cref="MessageCategory"/>,
 /// <see cref="ContactFieldType"/> and <see cref="ContactFieldVisibility"/> live on
 /// <c>Humans.Users.Contracts</c>, so the guard belongs to the section that owns them

--- a/tests/Humans.Users.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Users.Tests/Enums/EnumStringStabilityTests.cs
@@ -1,0 +1,57 @@
+using AwesomeAssertions;
+using Humans.Users.Contracts;
+using Xunit;
+
+namespace Humans.Users.Tests.Enums;
+
+/// <summary>
+/// Users' share of the string-stored-enum guard, moved out of
+/// <c>Humans.Domain.Tests.Enums.EnumStringStabilityTests</c> when that project was retired —
+/// <see cref="MembershipTier"/>, <see cref="ConsentCheckStatus"/>, <see cref="MessageCategory"/>,
+/// <see cref="ContactFieldType"/> and <see cref="ContactFieldVisibility"/> live on
+/// <c>Humans.Users.Contracts</c>, so the guard belongs to the section that owns them
+/// (nobodies-collective/Humans#866).
+/// </summary>
+/// <remarks>
+/// All five are persisted with <c>HasConversion&lt;string&gt;()</c>: renaming a member leaves
+/// the OLD string in the column. A rename needs a migration that UPDATEs the stored values.
+/// </remarks>
+public class EnumStringStabilityTests
+{
+    [HumansTheory]
+    [MemberData(nameof(StringStoredEnumData))]
+    public void StringStoredEnum_MemberNames_MustMatchExpected(
+        Type enumType, string[] expectedNames)
+    {
+        var actualNames = Enum.GetNames(enumType);
+
+        foreach (var expected in expectedNames)
+        {
+            actualNames.Should().Contain(expected,
+                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
+                $"If you renamed it, create a DB migration to UPDATE the old values.");
+        }
+    }
+
+    public static TheoryData<Type, string[]> StringStoredEnumData => new()
+    {
+        {
+            typeof(MembershipTier), ["Volunteer", "Colaborador", "Asociado"]
+        },
+        {
+            typeof(ConsentCheckStatus), ["Pending", "Cleared", "Flagged"]
+        },
+        {
+            typeof(ContactFieldType), ["Email", "Phone", "Signal", "Telegram", "WhatsApp", "Discord", "Other"]
+        },
+        {
+            typeof(ContactFieldVisibility), ["BoardOnly", "CoordinatorsAndBoard", "MyTeams", "AllActiveProfiles"]
+        },
+        {
+            typeof(MessageCategory), [
+                "System", "EventOperations", "CommunityUpdates", "Marketing", "Governance",
+                "CampaignCodes", "FacilitatedMessages", "Ticketing", "VolunteerUpdates", "TeamUpdates"
+            ]
+        }
+    };
+}

--- a/tests/Humans.Users.Tests/Enums/MessageCategoryExtensionsTests.cs
+++ b/tests/Humans.Users.Tests/Enums/MessageCategoryExtensionsTests.cs
@@ -1,9 +1,8 @@
 using AwesomeAssertions;
-using Humans.Domain.Enums;
 using Humans.Users.Contracts;
 using Xunit;
 
-namespace Humans.Domain.Tests.Enums;
+namespace Humans.Users.Tests.Enums;
 
 public class MessageCategoryExtensionsTests
 {


### PR DESCRIPTION
Open item 16 of the G5 batch-4 run, worked as **option (b)** per Peter's ruling that *a test assembly maps 1-1 to a production assembly*. `src/Humans.Domain` was deleted by G5 lane 3b (nobodies-collective/Humans#1316), leaving `tests/Humans.Domain.Tests` an orphan.

## What moved

Every section-owned `EnumStringStabilityTests` row left the central file for the test project of the assembly that now owns the enum:

| Owning assembly | Destination | Rows |
|---|---|---|
| `Humans.Teams.Contracts` | `tests/Humans.Teams.Tests/Enums/` | `TeamMemberRole`, `TeamJoinRequestStatus`, `RolePeriod` (3) |
| `Humans.Shifts.Contracts` | `tests/Humans.Shifts.Tests/Enums/` | `ShiftPriority`, `SignupPolicy`, `SignupStatus`, `RotaPeriod` (4) |
| `Humans.Users.Contracts` | `tests/Humans.Users.Tests/Enums/` | `MembershipTier`, `ConsentCheckStatus`, `ContactFieldType`, `ContactFieldVisibility`, `MessageCategory` (5) |
| `Humans.GoogleIntegration.Contracts` | `tests/Humans.GoogleIntegration.Tests/Enums/` | `GoogleResourceType`, `SyncMode`, `SyncServiceType`, `SyncAction`, `DrivePermissionLevel` (5) |
| `Humans.AuditLog.Contracts` | `tests/Humans.AuditLog.Tests/Enums/` | `AuditAction` (1) |

`MessageCategoryExtensionsTests` follows `MessageCategory` to `Humans.Users.Tests` (git-tracked rename).

Expected names are copied verbatim — **no persisted string changed, no migration involved.**

`Humans.Domain.Tests.csproj` drops all five contracts `ProjectReference`s it only held for those rows.

Second commit drops `Humans.Users.csproj`'s dead `InternalsVisibleTo("Humans.Domain.Tests")`. Its comment named `ContactFieldTests`/`ProfileTests`, which lane 2 phase 3 already moved into `Humans.Users.Tests`; `Humans.Domain.Tests` never referenced `Humans.Users` at all.

## What the delete is still blocked on

`tests/Humans.Domain.Tests` is **not** deleted. What is left has no 1-1 home to move to, and the brief forbids inventing one:

1. **`Humans.Interfaces`-owned** — `RoleNamesTests`, `EmailNormalizationTests`, `IbanFormatterTests`, `IbanValidatorTests`, plus the `SystemTeamType` and `EmailOutboxStatus` rows. `Humans.Interfaces` exists but has no test project; it is renamed to `Humans.Base` in lane 4b-iv.
2. **`tests/Humans.Testing`-owned** — `HumansFactSmokeTest`, `SkipAttributeSmokeTest`, `GlobalTimeoutDemoTest`. These cover the `HumansFact` / `HumansTheory` / `BrokenFact` / `DebuggerOnlyFact` attributes, which `tests/Directory.Build.props` compiles into every test project as shared source. They belong to no production assembly at all.

Both need a ruling before `git rm` + the `Humans.slnx` entry can go.

## Test-count delta

Measured on the full suite, before and after, same worktree:

| Project | Before | After | Δ |
|---|---|---|---|
| `Humans.Domain.Tests` | 90 | 63 | −27 |
| `Humans.Teams.Tests` | 254 | 257 | +3 |
| `Humans.Shifts.Tests` | 542 | 546 | +4 |
| `Humans.Users.Tests` | 493 | 507 | +14 |
| `Humans.GoogleIntegration.Tests` | 231 | 236 | +5 |
| `Humans.AuditLog.Tests` | 49 | 50 | +1 |
| **Solution total** | **5322** | **5322** | **0** |

Arithmetic: 18 theory rows moved (3+4+5+5+1) + 9 `MessageCategoryExtensionsTests` cases (8 `InlineData` + 1 fact) = 27 out of `Humans.Domain.Tests`, 27 into the five destinations. **Rows moved 27, rows deleted 0, net delta 0.** Every other project is byte-identical in count.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors
- `dotnet test Humans.slnx -v quiet` — 5322 total, 0 failed, 5 skipped (all pre-existing `BrokenFact`/`DebuggerOnlyFact`)
- `dotnet format --verify-no-changes` — clean on every file this PR touches (the one `CHARSET` error it reports is pre-existing on `main`, in `src/Humans.Infrastructure/Migrations/System/20260810152325_BaselineSystem.cs`)

Refs nobodies-collective/Humans#866

🤖 Generated with [Claude Code](https://claude.com/claude-code)
