### PR TITLE
fix: pin request parsing culture to en so comma-decimal cultures stop corrupting decimal form fields

### DIFF
--- a/src/Humans.Web/Localization/UiCultureOnlyRequestCultureProvider.cs
+++ b/src/Humans.Web/Localization/UiCultureOnlyRequestCultureProvider.cs
@@ -1,17 +1,22 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Primitives;
 
 namespace Humans.Web.Localization;
 
 /// <summary>
 /// Wraps an <see cref="IRequestCultureProvider"/> so its result always reports the
-/// numeric/date PARSING culture as "en", keeping only the translation (UI) culture from
-/// the inner provider. HTML forms (<c>type="number"</c>, decimal model binding) always POST
-/// dot-format regardless of display language, so binding under a comma-decimal request
-/// culture silently corrupts values — e.g. <c>decimal.Parse("60.00", es)</c> == 6000
-/// (nobodies-collective/Humans#1067). Wrapping every provider in the pipeline (cookie,
-/// Accept-Language, query string, the preference-based provider) means no path can leak a
-/// non-"en" parsing culture.
+/// numeric/date PARSING culture as "en", keeping the full ordered translation (UI) culture
+/// candidate list from the inner provider untouched. HTML forms (<c>type="number"</c>,
+/// decimal model binding) always POST dot-format regardless of display language, so binding
+/// under a comma-decimal request culture silently corrupts values — e.g.
+/// <c>decimal.Parse("60.00", es)</c> == 6000 (nobodies-collective/Humans#1067). Wrapping
+/// every provider in the pipeline (cookie, Accept-Language, query string, the
+/// preference-based provider) means no path can leak a non-"en" parsing culture.
+/// <c>UICultures</c> is forwarded as-is (not collapsed to its first entry) because
+/// <c>AcceptLanguageHeaderRequestCultureProvider</c> can return several ordered fallback
+/// candidates in one result, and <c>RequestLocalizationMiddleware</c> walks that list to
+/// find the first one that's actually supported.
 /// </summary>
 public sealed class UiCultureOnlyRequestCultureProvider(IRequestCultureProvider inner) : IRequestCultureProvider
 {
@@ -21,7 +26,9 @@ public sealed class UiCultureOnlyRequestCultureProvider(IRequestCultureProvider 
         if (result is null)
             return null;
 
-        var uiCulture = result.UICultures?.FirstOrDefault().ToString();
-        return new ProviderCultureResult("en", string.IsNullOrEmpty(uiCulture) ? "en" : uiCulture);
+        var uiCultures = result.UICultures is { Count: > 0 } candidates
+            ? candidates
+            : new List<StringSegment> { "en" };
+        return new ProviderCultureResult(new List<StringSegment> { "en" }, uiCultures);
     }
 }

--- a/src/Humans.Web/Localization/UiCultureOnlyRequestCultureProvider.cs
+++ b/src/Humans.Web/Localization/UiCultureOnlyRequestCultureProvider.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+
+namespace Humans.Web.Localization;
+
+/// <summary>
+/// Wraps an <see cref="IRequestCultureProvider"/> so its result always reports the
+/// numeric/date PARSING culture as "en", keeping only the translation (UI) culture from
+/// the inner provider. HTML forms (<c>type="number"</c>, decimal model binding) always POST
+/// dot-format regardless of display language, so binding under a comma-decimal request
+/// culture silently corrupts values — e.g. <c>decimal.Parse("60.00", es)</c> == 6000
+/// (nobodies-collective/Humans#1067). Wrapping every provider in the pipeline (cookie,
+/// Accept-Language, query string, the preference-based provider) means no path can leak a
+/// non-"en" parsing culture.
+/// </summary>
+public sealed class UiCultureOnlyRequestCultureProvider(IRequestCultureProvider inner) : IRequestCultureProvider
+{
+    public async Task<ProviderCultureResult?> DetermineProviderCultureResult(HttpContext httpContext)
+    {
+        var result = await inner.DetermineProviderCultureResult(httpContext);
+        if (result is null)
+            return null;
+
+        var uiCulture = result.UICultures?.FirstOrDefault().ToString();
+        return new ProviderCultureResult("en", string.IsNullOrEmpty(uiCulture) ? "en" : uiCulture);
+    }
+}

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -40,6 +40,7 @@ using Humans.Web.Hosting;
 using Humans.Web.ModelBinders;
 using Humans.Web.Data;
 using Humans.Users.Contracts;
+using Humans.Web.Localization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -539,6 +540,13 @@ builder.Services.Configure<RequestLocalizationOptions>(options =>
         }
         return null;
     }));
+
+    // Wrap every provider (the preference-based one above, plus the default query
+    // string/cookie/Accept-Language providers) so the parsing culture is always "en"
+    // regardless of which one wins — see UiCultureOnlyRequestCultureProvider (#1067).
+    options.RequestCultureProviders = options.RequestCultureProviders
+        .Select(provider => (IRequestCultureProvider)new UiCultureOnlyRequestCultureProvider(provider))
+        .ToList();
 });
 
 var app = builder.Build();

--- a/tests/Humans.Web.Tests/Infrastructure/UiCultureOnlyRequestCultureProviderTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/UiCultureOnlyRequestCultureProviderTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Web.Localization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Humans.Web.Tests.Infrastructure;
@@ -26,6 +27,25 @@ public class UiCultureOnlyRequestCultureProviderTests
         result.Should().NotBeNull();
         result!.Cultures[0].Value.Should().Be("en");
         result.UICultures[0].Value.Should().Be("es");
+    }
+
+    [HumansFact]
+    public async Task Preserves_full_ui_culture_fallback_chain()
+    {
+        // AcceptLanguageHeaderRequestCultureProvider can return several ordered candidates
+        // in one result (e.g. "pt-BR, es;q=0.9" with pt-BR unsupported); the middleware
+        // walks the whole list to find the first supported one. Collapsing to just the
+        // first candidate would silently drop "es" and fall back to the default culture.
+        var uiCultures = new List<StringSegment> { "pt-BR", "es" };
+        var inner = new FixedRequestCultureProvider(
+            new ProviderCultureResult(new List<StringSegment> { "en" }, uiCultures));
+        var provider = new UiCultureOnlyRequestCultureProvider(inner);
+
+        var result = await provider.DetermineProviderCultureResult(new DefaultHttpContext());
+
+        result.Should().NotBeNull();
+        result!.Cultures[0].Value.Should().Be("en");
+        result.UICultures.Select(c => c.Value).Should().Equal("pt-BR", "es");
     }
 
     [HumansFact]

--- a/tests/Humans.Web.Tests/Infrastructure/UiCultureOnlyRequestCultureProviderTests.cs
+++ b/tests/Humans.Web.Tests/Infrastructure/UiCultureOnlyRequestCultureProviderTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using Humans.Web.Localization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Xunit;
+
+namespace Humans.Web.Tests.Infrastructure;
+
+/// <summary>
+/// Coverage for the parsing-culture pin (nobodies-collective/Humans#1067): HTML forms
+/// (<c>type="number"</c>, decimal model binding) always POST dot-format regardless of
+/// display language, so a comma-decimal request culture silently corrupts values —
+/// <c>decimal.Parse("60.00", es)</c> == 6000. Every request-culture provider is wrapped so
+/// its result always reports "en" for the parsing culture, keeping only the UI culture.
+/// </summary>
+public class UiCultureOnlyRequestCultureProviderTests
+{
+    [HumansFact]
+    public async Task Forces_parsing_culture_to_en_regardless_of_inner_result()
+    {
+        var inner = new FixedRequestCultureProvider(new ProviderCultureResult("es", "es"));
+        var provider = new UiCultureOnlyRequestCultureProvider(inner);
+
+        var result = await provider.DetermineProviderCultureResult(new DefaultHttpContext());
+
+        result.Should().NotBeNull();
+        result!.Cultures[0].Value.Should().Be("en");
+        result.UICultures[0].Value.Should().Be("es");
+    }
+
+    [HumansFact]
+    public async Task Preserves_null_when_inner_provider_has_no_opinion()
+    {
+        var inner = new FixedRequestCultureProvider(result: null);
+        var provider = new UiCultureOnlyRequestCultureProvider(inner);
+
+        var result = await provider.DetermineProviderCultureResult(new DefaultHttpContext());
+
+        result.Should().BeNull();
+    }
+
+    private sealed class FixedRequestCultureProvider(ProviderCultureResult? result) : IRequestCultureProvider
+    {
+        public Task<ProviderCultureResult?> DetermineProviderCultureResult(HttpContext httpContext) =>
+            Task.FromResult(result);
+    }
+}


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1067

## Root cause

`Program.cs`'s custom request-culture provider only pins the parsing/format culture to `"en"` for authenticated users who have a `PreferredLanguage`. Everyone else (unauthenticated, or authenticated without a preference) falls through to the default `AcceptLanguageHeaderRequestCultureProvider`, which sets **both** the format culture and the UI culture from the browser's `Accept-Language` header. A browser sending `es`/`de`/`fr`/`it`/`ca` then gets a comma-decimal format culture.

HTML `type="number"` inputs always POST dot-format (`60.00`) regardless of display language, but MVC binds `decimal` using the request's format culture — under `es`, `.` is the group separator, so `decimal.Parse("60.00", es)` == `6000`. Every decimal form field was exposed: expense line amounts, expense max amount, store payment amounts, etc. The same problem exists via the language-switcher cookie (`LanguageController.SetLanguage` stores one culture for both format and UI) and via the (unused but still wired) query-string provider.

## Fix

Generalized the existing "format culture always `en`" behavior to every request-culture provider, not just the one preference-based branch, per the issue's suggested direction.

- Added `UiCultureOnlyRequestCultureProvider` (`src/Humans.Web/Localization/UiCultureOnlyRequestCultureProvider.cs`) — a decorator over `IRequestCultureProvider` that forces the result's parsing `Culture` to `"en"` while keeping whatever `UICulture` the wrapped provider decided.
- `Program.cs` now wraps every provider in `RequestLocalizationOptions.RequestCultureProviders` (the preference-based provider, plus the default query-string/cookie/Accept-Language providers) with this decorator. Translation (`UICulture`) still varies per user/browser/cookie exactly as before; only the format/parsing culture is pinned.

This fixes the reported POST-parsing bug everywhere at once (no per-field patching needed) and, as a side effect, also fixes the render-side prefill mentioned in the issue (`Expenses/LineEdit.cshtml`'s `@line.Amount.ToString("F2")` uses `CultureInfo.CurrentCulture`, which `UseRequestLocalization` now always sets to `"en"`), since #1336 already handled the other render-side prefills with explicit `InvariantCulture`.

## Testing

- `dotnet build Humans.slnx -v quiet` — 0 errors.
- `dotnet test Humans.slnx -v quiet` — full solution, all projects pass (Humans.Web.Tests: 551/551; Humans.Integration.Tests: 286/287, 1 pre-existing skip).
- New unit tests in `tests/Humans.Web.Tests/Infrastructure/UiCultureOnlyRequestCultureProviderTests.cs` cover: wrapped provider forces `Culture` to `"en"` while preserving `UICulture`, and passes through a `null` result unchanged.

## Files changed

- `src/Humans.Web/Program.cs`
- `src/Humans.Web/Localization/UiCultureOnlyRequestCultureProvider.cs` (new)
- `tests/Humans.Web.Tests/Infrastructure/UiCultureOnlyRequestCultureProviderTests.cs` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
