### PR TITLE
feat(finance): add the /Finance/Holded connector index

### DIFF
--- a/src/Sections/Humans.Finance/Controllers/FinanceController.cs
+++ b/src/Sections/Humans.Finance/Controllers/FinanceController.cs
@@ -1,5 +1,6 @@
 using Humans.Finance.Contracts;
 using Humans.Finance.Models;
+using Humans.Finance.Services;
 using Humans.Base.Authorization;
 using Humans.Base.Controllers;
 using Microsoft.AspNetCore.Authorization;
@@ -25,8 +26,16 @@ namespace Humans.Finance.Controllers;
 internal sealed class FinanceController(
     IUserServiceRead userService,
     IHoldedFinanceService holdedFinance,
+    IHoldedFinanceAdminService holdedConnector,
     ILogger<FinanceController> logger) : HumansControllerBase(userService)
 {
+    /// <summary>The connector index: what Finance's half of the Holded integration is doing, and a
+    /// way into every screen that already covers a piece of it. Cache reads only — see
+    /// <see cref="IHoldedFinanceAdminService.GetConnectorOverviewAsync"/>.</summary>
+    [HttpGet("Holded")]
+    public async Task<IActionResult> Holded(CancellationToken ct)
+        => View(await holdedConnector.GetConnectorOverviewAsync(ct));
+
     [HttpGet("HoldedAccounts")]
     public async Task<IActionResult> HoldedAccounts(int blockStart = 62900100)
     {

--- a/src/Sections/Humans.Finance/Data/IHoldedRepository.cs
+++ b/src/Sections/Humans.Finance/Data/IHoldedRepository.cs
@@ -15,6 +15,11 @@ internal interface IHoldedRepository : IRepository
     Task<IReadOnlyList<HoldedExpenseDoc>> GetUnmatchedAsync(CancellationToken ct = default);
     Task<IReadOnlyList<HoldedExpenseDoc>> GetMatchedForYearAsync(int calendarYear, CancellationToken ct = default);
 
+    /// <summary>Every pulled doc, matched or not, for the <c>/Finance/Holded</c> browse panel. The
+    /// two reads above are each a filtered slice — unmatched-only, and matched-in-one-year — so
+    /// neither composes into "all docs". Unordered: the caller sorts for display.</summary>
+    Task<IReadOnlyList<HoldedExpenseDoc>> GetAllDocsAsync(CancellationToken ct = default);
+
     // Creditor contact bindings (member -> Holded creditor account)
     Task<HoldedCreditorContact?> GetCreditorContactByUserAsync(Guid userId, CancellationToken ct = default);
     Task<IReadOnlyList<HoldedCreditorContact>> GetCreditorContactsAsync(CancellationToken ct = default);

--- a/src/Sections/Humans.Finance/Data/Repository.cs
+++ b/src/Sections/Humans.Finance/Data/Repository.cs
@@ -70,6 +70,12 @@ internal sealed class Repository(IDbContextFactory<FinanceDbContext> factory)
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<HoldedExpenseDoc>> GetAllDocsAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.HoldedExpenseDocs.AsNoTracking().ToListAsync(ct);
+    }
+
     public async Task<IReadOnlyList<HoldedExpenseDoc>> GetMatchedForYearAsync(int calendarYear, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);

--- a/src/Sections/Humans.Finance/Docs/Finance.md
+++ b/src/Sections/Humans.Finance/Docs/Finance.md
@@ -33,6 +33,7 @@ Finance is the **treasurer's reality side** of the money story. Budget owns plan
 - The **Provisioning page** (`/Finance/HoldedAccounts`) reconciles the live Holded chart-of-accounts against the local `HoldedCategoryMap`: diffs into Mapped / ToAdd / Orphan. "Add one (test)" / "Add all" create accounts in Holded + map rows locally. Additive only.
 - The **Holded Sync State** is a singleton row tracking the operational state of the recurring sync job (`Idle / Running / Error`).
 - The **Unmatched Queue** (`/Finance/HoldedUnmatched`) is the working surface where the treasurer inspects unattributed docs and triggers a re-sync.
+- The **Connector index** (`/Finance/Holded`) is the read-only answer to "what is Finance's half of Holded doing": doc-sync status with its age rendered as a **Stale** badge rather than left implied, the live `HoldedCategoryMap` rows, every pulled `HoldedExpenseDoc` with its match source and raw tags, and the counts that link out to the four working screens. It never calls Holded — cache reads only, so it cannot inherit the live-contacts timeout `/Finance/Creditors` carries (nobodies-collective/Humans#976). Its read model is `IHoldedFinanceAdminService`, section-**internal**, the same shape as the Holded section's `IHoldedAdminService`.
 
 ## Data Model
 
@@ -135,6 +136,7 @@ Every `/Finance/*` route is gated on `PolicyNames.FinanceAdminOrAdmin`, declared
 
 | Route | Purpose |
 |-------|---------|
+| `GET /Finance/Holded` | Connector index — doc-sync health with explicit staleness, the live category map, every pulled doc, and the way into the four screens below. Read-only, cache only (nobodies-collective/Humans#1000) |
 | `GET /Finance/HoldedAccounts` | Account provisioning UI (reconcile + apply) |
 | `GET /Finance/HoldedUnmatched` | Unmatched-doc worklist with deep links and "Sync now" |
 | `GET /Finance/Creditors` | Admin overview of all cached 400000xx creditor accounts with member bindings |
@@ -157,7 +159,9 @@ Every `/Finance/*` route is gated on `PolicyNames.FinanceAdminOrAdmin`, declared
 - A purchase doc is attributed **as a whole, by its first product line's** booked account (plus the union of doc-level and line-level tags), and its full `Total` lands on that one category. A multi-line doc booked across several Holded accounts is not split; line-level attribution is a deliberate later refinement (`Service.MapDoc`).
 - Actuals are keyed on the **calendar year** of the doc's Europe/Madrid date, matched against `BudgetYear.Year` parsed as an integer (`FinanceController` → `GetActualsForYearAsync` → `HoldedRepository.GetMatchedForYearAsync`). A budget year whose `Year` string is not a plain number, or that does not run January–December, shows no actuals.
 - Only `FinanceAdmin` or `Admin` may access any `/Finance/*` route (`[Authorize(Policy = PolicyNames.FinanceAdminOrAdmin)]` on `FinanceController`).
-- `FinanceController` performs no budget mutations at all — its eight actions are the Holded and creditor surface. Budget CRUD on the same prefix is `Humans.Budget`'s `BudgetAdminController`.
+- `FinanceController` performs no budget mutations at all — its nine actions are the Holded and creditor surface. Budget CRUD on the same prefix is `Humans.Budget`'s `BudgetAdminController`.
+- `/Finance/Holded` issues **no** Holded HTTP call. Every figure comes from `holded_doc_sync_state`, `holded_category_map`, `holded_expense_docs` and `holded_creditor_contacts`; the mirror's own health (API budget, ledger sweeps, chart of accounts) is `/Holded`'s and is linked, not restated. Pinned by `GetConnectorOverview_MakesNoHoldedApiCall`.
+- The doc sync counts as **stale** at 36 h — the nightly job's 24 h cadence plus half a day of grace — and never having run counts as stale too: budget actuals and the unmatched queue are equally wrong either way, so both raise the same alarm.
 - The sync job pulls all purchase docs from Holded each cycle (full-pull). Upsert is keyed on `HoldedDocId`; `CreatedAt` is preserved across re-syncs.
 - Full-pull is forced by a Holded API limitation (live probe, 2026-04-26): the purchase-documents endpoint's only date filters filter on `accountingDate`, which is null on most real purchase docs, so there is no reliable incremental-sync key for purchase documents. `ListPurchaseDocumentsAsync` therefore takes no date window at all — it walks `/api/v2/purchases` page by page internally under a 200-page safety cap. Approval state comes from a second full sweep, `ListDraftPurchaseIdsAsync` (`?approval_status=draft`): a doc absent from that set is marked `IsApproved`, so the set must be complete or a draft leaks into the actuals — the client throws rather than dropping an id-less row.
 - Attribution runs every sync. Fixing an account mapping or tag in Holded takes effect on next sync or via the manual "Sync Now" button.
@@ -216,7 +220,7 @@ No Tickets dependency: the cash-flow view that had one is Budget's. Budget never
 **Migrations:** `20260715103643_BaselineFinance` — consolidated onto `FinanceDbContext` (its own history table, `__EFMigrationsHistory_Finance`) when Finance moved off the shared `HumansDbContext` (nobodies-collective/Humans#858); the earlier per-feature migration chain (`HoldedActuals`, `HoldedCreditorData`, `HoldedCreditorContact`, `HoldedLedgerSingleSource`) was squashed into this baseline. Since then: `20260810195350_HoldedExpenseDocIsApproved` (swaps `ApprovedAt` for the nullable `IsApproved` flag) and `20260810204942_HoldedMirrorMovesToHoldedSection` (drops the ledger-mirror tables, which the Holded section now owns)  
 **Architecture tests:** `tests/Humans.Finance.Tests/FinanceArchitectureTests.cs`
 
-**Controllers.** `/Finance` is served by two controllers under one route prefix. `Humans.Finance.Controllers.FinanceController` owns the section's own eight actions — `HoldedAccounts`, `HoldedUnmatched`, `Creditors`, `CreditorStatement`, `Bind`, `Unbind`, `Provision`, `HoldedSync/Run`. The other 23 actions on the pre-G5 `FinanceController` were Budget CRUD (years, groups, categories, line items, ticketing projection, cash flow, audit log) and now live in `Humans.Budget.Controllers.BudgetAdminController`, own project since Budget's own G5, keeping `[Route("Finance")]` so no URL moved. See [`Budget.md`](../../Humans.Budget/Docs/Budget.md) for the Budget side of the split.
+**Controllers.** `/Finance` is served by two controllers under one route prefix. `Humans.Finance.Controllers.FinanceController` owns the section's own nine actions — `Holded`, `HoldedAccounts`, `HoldedUnmatched`, `Creditors`, `CreditorStatement`, `Bind`, `Unbind`, `Provision`, `HoldedSync/Run`. The other 23 actions on the pre-G5 `FinanceController` were Budget CRUD (years, groups, categories, line items, ticketing projection, cash flow, audit log) and now live in `Humans.Budget.Controllers.BudgetAdminController`, own project since Budget's own G5, keeping `[Route("Finance")]` so no URL moved. See [`Budget.md`](../../Humans.Budget/Docs/Budget.md) for the Budget side of the split.
 
 **The Holded connector is not this section.** `IHoldedClient`, `HoldedClient`, `HoldedClientOptions`, `HoldedApiException` and the connector DTOs belong to the **Holded** section — public on `Humans.Holded.Contracts`, implementation `internal` in `Humans.Holded/Services/` — with their own [`Holded-connector.md`](../../Humans.Holded/Docs/Holded-connector.md) (G5 lane 4b-2f, nobodies-collective/Humans#866). Finance consumes them through that leaf. Consequence for the boundary: `HoldedCreditorLedger.Lines` carries Finance's own `CreditorLedgerLine` rather than the connector's `HoldedLedgerLineDto`, because the contracts leaf may reference only the bottom of the graph and re-exporting another component's wire DTO across a section boundary is the thing the split exists to stop.
 
@@ -232,6 +236,9 @@ No Tickets dependency: the cash-flow view that had one is Budget's. Budget never
 > - `Domain/HoldedDocSyncState.cs`
 > - `Domain/HoldedMatchStatus.cs`, `HoldedMatchSource.cs`
 > - `Services/Service.cs`
+> - `Services/IHoldedFinanceAdminService.cs` — `/Finance/Holded`'s read model; **internal**, this section's screen is the only consumer
+> - `Models/HoldedConnectorVm.cs` — that screen's view models
+> - `Views/Finance/Holded.cshtml`, `SectionAdminNav.cs` — the page and its "Money" sidebar entry
 > - `Services/HoldedMatcher.cs`
 > - `../Humans.Finance.Contracts/IHoldedFinanceService.cs`
 > - `Data/IHoldedRepository.cs`

--- a/src/Sections/Humans.Finance/Docs/authorization.md
+++ b/src/Sections/Humans.Finance/Docs/authorization.md
@@ -2,4 +2,8 @@
 
 | Controller | Scope | Roles | Source |
 |---|---|---|---|
-| `FinanceController` | Class | `FinanceAdmin, Admin` | `PolicyNames.FinanceAdminOrAdmin` (Holded creditor-account surface — `HoldedAccounts`/`Provision`, `HoldedUnmatched`, `Creditors`/`Bind`/`Unbind`, `HoldedSync/Run`) |
+| `FinanceController` | Class | `FinanceAdmin, Admin` | `PolicyNames.FinanceAdminOrAdmin` (Holded creditor-account surface — `Holded`, `HoldedAccounts`/`Provision`, `HoldedUnmatched`, `Creditors`/`Bind`/`Unbind`, `HoldedSync/Run`) |
+
+`/Finance/Holded` is deliberately on the same policy as the rest of the prefix rather than AdminOnly: a
+finance admin who can already see creditor balances should be able to see the connector health those
+balances depend on (decided 2026-08-07, nobodies-collective/Humans#1000).

--- a/src/Sections/Humans.Finance/Docs/data-access.md
+++ b/src/Sections/Humans.Finance/Docs/data-access.md
@@ -38,8 +38,21 @@ surface — `budget` in the ctor), `IHoldedService` (the Holded section's
 ledger-mirror read surface — `holded` in the ctor; ledger-line /
 account-balance reads for creditor status, ledger, and account listing),
 `IHoldedClient` (Holded section leaf — purchase-document / contact / expense-account
-API calls). Implements `IHoldedFinanceService`, `IUserDataContributor`.
+API calls). Implements `IHoldedFinanceService`, `IHoldedFinanceAdminService`
+and `IUserDataContributor`.
 No `IMemoryCache`.
+
+`IHoldedFinanceAdminService` (`Services/IHoldedFinanceAdminService.cs`) is
+**internal** — the `/Finance/Holded` connector index is this section's own
+screen, so its read model is not cross-section surface; the same shape as the
+Holded section's `IHoldedAdminService`. Its one method,
+`GetConnectorOverviewAsync`, reads `HoldedDocSyncStates`,
+`HoldedCategoryMap`, `HoldedExpenseDocs` (via `GetAllDocsAsync` — the
+unmatched and matched-for-year reads are each a filtered slice and neither
+composes into "all docs") and `HoldedCreditorContacts`, plus
+`IBudgetServiceRead` for category names. **No `IHoldedClient` call** — the
+index must not inherit the connector's 30 s timeout
+(nobodies-collective/Humans#976, #1000).
 
 ### HoldedMatcher
 

--- a/src/Sections/Humans.Finance/Models/HoldedConnectorVm.cs
+++ b/src/Sections/Humans.Finance/Models/HoldedConnectorVm.cs
@@ -1,0 +1,75 @@
+using Humans.Finance.Domain;
+using NodaTime;
+
+namespace Humans.Finance.Models;
+
+/// <summary>
+/// The <c>/Finance/Holded</c> read model: the Finance-owned half of the Holded connector that had
+/// no screen at all (nobodies-collective/Humans#1000). Cache reads only — no Holded HTTP call is
+/// made building it, so the page never inherits the live-contacts latency <c>/Finance/Creditors</c>
+/// carries. The mirror's own health (API budget, ledger sweeps, chart of accounts) stays on
+/// <c>/Holded</c>; this page links there rather than restating it.
+/// </summary>
+internal sealed record HoldedConnectorVm(
+    HoldedDocSyncVm DocSync,
+    int CreditorBindingCount,
+    IReadOnlyList<HoldedCategoryMapVm> CategoryMap,
+    IReadOnlyList<HoldedDocVm> Docs)
+{
+    public int ActiveMappings => CategoryMap.Count(m => m.IsActive);
+    public int ArchivedMappings => CategoryMap.Count - ActiveMappings;
+    public int MatchedDocs => Docs.Count(d => d.MatchStatus == HoldedMatchStatus.Matched);
+    public int UnmatchedDocs => Docs.Count - MatchedDocs;
+}
+
+/// <summary>
+/// Finance's purchase-doc sync singleton, with its age resolved so the page can say "stale"
+/// instead of leaving a reader to subtract two timestamps. Every figure on
+/// <c>/Finance/HoldedUnmatched</c> and the budget actuals derives from this sync, so a stalled one
+/// makes those pages quietly wrong.
+/// </summary>
+/// <param name="SinceLastSync">Age of <paramref name="LastSyncAt"/>; null when it has never run.</param>
+/// <param name="IsStale">True when the sync has not completed inside <see cref="StaleAfter"/> —
+/// never having run counts as stale.</param>
+internal sealed record HoldedDocSyncVm(
+    Instant? LastSyncAt,
+    string Status,
+    string? LastError,
+    int LastSyncedDocCount,
+    Duration? SinceLastSync,
+    bool IsStale)
+{
+    /// <summary>The nightly job runs at 03:00, so 36 h is one missed run plus half a day of grace.</summary>
+    public static readonly Duration StaleAfter = Duration.FromHours(36);
+}
+
+/// <summary>One live <c>holded_category_map</c> row — what a budget category is actually booked to
+/// today, as opposed to the plan <c>/Finance/HoldedAccounts</c> renders.</summary>
+/// <param name="CategoryName">Null when the category is not in the active budget year — a row whose
+/// category was deleted or belongs to an earlier year. The provisioning page calls that an Orphan.</param>
+internal sealed record HoldedCategoryMapVm(
+    Guid BudgetCategoryId,
+    string? CategoryName,
+    string? GroupName,
+    int HoldedAccountNumber,
+    string HoldedAccountId,
+    string Tag,
+    bool IsActive,
+    Instant UpdatedAt);
+
+/// <summary>One pulled purchase doc, matched or not. <c>/Finance/HoldedUnmatched</c> shows only the
+/// unmatched subset, so this is the only place "why did this doc land on that category" can be
+/// answered — hence <paramref name="MatchSource"/> and the raw <paramref name="TagsJson"/>.</summary>
+internal sealed record HoldedDocVm(
+    string HoldedDocId,
+    string DocNumber,
+    string ContactName,
+    LocalDate Date,
+    decimal Total,
+    bool? IsApproved,
+    HoldedMatchStatus MatchStatus,
+    HoldedMatchSource MatchSource,
+    string? CategoryName,
+    string? BookedAccountId,
+    string TagsJson,
+    Instant LastSyncedAt);

--- a/src/Sections/Humans.Finance/Models/HoldedConnectorVm.cs
+++ b/src/Sections/Humans.Finance/Models/HoldedConnectorVm.cs
@@ -28,7 +28,15 @@ internal sealed record HoldedConnectorVm(
 /// <c>/Finance/HoldedUnmatched</c> and the budget actuals derives from this sync, so a stalled one
 /// makes those pages quietly wrong.
 /// </summary>
-/// <param name="SinceLastSync">Age of <paramref name="LastSyncAt"/>; null when it has never run.</param>
+/// <param name="LastSyncAt">Last <b>successful</b> completion, not last attempt: a failed run sets
+/// <paramref name="StatusChangedAt"/> and deliberately leaves this pointing at the older success.
+/// Labelling it "last run" is what made an erroring connector read as an idle one.</param>
+/// <param name="StatusChangedAt">When the connector last entered <paramref name="Status"/> — for an
+/// Error row, when the failing attempt happened. Without it a week-old error and a five-minute-old
+/// one render identically.</param>
+/// <param name="SinceLastSync">Age of <paramref name="LastSyncAt"/>; null when it has never
+/// succeeded. Staleness keys on this and not on the attempt, because the question the page answers
+/// is how old the cached data is — a run that failed refreshed nothing.</param>
 /// <param name="IsStale">True when the sync has not completed inside <see cref="StaleAfter"/> —
 /// never having run counts as stale.</param>
 internal sealed record HoldedDocSyncVm(
@@ -37,7 +45,8 @@ internal sealed record HoldedDocSyncVm(
     string? LastError,
     int LastSyncedDocCount,
     Duration? SinceLastSync,
-    bool IsStale)
+    bool IsStale,
+    Instant? StatusChangedAt = null)
 {
     /// <summary>The nightly job runs at 03:00, so 36 h is one missed run plus half a day of grace.</summary>
     public static readonly Duration StaleAfter = Duration.FromHours(36);

--- a/src/Sections/Humans.Finance/Section.cs
+++ b/src/Sections/Humans.Finance/Section.cs
@@ -30,6 +30,8 @@ public sealed class Section : ISection
         services.AddScoped<IHoldedRepository, Repository>();
         services.AddScoped<Service>();
         services.AddScoped<IHoldedFinanceService>(sp => sp.GetRequiredService<Service>());
+        // /Finance/Holded's read model. Internal — this section's own screen is the only consumer.
+        services.AddScoped<IHoldedFinanceAdminService>(sp => sp.GetRequiredService<Service>());
         // Owns the user-scoped holded_creditor_contacts table → GDPR export contributor (design-rules §8a).
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<Service>());
     }

--- a/src/Sections/Humans.Finance/SectionAdminNav.cs
+++ b/src/Sections/Humans.Finance/SectionAdminNav.cs
@@ -1,0 +1,20 @@
+using Humans.Base.Authorization;
+using Humans.Base.Interfaces;
+
+namespace Humans.Finance;
+
+/// <summary>Finance's contribution to the shared "Money" admin group (nobodies-collective/Humans#1077).</summary>
+/// <remarks>
+/// One link, deliberately: <c>/Finance/Holded</c> is the index for this section's Holded surface and
+/// carries the way into HoldedAccounts, HoldedUnmatched and Creditors, which had no sidebar entry of
+/// their own. It sits just below the mirror's own <c>/Holded</c> screen (weight 20).
+/// </remarks>
+internal sealed class SectionAdminNav : ISectionAdminNav
+{
+    public IEnumerable<AdminNavGroup> Groups() =>
+    [
+        new("Money", [
+            new("Holded connector", "Finance", "Holded", null, null, "fa-solid fa-plug", PolicyNames.FinanceAdminOrAdmin, Weight: 25)
+        ], Weight: 50)
+    ];
+}

--- a/src/Sections/Humans.Finance/Services/IHoldedFinanceAdminService.cs
+++ b/src/Sections/Humans.Finance/Services/IHoldedFinanceAdminService.cs
@@ -1,0 +1,18 @@
+using Humans.Base.Interfaces;
+using Humans.Finance.Models;
+
+namespace Humans.Finance.Services;
+
+/// <summary>
+/// The <c>/Finance/Holded</c> screen's read model. Internal: the screen lives in this section, so
+/// nothing outside it consumes this — the cross-section surface stays
+/// <see cref="Contracts.IHoldedFinanceService"/>. Mirrors the Holded section's own
+/// <c>IHoldedAdminService</c>, for the same reason.
+/// </summary>
+internal interface IHoldedFinanceAdminService : IApplicationService
+{
+    /// <summary>Everything <c>/Finance/Holded</c> renders, from the local cache only — no Holded
+    /// HTTP call, so the page cannot inherit the connector's timeout
+    /// (nobodies-collective/Humans#976).</summary>
+    Task<HoldedConnectorVm> GetConnectorOverviewAsync(CancellationToken ct = default);
+}

--- a/src/Sections/Humans.Finance/Services/Service.cs
+++ b/src/Sections/Humans.Finance/Services/Service.cs
@@ -341,7 +341,10 @@ internal sealed class Service(
                 age,
                 // Never having run is stale too: the actuals and the unmatched queue are empty for
                 // the same reason a stalled sync leaves them wrong, and both need the same alarm.
-                IsStale: age is null || age >= HoldedDocSyncVm.StaleAfter),
+                IsStale: age is null || age >= HoldedDocSyncVm.StaleAfter,
+                // A failed run moves only this: SyncAsync leaves LastSyncAt on the older success.
+                // Dropping it left an Error row unable to say when the failure actually happened.
+                state.StatusChangedAt),
             bindings.Count,
             map.Select(m => new HoldedCategoryMapVm(
                 m.BudgetCategoryId,

--- a/src/Sections/Humans.Finance/Services/Service.cs
+++ b/src/Sections/Humans.Finance/Services/Service.cs
@@ -5,6 +5,7 @@ using Humans.Gdpr.Contracts;
 using Humans.Holded.Contracts;
 using Humans.Finance.Data;
 using Humans.Finance.Domain;
+using Humans.Finance.Models;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
@@ -24,7 +25,7 @@ internal sealed class Service(
     IHoldedService holded,
     IClock clock,
     IMemoryCache cache,
-    ILogger<Service> logger) : IHoldedFinanceService, IUserDataContributor
+    ILogger<Service> logger) : IHoldedFinanceService, IHoldedFinanceAdminService, IUserDataContributor
 {
     private static readonly TimeSpan ContactsCacheDuration = TimeSpan.FromMinutes(2);
     private static readonly DateTimeZone MadridZone = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
@@ -305,6 +306,65 @@ internal sealed class Service(
     {
         var map = await repo.GetCategoryMapAsync(ct);
         return map.FirstOrDefault(m => m.IsActive && m.BudgetCategoryId == budgetCategoryId)?.HoldedAccountId;
+    }
+
+    // ─── Connector overview (/Finance/Holded) ─────────────────────────────────────
+
+    public async Task<HoldedConnectorVm> GetConnectorOverviewAsync(CancellationToken ct = default)
+    {
+        var state = await repo.GetOrCreateDocSyncStateAsync(ct);
+        var bindings = await repo.GetCreditorContactsAsync(ct);
+        var map = await repo.GetCategoryMapAsync(ct);
+        var docs = await repo.GetAllDocsAsync(ct);
+
+        // Category names come from the active budget year, the same source the provisioning plan
+        // uses. A map row or doc pointing outside it keeps a null name rather than a lookup per row.
+        var year = await budget.GetActiveYearAsync();
+        var categories = year is null
+            ? new Dictionary<Guid, (string Name, string Group)>()
+            : year.Groups
+                .SelectMany(g => g.Categories.Select(c => (c.Id, Name: c.Name, Group: g.Name)))
+                .ToDictionary(c => c.Id, c => (c.Name, c.Group));
+
+        string? NameOf(Guid? categoryId) =>
+            categoryId is { } id && categories.TryGetValue(id, out var c) ? c.Name : null;
+
+        var now = clock.GetCurrentInstant();
+        var age = state.LastSyncAt is { } last ? now - last : (Duration?)null;
+
+        return new HoldedConnectorVm(
+            new HoldedDocSyncVm(
+                state.LastSyncAt,
+                state.Status,
+                state.LastError,
+                state.LastSyncedDocCount,
+                age,
+                // Never having run is stale too: the actuals and the unmatched queue are empty for
+                // the same reason a stalled sync leaves them wrong, and both need the same alarm.
+                IsStale: age is null || age >= HoldedDocSyncVm.StaleAfter),
+            bindings.Count,
+            map.Select(m => new HoldedCategoryMapVm(
+                m.BudgetCategoryId,
+                NameOf(m.BudgetCategoryId),
+                categories.TryGetValue(m.BudgetCategoryId, out var g) ? g.Group : null,
+                m.HoldedAccountNumber,
+                m.HoldedAccountId,
+                m.Tag,
+                m.IsActive,
+                m.UpdatedAt)).ToList(),
+            docs.Select(d => new HoldedDocVm(
+                d.HoldedDocId,
+                d.DocNumber,
+                d.ContactName,
+                d.Date,
+                d.Total,
+                d.IsApproved,
+                d.MatchStatus,
+                d.MatchSource,
+                NameOf(d.BudgetCategoryId),
+                d.BookedAccountId,
+                d.TagsJson,
+                d.LastSyncedAt)).ToList());
     }
 
     private static string ReasonFor(HoldedExpenseDoc d)

--- a/src/Sections/Humans.Finance/Views/Finance/Holded.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/Holded.cshtml
@@ -62,7 +62,10 @@
         }
         else
         {
-            <text>The last purchase-doc sync ended in an <strong>error</strong>.</text>
+            <text>
+                The last purchase-doc sync attempt ended in an <strong>error</strong>@(sync.StatusChangedAt is { } failedAt
+                    ? $" ({failedAt.ToDateTime()})" : "").
+            </text>
         }
         Budget actuals and the unmatched queue are both derived from this sync, so both are showing
         stale numbers until it runs cleanly.
@@ -82,7 +85,7 @@
                     }
                 </div>
                 <div class="text-muted small">
-                    @(sync.SinceLastSync is { } since ? Age(since) : "never run")
+                    @(sync.SinceLastSync is { } since ? $"succeeded {Age(since)}" : "never succeeded")
                 </div>
             </div>
         </div>
@@ -134,8 +137,8 @@
         <table class="table table-sm align-middle mb-0">
             <thead>
                 <tr>
-                    <th>Status</th><th>Last run</th><th>Age</th>
-                    <th class="text-end">Docs last run</th><th>Last error</th>
+                    <th>Status</th><th>Status since</th><th>Last success</th><th>Age</th>
+                    <th class="text-end">Docs last success</th><th>Last error</th>
                 </tr>
             </thead>
             <tbody>
@@ -147,6 +150,7 @@
                             <span class="badge bg-warning text-dark">Stale</span>
                         }
                     </td>
+                    <td class="text-nowrap">@(sync.StatusChangedAt.ToDateTime() ?? "—")</td>
                     <td class="text-nowrap">@(sync.LastSyncAt.ToDateTime() ?? "never")</td>
                     <td class="text-nowrap">@(sync.SinceLastSync is { } age ? Age(age) : "—")</td>
                     <td class="text-end">@sync.LastSyncedDocCount</td>
@@ -156,8 +160,11 @@
         </table>
     </div>
     <div class="card-footer text-muted small">
-        The nightly job pulls every purchase doc and re-runs attribution over all of them, so a
-        mapping fixed in Holded takes effect on the next run. Anything older than
+        <strong>Last success</strong> is the last run that <em>completed</em> — a failed attempt
+        moves <strong>Status since</strong> and leaves the success time where it was, so an Error row
+        showing an old success means the job has been running and failing, not that it stopped being
+        scheduled. The nightly job pulls every purchase doc and re-runs attribution over all of them,
+        so a mapping fixed in Holded takes effect on the next run. Anything older than
         @((int)HoldedDocSyncVm.StaleAfter.TotalHours) h counts as stale. Trigger a run from
         <a asp-action="HoldedUnmatched">Unmatched docs</a>; the ledger mirror's own sweeps are
         separate and live on <a asp-controller="Holded" asp-action="Index">/Holded</a>.

--- a/src/Sections/Humans.Finance/Views/Finance/Holded.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/Holded.cshtml
@@ -1,0 +1,311 @@
+@model HoldedConnectorVm
+@using Humans.Finance.Domain
+@using NodaTime
+@{
+    ViewData["Title"] = "Holded Connector";
+    var sync = Model.DocSync;
+
+    string Age(Duration d) => d.TotalDays >= 1
+        ? $"{(int)d.TotalDays}d {d.Hours}h ago"
+        : $"{(int)d.TotalHours}h {d.Minutes}m ago";
+
+    string StatusBadge(string status) => status switch
+    {
+        "Running" => "bg-info",
+        "Error" => "bg-danger",
+        _ => "bg-success"
+    };
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Holded Connector</h1>
+    <div class="d-flex gap-2 flex-wrap">
+        <a asp-action="HoldedAccounts" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-list-ol me-1"></i>Account provisioning
+        </a>
+        <a asp-action="HoldedUnmatched" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-question me-1"></i>Unmatched docs
+        </a>
+        <a asp-action="Creditors" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-users me-1"></i>Creditors
+        </a>
+        <a asp-controller="Holded" asp-action="Index" class="btn btn-outline-secondary"
+           title="The ledger mirror's own screen: API budget, ledger sweeps, chart of accounts.">
+            <i class="fa-solid fa-book me-1"></i>Ledger mirror
+        </a>
+    </div>
+</div>
+
+<p class="text-muted">
+    Finance's half of the Holded integration — the purchase-doc sync, what each budget category is
+    booked to, and every doc pulled so far. Every figure is read from the local cache; this page
+    makes no Holded API call, so it cannot stall on one. The mirror's own health (API budget, ledger
+    sweeps, chart of accounts) lives on <a asp-controller="Holded" asp-action="Index">the ledger
+    mirror screen</a>; the pages linked above own the working surfaces and are not restated here.
+</p>
+
+@if (sync.IsStale || string.Equals(sync.Status, "Error", StringComparison.Ordinal))
+{
+    <div class="alert alert-warning">
+        <i class="fa-solid fa-triangle-exclamation me-2"></i>
+        @if (sync.LastSyncAt is null)
+        {
+            <text>The purchase-doc sync has <strong>never completed</strong>.</text>
+        }
+        else if (sync.IsStale)
+        {
+            <text>
+                The purchase-doc sync last completed <strong>@Age(sync.SinceLastSync!.Value)</strong>
+                — longer than the @((int)HoldedDocSyncVm.StaleAfter.TotalHours) h it is expected to
+                go between nightly runs.
+            </text>
+        }
+        else
+        {
+            <text>The last purchase-doc sync ended in an <strong>error</strong>.</text>
+        }
+        Budget actuals and the unmatched queue are both derived from this sync, so both are showing
+        stale numbers until it runs cleanly.
+    </div>
+}
+
+<div class="row g-3 mb-4">
+    <div class="col-6 col-lg-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="text-muted small">Doc sync</div>
+                <div class="fs-4">
+                    <span class="badge @StatusBadge(sync.Status)">@sync.Status</span>
+                    @if (sync.IsStale)
+                    {
+                        <span class="badge bg-warning text-dark">Stale</span>
+                    }
+                </div>
+                <div class="text-muted small">
+                    @(sync.SinceLastSync is { } since ? Age(since) : "never run")
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-lg-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="text-muted small">Category mappings</div>
+                <div class="fs-4">@Model.ActiveMappings</div>
+                <div class="text-muted small">
+                    active@(Model.ArchivedMappings > 0 ? $", {Model.ArchivedMappings} archived" : "")
+                    — <a href="#category-map">see below</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-lg-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="text-muted small">Purchase docs</div>
+                <div class="fs-4">@Model.Docs.Count</div>
+                <div class="text-muted small">
+                    @Model.MatchedDocs matched,
+                    <a asp-action="HoldedUnmatched">@Model.UnmatchedDocs unmatched</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-lg-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="text-muted small">Creditor bindings</div>
+                <div class="fs-4">@Model.CreditorBindingCount</div>
+                <div class="text-muted small">
+                    members bound — <a asp-action="Creditors">Creditors</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    @* Read-only by design: the "Sync now" trigger stays on /Finance/HoldedUnmatched and /Holded,
+       where it already lives, rather than being duplicated onto an index. *@
+    <div class="card-header">
+        <i class="fa-solid fa-rotate me-1"></i>Purchase-doc sync
+    </div>
+    <div class="table-responsive">
+        <table class="table table-sm align-middle mb-0">
+            <thead>
+                <tr>
+                    <th>Status</th><th>Last run</th><th>Age</th>
+                    <th class="text-end">Docs last run</th><th>Last error</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>
+                        <span class="badge @StatusBadge(sync.Status)">@sync.Status</span>
+                        @if (sync.IsStale)
+                        {
+                            <span class="badge bg-warning text-dark">Stale</span>
+                        }
+                    </td>
+                    <td class="text-nowrap">@(sync.LastSyncAt.ToDateTime() ?? "never")</td>
+                    <td class="text-nowrap">@(sync.SinceLastSync is { } age ? Age(age) : "—")</td>
+                    <td class="text-end">@sync.LastSyncedDocCount</td>
+                    <td class="small text-muted">@sync.LastError</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="card-footer text-muted small">
+        The nightly job pulls every purchase doc and re-runs attribution over all of them, so a
+        mapping fixed in Holded takes effect on the next run. Anything older than
+        @((int)HoldedDocSyncVm.StaleAfter.TotalHours) h counts as stale. Trigger a run from
+        <a asp-action="HoldedUnmatched">Unmatched docs</a>; the ledger mirror's own sweeps are
+        separate and live on <a asp-controller="Holded" asp-action="Index">/Holded</a>.
+    </div>
+</div>
+
+<div class="card mb-4" id="category-map">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span><i class="fa-solid fa-diagram-project me-1"></i>Category map</span>
+        <span class="badge bg-secondary">@Model.CategoryMap.Count rows</span>
+    </div>
+    @if (Model.CategoryMap.Count == 0)
+    {
+        <div class="card-body">
+            <p class="mb-0 text-muted">
+                Nothing mapped yet — provision the account block on
+                <a asp-action="HoldedAccounts">Account provisioning</a>.
+            </p>
+        </div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-sm table-striped align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th>Account</th><th>Budget category</th><th>Group</th>
+                        <th>Tag</th><th>State</th><th>Updated</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var m in Model.CategoryMap.OrderBy(m => m.HoldedAccountNumber))
+                    {
+                        <tr>
+                            <td class="text-nowrap">
+                                <a asp-controller="Holded" asp-action="Account" asp-route-number="@m.HoldedAccountNumber"><code>@m.HoldedAccountNumber</code></a>
+                            </td>
+                            <td>
+                                @if (m.CategoryName is { } name)
+                                {
+                                    @name
+                                }
+                                else
+                                {
+                                    <span class="text-muted" title="@m.BudgetCategoryId">not in the active budget year</span>
+                                }
+                            </td>
+                            <td class="text-muted">@m.GroupName</td>
+                            <td><code>@m.Tag</code></td>
+                            <td>
+                                @if (m.IsActive)
+                                {
+                                    <span class="badge bg-success">Active</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-secondary">Archived</span>
+                                }
+                            </td>
+                            <td class="text-nowrap text-muted small">@m.UpdatedAt.ToDateTime()</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer text-muted small">
+            What each budget category is booked to <em>today</em>. The plan — what provisioning would
+            add next — is on <a asp-action="HoldedAccounts">Account provisioning</a>. Nothing retires
+            a row today, so an Archived state should not appear; a category that disappeared from the
+            budget year keeps its active row and shows as an Orphan on the provisioning page instead.
+        </div>
+    }
+</div>
+
+<div class="card" id="docs">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span><i class="fa-solid fa-file-invoice me-1"></i>Purchase documents</span>
+        <span class="badge bg-secondary">@Model.Docs.Count docs</span>
+    </div>
+    @if (Model.Docs.Count == 0)
+    {
+        <div class="card-body"><p class="mb-0 text-muted">No docs pulled yet — run a sync.</p></div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-sm table-striped align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th>Date</th><th>Doc #</th><th>Contact</th><th class="text-end">Total</th>
+                        <th>Approved</th><th>Match</th><th>Via</th><th>Category</th><th>Raw</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var d in Model.Docs
+                        .OrderByDescending(d => d.Date)
+                        .ThenBy(d => d.DocNumber, StringComparer.Ordinal))
+                    {
+                        <tr>
+                            <td class="text-nowrap">@d.Date.ToDate()</td>
+                            <td class="text-nowrap">@d.DocNumber</td>
+                            <td>@d.ContactName</td>
+                            <td class="text-end">@d.Total.ToEuro()</td>
+                            <td>
+                                @if (d.IsApproved == true)
+                                {
+                                    <i class="fa-solid fa-check text-success" title="Approved in Holded — counts toward actuals"></i>
+                                }
+                                else
+                                {
+                                    <span class="text-muted" title="@(d.IsApproved is null ? "Pre-v2 row, not re-synced yet" : "Still a draft in Holded")">—</span>
+                                }
+                            </td>
+                            <td>
+                                @if (d.MatchStatus == HoldedMatchStatus.Matched)
+                                {
+                                    <span class="badge bg-success">Matched</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-warning text-dark">Unmatched</span>
+                                }
+                            </td>
+                            <td class="text-muted small">@d.MatchSource</td>
+                            <td>@d.CategoryName</td>
+                            <td>
+                                <details>
+                                    <summary class="small text-muted">show</summary>
+                                    <div class="small">
+                                        <div>Booked account id: <code>@(d.BookedAccountId ?? "—")</code></div>
+                                        <div>Tags: <code>@d.TagsJson</code></div>
+                                        <div>Holded doc id: <code>@d.HoldedDocId</code></div>
+                                        <div class="text-muted">Last synced @d.LastSyncedAt.ToDateTime()</div>
+                                    </div>
+                                </details>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer text-muted small">
+            <strong>Via</strong> is why the doc resolved: <code>Account</code> = its booked Holded
+            account matched a mapped category, <code>Tag</code> = a normalized tag did,
+            <code>None</code> = neither, which is what puts it in the
+            <a asp-action="HoldedUnmatched">unmatched queue</a>. Only approved docs count toward
+            budget actuals. Docs are read-only here — re-categorizing is done in Holded, and the next
+            sync picks the correction up.
+        </div>
+    }
+</div>

--- a/src/Sections/Humans.Holded/Docs/Holded.md
+++ b/src/Sections/Humans.Holded/Docs/Holded.md
@@ -47,6 +47,12 @@ mirror tables runs before this baseline recreates them.
 - `/Holded/Accounts/{number}` — the general-ledger page for ANY account (departments, banks,
   creditors), native Holded sign, header + all cached journal lines.
 
+**Not this section:** `/Finance/Holded` is Finance's own connector index — its purchase-doc sync
+staleness, category map and pulled docs (nobodies-collective/Humans#1000). The split is the table
+ownership: this screen covers what `HoldedDbContext` owns, that one covers what `FinanceDbContext`
+does. The two link to each other rather than restating each other's figures; the doc-sync row shown
+in the table above is still fetched through `IHoldedFinanceService.GetDocSyncInfoAsync`.
+
 ## Actors & Roles
 
 | Actor | Capabilities |

--- a/tests/Humans.Finance.Tests/FinanceArchitectureTests.cs
+++ b/tests/Humans.Finance.Tests/FinanceArchitectureTests.cs
@@ -33,6 +33,20 @@ public class FinanceArchitectureTests
     }
 
     [HumansFact]
+    public void ConnectorAdminReadModelStaysInternal()
+    {
+        // /Finance/Holded is this section's own screen, so its read model is section-internal —
+        // the cross-section surface stays IHoldedFinanceService on the contracts leaf. Same shape
+        // as the Holded section's IHoldedAdminService (nobodies-collective/Humans#1000).
+        typeof(Services.IHoldedFinanceAdminService).IsPublic
+            .Should().BeFalse(because: "a screen's own read model is not cross-section surface");
+
+        typeof(IHoldedFinanceService).Assembly.GetTypes()
+            .Should().NotContain(t => t.Name == "IHoldedFinanceAdminService",
+                because: "the contracts leaf carries only what other sections call");
+    }
+
+    [HumansFact]
     public void FinanceControllerRequiresFinanceAdminOrAdmin()
     {
         // Moved from Humans.Application.Tests' EndpointAuthorizationTests, which sweeps Shell's

--- a/tests/Humans.Finance.Tests/FinanceControllerTests.cs
+++ b/tests/Humans.Finance.Tests/FinanceControllerTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Finance.Contracts;
 using Humans.Finance.Controllers;
 using Humans.Finance.Models;
+using Humans.Finance.Services;
 using Humans.Users.Contracts;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,10 +22,11 @@ public class FinanceControllerTests
     private static readonly Guid Bo = Guid.NewGuid();
 
     private readonly IHoldedFinanceService _finance = Substitute.For<IHoldedFinanceService>();
+    private readonly IHoldedFinanceAdminService _connector = Substitute.For<IHoldedFinanceAdminService>();
     private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
 
     private FinanceController MakeController() =>
-        new(_users, _finance, NullLogger<FinanceController>.Instance);
+        new(_users, _finance, _connector, NullLogger<FinanceController>.Instance);
 
     private static CreditorContactBinding Bound(Guid userId, int? num) =>
         new(userId, $"contact-{userId:N}"[..12], num, CreditorContactSource.Auto);
@@ -199,6 +201,22 @@ public class FinanceControllerTests
         var lines = (IReadOnlyList<CreditorLedgerLine>)controller.ViewBag.Lines;
 
         lines.Select(l => (l.EntryNumber, l.Line)).Should().Equal((9, 1), (9, 2), (7, 1), (5, 1));
+    }
+
+    // ─── Connector index ─────────────────────────────────────────────────────────
+
+    [HumansFact]
+    public async Task Holded_RendersTheConnectorOverviewUnchanged()
+    {
+        // The action is dispatch only — the read model is the service's, and the page has no
+        // controller-side assembly to get wrong (nobodies-collective/Humans#1000).
+        var vm = new HoldedConnectorVm(
+            new HoldedDocSyncVm(null, "Idle", null, 0, null, IsStale: true), 3, [], []);
+        _connector.GetConnectorOverviewAsync(Arg.Any<CancellationToken>()).Returns(vm);
+
+        var result = await MakeController().Holded(Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeOfType<ViewResult>().Subject.Model.Should().BeSameAs(vm);
     }
 
     private static CreditorLedgerLine Ledger(int entry, int line, Instant date) => new()

--- a/tests/Humans.Finance.Tests/RepositoryTests.cs
+++ b/tests/Humans.Finance.Tests/RepositoryTests.cs
@@ -103,6 +103,27 @@ public class RepositoryTests
         rows.Select(d => d.HoldedDocId).Should().Equal("in");
     }
 
+    [HumansFact]
+    public async Task GetAllDocs_ReturnsBothSlices_WhichNeitherOtherReadCovers()
+    {
+        // /Finance/Holded browses every doc. The unmatched read filters to one status and the
+        // matched read to one year, so neither composes into this (nobodies-collective/Humans#1000).
+        var (repo, _) = Make();
+        await repo.UpsertDocsAsync(
+        [
+            Doc("matched-2026", status: HoldedMatchStatus.Matched, category: Guid.NewGuid(),
+                date: new LocalDate(2026, 5, 1)),
+            Doc("matched-2027", status: HoldedMatchStatus.Matched, category: Guid.NewGuid(),
+                date: new LocalDate(2027, 1, 1)),
+            Doc("unmatched", date: new LocalDate(2026, 6, 1)),
+        ], Now, Ct);
+
+        var rows = await repo.GetAllDocsAsync(Ct);
+
+        rows.Select(d => d.HoldedDocId).Should()
+            .BeEquivalentTo(["matched-2026", "matched-2027", "unmatched"]);
+    }
+
     // ─── Creditor bindings ───────────────────────────────────────────────────────
 
     [HumansFact]

--- a/tests/Humans.Finance.Tests/ServiceTests.cs
+++ b/tests/Humans.Finance.Tests/ServiceTests.cs
@@ -1698,4 +1698,191 @@ public class HoldedFinanceServiceTests
         info.LastSyncedDocCount.Should().Be(0);
         info.CreditorBindingCount.Should().Be(0);
     }
+
+    // ─── GetConnectorOverview (/Finance/Holded) ───────────────────────────────────
+
+    /// <summary>Seeds the active year with one group holding the given categories.</summary>
+    private void ActiveYearWith(params (Guid Id, string Name)[] categories) =>
+        _budget.GetActiveYearAsync().Returns(new BudgetYearDetail(
+            Id: Guid.NewGuid(),
+            Year: "2026",
+            Name: "Camp 2026",
+            Status: BudgetYearStatus.Active,
+            IsDeleted: false,
+            Groups:
+            [
+                new BudgetGroupDetail(
+                    Id: Guid.NewGuid(),
+                    BudgetYearId: Guid.NewGuid(),
+                    Name: "Operations",
+                    SortOrder: 1,
+                    IsRestricted: false,
+                    IsDepartmentGroup: false,
+                    IsTicketingGroup: false,
+                    TicketingProjection: null,
+                    Categories: categories
+                        .Select((c, i) => new BudgetCategoryDetail(
+                            c.Id, Guid.NewGuid(), c.Name, 0, ExpenditureType.OpEx, null, i, []))
+                        .ToList())
+            ]));
+
+    private void SeedConnector(
+        HoldedDocSyncState? state = null,
+        IReadOnlyList<HoldedCategoryMap>? map = null,
+        IReadOnlyList<HoldedExpenseDoc>? docs = null,
+        IReadOnlyList<HoldedCreditorContact>? bindings = null)
+    {
+        _repo.GetOrCreateDocSyncStateAsync(Arg.Any<CancellationToken>())
+            .Returns(state ?? new HoldedDocSyncState());
+        _repo.GetCategoryMapAsync(Arg.Any<CancellationToken>())
+            .Returns(map ?? []);
+        _repo.GetAllDocsAsync(Arg.Any<CancellationToken>())
+            .Returns(docs ?? []);
+        _repo.GetCreditorContactsAsync(Arg.Any<CancellationToken>())
+            .Returns(bindings ?? []);
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_MakesNoHoldedApiCall()
+    {
+        // The whole point of the page (nobodies-collective/Humans#1000): /Finance/Creditors already
+        // pays a live ListContactsAsync on every load behind a 30 s timeout, and the index must not
+        // inherit that latency or that failure mode.
+        ActiveYearWith();
+        SeedConnector();
+
+        await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        Assert.Empty(_client.ReceivedCalls());
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_SyncWithinTheWindow_IsNotStale()
+    {
+        ActiveYearWith();
+        SeedConnector(new HoldedDocSyncState
+        {
+            LastSyncAt = FixedNow - Duration.FromHours(5),
+            Status = "Idle",
+            LastSyncedDocCount = 7,
+        });
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.DocSync.IsStale.Should().BeFalse();
+        vm.DocSync.SinceLastSync.Should().Be(Duration.FromHours(5));
+        vm.DocSync.LastSyncedDocCount.Should().Be(7);
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_SyncOlderThanTheWindow_IsStale()
+    {
+        ActiveYearWith();
+        SeedConnector(new HoldedDocSyncState { LastSyncAt = FixedNow - Duration.FromHours(40) });
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.DocSync.IsStale.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_NeverSynced_IsStaleWithNoAge()
+    {
+        // Never having run leaves the actuals and the unmatched queue as wrong as a stalled sync
+        // does, so it raises the same alarm rather than rendering a reassuring blank.
+        ActiveYearWith();
+        SeedConnector(new HoldedDocSyncState());
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.DocSync.IsStale.Should().BeTrue();
+        vm.DocSync.SinceLastSync.Should().BeNull();
+        vm.DocSync.LastSyncAt.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_ListsActiveAndArchivedMappings_WithCategoryNames()
+    {
+        var live = Guid.NewGuid();
+        var gone = Guid.NewGuid();
+        ActiveYearWith((live, "Staff"));
+        SeedConnector(map:
+        [
+            new() { BudgetCategoryId = live, HoldedAccountNumber = 62900101, Tag = "staff", IsActive = true },
+            new() { BudgetCategoryId = gone, HoldedAccountNumber = 62900102, Tag = "gone", IsActive = false },
+        ]);
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.CategoryMap.Should().HaveCount(2);
+        vm.ActiveMappings.Should().Be(1);
+        vm.ArchivedMappings.Should().Be(1);
+        vm.CategoryMap.Single(m => m.BudgetCategoryId == live).CategoryName.Should().Be("Staff");
+        vm.CategoryMap.Single(m => m.BudgetCategoryId == live).GroupName.Should().Be("Operations");
+        // A row whose category left the active year keeps its row and loses only its name.
+        vm.CategoryMap.Single(m => m.BudgetCategoryId == gone).CategoryName.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_ListsEveryDoc_MatchedAndUnmatched()
+    {
+        var cat = Guid.NewGuid();
+        ActiveYearWith((cat, "Staff"));
+        SeedConnector(docs:
+        [
+            new()
+            {
+                HoldedDocId = "d1", DocNumber = "F260001", BudgetCategoryId = cat, Total = 121m,
+                MatchStatus = HoldedMatchStatus.Matched, MatchSource = HoldedMatchSource.Account,
+                BookedAccountId = "acc-1", TagsJson = "[\"staff\"]", IsApproved = true,
+            },
+            new()
+            {
+                HoldedDocId = "d2", DocNumber = "F260002", Total = 50m,
+                MatchStatus = HoldedMatchStatus.Unmatched, MatchSource = HoldedMatchSource.None,
+                TagsJson = "[]",
+            },
+        ]);
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.Docs.Should().HaveCount(2);
+        vm.MatchedDocs.Should().Be(1);
+        vm.UnmatchedDocs.Should().Be(1);
+
+        var matched = vm.Docs.Single(d => string.Equals(d.HoldedDocId, "d1", StringComparison.Ordinal));
+        matched.CategoryName.Should().Be("Staff");
+        matched.MatchSource.Should().Be(HoldedMatchSource.Account);
+        matched.BookedAccountId.Should().Be("acc-1");
+        matched.TagsJson.Should().Be("[\"staff\"]");
+
+        vm.Docs.Single(d => string.Equals(d.HoldedDocId, "d2", StringComparison.Ordinal)).CategoryName.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_NoActiveBudgetYear_StillRenders()
+    {
+        // The page is the connector's health, not the budget's — it must not go blank between years.
+        _budget.GetActiveYearAsync().Returns((BudgetYearDetail?)null);
+        SeedConnector(map: [new() { BudgetCategoryId = Guid.NewGuid(), HoldedAccountNumber = 62900101, IsActive = true }]);
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.CategoryMap.Should().ContainSingle().Which.CategoryName.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetConnectorOverview_CountsCreditorBindings()
+    {
+        ActiveYearWith();
+        SeedConnector(bindings:
+        [
+            new() { UserId = Guid.NewGuid(), HoldedContactId = "c1" },
+            new() { UserId = Guid.NewGuid(), HoldedContactId = "c2" },
+        ]);
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.CreditorBindingCount.Should().Be(2);
+    }
 }

--- a/tests/Humans.Finance.Tests/ServiceTests.cs
+++ b/tests/Humans.Finance.Tests/ServiceTests.cs
@@ -1801,6 +1801,33 @@ public class HoldedFinanceServiceTests
     }
 
     [HumansFact]
+    public async Task GetConnectorOverview_AFailedRun_KeepsTheSuccessTimeAndCarriesTheAttemptTime()
+    {
+        // SyncAsync stamps StatusChangedAt on failure and deliberately leaves LastSyncAt on the
+        // older success. Dropping StatusChangedAt made an Error row read as "nothing has run since
+        // the success" — the opposite of the truth, on the page that exists to say what is running.
+        var succeeded = FixedNow - Duration.FromHours(50);
+        var failed = FixedNow - Duration.FromHours(2);
+        ActiveYearWith();
+        SeedConnector(new HoldedDocSyncState
+        {
+            LastSyncAt = succeeded,
+            Status = "Error",
+            LastError = "holded said no",
+            StatusChangedAt = failed,
+            LastSyncedDocCount = 12,
+        });
+
+        var vm = await MakeService().GetConnectorOverviewAsync(Xunit.TestContext.Current.CancellationToken);
+
+        vm.DocSync.LastSyncAt.Should().Be(succeeded);
+        vm.DocSync.StatusChangedAt.Should().Be(failed);
+        // Staleness keys on the success, not the attempt: a run that failed refreshed nothing.
+        vm.DocSync.SinceLastSync.Should().Be(Duration.FromHours(50));
+        vm.DocSync.IsStale.Should().BeTrue();
+    }
+
+    [HumansFact]
     public async Task GetConnectorOverview_ListsActiveAndArchivedMappings_WithCategoryNames()
     {
         var live = Guid.NewGuid();

--- a/tests/Humans.Integration.Tests/Controllers/FinancePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/FinancePageRenderTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using AwesomeAssertions;
+using Humans.Integration.Tests.Infrastructure;
+
+namespace Humans.Integration.Tests.Controllers;
+
+/// <summary>
+/// Renders <c>/Finance/Holded</c> — the connector index added by
+/// nobodies-collective/Humans#1000 — through the real app.
+/// </summary>
+/// <remarks>
+/// The page is pure link-out plus three cached tables, so its failure modes are the silent ones
+/// a green build does not catch. A section RCL does not inherit the host's
+/// <c>Views/_ViewImports.cshtml</c>, and an anchor tag helper naming a controller/action pair
+/// that resolves to no endpoint omits its <c>href</c> entirely while still returning 200 with a
+/// link-shaped element that goes nowhere (the A2 incident behind
+/// <see cref="AdminNavTreeRoutingTests"/>). This page's whole purpose is those links, so each one
+/// is asserted as a real href rather than as "the page loaded".
+/// <para>
+/// Nothing is seeded: the empty database is the state the staleness alarm has to be legible in —
+/// a connector that has never synced is exactly as wrong as a stalled one, and rendering that
+/// blank was the gap the issue names.
+/// </para>
+/// </remarks>
+public class FinancePageRenderTests(HumansTestDatabase database) : IntegrationTestBase(database)
+{
+    [HumansFact(Timeout = 120000)]
+    public async Task The_connector_index_renders_and_links_out_to_every_screen_it_defers_to()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+
+        var response = await Client.GetAsync("/Finance/Holded", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "GET /Finance/Holded must render");
+        var html = await response.Content.ReadAsStringAsync(ct);
+
+        html.Should().Contain("Holded Connector");
+
+        // "Link out, don't rebuild" is the issue's constraint; an href-less anchor silently
+        // breaks it while the page still looks right.
+        foreach (var href in new[]
+                 {
+                     "/Finance/HoldedAccounts",
+                     "/Finance/HoldedUnmatched",
+                     "/Finance/Creditors",
+                     "/Holded",
+                 })
+        {
+            html.Should().Contain($"href=\"{href}\"", $"the index must link to {href}");
+        }
+
+        // A view-component element the section's _ViewImports failed to bind renders as literal
+        // markup: 200, correct-looking source, nothing on the page.
+        html.Should().NotContain("<vc:", "a view-component tag was left unrendered");
+    }
+
+    [HumansFact(Timeout = 120000)]
+    public async Task The_connector_index_offers_no_write_action()
+    {
+        // Read-only is the issue's constraint, not an accident of what got built: every trigger —
+        // Sync now, Provision, Bind, Unbind — stays on the screen that already owns it. A stray
+        // POST form here would be the first step back toward a second place to mutate from.
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+
+        var html = await (await Client.GetAsync("/Finance/Holded", ct)).Content.ReadAsStringAsync(ct);
+
+        // Named routes, not "no <form>": the admin layout's own chrome (language switcher,
+        // sign-out) posts, so the assertion has to be about this section's write endpoints.
+        foreach (var writeRoute in new[]
+                 {
+                     "/Finance/HoldedSync/Run",
+                     "/Finance/HoldedAccounts/Provision",
+                     "/Finance/Creditors/Bind",
+                     "/Finance/Creditors/Unbind",
+                 })
+        {
+            html.Should().NotContain(writeRoute, $"the connector index is read-only, but posts to {writeRoute}");
+        }
+    }
+
+    [HumansFact(Timeout = 120000)]
+    public async Task A_connector_that_has_never_synced_says_so_rather_than_rendering_blank()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+
+        var html = await (await Client.GetAsync("/Finance/Holded", ct)).Content.ReadAsStringAsync(ct);
+
+        html.Should().Contain("never completed", "staleness must be legible, not implied");
+        html.Should().Contain("Stale");
+    }
+}


### PR DESCRIPTION
Refs nobodies-collective/Humans#1000 — **9 of 10 acceptance criteria; the issue stays open.** AC2 (outbox panel) is not included; see the owner-decision section below.

Adds `/Finance/Holded` — a read-only index for Finance's half of the Holded connector, plus the
missing detail panels. Four of the six Holded-owned entities had no screen at all; three of them now
do, and the fourth is blocked on an architectural gate described at the bottom.

## What the page does

| Panel | Answers |
|---|---|
| Tiles | doc-sync status + age, mapped categories (active/archived), pulled docs (matched/unmatched), creditor bindings — each links to the screen that owns it |
| Purchase-doc sync | `HoldedDocSyncState`: status, last run, **age**, docs last run, last error |
| Category map | every live `holded_category_map` row — account, category, group, tag, active/archived |
| Purchase documents | every pulled `HoldedExpenseDoc` — date, doc #, contact, total, approved, match status, **match source**, category, and the raw payload behind a disclosure |

**Staleness is rendered, not implied.** The doc sync goes stale at 36 h (the nightly job's 24 h
cadence plus half a day of grace) and a connector that has *never* synced counts as stale too —
budget actuals and the unmatched queue are equally wrong either way, and rendering that as a blank
was the gap the issue names. The alarm is a page-level banner plus a `Stale` badge.

**Link out, don't rebuild.** `/Finance/HoldedAccounts`, `/Finance/HoldedUnmatched`,
`/Finance/Creditors` and `/Holded` are unchanged and linked; nothing they already show is restated
here. The split against `/Holded` is table ownership: that screen covers what `HoldedDbContext`
owns (API budget, ledger sweeps, chart of accounts), this one covers what `FinanceDbContext` does.

**Read-only, deliberately.** No Provision / Bind / Unbind / Sync-now on this page — every trigger
stays on the screen that already owns it. Pinned by
`The_connector_index_offers_no_write_action`, which asserts none of this section's four write routes
appears in the rendered HTML.

**No live Holded call.** `/Finance/Creditors` pays a synchronous `ListContactsAsync` behind a 30 s
timeout on every load (nobodies-collective/Humans#976); the index must not inherit that, so it reads
the Postgres cache only. Pinned by `GetConnectorOverview_MakesNoHoldedApiCall`.

## Reuse-first — what was rejected, and why

- **New public surface on `IHoldedFinanceService`** — rejected. `/Finance/Holded` is this section's
  own screen, so its read model is section-**internal**: `IHoldedFinanceAdminService`
  (`Services/`, `internal`, implemented by the existing `Service`, one method). This is the shape
  the Holded section already uses for `/Holded` (`IHoldedAdminService`). The contracts leaf grows by
  nothing. An architecture test pins both halves — the interface is not public, and the leaf does
  not carry it.
- **A new service/repository** — rejected. Everything hangs off the existing `Service` and
  `IHoldedRepository`; `GetDocSyncInfoAsync` and `GetCategoryMapAsync` were reused as-is.
- **A new sync-state read** — rejected. The doc-sync singleton already had
  `GetOrCreateDocSyncStateAsync`; only the age/staleness derivation is new, and it lives in the
  service (it is a rule, not a format) rather than in the controller or the view.
- **One new repository method: `GetAllDocsAsync`.** `GetUnmatchedAsync` filters to one status and
  `GetMatchedForYearAsync` to one year, so neither composes into "every doc" — the docs panel needs
  both slices plus matched rows outside the active year. Internal interface, no public surface.
  Unordered: the view sorts, per `display-sort-in-controllers`.
- **A new view component or partial** — rejected. Single-page markup with a model the controller
  already holds; a partial would only move it.
- **Controller-side assembly** — rejected. The action is one statement (`View(await …)`); counts are
  derived properties on the view model and ordering happens in the `@foreach`.
- **`SectionAdminNav.cs` is new** because Finance had none — its Holded pages had no sidebar entry
  at all. One item ("Holded connector") joins the shared "Money" group through the
  `ISectionAdminNav` seam; `AdminNavTreeRoutingTests` already proves the pair routes.

## Notes on the spec vs the code as it stands today

The issue's "Key files" list predates G5. `HoldedCategoryMap`, `HoldedExpenseDoc` and the doc-sync
singleton now live in `src/Sections/Humans.Finance/`; the ledger mirror's own `HoldedSyncState` moved
to `Humans.Holded` and is already rendered on `/Holded`. The singleton the issue describes — the one
carrying `LastSyncedDocCount` — is Finance's `HoldedDocSyncState`, which is what this page shows.

`HoldedCategoryMap` has `IsActive` but no `ArchivedAt`; both states are listed and labelled, and the
page says plainly that nothing retires a row today. `HoldedExpenseDoc` has no `RawPayload` column
post-v2 — the disclosure shows what replaced it (`TagsJson`, booked account id, Holded doc id, last
synced).

## Acceptance criteria

- [x] `/Finance/Holded` exists and links to every existing Holded screen rather than duplicating it
- [ ] **Outbox state is visible, including `FailedPermanently` rows** — blocked, see below
- [x] `HoldedSyncState` — status, last run, last error, doc count — visible, staleness legible
- [x] Active and archived `HoldedCategoryMap` rows are listable
- [x] `HoldedExpenseDoc` rows are browsable with match status and source
- [x] The index issues no live Holded HTTP calls — cache reads only
- [x] No cross-section EF join, no new table in `IHoldedRepository`
- [x] Authorized with `PolicyNames.FinanceAdminOrAdmin`, consistent with the rest of `/Finance`
- [x] No schema change — no migration, snapshot untouched
- [x] Section docs updated to record the new screen

## Needs new interface surface — owner approval required

**The outbox panel.** Not built. This is the issue's most valuable item, so it is a proposal, not a
descope — it needs a decision only Peter can make.

- **What is needed:** a cross-report listing of `HoldedExpenseOutboxEvent` — `ExpenseReportId`, event
  type, `OccurredAt`, `RetryCount`, `LastError`, `FailedPermanently` — filterable by state, each row
  linking to `/Expenses/{id}`.
- **Why nothing existing serves it:** `IExpenseReportServiceRead.GetHoldedTimelineAsync` returns
  exactly these fields but takes **one report** and additionally reads the creditor ledger per call
  (`GetCreditorStatusAsync` + `GetForSubmitterAsync`), so composing it over `GetAllAsync()` is an N+1
  across a section boundary. `CountFailedHoldedPushesAsync` is a bare count and sits on the
  **internal** `IExpenseReportService`, not the read contract. Enriching `ExpenseReportDto` per
  `read-model-enrichment` would put an outbox lookup on every report read path, including
  `GetAsync`.
- **The real blocker is not the method — it is the project graph.** `Humans.Expenses` references
  `Humans.Finance.Contracts`, and Expenses has **no `.Contracts` leaf project** (its `Contracts/`
  is a folder inside the section assembly). A Finance page reading the outbox therefore requires
  carving `Humans.Expenses.Contracts` out first, per
  `memory/architecture/section-project-cycle-fix.md` — the referenced-but-not-yet-demanded split.
  That is a new project plus a reference rewrite across every Expenses consumer, not an interface
  method.
- **Minimal proposal, on approval:** carve `Humans.Expenses.Contracts` (move `Contracts/` verbatim),
  add one method to `IExpenseReportServiceRead` —
  `Task<IReadOnlyList<ExpenseHoldedOutboxRow>> GetHoldedOutboxAsync(CancellationToken ct = default)`
  — with a flat DTO of the six fields above, served by one repository read on
  `ExpensesDbContext`. No cross-section EF join, no new table in `IHoldedRepository`, no schema
  change — the issue's own constraint on this criterion is satisfied by construction.
- **Alternative worth considering instead:** put the panel on an **Expenses** screen (next to
  `/Expenses/Review`, which already carries the written-off-push banner) and link to it from
  `/Finance/Holded`. Zero new cross-section surface, zero project split, and the outbox stays where
  its table does.
- **Partial state today:** per-report push state is already visible on `/Expenses/{id}` (sync state,
  retry count, last error, next retry, re-queue) and `/Expenses/Review` shows the written-off count
  — shipped by nobodies-collective/Humans#1045, after this issue was written. The gap is the
  cross-report *list*, not total invisibility.

## Verification

`dotnet build Humans.slnx` clean. `Humans.Finance.Tests` 103/103. Full solution suite green apart
from `Humans.Integration.Tests`, where a different set of Store / Stripe / Calendar / Users / Email
tests fails on each run under parallel load on this machine — none of them touched here, all passing
in isolation, and the three new `FinancePageRenderTests` pass in every run.

New coverage: staleness (fresh / stale / never-run), the no-Holded-call guarantee, category-map
active+archived with names resolved and nulled outside the active year, all-docs listing with match
source, the no-active-budget-year fall-through, `GetAllDocsAsync` returning both slices, the
controller action's pass-through, the internal-interface architecture test, and three real-app render
tests (renders, every promised link has a real `href`, never-synced says so, no write route present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
