### PR TITLE
feat(tickets): discount-code summary by campaign, drop EUR from aggregate cells

### DIFF
--- a/docs/guide/Tickets.md
+++ b/docs/guide/Tickets.md
@@ -78,7 +78,7 @@ A separate **Full Re-sync** button (Admin-only, with a confirmation prompt) clea
 
 `/Tickets/Codes` shows which discount codes have been used and ties them back to their campaigns. Code *generation* happens in the Campaigns section — open the relevant campaign at `/Campaigns/Admin/{id}` and use the generate-codes action there (Ticket Admin or Admin only). Board can view this page and the redemption table but cannot generate codes.
 
-`/Tickets/SalesAggregates` gives weekly (Monday–Sunday) and quarterly (calendar Q1–Q4, matching the Spanish tax convention) views of revenue, Donations, VIP Donations, VAT, and Net. Figures come from the VIP split logic, not the vendor's own tax line items. A By Ticket Type card breaks down tickets sold and face value (the listed price, before discounts and donations) per ticket type.
+`/Tickets/SalesAggregates` gives weekly (Monday–Sunday) and quarterly (calendar Q1–Q4, matching the Spanish tax convention) views of revenue, Donations, VIP Donations, VAT, and Net. Figures come from the VIP split logic, not the vendor's own tax line items. A By Ticket Type card breaks down tickets sold and face value (the listed price, before discounts and donations) per ticket type. A Discount Codes by Campaign card shows codes granted, codes used, and the average and total discount per campaign, with codes that match no campaign grant grouped as vendor codes. All money columns are EUR — the currency is named in the column header rather than repeated in each cell, so the tables paste cleanly into a spreadsheet.
 
 ### Who hasn't bought yet
 

--- a/src/Sections/Humans.Tickets/Controllers/TicketController.cs
+++ b/src/Sections/Humans.Tickets/Controllers/TicketController.cs
@@ -253,6 +253,14 @@ internal sealed class TicketController(
                 TicketsSold = t.TicketsSold,
                 FaceValue = t.FaceValue,
             }).ToList(),
+            ByDiscountCampaign = aggregates.ByDiscountCampaign.Select(d => new DiscountCampaignRow
+            {
+                CampaignTitle = d.CampaignTitle,
+                CodesGranted = d.CodesGranted,
+                CodesUsed = d.CodesUsed,
+                AverageDiscount = d.AverageDiscount,
+                TotalDiscount = d.TotalDiscount,
+            }).ToList(),
         };
 
         return View(model);

--- a/src/Sections/Humans.Tickets/Data/TicketRepository.cs
+++ b/src/Sections/Humans.Tickets/Data/TicketRepository.cs
@@ -613,6 +613,8 @@ internal sealed class TicketRepository(IDbContextFactory<TicketsDbContext> facto
                 BuyerName = o.BuyerName,
                 BuyerEmail = o.BuyerEmail,
                 VendorOrderId = o.VendorOrderId,
+                DiscountAmount = o.DiscountAmount,
+                IsPaid = o.PaymentStatus == TicketPaymentStatus.Paid,
             })
             .ToListAsync(ct);
     }

--- a/src/Sections/Humans.Tickets/Docs/Tickets.md
+++ b/src/Sections/Humans.Tickets/Docs/Tickets.md
@@ -114,7 +114,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 | `/Tickets/Codes` | GET | `TicketAdminBoardOrAdmin` | Discount code redemption tracking |
 | `/Tickets/GateList` | GET | `TicketAdminBoardOrAdmin` | Placeholder page (gate lookup is handled via `/Scanner/Tickets`) |
 | `/Tickets/WhoHasntBought` | GET | `TicketAdminBoardOrAdmin` | Active Volunteers without a ticket |
-| `/Tickets/SalesAggregates` | GET | `TicketAdminBoardOrAdmin` | Weekly + quarterly aggregate reports |
+| `/Tickets/SalesAggregates` | GET | `TicketAdminBoardOrAdmin` | Weekly + quarterly aggregate reports, by ticket type, discount codes by campaign |
 | `/Tickets/Sync` | POST | `TicketAdminOrAdmin` | Trigger incremental sync |
 | `/Tickets/FullResync` | POST | `AdminOnly` | Trigger full re-sync |
 | `/Tickets/Admin/Contacts` | GET | `TicketAdminOrAdmin` | Preview attendee-contact-import plan |

--- a/src/Sections/Humans.Tickets/Models/TicketViewModels.cs
+++ b/src/Sections/Humans.Tickets/Models/TicketViewModels.cs
@@ -172,7 +172,20 @@ internal sealed class TicketSalesAggregatesViewModel
     public List<WeeklySalesRow> WeeklySales { get; set; } = [];
     public List<QuarterlySalesRow> QuarterlySales { get; set; } = [];
     public List<TicketTypeSalesRow> ByTicketType { get; set; } = [];
+    public List<DiscountCampaignRow> ByDiscountCampaign { get; set; } = [];
     public string Currency { get; set; } = "EUR";
+}
+
+internal sealed class DiscountCampaignRow
+{
+    public string CampaignTitle { get; set; } = string.Empty;
+
+    /// <summary>Null for codes that match no grant — render blank.</summary>
+    public int? CodesGranted { get; set; }
+
+    public int CodesUsed { get; set; }
+    public decimal AverageDiscount { get; set; }
+    public decimal TotalDiscount { get; set; }
 }
 
 internal sealed class TicketTypeSalesRow

--- a/src/Sections/Humans.Tickets/Services/Dtos/TicketDashboardDtos.cs
+++ b/src/Sections/Humans.Tickets/Services/Dtos/TicketDashboardDtos.cs
@@ -67,6 +67,7 @@ internal sealed class TicketSalesAggregates
     public List<WeeklySalesAggregate> WeeklySales { get; init; } = [];
     public List<QuarterlySalesAggregate> QuarterlySales { get; init; } = [];
     public List<TicketTypeSalesAggregate> ByTicketType { get; init; } = [];
+    public List<DiscountCampaignAggregate> ByDiscountCampaign { get; init; } = [];
 }
 
 internal sealed class WeeklySalesAggregate
@@ -103,6 +104,27 @@ internal sealed class TicketTypeSalesAggregate
     /// discounts and donations are excluded), so it won't reconcile with
     /// the weekly/quarterly GrossRevenue figures.</summary>
     public decimal FaceValue { get; init; }
+}
+
+/// <summary>
+/// Discount-code usage and cost for one campaign. Grants come from the
+/// Campaigns section; the money comes from the paid orders whose
+/// <c>DiscountCode</c> matches a grant of that campaign. Codes redeemed on
+/// paid orders that match no grant land in a single unattributed row with
+/// <see cref="CodesGranted"/> null.
+/// </summary>
+internal sealed class DiscountCampaignAggregate
+{
+    public string CampaignTitle { get; init; } = string.Empty;
+
+    /// <summary>Null for the unattributed row — nothing granted those codes.</summary>
+    public int? CodesGranted { get; init; }
+
+    /// <summary>Paid orders that carried one of this campaign's codes.</summary>
+    public int CodesUsed { get; init; }
+
+    public decimal AverageDiscount { get; init; }
+    public decimal TotalDiscount { get; init; }
 }
 
 /// <summary>Aggregated code tracking data: campaign summaries + individual code details.</summary>
@@ -303,6 +325,8 @@ internal sealed class DiscountCodeOrderRow
     public string BuyerName { get; init; } = string.Empty;
     public string BuyerEmail { get; init; } = string.Empty;
     public string VendorOrderId { get; init; } = string.Empty;
+    public decimal? DiscountAmount { get; init; }
+    public bool IsPaid { get; init; }
 }
 
 /// <summary>CSV export data for orders.</summary>

--- a/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
@@ -378,46 +378,48 @@ internal sealed class TicketQueryService(
     }
 
     /// <summary>
-    /// Joins campaign grants (which know how many codes went out) to paid orders
-    /// (which know what the codes cost) on the code itself. Redeemed codes with no
-    /// matching grant collapse into one unattributed row.
+    /// One row per campaign that granted codes, whether or not any were redeemed, so the
+    /// granted column totals org-wide rather than over the campaigns that happen to have
+    /// paid usage. Amounts come from the paid orders that carried each campaign's codes;
+    /// redeemed codes with no matching grant collapse into one unattributed row.
     /// </summary>
     private async Task<List<DiscountCampaignAggregate>> BuildDiscountCampaignAggregatesAsync()
     {
-        var paidDiscountOrders = (await ticketRepository.GetOrdersWithDiscountCodesAsync())
-            .Where(o => o.IsPaid)
-            .ToList();
-        if (paidDiscountOrders.Count == 0)
-            return [];
-
         var campaignData = await campaignService.GetCodeTrackingAsync();
+        var campaignIds = campaignData.Campaigns.Select(c => c.CampaignId).ToHashSet();
 
         var campaignByCode = campaignData.Grants
-            .Where(g => !string.IsNullOrWhiteSpace(g.Code))
+            .Where(g => !string.IsNullOrWhiteSpace(g.Code) && campaignIds.Contains(g.CampaignId))
             .GroupBy(g => g.Code!, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First().CampaignId, StringComparer.OrdinalIgnoreCase);
 
-        var grantsByCampaign = campaignData.Campaigns
-            .ToDictionary(c => c.CampaignId, c => c);
+        var paidDiscountOrders = (await ticketRepository.GetOrdersWithDiscountCodesAsync())
+            .Where(o => o.IsPaid)
+            .ToList();
 
-        var rows = paidDiscountOrders
-            .GroupBy(o => campaignByCode.TryGetValue(o.DiscountCode, out var id) ? id : (Guid?)null)
-            .Where(g => g.Key is not null)
-            .Select(g =>
+        var usageByCampaign = paidDiscountOrders
+            .Where(o => campaignByCode.ContainsKey(o.DiscountCode))
+            .GroupBy(o => campaignByCode[o.DiscountCode])
+            .ToDictionary(
+                g => g.Key,
+                g => (Used: g.Count(), Total: g.Sum(o => o.DiscountAmount ?? 0m)));
+
+        var rows = campaignData.Campaigns
+            .Where(c => c.TotalGrants > 0)
+            .Select(c =>
             {
-                var used = g.Count();
-                var total = g.Sum(o => o.DiscountAmount ?? 0m);
-                grantsByCampaign.TryGetValue(g.Key!.Value, out var campaign);
+                usageByCampaign.TryGetValue(c.CampaignId, out var usage);
                 return new DiscountCampaignAggregate
                 {
-                    CampaignTitle = campaign?.CampaignTitle ?? "Unknown campaign",
-                    CodesGranted = campaign?.TotalGrants,
-                    CodesUsed = used,
-                    AverageDiscount = used > 0 ? Math.Round(total / used, 2) : 0m,
-                    TotalDiscount = total,
+                    CampaignTitle = c.CampaignTitle,
+                    CodesGranted = c.TotalGrants,
+                    CodesUsed = usage.Used,
+                    AverageDiscount = usage.Used > 0 ? Math.Round(usage.Total / usage.Used, 2) : 0m,
+                    TotalDiscount = usage.Total,
                 };
             })
             .OrderByDescending(r => r.TotalDiscount)
+            .ThenBy(r => r.CampaignTitle, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         var unattributed = paidDiscountOrders

--- a/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
+++ b/src/Sections/Humans.Tickets/Services/TicketQueryService.cs
@@ -373,7 +373,70 @@ internal sealed class TicketQueryService(
             WeeklySales = weeklySales,
             QuarterlySales = quarterlySales,
             ByTicketType = byTicketType,
+            ByDiscountCampaign = await BuildDiscountCampaignAggregatesAsync(),
         };
+    }
+
+    /// <summary>
+    /// Joins campaign grants (which know how many codes went out) to paid orders
+    /// (which know what the codes cost) on the code itself. Redeemed codes with no
+    /// matching grant collapse into one unattributed row.
+    /// </summary>
+    private async Task<List<DiscountCampaignAggregate>> BuildDiscountCampaignAggregatesAsync()
+    {
+        var paidDiscountOrders = (await ticketRepository.GetOrdersWithDiscountCodesAsync())
+            .Where(o => o.IsPaid)
+            .ToList();
+        if (paidDiscountOrders.Count == 0)
+            return [];
+
+        var campaignData = await campaignService.GetCodeTrackingAsync();
+
+        var campaignByCode = campaignData.Grants
+            .Where(g => !string.IsNullOrWhiteSpace(g.Code))
+            .GroupBy(g => g.Code!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().CampaignId, StringComparer.OrdinalIgnoreCase);
+
+        var grantsByCampaign = campaignData.Campaigns
+            .ToDictionary(c => c.CampaignId, c => c);
+
+        var rows = paidDiscountOrders
+            .GroupBy(o => campaignByCode.TryGetValue(o.DiscountCode, out var id) ? id : (Guid?)null)
+            .Where(g => g.Key is not null)
+            .Select(g =>
+            {
+                var used = g.Count();
+                var total = g.Sum(o => o.DiscountAmount ?? 0m);
+                grantsByCampaign.TryGetValue(g.Key!.Value, out var campaign);
+                return new DiscountCampaignAggregate
+                {
+                    CampaignTitle = campaign?.CampaignTitle ?? "Unknown campaign",
+                    CodesGranted = campaign?.TotalGrants,
+                    CodesUsed = used,
+                    AverageDiscount = used > 0 ? Math.Round(total / used, 2) : 0m,
+                    TotalDiscount = total,
+                };
+            })
+            .OrderByDescending(r => r.TotalDiscount)
+            .ToList();
+
+        var unattributed = paidDiscountOrders
+            .Where(o => !campaignByCode.ContainsKey(o.DiscountCode))
+            .ToList();
+        if (unattributed.Count > 0)
+        {
+            var total = unattributed.Sum(o => o.DiscountAmount ?? 0m);
+            rows.Add(new DiscountCampaignAggregate
+            {
+                CampaignTitle = "No campaign (vendor codes)",
+                CodesGranted = null,
+                CodesUsed = unattributed.Count,
+                AverageDiscount = Math.Round(total / unattributed.Count, 2),
+                TotalDiscount = total,
+            });
+        }
+
+        return rows;
     }
 
     public async Task<OrdersPageResult> GetOrdersPageAsync(

--- a/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
+++ b/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
@@ -243,6 +243,7 @@
                         <i class="fa-solid fa-circle-info"></i>
                         Codes granted comes from the campaign that issued them; the amounts come from the paid
                         orders that redeemed them, so "Each" is the average discount per redeeming order.
+                        Every campaign that granted codes is listed, including ones with no paid redemptions yet.
                         Codes redeemed on paid orders that match no campaign grant are grouped under
                         "No campaign (vendor codes)", where nothing was granted.
                     </small>
@@ -250,7 +251,7 @@
             }
             else
             {
-                <div class="text-muted text-center py-3">No discount codes redeemed yet.</div>
+                <div class="text-muted text-center py-3">No campaign codes granted or redeemed yet.</div>
             }
         </div>
     </div>

--- a/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
+++ b/src/Sections/Humans.Tickets/Views/Ticket/SalesAggregates.cshtml
@@ -24,11 +24,11 @@
                             <th>Week</th>
                             <th class="text-end">Orders</th>
                             <th class="text-end">Tickets Sold</th>
-                            <th class="text-end">Gross Revenue</th>
-                            <th class="text-end">Donations</th>
-                            <th class="text-end">VIP Donations</th>
-                            <th class="text-end">VAT</th>
-                            <th class="text-end">Net</th>
+                            <th class="text-end">Gross Revenue (@Model.Currency)</th>
+                            <th class="text-end">Donations (@Model.Currency)</th>
+                            <th class="text-end">VIP Donations (@Model.Currency)</th>
+                            <th class="text-end">VAT (@Model.Currency)</th>
+                            <th class="text-end">Net (@Model.Currency)</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -39,11 +39,11 @@
                                 <td>@week.WeekLabel</td>
                                 <td class="text-end">@week.OrderCount.ToString("N0")</td>
                                 <td class="text-end">@week.TicketsSold.ToString("N0")</td>
-                                <td class="text-end">@Model.Currency @week.GrossRevenue.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @week.Donations.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @week.VipDonations.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @week.VatAmount.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @net.ToString("N2")</td>
+                                <td class="text-end">@week.GrossRevenue.ToString("N2")</td>
+                                <td class="text-end">@week.Donations.ToString("N2")</td>
+                                <td class="text-end">@week.VipDonations.ToString("N2")</td>
+                                <td class="text-end">@week.VatAmount.ToString("N2")</td>
+                                <td class="text-end">@net.ToString("N2")</td>
                             </tr>
                         }
                     </tbody>
@@ -59,11 +59,11 @@
                             <td>Total</td>
                             <td class="text-end">@Model.WeeklySales.Sum(w => w.OrderCount).ToString("N0")</td>
                             <td class="text-end">@Model.WeeklySales.Sum(w => w.TicketsSold).ToString("N0")</td>
-                            <td class="text-end">@Model.Currency @weeklyTotalGross.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @weeklyTotalDonations.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @weeklyTotalVipDonations.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @weeklyTotalVat.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @weeklyTotalNet.ToString("N2")</td>
+                            <td class="text-end">@weeklyTotalGross.ToString("N2")</td>
+                            <td class="text-end">@weeklyTotalDonations.ToString("N2")</td>
+                            <td class="text-end">@weeklyTotalVipDonations.ToString("N2")</td>
+                            <td class="text-end">@weeklyTotalVat.ToString("N2")</td>
+                            <td class="text-end">@weeklyTotalNet.ToString("N2")</td>
                         </tr>
                     </tfoot>
                 </table>
@@ -88,11 +88,11 @@
                             <th>Quarter</th>
                             <th class="text-end">Orders</th>
                             <th class="text-end">Tickets Sold</th>
-                            <th class="text-end">Gross Revenue</th>
-                            <th class="text-end">Donations</th>
-                            <th class="text-end">VIP Donations</th>
-                            <th class="text-end">VAT</th>
-                            <th class="text-end">Net Revenue</th>
+                            <th class="text-end">Gross Revenue (@Model.Currency)</th>
+                            <th class="text-end">Donations (@Model.Currency)</th>
+                            <th class="text-end">VIP Donations (@Model.Currency)</th>
+                            <th class="text-end">VAT (@Model.Currency)</th>
+                            <th class="text-end">Net Revenue (@Model.Currency)</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -103,11 +103,11 @@
                                 <td>@q.QuarterLabel</td>
                                 <td class="text-end">@q.OrderCount.ToString("N0")</td>
                                 <td class="text-end">@q.TicketsSold.ToString("N0")</td>
-                                <td class="text-end">@Model.Currency @q.GrossRevenue.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @q.Donations.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @q.VipDonations.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @q.VatAmount.ToString("N2")</td>
-                                <td class="text-end">@Model.Currency @net.ToString("N2")</td>
+                                <td class="text-end">@q.GrossRevenue.ToString("N2")</td>
+                                <td class="text-end">@q.Donations.ToString("N2")</td>
+                                <td class="text-end">@q.VipDonations.ToString("N2")</td>
+                                <td class="text-end">@q.VatAmount.ToString("N2")</td>
+                                <td class="text-end">@net.ToString("N2")</td>
                             </tr>
                         }
                     </tbody>
@@ -123,11 +123,11 @@
                             <td>Total</td>
                             <td class="text-end">@Model.QuarterlySales.Sum(q => q.OrderCount).ToString("N0")</td>
                             <td class="text-end">@Model.QuarterlySales.Sum(q => q.TicketsSold).ToString("N0")</td>
-                            <td class="text-end">@Model.Currency @totalGross.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @totalDonations.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @totalVipDonations.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @totalVat.ToString("N2")</td>
-                            <td class="text-end">@Model.Currency @totalNet.ToString("N2")</td>
+                            <td class="text-end">@totalGross.ToString("N2")</td>
+                            <td class="text-end">@totalDonations.ToString("N2")</td>
+                            <td class="text-end">@totalVipDonations.ToString("N2")</td>
+                            <td class="text-end">@totalVat.ToString("N2")</td>
+                            <td class="text-end">@totalNet.ToString("N2")</td>
                         </tr>
                     </tfoot>
                 </table>
@@ -158,9 +158,9 @@
                     <thead>
                         <tr>
                             <th>Ticket Type</th>
-                            <th class="text-end">Price</th>
+                            <th class="text-end">Price (@Model.Currency)</th>
                             <th class="text-end">Tickets</th>
-                            <th class="text-end">Face Value</th>
+                            <th class="text-end">Face Value (@Model.Currency)</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -168,9 +168,9 @@
                         {
                             <tr>
                                 <td>@type.TicketTypeName</td>
-                                <td class="text-end">@Model.Currency @type.Price.ToString("N2")</td>
+                                <td class="text-end">@type.Price.ToString("N2")</td>
                                 <td class="text-end">@type.TicketsSold.ToString("N0")</td>
-                                <td class="text-end">@Model.Currency @type.FaceValue.ToString("N2")</td>
+                                <td class="text-end">@type.FaceValue.ToString("N2")</td>
                             </tr>
                         }
                     </tbody>
@@ -179,7 +179,7 @@
                             <td>Total</td>
                             <td></td>
                             <td class="text-end">@Model.ByTicketType.Sum(t => t.TicketsSold).ToString("N0")</td>
-                            <td class="text-end">@Model.Currency @Model.ByTicketType.Sum(t => t.FaceValue).ToString("N2")</td>
+                            <td class="text-end">@Model.ByTicketType.Sum(t => t.FaceValue).ToString("N2")</td>
                         </tr>
                     </tfoot>
                 </table>
@@ -188,12 +188,69 @@
                         <i class="fa-solid fa-circle-info"></i>
                         Face value is the listed ticket price — order-level discounts and donations are excluded,
                         so totals here won't match Gross Revenue in the tables above.
+                        Discounts applied are broken out below.
                     </small>
                 </div>
             }
             else
             {
                 <div class="text-muted text-center py-3">No paid orders yet.</div>
+            }
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <i class="fa-solid fa-tags"></i> Discount Codes by Campaign
+        </div>
+        <div class="card-body p-0">
+            @if (Model.ByDiscountCampaign.Count > 0)
+            {
+                <table class="table table-sm table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Campaign</th>
+                            <th class="text-end">Codes Granted</th>
+                            <th class="text-end">Codes Used</th>
+                            <th class="text-end">Each (@Model.Currency)</th>
+                            <th class="text-end">Total (@Model.Currency)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var campaign in Model.ByDiscountCampaign)
+                        {
+                            <tr>
+                                <td>@campaign.CampaignTitle</td>
+                                <td class="text-end">@(campaign.CodesGranted?.ToString("N0") ?? "—")</td>
+                                <td class="text-end">@campaign.CodesUsed.ToString("N0")</td>
+                                <td class="text-end">@campaign.AverageDiscount.ToString("N2")</td>
+                                <td class="text-end">@campaign.TotalDiscount.ToString("N2")</td>
+                            </tr>
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr class="fw-bold">
+                            <td>Total</td>
+                            <td class="text-end">@Model.ByDiscountCampaign.Sum(d => d.CodesGranted ?? 0).ToString("N0")</td>
+                            <td class="text-end">@Model.ByDiscountCampaign.Sum(d => d.CodesUsed).ToString("N0")</td>
+                            <td></td>
+                            <td class="text-end">@Model.ByDiscountCampaign.Sum(d => d.TotalDiscount).ToString("N2")</td>
+                        </tr>
+                    </tfoot>
+                </table>
+                <div class="px-3 py-2">
+                    <small class="text-muted">
+                        <i class="fa-solid fa-circle-info"></i>
+                        Codes granted comes from the campaign that issued them; the amounts come from the paid
+                        orders that redeemed them, so "Each" is the average discount per redeeming order.
+                        Codes redeemed on paid orders that match no campaign grant are grouped under
+                        "No campaign (vendor codes)", where nothing was granted.
+                    </small>
+                </div>
+            }
+            else
+            {
+                <div class="text-muted text-center py-3">No discount codes redeemed yet.</div>
             }
         </div>
     </div>

--- a/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
@@ -65,6 +65,9 @@ public sealed class TicketQueryServiceTests : TicketsTestHarness
 
         _teamService.GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, TeamInfo>());
+
+        _campaignService.GetCodeTrackingAsync(Arg.Any<CancellationToken>())
+            .Returns(new CampaignCodeTrackingData([], []));
     }
 
     [HumansFact]
@@ -301,6 +304,28 @@ public sealed class TicketQueryServiceTests : TicketsTestHarness
         vendor.CodesUsed.Should().Be(1);
         vendor.AverageDiscount.Should().Be(10m);
         vendor.TotalDiscount.Should().Be(10m);
+    }
+
+    [HumansFact]
+    public async Task GetSalesAggregatesAsync_ByDiscountCampaign_KeepsCampaignsWithNoPaidRedemptions()
+    {
+        var campaignId = Guid.NewGuid();
+        StubCodeTracking(
+            new CampaignCodeTrackingSummary(campaignId, "Unused Comps", TotalGrants: 4, Redeemed: 0),
+            [("UNUSED1", campaignId), ("UNUSED2", campaignId)]);
+
+        await TicketsDb.TicketOrders.AddAsync(
+            MakeDiscountOrder("ord_unpaid", TicketPaymentStatus.Refunded, "UNUSED1", 25m));
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var result = await _service.GetSalesAggregatesAsync();
+
+        var row = result.ByDiscountCampaign.Should().ContainSingle().Subject;
+        row.CampaignTitle.Should().Be("Unused Comps");
+        row.CodesGranted.Should().Be(4);
+        row.CodesUsed.Should().Be(0);
+        row.AverageDiscount.Should().Be(0m);
+        row.TotalDiscount.Should().Be(0m);
     }
 
     private void StubCodeTracking(

--- a/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Tickets.Tests/Services/TicketQueryServiceTests.cs
@@ -265,7 +265,78 @@ public sealed class TicketQueryServiceTests : TicketsTestHarness
         var result = await _service.GetSalesAggregatesAsync();
 
         result.ByTicketType.Should().BeEmpty();
+        result.ByDiscountCampaign.Should().BeEmpty();
     }
+
+    [HumansFact]
+    public async Task GetSalesAggregatesAsync_ByDiscountCampaign_SplitsGrantedCodesFromVendorCodes()
+    {
+        var campaignId = Guid.NewGuid();
+        StubCodeTracking(
+            new CampaignCodeTrackingSummary(campaignId, "Volunteer Comps", TotalGrants: 3, Redeemed: 2),
+            [("VOL1", campaignId), ("VOL2", campaignId), ("VOL3", campaignId)]);
+
+        await TicketsDb.TicketOrders.AddRangeAsync(
+            MakeDiscountOrder("ord_vol1", TicketPaymentStatus.Paid, "VOL1", 50m),
+            MakeDiscountOrder("ord_vol2", TicketPaymentStatus.Paid, "VOL2", 30m),
+            MakeDiscountOrder("ord_promo", TicketPaymentStatus.Paid, "PROMO10", 10m),
+            MakeDiscountOrder("ord_refunded", TicketPaymentStatus.Refunded, "VOL3", 999m));
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var result = await _service.GetSalesAggregatesAsync();
+
+        result.ByDiscountCampaign.Should().HaveCount(2);
+
+        var campaign = result.ByDiscountCampaign[0];
+        campaign.CampaignTitle.Should().Be("Volunteer Comps");
+        campaign.CodesGranted.Should().Be(3);
+        campaign.CodesUsed.Should().Be(2);
+        campaign.AverageDiscount.Should().Be(40m);
+        campaign.TotalDiscount.Should().Be(80m);
+
+        // Vendor codes always sort last and have nothing granted.
+        var vendor = result.ByDiscountCampaign[1];
+        vendor.CampaignTitle.Should().Be("No campaign (vendor codes)");
+        vendor.CodesGranted.Should().BeNull();
+        vendor.CodesUsed.Should().Be(1);
+        vendor.AverageDiscount.Should().Be(10m);
+        vendor.TotalDiscount.Should().Be(10m);
+    }
+
+    private void StubCodeTracking(
+        CampaignCodeTrackingSummary summary,
+        IEnumerable<(string Code, Guid CampaignId)> grants)
+    {
+        var grantRows = grants
+            .Select(g => new CampaignCodeTrackingGrant(
+                Guid.NewGuid(), g.CampaignId, summary.CampaignTitle, Guid.NewGuid(),
+                "Recipient", g.Code, RedeemedAt: null, LatestEmailStatus: null))
+            .ToList();
+
+        _campaignService.GetCodeTrackingAsync(Arg.Any<CancellationToken>())
+            .Returns(new CampaignCodeTrackingData([summary], grantRows));
+    }
+
+    private static TicketOrder MakeDiscountOrder(
+        string vendorOrderId,
+        TicketPaymentStatus paymentStatus,
+        string discountCode,
+        decimal discountAmount) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            VendorOrderId = vendorOrderId,
+            BuyerName = "Buyer",
+            BuyerEmail = "buyer@example.com",
+            TotalAmount = 100m,
+            Currency = "EUR",
+            PaymentStatus = paymentStatus,
+            VendorEventId = "ev_test",
+            PurchasedAt = Instant.FromUtc(2026, 3, 2, 10, 0),
+            SyncedAt = Instant.FromUtc(2026, 3, 2, 10, 0),
+            DiscountCode = discountCode,
+            DiscountAmount = discountAmount,
+        };
 
     [HumansFact]
     public async Task GetAvailableTicketTypesAsync_ReturnsDistinctTypes()


### PR DESCRIPTION
## What

**Discount Codes by Campaign** card on `/Tickets/SalesAggregates`. The page only reported face value, so the discounts that explain the gap to Gross Revenue were invisible.

| Column | Source |
|---|---|
| Codes Granted | `ICampaignServiceRead.GetCodeTrackingAsync()` — the campaign that issued them |
| Codes Used | paid orders whose `DiscountCode` matches one of that campaign's grants |
| Each | Total ÷ Used (nothing stores a per-code face value) |
| Total | `SUM(TicketOrder.DiscountAmount)` over those orders |

Codes redeemed on paid orders that match no grant collapse into one `No campaign (vendor codes)` row, Granted blank. Unpaid/refunded orders are excluded, matching the rest of the page.

**EUR out of the cells.** Every money column on the page is EUR; repeating `EUR ` in each cell broke copy/paste into Excel. The currency now lives in the column header (`Gross Revenue (EUR)`), across all three existing tables plus the new one.

## Notes

- No new repo method — extended the existing `GetOrdersWithDiscountCodesAsync` / `DiscountCodeOrderRow` with `DiscountAmount` + `IsPaid`.
- No new service interface — `TicketQueryService` already injects `ICampaignServiceRead`.
- No migration.

## Verification

`dotnet build Humans.slnx -v quiet` — 0 errors. `dotnet test Humans.slnx -v quiet` — full suite green, no failures. New test `GetSalesAggregatesAsync_ByDiscountCampaign_SplitsGrantedCodesFromVendorCodes` covers the campaign/vendor split and the unpaid-order exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)