### PR TITLE
feat(skills): /section-doctor — daily per-section review cycle

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -40,13 +40,27 @@ Glob/Grep to `$WORKTREE`.
 
 ## Phase 2: Plan check
 
-Read `docs/health/plan.md`. Replan when: no plan, plan exhausted, `--replan`, or a merged change
-since the plan's anchor materially reshapes an upcoming scheduled section (move/rename/major
-feature — routine churn is not staleness).
+**Find the live plan state first.** The previous run's PR may still be open (runs never merge),
+so the newest plan/log/queue may exist only on that PR branch, not on `origin/main`. Discover:
+
+```bash
+gh pr list --repo peterdrier/Humans --state open --json number,headRefName \
+  --jq '.[] | select(.headRefName | startswith("section-doctor/"))'
+```
+
+(`--search "head:..."` matches exact branch names, not prefixes — don't use it.) If an open run
+branch exists, fetch it and read `docs/health/*` from its tip; else read `origin/main`'s copy.
+Carry that state forward in this run's commits so plan/log history never forks.
+
+Replan when: no plan, plan exhausted, `--replan`, or a merged change since the plan's anchor
+materially reshapes an upcoming scheduled section (move/rename/major feature — routine churn is
+not staleness).
 
 **Replanning** (mid-level signals only — no deep reading):
 
-1. `reforge surface-score --format compact` for size + deltas.
+1. `dotnet build Humans.slnx -v quiet` first — an unbuilt solution silently under-reports
+   Reforge scores — then `reforge surface-score --format compact` for size + deltas. (The build
+   also serves Phase 3/4.)
 2. Last-assessed dates from every `src/Sections/Humans.*/Docs/health.md`. First cycle:
    never-assessed first, score descending (seed last-served from the Section Refactor History
    table in `docs/architecture/maintenance-log.md`). After the first full cycle: rank primarily
@@ -129,7 +143,8 @@ In the same worktree/PR: `health.md` history row; tick today's plan row (if a pl
 `--section` runs have none); append
 `docs/health/log.md` (`| date | section | what ran | outcome | PR |`); overwrite
 `docs/health/last-report.md` (assessment summary, worked, skipped + why); update this run's row
-in `docs/architecture/maintenance-log.md` per `maintenance-log-update`.
+in `docs/architecture/maintenance-log.md` per `maintenance-log-update`. PR-reference cells are
+written as `pending` here — Phase 7 backfills them once the PR number exists.
 
 ## Phase 6: Retro + self-amend
 
@@ -140,7 +155,8 @@ was wasted motion, what did the assessment miss that striking revealed. Then:
 - **Judgment lessons** (rubric axes, thresholds, play choices) → the Needs-Peter block.
 - **Durable project rules** → `memory/<bucket>/<name>.md` atom + INDEX line, same commit.
 
-Commit all Phase 5 + 6 edits before Phase 7 pushes — nothing lands after the final push.
+Commit all Phase 5 + 6 edits before Phase 7 pushes — the only thing that lands after is
+Phase 7's own PR-number backfill commit.
 
 ## Phase 7: PR
 
@@ -153,6 +169,9 @@ Body: assessment summary, worked/skipped bullets, and a **`## Needs Peter`** blo
 numbered, answerable in a word or two. **The PR body is the authoritative queue while the PR is
 open** (resume reads it from there); mirror the block into `docs/health/plan.md` (committed
 before the push) so merged runs carry it forward. One PR per run; never merge.
+
+Then backfill the real PR number over every `pending` reference (log row, health history row,
+plan mirror), commit, push again.
 
 ## Phase 8: Inline round (interactive runs only)
 
@@ -169,15 +188,25 @@ this; `resume` covers it. Unanswered items carry forward — never re-asked.
 `resume` gathers the queue from both places an item can live, then works it. No new assessment
 or strike work.
 
-1. **Open runs:** `gh pr list --repo peterdrier/Humans --state open --search "head:section-doctor/"`
-   — each PR body's `## Needs Peter` block (authoritative for unmerged runs; their plan.md
+1. **Open runs:** discover by branch-name prefix — `--search "head:..."` matches exact names,
+   not prefixes:
+   ```bash
+   gh pr list --repo peterdrier/Humans --state open --json number,headRefName \
+     --jq '.[] | select(.headRefName | startswith("section-doctor/"))'
+   ```
+   Each PR body's `## Needs Peter` block (authoritative for unmerged runs; their plan.md
    entries only exist on the PR branch).
 2. **Merged runs:** unticked `## Needs Peter` entries in `docs/health/plan.md` on `origin/main`.
 
-Present the open items inline; apply each answer as commits on that item's PR branch (reuse its
-worktree, or recreate from the branch — merged items get a fresh worktree off `origin/main`);
-tick the queue entry where it lives (PR body edit for open PRs, plan.md commit for merged);
-push.
+Present the open items inline, then apply each answer:
+
+- **Open-PR item** — commits on that item's PR branch (reuse its worktree, or recreate from the
+  branch). Tick the item in **both** places: the PR body *and* the branch's `docs/health/plan.md`
+  mirror — an unticked mirror would resurface as a merged-queue item after the PR lands and get
+  re-asked or applied twice. Push.
+- **Merged item** — fresh worktree + branch off `origin/main`, apply the answer, tick the plan.md
+  entry, push, **open its own PR** (an answer pushed to a branch with no PR is stranded), tear
+  the worktree down.
 
 ## Standing constraints
 
@@ -187,7 +216,8 @@ push.
 - Public-surface additions need Peter; dead-surface deletion is the job (reviewer-gated).
 - Explicit tagged model on every subagent. Never leave the branch red between commits.
 - Touches only: the section's files (+ callers where a play requires), `docs/health/*`, the
-  section's `health.md`, this skill's files, `memory/`.
+  section's `health.md`, `docs/architecture/maintenance-log.md` (Phase 5 row),
+  `docs/architecture/debt-ledger.yml` (off-section debt inbox), this skill's files, `memory/`.
 
 ## Lessons
 

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -106,9 +106,21 @@ assessment-only PR, note it in the plan.
 
 In the same worktree/PR: `health.md` history row; tick today's plan row; append
 `docs/health/log.md` (`| date | section | what ran | outcome | PR |`); overwrite
-`docs/health/last-report.md` (assessment summary, worked, skipped + why, retro, self-amendments).
+`docs/health/last-report.md` (assessment summary, worked, skipped + why); update this run's row
+in `docs/architecture/maintenance-log.md` per `maintenance-log-update`.
 
-## Phase 6: PR
+## Phase 6: Retro + self-amend
+
+Three questions, answered honestly in `last-report.md`: what did the plan/rubric get wrong, what
+was wasted motion, what did the assessment miss that striking revealed. Then:
+
+- **Mechanical lessons** → edit this skill's files now (dated one-liners in Lessons below).
+- **Judgment lessons** (rubric axes, thresholds, play choices) → the Needs-Peter block.
+- **Durable project rules** → `memory/<bucket>/<name>.md` atom + INDEX line, same commit.
+
+Commit all Phase 5 + 6 edits before Phase 7 pushes — nothing lands after the final push.
+
+## Phase 7: PR
 
 ```bash
 git push -u origin section-doctor/$TS
@@ -116,34 +128,34 @@ gh pr create --repo peterdrier/Humans --base main --title "doctor(<Section>): <h
 ```
 
 Body: assessment summary, worked/skipped bullets, and a **`## Needs Peter`** block — terse,
-numbered, answerable in a word or two. Mirror that block into `docs/health/plan.md` (committed
-before the push). One PR per run; never merge.
+numbered, answerable in a word or two. **The PR body is the authoritative queue while the PR is
+open** (resume reads it from there); mirror the block into `docs/health/plan.md` (committed
+before the push) so merged runs carry it forward. One PR per run; never merge.
 
-## Phase 7: Inline round (interactive runs only)
+## Phase 8: Inline round (interactive runs only)
 
 If Peter is present, present the Needs-Peter items inline now (terse, numbered, plain prose —
 never AskUserQuestion) and apply answers as new commits + push. Unattended morning runs skip
-this; `resume` covers it. Unanswered items carry forward in the plan doc — never re-asked.
-
-## Phase 8: Retro + self-amend
-
-Three questions, answered honestly in `last-report.md`: what did the plan/rubric get wrong, what
-was wasted motion, what did the assessment miss that striking revealed. Then:
-
-- **Mechanical lessons** → edit this skill's files now, same PR (dated one-liners).
-- **Judgment lessons** (rubric axes, thresholds, play choices) → Needs-Peter block.
-- **Durable project rules** → `memory/<bucket>/<name>.md` atom + INDEX line, same commit.
+this; `resume` covers it. Unanswered items carry forward — never re-asked.
 
 ## Phase 9: Teardown
 
-`cd $REPO_ROOT && git worktree remove $WORKTREE` (never `rm -rf`). Update
-`docs/architecture/maintenance-log.md` per `maintenance-log-update`.
+`cd $REPO_ROOT && git worktree remove $WORKTREE` (never `rm -rf`).
 
 ## Resume mode
 
-`resume`: read `## Needs Peter` in `docs/health/plan.md`; present open items inline; apply each
-answer as commits on that item's PR branch (reuse its worktree, or recreate from the branch);
-tick the queue entries in plan.md; push. No new assessment or strike work.
+`resume` gathers the queue from both places an item can live, then works it. No new assessment
+or strike work.
+
+1. **Open runs:** `gh pr list --repo peterdrier/Humans --state open --search "head:section-doctor/"`
+   — each PR body's `## Needs Peter` block (authoritative for unmerged runs; their plan.md
+   entries only exist on the PR branch).
+2. **Merged runs:** unticked `## Needs Peter` entries in `docs/health/plan.md` on `origin/main`.
+
+Present the open items inline; apply each answer as commits on that item's PR branch (reuse its
+worktree, or recreate from the branch — merged items get a fresh worktree off `origin/main`);
+tick the queue entry where it lives (PR body edit for open PRs, plan.md commit for merged);
+push.
 
 ## Standing constraints
 

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: section-doctor
+description: "Daily per-section review cycle. Reads the global plan at docs/health/plan.md (replanning from mid-level signals when exhausted or stale), inhales today's section front to back, refreshes its Docs/health.md scorecard + ideal shape, then spends a 2-3h budget on the biggest-value behavior-preserving improvements across code, tests, docs, comments, nav, and translations. One PR per run; judgment items queue in a Needs-Peter block; 'resume' applies Peter's answers later. Use for the morning section-improvement run, 'doctor <section>', or 'run section doctor'."
+argument-hint: "[resume] [--section=<Name>] [--budget=2.5h] [--replan]"
+---
+
+# Section Doctor
+
+Full design: `docs/superpowers/specs/2026-08-17-section-doctor-design.md`. This file is
+self-amending — Phase 9 edits it from run lessons; keep those edits terse and dated.
+
+**Contract: business functionality does not change.** That constraint is what buys the latitude
+to rewrite anything else about the section.
+
+## Invocation
+
+| Form | Behavior |
+|---|---|
+| *(none)* | daily run: replan if needed, execute today's plan entry |
+| `resume` | no new work — work the Needs-Peter queue (see Resume mode) |
+| `--section=<Name>` | skip the plan, doctor this section |
+| `--budget=<duration>` | override budget (default 2.5h); wall-clock, checked between items |
+| `--replan` | force a fresh plan |
+
+## Phase 0: Setup
+
+`REPO_ROOT=$(git rev-parse --show-toplevel)`. Parse args; record start time (`date -u`).
+
+## Phase 1: Worktree
+
+```bash
+git fetch origin main
+TS=$(date -u +%Y-%m-%dT%H%M%SZ)
+git worktree add $REPO_ROOT/.worktrees/section-doctor-$TS -b section-doctor/$TS origin/main
+WORKTREE=$REPO_ROOT/.worktrees/section-doctor-$TS  # cd here; all commands run inside
+```
+
+Scope is frozen at the branch point — never reconcile against `origin/main` mid-run. Scope every
+Glob/Grep to `$WORKTREE`.
+
+## Phase 2: Plan check
+
+Read `docs/health/plan.md`. Replan when: no plan, plan exhausted, `--replan`, or a merged change
+since the plan's anchor materially reshapes an upcoming scheduled section (move/rename/major
+feature — routine churn is not staleness).
+
+**Replanning** (mid-level signals only — no deep reading):
+
+1. `reforge surface-score --format compact` for size + deltas.
+2. Last-assessed dates from every `src/Sections/Humans.*/Docs/health.md`. First cycle:
+   never-assessed first, score descending (seed last-served from the Section Refactor History
+   table in `docs/architecture/maintenance-log.md`). After the first full cycle: rank primarily
+   by **score growth since last assessment** (+10% outranks +3%), then staleness.
+3. Tiebreak color: open issues per section, `docs/architecture/debt-ledger.yml` items,
+   churn under the section's paths since its last assessment.
+4. Skip sections with in-flight or imminently-planned feature work (check the active sprint plan).
+
+Write the 5–7 day table + anchor to `docs/health/plan.md`. Consecutive days for one section are
+allowed. The plan is advisory — today's findings may extend a section's stay.
+
+Take today's section (or `--section`). Sections are `src/Sections/` projects only.
+
+## Phase 3: Deep assessment
+
+Inhale the section front to back — this is the once-per-cycle expensive judgment. Dispatch
+parallel background lanes where useful; **every subagent gets an explicit model, tagged in name
+and description** (sonnet for mechanical scanning, opus-tier only where judgment earns it):
+
+- **Code/arch lane** — audit-surface posture on the section's services/interfaces; smells against
+  `peters-hard-rules.md` + `design-rules.md`; reforge surface + internal score; dead surface.
+- **Tests lane** — good/bad/ugly triage of the section's tests (slop, redundancy, gaps against
+  the invariants doc); Stryker only if budget clearly allows.
+- **Docs lane** — the section's `Docs/*.md` and `docs/guide/<Section>.md` vs code: do the
+  business docs match what the code actually does.
+- **Surface lane** — AI slop: wasteful comments, 500-words-that-should-be-50 docs/messages,
+  dead resources, missing translations, per-section nav quality (dead ends, missing backlinks).
+
+Then, from the whole picture, write the **ideal shape**: what this section would be if rewritten
+from scratch today (`/simplify` with a magic wand), and rank the concrete moves toward it by
+value. Refresh `src/Sections/Humans.<X>/Docs/health.md` (format in the spec; keep last 3
+history rows, prune older).
+
+## Phase 4: Strike
+
+Work the ranked list top-down until budget exhausted. Budget checks are real `date` reads between
+items, never estimates. Per item (one item or tight cluster per commit):
+
+1. Pick the play: a toolbox skill scoped to the section — `section-align`, `trim-tests`,
+   `simplify`, `section-read-split`, `reuse-review` (against the section's own surface),
+   the `.codex/skills/humans-refactor` lane process, a `debt-ledger.yml` item — or a direct fix.
+2. Fix it right — no surgical fixes. Reuse-first.
+3. `dotnet build Humans.slnx -v quiet`; targeted tests for the touched area.
+4. Non-mechanical changes (deletions beyond plainly-dead code, structural moves) → second-opinion
+   reviewer subagent, opus-tier, score-blind, default-reject: "name the concept that improved in
+   one sentence." Reject → rework once; second reject → revert, record.
+5. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet` before each push;
+   push every 3–5 items.
+
+**Skip-and-queue classes** (never block the loop): schema/EF changes of any kind, public/interface
+surface *additions*, privilege changes, anything needing Peter's judgment → skip, queue for
+Phase 7's Needs-Peter block. Off-section debt discovered → `debt-ledger.yml` inbox, never chased.
+If in-flight feature work on this section surfaces mid-run → stop striking, ship the
+assessment-only PR, note it in the plan.
+
+## Phase 5: Bookkeeping
+
+In the same worktree/PR: `health.md` history row; tick today's plan row; append
+`docs/health/log.md` (`| date | section | what ran | outcome | PR |`); overwrite
+`docs/health/last-report.md` (assessment summary, worked, skipped + why, retro, self-amendments).
+
+## Phase 6: PR
+
+```bash
+git push -u origin section-doctor/$TS
+gh pr create --repo peterdrier/Humans --base main --title "doctor(<Section>): <headline>" --body ...
+```
+
+Body: assessment summary, worked/skipped bullets, and a **`## Needs Peter`** block — terse,
+numbered, answerable in a word or two. Mirror that block into `docs/health/plan.md` (committed
+before the push). One PR per run; never merge.
+
+## Phase 7: Inline round (interactive runs only)
+
+If Peter is present, present the Needs-Peter items inline now (terse, numbered, plain prose —
+never AskUserQuestion) and apply answers as new commits + push. Unattended morning runs skip
+this; `resume` covers it. Unanswered items carry forward in the plan doc — never re-asked.
+
+## Phase 8: Retro + self-amend
+
+Three questions, answered honestly in `last-report.md`: what did the plan/rubric get wrong, what
+was wasted motion, what did the assessment miss that striking revealed. Then:
+
+- **Mechanical lessons** → edit this skill's files now, same PR (dated one-liners).
+- **Judgment lessons** (rubric axes, thresholds, play choices) → Needs-Peter block.
+- **Durable project rules** → `memory/<bucket>/<name>.md` atom + INDEX line, same commit.
+
+## Phase 9: Teardown
+
+`cd $REPO_ROOT && git worktree remove $WORKTREE` (never `rm -rf`). Update
+`docs/architecture/maintenance-log.md` per `maintenance-log-update`.
+
+## Resume mode
+
+`resume`: read `## Needs Peter` in `docs/health/plan.md`; present open items inline; apply each
+answer as commits on that item's PR branch (reuse its worktree, or recreate from the branch);
+tick the queue entries in plan.md; push. No new assessment or strike work.
+
+## Standing constraints
+
+- Business functionality does not change.
+- No EF migrations, schema changes, or data backfills — queue them. No analyzer suppressions.
+  Never touch `[DontFix]`.
+- Public-surface additions need Peter; dead-surface deletion is the job (reviewer-gated).
+- Explicit tagged model on every subagent. Never leave the branch red between commits.
+- Touches only: the section's files (+ callers where a play requires), `docs/health/*`, the
+  section's `health.md`, this skill's files, `memory/`.
+
+## Lessons
+
+(Phase 8 appends dated one-liners here.)

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -62,6 +62,9 @@ Take today's section (or `--section`). Sections are `src/Sections/` projects onl
 
 ## Phase 3: Deep assessment
 
+Start `dotnet build Humans.slnx -v quiet` (background) immediately — reforge scores need a
+built solution, and the build doubles as the strike phase's baseline.
+
 Inhale the section front to back — this is the once-per-cycle expensive judgment. Dispatch
 parallel background lanes where useful; **every subagent gets an explicit model, tagged in name
 and description** (sonnet for mechanical scanning, opus-tier only where judgment earns it):
@@ -104,7 +107,8 @@ assessment-only PR, note it in the plan.
 
 ## Phase 5: Bookkeeping
 
-In the same worktree/PR: `health.md` history row; tick today's plan row; append
+In the same worktree/PR: `health.md` history row; tick today's plan row (if a plan exists —
+`--section` runs have none); append
 `docs/health/log.md` (`| date | section | what ran | outcome | PR |`); overwrite
 `docs/health/last-report.md` (assessment summary, worked, skipped + why); update this run's row
 in `docs/architecture/maintenance-log.md` per `maintenance-log-update`.
@@ -170,3 +174,9 @@ push.
 ## Lessons
 
 (Phase 8 appends dated one-liners here.)
+
+- 2026-08-16: resx/XML edits must be structure-aware (python/XML tooling), never line-based sed
+  — neutral resx was one-line-per-entry but all 5 language variants were multi-line; sed
+  corrupted them and only the build caught it.
+- 2026-08-16: keep a by-hand read of the section's auth paths in the assessment — the doc-code
+  contradiction on phase gating was invisible to grep and to every lane.

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -69,14 +69,26 @@ Inhale the section front to back — this is the once-per-cycle expensive judgme
 parallel background lanes where useful; **every subagent gets an explicit model, tagged in name
 and description** (sonnet for mechanical scanning, opus-tier only where judgment earns it):
 
-- **Code/arch lane** — audit-surface posture on the section's services/interfaces; smells against
-  `peters-hard-rules.md` + `design-rules.md`; reforge surface + internal score; dead surface.
-- **Tests lane** — good/bad/ugly triage of the section's tests (slop, redundancy, gaps against
-  the invariants doc); Stryker only if budget clearly allows.
+- **Code/arch lane** — audit-surface posture on the section's services/interfaces with
+  per-method external-caller counts (reforge makes this cheap); smells against
+  `peters-hard-rules.md` + `design-rules.md`; reforge surface + internal score; dead surface;
+  reuse-review's unnecessary-surface checklist against the section's own Contracts;
+  a flow-trace simplification pass — walk each service/repository flow asking "is there a
+  simpler shape" (overlapping methods, pass-throughs, duplicated pipelines).
+- **Tests lane** — good/bad/ugly triage of the section's tests (slop, redundancy); **kick off
+  section-scoped Stryker in the background at lane start** — score goes in the scorecard,
+  surviving mutants seed test strikes; build the **invariant coverage matrix**: every
+  invariant, negative access rule, and trigger in the section doc mapped to a pinning test —
+  each gap is a ranked opportunity.
+- **InspectCode lane** — `jb inspectcode` scoped to the section's project(s) (see `/resharper`
+  for invocation); Tier 1/2 findings become strike items.
 - **Docs lane** — the section's `Docs/*.md` and `docs/guide/<Section>.md` vs code: do the
-  business docs match what the code actually does.
+  business docs match what the code actually does; verify the section doc's
+  `freshness:triggers` globs still resolve.
 - **Surface lane** — AI slop: wasteful comments, 500-words-that-should-be-50 docs/messages,
   dead resources, missing translations, per-section nav quality (dead ends, missing backlinks).
+- **Inbox** — section-tagged items in `docs/architecture/debt-ledger.yml`, open GitHub issues,
+  and in-app issues: work or rank them; off-section finds go to the debt inbox.
 
 Then, from the whole picture, write the **ideal shape**: what this section would be if rewritten
 from scratch today (`/simplify` with a magic wand), and rank the concrete moves toward it by
@@ -85,8 +97,9 @@ history rows, prune older).
 
 ## Phase 4: Strike
 
-Work the ranked list top-down until budget exhausted. Budget checks are real `date` reads between
-items, never estimates. Per item (one item or tight cluster per commit):
+Work the ranked list top-down until budget exhausted. **Drain the list — stopping early with
+strikeable items remaining is a failure mode, not a judgment call.** Budget checks are real
+`date` reads between items, never estimates. Per item (one item or tight cluster per commit):
 
 1. Pick the play: a toolbox skill scoped to the section — `section-align`, `trim-tests`,
    `simplify`, `section-read-split`, `reuse-review` (against the section's own surface),
@@ -96,7 +109,12 @@ items, never estimates. Per item (one item or tight cluster per commit):
 4. Non-mechanical changes (deletions beyond plainly-dead code, structural moves) → second-opinion
    reviewer subagent, opus-tier, score-blind, default-reject: "name the concept that improved in
    one sentence." Reject → rework once; second reject → revert, record.
-5. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet` before each push;
+5. **Doc fixes sweep the claim**: a wrong statement fixed in one doc must be grepped across
+   `docs/guide/`, other section docs, and the access matrix — it rarely lives in one file.
+6. **UI-affecting strikes get runtime verification**: render the changed page in the running app
+   (`dotnet run` + browser/test-site) before the PR — a green build does not prove a cshtml/JS
+   change works.
+7. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet` before each push;
    push every 3–5 items.
 
 **Skip-and-queue classes** (never block the loop): schema/EF changes of any kind, public/interface
@@ -180,3 +198,7 @@ push.
   corrupted them and only the build caught it.
 - 2026-08-16: keep a by-hand read of the section's auth paths in the assessment — the doc-code
   contradiction on phase gating was invisible to grep and to every lane.
+- 2026-08-16 (retro round 2, Peter): the shakedown run stopped at 40 of 150 minutes with
+  strikeable items still ranked — hence the drain-the-list rule; and absorbed abilities were
+  going unused (Stryker, InspectCode, invariant matrix, claim sweep, runtime verify, inbox) —
+  hence the expanded lanes above.

--- a/docs/architecture/freshness-catalog.yml
+++ b/docs/architecture/freshness-catalog.yml
@@ -337,3 +337,7 @@ ignore:
   # design records (historical, same genre as docs/superpowers/specs/).
   - src/Sections/*/Docs/20*.md
   - src/Sections/*/Contracts/README.md
+  # Section-doctor machine-owned files: scorecards + plan/log/report. The doctor run
+  # maintains them itself (docs/superpowers/specs/2026-08-17-section-doctor-design.md).
+  - src/Sections/*/Docs/health.md
+  - docs/health/**

--- a/docs/superpowers/specs/2026-08-17-section-doctor-design.md
+++ b/docs/superpowers/specs/2026-08-17-section-doctor-design.md
@@ -25,10 +25,12 @@ under `src/Sections/` and can be reviewed as a unit.
 4. **Toolbox in:** section-align, audit-surface, section-read-split, trim-tests, simplify,
    reuse-review (run against the section's own surface, not a diff), the refactor-swarm per-lane
    process (`.codex/skills/humans-refactor`), debt-sweep (absorbed — its ledger becomes a planner
-   input), nav-audit (as a per-section slice). **Out:** freshness-sweep, resharper, nuget-*,
-   triage-as-process (its issue outputs are planner signals). **refactor-swarm** becomes the
-   wrapper that runs multiple section-doctor lanes in parallel, especially for coordinated
-   cross-section changes.
+   input), nav-audit (as a per-section slice), resharper (absorbed as a per-section InspectCode
+   lane — 2026-08-16 retro; the weekly repo-wide `/resharper` retires once rotation covers every
+   section), test-site/run (runtime verification of UI strikes). **Out:** freshness-sweep,
+   nuget-*, triage-as-process (its issue outputs are planner and run-day inputs).
+   **refactor-swarm** becomes the wrapper that runs multiple section-doctor lanes in parallel,
+   especially for coordinated cross-section changes.
 5. **All surfaces in scope:** code, tests, docs, comments, GUI/nav, translations. Standing theme:
    AI-slop removal. Hard constraint granting the latitude: **business functionality does not
    change.**
@@ -145,16 +147,23 @@ The plan is advisory — run-day findings can extend a section's stay.
 - **2 Plan check** — read `docs/health/plan.md`; replan per the rules above if needed; take
   today's section.
 - **3 Deep assessment** (the expensive judgment, once per section per cycle) — inhale the section
-  front to back. Parallel subagent lanes where useful (models explicit + tagged): code/arch lane
-  (audit-surface posture, smells, reforge), tests lane (good/bad/ugly triage; Stryker if budget
-  allows), docs lane (section `Docs/*.md` + `docs/guide/<Section>.md` vs code — do the business
-  docs match what the code does), surface lane (slop: comments, verbosity, dead strings,
-  translations, nav dead-ends). Write the refreshed scorecard + **ideal shape** + ranked
-  opportunities into `health.md`.
-- **4 Strike** — work the ranked list top-down within budget. Each item names its play: a toolbox
-  skill run scoped to the section, or a direct fix. One item / tight cluster per commit; build +
-  targeted tests per item; full `dotnet test Humans.slnx -v quiet` before each push; push every
-  3–5 items. Budget checks are real `date` reads, never estimates. Non-mechanical changes
+  front to back, baseline build first (reforge needs it). Parallel subagent lanes where useful
+  (models explicit + tagged): code/arch lane (audit-surface posture with per-method caller
+  counts, smells, reforge, reuse-review checklist, flow-trace simplification pass), tests lane
+  (good/bad/ugly triage; **section-scoped Stryker kicked off in background**; the **invariant
+  coverage matrix** — every invariant/negative rule/trigger in the section doc mapped to a
+  pinning test), InspectCode lane (`jb inspectcode` scoped to the section), docs lane (section
+  `Docs/*.md` + `docs/guide/<Section>.md` vs code; trigger-glob verification), surface lane
+  (slop: comments, verbosity, dead strings, translations, nav dead-ends), inbox (section-tagged
+  debt-ledger items, open GitHub issues, in-app issues). Write the refreshed scorecard +
+  **ideal shape** + ranked opportunities into `health.md`.
+- **4 Strike** — work the ranked list top-down within budget, and **drain it** — stopping early
+  with strikeable items remaining is a failure mode (2026-08-16 retro: the shakedown stopped at
+  40 of 150 minutes). Each item names its play: a toolbox skill run scoped to the section, or a
+  direct fix. One item / tight cluster per commit; build + targeted tests per item; full
+  `dotnet test Humans.slnx -v quiet` before each push; push every 3–5 items. Budget checks are
+  real `date` reads, never estimates. Doc fixes sweep the claim across `docs/guide/` and sibling
+  docs; UI-affecting strikes get runtime verification in the running app. Non-mechanical changes
   (deletions beyond dead code, structural moves) get a second-opinion reviewer subagent
   (opus-tier, score-blind, default-reject — refactor-swarm posture).
 - **5 Bookkeeping** — update `health.md` history row, tick the plan, append `log.md`, overwrite
@@ -202,6 +211,8 @@ At cutover:
 - [ ] Retire `/debt-sweep` (skill + maintenance-log row marked absorbed; `debt-ledger.yml`
       survives as a planner input and strike source)
 - [ ] Retire standalone `/nav-audit` (absorbed as the per-section nav slice)
+- [ ] Retire the weekly repo-wide `/resharper` process (absorbed as the per-section InspectCode
+      lane) once rotation has covered every section
 - [ ] Demote `section-align`, `audit-surface`, `section-read-split`, `trim-tests`, `simplify`,
       `reuse-review` descriptions to note they are section-doctor plays (kept invocable)
 - [ ] Repoint `refactor-swarm` at section-doctor lanes

--- a/docs/superpowers/specs/2026-08-17-section-doctor-design.md
+++ b/docs/superpowers/specs/2026-08-17-section-doctor-design.md
@@ -144,8 +144,12 @@ The plan is advisory — run-day findings can extend a section's stay.
 - **1 Worktree** — `git fetch origin main`; worktree at `.worktrees/section-doctor-<TS>`, branch
   `section-doctor/<TS>` off `origin/main`. Scope frozen at branch point. All Glob/Grep scoped to
   the worktree.
-- **2 Plan check** — read `docs/health/plan.md`; replan per the rules above if needed; take
-  today's section.
+- **2 Plan check** — find the live plan state first: the previous run's PR may still be open, so
+  the newest plan/log/queue may exist only on that branch — discover open `section-doctor/*`
+  branches by `headRefName` prefix (GitHub's `head:` search qualifier matches exact names, not
+  prefixes), read `docs/health/*` from the newest tip, else from `origin/main`. Replan per the
+  rules above if needed (building first — an unbuilt solution under-reports reforge scores);
+  take today's section.
 - **3 Deep assessment** (the expensive judgment, once per section per cycle) — inhale the section
   front to back, baseline build first (reforge needs it). Parallel subagent lanes where useful
   (models explicit + tagged): code/arch lane (audit-surface posture with per-method caller
@@ -174,7 +178,8 @@ The plan is advisory — run-day findings can extend a section's stay.
   the Phase 7 push — nothing lands after it.
 - **7 PR** — one PR per run to `peterdrier/Humans:main`. Body: assessment summary, worked/skipped,
   **Needs Peter** block — authoritative while the PR is open — mirrored into `plan.md` for
-  carry-forward after merge. Never merges.
+  carry-forward after merge. After creation, the real PR number is backfilled over the
+  bookkeeping rows' `pending` placeholders in one more commit + push. Never merges.
 - **8 Inline round (interactive runs only)** — if Peter is present, present the Needs-Peter items
   inline (debt-sweep Phase 7 doctrine: terse, numbered, no AskUserQuestion) and apply answers
   now. Unattended runs skip this; `resume` covers it.
@@ -184,11 +189,13 @@ The plan is advisory — run-day findings can extend a section's stay.
 ## Resume mode
 
 `/section-doctor resume`: gather the queue from both places an item can live — `## Needs Peter`
-blocks in open `section-doctor/*` PR bodies (authoritative for unmerged runs, whose `plan.md`
-entries exist only on the PR branch) and unticked entries in `plan.md` on `origin/main` (merged
-runs). Present the items inline, apply Peter's answers as commits on each item's PR branch
-(re-using its worktree or recreating it; merged items get a fresh worktree), tick each entry
-where it lives, push. No new assessment work.
+blocks in open `section-doctor/*` PR bodies (discovered by `headRefName` prefix; authoritative
+for unmerged runs, whose `plan.md` entries exist only on the PR branch) and unticked entries in
+`plan.md` on `origin/main` (merged runs). Present the items inline, then apply: open-PR items
+as commits on that PR branch, ticking **both** the PR body and the branch's `plan.md` mirror
+(an unticked mirror would resurface after merge and be re-applied); merged items in a fresh
+worktree that ends in **its own PR** (an answer pushed with no PR is stranded) plus teardown.
+No new assessment work.
 
 ## Standing constraints
 

--- a/docs/superpowers/specs/2026-08-17-section-doctor-design.md
+++ b/docs/superpowers/specs/2026-08-17-section-doctor-design.md
@@ -158,23 +158,28 @@ The plan is advisory — run-day findings can extend a section's stay.
   (deletions beyond dead code, structural moves) get a second-opinion reviewer subagent
   (opus-tier, score-blind, default-reject — refactor-swarm posture).
 - **5 Bookkeeping** — update `health.md` history row, tick the plan, append `log.md`, overwrite
-  `last-report.md`.
+  `last-report.md`, update the run's maintenance-log row (all in the worktree, same PR).
 - **6 Retro + self-amend** — what was planned vs. what helped, wasted motion, rubric misses.
   Mechanical lessons → edit the skill's own files now, same PR. Judgment lessons → Needs-Peter
-  queue. Durable rules → `memory/` atom + INDEX line.
+  queue. Durable rules → `memory/` atom + INDEX line. All Phase 5–6 edits are committed before
+  the Phase 7 push — nothing lands after it.
 - **7 PR** — one PR per run to `peterdrier/Humans:main`. Body: assessment summary, worked/skipped,
-  **Needs Peter** block (mirrored into `plan.md`). Never merges.
+  **Needs Peter** block — authoritative while the PR is open — mirrored into `plan.md` for
+  carry-forward after merge. Never merges.
 - **8 Inline round (interactive runs only)** — if Peter is present, present the Needs-Peter items
   inline (debt-sweep Phase 7 doctrine: terse, numbered, no AskUserQuestion) and apply answers
   now. Unattended runs skip this; `resume` covers it.
-- **9 Teardown** — `git worktree remove` (never `rm -rf`). Update
-  `docs/architecture/maintenance-log.md` per `maintenance-log-update`.
+- **9 Teardown** — `git worktree remove` (never `rm -rf`). (The maintenance-log update happens
+  in Phase 5, inside the worktree — never in the main checkout after teardown.)
 
 ## Resume mode
 
-`/section-doctor resume`: read the Needs-Peter queue from `plan.md`, present the open items
-inline, apply Peter's answers as commits on each item's PR branch (re-using its worktree or
-recreating it from the branch), tick the queue entries, push. No new assessment work.
+`/section-doctor resume`: gather the queue from both places an item can live — `## Needs Peter`
+blocks in open `section-doctor/*` PR bodies (authoritative for unmerged runs, whose `plan.md`
+entries exist only on the PR branch) and unticked entries in `plan.md` on `origin/main` (merged
+runs). Present the items inline, apply Peter's answers as commits on each item's PR branch
+(re-using its worktree or recreating it; merged items get a fresh worktree), tick each entry
+where it lives, push. No new assessment work.
 
 ## Standing constraints
 

--- a/docs/superpowers/specs/2026-08-17-section-doctor-design.md
+++ b/docs/superpowers/specs/2026-08-17-section-doctor-design.md
@@ -1,0 +1,219 @@
+# Section Doctor — Design
+
+Spec for `/section-doctor`, the daily per-section review cycle. Designed in dialogue with Peter
+2026-08-17; decisions below are his calls.
+
+## Problem
+
+The per-section improvement skills (section-align, audit-surface, trim-tests, simplify,
+section-read-split, reuse-review, nav-audit, the refactor-swarm lane process) each cover one axis
+and are dying of obscurity — half of them are never remembered. Meanwhile sections accumulate AI
+slop (wasteful comments, 500-word docs that should be 50, test bloat), surface creep, and doc
+drift between deliberate refactor waves. With #866 (G5) nearly done, every section is a project
+under `src/Sections/` and can be reviewed as a unit.
+
+## Decisions (from design dialogue)
+
+1. **Evaluate-then-strike, with a plan cache.** A planner produces a global 5–7 day schedule of
+   which section runs which day; daily runs execute from it without replanning unless the plan is
+   exhausted or stale. (Not a fixed per-run checklist.)
+2. **One macro skill.** `/section-doctor` is the single entry point; the existing per-section
+   skills become plays in its toolbox, named by plan items. They remain directly invocable.
+3. **Self-amending.** Every run ends with a retro; mechanical lessons are applied as edits to the
+   skill's own files in the same PR; rubric-level changes queue for Peter; durable rules graduate
+   to `memory/` atoms.
+4. **Toolbox in:** section-align, audit-surface, section-read-split, trim-tests, simplify,
+   reuse-review (run against the section's own surface, not a diff), the refactor-swarm per-lane
+   process (`.codex/skills/humans-refactor`), debt-sweep (absorbed — its ledger becomes a planner
+   input), nav-audit (as a per-section slice). **Out:** freshness-sweep, resharper, nuget-*,
+   triage-as-process (its issue outputs are planner signals). **refactor-swarm** becomes the
+   wrapper that runs multiple section-doctor lanes in parallel, especially for coordinated
+   cross-section changes.
+5. **All surfaces in scope:** code, tests, docs, comments, GUI/nav, translations. Standing theme:
+   AI-slop removal. Hard constraint granting the latitude: **business functionality does not
+   change.**
+6. **Artifacts:** per-section scorecard at `src/Sections/Humans.<X>/Docs/health.md` (one-page
+   current state, last 3 assessments kept ≈ one quarter of history at one app-wide run/day);
+   global plan + run log under `docs/health/`. Sections not yet in `src/Sections/` are ignored —
+   they'll be gone soon.
+7. **Morning job, mostly autonomous.** Judgment items never block a run; they queue in a
+   "Needs Peter" block (PR body + plan doc). `/section-doctor resume` applies Peter's answers
+   later. Unanswered items carry forward, never re-asked.
+8. **Planner uses mid-level signals** — that's why it only runs every 5–7 days. Section size
+   (reforge score) and time-since-last-review dominate; once every section has been reviewed
+   once, add score-growth-since-last-review (a section +10% since its review outranks one +3%).
+9. **Run day inhales the whole section** and imagines the from-scratch ideal — what `/simplify`
+   would do with a magic wand. That not being possible, it records the ideal shape and spends the
+   budget on the biggest-value moves toward it. Budget 2–3h to start, with a few background
+   subagent threads.
+10. **Old skills are not deleted yet.** Section-doctor must prove itself first; a cutover
+    checklist (below) retires them when Peter says go.
+
+## Invocation
+
+| Form | Behavior |
+|---|---|
+| *(none)* | the daily run: replan if needed, then execute today's plan entry |
+| `resume` | no new work: read the Needs-Peter queue, take Peter's answers, apply them on the queued items' branches |
+| `--section=<Name>` | skip the plan, doctor this section today |
+| `--budget=<duration>` | override budget (default 2.5h). Wall-clock, checked between items |
+| `--replan` | force a fresh plan even if the current one is neither stale nor exhausted |
+
+## Artifacts
+
+### `src/Sections/Humans.<X>/Docs/health.md` (per section, machine-maintained)
+
+One page. Freshness-sweep ignores it (machine-owned).
+
+```markdown
+# <Section> — Health
+
+Last assessed: <date> @ <commit>
+
+## Scorecard
+| Axis | State |
+|---|---|
+| Reforge (surface / internal) | N / N |
+| Tests | count, mutation score if run, one-line verdict |
+| Docs vs code | one-line verdict |
+| Comments / slop | one-line verdict |
+| GUI / nav | one-line verdict |
+| Translations | missing-string count |
+| Arch conformance | smells, or "clean" |
+
+## Ideal shape
+<the magic-wand vision — a few sentences on what this section would be if rewritten from
+scratch today, and the gap between that and what exists>
+
+## Opportunities (ranked by value)
+1. <item — play — est. size>   ← unworked items carry to the next assessment
+
+## History (last 3 assessments)
+| Date | Reforge | Tests | Outcome | PR |
+```
+
+### `docs/health/plan.md` (global)
+
+```markdown
+# Section Doctor — Plan
+
+Anchor: <commit> (<date>)
+
+| Day | Section | Focus (from planner signals) | Status |
+
+## Needs Peter
+- [ ] <date> <section> (PR #N): <one-line question>
+```
+
+### `docs/health/log.md` (global)
+
+One line per run: `| date | section | what ran | outcome | PR |`. Append-only.
+
+### `docs/health/last-report.md`
+
+Overwritten each run, debt-sweep style: assessment summary, items worked, items skipped + why,
+retro lessons, self-amendments made.
+
+## The planner
+
+Runs only when the plan is exhausted, `--replan` is passed, or the plan is stale. Staleness is a
+judgment call with a guideline: a merged change since the anchor that materially reshapes an
+upcoming scheduled section (move, rename, major feature) justifies replanning; routine churn does
+not. Threshold expected to be tuned by the learning loop.
+
+Signals (mid-level — no deep reading):
+
+- `reforge surface-score --format compact` (size + deltas)
+- Last-assessed date from each `health.md` (first cycle: never-assessed first, score descending;
+  seed last-served knowledge from the Section Refactor History table in
+  `docs/architecture/maintenance-log.md`)
+- After the first full cycle: **score growth since last assessment** (percentage) as a primary
+  rank key
+- Tiebreak color: open GitHub/in-app issue counts per section, `debt-ledger.yml` items touching
+  the section, churn under the section's paths since its last assessment
+- Skip sections with in-flight or imminently-planned feature work (check the active sprint plan)
+
+Output: the 5–7 day table in `docs/health/plan.md`. Consecutive days for one section are allowed.
+The plan is advisory — run-day findings can extend a section's stay.
+
+## Run phases
+
+- **0 Setup** — parse args, record start time, `REPO_ROOT`.
+- **1 Worktree** — `git fetch origin main`; worktree at `.worktrees/section-doctor-<TS>`, branch
+  `section-doctor/<TS>` off `origin/main`. Scope frozen at branch point. All Glob/Grep scoped to
+  the worktree.
+- **2 Plan check** — read `docs/health/plan.md`; replan per the rules above if needed; take
+  today's section.
+- **3 Deep assessment** (the expensive judgment, once per section per cycle) — inhale the section
+  front to back. Parallel subagent lanes where useful (models explicit + tagged): code/arch lane
+  (audit-surface posture, smells, reforge), tests lane (good/bad/ugly triage; Stryker if budget
+  allows), docs lane (section `Docs/*.md` + `docs/guide/<Section>.md` vs code — do the business
+  docs match what the code does), surface lane (slop: comments, verbosity, dead strings,
+  translations, nav dead-ends). Write the refreshed scorecard + **ideal shape** + ranked
+  opportunities into `health.md`.
+- **4 Strike** — work the ranked list top-down within budget. Each item names its play: a toolbox
+  skill run scoped to the section, or a direct fix. One item / tight cluster per commit; build +
+  targeted tests per item; full `dotnet test Humans.slnx -v quiet` before each push; push every
+  3–5 items. Budget checks are real `date` reads, never estimates. Non-mechanical changes
+  (deletions beyond dead code, structural moves) get a second-opinion reviewer subagent
+  (opus-tier, score-blind, default-reject — refactor-swarm posture).
+- **5 Bookkeeping** — update `health.md` history row, tick the plan, append `log.md`, overwrite
+  `last-report.md`.
+- **6 Retro + self-amend** — what was planned vs. what helped, wasted motion, rubric misses.
+  Mechanical lessons → edit the skill's own files now, same PR. Judgment lessons → Needs-Peter
+  queue. Durable rules → `memory/` atom + INDEX line.
+- **7 PR** — one PR per run to `peterdrier/Humans:main`. Body: assessment summary, worked/skipped,
+  **Needs Peter** block (mirrored into `plan.md`). Never merges.
+- **8 Inline round (interactive runs only)** — if Peter is present, present the Needs-Peter items
+  inline (debt-sweep Phase 7 doctrine: terse, numbered, no AskUserQuestion) and apply answers
+  now. Unattended runs skip this; `resume` covers it.
+- **9 Teardown** — `git worktree remove` (never `rm -rf`). Update
+  `docs/architecture/maintenance-log.md` per `maintenance-log-update`.
+
+## Resume mode
+
+`/section-doctor resume`: read the Needs-Peter queue from `plan.md`, present the open items
+inline, apply Peter's answers as commits on each item's PR branch (re-using its worktree or
+recreating it from the branch), tick the queue entries, push. No new assessment work.
+
+## Standing constraints
+
+- **Business functionality does not change.** That is the contract that buys the latitude.
+- No surgical fixes (constitution). No EF migrations, schema changes, or data backfills — schema
+  opportunities go to the Needs-Peter queue. No analyzer suppressions; never touch `[DontFix]`.
+- Public/interface surface *additions* need Peter (reuse-first discipline) → queue. Deletions of
+  dead surface are in scope (that's the job), gated by the reviewer subagent.
+- Explicit model on every subagent, tagged in name + description.
+- Section projects only (`src/Sections/`); pre-G5 remnants are out of scope.
+- The run touches only: the section's files, its callers where a play requires (e.g. read-split
+  migrations), `docs/health/*`, the section's `health.md`, the skill's own files (retro), and
+  `memory/` (graduated rules).
+
+## Relationship to existing skills — cutover checklist
+
+Until section-doctor has proven itself over several runs (Peter's call), nothing is deleted.
+At cutover:
+
+- [ ] Retire `/debt-sweep` (skill + maintenance-log row marked absorbed; `debt-ledger.yml`
+      survives as a planner input and strike source)
+- [ ] Retire standalone `/nav-audit` (absorbed as the per-section nav slice)
+- [ ] Demote `section-align`, `audit-surface`, `section-read-split`, `trim-tests`, `simplify`,
+      `reuse-review` descriptions to note they are section-doctor plays (kept invocable)
+- [ ] Repoint `refactor-swarm` at section-doctor lanes
+- [ ] Retire the Section Refactor History table in `maintenance-log.md` (selection duty and data
+      live in the planner + `health.md` files)
+
+`freshness-sweep` is unaffected (repo-wide doc drift, diff-triggered); section-doctor's docs lane
+is the deep per-section complement.
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Plan/health file parse error | Abort before work; report |
+| Reforge unavailable | Assess without scores; note in report |
+| Item breaks build/tests, can't be made right | Revert item, record, continue |
+| Reviewer subagent rejects twice | Revert, skip, record |
+| Budget hit mid-list | Normal: commit what's done; `health.md` carries the remainder |
+| Push / PR fails | Worktree retained; fix manually |
+| Section has in-flight feature work discovered mid-run | Stop the strike phase, ship the assessment-only PR, note in plan |


### PR DESCRIPTION
Adds the `/section-doctor` skill and its design spec, from the 2026-08-17 design dialogue.

## What it is
One macro skill consolidating the per-section improvement skills into a daily cycle: a planner schedules 5–7 days of sections from mid-level signals (reforge score, time-since-review, later score-growth); each morning's run deep-assesses its section, refreshes `Docs/health.md` (scorecard + ideal shape + ranked opportunities, last 3 assessments kept), then strikes the top-value behavior-preserving improvements for ~2.5h. Judgment items queue in a Needs-Peter block (PR body + `docs/health/plan.md`); `resume` applies answers later. Self-amending via a mandatory retro phase.

## Not in this PR
- No skill retirements — debt-sweep, nav-audit, etc. stay live until section-doctor proves itself; cutover checklist is in the spec.
- `docs/health/` plan/log files are created lazily by the first run.

Spec: `docs/superpowers/specs/2026-08-17-section-doctor-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)