### PR TITLE
fix(widgets): WidgetGallery section key casing mismatch renders empty access matrix

### DIFF
--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -846,7 +846,7 @@
                         ("section", "<code>string</code> — section key from <code>AccessMatrixDefinitions.Sections</code> (e.g. teams, shifts, profile)")
                     )
                     <div class="wg-card-example">
-                        <vc:access-matrix section="teams" />
+                        <vc:access-matrix section="Teams" />
                     </div>
                 </div>
 

--- a/tests/Humans.Integration.Tests/Controllers/MovedSharedPartialsRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/MovedSharedPartialsRenderTests.cs
@@ -129,11 +129,11 @@ public class MovedSharedPartialsRenderTests(HumansTestDatabase database) : Integ
     /// span carrying an unknown attribute, so its absence is the proof.
     /// </para>
     /// <para>
-    /// <c>&lt;vc:access-matrix&gt;</c> is not asserted here: the gallery passes
-    /// <c>section="teams"</c> while <c>AccessMatrixDefinitions.Sections</c> is keyed
-    /// <c>"Teams"</c> under <c>StringComparer.Ordinal</c>, so that card has always rendered
-    /// empty. Its binding is covered by the Camps, Teams, Users, Onboarding and Governance page
-    /// render tests, which pass the registry's own casing.
+    /// <c>&lt;vc:access-matrix section="Teams"&gt;</c> is asserted here too: the gallery used
+    /// to pass <c>section="teams"</c> while <c>AccessMatrixDefinitions.Sections</c> is keyed
+    /// <c>"Teams"</c> under <c>StringComparer.Ordinal</c>, so that card rendered empty. Fixed
+    /// by correcting the gallery's literal to match the registry's own casing, same as every
+    /// other call site.
     /// </para>
     /// </remarks>
     [HumansFact(Timeout = 120000)]
@@ -159,6 +159,9 @@ public class MovedSharedPartialsRenderTests(HumansTestDatabase database) : Integ
         html.Should().NotContain("Bogus policy",
             because: "an unknown policy must fail closed — unbound, the helper suppresses nothing "
                    + "and the span renders like any element with an unrecognised attribute");
+        html.Should().Contain("Google resource sync",
+            because: "<vc:access-matrix section=\"Teams\"> resolved against "
+                   + "AccessMatrixDefinitions.Sections and rendered the Teams-only feature row");
 
         foreach (var literal in new[] { "<vc:human", "<vc:temp-data-alerts", "<markdown-editor" })
         {


### PR DESCRIPTION
## Summary

The `/WidgetGallery` demo page hardcoded `<vc:access-matrix section="teams" />` (lowercase) while `AccessMatrixDefinitions.Sections` is keyed `"Teams"` under `StringComparer.Ordinal`, so that card has always rendered empty.

**Reasoning**: fixed the caller rather than loosening the comparer, because every other real call site (Camps, Teams, Users, Onboarding, Governance, Tickets, Shifts, Google, CityPlanning) already passes the registry's exact PascalCase key — the comparer is consistently Ordinal everywhere in this registry, so this was purely a hand-typed literal that didn't match the established convention, not a systemic case-sensitivity gap.

## Changes

- `src/Humans.Web/Views/WidgetGallery/Index.cshtml`: `section="teams"` → `section="Teams"`.
- `tests/Humans.Integration.Tests/Controllers/MovedSharedPartialsRenderTests.cs`: added a regression assertion in the existing `/WidgetGallery` render test that the Teams-only "Google resource sync" feature row now renders (proving the access-matrix section key resolves against the registry), and updated the doc comment that previously documented this as a known-empty card.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet` — 5346 passed, 0 failed, 5 skipped (5351 total) across all 46 test projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)