### PR TITLE
fix(holded): normalize parse errors in the four remaining HoldedClient reads

### DIFF
--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -107,21 +107,32 @@ internal sealed class HoldedClient : IHoldedClient
 
         using var resp = await SendAsync(req, ct);
         await using var stream = await resp.Content.ReadAsStreamAsync(ct);
-        var node = await JsonNode.ParseAsync(stream, cancellationToken: ct)
-            ?? throw new HoldedTransientException("Holded returned empty body");
-
-        return new HoldedPurchaseDocumentDto
+        try
         {
-            Id = Prop(node, "id")?.GetValue<string>() ?? "",
-            DocNumber = Prop(node, "document_number")?.GetValue<string>() ?? "",
-            Subtotal = ReadDecimalV2(Prop(node, "subtotal")),
-            Tax = ReadDecimalV2(Prop(node, "tax")),
-            Total = ReadDecimalV2(Prop(node, "total")),
-            PaymentsTotal = ReadDecimalV2(Prop(node, "payments_total")),
-            PaymentsPending = ReadDecimalV2(Prop(node, "payments_pending")),
-            ApprovedAt = ParseApprovedAt(Prop(node, "approved_at")?.GetValue<string>()),
-            Tags = ReadTags(Prop(node, "tags")),
-        };
+            var node = await JsonNode.ParseAsync(stream, cancellationToken: ct)
+                ?? throw new HoldedTransientException("Holded returned empty body");
+
+            return new HoldedPurchaseDocumentDto
+            {
+                Id = Prop(node, "id")?.GetValue<string>() ?? "",
+                DocNumber = Prop(node, "document_number")?.GetValue<string>() ?? "",
+                Subtotal = ReadDecimalV2(Prop(node, "subtotal")),
+                Tax = ReadDecimalV2(Prop(node, "tax")),
+                Total = ReadDecimalV2(Prop(node, "total")),
+                PaymentsTotal = ReadDecimalV2(Prop(node, "payments_total")),
+                PaymentsPending = ReadDecimalV2(Prop(node, "payments_pending")),
+                ApprovedAt = ParseApprovedAt(Prop(node, "approved_at")?.GetValue<string>()),
+                Tags = ReadTags(Prop(node, "tags")),
+            };
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException
+            or FormatException or OverflowException)
+        {
+            // Same normalization as GetContactAsync: a value of an unexpected type belongs to the
+            // stored document, not to this request, so retrying cannot help.
+            throw new HoldedPermanentException(
+                $"Holded purchase document {documentId} could not be read.", ex);
+        }
     }
 
     public async Task<IReadOnlyList<HoldedExpenseAccountDto>> ListExpenseAccountsAsync(
@@ -129,12 +140,20 @@ internal sealed class HoldedClient : IHoldedClient
     {
         const int pageSafetyCap = 5; // a handful of expense accounts today, unpaginated in practice
         var items = await GetPagedAsync("/api/v2/expenses-accounts?limit=200", pageSafetyCap, ct);
-        return items.Select(n => new HoldedExpenseAccountDto
+        try
         {
-            Id = Prop(n, "id")?.GetValue<string>() ?? "",
-            AccountNum = ReadInt(Prop(n, "account_num")) ?? 0,
-            Name = Prop(n, "name")?.GetValue<string>() ?? "",
-        }).ToList();
+            return items.Select(n => new HoldedExpenseAccountDto
+            {
+                Id = Prop(n, "id")?.GetValue<string>() ?? "",
+                AccountNum = ReadInt(Prop(n, "account_num")) ?? 0,
+                Name = Prop(n, "name")?.GetValue<string>() ?? "",
+            }).ToList();
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException
+            or FormatException or OverflowException)
+        {
+            throw new HoldedPermanentException("Holded expense accounts could not be read.", ex);
+        }
     }
 
     public async Task<string> CreateExpenseAccountAsync(
@@ -145,10 +164,20 @@ internal sealed class HoldedClient : IHoldedClient
         { Content = JsonContent.Create(payload) };
         AttachAuth(req);
         using var resp = await SendAsync(req, ct);
-        var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync(ct))
-            ?? throw new HoldedTransientException("Holded returned empty body");
-        return node["id"]?.GetValue<string>()
-            ?? throw new HoldedTransientException("Holded create-account response missing id");
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        try
+        {
+            var node = JsonNode.Parse(body)
+                ?? throw new HoldedTransientException("Holded returned empty body");
+            return node["id"]?.GetValue<string>()
+                ?? throw new HoldedTransientException("Holded create-account response missing id");
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException
+            or FormatException or OverflowException)
+        {
+            throw new HoldedPermanentException(
+                "Holded create-account response could not be read.", ex);
+        }
     }
 
     public async Task<IReadOnlyList<HoldedPurchaseDocListItemDto>> ListPurchaseDocumentsAsync(
@@ -245,7 +274,19 @@ internal sealed class HoldedClient : IHoldedClient
     public async Task<IReadOnlyList<HoldedContactDto>> ListContactsAsync(CancellationToken ct = default)
     {
         const int pageSafetyCap = 50; // 10 000+ contacts (limit=200/page) — far above a small nonprofit's vendor/member list
-        var items = await GetPagedAsync("/api/v2/contacts?limit=200", pageSafetyCap, ct);
+        List<JsonNode> items;
+        try
+        {
+            items = await GetPagedAsync("/api/v2/contacts?limit=200", pageSafetyCap, ct);
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException
+            or FormatException or OverflowException)
+        {
+            // The page envelope itself (not a per-contact value) was unreadable — that's not the
+            // per-contact skip-and-log below (#994), which only covers one bad item in an otherwise
+            // good page.
+            throw new HoldedPermanentException("Holded contacts could not be read.", ex);
+        }
 
         var contacts = new List<HoldedContactDto>();
         var skipped = 0;

--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -126,10 +126,11 @@ internal sealed class HoldedClient : IHoldedClient
             };
         }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException
-            or FormatException or OverflowException)
+            or FormatException or OverflowException or UnparsableValueException)
         {
             // Same normalization as GetContactAsync: a value of an unexpected type belongs to the
-            // stored document, not to this request, so retrying cannot help.
+            // stored document, not to this request, so retrying cannot help. UnparsableValueException
+            // covers ParseApprovedAt's NodaTime .Value on a non-empty but malformed timestamp.
             throw new HoldedPermanentException(
                 $"Holded purchase document {documentId} could not be read.", ex);
         }
@@ -139,9 +140,9 @@ internal sealed class HoldedClient : IHoldedClient
         CancellationToken ct = default)
     {
         const int pageSafetyCap = 5; // a handful of expense accounts today, unpaginated in practice
-        var items = await GetPagedAsync("/api/v2/expenses-accounts?limit=200", pageSafetyCap, ct);
         try
         {
+            var items = await GetPagedAsync("/api/v2/expenses-accounts?limit=200", pageSafetyCap, ct);
             return items.Select(n => new HoldedExpenseAccountDto
             {
                 Id = Prop(n, "id")?.GetValue<string>() ?? "",

--- a/tests/Humans.Holded.Tests/Services/HoldedClientContactTests.cs
+++ b/tests/Humans.Holded.Tests/Services/HoldedClientContactTests.cs
@@ -118,6 +118,19 @@ public class HoldedClientContactTests
     }
 
     [HumansFact]
+    public async Task ListContacts_surfaces_an_unreadable_page_envelope_as_permanent_not_a_raw_parse_throw()
+    {
+        // A page-level parse failure (the envelope, not one contact's value) is distinct from the
+        // per-contact skip-and-log below (#994): the whole page is unreadable, so there is nothing
+        // to skip-and-continue.
+        var client = Make(new StubHandler(_ => Respond(HttpStatusCode.OK, "not json")));
+
+        var act = async () => await client.ListContactsAsync(Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HoldedPermanentException>();
+    }
+
+    [HumansFact]
     public async Task ListContacts_skips_an_unreadable_contact_and_keeps_the_rest()
     {
         // A value of the wrong type anywhere in the projection used to take down the whole page.

--- a/tests/Humans.Holded.Tests/Services/HoldedClientReadTests.cs
+++ b/tests/Humans.Holded.Tests/Services/HoldedClientReadTests.cs
@@ -36,6 +36,17 @@ public class HoldedClientReadTests
     }
 
     [HumansFact]
+    public async Task ListExpenseAccounts_surfaces_an_unreadable_account_as_permanent_not_a_raw_parse_throw()
+    {
+        var json = """{"items":[{"id":42,"name":"Otros servicios","account_num":62900000}],"cursor":null,"has_more":false}""";
+        var client = Make(new StubHandler(_ => Respond(HttpStatusCode.OK, json)));
+
+        var act = async () => await client.ListExpenseAccountsAsync(Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HoldedPermanentException>();
+    }
+
+    [HumansFact]
     public async Task ListPurchaseDocuments_parses_lines_account_and_tags()
     {
         var json = """
@@ -302,6 +313,17 @@ public class HoldedClientReadTests
 
         capturedMethod.Should().Be("POST");
         id.Should().Be("new1");
+    }
+
+    [HumansFact]
+    public async Task CreateExpenseAccount_surfaces_an_unreadable_response_as_permanent_not_a_raw_parse_throw()
+    {
+        var client = Make(new StubHandler(_ => Respond(HttpStatusCode.OK, "not json")));
+
+        var act = async () => await client.CreateExpenseAccountAsync(
+            62900000, "Otros servicios", Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HoldedPermanentException>();
     }
 
     private static HttpResponseMessage Respond(HttpStatusCode status, string body) =>

--- a/tests/Humans.Holded.Tests/Services/HoldedClientTests.cs
+++ b/tests/Humans.Holded.Tests/Services/HoldedClientTests.cs
@@ -83,6 +83,19 @@ public class HoldedClientTests
     }
 
     [HumansFact]
+    public async Task GetPurchaseDocumentAsync_surfaces_an_unreadable_body_as_permanent_not_a_raw_parse_throw()
+    {
+        // Callers handle only IHoldedClient's two typed exceptions; a raw parse throw from a bad
+        // stored value would escape the client and leak an Infrastructure detail upward.
+        var handler = new StubHandler(_ => Respond(HttpStatusCode.OK, """{"id":42,"document_number":"F001"}"""));
+        var client = Make(handler);
+
+        var act = async () => await client.GetPurchaseDocumentAsync("doc-123", Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HoldedPermanentException>();
+    }
+
+    [HumansFact]
     public async Task GetPurchaseDocumentAsync_404Throws_HoldedPermanent()
     {
         var handler = new StubHandler(_ => Respond(HttpStatusCode.NotFound, "{}"));


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1004

## Summary

`HoldedPermanentException` is documented as the classification for a malformed/unexpected-shape
response body on an otherwise-2xx response, but only 3 of the 11 `IHoldedClient` reads actually
normalized parse failures into it. This PR closes the gap for the four sites the issue named:

- `GetPurchaseDocumentAsync` — wraps the `JsonNode.ParseAsync` + DTO projection.
- `ListExpenseAccountsAsync` — wraps the post-`GetPagedAsync` `.Select(...)` projection.
- `CreateExpenseAccountAsync` — wraps the unguarded `JsonNode.Parse` + id read.
- `ListContactsAsync` — wraps the page-level `GetPagedAsync` call (the envelope, not the
  per-contact value). The per-contact skip-and-log inside the loop is unchanged, per
  nobodies-collective/Humans#994.

Each site uses the client's existing normalization shape:
`catch (Exception ex) when (ex is JsonException or InvalidOperationException or FormatException or OverflowException)`
→ `throw new HoldedPermanentException(...)`.

## Docs

The issue also asked to "restore the client-wide wording" in the Holded section doc. That doc
moved to `src/Sections/Humans.Holded/Docs/Holded-connector.md` at the G5 section move (it no
longer exists at `docs/sections/Holded.md`). Checked it: the "not client-wide" caveat that PR
peterdrier/Humans#1224 added to the old v1 doc was never carried into the v2 rewrite
(peterdrier/Humans#1261) — the current wording already reads unqualified/client-wide
("`HoldedPermanentException` (other 4xx, unreadable page bodies) is not [retry-eligible]"), which
is now accurate. No doc edit was needed.

## Tests

Added one test per newly-normalized failure path in `tests/Humans.Holded.Tests`, following the
existing "surfaces an unreadable X as permanent not a raw parse throw" convention:

- `HoldedClientTests.GetPurchaseDocumentAsync_surfaces_an_unreadable_body_as_permanent_not_a_raw_parse_throw`
- `HoldedClientReadTests.ListExpenseAccounts_surfaces_an_unreadable_account_as_permanent_not_a_raw_parse_throw`
- `HoldedClientReadTests.CreateExpenseAccount_surfaces_an_unreadable_response_as_permanent_not_a_raw_parse_throw`
- `HoldedClientContactTests.ListContacts_surfaces_an_unreadable_page_envelope_as_permanent_not_a_raw_parse_throw`

`dotnet test tests/Humans.Holded.Tests` — 73/73 passing (69 existing + 4 new).

Note: a full-solution `dotnet build Humans.slnx` was attempted but hit disk-space exhaustion
(H: drive at 98% full, unrelated Teams/Camps/Consent test-project resource-DLL copies failing)
— an environment condition from concurrent parallel worktrees, not from this change. The
`Humans.Holded` section project and `Humans.Holded.Tests` project both build and pass clean in
isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
