### PR TITLE
chore: ReSharper cleanup — test namespaces + leftover namespace junk

### DIFF
--- a/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
+++ b/src/Humans.Analyzers/EmailMutationPathsAnalyzer.cs
@@ -94,15 +94,15 @@ public sealed class EmailMutationPathsAnalyzer : DiagnosticAnalyzer
         var op = (IInvocationOperation)context.Operation;
         var method = op.TargetMethod;
         var name = method.Name;
-        if (!string.Equals(name, ServiceMethodName, System.StringComparison.Ordinal) &&
-            !string.Equals(name, RepositoryMethodName, System.StringComparison.Ordinal))
+        if (!string.Equals(name, ServiceMethodName, StringComparison.Ordinal) &&
+            !string.Equals(name, RepositoryMethodName, StringComparison.Ordinal))
             return;
 
         var callerTopLevel = context.ContainingSymbol.ContainingTopLevelType()?.ToDisplayString();
 
         if (InterfaceMethodMatcher.Targets(method, ServiceInterface, ServiceMethodName))
         {
-            if (!string.Equals(callerTopLevel, AllowedServiceCaller, System.StringComparison.Ordinal))
+            if (!string.Equals(callerTopLevel, AllowedServiceCaller, StringComparison.Ordinal))
                 context.ReportDiagnostic(Diagnostic.Create(ServiceCallerRule, op.Syntax.GetLocation()));
             return;
         }

--- a/src/Humans.Analyzers/IdentityColumnReadAnalyzer.cs
+++ b/src/Humans.Analyzers/IdentityColumnReadAnalyzer.cs
@@ -49,7 +49,7 @@ public sealed class IdentityColumnReadAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
     private static readonly ImmutableHashSet<string> ForbiddenGetters =
-        ImmutableHashSet.Create(System.StringComparer.Ordinal,
+        ImmutableHashSet.Create(StringComparer.Ordinal,
             "Email",
             "NormalizedEmail",
             "UserName",

--- a/src/Humans.Analyzers/IdentityColumnWriteAnalyzer.cs
+++ b/src/Humans.Analyzers/IdentityColumnWriteAnalyzer.cs
@@ -37,7 +37,7 @@ public sealed class IdentityColumnWriteAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
     private static readonly ImmutableHashSet<string> ForbiddenSetters =
-        ImmutableHashSet.Create(System.StringComparer.Ordinal,
+        ImmutableHashSet.Create(StringComparer.Ordinal,
             "Email",
             "NormalizedEmail",
             "EmailConfirmed",

--- a/src/Humans.Analyzers/IdentityFindByEmailAnalyzer.cs
+++ b/src/Humans.Analyzers/IdentityFindByEmailAnalyzer.cs
@@ -38,7 +38,7 @@ public sealed class IdentityFindByEmailAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
     private static readonly ImmutableHashSet<string> ForbiddenMethods =
-        ImmutableHashSet.Create(System.StringComparer.Ordinal,
+        ImmutableHashSet.Create(StringComparer.Ordinal,
             "FindByEmailAsync",
             "FindByNameAsync");
 

--- a/src/Humans.Analyzers/Internal/AssemblyScope.cs
+++ b/src/Humans.Analyzers/Internal/AssemblyScope.cs
@@ -30,7 +30,7 @@ internal static class AssemblyScope
             return false;
 
         return entryPoint.AllInterfaces.Any(i =>
-            string.Equals(i.ToDisplayString(), ISectionFullName, System.StringComparison.Ordinal));
+            string.Equals(i.ToDisplayString(), ISectionFullName, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ internal static class AssemblyScope
             return false;
 
         var ns = symbol.ContainingNamespace?.ToDisplayString();
-        if (ns is not null && ns.Split('.').Any(segment => string.Equals(segment, DataFolder, System.StringComparison.Ordinal)))
+        if (ns is not null && ns.Split('.').Any(segment => string.Equals(segment, DataFolder, StringComparison.Ordinal)))
             return true;
 
         foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
@@ -65,7 +65,7 @@ internal static class AssemblyScope
                 continue;
 
             var normalized = "/" + filePath.Replace('\\', '/').TrimStart('/') + "/";
-            if (normalized.IndexOf("/" + DataFolder + "/", System.StringComparison.Ordinal) >= 0)
+            if (normalized.IndexOf("/" + DataFolder + "/", StringComparison.Ordinal) >= 0)
                 return true;
         }
 

--- a/src/Humans.Analyzers/Internal/GrandfatheredCheck.cs
+++ b/src/Humans.Analyzers/Internal/GrandfatheredCheck.cs
@@ -67,7 +67,7 @@ internal static class GrandfatheredCheck
 
             var ruleIdArg = attr.ConstructorArguments[0];
             if (ruleIdArg.Value is string s &&
-                string.Equals(s, ruleId, System.StringComparison.Ordinal))
+                string.Equals(s, ruleId, StringComparison.Ordinal))
             {
                 return true;
             }
@@ -116,13 +116,13 @@ internal static class GrandfatheredCheck
                 continue;
 
             if (args[0].Value is not string ruleIdValue ||
-                !string.Equals(ruleIdValue, ruleId, System.StringComparison.Ordinal))
+                !string.Equals(ruleIdValue, ruleId, StringComparison.Ordinal))
             {
                 continue;
             }
 
             var scopeValue = args.Length >= 5 ? args[4].Value as string : null;
-            if (scopeValue is not null && string.Equals(scopeValue, scope, System.StringComparison.Ordinal))
+            if (scopeValue is not null && string.Equals(scopeValue, scope, StringComparison.Ordinal))
                 return true;
         }
 

--- a/src/Humans.Analyzers/Internal/InterfaceMethodMatcher.cs
+++ b/src/Humans.Analyzers/Internal/InterfaceMethodMatcher.cs
@@ -22,7 +22,7 @@ internal static class InterfaceMethodMatcher
         string interfaceFullName,
         string methodName)
     {
-        if (!string.Equals(method.Name, methodName, System.StringComparison.Ordinal))
+        if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
             return false;
 
         var containingType = method.ContainingType;
@@ -30,14 +30,14 @@ internal static class InterfaceMethodMatcher
             return false;
 
         // Direct interface call.
-        if (string.Equals(containingType.ToDisplayString(), interfaceFullName, System.StringComparison.Ordinal))
+        if (string.Equals(containingType.ToDisplayString(), interfaceFullName, StringComparison.Ordinal))
             return true;
 
         // Concrete-type or derived-class call — resolve via the interface map.
         foreach (var iface in containingType.AllInterfaces)
         {
-            if (!string.Equals(iface.ToDisplayString(), interfaceFullName, System.StringComparison.Ordinal) &&
-                !string.Equals(iface.OriginalDefinition.ToDisplayString(), interfaceFullName, System.StringComparison.Ordinal))
+            if (!string.Equals(iface.ToDisplayString(), interfaceFullName, StringComparison.Ordinal) &&
+                !string.Equals(iface.OriginalDefinition.ToDisplayString(), interfaceFullName, StringComparison.Ordinal))
                 continue;
 
             foreach (var iMember in iface.GetMembers(methodName).OfType<IMethodSymbol>())

--- a/src/Humans.Analyzers/Internal/Rules/CachingDecoratorRule.cs
+++ b/src/Humans.Analyzers/Internal/Rules/CachingDecoratorRule.cs
@@ -134,8 +134,8 @@ internal static class CachingDecoratorRule
         while (topLevel.ContainingType is not null)
             topLevel = topLevel.ContainingType;
 
-        if (!topLevel.Name.StartsWith("Caching", System.StringComparison.Ordinal)
-            || !topLevel.Name.EndsWith("Service", System.StringComparison.Ordinal))
+        if (!topLevel.Name.StartsWith("Caching", StringComparison.Ordinal)
+            || !topLevel.Name.EndsWith("Service", StringComparison.Ordinal))
             return null;
 
         return topLevel;

--- a/src/Humans.Analyzers/Internal/Rules/CrossSectionReadRule.cs
+++ b/src/Humans.Analyzers/Internal/Rules/CrossSectionReadRule.cs
@@ -75,13 +75,13 @@ internal static class CrossSectionReadRule
                     continue;
 
                 var readBase = fullInterface.AllInterfaces.FirstOrDefault(
-                    i => i.Name.EndsWith(ReadInterfaceSuffix, System.StringComparison.Ordinal));
+                    i => i.Name.EndsWith(ReadInterfaceSuffix, StringComparison.Ordinal));
                 if (readBase is null)
                     continue;
 
                 var dependencySection = Sections.Of(fullInterface, Sections.InterfaceNamespacePrefix);
                 if (dependencySection is null
-                    || string.Equals(dependencySection, callerSection, System.StringComparison.Ordinal))
+                    || string.Equals(dependencySection, callerSection, StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/src/Humans.Analyzers/Internal/Rules/PublicSurfaceRule.cs
+++ b/src/Humans.Analyzers/Internal/Rules/PublicSurfaceRule.cs
@@ -117,7 +117,7 @@ internal static class PublicSurfaceRule
     /// <summary>Matched the way <c>SectionResourceTypes()</c> matches it at runtime.</summary>
     private static bool IsResourceMarker(INamedTypeSymbol type) =>
         type is { TypeKind: TypeKind.Class, IsAbstract: false }
-        && type.Name.EndsWith(ResourceNameSuffix, System.StringComparison.Ordinal);
+        && type.Name.EndsWith(ResourceNameSuffix, StringComparison.Ordinal);
 
     /// <summary>The scaffolder emits migrations public and they are never hand-edited.</summary>
     private static bool IsEfMigration(INamedTypeSymbol type, INamedTypeSymbol? migrationBase) =>
@@ -134,7 +134,7 @@ internal static class PublicSurfaceRule
         if (HasAttribute(type, nonViewComponentAttr))
             return false;
 
-        return type.Name.EndsWith(ViewComponentNameSuffix, System.StringComparison.Ordinal)
+        return type.Name.EndsWith(ViewComponentNameSuffix, StringComparison.Ordinal)
             || HasAttribute(type, viewComponentAttr);
     }
 
@@ -172,7 +172,7 @@ internal static class PublicSurfaceRule
 
         return (recurringJobInterface is not null
                 && type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, recurringJobInterface)))
-            || type.Name.EndsWith(JobNameSuffix, System.StringComparison.Ordinal);
+            || type.Name.EndsWith(JobNameSuffix, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -183,7 +183,7 @@ internal static class PublicSurfaceRule
     private static bool IsUnderFolder(INamedTypeSymbol type, string segment)
     {
         var ns = type.ContainingNamespace?.ToDisplayString();
-        if (ns is not null && ns.Split('.').Any(s => string.Equals(s, segment, System.StringComparison.Ordinal)))
+        if (ns is not null && ns.Split('.').Any(s => string.Equals(s, segment, StringComparison.Ordinal)))
             return true;
 
         foreach (var syntaxRef in type.DeclaringSyntaxReferences)
@@ -193,7 +193,7 @@ internal static class PublicSurfaceRule
                 continue;
 
             var normalized = "/" + filePath.Replace('\\', '/').TrimStart('/') + "/";
-            if (normalized.IndexOf("/" + segment + "/", System.StringComparison.Ordinal) >= 0)
+            if (normalized.IndexOf("/" + segment + "/", StringComparison.Ordinal) >= 0)
                 return true;
         }
         return false;

--- a/src/Humans.Analyzers/Internal/Sections.cs
+++ b/src/Humans.Analyzers/Internal/Sections.cs
@@ -24,7 +24,7 @@ internal static class Sections
     public static string? FromNamespace(INamedTypeSymbol type, string namespacePrefix)
     {
         var ns = type.ContainingNamespace?.ToDisplayString();
-        if (ns is null || !ns.StartsWith(namespacePrefix, System.StringComparison.Ordinal))
+        if (ns is null || !ns.StartsWith(namespacePrefix, StringComparison.Ordinal))
             return null;
 
         var startIndex = namespacePrefix.Length;
@@ -57,10 +57,10 @@ internal static class Sections
     public static string? FromAssembly(IAssemblySymbol? assembly)
     {
         var name = assembly?.Name;
-        if (name is null || !name.StartsWith(AssemblyPrefix, System.StringComparison.Ordinal))
+        if (name is null || !name.StartsWith(AssemblyPrefix, StringComparison.Ordinal))
             return null;
 
-        if (name.EndsWith(ContractsSuffix, System.StringComparison.Ordinal))
+        if (name.EndsWith(ContractsSuffix, StringComparison.Ordinal))
         {
             var length = name.Length - AssemblyPrefix.Length - ContractsSuffix.Length;
             return length > 0 ? name.Substring(AssemblyPrefix.Length, length) : null;

--- a/src/Humans.Analyzers/Internal/SymbolExtensions.cs
+++ b/src/Humans.Analyzers/Internal/SymbolExtensions.cs
@@ -8,7 +8,7 @@ internal static class SymbolExtensions
     {
         for (var current = type; current is not null; current = current.BaseType)
         {
-            if (string.Equals(current.ToDisplayString(), fullMetadataName, System.StringComparison.Ordinal))
+            if (string.Equals(current.ToDisplayString(), fullMetadataName, StringComparison.Ordinal))
                 return true;
         }
         return false;
@@ -18,7 +18,7 @@ internal static class SymbolExtensions
     {
         for (var current = type; current is not null; current = current.BaseType)
         {
-            if (current.Name.StartsWith(prefix, System.StringComparison.Ordinal))
+            if (current.Name.StartsWith(prefix, StringComparison.Ordinal))
                 return true;
         }
         return false;

--- a/src/Humans.Analyzers/UserEmailLegacyFieldAnalyzer.cs
+++ b/src/Humans.Analyzers/UserEmailLegacyFieldAnalyzer.cs
@@ -36,12 +36,12 @@ public sealed class UserEmailLegacyFieldAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
     private static readonly ImmutableHashSet<string> UserEmailForbiddenMembers =
-        ImmutableHashSet.Create(System.StringComparer.Ordinal,
+        ImmutableHashSet.Create(StringComparer.Ordinal,
             "IsOAuth",
             "DisplayOrder");
 
     private static readonly ImmutableHashSet<string> UserForbiddenMembers =
-        ImmutableHashSet.Create(System.StringComparer.Ordinal,
+        ImmutableHashSet.Create(StringComparer.Ordinal,
             "GoogleEmail",
             "GetGoogleServiceEmail");
 

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -196,7 +196,7 @@ public sealed class TableDemoRow
 {
     public string Name { get; set; } = string.Empty;
     public decimal Amount { get; set; }
-    public NodaTime.Instant JoinedAt { get; set; }
+    public Instant JoinedAt { get; set; }
     public TicketAttendeeStatus Status { get; set; }
     public bool IsVip { get; set; }
 }

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -704,7 +704,7 @@ app.Use(async (context, next) =>
 {
     if (context.User.Identity?.IsAuthenticated == true
         && context.User.HasClaim(
-            System.Security.Claims.ClaimTypes.NameIdentifier,
+            ClaimTypes.NameIdentifier,
             Humans.Domain.Constants.SystemUserIds.GateTerminal.ToString()))
     {
         var path = context.Request.Path;

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -176,7 +176,7 @@ internal static class PillCounts
         var idClaim = http.HttpContext?.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
         if (idClaim is null || !Guid.TryParse(idClaim.Value, out var userId))
             return null;
-        var applications = sp.GetRequiredService<Humans.Governance.Contracts.IApplicationServiceRead>();
+        var applications = sp.GetRequiredService<Governance.Contracts.IApplicationServiceRead>();
         var count = await applications.GetUnvotedApplicationCountAsync(userId);
         return count > 0 ? count : null;
     }
@@ -190,7 +190,7 @@ internal static class PillCounts
 
     public static async ValueTask<int?> FeedbackQueue(IServiceProvider sp)
     {
-        var feedback = sp.GetRequiredService<Humans.Feedback.Contracts.IFeedbackServiceRead>();
+        var feedback = sp.GetRequiredService<Feedback.Contracts.IFeedbackServiceRead>();
         var count = await feedback.GetActionableCountAsync(CancellationToken.None);
         return count > 0 ? count : null;
     }

--- a/src/Humans.Web/Views/Guest/Index.cshtml
+++ b/src/Humans.Web/Views/Guest/Index.cshtml
@@ -52,7 +52,7 @@
                     </div>
                     @if (Model.TicketOrders.Count > 0)
                     {
-                        Func<Humans.Web.Models.GuestTicketOrderSummary, IHtmlContent> amountCell =
+                        Func<GuestTicketOrderSummary, IHtmlContent> amountCell =
                             r => new HtmlString($"{Html.Encode(r.TotalAmount.ToString("N2", CultureInfo.CurrentCulture))} {Html.Encode(r.Currency)}");
                         var ticketsTable = TableModel.For(Model.TicketOrders)
                             .Column(Localizer["Guest_TicketsHeader_Purchased"].Value, r => r.PurchasedAt.ToDate())

--- a/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
@@ -5,7 +5,7 @@
 
 @if (SignInManager.IsSignedIn(User))
 {
-    Humans.Users.Contracts.UserInfo? currentUser = null;
+    UserInfo? currentUser = null;
     if (Guid.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var currentUserId))
     {
         currentUser = await UserService.GetUserInfoAsync(currentUserId);

--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -488,9 +488,9 @@
                         ("stub", "<code>TicketStubInfo</code> — projection (attendee name + email, status, <code>HasPendingTransfer</code>, <code>PendingTransferRequestId</code>, <code>EarlyEntryDate</code>) from <code>ITicketServiceRead</code>")
                     )
                     <div class="wg-card-example" style="display:flex; gap:16px; flex-wrap:wrap;">
-                        <vc:ticket-stub stub="@(new Humans.Tickets.Contracts.TicketStubInfo("Sample Human", "sample@example.com", TicketAttendeeStatus.Valid, false, null, new NodaTime.LocalDate(2026, 8, 24)))" />
-                        <vc:ticket-stub stub="@(new Humans.Tickets.Contracts.TicketStubInfo("Sample Human", "sample@example.com", TicketAttendeeStatus.Valid, true, Guid.NewGuid(), null))" />
-                        <vc:ticket-stub stub="@(new Humans.Tickets.Contracts.TicketStubInfo("Sample Human", "sample@example.com", TicketAttendeeStatus.Void, false, null, null))" />
+                        <vc:ticket-stub stub="@(new TicketStubInfo("Sample Human", "sample@example.com", TicketAttendeeStatus.Valid, false, null, new NodaTime.LocalDate(2026, 8, 24)))" />
+                        <vc:ticket-stub stub="@(new TicketStubInfo("Sample Human", "sample@example.com", TicketAttendeeStatus.Valid, true, Guid.NewGuid(), null))" />
+                        <vc:ticket-stub stub="@(new TicketStubInfo("Sample Human", "sample@example.com", TicketAttendeeStatus.Void, false, null, null))" />
                     </div>
                 </div>
 

--- a/src/Sections/Humans.AuditLog/Contracts/IAuditViewerService.cs
+++ b/src/Sections/Humans.AuditLog/Contracts/IAuditViewerService.cs
@@ -80,7 +80,7 @@ public interface IAuditViewerService : IApplicationService
         string? entityType,
         Guid? entityId,
         Guid? userId,
-        IReadOnlyList<Humans.AuditLog.Contracts.AuditAction>? actions,
+        IReadOnlyList<AuditAction>? actions,
         int limit,
         CancellationToken ct = default);
 }

--- a/src/Sections/Humans.AuditLog/Models/AuditLogViewModels.cs
+++ b/src/Sections/Humans.AuditLog/Models/AuditLogViewModels.cs
@@ -4,7 +4,7 @@ namespace Humans.AuditLog.Models;
 
 internal sealed class AuditLogListViewModel() : PagedListViewModel(50)
 {
-    public IReadOnlyList<Humans.AuditLog.Contracts.AuditEvent> Events { get; set; } = [];
+    public IReadOnlyList<Contracts.AuditEvent> Events { get; set; } = [];
     public string? ActionFilter { get; set; }
     public int AnomalyCount { get; set; }
 }

--- a/src/Sections/Humans.AuditLog/Services/AuditViewerService.cs
+++ b/src/Sections/Humans.AuditLog/Services/AuditViewerService.cs
@@ -40,7 +40,7 @@ internal sealed class AuditViewerService(
         string? entityType,
         Guid? entityId,
         Guid? userId,
-        IReadOnlyList<Humans.AuditLog.Contracts.AuditAction>? actions,
+        IReadOnlyList<AuditAction>? actions,
         int limit,
         CancellationToken ct = default)
     {

--- a/src/Sections/Humans.AuditLog/Views/AuditLog/_Content.cshtml
+++ b/src/Sections/Humans.AuditLog/Views/AuditLog/_Content.cshtml
@@ -60,9 +60,9 @@
 }
 else
 {
-    Func<Humans.AuditLog.Contracts.AuditEvent, IHtmlContent> whenCell =
+    Func<AuditEvent, IHtmlContent> whenCell =
         @<text><span class="text-nowrap">@item.OccurredAt.ToInvariantTimestamp()</span></text>;
-    Func<Humans.AuditLog.Contracts.AuditEvent, IHtmlContent> actorCell = @<text>
+    Func<AuditEvent, IHtmlContent> actorCell = @<text>
         @if (!item.ActorUserId.HasValue)
         {
             <span class="badge bg-info">System</span>
@@ -72,15 +72,15 @@ else
             <vc:human user-id="@item.ActorUserId.Value" />
         }
     </text>;
-    Func<Humans.AuditLog.Contracts.AuditEvent, IHtmlContent> actionCell =
+    Func<AuditEvent, IHtmlContent> actionCell =
         @<text><span class="badge @item.Action.ToAuditBadgeClass()">@item.Action.ToAuditBadgeLabel()</span></text>;
-    Func<Humans.AuditLog.Contracts.AuditEvent, IHtmlContent> subjectCell = @<text>
+    Func<AuditEvent, IHtmlContent> subjectCell = @<text>
         @if (item.SubjectUserId.HasValue)
         {
             <vc:human user-id="@item.SubjectUserId.Value" />
         }
     </text>;
-    Func<Humans.AuditLog.Contracts.AuditEvent, IHtmlContent> targetCell = @<text>
+    Func<AuditEvent, IHtmlContent> targetCell = @<text>
         @if (item.TargetTeamId.HasValue && !string.IsNullOrEmpty(item.TargetTeamName))
         {
             <a asp-controller="Team" asp-action="Details" asp-route-slug="@item.TargetTeamSlug" class="text-decoration-none">@item.TargetTeamName</a>

--- a/src/Sections/Humans.Budget/Views/Budget/CategoryDetail.cshtml
+++ b/src/Sections/Humans.Budget/Views/Budget/CategoryDetail.cshtml
@@ -22,14 +22,14 @@
 }
 
 @functions {
-    private static NodaTime.LocalDate ComputeVatSettlementDate(NodaTime.LocalDate expectedDate)
+    private static LocalDate ComputeVatSettlementDate(LocalDate expectedDate)
     {
         var quarterEnd = expectedDate.Month switch
         {
-            >= 1 and <= 3 => new NodaTime.LocalDate(expectedDate.Year, 3, 31),
-            >= 4 and <= 6 => new NodaTime.LocalDate(expectedDate.Year, 6, 30),
-            >= 7 and <= 9 => new NodaTime.LocalDate(expectedDate.Year, 9, 30),
-            _ => new NodaTime.LocalDate(expectedDate.Year, 12, 31)
+            >= 1 and <= 3 => new LocalDate(expectedDate.Year, 3, 31),
+            >= 4 and <= 6 => new LocalDate(expectedDate.Year, 6, 30),
+            >= 7 and <= 9 => new LocalDate(expectedDate.Year, 9, 30),
+            _ => new LocalDate(expectedDate.Year, 12, 31)
         };
         return quarterEnd.PlusDays(45);
     }

--- a/src/Sections/Humans.Budget/Views/BudgetAdmin/AuditLog.cshtml
+++ b/src/Sections/Humans.Budget/Views/BudgetAdmin/AuditLog.cshtml
@@ -4,7 +4,7 @@
 @{
     ViewData["Title"] = "Budget Audit Log";
     var yearId = ViewBag.YearId as Guid?;
-    var years = ViewBag.Years as IReadOnlyList<Humans.Budget.Services.BudgetYearSummarySnapshot> ?? [];
+    var years = ViewBag.Years as IReadOnlyList<BudgetYearSummarySnapshot> ?? [];
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/Sections/Humans.Budget/Views/BudgetAdmin/CategoryDetail.cshtml
+++ b/src/Sections/Humans.Budget/Views/BudgetAdmin/CategoryDetail.cshtml
@@ -23,14 +23,14 @@
 }
 
 @functions {
-    private static NodaTime.LocalDate ComputeVatSettlementDate(NodaTime.LocalDate expectedDate)
+    private static LocalDate ComputeVatSettlementDate(LocalDate expectedDate)
     {
         var quarterEnd = expectedDate.Month switch
         {
-            >= 1 and <= 3 => new NodaTime.LocalDate(expectedDate.Year, 3, 31),
-            >= 4 and <= 6 => new NodaTime.LocalDate(expectedDate.Year, 6, 30),
-            >= 7 and <= 9 => new NodaTime.LocalDate(expectedDate.Year, 9, 30),
-            _ => new NodaTime.LocalDate(expectedDate.Year, 12, 31)
+            >= 1 and <= 3 => new LocalDate(expectedDate.Year, 3, 31),
+            >= 4 and <= 6 => new LocalDate(expectedDate.Year, 6, 30),
+            >= 7 and <= 9 => new LocalDate(expectedDate.Year, 9, 30),
+            _ => new LocalDate(expectedDate.Year, 12, 31)
         };
         return quarterEnd.PlusDays(45);
     }

--- a/src/Sections/Humans.Camps/Services/CampComplianceMatrixData.cs
+++ b/src/Sections/Humans.Camps/Services/CampComplianceMatrixData.cs
@@ -8,7 +8,7 @@ namespace Humans.Camps.Services;
 /// </summary>
 internal sealed record CampComplianceMatrixData(
     int Year,
-    IReadOnlyList<Humans.Camps.Contracts.CampRoleDefinitionInfo> Roles,
+    IReadOnlyList<CampRoleDefinitionInfo> Roles,
     IReadOnlyList<CampComplianceMatrixRow> Rows);
 
 /// <summary>

--- a/src/Sections/Humans.Camps/Services/CampRoleDrillDownData.cs
+++ b/src/Sections/Humans.Camps/Services/CampRoleDrillDownData.cs
@@ -6,7 +6,7 @@ namespace Humans.Camps.Services;
 /// for the requested role definition.
 /// </summary>
 internal sealed record CampRoleDrillDownData(
-    Humans.Camps.Contracts.CampRoleDefinitionInfo Definition,
+    CampRoleDefinitionInfo Definition,
     int Year,
     string? GroupEmail,
     IReadOnlyList<CampRoleDrillDownCampRow> Rows);

--- a/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
+++ b/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
@@ -3,7 +3,7 @@
 @* The placement strip's copy is City Planning's resource set, not SharedResource: the
    section carved its keys out at G5 (#866) and a Shell view cannot see them through the
    ambient Localizer. Shell references the section, so it injects the marker directly. *@
-@inject Microsoft.Extensions.Localization.IStringLocalizer<CityPlanningResource> CityPlanningLocalizer
+@inject IStringLocalizer<CityPlanningResource> CityPlanningLocalizer
 @{
     ViewData["Title"] = Model.Name;
     var isCityPlanningMember = ViewBag.IsCityPlanningTeamMember as bool? ?? false;

--- a/src/Sections/Humans.Camps/Views/CampAdmin/Index.cshtml
+++ b/src/Sections/Humans.Camps/Views/CampAdmin/Index.cshtml
@@ -169,13 +169,13 @@
 @* Withdrawn Camps *@
 @if (Model.WithdrawnCamps.Count > 0)
 {
-    Func<Humans.Camps.Models.CampCardViewModel, IHtmlContent> withdrawnNameCell =
+    Func<CampCardViewModel, IHtmlContent> withdrawnNameCell =
         @<text>
             <a asp-controller="Camp" asp-action="Details" asp-route-slug="@item.Slug">
                 @item.Name
             </a>
         </text>;
-    Func<Humans.Camps.Models.CampCardViewModel, IHtmlContent> withdrawnReactivateCell =
+    Func<CampCardViewModel, IHtmlContent> withdrawnReactivateCell =
         @<text>
             <form asp-controller="CampAdmin" asp-action="Reactivate" asp-route-seasonId="@item.SeasonId" method="post" class="d-inline">
                 @Html.AntiForgeryToken()

--- a/src/Sections/Humans.Debug/Controllers/DebugController.cs
+++ b/src/Sections/Humans.Debug/Controllers/DebugController.cs
@@ -225,7 +225,7 @@ internal sealed class DebugController(
                 Entries = snapshot.Select(e =>
                 {
                     entryCounts.TryGetValue(e.KeyType, out var activeCount);
-                    Humans.Application.CacheKeys.Metadata.TryGetValue(e.KeyType, out var meta);
+                    Application.CacheKeys.Metadata.TryGetValue(e.KeyType, out var meta);
                     return new CacheStatEntryViewModel
                     {
                         KeyType = e.KeyType,

--- a/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
@@ -356,7 +356,7 @@
                                         : $"{a.SupplierAccountNum} — {a.Name}";
                                     if (a.OwedToMember > 0) label += $" (owed {a.OwedToMember.ToEuro()})";
                                     if (a.Bindings.Any(b => b.UserId != submitterId)) label += " — bound to another member";
-                                    return new Microsoft.AspNetCore.Mvc.Rendering.SelectListItem
+                                    return new SelectListItem
                                     {
                                         Value = a.SupplierAccountNum.ToString(),
                                         Text = label,

--- a/src/Sections/Humans.Finance/Services/Service.cs
+++ b/src/Sections/Humans.Finance/Services/Service.cs
@@ -257,7 +257,7 @@ internal sealed class Service(
             Total = doc.Total,
             Currency = doc.Currency,
             IsApproved = !draftIds.Contains(doc.Id),
-            TagsJson = System.Text.Json.JsonSerializer.Serialize(tags),
+            TagsJson = JsonSerializer.Serialize(tags),
             BookedAccountId = bookedAccount,
             BudgetCategoryId = matchResult.CategoryId,
             MatchStatus = matchResult.CategoryId is null

--- a/src/Sections/Humans.Finance/Views/Finance/CreditorStatement.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/CreditorStatement.cshtml
@@ -1,7 +1,7 @@
 @model Humans.Finance.Contracts.HoldedCreditorLedger
 @{
     ViewData["Title"] = $"Creditor {Model.SupplierAccountNum}";
-    var lines = (IReadOnlyList<Humans.Finance.Contracts.CreditorLedgerLine>)ViewBag.Lines;
+    var lines = (IReadOnlyList<CreditorLedgerLine>)ViewBag.Lines;
 
     // Shown from the member's side: positive = the organisation owes them. The mirror keeps
     // Holded's sign (Σdebit − Σcredit); /Holded/Accounts/{num} below shows it unflipped.

--- a/src/Sections/Humans.Gate/Views/Gate/Index.cshtml
+++ b/src/Sections/Humans.Gate/Views/Gate/Index.cshtml
@@ -81,7 +81,7 @@
     </details>
 </div>
 
-@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
+@inject IFileVersionProvider FileVersionProvider
 @section Scripts {
     @* Shared keypad is a cache-busted classic script (no module import to go stale on the kiosk);
        the override panel uses it. Cache-bust the gate.js module import too (the tag-helper

--- a/src/Sections/Humans.Gate/Views/Gate/Pin.cshtml
+++ b/src/Sections/Humans.Gate/Views/Gate/Pin.cshtml
@@ -44,7 +44,7 @@
     <a asp-action="Claim" class="gate-pin-back">&larr; Not you? Pick a different name</a>
 </div>
 
-@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
+@inject IFileVersionProvider FileVersionProvider
 @section Scripts {
     @* The keypad itself is a cache-busted classic script (no module import to go stale); the
        page module wires it to the claim form. *@

--- a/src/Sections/Humans.GoogleIntegration/Views/Google/EmailRenames.cshtml
+++ b/src/Sections/Humans.GoogleIntegration/Views/Google/EmailRenames.cshtml
@@ -27,13 +27,13 @@
     }
     else
     {
-        Func<Humans.GoogleIntegration.Services.EmailRenameInfo, IHtmlContent> arrowCell =
+        Func<EmailRenameInfo, IHtmlContent> arrowCell =
             @<text><i class="fa-solid fa-arrow-right text-muted"></i></text>;
-        Func<Humans.GoogleIntegration.Services.EmailRenameInfo, IHtmlContent> oldEmailCell =
+        Func<EmailRenameInfo, IHtmlContent> oldEmailCell =
             @<text><code class="text-danger">@item.OldEmail</code></text>;
-        Func<Humans.GoogleIntegration.Services.EmailRenameInfo, IHtmlContent> newEmailCell =
+        Func<EmailRenameInfo, IHtmlContent> newEmailCell =
             @<text><code class="text-success">@item.NewEmail</code></text>;
-        Func<Humans.GoogleIntegration.Services.EmailRenameInfo, IHtmlContent> affectedCell = @<text>
+        Func<EmailRenameInfo, IHtmlContent> affectedCell = @<text>
             @if (item.AffectedResourceCount > 0)
             {
                 <span class="badge bg-warning text-dark">@item.AffectedResourceCount</span>

--- a/src/Sections/Humans.GoogleIntegration/Views/Google/GroupSettingsResults.cshtml
+++ b/src/Sections/Humans.GoogleIntegration/Views/Google/GroupSettingsResults.cshtml
@@ -83,11 +83,11 @@
 
             @if (report.HasDrift)
             {
-                Func<Humans.GoogleIntegration.Contracts.GroupSettingDrift, IHtmlContent> driftSettingCell =
+                Func<GroupSettingDrift, IHtmlContent> driftSettingCell =
                     @<text><code>@item.SettingName</code></text>;
-                Func<Humans.GoogleIntegration.Contracts.GroupSettingDrift, IHtmlContent> driftExpectedCell =
+                Func<GroupSettingDrift, IHtmlContent> driftExpectedCell =
                     @<text><span class="badge bg-success">@item.ExpectedValue</span></text>;
-                Func<Humans.GoogleIntegration.Contracts.GroupSettingDrift, IHtmlContent> driftActualCell =
+                Func<GroupSettingDrift, IHtmlContent> driftActualCell =
                     @<text><span class="badge bg-danger">@item.ActualValue</span></text>;
                 var driftTable = TableModel.For(report.Drifts)
                     .Template("Setting", driftSettingCell)

--- a/src/Sections/Humans.GoogleIntegration/Views/Google/_SyncOutboxTable.cshtml
+++ b/src/Sections/Humans.GoogleIntegration/Views/Google/_SyncOutboxTable.cshtml
@@ -14,13 +14,13 @@
 }
 else
 {
-    Func<Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEventSnapshot, IHtmlContent> eventTypeCell =
+    Func<GoogleSyncOutboxEventSnapshot, IHtmlContent> eventTypeCell =
         @<text><code>@item.EventType</code></text>;
-    Func<Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEventSnapshot, IHtmlContent> humanCell =
+    Func<GoogleSyncOutboxEventSnapshot, IHtmlContent> humanCell =
         @<text><vc:human user-id="@item.UserId" link="Admin" /></text>;
-    Func<Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEventSnapshot, IHtmlContent> googleEmailCell =
+    Func<GoogleSyncOutboxEventSnapshot, IHtmlContent> googleEmailCell =
         @<text><small class="text-muted">@googleEmailLookup.GetValueOrDefault(item.UserId, "unknown")</small></text>;
-    Func<Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEventSnapshot, IHtmlContent> resourceCell = evt =>
+    Func<GoogleSyncOutboxEventSnapshot, IHtmlContent> resourceCell = evt =>
     {
         var resources = resourceLookup.GetValueOrDefault(evt.TeamId);
         if (resources is { Count: > 0 })
@@ -32,7 +32,7 @@ else
         }
         return new HtmlString("<small class=\"text-muted\">-</small>");
     };
-    Func<Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEventSnapshot, IHtmlContent> retriesCell = @<text>
+    Func<GoogleSyncOutboxEventSnapshot, IHtmlContent> retriesCell = @<text>
         @if (item.RetryCount > 0)
         {
             <span class="badge bg-secondary">@item.RetryCount</span>
@@ -48,7 +48,7 @@ else
         .Template("Retries", retriesCell);
     if (showError)
     {
-        Func<Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEventSnapshot, IHtmlContent> errorCell = @<text>
+        Func<GoogleSyncOutboxEventSnapshot, IHtmlContent> errorCell = @<text>
             @if (!string.IsNullOrEmpty(item.LastError))
             {
                 <small class="text-danger" title="@item.LastError">
@@ -60,7 +60,7 @@ else
     }
     if (showRequeue)
     {
-        Func<Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEventSnapshot, IHtmlContent> requeueCell = @<text>
+        Func<GoogleSyncOutboxEventSnapshot, IHtmlContent> requeueCell = @<text>
             <form asp-action="RequeueOutboxEvent" asp-route-id="@item.Id" method="post">
                 @Html.AntiForgeryToken()
                 <button type="submit" class="btn btn-outline-warning btn-sm"

--- a/src/Sections/Humans.GoogleIntegration/Views/Google/_SyncTabContent.cshtml
+++ b/src/Sections/Humans.GoogleIntegration/Views/Google/_SyncTabContent.cshtml
@@ -174,10 +174,10 @@ else
                                 {
                                     var (stateLabel, badgeClass) = m.State switch
                                     {
-                                        Humans.GoogleIntegration.Contracts.MemberSyncState.Correct => ("Correct", "bg-success"),
-                                        Humans.GoogleIntegration.Contracts.MemberSyncState.Missing => ("Missing", "bg-warning text-dark"),
-                                        Humans.GoogleIntegration.Contracts.MemberSyncState.Inherited => ("Inherited", "bg-secondary"),
-                                        Humans.GoogleIntegration.Contracts.MemberSyncState.WrongRole => ("Wrong Role", "bg-info text-dark"),
+                                        MemberSyncState.Correct => ("Correct", "bg-success"),
+                                        MemberSyncState.Missing => ("Missing", "bg-warning text-dark"),
+                                        MemberSyncState.Inherited => ("Inherited", "bg-secondary"),
+                                        MemberSyncState.WrongRole => ("Wrong Role", "bg-info text-dark"),
                                         _ => ("Extra", "bg-danger")
                                     };
 

--- a/src/Sections/Humans.Governance/Views/Shared/_ApplicationsListContent.cshtml
+++ b/src/Sections/Humans.Governance/Views/Shared/_ApplicationsListContent.cshtml
@@ -46,18 +46,18 @@
 <div class="card">
     <div class="card-body p-0">
         @{
-            Func<Humans.Governance.Models.AdminApplicationViewModel, IHtmlContent> applicantCell =
+            Func<AdminApplicationViewModel, IHtmlContent> applicantCell =
                 @<text>
                     <vc:human user-id="@item.UserId" />
                     <div><small class="text-muted">@item.UserEmail</small></div>
                 </text>;
-            Func<Humans.Governance.Models.AdminApplicationViewModel, IHtmlContent> tierCell =
+            Func<AdminApplicationViewModel, IHtmlContent> tierCell =
                 @<text><span class="badge bg-info">@item.MembershipTier</span></text>;
-            Func<Humans.Governance.Models.AdminApplicationViewModel, IHtmlContent> statusCell =
+            Func<AdminApplicationViewModel, IHtmlContent> statusCell =
                 @<text><span class="badge @item.StatusBadgeClass">@item.Status</span></text>;
-            Func<Humans.Governance.Models.AdminApplicationViewModel, IHtmlContent> previewCell =
+            Func<AdminApplicationViewModel, IHtmlContent> previewCell =
                 @<text><small class="text-muted">@item.MotivationPreview</small></text>;
-            Func<Humans.Governance.Models.AdminApplicationViewModel, IHtmlContent> detailCell =
+            Func<AdminApplicationViewModel, IHtmlContent> detailCell =
                 @<text>
                     <a asp-action="AdminDetail" asp-route-id="@item.Id" class="btn btn-sm btn-outline-primary">
                         @SharedLocalizer["AdminApp_Review"]

--- a/src/Sections/Humans.Holded/Section.cs
+++ b/src/Sections/Humans.Holded/Section.cs
@@ -64,7 +64,7 @@ public sealed class Section : ISection
 
         services.AddScoped<IHoldedMirrorRepository, Repository>();
         services.AddScoped<Services.Service>();
-        services.AddScoped<Contracts.IHoldedService>(sp => sp.GetRequiredService<Services.Service>());
+        services.AddScoped<IHoldedService>(sp => sp.GetRequiredService<Services.Service>());
         services.AddScoped<Services.IHoldedAdminService>(sp => sp.GetRequiredService<Services.Service>());
 
         // The nightly pull's body (G5 step 6b). Its Hangfire target, HoldedSyncJob, is in

--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -88,7 +88,7 @@ internal sealed class HoldedClient : IHoldedClient
         using var content = new MultipartFormDataContent();
         var streamContent = new StreamContent(attachment.Content);
         streamContent.Headers.ContentType =
-            new System.Net.Http.Headers.MediaTypeHeaderValue(attachment.ContentType);
+            new MediaTypeHeaderValue(attachment.ContentType);
         content.Add(streamContent, "file", attachment.FileName);
 
         using var req = new HttpRequestMessage(HttpMethod.Post,

--- a/src/Sections/Humans.Scanner/Views/Scanner/Barcode.cshtml
+++ b/src/Sections/Humans.Scanner/Views/Scanner/Barcode.cshtml
@@ -62,7 +62,7 @@
     </div>
 </div>
 
-@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
+@inject IFileVersionProvider FileVersionProvider
 @section Scripts {
     @* Cache-bust the module import (the tag-helper asp-append-version can't reach an import
        statement) so a deployed update reaches long-cached tablets. Mirrors Gate/Index. *@

--- a/src/Sections/Humans.Scanner/Views/Scanner/Tickets.cshtml
+++ b/src/Sections/Humans.Scanner/Views/Scanner/Tickets.cshtml
@@ -63,7 +63,7 @@
     </div>
 </div>
 
-@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
+@inject IFileVersionProvider FileVersionProvider
 @section Scripts {
     @* Cache-bust the module import (the tag-helper asp-append-version can't reach an import
        statement) so a deployed update reaches long-cached tablets. Mirrors Gate/Index. *@

--- a/src/Sections/Humans.Store/Views/Store/Index.cshtml
+++ b/src/Sections/Humans.Store/Views/Store/Index.cshtml
@@ -122,9 +122,9 @@ else
 }
 else
 {
-    Func<Humans.Store.Services.Dtos.ProductDto, IHtmlContent> catalogDescriptionCell =
+    Func<ProductDto, IHtmlContent> catalogDescriptionCell =
         @<text>@Html.SanitizedMarkdown(item.Description)</text>;
-    Func<Humans.Store.Services.Dtos.ProductDto, IHtmlContent> catalogPriceCell =
+    Func<ProductDto, IHtmlContent> catalogPriceCell =
         @<text>
             @item.UnitPriceInclVatEur.ToEuro()
             <div class="text-muted small">(@item.UnitPriceEur.ToEuro() + @item.VatRatePercent.ToString("0.##", System.Globalization.CultureInfo.CurrentCulture)% VAT)</div>

--- a/src/Sections/Humans.Store/Views/StoreAdmin/Catalog.cshtml
+++ b/src/Sections/Humans.Store/Views/StoreAdmin/Catalog.cshtml
@@ -22,14 +22,14 @@
 }
 else
 {
-    Func<Humans.Store.Services.Dtos.ProductDto, IHtmlContent> catalogAdminNameCell = @<text>
+    Func<ProductDto, IHtmlContent> catalogAdminNameCell = @<text>
         <strong>@item.Name</strong>
         @if (!string.IsNullOrWhiteSpace(item.Description))
         {
             <div class="small text-muted">@Html.SanitizedMarkdown(item.Description)</div>
         }
     </text>;
-    Func<Humans.Store.Services.Dtos.ProductDto, IHtmlContent> catalogAdminStatusCell = @<text>
+    Func<ProductDto, IHtmlContent> catalogAdminStatusCell = @<text>
         @if (item.IsActive)
         {
             <span class="badge bg-success">Active</span>
@@ -39,7 +39,7 @@ else
             <span class="badge bg-secondary">Inactive</span>
         }
     </text>;
-    Func<Humans.Store.Services.Dtos.ProductDto, IHtmlContent> catalogAdminActionsCell = @<text>
+    Func<ProductDto, IHtmlContent> catalogAdminActionsCell = @<text>
         <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-outline-secondary">
             <i class="fa-solid fa-pen me-1"></i>Edit
         </a>

--- a/src/Sections/Humans.Teams/Views/Team/MyTeams.cshtml
+++ b/src/Sections/Humans.Teams/Views/Team/MyTeams.cshtml
@@ -18,17 +18,17 @@
     <div class="card mb-4">
         <div class="card-header">@Localizer["MyTeams_TeamMemberships"]</div>
         @{
-        Func<Humans.Teams.Models.MyTeamMembershipViewModel, IHtmlContent> membershipTeamCell = @<text>
+        Func<MyTeamMembershipViewModel, IHtmlContent> membershipTeamCell = @<text>
             <a asp-action="Details" asp-route-slug="@item.TeamSlug">@item.TeamName</a>
             @if (item.IsSystemTeam)
             {
                 <span class="badge bg-secondary ms-1">@Localizer["Teams_System"]</span>
             }
         </text>;
-        Func<Humans.Teams.Models.MyTeamMembershipViewModel, IHtmlContent> membershipRoleCell = @<text>
+        Func<MyTeamMembershipViewModel, IHtmlContent> membershipRoleCell = @<text>
             <partial name="_RoleBadge" model="@(item.IsCoordinator ? TeamMemberRole.Coordinator : TeamMemberRole.Member)" />
         </text>;
-        Func<Humans.Teams.Models.MyTeamMembershipViewModel, IHtmlContent> membershipActionsCell = @<text>
+        Func<MyTeamMembershipViewModel, IHtmlContent> membershipActionsCell = @<text>
             <a asp-action="Details" asp-route-slug="@item.TeamSlug" class="btn btn-sm btn-outline-primary">@SharedLocalizer["MyTeams_View"]</a>
             @if (item.IsCoordinator)
             {
@@ -72,11 +72,11 @@ else
     <div class="card">
         <div class="card-header">@Localizer["MyTeams_PendingRequests"]</div>
         @{
-        Func<Humans.Teams.Models.TeamJoinRequestSummaryViewModel, IHtmlContent> requestTeamCell =
+        Func<TeamJoinRequestSummaryViewModel, IHtmlContent> requestTeamCell =
             @<text><a asp-action="Details" asp-route-slug="@item.TeamSlug">@item.TeamName</a></text>;
-        Func<Humans.Teams.Models.TeamJoinRequestSummaryViewModel, IHtmlContent> requestStatusCell =
+        Func<TeamJoinRequestSummaryViewModel, IHtmlContent> requestStatusCell =
             @<text><span class="badge @item.StatusBadgeClass">@item.Status</span></text>;
-        Func<Humans.Teams.Models.TeamJoinRequestSummaryViewModel, IHtmlContent> requestWithdrawCell = @<text>
+        Func<TeamJoinRequestSummaryViewModel, IHtmlContent> requestWithdrawCell = @<text>
             <form asp-action="WithdrawRequest" asp-route-id="@item.Id" method="post" class="d-inline">
                 @Html.AntiForgeryToken()
                 <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="@Localizer["MyTeams_WithdrawConfirm"].Value">

--- a/src/Sections/Humans.Teams/Views/TeamAdmin/Members.cshtml
+++ b/src/Sections/Humans.Teams/Views/TeamAdmin/Members.cshtml
@@ -103,9 +103,9 @@
             <span class="badge bg-warning">@Model.PendingRequests.Count</span>
         </div>
         @{
-        Func<Humans.Teams.Models.TeamJoinRequestViewModel, IHtmlContent> pendingApplicantCell =
+        Func<TeamJoinRequestViewModel, IHtmlContent> pendingApplicantCell =
             @<text><vc:human user-id="@item.UserId" layout="AvatarName" size="32" /></text>;
-        Func<Humans.Teams.Models.TeamJoinRequestViewModel, IHtmlContent> pendingMessageCell = @<text>
+        Func<TeamJoinRequestViewModel, IHtmlContent> pendingMessageCell = @<text>
             @if (!string.IsNullOrEmpty(item.Message))
             {
                 <span style="white-space: pre-wrap;">@item.Message</span>
@@ -115,7 +115,7 @@
                 <span class="text-muted">@Localizer["TeamAdmin_NoMessage"]</span>
             }
         </text>;
-        Func<Humans.Teams.Models.TeamJoinRequestViewModel, IHtmlContent> pendingActionsCell = @<text>
+        Func<TeamJoinRequestViewModel, IHtmlContent> pendingActionsCell = @<text>
             <div class="d-flex gap-1">
                 <form asp-action="ApproveRequest" asp-route-slug="@Model.TeamSlug" asp-route-requestId="@item.Id" method="post" class="d-inline">
                     @Html.AntiForgeryToken()

--- a/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
+++ b/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
@@ -134,7 +134,7 @@
                 <div class="px-3 py-2">
                     <small class="text-muted">
                         <i class="fa-solid fa-circle-info"></i>
-                        VAT is computed at 10% on ticket revenue only (up to @(Humans.Tickets.Contracts.TicketConstants.VipThresholdEuros.ToString("N0")) EUR per ticket).
+                        VAT is computed at 10% on ticket revenue only (up to @TicketConstants.VipThresholdEuros.ToString("N0") EUR per ticket).
                         Amounts above this threshold are classified as VIP donations (VAT-free).
                         Standalone donations from TicketTailor are also VAT-free.
                     </small>

--- a/src/Sections/Humans.Users/Controllers/ProfileController.cs
+++ b/src/Sections/Humans.Users/Controllers/ProfileController.cs
@@ -2120,7 +2120,7 @@ internal sealed class ProfileController(
     // ─── Helpers ─────────────────────────────────────────────────────
 
     private (byte[] Data, string ContentType)? ResizeProfilePicture(byte[] imageData) =>
-        Humans.Users.Helpers.ProfilePictureProcessor.ResizeProfilePicture(imageData, logger);
+        Helpers.ProfilePictureProcessor.ResizeProfilePicture(imageData, logger);
 
     private async Task<EmailsViewModel> BuildEmailsViewModelAsync(User user, bool isAdminContext = false, CancellationToken ct = default)
     {

--- a/src/Sections/Humans.Users/Views/ProfilePictureMigrationAdmin/Index.cshtml
+++ b/src/Sections/Humans.Users/Views/ProfilePictureMigrationAdmin/Index.cshtml
@@ -84,7 +84,7 @@
         <div class="card-header">DB-only profile pictures</div>
         @{
             var dbOnlyRows = snapshot.DbOnlyRows.OrderByDescending(r => r.UpdatedAt).ToList();
-            Func<Humans.Users.Contracts.ProfilePictureMigrationRow, Microsoft.AspNetCore.Html.IHtmlContent> profileIdCell =
+            Func<ProfilePictureMigrationRow, IHtmlContent> profileIdCell =
                 @<text><code>@item.ProfileId</code></text>;
             var migrationTable = TableModel.For(dbOnlyRows)
                 .Template("Profile id", profileIdCell, c => c.NoSort())

--- a/src/Sections/Humans.Users/Views/Shared/_RolesListContent.cshtml
+++ b/src/Sections/Humans.Users/Views/Shared/_RolesListContent.cshtml
@@ -44,15 +44,15 @@
 <div class="card">
     <div class="card-body p-0">
         @{
-            Func<Humans.Users.Models.AdminRoleAssignmentViewModel, IHtmlContent> userCell =
+            Func<AdminRoleAssignmentViewModel, IHtmlContent> userCell =
                 @<text>
                     <vc:human user-id="@item.UserId" link="Admin" />
                     <br />
                     <small class="text-muted">@item.UserEmail</small>
                 </text>;
-            Func<Humans.Users.Models.AdminRoleAssignmentViewModel, IHtmlContent> roleCell =
+            Func<AdminRoleAssignmentViewModel, IHtmlContent> roleCell =
                 @<text><strong>@item.RoleName</strong></text>;
-            Func<Humans.Users.Models.AdminRoleAssignmentViewModel, IHtmlContent> validToCell =
+            Func<AdminRoleAssignmentViewModel, IHtmlContent> validToCell =
                 @<text>
                     @if (item.ValidTo.HasValue)
                     {
@@ -63,7 +63,7 @@
                         <span class="text-muted">-</span>
                     }
                 </text>;
-            Func<Humans.Users.Models.AdminRoleAssignmentViewModel, IHtmlContent> statusCell =
+            Func<AdminRoleAssignmentViewModel, IHtmlContent> statusCell =
                 @<text>
                     @if (item.IsActive)
                     {
@@ -74,7 +74,7 @@
                         <span class="badge bg-secondary">@Localizer["AdminHuman_Ended"]</span>
                     }
                 </text>;
-            Func<Humans.Users.Models.AdminRoleAssignmentViewModel, IHtmlContent> actionCell =
+            Func<AdminRoleAssignmentViewModel, IHtmlContent> actionCell =
                 @<text>
                     @if (item.IsActive)
                     {

--- a/tests/Humans.Agent.Tests/AgentToolDispatcherTests.cs
+++ b/tests/Humans.Agent.Tests/AgentToolDispatcherTests.cs
@@ -96,7 +96,7 @@ public class AgentToolDispatcherTests
         new(
             Id: Guid.NewGuid(),
             OccurredAt: NodaTime.Instant.FromUtc(2026, 4, 30, 17, 0),
-            Action: Humans.AuditLog.Contracts.AuditAction.ShiftSignupVoluntold,
+            Action: AuditLog.Contracts.AuditAction.ShiftSignupVoluntold,
             ActorUserId: actor,
             ActorDisplayName: "Frank",
             EntityType: "ShiftSignup",
@@ -121,7 +121,7 @@ public class AgentToolDispatcherTests
         new(
             Id: Guid.NewGuid(),
             OccurredAt: NodaTime.Instant.FromUtc(2026, 4, 30, 17, 0),
-            Action: Humans.AuditLog.Contracts.AuditAction.AnomalousPermissionDetected,
+            Action: AuditLog.Contracts.AuditAction.AnomalousPermissionDetected,
             ActorUserId: null,
             ActorDisplayName: null,
             EntityType: "GoogleResource",
@@ -155,7 +155,7 @@ public class AgentToolDispatcherTests
 
         var shiftView = MakeViewFor(viewer, signups);
 
-        var burnSettings = Substitute.For<Humans.Shifts.Contracts.IBurnSettingsService>();
+        var burnSettings = Substitute.For<IBurnSettingsService>();
         burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
@@ -186,7 +186,7 @@ public class AgentToolDispatcherTests
 
         var shiftView = MakeViewFor(viewer, [signup]);
 
-        var burnSettings = Substitute.For<Humans.Shifts.Contracts.IBurnSettingsService>();
+        var burnSettings = Substitute.For<IBurnSettingsService>();
         burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
@@ -211,7 +211,7 @@ public class AgentToolDispatcherTests
 
         var shiftView = MakeViewFor(viewer, []);
 
-        var burnSettings = Substitute.For<Humans.Shifts.Contracts.IBurnSettingsService>();
+        var burnSettings = Substitute.For<IBurnSettingsService>();
         burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
@@ -239,7 +239,7 @@ public class AgentToolDispatcherTests
         // Viewer has zero signups in their cached view.
         var shiftView = MakeViewFor(viewer, []);
 
-        var burnSettings = Substitute.For<Humans.Shifts.Contracts.IBurnSettingsService>();
+        var burnSettings = Substitute.For<IBurnSettingsService>();
         burnSettings.GetActiveAsync(Arg.Any<CancellationToken>()).Returns(ev);
 
         var dispatcher = MakeDispatcher(shiftView: shiftView, burnSettings: burnSettings);
@@ -266,7 +266,7 @@ public class AgentToolDispatcherTests
         result.Content.Should().Contain("must be a valid GUID");
     }
 
-    private static Humans.Shifts.Contracts.BurnSettingsInfo MakeEventSettings() => new(
+    private static BurnSettingsInfo MakeEventSettings() => new(
         Id: Guid.NewGuid(),
         EventName: "Test",
         Year: 2026,
@@ -292,7 +292,7 @@ public class AgentToolDispatcherTests
     /// <c>RenderShiftDetails</c> reads resolved against
     /// <see cref="MakeEventSettings"/> exactly as the section's projection does.
     /// </summary>
-    private static Humans.Shifts.Contracts.ShiftSignupSummary MakeShift(
+    private static ShiftSignupSummary MakeShift(
         RotaStub rota, int dayOffset, bool isAllDay,
         NodaTime.LocalTime? startTime = null, double durationHours = 0)
     {
@@ -314,9 +314,9 @@ public class AgentToolDispatcherTests
             absoluteEnd: date.At(end).InZoneLeniently(tz).ToInstant());
     }
 
-    private static Humans.Shifts.Contracts.ShiftSignupSummary MakeSignup(
+    private static ShiftSignupSummary MakeSignup(
         Guid? signupBlockId,
-        Humans.Shifts.Contracts.ShiftSignupSummary shift,
+        ShiftSignupSummary shift,
         SignupStatus status) =>
         shift with { Id = Guid.NewGuid(), SignupBlockId = signupBlockId, Status = status };
 
@@ -455,7 +455,7 @@ public class AgentToolDispatcherTests
     }
 
     /// <summary>A source whose folder listing is broken (revoked token, GitHub outage).</summary>
-    private sealed class UnlistableGuideSource : Humans.Application.Interfaces.IGuideContentSource
+    private sealed class UnlistableGuideSource : Application.Interfaces.IGuideContentSource
     {
         public Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default) =>
             throw new Octokit.NotFoundException("missing", System.Net.HttpStatusCode.NotFound);
@@ -469,9 +469,9 @@ public class AgentToolDispatcherTests
 
     private static AgentToolDispatcher MakeDispatcher(
         Humans.AuditLog.Contracts.IAuditViewerService? auditViewer = null,
-        Humans.Shifts.Contracts.IShiftView? shiftView = null,
-        Humans.Shifts.Contracts.IBurnSettingsService? burnSettings = null,
-        Humans.Application.Interfaces.IGuideContentSource? source = null)
+        IShiftView? shiftView = null,
+        IBurnSettingsService? burnSettings = null,
+        Application.Interfaces.IGuideContentSource? source = null)
     {
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
@@ -494,12 +494,12 @@ public class AgentToolDispatcherTests
             features,
             community,
             auditViewer ?? new StubAuditViewer(),
-            shiftView ?? Substitute.For<Humans.Shifts.Contracts.IShiftView>(),
-            burnSettings ?? Substitute.For<Humans.Shifts.Contracts.IBurnSettingsService>(),
+            shiftView ?? Substitute.For<IShiftView>(),
+            burnSettings ?? Substitute.For<IBurnSettingsService>(),
             logger);
     }
 
-    private sealed class StubGuideSource : Humans.Application.Interfaces.IGuideContentSource
+    private sealed class StubGuideSource : Application.Interfaces.IGuideContentSource
     {
         /// <summary>The only feature specs this stub repo contains — anything else 404s like GitHub would.</summary>
         internal static readonly string[] FeatureStems = ["26-events", "gate-admissions"];
@@ -526,13 +526,13 @@ public class AgentToolDispatcherTests
                         : []);
     }
 
-    private static Humans.Shifts.Contracts.IShiftView MakeViewFor(
-        Guid userId, IReadOnlyList<Humans.Shifts.Contracts.ShiftSignupSummary> signups)
+    private static IShiftView MakeViewFor(
+        Guid userId, IReadOnlyList<ShiftSignupSummary> signups)
     {
-        var view = Substitute.For<Humans.Shifts.Contracts.IShiftView>();
+        var view = Substitute.For<IShiftView>();
         var record = ShiftFixtures.UserSummary(userId, signups);
         view.GetUserAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<Humans.Shifts.Contracts.ShiftUserSummary>(record));
+            .Returns(new ValueTask<ShiftUserSummary>(record));
         return view;
     }
 

--- a/tests/Humans.Auth.Tests/Services/RoleAssignmentServiceTests.cs
+++ b/tests/Humans.Auth.Tests/Services/RoleAssignmentServiceTests.cs
@@ -301,7 +301,7 @@ public sealed class RoleAssignmentServiceTests : AuthTestHarness
 
         slices.Should().ContainSingle();
         slices[0].SectionName.Should().Be(
-            Humans.Gdpr.Contracts.GdprExportSections.RoleAssignments);
+            Gdpr.Contracts.GdprExportSections.RoleAssignments);
     }
 
     private Task SeedUserAsync(Guid userId, string displayName)

--- a/tests/Humans.Calendar.Tests/Services/CalendarServiceValidationTests.cs
+++ b/tests/Humans.Calendar.Tests/Services/CalendarServiceValidationTests.cs
@@ -170,7 +170,7 @@ public class CalendarServiceValidationTests
         var repo = Substitute.For<ICalendarRepository>();
         var audit = Substitute.For<IAuditLogService>();
         audit.LogAsync(
-                Arg.Any<Humans.AuditLog.Contracts.AuditAction>(),
+                Arg.Any<AuditAction>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<Guid?>(), Arg.Any<string?>())
@@ -224,7 +224,7 @@ public class CalendarServiceValidationTests
 
         var audit = Substitute.For<IAuditLogService>();
         audit.LogAsync(
-                Arg.Any<Humans.AuditLog.Contracts.AuditAction>(),
+                Arg.Any<AuditAction>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<Guid?>(), Arg.Any<string?>())
@@ -258,7 +258,7 @@ public class CalendarServiceValidationTests
 
         var audit = Substitute.For<IAuditLogService>();
         audit.LogAsync(
-                Arg.Any<Humans.AuditLog.Contracts.AuditAction>(),
+                Arg.Any<AuditAction>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<Guid?>(), Arg.Any<string?>())
@@ -278,7 +278,7 @@ public class CalendarServiceValidationTests
         var repo = Substitute.For<ICalendarRepository>();
         var audit = Substitute.For<IAuditLogService>();
         audit.LogAsync(
-                Arg.Any<Humans.AuditLog.Contracts.AuditAction>(),
+                Arg.Any<AuditAction>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<Guid?>(), Arg.Any<string?>())

--- a/tests/Humans.Camps.Tests/Data/CampRepositoryTests.cs
+++ b/tests/Humans.Camps.Tests/Data/CampRepositoryTests.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
 
-namespace Humans.Camps.Tests.Repositories;
+namespace Humans.Camps.Tests.Data;
 
 public sealed class CampRepositoryTests : IDisposable
 {

--- a/tests/Humans.Camps.Tests/Domain/CampSeasonTests.cs
+++ b/tests/Humans.Camps.Tests/Domain/CampSeasonTests.cs
@@ -3,7 +3,7 @@ using Humans.Domain.Enums;
 using NodaTime;
 using Xunit;
 
-namespace Humans.Camps.Tests.Entities;
+namespace Humans.Camps.Tests.Domain;
 
 public class CampSeasonTests
 {

--- a/tests/Humans.Camps.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Camps.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -42,7 +42,7 @@ internal static class UserInfoStubHelpers
                 BurnerName = displayName,
                 CreatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
                 UpdatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
-                State = Humans.Users.Contracts.ProfileState.Active,
+                State = ProfileState.Active,
                 IsApproved = true
             },
             [],

--- a/tests/Humans.Camps.Tests/Services/CachingCampServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CachingCampServiceTests.cs
@@ -90,7 +90,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
     public async Task CreateCampForSeedAsync_MakesTheNewCampVisibleToListReads()
     {
         await SeedSettingsAsync(publicYear: 2026, openSeasons: [2026]);
-        var ct = Xunit.TestContext.Current.CancellationToken;
+        var ct = TestContext.Current.CancellationToken;
 
         // Warm the snapshot first — this is the state the bug needs to show up in.
         var before = await _service.GetCampsForYearAsync(2026, ct);
@@ -158,7 +158,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         await SeedActiveMemberAsync(season.Id, hasEarlyEntry: false);
 
         // First read drives the warmup path (GetCampsWithLeadsForYearAsync).
-        var initial = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        var initial = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
         var warmedSeason = initial
             .Single(c => c.Id == camp.Id)
             .Seasons.Single(s => s.Year == 2026);
@@ -172,11 +172,11 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         var third = CampsDb.CampMembers
             .First(m => m.CampSeasonId == season.Id && !m.HasEarlyEntry);
         third.HasEarlyEntry = true;
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
-        await _service.InvalidateCampAsync(camp.Id, Xunit.TestContext.Current.CancellationToken);
+        await _service.InvalidateCampAsync(camp.Id, TestContext.Current.CancellationToken);
 
-        var refreshed = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        var refreshed = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
         var refreshedSeason = refreshed
             .Single(c => c.Id == camp.Id)
             .Seasons.Single(s => s.Year == 2026);
@@ -196,7 +196,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         await SeedCampWithSeasonAsync(year: 2026);
 
         // Drive warmup once so the warm-year set is populated.
-        _ = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        _ = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
 
         // Request a cold year — must NOT return empty even though the snapshot
         // has no rows for 2023. Inner-substitute returns a known sentinel.
@@ -215,7 +215,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
             .GetCampsForYearAsync(2023, Arg.Any<CancellationToken>())
             .Returns(coldYearResult);
 
-        var actual = await _service.GetCampsForYearAsync(2023, Xunit.TestContext.Current.CancellationToken);
+        var actual = await _service.GetCampsForYearAsync(2023, TestContext.Current.CancellationToken);
 
         actual.Should().BeEquivalentTo(coldYearResult,
             because: "years outside the warm scope must fall back to the inner service rather than return an empty snapshot slice");
@@ -228,9 +228,9 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         await SeedSettingsAsync(publicYear: 2026, openSeasons: [2026]);
         await SeedCampWithSeasonAsync(year: 2026);
 
-        _ = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        _ = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
         _innerSubstitute.ClearReceivedCalls();
-        _ = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        _ = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
 
         await _innerSubstitute
             .DidNotReceive()
@@ -284,10 +284,10 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         _innerSubstitute.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
             .Returns(cachedCamps);
 
-        _ = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        _ = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
         _innerSubstitute.ClearReceivedCalls();
 
-        var camp = (await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken)).Single(c => c.Id == campId);
+        var camp = (await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken)).Single(c => c.Id == campId);
         camp.IsLead(leadUserId).Should().BeTrue();
 
         await _innerSubstitute
@@ -340,10 +340,10 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         _innerSubstitute.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
             .Returns(cachedCamps);
 
-        _ = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        _ = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
         _innerSubstitute.ClearReceivedCalls();
 
-        var actual = await _service.GetCampSeasonByIdAsync(seasonId, Xunit.TestContext.Current.CancellationToken);
+        var actual = await _service.GetCampSeasonByIdAsync(seasonId, TestContext.Current.CancellationToken);
 
         actual.Should().BeSameAs(cachedSeason);
         await _innerSubstitute
@@ -357,11 +357,11 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         await SeedSettingsAsync(publicYear: 2026, openSeasons: [2026]);
         var (camp, season) = await SeedCampWithSeasonAsync(year: 2026);
 
-        _ = await _service.GetCampsForYearAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        _ = await _service.GetCampsForYearAsync(2026, TestContext.Current.CancellationToken);
         _innerSubstitute.ClearReceivedCalls();
         _innerRoleAccess.ClearReceivedCalls();
 
-        var result = await _service.GetCampSeasonsForComplianceAsync(2026, Xunit.TestContext.Current.CancellationToken);
+        var result = await _service.GetCampSeasonsForComplianceAsync(2026, TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle(item =>
             item.CampId == camp.Id &&
@@ -386,7 +386,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         await SeedActiveMemberAsync(season.Id, hasEarlyEntry: false);
         await SeedMemberAsync(season.Id, CampMemberStatus.Pending, hasEarlyEntry: true);
 
-        var grants = await _service.GetEarlyEntriesAsync(Xunit.TestContext.Current.CancellationToken);
+        var grants = await _service.GetEarlyEntriesAsync(TestContext.Current.CancellationToken);
 
         grants.Should().ContainSingle()
             .Which.Should().Be(new EarlyEntryGrant(granted.UserId, eeStartDate, "Camp: Test Camp"));
@@ -401,7 +401,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         List<int> openSeasons,
         LocalDate? eeStartDate = null)
     {
-        if (!await CampsDb.CampSettings.AnyAsync(Xunit.TestContext.Current.CancellationToken))
+        if (!await CampsDb.CampSettings.AnyAsync(TestContext.Current.CancellationToken))
         {
             CampsDb.CampSettings.Add(new CampSettings
             {
@@ -410,7 +410,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
                 OpenSeasons = openSeasons,
                 EeStartDate = eeStartDate
             });
-            await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+            await SaveAllAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -420,7 +420,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         await SeedSettingsAsync(publicYear: 2026, openSeasons: [2026]);
         var (camp, _) = await SeedCampWithSeasonAsync(year: 2026); // season "Test Camp", Active
 
-        var results = await _service.SearchAsync("test camp", int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+        var results = await _service.SearchAsync("test camp", int.MaxValue, TestContext.Current.CancellationToken);
 
         var hit = results.Should().ContainSingle().Subject;
         hit.Slug.Should().Be(camp.Slug);
@@ -449,7 +449,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         await SeedCampWithSeasonAsync(year: 2026, status);
 
         var results = await _service.SearchAsync(
-            "test camp", int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+            "test camp", int.MaxValue, TestContext.Current.CancellationToken);
 
         results.Should().BeEmpty();
     }
@@ -463,7 +463,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         var (camp, _) = await SeedCampWithSeasonAsync(year: 2026, CampSeasonStatus.Pending);
 
         var results = await _service.SearchAsync(
-            camp.Id.ToString(), int.MaxValue, Xunit.TestContext.Current.CancellationToken);
+            camp.Id.ToString(), int.MaxValue, TestContext.Current.CancellationToken);
 
         results.Should().ContainSingle().Which.Slug.Should().Be(camp.Slug);
     }
@@ -504,7 +504,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
         };
         CampsDb.Camps.Add(camp);
         CampsDb.CampSeasons.Add(season);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
         return (camp, season);
     }
 
@@ -527,7 +527,7 @@ public sealed class CachingCampServiceTests : CampsTestHarness
             HasEarlyEntry = hasEarlyEntry,
         };
         CampsDb.CampMembers.Add(member);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
         return member;
     }
 

--- a/tests/Humans.Camps.Tests/Services/CampContactServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampContactServiceTests.cs
@@ -69,7 +69,7 @@ public class CampContactServiceTests : IDisposable
             "alice@example.com");
 
         await _auditLogService.Received(1).LogAsync(
-            Arg.Any<Humans.AuditLog.Contracts.AuditAction>(),
+            Arg.Any<AuditAction>(),
             Arg.Any<string>(),
             _campId,
             Arg.Any<string>(),

--- a/tests/Humans.Camps.Tests/Services/CampRoleServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampRoleServiceTests.cs
@@ -774,7 +774,7 @@ public sealed class CampRoleServiceTests : CampsTestHarness
         {
             Id = Guid.NewGuid(),
             Name = name,
-            Slug = slug ?? Humans.Application.Helpers.SlugHelper.GenerateSlug(name) + "-" + Guid.NewGuid().ToString("N").Substring(0, 6),
+            Slug = slug ?? Application.Helpers.SlugHelper.GenerateSlug(name) + "-" + Guid.NewGuid().ToString("N").Substring(0, 6),
             SlotCount = slotCount,
             MinimumRequired = minimumRequired,
             CreatedAt = Clock.GetCurrentInstant(),

--- a/tests/Humans.Containers.Tests/Authorization/ContainerAuthorizationHandlerTests.cs
+++ b/tests/Humans.Containers.Tests/Authorization/ContainerAuthorizationHandlerTests.cs
@@ -1,16 +1,16 @@
-using Humans.Containers.Authorization;
-using Humans.Containers.Contracts;
 using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Camps.Contracts;
 using Humans.CityPlanning.Contracts;
+using Humans.Containers.Authorization;
+using Humans.Containers.Contracts;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Microsoft.AspNetCore.Authorization;
 using NodaTime;
 using NSubstitute;
 
-namespace Humans.Containers.Tests;
+namespace Humans.Containers.Tests.Authorization;
 
 public sealed class ContainerAuthorizationHandlerTests
 {

--- a/tests/Humans.Containers.Tests/Services/ServiceImageTests.cs
+++ b/tests/Humans.Containers.Tests/Services/ServiceImageTests.cs
@@ -1,5 +1,4 @@
 using AwesomeAssertions;
-using Xunit;
 using Humans.Application.Interfaces;
 using Humans.AuditLog.Contracts;
 using Humans.Camps.Contracts;
@@ -11,8 +10,9 @@ using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Xunit;
 
-namespace Humans.Containers.Tests;
+namespace Humans.Containers.Tests.Services;
 
 public sealed class ServiceImageTests
 {

--- a/tests/Humans.Containers.Tests/Services/ServiceImageTests.cs
+++ b/tests/Humans.Containers.Tests/Services/ServiceImageTests.cs
@@ -56,7 +56,7 @@ public sealed class ServiceImageTests
             UpdatedAt = StartTime,
         };
         ctx.Containers.Add(container);
-        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
         return container;
     }
 
@@ -67,7 +67,7 @@ public sealed class ServiceImageTests
             CampId: CampId,
             Name: "Test",
             Description: null,
-            MainImage: FakeImage()), ct: Xunit.TestContext.Current.CancellationToken);
+            MainImage: FakeImage()), ct: TestContext.Current.CancellationToken);
 
         result.CampId.Should().Be(CampId);
         result.ImageStoragePath.Should().StartWith($"/uploads/containers/{result.Id}/");
@@ -87,11 +87,11 @@ public sealed class ServiceImageTests
             CampId: container.CampId,
             Name: container.Name,
             Description: null,
-            RemoveMainImage: true), actorUserId: Guid.NewGuid(), ct: Xunit.TestContext.Current.CancellationToken);
+            RemoveMainImage: true), actorUserId: Guid.NewGuid(), ct: TestContext.Current.CancellationToken);
 
         await _fileStorage.Received(1).DeleteAsync("uploads/containers/id/main-guid.jpg", Arg.Any<CancellationToken>());
 
-        var updated = await _sut.GetByIdAsync(container.Id, Xunit.TestContext.Current.CancellationToken);
+        var updated = await _sut.GetByIdAsync(container.Id, TestContext.Current.CancellationToken);
         updated!.ImageStoragePath.Should().BeNull();
     }
 
@@ -104,11 +104,11 @@ public sealed class ServiceImageTests
             CampId: container.CampId,
             Name: container.Name,
             Description: null,
-            MainImage: FakeImage()), actorUserId: Guid.NewGuid(), ct: Xunit.TestContext.Current.CancellationToken);
+            MainImage: FakeImage()), actorUserId: Guid.NewGuid(), ct: TestContext.Current.CancellationToken);
 
         await _fileStorage.Received(1).DeleteAsync("uploads/containers/id/main-old.jpg", Arg.Any<CancellationToken>());
 
-        var updated = await _sut.GetByIdAsync(container.Id, Xunit.TestContext.Current.CancellationToken);
+        var updated = await _sut.GetByIdAsync(container.Id, TestContext.Current.CancellationToken);
         updated!.ImageStoragePath.Should().StartWith($"/uploads/containers/{container.Id}/");
         updated.ImageStoragePath.Should().EndWith(".jpg");
     }
@@ -118,7 +118,7 @@ public sealed class ServiceImageTests
     {
         var container = await SeedContainerAsync(imagePath: "uploads/containers/id/main.jpg");
 
-        await _sut.DeleteAsync(container.Id, actorUserId: Guid.NewGuid(), ct: Xunit.TestContext.Current.CancellationToken);
+        await _sut.DeleteAsync(container.Id, actorUserId: Guid.NewGuid(), ct: TestContext.Current.CancellationToken);
 
         await _fileStorage.Received(1).DeleteAsync("uploads/containers/id/main.jpg", Arg.Any<CancellationToken>());
     }
@@ -132,7 +132,7 @@ public sealed class ServiceImageTests
         var act = async () => await _sut.CreateAsync(actorUserId: Guid.NewGuid(), data: new ContainerData(
             CampId: CampId,
             Name: name,
-            Description: null), ct: Xunit.TestContext.Current.CancellationToken);
+            Description: null), ct: TestContext.Current.CancellationToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*must not contain*");
@@ -145,7 +145,7 @@ public sealed class ServiceImageTests
             CampId: CampId,
             Name: "Bad",
             Description: null,
-            MainImage: new(Stream.Null, "image/jpeg", "trojan.html", 1024)), ct: Xunit.TestContext.Current.CancellationToken);
+            MainImage: new(Stream.Null, "image/jpeg", "trojan.html", 1024)), ct: TestContext.Current.CancellationToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*end in .jpg*");

--- a/tests/Humans.Containers.Tests/Services/ServicePlacementTests.cs
+++ b/tests/Humans.Containers.Tests/Services/ServicePlacementTests.cs
@@ -10,7 +10,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 
-namespace Humans.Containers.Tests;
+namespace Humans.Containers.Tests.Services;
 
 public sealed class ServicePlacementTests
 {

--- a/tests/Humans.Events.Tests/Controllers/EventsApiControllerTests.cs
+++ b/tests/Humans.Events.Tests/Controllers/EventsApiControllerTests.cs
@@ -1,17 +1,17 @@
 using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Camps.Contracts;
-using Humans.Events.Services;
+using Humans.Events.Contracts;
 using Humans.Events.Controllers;
 using Humans.Events.Models;
+using Humans.Events.Services;
+using Humans.Users.Contracts;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using NSubstitute;
-using Humans.Events.Contracts;
-using Humans.Users.Contracts;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Controllers;
 
 /// <summary>
 /// Host-attribution coverage for <see cref="EventsApiController"/> (US-26.3 / US-26.6).

--- a/tests/Humans.Events.Tests/Controllers/EventsControllerTests.cs
+++ b/tests/Humans.Events.Tests/Controllers/EventsControllerTests.cs
@@ -1,22 +1,22 @@
 using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Camps.Contracts;
-using Humans.Events.Services;
-using Humans.Shifts.Contracts;
 using Humans.Domain.Constants;
-using Humans.Events.Domain;
 using Humans.Events.Contracts;
 using Humans.Events.Controllers;
+using Humans.Events.Domain;
 using Humans.Events.Models;
+using Humans.Events.Services;
+using Humans.Shifts.Contracts;
+using Humans.Users.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
-using Humans.Users.Contracts;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Controllers;
 
 /// <summary>
 /// Authorization coverage for the individual-event edit route

--- a/tests/Humans.Events.Tests/Data/RepositoryTests.cs
+++ b/tests/Humans.Events.Tests/Data/RepositoryTests.cs
@@ -1,13 +1,12 @@
 using AwesomeAssertions;
-
-using Humans.Events.Domain;
 using Humans.Events.Contracts;
 using Humans.Events.Data;
+using Humans.Events.Domain;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Data;
 
 public sealed class EventRepositoryTests : IDisposable
 {

--- a/tests/Humans.Events.Tests/Domain/EventTests.cs
+++ b/tests/Humans.Events.Tests/Domain/EventTests.cs
@@ -5,7 +5,7 @@ using NodaTime;
 using NodaTime.Testing;
 using Xunit;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Domain;
 
 public sealed class EventTests
 {

--- a/tests/Humans.Events.Tests/Services/BulkEventCsvParserTests.cs
+++ b/tests/Humans.Events.Tests/Services/BulkEventCsvParserTests.cs
@@ -3,7 +3,7 @@ using Humans.Events.Services;
 using NodaTime;
 using Xunit;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Services;
 
 public sealed class BulkEventCsvParserTests
 {

--- a/tests/Humans.Events.Tests/Services/EventConflictDetectorTests.cs
+++ b/tests/Humans.Events.Tests/Services/EventConflictDetectorTests.cs
@@ -3,7 +3,7 @@ using Humans.Events.Services;
 using NodaTime;
 using Xunit;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Services;
 
 public sealed class EventConflictDetectorTests
 {

--- a/tests/Humans.Events.Tests/Services/EventOccurrenceExpanderTests.cs
+++ b/tests/Humans.Events.Tests/Services/EventOccurrenceExpanderTests.cs
@@ -1,9 +1,9 @@
 using AwesomeAssertions;
+using Humans.Events.Contracts;
 using Humans.Events.Services;
 using NodaTime;
-using Humans.Events.Contracts;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Services;
 
 public sealed class EventOccurrenceExpanderTests
 {

--- a/tests/Humans.Events.Tests/Services/ServiceCalendarFeedTests.cs
+++ b/tests/Humans.Events.Tests/Services/ServiceCalendarFeedTests.cs
@@ -1,17 +1,17 @@
 using AwesomeAssertions;
 using Humans.Email.Contracts;
-using Humans.Events.Data;
-using Humans.Shifts.Contracts;
-using Humans.Events.Services;
-using Humans.Events.Domain;
 using Humans.Events.Contracts;
+using Humans.Events.Data;
+using Humans.Events.Domain;
+using Humans.Events.Services;
+using Humans.Shifts.Contracts;
+using Humans.Users.Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
-using Humans.Users.Contracts;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Services;
 
 public class EventServiceCalendarFeedTests
 {

--- a/tests/Humans.Events.Tests/Services/ServiceTests.cs
+++ b/tests/Humans.Events.Tests/Services/ServiceTests.cs
@@ -1,22 +1,21 @@
 using AwesomeAssertions;
 using Humans.Application.Csv;
-using Humans.Events.Services.Dtos;
 using Humans.Email.Contracts;
-using Humans.Gdpr.Contracts;
-using Humans.Events.Data;
-using Humans.Shifts.Contracts;
-using Humans.Events.Services;
-
-using Humans.Events.Domain;
 using Humans.Events.Contracts;
+using Humans.Events.Data;
+using Humans.Events.Domain;
+using Humans.Events.Services;
+using Humans.Events.Services.Dtos;
+using Humans.Gdpr.Contracts;
+using Humans.Shifts.Contracts;
+using Humans.Users.Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Xunit;
-using Humans.Users.Contracts;
 
-namespace Humans.Events.Tests;
+namespace Humans.Events.Tests.Services;
 
 public sealed class EventServiceTests
 {

--- a/tests/Humans.GoogleIntegration.Tests/GoogleAdminServiceTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleAdminServiceTests.cs
@@ -909,6 +909,6 @@ public class GoogleAdminServiceTests
     private static TeamInfo MakeTeamInfo(Guid id, string name, string slug) =>
         new(id, name, null, slug, IsActive: true, IsSystemTeam: false,
             SystemTeamType.None, RequiresApproval: false, IsPublicPage: false, IsHidden: false,
-            IsPromotedToDirectory: false, NodaTime.SystemClock.Instance.GetCurrentInstant(), []);
+            IsPromotedToDirectory: false, SystemClock.Instance.GetCurrentInstant(), []);
 
 }

--- a/tests/Humans.GoogleIntegration.Tests/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleGroupSyncServiceTests.cs
@@ -867,7 +867,7 @@ public sealed class GoogleGroupSyncServiceTests
     private static TeamInfo MakeTeamInfo(Guid id, string name, string slug, string? googleGroupPrefix = null) =>
         new(id, name, null, slug, IsActive: true, IsSystemTeam: false,
             SystemTeamType.None, RequiresApproval: false, IsPublicPage: false, IsHidden: false,
-            IsPromotedToDirectory: false, NodaTime.SystemClock.Instance.GetCurrentInstant(), [],
+            IsPromotedToDirectory: false, SystemClock.Instance.GetCurrentInstant(), [],
             GoogleGroupPrefix: googleGroupPrefix);
 
 }

--- a/tests/Humans.GoogleIntegration.Tests/GoogleWorkspaceSyncServiceReconciliationTests.cs
+++ b/tests/Humans.GoogleIntegration.Tests/GoogleWorkspaceSyncServiceReconciliationTests.cs
@@ -125,7 +125,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : Infrastructu
     [HumansFact]
     public async Task SyncResourcesByTypeAsync_SoftDeletedTeamWithExtraPermission_RevokesAccessAndDeactivatesResource()
     {
-        var ct = Xunit.TestContext.Current.CancellationToken;
+        var ct = TestContext.Current.CancellationToken;
         var teamId = Guid.NewGuid();
         var googleId = await CreateGoogleFolderAsync("Doomed Folder");
         const string extraEmail = "ex-member@nobodies.team";
@@ -162,7 +162,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : Infrastructu
     [HumansFact]
     public async Task SyncResourcesByTypeAsync_SharedGoogleIdGroupErrors_NoRowInGroupIsDeactivated()
     {
-        var ct = Xunit.TestContext.Current.CancellationToken;
+        var ct = TestContext.Current.CancellationToken;
         var teamId1 = Guid.NewGuid();
         var teamId2 = Guid.NewGuid();
 
@@ -197,7 +197,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : Infrastructu
     [HumansFact]
     public async Task SyncResourcesByTypeAsync_PartialErrorWithinTeam_DefersDeactivationForBothRows()
     {
-        var ct = Xunit.TestContext.Current.CancellationToken;
+        var ct = TestContext.Current.CancellationToken;
         var teamId = Guid.NewGuid();
 
         var cleanGoogleId = await CreateGoogleFolderAsync("Clean Folder");
@@ -225,7 +225,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : Infrastructu
     [HumansFact]
     public async Task SyncResourcesByTypeAsync_DriveFolderPass_DoesNotDeactivateGroupOrDriveFileRowsForSameTeam()
     {
-        var ct = Xunit.TestContext.Current.CancellationToken;
+        var ct = TestContext.Current.CancellationToken;
         var teamId = Guid.NewGuid();
 
         var googleId = await CreateGoogleFolderAsync("Folder");
@@ -265,7 +265,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : Infrastructu
         // so soft-deleted teams' linked Drive *files* never had their Google
         // permissions revoked. Fixed by GetActiveByResourceTypeAsync (fetch by
         // the exact requested type instead of overfetching DriveFolder rows).
-        var ct = Xunit.TestContext.Current.CancellationToken;
+        var ct = TestContext.Current.CancellationToken;
         var teamId = Guid.NewGuid();
         var googleId = await CreateGoogleFolderAsync("Doomed File");
         const string extraEmail = "ex-member@nobodies.team";
@@ -298,7 +298,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : Infrastructu
     [InlineData(SyncMode.None)]
     public async Task SyncResourcesByTypeAsync_WhenNotAddAndRemove_DoesNotDeactivateOrRevoke(SyncMode mode)
     {
-        var ct = Xunit.TestContext.Current.CancellationToken;
+        var ct = TestContext.Current.CancellationToken;
         _syncSettingsService.GetModeAsync(SyncServiceType.GoogleDrive, Arg.Any<CancellationToken>())
             .Returns(mode);
 

--- a/tests/Humans.Guide.Tests/Services/GuideRoleResolverTests.cs
+++ b/tests/Humans.Guide.Tests/Services/GuideRoleResolverTests.cs
@@ -78,7 +78,7 @@ public class GuideRoleResolverTests
     {
         var resolver = CreateResolver();
 
-        var result = await resolver.ResolveAsync(new ClaimsPrincipal(new ClaimsIdentity()), Xunit.TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(new ClaimsPrincipal(new ClaimsIdentity()), TestContext.Current.CancellationToken);
 
         result.IsAuthenticated.Should().BeFalse();
         result.IsTeamCoordinator.Should().BeFalse();
@@ -91,7 +91,7 @@ public class GuideRoleResolverTests
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(Guid.NewGuid(), RoleNames.Admin, RoleNames.Board);
 
-        var result = await resolver.ResolveAsync(user, Xunit.TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(user, TestContext.Current.CancellationToken);
 
         result.IsAuthenticated.Should().BeTrue();
         result.SystemRoles.Should().Contain([RoleNames.Admin, RoleNames.Board]);
@@ -107,7 +107,7 @@ public class GuideRoleResolverTests
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(userId);
 
-        var result = await resolver.ResolveAsync(user, Xunit.TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(user, TestContext.Current.CancellationToken);
 
         result.IsTeamCoordinator.Should().BeTrue();
     }
@@ -124,7 +124,7 @@ public class GuideRoleResolverTests
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(userId);
 
-        var result = await resolver.ResolveAsync(user, Xunit.TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(user, TestContext.Current.CancellationToken);
 
         result.IsTeamCoordinator.Should().BeFalse();
     }
@@ -139,7 +139,7 @@ public class GuideRoleResolverTests
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(userId);
 
-        var result = await resolver.ResolveAsync(user, Xunit.TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(user, TestContext.Current.CancellationToken);
 
         result.IsTeamCoordinator.Should().BeFalse();
     }
@@ -155,7 +155,7 @@ public class GuideRoleResolverTests
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(userId);
 
-        var result = await resolver.ResolveAsync(user, Xunit.TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(user, TestContext.Current.CancellationToken);
 
         result.IsTeamCoordinator.Should().BeTrue();
     }
@@ -171,7 +171,7 @@ public class GuideRoleResolverTests
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(Guid.NewGuid(), role);
 
-        var result = await resolver.ResolveAsync(user, Xunit.TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(user, TestContext.Current.CancellationToken);
 
         result.SystemRoles.Should().Contain(role);
     }

--- a/tests/Humans.Onboarding.Tests/Services/OnboardingServiceTests.cs
+++ b/tests/Humans.Onboarding.Tests/Services/OnboardingServiceTests.cs
@@ -1,20 +1,19 @@
 using AwesomeAssertions;
 using Humans.AuditLog.Contracts;
 using Humans.Consent.Contracts;
+using Humans.Domain.Constants;
 using Humans.Email.Contracts;
 using Humans.Governance.Contracts;
 using Humans.Notifications.Contracts;
 using Humans.Onboarding.Contracts;
 using Humans.Onboarding.Services;
-using Humans.Domain.Constants;
+using Humans.Teams.Contracts;
+using Humans.Users.Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
-using Humans.Users.Contracts;
 
-using Humans.Teams.Contracts;
-
-namespace Humans.Onboarding.Tests.Services.Onboarding;
+namespace Humans.Onboarding.Tests.Services;
 
 public sealed class OnboardingServiceTests
 {

--- a/tests/Humans.Onboarding.Tests/Services/OnboardingWidgetStateTests.cs
+++ b/tests/Humans.Onboarding.Tests/Services/OnboardingWidgetStateTests.cs
@@ -1,15 +1,15 @@
 using Humans.Consent.Contracts;
+using Humans.Domain.Constants;
 using Humans.Governance.Contracts;
 using Humans.Onboarding.Contracts;
-using Humans.Shifts.Contracts;
 using Humans.Onboarding.Services;
-using Humans.Domain.Constants;
+using Humans.Shifts.Contracts;
+using Humans.Users.Contracts;
 using NodaTime;
 using NSubstitute;
 using Xunit;
-using Humans.Users.Contracts;
 
-namespace Humans.Onboarding.Tests.Services.Onboarding;
+namespace Humans.Onboarding.Tests.Services;
 
 public class OnboardingWidgetStateTests
 {

--- a/tests/Humans.Onboarding.Tests/Services/UserInfoStubs.cs
+++ b/tests/Humans.Onboarding.Tests/Services/UserInfoStubs.cs
@@ -44,7 +44,7 @@ internal static class UserInfoStubs
                 BurnerName = displayName,
                 CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 UpdatedAt = SystemClock.Instance.GetCurrentInstant(),
-                State = Humans.Users.Contracts.ProfileState.Active,
+                State = ProfileState.Active,
                 IsApproved = true,
             },
             [],

--- a/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerDietaryGateTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/ShiftsControllerDietaryGateTests.cs
@@ -160,10 +160,10 @@ public class ShiftsControllerDietaryGateTests
         model.SignupsBlockedByMissingDietary.Should().BeFalse();
     }
 
-    private async Task<Humans.Shifts.Models.MyShiftsViewModel> GetMineViewModel()
+    private async Task<MyShiftsViewModel> GetMineViewModel()
     {
         var result = await _controller.Mine();
         return result.Should().BeOfType<ViewResult>()
-                     .Which.Model.Should().BeOfType<Humans.Shifts.Models.MyShiftsViewModel>().Subject;
+                     .Which.Model.Should().BeOfType<MyShiftsViewModel>().Subject;
     }
 }

--- a/tests/Humans.Shifts.Tests/Controllers/VolunteerTrackingControllerTests.cs
+++ b/tests/Humans.Shifts.Tests/Controllers/VolunteerTrackingControllerTests.cs
@@ -50,7 +50,7 @@ public class VolunteerTrackingControllerTests
     private readonly IBurnSettingsService _burnSettings = Substitute.For<IBurnSettingsService>();
     private readonly IVolunteerTrackingExportService _exportService =
         Substitute.For<IVolunteerTrackingExportService>();
-    private readonly Humans.Shifts.Models.VolunteerTrackingXlsxBuilder _xlsxBuilder = new();
+    private readonly VolunteerTrackingXlsxBuilder _xlsxBuilder = new();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
     private readonly IStringLocalizer<ShiftsResource> _localizer =

--- a/tests/Humans.Shifts.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Shifts.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -42,7 +42,7 @@ internal static class UserInfoStubHelpers
                 BurnerName = displayName,
                 CreatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
                 UpdatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
-                State = Humans.Users.Contracts.ProfileState.Active,
+                State = ProfileState.Active,
                 IsApproved = true
             },
             [],

--- a/tests/Humans.Shifts.Tests/Models/EmailRotaViewModelTests.cs
+++ b/tests/Humans.Shifts.Tests/Models/EmailRotaViewModelTests.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using AwesomeAssertions;
 using Humans.Shifts.Models;
 
-namespace Humans.Shifts.Tests.Controllers;
+namespace Humans.Shifts.Tests.Models;
 
 /// <summary>
 /// Validation coverage for <see cref="EmailRotaViewModel"/> — the compose-form

--- a/tests/Humans.Shifts.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -1142,7 +1142,7 @@ public sealed class ShiftDashboardMetricsTests : ShiftsTestHarness
         }
 
         public Task<IReadOnlyList<HumanSearchResult>> SearchUsersAsync(
-            string query, Humans.Users.Contracts.PersonSearchFields fields,
+            string query, PersonSearchFields fields,
             int limit = 10, CancellationToken ct = default) => throw new NotSupportedException();
 
         public async ValueTask<IReadOnlyDictionary<Guid, UserInfo>> GetUserInfosAsync(

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementReadMathTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementReadMathTests.cs
@@ -326,7 +326,7 @@ public sealed class ShiftManagementReadMathTests : ShiftsTestHarness
     // Helpers
     // ============================================================
 
-    private static CancellationToken Ct => Xunit.TestContext.Current.CancellationToken;
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
     private static TeamInfo ToTeamInfo(Team team) =>
         new(

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementWriteGuardTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementWriteGuardTests.cs
@@ -755,7 +755,7 @@ public sealed class ShiftManagementWriteGuardTests : ShiftsTestHarness
     // Helpers
     // ============================================================
 
-    private static CancellationToken Ct => Xunit.TestContext.Current.CancellationToken;
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
     private static TeamInfo ToTeamInfo(Team team) =>
         new(

--- a/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceTests.cs
@@ -78,7 +78,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
     {
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -92,7 +92,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
     {
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -107,7 +107,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
         SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -123,7 +123,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var shift2 = SeedShift(rota, dayOffset: 1, startHour: 10, durationHours: 4);
         var userId = Guid.NewGuid();
         SeedSignup(userId, shift1.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // shift1: day 1, 10:00-14:00 — shift2: day 1, 10:00-14:00 (identical times)
         var result = await _service.SignUpAsync(userId, shift2.Id);
@@ -147,7 +147,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var allDay = SeedAllDayShift(rota, dayOffset: 1);
         var userId = Guid.NewGuid();
         SeedSignup(userId, nightWatch.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, allDay.Id);
 
@@ -170,7 +170,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var allDay = SeedAllDayShift(rota, dayOffset: 0);
         var userId = Guid.NewGuid();
         SeedSignup(userId, allDay.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, earlyShift.Id);
 
@@ -184,7 +184,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (es, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         es.IsShiftBrowsingOpen = false;
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -198,7 +198,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         shift.AdminOnly = true;
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -217,7 +217,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Pending);
         var reviewerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.ApproveAsync(signup.Id, reviewerId);
 
@@ -237,7 +237,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         // User has pending signup for shift2 (same time slot)
         var pendingSignup = SeedSignup(userId, shift2.Id, SignupStatus.Pending);
         var reviewerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.ApproveAsync(pendingSignup.Id, reviewerId);
 
@@ -256,7 +256,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.BailAsync(signup.Id, userId, "Can't make it");
 
@@ -275,7 +275,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         es.EarlyEntryClose = TestNow - Duration.FromHours(1);
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.BailAsync(signup.Id, userId, null);
 
@@ -293,7 +293,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (es, rota, _) = SeedShiftScenario(SignupPolicy.Public);
         var shift = SeedAllDayShift(rota, dayOffset: 1); // qualifies for cantina meal
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var outcome = await _service.ToggleDayAsync(
             userId, shift.Id, es.Id, privileged: false, hasDietaryPreference: true);
@@ -310,14 +310,14 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (es, rota, _) = SeedShiftScenario(SignupPolicy.Public);
         var shift = SeedAllDayShift(rota, dayOffset: 1); // qualifies for cantina meal
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var outcome = await _service.ToggleDayAsync(
             userId, shift.Id, es.Id, privileged: false, hasDietaryPreference: false);
 
         outcome.NeedsDietaryFirst.Should().BeTrue();
         outcome.Result.Should().BeNull();
-        var signupCount = await ShiftsDb.ShiftSignups.CountAsync(s => s.UserId == userId, Xunit.TestContext.Current.CancellationToken);
+        var signupCount = await ShiftsDb.ShiftSignups.CountAsync(s => s.UserId == userId, TestContext.Current.CancellationToken);
         signupCount.Should().Be(0);
     }
 
@@ -328,7 +328,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         // dietary gate never applies regardless of hasDietaryPreference.
         var (es, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var outcome = await _service.ToggleDayAsync(
             userId, shift.Id, es.Id, privileged: false, hasDietaryPreference: false);
@@ -345,7 +345,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var shift = SeedAllDayShift(rota, dayOffset: 1); // qualifies for cantina meal
         var userId = Guid.NewGuid();
         SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var outcome = await _service.ToggleDayAsync(
             userId, shift.Id, es.Id, privileged: false, hasDietaryPreference: false);
@@ -361,7 +361,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
     {
         var (es, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var outcome = await _service.ToggleDayAsync(
             userId, shift.Id, es.Id, privileged: true, hasDietaryPreference: true);
@@ -374,7 +374,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
     {
         var (es, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var outcome = await _service.ToggleDayAsync(
             userId, shift.Id, es.Id, privileged: false, hasDietaryPreference: true);
@@ -392,7 +392,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.VoluntellAsync(volunteerId, shift.Id, enrollerId);
 
@@ -410,7 +410,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.VoluntellAsync(volunteerId, shift.Id, enrollerId);
 
@@ -430,7 +430,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         shift.Duration = Duration.FromHours(2);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.VoluntellAsync(volunteerId, shift.Id, enrollerId);
 
@@ -470,7 +470,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
         var reviewerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.MarkNoShowAsync(signup.Id, reviewerId);
 
@@ -493,7 +493,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
         var reviewerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.MarkNoShowAsync(signup.Id, reviewerId);
 
@@ -520,7 +520,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var userId = Guid.NewGuid();
         var signup = SeedSignup(userId, shift.Id, status);
         var reviewerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.MarkNoShowAsync(signup.Id, reviewerId);
 
@@ -542,7 +542,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         for (var day = -5; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1);
@@ -551,7 +551,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         result.Success.Should().BeTrue();
         var signups = await ShiftsDb.ShiftSignups
             .Where(s => s.UserId == userId)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         signups.Should().HaveCount(3);
         signups.Should().AllSatisfy(s => s.SignupBlockId.Should().NotBeNull());
         signups.Select(s => s.SignupBlockId).Distinct().Should().HaveCount(1);
@@ -567,11 +567,11 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
         // Find the day -2 shift and create an existing signup
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
         var dayMinus2Shift = await ShiftsDb.Shifts
-            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, Xunit.TestContext.Current.CancellationToken);
+            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, TestContext.Current.CancellationToken);
         SeedSignup(userId, dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act: try to sign up for days -3 to -1
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1);
@@ -590,12 +590,12 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         for (var day = -3; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var dayMinus2Shift = await ShiftsDb.Shifts
-            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, Xunit.TestContext.Current.CancellationToken);
+            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, TestContext.Current.CancellationToken);
         var existingSignup = SeedSignup(userId, dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.SignUpRangeAsync(
@@ -612,7 +612,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
 
         var signups = await ShiftsDb.ShiftSignups
             .Where(s => s.UserId == userId)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         signups.Should().HaveCount(3); // 1 pre-existing + 2 new
         var newOffsets = signups
             .Where(s => s.Id != existingSignup.Id)
@@ -633,18 +633,18 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         for (var day = -4; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var dayMinus3Shift = await ShiftsDb.Shifts
-            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -3, Xunit.TestContext.Current.CancellationToken);
+            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -3, TestContext.Current.CancellationToken);
         SeedSignup(userId, dayMinus3Shift.Id, SignupStatus.Confirmed);
 
         var dayMinus2Shift = await ShiftsDb.Shifts
-            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, Xunit.TestContext.Current.CancellationToken);
+            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, TestContext.Current.CancellationToken);
         // SeedAllDayShift sets MaxVolunteers = 5; fill day -2 with 5 distinct other users.
         for (var i = 0; i < dayMinus2Shift.MaxVolunteers; i++)
             SeedSignup(Guid.NewGuid(), dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.SignUpRangeAsync(
@@ -664,7 +664,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             .Where(s => s.UserId == userId && s.SignupBlockId != null)
             .Join(ShiftsDb.Shifts, s => s.ShiftId, sh => sh.Id, (_, sh) => sh.DayOffset)
             .OrderBy(o => o)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         newSignups.Should().Equal(-4, -1);
     }
 
@@ -710,7 +710,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
 
         var userId = Guid.NewGuid();
         SeedSignup(userId, conflictingShift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.SignUpRangeAsync(
@@ -729,7 +729,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             .Where(s => s.UserId == userId && s.Shift.RotaId == buildRota.Id)
             .Join(ShiftsDb.Shifts, s => s.ShiftId, sh => sh.Id, (_, sh) => sh.DayOffset)
             .OrderBy(o => o)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         newOffsets.Should().Equal(-3, -1);
     }
 
@@ -743,11 +743,11 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var shifts = new List<Shift>();
         for (var day = -3; day <= -1; day++)
             shifts.Add(SeedAllDayShift(rota, day));
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         foreach (var shift in shifts)
             SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.SignUpRangeAsync(
@@ -762,7 +762,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         result.Error.Should().NotBeNull();
         result.Error.Should().Contain("Nothing to add");
 
-        var totalSignups = await ShiftsDb.ShiftSignups.CountAsync(s => s.UserId == userId, Xunit.TestContext.Current.CancellationToken);
+        var totalSignups = await ShiftsDb.ShiftSignups.CountAsync(s => s.UserId == userId, TestContext.Current.CancellationToken);
         totalSignups.Should().Be(3); // only the 3 pre-existing
     }
 
@@ -810,13 +810,13 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         ShiftsDb.Shifts.Add(crossRotaShift);
 
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var dayMinus3Shift = await ShiftsDb.Shifts
-            .FirstAsync(s => s.RotaId == buildRota.Id && s.DayOffset == -3, Xunit.TestContext.Current.CancellationToken);
+            .FirstAsync(s => s.RotaId == buildRota.Id && s.DayOffset == -3, TestContext.Current.CancellationToken);
         SeedSignup(userId, dayMinus3Shift.Id, SignupStatus.Confirmed);  // already-signed-up case
         SeedSignup(userId, crossRotaShift.Id, SignupStatus.Confirmed);  // time-conflict case
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.SignUpRangeAsync(
@@ -836,7 +836,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             .Where(s => s.UserId == userId && s.Shift.RotaId == buildRota.Id && s.ShiftId != dayMinus3Shift.Id)
             .Join(ShiftsDb.Shifts, s => s.ShiftId, sh => sh.Id, (_, sh) => sh.DayOffset)
             .OrderBy(o => o)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         newOffsets.Should().Equal(-4, -1);
     }
 
@@ -881,7 +881,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
 
         var userId = Guid.NewGuid();
         SeedSignup(userId, conflictingShift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act — no skipConflicts argument; defaults to false.
         var result = await _service.SignUpRangeAsync(userId, buildRota.Id, -3, -1);
@@ -893,7 +893,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
 
         var newSignupCount = await ShiftsDb.ShiftSignups
             .Where(s => s.UserId == userId && s.Shift.RotaId == buildRota.Id)
-            .CountAsync(Xunit.TestContext.Current.CancellationToken);
+            .CountAsync(TestContext.Current.CancellationToken);
         newSignupCount.Should().Be(0);
     }
 
@@ -917,7 +917,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             var signup = SeedSignup(userId, shift.Id, SignupStatus.Confirmed);
             signup.SignupBlockId = blockId;
         }
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         await _service.BailRangeAsync(blockId, userId);
@@ -925,7 +925,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         // Assert: all 3 signups now Bailed
         var signups = await ShiftsDb.ShiftSignups
             .Where(s => s.SignupBlockId == blockId)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         signups.Should().HaveCount(3);
         signups.Should().AllSatisfy(s => s.Status.Should().Be(SignupStatus.Bailed));
     }
@@ -944,7 +944,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             SeedAllDayShift(rota, day);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
@@ -953,7 +953,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         result.Success.Should().BeTrue();
         var signups = await ShiftsDb.ShiftSignups
             .Where(s => s.UserId == volunteerId)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         signups.Should().HaveCount(3);
         signups.Should().AllSatisfy(s =>
         {
@@ -975,13 +975,13 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             SeedAllDayShift(rota, day);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Pre-existing signup on day -2
         var dayMinus2Shift = await ShiftsDb.Shifts
-            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, Xunit.TestContext.Current.CancellationToken);
+            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2, TestContext.Current.CancellationToken);
         SeedSignup(volunteerId, dayMinus2Shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
@@ -990,7 +990,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         result.Success.Should().BeTrue();
         var newSignups = await ShiftsDb.ShiftSignups
             .Where(s => s.UserId == volunteerId && s.Enrolled)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+            .ToListAsync(TestContext.Current.CancellationToken);
         newSignups.Should().HaveCount(2);
     }
 
@@ -1017,7 +1017,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             SeedAllDayShift(rota, day);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
 
@@ -1037,7 +1037,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             SeedAllDayShift(rota, day);
         var volunteerId = Guid.NewGuid();
         var enrollerId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
 
@@ -1054,7 +1054,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
     {
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.Public);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -1071,7 +1071,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
     {
         var (_, _, shift) = SeedShiftScenario(SignupPolicy.RequireApproval);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpAsync(userId, shift.Id);
 
@@ -1092,7 +1092,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         for (var day = -3; day <= -1; day++)
             SeedAllDayShift(rota, day);
         var userId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
         var result = await _service.SignUpRangeAsync(userId, rota.Id, -3, -1);
 
@@ -1116,9 +1116,9 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var targetUserId = Guid.NewGuid();
         var actorUserId = Guid.NewGuid();
         SeedSignup(sourceUserId, shift.Id, SignupStatus.Confirmed);
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
-        await _service.ReassignAsync(sourceUserId, targetUserId, actorUserId, TestNow, Xunit.TestContext.Current.CancellationToken);
+        await _service.ReassignAsync(sourceUserId, targetUserId, actorUserId, TestNow, TestContext.Current.CancellationToken);
 
         await AuditLog.Received(1).LogAsync(
             AuditAction.ShiftSignupReassigned, nameof(User), targetUserId,
@@ -1134,9 +1134,9 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
         var sourceUserId = Guid.NewGuid();
         var targetUserId = Guid.NewGuid();
         var actorUserId = Guid.NewGuid();
-        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        await SaveAllAsync(TestContext.Current.CancellationToken);
 
-        await _service.ReassignAsync(sourceUserId, targetUserId, actorUserId, TestNow, Xunit.TestContext.Current.CancellationToken);
+        await _service.ReassignAsync(sourceUserId, targetUserId, actorUserId, TestNow, TestContext.Current.CancellationToken);
 
         await AuditLog.DidNotReceive().LogAsync(
             AuditAction.ShiftSignupReassigned, Arg.Any<string>(), Arg.Any<Guid>(),

--- a/tests/Humans.Teams.Tests/Architecture/TeamPageArchitectureTests.cs
+++ b/tests/Humans.Teams.Tests/Architecture/TeamPageArchitectureTests.cs
@@ -1,11 +1,11 @@
-using Humans.GoogleIntegration.Contracts;
-using Humans.Teams.Services;
 using AwesomeAssertions;
 using Humans.Application.Interfaces.Repositories;
+using Humans.GoogleIntegration.Contracts;
 using Humans.Teams.Contracts;
+using Humans.Teams.Services;
 using TeamPageService = Humans.Teams.Services.TeamPageService;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Architecture;
 
 /// <summary>
 /// Architecture tests enforcing the §15 Application-layer shape for

--- a/tests/Humans.Teams.Tests/Architecture/TeamsArchitectureTests.cs
+++ b/tests/Humans.Teams.Tests/Architecture/TeamsArchitectureTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Architecture;
 
 /// <summary>
 /// What is left of the Teams §15 checks (issue #540). The read split is the subject:

--- a/tests/Humans.Teams.Tests/Authorization/TeamAuthorizationHandlerTests.cs
+++ b/tests/Humans.Teams.Tests/Authorization/TeamAuthorizationHandlerTests.cs
@@ -1,15 +1,15 @@
 using System.Security.Claims;
 using AwesomeAssertions;
-using Humans.Teams.Contracts;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Teams.Authorization;
+using Humans.Teams.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using NodaTime;
 using NSubstitute;
 using Xunit;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Authorization;
 
 public sealed class TeamAuthorizationHandlerTests
 {

--- a/tests/Humans.Teams.Tests/Controllers/TeamAdminControllerTicketLookupTests.cs
+++ b/tests/Humans.Teams.Tests/Controllers/TeamAdminControllerTicketLookupTests.cs
@@ -1,10 +1,10 @@
 using AwesomeAssertions;
-using Humans.Tickets.Contracts;
 using Humans.Teams.Controllers;
-using NodaTime;
+using Humans.Tickets.Contracts;
 using Humans.Users.Contracts;
+using NodaTime;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Controllers;
 
 public class TeamAdminControllerTicketLookupTests
 {

--- a/tests/Humans.Teams.Tests/Data/TeamRepositoryTests.cs
+++ b/tests/Humans.Teams.Tests/Data/TeamRepositoryTests.cs
@@ -1,17 +1,19 @@
-using Humans.Users.Contracts;
 // User.DisplayName is Obsolete; SeedUserAsync sets it on the unpersisted User
 // it hands back to callers.
-#pragma warning disable CS0618
+
 using AwesomeAssertions;
-using Humans.Teams.Domain;
 using Humans.Domain.Enums;
+using Humans.Teams.Contracts;
 using Humans.Teams.Data;
+using Humans.Teams.Domain;
+using Humans.Users.Contracts;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
 
-using Humans.Teams.Contracts;
-namespace Humans.Teams.Tests;
+#pragma warning disable CS0618
+
+namespace Humans.Teams.Tests.Data;
 
 /// <summary>
 /// Repository tests for the Teams section — issue #540a (§15 Part 1 —

--- a/tests/Humans.Teams.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Teams.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -42,7 +42,7 @@ internal static class UserInfoStubHelpers
                 BurnerName = displayName,
                 CreatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
                 UpdatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
-                State = Humans.Users.Contracts.ProfileState.Active,
+                State = ProfileState.Active,
                 IsApproved = true
             },
             [],

--- a/tests/Humans.Teams.Tests/Services/CachingTeamServiceGetTeamDetailTests.cs
+++ b/tests/Humans.Teams.Tests/Services/CachingTeamServiceGetTeamDetailTests.cs
@@ -1,15 +1,15 @@
-using Humans.Auth.Contracts;
 using AwesomeAssertions;
+using Humans.Auth.Contracts;
 using Humans.Teams.Contracts;
 using Humans.Teams.Domain;
 using Humans.Teams.Services;
+using Humans.Users.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
-using Humans.Users.Contracts;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 /// <summary>
 /// Pins the T-01 invariant: <see cref="CachingTeamService.GetTeamDetailAsync"/>

--- a/tests/Humans.Teams.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/CachingTeamServiceTests.cs
@@ -1,17 +1,17 @@
-using Humans.Auth.Contracts;
 using AwesomeAssertions;
-using Humans.Teams.Contracts;
-using Humans.Teams.Tests.Infrastructure;
-using Humans.Teams.Domain;
+using Humans.Auth.Contracts;
 using Humans.Domain.Enums;
+using Humans.Teams.Contracts;
+using Humans.Teams.Domain;
 using Humans.Teams.Services;
+using Humans.Teams.Tests.Infrastructure;
+using Humans.Users.Contracts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using Humans.Users.Contracts;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 public sealed class CachingTeamServiceTests : TeamsTestHarness
 {

--- a/tests/Humans.Teams.Tests/Services/TeamEarlyEntryProjectionTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamEarlyEntryProjectionTests.cs
@@ -1,9 +1,9 @@
 using AwesomeAssertions;
-using Humans.Teams.Services;
 using Humans.Teams.Domain;
+using Humans.Teams.Services;
 using NodaTime;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 public class TeamEarlyEntryProjectionTests
 {

--- a/tests/Humans.Teams.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamRoleServiceTests.cs
@@ -1,32 +1,31 @@
-using Humans.GoogleIntegration.Contracts;
-using Humans.Shifts.Services;
-using Humans.Auth.Contracts;
-using Humans.Auth.Services;
-using Humans.Auth.Domain;
-using Humans.Auth.Data;
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Caching;
+using Humans.Auth.Contracts;
+using Humans.Auth.Data;
+using Humans.Auth.Domain;
+using Humans.Auth.Services;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
+using Humans.Email.Contracts;
+using Humans.GoogleIntegration.Contracts;
+using Humans.GoogleIntegration.Data;
+using Humans.GoogleIntegration.Services;
+using Humans.Shifts.Contracts;
+using Humans.Shifts.Data;
+using Humans.Shifts.Services;
+using Humans.Teams.Contracts;
+using Humans.Teams.Data;
+using Humans.Teams.Domain;
+using Humans.Teams.Tests.Infrastructure;
+using Humans.Users.Contracts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
-using Humans.Domain.Constants;
-using Humans.Teams.Domain;
-using Humans.Domain.Enums;
-using Humans.Application.Interfaces.Caching;
-using Humans.Shifts.Contracts;
-using Humans.Teams.Tests.Infrastructure;
-using Humans.Teams.Data;
 using RoleAssignmentService = Humans.Auth.Services.RoleAssignmentService;
 using TeamService = Humans.Teams.Services.TeamService;
-using Humans.Email.Contracts;
-using Humans.Teams.Contracts;
-using Humans.GoogleIntegration.Services;
 
-using Humans.GoogleIntegration.Data;
-using Humans.Shifts.Data;
-using Humans.Users.Contracts;
-
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 public sealed class TeamRoleServiceTests : TeamsTestHarness
 {

--- a/tests/Humans.Teams.Tests/Services/TeamServiceEarlyEntryTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamServiceEarlyEntryTests.cs
@@ -1,22 +1,22 @@
-using Humans.GoogleIntegration.Contracts;
-using Humans.Shifts.Services;
-using Humans.Auth.Contracts;
-using Humans.Teams.Data;
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Caching;
+using Humans.AuditLog.Contracts;
+using Humans.Auth.Contracts;
+using Humans.EarlyEntry.Contracts;
+using Humans.Gdpr.Contracts;
+using Humans.GoogleIntegration.Contracts;
+using Humans.Notifications.Contracts;
+using Humans.Shifts.Contracts;
+using Humans.Shifts.Services;
+using Humans.Teams.Data;
+using Humans.Teams.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
-using Humans.AuditLog.Contracts;
-using Humans.Application.Interfaces.Caching;
-using Humans.EarlyEntry.Contracts;
-using Humans.Gdpr.Contracts;
-using Humans.Notifications.Contracts;
-using Humans.Shifts.Contracts;
-using Humans.Teams.Domain;
 using TeamService = Humans.Teams.Services.TeamService;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 /// <summary>
 /// Logic of the Teams early-entry surface on <see cref="TeamService"/>:

--- a/tests/Humans.Teams.Tests/Services/TeamServiceSlugRaceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamServiceSlugRaceTests.cs
@@ -1,21 +1,21 @@
-using Humans.GoogleIntegration.Contracts;
-using Humans.Shifts.Services;
-using Humans.Auth.Contracts;
-using Humans.Teams.Data;
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Caching;
+using Humans.AuditLog.Contracts;
+using Humans.Auth.Contracts;
+using Humans.EarlyEntry.Contracts;
+using Humans.GoogleIntegration.Contracts;
+using Humans.Notifications.Contracts;
+using Humans.Shifts.Contracts;
+using Humans.Shifts.Services;
+using Humans.Teams.Data;
+using Humans.Teams.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
-using Humans.AuditLog.Contracts;
-using Humans.Application.Interfaces.Caching;
-using Humans.EarlyEntry.Contracts;
-using Humans.Notifications.Contracts;
-using Humans.Shifts.Contracts;
-using Humans.Teams.Domain;
 using TeamService = Humans.Teams.Services.TeamService;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 /// <summary>
 /// Regression tests for Codex PR#300 P2: the create-team slug retry loop

--- a/tests/Humans.Teams.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamServiceTests.cs
@@ -1,11 +1,3 @@
-using Humans.GoogleIntegration.Contracts;
-using Humans.Shifts.Services;
-using Humans.Auth.Contracts;
-using Humans.Auth.Services;
-using Humans.Auth.Data;
-using Humans.Application;
-using Humans.Application.Interfaces.Caching;
-using Humans.Teams.Services;
 // Tests seed TeamMember.User navs directly for DB-roundtrip verification.
 // TeamMember.User is Obsolete per Â§6c and is never populated by production
 // code (nobodies-collective/Humans#979 removed the in-memory stitcher); the
@@ -14,29 +6,36 @@ using Humans.Teams.Services;
 // instead of raw entity inserts.
 #pragma warning disable CS0618
 using AwesomeAssertions;
+using Humans.Application;
+using Humans.Application.Interfaces.Caching;
+using Humans.Auth.Contracts;
+using Humans.Auth.Data;
+using Humans.Auth.Services;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
+using Humans.Email.Contracts;
+using Humans.GoogleIntegration.Contracts;
+using Humans.GoogleIntegration.Data;
+using Humans.GoogleIntegration.Services;
+using Humans.Shifts.Contracts;
+using Humans.Shifts.Data;
+using Humans.Shifts.Domain;
+using Humans.Shifts.Services;
+using Humans.Teams.Contracts;
+using Humans.Teams.Data;
+using Humans.Teams.Domain;
+using Humans.Teams.Services;
+using Humans.Teams.Tests.Infrastructure;
+using Humans.Users.Contracts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
-using Humans.Domain.Constants;
-using Humans.Shifts.Domain;
-using Humans.Teams.Domain;
-using Humans.Domain.Enums;
-using Humans.Shifts.Contracts;
-using Humans.Teams.Tests.Infrastructure;
-using Humans.Teams.Data;
 using RoleAssignmentService = Humans.Auth.Services.RoleAssignmentService;
 using TeamService = Humans.Teams.Services.TeamService;
-using Humans.Email.Contracts;
-using Humans.Teams.Contracts;
-using Humans.GoogleIntegration.Services;
 
-using Humans.GoogleIntegration.Data;
-using Humans.Shifts.Data;
-using Humans.Users.Contracts;
-
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 public sealed class TeamServiceTests : TeamsTestHarness
 {

--- a/tests/Humans.Teams.Tests/Services/TeamsDependencyCycleTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamsDependencyCycleTests.cs
@@ -1,22 +1,22 @@
-using Humans.Shifts.Services;
-using Humans.Auth.Contracts;
-using Humans.Users.Contracts;
 using AwesomeAssertions;
-using Humans.AuditLog.Contracts;
 using Humans.Application.Interfaces.Caching;
+using Humans.AuditLog.Contracts;
+using Humans.Auth.Contracts;
 using Humans.EarlyEntry.Contracts;
-using Humans.Shifts.Contracts;
 using Humans.Email.Contracts;
 using Humans.Notifications.Contracts;
+using Humans.Shifts.Contracts;
+using Humans.Shifts.Services;
 using Humans.Teams.Contracts;
 using Humans.Teams.Data;
 using Humans.Teams.Services;
+using Humans.Users.Contracts;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
-namespace Humans.Teams.Tests;
+namespace Humans.Teams.Tests.Services;
 
 /// <summary>
 /// The real-graph half of <c>DependencyCycleResolutionTests</c>: <c>UserService</c> injects

--- a/tests/Humans.Users.Tests/Architecture/UserArchitectureTests.cs
+++ b/tests/Humans.Users.Tests/Architecture/UserArchitectureTests.cs
@@ -75,7 +75,7 @@ public class UserArchitectureTests
         var typesToScan = new[]
         {
             typeof(IUserEmailService),
-            typeof(Humans.Users.Data.Repositories.UserRepository),
+            typeof(UserRepository),
             typeof(IUserRepository),
         };
 
@@ -146,7 +146,7 @@ public class UserArchitectureTests
     [HumansFact]
     public void User_HasNoCrossDomainNavigationProperties()
     {
-        var userType = typeof(Humans.Users.Contracts.User);
+        var userType = typeof(User);
         var declaredProps = userType
             .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
             .Select(p => p.Name)

--- a/tests/Humans.Users.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Users.Tests/Controllers/ProfileControllerEditTests.cs
@@ -514,7 +514,7 @@ public class ProfileControllerEditTests
                 AllergyOtherText = "Mango",
             }));
 
-        var result = await _controller.Edit(ct: Xunit.TestContext.Current.CancellationToken);
+        var result = await _controller.Edit(ct: TestContext.Current.CancellationToken);
 
         var viewModel = result.Should().BeOfType<ViewResult>().Subject
             .Model.Should().BeOfType<ProfileViewModel>().Subject;

--- a/tests/Humans.Users.Tests/Controllers/ProfileControllerPopoverTests.cs
+++ b/tests/Humans.Users.Tests/Controllers/ProfileControllerPopoverTests.cs
@@ -188,7 +188,7 @@ public class ProfileControllerPopoverTests
         _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
             .Returns(BuildUserInfo(user, profile, userEmails: null));
         _teamService.GetActiveTeamMembershipsForUserAsync(id, Arg.Any<CancellationToken>())
-            .Returns(new List<Humans.Teams.Contracts.TeamMembership>());
+            .Returns(new List<TeamMembership>());
 
         var result = await _controller.Popover(id, Xunit.TestContext.Current.CancellationToken);
 
@@ -225,7 +225,7 @@ public class ProfileControllerPopoverTests
         _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
             .Returns(BuildUserInfo(user, profile, userEmails: null));
         _teamService.GetActiveTeamMembershipsForUserAsync(id, Arg.Any<CancellationToken>())
-            .Returns(new List<Humans.Teams.Contracts.TeamMembership>());
+            .Returns(new List<TeamMembership>());
 
         var season = new CampSeasonInfo(
             Guid.NewGuid(), Guid.NewGuid(), "camp-funhouse", 2026, null,

--- a/tests/Humans.Users.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Users.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -42,7 +42,7 @@ internal static class UserInfoStubHelpers
                 BurnerName = displayName,
                 CreatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
                 UpdatedAt = NodaTime.SystemClock.Instance.GetCurrentInstant(),
-                State = Humans.Users.Contracts.ProfileState.Active,
+                State = ProfileState.Active,
                 IsApproved = true
             },
             [],

--- a/tests/Humans.Users.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Users.Tests/Services/ProfileServiceTests.cs
@@ -406,7 +406,7 @@ public sealed class ProfileServiceTests : ServiceTestHarness
         await SeedUserAsync(userId);
         var request = MakeRequest() with
         {
-            Allergies = [Humans.Users.Contracts.DietaryOptions.OtherOption],
+            Allergies = [DietaryOptions.OtherOption],
             AllergyOtherText = "   ",
         };
 

--- a/tests/Humans.Web.Tests/Architecture/AgentShiftViewReadTests.cs
+++ b/tests/Humans.Web.Tests/Architecture/AgentShiftViewReadTests.cs
@@ -32,7 +32,7 @@ public class AgentShiftViewReadTests
     ];
 
     private static Type SectionType(string fullName) =>
-        Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies()
+        Extensions.SectionDiscoveryExtensions.SectionAssemblies()
             .Select(a => a.GetType(fullName, throwOnError: false))
             .FirstOrDefault(t => t is not null)
         ?? throw new InvalidOperationException(

--- a/tests/Humans.Web.Tests/Architecture/Rules/ApplicationServicesTakeNoMemoryCacheRule.cs
+++ b/tests/Humans.Web.Tests/Architecture/Rules/ApplicationServicesTakeNoMemoryCacheRule.cs
@@ -114,7 +114,7 @@ public class ApplicationServicesTakeNoMemoryCacheRule
     /// section type from this project rather than two.
     /// </summary>
     private static Type SectionType(string fullName) =>
-        Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies()
+        Extensions.SectionDiscoveryExtensions.SectionAssemblies()
             .Select(a => a.GetType(fullName, throwOnError: false))
             .FirstOrDefault(t => t is not null)
         ?? throw new InvalidOperationException(

--- a/tests/Humans.Web.Tests/Architecture/Rules/ApplicationSweepScope.cs
+++ b/tests/Humans.Web.Tests/Architecture/Rules/ApplicationSweepScope.cs
@@ -26,5 +26,5 @@ internal static class ApplicationSweepScope
 {
     /// <summary>Every G5 section assembly, via the same discovery the runtime uses.</summary>
     public static IEnumerable<Assembly> Assemblies() =>
-        Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies();
+        Extensions.SectionDiscoveryExtensions.SectionAssemblies();
 }

--- a/tests/Humans.Web.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
+++ b/tests/Humans.Web.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
@@ -31,7 +31,7 @@ public class ServiceBoundaryArchitectureTests
     /// <c>Humans.Web</c> since G5 lane 5b-6 deleted <c>Humans.Infrastructure</c>.
     /// </summary>
     private static Type HostRepository(string fullName) =>
-        typeof(Web.Extensions.InfrastructureServiceCollectionExtensions).Assembly
+        typeof(Extensions.InfrastructureServiceCollectionExtensions).Assembly
             .GetType(fullName, throwOnError: false)
         ?? throw new InvalidOperationException(
             $"{fullName} not found in Humans.Web — did it move or get renamed?");
@@ -187,24 +187,24 @@ public class ServiceBoundaryArchitectureTests
     /// </remarks>
     private static readonly Type[] LeafResidentEntities =
     [
-        typeof(Humans.Users.Contracts.User),
-        typeof(Humans.Users.Contracts.UserEmail),
-        typeof(Humans.Users.Contracts.EventParticipation),
-        typeof(Humans.Users.Contracts.Profile),
-        typeof(Humans.Users.Contracts.ContactField),
-        typeof(Humans.Users.Contracts.ProfileLanguage),
-        typeof(Humans.Users.Contracts.VolunteerHistoryEntry),
-        typeof(Humans.Users.Contracts.CommunicationPreference),
-        typeof(Humans.Users.Contracts.AccountMergeRequest),
+        typeof(Users.Contracts.User),
+        typeof(Users.Contracts.UserEmail),
+        typeof(Users.Contracts.EventParticipation),
+        typeof(Users.Contracts.Profile),
+        typeof(Users.Contracts.ContactField),
+        typeof(Users.Contracts.ProfileLanguage),
+        typeof(Users.Contracts.VolunteerHistoryEntry),
+        typeof(Users.Contracts.CommunicationPreference),
+        typeof(Users.Contracts.AccountMergeRequest),
         // GoogleIntegration's three entities, same shape and same reason
         // (nobodies-collective/Humans#866, G5 lane 4b-2j): GoogleResource and
         // GoogleSyncOutboxEvent are public members of IGoogleSyncService /
         // IGoogleSyncOutboxService on Humans.GoogleIntegration.Contracts, and a leaf
         // cannot reference its own section project, so they live on the leaf rather
         // than under Humans.GoogleIntegration.Domain.
-        typeof(Humans.GoogleIntegration.Contracts.GoogleResource),
-        typeof(Humans.GoogleIntegration.Contracts.GoogleSyncOutboxEvent),
-        typeof(Humans.GoogleIntegration.Contracts.SyncServiceSettings),
+        typeof(GoogleIntegration.Contracts.GoogleResource),
+        typeof(GoogleIntegration.Contracts.GoogleSyncOutboxEvent),
+        typeof(GoogleIntegration.Contracts.SyncServiceSettings),
     ];
 
     internal static IEnumerable<string> ScanApplicationServiceEntityReadReturns()
@@ -220,7 +220,7 @@ public class ServiceBoundaryArchitectureTests
         // Humans.Domain) so the sweep re-arms if anything lands back there before
         // phase 5a deletes the project. Coverage did not shrink — the three entities
         // are listed in LeafResidentEntities above.
-        var entityTypes = typeof(Humans.Domain.Enums.GoogleSyncSource).Assembly
+        var entityTypes = typeof(Domain.Enums.GoogleSyncSource).Assembly
             .GetTypes()
             .Where(t => string.Equals(t.Namespace, "Humans.Domain.Entities", StringComparison.Ordinal))
             .Concat(SectionAssemblies()
@@ -291,7 +291,7 @@ public class ServiceBoundaryArchitectureTests
     /// never carries a hard-coded list of moved sections.
     /// </summary>
     private static IEnumerable<Assembly> SectionAssemblies() =>
-        Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies();
+        Extensions.SectionDiscoveryExtensions.SectionAssemblies();
 
     /// <summary>
     /// Every G5 contracts leaf. Discovered from the dependency graph by name rather than by

--- a/tests/Humans.Web.Tests/Authorization/AuthorizationPolicyTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/AuthorizationPolicyTests.cs
@@ -474,7 +474,7 @@ public class AuthorizationPolicyTests : IDisposable
     /// or dropped controller fails the test rather than quietly leaving the sweep.
     /// </summary>
     private static Type SectionType(string fullName) =>
-        Humans.Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies()
+        Extensions.SectionDiscoveryExtensions.SectionAssemblies()
             .Select(a => a.GetType(fullName, throwOnError: false))
             .FirstOrDefault(t => t is not null)
         ?? throw new InvalidOperationException(

--- a/tests/Humans.Web.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
+++ b/tests/Humans.Web.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
@@ -86,7 +86,7 @@ public class GdprExportDependencyInjectionTests
     /// list rather than dropping it — the silent-omission bug this class exists to prevent.
     /// </summary>
     private static Type SectionType(string fullName) =>
-        Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies()
+        Extensions.SectionDiscoveryExtensions.SectionAssemblies()
             .Select(a => a.GetType(fullName, throwOnError: false))
             .FirstOrDefault(t => t is not null)
         ?? throw new InvalidOperationException(
@@ -116,11 +116,11 @@ public class GdprExportDependencyInjectionTests
         // sweep the way it would with a hard-coded assembly list (design §10).
         // Humans.Infrastructure was the first entry until G5 lane 5b-6 deleted it; its residue
         // (and, at 5c, Dashboard's) lands in Humans.Web, so the host assembly takes its place.
-        var hostAssembly = typeof(Web.Extensions.InfrastructureServiceCollectionExtensions).Assembly;
+        var hostAssembly = typeof(Extensions.InfrastructureServiceCollectionExtensions).Assembly;
         var applicationAssembly = typeof(Humans.Users.Services.UserService).Assembly;
 
         var foundContributors = new[] { hostAssembly, applicationAssembly }
-            .Concat(Web.Extensions.SectionDiscoveryExtensions.SectionAssemblies())
+            .Concat(Extensions.SectionDiscoveryExtensions.SectionAssemblies())
             .SelectMany(asm => asm.GetTypes())
             .Where(t => t is { IsClass: true, IsAbstract: false })
             .Where(t => typeof(IUserDataContributor).IsAssignableFrom(t))
@@ -141,7 +141,7 @@ public class GdprExportDependencyInjectionTests
         // so the test doesn't need a live DbContext, Postgres, or config.
         var services = new ServiceCollection();
         var config = BuildMinimalConfiguration();
-        Web.Extensions.InfrastructureServiceCollectionExtensions
+        Extensions.InfrastructureServiceCollectionExtensions
             .AddHumansInfrastructure(
                 services,
                 config,
@@ -170,7 +170,7 @@ public class GdprExportDependencyInjectionTests
     public void GdprExportServiceIsRegistered()
     {
         var services = new ServiceCollection();
-        Web.Extensions.InfrastructureServiceCollectionExtensions
+        Extensions.InfrastructureServiceCollectionExtensions
             .AddHumansInfrastructure(
                 services,
                 BuildMinimalConfiguration(),
@@ -193,7 +193,7 @@ public class GdprExportDependencyInjectionTests
         // `ExpectedContributorTypes`.
         var services = new ServiceCollection();
         var config = BuildMinimalConfiguration();
-        Web.Extensions.InfrastructureServiceCollectionExtensions
+        Extensions.InfrastructureServiceCollectionExtensions
             .AddHumansInfrastructure(
                 services,
                 config,


### PR DESCRIPTION
Peter's ReSharper pass, round two (2 commits): test-project namespace fixes and leftover namespace cleanup. 114 files, +441/−444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)