### PR TITLE
feat(expenses): invoice lines with proof rows + inline attachment viewing

### DIFF
--- a/src/Sections/Humans.Expenses/Contracts/ExpenseAttachmentDto.cs
+++ b/src/Sections/Humans.Expenses/Contracts/ExpenseAttachmentDto.cs
@@ -13,4 +13,20 @@ public sealed record ExpenseAttachmentDto
     public required Instant UploadedAt { get; init; }
     /// <summary>When this file reached the report's Holded purchase document; null = not yet pushed.</summary>
     public Instant? HoldedUploadedAt { get; init; }
+
+    /// <summary>Renders in an &lt;img&gt; tag — drives the thumbnail preview.</summary>
+    public bool IsImage => IsImageType(ContentType);
+
+    /// <summary>Browsers render these natively, so the viewer link can open them inline instead of
+    /// forcing a download. Of the allowed upload types that leaves out only HEIC.</summary>
+    public bool IsInlineViewable => IsInlineViewableType(ContentType);
+
+    public static bool IsImageType(string contentType) =>
+        contentType.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase)
+        || contentType.Equals("image/jpg", StringComparison.OrdinalIgnoreCase)
+        || contentType.Equals("image/png", StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsInlineViewableType(string contentType) =>
+        IsImageType(contentType)
+        || contentType.Equals("application/pdf", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Sections/Humans.Expenses/Contracts/ExpenseLineDto.cs
+++ b/src/Sections/Humans.Expenses/Contracts/ExpenseLineDto.cs
@@ -9,5 +9,8 @@ public sealed record ExpenseLineDto
     public required ExpenseLineType LineType { get; init; }
     public Guid? AttachmentId { get; init; }
     public ExpenseAttachmentDto? Attachment { get; init; }
+    /// <summary>Non-null marks a proof row backing the referenced Invoice line. Proof rows are
+    /// excluded from the report total and from the Holded push — reviewed, never booked.</summary>
+    public Guid? ParentLineId { get; init; }
     public required int SortOrder { get; init; }
 }

--- a/src/Sections/Humans.Expenses/Contracts/ExpenseLineType.cs
+++ b/src/Sections/Humans.Expenses/Contracts/ExpenseLineType.cs
@@ -3,10 +3,14 @@ namespace Humans.Expenses.Contracts;
 /// <summary>
 /// Kind of expense line. <see cref="Receipt"/> lines require an attachment at submit time;
 /// travel lines (<see cref="Mileage"/> / <see cref="PerDiem"/>) are justified by the trip, not a receipt.
+/// <see cref="Invoice"/> is a supplier invoice (ZZP / autónomo payee) — it requires the invoice file
+/// attached and can carry proof rows (Receipt lines with <c>ParentLineId</c> set) that back it up
+/// for review but are never booked or pushed to Holded.
 /// </summary>
 public enum ExpenseLineType
 {
     Receipt = 0,
     Mileage,
-    PerDiem
+    PerDiem,
+    Invoice
 }

--- a/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
+++ b/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
@@ -276,7 +276,7 @@ internal sealed class ExpensesController(
     }
 
     [HttpGet("{id:guid}/Lines/New")]
-    public async Task<IActionResult> NewLine(Guid id, ExpenseLineType type = ExpenseLineType.Receipt)
+    public async Task<IActionResult> NewLine(Guid id, ExpenseLineType? type = null)
     {
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
@@ -290,11 +290,13 @@ internal sealed class ExpensesController(
             return RedirectToAction(nameof(Detail), new { id });
         }
 
-        return View(new ExpenseLineNewViewModel
+        var model = new ExpenseLineNewViewModel
         {
             ReportId = id,
             IsInvoice = type == ExpenseLineType.Invoice,
-        });
+        };
+        // No type chosen yet → the invoice-or-receipt chooser comes first.
+        return type is null ? View("NewLineChoice", model) : View(model);
     }
 
     [HttpPost("{id:guid}/Lines/Add")]

--- a/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
+++ b/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
@@ -292,7 +292,8 @@ internal sealed class ExpensesController(
             return RedirectToAction(nameof(Edit), new { id });
         }
 
-        var result = await service.AddLineWithResultAsync(id, user.Id, input.Description, input.Amount);
+        var result = await service.AddLineWithResultAsync(
+            id, user.Id, input.Description, input.Amount, input.LineType, input.ParentLineId);
         SetMutationResultWithDetails(result, "Line added.", "Failed to add line");
 
         return RedirectToAction(nameof(Edit), new { id });
@@ -488,7 +489,16 @@ internal sealed class ExpensesController(
     }
 
     [HttpGet("Attachment/{attachmentId:guid}")]
-    public async Task<IActionResult> Attachment(Guid attachmentId)
+    public Task<IActionResult> Attachment(Guid attachmentId)
+        => StreamAttachmentAsync(attachmentId, inline: false);
+
+    /// <summary>Same file, rendered in the browser tab (images + PDFs) instead of downloaded, so a
+    /// reviewer can check receipts without saving them. Non-renderable types fall back to download.</summary>
+    [HttpGet("Attachment/{attachmentId:guid}/View")]
+    public Task<IActionResult> AttachmentView(Guid attachmentId)
+        => StreamAttachmentAsync(attachmentId, inline: true);
+
+    private async Task<IActionResult> StreamAttachmentAsync(Guid attachmentId, bool inline)
     {
         try
         {
@@ -505,6 +515,11 @@ internal sealed class ExpensesController(
 
             var attachment = await expenseReadService.TryReadAttachmentAsync(owningReport, attachmentId);
             if (attachment is null) return NotFound();
+
+            // Inline only for the browser-renderable subset of the upload whitelist — no filename
+            // means no Content-Disposition: attachment, so the browser shows it in the tab.
+            if (inline && ExpenseAttachmentDto.IsInlineViewableType(attachment.ContentType))
+                return File(attachment.Bytes, attachment.ContentType);
 
             return File(attachment.Bytes, attachment.ContentType, attachment.OriginalFileName);
         }

--- a/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
+++ b/src/Sections/Humans.Expenses/Controllers/ExpensesController.cs
@@ -275,9 +275,32 @@ internal sealed class ExpensesController(
         return View(model);
     }
 
+    [HttpGet("{id:guid}/Lines/New")]
+    public async Task<IActionResult> NewLine(Guid id, ExpenseLineType type = ExpenseLineType.Receipt)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var report = await expenseReadService.GetAsync(id);
+        if (report is null) return NotFound();
+        if (report.SubmitterUserId != user.Id) return Forbid();
+        if (report.Status != ExpenseReportStatus.Draft)
+        {
+            SetError("This report can no longer be edited.");
+            return RedirectToAction(nameof(Detail), new { id });
+        }
+
+        return View(new ExpenseLineNewViewModel
+        {
+            ReportId = id,
+            IsInvoice = type == ExpenseLineType.Invoice,
+        });
+    }
+
     [HttpPost("{id:guid}/Lines/Add")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> AddLine(Guid id, AddLineInputModel input)
+    [RequestSizeLimit(25 * 1024 * 1024)] // 25 MB limit on request; service enforces 20 MB + content type
+    public async Task<IActionResult> AddLine(Guid id, AddLineInputModel input, IFormFile? file)
     {
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
@@ -286,17 +309,90 @@ internal sealed class ExpensesController(
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
+        // Where the submitter came from — and returns to on a validation error.
+        IActionResult BackToForm() => input.ParentLineId is { } parent
+            ? RedirectToAction(nameof(LineProofs), new { id, lineId = parent })
+            : RedirectToAction(nameof(NewLine), new { id, type = input.LineType });
+
         if (!ModelState.IsValid)
         {
             SetError("Invalid line data.");
-            return RedirectToAction(nameof(Edit), new { id });
+            return BackToForm();
         }
 
-        var result = await service.AddLineWithResultAsync(
-            id, user.Id, input.Description, input.Amount, input.LineType, input.ParentLineId);
-        SetMutationResultWithDetails(result, "Line added.", "Failed to add line");
+        await using var stream = file?.OpenReadStream();
+        var upload = file is null || stream is null
+            ? null
+            : new ExpenseFileUpload(file.FileName, file.ContentType, stream);
 
+        var result = await service.AddLineWithResultAsync(
+            id, user.Id, input.Description, input.Amount, input.LineType, input.ParentLineId, upload);
+
+        if (!result.Succeeded)
+        {
+            SetError(result.ErrorMessage is null ? "Failed to add line" : $"Failed to add line: {result.ErrorMessage}");
+            return BackToForm();
+        }
+
+        if (input.ParentLineId is { } parentId)
+        {
+            SetSuccess("Receipt added.");
+            return RedirectToAction(nameof(LineProofs), new { id, lineId = parentId });
+        }
+        if (input.LineType == ExpenseLineType.Invoice)
+        {
+            SetSuccess("Invoice added. Now add the receipts behind it.");
+            return RedirectToAction(nameof(LineProofs), new { id, lineId = result.LineId });
+        }
+        SetSuccess("Line added.");
         return RedirectToAction(nameof(Edit), new { id });
+    }
+
+    [HttpGet("{id:guid}/Lines/{lineId:guid}")]
+    public async Task<IActionResult> LineEdit(Guid id, Guid lineId)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var report = await expenseReadService.GetAsync(id);
+        if (report is null) return NotFound();
+        if (report.SubmitterUserId != user.Id) return Forbid();
+
+        var line = report.Lines.FirstOrDefault(l => l.Id == lineId);
+        if (line is null) return NotFound();
+
+        return View(new ExpenseLineEditViewModel
+        {
+            Report = report,
+            Line = line,
+            CanEditLines = report.Status == ExpenseReportStatus.Draft,
+        });
+    }
+
+    [HttpGet("{id:guid}/Lines/{lineId:guid}/Proofs")]
+    public async Task<IActionResult> LineProofs(Guid id, Guid lineId)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var report = await expenseReadService.GetAsync(id);
+        if (report is null) return NotFound();
+        if (report.SubmitterUserId != user.Id) return Forbid();
+
+        var invoiceLine = report.Lines.FirstOrDefault(
+            l => l.Id == lineId && l.LineType == ExpenseLineType.Invoice);
+        if (invoiceLine is null) return NotFound();
+
+        return View(new ExpenseLineProofsViewModel
+        {
+            Report = report,
+            InvoiceLine = invoiceLine,
+            Proofs = report.Lines
+                .Where(l => l.ParentLineId == lineId)
+                .OrderBy(l => l.SortOrder)
+                .ToList(),
+            CanEditLines = report.Status == ExpenseReportStatus.Draft,
+        });
     }
 
     // Mileage and per-diem lines can no longer be created: the Add mileage / Add per diem forms and
@@ -319,13 +415,13 @@ internal sealed class ExpensesController(
         if (!ModelState.IsValid)
         {
             SetError("Invalid line data.");
-            return RedirectToAction(nameof(Edit), new { id });
+            return RedirectToAction(nameof(LineEdit), new { id, lineId = input.LineId });
         }
 
         var result = await service.UpdateLineWithResultAsync(id, user.Id, input.LineId, input.Description, input.Amount);
         SetMutationResultWithDetails(result, "Line updated.", "Failed to update line");
 
-        return RedirectToAction(nameof(Edit), new { id });
+        return RedirectToAction(nameof(LineEdit), new { id, lineId = input.LineId });
     }
 
     [HttpPost("{id:guid}/Lines/{lineId:guid}/Remove")]
@@ -339,10 +435,15 @@ internal sealed class ExpensesController(
         if (report is null) return NotFound();
         if (report.SubmitterUserId != user.Id) return Forbid();
 
+        // A removed proof row returns the submitter to its invoice's proofs page.
+        var parentLineId = report.Lines.FirstOrDefault(l => l.Id == lineId)?.ParentLineId;
+
         var result = await service.RemoveLineWithResultAsync(id, user.Id, lineId);
         SetMutationResultWithDetails(result, "Line removed.", "Failed to remove line");
 
-        return RedirectToAction(nameof(Edit), new { id });
+        return parentLineId is { } parent
+            ? RedirectToAction(nameof(LineProofs), new { id, lineId = parent })
+            : RedirectToAction(nameof(Edit), new { id });
     }
 
     [HttpPost("{id:guid}/Lines/{lineId:guid}/Attach")]
@@ -360,7 +461,7 @@ internal sealed class ExpensesController(
         if (file is null || file.Length == 0)
         {
             SetError("Please select a file.");
-            return RedirectToAction(nameof(Edit), new { id });
+            return RedirectToAction(nameof(LineEdit), new { id, lineId });
         }
 
         await using var stream = file.OpenReadStream();
@@ -369,7 +470,7 @@ internal sealed class ExpensesController(
 
         SetMutationResult(result, "Attachment uploaded.", "Failed to upload attachment.");
 
-        return RedirectToAction(nameof(Edit), new { id });
+        return RedirectToAction(nameof(LineEdit), new { id, lineId });
     }
 
     [HttpPost("{id:guid}/Lines/{lineId:guid}/RemoveAttachment")]
@@ -393,7 +494,7 @@ internal sealed class ExpensesController(
             logger.LogError(ex, "Error removing attachment from line {LineId} on report {ReportId}", lineId, id);
             SetError($"Failed to remove attachment: {ex.Message}");
         }
-        return RedirectToAction(nameof(Edit), new { id });
+        return RedirectToAction(nameof(LineEdit), new { id, lineId });
     }
 
     [HttpPost("{id:guid}/Submit")]

--- a/src/Sections/Humans.Expenses/Data/Configurations/ExpenseLineConfiguration.cs
+++ b/src/Sections/Humans.Expenses/Data/Configurations/ExpenseLineConfiguration.cs
@@ -25,6 +25,13 @@ internal sealed class ExpenseLineConfiguration : IEntityTypeConfiguration<Expens
             .HasForeignKey(x => x.AttachmentId)
             .OnDelete(DeleteBehavior.Restrict);
 
+        // Proof rows point at their Invoice line. Restrict, not cascade: the service removes
+        // proofs explicitly so their attachment rows + files are cleaned up too.
+        b.HasOne<ExpenseLine>()
+            .WithMany()
+            .HasForeignKey(x => x.ParentLineId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         b.HasIndex(x => x.ExpenseReportId);
     }
 }

--- a/src/Sections/Humans.Expenses/Data/ExpenseReportMapper.cs
+++ b/src/Sections/Humans.Expenses/Data/ExpenseReportMapper.cs
@@ -38,6 +38,7 @@ internal static class ExpenseReportMapper
             Amount = l.Amount,
             LineType = l.LineType,
             AttachmentId = l.AttachmentId,
+            ParentLineId = l.ParentLineId,
             Attachment = l.Attachment is null
                 ? null
                 : new ExpenseAttachmentDto

--- a/src/Sections/Humans.Expenses/Data/ExpenseRepository.cs
+++ b/src/Sections/Humans.Expenses/Data/ExpenseRepository.cs
@@ -110,7 +110,8 @@ internal sealed class ExpenseRepository(IDbContextFactory<ExpensesDbContext> fac
         if (report is null) return false;
         line.ExpenseReportId = reportId;
         line.SortOrder = await ctx.ExpenseLines.CountAsync(l => l.ExpenseReportId == reportId, ct);
-        report.Total += line.Amount;
+        // Proof rows back an invoice line for review only — they never count toward the total.
+        if (line.ParentLineId is null) report.Total += line.Amount;
         ctx.ExpenseLines.Add(line);
         await ctx.SaveChangesAsync(ct);
         return true;
@@ -125,7 +126,8 @@ internal sealed class ExpenseRepository(IDbContextFactory<ExpensesDbContext> fac
         var tracked = await ctx.ExpenseLines
             .FirstOrDefaultAsync(l => l.Id == line.Id && l.ExpenseReportId == reportId, ct);
         if (report is null || tracked is null) return false;
-        report.Total = report.Total - tracked.Amount + line.Amount;
+        if (tracked.ParentLineId is null)
+            report.Total = report.Total - tracked.Amount + line.Amount;
         tracked.Description = line.Description;
         tracked.Amount = line.Amount;
         await ctx.SaveChangesAsync(ct);
@@ -142,7 +144,8 @@ internal sealed class ExpenseRepository(IDbContextFactory<ExpensesDbContext> fac
             .FirstOrDefaultAsync(l => l.Id == lineId && l.ExpenseReportId == reportId, ct);
         if (report is null || tracked is null) return false;
         ctx.ExpenseLines.Remove(tracked);
-        report.Total = report.Total - tracked.Amount;
+        if (tracked.ParentLineId is null)
+            report.Total = report.Total - tracked.Amount;
         await ctx.SaveChangesAsync(ct);
         return true;
     }

--- a/src/Sections/Humans.Expenses/Data/ExpenseRepository.cs
+++ b/src/Sections/Humans.Expenses/Data/ExpenseRepository.cs
@@ -134,7 +134,7 @@ internal sealed class ExpenseRepository(IDbContextFactory<ExpensesDbContext> fac
         return true;
     }
 
-    public async Task<bool> RemoveLineAsync(
+    public async Task<IReadOnlyList<ExpenseAttachment>?> RemoveLineAsync(
         Guid reportId, Guid lineId, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
@@ -142,12 +142,30 @@ internal sealed class ExpenseRepository(IDbContextFactory<ExpensesDbContext> fac
             .FirstOrDefaultAsync(r => r.Id == reportId, ct);
         var tracked = await ctx.ExpenseLines
             .FirstOrDefaultAsync(l => l.Id == lineId && l.ExpenseReportId == reportId, ct);
-        if (report is null || tracked is null) return false;
+        if (report is null || tracked is null) return null;
+
+        // An invoice line takes its proof rows with it. Line rows, proof rows, and their attachment
+        // rows all go in the same SaveChanges (EF orders deletes dependents-first), so the removal
+        // is all-or-nothing at the database.
+        var proofs = await ctx.ExpenseLines
+            .Where(l => l.ParentLineId == lineId)
+            .ToListAsync(ct);
+        var attachmentIds = proofs.Append(tracked)
+            .Where(l => l.AttachmentId is not null)
+            .Select(l => l.AttachmentId!.Value)
+            .ToList();
+        var attachments = await ctx.ExpenseAttachments
+            .Where(a => attachmentIds.Contains(a.Id))
+            .ToListAsync(ct);
+
+        ctx.ExpenseLines.RemoveRange(proofs);
         ctx.ExpenseLines.Remove(tracked);
+        ctx.ExpenseAttachments.RemoveRange(attachments);
+        // Proof rows never counted toward the total, so only the line itself adjusts it.
         if (tracked.ParentLineId is null)
             report.Total = report.Total - tracked.Amount;
         await ctx.SaveChangesAsync(ct);
-        return true;
+        return attachments;
     }
 
     public async Task<Guid> AddAttachmentAsync(

--- a/src/Sections/Humans.Expenses/Data/IExpenseRepository.cs
+++ b/src/Sections/Humans.Expenses/Data/IExpenseRepository.cs
@@ -36,7 +36,13 @@ internal interface IExpenseRepository : IRepository
         Guid reportId, ExpenseLine line, CancellationToken ct = default);
     Task<bool> UpdateLineAsync(
         Guid reportId, ExpenseLine line, CancellationToken ct = default);
-    Task<bool> RemoveLineAsync(
+    /// <summary>
+    /// Removes the line, any proof rows under it, and every attachment row they reference, in one
+    /// atomic save — a proof added concurrently makes the whole removal fail rather than leaving
+    /// half the rows gone. Returns the removed attachments so the caller can delete their files
+    /// (after the commit), or null when the report or line does not exist.
+    /// </summary>
+    Task<IReadOnlyList<ExpenseAttachment>?> RemoveLineAsync(
         Guid reportId, Guid lineId, CancellationToken ct = default);
     Task<Guid> AddAttachmentAsync(
         ExpenseAttachment attachment, CancellationToken ct = default);

--- a/src/Sections/Humans.Expenses/Data/Migrations/20260818212349_ExpenseLineProofRows.Designer.cs
+++ b/src/Sections/Humans.Expenses/Data/Migrations/20260818212349_ExpenseLineProofRows.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Expenses.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Expenses.Data.Migrations
 {
     [DbContext(typeof(ExpensesDbContext))]
-    partial class ExpensesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818212349_ExpenseLineProofRows")]
+    partial class ExpenseLineProofRows
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Expenses/Data/Migrations/20260818212349_ExpenseLineProofRows.cs
+++ b/src/Sections/Humans.Expenses/Data/Migrations/20260818212349_ExpenseLineProofRows.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Expenses.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExpenseLineProofRows : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ParentLineId",
+                table: "expense_lines",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_expense_lines_ParentLineId",
+                table: "expense_lines",
+                column: "ParentLineId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_expense_lines_expense_lines_ParentLineId",
+                table: "expense_lines",
+                column: "ParentLineId",
+                principalTable: "expense_lines",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_expense_lines_expense_lines_ParentLineId",
+                table: "expense_lines");
+
+            migrationBuilder.DropIndex(
+                name: "IX_expense_lines_ParentLineId",
+                table: "expense_lines");
+
+            migrationBuilder.DropColumn(
+                name: "ParentLineId",
+                table: "expense_lines");
+        }
+    }
+}

--- a/src/Sections/Humans.Expenses/Docs/Expenses.md
+++ b/src/Sections/Humans.Expenses/Docs/Expenses.md
@@ -98,6 +98,9 @@ Append-on-approve, drained by `HoldedExpenseOutboxJob`. Fields: `EventType` (Cre
 | `/Expenses/New` | GET/POST | Authenticated | Create draft |
 | `/Expenses/{id}` | GET | Authenticated (resource-based: owner + Finance) | Detail |
 | `/Expenses/{id}/Edit` | GET/POST | Authenticated (owner, Draft only) | Edit draft |
+| `/Expenses/{id}/Lines/New` | GET | Authenticated (owner, Draft only) | Focused add-line page (receipt default; `?type=Invoice` for the invoice flow). One submit creates line + attachment together |
+| `/Expenses/{id}/Lines/{lineId}` | GET | Authenticated (owner) | Focused line page — edit description/amount, view/replace/remove the file, remove the line |
+| `/Expenses/{id}/Lines/{lineId}/Proofs` | GET | Authenticated (owner) | Invoice line's proofs page — coverage vs invoice amount, list, add/remove proof rows |
 | `/Expenses/{id}/Lines/*` | POST | Authenticated (owner) | Line mutations |
 | `/Expenses/{id}/Submit` | POST | Authenticated (owner) | Submit |
 | `/Expenses/{id}/Withdraw` | POST | Authenticated (owner, submitted states) | Withdraw |

--- a/src/Sections/Humans.Expenses/Docs/Expenses.md
+++ b/src/Sections/Humans.Expenses/Docs/Expenses.md
@@ -13,7 +13,8 @@ Members submit expense reports for reimbursement. Finance Admin reviews and appr
 ## Concepts
 
 - An **ExpenseReport** is the top-level reimbursement request. It moves through a state machine (see Invariants) and is owned by the submitter until submitted.
-- An **ExpenseLine** is one line item within a report — a description, amount, and optional attachment. Each line has a `LineType` (Receipt / Mileage / PerDiem). **Receipt** lines require an attachment at submit time. **Mileage** lines are computed server-side as km × the configured per-km rate (€0.26/km, 2026 Spanish IRPF tax-exempt rate); **PerDiem** lines are computed as days × the Spanish day-trip (€26.67) or overnight (€53.34) rate. Both travel types have their amount and rate written into the description at creation time and never require an attachment. Rates live in `TravelReimbursementConfig` (bound from `appsettings.json` `TravelReimbursement` section; defaults are the 2026 values).
+- An **ExpenseLine** is one line item within a report — a description, amount, and optional attachment. Each line has a `LineType` (Receipt / Mileage / PerDiem / Invoice). **Receipt** lines require an attachment at submit time. **Mileage** lines are computed server-side as km × the configured per-km rate (€0.26/km, 2026 Spanish IRPF tax-exempt rate); **PerDiem** lines are computed as days × the Spanish day-trip (€26.67) or overnight (€53.34) rate. Both travel types have their amount and rate written into the description at creation time and never require an attachment. Rates live in `TravelReimbursementConfig` (bound from `appsettings.json` `TravelReimbursement` section; defaults are the 2026 values).
+- An **Invoice** line is a supplier invoice from a payee who invoices the org (ZZP / autónomo contractor). It requires the invoice file attached at submit time and is what gets booked into Holded. Because these are reimbursements (not just payments), an invoice line can carry **proof rows**: Receipt lines with `ParentLineId` pointing at the invoice line, each with its own attachment, showing the underlying expenses behind the invoiced amount. Proof rows are reviewed with the report but are **excluded from `Total`** and **never pushed to Holded** (neither as document lines nor as attachments). The detail view shows the proof sum vs the invoice amount to the approvers — display-only, never enforced (VAT and fees mean the two need not match).
 - **Travel lines can no longer be created.** The Add mileage / Add per diem forms and the `Lines/AddMileage` + `Lines/AddPerDiem` endpoints have been removed, so no new Mileage or PerDiem line can enter the system. The service-layer plumbing (`AddMileageLineWithResultAsync`, `AddPerDiemLineWithResultAsync`, `ExpenseLineType.Mileage`/`PerDiem`, `PerDiemKind`, `TravelReimbursementConfig`) is retained: pre-existing travel lines still render, submit, and total correctly, and the feature is re-enabled by restoring the two controller actions and the two `Edit.cshtml` forms.
 - An **ExpenseAttachment** is a receipt or supporting document uploaded to a line item. Files are stored on disk via the shared `IFileStorage` abstraction (key `uploads/expense-attachments/{attachmentId}{.ext}`); the download route at `/Expenses/Attachment/{id}` re-authorizes the caller and streams bytes with the original filename via `Content-Disposition`. Metadata only in the DB.
 - A **HoldedExpenseOutboxEvent** is an async task queued when a report is approved or its category tag changes — drained by `HoldedExpenseOutboxJob` to create/update Holded purchase documents.
@@ -62,8 +63,9 @@ Members submit expense reports for reimbursement. Finance Admin reviews and appr
 | ExpenseReportId | Guid | FK → expense_reports |
 | Description | string | |
 | Amount | decimal | |
-| LineType | ExpenseLineType | Receipt \| Mileage \| PerDiem; default Receipt |
+| LineType | ExpenseLineType | Receipt \| Mileage \| PerDiem \| Invoice; default Receipt |
 | AttachmentId | Guid? | FK → expense_attachments |
+| ParentLineId | Guid? | self-FK → expense_lines; non-null marks a proof row backing that Invoice line |
 | SortOrder | int | |
 
 ### ExpenseAttachment
@@ -101,6 +103,7 @@ Append-on-approve, drained by `HoldedExpenseOutboxJob`. Fields: `EventType` (Cre
 | `/Expenses/{id}/Withdraw` | POST | Authenticated (owner, submitted states) | Withdraw |
 | `/Expenses/{id}/Iban` | GET/POST | Authenticated (resource-based: self, FinanceAdmin with report context) | View/set IBAN |
 | `/Expenses/Attachment/{id}` | GET | Authenticated (resource-based) | Download attachment |
+| `/Expenses/Attachment/{id}/View` | GET | Authenticated (resource-based) | Same file inline (images + PDFs render in the tab; other types fall back to download) |
 | `/Expenses/Coordinator` | GET | Authenticated (coordinator) | Coordinator queue |
 | `/Expenses/{id}/Endorse` | POST | Authenticated (coordinator, resource-based) | Endorse |
 | `/Expenses/{id}/CoordinatorReject` | POST | Authenticated (coordinator, resource-based) | Coordinator reject |
@@ -122,7 +125,8 @@ Append-on-approve, drained by `HoldedExpenseOutboxJob`. Fields: `EventType` (Cre
 ## Invariants
 
 - A report follows the lifecycle: Draft → Submitted → (CoordinatorEndorsed →) Approved. `Approved` is terminal for the report — paid/unpaid is read from the member's Holded creditor ledger, never stamped on the report. Terminal alternate: Withdrawn (from Submitted/CoordinatorEndorsed/Approved). `ExpenseReportService` enforces all transitions; `IExpenseRepository` persists them atomically.
-- A report cannot be submitted without at least one line. Every **Receipt** line must have an attachment at submit time; Mileage/PerDiem lines never require one (a pure-travel report submits with zero attachments).
+- A report cannot be submitted without at least one line. Every **Receipt** line (proof rows included) and every **Invoice** line must have an attachment at submit time; Mileage/PerDiem lines never require one (a pure-travel report submits with zero attachments).
+- A proof row must reference an Invoice line on the same report, must itself be a Receipt line, and nests one level only (enforced at add time). Removing an invoice line removes its proof rows and their attachments. Proof rows never contribute to `Total`, never appear as Holded document lines, and their files are never uploaded to the Holded doc. Proof coverage vs the invoice amount is displayed to reviewers but never enforced.
 - Travel lines (Mileage/PerDiem) cannot be edited after creation — their amounts are computed from their inputs and the receipt requirement is waived on that basis, so `UpdateLineAsync` rejects them. To change one, remove it and re-add it so the amount is recomputed. Only Receipt lines accept free-text description/amount edits.
 - Only the deciders set `MaxAmount` — the coordinator on Endorse, a finance admin on Approve. Each decision form is prefilled with the current cap and its submitted value replaces it outright: blank clears the cap (the approve form's "Leave blank for no cap" is literal). The submitter can never set or see a cap input, and neither decider path may lower it below 0.01 or above 1,000,000. A cap is recorded in the decision's own `ExpenseEndorse` / `ExpenseApprove` audit entry, not a separate action.
 - Payable is `min(Total, MaxAmount)` (`ExpenseReportDto.Payable`). Owed/paid math, the review and coordinator queues, and the detail view all read the payable; `Total` renders only as the receipts total.

--- a/src/Sections/Humans.Expenses/Domain/ExpenseLine.cs
+++ b/src/Sections/Humans.Expenses/Domain/ExpenseLine.cs
@@ -10,6 +10,9 @@ internal sealed class ExpenseLine
     public decimal Amount { get; set; }
     public ExpenseLineType LineType { get; set; }
     public Guid? AttachmentId { get; set; }
+    /// <summary>Non-null marks a proof row backing the referenced Invoice line. Proof rows are
+    /// excluded from the report total and from the Holded push — reviewed, never booked.</summary>
+    public Guid? ParentLineId { get; set; }
     public int SortOrder { get; set; }
 
     public ExpenseAttachment? Attachment { get; set; }

--- a/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
+++ b/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
@@ -109,6 +109,29 @@ internal sealed class ExpenseDetailViewModel
     public IReadOnlyList<HoldedCreditorAccountRow> CreditorAccounts { get; init; } = [];
 }
 
+internal sealed class ExpenseLineNewViewModel
+{
+    public required Guid ReportId { get; init; }
+    /// <summary>Invoice mode: the payee is a business invoicing the association (VAT-recoverable).</summary>
+    public required bool IsInvoice { get; init; }
+}
+
+internal sealed class ExpenseLineEditViewModel
+{
+    public required ExpenseReportDto Report { get; init; }
+    public required ExpenseLineDto Line { get; init; }
+    public required bool CanEditLines { get; init; }
+}
+
+internal sealed class ExpenseLineProofsViewModel
+{
+    public required ExpenseReportDto Report { get; init; }
+    public required ExpenseLineDto InvoiceLine { get; init; }
+    public required IReadOnlyList<ExpenseLineDto> Proofs { get; init; }
+    public required bool CanEditLines { get; init; }
+    public decimal ProofTotal => Proofs.Sum(p => p.Amount);
+}
+
 internal sealed class AddLineInputModel
 {
     [Required, StringLength(500)]

--- a/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
+++ b/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
@@ -116,6 +116,12 @@ internal sealed class AddLineInputModel
 
     [Required, Range(0.01, 1_000_000)]
     public decimal Amount { get; set; }
+
+    /// <summary>Receipt (default) or Invoice; the service rejects travel types on this path.</summary>
+    public ExpenseLineType LineType { get; set; } = ExpenseLineType.Receipt;
+
+    /// <summary>Set when adding a proof row under an invoice line.</summary>
+    public Guid? ParentLineId { get; set; }
 }
 
 internal sealed class EditLineInputModel

--- a/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
@@ -396,39 +396,27 @@ internal sealed class ExpenseReportService(
         Guid reportId, Guid submitterUserId, Guid lineId,
         CancellationToken ct = default)
     {
-        var report = await RequireEditableReportAsync(reportId, submitterUserId, ct);
+        await RequireEditableReportAsync(reportId, submitterUserId, ct);
 
-        // An invoice line takes its proof rows with it — each cleaned up like any other line.
-        foreach (var proof in report.Lines.Where(l => l.ParentLineId == lineId))
+        // One atomic save removes the line, any proof rows under it, and their attachment rows;
+        // the files are deleted only after that commit (best-effort — an orphan file is a warning,
+        // an orphan row is a bug).
+        var removedAttachments = await repo.RemoveLineAsync(reportId, lineId, ct)
+            ?? throw new InvalidOperationException("Failed to remove line.");
+
+        foreach (var attachment in removedAttachments)
         {
-            await CleanLineAttachmentAsync(proof, ct);
-            var proofOk = await repo.RemoveLineAsync(reportId, proof.Id, ct);
-            if (!proofOk) throw new InvalidOperationException("Failed to remove proof row.");
-        }
-
-        // Clean attachment first to avoid orphan row + file blob.
-        var line = report.Lines.FirstOrDefault(l => l.Id == lineId);
-        if (line is not null) await CleanLineAttachmentAsync(line, ct);
-
-        var ok = await repo.RemoveLineAsync(reportId, lineId, ct);
-        if (!ok) throw new InvalidOperationException("Failed to remove line.");
-    }
-
-    private async Task CleanLineAttachmentAsync(ExpenseLineDto line, CancellationToken ct)
-    {
-        if (line.Attachment is null) return;
-        await repo.SetLineAttachmentAsync(line.Id, null, ct);
-        await repo.RemoveAttachmentAsync(line.Attachment.Id, ct);
-        try
-        {
-            await fileStorage.DeleteAsync(
-                AttachmentKey(line.Attachment.Id, line.Attachment.Extension), ct);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex,
-                "Could not delete attachment file {AttachmentId} while removing line {LineId}",
-                line.Attachment.Id, line.Id);
+            try
+            {
+                await fileStorage.DeleteAsync(
+                    AttachmentKey(attachment.Id, attachment.Extension), ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Could not delete attachment file {AttachmentId} while removing line {LineId}",
+                    attachment.Id, lineId);
+            }
         }
     }
 

--- a/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
@@ -301,21 +301,42 @@ internal sealed class ExpenseReportService(
         return line.Id;
     }
 
-    public Task<ExpenseMutationResult> AddLineWithResultAsync(
+    public async Task<ExpenseAddLineResult> AddLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
         ExpenseLineType lineType = ExpenseLineType.Receipt,
         Guid? parentLineId = null,
-        CancellationToken ct = default) =>
-        RunMutationAsync(async () =>
+        ExpenseFileUpload? file = null,
+        CancellationToken ct = default)
+    {
+        try
         {
             // Travel lines are computed and can no longer be created; this path takes free-text
             // amounts, so it accepts only the receipt-backed types.
             if (lineType is not (ExpenseLineType.Receipt or ExpenseLineType.Invoice))
                 throw new ExpenseValidationException("Only receipt and invoice lines can be added.");
-            await AddLineAsync(reportId, submitterUserId, description, amount, lineType, parentLineId, ct);
-            return ExpenseMutationResult.Success;
-        }, "Error adding line to report {ReportId}", null, reportId);
+            // Validate the file before creating anything, so a bad upload leaves no half-made line.
+            if (file is not null)
+                ValidateAttachmentUpload(file.FileName, file.ContentType, file.Content);
+
+            var lineId = await AddLineAsync(
+                reportId, submitterUserId, description, amount, lineType, parentLineId, ct);
+            if (file is not null)
+                await AttachFileToLineAsync(
+                    reportId, submitterUserId, lineId, file.FileName, file.ContentType, file.Content, ct);
+            return new ExpenseAddLineResult(true, null, lineId);
+        }
+        catch (ExpenseValidationException ex)
+        {
+            logger.LogWarning("Error adding line to report {ReportId}: {Reason}", reportId, ex.Message);
+            return new ExpenseAddLineResult(false, ex.Message, null);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error adding line to report {ReportId}", reportId);
+            return new ExpenseAddLineResult(false, ex.Message, null);
+        }
+    }
 
     public Task<ExpenseMutationResult> AddMileageLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
@@ -436,10 +457,8 @@ internal sealed class ExpenseReportService(
         "application/pdf", "image/jpeg", "image/jpg", "image/png", "image/heic"
     };
 
-    internal async Task<Guid> AttachFileToLineAsync(
-        Guid reportId, Guid submitterUserId,
-        Guid lineId, string originalFileName, string contentType,
-        Stream content, CancellationToken ct = default)
+    private static void ValidateAttachmentUpload(
+        string originalFileName, string contentType, Stream content)
     {
         if (content is null || content.Length == 0)
             throw new ExpenseValidationException("Please select a file.");
@@ -449,6 +468,15 @@ internal sealed class ExpenseReportService(
         var extension = Path.GetExtension(originalFileName).ToLowerInvariant();
         if (!AllowedContentTypes.Contains(contentType) || !AllowedExtensions.Contains(extension))
             throw new ExpenseValidationException("Unsupported file type. Upload PDF, JPEG, PNG, or HEIC.");
+    }
+
+    internal async Task<Guid> AttachFileToLineAsync(
+        Guid reportId, Guid submitterUserId,
+        Guid lineId, string originalFileName, string contentType,
+        Stream content, CancellationToken ct = default)
+    {
+        ValidateAttachmentUpload(originalFileName, contentType, content);
+        var extension = Path.GetExtension(originalFileName).ToLowerInvariant();
 
         var report = await RequireEditableReportAsync(reportId, submitterUserId, ct);
 

--- a/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
@@ -271,9 +271,21 @@ internal sealed class ExpenseReportService(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
         ExpenseLineType lineType = ExpenseLineType.Receipt,
+        Guid? parentLineId = null,
         CancellationToken ct = default)
     {
-        await RequireEditableReportAsync(reportId, submitterUserId, ct);
+        var report = await RequireEditableReportAsync(reportId, submitterUserId, ct);
+
+        if (parentLineId is { } parentId)
+        {
+            // A proof row is a Receipt backing an Invoice line on the same report. One level only.
+            if (lineType != ExpenseLineType.Receipt)
+                throw new ExpenseValidationException("Proof rows must be receipt lines.");
+            var parent = report.Lines.FirstOrDefault(l => l.Id == parentId)
+                ?? throw new ExpenseValidationException("Parent line not found on this report.");
+            if (parent.LineType != ExpenseLineType.Invoice)
+                throw new ExpenseValidationException("Proof rows can only be added to an invoice line.");
+        }
 
         var line = new ExpenseLine
         {
@@ -281,7 +293,8 @@ internal sealed class ExpenseReportService(
             ExpenseReportId = reportId,
             Description = description,
             Amount = amount,
-            LineType = lineType
+            LineType = lineType,
+            ParentLineId = parentLineId
         };
         var ok = await repo.AddLineAsync(reportId, line, ct);
         if (!ok) throw new InvalidOperationException("Failed to add line.");
@@ -291,10 +304,16 @@ internal sealed class ExpenseReportService(
     public Task<ExpenseMutationResult> AddLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
+        ExpenseLineType lineType = ExpenseLineType.Receipt,
+        Guid? parentLineId = null,
         CancellationToken ct = default) =>
         RunMutationAsync(async () =>
         {
-            await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.Receipt, ct);
+            // Travel lines are computed and can no longer be created; this path takes free-text
+            // amounts, so it accepts only the receipt-backed types.
+            if (lineType is not (ExpenseLineType.Receipt or ExpenseLineType.Invoice))
+                throw new ExpenseValidationException("Only receipt and invoice lines can be added.");
+            await AddLineAsync(reportId, submitterUserId, description, amount, lineType, parentLineId, ct);
             return ExpenseMutationResult.Success;
         }, "Error adding line to report {ReportId}", null, reportId);
 
@@ -311,7 +330,7 @@ internal sealed class ExpenseReportService(
                 $"{km.ToString("0.#", CultureInfo.InvariantCulture)} km @ " +
                 $"€{rate.ToString("0.00", CultureInfo.InvariantCulture)} = " +
                 $"€{amount.ToString("0.00", CultureInfo.InvariantCulture)}";
-            await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.Mileage, ct);
+            await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.Mileage, ct: ct);
             return ExpenseMutationResult.Success;
         }, "Error adding mileage line to report {ReportId}", null, reportId);
 
@@ -331,7 +350,7 @@ internal sealed class ExpenseReportService(
                 $"€{amount.ToString("0.00", CultureInfo.InvariantCulture)}";
             if (!string.IsNullOrWhiteSpace(note))
                 description += $" — {note.Trim()}";
-            await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.PerDiem, ct);
+            await AddLineAsync(reportId, submitterUserId, description, amount, ExpenseLineType.PerDiem, ct: ct);
             return ExpenseMutationResult.Success;
         }, "Error adding per-diem line to report {ReportId}", null, reportId);
 
@@ -348,7 +367,7 @@ internal sealed class ExpenseReportService(
         // receipt requirement on that basis. A free-text amount/description edit here would let a
         // submitter claim an arbitrary unreceipted amount on a Mileage/PerDiem line. To change one,
         // remove it and re-add so the amount is always recomputed from its inputs.
-        if (existing.LineType != ExpenseLineType.Receipt)
+        if (existing.LineType is ExpenseLineType.Mileage or ExpenseLineType.PerDiem)
             throw new ExpenseValidationException(
                 "Travel lines are computed from their inputs and cannot be edited. Remove the line and add it again to change it.");
 
@@ -379,27 +398,38 @@ internal sealed class ExpenseReportService(
     {
         var report = await RequireEditableReportAsync(reportId, submitterUserId, ct);
 
+        // An invoice line takes its proof rows with it — each cleaned up like any other line.
+        foreach (var proof in report.Lines.Where(l => l.ParentLineId == lineId))
+        {
+            await CleanLineAttachmentAsync(proof, ct);
+            var proofOk = await repo.RemoveLineAsync(reportId, proof.Id, ct);
+            if (!proofOk) throw new InvalidOperationException("Failed to remove proof row.");
+        }
+
         // Clean attachment first to avoid orphan row + file blob.
         var line = report.Lines.FirstOrDefault(l => l.Id == lineId);
-        if (line?.Attachment is not null)
-        {
-            await repo.SetLineAttachmentAsync(lineId, null, ct);
-            await repo.RemoveAttachmentAsync(line.Attachment.Id, ct);
-            try
-            {
-                await fileStorage.DeleteAsync(
-                    AttachmentKey(line.Attachment.Id, line.Attachment.Extension), ct);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex,
-                    "Could not delete attachment file {AttachmentId} while removing line {LineId}",
-                    line.Attachment.Id, lineId);
-            }
-        }
+        if (line is not null) await CleanLineAttachmentAsync(line, ct);
 
         var ok = await repo.RemoveLineAsync(reportId, lineId, ct);
         if (!ok) throw new InvalidOperationException("Failed to remove line.");
+    }
+
+    private async Task CleanLineAttachmentAsync(ExpenseLineDto line, CancellationToken ct)
+    {
+        if (line.Attachment is null) return;
+        await repo.SetLineAttachmentAsync(line.Id, null, ct);
+        await repo.RemoveAttachmentAsync(line.Attachment.Id, ct);
+        try
+        {
+            await fileStorage.DeleteAsync(
+                AttachmentKey(line.Attachment.Id, line.Attachment.Extension), ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Could not delete attachment file {AttachmentId} while removing line {LineId}",
+                line.Attachment.Id, line.Id);
+        }
     }
 
     public Task<ExpenseMutationResult> RemoveLineWithResultAsync(
@@ -518,8 +548,10 @@ internal sealed class ExpenseReportService(
         if (!report.Lines.Any())
             throw new ExpenseValidationException("Report must have at least one line.");
 
-        if (report.Lines.Any(l => l.LineType == ExpenseLineType.Receipt && l.AttachmentId is null))
-            throw new ExpenseValidationException("Receipt lines must have an attachment before submitting.");
+        // Receipt lines (proof rows included) need their receipt; invoice lines need the invoice file.
+        if (report.Lines.Any(l => l.LineType is ExpenseLineType.Receipt or ExpenseLineType.Invoice
+                                  && l.AttachmentId is null))
+            throw new ExpenseValidationException("Receipt and invoice lines must have an attachment before submitting.");
 
         var profile = (await userService.GetUserInfoAsync(submitterUserId, ct))?.Profile;
         if (profile?.Iban is null)
@@ -1037,8 +1069,14 @@ internal sealed class ExpenseReportService(
         // the category has no active mapping; the doc still creates, just unbooked.
         var holdedAccountId = await holdedFinance.GetHoldedAccountIdForCategoryAsync(report.BudgetCategoryId, ct);
 
-        var docLines = report.Lines
+        // Proof rows back an invoice line for review only — they are not booked and their
+        // files are not uploaded. What Holded gets is the invoice itself.
+        var bookableLines = report.Lines
+            .Where(l => l.ParentLineId is null)
             .OrderBy(l => l.SortOrder)
+            .ToList();
+
+        var docLines = bookableLines
             .Select(l => new HoldedPurchaseDocumentLineInput
             {
                 Description = l.Description,
@@ -1084,7 +1122,7 @@ internal sealed class ExpenseReportService(
         // 3. Upload attachments. Each upload is recorded so a re-run — after a failure partway
         // through this loop, or after a finance admin requeues the event — resumes instead of
         // adding a second copy of every earlier file to the same doc.
-        foreach (var line in report.Lines.OrderBy(l => l.SortOrder))
+        foreach (var line in bookableLines)
         {
             if (line.AttachmentId is null || line.Attachment is null) continue;
             if (line.Attachment.HoldedUploadedAt is not null) continue;
@@ -1242,6 +1280,7 @@ internal sealed class ExpenseReportService(
                     l.Description,
                     l.Amount,
                     l.LineType,
+                    l.ParentLineId,
                     l.SortOrder,
                     Attachment = l.Attachment is null
                         ? null

--- a/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
@@ -322,8 +322,19 @@ internal sealed class ExpenseReportService(
             var lineId = await AddLineAsync(
                 reportId, submitterUserId, description, amount, lineType, parentLineId, ct);
             if (file is not null)
-                await AttachFileToLineAsync(
-                    reportId, submitterUserId, lineId, file.FileName, file.ContentType, file.Content, ct);
+            {
+                try
+                {
+                    await AttachFileToLineAsync(
+                        reportId, submitterUserId, lineId, file.FileName, file.ContentType, file.Content, ct);
+                }
+                catch
+                {
+                    // The form retries the whole add, so a line left behind here would duplicate.
+                    await repo.RemoveLineAsync(reportId, lineId, ct);
+                    throw;
+                }
+            }
             return new ExpenseAddLineResult(true, null, lineId);
         }
         catch (ExpenseValidationException ex)

--- a/src/Sections/Humans.Expenses/Services/IExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/IExpenseReportService.cs
@@ -16,15 +16,18 @@ internal interface IExpenseReportService : IExpenseReportServiceRead, IApplicati
         CancellationToken ct = default);
 
     /// <summary>
-    /// Adds a Receipt or Invoice line. A non-null <paramref name="parentLineId"/> adds a proof row
-    /// backing that Invoice line — reviewed with the report but excluded from the total and never
-    /// pushed to Holded. Travel line types are rejected (their creation paths were removed).
+    /// Adds a Receipt or Invoice line, attaching <paramref name="file"/> in the same operation when
+    /// one is supplied (validated before the line is created, so a bad upload leaves nothing
+    /// half-made). A non-null <paramref name="parentLineId"/> adds a proof row backing that Invoice
+    /// line — reviewed with the report but excluded from the total and never pushed to Holded.
+    /// Travel line types are rejected (their creation paths were removed).
     /// </summary>
-    Task<ExpenseMutationResult> AddLineWithResultAsync(
+    Task<ExpenseAddLineResult> AddLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
         ExpenseLineType lineType = ExpenseLineType.Receipt,
         Guid? parentLineId = null,
+        ExpenseFileUpload? file = null,
         CancellationToken ct = default);
 
     Task<ExpenseMutationResult> UpdateLineWithResultAsync(
@@ -105,6 +108,13 @@ internal sealed record ExpenseMutationResult(bool Succeeded, string? ErrorMessag
 
     public static ExpenseMutationResult Failure(string message) => new(false, message);
 }
+
+/// <summary>Line-add outcome; <see cref="LineId"/> is set on success so the caller can redirect
+/// into the new line's flow (an invoice line continues to its proofs page).</summary>
+internal sealed record ExpenseAddLineResult(bool Succeeded, string? ErrorMessage, Guid? LineId);
+
+/// <summary>An uploaded file passed through to the service untouched.</summary>
+internal sealed record ExpenseFileUpload(string FileName, string ContentType, Stream Content);
 
 internal sealed record ExpenseIbanSaveResult(
     bool Succeeded,

--- a/src/Sections/Humans.Expenses/Services/IExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/IExpenseReportService.cs
@@ -15,9 +15,16 @@ internal interface IExpenseReportService : IExpenseReportServiceRead, IApplicati
         Guid budgetCategoryId, string? note,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Adds a Receipt or Invoice line. A non-null <paramref name="parentLineId"/> adds a proof row
+    /// backing that Invoice line — reviewed with the report but excluded from the total and never
+    /// pushed to Holded. Travel line types are rejected (their creation paths were removed).
+    /// </summary>
     Task<ExpenseMutationResult> AddLineWithResultAsync(
         Guid reportId, Guid submitterUserId,
         string description, decimal amount,
+        ExpenseLineType lineType = ExpenseLineType.Receipt,
+        Guid? parentLineId = null,
         CancellationToken ct = default);
 
     Task<ExpenseMutationResult> UpdateLineWithResultAsync(

--- a/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
@@ -98,30 +98,86 @@
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var line in r.Lines.OrderBy(l => l.SortOrder))
-                            {
-                                <tr>
-                                    <td>@(line.SortOrder + 1)</td>
-                                    <td>@line.Description</td>
-                                    <td class="text-end">@line.Amount.ToEuro()</td>
-                                    <td>
-                                        @if (line.LineType != ExpenseLineType.Receipt)
+                            @{
+                                var proofsByParent = r.Lines.Where(l => l.ParentLineId is not null)
+                                    .GroupBy(l => l.ParentLineId!.Value)
+                                    .ToDictionary(g => g.Key, g => g.OrderBy(l => l.SortOrder).ToList());
+                                var topLevelLines = r.Lines.Where(l => l.ParentLineId is null).OrderBy(l => l.SortOrder).ToList();
+
+                                async Task AttachmentCell(ExpenseLineDto line)
+                                {
+                                    if (line.LineType is ExpenseLineType.Mileage or ExpenseLineType.PerDiem)
+                                    {
+                                        <span class="badge bg-info text-dark">@(line.LineType == ExpenseLineType.Mileage ? "Mileage" : "Per diem")</span>
+                                    }
+                                    else if (line.Attachment is not null)
+                                    {
+                                        if (line.Attachment.IsImage)
                                         {
-                                            <span class="badge bg-info text-dark">@(line.LineType == ExpenseLineType.Mileage ? "Mileage" : "Per diem")</span>
-                                        }
-                                        else if (line.Attachment is not null)
-                                        {
-                                            <a asp-action="Attachment" asp-route-attachmentId="@line.Attachment.Id"
-                                               class="text-decoration-none" target="_blank">
-                                                <i class="fa-solid fa-paperclip me-1"></i>@line.Attachment.OriginalFileName
+                                            <a href="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })" target="_blank" class="me-2">
+                                                <img src="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })"
+                                                     alt="@line.Attachment.OriginalFileName" class="rounded border"
+                                                     style="max-height:48px; max-width:80px; object-fit:cover;" loading="lazy" />
                                             </a>
                                         }
-                                        else
+                                        <a href="@Url.Action(line.Attachment.IsInlineViewable ? "AttachmentView" : "Attachment", new { attachmentId = line.Attachment.Id })"
+                                           class="text-decoration-none" target="_blank">
+                                            <i class="fa-solid fa-paperclip me-1"></i>@line.Attachment.OriginalFileName
+                                        </a>
+                                        if (line.Attachment.IsInlineViewable)
                                         {
-                                            <span class="text-warning small"><i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment</span>
+                                            <a href="@Url.Action("Attachment", new { attachmentId = line.Attachment.Id })"
+                                               class="text-decoration-none small text-muted ms-1" title="Download">
+                                                <i class="fa-solid fa-download"></i>
+                                            </a>
                                         }
+                                    }
+                                    else
+                                    {
+                                        <span class="text-warning small"><i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment</span>
+                                    }
+                                }
+                            }
+                            @foreach (var line in topLevelLines)
+                            {
+                                <tr>
+                                    <td>@(topLevelLines.IndexOf(line) + 1)</td>
+                                    <td>
+                                        @if (line.LineType == ExpenseLineType.Invoice)
+                                        {
+                                            <span class="badge bg-primary me-1">Invoice</span>
+                                        }
+                                        @line.Description
                                     </td>
+                                    <td class="text-end">@line.Amount.ToEuro()</td>
+                                    <td>@{ await AttachmentCell(line); }</td>
                                 </tr>
+                                @if (line.LineType == ExpenseLineType.Invoice)
+                                {
+                                    var proofs = proofsByParent.TryGetValue(line.Id, out var p) ? p : [];
+                                    foreach (var proof in proofs)
+                                    {
+                                        <tr class="text-muted">
+                                            <td></td>
+                                            <td class="ps-4"><i class="fa-solid fa-turn-up fa-rotate-90 me-1 small"></i>@proof.Description</td>
+                                            <td class="text-end">(@proof.Amount.ToEuro())</td>
+                                            <td>@{ await AttachmentCell(proof); }</td>
+                                        </tr>
+                                    }
+                                    var proofTotal = proofs.Sum(x => x.Amount);
+                                    <tr class="small">
+                                        <td></td>
+                                        <td class="ps-4 text-muted" colspan="2">
+                                            @* Display-only for the approvers: VAT and fees mean the proofs need not match. *@
+                                            Proof of expenses:
+                                            <span class="badge @(proofTotal >= line.Amount ? "bg-success" : "bg-warning text-dark")">
+                                                @proofTotal.ToEuro() of @line.Amount.ToEuro() invoiced
+                                            </span>
+                                            — reviewed only, not sent to Holded.
+                                        </td>
+                                        <td></td>
+                                    </tr>
+                                }
                             }
                         </tbody>
                         <tfoot>

--- a/src/Sections/Humans.Expenses/Views/Expenses/Edit.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Edit.cshtml
@@ -63,97 +63,190 @@
     </div>
 </div>
 
+@{
+    var proofsByParent = r.Lines.Where(l => l.ParentLineId is not null)
+        .GroupBy(l => l.ParentLineId!.Value)
+        .ToDictionary(g => g.Key, g => g.OrderBy(l => l.SortOrder).ToList());
+    var topLevelLines = r.Lines.Where(l => l.ParentLineId is null).OrderBy(l => l.SortOrder).ToList();
+
+    async Task AttachmentBlock(ExpenseLineDto line, string uploadLabel)
+    {
+        if (line.Attachment is not null)
+        {
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+                @if (line.Attachment.IsImage)
+                {
+                    <a href="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })" target="_blank">
+                        <img src="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })"
+                             alt="@line.Attachment.OriginalFileName" class="rounded border"
+                             style="max-height:60px; max-width:100px; object-fit:cover;" loading="lazy" />
+                    </a>
+                }
+                <a href="@Url.Action(line.Attachment.IsInlineViewable ? "AttachmentView" : "Attachment", new { attachmentId = line.Attachment.Id })"
+                   class="text-decoration-none small" target="_blank">
+                    <i class="fa-solid fa-paperclip me-1"></i>@line.Attachment.OriginalFileName
+                    <span class="text-muted">(@(line.Attachment.SizeBytes / 1024) KB)</span>
+                </a>
+                @if (line.Attachment.IsInlineViewable)
+                {
+                    <a href="@Url.Action("Attachment", new { attachmentId = line.Attachment.Id })"
+                       class="text-decoration-none small text-muted" title="Download">
+                        <i class="fa-solid fa-download"></i>
+                    </a>
+                }
+                @if (Model.CanEditLines)
+                {
+                    <form action="@Url.Action("RemoveAttachment", new { id = r.Id, lineId = line.Id })"
+                          method="post" class="d-inline">
+                        @Html.AntiForgeryToken()
+                        <button type="submit" class="btn btn-sm btn-outline-secondary">Remove attachment</button>
+                    </form>
+                }
+            </div>
+        }
+        else if (Model.CanEditLines)
+        {
+            <form action="@Url.Action("AttachFile", new { id = r.Id, lineId = line.Id })"
+                  method="post" enctype="multipart/form-data" class="d-flex gap-2 align-items-center flex-wrap">
+                @Html.AntiForgeryToken()
+                <input type="file" name="file" class="form-control form-control-sm" style="max-width:260px;"
+                       accept=".pdf,.jpg,.jpeg,.png,.heic" />
+                <button type="submit" class="btn btn-sm btn-outline-primary">@uploadLabel</button>
+            </form>
+            <div class="form-text text-warning mt-1">
+                <i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment — required before submit.
+            </div>
+        }
+        else
+        {
+            <span class="text-warning small"><i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment</span>
+        }
+    }
+
+    async Task EditLineForm(ExpenseLineDto line)
+    {
+        if (!Model.CanEditLines || line.LineType is ExpenseLineType.Mileage or ExpenseLineType.PerDiem) return;
+        <details class="mt-2">
+            <summary class="text-muted small" style="cursor:pointer;">Edit description / amount</summary>
+            <form action="@Url.Action("UpdateLine", new { id = r.Id })" method="post" class="mt-2">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="LineId" value="@line.Id" />
+                <div class="row g-2">
+                    <div class="col-md-7">
+                        <input type="text" name="Description" value="@line.Description"
+                               class="form-control form-control-sm" maxlength="500" required />
+                    </div>
+                    <div class="col-md-3">
+                        <input type="number" name="Amount" value="@line.Amount.ToString("F2")"
+                               class="form-control form-control-sm" step="0.01" min="0.01" required />
+                    </div>
+                    <div class="col-md-2">
+                        <button type="submit" class="btn btn-sm btn-primary w-100">Save</button>
+                    </div>
+                </div>
+            </form>
+        </details>
+    }
+
+    async Task RemoveLineButton(ExpenseLineDto line, string confirmText)
+    {
+        if (!Model.CanEditLines) return;
+        <form action="@Url.Action("RemoveLine", new { id = r.Id, lineId = line.Id })"
+              method="post" class="d-inline">
+            @Html.AntiForgeryToken()
+            <button type="submit" class="btn btn-sm btn-outline-danger"
+                    data-confirm="@confirmText">Remove line</button>
+        </form>
+    }
+}
+
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
         <strong>Expense lines</strong>
-        <span class="badge bg-secondary">@r.Lines.Count line(s) — @r.Total.ToEuro()</span>
+        <span class="badge bg-secondary">@topLevelLines.Count line(s) — @r.Total.ToEuro()</span>
     </div>
     <div class="card-body p-0">
-        @foreach (var line in r.Lines.OrderBy(l => l.SortOrder))
+        @foreach (var line in topLevelLines)
         {
             <div class="border-bottom p-3">
                 <div class="d-flex justify-content-between align-items-start mb-2">
                     <div>
+                        @if (line.LineType == ExpenseLineType.Invoice)
+                        {
+                            <span class="badge bg-primary me-1">Invoice</span>
+                        }
                         <strong>@line.Description</strong>
                         <span class="ms-2 text-muted">@line.Amount.ToEuro()</span>
                     </div>
                     <div class="d-flex gap-2 flex-wrap justify-content-end">
-                        @if (Model.CanEditLines)
-                        {
-                            <form asp-action="RemoveLine" asp-route-id="@r.Id" asp-route-lineId="@line.Id"
-                                  method="post" class="d-inline">
-                                @Html.AntiForgeryToken()
-                                <button type="submit" class="btn btn-sm btn-outline-danger"
-                                        data-confirm="Remove this line and its attachment?">Remove line</button>
-                            </form>
-                        }
+                        @{ await RemoveLineButton(line, line.LineType == ExpenseLineType.Invoice
+                               ? "Remove this invoice line, its attachment, and all its proof rows?"
+                               : "Remove this line and its attachment?"); }
                     </div>
                 </div>
 
-                @if (line.LineType != ExpenseLineType.Receipt)
+                @if (line.LineType is ExpenseLineType.Mileage or ExpenseLineType.PerDiem)
                 {
                     <span class="badge bg-info text-dark">
                         <i class="fa-solid fa-route me-1"></i>@(line.LineType == ExpenseLineType.Mileage ? "Mileage" : "Per diem") — no receipt needed
                     </span>
                 }
-                else if (line.Attachment is not null)
+                else
                 {
-                    <div class="d-flex align-items-center gap-2 flex-wrap">
-                        <a asp-action="Attachment" asp-route-attachmentId="@line.Attachment.Id"
-                           class="text-decoration-none small" target="_blank">
-                            <i class="fa-solid fa-paperclip me-1"></i>@line.Attachment.OriginalFileName
-                            <span class="text-muted">(@(line.Attachment.SizeBytes / 1024) KB)</span>
-                        </a>
+                    await AttachmentBlock(line, line.LineType == ExpenseLineType.Invoice ? "Upload invoice" : "Upload receipt");
+                    await EditLineForm(line);
+                }
+
+                @if (line.LineType == ExpenseLineType.Invoice)
+                {
+                    var proofs = proofsByParent.TryGetValue(line.Id, out var p) ? p : [];
+                    var proofTotal = proofs.Sum(x => x.Amount);
+                    <div class="ms-4 mt-3 border-start ps-3">
+                        <div class="small mb-2">
+                            <strong>Proof of expenses</strong>
+                            <span class="badge @(proofTotal >= line.Amount ? "bg-success" : "bg-warning text-dark") ms-2">
+                                @proofTotal.ToEuro() of @line.Amount.ToEuro() invoiced
+                            </span>
+                            <span class="text-muted ms-1">— reviewed with the report, not sent to Holded.</span>
+                        </div>
+                        @foreach (var proof in proofs)
+                        {
+                            <div class="border-bottom py-2">
+                                <div class="d-flex justify-content-between align-items-start mb-1">
+                                    <div>
+                                        @proof.Description
+                                        <span class="ms-2 text-muted">@proof.Amount.ToEuro()</span>
+                                    </div>
+                                    <div>
+                                        @{ await RemoveLineButton(proof, "Remove this proof row and its attachment?"); }
+                                    </div>
+                                </div>
+                                @{ await AttachmentBlock(proof, "Upload receipt"); await EditLineForm(proof); }
+                            </div>
+                        }
                         @if (Model.CanEditLines)
                         {
-                            <form asp-action="RemoveAttachment" asp-route-id="@r.Id" asp-route-lineId="@line.Id"
-                                  method="post" class="d-inline">
+                            <form action="@Url.Action("AddLine", new { id = r.Id })" method="post" class="mt-2">
                                 @Html.AntiForgeryToken()
-                                <button type="submit" class="btn btn-sm btn-outline-secondary">Remove attachment</button>
+                                <input type="hidden" name="ParentLineId" value="@line.Id" />
+                                <div class="row g-2 align-items-end">
+                                    <div class="col-md-6">
+                                        <input type="text" name="Description" class="form-control form-control-sm"
+                                               maxlength="500" placeholder="Underlying expense (what the invoice covers)" required />
+                                    </div>
+                                    <div class="col-md-3">
+                                        <input type="number" name="Amount" class="form-control form-control-sm"
+                                               step="0.01" min="0.01" placeholder="0.00" required />
+                                    </div>
+                                    <div class="col-md-3">
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary w-100">
+                                            <i class="fa-solid fa-plus me-1"></i>Add proof
+                                        </button>
+                                    </div>
+                                </div>
                             </form>
                         }
                     </div>
-                }
-                else if (Model.CanEditLines)
-                {
-                    <form asp-action="AttachFile" asp-route-id="@r.Id" asp-route-lineId="@line.Id"
-                          method="post" enctype="multipart/form-data" class="d-flex gap-2 align-items-center flex-wrap">
-                        @Html.AntiForgeryToken()
-                        <input type="file" name="file" class="form-control form-control-sm" style="max-width:260px;"
-                               accept=".pdf,.jpg,.jpeg,.png,.heic" />
-                        <button type="submit" class="btn btn-sm btn-outline-primary">Upload receipt</button>
-                    </form>
-                    <div class="form-text text-warning mt-1">
-                        <i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment — required before submit.
-                    </div>
-                }
-                else
-                {
-                    <span class="text-warning small"><i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment</span>
-                }
-
-                @if (Model.CanEditLines && line.LineType == ExpenseLineType.Receipt)
-                {
-                    <details class="mt-2">
-                        <summary class="text-muted small" style="cursor:pointer;">Edit description / amount</summary>
-                        <form asp-action="UpdateLine" asp-route-id="@r.Id" method="post" class="mt-2">
-                            @Html.AntiForgeryToken()
-                            <input type="hidden" name="LineId" value="@line.Id" />
-                            <div class="row g-2">
-                                <div class="col-md-7">
-                                    <input type="text" name="Description" value="@line.Description"
-                                           class="form-control form-control-sm" maxlength="500" required />
-                                </div>
-                                <div class="col-md-3">
-                                    <input type="number" name="Amount" value="@line.Amount.ToString("F2")"
-                                           class="form-control form-control-sm" step="0.01" min="0.01" required />
-                                </div>
-                                <div class="col-md-2">
-                                    <button type="submit" class="btn btn-sm btn-primary w-100">Save</button>
-                                </div>
-                            </div>
-                        </form>
-                    </details>
                 }
             </div>
         }
@@ -165,21 +258,32 @@
             <form asp-action="AddLine" asp-route-id="@r.Id" method="post">
                 @Html.AntiForgeryToken()
                 <div class="row g-2 align-items-end">
-                    <div class="col-md-6">
+                    <div class="col-md-4">
                         <label class="form-label form-label-sm">Description</label>
                         <input type="text" name="Description" class="form-control form-control-sm"
                                maxlength="500" placeholder="What was bought / paid for?" required />
                     </div>
-                    <div class="col-md-3">
+                    <div class="col-md-2">
                         <label class="form-label form-label-sm">Amount (EUR)</label>
                         <input type="number" name="Amount" class="form-control form-control-sm"
                                step="0.01" min="0.01" placeholder="0.00" required />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label form-label-sm">Type</label>
+                        <select name="LineType" class="form-select form-select-sm">
+                            <option value="@ExpenseLineType.Receipt" selected>Receipt</option>
+                            <option value="@ExpenseLineType.Invoice">Supplier invoice</option>
+                        </select>
                     </div>
                     <div class="col-md-3">
                         <button type="submit" class="btn btn-sm btn-outline-primary w-100">
                             <i class="fa-solid fa-plus me-1"></i>Add line
                         </button>
                     </div>
+                </div>
+                <div class="form-text mt-1">
+                    Choose <em>Supplier invoice</em> when the payee invoices us (ZZP / autónomo) — you can then
+                    attach the underlying receipts as proof rows under it.
                 </div>
             </form>
         </div>

--- a/src/Sections/Humans.Expenses/Views/Expenses/Edit.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Edit.cshtml
@@ -68,224 +68,81 @@
         .GroupBy(l => l.ParentLineId!.Value)
         .ToDictionary(g => g.Key, g => g.OrderBy(l => l.SortOrder).ToList());
     var topLevelLines = r.Lines.Where(l => l.ParentLineId is null).OrderBy(l => l.SortOrder).ToList();
-
-    async Task AttachmentBlock(ExpenseLineDto line, string uploadLabel)
-    {
-        if (line.Attachment is not null)
-        {
-            <div class="d-flex align-items-center gap-2 flex-wrap">
-                @if (line.Attachment.IsImage)
-                {
-                    <a href="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })" target="_blank">
-                        <img src="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })"
-                             alt="@line.Attachment.OriginalFileName" class="rounded border"
-                             style="max-height:60px; max-width:100px; object-fit:cover;" loading="lazy" />
-                    </a>
-                }
-                <a href="@Url.Action(line.Attachment.IsInlineViewable ? "AttachmentView" : "Attachment", new { attachmentId = line.Attachment.Id })"
-                   class="text-decoration-none small" target="_blank">
-                    <i class="fa-solid fa-paperclip me-1"></i>@line.Attachment.OriginalFileName
-                    <span class="text-muted">(@(line.Attachment.SizeBytes / 1024) KB)</span>
-                </a>
-                @if (line.Attachment.IsInlineViewable)
-                {
-                    <a href="@Url.Action("Attachment", new { attachmentId = line.Attachment.Id })"
-                       class="text-decoration-none small text-muted" title="Download">
-                        <i class="fa-solid fa-download"></i>
-                    </a>
-                }
-                @if (Model.CanEditLines)
-                {
-                    <form action="@Url.Action("RemoveAttachment", new { id = r.Id, lineId = line.Id })"
-                          method="post" class="d-inline">
-                        @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-sm btn-outline-secondary">Remove attachment</button>
-                    </form>
-                }
-            </div>
-        }
-        else if (Model.CanEditLines)
-        {
-            <form action="@Url.Action("AttachFile", new { id = r.Id, lineId = line.Id })"
-                  method="post" enctype="multipart/form-data" class="d-flex gap-2 align-items-center flex-wrap">
-                @Html.AntiForgeryToken()
-                <input type="file" name="file" class="form-control form-control-sm" style="max-width:260px;"
-                       accept=".pdf,.jpg,.jpeg,.png,.heic" />
-                <button type="submit" class="btn btn-sm btn-outline-primary">@uploadLabel</button>
-            </form>
-            <div class="form-text text-warning mt-1">
-                <i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment — required before submit.
-            </div>
-        }
-        else
-        {
-            <span class="text-warning small"><i class="fa-solid fa-triangle-exclamation me-1"></i>No attachment</span>
-        }
-    }
-
-    async Task EditLineForm(ExpenseLineDto line)
-    {
-        if (!Model.CanEditLines || line.LineType is ExpenseLineType.Mileage or ExpenseLineType.PerDiem) return;
-        <details class="mt-2">
-            <summary class="text-muted small" style="cursor:pointer;">Edit description / amount</summary>
-            <form action="@Url.Action("UpdateLine", new { id = r.Id })" method="post" class="mt-2">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="LineId" value="@line.Id" />
-                <div class="row g-2">
-                    <div class="col-md-7">
-                        <input type="text" name="Description" value="@line.Description"
-                               class="form-control form-control-sm" maxlength="500" required />
-                    </div>
-                    <div class="col-md-3">
-                        <input type="number" name="Amount" value="@line.Amount.ToString("F2")"
-                               class="form-control form-control-sm" step="0.01" min="0.01" required />
-                    </div>
-                    <div class="col-md-2">
-                        <button type="submit" class="btn btn-sm btn-primary w-100">Save</button>
-                    </div>
-                </div>
-            </form>
-        </details>
-    }
-
-    async Task RemoveLineButton(ExpenseLineDto line, string confirmText)
-    {
-        if (!Model.CanEditLines) return;
-        <form action="@Url.Action("RemoveLine", new { id = r.Id, lineId = line.Id })"
-              method="post" class="d-inline">
-            @Html.AntiForgeryToken()
-            <button type="submit" class="btn btn-sm btn-outline-danger"
-                    data-confirm="@confirmText">Remove line</button>
-        </form>
-    }
 }
 
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
         <strong>Expense lines</strong>
-        <span class="badge bg-secondary">@topLevelLines.Count line(s) — @r.Total.ToEuro()</span>
+        <span class="badge bg-secondary">@r.Total.ToEuro()</span>
     </div>
-    <div class="card-body p-0">
-        @foreach (var line in topLevelLines)
-        {
-            <div class="border-bottom p-3">
-                <div class="d-flex justify-content-between align-items-start mb-2">
-                    <div>
-                        @if (line.LineType == ExpenseLineType.Invoice)
-                        {
-                            <span class="badge bg-primary me-1">Invoice</span>
-                        }
-                        <strong>@line.Description</strong>
-                        <span class="ms-2 text-muted">@line.Amount.ToEuro()</span>
-                    </div>
-                    <div class="d-flex gap-2 flex-wrap justify-content-end">
-                        @{ await RemoveLineButton(line, line.LineType == ExpenseLineType.Invoice
-                               ? "Remove this invoice line, its attachment, and all its proof rows?"
-                               : "Remove this line and its attachment?"); }
-                    </div>
-                </div>
-
-                @if (line.LineType is ExpenseLineType.Mileage or ExpenseLineType.PerDiem)
-                {
-                    <span class="badge bg-info text-dark">
-                        <i class="fa-solid fa-route me-1"></i>@(line.LineType == ExpenseLineType.Mileage ? "Mileage" : "Per diem") — no receipt needed
-                    </span>
-                }
-                else
-                {
-                    await AttachmentBlock(line, line.LineType == ExpenseLineType.Invoice ? "Upload invoice" : "Upload receipt");
-                    await EditLineForm(line);
-                }
-
-                @if (line.LineType == ExpenseLineType.Invoice)
-                {
-                    var proofs = proofsByParent.TryGetValue(line.Id, out var p) ? p : [];
-                    var proofTotal = proofs.Sum(x => x.Amount);
-                    <div class="ms-4 mt-3 border-start ps-3">
-                        <div class="small mb-2">
-                            <strong>Proof of expenses</strong>
-                            <span class="badge @(proofTotal >= line.Amount ? "bg-success" : "bg-warning text-dark") ms-2">
-                                @proofTotal.ToEuro() of @line.Amount.ToEuro() invoiced
-                            </span>
-                            <span class="text-muted ms-1">— reviewed with the report, not sent to Holded.</span>
-                        </div>
-                        @foreach (var proof in proofs)
-                        {
-                            <div class="border-bottom py-2">
-                                <div class="d-flex justify-content-between align-items-start mb-1">
-                                    <div>
-                                        @proof.Description
-                                        <span class="ms-2 text-muted">@proof.Amount.ToEuro()</span>
-                                    </div>
-                                    <div>
-                                        @{ await RemoveLineButton(proof, "Remove this proof row and its attachment?"); }
-                                    </div>
-                                </div>
-                                @{ await AttachmentBlock(proof, "Upload receipt"); await EditLineForm(proof); }
-                            </div>
-                        }
-                        @if (Model.CanEditLines)
-                        {
-                            <form action="@Url.Action("AddLine", new { id = r.Id })" method="post" class="mt-2">
-                                @Html.AntiForgeryToken()
-                                <input type="hidden" name="ParentLineId" value="@line.Id" />
-                                <div class="row g-2 align-items-end">
-                                    <div class="col-md-6">
-                                        <input type="text" name="Description" class="form-control form-control-sm"
-                                               maxlength="500" placeholder="Underlying expense (what the invoice covers)" required />
-                                    </div>
-                                    <div class="col-md-3">
-                                        <input type="number" name="Amount" class="form-control form-control-sm"
-                                               step="0.01" min="0.01" placeholder="0.00" required />
-                                    </div>
-                                    <div class="col-md-3">
-                                        <button type="submit" class="btn btn-sm btn-outline-secondary w-100">
-                                            <i class="fa-solid fa-plus me-1"></i>Add proof
-                                        </button>
-                                    </div>
-                                </div>
-                            </form>
-                        }
-                    </div>
-                }
-            </div>
-        }
-    </div>
+    @if (topLevelLines.Count == 0)
+    {
+        <div class="card-body text-muted">No lines yet. Add your first receipt or invoice below.</div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-sm align-middle mb-0">
+                <tbody>
+                    @foreach (var line in topLevelLines)
+                    {
+                        var proofs = proofsByParent.TryGetValue(line.Id, out var p) ? p : [];
+                        <tr>
+                            <td>@line.Description</td>
+                            <td class="text-end text-nowrap">@line.Amount.ToEuro()</td>
+                            <td>
+                                @switch (line.LineType)
+                                {
+                                    case ExpenseLineType.Mileage:
+                                        <span class="badge bg-info text-dark">Mileage</span>
+                                        break;
+                                    case ExpenseLineType.PerDiem:
+                                        <span class="badge bg-info text-dark">Per diem</span>
+                                        break;
+                                    case ExpenseLineType.Invoice:
+                                        <span class="badge bg-primary">Invoice</span>
+                                        <a asp-action="LineProofs" asp-route-id="@r.Id" asp-route-lineId="@line.Id"
+                                           class="badge rounded-pill text-decoration-none @(proofs.Sum(x => x.Amount) >= line.Amount ? "bg-success" : "bg-secondary")">
+                                            @proofs.Count receipt@(proofs.Count == 1 ? "" : "s") behind it
+                                        </a>
+                                        break;
+                                    default:
+                                        @if (line.Attachment is not null)
+                                        {
+                                            <span class="badge bg-success">Receipt attached</span>
+                                        }
+                                        else
+                                        {
+                                            <a asp-action="LineEdit" asp-route-id="@r.Id" asp-route-lineId="@line.Id"
+                                               class="badge bg-warning text-dark text-decoration-none">Needs receipt</a>
+                                        }
+                                        break;
+                                }
+                            </td>
+                            <td class="text-end text-nowrap">
+                                <a asp-action="LineEdit" asp-route-id="@r.Id" asp-route-lineId="@line.Id"
+                                   class="btn btn-sm btn-outline-secondary">@(Model.CanEditLines ? "Edit" : "View")</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+                <tfoot>
+                    <tr class="fw-semibold">
+                        <td class="text-end">Total</td>
+                        <td class="text-end">@r.Total.ToEuro()</td>
+                        <td colspan="2"></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    }
 
     @if (Model.CanEditLines)
     {
         <div class="card-footer">
-            <form asp-action="AddLine" asp-route-id="@r.Id" method="post">
-                @Html.AntiForgeryToken()
-                <div class="row g-2 align-items-end">
-                    <div class="col-md-4">
-                        <label class="form-label form-label-sm">Description</label>
-                        <input type="text" name="Description" class="form-control form-control-sm"
-                               maxlength="500" placeholder="What was bought / paid for?" required />
-                    </div>
-                    <div class="col-md-2">
-                        <label class="form-label form-label-sm">Amount (EUR)</label>
-                        <input type="number" name="Amount" class="form-control form-control-sm"
-                               step="0.01" min="0.01" placeholder="0.00" required />
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label form-label-sm">Type</label>
-                        <select name="LineType" class="form-select form-select-sm">
-                            <option value="@ExpenseLineType.Receipt" selected>Receipt</option>
-                            <option value="@ExpenseLineType.Invoice">Supplier invoice</option>
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <button type="submit" class="btn btn-sm btn-outline-primary w-100">
-                            <i class="fa-solid fa-plus me-1"></i>Add line
-                        </button>
-                    </div>
-                </div>
-                <div class="form-text mt-1">
-                    Choose <em>Supplier invoice</em> when the payee invoices us (ZZP / autónomo) — you can then
-                    attach the underlying receipts as proof rows under it.
-                </div>
-            </form>
+            <a asp-action="NewLine" asp-route-id="@r.Id" class="btn btn-primary">
+                <i class="fa-solid fa-plus me-1"></i>Add line
+            </a>
         </div>
     }
     else if (r.Status != ExpenseReportStatus.Draft)
@@ -299,15 +156,3 @@
 <div class="d-flex gap-2">
     <a asp-action="Detail" asp-route-id="@r.Id" class="btn btn-outline-secondary">Back to report</a>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('[data-confirm]').forEach(function(btn) {
-        btn.addEventListener('click', function(e) {
-            if (!confirm(this.getAttribute('data-confirm'))) {
-                e.preventDefault();
-            }
-        });
-    });
-});
-</script>

--- a/src/Sections/Humans.Expenses/Views/Expenses/LineEdit.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/LineEdit.cshtml
@@ -1,0 +1,152 @@
+@model Humans.Expenses.Models.ExpenseLineEditViewModel
+@{
+    ViewData["Title"] = "Edit Line";
+    var r = Model.Report;
+    var line = Model.Line;
+    var isTravel = line.LineType is ExpenseLineType.Mileage or ExpenseLineType.PerDiem;
+    var isProof = line.ParentLineId is not null;
+}
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">My Expense Reports</a></li>
+        <li class="breadcrumb-item"><a asp-action="Edit" asp-route-id="@r.Id">Edit Report</a></li>
+        @if (isProof)
+        {
+            <li class="breadcrumb-item"><a asp-action="LineProofs" asp-route-id="@r.Id" asp-route-lineId="@line.ParentLineId">Receipts behind the invoice</a></li>
+        }
+        <li class="breadcrumb-item active" aria-current="page">Line</li>
+    </ol>
+</nav>
+
+<div class="row justify-content-center">
+    <div class="col-lg-7">
+        <div class="card mb-3">
+            <div class="card-header">
+                <strong>
+                    @(line.LineType == ExpenseLineType.Invoice ? "Invoice" : isProof ? "Receipt behind the invoice" : line.LineType.ToString())
+                </strong>
+            </div>
+            <div class="card-body">
+                @if (isTravel)
+                {
+                    <p class="mb-1">@line.Description</p>
+                    <p class="text-muted small mb-0">
+                        Travel lines are computed from their inputs and cannot be edited.
+                        Remove the line from the report and add it again to change it.
+                    </p>
+                }
+                else if (Model.CanEditLines)
+                {
+                    <form asp-action="UpdateLine" asp-route-id="@r.Id" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="LineId" value="@line.Id" />
+                        <div class="mb-3">
+                            <label class="form-label">Description <span class="text-danger">*</span></label>
+                            <input type="text" name="Description" value="@line.Description" class="form-control" maxlength="500" required />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Amount (EUR) <span class="text-danger">*</span></label>
+                            <input type="number" name="Amount" value="@line.Amount.ToString("F2")" class="form-control" step="0.01" min="0.01" required style="max-width:200px;" />
+                        </div>
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </form>
+                }
+                else
+                {
+                    <p class="mb-1">@line.Description</p>
+                    <p class="mb-0"><strong>@line.Amount.ToEuro()</strong></p>
+                }
+            </div>
+        </div>
+
+        @if (!isTravel)
+        {
+            <div class="card mb-3">
+                <div class="card-header"><strong>@(line.LineType == ExpenseLineType.Invoice ? "Invoice file" : "Receipt file")</strong></div>
+                <div class="card-body">
+                    @if (line.Attachment is not null)
+                    {
+                        <div class="d-flex align-items-center gap-3 flex-wrap">
+                            @if (line.Attachment.IsImage)
+                            {
+                                <a href="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })" target="_blank">
+                                    <img src="@Url.Action("AttachmentView", new { attachmentId = line.Attachment.Id })"
+                                         alt="@line.Attachment.OriginalFileName" class="rounded border"
+                                         style="max-height:120px; max-width:200px; object-fit:cover;" loading="lazy" />
+                                </a>
+                            }
+                            <div>
+                                <a href="@Url.Action(line.Attachment.IsInlineViewable ? "AttachmentView" : "Attachment", new { attachmentId = line.Attachment.Id })"
+                                   class="text-decoration-none" target="_blank">
+                                    <i class="fa-solid fa-paperclip me-1"></i>@line.Attachment.OriginalFileName
+                                </a>
+                                <span class="text-muted small">(@(line.Attachment.SizeBytes / 1024) KB)</span>
+                                @if (Model.CanEditLines)
+                                {
+                                    <form asp-action="RemoveAttachment" asp-route-id="@r.Id" asp-route-lineId="@line.Id" method="post" class="mt-2">
+                                        @Html.AntiForgeryToken()
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary"
+                                                data-confirm="Remove this file? You'll need to upload another before submitting.">Remove file</button>
+                                    </form>
+                                }
+                            </div>
+                        </div>
+                    }
+                    else if (Model.CanEditLines)
+                    {
+                        <p class="text-muted small">Required before the report can be submitted.</p>
+                        <form asp-action="AttachFile" asp-route-id="@r.Id" asp-route-lineId="@line.Id"
+                              method="post" enctype="multipart/form-data" class="d-flex gap-2 align-items-center flex-wrap">
+                            @Html.AntiForgeryToken()
+                            <input type="file" name="file" class="form-control" style="max-width:320px;"
+                                   accept=".pdf,.jpg,.jpeg,.png,.heic" required />
+                            <button type="submit" class="btn btn-outline-primary">Upload</button>
+                        </form>
+                    }
+                    else
+                    {
+                        <span class="text-muted">No file attached.</span>
+                    }
+                </div>
+            </div>
+        }
+
+        <div class="d-flex gap-2">
+            @if (isProof)
+            {
+                <a asp-action="LineProofs" asp-route-id="@r.Id" asp-route-lineId="@line.ParentLineId" class="btn btn-outline-secondary">Back to invoice receipts</a>
+            }
+            else
+            {
+                <a asp-action="Edit" asp-route-id="@r.Id" class="btn btn-outline-secondary">Back to report</a>
+                @if (line.LineType == ExpenseLineType.Invoice)
+                {
+                    <a asp-action="LineProofs" asp-route-id="@r.Id" asp-route-lineId="@line.Id" class="btn btn-outline-primary">Receipts behind this invoice</a>
+                }
+            }
+            @if (Model.CanEditLines)
+            {
+                <form asp-action="RemoveLine" asp-route-id="@r.Id" asp-route-lineId="@line.Id" method="post" class="ms-auto">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-outline-danger"
+                            data-confirm="@(line.LineType == ExpenseLineType.Invoice ? "Remove this invoice and all the receipts behind it?" : "Remove this line and its file?")">
+                        Remove line
+                    </button>
+                </form>
+            }
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('[data-confirm]').forEach(function(btn) {
+        btn.addEventListener('click', function(e) {
+            if (!confirm(this.getAttribute('data-confirm'))) {
+                e.preventDefault();
+            }
+        });
+    });
+});
+</script>

--- a/src/Sections/Humans.Expenses/Views/Expenses/LineProofs.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/LineProofs.cshtml
@@ -1,0 +1,132 @@
+@model Humans.Expenses.Models.ExpenseLineProofsViewModel
+@{
+    ViewData["Title"] = "Receipts Behind the Invoice";
+    var r = Model.Report;
+    var invoice = Model.InvoiceLine;
+    var covered = Model.ProofTotal >= invoice.Amount;
+}
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">My Expense Reports</a></li>
+        <li class="breadcrumb-item"><a asp-action="Edit" asp-route-id="@r.Id">Edit Report</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Receipts behind the invoice</li>
+    </ol>
+</nav>
+
+<div class="row justify-content-center">
+    <div class="col-lg-7">
+        <div class="card mb-3">
+            <div class="card-header"><strong>Invoice</strong></div>
+            <div class="card-body d-flex justify-content-between align-items-center">
+                <div>
+                    @invoice.Description
+                    @if (invoice.Attachment is not null)
+                    {
+                        <a href="@Url.Action(invoice.Attachment.IsInlineViewable ? "AttachmentView" : "Attachment", new { attachmentId = invoice.Attachment.Id })"
+                           class="text-decoration-none small ms-2" target="_blank">
+                            <i class="fa-solid fa-paperclip me-1"></i>@invoice.Attachment.OriginalFileName
+                        </a>
+                    }
+                </div>
+                <strong>@invoice.Amount.ToEuro()</strong>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <strong>Receipts behind it</strong>
+                <span class="badge @(covered ? "bg-success" : "bg-secondary")">@Model.ProofTotal.ToEuro() of @invoice.Amount.ToEuro()</span>
+            </div>
+            @if (Model.Proofs.Count == 0)
+            {
+                <div class="card-body text-muted">
+                    None yet. Add the receipts that show what the invoiced amount covers —
+                    they're checked with the report but not sent to the accountant's system.
+                </div>
+            }
+            else
+            {
+                <ul class="list-group list-group-flush">
+                    @foreach (var proof in Model.Proofs)
+                    {
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <div>
+                                @proof.Description
+                                @if (proof.Attachment is not null)
+                                {
+                                    <a href="@Url.Action(proof.Attachment.IsInlineViewable ? "AttachmentView" : "Attachment", new { attachmentId = proof.Attachment.Id })"
+                                       class="text-decoration-none small ms-2" target="_blank">
+                                        <i class="fa-solid fa-paperclip me-1"></i>@proof.Attachment.OriginalFileName
+                                    </a>
+                                }
+                                else
+                                {
+                                    <a asp-action="LineEdit" asp-route-id="@r.Id" asp-route-lineId="@proof.Id" class="small ms-2">
+                                        add the receipt file
+                                    </a>
+                                }
+                            </div>
+                            <div class="d-flex align-items-center gap-3">
+                                <span>@proof.Amount.ToEuro()</span>
+                                @if (Model.CanEditLines)
+                                {
+                                    <form asp-action="RemoveLine" asp-route-id="@r.Id" asp-route-lineId="@proof.Id" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="Remove this receipt?">Remove</button>
+                                    </form>
+                                }
+                            </div>
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+
+        @if (Model.CanEditLines)
+        {
+            <div class="card mb-3">
+                <div class="card-header"><strong>Add a receipt</strong></div>
+                <div class="card-body">
+                    <form asp-action="AddLine" asp-route-id="@r.Id" method="post" enctype="multipart/form-data">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="ParentLineId" value="@invoice.Id" />
+
+                        <div class="mb-3">
+                            <label class="form-label">What was it? <span class="text-danger">*</span></label>
+                            <input type="text" name="Description" class="form-control" maxlength="500" required
+                                   placeholder="e.g. Materials from the hardware store" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Amount (EUR) <span class="text-danger">*</span></label>
+                            <input type="number" name="Amount" class="form-control" step="0.01" min="0.01" placeholder="0.00" required style="max-width:200px;" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">The receipt (photo or PDF) <span class="text-danger">*</span></label>
+                            <input type="file" name="file" class="form-control" accept=".pdf,.jpg,.jpeg,.png,.heic" required />
+                        </div>
+                        <button type="submit" class="btn btn-outline-primary">
+                            <i class="fa-solid fa-plus me-1"></i>Add receipt
+                        </button>
+                    </form>
+                </div>
+            </div>
+        }
+
+        <div class="d-flex gap-2">
+            <a asp-action="Edit" asp-route-id="@r.Id" class="btn btn-primary">Done</a>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('[data-confirm]').forEach(function(btn) {
+        btn.addEventListener('click', function(e) {
+            if (!confirm(this.getAttribute('data-confirm'))) {
+                e.preventDefault();
+            }
+        });
+    });
+});
+</script>

--- a/src/Sections/Humans.Expenses/Views/Expenses/LineProofs.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/LineProofs.cshtml
@@ -71,6 +71,8 @@
                                 <span>@proof.Amount.ToEuro()</span>
                                 @if (Model.CanEditLines)
                                 {
+                                    <a asp-action="LineEdit" asp-route-id="@r.Id" asp-route-lineId="@proof.Id"
+                                       class="btn btn-sm btn-outline-secondary">Edit</a>
                                     <form asp-action="RemoveLine" asp-route-id="@r.Id" asp-route-lineId="@proof.Id" method="post" class="d-inline">
                                         @Html.AntiForgeryToken()
                                         <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="Remove this receipt?">Remove</button>

--- a/src/Sections/Humans.Expenses/Views/Expenses/NewLine.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/NewLine.cshtml
@@ -1,0 +1,84 @@
+@model Humans.Expenses.Models.ExpenseLineNewViewModel
+@{
+    ViewData["Title"] = Model.IsInvoice ? "Add Invoice" : "Add Receipt";
+}
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">My Expense Reports</a></li>
+        <li class="breadcrumb-item"><a asp-action="Edit" asp-route-id="@Model.ReportId">Edit Report</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@(Model.IsInvoice ? "Add invoice" : "Add receipt")</li>
+    </ol>
+</nav>
+
+<div class="row justify-content-center">
+    <div class="col-lg-7">
+        <div class="card">
+            <div class="card-header">
+                <strong>@(Model.IsInvoice ? "Add an invoice" : "Add a receipt")</strong>
+            </div>
+            <div class="card-body">
+                @if (Model.IsInvoice)
+                {
+                    <p class="text-muted">
+                        The company's invoice to the association. After saving you'll add the receipts
+                        behind it, so the Board can see what the invoiced amount covers.
+                    </p>
+                }
+                else
+                {
+                    <p class="text-muted">
+                        Something you paid for yourself and want reimbursed. Describe it, enter the
+                        amount, and attach a photo or PDF of the receipt.
+                    </p>
+                }
+
+                <form asp-action="AddLine" asp-route-id="@Model.ReportId" method="post" enctype="multipart/form-data">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="LineType" value="@(Model.IsInvoice ? ExpenseLineType.Invoice : ExpenseLineType.Receipt)" />
+
+                    <div class="mb-3">
+                        <label class="form-label">@(Model.IsInvoice ? "What is the invoice for?" : "What did you buy?") <span class="text-danger">*</span></label>
+                        <input type="text" name="Description" class="form-control" maxlength="500" required
+                               placeholder="@(Model.IsInvoice ? "e.g. Build crew labour, invoice 2026-042" : "e.g. Timber for the shade structure")" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Amount (EUR) <span class="text-danger">*</span></label>
+                        <input type="number" name="Amount" class="form-control" step="0.01" min="0.01" placeholder="0.00" required style="max-width:200px;" />
+                    </div>
+
+                    <div class="mb-4">
+                        <label class="form-label">@(Model.IsInvoice ? "The invoice (PDF or photo)" : "The receipt (photo or PDF)") <span class="text-danger">*</span></label>
+                        <input type="file" name="file" class="form-control" accept=".pdf,.jpg,.jpeg,.png,.heic" required />
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">
+                            @(Model.IsInvoice ? "Save & add receipts" : "Save receipt")
+                        </button>
+                        <a asp-action="Edit" asp-route-id="@Model.ReportId" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        @if (Model.IsInvoice)
+        {
+            <p class="mt-3 text-center">
+                <a asp-action="NewLine" asp-route-id="@Model.ReportId" class="text-decoration-none">
+                    &larr; Just a receipt you paid yourself? Switch back
+                </a>
+            </p>
+        }
+        else
+        {
+            <div class="alert alert-light border mt-3">
+                <i class="fa-solid fa-file-invoice me-1"></i>
+                <strong>Have a business (ZZP / autónomo)?</strong> Invoice the association instead —
+                we can reclaim the VAT, which saves everyone 21%.
+                <a asp-action="NewLine" asp-route-id="@Model.ReportId" asp-route-type="@ExpenseLineType.Invoice">Add an invoice &rarr;</a>
+            </div>
+        }
+    </div>
+</div>

--- a/src/Sections/Humans.Expenses/Views/Expenses/NewLine.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/NewLine.cshtml
@@ -21,8 +21,8 @@
                 @if (Model.IsInvoice)
                 {
                     <p class="text-muted">
-                        The company's invoice to the association. After saving you'll add the receipts
-                        behind it, so the Board can see what the invoiced amount covers.
+                        The company's invoice, made out to the NCA. After saving you'll add the
+                        receipts behind it, so the approver can see what the invoiced amount covers.
                     </p>
                 }
                 else
@@ -63,22 +63,10 @@
             </div>
         </div>
 
-        @if (Model.IsInvoice)
-        {
-            <p class="mt-3 text-center">
-                <a asp-action="NewLine" asp-route-id="@Model.ReportId" class="text-decoration-none">
-                    &larr; Just a receipt you paid yourself? Switch back
-                </a>
-            </p>
-        }
-        else
-        {
-            <div class="alert alert-light border mt-3">
-                <i class="fa-solid fa-file-invoice me-1"></i>
-                <strong>Have a business (ZZP / autónomo)?</strong> Invoice the association instead —
-                we can reclaim the VAT, which saves everyone 21%.
-                <a asp-action="NewLine" asp-route-id="@Model.ReportId" asp-route-type="@ExpenseLineType.Invoice">Add an invoice &rarr;</a>
-            </div>
-        }
+        <p class="mt-3 text-center">
+            <a asp-action="NewLine" asp-route-id="@Model.ReportId" class="text-decoration-none">
+                &larr; @(Model.IsInvoice ? "Not an invoice?" : "Not a receipt?") Change type
+            </a>
+        </p>
     </div>
 </div>

--- a/src/Sections/Humans.Expenses/Views/Expenses/NewLineChoice.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/NewLineChoice.cshtml
@@ -1,0 +1,51 @@
+@model Humans.Expenses.Models.ExpenseLineNewViewModel
+@{
+    ViewData["Title"] = "Add Line";
+}
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">My Expense Reports</a></li>
+        <li class="breadcrumb-item"><a asp-action="Edit" asp-route-id="@Model.ReportId">Edit Report</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Add line</li>
+    </ol>
+</nav>
+
+<div class="row justify-content-center">
+    <div class="col-lg-7">
+        <h1 class="h4 mb-4">What are you adding?</h1>
+
+        <a asp-action="NewLine" asp-route-id="@Model.ReportId" asp-route-type="@ExpenseLineType.Invoice"
+           class="card mb-3 text-decoration-none text-body">
+            <div class="card-body d-flex gap-3">
+                <div class="fs-2 text-primary"><i class="fa-solid fa-file-invoice"></i></div>
+                <div>
+                    <h2 class="h6 mb-1">An invoice <span class="badge bg-success ms-1">preferred</span></h2>
+                    <p class="mb-0 text-muted small">
+                        A business (ZZP / autónomo) invoices the association for the work or goods.
+                        The invoice must be made out to the NCA. Much preferred — the association can
+                        reclaim the VAT, saving 21%. You'll attach the invoice, then the receipts
+                        behind it for the approver.
+                    </p>
+                </div>
+            </div>
+        </a>
+
+        <a asp-action="NewLine" asp-route-id="@Model.ReportId" asp-route-type="@ExpenseLineType.Receipt"
+           class="card mb-3 text-decoration-none text-body">
+            <div class="card-body d-flex gap-3">
+                <div class="fs-2 text-secondary"><i class="fa-solid fa-receipt"></i></div>
+                <div>
+                    <h2 class="h6 mb-1">A receipt</h2>
+                    <p class="mb-0 text-muted small">
+                        You paid for something yourself and want to be reimbursed. Receipts are only
+                        approved in certain circumstances — generally when an invoice wasn't
+                        possible, or the amount is small.
+                    </p>
+                </div>
+            </div>
+        </a>
+
+        <a asp-action="Edit" asp-route-id="@Model.ReportId" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+</div>

--- a/tests/Humans.Expenses.Tests/Data/ExpenseRepositoryTests.cs
+++ b/tests/Humans.Expenses.Tests/Data/ExpenseRepositoryTests.cs
@@ -90,8 +90,8 @@ public class ExpenseRepositoryTests
         await _sut.AddLineAsync(report.Id,
             new ExpenseLine { Id = Guid.NewGuid(), Description = "b", Amount = 20m }, Xunit.TestContext.Current.CancellationToken);
 
-        var ok = await _sut.RemoveLineAsync(report.Id, lineId, Xunit.TestContext.Current.CancellationToken);
-        ok.Should().BeTrue();
+        var removed = await _sut.RemoveLineAsync(report.Id, lineId, Xunit.TestContext.Current.CancellationToken);
+        removed.Should().NotBeNull();
 
         var loaded = await _sut.GetByIdAsync(report.Id, Xunit.TestContext.Current.CancellationToken);
         loaded!.Lines.Should().HaveCount(1);
@@ -147,12 +147,48 @@ public class ExpenseRepositoryTests
         await _sut.AddLineAsync(report.Id,
             new ExpenseLine { Id = proofId, Description = "proof", Amount = 400m, ParentLineId = invoiceId }, Xunit.TestContext.Current.CancellationToken);
 
-        var ok = await _sut.RemoveLineAsync(report.Id, proofId, Xunit.TestContext.Current.CancellationToken);
-        ok.Should().BeTrue();
+        var removed = await _sut.RemoveLineAsync(report.Id, proofId, Xunit.TestContext.Current.CancellationToken);
+        removed.Should().NotBeNull();
 
         var loaded = await _sut.GetByIdAsync(report.Id, Xunit.TestContext.Current.CancellationToken);
         loaded!.Total.Should().Be(1000m);
         loaded.Lines.Should().HaveCount(1);
+    }
+
+    [HumansFact]
+    public async Task RemoveLineAsync_InvoiceLine_RemovesProofsAndAttachmentRows_InOneSave()
+    {
+        var report = MakeReport();
+        await _sut.AddDraftAsync(report, Xunit.TestContext.Current.CancellationToken);
+        var invoiceId = Guid.NewGuid();
+        var proofId = Guid.NewGuid();
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = invoiceId, Description = "invoice", Amount = 1000m, LineType = ExpenseLineType.Invoice }, Xunit.TestContext.Current.CancellationToken);
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = proofId, Description = "proof", Amount = 400m, ParentLineId = invoiceId }, Xunit.TestContext.Current.CancellationToken);
+
+        var proofAttachment = new ExpenseAttachment
+        {
+            Id = Guid.NewGuid(),
+            OriginalFileName = "proof.pdf",
+            Extension = ".pdf",
+            ContentType = "application/pdf",
+            SizeBytes = 100,
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = Instant.FromUtc(2026, 5, 1, 0, 0)
+        };
+        await _sut.AddAttachmentAsync(proofAttachment, Xunit.TestContext.Current.CancellationToken);
+        await _sut.SetLineAttachmentAsync(proofId, proofAttachment.Id, Xunit.TestContext.Current.CancellationToken);
+
+        var removed = await _sut.RemoveLineAsync(report.Id, invoiceId, Xunit.TestContext.Current.CancellationToken);
+
+        removed.Should().NotBeNull();
+        removed.Should().ContainSingle(a => a.Id == proofAttachment.Id);
+        var loaded = await _sut.GetByIdAsync(report.Id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Lines.Should().BeEmpty();
+        loaded.Total.Should().Be(0m);
+        await using var ctx = await _factory.CreateDbContextAsync(Xunit.TestContext.Current.CancellationToken);
+        (await ctx.ExpenseAttachments.CountAsync(Xunit.TestContext.Current.CancellationToken)).Should().Be(0);
     }
 
     [HumansFact]

--- a/tests/Humans.Expenses.Tests/Data/ExpenseRepositoryTests.cs
+++ b/tests/Humans.Expenses.Tests/Data/ExpenseRepositoryTests.cs
@@ -99,6 +99,63 @@ public class ExpenseRepositoryTests
     }
 
     [HumansFact]
+    public async Task AddLineAsync_ProofRow_DoesNotChangeTotal()
+    {
+        var report = MakeReport();
+        await _sut.AddDraftAsync(report, Xunit.TestContext.Current.CancellationToken);
+        var invoiceId = Guid.NewGuid();
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = invoiceId, Description = "invoice", Amount = 1000m, LineType = ExpenseLineType.Invoice }, Xunit.TestContext.Current.CancellationToken);
+
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = Guid.NewGuid(), Description = "proof", Amount = 400m, ParentLineId = invoiceId }, Xunit.TestContext.Current.CancellationToken);
+
+        var loaded = await _sut.GetByIdAsync(report.Id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Total.Should().Be(1000m);
+        loaded.Lines.Should().HaveCount(2);
+    }
+
+    [HumansFact]
+    public async Task UpdateLineAsync_ProofRow_DoesNotChangeTotal()
+    {
+        var report = MakeReport();
+        await _sut.AddDraftAsync(report, Xunit.TestContext.Current.CancellationToken);
+        var invoiceId = Guid.NewGuid();
+        var proofId = Guid.NewGuid();
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = invoiceId, Description = "invoice", Amount = 1000m, LineType = ExpenseLineType.Invoice }, Xunit.TestContext.Current.CancellationToken);
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = proofId, Description = "proof", Amount = 400m, ParentLineId = invoiceId }, Xunit.TestContext.Current.CancellationToken);
+
+        await _sut.UpdateLineAsync(report.Id,
+            new ExpenseLine { Id = proofId, Description = "proof edited", Amount = 999m }, Xunit.TestContext.Current.CancellationToken);
+
+        var loaded = await _sut.GetByIdAsync(report.Id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Total.Should().Be(1000m);
+        loaded.Lines.Single(l => l.Id == proofId).Amount.Should().Be(999m);
+    }
+
+    [HumansFact]
+    public async Task RemoveLineAsync_ProofRow_DoesNotChangeTotal()
+    {
+        var report = MakeReport();
+        await _sut.AddDraftAsync(report, Xunit.TestContext.Current.CancellationToken);
+        var invoiceId = Guid.NewGuid();
+        var proofId = Guid.NewGuid();
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = invoiceId, Description = "invoice", Amount = 1000m, LineType = ExpenseLineType.Invoice }, Xunit.TestContext.Current.CancellationToken);
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = proofId, Description = "proof", Amount = 400m, ParentLineId = invoiceId }, Xunit.TestContext.Current.CancellationToken);
+
+        var ok = await _sut.RemoveLineAsync(report.Id, proofId, Xunit.TestContext.Current.CancellationToken);
+        ok.Should().BeTrue();
+
+        var loaded = await _sut.GetByIdAsync(report.Id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Total.Should().Be(1000m);
+        loaded.Lines.Should().HaveCount(1);
+    }
+
+    [HumansFact]
     public async Task SetLineAttachmentAsync_LinksAttachment()
     {
         var report = MakeReport();

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
@@ -223,9 +223,11 @@ public class ExpenseReportServiceHoldedOutboxTests
         // Proof rows back an invoice line for review only — Holded gets the invoice line and the
         // invoice file, never the proofs.
         var invoiceLine = MakeLineWithAttachment(Guid.NewGuid(), "invoice.pdf", 0, holdedUploadedAt: null)
-            with { LineType = ExpenseLineType.Invoice, Amount = 1000m };
+            with
+        { LineType = ExpenseLineType.Invoice, Amount = 1000m };
         var proofLine = MakeLineWithAttachment(Guid.NewGuid(), "proof.pdf", 1, holdedUploadedAt: null)
-            with { ParentLineId = invoiceLine.Id, Amount = 400m };
+            with
+        { ParentLineId = invoiceLine.Id, Amount = 400m };
 
         var report = MakeReport() with { Total = 1000m, Lines = [invoiceLine, proofLine] };
         var outboxEvent = MakeEvent(report.Id, HoldedExpenseOutboxEventType.CreateIncomingDoc);

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
@@ -218,6 +218,48 @@ public class ExpenseReportServiceHoldedOutboxTests
     }
 
     [HumansFact]
+    public async Task CreateIncomingDoc_ExcludesProofRows_FromDocLinesAndAttachmentUploads()
+    {
+        // Proof rows back an invoice line for review only — Holded gets the invoice line and the
+        // invoice file, never the proofs.
+        var invoiceLine = MakeLineWithAttachment(Guid.NewGuid(), "invoice.pdf", 0, holdedUploadedAt: null)
+            with { LineType = ExpenseLineType.Invoice, Amount = 1000m };
+        var proofLine = MakeLineWithAttachment(Guid.NewGuid(), "proof.pdf", 1, holdedUploadedAt: null)
+            with { ParentLineId = invoiceLine.Id, Amount = 400m };
+
+        var report = MakeReport() with { Total = 1000m, Lines = [invoiceLine, proofLine] };
+        var outboxEvent = MakeEvent(report.Id, HoldedExpenseOutboxEventType.CreateIncomingDoc);
+
+        _repo.GetUnprocessedOutboxAsync(Arg.Any<Instant>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([outboxEvent]);
+        _repo.GetByIdAsync(report.Id, Arg.Any<CancellationToken>())
+            .Returns(report);
+        _holdedClient.CreatePurchaseDocumentAsync(Arg.Any<HoldedPurchaseDocumentInput>(), Arg.Any<CancellationToken>())
+            .Returns("doc-invoice-1");
+        _fileStorage.TryReadAsync(
+                $"uploads/expense-attachments/{invoiceLine.Attachment!.Id}.pdf",
+                Arg.Any<CancellationToken>())
+            .Returns([1, 2]);
+
+        await _sut.DrainHoldedOutboxAsync(BatchSize, Xunit.TestContext.Current.CancellationToken);
+
+        await _holdedClient.Received(1).CreatePurchaseDocumentAsync(
+            Arg.Is<HoldedPurchaseDocumentInput>(i =>
+                i.Lines.Count == 1 && i.Lines[0].Amount == 1000m),
+            Arg.Any<CancellationToken>());
+        await _holdedClient.Received(1).UploadAttachmentAsync(
+            "doc-invoice-1",
+            Arg.Is<HoldedAttachmentInput>(a => a.FileName == "invoice.pdf"),
+            Arg.Any<CancellationToken>());
+        await _holdedClient.DidNotReceive().UploadAttachmentAsync(
+            Arg.Any<string>(),
+            Arg.Is<HoldedAttachmentInput>(a => a.FileName == "proof.pdf"),
+            Arg.Any<CancellationToken>());
+        await _repo.Received(1).MarkOutboxProcessedAsync(
+            outboxEvent.Id, Now, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task CreateIncomingDoc_BooksLinesToTheMappedHoldedAccount()
     {
         // Tags are dead on the write side (Peter, 2026-08-10) — the doc is booked to the right

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
@@ -244,7 +244,7 @@ public sealed class ExpenseReportServiceTests
         var submitter = Guid.NewGuid();
         var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
 
-        var result = await _sut.AddLineWithResultAsync(id, submitter, "Supplies", 25.50m, Xunit.TestContext.Current.CancellationToken);
+        var result = await _sut.AddLineWithResultAsync(id, submitter, "Supplies", 25.50m, ct: Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeTrue();
         result.ErrorMessage.Should().BeNull();
@@ -260,7 +260,7 @@ public sealed class ExpenseReportServiceTests
         var other = Guid.NewGuid();
         var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
 
-        var result = await _sut.AddLineWithResultAsync(id, other, "x", 10m, Xunit.TestContext.Current.CancellationToken);
+        var result = await _sut.AddLineWithResultAsync(id, other, "x", 10m, ct: Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeFalse();
         result.ErrorMessage.Should().Contain("Only the submitter");
@@ -501,7 +501,7 @@ public sealed class ExpenseReportServiceTests
         var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
 
         var result = await sut.AddLineWithResultAsync(
-            id, submitter, "Supplies", 25m, Xunit.TestContext.Current.CancellationToken);
+            id, submitter, "Supplies", 25m, ct: Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeFalse();
         logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Error);
@@ -607,6 +607,116 @@ public sealed class ExpenseReportServiceTests
         var act = async () => await _sut.RemoveAttachmentFromLineAsync(id, submitter, lineId, Xunit.TestContext.Current.CancellationToken);
         await act.Should().NotThrowAsync();
         await _fileStorage.DidNotReceiveWithAnyArgs().DeleteAsync(null!, Arg.Any<CancellationToken>());
+    }
+
+    // ───────────────── Invoice lines + proof rows ────────────────────────────
+
+    [HumansFact]
+    public async Task AddLineAsync_ProofRow_UnderInvoiceLine_ExcludedFromTotal()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        var invoiceId = await _sut.AddLineAsync(id, submitter, "Invoice 2026-042", 1000m, ExpenseLineType.Invoice, ct: Xunit.TestContext.Current.CancellationToken);
+
+        await _sut.AddLineAsync(id, submitter, "Timber", 400m, parentLineId: invoiceId, ct: Xunit.TestContext.Current.CancellationToken);
+
+        var loaded = await _sut.GetAsync(id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Total.Should().Be(1000m);
+        loaded.Lines.Should().HaveCount(2);
+        loaded.Lines.Single(l => l.ParentLineId is not null).ParentLineId.Should().Be(invoiceId);
+    }
+
+    [HumansFact]
+    public async Task AddLineAsync_ProofRow_Throws_WhenParentIsNotInvoice()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        var receiptId = await _sut.AddLineAsync(id, submitter, "Plain receipt", 50m, ct: Xunit.TestContext.Current.CancellationToken);
+
+        var act = async () => await _sut.AddLineAsync(id, submitter, "Proof", 10m, parentLineId: receiptId, ct: Xunit.TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invoice line*");
+    }
+
+    [HumansFact]
+    public async Task AddLineAsync_ProofRow_Throws_WhenParentMissing()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+
+        var act = async () => await _sut.AddLineAsync(id, submitter, "Proof", 10m, parentLineId: Guid.NewGuid(), ct: Xunit.TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Parent line not found*");
+    }
+
+    [HumansFact]
+    public async Task AddLineWithResultAsync_RejectsTravelTypes()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+
+        var result = await _sut.AddLineWithResultAsync(id, submitter, "Trip", 26m, ExpenseLineType.Mileage, ct: Xunit.TestContext.Current.CancellationToken);
+        result.Succeeded.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("receipt and invoice");
+    }
+
+    [HumansFact]
+    public async Task RemoveLineAsync_InvoiceLine_RemovesItsProofRows_AndTheirFiles()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        var invoiceId = await _sut.AddLineAsync(id, submitter, "Invoice", 1000m, ExpenseLineType.Invoice, ct: Xunit.TestContext.Current.CancellationToken);
+        var proofId = await _sut.AddLineAsync(id, submitter, "Timber", 400m, parentLineId: invoiceId, ct: Xunit.TestContext.Current.CancellationToken);
+
+        var proofAttachment = MakeAttachment(submitter);
+        await _expenseRepo.AddAttachmentAsync(proofAttachment, Xunit.TestContext.Current.CancellationToken);
+        await _expenseRepo.SetLineAttachmentAsync(proofId, proofAttachment.Id, Xunit.TestContext.Current.CancellationToken);
+
+        await _sut.RemoveLineAsync(id, submitter, invoiceId, Xunit.TestContext.Current.CancellationToken);
+
+        var loaded = await _sut.GetAsync(id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Lines.Should().BeEmpty();
+        loaded.Total.Should().Be(0m);
+        await _fileStorage.Received(1).DeleteAsync(
+            $"uploads/expense-attachments/{proofAttachment.Id}{proofAttachment.Extension}",
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SubmitAsync_Throws_WhenInvoiceLineHasNoAttachment()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        await _sut.AddLineAsync(id, submitter, "Invoice, no file", 1000m, ExpenseLineType.Invoice, ct: Xunit.TestContext.Current.CancellationToken);
+        SetupUserAndProfile(submitter, "Bob", "ES1234");
+
+        var act = async () => await _sut.SubmitAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*attachment*");
+    }
+
+    [HumansFact]
+    public async Task SubmitAsync_Throws_WhenProofRowHasNoAttachment()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        var invoiceId = await _sut.AddLineAsync(id, submitter, "Invoice", 1000m, ExpenseLineType.Invoice, ct: Xunit.TestContext.Current.CancellationToken);
+        var invoiceFile = MakeAttachment(submitter);
+        await _expenseRepo.AddAttachmentAsync(invoiceFile, Xunit.TestContext.Current.CancellationToken);
+        await _expenseRepo.SetLineAttachmentAsync(invoiceId, invoiceFile.Id, Xunit.TestContext.Current.CancellationToken);
+        await _sut.AddLineAsync(id, submitter, "Proof, no file", 400m, parentLineId: invoiceId, ct: Xunit.TestContext.Current.CancellationToken);
+        SetupUserAndProfile(submitter, "Bob", "ES1234");
+
+        var act = async () => await _sut.SubmitAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*attachment*");
     }
 
     // ─────────────────────────────── 4.4 ─────────────────────────────────────
@@ -755,7 +865,7 @@ public sealed class ExpenseReportServiceTests
         var (_, category) = SetupActiveYear();
         var submitter = Guid.NewGuid();
         var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
-        await _sut.AddLineWithResultAsync(id, submitter, "Tent", 50m, Xunit.TestContext.Current.CancellationToken); // Receipt line, no attachment
+        await _sut.AddLineWithResultAsync(id, submitter, "Tent", 50m, ct: Xunit.TestContext.Current.CancellationToken); // Receipt line, no attachment
         SetupUserAndProfile(submitter, "Alice Tester", "ES9121000418450200051332");
 
         var result = await _sut.SubmitWithResultAsync(id, submitter, Xunit.TestContext.Current.CancellationToken);

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
@@ -653,6 +653,45 @@ public sealed class ExpenseReportServiceTests
     }
 
     [HumansFact]
+    public async Task AddLineWithResultAsync_WithFile_CreatesLineAndAttachment_InOneCall()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+
+        using var content = new MemoryStream([1, 2, 3]);
+        var result = await _sut.AddLineWithResultAsync(
+            id, submitter, "Timber", 40m,
+            file: new ExpenseFileUpload("receipt.pdf", "application/pdf", content),
+            ct: Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeTrue();
+        result.LineId.Should().NotBeNull();
+        var loaded = await _sut.GetAsync(id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Lines.Single().AttachmentId.Should().NotBeNull();
+        loaded.Lines.Single().Attachment!.OriginalFileName.Should().Be("receipt.pdf");
+    }
+
+    [HumansFact]
+    public async Task AddLineWithResultAsync_WithBadFile_CreatesNothing()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+
+        using var content = new MemoryStream([1, 2, 3]);
+        var result = await _sut.AddLineWithResultAsync(
+            id, submitter, "Timber", 40m,
+            file: new ExpenseFileUpload("virus.exe", "application/octet-stream", content),
+            ct: Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeFalse();
+        result.LineId.Should().BeNull();
+        var loaded = await _sut.GetAsync(id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Lines.Should().BeEmpty();
+    }
+
+    [HumansFact]
     public async Task AddLineWithResultAsync_RejectsTravelTypes()
     {
         var (_, category) = SetupActiveYear();

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
@@ -673,6 +673,29 @@ public sealed class ExpenseReportServiceTests
     }
 
     [HumansFact]
+    public async Task AddLineWithResultAsync_RollsBackLine_WhenUploadFailsAfterCreation()
+    {
+        var (_, category) = SetupActiveYear();
+        var submitter = Guid.NewGuid();
+        var id = await _sut.CreateDraftAsync(submitter, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        _fileStorage.SaveAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new IOException("disk full"));
+
+        using var content = new MemoryStream([1, 2, 3]);
+        var result = await _sut.AddLineWithResultAsync(
+            id, submitter, "Timber", 40m,
+            file: new ExpenseFileUpload("receipt.pdf", "application/pdf", content),
+            ct: Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeFalse();
+        result.LineId.Should().BeNull();
+        // The form retries the whole add — a leftover line would duplicate on retry.
+        var loaded = await _sut.GetAsync(id, Xunit.TestContext.Current.CancellationToken);
+        loaded!.Lines.Should().BeEmpty();
+        loaded.Total.Should().Be(0m);
+    }
+
+    [HumansFact]
     public async Task AddLineWithResultAsync_WithBadFile_CreatesNothing()
     {
         var (_, category) = SetupActiveYear();


### PR DESCRIPTION
**Section:** Expenses

Company payees (ZZP / autónomo) invoice the org instead of handing over receipts. Because we reimburse rather than just pay, the accountant wants the underlying receipts behind the invoice checked at approval — without them ending up in Holded.

## What changed

- **`ExpenseLineType.Invoice`** — marks a supplier invoice line. Requires the invoice file attached at submit; it is what gets booked into Holded. Selectable in the add-line form ("Supplier invoice").
- **Proof rows** — Receipt lines with a new `ExpenseLine.ParentLineId` self-FK pointing at an invoice line on the same report. Added via "Add proof" under the invoice line; each needs its own receipt attachment at submit. They are:
  - excluded from `Total` (and therefore Payable),
  - never pushed to Holded — neither as document lines nor as file uploads,
  - shown to approvers nested under their invoice with a coverage badge (`€X of €Y invoiced`) — **display-only, never enforced** (VAT/fees mean proofs need not match).
- Removing an invoice line cascades its proof rows (service-side, so attachment rows + files are cleaned up; DB FK is Restrict).
- Invoice lines are free-text editable like receipts; travel lines stay locked.
- **Inline attachment viewing** — new `/Expenses/Attachment/{id}/View` route serves images and PDFs with inline disposition (same resource-based auth); Edit/Detail show image thumbnails and open attachments in a browser tab instead of forcing a download. HEIC falls back to download. A small download icon keeps the old behavior.

## Migration

`ExpenseLineProofRows` — adds nullable `ParentLineId` + self-FK (Restrict) + index on `expense_lines`. Enum is stored as string, so `Invoice` needs no schema change.

## Tests

`dotnet test Humans.slnx` fully green. New coverage: proof rows excluded from Total (add/update/remove), parent-must-be-invoice / parent-missing validation, travel types rejected on the add path, invoice-line removal cascades proofs + files, submit requires attachments on invoice and proof lines, Holded push excludes proof lines and proof files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)