### PR TITLE
fix: skip EF migration-history reads that log Errors before the section table exists

### DIFF
--- a/src/Humans.Base/Hosting/DatabaseMigrationHostedService.cs
+++ b/src/Humans.Base/Hosting/DatabaseMigrationHostedService.cs
@@ -1,3 +1,4 @@
+using Humans.Base.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -74,7 +75,16 @@ internal sealed class DatabaseMigrationHostedService(
         foreach (var context in sectionContexts)
         {
             var contextName = context.GetType().Name;
-            var pending = await context.Database.GetPendingMigrationsAsync(cancellationToken);
+
+            // GetPendingMigrationsAsync issues a SELECT against the section's history table and
+            // logs it as an Error if that table doesn't exist yet - true on the first boot after
+            // a section is peeled, before SectionMigrationRunner has created it
+            // (nobodies-collective/Humans#1022). When it's absent, every migration the context
+            // knows about is pending by definition, so skip the failing read.
+            var historyTable = SectionMigrationsHistory.TableFor(context.GetType());
+            var pending = await SectionMigrationRunner.TableExistsAsync(context, historyTable, cancellationToken)
+                ? await context.Database.GetPendingMigrationsAsync(cancellationToken)
+                : context.Database.GetMigrations();
             frontier.AddRange(pending.Select(migration => $"{contextName}:{migration}"));
         }
 

--- a/src/Humans.Base/Hosting/SectionMigrationRunner.cs
+++ b/src/Humans.Base/Hosting/SectionMigrationRunner.cs
@@ -1,3 +1,4 @@
+using Humans.Base.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -55,9 +56,20 @@ internal static class SectionMigrationRunner
         var contextName = db.GetType().Name;
         try
         {
-            var applied = (await db.Database.GetAppliedMigrationsAsync(ct)).ToList();
+            var historyTable = SectionMigrationsHistory.TableFor(db.GetType());
+            var historyTableExists = await TableExistsAsync(db, historyTable, ct);
 
-            if (applied.Count == 0 && await SentinelTableExistsAsync(db, sentinelTable, ct))
+            // Reads through GetAppliedMigrationsAsync/GetPendingMigrationsAsync issue a SELECT
+            // against the history table and log it as an Error if the table doesn't exist yet
+            // (EF swallows the failure and reports "nothing applied", but the log noise reads
+            // like an outage on every first boot after a section is peeled - #1022). The
+            // information_schema probe above is the only way to ask "does it exist" without
+            // that failing SELECT, so skip the EF reads entirely when it says no.
+            var applied = historyTableExists
+                ? (await db.Database.GetAppliedMigrationsAsync(ct)).ToList()
+                : [];
+
+            if (applied.Count == 0 && await TableExistsAsync(db, sentinelTable, ct))
             {
                 var baselineId = db.Database.GetMigrations().First();
                 logger.LogWarning(
@@ -66,9 +78,12 @@ internal static class SectionMigrationRunner
                 await beforeSchemaChange(ct);
                 await RecordBaselineAsAppliedAsync(db, baselineId, ct);
                 applied = (await db.Database.GetAppliedMigrationsAsync(ct)).ToList();
+                historyTableExists = true;
             }
 
-            var pending = (await db.Database.GetPendingMigrationsAsync(ct)).ToList();
+            var pending = historyTableExists
+                ? (await db.Database.GetPendingMigrationsAsync(ct)).ToList()
+                : db.Database.GetMigrations().ToList();
 
             // Warning level so the per-boot migration breadcrumb survives production's
             // default log filtering (nobodies-collective/Humans#960).
@@ -101,7 +116,13 @@ internal static class SectionMigrationRunner
         }
     }
 
-    private static async Task<bool> SentinelTableExistsAsync(DbContext db, string sentinelTable, CancellationToken ct)
+    /// <summary>
+    /// Whether <paramref name="tableName"/> exists in the <c>public</c> schema. Used both for
+    /// the section's sentinel table (baseline-branch detection) and its own migrations-history
+    /// table (nobodies-collective/Humans#1022) - an information_schema probe, never the EF
+    /// history read itself, which logs an Error if the table is missing.
+    /// </summary>
+    internal static async Task<bool> TableExistsAsync(DbContext db, string tableName, CancellationToken ct)
     {
         await db.Database.OpenConnectionAsync(ct);
         try
@@ -112,13 +133,13 @@ internal static class SectionMigrationRunner
             {
                 // Plain string comparison, not to_regclass: to_regclass parses its
                 // argument as an identifier and lowercases unquoted names, so a
-                // mixed-case sentinel like DataProtectionKeys would never match.
+                // mixed-case table name like DataProtectionKeys would never match.
                 command.CommandText =
                     "SELECT EXISTS (SELECT 1 FROM information_schema.tables " +
                     "WHERE table_schema = 'public' AND table_name = @table)";
                 var parameter = command.CreateParameter();
                 parameter.ParameterName = "@table";
-                parameter.Value = sentinelTable;
+                parameter.Value = tableName;
                 command.Parameters.Add(parameter);
                 var result = await command.ExecuteScalarAsync(ct);
                 return result is true;


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1022

## Problem

On the first boot after a section is peeled, its `__EFMigrationsHistory_<Section>` table doesn't exist yet. Two startup reads probed it anyway — `db.Database.GetAppliedMigrationsAsync` (`SectionMigrationRunner.MigrateAsync`) and `db.Database.GetPendingMigrationsAsync` (`DatabaseMigrationHostedService.CollectPendingFrontierAsync`) — and EF logs each failing SELECT as an Error before swallowing it and reporting "nothing applied". 13 sections × 2 passes = 26 Error-level lines on the peel deploy, reading like an outage at exactly the moment someone is watching.

## Fix

Lifted the existing `information_schema.tables` probe (`SectionMigrationRunner.SentinelTableExistsAsync`, already used for baseline-branch detection) into a generic `TableExistsAsync(DbContext, string, CancellationToken)`, and pointed it at each context's own history table name (`SectionMigrationsHistory.TableFor`) at both call sites:

- `SectionMigrationRunner.MigrateAsync`: checks history-table existence first; when absent, skips `GetAppliedMigrationsAsync` (treats `applied` as empty) and, later, skips `GetPendingMigrationsAsync` too — using `GetMigrations()` directly, same as a genuinely fresh database. Once the baseline-record branch creates the table mid-method, the flag flips and later reads go through EF normally.
- `DatabaseMigrationHostedService.CollectPendingFrontierAsync`: same guard — when the history table is absent, every migration the context knows about is pending by definition, so the frontier entry comes from `GetMigrations()` without the failing read.

No query is issued on any branch that we already know will fail. EF's `Database.Command` error logging is untouched — real command failures still log at Error.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors.
- `dotnet test Humans.slnx -v quiet --filter FullyQualifiedName~SectionMigrationRunnerTests` — 3/3 passed against real Postgres (Testcontainers), proving all three baseline branches (history has rows / empty+sentinel present / empty+sentinel absent) still behave identically, and the fresh-database path still applies every migration and history row correctly.

## Acceptance criteria

- [x] Booting a section context against a database where its `__EFMigrationsHistory_<Section>` table does not exist produces no Error-level log events — both probed call sites now skip the failing EF read entirely when the table is absent.
- [x] The three baseline branches still behave identically — `SectionMigrationRunnerTests` (3/3 passing, real Postgres) covers all three.
- [x] The snapshot pending-frontier still lists every pending migration for a not-yet-created section context — falls back to `GetMigrations()` (all migrations = all pending when history doesn't exist).
- [x] EF `Database.Command` error logging is left at its current level — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
