### PR TITLE
refactor(tests): make Humans.Testing a real project instead of props shared source

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -106,6 +106,7 @@
     <!-- HTML parsing for the localization-coverage sweep; pinned to the version HtmlSanitizer already resolves so the solution-wide graph is unchanged. -->
     <PackageVersion Include="AngleSharp" Version="1.6.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />

--- a/Humans.slnx
+++ b/Humans.slnx
@@ -75,6 +75,8 @@
     <File Path="tests/Directory.Build.props" />
     <Project Path="tests/Humans.Analyzers.Tests/Humans.Analyzers.Tests.csproj" />
     <Project Path="tests/Humans.Interfaces.Tests/Humans.Interfaces.Tests.csproj" />
+    <Project Path="tests/Humans.Testing/Humans.Testing.csproj" />
+    <Project Path="tests/Humans.Testing.Tests/Humans.Testing.Tests.csproj" />
     <Project Path="tests/Humans.AuditLog.Tests/Humans.AuditLog.Tests.csproj" />
     <Project Path="tests/Humans.Integration.Tests/Humans.Integration.Tests.csproj" />
     <Project Path="tests/Humans.Agent.Tests/Humans.Agent.Tests.csproj" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -24,8 +24,10 @@
     <None Include="$(MSBuildThisFileDirectory)xunit.runner.json" Link="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <!-- Common test packages -->
-  <ItemGroup>
+  <!-- Common test packages. Humans.Testing is the one non-test project here (a plain
+       library the group below must not turn into a test host); it declares its own
+       packages. -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Humans.Testing'">
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
@@ -44,66 +46,17 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Shared HumansFact / HumansTheory attributes (5s default timeout, infinite forbidden)
-       plus BrokenFact and DebuggerOnlyFact skip helpers. -->
-  <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\HumansFactAttribute.cs" Link="Humans.Testing\HumansFactAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\HumansTheoryAttribute.cs" Link="Humans.Testing\HumansTheoryAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\BrokenFactAttribute.cs" Link="Humans.Testing\BrokenFactAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\DebuggerOnlyFactAttribute.cs" Link="Humans.Testing\DebuggerOnlyFactAttribute.cs" />
-    <!-- Fluent IServiceProvider-substitute builder. Shared here (rather than left in
-         Humans.Application.Tests) so a section test project whose service resolves a
-         dependency through IServiceProvider inherits it — Governance's MembershipCalculator
-         does, to break a DI cycle (nobodies-collective/Humans#866). NSubstitute only. -->
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\ServiceLocatorBuilder.cs" Link="Humans.Testing\ServiceLocatorBuilder.cs" />
+  <!-- The shared harness (HumansFact/HumansTheory attributes, ServiceLocatorBuilder,
+       CapturingLogger, TestDbContextFactory, Shifts DTO fixtures) is a real project,
+       referenced once here rather than declared in every test csproj.
+       Humans.Analyzers.Tests is excluded: the reference would put Humans.*, EF and
+       AspNetCore assemblies on its TPA list, where AnalyzerTestHarness's synthetic
+       compilations collide with the stubs the tests declare (CS0433). It compiles the
+       four attribute files directly in its own csproj instead. -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Humans.Testing'
+                        AND '$(MSBuildProjectName)' != 'Humans.Analyzers.Tests'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Humans.Testing\Humans.Testing.csproj" />
     <Using Include="Humans.Testing" />
-  </ItemGroup>
-
-  <!-- In-memory ILogger. Unconditional: it needs Microsoft.Extensions.Logging and nothing
-       else, so a section test project with no EF on its compile path can still use it.
-       It was bundled with TestDbContextFactory below until Humans.Mailer.Tests wanted the
-       one without the other (nobodies-collective/Humans#866). -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Humans.Analyzers.Tests'">
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\CapturingLogger.cs" Link="Humans.Testing\CapturingLogger.cs" />
-  </ItemGroup>
-
-  <!-- BurnSettingsInfo builder. Needs Humans.Shifts.Contracts, which every test project
-       below now declares directly: the transitive path ran through Humans.Application until
-       G5 lane 5c dropped that reference (nobodies-collective/Humans#866). The two exclusions
-       stay — Humans.Analyzers.Tests feeds synthetic compilations to analyzers, and
-       Humans.Interfaces.Tests sits at the bottom of the graph. Shared rather than
-       copied because fifteen call sites across six section test projects stub
-       IBurnSettingsService after the Shifts read boundary moved every cross-section burn
-       read off the entity-returning IShiftManagementService.GetActiveAsync
-       (nobodies-collective/Humans#866), and the record is positional with eighteen
-       members. -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Humans.Analyzers.Tests'
-                        AND '$(MSBuildProjectName)' != 'Humans.Interfaces.Tests'">
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\BurnSettingsInfoFixtures.cs" Link="Humans.Testing\BurnSettingsInfoFixtures.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\ShiftUserSummaryFixtures.cs" Link="Humans.Testing\ShiftUserSummaryFixtures.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\UrgentShiftInfoFixtures.cs" Link="Humans.Testing\UrgentShiftInfoFixtures.cs" />
-  </ItemGroup>
-
-  <!-- Generic in-memory IDbContextFactory for per-section DbContexts. Shared here so a
-       section test project created at G5 (nobodies-collective/Humans#866) inherits it with
-       the rest of the harness. The projects listed below have no EF Core on their compile
-       path and are excluded: Humans.Analyzers.Tests feeds synthetic compilations to
-       analyzers, and Humans.Scanner.Tests / Humans.Cantina.Tests / Humans.Development.Tests
-       / Humans.Mailer.Tests cover sections that own no tables *and* pull no EF in
-       transitively. All would otherwise have to take an EF package purely so a fixture they
-       never use compiles.
-
-       The criterion is "no EF on the compile path", not "the section owns no tables" — the
-       two came apart at Humans.Debug.Tests, whose section owns no tables and still needs no
-       exclusion because the section names Base's QueryStatistics / InMemoryLogSink. Add a
-       clause only after a build actually fails. -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Humans.Analyzers.Tests'
-                        AND '$(MSBuildProjectName)' != 'Humans.Scanner.Tests'
-                        AND '$(MSBuildProjectName)' != 'Humans.Cantina.Tests'
-                        AND '$(MSBuildProjectName)' != 'Humans.Development.Tests'
-                        AND '$(MSBuildProjectName)' != 'Humans.Mailer.Tests'
-                        AND '$(MSBuildProjectName)' != 'Humans.Monitor.Tests'">
-    <Compile Include="$(MSBuildThisFileDirectory)Humans.Testing\TestDbContextFactory.cs" Link="Humans.Testing\TestDbContextFactory.cs" />
   </ItemGroup>
 
   <!-- BannedApiAnalyzers: forbid bare [Fact] and [Theory] in tests. RS0030 suppression

--- a/tests/Humans.Analyzers.Tests/AnalyzerTestHarness.cs
+++ b/tests/Humans.Analyzers.Tests/AnalyzerTestHarness.cs
@@ -70,26 +70,23 @@ internal static class AnalyzerTestHarness
     }
 
     /// <summary>
-    /// The analyzer assembly must never be a reference of an analyzed
-    /// compilation. It carries linked copies of the architecture attributes
-    /// (its name oracle — see nobodies-collective/Humans#1057), and
-    /// <c>GetTypeByMetadataName</c> returns <c>null</c> when a name is declared
-    /// in more than one place, so leaving it in would make every marker lookup
-    /// ambiguous and quietly disable the rule under test. Production never
-    /// references it either: <c>src/Directory.Build.props</c> attaches it with
-    /// <c>ReferenceOutputAssembly="false"</c>.
+    /// No Humans.* assembly may be a reference of an analyzed compilation. The
+    /// analyzer assembly carries linked copies of the architecture attributes
+    /// (its name oracle — see nobodies-collective/Humans#1057), and the tests
+    /// declare their own stubs for production markers (ISection, IRecurringJob,
+    /// the attributes) — a real Humans assembly alongside them makes every such
+    /// name ambiguous: CS0433 in the snippet, and <c>GetTypeByMetadataName</c>
+    /// returning <c>null</c>, which quietly disables the rule under test.
     /// </summary>
     private static ImmutableArray<MetadataReference> BuildBaseReferences()
     {
-        var analyzerAssemblyFileName = Path.GetFileName(typeof(SurfaceBudgetAnalyzer).Assembly.Location);
-
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();
         var trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
         foreach (var path in trustedAssemblies.Split(Path.PathSeparator))
         {
             if (path.Length == 0)
                 continue;
-            if (string.Equals(Path.GetFileName(path), analyzerAssemblyFileName, StringComparison.OrdinalIgnoreCase))
+            if (Path.GetFileName(path).StartsWith("Humans.", StringComparison.OrdinalIgnoreCase))
                 continue;
 
             builder.Add(MetadataReference.CreateFromFile(path));

--- a/tests/Humans.Analyzers.Tests/Humans.Analyzers.Tests.csproj
+++ b/tests/Humans.Analyzers.Tests/Humans.Analyzers.Tests.csproj
@@ -5,6 +5,21 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <!--
+    The HumansFact/HumansTheory attributes as shared source instead of the
+    Humans.Testing project reference every other test project gets from
+    tests/Directory.Build.props: that reference would put Humans.*, EF and
+    AspNetCore assemblies on this host's TPA list, where AnalyzerTestHarness's
+    synthetic compilations collide with the stubs the tests declare (CS0433).
+  -->
+  <ItemGroup>
+    <Compile Include="..\Humans.Testing\HumansFactAttribute.cs" Link="Humans.Testing\HumansFactAttribute.cs" />
+    <Compile Include="..\Humans.Testing\HumansTheoryAttribute.cs" Link="Humans.Testing\HumansTheoryAttribute.cs" />
+    <Compile Include="..\Humans.Testing\BrokenFactAttribute.cs" Link="Humans.Testing\BrokenFactAttribute.cs" />
+    <Compile Include="..\Humans.Testing\DebuggerOnlyFactAttribute.cs" Link="Humans.Testing\DebuggerOnlyFactAttribute.cs" />
+    <Using Include="Humans.Testing" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>

--- a/tests/Humans.Interfaces.Tests/Humans.Interfaces.Tests.csproj
+++ b/tests/Humans.Interfaces.Tests/Humans.Interfaces.Tests.csproj
@@ -2,8 +2,7 @@
 
   <!--
     Base's test project. Holds what Humans.Application.Tests and Humans.Domain.Tests carried
-    for types that live here (nobodies-collective/Humans#866, rulings 49-51), plus the
-    tests/Humans.Testing attribute smoke tests, which belong to no production assembly.
+    for types that live here (nobodies-collective/Humans#866, rulings 49-51).
   -->
 
   <ItemGroup>

--- a/tests/Humans.Testing.Tests/GlobalTimeoutDemoTest.cs
+++ b/tests/Humans.Testing.Tests/GlobalTimeoutDemoTest.cs
@@ -1,6 +1,6 @@
 using Xunit;
 
-namespace Humans.Interfaces.Tests;
+namespace Humans.Testing.Tests;
 
 /// <summary>
 /// Demonstration of xUnit v3's per-test <c>[Fact(Timeout = N)]</c>

--- a/tests/Humans.Testing.Tests/Humans.Testing.Tests.csproj
+++ b/tests/Humans.Testing.Tests/Humans.Testing.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for the Humans.Testing harness library: the HumansFact/HumansTheory
+    attribute smoke tests and the timeout demo. The Humans.Testing reference
+    comes from tests/Directory.Build.props like every other test project.
+  -->
+
+</Project>

--- a/tests/Humans.Testing.Tests/HumansFactSmokeTest.cs
+++ b/tests/Humans.Testing.Tests/HumansFactSmokeTest.cs
@@ -1,6 +1,6 @@
 using Xunit;
 
-namespace Humans.Interfaces.Tests;
+namespace Humans.Testing.Tests;
 
 public class HumansFactSmokeTest
 {

--- a/tests/Humans.Testing.Tests/SkipAttributeSmokeTest.cs
+++ b/tests/Humans.Testing.Tests/SkipAttributeSmokeTest.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 using Xunit;
 
-namespace Humans.Interfaces.Tests;
+namespace Humans.Testing.Tests;
 
 public class SkipAttributeSmokeTest
 {

--- a/tests/Humans.Testing/CapturingLogger.cs
+++ b/tests/Humans.Testing/CapturingLogger.cs
@@ -7,13 +7,7 @@ namespace Humans.Testing;
 /// tests can assert on level and message without involving a real logging
 /// framework.
 /// </summary>
-/// <remarks>
-/// Shared via <c>tests/Directory.Build.props</c> rather than owned by one test project,
-/// so a section test project created at G5 (nobodies-collective/Humans#866) inherits it
-/// along with the rest of the harness. It lived at the bottom of
-/// <c>AuditLogServiceTests.cs</c> until Finance's move needed it from a second assembly.
-/// </remarks>
-internal sealed class CapturingLogger<T> : ILogger<T>
+public sealed class CapturingLogger<T> : ILogger<T>
 {
     public sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
 

--- a/tests/Humans.Testing/Humans.Testing.csproj
+++ b/tests/Humans.Testing/Humans.Testing.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Shared test-support library: HumansFact/HumansTheory/BrokenFact/DebuggerOnlyFact,
+    ServiceLocatorBuilder, CapturingLogger, TestDbContextFactory and the Shifts DTO
+    fixtures. Referenced by every test project via tests/Directory.Build.props.
+    Not a test project itself, and never referenced from src/.
+  -->
+
+  <PropertyGroup>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- BurnSettingsInfo / ShiftUserSummary / UrgentShiftInfo fixtures. -->
+    <ProjectReference Include="..\..\src\Sections\Humans.Shifts.Contracts\Humans.Shifts.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="NodaTime" />
+    <PackageReference Include="NSubstitute" />
+    <!-- FactAttribute/TheoryAttribute for the attribute subclasses, without the
+         self-executing test-host targets the full xunit.v3 package injects. -->
+    <PackageReference Include="xunit.v3.extensibility.core" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Humans.Testing/TestDbContextFactory.cs
+++ b/tests/Humans.Testing/TestDbContextFactory.cs
@@ -8,12 +8,7 @@ namespace Humans.Testing;
 /// <c>TestDbContextFactory&lt;StoreDbContext&gt;</c>. Same contract as the production
 /// factory: each call returns a fresh context over the same store.
 /// </summary>
-/// <remarks>
-/// Shared via <c>tests/Directory.Build.props</c> rather than owned by one test project,
-/// so a section test project created at G5 (nobodies-collective/Humans#866) inherits it
-/// along with the rest of the harness.
-/// </remarks>
-internal sealed class TestDbContextFactory<TContext>(DbContextOptions<TContext> options)
+public sealed class TestDbContextFactory<TContext>(DbContextOptions<TContext> options)
     : IDbContextFactory<TContext>
     where TContext : DbContext
 {


### PR DESCRIPTION
`tests/Humans.Testing` becomes a class library referenced once from `tests/Directory.Build.props`, replacing the per-file `<Compile Include>` shared-source mechanism and all its exclusion conditions.

## Shape
- **`tests/Humans.Testing.csproj` (new):** `IsTestProject=false`; packages `xunit.v3.extensibility.core` (new pin @3.2.2 — the full `xunit.v3` package would inject the self-executing test-host targets into a library), NSubstitute, EF Core, NodaTime; ProjectReference to `Humans.Shifts.Contracts` for the Burn/Shift fixtures. `ILogger` flows via Base's AspNetCore framework reference.
- **`tests/Directory.Build.props`:** the five Compile-include groups and their per-project exclusion conditions collapse to one gated `<ProjectReference>` + `<Using>`; the common-test-packages group is gated off `Humans.Testing`.
- **`CapturingLogger` / `TestDbContextFactory`** go `internal` → `public` (internal only worked compiled-in).
- **`tests/Humans.Testing.Tests` (new):** the three attribute smoke tests move here from `Humans.Interfaces.Tests`, restoring the 1:1 test↔assembly mapping now that Humans.Testing is a real assembly.

## The one deliberate exception
`Humans.Analyzers.Tests` does NOT take the project reference: it would put Humans.*, EF and AspNetCore assemblies on the test host's trusted-assembly list, which `AnalyzerTestHarness` feeds to its synthetic compilations — colliding (CS0433) with the stubs the tests deliberately declare (`ISection`, `ITagHelper`, `Migration`, the architecture attributes). It compile-includes the four attribute files directly in its own csproj (same literal-path pattern as its embedded production-attribute sources), and the harness now excludes all `Humans.*` assemblies from base references instead of just the analyzer dll.

## Verification
`dotnet test Humans.slnx`: 5,362 passed / 0 failed / 5 skipped across 46 test projects (was 45 + shared source; Humans.Testing itself correctly doesn't run as a test project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)