### PR TITLE
feat(surveys): improve audience review workflow

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -252,10 +252,13 @@ themes:
     detect: "grep -c '^  - added:' docs/architecture/debt-ledger.yml"
     review: per-item
     last_swept: 2026-06-14
-    remaining: 9
+    remaining: 10
     notes: Each inbox entry carries its own review tier; drained entries are deleted from the list.
 inbox:
   # Seeded from the open items in docs/architecture/tech-debt-2026-04-23.md.
+  - added: 2026-08-18
+    what: "DevelopmentDashboardSeeder fails on a fresh Development database while seeding dashboard scenarios: it calls Signup.Refuse() after the signup has already reached Confirmed state, raising 'Cannot refuse signup in Confirmed state' and aborting the remaining seed data. Reproduced while locally testing the Surveys audience workflow; needs a focused correction to the scenario's state-transition ordering."
+    review: panel
   - added: 2026-08-16
     what: "21 classes carry [CrossSectionWrite(\"reason\")] (grep src/ --include=*.cs) — each is a cross-section write through another section's full I*Service, which HUM0032 accepts only because the marker is there. The preferred shape is the other way round: the section that owns the data ships a view component and writes its own rows, so the consumer never holds the write interface. Introduced with the marker in nobodies-collective/Humans#1064; every one is a pre-existing call newly made visible, not new coupling. Work them down per owning section, not as one sweep — several (GoogleIntegration's four sync services, Development's two dev seeders) are provisioning paths where a view component is the wrong answer and the marker is the final state."
     review: panel

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -170,7 +170,7 @@ internal sealed class SurveyAdminController(
         var statuses = await surveyService.GetInviteStatusesAsync(id, ct);
         var audienceTeamName = detail.Editable.AudienceType == SurveyAudienceType.Team
             && detail.Editable.AudienceTeamId is { } teamId
-                ? (await LoadTeamsAsync(ct)).FirstOrDefault(t => t.Id == teamId)?.Name
+                ? (await teamService.GetTeamAsync(teamId, ct))?.Name
                 : null;
 
         var vm = new SurveySendViewModel

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -70,6 +70,12 @@ internal sealed class SurveyAdminController(
         var actorId = GetCurrentUserId();
         if (actorId is null) return Forbid();
 
+        if (model.AudienceType == SurveyAudienceType.Team && model.AudienceTeamId is null)
+        {
+            ModelState.AddModelError(nameof(model.AudienceTeamId),
+                "Choose a team for the Team audience.");
+        }
+
         if (model.AudienceType == SurveyAudienceType.LoggedInSince && model.AudienceLoggedInSince is null)
         {
             ModelState.AddModelError(nameof(model.AudienceLoggedInSince),
@@ -127,17 +133,21 @@ internal sealed class SurveyAdminController(
             SetSuccess(model.Id is null ? "Survey created." : "Survey saved.");
         }
 
-        return RedirectToAction(nameof(Edit), new { id });
+        return string.Equals(submitAction, "save-review", StringComparison.Ordinal)
+            ? RedirectToAction(nameof(Send), new { id })
+            : RedirectToAction(nameof(Edit), new { id });
     }
 
     [HttpPost("Open/{id:guid}")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Open(Guid id, CancellationToken ct)
+    public async Task<IActionResult> Open(Guid id, bool continueToSend, CancellationToken ct)
     {
         var actorId = GetCurrentUserId();
         if (actorId is null) return Forbid();
         await RunStatusTransitionAsync(id, () => surveyService.OpenAsync(id, actorId.Value, ct), "Survey opened.");
-        return RedirectToAction(nameof(Edit), new { id });
+        return continueToSend
+            ? RedirectToAction(nameof(Send), new { id })
+            : RedirectToAction(nameof(Edit), new { id });
     }
 
     [HttpPost("Close/{id:guid}")]
@@ -156,8 +166,12 @@ internal sealed class SurveyAdminController(
         var detail = await surveyService.GetForEditAsync(id, ct);
         if (detail is null) return NotFound();
 
-        var previewCount = await surveyService.PreviewAudienceCountAsync(id, ct);
+        var newRecipientCount = await surveyService.PreviewAudienceCountAsync(id, ct);
         var statuses = await surveyService.GetInviteStatusesAsync(id, ct);
+        var audienceTeamName = detail.Editable.AudienceType == SurveyAudienceType.Team
+            && detail.Editable.AudienceTeamId is { } teamId
+                ? (await LoadTeamsAsync(ct)).FirstOrDefault(t => t.Id == teamId)?.Name
+                : null;
 
         var vm = new SurveySendViewModel
         {
@@ -165,7 +179,9 @@ internal sealed class SurveyAdminController(
             Title = detail.Editable.Title.Resolve(detail.Editable.DefaultCulture, detail.Editable.DefaultCulture),
             Status = detail.Status,
             AudienceType = detail.Editable.AudienceType,
-            PreviewCount = previewCount,
+            AudienceTeamName = audienceTeamName,
+            AudienceLoggedInSince = detail.Editable.AudienceLoggedInSince?.InZone(Zone).Date,
+            NewRecipientCount = newRecipientCount,
             Invitations = statuses.OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase).ToList(),
         };
         return View(vm);

--- a/src/Sections/Humans.Surveys/Docs/Surveys.md
+++ b/src/Sections/Humans.Surveys/Docs/Surveys.md
@@ -139,6 +139,8 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 ## Routing
 
 - **`/Survey/Admin/*`** — `SurveyAdminController` (BoardOrAdmin): index, builder, send, results, CSV/JSON export.
+  The builder's **Save and review recipients** action continues to the Send page; a Draft with
+  net-new recipients can be opened there before the separate invitation confirmation.
 - **`/Survey/Answer?t={token}`** — `SurveyController` invited wizard (token carries identity; never the current principal).
 - **`/Survey/{slug}`** — `SurveyController` public anonymous wizard. Literal segments `Admin`/`Answer` are **reserved slugs** and resolve before `{slug}`.
 - **`/api/surveys/*`** — `SurveysApiController` (key-authed, read-only).
@@ -166,7 +168,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 - **`Completed` is a boolean with no timestamp** and `survey_invitations` has no `UpdatedAt`: recording *when* a CompletionTracked invitee finished would correlate (user-linked) with the unattributed response's `SubmittedAt` and re-identify them.
 - **Resume is Identified-only.** An in-progress Identified response is a persisted draft (`SubmittedAt is null`), found by `(SurveyId, UserId, SubmittedAt is null)`. CompletionTracked/Anonymous carry no link, are held in session, and **restart** on reopen.
 - **Branching is server-side and authoritative.** A null `ShowIf` is visible; hidden questions are never treated as required; at submit the full branching is re-evaluated and answers to hidden questions are **dropped/rejected** (the client cannot smuggle them). Author-save rejects `ShowIf` forward-references (`SurveyBranchingEvaluator.ValidateNoForwardReferences`).
-- **Invitation send is idempotent and additive.** Each send resolves the audience, diffs against existing `(SurveyId, UserId)` invitations, and creates+emails only net-new recipients; nobody is double-invited and **sends never revoke**. Requires the survey Open with an audience. Invites are operational (`MessageCategory.System`, always-send) — surveys are never marketing.
+- **Invitation send is idempotent and additive.** Each send resolves the audience, diffs against existing `(SurveyId, UserId)` invitations, and creates+emails only net-new recipients; nobody is double-invited and **sends never revoke**. The Send page previews that exact net-new count, not the raw audience size. Requires the survey Open with a valid audience configuration (`Team` requires a team; `LoggedInSince` requires a cutoff date). Invites are operational (`MessageCategory.System`, always-send) — surveys are never marketing.
 - **Exactly one reminder.** The 7-day reminder fires once per invitee (Open survey, `Completed == false`, `SentAt ≥ 7 days ago`, `ReminderSentAt is null`), stamping `ReminderSentAt` so it never repeats.
 - **Public responses are always Anonymous + `InputMethod=Slug`.** The slug path requires `AllowAnonymous`; reserved slugs `admin`/`answer` are rejected by the builder and 404 on the answer path.
 <!-- wheat: docs/plans/2026-06-27-post-event-app-feedback-survey.md §1.2, §3, §4 -->

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -67,17 +67,19 @@ internal sealed class SurveyClosedViewModel
     public string? Reason { get; init; }
 }
 
-/// <summary>Admin Send page: header (title/status/audience), resolved audience size, and per-invite status rows (sorted in the controller).</summary>
+/// <summary>Admin Send page: header, net-new recipient count, and per-invite status rows (sorted in the controller).</summary>
 internal sealed class SurveySendViewModel
 {
     public Guid Id { get; init; }
     public string Title { get; init; } = string.Empty;
     public SurveyStatus Status { get; init; }
     public SurveyAudienceType? AudienceType { get; init; }
-    public int PreviewCount { get; init; }
+    public string? AudienceTeamName { get; init; }
+    public LocalDate? AudienceLoggedInSince { get; init; }
+    public int NewRecipientCount { get; init; }
     public IReadOnlyList<SurveyInviteStatus> Invitations { get; init; } = [];
 
-    public bool CanSend => Status == SurveyStatus.Open && AudienceType is not null;
+    public bool CanSend => Status == SurveyStatus.Open && AudienceType is not null && NewRecipientCount > 0;
 }
 
 /// <summary>

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -47,7 +47,10 @@ internal interface ISurveyService : IApplicationService
     Task CloseAsync(Guid surveyId, Guid actorUserId, CancellationToken ct = default);
 
     // ── Invitations ────────────────────────────────────────────────────────
-    /// <summary>Resolves the survey's audience and returns its size; 0 if the survey has no audience.</summary>
+    /// <summary>
+    /// Resolves the survey's audience and returns the number of net-new recipients who would receive
+    /// an invitation on the next send; 0 if there is no configured audience or everyone is invited.
+    /// </summary>
     Task<int> PreviewAudienceCountAsync(Guid surveyId, CancellationToken ct = default);
 
     /// <summary>

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -72,6 +72,8 @@ internal sealed class SurveyService(
 
     public async Task<Guid> CreateAsync(SurveyEditInput input, Guid actorUserId, CancellationToken ct = default)
     {
+        ValidateAudienceConfiguration(
+            input.AudienceType, input.AudienceTeamId, input.AudienceLoggedInSince, requireAudience: false);
         var now = clock.GetCurrentInstant();
         var surveyId = Guid.NewGuid();
         var questions = MapQuestions(surveyId, input);
@@ -107,6 +109,8 @@ internal sealed class SurveyService(
 
     public async Task UpdateAsync(Guid surveyId, SurveyEditInput input, Guid actorUserId, CancellationToken ct = default)
     {
+        ValidateAudienceConfiguration(
+            input.AudienceType, input.AudienceTeamId, input.AudienceLoggedInSince, requireAudience: false);
         var now = clock.GetCurrentInstant();
         var questions = MapQuestions(surveyId, input);
         ValidateBranching(questions);
@@ -230,9 +234,13 @@ internal sealed class SurveyService(
     {
         var survey = await repo.GetByIdAsync(surveyId, ct);
         if (survey?.AudienceType is null) return 0;
+        if (AudienceConfigurationError(
+                survey.AudienceType, survey.AudienceTeamId, survey.AudienceLoggedInSince, requireAudience: true) is not null)
+            return 0;
 
         var recipients = await ResolveRecipientIdsAsync(survey.AudienceType.Value, survey.AudienceTeamId, survey.AudienceLoggedInSince, ct);
-        return recipients.Count;
+        var alreadyInvited = await repo.GetInvitedUserIdsAsync(surveyId, ct);
+        return recipients.Except(alreadyInvited).Count();
     }
 
     public async Task<SendResult> SendInvitesAsync(Guid surveyId, Guid actorUserId, CancellationToken ct = default)
@@ -241,11 +249,14 @@ internal sealed class SurveyService(
             ?? throw new InvalidOperationException("Survey not found.");
         if (survey.Status != SurveyStatus.Open)
             throw new InvalidOperationException("Invitations can only be sent for an Open survey.");
-        if (survey.AudienceType is null)
-            throw new InvalidOperationException("Survey has no audience to invite.");
+        var audienceType = survey.AudienceType
+            ?? throw new InvalidOperationException("Survey has no audience to invite.");
+        ValidateAudienceConfiguration(
+            audienceType, survey.AudienceTeamId, survey.AudienceLoggedInSince, requireAudience: true);
 
         var now = clock.GetCurrentInstant();
-        var target = await ResolveRecipientIdsAsync(survey.AudienceType.Value, survey.AudienceTeamId, survey.AudienceLoggedInSince, ct);
+        var target = await ResolveRecipientIdsAsync(
+            audienceType, survey.AudienceTeamId, survey.AudienceLoggedInSince, ct);
         var alreadyInvited = await repo.GetInvitedUserIdsAsync(surveyId, ct);
         var netNew = target.Except(alreadyInvited).ToList();
 
@@ -1044,6 +1055,28 @@ internal sealed class SurveyService(
             .Where(u => u.IsApproved && !u.IsGdprAnonymized && !u.IsDeletionPending && !u.IsMerged)
             .Select(u => u.Id)
             .ToList();
+    }
+
+    private static void ValidateAudienceConfiguration(
+        SurveyAudienceType? type, Guid? teamId, Instant? loggedInSince, bool requireAudience)
+    {
+        var error = AudienceConfigurationError(type, teamId, loggedInSince, requireAudience);
+        if (error is not null)
+            throw new InvalidOperationException(error);
+    }
+
+    private static string? AudienceConfigurationError(
+        SurveyAudienceType? type, Guid? teamId, Instant? loggedInSince, bool requireAudience)
+    {
+        if (type is null)
+            return requireAudience ? "Survey has no audience to invite." : null;
+        if (!Enum.IsDefined(type.Value))
+            return "The selected survey audience is not supported.";
+        if (type == SurveyAudienceType.Team && teamId is null)
+            return "A team is required for the Team audience.";
+        if (type == SurveyAudienceType.LoggedInSince && loggedInSince is null)
+            return "A cutoff date is required for the Logged in since audience.";
+        return null;
     }
 
     /// <summary>Maps builder input to tracked entities, assigning new ids where the input id is null.</summary>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -4,6 +4,16 @@
     ViewData["Title"] = Model.IsNew ? "New survey" : "Edit survey";
     // The culture the localized-field partials render visible initially (see _SurveyLocalizedField).
     ViewData["SurveyActiveCulture"] = Model.DefaultCulture;
+
+    static string AudienceLabel(SurveyAudienceType audience) => audience switch
+    {
+        SurveyAudienceType.Team => "A team",
+        SurveyAudienceType.AllActiveMembers => "All active humans",
+        SurveyAudienceType.TicketHolders => "Current ticket holders",
+        SurveyAudienceType.ShiftParticipants => "Humans with shifts",
+        SurveyAudienceType.LoggedInSince => "Humans logged in since a date",
+        _ => audience.ToString(),
+    };
 }
 
 <nav aria-label="breadcrumb">
@@ -101,26 +111,29 @@
                 <div class="col-md-3">
                     <label class="form-label small">Audience</label>
                     <select asp-for="AudienceType" class="form-select form-select-sm">
-                        <option value="">(choose at send time)</option>
+                        <option value="">No audience selected</option>
                         @foreach (var a in Enum.GetValues<SurveyAudienceType>())
                         {
-                            <option value="@a">@a</option>
+                            <option value="@a">@AudienceLabel(a)</option>
                         }
                     </select>
+                    <div class="form-text">Invitations are reviewed and sent separately after saving.</div>
                 </div>
-                <div class="col-md-3">
-                    <label class="form-label small">Team (if audience = Team)</label>
+                <div class="col-md-3" id="audience-team-field" style="@(Model.AudienceType == SurveyAudienceType.Team ? "" : "display:none")">
+                    <label class="form-label small">Team</label>
                     <select asp-for="AudienceTeamId" class="form-select form-select-sm">
-                        <option value="">—</option>
+                        <option value="">Choose a team</option>
                         @foreach (var t in Model.Teams)
                         {
                             <option value="@t.Id">@t.Name</option>
                         }
                     </select>
+                    <span asp-validation-for="AudienceTeamId" class="text-danger small"></span>
                 </div>
                 <div class="col-md-2" id="logged-in-since-field" style="@(Model.AudienceType == SurveyAudienceType.LoggedInSince ? "" : "display:none")">
                     <label class="form-label small">Logged in since</label>
                     <input type="date" name="AudienceLoggedInSince" value="@Model.AudienceLoggedInSinceInput" class="form-control form-control-sm" />
+                    <span asp-validation-for="AudienceLoggedInSince" class="text-danger small"></span>
                 </div>
                 <div class="col-md-4">
                     <label class="form-label small">Public link slug (optional; requires Allow anonymous)</label>
@@ -148,6 +161,9 @@
             <button type="submit" name="submitAction" value="save-translate" class="btn btn-outline-primary"
                     title="Saves, then machine-translates fields still missing in other languages from the default language. Existing text is never overwritten — review before opening.">
                 Save + translate missing
+            </button>
+            <button type="submit" name="submitAction" value="save-review" class="btn btn-outline-primary">
+                Save and review recipients
             </button>
             <button type="submit" class="btn btn-primary">Save survey</button>
         </div>
@@ -215,9 +231,11 @@
 
             // ── audience cutoff visibility ───────────────────────────────────
             const audienceType = document.querySelector('select[name="AudienceType"]');
+            const audienceTeamField = document.getElementById('audience-team-field');
             const loggedInSinceField = document.getElementById('logged-in-since-field');
 
             function applyAudienceVisibility() {
+                audienceTeamField.style.display = audienceType.value === 'Team' ? '' : 'none';
                 loggedInSinceField.style.display = audienceType.value === 'LoggedInSince' ? '' : 'none';
             }
 

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
@@ -23,6 +23,16 @@
         EmailOutboxStatus.Queued => "bg-info text-dark",
         _ => "bg-light text-dark",
     };
+
+    static string AudienceLabel(SurveyAudienceType audience) => audience switch
+    {
+        SurveyAudienceType.Team => "Team",
+        SurveyAudienceType.AllActiveMembers => "All active humans",
+        SurveyAudienceType.TicketHolders => "Current ticket holders",
+        SurveyAudienceType.ShiftParticipants => "Humans with shifts",
+        SurveyAudienceType.LoggedInSince => "Humans logged in since a date",
+        _ => audience.ToString(),
+    };
 }
 
 <nav aria-label="breadcrumb">
@@ -49,19 +59,54 @@
         }
         else
         {
-            <p class="mb-2">Audience: <strong>@Model.AudienceType</strong>, ~@Model.PreviewCount recipient(s).</p>
+            <p class="mb-2">
+                Audience: <strong>@AudienceLabel(Model.AudienceType.Value)</strong>
+                @if (Model.AudienceType == SurveyAudienceType.Team)
+                {
+                    <span>— @(Model.AudienceTeamName ?? "no team selected")</span>
+                }
+                else if (Model.AudienceType == SurveyAudienceType.LoggedInSince)
+                {
+                    <span>— @(Model.AudienceLoggedInSince?.ToDate() ?? "no date selected")</span>
+                }
+            </p>
+            <p class="mb-2">
+                <strong>@Model.NewRecipientCount</strong> new invitation(s) will be sent.
+                @if (Model.Invitations.Count > 0)
+                {
+                    <span>@Model.Invitations.Count invitation(s) have already been sent and will not be repeated.</span>
+                }
+            </p>
         }
 
         @if (Model.Status != SurveyStatus.Open)
         {
-            <p class="text-muted mb-0">The survey must be <strong>Open</strong> to send invitations. Open it from the <a asp-controller="SurveyAdmin" asp-action="Edit" asp-route-id="@Model.Id">builder</a> first.</p>
+            <p class="text-muted">The survey must be <strong>Open</strong> before invitations can be sent.</p>
+            @if (Model.AudienceType is not null && Model.NewRecipientCount > 0)
+            {
+                <form asp-controller="SurveyAdmin" asp-action="Open" asp-route-id="@Model.Id" method="post" class="d-inline">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="continueToSend" value="true" />
+                    <button type="submit" class="btn btn-success"
+                            data-confirm="Open this survey so it can receive responses?">
+                        Open survey
+                    </button>
+                </form>
+            }
         }
         else if (Model.CanSend)
         {
             <form asp-controller="SurveyAdmin" asp-action="Send" asp-route-id="@Model.Id" method="post" class="d-inline">
                 @Html.AntiForgeryToken()
-                <button type="submit" class="btn btn-primary" data-confirm="Send invitations to the current audience? Already-invited people are skipped.">Send invitations</button>
+                <button type="submit" class="btn btn-primary"
+                        data-confirm="Send @Model.NewRecipientCount new invitation(s) to the current audience? Already-invited humans are skipped.">
+                    Send @Model.NewRecipientCount invitation(s)
+                </button>
             </form>
+        }
+        else if (Model.AudienceType is not null && Model.NewRecipientCount == 0)
+        {
+            <p class="text-muted mb-0">There are no new humans to invite from the current audience.</p>
         }
     </div>
 </div>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
@@ -93,6 +93,10 @@
                     </button>
                 </form>
             }
+            else if (Model.AudienceType is not null)
+            {
+                <p class="text-muted mb-0">There are no new humans to invite from the current audience.</p>
+            }
         }
         else if (Model.CanSend)
         {

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Humans.Surveys.Data;
+using Humans.Surveys.Domain;
 using Humans.Integration.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,6 +58,85 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
             new LocalDateTime(2026, 7, 14, 10, 30).InZoneLeniently(Madrid).ToInstant());
         survey.ClosesAt.Should().Be(
             new LocalDateTime(2026, 8, 1, 18, 45, 30).InZoneLeniently(Madrid).ToInstant());
+    }
+
+    [HumansFact(Timeout = 60000)]
+    public async Task Save_rejects_team_audience_without_a_team()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var token = await GetCreateTokenAsync();
+        var title = $"Invalid team audience {Guid.NewGuid():N}";
+
+        var saveResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", token),
+            ("Title[en]", title),
+            ("AudienceType", nameof(SurveyAudienceType.Team))),
+            Xunit.TestContext.Current.CancellationToken);
+
+        saveResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await saveResp.Content.ReadAsStringAsync(Xunit.TestContext.Current.CancellationToken);
+        html.Should().Contain("Choose a team for the Team audience.");
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
+        var surveys = await db.Surveys.AsNoTracking()
+            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        surveys.Any(s => s.Title.Values.Values.Contains(title, StringComparer.Ordinal))
+            .Should().BeFalse();
+    }
+
+    [HumansFact(Timeout = 60000)]
+    public async Task Save_and_review_recipients_redirects_to_send_with_persisted_audience()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var token = await GetCreateTokenAsync();
+        var title = $"Review recipients {Guid.NewGuid():N}";
+
+        var saveResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", token),
+            ("Title[en]", title),
+            ("AudienceType", nameof(SurveyAudienceType.AllActiveMembers)),
+            ("submitAction", "save-review")),
+            Xunit.TestContext.Current.CancellationToken);
+
+        ((int)saveResp.StatusCode).Should().BeOneOf(
+            (int)HttpStatusCode.Found, (int)HttpStatusCode.Redirect);
+        var location = saveResp.Headers.Location!.ToString();
+        var idMatch = Regex.Match(location, "/Survey/Admin/Send/(?<id>[0-9a-fA-F-]{36})",
+            RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(2));
+        idMatch.Success.Should().BeTrue($"expected redirect to Send/{{id}}, got '{location}'");
+        var surveyId = Guid.Parse(idMatch.Groups["id"].Value);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
+        var survey = await db.Surveys.AsNoTracking()
+            .FirstAsync(s => s.Id == surveyId, Xunit.TestContext.Current.CancellationToken);
+        survey.AudienceType.Should().Be(SurveyAudienceType.AllActiveMembers);
+
+        var sendResp = await Client.GetAsync(location, Xunit.TestContext.Current.CancellationToken);
+        sendResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var sendHtml = await sendResp.Content.ReadAsStringAsync(Xunit.TestContext.Current.CancellationToken);
+        var sendToken = ExtractAntiForgeryToken(sendHtml);
+        sendToken.Should().NotBeNullOrEmpty();
+
+        var openResp = await Client.PostAsync($"/Survey/Admin/Open/{surveyId}", BuildForm(
+            ("__RequestVerificationToken", sendToken!),
+            ("continueToSend", "true")), Xunit.TestContext.Current.CancellationToken);
+
+        ((int)openResp.StatusCode).Should().BeOneOf(
+            (int)HttpStatusCode.Found, (int)HttpStatusCode.Redirect);
+        openResp.Headers.Location!.ToString().Should().Be($"/Survey/Admin/Send/{surveyId}");
+    }
+
+    private async Task<string> GetCreateTokenAsync()
+    {
+        var createResp = await Client.GetAsync(
+            "/Survey/Admin/Create", Xunit.TestContext.Current.CancellationToken);
+        createResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var token = ExtractAntiForgeryToken(
+            await createResp.Content.ReadAsStringAsync(Xunit.TestContext.Current.CancellationToken));
+        token.Should().NotBeNullOrEmpty();
+        return token!;
     }
 
     private static string? ExtractAntiForgeryToken(string html)

--- a/tests/Humans.Surveys.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Surveys.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -1,0 +1,75 @@
+using AwesomeAssertions;
+using Humans.Domain.Enums;
+using Humans.Surveys.Controllers;
+using Humans.Surveys.Domain;
+using Humans.Surveys.Models;
+using Humans.Surveys.Services;
+using Humans.Teams.Contracts;
+using Humans.Users.Contracts;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Surveys.Tests.Controllers;
+
+public sealed class SurveyAdminControllerTests
+{
+    [HumansFact]
+    public async Task Send_preserves_the_name_of_a_deactivated_audience_team()
+    {
+        var surveyId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var surveys = Substitute.For<ISurveyService>();
+        var teams = Substitute.For<ITeamServiceRead>();
+        var editable = new SurveyEditInput(
+            Text("Team survey"),
+            LocalizedText.Empty,
+            LocalizedText.Empty,
+            "en",
+            false,
+            null,
+            null,
+            SurveyAudienceType.Team,
+            teamId,
+            null,
+            null,
+            []);
+        surveys.GetForEditAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(new SurveyDetail(surveyId, SurveyStatus.Open, editable));
+        surveys.PreviewAudienceCountAsync(surveyId, Arg.Any<CancellationToken>()).Returns(3);
+        surveys.GetInviteStatusesAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SurveyInviteStatus>());
+        teams.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(new TeamInfo(
+                teamId,
+                "Archived Team",
+                null,
+                "archived-team",
+                IsActive: false,
+                IsSystemTeam: false,
+                SystemTeamType.None,
+                RequiresApproval: false,
+                IsPublicPage: false,
+                IsHidden: false,
+                IsPromotedToDirectory: false,
+                Instant.FromUtc(2026, 1, 1, 0, 0),
+                []));
+        var sut = new SurveyAdminController(
+            surveys,
+            teams,
+            Substitute.For<IUserServiceRead>(),
+            NullLogger<SurveyAdminController>.Instance);
+
+        var result = await sut.Send(surveyId, Xunit.TestContext.Current.CancellationToken);
+
+        var model = result.Should().BeOfType<ViewResult>().Subject.Model
+            .Should().BeOfType<SurveySendViewModel>().Subject;
+        model.AudienceTeamName.Should().Be("Archived Team");
+        await teams.Received(1).GetTeamAsync(teamId, Arg.Any<CancellationToken>());
+        await teams.DidNotReceive().GetTeamsAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static LocalizedText Text(string en) =>
+        new(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = en });
+}

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -80,6 +80,11 @@ public class SurveyServiceTests
     private static SurveyEditInput InputWithSlug(string? slug) =>
         new(L("Title"), L("Intro"), L("Thanks"), "en", true, null, null, null, null, null, slug, []);
 
+    private static SurveyEditInput InputWithAudience(
+        SurveyAudienceType audience, Guid? teamId = null, Instant? loggedInSince = null) =>
+        new(L("Title"), L("Intro"), L("Thanks"), "en", false, null, null,
+            audience, teamId, loggedInSince, null, []);
+
     [HumansTheory]
     [InlineData("admin")]
     [InlineData("Admin")]
@@ -116,6 +121,40 @@ public class SurveyServiceTests
 
         captured.Should().NotBeNull();
         captured!.PublicSlug.Should().Be("summer-feedback");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_team_audience_without_team_and_does_not_persist()
+    {
+        var act = async () => await CreateService().CreateAsync(
+            InputWithAudience(SurveyAudienceType.Team), Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*team is required*");
+        await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task UpdateAsync_rejects_logged_in_since_audience_without_cutoff_and_does_not_persist()
+    {
+        var act = async () => await CreateService().UpdateAsync(
+            Guid.NewGuid(), InputWithAudience(SurveyAudienceType.LoggedInSince),
+            Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cutoff date is required*");
+        await _repo.DidNotReceive().UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_unknown_audience_and_does_not_persist()
+    {
+        var act = async () => await CreateService().CreateAsync(
+            InputWithAudience((SurveyAudienceType)999), Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not supported*");
+        await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -252,17 +291,20 @@ public class SurveyServiceTests
             .ToList());
 
     [HumansFact]
-    public async Task PreviewAudienceCountAsync_team_counts_team_members()
+    public async Task PreviewAudienceCountAsync_team_counts_only_net_new_members()
     {
         var teamId = Guid.NewGuid();
+        Guid alreadyInvited = Guid.NewGuid(), newA = Guid.NewGuid(), newB = Guid.NewGuid();
         var survey = SurveyWith(SurveyStatus.Draft, SurveyAudienceType.Team, teamId);
         _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
         _teamService.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
-            .Returns(TeamWith(teamId, Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()));
+            .Returns(TeamWith(teamId, alreadyInvited, newA, newB));
+        _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns(new HashSet<Guid> { alreadyInvited });
 
         var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
 
-        count.Should().Be(3);
+        count.Should().Be(2);
     }
 
     [HumansFact]
@@ -278,6 +320,8 @@ public class SurveyServiceTests
             UserWithLastLogin(Guid.NewGuid(), cutoff + Duration.FromDays(30)), // after → included
             UserWithLastLogin(Guid.NewGuid(), null),                           // never logged in → excluded
         });
+        _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns(new HashSet<Guid>());
 
         var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
 
@@ -300,6 +344,8 @@ public class SurveyServiceTests
             UserWithLastLogin(Guid.NewGuid(), recentLogin, UserState.Suspended),      // status wall → excluded
             UserWithLastLogin(Guid.NewGuid(), recentLogin, UserState.AdminSuspended), // status wall → excluded
         });
+        _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns(new HashSet<Guid>());
 
         var count = await CreateService().PreviewAudienceCountAsync(survey.Id, TestContext.Current.CancellationToken);
 
@@ -441,6 +487,21 @@ public class SurveyServiceTests
         var act = async () => await CreateService().SendInvitesAsync(survey.Id, Guid.NewGuid(), TestContext.Current.CancellationToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [HumansFact]
+    public async Task SendInvitesAsync_throws_when_team_audience_has_no_team()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, SurveyAudienceType.Team, null);
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+
+        var act = async () => await CreateService().SendInvitesAsync(
+            survey.Id, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*team is required*");
+        await _repo.DidNotReceive().AddInvitationAndSaveAsync(
+            Arg.Any<SurveyInvitation>(), Arg.Any<CancellationToken>());
     }
 
     // ── Reminders (7-day nudge) ────────────────────────────────────────────────


### PR DESCRIPTION
## What

Improve the existing Survey audience workflow so authors can choose a clearly labelled audience, save and review recipients, see the exact net-new invitation count, open the survey from the review step, and explicitly confirm the additive send.

Refs nobodies-collective/Humans#1072. Approved at the 2026-08-17 Nobodies Collective board meeting: https://nobodies.team/transparency/2026-08-17-board.html

## Why

The backend invitation capability already existed, but the authoring flow implied the audience could be chosen later, allowed incomplete audience configuration, and previewed the raw audience rather than the number of invitations the next send would create.

## Existing surface checked

No new durable surface.

- Reused `ISurveyService.PreviewAudienceCountAsync`, changing its internal documented semantics from raw audience size to net-new recipients.
- Reused the existing `SurveyAdminController.Save`, `Open`, and `Send` actions/routes.
- Extended the existing Survey builder, Send view, and `SurveySendViewModel`.
- Reused `SurveyRepository.GetInvitedUserIdsAsync` and the existing audience resolvers.
- Preserved the existing typed `IEmailMessageFactory.SurveyInvitation` and Email outbox path.
- Added one focused controller regression-test file; added no public types, interface methods, service/repository methods, routes, pages, DI registrations, packages, or migrations.

## UI changes / screenshots

Local end-to-end verification covered:

1. Select a human-readable audience in the builder; Team and LoggedInSince fields appear only when applicable.
2. **Save and review recipients** continues to the existing Send page.
3. The Send page shows the selected team/date, exact net-new count, and prior invitation count.
4. A Draft can be opened from the Send page, returning there for the separate send confirmation.
5. After sending, the net-new count becomes zero and the send button disappears.

Screenshots should be captured from the PR preview once it is deployed; the local test instance uses disposable seeded data.

## Checklist

- [ ] **Section labeled** — the repository currently has no `section:surveys` label, and the contributor account cannot create/apply labels; maintainer action needed.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork). No direct commits to `main`.
- [x] **Branched off `peterdrier/Humans:main`** (`qa/main` in Daniel's local remote naming), not production.
- [x] **Issue refs are qualified** (`nobodies-collective/Humans#1072`).
- [x] **EF migrations** — none.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No.
- [x] **Reuse-first checked** — no unnecessary durable surface found.
- [x] **Build + test pass locally**:
  - `dotnet build Humans.slnx -v quiet`
  - `dotnet test Humans.slnx -v quiet`
  - Surveys: 132 passed
  - Full integration project: 284 passed, 1 skipped
  - Focused Survey admin MVC tests: 3 passed
- [x] **Nav coverage** — no new page or route; existing builder/Send pages and actions are reused.
- [x] **No magic strings** — `nameof()` / enum references used where applicable; form command values are wire values.
- [x] **Dates/times via NodaTime**, no icons added.

## Reviewer notes

- Audience configuration is enforced in `SurveyService` at create/update/send boundaries. Drafts may still have no audience; a selected Team requires a team ID and LoggedInSince requires a cutoff.
- The Send preview now performs the same audience resolution and existing-invitation subtraction as the send path. Every human has an email per the project invariant, so no artificial "missing email" category was introduced.
- Sending remains explicit, additive, and idempotent; no invitation is revoked or repeated.
- Custom invitation copy/Markdown remains intentionally out of scope to keep this a focused proving change. There is no schema or Email-contract change.
- Local disposable-DB verification created four invitation rows across two additive sends and four successfully processed Email outbox rows.
- An unrelated fresh-development-database `DevelopmentDashboardSeeder` state-transition defect was discovered during local testing and recorded in the required debt ledger rather than fixed in this scope.