### PR TITLE
fix: route Search, Tour and Users' EventsCard through the section contribution seams

### DIFF
--- a/docs/features/global/section-activation.md
+++ b/docs/features/global/section-activation.md
@@ -65,21 +65,25 @@ validates nothing and cannot fail. With an allowlist present it throws
 
 Only references the compiler emits. A section named as a *string* — an
 `asp-controller="X"` link in a Razor view, `Component.InvokeAsync("Y")` — produces no
-assembly reference, so no reference-based scan can find it. Two shapes exist:
+assembly reference, so no reference-based scan can find it.
 
-- **Shell to section.** `_Layout.cshtml` links `Search` and `Tour` that way, and both are
-  real sections, so an allowlist can deactivate them: validation passes, the provider
-  removes the controller, the link 404s.
+nobodies-collective/Humans#1090 found two shapes of this and closed most of it:
+
+- **Shell to section.** `_Layout.cshtml` used to link `Search` and `Tour` that way. Both
+  are now `ISectionNav` contributions (`Humans.Search/SectionNav.cs`,
+  `Humans.Tour/SectionNav.cs`) — Shell no longer names either, so deactivating them is
+  invisible to Shell and safe.
 - **Section to section.** `Humans.Users/Views/Profile/Index.cshtml` and
-  `Humans.Camps/Views/Camp/Details.cshtml` both invoke Events' `EventsCard` by name, and
-  neither project references Events, so no graph edge records it. Deactivating Events with
-  either consumer active passes validation and throws on those pages at request time.
-
-Both are tracked as nobodies-collective/Humans#1090, which needs a decision rather than a
-patch: a string is invisible to any reference-based scan, and writing the names down is
-exactly what nobodies-collective/Humans#1073 exists to remove. The `<vc:chrome-slot>` and
-`ISectionContribution` seams the epic's lanes introduce are what turns these into real
-edges — a contributed component is discovered from the section's own assembly.
+  `Humans.Camps/Views/Camp/Details.cshtml` both invoke Events' `EventsCard` by name.
+  `Humans.Users` now references `Humans.Events` and renders it as `<vc:events-card>`, a
+  real, discovery-checked graph edge. `Humans.Camps` could not follow: `Humans.Events`
+  already references `Humans.Camps` (`EventsController` derives from
+  `HumansCampControllerBase`), so a `Camps → Events` reference would cycle. That call site
+  is still invoke-by-name and still invisible to the scan — deactivating Events while
+  Camps is active passes validation and throws on `Camp/Details` at request time. Fixing it
+  needs either breaking the existing `Events → Camps` reference (relocating
+  `HumansCampControllerBase`) or a generic runtime-availability mechanism; both are
+  design decisions, tracked in #1090.
 
 Shell pins **26 of the 42 shipped sections** today. Any allowlist must therefore contain
 those 26 plus the transitive closure of what they consume, which leaves activation useful

--- a/src/Humans.Base/Interfaces/ISectionNav.cs
+++ b/src/Humans.Base/Interfaces/ISectionNav.cs
@@ -13,6 +13,10 @@ namespace Humans.Base.Interfaces;
 /// children are gated by their own <paramref name="Policy"/>/<paramref name="Visible"/> the
 /// same way top-level items are. A child with <paramref name="Divider"/> set renders a
 /// dropdown-menu divider instead of a link, gated the same way as the group it introduces.
+/// <paramref name="IconCssClass"/>, when set, renders that icon instead of the localized
+/// label text on a top-level item — <paramref name="Label"/> still supplies the accessible
+/// name (<c>aria-label</c>/<c>title</c>), which is how the Search magnifying glass link
+/// stays icon-only.
 /// </remarks>
 public sealed record MemberNavItem(
     string Label,
@@ -24,7 +28,8 @@ public sealed record MemberNavItem(
     string? CssClass = null,
     Func<IServiceProvider, ClaimsPrincipal, bool>? Visible = null,
     IReadOnlyList<MemberNavItem>? Children = null,
-    bool Divider = false);
+    bool Divider = false,
+    string? IconCssClass = null);
 
 /// <summary>The member top-nav links a section contributes.</summary>
 public interface ISectionNav : ISectionContribution

--- a/src/Humans.Web/Views/Shared/Components/SectionNav/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/SectionNav/Default.cshtml
@@ -35,7 +35,18 @@
     else
     {
         <li class="nav-item">
-            @if (item.RawHref is not null)
+            @if (item.IconCssClass is not null)
+            {
+                @if (item.RawHref is not null)
+                {
+                    <a class="nav-link @item.CssClass" href="@item.RawHref" aria-label="@NavLocalizer[item.Label]" title="@NavLocalizer[item.Label]"><i class="@item.IconCssClass"></i></a>
+                }
+                else
+                {
+                    <a class="nav-link @item.CssClass" asp-area="" asp-controller="@item.Controller" asp-action="@item.Action" aria-label="@NavLocalizer[item.Label]" title="@NavLocalizer[item.Label]"><i class="@item.IconCssClass"></i></a>
+                }
+            }
+            else if (item.RawHref is not null)
             {
                 <a class="nav-link @item.CssClass" href="@item.RawHref">@NavLocalizer[item.Label]</a>
             }

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -78,29 +78,15 @@
                         var hasProfile = RoleAssignmentClaimsTransformation.IsActive(User);
                     }
                     <ul class="navbar-nav flex-grow-1">
-                        @if (isAuthenticated)
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-controller="Search" asp-action="Index"
-                                   aria-label="Search" title="Search">
-                                    <i class="fa-solid fa-magnifying-glass"></i>
-                                </a>
-                            </li>
-                        }
-                        @* Links sections contribute through ISectionNav; renders nothing while none do. *@
+                        @* Links sections contribute through ISectionNav; renders nothing while none do.
+                           Search and Tour are real sections (Humans.Search, Humans.Tour) and contribute
+                           their own nav links here rather than being named by this file — see
+                           nobodies-collective/Humans#1090. *@
                         <vc:section-nav />
                         @if (!isAuthenticated || !hasProfile)
                         {
                             <li class="nav-item">
                                 <a class="nav-link" asp-controller="Legal" asp-action="Index">Legal</a>
-                            </li>
-                        }
-                        @if (!isAuthenticated)
-                        {
-                            @* Anonymous-only: the signed-in top nav is too busy for a Tour slot —
-                               members get a dashboard tile instead (Home/Dashboard.cshtml). *@
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Tour" asp-action="Index">Tour</a>
                             </li>
                         }
                         <li class="nav-item" authorize-policy="AnyAdminRole">

--- a/src/Sections/Humans.Search/SectionNav.cs
+++ b/src/Sections/Humans.Search/SectionNav.cs
@@ -1,0 +1,24 @@
+using Humans.Base.Interfaces;
+
+namespace Humans.Search;
+
+/// <summary>
+/// Member top-nav contribution — was the icon-only magnifying-glass link Shell's
+/// <c>_Layout.cshtml</c> named by <c>asp-controller="Search"</c>
+/// (nobodies-collective/Humans#1090). Gated on plain authentication, not
+/// <see cref="Humans.Base.Authorization.PolicyNames.AppAccess"/> — search is available before
+/// a human has an active profile, unlike most nav items.
+/// </summary>
+internal sealed class SectionNav : ISectionNav
+{
+    public IEnumerable<MemberNavItem> Items() =>
+    [
+        new(
+            "Search",
+            Controller: "Search",
+            Action: "Index",
+            Weight: 0,
+            IconCssClass: "fa-solid fa-magnifying-glass",
+            Visible: (_, user) => user.Identity?.IsAuthenticated == true)
+    ];
+}

--- a/src/Sections/Humans.Tour/SectionNav.cs
+++ b/src/Sections/Humans.Tour/SectionNav.cs
@@ -1,0 +1,23 @@
+using Humans.Base.Interfaces;
+
+namespace Humans.Tour;
+
+/// <summary>
+/// Member top-nav contribution — was the anonymous-only Tour link Shell's
+/// <c>_Layout.cshtml</c> named by <c>asp-controller="Tour"</c>
+/// (nobodies-collective/Humans#1090). Anonymous-only: the signed-in top nav is too busy for
+/// a Tour slot — members get a dashboard tile instead (Home/Dashboard.cshtml). High weight so
+/// it sorts last among contributed nav links, closest to its previous position beside Legal.
+/// </summary>
+internal sealed class SectionNav : ISectionNav
+{
+    public IEnumerable<MemberNavItem> Items() =>
+    [
+        new(
+            "Tour",
+            Controller: "Tour",
+            Action: "Index",
+            Weight: 1000,
+            Visible: (_, user) => user.Identity?.IsAuthenticated != true)
+    ];
+}

--- a/src/Sections/Humans.Users/Humans.Users.csproj
+++ b/src/Sections/Humans.Users/Humans.Users.csproj
@@ -91,6 +91,16 @@
       nothing in Humans.Users.
     -->
     <ProjectReference Include="..\Humans.Camps\Humans.Camps.csproj" />
+    <!--
+      Views/Profile/Index.cshtml renders <vc:events-card />, whose EventsCardViewComponent is
+      public in Humans.Events/ViewComponents/ but whose tag helper Razor only generates from
+      the declaring assembly — @addTagHelper needs the assembly, not its Contracts leaf. Same
+      shape as the Humans.Camps reference above (nobodies-collective/Humans#1090 — the
+      invoke-by-name call this replaces produced no assembly reference, so the section
+      activation dependency graph could not see it). Acyclic — Humans.Events references
+      Humans.Users.Contracts, never this project.
+    -->
+    <ProjectReference Include="..\Humans.Events\Humans.Events.csproj" />
     <ProjectReference Include="..\Humans.AuditLog.Contracts\Humans.AuditLog.Contracts.csproj" />
     <!-- ProfileController injects IAuditViewerService and AdminDetail.cshtml renders
          <vc:audit-log>; both moved out of Humans.Application / Humans.UI into the AuditLog

--- a/src/Sections/Humans.Users/Views/Profile/Index.cshtml
+++ b/src/Sections/Humans.Users/Views/Profile/Index.cshtml
@@ -78,7 +78,7 @@
         }
 
         @* Approved personal (non-camp) events this human submitted this edition (auto-hidden when empty); camp events show on the camp's page *@
-        @await Component.InvokeAsync("EventsCard", new { userId = Model.UserId })
+        <vc:events-card user-id="@Model.UserId" />
 
         @if (!Model.IsOwnProfile && Model.CanViewShiftSignups)
         {

--- a/src/Sections/Humans.Users/Views/Profile/_ViewImports.cshtml
+++ b/src/Sections/Humans.Users/Views/Profile/_ViewImports.cshtml
@@ -36,9 +36,13 @@
 @addTagHelper *, Humans.Camps
 @* <vc:audit-log> (Index's sent-messages panel) is the AuditLog section's own component. *@
 @addTagHelper *, Humans.AuditLog
-@* No @addTagHelper for Humans.Web — a section RCL cannot reference the Shell. AccessMatrix
-   moved to Humans.UI (nobodies-collective/Humans#1056) and now binds as <vc:access-matrix>;
-   the still-Shell-owned components this page renders (EventsCard,
-   CommunicationPreferencesPanel) stay invoked by name until they move too. A <vc:> element
-   for an unimported assembly renders as inert markup with a green build and no runtime
-   error, so never add one without its @addTagHelper. *@
+@* <vc:events-card> is the Events section's own component (nobodies-collective/Humans#1090 —
+   was invoked by name, which produced no assembly reference for the section activation
+   dependency graph to see). *@
+@addTagHelper *, Humans.Events
+@* No @addTagHelper for Humans.Web — a section RCL cannot reference the Shell.
+   AccessMatrix moved to Humans.UI (nobodies-collective/Humans#1056) and now binds as
+   <vc:access-matrix>; the still-Shell-owned CommunicationPreferencesPanel stays invoked by
+   name until it moves too. A <vc:> element for an unimported assembly renders as inert
+   markup with a green build and no runtime error, so never add one without its
+   @addTagHelper. *@


### PR DESCRIPTION
Refs nobodies-collective/Humans#1090 — **partial; the issue stays open.** Search, Tour and the Users EventsCard call site are fixed. Camps' EventsCard call site is not, and needs an owner decision (see the owner-approval section below).

## Problem

`Sections:Active` validates the deactivation allowlist against a dependency graph derived
from real assembly references (nobodies-collective/Humans#1081). Four call sites named a
section only as a *string* — `asp-controller="X"` in Razor, `Component.InvokeAsync("Y")` —
which produces no assembly reference, so the graph could not see them. Deactivating the
named section passed validation and then 404'd or threw at request time:

- Shell → section: `_Layout.cshtml` linked `Search` and `Tour` by `asp-controller`.
- Section → section: `Humans.Users/Views/Profile/Index.cshtml` and
  `Humans.Camps/Views/Camp/Details.cshtml` both invoked Events' `EventsCard` view component
  by name (found by Codex on peterdrier#1389, per the issue comment).

## Fix

**Search and Tour** now contribute their own member-nav link via `ISectionNav`
(`Humans.Search/SectionNav.cs`, `Humans.Tour/SectionNav.cs`) — the same seam
nobodies-collective/Humans#1077 established. `_Layout.cshtml` no longer names either
section; `<vc:section-nav />` renders whatever active sections contribute. `MemberNavItem`
gained an optional `IconCssClass` (Search's magnifying glass is icon-only — `Label` still
supplies the `aria-label`/`title`).

One visible side effect for anonymous (not signed-in) visitors: Tour used to render after
Legal; it's now inside the section-nav block, which renders before Legal, so the two swap
order. Weighted last among today's nav contributions (1000) to sit as close to its old
position as the seam allows.

**Users → Events (`EventsCard` on the profile page)** now goes through a real project
reference (`Humans.Users.csproj` → `Humans.Events.csproj`) and the strongly-typed
`<vc:events-card user-id="..." />` tag helper, replacing the invoke-by-name call —
same shape as the existing `Humans.Camps`/`<vc:my-camps>` reference already in
`Humans.Users.csproj`. This is a real, discovery-checked graph edge: deactivating Events
while Users is active now fails `Sections:Active` validation at startup instead of throwing
on the profile page.

## Not fixed — Camps → Events (`EventsCard` on the camp detail page)

`Humans.Camps/Views/Camp/Details.cshtml` still calls
`Component.InvokeAsync("EventsCard", new { campId = Model.Id })` by name, unchanged.

The same fix (a `Humans.Camps.csproj` → `Humans.Events.csproj` reference plus
`<vc:events-card camp-id="..." />`) is blocked by an **existing cycle**:
`Humans.Events.csproj` already references `Humans.Camps.csproj` (`EventsController`
derives from `Humans.Camps`' `HumansCampControllerBase` so Workshop Leads can submit camp
events — see the reference's own comment in `Humans.Events.csproj`). Adding the reverse
reference is a circular project reference MSBuild refuses to build.

## Needs new interface surface — owner approval required

Closing the Camps → Events shape needs one of:

1. **Break the existing `Events → Camps` reference** — relocate `HumansCampControllerBase`
   (or the piece of it `EventsController` needs) somewhere both projects can reach
   acyclically. A real refactor of established, documented architecture, not a call-site fix.
2. **A generic runtime-availability mechanism** (issue's option 3: "render only when
   routable") — e.g. a tag helper or `Component.InvokeAsync` wrapper that checks
   `IViewComponentDescriptorCollectionProvider`/`IActionDescriptorCollectionProvider` before
   rendering, and skips silently when the target isn't currently registered. This is new
   shared Shell infrastructure with no existing precedent in this codebase.

Both are design decisions past "fix minimally" for a standard-tier issue. Left as-is per
the issue's own framing ("no derived fix exists inside #1081 itself... the decision
needed"); `docs/features/global/section-activation.md` now documents this remaining gap.
Recommend a follow-up issue scoped to this one call site once Peter picks a direction —
happy to open it if that's useful, or this PR's own issue can stay open against just this
piece.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors (35 pre-existing warnings, none from this
  change).
- `dotnet test` on `Humans.Web.Tests` (549), `Humans.Users.Tests` (543),
  `Humans.Events.Tests` (161), `Humans.Search.Tests` (33), `Humans.Integration.Tests` (286)
  — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
