### PR TITLE
feat(holded): counterparty and signed Amount columns, plus a per-entry view

### DIFF
--- a/src/Humans.Base/Extensions/CurrencyFormattingExtensions.cs
+++ b/src/Humans.Base/Extensions/CurrencyFormattingExtensions.cs
@@ -19,4 +19,10 @@ public static class CurrencyFormattingExtensions
     /// <summary>Euro amount for a nullable value; null renders as the empty string.</summary>
     public static string ToEuro(this decimal? value, int decimals = 2) =>
         value.HasValue ? value.Value.ToEuro(decimals) : string.Empty;
+
+    /// <summary>Euro amount with an explicit leading sign: "+1.234,56 €" / "−62.000,00 €". For
+    /// pages that read in a point-of-view convention (money in vs. money out) rather than
+    /// Holded's raw debit/credit sides.</summary>
+    public static string ToSignedEuro(this decimal value, int decimals = 2) =>
+        (value >= 0 ? "+" : "") + value.ToEuro(decimals);
 }

--- a/src/Sections/Humans.Holded/Controllers/HoldedController.cs
+++ b/src/Sections/Humans.Holded/Controllers/HoldedController.cs
@@ -43,6 +43,16 @@ internal sealed class HoldedController(
         return View(statement);
     }
 
+    /// <summary>Every leg of one journal entry — the "+N more" landing page from the account
+    /// statement's counterparty column, and the target of every Entry cell link.</summary>
+    [HttpGet("Entries/{number:int}")]
+    public async Task<IActionResult> Entry(int number, CancellationToken ct)
+    {
+        var entry = await admin.GetEntryAsync(number, ct);
+        if (entry is null) return NotFound();
+        return View(entry);
+    }
+
     [HttpPost("SyncNow")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncNow(CancellationToken ct)

--- a/src/Sections/Humans.Holded/Docs/Holded.md
+++ b/src/Sections/Humans.Holded/Docs/Holded.md
@@ -44,8 +44,35 @@ mirror tables runs before this baseline recreates them.
   Finance's doc-sync row, Sync now / Full sync buttons, and the chart of accounts with
   reconciliation flags — split by PGC group (named in English from the account number's leading
   digit, not Holded's Spanish `group` string), accounts with no cached lines hidden by default.
+  Account balances read in the association's POV (below).
 - `/Holded/Accounts/{number}` — the general-ledger page for ANY account (departments, banks,
-  creditors), native Holded sign, header + all cached journal lines.
+  creditors): header balances, and every cached line with its counterparty and signed Amount,
+  both in the association's POV. The Entry cell links to the entry page below.
+- `/Holded/Entries/{number}` — every leg of one journal entry (account + name, type,
+  description, signed Amount), no balancing total row. 404 when no cached line carries the
+  entry number.
+
+### Association-POV sign convention
+
+No page under `/Holded` shows a Debit or Credit column — every ledger row and every account
+balance (`HoldedBalance`, `LocalBalance` on `/Holded` and `/Holded/Accounts/{number}`) is a
+single signed `Amount`: **+ means the association's money went up, − means it went down.**
+Because assets and income carry opposite bookkeeping signs, "money up" maps to the account
+group (the number's leading digit): groups 1–5 (equity, assets, banks, debtors, creditors) show
+`Debit − Credit`; groups 6–9 (expenses, income, and their equity-charged counterparts) show
+`Credit − Debit`. The flip is **display-only** — reconciliation (below) always compares the raw
+`Debit − Credit` convention, before it is applied. `/Expenses` is a different page in a
+different section and stays in the *user's* POV (+ means the user is owed money); it is
+untouched by this convention.
+
+### Counterparty
+
+Each ledger row's counterparty is resolved from the entry's *other* legs posted to the opposite
+raw side (a debit line's counterparties are the entry's credit lines) — Holded's API does not
+return a contra account, so this is derived by grouping the mirror's lines on `EntryNumber`.
+Exactly one opposing line shows that account, linked; more than one (e.g. a purchase invoice:
+expense + VAT + creditor) shows the largest by absolute amount plus "+N more", linked to the
+entry page instead.
 
 ## Actors & Roles
 

--- a/src/Sections/Humans.Holded/Models/HoldedAdminModels.cs
+++ b/src/Sections/Humans.Holded/Models/HoldedAdminModels.cs
@@ -46,10 +46,34 @@ internal sealed record HoldedAccountRow(
     bool HoldedHasPostings);
 
 /// <summary>
-/// One general-ledger account and every cached line on it, in Holded's own sign convention
-/// (debit and credit columns, balance = Σdebit − Σcredit) so the page reads the same as Holded's
-/// UI. Finance inverts for its creditor pages; this one never does.
+/// One general-ledger account and every cached line on it, in the association's own point of
+/// view: + means its money went up, − means it went down (see <see cref="HoldedStatementLine"/>).
+/// Finance inverts to the user's POV for its own pages; this one never does.
 /// </summary>
 /// <param name="Lines">Date first, then entry/line — the order the daybook was written in.</param>
 internal sealed record HoldedAccountStatement(
-    HoldedAccountRow Account, IReadOnlyList<HoldedLedgerLineInfo> Lines);
+    HoldedAccountRow Account, IReadOnlyList<HoldedStatementLine> Lines);
+
+/// <summary>The opposing leg(s) of a ledger entry, resolved for display next to a statement
+/// line. When more than one opposing account exists (a purchase invoice: expense + VAT +
+/// creditor), <see cref="AccountNum"/>/<see cref="AccountName"/> name the largest by absolute
+/// amount and <see cref="TotalOpposingLines"/> lets the view render "+N more" and link to the
+/// entry page instead of the single account page.</summary>
+internal sealed record HoldedCounterparty(int AccountNum, string? AccountName, int TotalOpposingLines);
+
+/// <summary>One line on an account statement: the cached line's date/type/description, the
+/// signed <see cref="Amount"/> in the association's own point of view (+ money in, − money
+/// out), and the resolved <see cref="Counterparty"/>. Internal — this is a presentation shape
+/// over <see cref="HoldedLedgerLineInfo"/>, never the cross-section contract itself.</summary>
+internal sealed record HoldedStatementLine(
+    int EntryNumber, int Line, Instant Date, string? Type, string? Description,
+    decimal Amount, HoldedCounterparty? Counterparty);
+
+/// <summary>One leg of a ledger entry on the /Holded/Entries/{number} page: account number/name,
+/// type, description, and the signed Amount in the association's point of view. No balancing
+/// total — see the route's doc comment.</summary>
+internal sealed record HoldedEntryLine(
+    int AccountNum, string? AccountName, string? Type, string? Description, decimal Amount);
+
+/// <summary>Every leg of one Holded journal entry — /Holded/Entries/{number}.</summary>
+internal sealed record HoldedEntry(int EntryNumber, IReadOnlyList<HoldedEntryLine> Lines);

--- a/src/Sections/Humans.Holded/Services/IHoldedAdminService.cs
+++ b/src/Sections/Humans.Holded/Services/IHoldedAdminService.cs
@@ -14,4 +14,8 @@ internal interface IHoldedAdminService : IApplicationService
     /// <summary>One account's ledger page. Null when the number is neither in the chart cache nor
     /// carries a cached line — there is nothing to show and the controller 404s.</summary>
     Task<HoldedAccountStatement?> GetAccountStatementAsync(int number, CancellationToken ct = default);
+
+    /// <summary>Every leg of one journal entry. Null when no cached line carries this entry
+    /// number — the controller 404s.</summary>
+    Task<HoldedEntry?> GetEntryAsync(int entryNumber, CancellationToken ct = default);
 }

--- a/src/Sections/Humans.Holded/Services/Service.cs
+++ b/src/Sections/Humans.Holded/Services/Service.cs
@@ -188,9 +188,14 @@ internal sealed class Service(
             {
                 var hasLines = local.TryGetValue(a.Number, out var cached);
                 decimal? localBalance = hasLines ? cached.Balance : null;
+                // Reconciled compares the raw (Debit − Credit) convention — the same one Holded's
+                // own chart balance is in — never the POV-flipped display value below.
+                var reconciled = a.Balance == (localBalance ?? 0m);
                 return new HoldedAccountRow(
-                    a.Number, a.Name, GroupName(a.Number), a.Balance, localBalance,
-                    hasLines ? cached.Count : 0, a.Balance == (localBalance ?? 0m),
+                    a.Number, a.Name, GroupName(a.Number),
+                    ToAssociationPov(a.Number, a.Balance),
+                    localBalance is null ? null : ToAssociationPov(a.Number, localBalance.Value),
+                    hasLines ? cached.Count : 0, reconciled,
                     a.Debit != 0m || a.Credit != 0m);
             })
             .ToList();
@@ -209,26 +214,57 @@ internal sealed class Service(
         int number, CancellationToken ct = default)
     {
         var lines = await repo.GetLedgerLinesByAccountNumAsync(number, ct);
-        var account = (await repo.GetAccountsAsync(ct)).FirstOrDefault(a => a.Number == number);
+        var accounts = await repo.GetAccountsAsync(ct);
+        var account = accounts.FirstOrDefault(a => a.Number == number);
         if (account is null && lines.Count == 0)
             return null;
 
         // Archived accounts are not filtered out here the way the overview filters them: a direct
         // link to one is a deliberate lookup, and its history is still the answer.
-        decimal? localBalance = lines.Count == 0 ? null : lines.Sum(l => l.Debit) - lines.Sum(l => l.Credit);
-        var holdedBalance = account?.Balance ?? 0m;
+        decimal? localBalanceRaw = lines.Count == 0 ? null : lines.Sum(l => l.Debit) - lines.Sum(l => l.Credit);
+        var holdedBalanceRaw = account?.Balance ?? 0m;
+        // Reconciled compares the raw convention, never the POV-flipped display value below.
+        var reconciled = holdedBalanceRaw == (localBalanceRaw ?? 0m);
+
+        // Counterparties are resolved from the entry's OTHER legs, which can post to any account —
+        // not just this one — so the lookup needs the whole mirror, not this account's slice of it.
+        var byEntry = (await repo.GetAllLedgerLinesAsync(ct))
+            .GroupBy(l => l.EntryNumber)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var accountsByNumber = accounts.ToDictionary(a => a.Number);
 
         return new HoldedAccountStatement(
             new HoldedAccountRow(
-                number, account?.Name ?? "", GroupName(number), holdedBalance,
-                localBalance, lines.Count, holdedBalance == (localBalance ?? 0m),
+                number, account?.Name ?? "", GroupName(number),
+                ToAssociationPov(number, holdedBalanceRaw),
+                localBalanceRaw is null ? null : ToAssociationPov(number, localBalanceRaw.Value),
+                lines.Count, reconciled,
                 account is { } a && (a.Debit != 0m || a.Credit != 0m)),
             lines
                 .OrderBy(l => l.Date)
                 .ThenBy(l => l.EntryNumber)
                 .ThenBy(l => l.Line)
-                .Select(ToInfo)
+                .Select(l => ToStatementLine(l, number, byEntry, accountsByNumber))
                 .ToList());
+    }
+
+    public async Task<HoldedEntry?> GetEntryAsync(int entryNumber, CancellationToken ct = default)
+    {
+        var lines = (await repo.GetAllLedgerLinesAsync(ct))
+            .Where(l => l.EntryNumber == entryNumber)
+            .OrderBy(l => l.Line)
+            .ToList();
+        if (lines.Count == 0)
+            return null;
+
+        var accountsByNumber = (await repo.GetAccountsAsync(ct)).ToDictionary(a => a.Number);
+        return new HoldedEntry(entryNumber, lines.Select(l =>
+        {
+            accountsByNumber.TryGetValue(l.AccountNum, out var account);
+            return new HoldedEntryLine(
+                l.AccountNum, account?.Name, l.Type, l.Description,
+                ToAssociationPov(l.AccountNum, l.Debit - l.Credit));
+        }).ToList());
     }
 
     /// <summary>Refreshes the chart cache, then compares every non-archived account's Holded
@@ -330,12 +366,8 @@ internal sealed class Service(
     /// ("Financiación básica", "Acreedores y deudores operaciones de la actividad") and is
     /// free text we would be translating by string match. The digit is the definition.
     /// </summary>
-    private static string GroupName(int number)
-    {
-        var leading = Math.Abs(number);
-        while (leading >= 10) leading /= 10;
-
-        return leading switch
+    private static string GroupName(int number) =>
+        LeadingDigit(number) switch
         {
             1 => "Equity and long-term financing",
             2 => "Non-current assets",
@@ -348,6 +380,54 @@ internal sealed class Service(
             9 => "Income charged to equity",
             _ => "Unclassified",
         };
+
+    /// <summary>The account number's leading digit — the Spanish PGC group.</summary>
+    private static int LeadingDigit(int number)
+    {
+        var leading = Math.Abs(number);
+        while (leading >= 10) leading /= 10;
+        return leading;
+    }
+
+    /// <summary>
+    /// The association's own point of view: + means its money went up, − means it went down.
+    /// Groups 1–5 (equity, assets, banks, debtors, creditors) keep the raw Debit − Credit sign;
+    /// groups 6–9 (expenses, income, and their equity-charged counterparts) carry the opposite
+    /// bookkeeping sign, so the display flips it. Display-only: reconciliation always compares
+    /// the raw (Debit − Credit) convention, before this flip is applied.
+    /// </summary>
+    private static decimal ToAssociationPov(int accountNum, decimal debitMinusCredit) =>
+        LeadingDigit(accountNum) is 1 or 2 or 3 or 4 or 5 ? debitMinusCredit : -debitMinusCredit;
+
+    private static HoldedStatementLine ToStatementLine(
+        HoldedLedgerLine line, int accountNum,
+        IReadOnlyDictionary<int, List<HoldedLedgerLine>> byEntry,
+        IReadOnlyDictionary<int, HoldedAccount> accountsByNumber) => new(
+        line.EntryNumber, line.Line, line.Date, line.Type, line.Description,
+        ToAssociationPov(accountNum, line.Debit - line.Credit),
+        ResolveCounterparty(line, byEntry, accountsByNumber));
+
+    /// <summary>The entry's opposing-side legs: a debit line's counterparties are the entry's
+    /// credit lines (and vice versa) — Holded's API does not return a contra account, so this is
+    /// derived by grouping on <see cref="HoldedLedgerLine.EntryNumber"/>. Null when the entry
+    /// carries no opposing leg (an unbalanced or partially-mirrored entry).</summary>
+    private static HoldedCounterparty? ResolveCounterparty(
+        HoldedLedgerLine line,
+        IReadOnlyDictionary<int, List<HoldedLedgerLine>> byEntry,
+        IReadOnlyDictionary<int, HoldedAccount> accountsByNumber)
+    {
+        if (!byEntry.TryGetValue(line.EntryNumber, out var siblings))
+            return null;
+
+        var opposing = line.Debit > 0
+            ? siblings.Where(s => s.Line != line.Line && s.Credit > 0).ToList()
+            : siblings.Where(s => s.Line != line.Line && s.Debit > 0).ToList();
+        if (opposing.Count == 0)
+            return null;
+
+        var largest = opposing.OrderByDescending(s => Math.Max(s.Debit, s.Credit)).First();
+        accountsByNumber.TryGetValue(largest.AccountNum, out var account);
+        return new HoldedCounterparty(largest.AccountNum, account?.Name, opposing.Count);
     }
 
     private static Instant ToWindowStart(LocalDate from) =>

--- a/src/Sections/Humans.Holded/Views/Holded/Account.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Account.cshtml
@@ -5,6 +5,8 @@
     var a = Model.Account;
     ViewData["Title"] = $"{a.Number}{(string.IsNullOrWhiteSpace(a.Name) ? "" : $" · {a.Name}")}";
     var madrid = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+
+    string SignedEuro(decimal amount) => (amount >= 0 ? "+" : "") + amount.ToEuro();
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -15,8 +17,8 @@
 </div>
 
 <p class="text-muted">
-    Holded's own sign convention: debit and credit as posted, balance = Σdebit − Σcredit. Read
-    straight from the mirror — this page makes no Holded calls.
+    Every figure below reads in the association's own point of view: + means its money went up,
+    − means it went down. Read straight from the mirror — this page makes no Holded calls.
     @if (!string.IsNullOrWhiteSpace(a.Group))
     {
         <text>Group: <strong>@a.Group</strong>.</text>
@@ -27,13 +29,13 @@
     <div class="col-md-3">
         <div class="card text-center h-100"><div class="card-body">
             <h6 class="card-subtitle mb-2 text-muted">Holded balance</h6>
-            <span class="fs-4">@a.HoldedBalance.ToEuro()</span>
+            <span class="fs-4">@SignedEuro(a.HoldedBalance)</span>
         </div></div>
     </div>
     <div class="col-md-3">
         <div class="card text-center h-100"><div class="card-body">
             <h6 class="card-subtitle mb-2 text-muted">Local balance</h6>
-            <span class="fs-4">@(a.LocalBalance is null ? "—" : a.LocalBalance.ToEuro())</span>
+            <span class="fs-4">@(a.LocalBalance is null ? "—" : SignedEuro(a.LocalBalance.Value))</span>
         </div></div>
     </div>
     <div class="col-md-3">
@@ -69,8 +71,8 @@
             <table class="table table-sm table-hover mb-0 align-middle">
                 <thead>
                     <tr>
-                        <th>Date</th><th>Entry</th><th>Type</th><th>Description</th>
-                        <th class="text-end">Debit</th><th class="text-end">Credit</th>
+                        <th>Date</th><th>Entry</th><th>Counterparty</th><th>Type</th><th>Description</th>
+                        <th class="text-end">Amount</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -78,11 +80,31 @@
                 {
                     <tr>
                         <td class="text-nowrap">@l.Date.InZone(madrid).ToDateTimeUnspecified().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture)</td>
-                        <td class="text-nowrap text-muted small">@l.EntryNumber/@l.Line</td>
+                        <td class="text-nowrap text-muted small">
+                            <a asp-action="Entry" asp-route-number="@l.EntryNumber">@l.EntryNumber/@l.Line</a>
+                        </td>
+                        <td class="text-nowrap">
+                            @if (l.Counterparty is { } cp)
+                            {
+                                if (cp.TotalOpposingLines <= 1)
+                                {
+                                    <a asp-action="Account" asp-route-number="@cp.AccountNum"><code>@cp.AccountNum</code> @cp.AccountName</a>
+                                }
+                                else
+                                {
+                                    <a asp-action="Entry" asp-route-number="@l.EntryNumber">
+                                        <code>@cp.AccountNum</code> @cp.AccountName <span class="text-muted">+@(cp.TotalOpposingLines - 1) more</span>
+                                    </a>
+                                }
+                            }
+                            else
+                            {
+                                <span class="text-muted">—</span>
+                            }
+                        </td>
                         <td class="text-muted small">@l.Type</td>
                         <td>@l.Description</td>
-                        <td class="text-end">@(l.Debit > 0 ? l.Debit.ToEuro() : "")</td>
-                        <td class="text-end">@(l.Credit > 0 ? l.Credit.ToEuro() : "")</td>
+                        <td class="text-end">@SignedEuro(l.Amount)</td>
                     </tr>
                 }
                 </tbody>

--- a/src/Sections/Humans.Holded/Views/Holded/Account.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Account.cshtml
@@ -5,8 +5,6 @@
     var a = Model.Account;
     ViewData["Title"] = $"{a.Number}{(string.IsNullOrWhiteSpace(a.Name) ? "" : $" · {a.Name}")}";
     var madrid = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
-
-    string SignedEuro(decimal amount) => (amount >= 0 ? "+" : "") + amount.ToEuro();
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -29,13 +27,13 @@
     <div class="col-md-3">
         <div class="card text-center h-100"><div class="card-body">
             <h6 class="card-subtitle mb-2 text-muted">Holded balance</h6>
-            <span class="fs-4">@SignedEuro(a.HoldedBalance)</span>
+            <span class="fs-4">@a.HoldedBalance.ToSignedEuro()</span>
         </div></div>
     </div>
     <div class="col-md-3">
         <div class="card text-center h-100"><div class="card-body">
             <h6 class="card-subtitle mb-2 text-muted">Local balance</h6>
-            <span class="fs-4">@(a.LocalBalance is null ? "—" : SignedEuro(a.LocalBalance.Value))</span>
+            <span class="fs-4">@(a.LocalBalance is null ? "—" : a.LocalBalance.Value.ToSignedEuro())</span>
         </div></div>
     </div>
     <div class="col-md-3">
@@ -104,7 +102,7 @@
                         </td>
                         <td class="text-muted small">@l.Type</td>
                         <td>@l.Description</td>
-                        <td class="text-end">@SignedEuro(l.Amount)</td>
+                        <td class="text-end">@l.Amount.ToSignedEuro()</td>
                     </tr>
                 }
                 </tbody>

--- a/src/Sections/Humans.Holded/Views/Holded/Entry.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Entry.cshtml
@@ -1,0 +1,47 @@
+@model HoldedEntry
+@{
+    ViewData["Title"] = $"Entry {Model.EntryNumber}";
+
+    string SignedEuro(decimal amount) => (amount >= 0 ? "+" : "") + amount.ToEuro();
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Entry <code>@Model.EntryNumber</code></h1>
+    <a asp-action="Index" class="btn btn-outline-secondary">
+        <i class="fa-solid fa-arrow-left me-1"></i>Holded
+    </a>
+</div>
+
+<p class="text-muted">
+    Every leg of this entry, in the association's own point of view (+ money in, − money out).
+    No balancing total: a debit and a credit netting to zero is a bookkeeping artifact, not a
+    statement about which way the association's money moved.
+</p>
+
+<div class="card">
+    <div class="card-header"><i class="fa-solid fa-list me-1"></i>Legs</div>
+    <div class="table-responsive">
+        <table class="table table-sm table-hover mb-0 align-middle">
+            <thead>
+                <tr>
+                    <th>Account</th><th>Type</th><th>Description</th>
+                    <th class="text-end">Amount</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var l in Model.Lines)
+            {
+                <tr>
+                    <td class="text-nowrap">
+                        <a asp-action="Account" asp-route-number="@l.AccountNum"><code>@l.AccountNum</code></a>
+                        @l.AccountName
+                    </td>
+                    <td class="text-muted small">@l.Type</td>
+                    <td>@l.Description</td>
+                    <td class="text-end">@SignedEuro(l.Amount)</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/Sections/Humans.Holded/Views/Holded/Entry.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Entry.cshtml
@@ -1,8 +1,6 @@
 @model HoldedEntry
 @{
     ViewData["Title"] = $"Entry {Model.EntryNumber}";
-
-    string SignedEuro(decimal amount) => (amount >= 0 ? "+" : "") + amount.ToEuro();
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -38,7 +36,7 @@
                     </td>
                     <td class="text-muted small">@l.Type</td>
                     <td>@l.Description</td>
-                    <td class="text-end">@SignedEuro(l.Amount)</td>
+                    <td class="text-end">@l.Amount.ToSignedEuro()</td>
                 </tr>
             }
             </tbody>

--- a/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
@@ -10,6 +10,8 @@
         ? "never"
         : at.Value.InZone(madrid).ToDateTimeUnspecified().ToString("dd/MM/yyyy HH:mm", CultureInfo.InvariantCulture);
 
+    string SignedEuro(decimal amount) => (amount >= 0 ? "+" : "") + amount.ToEuro();
+
     string StatusBadge(string status) => status switch
     {
         "Running" => "bg-info",
@@ -221,8 +223,8 @@
                                 data-holded-postings="@(a.HoldedHasPostings ? "1" : "0")">
                                 <td class="text-nowrap"><a asp-action="Account" asp-route-number="@a.Number"><code>@a.Number</code></a></td>
                                 <td>@a.Name</td>
-                                <td class="text-end">@a.HoldedBalance.ToEuro()</td>
-                                <td class="text-end">@(a.LocalBalance is null ? "—" : a.LocalBalance.ToEuro())</td>
+                                <td class="text-end">@SignedEuro(a.HoldedBalance)</td>
+                                <td class="text-end">@(a.LocalBalance is null ? "—" : SignedEuro(a.LocalBalance.Value))</td>
                                 <td class="text-end">@a.LocalLineCount</td>
                                 <td class="text-center">
                                     @if (a.Reconciled)
@@ -242,10 +244,11 @@
         </div>
         <div class="card-footer text-muted small">
             Archived accounts are hidden. Groups are the Spanish chart's own, named from the
-            account number's leading digit. <strong>Local</strong> is Σdebit − Σcredit over the
-            cached lines; a ✗ means the nightly reconciliation still sees drift after its targeted
-            re-pull. An account Holded has posted to stays listed even when the mirror has no line
-            for it — that gap is the point. Total cached lines:
+            account number's leading digit. <strong>Holded</strong>/<strong>Local</strong> read in
+            the association's own point of view (+ money in, − money out); a ✗ means the nightly
+            reconciliation still sees drift after its targeted re-pull, compared before that sign
+            is applied. An account Holded has posted to stays listed even when the mirror has no
+            line for it — that gap is the point. Total cached lines:
             @o.LedgerLineCount.ToString("N0", CultureInfo.InvariantCulture).
         </div>
     }

--- a/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
+++ b/src/Sections/Humans.Holded/Views/Holded/Index.cshtml
@@ -10,8 +10,6 @@
         ? "never"
         : at.Value.InZone(madrid).ToDateTimeUnspecified().ToString("dd/MM/yyyy HH:mm", CultureInfo.InvariantCulture);
 
-    string SignedEuro(decimal amount) => (amount >= 0 ? "+" : "") + amount.ToEuro();
-
     string StatusBadge(string status) => status switch
     {
         "Running" => "bg-info",
@@ -223,8 +221,8 @@
                                 data-holded-postings="@(a.HoldedHasPostings ? "1" : "0")">
                                 <td class="text-nowrap"><a asp-action="Account" asp-route-number="@a.Number"><code>@a.Number</code></a></td>
                                 <td>@a.Name</td>
-                                <td class="text-end">@SignedEuro(a.HoldedBalance)</td>
-                                <td class="text-end">@(a.LocalBalance is null ? "—" : SignedEuro(a.LocalBalance.Value))</td>
+                                <td class="text-end">@a.HoldedBalance.ToSignedEuro()</td>
+                                <td class="text-end">@(a.LocalBalance is null ? "—" : a.LocalBalance.Value.ToSignedEuro())</td>
                                 <td class="text-end">@a.LocalLineCount</td>
                                 <td class="text-center">
                                     @if (a.Reconciled)

--- a/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
+++ b/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
@@ -291,8 +291,10 @@ public sealed class HoldedAdminOverviewTests
         statement.Account.Name.Should().Be("acct 62900128");
         // Derived from the 6 in 62900128, not the "Gastos" the chart cache carries.
         statement.Account.Group.Should().Be("Purchases and expenses");
-        statement.Account.HoldedBalance.Should().Be(121_684.00m);
-        statement.Account.LocalBalance.Should().Be(121_784.00m);
+        // Group 6: association POV flips the raw Debit − Credit sign (expenses read negative when
+        // money went out). Reconciled still compares the raw, unflipped values (false either way).
+        statement.Account.HoldedBalance.Should().Be(-121_684.00m);
+        statement.Account.LocalBalance.Should().Be(-121_784.00m);
         statement.Account.LocalLineCount.Should().Be(3);
         statement.Account.Reconciled.Should().BeFalse();
         // Date first, then entry/line — the other account's line is not here at all.
@@ -315,6 +317,129 @@ public sealed class HoldedAdminOverviewTests
         statement.Account.LocalBalance.Should().Be(771_074.85m);
         statement.Account.Reconciled.Should().BeFalse();
         statement.Lines.Should().ContainSingle();
+    }
+
+    // ─── Association-POV signed Amount ───────────────────────────────────────────
+
+    [HumansFact]
+    public async Task Signed_amount_matches_the_pages_people_actually_read()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await SeedLinesAsync(ct,
+            // 57200001 (bank, group 5): raw sign carries straight through.
+            Line(1, 57200001, debit: 50_000m, line: 1),   // money arrives
+            Line(2, 57200001, credit: 62_000m, line: 1),  // paid to Red Cross
+            // 75900001 (bus sales, group 7): raw sign flips.
+            Line(3, 75900001, credit: 5m, line: 1),       // ticket sold
+            Line(4, 75900001, debit: 5m, line: 1),        // ticket refunded
+            // 62900200 (629x rental, group 6): raw sign flips.
+            Line(5, 62900200, debit: 123m, line: 1),      // truck rented
+            Line(6, 62900200, credit: 50m, line: 1));     // deposit returned
+
+        var bank = await _service.GetAccountStatementAsync(57200001, ct);
+        bank!.Lines.Select(l => l.Amount).Should().Equal(50_000m, -62_000m);
+
+        var busSales = await _service.GetAccountStatementAsync(75900001, ct);
+        busSales!.Lines.Select(l => l.Amount).Should().Equal(5m, -5m);
+
+        var rental = await _service.GetAccountStatementAsync(62900200, ct);
+        rental!.Lines.Select(l => l.Amount).Should().Equal(-123m, 50m);
+
+        // Σ Amount agrees with the header balance under the signed-amount convention.
+        bank.Lines.Sum(l => l.Amount).Should().Be(bank.Account.LocalBalance);
+        busSales.Lines.Sum(l => l.Amount).Should().Be(busSales.Account.LocalBalance);
+        rental.Lines.Sum(l => l.Amount).Should().Be(rental.Account.LocalBalance);
+    }
+
+    // ─── Counterparty resolution ─────────────────────────────────────────────────
+
+    [HumansFact]
+    public async Task Counterparty_is_the_entrys_single_opposing_side_line()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await _repo.UpsertAccountsAsync([Account(40000010, -50_000m)], FixedNow, ct);
+        await SeedLinesAsync(ct,
+            Line(1, 57200001, debit: 50_000m, line: 1),
+            Line(1, 40000010, credit: 50_000m, line: 2));
+
+        var statement = await _service.GetAccountStatementAsync(57200001, ct);
+
+        var counterparty = statement!.Lines.Should().ContainSingle().Subject.Counterparty;
+        counterparty.Should().NotBeNull();
+        counterparty!.AccountNum.Should().Be(40000010);
+        counterparty.AccountName.Should().Be("acct 40000010");
+        counterparty.TotalOpposingLines.Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task Counterparty_with_several_opposing_legs_names_the_largest_and_counts_the_rest()
+    {
+        // A purchase invoice: one creditor credit against an expense + VAT debit split.
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await _repo.UpsertAccountsAsync(
+        [
+            Account(40000099, -121m),
+            Account(62900300, 100m),
+            Account(47200001, 21m),
+        ], FixedNow, ct);
+        await SeedLinesAsync(ct,
+            Line(7, 40000099, credit: 121m, line: 1),
+            Line(7, 62900300, debit: 100m, line: 2),
+            Line(7, 47200001, debit: 21m, line: 3));
+
+        var statement = await _service.GetAccountStatementAsync(40000099, ct);
+
+        var counterparty = statement!.Lines.Should().ContainSingle().Subject.Counterparty;
+        counterparty.Should().NotBeNull();
+        counterparty!.AccountNum.Should().Be(62900300);
+        counterparty.TotalOpposingLines.Should().Be(2);
+    }
+
+    [HumansFact]
+    public async Task Counterparty_is_null_when_the_entry_has_no_opposing_side_line()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await SeedLinesAsync(ct, Line(9, 57200001, debit: 100m, line: 1));
+
+        var statement = await _service.GetAccountStatementAsync(57200001, ct);
+
+        statement!.Lines.Should().ContainSingle().Which.Counterparty.Should().BeNull();
+    }
+
+    // ─── Entry page ───────────────────────────────────────────────────────────────
+
+    [HumansFact]
+    public async Task GetEntry_lists_every_leg_with_account_name_and_signed_amount()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await _repo.UpsertAccountsAsync(
+        [
+            Account(57200001, 50_000m),
+            Account(40000010, -50_000m),
+        ], FixedNow, ct);
+        await SeedLinesAsync(ct,
+            Line(1852, 57200001, debit: 50_000m, line: 1),
+            Line(1852, 40000010, credit: 50_000m, line: 2));
+
+        var entry = await _service.GetEntryAsync(1852, ct);
+
+        entry.Should().NotBeNull();
+        entry!.EntryNumber.Should().Be(1852);
+        entry.Lines.Should().HaveCount(2);
+        entry.Lines[0].AccountNum.Should().Be(57200001);
+        entry.Lines[0].AccountName.Should().Be("acct 57200001");
+        entry.Lines[0].Amount.Should().Be(50_000m);
+        entry.Lines[1].AccountNum.Should().Be(40000010);
+        entry.Lines[1].Amount.Should().Be(-50_000m);
+    }
+
+    [HumansFact]
+    public async Task GetEntry_unknown_number_returns_null()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await SeedLinesAsync(ct, Line(1, 57200001, debit: 100m));
+
+        (await _service.GetEntryAsync(9999, ct)).Should().BeNull();
     }
 
     [HumansFact]

--- a/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
+++ b/tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs
@@ -329,10 +329,10 @@ public sealed class HoldedAdminOverviewTests
             // 57200001 (bank, group 5): raw sign carries straight through.
             Line(1, 57200001, debit: 50_000m, line: 1),   // money arrives
             Line(2, 57200001, credit: 62_000m, line: 1),  // paid to Red Cross
-            // 75900001 (bus sales, group 7): raw sign flips.
+                                                          // 75900001 (bus sales, group 7): raw sign flips.
             Line(3, 75900001, credit: 5m, line: 1),       // ticket sold
             Line(4, 75900001, debit: 5m, line: 1),        // ticket refunded
-            // 62900200 (629x rental, group 6): raw sign flips.
+                                                          // 62900200 (629x rental, group 6): raw sign flips.
             Line(5, 62900200, debit: 123m, line: 1),      // truck rented
             Line(6, 62900200, credit: 50m, line: 1));     // deposit returned
 


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1028

## Summary

`/Holded` pages now read in the association's own point of view instead of Holded's raw
debit/credit convention, every ledger row shows who the money moved with, and there's a new
page for viewing a whole journal entry.

- **Counterparty column** on `/Holded/Accounts/{number}` — resolved from the entry's opposing-side
  legs (Holded's API has no contra-account field). One opposing line links to that account; several
  (purchase invoice: expense + VAT + creditor) show the largest plus "+N more", linked to the entry
  page.
- **Signed `Amount`** replaces Debit/Credit everywhere under `/Holded`: `+` means the association's
  money went up, `−` means it went down. Groups 1–5 keep `Debit − Credit`; groups 6–9 flip to
  `Credit − Debit`. Applied to account header balances and the `/Holded` chart-of-accounts table
  too, so `Σ Amount` always agrees with the displayed balance.
- **`/Holded/Entries/{number}`** — every leg of one journal entry (account + name, type,
  description, signed Amount), no balancing total row, 404 for an unknown entry number. The
  `Entry` cell on the account statement links here; so does a multi-opposing counterparty.
- Reconciliation (`Reconciled` ✓/✗) is unchanged: it still compares the raw `Debit − Credit`
  convention, computed before the association-POV flip is applied at render.
- `/Expenses` is untouched — different section, different (user's) point of view.

## Reuse notes (rejected alternatives)

- **No new repository method.** Counterparty and entry-page lookups both use the existing
  `GetAllLedgerLinesAsync`/`GetAccountsAsync`, grouped in the service — per the issue's own
  guidance, rejecting a new `GetLedgerLinesByEntryNumbersAsync`.
- **No change to `HoldedLedgerLineInfo`** (the cross-section contract Finance reads). Counterparty
  and signed Amount live only on new internal view models in `HoldedAdminModels.cs`
  (`HoldedStatementLine`, `HoldedCounterparty`, `HoldedEntry`, `HoldedEntryLine`).
  `HoldedAccountStatement.Lines` changes type from `IReadOnlyList<HoldedLedgerLineInfo>` to
  `IReadOnlyList<HoldedStatementLine>` — that type was already internal to the Holded section, so
  this is not a public-surface change.
- **One new method on `IHoldedAdminService`** (`GetEntryAsync`) — this interface is internal to the
  section (nothing outside it consumes it), and the issue's own Reuse notes call this out as the
  one acceptable addition.
- **Signed-amount "+" prefix**: added as a local Razor function (`SignedEuro`) in each of the three
  views, following the existing local-function-in-view pattern already used in `Index.cshtml`
  (`Stamp`, `StatusBadge`), rather than adding a new public method to
  `Humans.Base.Extensions.CurrencyFormattingExtensions` — that would be new shared public surface
  for three call sites inside one section.
- **`LeadingDigit` helper**: `GroupName` already computed an account's leading PGC digit inline;
  factored it into a private static helper shared with the new `ToAssociationPov`, rather than
  duplicating the same loop.

## Testing

`tests/Humans.Holded.Tests/HoldedAdminOverviewTests.cs` — 6 new tests: signed Amount matches every
example in the acceptance criteria (`57200001` ±, `75900001` ±, a `629x` account ±) plus the
Σ Amount == displayed balance invariant; counterparty resolution (single opposing line, several
opposing lines → largest + count, no opposing line → null); the entry page (all legs with signed
amounts, 404 for an unknown entry number). One existing test's expected balance was updated to the
now-flipped sign for its group-6 account.

`dotnet build Humans.slnx -v quiet` — 0 errors, 0 new warnings.
`dotnet test tests/Humans.Holded.Tests/Humans.Holded.Tests.csproj -v quiet` — 75/75 passed.
`dotnet test tests/Humans.Finance.Tests/Humans.Finance.Tests.csproj -v quiet` — 92/92 passed
(confirms `HoldedLedgerLineInfo`/`IHoldedService` are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
