### PR TITLE
Make section activation a configuration decision (#1081)

### DIFF
--- a/docs/features/global/section-activation.md
+++ b/docs/features/global/section-activation.md
@@ -1,0 +1,93 @@
+<!-- freshness:triggers
+  src/Humans.Web/Extensions/SectionActivation.cs
+  src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
+  src/Humans.Web/Hosting/SectionControllerFeatureProvider.cs
+  src/Humans.Web/Hosting/SectionViewComponentFeatureProvider.cs
+-->
+<!-- freshness:flag-on-change
+  The `Sections:Active` contract, what startup validates, and the count of sections Shell itself pins — review whenever activation, discovery, or a Shell-to-section reference changes.
+-->
+
+# Section Activation
+
+## Business Context
+
+Every section assembly ships in every build. Which of them a given deployment actually
+runs is a per-deployment configuration decision (nobodies-collective/Humans#1081), so one
+artifact can serve a full production install, a stripped preview, or a demo without a
+separate build.
+
+No section name is written down in Shell. The allowlist is validated against what
+discovery found, and the dependency graph is derived from real assembly references — a new
+section is activatable the moment it ships an `ISection` entry point.
+
+## Configuration
+
+`Sections:Active` — an array of section names. A section's name is its assembly name
+without the `Humans.` prefix, so `Humans.Store` is `Store`. Matching is case-insensitive.
+
+| Value | Meaning |
+|---|---|
+| Key absent (the shipped default) | Every discovered section is active |
+| `["Store", "Users", …]` | Exactly those sections |
+| `[]` | Zero sections — a config error in practice, see below |
+
+Absent and `[]` are **not** the same. An absent key binds to `null`; an explicitly empty
+array binds to a zero-length array. Absent means "everything", empty means "nothing", and
+nothing is not a runnable configuration because Shell itself consumes sections.
+
+```json
+{
+  "Sections": {
+    "Active": [ "Auth", "Users", "Teams" ]
+  }
+}
+```
+
+## What startup validates
+
+`SectionActivation.Configure` runs once in `Program.cs`, before anything reads the active
+set. With the key absent it validates nothing and cannot fail. With an allowlist present it
+throws `InvalidOperationException` when:
+
+- **A name is not a section.** The message lists every discovered section, so a typo is one
+  read away from its fix rather than a section that silently vanishes.
+- **An active section's dependency is deactivated.** A section reaches another only through
+  that section's `.Contracts` assembly, so a referenced `Humans.X.Contracts` maps back to
+  section `X`; the graph is those edges.
+- **A section Shell itself consumes is deactivated.** Shell always runs — `HomeController`
+  names `IUserService` — so its own references are validated as if it were an active
+  section. It appears in error messages under its assembly name, `Web`.
+
+Shell pins **26 of the 42 shipped sections** today. Any allowlist must therefore contain
+those 26 plus the transitive closure of what they consume, which leaves activation useful
+mainly for the sections Shell does not name. That number is the epic's debt measure, not a
+design target: each seam lane (nobodies-collective/Humans#1073 and its lanes) removes Shell
+references by moving nav, tiles, chrome and policies behind `ISectionContribution` seams,
+and the pinned set shrinks with it.
+
+## What a deactivated section contributes
+
+Nothing. Composition reads `ActiveSectionAssemblies()` throughout, so a deactivated section
+has no `Register` call, no DI registrations, no controllers, no view components, no
+recurring jobs, no authorization policies, no health checks, no endpoints, no nav or tile
+entries, and no resource types.
+
+Controllers and view components need explicit removal rather than mere omission: MVC's
+default feature providers walk every application part and would otherwise keep a
+deactivated section's *public* controllers routable and its *public* view components
+resolvable, failing at request time on services nobody registered.
+`SectionControllerFeatureProvider` and `SectionViewComponentFeatureProvider` drop them.
+
+## Diagnosing
+
+Startup logs both sets at `Information`:
+
+```
+Sections: 39 active of 42 discovered. Active: Agent, Auth, …. Inactive: Cantina, Guide, Tour
+```
+
+That line is the first thing to read when a section's page 404s — a deactivated section is
+indistinguishable from a missing one at the URL, where the old by-name registration would
+have been a compile error. See
+[`section-controllers-need-feature-provider`](../../../memory/architecture/section-controllers-need-feature-provider.md).

--- a/docs/features/global/section-activation.md
+++ b/docs/features/global/section-activation.md
@@ -47,9 +47,10 @@ nothing is not a runnable configuration because Shell itself consumes sections.
 
 ## What startup validates
 
-`SectionActivation.Configure` runs once in `Program.cs`, before anything reads the active
-set. With the key absent it validates nothing and cannot fail. With an allowlist present it
-throws `InvalidOperationException` when:
+`SectionActivation.Resolve` runs once in `Program.cs`, producing that host's
+`SectionAssemblySnapshot` before anything composes from discovery. With the key absent it
+validates nothing and cannot fail. With an allowlist present it throws
+`InvalidOperationException` when:
 
 - **A name is not a section.** The message lists every discovered section, so a typo is one
   read away from its fix rather than a section that silently vanishes.
@@ -62,13 +63,23 @@ throws `InvalidOperationException` when:
 
 ### What the scan cannot see
 
-Only references the compiler emits. A section Shell names as a *string* — an
+Only references the compiler emits. A section named as a *string* — an
 `asp-controller="X"` link in a Razor view, `Component.InvokeAsync("Y")` — produces no
-assembly reference, so no reference-based scan can find it. `_Layout.cshtml` still links
-`Search` and `Tour` that way, and both are real sections, so an allowlist can deactivate
-them: validation passes, the provider removes the controller, the link 404s. Tracked as
-nobodies-collective/Humans#1090, which needs a decision rather than a patch — the epic
-treats those two as Shell chrome while activation treats them as sections.
+assembly reference, so no reference-based scan can find it. Two shapes exist:
+
+- **Shell to section.** `_Layout.cshtml` links `Search` and `Tour` that way, and both are
+  real sections, so an allowlist can deactivate them: validation passes, the provider
+  removes the controller, the link 404s.
+- **Section to section.** `Humans.Users/Views/Profile/Index.cshtml` and
+  `Humans.Camps/Views/Camp/Details.cshtml` both invoke Events' `EventsCard` by name, and
+  neither project references Events, so no graph edge records it. Deactivating Events with
+  either consumer active passes validation and throws on those pages at request time.
+
+Both are tracked as nobodies-collective/Humans#1090, which needs a decision rather than a
+patch: a string is invisible to any reference-based scan, and writing the names down is
+exactly what nobodies-collective/Humans#1073 exists to remove. The `<vc:chrome-slot>` and
+`ISectionContribution` seams the epic's lanes introduce are what turns these into real
+edges — a contributed component is discovered from the section's own assembly.
 
 Shell pins **26 of the 42 shipped sections** today. Any allowlist must therefore contain
 those 26 plus the transitive closure of what they consume, which leaves activation useful
@@ -79,10 +90,10 @@ and the pinned set shrinks with it.
 
 ## What a deactivated section contributes
 
-Nothing. Composition reads `ActiveSectionAssemblies()` throughout, so a deactivated section
-has no `Register` call, no DI registrations, no controllers, no view components, no
-recurring jobs, no authorization policies, no health checks, no endpoints, no nav or tile
-entries, and no resource types.
+Nothing. Composition reads the host's `SectionAssemblySnapshot` throughout, so a
+deactivated section has no `Register` call, no DI registrations, no controllers, no view
+components, no recurring jobs, no authorization policies, no health checks, no endpoints,
+no nav or tile entries, and no resource types.
 
 Controllers and view components need explicit removal rather than mere omission: MVC's
 default feature providers walk every application part and would otherwise keep a
@@ -90,13 +101,18 @@ deactivated section's *public* controllers routable and its *public* view compon
 resolvable, failing at request time on services nobody registered.
 `SectionControllerFeatureProvider` and `SectionViewComponentFeatureProvider` drop them.
 
-Those two providers are the only place a section set is cached, because they see one type
-at a time and re-walking the dependency graph per type is too slow. The cache is a
-`SectionAssemblySnapshot` built **per host** and handed to them at construction — never a
-static. Several hosts share a process (every `WebApplicationFactory` in the integration
-suite builds one), and a process-wide cache would serve whichever host composed first to
-all of them, routing one host's controllers inside another. Everything else re-reads
-`ActiveSectionAssemblies()` per call and is unaffected.
+### One snapshot per host
+
+The active/inactive split is a `SectionAssemblySnapshot` built **per host** in `Program.cs`
+and passed through composition — never process-wide state. Several hosts share a process
+(every `WebApplicationFactory` in the integration suite builds one), and a shared active set
+serves whichever host composed first to all of them, registering one host's sections inside
+another and routing its controllers there.
+
+The composition-time consumers take it as a parameter (`AddDiscoveredSections`,
+`AddHumansInfrastructure`, `AddHumansAuthorizationPolicies`, the health-check, resource and
+endpoint loops, and the two feature providers at construction). It is also registered as a
+singleton, so the post-build pass that schedules recurring jobs resolves that host's own.
 
 ## Diagnosing
 

--- a/docs/features/global/section-activation.md
+++ b/docs/features/global/section-activation.md
@@ -60,6 +60,16 @@ throws `InvalidOperationException` when:
   names `IUserService` — so its own references are validated as if it were an active
   section. It appears in error messages under its assembly name, `Web`.
 
+### What the scan cannot see
+
+Only references the compiler emits. A section Shell names as a *string* — an
+`asp-controller="X"` link in a Razor view, `Component.InvokeAsync("Y")` — produces no
+assembly reference, so no reference-based scan can find it. `_Layout.cshtml` still links
+`Search` and `Tour` that way, and both are real sections, so an allowlist can deactivate
+them: validation passes, the provider removes the controller, the link 404s. Tracked as
+nobodies-collective/Humans#1090, which needs a decision rather than a patch — the epic
+treats those two as Shell chrome while activation treats them as sections.
+
 Shell pins **26 of the 42 shipped sections** today. Any allowlist must therefore contain
 those 26 plus the transitive closure of what they consume, which leaves activation useful
 mainly for the sections Shell does not name. That number is the epic's debt measure, not a

--- a/docs/features/global/section-activation.md
+++ b/docs/features/global/section-activation.md
@@ -1,6 +1,7 @@
 <!-- freshness:triggers
   src/Humans.Web/Extensions/SectionActivation.cs
   src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
+  src/Humans.Web/Hosting/SectionAssemblySnapshot.cs
   src/Humans.Web/Hosting/SectionControllerFeatureProvider.cs
   src/Humans.Web/Hosting/SectionViewComponentFeatureProvider.cs
 -->
@@ -78,6 +79,14 @@ default feature providers walk every application part and would otherwise keep a
 deactivated section's *public* controllers routable and its *public* view components
 resolvable, failing at request time on services nobody registered.
 `SectionControllerFeatureProvider` and `SectionViewComponentFeatureProvider` drop them.
+
+Those two providers are the only place a section set is cached, because they see one type
+at a time and re-walking the dependency graph per type is too slow. The cache is a
+`SectionAssemblySnapshot` built **per host** and handed to them at construction — never a
+static. Several hosts share a process (every `WebApplicationFactory` in the integration
+suite builds one), and a process-wide cache would serve whichever host composed first to
+all of them, routing one host's controllers inside another. Everything else re-reads
+`ActiveSectionAssemblies()` per call and is unaffected.
 
 ## Diagnosing
 

--- a/memory/architecture/section-controllers-need-feature-provider.md
+++ b/memory/architecture/section-controllers-need-feature-provider.md
@@ -21,6 +21,9 @@ peterdrier/Humans#1223).
 **How to apply:** `Section.cs : ISection` is what turns discovery on — it serves the analyzers, DI
 discovery *and* controller discovery, so there is nothing per-section to register. If a section route
 404s while the controller is clearly present, check that the section is in Shell's discovered list,
+then that `Sections:Active` has not deactivated it (the provider drops a deactivated section's
+controllers, public ones included — see
+[`docs/features/global/section-activation.md`](../../docs/features/global/section-activation.md)),
 then that Shell still adds the feature provider to `AddControllersWithViews`. Do not "fix" it by
 making the controller `public` — a public constructor cannot take an internal service (CS0051), so
 that fix cascades until the section's whole service layer is public.

--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -4,6 +4,7 @@ using Humans.Web.Extensions;
 using Humans.Base.Constants;
 using Humans.Base.Authorization;
 using Humans.Shifts.Contracts;
+using Humans.Web.Hosting;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Humans.Web.Authorization;
@@ -16,7 +17,9 @@ namespace Humans.Web.Authorization;
 /// </summary>
 public static class AuthorizationPolicyExtensions
 {
-    public static IServiceCollection AddHumansAuthorizationPolicies(this IServiceCollection services)
+    internal static IServiceCollection AddHumansAuthorizationPolicies(
+        this IServiceCollection services,
+        SectionAssemblySnapshot sections)
     {
         // TeamAuthorizationHandler is registered by Humans.Teams' Section.Register: the handler
         // moved into the section at its G5 and is internal there, while the policies it backs
@@ -112,7 +115,7 @@ public static class AuthorizationPolicyExtensions
 
         // Sections register their own policies. Configure<AuthorizationOptions> is additive,
         // so cross-section policies keep registering above.
-        var contributors = SectionDiscoveryExtensions.DiscoverImplementations<ISectionPolicies>();
+        var contributors = SectionDiscoveryExtensions.DiscoverImplementations<ISectionPolicies>(sections);
         if (contributors.Count > 0)
         {
             services.Configure<AuthorizationOptions>(options =>

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -7,16 +7,18 @@ using Humans.Base.Services;
 using Humans.Web.Services;
 using Humans.Web.Extensions.Infrastructure;
 using Humans.Web.Extensions.Sections;
+using Humans.Web.Hosting;
 using Humans.Web.Services.Dashboard;
 
 namespace Humans.Web.Extensions;
 
 public static class InfrastructureServiceCollectionExtensions
 {
-    public static IServiceCollection AddHumansInfrastructure(
+    internal static IServiceCollection AddHumansInfrastructure(
         this IServiceCollection services,
         IConfiguration configuration,
         IHostEnvironment environment,
+        SectionAssemblySnapshot sections,
         ConfigurationRegistry? configRegistry = null)
     {
         // Cross-cutting infrastructure — options bindings, integrations, config metadata.
@@ -96,7 +98,7 @@ public static class InfrastructureServiceCollectionExtensions
 
         // Sections that have moved into their own project (nobodies-collective/Humans#866)
         // register themselves via ISection and are discovered, not named.
-        services.AddDiscoveredSections(configuration);
+        services.AddDiscoveredSections(sections, configuration);
 
         return services;
     }

--- a/src/Humans.Web/Extensions/RecurringJobExtensions.cs
+++ b/src/Humans.Web/Extensions/RecurringJobExtensions.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Hangfire;
 using Hangfire.Storage;
 using Humans.Base.Interfaces;
+using Humans.Web.Hosting;
 
 namespace Humans.Web.Extensions;
 
@@ -72,7 +73,8 @@ public static class RecurringJobExtensions
     /// <c>Humans.Integration.Tests</c> can walk the same set a real boot schedules.
     /// </summary>
     internal static IEnumerable<ScheduledJob> ContributedJobs(IServiceProvider services) =>
-        SectionDiscoveryExtensions.DiscoverImplementations<ISectionJobs>()
+        SectionDiscoveryExtensions.DiscoverImplementations<ISectionJobs>(
+                services.GetRequiredService<SectionAssemblySnapshot>())
             .SelectMany(contributor => contributor.Jobs(services))
             .Select(ToScheduledJob);
 

--- a/src/Humans.Web/Extensions/SectionActivation.cs
+++ b/src/Humans.Web/Extensions/SectionActivation.cs
@@ -26,8 +26,13 @@ public static class SectionActivation
     /// <summary>Null means every discovered section — the default.</summary>
     private static IReadOnlySet<string>? _active;
 
-    /// <summary>Reads the allowlist and fails startup if it breaks an active section's dependencies.</summary>
-    public static void Configure(IConfiguration configuration) =>
+    /// <summary>
+    /// Reads the allowlist and fails startup if it breaks an active section's dependencies.
+    /// Returns the resolved set — null for the default, every section — so the composing
+    /// host can hand it to the parts that need a snapshot of its own composition rather
+    /// than a process-wide read.
+    /// </summary>
+    public static IReadOnlySet<string>? Configure(IConfiguration configuration) =>
         _active = Resolve(
             SectionDiscoveryExtensions.SectionAssemblies(),
             typeof(SectionActivation).Assembly,

--- a/src/Humans.Web/Extensions/SectionActivation.cs
+++ b/src/Humans.Web/Extensions/SectionActivation.cs
@@ -14,8 +14,10 @@ namespace Humans.Web.Extensions;
 /// validated against, and the dependency graph derived from, what discovery actually found.
 /// </para>
 /// <para>
-/// Set once at startup, before anything reads <see cref="SectionDiscoveryExtensions.ActiveSectionAssemblies"/>,
-/// because discovery runs during composition from several places that hold no configuration.
+/// Resolved once per host into a <see cref="Hosting.SectionAssemblySnapshot"/> the host
+/// then carries through its own composition. Deliberately no process-wide state: several
+/// hosts share a process — every <c>WebApplicationFactory</c> in the integration suite
+/// builds one — and a static allowlist would let a host compose against another's.
 /// </para>
 /// </remarks>
 public static class SectionActivation
@@ -23,24 +25,15 @@ public static class SectionActivation
     /// <summary>Configuration key holding the active-section allowlist.</summary>
     public const string ActiveKey = "Sections:Active";
 
-    /// <summary>Null means every discovered section — the default.</summary>
-    private static IReadOnlySet<string>? _active;
-
     /// <summary>
-    /// Reads the allowlist and fails startup if it breaks an active section's dependencies.
-    /// Returns the resolved set — null for the default, every section — so the composing
-    /// host can hand it to the parts that need a snapshot of its own composition rather
-    /// than a process-wide read.
+    /// The sections this host runs — null for the default, every section. Reads the
+    /// allowlist and fails startup if it breaks an active section's dependencies.
     /// </summary>
-    public static IReadOnlySet<string>? Configure(IConfiguration configuration) =>
-        _active = Resolve(
+    public static IReadOnlySet<string>? Resolve(IConfiguration configuration) =>
+        Resolve(
             SectionDiscoveryExtensions.SectionAssemblies(),
             typeof(SectionActivation).Assembly,
             configuration);
-
-    /// <summary>True when this deployment runs the named section.</summary>
-    public static bool IsActive(string sectionName) =>
-        _active is null || _active.Contains(sectionName);
 
     /// <summary>
     /// The active set for <paramref name="discovered"/> under <paramref name="configuration"/>,

--- a/src/Humans.Web/Extensions/SectionActivation.cs
+++ b/src/Humans.Web/Extensions/SectionActivation.cs
@@ -28,7 +28,10 @@ public static class SectionActivation
 
     /// <summary>Reads the allowlist and fails startup if it breaks an active section's dependencies.</summary>
     public static void Configure(IConfiguration configuration) =>
-        _active = Resolve(SectionDiscoveryExtensions.SectionAssemblies(), configuration);
+        _active = Resolve(
+            SectionDiscoveryExtensions.SectionAssemblies(),
+            typeof(SectionActivation).Assembly,
+            configuration);
 
     /// <summary>True when this deployment runs the named section.</summary>
     public static bool IsActive(string sectionName) =>
@@ -36,25 +39,27 @@ public static class SectionActivation
 
     /// <summary>
     /// The active set for <paramref name="discovered"/> under <paramref name="configuration"/>,
-    /// or null when the allowlist is absent and everything is active.
+    /// or null when the allowlist is absent and everything is active. <paramref name="shell"/>
+    /// always runs, so what it consumes is validated alongside the active sections.
     /// </summary>
     /// <exception cref="InvalidOperationException">
-    /// The allowlist names something that is not a section, or deactivates a section an
-    /// active one depends on.
+    /// The allowlist names something that is not a section, or deactivates a section that
+    /// Shell or an active section depends on.
     /// </exception>
     internal static IReadOnlySet<string>? Resolve(
         IReadOnlyList<Assembly> discovered,
+        Assembly shell,
         IConfiguration configuration)
     {
-        var allowed = configuration.GetSection(ActiveKey).Get<string[]>() ?? [];
-        if (allowed.Length == 0)
+        // Absent binds to null; an explicitly configured empty array binds to an empty
+        // array, and means zero sections — not "everything", which is what absent means.
+        var allowed = configuration.GetSection(ActiveKey).Get<string[]>();
+        if (allowed is null)
         {
             return null;
         }
 
-        var names = discovered
-            .Select(SectionDiscoveryExtensions.SectionName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var names = SectionNames(discovered);
 
         var unknown = allowed.Where(name => !names.Contains(name)).ToList();
         if (unknown.Count > 0)
@@ -68,7 +73,7 @@ public static class SectionActivation
         var allowedSet = allowed.ToHashSet(StringComparer.OrdinalIgnoreCase);
         var active = names.Where(allowedSet.Contains).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        ThrowOnUnmetDependencies(discovered, active);
+        ThrowOnUnmetDependencies(discovered, shell, active);
 
         return active;
     }
@@ -82,28 +87,45 @@ public static class SectionActivation
     internal static IReadOnlyDictionary<string, IReadOnlyList<string>> DependencyGraph(
         IReadOnlyList<Assembly> discovered)
     {
-        var names = discovered
-            .Select(SectionDiscoveryExtensions.SectionName)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var names = SectionNames(discovered);
 
         return discovered.ToDictionary(
             SectionDiscoveryExtensions.SectionName,
-            assembly =>
-            {
-                var self = SectionDiscoveryExtensions.SectionName(assembly);
-                return (IReadOnlyList<string>)
-                [
-                    .. assembly.GetReferencedAssemblies()
-                        .Select(reference => reference.Name)
-                        .OfType<string>()
-                        .Where(name => name.StartsWith("Humans.", StringComparison.Ordinal))
-                        .Select(OwningSection)
-                        .Where(name => names.Contains(name) && !name.Equals(self, StringComparison.OrdinalIgnoreCase))
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .Order(StringComparer.Ordinal)
-                ];
-            },
+            assembly => ConsumedSections(assembly, names),
             StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The sections Shell itself consumes, read the same way as a section's own edges.
+    /// Shell always runs — <c>HomeController</c> names <c>IUserService</c> — so these are
+    /// dependencies no section-to-section edge records, and an allowlist that drops one
+    /// composes an app that fails per request instead of at startup.
+    /// </summary>
+    internal static IReadOnlyList<string> ShellDependencies(
+        IReadOnlyList<Assembly> discovered,
+        Assembly shell) =>
+        ConsumedSections(shell, SectionNames(discovered));
+
+    private static HashSet<string> SectionNames(IReadOnlyList<Assembly> discovered) =>
+        discovered.Select(SectionDiscoveryExtensions.SectionName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The discovered sections an assembly references, excluding itself.</summary>
+    private static IReadOnlyList<string> ConsumedSections(Assembly assembly, HashSet<string> names)
+    {
+        var self = SectionDiscoveryExtensions.SectionName(assembly);
+
+        return
+        [
+            .. assembly.GetReferencedAssemblies()
+                .Select(reference => reference.Name)
+                .OfType<string>()
+                .Where(name => name.StartsWith("Humans.", StringComparison.Ordinal))
+                .Select(OwningSection)
+                .Where(name => names.Contains(name) && !name.Equals(self, StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.Ordinal)
+        ];
     }
 
     /// <summary>The section a referenced <c>Humans.*</c> assembly belongs to.</summary>
@@ -117,16 +139,23 @@ public static class SectionActivation
 
     private static void ThrowOnUnmetDependencies(
         IReadOnlyList<Assembly> discovered,
+        Assembly shell,
         IReadOnlySet<string> active)
     {
         var graph = DependencyGraph(discovered);
 
-        var unmet = active
-            .SelectMany(section => graph[section].Where(dependency => !active.Contains(dependency))
-                .Select(dependency => (Dependency: dependency, Dependent: section)))
+        var consumers = active
+            .Select(section => (Consumer: section, Consumed: graph[section]))
+            .Append((
+                Consumer: SectionDiscoveryExtensions.SectionName(shell),
+                Consumed: ShellDependencies(discovered, shell)));
+
+        var unmet = consumers
+            .SelectMany(x => x.Consumed.Where(dependency => !active.Contains(dependency))
+                .Select(dependency => (Dependency: dependency, Dependent: x.Consumer)))
             .GroupBy(x => x.Dependency, StringComparer.OrdinalIgnoreCase)
             .OrderBy(g => g.Key, StringComparer.Ordinal)
-            .Select(g => $"{g.Key} (consumed by {string.Join(", ", g.Select(x => x.Dependent).Order(StringComparer.Ordinal))})")
+            .Select(g => $"{g.Key} (consumed by {string.Join(", ", g.Select(x => x.Dependent).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.Ordinal))})")
             .ToList();
 
         if (unmet.Count > 0)

--- a/src/Humans.Web/Extensions/SectionActivation.cs
+++ b/src/Humans.Web/Extensions/SectionActivation.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+
+namespace Humans.Web.Extensions;
+
+/// <summary>
+/// Which of the discovered sections this deployment runs. Every section assembly ships;
+/// activation is a per-deployment configuration decision (nobodies-collective/Humans#1081).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Configured as a name allowlist under <c>Sections:Active</c>. Absent — the shipped
+/// default — means every discovered section is active, which is what the app did before
+/// this existed. No section name is written down anywhere in Shell: the allowlist is
+/// validated against, and the dependency graph derived from, what discovery actually found.
+/// </para>
+/// <para>
+/// Set once at startup, before anything reads <see cref="SectionDiscoveryExtensions.ActiveSectionAssemblies"/>,
+/// because discovery runs during composition from several places that hold no configuration.
+/// </para>
+/// </remarks>
+public static class SectionActivation
+{
+    /// <summary>Configuration key holding the active-section allowlist.</summary>
+    public const string ActiveKey = "Sections:Active";
+
+    /// <summary>Null means every discovered section — the default.</summary>
+    private static IReadOnlySet<string>? _active;
+
+    /// <summary>Reads the allowlist and fails startup if it breaks an active section's dependencies.</summary>
+    public static void Configure(IConfiguration configuration) =>
+        _active = Resolve(SectionDiscoveryExtensions.SectionAssemblies(), configuration);
+
+    /// <summary>True when this deployment runs the named section.</summary>
+    public static bool IsActive(string sectionName) =>
+        _active is null || _active.Contains(sectionName);
+
+    /// <summary>
+    /// The active set for <paramref name="discovered"/> under <paramref name="configuration"/>,
+    /// or null when the allowlist is absent and everything is active.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The allowlist names something that is not a section, or deactivates a section an
+    /// active one depends on.
+    /// </exception>
+    internal static IReadOnlySet<string>? Resolve(
+        IReadOnlyList<Assembly> discovered,
+        IConfiguration configuration)
+    {
+        var allowed = configuration.GetSection(ActiveKey).Get<string[]>() ?? [];
+        if (allowed.Length == 0)
+        {
+            return null;
+        }
+
+        var names = discovered
+            .Select(SectionDiscoveryExtensions.SectionName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var unknown = allowed.Where(name => !names.Contains(name)).ToList();
+        if (unknown.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"{ActiveKey} names {string.Join(", ", unknown)}, which no section assembly declares. "
+                + $"Discovered sections: {string.Join(", ", names.Order(StringComparer.Ordinal))}.");
+        }
+
+        // Canonical spelling, so log lines and IsActive agree with what discovery found.
+        var allowedSet = allowed.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var active = names.Where(allowedSet.Contains).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        ThrowOnUnmetDependencies(discovered, active);
+
+        return active;
+    }
+
+    /// <summary>
+    /// Section name to the sections it consumes. Derived from real assembly references
+    /// (G5 decision #9 — derived, never declared): a section reaches another only through
+    /// that section's <c>.Contracts</c> assembly, which is a separate assembly, so a
+    /// referenced <c>Humans.X.Contracts</c> maps back to section <c>X</c> by name.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, IReadOnlyList<string>> DependencyGraph(
+        IReadOnlyList<Assembly> discovered)
+    {
+        var names = discovered
+            .Select(SectionDiscoveryExtensions.SectionName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return discovered.ToDictionary(
+            SectionDiscoveryExtensions.SectionName,
+            assembly =>
+            {
+                var self = SectionDiscoveryExtensions.SectionName(assembly);
+                return (IReadOnlyList<string>)
+                [
+                    .. assembly.GetReferencedAssemblies()
+                        .Select(reference => reference.Name)
+                        .OfType<string>()
+                        .Where(name => name.StartsWith("Humans.", StringComparison.Ordinal))
+                        .Select(OwningSection)
+                        .Where(name => names.Contains(name) && !name.Equals(self, StringComparison.OrdinalIgnoreCase))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .Order(StringComparer.Ordinal)
+                ];
+            },
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The section a referenced <c>Humans.*</c> assembly belongs to.</summary>
+    private static string OwningSection(string assemblyName)
+    {
+        var name = assemblyName["Humans.".Length..];
+        return name.EndsWith(".Contracts", StringComparison.Ordinal)
+            ? name[..^".Contracts".Length]
+            : name;
+    }
+
+    private static void ThrowOnUnmetDependencies(
+        IReadOnlyList<Assembly> discovered,
+        IReadOnlySet<string> active)
+    {
+        var graph = DependencyGraph(discovered);
+
+        var unmet = active
+            .SelectMany(section => graph[section].Where(dependency => !active.Contains(dependency))
+                .Select(dependency => (Dependency: dependency, Dependent: section)))
+            .GroupBy(x => x.Dependency, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => $"{g.Key} (consumed by {string.Join(", ", g.Select(x => x.Dependent).Order(StringComparer.Ordinal))})")
+            .ToList();
+
+        if (unmet.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"{ActiveKey} deactivates section(s) that active sections consume: {string.Join("; ", unmet)}. "
+                + "Activate them, or deactivate the sections that depend on them.");
+        }
+    }
+}

--- a/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
+++ b/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
@@ -140,6 +140,18 @@ public static class SectionDiscoveryExtensions
     /// </summary>
     internal static bool IsSectionAssembly(Assembly assembly) => SectionAssemblySet.Value.Contains(assembly);
 
+    private static readonly Lazy<HashSet<Assembly>> InactiveSectionAssemblySet =
+        new(() => [.. SectionAssemblies().Except(ActiveSectionAssemblies())]);
+
+    /// <summary>
+    /// True for a section assembly this deployment deactivated. MVC's default feature
+    /// providers walk every application part, so a deactivated section's <em>public</em>
+    /// controllers and view components stay routable unless something takes them back out —
+    /// and they then resolve services no <c>Register</c> call ever added (#1081).
+    /// </summary>
+    internal static bool IsInactiveSectionAssembly(Assembly assembly) =>
+        InactiveSectionAssemblySet.Value.Contains(assembly);
+
     /// <summary>The section a <paramref name="assembly"/> is: its name without the
     /// <c>Humans.</c> prefix.</summary>
     internal static string SectionName(Assembly assembly) =>

--- a/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
+++ b/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
@@ -132,26 +132,6 @@ public static class SectionDiscoveryExtensions
             // carries a cross-section FK, so the contexts migrate independently.
             .OrderBy(s => s.Name, StringComparer.Ordinal)];
 
-    private static readonly Lazy<HashSet<Assembly>> SectionAssemblySet = new(() => [.. ActiveSectionAssemblies()]);
-
-    /// <summary>
-    /// True for a section assembly. Used by the MVC feature providers, which see one
-    /// type at a time and would otherwise re-walk the dependency graph per type.
-    /// </summary>
-    internal static bool IsSectionAssembly(Assembly assembly) => SectionAssemblySet.Value.Contains(assembly);
-
-    private static readonly Lazy<HashSet<Assembly>> InactiveSectionAssemblySet =
-        new(() => [.. SectionAssemblies().Except(ActiveSectionAssemblies())]);
-
-    /// <summary>
-    /// True for a section assembly this deployment deactivated. MVC's default feature
-    /// providers walk every application part, so a deactivated section's <em>public</em>
-    /// controllers and view components stay routable unless something takes them back out —
-    /// and they then resolve services no <c>Register</c> call ever added (#1081).
-    /// </summary>
-    internal static bool IsInactiveSectionAssembly(Assembly assembly) =>
-        InactiveSectionAssemblySet.Value.Contains(assembly);
-
     /// <summary>The section a <paramref name="assembly"/> is: its name without the
     /// <c>Humans.</c> prefix.</summary>
     internal static string SectionName(Assembly assembly) =>

--- a/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
+++ b/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Humans.Base.Interfaces;
+using Humans.Web.Hosting;
 using Microsoft.Extensions.DependencyModel;
 
 namespace Humans.Web.Extensions;
@@ -12,17 +13,19 @@ namespace Humans.Web.Extensions;
 /// </summary>
 /// <remarks>
 /// Which of the discovered sections a deployment actually runs is configuration —
-/// see <see cref="SectionActivation"/>. Everything below composes from
-/// <see cref="ActiveSectionAssemblies"/>, so a deactivated section contributes no
-/// registration, no controller, no job and no nav without any of them naming it.
+/// see <see cref="SectionActivation"/>. Everything below composes from the host's own
+/// <see cref="SectionAssemblySnapshot"/>, so a deactivated section contributes no
+/// registration, no controller, no job and no nav without any of them naming it, and one
+/// host in a shared process never composes another's sections.
 /// </remarks>
 public static class SectionDiscoveryExtensions
 {
-    public static IServiceCollection AddDiscoveredSections(
+    internal static IServiceCollection AddDiscoveredSections(
         this IServiceCollection services,
+        SectionAssemblySnapshot snapshot,
         IConfiguration configuration)
     {
-        var sections = DiscoverSections();
+        var sections = DiscoverSections(snapshot);
 
         foreach (var (_, section) in sections)
         {
@@ -45,7 +48,7 @@ public static class SectionDiscoveryExtensions
             string.Join(", ", sections.Select(s => s.Name)),
             inactive.Count == 0 ? "(none)" : string.Join(", ", inactive));
 
-        RegisterContributions(services);
+        RegisterContributions(services, snapshot);
 
         return services;
     }
@@ -59,9 +62,9 @@ public static class SectionDiscoveryExtensions
     /// Derived from the marker, never a list of seams: a new seam interface deriving from
     /// <see cref="ISectionContribution"/> is discovered with no edit here.
     /// </remarks>
-    private static void RegisterContributions(IServiceCollection services)
+    private static void RegisterContributions(IServiceCollection services, SectionAssemblySnapshot snapshot)
     {
-        var contributions = DiscoverImplementations<ISectionContribution>();
+        var contributions = DiscoverImplementations<ISectionContribution>(snapshot);
 
         foreach (var contribution in contributions)
         {
@@ -88,8 +91,8 @@ public static class SectionDiscoveryExtensions
     /// <c>Contracts/</c> exposes (design: minimal public surface, HUM0034).
     /// Ordered by section name then type name so composition order is stable.
     /// </remarks>
-    public static IReadOnlyList<T> DiscoverImplementations<T>() where T : class =>
-        [.. ActiveSectionAssemblies()
+    internal static IReadOnlyList<T> DiscoverImplementations<T>(SectionAssemblySnapshot snapshot) where T : class =>
+        [.. snapshot.Active
             .SelectMany(a => a.GetTypes()
                 .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(T).IsAssignableFrom(t))
                 .Select(t => (Section: SectionName(a), Type: t)))
@@ -107,8 +110,8 @@ public static class SectionDiscoveryExtensions
     /// the public <c>&lt;Section&gt;Resource</c> class beside it. Consumed by the boot
     /// localization diagnostic, which asserts each set actually resolves.
     /// </summary>
-    public static IReadOnlyList<Type> SectionResourceTypes() =>
-        [.. ActiveSectionAssemblies()
+    internal static IReadOnlyList<Type> SectionResourceTypes(SectionAssemblySnapshot snapshot) =>
+        [.. snapshot.Active
             .SelectMany(a => a.GetExportedTypes())
             .Where(t => t is { IsClass: true, IsAbstract: false }
                         && t.Name.EndsWith("Resource", StringComparison.Ordinal))
@@ -121,8 +124,8 @@ public static class SectionDiscoveryExtensions
     /// <em>is</em> section Store, so one identity serves discovery, logging and the
     /// analyzers without anything having to declare it twice.
     /// </remarks>
-    private static IReadOnlyList<(string Name, ISection Section)> DiscoverSections() =>
-        [.. ActiveSectionAssemblies()
+    private static IReadOnlyList<(string Name, ISection Section)> DiscoverSections(SectionAssemblySnapshot snapshot) =>
+        [.. snapshot.Active
             .SelectMany(a => SectionEntryPoints(a)
                 .Select(t => (
                     Name: SectionName(a),
@@ -165,15 +168,6 @@ public static class SectionDiscoveryExtensions
 
         return [.. candidates.Where(a => SectionEntryPoints(a).Any())];
     }
-
-    /// <summary>
-    /// The section assemblies this deployment runs: <see cref="SectionAssemblies"/> minus
-    /// whatever <see cref="SectionActivation"/> deactivated. Composition reads this;
-    /// <see cref="SectionAssemblies"/> stays the full shipped set, which is what the
-    /// architecture sweeps want.
-    /// </summary>
-    public static IReadOnlyList<Assembly> ActiveSectionAssemblies() =>
-        [.. SectionAssemblies().Where(a => SectionActivation.IsActive(SectionName(a)))];
 
     private static Assembly? TryLoad(string name)
     {

--- a/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
+++ b/src/Humans.Web/Extensions/SectionDiscoveryExtensions.cs
@@ -11,10 +11,10 @@ namespace Humans.Web.Extensions;
 /// section instead of growing one.
 /// </summary>
 /// <remarks>
-/// Sections are still <em>not</em> optional and their ProjectReferences stay hard-coded
-/// (design §12.2). This only removes the by-name call. Later optionality is a change of
-/// where the assembly list comes from — a config allowlist, or an AssemblyLoadContext
-/// over a plugin folder — with no section code touched.
+/// Which of the discovered sections a deployment actually runs is configuration —
+/// see <see cref="SectionActivation"/>. Everything below composes from
+/// <see cref="ActiveSectionAssemblies"/>, so a deactivated section contributes no
+/// registration, no controller, no job and no nav without any of them naming it.
 /// </remarks>
 public static class SectionDiscoveryExtensions
 {
@@ -29,13 +29,21 @@ public static class SectionDiscoveryExtensions
             section.Register(services, configuration);
         }
 
-        // A section that fails to load is now silently absent where the by-name call
-        // was a compile error, so the discovered set is logged: that is what you check
-        // when one of its pages 404s (design §6).
+        // A section is now silently absent when it fails to load or when config deactivates
+        // it, where the by-name call was a compile error — so both sets are logged: that is
+        // what you check when one of its pages 404s (design §6).
+        var inactive = SectionAssemblies()
+            .Select(SectionName)
+            .Except(sections.Select(s => s.Name), StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
         Serilog.Log.Information(
-            "Discovered {Count} section project(s): {Sections}",
+            "Sections: {ActiveCount} active of {DiscoveredCount} discovered. Active: {Active}. Inactive: {Inactive}",
             sections.Count,
-            string.Join(", ", sections.Select(s => s.Name)));
+            sections.Count + inactive.Count,
+            string.Join(", ", sections.Select(s => s.Name)),
+            inactive.Count == 0 ? "(none)" : string.Join(", ", inactive));
 
         RegisterContributions(services);
 
@@ -81,7 +89,7 @@ public static class SectionDiscoveryExtensions
     /// Ordered by section name then type name so composition order is stable.
     /// </remarks>
     public static IReadOnlyList<T> DiscoverImplementations<T>() where T : class =>
-        [.. SectionAssemblies()
+        [.. ActiveSectionAssemblies()
             .SelectMany(a => a.GetTypes()
                 .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(T).IsAssignableFrom(t))
                 .Select(t => (Section: SectionName(a), Type: t)))
@@ -100,7 +108,7 @@ public static class SectionDiscoveryExtensions
     /// localization diagnostic, which asserts each set actually resolves.
     /// </summary>
     public static IReadOnlyList<Type> SectionResourceTypes() =>
-        [.. SectionAssemblies()
+        [.. ActiveSectionAssemblies()
             .SelectMany(a => a.GetExportedTypes())
             .Where(t => t is { IsClass: true, IsAbstract: false }
                         && t.Name.EndsWith("Resource", StringComparison.Ordinal))
@@ -114,7 +122,7 @@ public static class SectionDiscoveryExtensions
     /// analyzers without anything having to declare it twice.
     /// </remarks>
     private static IReadOnlyList<(string Name, ISection Section)> DiscoverSections() =>
-        [.. SectionAssemblies()
+        [.. ActiveSectionAssemblies()
             .SelectMany(a => SectionEntryPoints(a)
                 .Select(t => (
                     Name: SectionName(a),
@@ -124,7 +132,7 @@ public static class SectionDiscoveryExtensions
             // carries a cross-section FK, so the contexts migrate independently.
             .OrderBy(s => s.Name, StringComparer.Ordinal)];
 
-    private static readonly Lazy<HashSet<Assembly>> SectionAssemblySet = new(() => [.. SectionAssemblies()]);
+    private static readonly Lazy<HashSet<Assembly>> SectionAssemblySet = new(() => [.. ActiveSectionAssemblies()]);
 
     /// <summary>
     /// True for a section assembly. Used by the MVC feature providers, which see one
@@ -134,7 +142,7 @@ public static class SectionDiscoveryExtensions
 
     /// <summary>The section a <paramref name="assembly"/> is: its name without the
     /// <c>Humans.</c> prefix.</summary>
-    private static string SectionName(Assembly assembly) =>
+    internal static string SectionName(Assembly assembly) =>
         assembly.GetName().Name!["Humans.".Length..];
 
     /// <summary>The <c>Section : ISection</c> entry points an assembly declares.</summary>
@@ -165,6 +173,15 @@ public static class SectionDiscoveryExtensions
 
         return [.. candidates.Where(a => SectionEntryPoints(a).Any())];
     }
+
+    /// <summary>
+    /// The section assemblies this deployment runs: <see cref="SectionAssemblies"/> minus
+    /// whatever <see cref="SectionActivation"/> deactivated. Composition reads this;
+    /// <see cref="SectionAssemblies"/> stays the full shipped set, which is what the
+    /// architecture sweeps want.
+    /// </summary>
+    public static IReadOnlyList<Assembly> ActiveSectionAssemblies() =>
+        [.. SectionAssemblies().Where(a => SectionActivation.IsActive(SectionName(a)))];
 
     private static Assembly? TryLoad(string name)
     {

--- a/src/Humans.Web/Hosting/SectionAssemblySnapshot.cs
+++ b/src/Humans.Web/Hosting/SectionAssemblySnapshot.cs
@@ -5,20 +5,21 @@ namespace Humans.Web.Hosting;
 
 /// <summary>
 /// One host's view of the shipped section assemblies, split by what that host's
-/// <c>Sections:Active</c> activated. Handed to the MVC feature providers, which see one
-/// type at a time and would otherwise re-walk the dependency graph per type.
+/// <c>Sections:Active</c> activated. Everything a host composes from discovery —
+/// registrations, contributions, policies, jobs, health checks, endpoints, resources and
+/// the two MVC feature providers — reads this, so a host composes only its own sections.
 /// </summary>
 /// <remarks>
-/// Per host, deliberately not a static cache. Several hosts share a process — every
-/// <c>WebApplicationFactory</c> in the integration suite builds one — and a static set
-/// freezes whichever host composed first, so a later host with a different allowlist would
-/// route the first host's controllers and resolve its view components. The rest of
-/// discovery re-reads <see cref="SectionDiscoveryExtensions.ActiveSectionAssemblies"/> per
-/// call and is unaffected; these two lookups are the only cached ones (#1081).
+/// Per host, deliberately not process state. Several hosts share a process — every
+/// <c>WebApplicationFactory</c> in the integration suite builds one — and a shared active
+/// set serves whichever host composed first to all of them, registering one host's sections
+/// inside another and routing its controllers there (#1081). Built once in <c>Program.cs</c>
+/// from that host's configuration, registered as a singleton so post-build composition
+/// (recurring jobs) resolves the same instance.
 /// </remarks>
 internal sealed class SectionAssemblySnapshot
 {
-    private readonly HashSet<Assembly> _active;
+    private readonly HashSet<Assembly> _activeLookup;
     private readonly HashSet<Assembly> _inactive;
 
     /// <param name="shipped">Every section assembly in the build.</param>
@@ -27,13 +28,21 @@ internal sealed class SectionAssemblySnapshot
     /// </param>
     internal SectionAssemblySnapshot(IReadOnlyList<Assembly> shipped, IReadOnlySet<string>? activeSections)
     {
-        _active = [.. shipped.Where(a => activeSections is null
-                                         || activeSections.Contains(SectionDiscoveryExtensions.SectionName(a)))];
-        _inactive = [.. shipped.Where(a => !_active.Contains(a))];
+        Active = [.. shipped.Where(a => activeSections is null
+                                        || activeSections.Contains(SectionDiscoveryExtensions.SectionName(a)))];
+        _activeLookup = [.. Active];
+        _inactive = [.. shipped.Where(a => !_activeLookup.Contains(a))];
     }
 
+    /// <summary>This host's split of <c>Sections:Active</c>, resolved and validated.</summary>
+    internal static SectionAssemblySnapshot For(IConfiguration configuration) =>
+        new(SectionDiscoveryExtensions.SectionAssemblies(), SectionActivation.Resolve(configuration));
+
+    /// <summary>The section assemblies this host runs. Composition reads this, never the shipped set.</summary>
+    internal IReadOnlyList<Assembly> Active { get; }
+
     /// <summary>True for a section assembly this host runs — the public check may be relaxed for it.</summary>
-    internal bool IsActiveSection(Assembly assembly) => _active.Contains(assembly);
+    internal bool IsActiveSection(Assembly assembly) => _activeLookup.Contains(assembly);
 
     /// <summary>
     /// True for a section assembly this host deactivated. MVC's default feature providers

--- a/src/Humans.Web/Hosting/SectionAssemblySnapshot.cs
+++ b/src/Humans.Web/Hosting/SectionAssemblySnapshot.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Humans.Web.Extensions;
+
+namespace Humans.Web.Hosting;
+
+/// <summary>
+/// One host's view of the shipped section assemblies, split by what that host's
+/// <c>Sections:Active</c> activated. Handed to the MVC feature providers, which see one
+/// type at a time and would otherwise re-walk the dependency graph per type.
+/// </summary>
+/// <remarks>
+/// Per host, deliberately not a static cache. Several hosts share a process — every
+/// <c>WebApplicationFactory</c> in the integration suite builds one — and a static set
+/// freezes whichever host composed first, so a later host with a different allowlist would
+/// route the first host's controllers and resolve its view components. The rest of
+/// discovery re-reads <see cref="SectionDiscoveryExtensions.ActiveSectionAssemblies"/> per
+/// call and is unaffected; these two lookups are the only cached ones (#1081).
+/// </remarks>
+internal sealed class SectionAssemblySnapshot
+{
+    private readonly HashSet<Assembly> _active;
+    private readonly HashSet<Assembly> _inactive;
+
+    /// <param name="shipped">Every section assembly in the build.</param>
+    /// <param name="activeSections">
+    /// The section names this host activated, or null for the default — every section.
+    /// </param>
+    internal SectionAssemblySnapshot(IReadOnlyList<Assembly> shipped, IReadOnlySet<string>? activeSections)
+    {
+        _active = [.. shipped.Where(a => activeSections is null
+                                         || activeSections.Contains(SectionDiscoveryExtensions.SectionName(a)))];
+        _inactive = [.. shipped.Where(a => !_active.Contains(a))];
+    }
+
+    /// <summary>True for a section assembly this host runs — the public check may be relaxed for it.</summary>
+    internal bool IsActiveSection(Assembly assembly) => _active.Contains(assembly);
+
+    /// <summary>
+    /// True for a section assembly this host deactivated. MVC's default feature providers
+    /// walk every application part, so a deactivated section's <em>public</em> controllers
+    /// and view components stay routable unless something takes them back out — and they
+    /// then resolve services no <c>Register</c> call ever added.
+    /// </summary>
+    internal bool IsInactiveSection(Assembly assembly) => _inactive.Contains(assembly);
+}

--- a/src/Humans.Web/Hosting/SectionControllerFeatureProvider.cs
+++ b/src/Humans.Web/Hosting/SectionControllerFeatureProvider.cs
@@ -27,6 +27,11 @@ internal sealed class SectionControllerFeatureProvider : ControllerFeatureProvid
 
     protected override bool IsController(TypeInfo typeInfo)
     {
+        // A deactivated section routes nothing, public or not — the base provider would
+        // otherwise still take its public controllers (#1081).
+        if (SectionDiscoveryExtensions.IsInactiveSectionAssembly(typeInfo.Assembly))
+            return false;
+
         if (base.IsController(typeInfo))
             return true;
 

--- a/src/Humans.Web/Hosting/SectionControllerFeatureProvider.cs
+++ b/src/Humans.Web/Hosting/SectionControllerFeatureProvider.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Humans.Web.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 
@@ -21,7 +20,8 @@ namespace Humans.Web.Hosting;
 /// nameable from any other section. Scoped to assemblies declaring an
 /// <c>ISection</c> entry point, the same test the analyzers and DI discovery use.
 /// </remarks>
-internal sealed class SectionControllerFeatureProvider : ControllerFeatureProvider
+internal sealed class SectionControllerFeatureProvider(SectionAssemblySnapshot sections)
+    : ControllerFeatureProvider
 {
     private const string ControllerSuffix = "Controller";
 
@@ -29,7 +29,7 @@ internal sealed class SectionControllerFeatureProvider : ControllerFeatureProvid
     {
         // A deactivated section routes nothing, public or not — the base provider would
         // otherwise still take its public controllers (#1081).
-        if (SectionDiscoveryExtensions.IsInactiveSectionAssembly(typeInfo.Assembly))
+        if (sections.IsInactiveSection(typeInfo.Assembly))
             return false;
 
         if (base.IsController(typeInfo))
@@ -37,7 +37,7 @@ internal sealed class SectionControllerFeatureProvider : ControllerFeatureProvid
 
         // Only relax the public check, and only for section assemblies. Every other
         // condition below mirrors ControllerFeatureProvider.IsController.
-        if (!SectionDiscoveryExtensions.IsSectionAssembly(typeInfo.Assembly))
+        if (!sections.IsActiveSection(typeInfo.Assembly))
             return false;
 
         if (!typeInfo.IsClass || typeInfo.IsAbstract || typeInfo.ContainsGenericParameters)

--- a/src/Humans.Web/Hosting/SectionViewComponentFeatureProvider.cs
+++ b/src/Humans.Web/Hosting/SectionViewComponentFeatureProvider.cs
@@ -45,6 +45,14 @@ internal sealed class SectionViewComponentFeatureProvider
                     feature.ViewComponents.Add(type);
             }
         }
+
+        // The default provider already took every public one, including from sections this
+        // deployment deactivated; drop those, or they resolve services nobody registered (#1081).
+        for (var i = feature.ViewComponents.Count - 1; i >= 0; i--)
+        {
+            if (SectionDiscoveryExtensions.IsInactiveSectionAssembly(feature.ViewComponents[i].Assembly))
+                feature.ViewComponents.RemoveAt(i);
+        }
     }
 
     private static bool IsSectionViewComponent(TypeInfo typeInfo)

--- a/src/Humans.Web/Hosting/SectionViewComponentFeatureProvider.cs
+++ b/src/Humans.Web/Hosting/SectionViewComponentFeatureProvider.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Humans.Web.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
@@ -30,7 +29,7 @@ namespace Humans.Web.Hosting;
 /// two of them (design §15 step 3b).
 /// </para>
 /// </remarks>
-internal sealed class SectionViewComponentFeatureProvider
+internal sealed class SectionViewComponentFeatureProvider(SectionAssemblySnapshot sections)
     : IApplicationFeatureProvider<ViewComponentFeature>
 {
     private const string ViewComponentSuffix = "ViewComponent";
@@ -41,7 +40,7 @@ internal sealed class SectionViewComponentFeatureProvider
         {
             foreach (var type in part.Types)
             {
-                if (IsSectionViewComponent(type) && !feature.ViewComponents.Contains(type))
+                if (IsSectionViewComponent(type, sections) && !feature.ViewComponents.Contains(type))
                     feature.ViewComponents.Add(type);
             }
         }
@@ -50,19 +49,19 @@ internal sealed class SectionViewComponentFeatureProvider
         // deployment deactivated; drop those, or they resolve services nobody registered (#1081).
         for (var i = feature.ViewComponents.Count - 1; i >= 0; i--)
         {
-            if (SectionDiscoveryExtensions.IsInactiveSectionAssembly(feature.ViewComponents[i].Assembly))
+            if (sections.IsInactiveSection(feature.ViewComponents[i].Assembly))
                 feature.ViewComponents.RemoveAt(i);
         }
     }
 
-    private static bool IsSectionViewComponent(TypeInfo typeInfo)
+    private static bool IsSectionViewComponent(TypeInfo typeInfo, SectionAssemblySnapshot sections)
     {
         // Only relax the public check, and only for section assemblies. The default
         // provider has already taken every public one.
         if (typeInfo.IsPublic)
             return false;
 
-        if (!SectionDiscoveryExtensions.IsSectionAssembly(typeInfo.Assembly))
+        if (!sections.IsActiveSection(typeInfo.Assembly))
             return false;
 
         if (!typeInfo.IsClass || typeInfo.IsAbstract || typeInfo.ContainsGenericParameters)

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -65,6 +65,10 @@ Log.Logger = logConfig.CreateLogger();
 
 builder.Host.UseSerilog();
 
+// Before anything composes from discovery: which sections this deployment runs, and a hard
+// stop if the allowlist deactivates one an active section consumes (#1081).
+SectionActivation.Configure(builder.Configuration);
+
 // Fail fast on DI cycles/captive deps; factory lambdas still need smoke coverage.
 builder.Host.UseDefaultServiceProvider(options =>
 {

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -67,7 +67,7 @@ builder.Host.UseSerilog();
 
 // Before anything composes from discovery: which sections this deployment runs, and a hard
 // stop if the allowlist deactivates one an active section consumes (#1081).
-SectionActivation.Configure(builder.Configuration);
+var activeSections = SectionActivation.Configure(builder.Configuration);
 
 // Fail fast on DI cycles/captive deps; factory lambdas still need smoke coverage.
 builder.Host.UseDefaultServiceProvider(options =>
@@ -481,13 +481,18 @@ var mvcBuilder = builder.Services.AddControllersWithViews(options =>
 
 // A section project's controllers are internal (nobodies-collective/Humans#866); MVC's
 // default provider only discovers public ones, and says nothing when it doesn't.
+// One snapshot per host, not a static: several hosts share a process in the integration
+// suite, and a static set would freeze whichever composed first (#1081).
+var sectionAssemblies = new SectionAssemblySnapshot(
+    SectionDiscoveryExtensions.SectionAssemblies(), activeSections);
+
 mvcBuilder.ConfigureApplicationPartManager(apm =>
-    apm.FeatureProviders.Add(new SectionControllerFeatureProvider()));
+    apm.FeatureProviders.Add(new SectionControllerFeatureProvider(sectionAssemblies)));
 
 // …and the same for a section's view components, which MVC discovers through a separate,
 // equally public-only convention (Notifications' bell).
 mvcBuilder.ConfigureApplicationPartManager(apm =>
-    apm.FeatureProviders.Add(new SectionViewComponentFeatureProvider()));
+    apm.FeatureProviders.Add(new SectionViewComponentFeatureProvider(sectionAssemblies)));
 
 // DevLoginController depends on DevPersonaSeeder (non-Production only); exclude in Prod so
 // ValidateOnBuild passes and /dev/login/* 404s cleanly. Must be added after

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -66,8 +66,11 @@ Log.Logger = logConfig.CreateLogger();
 builder.Host.UseSerilog();
 
 // Before anything composes from discovery: which sections this deployment runs, and a hard
-// stop if the allowlist deactivates one an active section consumes (#1081).
-var activeSections = SectionActivation.Configure(builder.Configuration);
+// stop if the allowlist deactivates one an active section consumes (#1081). One snapshot
+// per host, never a static — several hosts share a process in the integration suite, and a
+// shared active set composes one host's sections inside another.
+var sectionAssemblies = SectionAssemblySnapshot.For(builder.Configuration);
+builder.Services.AddSingleton(sectionAssemblies);
 
 // Fail fast on DI cycles/captive deps; factory lambdas still need smoke coverage.
 builder.Host.UseDefaultServiceProvider(options =>
@@ -218,7 +221,7 @@ builder.Services.AddAuthentication()
     });
 
 // Canonical policies — see docs/authorization-inventory.md.
-builder.Services.AddHumansAuthorizationPolicies();
+builder.Services.AddHumansAuthorizationPolicies(sectionAssemblies);
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddTransient<Microsoft.AspNetCore.Authentication.IClaimsTransformation, RoleAssignmentClaimsTransformation>();
 
@@ -287,7 +290,7 @@ var healthChecks = builder.Services.AddHealthChecks()
     .AddCheck<ConfigurationHealthCheck>("configuration");
 
 // Sections add their own checks; the names are monitoring keys, so they stay with the owner.
-foreach (var contributor in SectionDiscoveryExtensions.DiscoverImplementations<ISectionHealthChecks>())
+foreach (var contributor in SectionDiscoveryExtensions.DiscoverImplementations<ISectionHealthChecks>(sectionAssemblies))
 {
     contributor.AddHealthChecks(healthChecks, builder.Configuration);
 }
@@ -299,7 +302,8 @@ if (!builder.Environment.IsEnvironment("Testing"))
     healthChecks.AddHangfire(options => options.MinimumAvailableServers = 1, name: "hangfire");
 }
 
-builder.Services.AddHumansInfrastructure(builder.Configuration, builder.Environment, configRegistry);
+builder.Services.AddHumansInfrastructure(
+    builder.Configuration, builder.Environment, sectionAssemblies, configRegistry);
 
 builder.Services.AddResponseCompression(options =>
 {
@@ -480,12 +484,8 @@ var mvcBuilder = builder.Services.AddControllersWithViews(options =>
     });
 
 // A section project's controllers are internal (nobodies-collective/Humans#866); MVC's
-// default provider only discovers public ones, and says nothing when it doesn't.
-// One snapshot per host, not a static: several hosts share a process in the integration
-// suite, and a static set would freeze whichever composed first (#1081).
-var sectionAssemblies = new SectionAssemblySnapshot(
-    SectionDiscoveryExtensions.SectionAssemblies(), activeSections);
-
+// default provider only discovers public ones, and says nothing when it doesn't. Same
+// per-host snapshot the rest of composition read.
 mvcBuilder.ConfigureApplicationPartManager(apm =>
     apm.FeatureProviders.Add(new SectionControllerFeatureProvider(sectionAssemblies)));
 
@@ -602,7 +602,7 @@ CurrentUserEnricher.StaticAccessor = app.Services.GetRequiredService<IHttpContex
 // the set renders as its raw key. Checking that the manifest the localizer will look
 // for is actually embedded needs no key-name convention and no culture, so a new
 // section adds nothing here.
-foreach (var resourceType in SectionDiscoveryExtensions.SectionResourceTypes())
+foreach (var resourceType in SectionDiscoveryExtensions.SectionResourceTypes(sectionAssemblies))
 {
     var expected = resourceType.FullName + ".resources";
     var embedded = resourceType.Assembly.GetManifestResourceNames();
@@ -829,7 +829,7 @@ app.MapControllerRoute(
 app.MapRazorPages();
 
 // Sections map what routing cannot discover on its own — hubs and the like.
-foreach (var contributor in SectionDiscoveryExtensions.DiscoverImplementations<ISectionEndpoints>())
+foreach (var contributor in SectionDiscoveryExtensions.DiscoverImplementations<ISectionEndpoints>(sectionAssemblies))
 {
     contributor.MapEndpoints(app);
 }

--- a/tests/Humans.Integration.Tests/Infrastructure/PhysicalDefaultParityTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/PhysicalDefaultParityTests.cs
@@ -5,6 +5,7 @@ using Humans.Base.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Humans.Web.Extensions;
+using Humans.Web.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -167,7 +168,9 @@ public sealed class PhysicalDefaultParityTests(HumansTestDatabase database)
     {
         var services = new ServiceCollection()
             .AddHumansPersistence()
-            .AddDiscoveredSections(new ConfigurationBuilder().Build());
+            .AddDiscoveredSections(
+                SectionAssemblySnapshot.For(new ConfigurationBuilder().Build()),
+                new ConfigurationBuilder().Build());
 
         return
         [

--- a/tests/Humans.Web.Tests/Architecture/DbContextEntityOwnershipTests.cs
+++ b/tests/Humans.Web.Tests/Architecture/DbContextEntityOwnershipTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using AwesomeAssertions;
 using Humans.Base.Hosting;
 using Humans.Web.Extensions;
+using Humans.Web.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -112,7 +113,9 @@ public class DbContextEntityOwnershipTests
     {
         var services = new ServiceCollection()
             .AddHumansPersistence()
-            .AddDiscoveredSections(new ConfigurationBuilder().Build());
+            .AddDiscoveredSections(
+                SectionAssemblySnapshot.For(new ConfigurationBuilder().Build()),
+                new ConfigurationBuilder().Build());
 
         return
         [

--- a/tests/Humans.Web.Tests/Authorization/AuthorizationPolicyTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/AuthorizationPolicyTests.cs
@@ -10,6 +10,8 @@ using Humans.Teams.Contracts;
 using Humans.Base.Constants;
 using Humans.Base.Authorization;
 using Humans.Web.Authorization;
+using Humans.Web.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
@@ -58,7 +60,8 @@ public class AuthorizationPolicyTests : IDisposable
         // AddHumansAuthorizationPolicies, so this graph registers them directly.
         services.AddScoped<IAuthorizationHandler, IsAnyTeamManagerOrCoordinatorHandler>();
         services.AddSingleton<IAuthorizationHandler, HumanAdminOnlyHandler>();
-        services.AddHumansAuthorizationPolicies();
+        services.AddHumansAuthorizationPolicies(
+            SectionAssemblySnapshot.For(new ConfigurationBuilder().Build()));
         _serviceProvider = services.BuildServiceProvider();
         _authorizationService = _serviceProvider.GetRequiredService<IAuthorizationService>();
     }

--- a/tests/Humans.Web.Tests/Infrastructure/SectionActivationTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/SectionActivationTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using AwesomeAssertions;
 using Humans.Web.Extensions;
+using Humans.Web.Hosting;
 using Microsoft.Extensions.Configuration;
 
 namespace Humans.Web.Tests.Infrastructure;
@@ -33,7 +34,8 @@ public sealed class SectionActivationTests
         SectionActivation.Resolve(Discovered, Shell, new ConfigurationBuilder().Build())
             .Should().BeNull(because: "the shipped default runs every section that ships");
 
-        Discovered.Should().OnlyContain(a => SectionActivation.IsActive(SectionName(a)));
+        new SectionAssemblySnapshot(Discovered, activeSections: null)
+            .Active.Should().BeEquivalentTo(Discovered);
     }
 
     [HumansFact]

--- a/tests/Humans.Web.Tests/Infrastructure/SectionActivationTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/SectionActivationTests.cs
@@ -18,6 +18,9 @@ public sealed class SectionActivationTests
 {
     private static IReadOnlyList<Assembly> Discovered => SectionDiscoveryExtensions.SectionAssemblies();
 
+    /// <summary>The Shell assembly, which always runs and consumes sections of its own.</summary>
+    private static Assembly Shell => typeof(SectionActivation).Assembly;
+
     private static IConfiguration Allowlist(params string[] sections) =>
         new ConfigurationBuilder()
             .AddInMemoryCollection(sections
@@ -27,7 +30,7 @@ public sealed class SectionActivationTests
     [HumansFact]
     public void NoAllowlistActivatesEverySection()
     {
-        SectionActivation.Resolve(Discovered, new ConfigurationBuilder().Build())
+        SectionActivation.Resolve(Discovered, Shell, new ConfigurationBuilder().Build())
             .Should().BeNull(because: "the shipped default runs every section that ships");
 
         Discovered.Should().OnlyContain(a => SectionActivation.IsActive(SectionName(a)));
@@ -38,30 +41,59 @@ public sealed class SectionActivationTests
     {
         var all = Discovered.Select(SectionName).ToList();
 
-        SectionActivation.Resolve(Discovered, Allowlist([.. all]))
+        SectionActivation.Resolve(Discovered, Shell, Allowlist([.. all]))
             .Should().BeEquivalentTo(all);
     }
 
     [HumansFact]
     public void AllowlistIsMatchedCaseInsensitivelyAndCanonicalised()
     {
-        // A section that consumes nothing, so the allowlist can hold it alone.
-        var leaves = SectionActivation.DependencyGraph(Discovered)
-            .Where(e => e.Value.Count == 0)
-            .Select(e => e.Key)
-            .Order(StringComparer.Ordinal)
-            .ToList();
+        var all = Discovered.Select(SectionName).ToList();
 
-        leaves.Should().NotBeEmpty(because: "some section sits at the bottom of the graph");
+        SectionActivation.Resolve(Discovered, Shell, Allowlist([.. all.Select(n => n.ToUpperInvariant())]))
+            .Should().BeEquivalentTo(all,
+                because: "names match case-insensitively and come back spelled as discovery found them");
+    }
 
-        SectionActivation.Resolve(Discovered, Allowlist(leaves[0].ToUpperInvariant()))
-            .Should().Contain(leaves[0]);
+    [HumansFact]
+    public void ExplicitlyEmptyAllowlistIsZeroSectionsNotEverySection()
+    {
+        // How `"Sections:Active": []` binds: the key is present with an empty value, which
+        // is what separates it from the key being absent.
+        var empty = new ConfigurationBuilder()
+            .AddInMemoryCollection([new KeyValuePair<string, string?>(SectionActivation.ActiveKey, "")])
+            .Build();
+
+        var act = () => SectionActivation.Resolve(Discovered, Shell, empty);
+
+        act.Should().Throw<InvalidOperationException>(
+            because: "activating nothing leaves Shell running with none of the sections it consumes, "
+                     + "where the absent key means every section and resolves to null");
+    }
+
+    [HumansFact]
+    public void DeactivatingASectionShellItselfConsumesFails()
+    {
+        var shellDependencies = SectionActivation.ShellDependencies(Discovered, Shell);
+        shellDependencies.Should().NotBeEmpty(
+            because: "Shell's own controllers name section Contracts types");
+
+        var dropped = shellDependencies[0];
+        var allowed = Discovered.Select(SectionName)
+            .Where(name => !name.Equals(dropped, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        var act = () => SectionActivation.Resolve(Discovered, Shell, Allowlist(allowed));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{dropped}*{SectionName(Shell)}*",
+                because: "Shell always runs, so no allowlist may deactivate what Shell consumes");
     }
 
     [HumansFact]
     public void AllowlistNamingSomethingThatIsNotASectionFails()
     {
-        var act = () => SectionActivation.Resolve(Discovered, Allowlist("NotASection"));
+        var act = () => SectionActivation.Resolve(Discovered, Shell, Allowlist("NotASection"));
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*NotASection*", because: "a typo must not silently drop a section");
@@ -72,7 +104,7 @@ public sealed class SectionActivationTests
     {
         var (dependent, dependency) = FirstEdge();
 
-        var act = () => SectionActivation.Resolve(Discovered, Allowlist(dependent));
+        var act = () => SectionActivation.Resolve(Discovered, Shell, Allowlist(dependent));
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage($"*{dependency}*{dependent}*",

--- a/tests/Humans.Web.Tests/Infrastructure/SectionActivationTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/SectionActivationTests.cs
@@ -1,0 +1,134 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Web.Extensions;
+using Microsoft.Extensions.Configuration;
+
+namespace Humans.Web.Tests.Infrastructure;
+
+/// <summary>
+/// The activation mechanism (nobodies-collective/Humans#1081): a config allowlist filters the
+/// discovered section set, and deactivating a section an active one consumes fails startup.
+/// </summary>
+/// <remarks>
+/// Every case drives off what discovery actually found and what the assemblies actually
+/// reference — no section is named here, because naming one would be the pinned list the
+/// mechanism exists to avoid.
+/// </remarks>
+public sealed class SectionActivationTests
+{
+    private static IReadOnlyList<Assembly> Discovered => SectionDiscoveryExtensions.SectionAssemblies();
+
+    private static IConfiguration Allowlist(params string[] sections) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(sections
+                .Select((name, i) => new KeyValuePair<string, string?>($"{SectionActivation.ActiveKey}:{i}", name)))
+            .Build();
+
+    [HumansFact]
+    public void NoAllowlistActivatesEverySection()
+    {
+        SectionActivation.Resolve(Discovered, new ConfigurationBuilder().Build())
+            .Should().BeNull(because: "the shipped default runs every section that ships");
+
+        Discovered.Should().OnlyContain(a => SectionActivation.IsActive(SectionName(a)));
+    }
+
+    [HumansFact]
+    public void AllowlistNamingEverySectionIsTheDefaultSet()
+    {
+        var all = Discovered.Select(SectionName).ToList();
+
+        SectionActivation.Resolve(Discovered, Allowlist([.. all]))
+            .Should().BeEquivalentTo(all);
+    }
+
+    [HumansFact]
+    public void AllowlistIsMatchedCaseInsensitivelyAndCanonicalised()
+    {
+        // A section that consumes nothing, so the allowlist can hold it alone.
+        var leaves = SectionActivation.DependencyGraph(Discovered)
+            .Where(e => e.Value.Count == 0)
+            .Select(e => e.Key)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        leaves.Should().NotBeEmpty(because: "some section sits at the bottom of the graph");
+
+        SectionActivation.Resolve(Discovered, Allowlist(leaves[0].ToUpperInvariant()))
+            .Should().Contain(leaves[0]);
+    }
+
+    [HumansFact]
+    public void AllowlistNamingSomethingThatIsNotASectionFails()
+    {
+        var act = () => SectionActivation.Resolve(Discovered, Allowlist("NotASection"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*NotASection*", because: "a typo must not silently drop a section");
+    }
+
+    [HumansFact]
+    public void DeactivatingAConsumedSectionFailsAndNamesTheDependents()
+    {
+        var (dependent, dependency) = FirstEdge();
+
+        var act = () => SectionActivation.Resolve(Discovered, Allowlist(dependent));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{dependency}*{dependent}*",
+                because: "the message has to say what is missing and who wanted it");
+    }
+
+    [HumansFact]
+    public void DependencyGraphResolvesAReferencedContractsAssemblyToItsSection()
+    {
+        var graph = SectionActivation.DependencyGraph(Discovered);
+        var names = Discovered.Select(SectionName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var contractsEdges = Discovered
+            .SelectMany(a => a.GetReferencedAssemblies()
+                .Select(r => r.Name)
+                .OfType<string>()
+                .Where(n => n.StartsWith("Humans.", StringComparison.Ordinal)
+                            && n.EndsWith(".Contracts", StringComparison.Ordinal))
+                .Select(n => (
+                    Dependent: SectionName(a),
+                    Dependency: n["Humans.".Length..^".Contracts".Length])))
+            .Where(e => names.Contains(e.Dependency)
+                        && !e.Dependency.Equals(e.Dependent, StringComparison.OrdinalIgnoreCase))
+            .Distinct()
+            .ToList();
+
+        contractsEdges.Should().NotBeEmpty(
+            because: "sections reach each other through Contracts assemblies, so the closure "
+                     + "check is vacuous if none of those references resolve back to a section");
+
+        contractsEdges.Should().OnlyContain(e => graph[e.Dependent].Contains(e.Dependency));
+    }
+
+    [HumansFact]
+    public void DependencyGraphCoversEverySectionAndNothingElse()
+    {
+        var graph = SectionActivation.DependencyGraph(Discovered);
+        var names = Discovered.Select(SectionName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        graph.Keys.Should().BeEquivalentTo(names);
+        graph.Should().OnlyContain(e => e.Value.All(d => names.Contains(d) && d != e.Key));
+    }
+
+    /// <summary>Any real section-to-section edge, chosen deterministically.</summary>
+    private static (string Dependent, string Dependency) FirstEdge()
+    {
+        var edge = SectionActivation.DependencyGraph(Discovered)
+            .Where(e => e.Value.Count > 0)
+            .OrderBy(e => e.Key, StringComparer.Ordinal)
+            .Select(e => (Dependent: e.Key, Dependency: e.Value[0]))
+            .FirstOrDefault();
+
+        edge.Dependent.Should().NotBeNull(because: "sections do consume each other's Contracts");
+        return edge;
+    }
+
+    private static string SectionName(Assembly assembly) =>
+        assembly.GetName().Name!["Humans.".Length..];
+}

--- a/tests/Humans.Web.Tests/Infrastructure/SectionAssemblySnapshotTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/SectionAssemblySnapshotTests.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Web.Extensions;
+using Humans.Web.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace Humans.Web.Tests.Infrastructure;
+
+/// <summary>
+/// The MVC feature providers read their section sets from a per-host snapshot
+/// (nobodies-collective/Humans#1081). Several hosts share a process — every
+/// <c>WebApplicationFactory</c> in the integration suite builds one — so a process-wide
+/// cache would serve whichever host composed first to all of them.
+/// </summary>
+public sealed class SectionAssemblySnapshotTests
+{
+    private static IReadOnlyList<Assembly> Shipped => SectionDiscoveryExtensions.SectionAssemblies();
+
+    private static Assembly Shell => typeof(SectionActivation).Assembly;
+
+    private static string SectionName(Assembly assembly) =>
+        assembly.GetName().Name!["Humans.".Length..];
+
+    private static IConfiguration Allowlist(params string[] sections) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(sections
+                .Select((name, i) => new KeyValuePair<string, string?>($"{SectionActivation.ActiveKey}:{i}", name)))
+            .Build();
+
+    [HumansFact]
+    public void TwoHostsInOneProcessEachSeeTheirOwnSections()
+    {
+        var dropped = DeactivatableSection();
+        var assembly = Shipped.Single(a =>
+            SectionName(a).Equals(dropped, StringComparison.OrdinalIgnoreCase));
+
+        var kept = Shipped.Select(SectionName)
+            .Where(name => !name.Equals(dropped, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        // Host 1 deactivates it; host 2 takes the default, which is every section.
+        var hostOne = new SectionAssemblySnapshot(
+            Shipped, SectionActivation.Resolve(Shipped, Shell, Allowlist(kept)));
+        var hostTwo = new SectionAssemblySnapshot(
+            Shipped, SectionActivation.Resolve(Shipped, Shell, new ConfigurationBuilder().Build()));
+
+        hostOne.IsInactiveSection(assembly).Should().BeTrue(because: $"host 1 deactivated {dropped}");
+        hostOne.IsActiveSection(assembly).Should().BeFalse();
+
+        hostTwo.IsInactiveSection(assembly).Should().BeFalse(
+            because: "host 2 activated every section and must not inherit host 1's set");
+        hostTwo.IsActiveSection(assembly).Should().BeTrue();
+
+        // Composing host 2 leaves host 1's own view of the world alone.
+        hostOne.IsInactiveSection(assembly).Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void TheDefaultAllowlistActivatesEverySection()
+    {
+        var snapshot = new SectionAssemblySnapshot(Shipped, activeSections: null);
+
+        Shipped.Should().OnlyContain(a => snapshot.IsActiveSection(a));
+        Shipped.Should().NotContain(a => snapshot.IsInactiveSection(a));
+    }
+
+    /// <summary>
+    /// A section that can be switched off on its own: not pinned by Shell, and consumed by
+    /// no other section, so the allowlist still validates. Derived, never named.
+    /// </summary>
+    private static string DeactivatableSection()
+    {
+        var consumed = SectionActivation.DependencyGraph(Shipped)
+            .Values.SelectMany(dependencies => dependencies)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var pinnedByShell = SectionActivation.ShellDependencies(Shipped, Shell)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var deactivatable = Shipped.Select(SectionName)
+            .Where(name => !consumed.Contains(name) && !pinnedByShell.Contains(name))
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        deactivatable.Should().NotBeEmpty(
+            because: "some section is a leaf Shell does not name, or nothing is deactivatable at all");
+
+        return deactivatable[0];
+    }
+}

--- a/tests/Humans.Web.Tests/Infrastructure/SectionAssemblySnapshotTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/SectionAssemblySnapshotTests.cs
@@ -3,14 +3,16 @@ using AwesomeAssertions;
 using Humans.Web.Extensions;
 using Humans.Web.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Humans.Web.Tests.Infrastructure;
 
 /// <summary>
-/// The MVC feature providers read their section sets from a per-host snapshot
-/// (nobodies-collective/Humans#1081). Several hosts share a process — every
-/// <c>WebApplicationFactory</c> in the integration suite builds one — so a process-wide
-/// cache would serve whichever host composed first to all of them.
+/// Everything a host composes from discovery reads its own snapshot
+/// (nobodies-collective/Humans#1081) — the MVC feature providers and the section
+/// registrations alike. Several hosts share a process — every <c>WebApplicationFactory</c>
+/// in the integration suite builds one — so process-wide activation state would compose one
+/// host's sections inside another.
 /// </summary>
 public sealed class SectionAssemblySnapshotTests
 {
@@ -55,6 +57,28 @@ public sealed class SectionAssemblySnapshotTests
         hostOne.IsInactiveSection(assembly).Should().BeTrue();
     }
 
+    /// <summary>
+    /// Registrations come from the host's own snapshot too, not only the MVC providers:
+    /// two hosts composing in one process each register only the sections they activated.
+    /// </summary>
+    [HumansFact]
+    public void TwoHostsInOneProcessRegisterOnlyTheirOwnSections()
+    {
+        var (dropped, assembly) = DeactivatableSectionThatRegisters();
+
+        var kept = Shipped.Select(SectionName)
+            .Where(name => !name.Equals(dropped, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        var hostOne = Compose(SectionActivation.Resolve(Shipped, Shell, Allowlist(kept)));
+        var hostTwo = Compose(activeSections: null);
+
+        RegisteringAssemblies(hostOne).Should().NotContain(assembly,
+            because: $"host 1 deactivated {dropped}, so its Register never ran");
+        RegisteringAssemblies(hostTwo).Should().Contain(assembly,
+            because: "host 2 activated every section and must not inherit host 1's set");
+    }
+
     [HumansFact]
     public void TheDefaultAllowlistActivatesEverySection()
     {
@@ -65,10 +89,10 @@ public sealed class SectionAssemblySnapshotTests
     }
 
     /// <summary>
-    /// A section that can be switched off on its own: not pinned by Shell, and consumed by
+    /// Sections that can be switched off on their own: not pinned by Shell, and consumed by
     /// no other section, so the allowlist still validates. Derived, never named.
     /// </summary>
-    private static string DeactivatableSection()
+    private static IReadOnlyList<string> Deactivatable()
     {
         var consumed = SectionActivation.DependencyGraph(Shipped)
             .Values.SelectMany(dependencies => dependencies)
@@ -85,6 +109,46 @@ public sealed class SectionAssemblySnapshotTests
         deactivatable.Should().NotBeEmpty(
             because: "some section is a leaf Shell does not name, or nothing is deactivatable at all");
 
-        return deactivatable[0];
+        return deactivatable;
     }
+
+    private static string DeactivatableSection() => Deactivatable()[0];
+
+    /// <summary>The first deactivatable section whose <c>Register</c> actually adds something.</summary>
+    private static (string Name, Assembly Assembly) DeactivatableSectionThatRegisters()
+    {
+        var registering = RegisteringAssemblies(Compose(activeSections: null));
+
+        var candidates = Deactivatable()
+            .Select(name => (Name: name, Assembly: AssemblyOf(name)))
+            .Where(candidate => registering.Contains(candidate.Assembly))
+            .ToList();
+
+        candidates.Should().NotBeEmpty(
+            because: "a deactivatable section that registers nothing cannot show a registration difference");
+
+        return candidates[0];
+    }
+
+    private static Assembly AssemblyOf(string section) =>
+        Shipped.Single(a => SectionName(a).Equals(section, StringComparison.OrdinalIgnoreCase));
+
+    private static IServiceCollection Compose(IReadOnlySet<string>? activeSections) =>
+        new ServiceCollection().AddDiscoveredSections(
+            new SectionAssemblySnapshot(Shipped, activeSections),
+            new ConfigurationBuilder().Build());
+
+    /// <summary>
+    /// The assemblies a composed collection actually registered from. Keyed descriptors
+    /// expose their type under different properties and throw on the unkeyed ones.
+    /// </summary>
+    private static HashSet<Assembly> RegisteringAssemblies(IServiceCollection services) =>
+        [.. services
+            .SelectMany(d => new[]
+            {
+                d.IsKeyedService ? d.KeyedImplementationType : d.ImplementationType,
+                (d.IsKeyedService ? d.KeyedImplementationInstance : d.ImplementationInstance)?.GetType(),
+            })
+            .OfType<Type>()
+            .Select(t => t.Assembly)];
 }

--- a/tests/Humans.Web.Tests/Infrastructure/SectionControllerDiscoveryTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/SectionControllerDiscoveryTests.cs
@@ -57,7 +57,7 @@ public sealed class SectionControllerDiscoveryTests
         // The provider relaxes IsPublic *only* for assemblies declaring an ISection entry
         // point. If that narrowing ever regressed, every internal class ending in
         // "Controller" anywhere would become routable.
-        var provider = new SectionControllerFeatureProvider();
+        var provider = new SectionControllerFeatureProvider(EverySectionActive);
         var feature = new ControllerFeature();
 
         provider.PopulateFeature(
@@ -70,7 +70,7 @@ public sealed class SectionControllerDiscoveryTests
 
     private static IReadOnlyList<Type> DiscoverControllers(IEnumerable<Assembly> assemblies)
     {
-        var provider = new SectionControllerFeatureProvider();
+        var provider = new SectionControllerFeatureProvider(EverySectionActive);
         var feature = new ControllerFeature();
 
         provider.PopulateFeature(
@@ -79,6 +79,10 @@ public sealed class SectionControllerDiscoveryTests
 
         return [.. feature.Controllers.Select(t => t.AsType())];
     }
+
+    /// <summary>The default composition: no allowlist, so every shipped section is active.</summary>
+    private static SectionAssemblySnapshot EverySectionActive =>
+        new(SectionDiscoveryExtensions.SectionAssemblies(), activeSections: null);
 
     private sealed class NotASectionController : Controller;
 }

--- a/tests/Humans.Web.Tests/Sections/SectionSeamTests.cs
+++ b/tests/Humans.Web.Tests/Sections/SectionSeamTests.cs
@@ -3,6 +3,8 @@ using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Base.Interfaces;
 using Humans.Web.Extensions;
+using Humans.Web.Hosting;
+using Microsoft.Extensions.Configuration;
 using Humans.Web.ViewComponents;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -100,7 +102,8 @@ public class SectionSeamTests
     [HumansFact]
     public void Internal_Section_Contributions_Are_Reflection_Constructible()
     {
-        var navs = SectionDiscoveryExtensions.DiscoverImplementations<ISectionAdminNav>();
+        var navs = SectionDiscoveryExtensions.DiscoverImplementations<ISectionAdminNav>(
+            SectionAssemblySnapshot.For(new ConfigurationBuilder().Build()));
 
         navs.Should().NotBeEmpty();
         navs.Should().OnlyContain(n => !n.GetType().IsPublic, "contributions stay off the section's public surface");

--- a/tests/Humans.Web.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
+++ b/tests/Humans.Web.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Humans.Gdpr.Contracts;
+using Humans.Web.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -145,7 +146,8 @@ public class GdprExportDependencyInjectionTests
             .AddHumansInfrastructure(
                 services,
                 config,
-                new StubHostEnvironment());
+                new StubHostEnvironment(),
+                SectionAssemblySnapshot.For(config));
 
         var contributorDescriptors = services
             .Where(d => d.ServiceType == typeof(IUserDataContributor))
@@ -174,7 +176,8 @@ public class GdprExportDependencyInjectionTests
             .AddHumansInfrastructure(
                 services,
                 BuildMinimalConfiguration(),
-                new StubHostEnvironment());
+                new StubHostEnvironment(),
+                SectionAssemblySnapshot.For(BuildMinimalConfiguration()));
 
         services.Should().ContainSingle(d => d.ServiceType == typeof(IGdprExportService),
             "the GDPR export orchestrator must be registered exactly once");
@@ -197,7 +200,8 @@ public class GdprExportDependencyInjectionTests
             .AddHumansInfrastructure(
                 services,
                 config,
-                new StubHostEnvironment());
+                new StubHostEnvironment(),
+                SectionAssemblySnapshot.For(config));
 
         // Replace every contributor's concrete-type registration with a fake
         // instance of that same type. GetUninitializedObject skips the


### PR DESCRIPTION
Filters the discovered section set by configuration before `Register` runs, so which sections a deployment runs is a config decision rather than a compile-time one.

## Config shape

```json
"Sections": {
  "Active": [ "Users", "Teams", "Shifts" ]
}
```

Absent — the shipped default, and nothing was added to `appsettings.json` — means every discovered section is active, byte-identical behavior to today. Names are matched case-insensitively against what discovery found; a name that is not a section fails startup rather than silently dropping one.

## What follows the active set

`SectionDiscoveryExtensions.ActiveSectionAssemblies()` is the new composition root; `SectionAssemblies()` stays the full shipped set, which is what the architecture sweeps and `DevLoginControllerExclusionProvider` want. Reading the active set: `Register`, `RegisterContributions`, `DiscoverImplementations<T>()` (jobs, health checks, endpoints, policies, nav, tiles, chrome), `IsSectionAssembly` (controllers and view components, so routes 404), and `SectionResourceTypes()`.

## Dependency closure

Derived, never declared (G5 decision #9). `SectionActivation.DependencyGraph` walks each section assembly's `GetReferencedAssemblies()`, keeps the `Humans.*` ones, and maps a referenced `Humans.X.Contracts` back to section `X` by name — the Contracts leaves being separate assemblies is exactly why the mapping is needed. Self-edges and non-section references drop out.

An allowlist that deactivates a consumed section throws at boot:

```
Sections:Active deactivates section(s) that active sections consume: AuditLog (consumed by Agent);
Auth (consumed by Agent); ... Activate them, or deactivate the sections that depend on them.
```

(that is real output, from the test run). Transitivity needs no extra pass: every active section is checked, so a chain breaks at whichever link is missing.

## No literal ties

No section name appears in Shell or in the tests. The tests derive their fixtures from the discovered set and from real assembly references — the deactivation case picks the first section with a dependency, the case-insensitivity case picks a graph leaf.

## Migrations

Verified by reading the registration path, not by running a deploy. `AddSectionDbContext<T>` is called from inside `Section.Register` in all 37 table-owning sections, and it is the only thing that registers the `SectionDbContextRegistration` that `DatabaseMigrationHostedService` enumerates. Not calling `Register` therefore leaves nothing for the migration runner to find — no central context list exists to fall back on.

## Boot diagnostic

`Sections: {ActiveCount} active of {DiscoveredCount} discovered. Active: ... Inactive: ...`

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors.
- `Humans.Web.Tests` — 549 passed, including the 7 new `SectionActivationTests`. `Humans.Users.Tests` — 540 passed.
- `Humans.Integration.Tests` — intermittent failures on this machine, all of them `Test execution timed out after 30000 milliseconds` under heavy parallel load (eight other lanes building concurrently); a different set fails each run and every one of them passes in isolation. Not a change-induced failure, but it means the integration suite is unverified-green here and wants a clean CI run.

## Left for Peter

The QA deploy proof — toggling one real section off and back on on the preview deploy — is the one acceptance criterion an agent cannot execute.

Part of nobodies-collective/Humans#1073 — closes nobodies-collective/Humans#1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
