### PR TITLE
refactor: sections contribute their layout chrome

### DIFF
--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -258,15 +258,6 @@ else if (Model.IsShiftBrowsingOpen && Model.IsVolunteerMember)
     </div>
 </div>
 
-@* ─── Google Resources (volunteer only) ───
-   IsVolunteerMember comes from Governance's membership snapshot (HomeController) — Web
-   knowledge GoogleIntegration's contribution has no way to derive itself, so the gate
-   stays here rather than moving into the section. *@
-@if (Model.IsVolunteerMember)
-{
-    <div class="row justify-content-center mb-4">
-        <div class="col-lg-8">
-            <vc:chrome-slot name="member-dashboard" />
-        </div>
-    </div>
-}
+@* Contributed dashboard content. Each contributing section gates its own visibility and
+   brings its own row markup, so an empty slot leaves no empty row behind. *@
+<vc:chrome-slot name="member-dashboard" />

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -65,7 +65,8 @@
     </div>
 }
 
-@* Governance's term card and Tickets' ticket card, contributed into the slot. *@
+@* Contributed dashboard content. Each contributing section gates its own visibility
+   and brings its own row markup, so an empty slot leaves no empty row behind. *@
 <vc:chrome-slot name="member-dashboard" />
 
 @{
@@ -258,6 +259,3 @@ else if (Model.IsShiftBrowsingOpen && Model.IsVolunteerMember)
     </div>
 </div>
 
-@* Contributed dashboard content. Each contributing section gates its own visibility and
-   brings its own row markup, so an empty slot leaves no empty row behind. *@
-<vc:chrome-slot name="member-dashboard" />

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -258,13 +258,15 @@ else if (Model.IsShiftBrowsingOpen && Model.IsVolunteerMember)
     </div>
 </div>
 
-@* ─── Google Resources (volunteer only) ─── *@
+@* ─── Google Resources (volunteer only) ───
+   IsVolunteerMember comes from Governance's membership snapshot (HomeController) — Web
+   knowledge GoogleIntegration's contribution has no way to derive itself, so the gate
+   stays here rather than moving into the section. *@
 @if (Model.IsVolunteerMember)
 {
     <div class="row justify-content-center mb-4">
         <div class="col-lg-8">
-            @await Component.InvokeAsync("MyGoogleResources")
+            <vc:chrome-slot name="member-dashboard" />
         </div>
     </div>
 }
-

--- a/src/Humans.Web/Views/Shared/_AdminLayout.cshtml
+++ b/src/Humans.Web/Views/Shared/_AdminLayout.cshtml
@@ -49,10 +49,7 @@
                     <i class="fa-solid fa-arrow-left-long" aria-hidden="true"></i>
                     <span>Exit admin</span>
                 </a>
-                @if (User.Identity?.IsAuthenticated == true)
-                {
-                    @await Component.InvokeAsync("NotificationBell")
-                }
+                <vc:chrome-slot name="header-right" />
                 <partial name="_LoginPartial" />
             </div>
         </nav>

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -108,10 +108,6 @@
                         </li>
                     </ul>
                     <div class="d-flex align-items-center gap-2 position-relative">
-                        @if (User.Identity?.IsAuthenticated == true)
-                        {
-                            @await Component.InvokeAsync("NotificationBell")
-                        }
                         <vc:chrome-slot name="header-right" />
                         <partial name="_LanguageChooser" />
                         <partial name="_LoginPartial" />
@@ -119,7 +115,6 @@
                 </div>
             </div>
         </nav>
-        @await Component.InvokeAsync("OnboardingProgressBanner")
         <vc:chrome-slot name="above-content" />
     </header>
     <environment exclude="Production">

--- a/src/Sections/Humans.GoogleIntegration/Humans.GoogleIntegration.csproj
+++ b/src/Sections/Humans.GoogleIntegration/Humans.GoogleIntegration.csproj
@@ -48,6 +48,8 @@
     <ProjectReference Include="..\Humans.Auth.Contracts\Humans.Auth.Contracts.csproj" />
     <ProjectReference Include="..\Humans.AuditLog.Contracts\Humans.AuditLog.Contracts.csproj" />
     <ProjectReference Include="..\Humans.Email.Contracts\Humans.Email.Contracts.csproj" />
+    <!-- IMembershipCalculatorRead: MyGoogleResourcesViewComponent owns its own volunteer gate. -->
+    <ProjectReference Include="..\Humans.Governance.Contracts\Humans.Governance.Contracts.csproj" />
     <ProjectReference Include="..\Humans.Notifications.Contracts\Humans.Notifications.Contracts.csproj" />
     <ProjectReference Include="..\Humans.SystemSettings.Contracts\Humans.SystemSettings.Contracts.csproj" />
     <ProjectReference Include="..\Humans.Teams.Contracts\Humans.Teams.Contracts.csproj" />

--- a/src/Sections/Humans.GoogleIntegration/SectionMemberDashboard.cs
+++ b/src/Sections/Humans.GoogleIntegration/SectionMemberDashboard.cs
@@ -1,0 +1,10 @@
+using Humans.Base.Interfaces;
+
+namespace Humans.GoogleIntegration;
+
+/// <summary>Dashboard contribution — was the member-dashboard invocation in Home/Dashboard.cshtml.</summary>
+internal sealed class SectionMemberDashboard : ISectionMemberDashboard
+{
+    public IEnumerable<ChromeComponent> Components() =>
+        [new(ChromeSlots.MemberDashboard, "MyGoogleResources")];
+}

--- a/src/Sections/Humans.GoogleIntegration/ViewComponents/MyGoogleResourcesViewComponent.cs
+++ b/src/Sections/Humans.GoogleIntegration/ViewComponents/MyGoogleResourcesViewComponent.cs
@@ -1,4 +1,5 @@
 using Humans.GoogleIntegration.Contracts;
+using Humans.Governance.Contracts;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 
@@ -6,6 +7,7 @@ namespace Humans.GoogleIntegration.ViewComponents;
 
 public sealed class MyGoogleResourcesViewComponent(
     ITeamResourceService teamResourceService,
+    IMembershipCalculatorRead membershipCalculatorRead,
     ILogger<MyGoogleResourcesViewComponent> logger) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync()
@@ -13,6 +15,12 @@ public sealed class MyGoogleResourcesViewComponent(
         try
         {
             if (!Guid.TryParse(UserClaimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
+                return Content(string.Empty);
+
+            // Volunteer-only, and the section owns the gate: the member-dashboard slot is
+            // shared, so Shell must not decide this on GoogleIntegration's behalf.
+            var snapshot = await membershipCalculatorRead.GetMembershipSnapshotAsync(userId);
+            if (!snapshot.IsVolunteerMember)
                 return Content(string.Empty);
 
             var resources = await teamResourceService.GetUserTeamResourcesAsync(userId);

--- a/src/Sections/Humans.GoogleIntegration/Views/Shared/Components/MyGoogleResources/Default.cshtml
+++ b/src/Sections/Humans.GoogleIntegration/Views/Shared/Components/MyGoogleResources/Default.cshtml
@@ -1,31 +1,36 @@
 @model Humans.GoogleIntegration.ViewComponents.MyGoogleResourcesViewModel
 
-<div class="card mb-4">
-    <div class="card-header">
-        <i class="fa-solid fa-cloud me-1"></i> Your Google Resources
-    </div>
-    <div class="list-group list-group-flush">
-        @foreach (var item in Model.Resources)
-        {
-            var icon = item.Resource.ResourceType == GoogleResourceType.Group
-                ? "fa-solid fa-users"
-                : "fa-solid fa-folder";
-
-            <div class="list-group-item d-flex justify-content-between align-items-center py-2">
-                <div>
-                    <i class="@icon me-2 text-muted"></i>
-                    @if (item.Resource.Url is not null)
-                    {
-                        <a href="@item.Resource.Url" target="_blank" rel="noopener noreferrer">@item.Resource.Name</a>
-                    }
-                    else
-                    {
-                        @item.Resource.Name
-                    }
-                </div>
-                <a asp-controller="Team" asp-action="Details" asp-route-slug="@item.TeamSlug"
-                   class="badge bg-light text-dark border text-decoration-none">@item.TeamName</a>
+@* Row markup lives here, not in the shared member-dashboard slot. *@
+<div class="row justify-content-center mb-4">
+    <div class="col-lg-8">
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-cloud me-1"></i> Your Google Resources
             </div>
-        }
+            <div class="list-group list-group-flush">
+                @foreach (var item in Model.Resources)
+                {
+                    var icon = item.Resource.ResourceType == GoogleResourceType.Group
+                        ? "fa-solid fa-users"
+                        : "fa-solid fa-folder";
+
+                    <div class="list-group-item d-flex justify-content-between align-items-center py-2">
+                        <div>
+                            <i class="@icon me-2 text-muted"></i>
+                            @if (item.Resource.Url is not null)
+                            {
+                                <a href="@item.Resource.Url" target="_blank" rel="noopener noreferrer">@item.Resource.Name</a>
+                            }
+                            else
+                            {
+                                @item.Resource.Name
+                            }
+                        </div>
+                        <a asp-controller="Team" asp-action="Details" asp-route-slug="@item.TeamSlug"
+                           class="badge bg-light text-dark border text-decoration-none">@item.TeamName</a>
+                    </div>
+                }
+            </div>
+        </div>
     </div>
 </div>

--- a/src/Sections/Humans.Notifications/SectionChrome.cs
+++ b/src/Sections/Humans.Notifications/SectionChrome.cs
@@ -1,0 +1,10 @@
+using Humans.Base.Interfaces;
+
+namespace Humans.Notifications;
+
+/// <summary>Layout chrome contribution — was the header-right invocation in Shell's layouts.</summary>
+internal sealed class SectionChrome : ISectionChrome
+{
+    public IEnumerable<ChromeComponent> Components() =>
+        [new(ChromeSlots.HeaderRight, "NotificationBell")];
+}

--- a/src/Sections/Humans.Notifications/ViewComponents/NotificationBellViewComponent.cs
+++ b/src/Sections/Humans.Notifications/ViewComponents/NotificationBellViewComponent.cs
@@ -10,6 +10,11 @@ internal sealed class NotificationBellViewComponent(INotificationInboxService no
 {
     public async Task<IViewComponentResult> InvokeAsync()
     {
+        // Was gated by Shell's `@if (User.Identity?.IsAuthenticated == true)` around the
+        // by-name invocation; the chrome slot invokes unconditionally, so gate here instead.
+        if (UserClaimsPrincipal?.Identity?.IsAuthenticated != true)
+            return Content(string.Empty);
+
         var userId = GetUserId();
         if (userId is null)
             return View(new NotificationBadgeViewModel());

--- a/src/Sections/Humans.Onboarding/SectionChrome.cs
+++ b/src/Sections/Humans.Onboarding/SectionChrome.cs
@@ -1,0 +1,10 @@
+using Humans.Base.Interfaces;
+
+namespace Humans.Onboarding;
+
+/// <summary>Layout chrome contribution — was the above-content invocation in Shell's <c>_Layout.cshtml</c>.</summary>
+internal sealed class SectionChrome : ISectionChrome
+{
+    public IEnumerable<ChromeComponent> Components() =>
+        [new(ChromeSlots.AboveContent, "OnboardingProgressBanner")];
+}


### PR DESCRIPTION
Reopens nobodies-collective/Humans#1079 — #1395 was merged with its base still set to `1077-member-nav` rather than `main`, so its squash landed on that stale stack branch and never reached main. Same content, rebased onto current main.

Sections contribute their layout chrome through `ISectionChrome`, rendered by `<vc:chrome-slot>`, instead of `_Layout.cshtml` naming each section's partial.

Also carries the review fix from #1395: GoogleIntegration owns its own volunteer gate. The `member-dashboard` slot is shared, so `Dashboard.cshtml` gating it on `Model.IsVolunteerMember` put one section's rule in Shell's view; the section now reads the membership snapshot itself and brings its own row markup.

Closes nobodies-collective/Humans#1079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
