### PR TITLE
Hide the Expenses statement panel when no Holded creditor account is linked

### DIFF
--- a/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
@@ -82,6 +82,8 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nou informe</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>De moment no hi ha cap any pressupostari actiu. No es poden presentar informes de despeses fins que no s'activi un any pressupostari.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>El teu compte de creditor a Holded ({0}) està vinculat, però encara no s'hi ha registrat res. El teu extracte apareixerà quan es registri el teu primer informe de despeses.</value></data>
+  <data name="Expenses_StatementPendingFirstReport" xml:space="preserve"><value>El teu extracte de despeses apareixerà aquí quan el teu primer informe es registri a Holded.</value></data>
+  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>El teu compte de creditor a Holded encara no està vinculat, així que no es pot mostrar el teu extracte. Demana a un administrador de Finances que el vinculi.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Encara no has establert el teu IBAN de pagament. Se't demanarà que l'estableixis quan presentis un informe.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Encara no hi ha informes de despeses.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No hi ha cap informe esperant el teu aval.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
@@ -82,7 +82,6 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nou informe</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>De moment no hi ha cap any pressupostari actiu. No es poden presentar informes de despeses fins que no s'activi un any pressupostari.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>El teu compte de creditor a Holded ({0}) està vinculat, però encara no s'hi ha registrat res. El teu extracte apareixerà quan es registri el teu primer informe de despeses.</value></data>
-  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>El teu compte de creditor a Holded encara no està vinculat, així que no es pot mostrar el teu extracte. Demana a un administrador de Finances que el vinculi.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Encara no has establert el teu IBAN de pagament. Se't demanarà que l'estableixis quan presentis un informe.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Encara no hi ha informes de despeses.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No hi ha cap informe esperant el teu aval.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.de.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.de.resx
@@ -82,6 +82,8 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Neue Abrechnung</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Es gibt derzeit kein aktives Budgetjahr. Spesenabrechnungen können erst eingereicht werden, wenn ein Budgetjahr aktiviert ist.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Dein Holded-Kreditorenkonto ({0}) ist verknüpft, es wurde aber noch nichts darauf gebucht. Dein Kontoauszug erscheint, sobald deine erste Spesenabrechnung erfasst ist.</value></data>
+  <data name="Expenses_StatementPendingFirstReport" xml:space="preserve"><value>Deine Spesenübersicht erscheint hier, sobald dein erster Bericht in Holded erfasst ist.</value></data>
+  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Dein Holded-Kreditorenkonto ist noch nicht verknüpft, daher kann dein Kontoauszug nicht angezeigt werden. Bitte das Finanzteam, es zu verknüpfen.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Du hast deine Zahlungs-IBAN noch nicht hinterlegt. Du wirst beim Einreichen einer Abrechnung aufgefordert, sie anzugeben.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Noch keine Spesenabrechnungen.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Keine Abrechnungen, die auf deine Befürwortung warten.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.de.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.de.resx
@@ -82,7 +82,6 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Neue Abrechnung</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Es gibt derzeit kein aktives Budgetjahr. Spesenabrechnungen können erst eingereicht werden, wenn ein Budgetjahr aktiviert ist.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Dein Holded-Kreditorenkonto ({0}) ist verknüpft, es wurde aber noch nichts darauf gebucht. Dein Kontoauszug erscheint, sobald deine erste Spesenabrechnung erfasst ist.</value></data>
-  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Dein Holded-Kreditorenkonto ist noch nicht verknüpft, daher kann dein Kontoauszug nicht angezeigt werden. Bitte das Finanzteam, es zu verknüpfen.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Du hast deine Zahlungs-IBAN noch nicht hinterlegt. Du wirst beim Einreichen einer Abrechnung aufgefordert, sie anzugeben.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Noch keine Spesenabrechnungen.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Keine Abrechnungen, die auf deine Befürwortung warten.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.es.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.es.resx
@@ -82,6 +82,8 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nuevo informe</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>No hay ningún año presupuestario activo en este momento. No se pueden presentar informes de gastos hasta que se active un año presupuestario.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Tu cuenta de acreedor en Holded ({0}) está vinculada, pero aún no se ha registrado nada en ella. Tu extracto aparecerá cuando se registre tu primer informe de gastos.</value></data>
+  <data name="Expenses_StatementPendingFirstReport" xml:space="preserve"><value>Tu extracto de gastos aparecerá aquí cuando tu primer informe se registre en Holded.</value></data>
+  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Tu cuenta de acreedor en Holded aún no está vinculada, así que no se puede mostrar tu extracto. Pide a un administrador de Finanzas que la vincule.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Aún no has establecido tu IBAN de pago. Se te pedirá que lo establezcas cuando envíes un informe.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Aún no hay informes de gastos.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No hay informes a la espera de tu aval.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.es.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.es.resx
@@ -82,7 +82,6 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nuevo informe</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>No hay ningún año presupuestario activo en este momento. No se pueden presentar informes de gastos hasta que se active un año presupuestario.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Tu cuenta de acreedor en Holded ({0}) está vinculada, pero aún no se ha registrado nada en ella. Tu extracto aparecerá cuando se registre tu primer informe de gastos.</value></data>
-  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Tu cuenta de acreedor en Holded aún no está vinculada, así que no se puede mostrar tu extracto. Pide a un administrador de Finanzas que la vincule.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Aún no has establecido tu IBAN de pago. Se te pedirá que lo establezcas cuando envíes un informe.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Aún no hay informes de gastos.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No hay informes a la espera de tu aval.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
@@ -82,7 +82,6 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nouvelle note</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Il n'y a aucune année budgétaire active pour le moment. Les notes de frais ne peuvent pas être déposées tant qu'une année budgétaire n'est pas activée.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Votre compte créditeur Holded ({0}) est lié, mais rien n'y a encore été enregistré. Votre relevé apparaîtra dès l'enregistrement de votre première note de frais.</value></data>
-  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Votre compte créditeur Holded n'est pas encore lié, votre relevé ne peut donc pas être affiché. Demandez à un administrateur Finances de le lier.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Vous n'avez pas encore renseigné votre IBAN de paiement. Vous serez invité à le faire au moment de soumettre une note.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Aucune note de frais pour le moment.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Aucune note en attente de votre validation.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
@@ -82,6 +82,8 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nouvelle note</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Il n'y a aucune année budgétaire active pour le moment. Les notes de frais ne peuvent pas être déposées tant qu'une année budgétaire n'est pas activée.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Votre compte créditeur Holded ({0}) est lié, mais rien n'y a encore été enregistré. Votre relevé apparaîtra dès l'enregistrement de votre première note de frais.</value></data>
+  <data name="Expenses_StatementPendingFirstReport" xml:space="preserve"><value>Votre relevé de frais apparaîtra ici une fois votre premier rapport enregistré dans Holded.</value></data>
+  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Votre compte créditeur Holded n'est pas encore lié, votre relevé ne peut donc pas être affiché. Demandez à un administrateur Finances de le lier.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Vous n'avez pas encore renseigné votre IBAN de paiement. Vous serez invité à le faire au moment de soumettre une note.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Aucune note de frais pour le moment.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Aucune note en attente de votre validation.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.it.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.it.resx
@@ -82,7 +82,6 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nuova nota</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Al momento non c'è alcun anno di budget attivo. Le note spese non possono essere presentate finché un anno di budget non viene attivato.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Il tuo conto creditore su Holded ({0}) è collegato, ma non vi è ancora stato registrato nulla. Il tuo estratto conto apparirà quando sarà registrata la tua prima nota spese.</value></data>
-  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Il tuo conto creditore su Holded non è ancora collegato, quindi non è possibile mostrare il tuo estratto conto. Chiedi a un amministratore Finanze di collegarlo.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Non hai ancora impostato il tuo IBAN per i pagamenti. Ti verrà chiesto di impostarlo quando presenti una nota.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Ancora nessuna nota spese.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Nessuna nota in attesa del tuo avallo.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.it.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.it.resx
@@ -82,6 +82,8 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nuova nota</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>Al momento non c'è alcun anno di budget attivo. Le note spese non possono essere presentate finché un anno di budget non viene attivato.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Il tuo conto creditore su Holded ({0}) è collegato, ma non vi è ancora stato registrato nulla. Il tuo estratto conto apparirà quando sarà registrata la tua prima nota spese.</value></data>
+  <data name="Expenses_StatementPendingFirstReport" xml:space="preserve"><value>Il tuo estratto conto spese apparirà qui quando il tuo primo rapporto sarà registrato in Holded.</value></data>
+  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Il tuo conto creditore su Holded non è ancora collegato, quindi non è possibile mostrare il tuo estratto conto. Chiedi a un amministratore Finanze di collegarlo.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>Non hai ancora impostato il tuo IBAN per i pagamenti. Ti verrà chiesto di impostarlo quando presenti una nota.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>Ancora nessuna nota spese.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>Nessuna nota in attesa del tuo avallo.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.resx
@@ -82,6 +82,8 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>New Report</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>There is no active budget year at the moment. Expense reports cannot be filed until a budget year is activated.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Your Holded creditor account ({0}) is linked, but nothing has been booked to it yet. Your statement will appear once your first expense report is registered.</value></data>
+  <data name="Expenses_StatementPendingFirstReport" xml:space="preserve"><value>Your expense statement will appear here once your first report is registered in Holded.</value></data>
+  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Your Holded creditor account is not linked yet, so your statement cannot be shown. Ask a Finance admin to link it.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>You have not yet set your payment IBAN. You will be prompted to set it when you submit a report.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>No expense reports yet.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No reports awaiting your endorsement.</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.resx
@@ -82,7 +82,6 @@
   <data name="Expenses_NewReport" xml:space="preserve"><value>New Report</value></data>
   <data name="Expenses_NoActiveYear" xml:space="preserve"><value>There is no active budget year at the moment. Expense reports cannot be filed until a budget year is activated.</value></data>
   <data name="Expenses_CreditorAccountNoActivity" xml:space="preserve"><value>Your Holded creditor account ({0}) is linked, but nothing has been booked to it yet. Your statement will appear once your first expense report is registered.</value></data>
-  <data name="Expenses_NoCreditorAccount" xml:space="preserve"><value>Your Holded creditor account is not linked yet, so your statement cannot be shown. Ask a Finance admin to link it.</value></data>
   <data name="Expenses_NoIban" xml:space="preserve"><value>You have not yet set your payment IBAN. You will be prompted to set it when you submit a report.</value></data>
   <data name="Expenses_NoReports" xml:space="preserve"><value>No expense reports yet.</value></data>
   <data name="Expenses_NoReportsAwaiting" xml:space="preserve"><value>No reports awaiting your endorsement.</value></data>

--- a/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
+++ b/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
@@ -25,6 +25,11 @@ internal sealed class ExpensesIndexViewModel
     /// before its first journal entry, and not the same thing as an unresolved binding.</summary>
     public bool AwaitingFirstLedgerActivity => BoundAccountNum is not null && AccountLedger is null;
 
+    /// <summary>Unbound although a report already reached Holded — auto-bind failed and only a manual
+    /// bind clears it (nobodies-collective/Humans#972). Unbound with no pushed report is just "not yet".</summary>
+    public bool CreditorBindingFailed =>
+        BoundAccountNum is null && Reports.Any(r => r.HoldedDocId is not null);
+
     /// <summary>True when this user is a coordinator for any budget-year team, regardless of queue depth.</summary>
     public bool IsCoordinator { get; init; }
 

--- a/src/Sections/Humans.Expenses/Views/Expenses/Index.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Index.cshtml
@@ -69,7 +69,20 @@ else if (Model.AwaitingFirstLedgerActivity)
         <i class="fa-solid fa-circle-info me-1"></i>@Localizer["Expenses_CreditorAccountNoActivity", Model.BoundAccountNum!]
     </div>
 }
-@* Unbound: no creditor account exists until the first report reaches Holded, so show nothing. *@
+else if (Model.CreditorBindingFailed)
+{
+    @* A report reached Holded but the account never resolved: genuinely stuck, Finance must bind it. *@
+    <div class="alert alert-warning">
+        <i class="fa-solid fa-circle-exclamation me-1"></i>@Localizer["Expenses_NoCreditorAccount"]
+    </div>
+}
+else
+{
+    @* Unbound with nothing pushed yet — the normal pre-first-report state, not a problem to report. *@
+    <div class="alert alert-secondary">
+        <i class="fa-solid fa-circle-info me-1"></i>@Localizer["Expenses_StatementPendingFirstReport"]
+    </div>
+}
 
 @if (!Model.HasActiveYear)
 {

--- a/src/Sections/Humans.Expenses/Views/Expenses/Index.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Index.cshtml
@@ -69,12 +69,7 @@ else if (Model.AwaitingFirstLedgerActivity)
         <i class="fa-solid fa-circle-info me-1"></i>@Localizer["Expenses_CreditorAccountNoActivity", Model.BoundAccountNum!]
     </div>
 }
-else
-{
-    <div class="alert alert-secondary">
-        <i class="fa-solid fa-circle-info me-1"></i>@Localizer["Expenses_NoCreditorAccount"]
-    </div>
-}
+@* Unbound: no creditor account exists until the first report reaches Holded, so show nothing. *@
 
 @if (!Model.HasActiveYear)
 {

--- a/tests/Humans.Expenses.Tests/Models/ExpensesIndexViewModelTests.cs
+++ b/tests/Humans.Expenses.Tests/Models/ExpensesIndexViewModelTests.cs
@@ -1,6 +1,8 @@
 using AwesomeAssertions;
+using Humans.Expenses.Contracts;
 using Humans.Expenses.Models;
 using Humans.Finance.Contracts;
+using NodaTime;
 
 namespace Humans.Expenses.Tests.Models;
 
@@ -11,8 +13,30 @@ namespace Humans.Expenses.Tests.Models;
 /// </summary>
 public class ExpensesIndexViewModelTests
 {
-    private static ExpensesIndexViewModel Vm(int? boundAccountNum, HoldedCreditorLedger? ledger) =>
-        new() { Reports = [], BoundAccountNum = boundAccountNum, AccountLedger = ledger };
+    private static ExpensesIndexViewModel Vm(
+        int? boundAccountNum, HoldedCreditorLedger? ledger, params string?[] reportHoldedDocIds) =>
+        new()
+        {
+            Reports = [.. reportHoldedDocIds.Select(Report)],
+            BoundAccountNum = boundAccountNum,
+            AccountLedger = ledger
+        };
+
+    private static ExpenseReportDto Report(string? holdedDocId) => new()
+    {
+        Id = Guid.NewGuid(),
+        SubmitterUserId = Guid.NewGuid(),
+        BudgetCategoryId = Guid.NewGuid(),
+        BudgetYearId = Guid.NewGuid(),
+        Status = ExpenseReportStatus.Approved,
+        PayeeName = "Test Payee",
+        PayeeIban = "ES9121000418450200051332",
+        Total = 100m,
+        HoldedDocId = holdedDocId,
+        CreatedAt = Instant.MinValue,
+        UpdatedAt = Instant.MinValue,
+        Lines = []
+    };
 
     [HumansFact]
     public void Bound_with_no_cached_lines_is_awaiting_activity_not_unbound()
@@ -39,5 +63,29 @@ public class ExpensesIndexViewModelTests
         var vm = Vm(boundAccountNum: 40000004, ledger: ledger);
 
         vm.AwaitingFirstLedgerActivity.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public void Unbound_with_a_report_already_in_holded_is_a_failed_binding()
+    {
+        var vm = Vm(boundAccountNum: null, ledger: null, "doc-1");
+
+        vm.CreditorBindingFailed.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void Unbound_with_nothing_pushed_to_holded_is_not_a_failed_binding()
+    {
+        var vm = Vm(boundAccountNum: null, ledger: null, [null]);
+
+        vm.CreditorBindingFailed.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public void Bound_is_never_a_failed_binding()
+    {
+        var vm = Vm(boundAccountNum: 40000004, ledger: null, "doc-1");
+
+        vm.CreditorBindingFailed.Should().BeFalse();
     }
 }


### PR DESCRIPTION
**Section:** Expenses

Members with no linked Holded creditor account saw:

> Your Holded creditor account is not linked yet, so your statement cannot be shown. Ask a Finance admin to link it.

That is the normal state before a member's first expense report is uploaded to Holded and the account is created — nothing for Finance to fix. The panel is now simply skipped when unbound. The bound-but-no-activity-yet branch is unchanged.

`Expenses_NoCreditorAccount` is now unused, so it's removed from all six `ExpensesResource*.resx` files.

Build clean; `Humans.Expenses.Tests` (207) and `BudgetPageRenderTests` (4) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)