### PR TITLE
feat(expenses): department + requested/max/payable columns on the review queues

### DIFF
--- a/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
+++ b/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
@@ -599,6 +599,7 @@ internal sealed class ExpensesController(
             {
                 Reports = reports,
                 SubmitterNames = submitterNames,
+                DepartmentNames = await ResolveDepartmentNamesAsync(),
                 FailedHoldedPushCount = await service.CountFailedHoldedPushesAsync(),
             });
         }
@@ -723,6 +724,20 @@ internal sealed class ExpensesController(
             id => users.TryGetValue(id, out var u) && !string.IsNullOrWhiteSpace(u.BurnerName)
                 ? u.BurnerName
                 : "(unknown)");
+    }
+
+    /// <summary>Active-year budget category id → department label. Categories in the department
+    /// group are one per team, so their own name is the department; anything else keeps its group
+    /// prefix so a non-department booking is still readable.</summary>
+    private async Task<IReadOnlyDictionary<Guid, string>> ResolveDepartmentNamesAsync()
+    {
+        var activeYear = await budgetService.GetActiveYearAsync();
+        if (activeYear is null) return new Dictionary<Guid, string>();
+
+        return activeYear.Groups
+            .SelectMany(g => g.Categories.Select(c =>
+                (c.Id, Display: g.IsDepartmentGroup ? c.Name : $"{g.Name} / {c.Name}")))
+            .ToDictionary(x => x.Id, x => x.Display);
     }
 
     private async Task PopulateEditModelAsync(ExpenseEditViewModel model, ExpenseReportDto report)

--- a/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
@@ -63,7 +63,9 @@
   <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Esborrany</value></data>
   <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Presentat</value></data>
   <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Retirat</value></data>
+  <data name="Expenses_ColPayable" xml:space="preserve"><value>A pagar</value></data>
   <data name="Expenses_ColReport" xml:space="preserve"><value>Informe</value></data>
+  <data name="Expenses_ColRequested" xml:space="preserve"><value>Sol·licitat</value></data>
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Assumpte</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Presentat</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Presentat per</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.de.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.de.resx
@@ -63,7 +63,9 @@
   <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Entwurf</value></data>
   <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Eingereicht</value></data>
   <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Zurückgezogen</value></data>
+  <data name="Expenses_ColPayable" xml:space="preserve"><value>Zahlbar</value></data>
   <data name="Expenses_ColReport" xml:space="preserve"><value>Abrechnung</value></data>
+  <data name="Expenses_ColRequested" xml:space="preserve"><value>Beantragt</value></data>
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Betreff</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Eingereicht</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Eingereicht von</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.es.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.es.resx
@@ -63,7 +63,9 @@
   <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Borrador</value></data>
   <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Enviado</value></data>
   <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Retirado</value></data>
+  <data name="Expenses_ColPayable" xml:space="preserve"><value>A pagar</value></data>
   <data name="Expenses_ColReport" xml:space="preserve"><value>Informe</value></data>
+  <data name="Expenses_ColRequested" xml:space="preserve"><value>Solicitado</value></data>
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Asunto</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Enviado</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Enviado por</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
@@ -63,7 +63,9 @@
   <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Brouillon</value></data>
   <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Soumise</value></data>
   <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Retirée</value></data>
+  <data name="Expenses_ColPayable" xml:space="preserve"><value>À payer</value></data>
   <data name="Expenses_ColReport" xml:space="preserve"><value>Note</value></data>
+  <data name="Expenses_ColRequested" xml:space="preserve"><value>Demandé</value></data>
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Objet</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Soumise</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Soumise par</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.it.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.it.resx
@@ -63,7 +63,9 @@
   <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Bozza</value></data>
   <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Presentata</value></data>
   <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Ritirata</value></data>
+  <data name="Expenses_ColPayable" xml:space="preserve"><value>Da pagare</value></data>
   <data name="Expenses_ColReport" xml:space="preserve"><value>Nota</value></data>
+  <data name="Expenses_ColRequested" xml:space="preserve"><value>Richiesto</value></data>
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Oggetto</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Presentata</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Presentata da</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.resx
@@ -63,7 +63,9 @@
   <data name="Enum_ExpenseReportStatus_Draft" xml:space="preserve"><value>Draft</value></data>
   <data name="Enum_ExpenseReportStatus_Submitted" xml:space="preserve"><value>Submitted</value></data>
   <data name="Enum_ExpenseReportStatus_Withdrawn" xml:space="preserve"><value>Withdrawn</value></data>
+  <data name="Expenses_ColPayable" xml:space="preserve"><value>Payable</value></data>
   <data name="Expenses_ColReport" xml:space="preserve"><value>Report</value></data>
+  <data name="Expenses_ColRequested" xml:space="preserve"><value>Requested</value></data>
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Subject</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Submitted</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Submitted by</value></data>

--- a/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
+++ b/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
@@ -146,6 +146,9 @@ internal sealed class ExpenseReviewViewModel
 {
     public required IReadOnlyList<ExpenseReportDto> Reports { get; init; }
     public required IReadOnlyDictionary<Guid, string> SubmitterNames { get; init; }
+    /// <summary>Budget category id → department. Department-group categories are one per team, so
+    /// the category name is the department; other groups show as "Group / Category".</summary>
+    public required IReadOnlyDictionary<Guid, string> DepartmentNames { get; init; }
     /// <summary>Pushes to Holded that were written off and need a finance admin to look at them.
     /// Zero hides the banner.</summary>
     public required int FailedHoldedPushCount { get; init; }

--- a/src/Sections/Humans.Expenses/Views/Expenses/Coordinator.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Coordinator.cshtml
@@ -27,13 +27,13 @@ else
         @<text><a asp-action="Detail" asp-route-id="@item.Id">@item.Id.ToString()[..8]…</a></text>;
     Func<ExpenseReportDto, IHtmlContent> submittedAtCell =
         @<text>@(item.SubmittedAt.HasValue ? item.SubmittedAt.Value.ToDate() : "")</text>;
-    @* Capped reports pay the cap, not the receipts total — show both so the difference is visible. *@
+    @* Requested is the receipts total; a capped report pays the cap instead, so all three columns
+       stay visible rather than collapsing into one. *@
+    Func<ExpenseReportDto, IHtmlContent> requestedCell = @<text>@item.Total.ToEuro()</text>;
+    Func<ExpenseReportDto, IHtmlContent> maxAmountCell =
+        @<text>@(item.MaxAmount is { } cap ? cap.ToEuro() : "")</text>;
     Func<ExpenseReportDto, IHtmlContent> payableCell = @<text>
-        @item.Payable.ToEuro()
-        @if (item.Payable < item.Total)
-        {
-            <span class="text-muted small ms-1"><s>@item.Total.ToEuro()</s></span>
-        }
+        <span class="@(item.Payable < item.Total ? "fw-semibold text-danger" : "")">@item.Payable.ToEuro()</span>
     </text>;
     Func<ExpenseReportDto, IHtmlContent> actionsCell = @<text>
         <div class="d-flex gap-2 justify-content-end">
@@ -65,8 +65,10 @@ else
     var table = TableModel.For(Model.Reports)
         .Template(Localizer["Expenses_ColReport"].Value, reportCell)
         .Column(Localizer["Expenses_ColSubmittedBy"].Value, r => Model.SubmitterNames.TryGetValue(r.SubmitterUserId, out var name) ? name : SharedLocalizer["Common_Unknown"].Value)
-        .Column(Localizer["Expenses_ColSubject"].Value, r => r.Note is { Length: > 60 } n ? n[..60] + "…" : r.Note)
-        .Template(SharedLocalizer["Common_Total"].Value, payableCell, c => c.End())
+        .Column(Localizer["Expenses_ColSubject"].Value, r => r.Note is { Length: > 80 } n ? n[..80] + "…" : r.Note)
+        .Template(Localizer["Expenses_ColRequested"].Value, requestedCell, c => c.End())
+        .Template(Localizer["Expenses_MaxAmount"].Value, maxAmountCell, c => c.End())
+        .Template(Localizer["Expenses_ColPayable"].Value, payableCell, c => c.End())
         .Column(SharedLocalizer["Common_Status"].Value, r => r.Status, c => c.EnumBadge())
         .Template(Localizer["Expenses_ColSubmitted"].Value, submittedAtCell)
         .Template(SharedLocalizer["Common_Actions"].Value, actionsCell, c => c.NoSort().End())

--- a/src/Sections/Humans.Expenses/Views/Expenses/Review.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Review.cshtml
@@ -44,8 +44,11 @@ else
                 <tr>
                     <th>Report</th>
                     <th>Submitter</th>
+                    <th>Department</th>
                     <th>Subject</th>
-                    <th>Total</th>
+                    <th class="text-end">Requested</th>
+                    <th class="text-end">Max</th>
+                    <th class="text-end">Payable</th>
                     <th>Status</th>
                     <th>Submitted</th>
                     <th class="text-end">Actions</th>
@@ -61,15 +64,18 @@ else
                             </a>
                         </td>
                         <td>@(Model.SubmitterNames.TryGetValue(r.SubmitterUserId, out var name) ? name : "(unknown)")</td>
-                        <td>@(r.Note is { Length: > 60 } n ? n[..60] + "…" : r.Note)</td>
-                        @* Capped reports pay the cap, not the receipts total — show both so the difference is visible. *@
-                        <td>
-                            @r.Payable.ToEuro()
-                            @if (r.Payable < r.Total)
+                        <td>@(Model.DepartmentNames.TryGetValue(r.BudgetCategoryId, out var dept) ? dept : "(unknown)")</td>
+                        <td>@(r.Note is { Length: > 80 } n ? n[..80] + "…" : r.Note)</td>
+                        @* Requested is the receipts total; a capped report pays the cap instead, so all
+                           three columns stay visible rather than collapsing into one. *@
+                        <td class="text-end">@r.Total.ToEuro()</td>
+                        <td class="text-end">
+                            @if (r.MaxAmount is { } cap)
                             {
-                                <span class="text-muted small ms-1"><s>@r.Total.ToEuro()</s></span>
+                                @cap.ToEuro()
                             }
                         </td>
+                        <td class="text-end @(r.Payable < r.Total ? "fw-semibold text-danger" : "")">@r.Payable.ToEuro()</td>
                         <td>
                             <span class="badge @badgeClass(r.Status)">@r.Status</span>
                         </td>


### PR DESCRIPTION
`/Expenses/Review` (finance) and `/Expenses/Coordinator` (department review) both showed a single **Total** column that rendered the payable with the receipts total struck through — the two numbers were there but hard to read, and neither page said which department the spend was for.

**Review** (`/Expenses/Review`)
- New **Department** column. Categories in the budget's department group are one per team, so they show the team name; anything else keeps its `Group / Category` prefix.
- **Total** → **Requested** / **Max** / **Payable**. Requested is the receipts total, Max is the cap when one was set, Payable is what actually pays (red + bold when capped).
- Note preview 60 → 80 chars.

**Coordinator** (`/Expenses/Coordinator`)
- Same three amount columns and the wider note. No Department column — the queue is already scoped to the coordinator's own departments.

Department names come from the active budget year via the existing `IBudgetServiceRead.GetActiveYearAsync()`, the same source `/Expenses` and the coordinator queue already use. No new service, repository, or interface surface.

New resx keys `Expenses_ColRequested` / `Expenses_ColPayable` in all six languages; `Expenses_MaxAmount` reused for the Max header.

Build clean, full solution test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)