### PR TITLE
test: cover the history-table-absent fallback in CollectPendingFrontierAsync

### DIFF
--- a/src/Humans.Base/Hosting/DatabaseMigrationHostedService.cs
+++ b/src/Humans.Base/Hosting/DatabaseMigrationHostedService.cs
@@ -68,7 +68,7 @@ internal sealed class DatabaseMigrationHostedService(
     /// <c>GetPendingMigrationsAsync</c> per context - nothing here applies anything
     /// (nobodies-collective/Humans#989).
     /// </summary>
-    private static async Task<List<string>> CollectPendingFrontierAsync(
+    internal static async Task<List<string>> CollectPendingFrontierAsync(
         IEnumerable<DbContext> sectionContexts, CancellationToken cancellationToken)
     {
         var frontier = new List<string>();

--- a/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
@@ -313,7 +313,23 @@ public sealed class SectionMigrationRunnerTests(HumansTestDatabase database)
         var connectionString = await CreateDatabaseAsync("frontier_no_history");
         await CreateUsersSchemaWithoutHistoryAsync(connectionString);
 
-        await using var db = CreateSectionContext<UsersDbContext>(connectionString);
+        // EF.LogTo captures every command EF sends, including ones that fail — a regression
+        // back to calling GetPendingMigrationsAsync unconditionally would still send a SELECT
+        // against the (missing) history table and log it before the failure, so this catches
+        // the regression even though the returned set alone can't distinguish it.
+        var commandLog = new List<string>();
+        var historyTable = SectionMigrationsHistory.TableFor<UsersDbContext>();
+        var options = new DbContextOptionsBuilder<UsersDbContext>()
+            .UseNpgsql(connectionString, npgsql =>
+            {
+                npgsql.UseNodaTime();
+                npgsql.MigrationsAssembly(typeof(UsersDbContext).Assembly.GetName().Name!);
+                npgsql.MigrationsHistoryTable(historyTable);
+            })
+            .LogTo(commandLog.Add, Microsoft.Extensions.Logging.LogLevel.Debug)
+            .Options;
+
+        await using var db = new UsersDbContext(options);
         var expected = db.Database.GetMigrations()
             .Select(migration => $"{nameof(UsersDbContext)}:{migration}")
             .ToList();
@@ -322,6 +338,13 @@ public sealed class SectionMigrationRunnerTests(HumansTestDatabase database)
             [db], TestContext.Current.CancellationToken);
 
         frontier.Should().BeEquivalentTo(expected);
+
+        // The history table name only appears double-quoted when used as a SQL identifier
+        // (a FROM/JOIN target) - the legitimate information_schema probe passes it as a
+        // parameter value instead, which logs single-quoted.
+        commandLog.Should().NotContain(
+            entry => entry.Contains($"\"{historyTable}\"", StringComparison.Ordinal),
+            $"the fallback must never query {historyTable} directly - that's the #1022 regression");
     }
 
     [HumansFact]

--- a/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/SectionMigrationRunnerTests.cs
@@ -304,6 +304,27 @@ public sealed class SectionMigrationRunnerTests(HumansTestDatabase database)
     }
 
     [HumansFact]
+    public async Task CollectPendingFrontier_HistoryTableAbsent_ReturnsFullMigrationSet()
+    {
+        // Same fixture shape as ExistingDatabase_UsersBaselineMarkedApplied_WithoutExecuting:
+        // tables present, no history table. GetPendingMigrationsAsync would log an Error
+        // reading a history table that doesn't exist yet (nobodies-collective/Humans#1022);
+        // CollectPendingFrontierAsync must fall back to the full migration set instead.
+        var connectionString = await CreateDatabaseAsync("frontier_no_history");
+        await CreateUsersSchemaWithoutHistoryAsync(connectionString);
+
+        await using var db = CreateSectionContext<UsersDbContext>(connectionString);
+        var expected = db.Database.GetMigrations()
+            .Select(migration => $"{nameof(UsersDbContext)}:{migration}")
+            .ToList();
+
+        var frontier = await DatabaseMigrationHostedService.CollectPendingFrontierAsync(
+            [db], TestContext.Current.CancellationToken);
+
+        frontier.Should().BeEquivalentTo(expected);
+    }
+
+    [HumansFact]
     public async Task BothPaths_ProduceEquivalentUsersSchema()
     {
         // Model create-script path (the stand-in for a chain-built database — valid


### PR DESCRIPTION
Follow-up to #1398, which merged before this test was ready.

`CollectPendingFrontierAsync` only runs under Production/Staging, so the history-table existence check that #1398 added — the actual fix for the 26-errors-per-deploy problem — never executed under test.

Adds `CollectPendingFrontier_HistoryTableAbsent_ReturnsFullMigrationSet`: builds a Users schema with the tables present but no history table (the exact scenario), calls the method directly, and asserts the full migration set comes back without going through `GetPendingMigrationsAsync`.

`CollectPendingFrontierAsync` widens from `private` to `internal` on an already-`internal sealed` class, matching `TableExistsAsync` beside it. No public surface change.

Build clean; `SectionMigrationRunnerTests` 4/4 pass against real Postgres.

Refs nobodies-collective/Humans#1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
