### PR TITLE
feat(store): issue per-item-accounted Holded v2 facturas and receipts

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -450,6 +450,7 @@ graph LR
     Store --> Camp
     Store --> Team
     Store --> ShiftMgmt
+    Store --> Holded
     Store --> Audit
 
     %% Surveys

--- a/docs/guide/Store.md
+++ b/docs/guide/Store.md
@@ -18,7 +18,7 @@ Store Admin and Finance Admin look after the catalogue, keep an eye on orders, a
 - **Camp orders** (`/Store`) — browse this year's catalogue and manage your camp's orders
 - **Order detail** (`/Store/Order/{id}`) — an order's items, balance, and payment status; pay by card from here
 - **Catalogue** (`/Store/Admin/Catalog`) — create and manage products (Store Admin)
-- **Add / edit a product** (`/Store/Admin/Catalog/Edit`) — product form: name, description, price, VAT, optional deposit, ordering deadline (Store Admin)
+- **Add / edit a product** (`/Store/Admin/Catalog/Edit`) — product form: name, description, price, VAT, optional deposit, ordering deadline, Holded revenue account (Store Admin)
 - **Summary report** (`/Store/Admin/Summary`) — totals by camp and by product for a year (Store Admin, Finance Admin, Admin)
 - **Stripe payments** (`/Store/Admin/Payments`) — reconcile card payments against the ledger and record any that weren't picked up automatically (Store Admin, Finance Admin, Admin)
 
@@ -50,7 +50,7 @@ The tasks below need the **Store Admin**, **Finance Admin**, or **Admin** role. 
 
 ### Manage the catalogue
 
-Go to `/Store/Admin/Catalog` to see all products, and add or edit one at `/Store/Admin/Catalog/Edit`. Each product has a name, description, unit price (EUR), VAT rate, an optional per-unit deposit, an ordering deadline, and an active/inactive switch. The product form shows both an ex-VAT and an incl-VAT price field — enter either and the other updates automatically. Switching a product off hides it from new orders without touching orders that already include it. Products belong to a year — the current event year decides which catalogue is live.
+Go to `/Store/Admin/Catalog` to see all products, and add or edit one at `/Store/Admin/Catalog/Edit`. Each product has a name, description, unit price (EUR), VAT rate, an optional per-unit deposit, an ordering deadline, and an active/inactive switch. The product form shows both an ex-VAT and an incl-VAT price field — enter either and the other updates automatically. Each product also carries the **Holded revenue account** — the account number your accountant issued for that item, so its sales land in their own line in the books and you can read per-item break-even straight off the ledger. An item without one can't be invoiced. The matching internal account for department use is worked out from it automatically and shown next to it in the catalogue list. Switching a product off hides it from new orders without touching orders that already include it. Products belong to a year — the current event year decides which catalogue is live.
 
 ### Summary report
 
@@ -60,7 +60,23 @@ Go to `/Store/Admin/Catalog` to see all products, and add or edit one at `/Store
 
 `/Store/Admin/Payments` reconciles card payments taken through Stripe against what's recorded on orders. Card payments normally record themselves automatically, but if that automatic step isn't set up (or a payment slips through), this page lists every Stripe checkout and flags any paid one that hasn't been recorded yet. One click records all the missing ones — pulling the amount straight from Stripe, never re-typing it — and it's safe to run again any time. Payments recorded here but no longer found in Stripe are listed separately for you to look into; nothing is ever removed automatically. Sessions that are recorded but still awaiting settlement (e.g. a SEPA debit mandate that has been captured but hasn't cleared yet) are shown as **Recorded / Pending** — they are not counted toward the order balance until Stripe confirms the transfer.
 
-> **Heads up:** the Finance order-review screen (entering manual payments by hand and issuing invoices) isn't switched on yet.
+### Issuing a camp's invoice
+
+Open the camp's order and use **Issue invoice**. It creates the document in Holded and approves
+it in one step, then freezes the order — the prices stop tracking the catalogue and the order can
+never be issued a second time.
+
+Which document you get depends on the billing details on the order. With a name, an address and a
+tax ID (a NIF, or a foreign camp's home-country tax number or passport number) you get a **full
+factura**. Without them you get a **simplified invoice** — but only up to the legal ceiling; above
+it you'll be asked to fill the details in first. Refundable deposits are shown as separate VAT-free
+lines, because a deposit is money held, not money earned.
+
+If an item is missing its Holded revenue account, or the deposit account hasn't been configured
+yet, nothing is sent to Holded and you're told exactly what to fix.
+
+> **Heads up:** the Finance order-review screen (entering manual payments by hand) isn't switched
+> on yet.
 
 ## Related sections
 

--- a/src/Sections/Humans.AuditLog.Contracts/AuditAction.cs
+++ b/src/Sections/Humans.AuditLog.Contracts/AuditAction.cs
@@ -125,6 +125,7 @@ public enum AuditAction
     StoreProductUpdated,
     StoreProductPriceChanged,
     StoreProductDeactivated,
+    StoreInvoiceIssued,
     StorePaymentRecorded,
     StorePaymentSettled,
     StorePaymentFailed,

--- a/src/Sections/Humans.Holded.Contracts/HoldedContactDtos.cs
+++ b/src/Sections/Humans.Holded.Contracts/HoldedContactDtos.cs
@@ -11,9 +11,18 @@ public sealed record HoldedContactInput
     /// have no `custom_id` field (it is read-only on GET). Kept on the DTO for now since nothing
     /// reads it back for lookup; no functional loss.</summary>
     public string? CustomId { get; init; }
-    /// <summary>Holded contact type. Creditors/suppliers get a 400000xx account.</summary>
+    /// <summary>Holded contact type — <c>creditor</c>/<c>supplier</c> get a 400000xx account,
+    /// <c>client</c>/<c>debtor</c> a 430000xx one. Store's factura counterparties are clients.</summary>
     public string Type { get; init; } = "creditor";
     public string? Iban { get; init; }
+    /// <summary>Tax identification number — v2 `code`. NIF/CIF for Spanish counterparties; a
+    /// home-country tax id or passport number for foreign camps (no NIF is required of them).</summary>
+    public string? TaxCode { get; init; }
+    public string? Email { get; init; }
+    /// <summary>Street address — sent as `bill_address.address`. Required on a full factura.</summary>
+    public string? Address { get; init; }
+    /// <summary>ISO 3166-1 alpha-2 — sent as `bill_address.country_code`.</summary>
+    public string? CountryCode { get; init; }
     /// <summary>When set, update this existing contact rather than create a new one.</summary>
     public string? ExistingContactId { get; init; }
 }

--- a/src/Sections/Humans.Holded.Contracts/HoldedSalesDocumentDtos.cs
+++ b/src/Sections/Humans.Holded.Contracts/HoldedSalesDocumentDtos.cs
@@ -60,6 +60,10 @@ public sealed record HoldedSalesDocumentDto
     public required decimal Tax { get; init; }
     public required decimal Total { get; init; }
     public string? Status { get; init; }
+    /// <summary>True while the document is still a draft: it books no revenue and carries no
+    /// sequential number until <see cref="IHoldedClient.ApproveSalesDocumentAsync"/> runs. Null
+    /// when Holded does not report the field.</summary>
+    public bool? IsDraft { get; init; }
     /// <summary>The verbatim response body, kept for the audited payload on <c>store_invoices</c>.</summary>
     public required string RawJson { get; init; }
 }

--- a/src/Sections/Humans.Holded.Contracts/HoldedSalesDocumentDtos.cs
+++ b/src/Sections/Humans.Holded.Contracts/HoldedSalesDocumentDtos.cs
@@ -1,0 +1,61 @@
+using NodaTime;
+
+namespace Humans.Holded.Contracts;
+
+/// <summary>
+/// Which outbound sales document Holded should create. The two share one payload shape and
+/// one pipeline (create → approve → read); only the endpoint segment differs.
+/// </summary>
+public enum HoldedSalesDocumentKind
+{
+    /// <summary>Full <i>factura</i> — <c>/api/v2/invoices</c>. Requires an identified contact.</summary>
+    Invoice,
+
+    /// <summary><i>Factura simplificada</i> — <c>/api/v2/sales-receipts</c>. No counterparty needed.</summary>
+    SalesReceipt,
+}
+
+/// <summary>
+/// One line of an outbound sales document. <see cref="AccountId"/> is the Holded chart-of-accounts
+/// <b>id</b> (24-hex), not the 8-digit number — resolve it through
+/// <see cref="IHoldedClient.ListAccountingAccountsAsync"/> before building the line.
+/// </summary>
+public sealed record HoldedSalesDocumentLineInput
+{
+    public required string Name { get; init; }
+    public required decimal Units { get; init; }
+    /// <summary>Unit price, VAT-exclusive.</summary>
+    public required decimal Price { get; init; }
+    /// <summary>Holded sales tax keys, e.g. <c>s_iva_21</c> / <c>s_iva_0</c>. Empty applies the
+    /// contact's default tax, so never leave it empty for a line whose rate matters.</summary>
+    public IReadOnlyList<string> Taxes { get; init; } = [];
+    /// <summary>Holded account id this line books to. Null falls back to Holded's default income account.</summary>
+    public string? AccountId { get; init; }
+}
+
+/// <summary>Create payload for an invoice or sales receipt.</summary>
+public sealed record HoldedSalesDocumentInput
+{
+    /// <summary>Required for <see cref="HoldedSalesDocumentKind.Invoice"/>; omitted for a receipt.</summary>
+    public string? ContactId { get; init; }
+    public string? ContactName { get; init; }
+    public required Instant Date { get; init; }
+    public string? Description { get; init; }
+    /// <summary>Internal notes — visible to us, not printed on the document.</summary>
+    public string? Notes { get; init; }
+    public required IReadOnlyList<HoldedSalesDocumentLineInput> Lines { get; init; }
+}
+
+/// <summary>A sales document as Holded returns it after approval.</summary>
+public sealed record HoldedSalesDocumentDto
+{
+    public required string Id { get; init; }
+    /// <summary>Holded's sequential document number. Assigned at approval; empty on a draft.</summary>
+    public required string DocNumber { get; init; }
+    public required decimal Subtotal { get; init; }
+    public required decimal Tax { get; init; }
+    public required decimal Total { get; init; }
+    public string? Status { get; init; }
+    /// <summary>The verbatim response body, kept for the audited payload on <c>store_invoices</c>.</summary>
+    public required string RawJson { get; init; }
+}

--- a/src/Sections/Humans.Holded.Contracts/HoldedSalesDocumentDtos.cs
+++ b/src/Sections/Humans.Holded.Contracts/HoldedSalesDocumentDtos.cs
@@ -43,6 +43,10 @@ public sealed record HoldedSalesDocumentInput
     public string? Description { get; init; }
     /// <summary>Internal notes — visible to us, not printed on the document.</summary>
     public string? Notes { get; init; }
+    /// <summary>Internal labels. Not printed, and — unlike <see cref="Notes"/> — returned by the
+    /// list endpoints, so a tag is the only thing that makes a document findable by whatever
+    /// created it. See <see cref="IHoldedClient.FindSalesDocumentIdsByTagAsync"/>.</summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
     public required IReadOnlyList<HoldedSalesDocumentLineInput> Lines { get; init; }
 }
 

--- a/src/Sections/Humans.Holded.Contracts/IHoldedClient.cs
+++ b/src/Sections/Humans.Holded.Contracts/IHoldedClient.cs
@@ -54,6 +54,13 @@ public interface IHoldedClient
     Task ApproveSalesDocumentAsync(
         HoldedSalesDocumentKind kind, string documentId, CancellationToken ct = default);
 
+    /// <summary>Ids of the sales documents of <paramref name="kind"/> carrying <paramref name="tag"/>.
+    /// v2 has no server-side tag filter and its list responses omit <c>notes</c>, so the collection is
+    /// walked and matched on the tag client-side. Used to find a document a previous attempt already
+    /// issued before issuing a second one.</summary>
+    Task<IReadOnlyList<string>> FindSalesDocumentIdsByTagAsync(
+        HoldedSalesDocumentKind kind, string tag, CancellationToken ct = default);
+
     /// <summary>Reads a sales document back — the post-approval document number and totals.</summary>
     Task<HoldedSalesDocumentDto> GetSalesDocumentAsync(
         HoldedSalesDocumentKind kind, string documentId, CancellationToken ct = default);

--- a/src/Sections/Humans.Holded.Contracts/IHoldedClient.cs
+++ b/src/Sections/Humans.Holded.Contracts/IHoldedClient.cs
@@ -45,6 +45,19 @@ public interface IHoldedClient
     /// <summary>Creates or updates a contact; returns the contact id.</summary>
     Task<string> UpsertContactAsync(HoldedContactInput input, CancellationToken ct = default);
 
+    /// <summary>Creates a draft invoice or sales receipt; returns the new doc id. A draft books
+    /// nothing — follow with <see cref="ApproveSalesDocumentAsync"/>.</summary>
+    Task<string> CreateSalesDocumentAsync(
+        HoldedSalesDocumentKind kind, HoldedSalesDocumentInput input, CancellationToken ct = default);
+
+    /// <summary>Approves a sales document. Only an approved doc books revenue and gets a number.</summary>
+    Task ApproveSalesDocumentAsync(
+        HoldedSalesDocumentKind kind, string documentId, CancellationToken ct = default);
+
+    /// <summary>Reads a sales document back — the post-approval document number and totals.</summary>
+    Task<HoldedSalesDocumentDto> GetSalesDocumentAsync(
+        HoldedSalesDocumentKind kind, string documentId, CancellationToken ct = default);
+
     /// <summary>Reads one contact; exposes supplierRecord.num (the 400000xx account).</summary>
     Task<HoldedContactDto> GetContactAsync(string contactId, CancellationToken ct = default);
 

--- a/src/Sections/Humans.Holded/Docs/Holded-connector.md
+++ b/src/Sections/Humans.Holded/Docs/Holded-connector.md
@@ -17,6 +17,12 @@ section** it belongs to (ledger mirror, sync, `/Holded` admin screen) has its ow
 - A **Purchase Document** in Holded is the org's incoming invoice/expense record. Expenses
   creates one per approved expense report, **booked to its 629 expense account at creation**
   (`items[].account`); tags are never written (dead v1 workaround).
+- A **Sales Document** is the org's outgoing revenue record, in two kinds behind one
+  `HoldedSalesDocumentKind`: a full `invoice` (identified contact required) and a
+  `sales-receipt` (*factura simplificada*, no contact). They share one payload shape and one
+  pipeline — create → **approve** → read back — because a Holded draft books no revenue and
+  carries no document number. Store creates them per camp order, with `items[].account` per
+  line. `items[].account` is the chart account's **id**, not its 8-digit number.
 - The **API key** is bound from the `HOLDED_API_KEY_V2` env var only — never `appsettings.json`,
   never logged. Jobs and pages no-op cleanly when it is unset (PR-preview / local dev).
 - Errors are classified at the client boundary: `HoldedTransientException` (5xx, network,
@@ -39,13 +45,18 @@ section** it belongs to (ledger mirror, sync, `/Holded` admin screen) has its ow
 - `ledger-entries` dates arrive as `DD/MM/YYYY` (parsed via `HoldedLedgerDatePattern` in
   `DateFormattingExtensions`); purchases/contacts dates are ISO. Decimals arrive as strings.
 - Currency is EUR-only. Multi-currency is out of scope.
+- Line taxes are Holded **tax keys**, scoped by direction: `s_iva_21` / `s_iva_0` on sales
+  documents, `p_iva_21` on purchases. The decimal separator is dropped, not rounded —
+  7.5% is `s_iva_75`.
+- Post-issuance corrections are a *factura rectificativa* in Holded, never a mutation of the
+  issued document — the same reason there is no doc-update endpoint below.
 - There is **no tag/doc-update endpoint in v2**; recategorizing a pushed doc is done inside
   Holded (reclassify the line) and the ledger mirror picks the correction up.
 
 ## Cross-Section Dependencies
 
-Inbound: Expenses (doc push via outbox), Finance (provisioning, contacts, doc sync), Holded
-section (ledger/accounts/usage). Outbound: none — the connector owns no tables and no UI.
+Inbound: Expenses (doc push via outbox), Finance (provisioning, contacts, doc sync), Store
+(sales-document issuance + chart read), Holded section (ledger/accounts/usage). Outbound: none — the connector owns no tables and no UI.
 
 ## Architecture
 

--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -258,6 +258,33 @@ internal sealed class HoldedClient : IHoldedClient
         using var resp = await SendAsync(req, ct);
     }
 
+    public async Task<IReadOnlyList<string>> FindSalesDocumentIdsByTagAsync(
+        HoldedSalesDocumentKind kind, string tag, CancellationToken ct = default)
+    {
+        const int pageSafetyCap = 200; // 40 000 documents — far above a small nonprofit's volume
+        var items = await GetPagedAsync($"/api/v2/{SalesSegment(kind)}?limit=200", pageSafetyCap, ct);
+        try
+        {
+            return items
+                .Where(n => ReadTags(Prop(n, "tags")).Contains(tag, StringComparer.Ordinal))
+                // A match without an id cannot be dropped: the caller reads an empty result as
+                // "nothing issued yet" and creates a second approved document.
+                .Select(n => Prop(n, "id")?.GetValue<string>() is { Length: > 0 } id
+                    ? id
+                    : throw new HoldedPermanentException(
+                        "Holded sales document is missing required field 'id' — refusing the page."))
+                .ToList();
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException
+            or FormatException or OverflowException)
+        {
+            // Same normalization as ListPurchaseDocumentsAsync: the value that failed to parse
+            // belongs to the stored document, not to this request, so a retry cannot help.
+            throw new HoldedPermanentException(
+                $"Holded {SalesSegment(kind)} documents could not be searched.", ex);
+        }
+    }
+
     public async Task<HoldedSalesDocumentDto> GetSalesDocumentAsync(
         HoldedSalesDocumentKind kind, string documentId, CancellationToken ct = default)
     {
@@ -299,6 +326,7 @@ internal sealed class HoldedClient : IHoldedClient
         date = LocalDatePattern.Iso.Format(input.Date.InZone(MadridZone).Date),
         description = input.Description,
         notes = input.Notes,
+        tags = input.Tags,
         currency = "EUR",
         items = input.Lines.Select(l => new
         {

--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -190,12 +190,22 @@ internal sealed class HoldedClient : IHoldedClient
     public async Task<string> UpsertContactAsync(HoldedContactInput input, CancellationToken ct = default)
     {
         // v2 contacts POST/PUT have no `custom_id` field (see HoldedContactInput.CustomId) — not sent.
+        // bill_address is omitted entirely when we hold no address parts: sending an object of nulls
+        // would blank an address already on the contact.
+        object? billAddress =
+            string.IsNullOrWhiteSpace(input.Address) && string.IsNullOrWhiteSpace(input.CountryCode)
+                ? null
+                : new { address = input.Address, country_code = input.CountryCode };
+
         var payload = new
         {
             name = input.Name,
             trade_name = input.TradeName,
             type = input.Type,
             iban = input.Iban,
+            code = input.TaxCode,
+            email = input.Email,
+            bill_address = billAddress,
         };
 
         var isUpdate = !string.IsNullOrEmpty(input.ExistingContactId);
@@ -214,6 +224,91 @@ internal sealed class HoldedClient : IHoldedClient
             ?? input.ExistingContactId
             ?? throw new HoldedTransientException("Holded contact upsert response missing id");
     }
+
+    /// <summary>The v2 path segment for a sales-document kind. Both kinds share the same payload
+    /// shape and the same create/approve/read pipeline; only this segment differs.</summary>
+    private static string SalesSegment(HoldedSalesDocumentKind kind) => kind switch
+    {
+        HoldedSalesDocumentKind.Invoice => "invoices",
+        HoldedSalesDocumentKind.SalesReceipt => "sales-receipts",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown Holded sales-document kind."),
+    };
+
+    public async Task<string> CreateSalesDocumentAsync(
+        HoldedSalesDocumentKind kind, HoldedSalesDocumentInput input, CancellationToken ct = default)
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post, $"/api/v2/{SalesSegment(kind)}")
+        { Content = JsonContent.Create(BuildSalesDocumentPayload(input)) };
+        AttachAuth(req);
+
+        using var resp = await SendAsync(req, ct);
+        var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync(ct))
+            ?? throw new HoldedTransientException("Holded returned empty body");
+        return Prop(node, "id")?.GetValue<string>()
+            ?? throw new HoldedTransientException("Holded sales-document response missing id");
+    }
+
+    public async Task ApproveSalesDocumentAsync(
+        HoldedSalesDocumentKind kind, string documentId, CancellationToken ct = default)
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Post, $"/api/v2/{SalesSegment(kind)}/{documentId}/approve");
+        AttachAuth(req);
+        using var resp = await SendAsync(req, ct);
+    }
+
+    public async Task<HoldedSalesDocumentDto> GetSalesDocumentAsync(
+        HoldedSalesDocumentKind kind, string documentId, CancellationToken ct = default)
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Get, $"/api/v2/{SalesSegment(kind)}/{documentId}");
+        AttachAuth(req);
+        using var resp = await SendAsync(req, ct);
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        try
+        {
+            var node = JsonNode.Parse(body)
+                ?? throw new HoldedTransientException("Holded returned empty body");
+            return new HoldedSalesDocumentDto
+            {
+                Id = Prop(node, "id")?.GetValue<string>() ?? documentId,
+                DocNumber = Prop(node, "document_number")?.GetValue<string>() ?? "",
+                Subtotal = ReadDecimalV2(Prop(node, "subtotal")),
+                Tax = ReadDecimalV2(Prop(node, "tax")),
+                Total = ReadDecimalV2(Prop(node, "total")),
+                Status = Prop(node, "status")?.GetValue<string>(),
+                RawJson = body,
+            };
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException
+            or FormatException or OverflowException)
+        {
+            // The doc is already created and approved at this point, so a retry would duplicate it.
+            // Permanent is the honest classification: the value that failed to parse belongs to the
+            // stored document, not to this request.
+            throw new HoldedPermanentException(
+                $"Holded {SalesSegment(kind)} document {documentId} could not be read.", ex);
+        }
+    }
+
+    private static object BuildSalesDocumentPayload(HoldedSalesDocumentInput input) => new
+    {
+        contact_id = input.ContactId,
+        contact_name = input.ContactName,
+        date = LocalDatePattern.Iso.Format(input.Date.InZone(MadridZone).Date),
+        description = input.Description,
+        notes = input.Notes,
+        currency = "EUR",
+        items = input.Lines.Select(l => new
+        {
+            name = l.Name,
+            units = l.Units,
+            price = l.Price,
+            taxes = l.Taxes,
+            account = l.AccountId,
+        }).ToList(),
+    };
 
     public async Task<HoldedContactDto> GetContactAsync(string contactId, CancellationToken ct = default)
     {

--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -305,6 +305,7 @@ internal sealed class HoldedClient : IHoldedClient
                 Tax = ReadDecimalV2(Prop(node, "tax")),
                 Total = ReadDecimalV2(Prop(node, "total")),
                 Status = Prop(node, "status")?.GetValue<string>(),
+                IsDraft = Prop(node, "draft")?.GetValue<bool>(),
                 RawJson = body,
             };
         }

--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Humans.Base.Extensions;
 using Humans.Base.Helpers;
 using Humans.Holded.Contracts;
@@ -18,6 +19,14 @@ internal sealed class HoldedClient : IHoldedClient
 {
     private const int DefaultRetryAfterSeconds = 5;
     private const int MaxRetryAfterSeconds = 60;
+
+    /// <summary>Every outbound payload omits its null members instead of sending them. Holded applies
+    /// each key a POST/PUT carries, so <c>"code":null</c> on a contact update blanks the tax id
+    /// already stored against that contact — and a creditor update supplies only the handful of
+    /// fields it means to change. Omission is "leave it alone", which is what every caller means;
+    /// nothing here ever clears a Holded field on purpose.</summary>
+    private static readonly JsonSerializerOptions OmitNulls =
+        new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
 
     // v2 ledger-entries dates arrive as DD/MM/YYYY, filtered on the *accounting* date; parsed to
     // Madrid midnight for a stable Instant.
@@ -70,7 +79,7 @@ internal sealed class HoldedClient : IHoldedClient
         };
 
         using var req = new HttpRequestMessage(HttpMethod.Post, "/api/v2/purchases")
-        { Content = JsonContent.Create(payload) };
+        { Content = JsonContent.Create(payload, options: OmitNulls) };
         AttachAuth(req);
 
         using var resp = await SendAsync(req, ct);
@@ -142,7 +151,7 @@ internal sealed class HoldedClient : IHoldedClient
     {
         var payload = new { name, account_num = accountNum };
         using var req = new HttpRequestMessage(HttpMethod.Post, "/api/v2/expenses-accounts")
-        { Content = JsonContent.Create(payload) };
+        { Content = JsonContent.Create(payload, options: OmitNulls) };
         AttachAuth(req);
         using var resp = await SendAsync(req, ct);
         var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync(ct))
@@ -190,8 +199,9 @@ internal sealed class HoldedClient : IHoldedClient
     public async Task<string> UpsertContactAsync(HoldedContactInput input, CancellationToken ct = default)
     {
         // v2 contacts POST/PUT have no `custom_id` field (see HoldedContactInput.CustomId) — not sent.
-        // bill_address is omitted entirely when we hold no address parts: sending an object of nulls
-        // would blank an address already on the contact.
+        // bill_address stays null when we hold no address parts, and OmitNulls then drops the key:
+        // an object of nulls, or the key with a null value, would both blank an address already on
+        // the contact.
         object? billAddress =
             string.IsNullOrWhiteSpace(input.Address) && string.IsNullOrWhiteSpace(input.CountryCode)
                 ? null
@@ -214,7 +224,7 @@ internal sealed class HoldedClient : IHoldedClient
             isUpdate
                 ? $"/api/v2/contacts/{input.ExistingContactId}"
                 : "/api/v2/contacts")
-        { Content = JsonContent.Create(payload) };
+        { Content = JsonContent.Create(payload, options: OmitNulls) };
         AttachAuth(req);
 
         using var resp = await SendAsync(req, ct);
@@ -239,7 +249,7 @@ internal sealed class HoldedClient : IHoldedClient
     {
         using var req = new HttpRequestMessage(
             HttpMethod.Post, $"/api/v2/{SalesSegment(kind)}")
-        { Content = JsonContent.Create(BuildSalesDocumentPayload(input)) };
+        { Content = JsonContent.Create(BuildSalesDocumentPayload(input), options: OmitNulls) };
         AttachAuth(req);
 
         using var resp = await SendAsync(req, ct);

--- a/src/Sections/Humans.Store/Authorization/OrderAuthorizationHandler.cs
+++ b/src/Sections/Humans.Store/Authorization/OrderAuthorizationHandler.cs
@@ -20,6 +20,8 @@ namespace Humans.Store.Authorization;
 /// - TeamsAdmin: View any order (camp or team); manage (AddLine/RemoveLine/Delete)
 ///   team orders only. Camp orders are view-only. Additive — a TeamsAdmin who is also
 ///   a camp lead still gets camp-edit rights through the lead path below.
+/// - Delete and IssueInvoice are Store-admin-only on every order, and IssueInvoice is
+///   additionally denied on team orders even for admins (team orders are non-billable).
 /// - Camp lead/co-lead of the camp owning the resource's CampSeason: allow camp orders.
 /// - Coordinator (department-level management role holder) of the resource's Team:
 ///   allow team orders for View/AddLine/RemoveLine; EditCounterparty and Pay are
@@ -125,8 +127,8 @@ internal sealed class OrderAuthorizationHandler(
             if (resource.IsTeamOrder && IsTeamBillingBlocked(req))
                 continue;
 
-            // Delete is admin-only; camp leads and team coordinators never delete their own orders.
-            if (req == OrderOperationRequirement.Delete) continue;
+            // Delete and IssueInvoice are admin-only; camp leads and team coordinators get neither.
+            if (IsStoreAdminOnly(req)) continue;
 
             if (IsMutating(req) && !IsOpenOrCreate(resource))
             {
@@ -182,7 +184,14 @@ internal sealed class OrderAuthorizationHandler(
 
     private static bool IsTeamBillingBlocked(OrderOperationRequirement requirement)
         => requirement == OrderOperationRequirement.EditCounterparty
-            || requirement == OrderOperationRequirement.Pay;
+            || requirement == OrderOperationRequirement.Pay
+            || requirement == OrderOperationRequirement.IssueInvoice;
+
+    /// <summary>Operations no camp lead, coordinator or TeamsAdmin ever gets — only the Store
+    /// admin block above succeeds them.</summary>
+    private static bool IsStoreAdminOnly(OrderOperationRequirement requirement)
+        => requirement == OrderOperationRequirement.Delete
+            || requirement == OrderOperationRequirement.IssueInvoice;
 
     private static bool IsLineEdit(OrderOperationRequirement requirement)
         => requirement == OrderOperationRequirement.AddLine

--- a/src/Sections/Humans.Store/Authorization/OrderOperationRequirement.cs
+++ b/src/Sections/Humans.Store/Authorization/OrderOperationRequirement.cs
@@ -20,6 +20,8 @@ internal sealed class OrderOperationRequirement : IAuthorizationRequirement
     public static readonly OrderOperationRequirement Pay = new(nameof(Pay));
     /// <summary>Delete a zero-balance order. Admin-only — camp leads and team coordinators cannot delete their own orders.</summary>
     public static readonly OrderOperationRequirement Delete = new(nameof(Delete));
+    /// <summary>Issue the order's Holded factura. Admin-only, and never on a non-billable team order.</summary>
+    public static readonly OrderOperationRequirement IssueInvoice = new(nameof(IssueInvoice));
 
     public string OperationName { get; }
 

--- a/src/Sections/Humans.Store/Controllers/StoreAdminController.cs
+++ b/src/Sections/Humans.Store/Controllers/StoreAdminController.cs
@@ -103,6 +103,7 @@ internal sealed class StoreAdminController(
             UnitPriceEur = p.UnitPriceEur,
             VatRatePercent = p.VatRatePercent,
             DepositAmountEur = p.DepositAmountEur,
+            HoldedRevenueAccountNum = p.HoldedRevenueAccountNum,
             OrderableUntil = LocalDatePattern.Iso.Format(p.OrderableUntil),
             IsActive = p.IsActive
         };
@@ -129,7 +130,8 @@ internal sealed class StoreAdminController(
                 input.VatRatePercent,
                 input.DepositAmountEur,
                 input.OrderableUntil,
-                input.IsActive),
+                input.IsActive,
+                input.HoldedRevenueAccountNum),
             user.Id,
             ct);
 

--- a/src/Sections/Humans.Store/Controllers/StoreController.cs
+++ b/src/Sections/Humans.Store/Controllers/StoreController.cs
@@ -80,10 +80,15 @@ internal sealed class StoreController(
         var canEdit = (await authService.AuthorizeAsync(User, order, OrderOperationRequirement.AddLine)).Succeeded;
         var canPay = (await authService.AuthorizeAsync(User, order, OrderOperationRequirement.Pay)).Succeeded;
         var canDeleteAuth = (await authService.AuthorizeAsync(User, order, OrderOperationRequirement.Delete)).Succeeded;
+        var canIssueAuth = (await authService.AuthorizeAsync(User, order, OrderOperationRequirement.IssueInvoice)).Succeeded;
         var pageData = await storeService.GetOrderPageDataAsync(order, canEdit, canPay, ct);
         var (catalog, removableLineIds) = await FilterLineEditAffordancesAsync(order, pageData.Catalog, canEdit, ct);
         return View(OrderViewModel.FromPageData(
-            pageData, canDeleteAuth && order.BalanceEur == 0m, catalog, removableLineIds));
+            pageData,
+            canDeleteAuth && order.BalanceEur == 0m,
+            canIssueAuth && order.State == OrderState.Open && order.Lines.Count > 0,
+            catalog,
+            removableLineIds));
     }
 
     /// <summary>
@@ -164,6 +169,42 @@ internal sealed class StoreController(
             SetError("Could not start Stripe checkout. Please try again or contact an admin.");
             return RedirectToAction(nameof(Order), new { id });
         }
+    }
+
+    [HttpPost("Order/{id:guid}/IssueInvoice")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> IssueInvoice(Guid id)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var order = await storeService.GetOrderAsync(id);
+        if (order is null) return NotFound();
+
+        var auth = await authService.AuthorizeAsync(User, order, OrderOperationRequirement.IssueInvoice);
+        if (!auth.Succeeded) return Forbid();
+
+        try
+        {
+            // No request-scoped token anywhere on this path: issuance creates and approves a
+            // document in Holded, and a torn write leaves a doc we have no local record of
+            // (memory/architecture/cancellation-token-propagation.md).
+            await storeService.IssueInvoiceAsync(id, user.Id, CancellationToken.None);
+            SetSuccess("Invoice issued in Holded. The order is now frozen.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Expected refusals (already invoiced, missing account, receipt over threshold) —
+            // the message is written for the admin, so surface it and log at warning.
+            logger.LogWarning("Invoice issuance rejected for order {OrderId}: {Reason}", id, ex.Message);
+            SetError(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Holded invoice issuance failed for order {OrderId}", id);
+            SetError("Could not issue the invoice in Holded. Check the logs and try again.");
+        }
+        return RedirectToAction(nameof(Order), new { id });
     }
 
     [HttpPost("Order/Create/{campSeasonId:guid}")]

--- a/src/Sections/Humans.Store/Controllers/StoreController.cs
+++ b/src/Sections/Humans.Store/Controllers/StoreController.cs
@@ -85,7 +85,7 @@ internal sealed class StoreController(
         var (catalog, removableLineIds) = await FilterLineEditAffordancesAsync(order, pageData.Catalog, canEdit, ct);
         return View(OrderViewModel.FromPageData(
             pageData,
-            canDeleteAuth && order.BalanceEur == 0m,
+            canDeleteAuth && order.BalanceEur == 0m && order.State == OrderState.Open,
             canIssueAuth && order.State == OrderState.Open && order.Lines.Count > 0,
             catalog,
             removableLineIds));

--- a/src/Sections/Humans.Store/Data/IStoreRepository.cs
+++ b/src/Sections/Humans.Store/Data/IStoreRepository.cs
@@ -30,12 +30,13 @@ internal interface IStoreRepository : IRepository
     Task<IReadOnlyList<Product>> GetAllProductsForYearAsync(int year, CancellationToken ct = default);
     Task<Product?> GetProductByIdAsync(Guid productId, CancellationToken ct = default);
     /// <summary>
-    /// Resolves product display names for the given ids regardless of whether
-    /// the product is currently active or belongs to the active year. Used by
-    /// order-mapping code so issued/historical lines render with their actual
-    /// product name even after the product has been deactivated.
+    /// Resolves products for the given ids regardless of whether the product is
+    /// currently active or belongs to the active year. Order-mapping code projects
+    /// the name from it, so issued/historical lines render with their actual product
+    /// name even after the product has been deactivated; issuance also reads each
+    /// line's <see cref="Product.HoldedRevenueAccountNum"/> from here.
     /// </summary>
-    Task<IReadOnlyDictionary<Guid, string>> GetProductNamesByIdsAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct = default);
+    Task<IReadOnlyList<Product>> GetProductsByIdsAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct = default);
     Task AddProductAsync(Product product, CancellationToken ct = default);
     Task UpdateProductAsync(Product product, CancellationToken ct = default);
 
@@ -125,7 +126,15 @@ internal interface IStoreRepository : IRepository
     Task<IReadOnlyList<RecordedStripePayment>> GetRecordedStripePaymentsAsync(CancellationToken ct = default);
 
     // Invoices
-    Task AddInvoiceAsync(Invoice invoice, CancellationToken ct = default);
+
+    /// <summary>
+    /// Writes the issued <paramref name="invoice"/> and the now-frozen <paramref name="order"/>
+    /// (state, <c>IssuedInvoiceId</c>, and the line snapshots repriced at issue time) in one
+    /// <c>SaveChanges</c>. One method rather than two because the Store invariant is atomic-on-
+    /// success: an order must never be left <c>InvoiceIssued</c> without its invoice row, or
+    /// carry an invoice row while still <c>Open</c>.
+    /// </summary>
+    Task SaveIssuedInvoiceAsync(Invoice invoice, Order order, CancellationToken ct = default);
 
     // Treasury sync state
     Task<TreasurySyncState> GetOrCreateTreasurySyncStateAsync(CancellationToken ct = default);

--- a/src/Sections/Humans.Store/Data/Migrations/20260819213719_StoreProductRevenueAccount.Designer.cs
+++ b/src/Sections/Humans.Store/Data/Migrations/20260819213719_StoreProductRevenueAccount.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Store.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Store.Data.Migrations
 {
     [DbContext(typeof(StoreDbContext))]
-    partial class StoreDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260819213719_StoreProductRevenueAccount")]
+    partial class StoreProductRevenueAccount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Store/Data/Migrations/20260819213719_StoreProductRevenueAccount.cs
+++ b/src/Sections/Humans.Store/Data/Migrations/20260819213719_StoreProductRevenueAccount.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Store.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class StoreProductRevenueAccount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "HoldedRevenueAccountNum",
+                table: "store_products",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HoldedRevenueAccountNum",
+                table: "store_products");
+        }
+    }
+}

--- a/src/Sections/Humans.Store/Data/Repository.cs
+++ b/src/Sections/Humans.Store/Data/Repository.cs
@@ -263,9 +263,26 @@ internal sealed class Repository(IDbContextFactory<StoreDbContext> factory) : IS
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
         ctx.Invoices.Add(invoice);
-        // The order arrives detached (AsNoTracking + Includes), so Update attaches the whole
-        // aggregate — the repriced line snapshots ride along with the state flip.
-        ctx.Orders.Update(order);
+
+        // The order arrives detached (AsNoTracking + Includes) from a read taken before several
+        // Holded round-trips, so its Payments are stale — a Stripe webhook may have settled one in
+        // the meantime. Update(order) would mark that whole graph modified and write the stale
+        // payment rows back, and there is no concurrency token to catch it
+        // (memory/architecture/no-concurrency-tokens.md). So attach the aggregate and mark only the
+        // columns issuance owns: the state flip, and the repriced line snapshots.
+        ctx.Orders.Attach(order);
+        var orderEntry = ctx.Entry(order);
+        orderEntry.Property(o => o.State).IsModified = true;
+        orderEntry.Property(o => o.IssuedInvoiceId).IsModified = true;
+        orderEntry.Property(o => o.UpdatedAt).IsModified = true;
+        foreach (var line in order.Lines)
+        {
+            var lineEntry = ctx.Entry(line);
+            lineEntry.Property(l => l.UnitPriceSnapshot).IsModified = true;
+            lineEntry.Property(l => l.VatRateSnapshot).IsModified = true;
+            lineEntry.Property(l => l.DepositAmountSnapshot).IsModified = true;
+        }
+
         await ctx.SaveChangesAsync(ct);
     }
 

--- a/src/Sections/Humans.Store/Data/Repository.cs
+++ b/src/Sections/Humans.Store/Data/Repository.cs
@@ -43,15 +43,13 @@ internal sealed class Repository(IDbContextFactory<StoreDbContext> factory) : IS
         return await ctx.Products.AsNoTracking().FirstOrDefaultAsync(p => p.Id == productId, ct);
     }
 
-    public async Task<IReadOnlyDictionary<Guid, string>> GetProductNamesByIdsAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct = default)
+    public async Task<IReadOnlyList<Product>> GetProductsByIdsAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct = default)
     {
-        if (ids.Count == 0) return new Dictionary<Guid, string>();
+        if (ids.Count == 0) return [];
         await using var ctx = await factory.CreateDbContextAsync(ct);
-        var rows = await ctx.Products.AsNoTracking()
+        return await ctx.Products.AsNoTracking()
             .Where(p => ids.Contains(p.Id))
-            .Select(p => new { p.Id, p.Name })
             .ToListAsync(ct);
-        return rows.ToDictionary(r => r.Id, r => r.Name);
     }
 
     public async Task AddProductAsync(Product product, CancellationToken ct = default)
@@ -261,10 +259,13 @@ internal sealed class Repository(IDbContextFactory<StoreDbContext> factory) : IS
     // Invoices
     // ==========================================================================
 
-    public async Task AddInvoiceAsync(Invoice invoice, CancellationToken ct = default)
+    public async Task SaveIssuedInvoiceAsync(Invoice invoice, Order order, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
         ctx.Invoices.Add(invoice);
+        // The order arrives detached (AsNoTracking + Includes), so Update attaches the whole
+        // aggregate — the repriced line snapshots ride along with the state flip.
+        ctx.Orders.Update(order);
         await ctx.SaveChangesAsync(ct);
     }
 

--- a/src/Sections/Humans.Store/Docs/Store.md
+++ b/src/Sections/Humans.Store/Docs/Store.md
@@ -36,6 +36,7 @@ Catalog item for a given event year.
 | UnitPriceEur | numeric(12,2) | |
 | VatRatePercent | numeric(5,2) | |
 | DepositAmountEur | numeric(12,2)? | Optional per-unit deposit |
+| HoldedRevenueAccountNum | int? | Holded chart number this item's external revenue books to (`75900001` Bus Tickets, `75900002` ice, …). Set by StoreAdmin from Acountax's numbering; null until issued. The internal-recharge twin (`75910002`) is **derived** (`ProductDto.InternalRechargeAccountNum` = number + 10 000), never stored. |
 | OrderableUntil | LocalDate | Add-line deadline |
 | IsActive | bool | Soft-deactivate |
 | CreatedAt | Instant | |
@@ -176,7 +177,8 @@ Stored as **string** via `HasConversion<string>()` with column default `Paid`. `
 - `/Store/Admin/Catalog/Edit[/{id}]` — Create / edit product.
 - `/Store/Admin/Catalog/Save` — POST save product.
 - `/Store/Admin/Catalog/Deactivate/{id}` — POST soft-deactivate product.
-- `/Store/Admin/Orders` — FinanceAdmin order ledger + payment entry + Issue Invoice. **Not yet implemented (Phase 5 stub).**
+- `/Store/Order/{id}/IssueInvoice` — POST: Store admin issues the order's Holded factura. The button lives on the order page, next to Delete, and renders only for an `Open` camp order with at least one line.
+- `/Store/Admin/Orders` — FinanceAdmin order ledger + manual payment entry. **Not yet implemented** (`RecordManualPaymentAsync` still throws `NotSupportedException("Phase 5")`).
 - `/Store/Admin/Summary` — FinanceAdmin/StoreAdmin/Admin aggregate report: by-counterparty (with Type column distinguishing Camp / Team), by-item (sums lines from both camp and team orders for supplier aggregation), counterparties × products cross-tab for a given year. **Totals use effective pricing** — Open orders are repriced to the live catalog (matching the order-page behavior), InvoiceIssued orders use their frozen snapshots. Reuses `PolicyNames.StoreCatalogAdmin`.
 - `/Store/Admin/Payments` — FinanceAdmin/StoreAdmin/Admin Stripe payment reconciliation screen: webhook/checkout health banner, every Store Checkout Session matched to its order with a status (Recorded / Missing / Unmatched / Unpaid), and orphan recorded payments. Reuses `PolicyNames.StoreCatalogAdmin`. Linked from the Store-admin button group on `/Store` and the admin sidebar (**Store → Store payments**).
 - `/Store/Admin/Payments/RecordMissing` — POST: records every paid, order-matched, not-yet-recorded session via the idempotent `RecordStripePaymentAsync` path.
@@ -190,7 +192,7 @@ Stored as **string** via `HasConversion<string>()` with column default `Paid`. `
 | Coordinator (department) | View / create the single team order for departments (top-level teams) they coordinate, scoped to the active event year. Add and remove lines while the product's `OrderableUntil` has not passed. No pay, no counterparty edit, no invoice — team orders are non-billable. |
 | StoreAdmin | **Store-domain superset** (per `memory/code/admin-role-superset.md`): catalog CRUD, view all orders, record manual payments, issue invoices, run treasury sync, reconcile Stripe payments (`/Store/Admin/Payments`). Equivalent to FinanceAdmin within the Store section. EditCounterparty/Pay remain denied on team orders even for admins. |
 | TeamsAdmin | **View any order** (camp or team) and **manage team orders only** (AddLine / RemoveLine while `Open`; Delete any state). Camp orders are view-only. Never Pay / EditCounterparty (team orders are non-billable). Additive — a TeamsAdmin who is also a camp lead keeps camp-edit rights through the lead path. |
-| FinanceAdmin, Admin | All Camp Lead and StoreAdmin capabilities. Record manual payments (incl. refunds via negative amounts) regardless of order state. Issue invoice (single + Issue All). View `/Store/Admin/Summary` and `/Store/Admin/Payments`. Reconcile missing Stripe payments. Run treasury sync on demand. EditCounterparty/Pay remain denied on team orders. |
+| FinanceAdmin, Admin | All Camp Lead and StoreAdmin capabilities. Record manual payments (incl. refunds via negative amounts) regardless of order state. Issue invoice from the order page. View `/Store/Admin/Summary` and `/Store/Admin/Payments`. Reconcile missing Stripe payments. Run treasury sync on demand. EditCounterparty/Pay remain denied on team orders. |
 
 ## Invariants
 
@@ -206,8 +208,14 @@ Stored as **string** via `HasConversion<string>()` with column default `Paid`. `
 - Payments may be recorded regardless of order state — payments do not freeze on issuance.
 - **Spanish VAT applies to every order regardless of buyer country** — all goods are physically handed over on-site in Spain, so place of supply is Spain and there is no B2B reverse-charge path. VAT comes solely from the per-product `VatRatePercent` snapshot; `CounterpartyCountryCode` is stored for the factura but never consulted for tax.
 - **Deposits are VAT-free** (refundable security deposits / fianzas are not subject to VAT): `BalanceCalculator.Compute` adds deposit amounts without applying VAT, and the future Holded invoice renders each deposit as a separate `tax = 0` line.
-- Issuing an invoice is idempotent: re-issuing an order that already has `IssuedInvoiceId` set throws and does NOT call Holded.
-- Issue-invoice failure mid-flight leaves the order in `Open` state with no `Invoice` row (atomic on success only).
+- Issuing an invoice is idempotent: re-issuing an order that already has `IssuedInvoiceId` set (or already in `InvoiceIssued`) throws and does NOT call Holded.
+- Issue-invoice failure mid-flight leaves the order in `Open` state with no `Invoice` row (atomic on success only — `IStoreRepository.SaveIssuedInvoiceAsync` writes the invoice row and the frozen order in one `SaveChanges`).
+- **Issuance freezes the price (#816).** Before flipping to `InvoiceIssued`, each line's `UnitPriceSnapshot` / `VatRateSnapshot` / `DepositAmountSnapshot` is rewritten from the live catalog, so the issued document and the order agree forever after.
+- **Every issued document is approved.** A Holded draft books no revenue, so `IssueInvoiceAsync` calls `POST /api/v2/{invoices|sales-receipts}/{id}/approve` before writing anything locally, then reads the doc back for its assigned `document_number`.
+- **Factura vs factura simplificada.** An order carrying name **and** address **and** tax id (NIF, a foreign tax id, or a passport number) issues a full `invoice` against an upserted Holded `client` contact. Anything less issues a `sales-receipt` with no contact — and only up to `Store:SimplifiedInvoiceThresholdEur` (default €400). Above it the counterparty details are mandatory and issuance is refused rather than downgraded.
+- **Revenue books per item.** Each line carries `items[].account` resolved from its product's `HoldedRevenueAccountNum` against the live chart (Holded's field takes the account *id*, not the number, so the chart is read at issue time). A product with no account number, or a number absent from Holded's chart, refuses issuance by name rather than booking to a catch-all.
+- **Deposits post tax-0 to the liability account.** Each deposit-bearing line adds a separate `s_iva_0` line booked to `Store:DepositLiabilityAccountNum` (fianzas). An order with deposits and no configured liability account refuses issuance — a refundable deposit is never booked as income.
+- Issuing is **Store-admin only** and never applies to a team order (see Negative Access Rules).
 - A Stripe `checkout.session.completed` event with a known `humans_store_order_id` inserts at most one `Payment` per `StripePaymentIntentId` (filtered unique index + service-level dedup check). The inserted row's `Status` is **`Paid`** when `session.payment_status == "paid"` (sync card/wallet) and **`Pending`** otherwise (`"unpaid"` — async mandate captured but not yet cleared, e.g. SEPA).
 - **Balance counts `Paid` only.** `BalanceCalculator.Compute` sums payments where `Status == Paid`; `Pending` and `Failed` rows are excluded, so a captured-but-uncleared mandate never makes an order look paid.
 - **Async-payment state machine** (`HandleStripeCheckoutWebhookEventAsync`, all idempotent):
@@ -225,6 +233,8 @@ Stored as **string** via `HasConversion<string>()` with column default `Paid`. `
 - A Camp Lead **cannot** view or edit orders for camp-seasons they do not lead (resource-based auth).
 - Anyone other than StoreAdmin/FinanceAdmin/Admin **cannot** issue an invoice or run the treasury sync job manually.
 - Re-issuing an already-issued order **cannot** succeed — the second call throws and does not contact Holded.
+- A camp lead, department coordinator or TeamsAdmin **cannot** issue an invoice — `IssueInvoice` is Store-admin only.
+- A team order **cannot** be invoiced, by anyone, including admins.
 
 ## Triggers
 
@@ -234,9 +244,9 @@ Stored as **string** via `HasConversion<string>()` with column default `Paid`. `
 - The Stripe webhook controller (`StoreStripeWebhookController`) verifies the request signature via `IStripeService.ParseStoreCheckoutEvent` and dispatches to `Service.HandleStripeCheckoutWebhookEventAsync`, which handles all four `checkout.session.*` events (completed + the async-payment state machine above). Idempotent on `StripePaymentIntentId`.
 - `/Store/Admin/Payments/RecordMissing` reconciles Stripe → ledger on demand (admin-triggered), recording missing paid sessions via the same idempotent path and emitting one `StorePaymentsReconciled` summary audit entry (with the human actor) plus the per-payment `StorePaymentRecorded` entries. The webhook is therefore no longer the *sole* writer of Stripe payments — but it remains the only automatic one.
 
+- `IssueInvoiceAsync` (nobodies-collective/Humans#1029) — upserts the Holded `client` contact for an identified counterparty, creates the v2 sales document with per-line revenue accounts, approves it, reads it back, and writes `store_invoices` (both payloads) + the frozen order in one save. Emits `StoreInvoiceIssued` against `StoreInvoice`, cross-referenced to the order.
+
 **Not yet shipped (Phase 5+):**
-- `IssueInvoiceAsync` — will call `IHoldedClient.UpsertContactAsync` then `IHoldedClient.CreateInvoiceAsync`, write the `Invoice` row, flip `Order.State = InvoiceIssued`, and emit `StorePaymentRecorded` audit entry. Currently throws `NotSupportedException("Phase 5")`.
-  - Issuance rules carried from the design: the effective counterparty falls back to the camp name when `CounterpartyName` is blank; the Holded contact upsert matches by VAT-id when present, else name + country; each deposit-bearing line adds a separate VAT-free (`tax = 0`) invoice line. Gotcha: the outbound Holded `invoice` and contact payload shapes were **never verified against real data** (the 2026-04 probe saw only purchase docs) — dump a real invoice + contact via the API and lock the field mapping before implementing (`HoldedClient.UpsertContactAsync` still carries a `TODO(probe)`).
 - `RecordManualPaymentAsync` — manual payment entry by FinanceAdmin. Currently throws `NotSupportedException("Phase 5")`.
 - `StoreTreasurySyncJob` (Hangfire recurring) — polls `IHoldedClient.ListTreasuryEntriesAsync` from `TreasurySyncState.LastSyncAt`, inserts `Payment(Method=BankTransfer)` for unambiguous matches, advances cursor. Not yet implemented (the original Label matching key was removed in #816).
 
@@ -246,7 +256,7 @@ Stored as **string** via `HasConversion<string>()` with column default `Paid`. `
 - **Teams:** `ITeamServiceRead` for department lookups (team name, department check via `ParentTeamId is null`, coordinator check via `ManagementRoleHolderUserIds`). Existing methods only — no new surface added to its `[SurfaceBudget(4)]`.
 - **Shifts:** `IBurnSettingsService.GetActiveAsync()` for the active event's `Year` and `TimeZoneId` — used to (a) resolve the active catalog year on `/Store` and `/Store/Admin/Catalog`, (b) populate `Year` on new team orders, and (c) compute "today in event time zone" for the `OrderableUntil` deadline gate.
 - **Auth/Roles:** `RoleNames.StoreAdmin` (this section), `RoleNames.FinanceAdmin`, `RoleNames.Admin`.
-- **Holded connector** (`Humans.Holded`): `IHoldedClient` extended with `UpsertContactAsync`, `CreateInvoiceAsync`, `ListTreasuryEntriesAsync` in Phase 4.
+- **Holded connector** (`Humans.Holded`, via `Humans.Holded.Contracts`): `IHoldedClient.UpsertContactAsync`, `CreateSalesDocumentAsync` / `ApproveSalesDocumentAsync` / `GetSalesDocumentAsync` (kind-parameterized over invoice vs sales receipt), and `ListAccountingAccountsAsync` for the account-number → account-id resolution. Never the connector's internals — the vendor stays swappable (`memory/architecture/vendor-connectors-own-sections.md`).
 - **Stripe** (`Humans.Stripe`): `IStripeService.CreateCheckoutSessionAsync` for camp-lead payments; `StoreStripeWebhookController` for `checkout.session.completed` ingestion.
 - **Audit Log:** `IAuditLogService` for every mutation.
 
@@ -274,4 +284,14 @@ The Store section uses `IStripeService` (`Humans.Stripe.Contracts`; internal imp
 - **Cross-section calls** route through `ICampServiceRead` (camp / camp-season lookups), `IBurnSettingsService` (active event year + time-zone), `IAuditLogService`, `IHoldedClient`, `IStripeService`.
 - **Architecture test:** none — `StoreArchitectureTests` was deleted at G5. Both its assertions became false or vacuous once the section became one assembly (the assembly now contains `StoreDbContext` by design, and interface-implementation is a tautology). What it encoded is policed by `ApplicationServiceDbContextInjectionAnalyzer` plus the assembly boundary itself. Store's unit tests live in `tests/Humans.Store.Tests`; its controller tests stay in `Humans.Integration.Tests`.
 
-Implementation status: catalog CRUD (create, update, deactivate), order create, add/remove line, counterparty edit, and Stripe payment recording are live. `RecordManualPaymentAsync`, `IssueInvoiceAsync`, treasury sync, and the Orders admin view throw `NotSupportedException("Phase 5")`. See [`Store-feature.md`](features/Store-feature.md).
+### Configuration
+
+Bound from `Store:*` into `StoreSectionOptions` in `Section.Register`. Both values are
+Acountax's call and change without a deploy:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `Store:DepositLiabilityAccountNum` | unset | Holded chart number of the refundable-deposit (fianzas) liability account. Unset refuses issuance of any order carrying a deposit. |
+| `Store:SimplifiedInvoiceThresholdEur` | `400` | Order total at or below which a counterparty-less order may issue as a *factura simplificada*. Spanish law allows €400 generally / €3,000 for retail-type B2C; the conservative figure is the default until Acountax rules. |
+
+Implementation status: catalog CRUD (create, update, deactivate), order create, add/remove line, counterparty edit, Stripe payment recording, and Holded invoice issuance are live. `RecordManualPaymentAsync`, treasury sync, and the Orders admin view throw `NotSupportedException("Phase 5")`. See [`Store-feature.md`](features/Store-feature.md).

--- a/src/Sections/Humans.Store/Docs/authorization.md
+++ b/src/Sections/Humans.Store/Docs/authorization.md
@@ -3,14 +3,18 @@
 | Controller | Scope | Roles | Source |
 |---|---|---|---|
 | `StoreController` | Class | `[Authorize]` (authenticated) | — |
-| `StoreController` runtime guards | In-method | `authService.AuthorizeAsync(User, order/resource, OrderOperationRequirement.{View, AddLine, RemoveLine, EditCounterparty, Pay, Delete})` for existing orders (`AddLine`/`RemoveLine` authorize against an `OrderLineContext` carrying the product's order deadline when known, else the plain order) and `OrderCreateContext` for `Create` (camp orders) / `CreateTeamOrder` (team orders). `Index` also seeds `isPrivilegedReader = RoleChecks.CanAdministerStore(User) \|\| RoleChecks.IsTeamsAdmin(User)`. | Resource-based (see handler below) |
+| `StoreController` runtime guards | In-method | `authService.AuthorizeAsync(User, order/resource, OrderOperationRequirement.{View, AddLine, RemoveLine, EditCounterparty, Pay, Delete, IssueInvoice})` for existing orders (`AddLine`/`RemoveLine` authorize against an `OrderLineContext` carrying the product's order deadline when known, else the plain order) and `OrderCreateContext` for `Create` (camp orders) / `CreateTeamOrder` (team orders). `Index` also seeds `isPrivilegedReader = RoleChecks.CanAdministerStore(User) \|\| RoleChecks.IsTeamsAdmin(User)`. | Resource-based (see handler below) |
 | `StoreAdminController` | Class | `StoreAdmin, FinanceAdmin, Admin` | `PolicyNames.StoreCatalogAdmin` |
 | `StoreAdminController.Payments` | Action | `StoreAdmin, FinanceAdmin, Admin` inherited (`[HttpGet("Payments")]`) | `PolicyNames.StoreCatalogAdmin` (Stripe ↔ Store ledger reconciliation report) |
 | `StoreAdminController.RecordMissingPayments` | Action | `StoreAdmin, FinanceAdmin, Admin` inherited (`[HttpPost("Payments/RecordMissing")]`) | `PolicyNames.StoreCatalogAdmin` (records missing Stripe payments) |
 | `StoreStripeWebhookController` | Class | `AllowAnonymous` (Stripe signature-verified) | — |
 
+`Delete` and `IssueInvoice` are Store-admin-only on every order — no camp lead, department
+coordinator or TeamsAdmin path succeeds them. `IssueInvoice` is additionally denied on team
+orders even for admins, alongside `EditCounterparty` and `Pay`: team orders are non-billable.
+
 ## Resource-Based Authorization Handler
 
 | Handler | Requirement | Resource | Path |
 |---|---|---|---|
-| `OrderAuthorizationHandler` | `OrderOperationRequirement` (`View`, `Create`, `AddLine`, `RemoveLine`, `EditCounterparty`, `Pay`, `Delete`) | `OrderDto` / `OrderCreateContext` / `OrderLineContext` (deadline-aware line checks) | `Authorization/OrderAuthorizationHandler.cs` (registered in `Section.cs`) |
+| `OrderAuthorizationHandler` | `OrderOperationRequirement` (`View`, `Create`, `AddLine`, `RemoveLine`, `EditCounterparty`, `Pay`, `Delete`, `IssueInvoice`) | `OrderDto` / `OrderCreateContext` / `OrderLineContext` (deadline-aware line checks) | `Authorization/OrderAuthorizationHandler.cs` (registered in `Section.cs`) |

--- a/src/Sections/Humans.Store/Docs/data-access.md
+++ b/src/Sections/Humans.Store/Docs/data-access.md
@@ -24,8 +24,10 @@ Cross-section calls via `IAuditLogService`, `ICampServiceRead`,
 `ITeamServiceRead` (team-order counterparty surface),
 `IShiftManagementService`, `IStripeService` (the `Humans.Stripe` connector
 section — creates Checkout sessions, lists sessions for reconciliation, handles
-webhook events including SEPA async-payment transitions), plus `IClock`.
-No `IMemoryCache`.
+webhook events including SEPA async-payment transitions), `IHoldedClient` (the
+`Humans.Holded` connector section — contact upsert, sales-document create/approve/read
+and the chart-of-accounts read that resolves account numbers to Holded ids), plus
+`IClock`. No `IMemoryCache`.
 
 `StoreService` owns the full Stripe **payment flow**: synchronous card/wallet
 payments are recorded as `Paid` on `checkout.session.completed`; SEPA/delayed
@@ -41,6 +43,12 @@ orders reprice live against the single active event-year catalog
 (`StoreProducts`), so legacy `Year = 0` orders still reprice correctly.
 All surfaces read/write only Store-owned tables through `IStoreRepository`;
 reconciliation reads live Stripe sessions via `IStripeService`.
+
+`IssueInvoiceAsync` is the section's only outbound write: it reprices the order's line
+snapshots from the live catalog, builds one Holded line per order line (plus a tax-0 line
+per deposit), creates **and approves** the document, then writes `StoreInvoices` and the
+frozen `StoreOrders` row in a single `SaveIssuedInvoiceAsync` — one `SaveChanges`, because
+an order must never be `InvoiceIssued` without its invoice row.
 
 ### BalanceCalculator
 

--- a/src/Sections/Humans.Store/Domain/Product.cs
+++ b/src/Sections/Humans.Store/Domain/Product.cs
@@ -13,6 +13,16 @@ internal sealed class Product
     public decimal UnitPriceEur { get; set; }
     public decimal VatRatePercent { get; set; }
     public decimal? DepositAmountEur { get; set; }
+
+    /// <summary>
+    /// The 8-digit Holded chart-of-accounts number this item's external revenue books to
+    /// (<c>75900001</c> Bus Tickets, <c>75900002</c> ice, …), set by StoreAdmin from Acountax's
+    /// numbering. Null until Acountax has issued one — issuing an invoice for a line whose product
+    /// has no number is refused rather than booked to a catch-all. The internal-recharge twin
+    /// (<c>75910002</c>) is derived, never stored.
+    /// </summary>
+    public int? HoldedRevenueAccountNum { get; set; }
+
     public LocalDate OrderableUntil { get; set; }
     public bool IsActive { get; set; } = true;
     public Instant CreatedAt { get; set; }

--- a/src/Sections/Humans.Store/Humans.Store.csproj
+++ b/src/Sections/Humans.Store/Humans.Store.csproj
@@ -24,6 +24,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Humans.Base\Humans.Base.csproj" />
     <ProjectReference Include="..\Humans.AuditLog.Contracts\Humans.AuditLog.Contracts.csproj" />
+    <!-- Holded invoice/sales-receipt issuance (IHoldedClient). The connector is its own
+         section per memory/architecture/vendor-connectors-own-sections.md; Store consumes it
+         through the Contracts leaf, never its internals. -->
+    <ProjectReference Include="..\Humans.Holded.Contracts\Humans.Holded.Contracts.csproj" />
     <ProjectReference Include="..\Humans.Camps.Contracts\Humans.Camps.Contracts.csproj" />
     <ProjectReference Include="..\Humans.Teams.Contracts\Humans.Teams.Contracts.csproj" />
     <ProjectReference Include="..\Humans.Shifts.Contracts\Humans.Shifts.Contracts.csproj" />

--- a/src/Sections/Humans.Store/Models/IndexViewModel.cs
+++ b/src/Sections/Humans.Store/Models/IndexViewModel.cs
@@ -30,6 +30,10 @@ internal sealed class OrderViewModel
     /// <summary>True when the current user is a Store admin AND the order's balance is zero. Surfaces the Delete button.</summary>
     public bool CanDelete { get; init; }
 
+    /// <summary>True when the current user may issue this camp order's Holded factura — Store
+    /// admin, order still Open, at least one line. Surfaces the Issue invoice button.</summary>
+    public bool CanIssueInvoice { get; init; }
+
     /// <summary>
     /// Line ids whose Remove button renders, resolved per line against the order authorization
     /// handler in the controller: past the product's order deadline only Store admins qualify.
@@ -39,9 +43,11 @@ internal sealed class OrderViewModel
     public static OrderViewModel FromPageData(
         OrderPageData pageData,
         bool canDelete,
+        bool canIssueInvoice,
         IReadOnlyList<ProductDto> catalog,
         IReadOnlyCollection<Guid> removableLineIds) => new()
         {
+            CanIssueInvoice = canIssueInvoice,
             Order = pageData.Order,
             Catalog = catalog,
             CounterpartyDisplayName = pageData.CounterpartyDisplayName,

--- a/src/Sections/Humans.Store/Models/ProductInputModel.cs
+++ b/src/Sections/Humans.Store/Models/ProductInputModel.cs
@@ -28,6 +28,10 @@ internal sealed class ProductInputModel
     [Range(0.0, 1_000_000.0)]
     public decimal? DepositAmountEur { get; set; }
 
+    /// <summary>Holded chart number this item's external revenue books to, from Acountax.</summary>
+    [Range(10_000_000, 99_999_999, ErrorMessage = "Use the 8-digit Holded chart number, e.g. 75900002")]
+    public int? HoldedRevenueAccountNum { get; set; }
+
     [Required(AllowEmptyStrings = false)]
     [RegularExpression(@"^\d{4}-\d{2}-\d{2}$", ErrorMessage = "Use YYYY-MM-DD format")]
     public string OrderableUntil { get; set; } = string.Empty;

--- a/src/Sections/Humans.Store/Section.cs
+++ b/src/Sections/Humans.Store/Section.cs
@@ -18,6 +18,10 @@ public sealed class Section : ISection
 {
     public void Register(IServiceCollection services, IConfiguration configuration)
     {
+        // Acountax's two numbers — the fianzas liability account and the simplified-invoice
+        // threshold. Both change without a deploy, hence configuration.
+        services.Configure<StoreSectionOptions>(configuration.GetSection(StoreSectionOptions.Section));
+
         services.AddSectionDbContext<StoreDbContext>(sentinelTable: "store_orders");
 
         // §15b repository pattern: Repository uses IDbContextFactory<StoreDbContext>

--- a/src/Sections/Humans.Store/Services/AuditEntityTypes.cs
+++ b/src/Sections/Humans.Store/Services/AuditEntityTypes.cs
@@ -24,4 +24,5 @@ internal static class AuditEntityTypes
     public const string Order = "StoreOrder";
     public const string OrderLine = "StoreOrderLine";
     public const string Payment = "StorePayment";
+    public const string Invoice = "StoreInvoice";
 }

--- a/src/Sections/Humans.Store/Services/Dtos/ProductDto.cs
+++ b/src/Sections/Humans.Store/Services/Dtos/ProductDto.cs
@@ -11,11 +11,28 @@ internal sealed record ProductDto(
     decimal VatRatePercent,
     decimal? DepositAmountEur,
     LocalDate OrderableUntil,
-    bool IsActive)
+    bool IsActive,
+    int? HoldedRevenueAccountNum = null)
 {
+    /// <summary>
+    /// Distance from an item's external revenue account to its internal-recharge twin:
+    /// <c>75900002</c> (ice sold to camps) → <c>75910002</c> (ice consumed by a department).
+    /// Internal consumption must not land in the external account — it would gross up declared
+    /// revenue for an event that carries no VAT and no counterparty.
+    /// </summary>
+    private const int InternalRechargeAccountOffset = 10_000;
+
     /// <summary>
     /// Unit price including VAT, for display. Rounded to 2 dp away-from-zero to match the
     /// authoritative VAT rounding used by BalanceCalculator.
     /// </summary>
     public decimal UnitPriceInclVatEur => Math.Round(UnitPriceEur * (1 + VatRatePercent / 100m), 2, MidpointRounding.AwayFromZero);
+
+    /// <summary>
+    /// The account season-close department-allocation journal entries credit at catalog price.
+    /// Derived, never stored; Acountax creates it in Holded the first time a department consumes
+    /// the item.
+    /// </summary>
+    public int? InternalRechargeAccountNum =>
+        HoldedRevenueAccountNum is { } num ? num + InternalRechargeAccountOffset : null;
 }

--- a/src/Sections/Humans.Store/Services/Service.cs
+++ b/src/Sections/Humans.Store/Services/Service.cs
@@ -973,7 +973,9 @@ internal sealed class Service(
     /// without calling Holded, and — because a document approved by an attempt that then failed
     /// locally leaves no trace here — Holded is searched for a document already tagged with this
     /// order before anything is created. A match is adopted, never re-issued: a second approved
-    /// factura is a real legal document, correctable only by a factura rectificativa.
+    /// factura is a real legal document, correctable only by a factura rectificativa. A recovered
+    /// document is checked against the order's current totals first (divergence refuses loudly)
+    /// and approved if the earlier attempt died between create and approve.
     /// </summary>
     [ExternalWrite]
     public async Task IssueInvoiceAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default)
@@ -1015,6 +1017,19 @@ internal sealed class Service(
         if (await FindAlreadyIssuedDocumentAsync(tag, ct) is { } alreadyIssued)
         {
             var (adoptedKind, adoptedDoc) = alreadyIssued;
+            // Before anything is written, and before the order is frozen against it: the order
+            // stayed Open, so it could have been edited or repriced since that document was
+            // created. Divergence is a human's problem, not something to reconcile silently.
+            EnsureRecoveredDocumentMatches(order, adoptedDoc, totals);
+            if (adoptedDoc.IsDraft == true)
+            {
+                // Creation succeeded and approval did not. A draft books no revenue and carries no
+                // sequential number, so freezing the order against it would leave the order
+                // invoiced with no legal invoice behind it — finish the issuance instead.
+                await holdedClient.ApproveSalesDocumentAsync(adoptedKind, adoptedDoc.Id, CancellationToken.None);
+                adoptedDoc = await holdedClient.GetSalesDocumentAsync(
+                    adoptedKind, adoptedDoc.Id, CancellationToken.None);
+            }
             await CommitInvoiceAsync(
                 order, adoptedDoc,
                 JsonSerializer.Serialize(new { kind = adoptedKind.ToString(), adopted = true, tag }),
@@ -1090,6 +1105,35 @@ internal sealed class Service(
             $"Issued Holded {DocumentKindName(kind)} {document.DocNumber} "
             + $"for EUR {totalDue:0.00} on order {order.Id}",
             ct);
+    }
+
+    /// <summary>
+    /// Refuses adoption when the recovered document no longer describes this order. The order stays
+    /// <c>Open</c> after a failed attempt, so its lines can be edited and its catalog prices can
+    /// move before the retry — adopting on the tag alone would freeze the order against a document
+    /// that says something else, permanently. Correcting an issued document is a factura
+    /// rectificativa, which is a human decision, so this fails loudly rather than choosing a side.
+    /// </summary>
+    private static void EnsureRecoveredDocumentMatches(
+        Order order, HoldedSalesDocumentDto document, BalanceCalculator.Result totals)
+    {
+        // Deposits are ordinary tax-0 lines on the document, so they land in Holded's subtotal.
+        var expectedSubtotal = decimal.Round(totals.LinesSubtotalEur + totals.DepositTotalEur, 2);
+        var expectedTax = decimal.Round(totals.VatTotalEur, 2);
+        var expectedTotal = decimal.Round(expectedSubtotal + expectedTax, 2);
+        if (decimal.Round(document.Subtotal, 2) == expectedSubtotal
+            && decimal.Round(document.Tax, 2) == expectedTax
+            && decimal.Round(document.Total, 2) == expectedTotal)
+            return;
+
+        var name = string.IsNullOrEmpty(document.DocNumber) ? document.Id : document.DocNumber;
+        throw new InvalidOperationException(
+            $"Holded already holds document {name} for order {order.Id}, but it no longer matches "
+            + $"the order: the document reads EUR {document.Subtotal:0.00} + {document.Tax:0.00} VAT "
+            + $"= {document.Total:0.00}, while the order now totals EUR {expectedSubtotal:0.00} + "
+            + $"{expectedTax:0.00} VAT = {expectedTotal:0.00}. The order was changed after that "
+            + "document was created. Resolve it by hand — correcting an issued document is a factura "
+            + "rectificativa, and no second document will be issued in the meantime.");
     }
 
     /// <summary>The tag every store sales document carries. Holded's list endpoints return

--- a/src/Sections/Humans.Store/Services/Service.cs
+++ b/src/Sections/Humans.Store/Services/Service.cs
@@ -969,8 +969,11 @@ internal sealed class Service(
     /// <see cref="StoreSectionOptions.SimplifiedInvoiceThresholdEur"/> a receipt is not legal,
     /// so a counterparty-less order that large is refused rather than downgraded.
     ///
-    /// Idempotent: an order that already carries an <c>IssuedInvoiceId</c> throws without
-    /// calling Holded. Failure before the save leaves the order <c>Open</c> with no invoice row.
+    /// Idempotent on both sides: an order that already carries an <c>IssuedInvoiceId</c> throws
+    /// without calling Holded, and — because a document approved by an attempt that then failed
+    /// locally leaves no trace here — Holded is searched for a document already tagged with this
+    /// order before anything is created. A match is adopted, never re-issued: a second approved
+    /// factura is a real legal document, correctable only by a factura rectificativa.
     /// </summary>
     [ExternalWrite]
     public async Task IssueInvoiceAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default)
@@ -1002,6 +1005,25 @@ internal sealed class Service(
             line.UnitPriceSnapshot = t.EffectiveUnitPrice;
             line.VatRateSnapshot = t.EffectiveVatRate;
             line.DepositAmountSnapshot = t.EffectiveDeposit;
+        }
+
+        // The local guard above cannot see a document approved by an attempt that then failed
+        // before its save, so ask Holded before creating anything. Read-only, and it runs ahead of
+        // the line-account resolution so that a catalog edited in between cannot block the
+        // reconciliation of a document that already exists.
+        var tag = OrderDocumentTag(order.Id);
+        if (await FindAlreadyIssuedDocumentAsync(tag, ct) is { } alreadyIssued)
+        {
+            var (adoptedKind, adoptedDoc) = alreadyIssued;
+            await CommitInvoiceAsync(
+                order, adoptedDoc,
+                JsonSerializer.Serialize(new { kind = adoptedKind.ToString(), adopted = true, tag }),
+                actorUserId,
+                $"Adopted Holded {DocumentKindName(adoptedKind)} {adoptedDoc.DocNumber} "
+                + $"(EUR {adoptedDoc.Total:0.00}), already issued for order {order.Id} by an earlier "
+                + "attempt that failed before saving — no second document was created",
+                ct);
+            return;
         }
 
         var totalDue = totals.LinesSubtotalEur + totals.VatTotalEur + totals.DepositTotalEur;
@@ -1052,6 +1074,7 @@ internal sealed class Service(
             Date = clock.GetCurrentInstant(),
             Description = $"Nobodies Collective store — {displayName}",
             Notes = $"Humans store order {order.Id}",
+            Tags = [tag],
             Lines = documentLines,
         };
 
@@ -1060,6 +1083,58 @@ internal sealed class Service(
         await holdedClient.ApproveSalesDocumentAsync(kind, docId, CancellationToken.None);
         var document = await holdedClient.GetSalesDocumentAsync(kind, docId, CancellationToken.None);
 
+        await CommitInvoiceAsync(
+            order, document,
+            JsonSerializer.Serialize(new { kind = kind.ToString(), input }),
+            actorUserId,
+            $"Issued Holded {DocumentKindName(kind)} {document.DocNumber} "
+            + $"for EUR {totalDue:0.00} on order {order.Id}",
+            ct);
+    }
+
+    /// <summary>The tag every store sales document carries. Holded's list endpoints return
+    /// <c>tags</c> but not <c>notes</c>, so this — not the human-readable note beside it — is what
+    /// makes a document findable by the order it was issued for.</summary>
+    private static string OrderDocumentTag(Guid orderId) => $"humans-order-{orderId}";
+
+    private static string DocumentKindName(HoldedSalesDocumentKind kind) =>
+        kind == HoldedSalesDocumentKind.Invoice ? "factura" : "factura simplificada";
+
+    /// <summary>
+    /// The sales document a previous attempt already created for this order, or null. Both kinds
+    /// are searched: the counterparty details decide the kind and can be filled in between two
+    /// attempts, so the earlier document may be of the other kind — and adopting it is still right,
+    /// because what must not happen is a second approved document.
+    /// </summary>
+    private async Task<(HoldedSalesDocumentKind Kind, HoldedSalesDocumentDto Document)?>
+        FindAlreadyIssuedDocumentAsync(string tag, CancellationToken ct)
+    {
+        foreach (var kind in new[] { HoldedSalesDocumentKind.Invoice, HoldedSalesDocumentKind.SalesReceipt })
+        {
+            var ids = await holdedClient.FindSalesDocumentIdsByTagAsync(kind, tag, ct);
+            if (ids.Count == 0) continue;
+            if (ids.Count > 1)
+                // The duplicate this guard exists to prevent has already happened — only a factura
+                // rectificativa clears it. Adopting the first still stops a third being issued.
+                logger.LogWarning(
+                    "Holded holds {Count} {Kind} documents tagged {Tag}: {Ids}. Adopting the first.",
+                    ids.Count, kind, tag, string.Join(", ", ids));
+            return (kind, await holdedClient.GetSalesDocumentAsync(kind, ids[0], ct));
+        }
+        return null;
+    }
+
+    /// <summary>Writes the <c>store_invoices</c> row and the frozen order in one save, then audits.
+    /// Shared by first issuance and by adoption of an already-issued document — the two differ only
+    /// in the request payload they can honestly record and in what the audit line says.</summary>
+    private async Task CommitInvoiceAsync(
+        Order order,
+        HoldedSalesDocumentDto document,
+        string requestPayload,
+        Guid actorUserId,
+        string auditDetail,
+        CancellationToken ct)
+    {
         var invoice = new Invoice
         {
             Id = Guid.NewGuid(),
@@ -1068,7 +1143,7 @@ internal sealed class Service(
             HoldedDocNumber = document.DocNumber,
             IssuedAt = clock.GetCurrentInstant(),
             IssuedByUserId = actorUserId,
-            RequestPayload = JsonSerializer.Serialize(new { kind = kind.ToString(), input }),
+            RequestPayload = requestPayload,
             ResponsePayload = document.RawJson,
         };
 
@@ -1079,9 +1154,7 @@ internal sealed class Service(
 
         await audit.LogAsync(
             AuditAction.StoreInvoiceIssued, AuditEntityTypes.Invoice, invoice.Id,
-            $"Issued Holded {(kind == HoldedSalesDocumentKind.Invoice ? "factura" : "factura simplificada")} "
-            + $"{document.DocNumber} for EUR {totalDue:0.00} on order {order.Id}",
-            actorUserId,
+            auditDetail, actorUserId,
             order.Id, AuditEntityTypes.Order);
     }
 

--- a/src/Sections/Humans.Store/Services/Service.cs
+++ b/src/Sections/Humans.Store/Services/Service.cs
@@ -365,6 +365,12 @@ internal sealed class Service(
         var order = await repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct)
             ?? throw new InvalidOperationException($"Order {orderId} not found.");
 
+        // An issued order is referenced by its store_invoices row under a restrictive foreign key,
+        // and a paid one reads zero-balance — without this the delete would reach EF and blow up.
+        if (order.State != OrderState.Open)
+            throw new InvalidOperationException(
+                $"Order {orderId} has been invoiced; an invoiced order cannot be deleted.");
+
         var currentPrices = await LoadCurrentPricesAsync(ct);
         var balance = BalanceCalculator.Compute(order, currentPrices).BalanceEur;
         if (balance != 0m)
@@ -1146,26 +1152,31 @@ internal sealed class Service(
 
     /// <summary>
     /// The sales document a previous attempt already created for this order, or null. Both kinds
-    /// are searched: the counterparty details decide the kind and can be filled in between two
-    /// attempts, so the earlier document may be of the other kind — and adopting it is still right,
-    /// because what must not happen is a second approved document.
+    /// are searched in full: the counterparty details decide the kind and can be filled in between
+    /// two attempts, so the earlier document may be of the other kind — and adopting it is still
+    /// right, because what must not happen is a second approved document. When several match, an
+    /// already-approved one wins over a draft: approving the draft beside it would book the revenue
+    /// twice and hand out a second legal number.
     /// </summary>
     private async Task<(HoldedSalesDocumentKind Kind, HoldedSalesDocumentDto Document)?>
         FindAlreadyIssuedDocumentAsync(string tag, CancellationToken ct)
     {
+        var found = new List<(HoldedSalesDocumentKind Kind, HoldedSalesDocumentDto Document)>();
         foreach (var kind in new[] { HoldedSalesDocumentKind.Invoice, HoldedSalesDocumentKind.SalesReceipt })
         {
-            var ids = await holdedClient.FindSalesDocumentIdsByTagAsync(kind, tag, ct);
-            if (ids.Count == 0) continue;
-            if (ids.Count > 1)
-                // The duplicate this guard exists to prevent has already happened — only a factura
-                // rectificativa clears it. Adopting the first still stops a third being issued.
-                logger.LogWarning(
-                    "Holded holds {Count} {Kind} documents tagged {Tag}: {Ids}. Adopting the first.",
-                    ids.Count, kind, tag, string.Join(", ", ids));
-            return (kind, await holdedClient.GetSalesDocumentAsync(kind, ids[0], ct));
+            foreach (var id in await holdedClient.FindSalesDocumentIdsByTagAsync(kind, tag, ct))
+                found.Add((kind, await holdedClient.GetSalesDocumentAsync(kind, id, ct)));
         }
-        return null;
+        if (found.Count == 0) return null;
+        if (found.Count > 1)
+            // The duplicate this guard exists to prevent has already happened — only a factura
+            // rectificativa clears it. Adopting one still stops a third being issued.
+            logger.LogWarning(
+                "Holded holds {Count} documents tagged {Tag}: {Ids}. Adopting an approved one if there is any.",
+                found.Count, tag, string.Join(", ", found.Select(f => $"{f.Kind}:{f.Document.Id}")));
+
+        var approved = found.FirstOrDefault(f => f.Document.IsDraft != true);
+        return approved.Document is not null ? approved : found[0];
     }
 
     /// <summary>Writes the <c>store_invoices</c> row and the frozen order in one save, then audits.

--- a/src/Sections/Humans.Store/Services/Service.cs
+++ b/src/Sections/Humans.Store/Services/Service.cs
@@ -1,5 +1,9 @@
+using System.Globalization;
+using System.Text.Json;
 using Humans.AuditLog.Contracts;
+using Humans.Base.Attributes;
 using Humans.Camps.Contracts;
+using Humans.Holded.Contracts;
 using Humans.Shifts.Contracts;
 using Humans.Store.Contracts;
 using Humans.Store.Data;
@@ -7,6 +11,7 @@ using Humans.Store.Domain;
 using Humans.Teams.Contracts;
 using Humans.Store.Services.Dtos;
 using Humans.Stripe.Contracts;
+using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Text;
 
@@ -20,6 +25,8 @@ internal sealed class Service(
     IClock clock,
     IBurnSettingsService burnSettings,
     IStripeService stripeService,
+    IHoldedClient holdedClient,
+    IOptions<StoreSectionOptions> options,
     ILogger<Service> logger) : IStoreServiceRead
 {
     public Task<IndexData> GetIndexDataAsync(Guid userId, CancellationToken ct = default) =>
@@ -97,7 +104,7 @@ internal sealed class Service(
             else
             {
                 var productIds = existing.Lines.Select(l => l.ProductId).Distinct().ToList();
-                var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
+                var productNames = await LoadProductNamesAsync(productIds, ct);
                 orders = [await MapOrderAsync(existing, productNames, teamOrderPrices, ct)];
             }
             counterparties.Add(new CounterpartyOrders(
@@ -181,6 +188,7 @@ internal sealed class Service(
             UnitPriceEur = draft.UnitPriceEur,
             VatRatePercent = draft.VatRatePercent,
             DepositAmountEur = draft.DepositAmountEur,
+            HoldedRevenueAccountNum = draft.HoldedRevenueAccountNum,
             OrderableUntil = draft.OrderableUntil,
             IsActive = draft.IsActive,
             CreatedAt = now,
@@ -209,6 +217,7 @@ internal sealed class Service(
         product.UnitPriceEur = draft.UnitPriceEur;
         product.VatRatePercent = draft.VatRatePercent;
         product.DepositAmountEur = draft.DepositAmountEur;
+        product.HoldedRevenueAccountNum = draft.HoldedRevenueAccountNum;
         product.OrderableUntil = draft.OrderableUntil;
         product.IsActive = draft.IsActive;
         product.UpdatedAt = clock.GetCurrentInstant();
@@ -245,7 +254,8 @@ internal sealed class Service(
             request.VatRatePercent,
             request.DepositAmountEur,
             parseResult.Value,
-            request.IsActive);
+            request.IsActive,
+            request.HoldedRevenueAccountNum);
 
         try
         {
@@ -295,13 +305,15 @@ internal sealed class Service(
             throw new ArgumentException("VAT rate cannot be negative", nameof(draft));
         if (draft.DepositAmountEur is < 0m)
             throw new ArgumentException("Deposit cannot be negative", nameof(draft));
+        if (draft.HoldedRevenueAccountNum is { } account and (< 10_000_000 or > 99_999_999))
+            throw new ArgumentException("Holded revenue account must be an 8-digit chart number", nameof(draft));
     }
 
     public async Task<IReadOnlyList<OrderDto>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default)
     {
         var orders = await repo.GetOrdersForCampSeasonAsync(campSeasonId, ct);
         var productIds = orders.SelectMany(o => o.Lines).Select(l => l.ProductId).Distinct().ToList();
-        var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
+        var productNames = await LoadProductNamesAsync(productIds, ct);
         var currentPrices = await LoadCurrentPricesAsync(ct);
         var result = new List<OrderDto>(orders.Count);
         foreach (var o in orders)
@@ -314,7 +326,7 @@ internal sealed class Service(
         var o = await repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct);
         if (o is null) return null;
         var productIds = o.Lines.Select(l => l.ProductId).Distinct().ToList();
-        var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
+        var productNames = await LoadProductNamesAsync(productIds, ct);
         var currentPrices = await LoadCurrentPricesAsync(ct);
         return await MapOrderAsync(o, productNames, currentPrices, ct);
     }
@@ -406,7 +418,7 @@ internal sealed class Service(
         var order = await repo.GetOrderForTeamAsync(teamId, year, ct);
         if (order is null) return null;
         var productIds = order.Lines.Select(l => l.ProductId).Distinct().ToList();
-        var productNames = await repo.GetProductNamesByIdsAsync(productIds, ct);
+        var productNames = await LoadProductNamesAsync(productIds, ct);
         var currentPrices = await LoadCurrentPricesAsync(ct);
         return await MapOrderAsync(order, productNames, currentPrices, ct);
     }
@@ -944,15 +956,238 @@ internal sealed class Service(
     }
 
     /// <summary>
-    /// Phase 5 — not yet implemented. <b>Freeze seam (#816):</b> before flipping
-    /// <see cref="Order.State"/> to <see cref="OrderState.InvoiceIssued"/>, the
-    /// implementation MUST re-write each line's <c>UnitPriceSnapshot</c>,
-    /// <c>VatRateSnapshot</c>, and <c>DepositAmountSnapshot</c> from the current catalog
-    /// price, so the issued invoice captures the exact prices shown at issue time. Until
-    /// then every order stays Open and reprices live, which is the desired in-season behavior.
+    /// Issues the camp order's consolidated Holded sales document and freezes the order.
+    ///
+    /// Pipeline: freeze the line snapshots at today's catalog price (#816) → resolve each
+    /// product's revenue account → build the lines (goods at the product's VAT rate, deposits
+    /// tax-0 to the fianzas liability account) → create the document and <b>approve</b> it (a
+    /// draft books nothing) → write <c>store_invoices</c> with both payloads and flip the order
+    /// to <see cref="OrderState.InvoiceIssued"/> in one save.
+    ///
+    /// Document kind: a full <i>factura</i> when counterparty details are on file, a
+    /// <i>factura simplificada</i> (sales receipt) otherwise. Above
+    /// <see cref="StoreSectionOptions.SimplifiedInvoiceThresholdEur"/> a receipt is not legal,
+    /// so a counterparty-less order that large is refused rather than downgraded.
+    ///
+    /// Idempotent: an order that already carries an <c>IssuedInvoiceId</c> throws without
+    /// calling Holded. Failure before the save leaves the order <c>Open</c> with no invoice row.
     /// </summary>
-    public Task IssueInvoiceAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 5");
+    [ExternalWrite]
+    public async Task IssueInvoiceAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default)
+    {
+        var order = await repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct)
+            ?? throw new InvalidOperationException($"Order {orderId} not found");
+        EnsureBillable(order);
+
+        // Idempotency guard — deliberately before any Holded call, so a double-submit cannot
+        // create a second document.
+        if (order.IssuedInvoiceId is not null || order.State != OrderState.Open)
+            throw new InvalidOperationException("This order has already been invoiced.");
+
+        if (order.Lines.Count == 0)
+            throw new InvalidOperationException("Cannot invoice an order with no lines.");
+
+        if (!holdedClient.IsConfigured)
+            throw new InvalidOperationException(
+                "Holded is not configured in this environment, so no invoice can be issued.");
+
+        // Freeze seam (#816): rewrite each snapshot from the live catalog before issuing, so the
+        // document and the order agree forever after. BalanceCalculator already computed the
+        // effective prices for an Open order — reuse them rather than re-deriving.
+        var totals = BalanceCalculator.Compute(order, await LoadCurrentPricesAsync(ct));
+        var totalsByLine = totals.Lines.ToDictionary(t => t.LineId);
+        foreach (var line in order.Lines)
+        {
+            var t = totalsByLine[line.Id];
+            line.UnitPriceSnapshot = t.EffectiveUnitPrice;
+            line.VatRateSnapshot = t.EffectiveVatRate;
+            line.DepositAmountSnapshot = t.EffectiveDeposit;
+        }
+
+        var totalDue = totals.LinesSubtotalEur + totals.VatTotalEur + totals.DepositTotalEur;
+        if (totalDue <= 0m)
+            throw new InvalidOperationException("Cannot invoice an order with a zero total.");
+
+        var products = (await repo.GetProductsByIdsAsync(
+                order.Lines.Select(l => l.ProductId).Distinct().ToList(), ct))
+            .ToDictionary(p => p.Id);
+
+        var documentLines = await BuildInvoiceLinesAsync(order, totalsByLine, products, ct);
+
+        // A receipt carries no counterparty, so it is only lawful below the simplified-invoice
+        // threshold. Above it the details are mandatory — refuse rather than silently issue the
+        // wrong document type.
+        var counterparty = ResolveInvoiceCounterparty(order);
+        var kind = counterparty is null
+            ? HoldedSalesDocumentKind.SalesReceipt
+            : HoldedSalesDocumentKind.Invoice;
+        if (counterparty is null && totalDue > options.Value.SimplifiedInvoiceThresholdEur)
+            throw new InvalidOperationException(
+                $"An order of EUR {totalDue:0.00} needs a full factura: fill in the counterparty's "
+                + "name, address and tax id (or passport number) first.");
+
+        var displayName = await ResolveCounterpartyDisplayNameAsync(order, ct);
+        string? contactId = null;
+        if (counterparty is not null)
+        {
+            // Not the request token: everything from here on writes to Holded, and a half-created
+            // contact/document has no local compensation (memory/architecture/cancellation-token-propagation.md).
+            contactId = await holdedClient.UpsertContactAsync(
+                new HoldedContactInput
+                {
+                    Name = counterparty.Name,
+                    Type = "client",
+                    TaxCode = counterparty.TaxId,
+                    Address = counterparty.Address,
+                    CountryCode = counterparty.CountryCode,
+                    Email = counterparty.Email,
+                },
+                CancellationToken.None);
+        }
+
+        var input = new HoldedSalesDocumentInput
+        {
+            ContactId = contactId,
+            ContactName = counterparty?.Name ?? displayName,
+            Date = clock.GetCurrentInstant(),
+            Description = $"Nobodies Collective store — {displayName}",
+            Notes = $"Humans store order {order.Id}",
+            Lines = documentLines,
+        };
+
+        var docId = await holdedClient.CreateSalesDocumentAsync(kind, input, CancellationToken.None);
+        // A draft books no revenue, so approval is part of issuance, not a later step.
+        await holdedClient.ApproveSalesDocumentAsync(kind, docId, CancellationToken.None);
+        var document = await holdedClient.GetSalesDocumentAsync(kind, docId, CancellationToken.None);
+
+        var invoice = new Invoice
+        {
+            Id = Guid.NewGuid(),
+            OrderId = order.Id,
+            HoldedDocId = document.Id,
+            HoldedDocNumber = document.DocNumber,
+            IssuedAt = clock.GetCurrentInstant(),
+            IssuedByUserId = actorUserId,
+            RequestPayload = JsonSerializer.Serialize(new { kind = kind.ToString(), input }),
+            ResponsePayload = document.RawJson,
+        };
+
+        order.State = OrderState.InvoiceIssued;
+        order.IssuedInvoiceId = invoice.Id;
+        order.UpdatedAt = clock.GetCurrentInstant();
+        await repo.SaveIssuedInvoiceAsync(invoice, order, ct);
+
+        await audit.LogAsync(
+            AuditAction.StoreInvoiceIssued, AuditEntityTypes.Invoice, invoice.Id,
+            $"Issued Holded {(kind == HoldedSalesDocumentKind.Invoice ? "factura" : "factura simplificada")} "
+            + $"{document.DocNumber} for EUR {totalDue:0.00} on order {order.Id}",
+            actorUserId,
+            order.Id, AuditEntityTypes.Order);
+    }
+
+    /// <summary>
+    /// One document line per order line, plus a separate VAT-free line for each line that carries
+    /// a deposit. Refundable deposits are a liability, not income, so they post tax-0 to the
+    /// configured fianzas account instead of the item's revenue account.
+    /// </summary>
+    private async Task<IReadOnlyList<HoldedSalesDocumentLineInput>> BuildInvoiceLinesAsync(
+        Order order,
+        IReadOnlyDictionary<Guid, BalanceCalculator.LineTotals> totalsByLine,
+        IReadOnlyDictionary<Guid, Product> products,
+        CancellationToken ct)
+    {
+        var missingAccount = order.Lines
+            .Select(l => products.GetValueOrDefault(l.ProductId))
+            .Where(p => p?.HoldedRevenueAccountNum is null)
+            .Select(p => p?.Name ?? "(unknown product)")
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (missingAccount.Count > 0)
+            throw new InvalidOperationException(
+                "These catalog items have no Holded revenue account yet: "
+                + string.Join(", ", missingAccount)
+                + ". Set it on /Store/Admin/Catalog before issuing.");
+
+        var needsDepositAccount = order.Lines.Any(l => totalsByLine[l.Id].DepositEur > 0m);
+        var depositAccountNum = options.Value.DepositLiabilityAccountNum;
+        if (needsDepositAccount && depositAccountNum is null)
+            throw new InvalidOperationException(
+                "This order carries refundable deposits but no deposit liability account is "
+                + "configured (Store:DepositLiabilityAccountNum). Deposits are not income and "
+                + "must not be booked to a revenue account.");
+
+        // Holded's items[].account is the chart account's *id*, not its 8-digit number, so the
+        // numbers StoreAdmin holds are resolved against the live chart on every issue — a fresh
+        // read also picks up an account Acountax created minutes ago.
+        var wanted = order.Lines
+            .Select(l => products[l.ProductId].HoldedRevenueAccountNum!.Value)
+            .Concat(needsDepositAccount ? [depositAccountNum!.Value] : Array.Empty<int>())
+            .ToHashSet();
+        var accountIdsByNum = (await holdedClient.ListAccountingAccountsAsync(ct))
+            .Where(a => wanted.Contains(a.Number))
+            .ToDictionary(a => a.Number, a => a.Id);
+
+        var unknown = wanted.Where(n => !accountIdsByNum.ContainsKey(n)).ToList();
+        if (unknown.Count > 0)
+            throw new InvalidOperationException(
+                "These accounts do not exist in Holded's chart of accounts: "
+                + string.Join(", ", unknown.OrderBy(n => n))
+                + ". Ask Acountax to create them, then re-issue.");
+
+        var lines = new List<HoldedSalesDocumentLineInput>();
+        foreach (var line in order.Lines)
+        {
+            var product = products[line.ProductId];
+            var t = totalsByLine[line.Id];
+            lines.Add(new HoldedSalesDocumentLineInput
+            {
+                Name = product.Name,
+                Units = line.Qty,
+                Price = t.EffectiveUnitPrice,
+                Taxes = [SalesTaxKey(t.EffectiveVatRate)],
+                AccountId = accountIdsByNum[product.HoldedRevenueAccountNum!.Value],
+            });
+
+            if (t.EffectiveDeposit is not { } depositPerUnit || depositPerUnit <= 0m) continue;
+            lines.Add(new HoldedSalesDocumentLineInput
+            {
+                Name = $"{product.Name} — refundable deposit",
+                Units = line.Qty,
+                Price = depositPerUnit,
+                Taxes = [SalesTaxKey(0m)],
+                AccountId = accountIdsByNum[depositAccountNum!.Value],
+            });
+        }
+        return lines;
+    }
+
+    /// <summary>
+    /// Holded's sales tax key for a VAT rate: 21 → <c>s_iva_21</c>, 7.5 → <c>s_iva_75</c>,
+    /// 0 → <c>s_iva_0</c> (the decimal separator is dropped, not rounded away).
+    /// </summary>
+    private static string SalesTaxKey(decimal vatRatePercent) =>
+        "s_iva_" + vatRatePercent.ToString("0.##", CultureInfo.InvariantCulture).Replace(".", "", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The identified counterparty a full factura needs, or null when the order does not carry
+    /// enough to identify one. Spanish law wants name + address + a tax id; a foreign camp's
+    /// home-country tax id or passport number stands in for a NIF, so the field is only ever
+    /// checked for presence.
+    /// </summary>
+    private static InvoiceCounterparty? ResolveInvoiceCounterparty(Order order) =>
+        string.IsNullOrWhiteSpace(order.CounterpartyName)
+        || string.IsNullOrWhiteSpace(order.CounterpartyAddress)
+        || string.IsNullOrWhiteSpace(order.CounterpartyVatId)
+            ? null
+            : new InvoiceCounterparty(
+                order.CounterpartyName.Trim(),
+                order.CounterpartyVatId.Trim(),
+                order.CounterpartyAddress.Trim(),
+                order.CounterpartyCountryCode?.Trim(),
+                order.CounterpartyEmail?.Trim());
+
+    private sealed record InvoiceCounterparty(
+        string Name, string TaxId, string Address, string? CountryCode, string? Email);
 
     public async Task<SummaryDto> GetStoreSummaryAsync(int year, CancellationToken ct = default)
     {
@@ -1097,7 +1332,12 @@ internal sealed class Service(
 
     private static ProductDto MapProduct(Product p) =>
         new(p.Id, p.Year, p.Name, p.Description, p.UnitPriceEur, p.VatRatePercent,
-            p.DepositAmountEur, p.OrderableUntil, p.IsActive);
+            p.DepositAmountEur, p.OrderableUntil, p.IsActive, p.HoldedRevenueAccountNum);
+
+    /// <summary>Display names for the given product ids, live or deactivated, any year.</summary>
+    private async Task<IReadOnlyDictionary<Guid, string>> LoadProductNamesAsync(
+        IReadOnlyCollection<Guid> productIds, CancellationToken ct) =>
+        (await repo.GetProductsByIdsAsync(productIds, ct)).ToDictionary(p => p.Id, p => p.Name);
 
     /// <summary>
     /// Loads the current catalog price components (incl. deactivated products) for the active

--- a/src/Sections/Humans.Store/Services/ServiceContracts.cs
+++ b/src/Sections/Humans.Store/Services/ServiceContracts.cs
@@ -17,7 +17,8 @@ internal sealed record ProductSaveRequest(
     decimal VatRatePercent,
     decimal? DepositAmountEur,
     string? OrderableUntil,
-    bool IsActive);
+    bool IsActive,
+    int? HoldedRevenueAccountNum);
 
 internal sealed record CatalogSaveResult(
     bool Succeeded,

--- a/src/Sections/Humans.Store/StoreSectionOptions.cs
+++ b/src/Sections/Humans.Store/StoreSectionOptions.cs
@@ -1,0 +1,27 @@
+namespace Humans.Store;
+
+/// <summary>
+/// Section-owned settings, bound in <see cref="Section.Register"/> from <c>Store:*</c>.
+/// Both values are Acountax's call and change without a code deploy, which is why they are
+/// configuration rather than constants.
+/// </summary>
+internal sealed class StoreSectionOptions
+{
+    public const string Section = "Store";
+
+    /// <summary>
+    /// Holded chart number of the refundable-deposit liability account (<i>fianzas recibidas</i>).
+    /// Deposits are not income: they post as tax-0 lines to this account until refunded or
+    /// forfeited. Null until Acountax names it — issuing an invoice that carries a deposit line
+    /// is refused while it is unset rather than booking the deposit as revenue.
+    /// </summary>
+    public int? DepositLiabilityAccountNum { get; set; }
+
+    /// <summary>
+    /// Order total (incl. VAT and deposits) at or below which an order with no counterparty
+    /// details may be issued as a <i>factura simplificada</i>. Spanish law allows €400 generally
+    /// and €3,000 for retail-type B2C supplies; which category store items fall under is
+    /// Acountax's call, so the default is the conservative €400.
+    /// </summary>
+    public decimal SimplifiedInvoiceThresholdEur { get; set; } = 400m;
+}

--- a/src/Sections/Humans.Store/Views/Store/Order.cshtml
+++ b/src/Sections/Humans.Store/Views/Store/Order.cshtml
@@ -21,6 +21,16 @@
     <div class="d-flex align-items-center gap-2">
         <span class="badge bg-info text-dark fs-6">@order.CounterpartyType</span>
         <span class="badge bg-secondary fs-6">@order.State</span>
+        @if (Model.CanIssueInvoice)
+        {
+            <form asp-action="IssueInvoice" asp-route-id="@order.Id" method="post" class="mb-0">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-sm btn-outline-primary"
+                        data-confirm="Issue this order's factura in Holded? Prices freeze at today's catalog and the order can never be re-issued.">
+                    <i class="fa-solid fa-file-invoice me-1"></i> Issue invoice
+                </button>
+            </form>
+        }
         @if (Model.CanDelete)
         {
             <form asp-action="Delete" asp-route-id="@order.Id" method="post" class="mb-0">

--- a/src/Sections/Humans.Store/Views/StoreAdmin/Catalog.cshtml
+++ b/src/Sections/Humans.Store/Views/StoreAdmin/Catalog.cshtml
@@ -1,3 +1,4 @@
+@using System.Globalization
 @using Microsoft.AspNetCore.Html
 @model CatalogAdminViewModel
 @{
@@ -61,6 +62,8 @@ else
                 .Column("Unit price", r => r.UnitPriceEur, c => c.Currency().End())
                 .Column("VAT %", r => r.VatRatePercent, c => c.Number().End())
                 .Column("Deposit", r => r.DepositAmountEur, c => c.Currency().End())
+                .Column("Revenue acct", r => r.HoldedRevenueAccountNum?.ToString(CultureInfo.InvariantCulture) ?? "—")
+                .Column("Internal acct", r => r.InternalRechargeAccountNum?.ToString(CultureInfo.InvariantCulture) ?? "—")
                 .Column("Orderable until", r => r.OrderableUntil.ToDate())
                 .Template("Status", catalogAdminStatusCell)
                 .Template("Actions", catalogAdminActionsCell, c => c.NoSort().End())

--- a/src/Sections/Humans.Store/Views/StoreAdmin/CatalogEdit.cshtml
+++ b/src/Sections/Humans.Store/Views/StoreAdmin/CatalogEdit.cshtml
@@ -61,6 +61,18 @@
                     <input asp-for="OrderableUntil" type="date" class="form-control" />
                     <span asp-validation-for="OrderableUntil" class="text-danger small"></span>
                 </div>
+                <div class="col-md-6">
+                    <label asp-for="HoldedRevenueAccountNum" class="form-label">Holded revenue account</label>
+                    <input asp-for="HoldedRevenueAccountNum" type="number" step="1" class="form-control"
+                           placeholder="e.g. 75900002" />
+                    <span asp-validation-for="HoldedRevenueAccountNum" class="text-danger small"></span>
+                    <div class="form-text">
+                        The per-item account Acountax issued. Invoices book this item's revenue here, so
+                        per-item break-even reads straight off the ledger. Internal department recharges
+                        go to the derived twin (<code>75910002</code> for <code>75900002</code>) — it is
+                        not stored. Required before this item can be invoiced.
+                    </div>
+                </div>
                 <div class="col-12">
                     <div class="form-check">
                         <input asp-for="IsActive" class="form-check-input" />

--- a/tests/Humans.Holded.Tests/Services/HoldedClientSalesDocumentTests.cs
+++ b/tests/Humans.Holded.Tests/Services/HoldedClientSalesDocumentTests.cs
@@ -186,9 +186,43 @@ public class HoldedClientSalesDocumentTests
     }
 
     [HumansFact]
-    public async Task UpsertContactAsync_OmitsBillAddressWhenNoAddressIsHeld()
+    public async Task UpsertContactAsync_OmitsEveryFieldItHoldsNoValueFor()
     {
-        // Sending an object of nulls would blank an address already on the contact.
+        // Holded applies every key a PUT carries, so a null blanks the stored value. Finance's
+        // creditor update supplies only name/trade name/type/iban — the tax code, email and billing
+        // address maintained in Holded for that contact must survive it untouched.
+        string? body = null;
+        var handler = new StubHandler(req =>
+        {
+            body = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return Respond(HttpStatusCode.OK, """{"id":"contact-1"}""");
+        });
+
+        await Make(handler).UpsertContactAsync(
+            new HoldedContactInput
+            {
+                Name = "Supplier",
+                Type = "creditor",
+                Iban = "ES9121000418450200051332",
+                ExistingContactId = "contact-1",
+            },
+            Xunit.TestContext.Current.CancellationToken);
+
+        body.Should().NotContain("code");
+        body.Should().NotContain("email");
+        body.Should().NotContain("bill_address");
+        body.Should().NotContain("trade_name");
+        body.Should().NotContain("null");
+        // What it does mean to send still goes.
+        body.Should().Contain("\"name\":\"Supplier\"");
+        body.Should().Contain("\"type\":\"creditor\"");
+        body.Should().Contain("\"iban\":\"ES9121000418450200051332\"");
+    }
+
+    [HumansFact]
+    public async Task UpsertContactAsync_StillSendsTheFieldsItDoesHold()
+    {
+        // Omission must not swallow a value a caller deliberately supplied.
         string? body = null;
         var handler = new StubHandler(req =>
         {
@@ -196,11 +230,42 @@ public class HoldedClientSalesDocumentTests
             return Respond(HttpStatusCode.Created, """{"id":"contact-1"}""");
         });
 
-        await Make(handler).UpsertContactAsync(
-            new HoldedContactInput { Name = "Supplier", Type = "creditor" },
+        await Make(handler).UpsertContactAsync(new HoldedContactInput
+        {
+            Name = "Camp Frio SL",
+            TradeName = "Camp Frio",
+            Type = "client",
+            TaxCode = "B12345678",
+            Email = "lead@campfrio.example",
+            Address = "Calle Falsa 1",
+            CountryCode = "ES",
+        }, Xunit.TestContext.Current.CancellationToken);
+
+        body.Should().Contain("\"trade_name\":\"Camp Frio\"");
+        body.Should().Contain("\"code\":\"B12345678\"");
+        body.Should().Contain("\"email\":\"lead@campfrio.example\"");
+        body.Should().Contain("\"address\":\"Calle Falsa 1\"");
+        body.Should().Contain("\"country_code\":\"ES\"");
+    }
+
+    [HumansFact]
+    public async Task CreateSalesDocumentAsync_OmitsTheContactOnAReceipt()
+    {
+        // A sales receipt carries no counterparty; `"contact_id":null` is not the same as absent.
+        string? body = null;
+        var handler = new StubHandler(req =>
+        {
+            body = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return Respond(HttpStatusCode.Created, """{"id":"doc-9"}""");
+        });
+
+        await Make(handler).CreateSalesDocumentAsync(
+            HoldedSalesDocumentKind.SalesReceipt,
+            Input() with { ContactId = null },
             Xunit.TestContext.Current.CancellationToken);
 
-        body.Should().Contain("\"bill_address\":null");
+        body.Should().NotContain("contact_id");
+        body.Should().Contain("\"contact_name\":\"Camp Frio SL\"");
     }
 
     private static HttpResponseMessage Respond(HttpStatusCode status, string body) =>

--- a/tests/Humans.Holded.Tests/Services/HoldedClientSalesDocumentTests.cs
+++ b/tests/Humans.Holded.Tests/Services/HoldedClientSalesDocumentTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Text;
+using AwesomeAssertions;
+using Humans.Holded.Contracts;
+using Humans.Holded.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using NodaTime.Testing;
+using Xunit;
+
+namespace Humans.Holded.Tests.Services;
+
+/// <summary>
+/// Wire shape of the v2 sales-document pipeline (nobodies-collective/Humans#1029). Field names
+/// are locked against <c>https://api.holded.com/openapi/api2.json</c> and a live read of the
+/// account's documents (2026-08-19): <c>items[].account</c> carries the chart account's
+/// <b>id</b>, and <c>items[].taxes</c> carries sales tax keys such as <c>s_iva_21</c>.
+/// </summary>
+public class HoldedClientSalesDocumentTests
+{
+    private static HoldedClient Make(StubHandler handler) =>
+        new(
+            new HttpClient(handler) { BaseAddress = new Uri("https://api.holded.com") },
+            Options.Create(new HoldedClientOptions { ApiKey = "test-key" }),
+            NullLogger<HoldedClient>.Instance,
+            new HoldedCallLog(),
+            new FakeClock(Instant.FromUtc(2026, 9, 1, 12, 0)));
+
+    private static HoldedSalesDocumentInput Input() => new()
+    {
+        ContactId = "contact-1",
+        ContactName = "Camp Frio SL",
+        Date = Instant.FromUtc(2026, 9, 1, 0, 0),
+        Description = "Store order",
+        Lines =
+        [
+            new() { Name = "Ice", Units = 20m, Price = 5m, Taxes = ["s_iva_21"], AccountId = "acct-ice" },
+            new() { Name = "Ice — refundable deposit", Units = 20m, Price = 3m, Taxes = ["s_iva_0"], AccountId = "acct-dep" },
+        ],
+    };
+
+    [HumansTheory]
+    [InlineData(HoldedSalesDocumentKind.Invoice, "/api/v2/invoices")]
+    [InlineData(HoldedSalesDocumentKind.SalesReceipt, "/api/v2/sales-receipts")]
+    public async Task CreateSalesDocumentAsync_PostsExpectedJson_AndReturnsId(
+        HoldedSalesDocumentKind kind, string expectedPath)
+    {
+        string? body = null;
+        var handler = new StubHandler(req =>
+        {
+            req.Method.Method.Should().Be("POST");
+            req.RequestUri!.PathAndQuery.Should().Be(expectedPath);
+            req.Headers.Authorization!.Parameter.Should().Be("test-key");
+            body = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return Respond(HttpStatusCode.Created, """{"id":"doc-9"}""");
+        });
+
+        var id = await Make(handler).CreateSalesDocumentAsync(
+            kind, Input(), Xunit.TestContext.Current.CancellationToken);
+
+        id.Should().Be("doc-9");
+        body.Should().Contain("\"contact_id\":\"contact-1\"");
+        body.Should().Contain("\"date\":\"2026-09-01\"");
+        body.Should().Contain("\"currency\":\"EUR\"");
+        body.Should().Contain("\"account\":\"acct-ice\"");
+        body.Should().Contain("\"account\":\"acct-dep\"");
+        body.Should().Contain("\"taxes\":[\"s_iva_21\"]");
+        body.Should().Contain("\"taxes\":[\"s_iva_0\"]");
+    }
+
+    [HumansTheory]
+    [InlineData(HoldedSalesDocumentKind.Invoice, "/api/v2/invoices/doc-9/approve")]
+    [InlineData(HoldedSalesDocumentKind.SalesReceipt, "/api/v2/sales-receipts/doc-9/approve")]
+    public async Task ApproveSalesDocumentAsync_PostsToTheApprovePath(
+        HoldedSalesDocumentKind kind, string expectedPath)
+    {
+        var handler = new StubHandler(req =>
+        {
+            req.Method.Method.Should().Be("POST");
+            req.RequestUri!.PathAndQuery.Should().Be(expectedPath);
+            return Respond(HttpStatusCode.OK, "{}");
+        });
+
+        await Make(handler).ApproveSalesDocumentAsync(
+            kind, "doc-9", Xunit.TestContext.Current.CancellationToken);
+    }
+
+    [HumansFact]
+    public async Task GetSalesDocumentAsync_ParsesTotalsAndKeepsTheRawBody()
+    {
+        // Decimals arrive as strings, per the connector invariant.
+        const string json = """
+        {"id":"doc-9","document_number":"2026-0007","subtotal":"160.00","tax":"21.00",
+         "total":"181.00","status":"pending"}
+        """;
+        var handler = new StubHandler(req =>
+        {
+            req.RequestUri!.PathAndQuery.Should().Be("/api/v2/invoices/doc-9");
+            return Respond(HttpStatusCode.OK, json);
+        });
+
+        var doc = await Make(handler).GetSalesDocumentAsync(
+            HoldedSalesDocumentKind.Invoice, "doc-9", Xunit.TestContext.Current.CancellationToken);
+
+        doc.Id.Should().Be("doc-9");
+        doc.DocNumber.Should().Be("2026-0007");
+        doc.Subtotal.Should().Be(160.00m);
+        doc.Tax.Should().Be(21.00m);
+        doc.Total.Should().Be(181.00m);
+        doc.Status.Should().Be("pending");
+        doc.RawJson.Should().Be(json);
+    }
+
+    [HumansFact]
+    public async Task UpsertContactAsync_SendsTaxCodeAndBillingAddressForAClient()
+    {
+        string? body = null;
+        var handler = new StubHandler(req =>
+        {
+            body = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return Respond(HttpStatusCode.Created, """{"id":"contact-1"}""");
+        });
+
+        await Make(handler).UpsertContactAsync(new HoldedContactInput
+        {
+            Name = "Camp Frio SL",
+            Type = "client",
+            TaxCode = "B12345678",
+            Address = "Calle Falsa 1",
+            CountryCode = "ES",
+            Email = "lead@campfrio.example",
+        }, Xunit.TestContext.Current.CancellationToken);
+
+        body.Should().Contain("\"type\":\"client\"");
+        body.Should().Contain("\"code\":\"B12345678\"");
+        body.Should().Contain("\"country_code\":\"ES\"");
+        body.Should().Contain("\"address\":\"Calle Falsa 1\"");
+    }
+
+    [HumansFact]
+    public async Task UpsertContactAsync_OmitsBillAddressWhenNoAddressIsHeld()
+    {
+        // Sending an object of nulls would blank an address already on the contact.
+        string? body = null;
+        var handler = new StubHandler(req =>
+        {
+            body = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return Respond(HttpStatusCode.Created, """{"id":"contact-1"}""");
+        });
+
+        await Make(handler).UpsertContactAsync(
+            new HoldedContactInput { Name = "Supplier", Type = "creditor" },
+            Xunit.TestContext.Current.CancellationToken);
+
+        body.Should().Contain("\"bill_address\":null");
+    }
+
+    private static HttpResponseMessage Respond(HttpStatusCode status, string body) =>
+        new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request));
+    }
+}

--- a/tests/Humans.Holded.Tests/Services/HoldedClientSalesDocumentTests.cs
+++ b/tests/Humans.Holded.Tests/Services/HoldedClientSalesDocumentTests.cs
@@ -33,6 +33,7 @@ public class HoldedClientSalesDocumentTests
         ContactName = "Camp Frio SL",
         Date = Instant.FromUtc(2026, 9, 1, 0, 0),
         Description = "Store order",
+        Tags = ["humans-order-1"],
         Lines =
         [
             new() { Name = "Ice", Units = 20m, Price = 5m, Taxes = ["s_iva_21"], AccountId = "acct-ice" },
@@ -67,6 +68,52 @@ public class HoldedClientSalesDocumentTests
         body.Should().Contain("\"account\":\"acct-dep\"");
         body.Should().Contain("\"taxes\":[\"s_iva_21\"]");
         body.Should().Contain("\"taxes\":[\"s_iva_0\"]");
+        // The tag is what makes this document findable again: v2's list endpoints return `tags`
+        // but not `notes`, so it — not the note beside it — carries the originating order.
+        body.Should().Contain("\"tags\":[\"humans-order-1\"]");
+    }
+
+    [HumansTheory]
+    [InlineData(HoldedSalesDocumentKind.Invoice, "/api/v2/invoices?limit=200")]
+    [InlineData(HoldedSalesDocumentKind.SalesReceipt, "/api/v2/sales-receipts?limit=200")]
+    public async Task FindSalesDocumentIdsByTagAsync_ReturnsOnlyTheTaggedDocuments(
+        HoldedSalesDocumentKind kind, string expectedPath)
+    {
+        // v2 has no server-side tag filter, so the whole collection is walked and matched here.
+        const string json = """
+        {"items":[
+          {"id":"doc-1","tags":["humans-order-1"]},
+          {"id":"doc-2","tags":["humans-order-2"]},
+          {"id":"doc-3","tags":[]},
+          {"id":"doc-4","tags":["other","humans-order-2"]}
+        ],"has_more":false}
+        """;
+        var handler = new StubHandler(req =>
+        {
+            req.Method.Method.Should().Be("GET");
+            req.RequestUri!.PathAndQuery.Should().Be(expectedPath);
+            return Respond(HttpStatusCode.OK, json);
+        });
+
+        var ids = await Make(handler).FindSalesDocumentIdsByTagAsync(
+            kind, "humans-order-2", Xunit.TestContext.Current.CancellationToken);
+
+        ids.Should().Equal("doc-2", "doc-4");
+    }
+
+    [HumansFact]
+    public async Task FindSalesDocumentIdsByTagAsync_RefusesAMatchWithNoId()
+    {
+        // An empty result reads as "nothing issued yet" and lets a second document be created,
+        // so a match that cannot be identified must fail the search rather than be dropped.
+        var handler = new StubHandler(_ => Respond(
+            HttpStatusCode.OK,
+            """{"items":[{"tags":["humans-order-1"]}],"has_more":false}"""));
+
+        var act = async () => await Make(handler).FindSalesDocumentIdsByTagAsync(
+            HoldedSalesDocumentKind.Invoice, "humans-order-1", Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HoldedPermanentException>();
     }
 
     [HumansTheory]

--- a/tests/Humans.Store.Tests/Data/RepositoryTests.cs
+++ b/tests/Humans.Store.Tests/Data/RepositoryTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Store.Contracts;
 using Humans.Store.Data;
 using Humans.Store.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -88,6 +89,77 @@ public sealed class RepositoryTests
         fetched.Id.Should().Be(orderId);
         fetched.Lines.Should().BeEmpty();
         fetched.Payments.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task SaveIssuedInvoiceAsync_does_not_write_back_a_payment_settled_mid_issuance()
+    {
+        // The order is read before several slow Holded calls; a Stripe webhook can settle a payment
+        // in between. Writing the stale aggregate back would lose the settlement, and there is no
+        // concurrency token to catch it.
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var orderId = Guid.NewGuid();
+        var lineId = Guid.NewGuid();
+        var paymentId = Guid.NewGuid();
+        var at = Instant.FromUtc(2026, 3, 1, 12, 0);
+        await _repo.AddOrderAsync(new Order
+        {
+            Id = orderId,
+            CampSeasonId = Guid.NewGuid(),
+            Year = 2026,
+            State = OrderState.Open,
+            CreatedAt = at,
+            UpdatedAt = at,
+        }, ct);
+        await _repo.AddLineAsync(new OrderLine
+        {
+            Id = lineId,
+            OrderId = orderId,
+            ProductId = Guid.NewGuid(),
+            Qty = 2,
+            UnitPriceSnapshot = 4m,
+            VatRateSnapshot = 21m,
+            AddedAt = at,
+            AddedByUserId = Guid.NewGuid(),
+        }, ct);
+        await _repo.AddPaymentAsync(new Payment
+        {
+            Id = paymentId,
+            OrderId = orderId,
+            AmountEur = 10m,
+            Method = PaymentMethod.Stripe,
+            Status = PaymentStatus.Pending,
+            StripePaymentIntentId = "pi_1",
+            ReceivedAt = at,
+        }, ct);
+
+        // Issuance reads the order — with the payment still Pending.
+        var stale = await _repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct);
+        stale.Should().NotBeNull();
+
+        // …and while Holded is being called, the webhook settles it.
+        await _repo.UpdatePaymentStatusAsync(paymentId, PaymentStatus.Paid, ct);
+
+        stale!.State = OrderState.InvoiceIssued;
+        stale.Lines.Single().UnitPriceSnapshot = 5m;
+        var invoice = new Invoice
+        {
+            Id = Guid.NewGuid(),
+            OrderId = orderId,
+            HoldedDocId = "doc-1",
+            HoldedDocNumber = "2026-0007",
+            IssuedAt = at,
+            IssuedByUserId = Guid.NewGuid(),
+        };
+        stale.IssuedInvoiceId = invoice.Id;
+        await _repo.SaveIssuedInvoiceAsync(invoice, stale, ct);
+
+        var reloaded = await _repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct);
+        reloaded!.Payments.Single().Status.Should().Be(PaymentStatus.Paid);
+        // The columns issuance does own still land.
+        reloaded.State.Should().Be(OrderState.InvoiceIssued);
+        reloaded.IssuedInvoiceId.Should().Be(invoice.Id);
+        reloaded.Lines.Single().UnitPriceSnapshot.Should().Be(5m);
     }
 
     private static Product MakeProduct(int year, bool isActive, string name)

--- a/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
@@ -22,7 +22,8 @@ namespace Humans.Store.Tests.Services;
 /// <summary>
 /// Phase 5 issuance (nobodies-collective/Humans#1029): the v2 create+approve pipeline, per-line
 /// revenue accounts, tax-0 deposit lines to the fianzas account, the receipt/factura branch, and
-/// the idempotent re-issue guard.
+/// both idempotency guards — the local one, and the pre-issue search that adopts a document an
+/// earlier attempt approved before failing to save.
 /// </summary>
 public class ServiceIssueInvoiceTests
 {
@@ -77,6 +78,9 @@ public class ServiceIssueInvoiceTests
             });
         _holded.UpsertContactAsync(Arg.Any<HoldedContactInput>(), Arg.Any<CancellationToken>())
             .Returns("contact-1");
+        _holded.FindSalesDocumentIdsByTagAsync(
+                Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<string>());
 
         _service = new Service(
             _repo, _audit, _camps, _teams, _clock, _shifts, _stripe, _holded,
@@ -366,5 +370,113 @@ public class ServiceIssueInvoiceTests
         var input = await CapturedInputAsync(order);
 
         input.Lines[0].Taxes.Should().Equal(expectedKey);
+    }
+
+    // ==========================================================================
+    // Duplicate-issuance guard: search Holded before creating anything
+    // ==========================================================================
+
+    /// <summary>Stubs a document already tagged with <paramref name="order"/>'s tag, of
+    /// <paramref name="kind"/>, as a failed earlier attempt would have left behind.</summary>
+    private void ArrangeAlreadyIssued(Order order, HoldedSalesDocumentKind kind, string docId = "doc-earlier")
+    {
+        _holded.FindSalesDocumentIdsByTagAsync(kind, $"humans-order-{order.Id}", Arg.Any<CancellationToken>())
+            .Returns(new List<string> { docId });
+        _holded.GetSalesDocumentAsync(kind, docId, Arg.Any<CancellationToken>())
+            .Returns(new HoldedSalesDocumentDto
+            {
+                Id = docId,
+                DocNumber = "2026-0003",
+                Subtotal = 100m,
+                Tax = 21m,
+                Total = 121m,
+                Status = "pending",
+                RawJson = """{"id":"doc-earlier"}""",
+            });
+    }
+
+    [HumansFact]
+    public async Task First_issuance_searches_holded_before_creating_and_tags_the_document()
+    {
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+
+        var input = await CapturedInputAsync(order);
+
+        // Both kinds are searched: the counterparty details decide the kind and can change
+        // between two attempts, so an earlier document may be of the other kind.
+        await _holded.Received(1).FindSalesDocumentIdsByTagAsync(
+            HoldedSalesDocumentKind.Invoice, $"humans-order-{order.Id}", Arg.Any<CancellationToken>());
+        await _holded.Received(1).FindSalesDocumentIdsByTagAsync(
+            HoldedSalesDocumentKind.SalesReceipt, $"humans-order-{order.Id}", Arg.Any<CancellationToken>());
+        input.Tags.Should().Equal($"humans-order-{order.Id}");
+        await _holded.Received(1).CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task A_document_an_earlier_attempt_already_approved_is_adopted_not_reissued()
+    {
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+        ArrangeAlreadyIssued(order, HoldedSalesDocumentKind.Invoice);
+        Invoice? saved = null;
+        Order? savedOrder = null;
+        await _repo.SaveIssuedInvoiceAsync(
+            Arg.Do<Invoice>(i => saved = i), Arg.Do<Order>(o => savedOrder = o), Arg.Any<CancellationToken>());
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        // A second approved factura is a real legal document, correctable only by a rectificativa.
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        await _holded.DidNotReceive().ApproveSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // Nor is a contact upserted — nothing at all is written to Holded on this path.
+        await _holded.DidNotReceive().UpsertContactAsync(
+            Arg.Any<HoldedContactInput>(), Arg.Any<CancellationToken>());
+
+        // The local record is reconciled from the document that exists, which is the whole point.
+        saved.Should().NotBeNull();
+        saved!.HoldedDocId.Should().Be("doc-earlier");
+        saved.HoldedDocNumber.Should().Be("2026-0003");
+        saved.ResponsePayload.Should().Be("""{"id":"doc-earlier"}""");
+        saved.RequestPayload.Should().Contain("adopted");
+        savedOrder.Should().NotBeNull();
+        savedOrder!.State.Should().Be(OrderState.InvoiceIssued);
+        savedOrder.IssuedInvoiceId.Should().Be(saved.Id);
+    }
+
+    [HumansFact]
+    public async Task An_earlier_document_of_the_other_kind_is_adopted_too()
+    {
+        // The earlier attempt ran before the counterparty details were filled in, so it issued a
+        // receipt; this attempt would issue a factura. Adopting is still right — what must not
+        // happen is a second approved document.
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+        ArrangeAlreadyIssued(order, HoldedSalesDocumentKind.SalesReceipt);
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        await _repo.Received(1).SaveIssuedInvoiceAsync(
+            Arg.Any<Invoice>(), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Adoption_does_not_need_a_resolvable_revenue_account()
+    {
+        // A catalog edited between the two attempts must not block reconciliation of a document
+        // that already exists — the search runs ahead of the line-account resolution.
+        var order = CampOrder();
+        Arrange(order, IceProduct(account: null));
+        ArrangeAlreadyIssued(order, HoldedSalesDocumentKind.Invoice);
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await _repo.Received(1).SaveIssuedInvoiceAsync(
+            Arg.Any<Invoice>(), Arg.Any<Order>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
@@ -380,16 +380,17 @@ public class ServiceIssueInvoiceTests
     /// <see cref="IceProduct"/>'s price: 20 x EUR 5 = 100, +21% VAT = 121.</summary>
     private static HoldedSalesDocumentDto SalesDoc(
         string docNumber = "2026-0003", bool? isDraft = null,
-        decimal subtotal = 100m, decimal tax = 21m, decimal total = 121m) => new()
+        decimal subtotal = 100m, decimal tax = 21m, decimal total = 121m,
+        string id = "doc-earlier") => new()
         {
-            Id = "doc-earlier",
+            Id = id,
             DocNumber = docNumber,
             Subtotal = subtotal,
             Tax = tax,
             Total = total,
             Status = "pending",
             IsDraft = isDraft,
-            RawJson = """{"id":"doc-earlier"}""",
+            RawJson = $$"""{"id":"{{id}}"}""",
         };
 
     /// <summary>Stubs a document already tagged with <paramref name="order"/>'s tag, of
@@ -515,6 +516,67 @@ public class ServiceIssueInvoiceTests
         // And the number Holded assigns at approval is the one that gets stored.
         saved.Should().NotBeNull();
         saved!.HoldedDocNumber.Should().Be("2026-0003");
+    }
+
+    [HumansFact]
+    public async Task An_approved_match_is_adopted_over_a_draft_left_beside_it()
+    {
+        // Two earlier attempts, one of which got as far as approving. Approving the leftover draft
+        // as well would book the revenue twice and hand out a second legal number.
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+        var tag = $"humans-order-{order.Id}";
+        _holded.FindSalesDocumentIdsByTagAsync(
+                HoldedSalesDocumentKind.Invoice, tag, Arg.Any<CancellationToken>())
+            .Returns(new List<string> { "doc-draft", "doc-approved" });
+        _holded.GetSalesDocumentAsync(
+                HoldedSalesDocumentKind.Invoice, "doc-draft", Arg.Any<CancellationToken>())
+            .Returns(SalesDoc(docNumber: "", isDraft: true, id: "doc-draft"));
+        _holded.GetSalesDocumentAsync(
+                HoldedSalesDocumentKind.Invoice, "doc-approved", Arg.Any<CancellationToken>())
+            .Returns(SalesDoc(isDraft: false, id: "doc-approved"));
+        Invoice? saved = null;
+        await _repo.SaveIssuedInvoiceAsync(
+            Arg.Do<Invoice>(i => saved = i), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await _holded.DidNotReceive().ApproveSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        saved.Should().NotBeNull();
+        saved!.HoldedDocId.Should().Be("doc-approved");
+    }
+
+    [HumansFact]
+    public async Task An_approved_receipt_wins_over_an_invoice_draft_of_the_other_kind()
+    {
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+        var tag = $"humans-order-{order.Id}";
+        _holded.FindSalesDocumentIdsByTagAsync(
+                HoldedSalesDocumentKind.Invoice, tag, Arg.Any<CancellationToken>())
+            .Returns(new List<string> { "doc-draft" });
+        _holded.GetSalesDocumentAsync(
+                HoldedSalesDocumentKind.Invoice, "doc-draft", Arg.Any<CancellationToken>())
+            .Returns(SalesDoc(docNumber: "", isDraft: true, id: "doc-draft"));
+        _holded.FindSalesDocumentIdsByTagAsync(
+                HoldedSalesDocumentKind.SalesReceipt, tag, Arg.Any<CancellationToken>())
+            .Returns(new List<string> { "doc-receipt" });
+        _holded.GetSalesDocumentAsync(
+                HoldedSalesDocumentKind.SalesReceipt, "doc-receipt", Arg.Any<CancellationToken>())
+            .Returns(SalesDoc(isDraft: false, id: "doc-receipt"));
+        Invoice? saved = null;
+        await _repo.SaveIssuedInvoiceAsync(
+            Arg.Do<Invoice>(i => saved = i), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await _holded.DidNotReceive().ApproveSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        saved.Should().NotBeNull();
+        saved!.HoldedDocId.Should().Be("doc-receipt");
     }
 
     [HumansFact]

--- a/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
@@ -1,0 +1,370 @@
+using AwesomeAssertions;
+using Humans.AuditLog.Contracts;
+using Humans.Base.Enums;
+using Humans.Camps.Contracts;
+using Humans.Holded.Contracts;
+using Humans.Shifts.Contracts;
+using Humans.Store.Contracts;
+using Humans.Store.Data;
+using Humans.Store.Domain;
+using Humans.Store.Services;
+using Humans.Stripe.Contracts;
+using Humans.Teams.Contracts;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Store.Tests.Services;
+
+/// <summary>
+/// Phase 5 issuance (nobodies-collective/Humans#1029): the v2 create+approve pipeline, per-line
+/// revenue accounts, tax-0 deposit lines to the fianzas account, the receipt/factura branch, and
+/// the idempotent re-issue guard.
+/// </summary>
+public class ServiceIssueInvoiceTests
+{
+    private const int IceAccountNum = 75_900_002;
+    private const int DepositAccountNum = 56_000_000;
+    private const string IceAccountId = "acct-ice";
+    private const string DepositAccountId = "acct-deposit";
+
+    private readonly IStoreRepository _repo = Substitute.For<IStoreRepository>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+    private readonly ICampServiceRead _camps = Substitute.For<ICampServiceRead>();
+    private readonly ITeamServiceRead _teams = Substitute.For<ITeamServiceRead>();
+    private readonly IBurnSettingsService _shifts = Substitute.For<IBurnSettingsService>();
+    private readonly IStripeService _stripe = Substitute.For<IStripeService>();
+    private readonly IHoldedClient _holded = Substitute.For<IHoldedClient>();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 9, 1, 10, 0));
+    private readonly StoreSectionOptions _options = new()
+    {
+        DepositLiabilityAccountNum = DepositAccountNum,
+        SimplifiedInvoiceThresholdEur = 400m,
+    };
+    private readonly Service _service;
+
+    private readonly Guid _productId = Guid.NewGuid();
+    private readonly Guid _actor = Guid.NewGuid();
+
+    public ServiceIssueInvoiceTests()
+    {
+        _shifts.GetActiveAsync().Returns(BurnFixtures.Burn(year: 2026, timeZoneId: "Europe/Madrid"));
+        _camps.GetCampsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>());
+        _holded.IsConfigured.Returns(true);
+        _holded.ListAccountingAccountsAsync(Arg.Any<CancellationToken>()).Returns(
+        [
+            Account(IceAccountNum, IceAccountId),
+            Account(DepositAccountNum, DepositAccountId),
+        ]);
+        _holded.CreateSalesDocumentAsync(
+                Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>())
+            .Returns("doc-1");
+        _holded.GetSalesDocumentAsync(
+                Arg.Any<HoldedSalesDocumentKind>(), "doc-1", Arg.Any<CancellationToken>())
+            .Returns(new HoldedSalesDocumentDto
+            {
+                Id = "doc-1",
+                DocNumber = "2026-0007",
+                Subtotal = 100m,
+                Tax = 21m,
+                Total = 121m,
+                Status = "pending",
+                RawJson = """{"id":"doc-1"}""",
+            });
+        _holded.UpsertContactAsync(Arg.Any<HoldedContactInput>(), Arg.Any<CancellationToken>())
+            .Returns("contact-1");
+
+        _service = new Service(
+            _repo, _audit, _camps, _teams, _clock, _shifts, _stripe, _holded,
+            Options.Create(_options), NullLogger<Service>.Instance);
+    }
+
+    private static HoldedAccountDto Account(int number, string id) => new()
+    {
+        Id = id,
+        Number = number,
+        Name = $"Account {number}",
+        Debit = 0m,
+        Credit = 0m,
+        Balance = 0m,
+    };
+
+    private Product IceProduct(decimal unitPrice = 5m, decimal vat = 21m, decimal? deposit = null, int? account = IceAccountNum) => new()
+    {
+        Id = _productId,
+        Year = 2026,
+        Name = "Ice",
+        UnitPriceEur = unitPrice,
+        VatRatePercent = vat,
+        DepositAmountEur = deposit,
+        HoldedRevenueAccountNum = account,
+        OrderableUntil = new LocalDate(2026, 8, 1),
+        IsActive = true,
+    };
+
+    /// <summary>An Open camp order for <paramref name="qty"/> units, with counterparty details unless suppressed.</summary>
+    private Order CampOrder(int qty = 20, bool identified = true, decimal? depositSnapshot = null)
+    {
+        var id = Guid.NewGuid();
+        return new Order
+        {
+            Id = id,
+            CampSeasonId = Guid.NewGuid(),
+            Year = 2026,
+            State = OrderState.Open,
+            CounterpartyName = identified ? "Camp Frío SL" : null,
+            CounterpartyVatId = identified ? "B12345678" : null,
+            CounterpartyAddress = identified ? "Calle Falsa 1, Zaragoza" : null,
+            CounterpartyCountryCode = identified ? "ES" : null,
+            CounterpartyEmail = identified ? "lead@campfrio.example" : null,
+            Lines =
+            [
+                new OrderLine
+                {
+                    Id = Guid.NewGuid(),
+                    OrderId = id,
+                    ProductId = _productId,
+                    Qty = qty,
+                    UnitPriceSnapshot = 4m,
+                    VatRateSnapshot = 21m,
+                    DepositAmountSnapshot = depositSnapshot,
+                },
+            ],
+        };
+    }
+
+    private void Arrange(Order order, Product product)
+    {
+        _repo.GetOrderWithLinesAndPaymentsAsync(order.Id, Arg.Any<CancellationToken>()).Returns(order);
+        _repo.GetAllProductsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Product> { product });
+        _repo.GetProductsByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Product> { product });
+    }
+
+    private async Task<HoldedSalesDocumentInput> CapturedInputAsync(Order order)
+    {
+        HoldedSalesDocumentInput? captured = null;
+        await _holded.CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(),
+            Arg.Do<HoldedSalesDocumentInput>(i => captured = i),
+            Arg.Any<CancellationToken>());
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+        captured.Should().NotBeNull();
+        return captured!;
+    }
+
+    [HumansFact]
+    public async Task Issues_a_full_factura_with_per_line_revenue_accounts_and_approves_it()
+    {
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+
+        var input = await CapturedInputAsync(order);
+
+        input.ContactId.Should().Be("contact-1");
+        input.Lines.Should().HaveCount(1);
+        input.Lines[0].AccountId.Should().Be(IceAccountId);
+        input.Lines[0].Taxes.Should().Equal("s_iva_21");
+        input.Lines[0].Units.Should().Be(20m);
+        // Priced from the live catalog, not the stale €4 snapshot — the #816 freeze seam.
+        input.Lines[0].Price.Should().Be(5m);
+
+        await _holded.Received(1).CreateSalesDocumentAsync(
+            HoldedSalesDocumentKind.Invoice, Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        // A draft books no revenue: approval is part of issuance.
+        await _holded.Received(1).ApproveSalesDocumentAsync(
+            HoldedSalesDocumentKind.Invoice, "doc-1", Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Writes_the_invoice_row_with_both_payloads_and_freezes_the_order()
+    {
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+        Invoice? savedInvoice = null;
+        Order? savedOrder = null;
+        await _repo.SaveIssuedInvoiceAsync(
+            Arg.Do<Invoice>(i => savedInvoice = i),
+            Arg.Do<Order>(o => savedOrder = o),
+            Arg.Any<CancellationToken>());
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        savedInvoice.Should().NotBeNull();
+        savedInvoice!.HoldedDocId.Should().Be("doc-1");
+        savedInvoice.HoldedDocNumber.Should().Be("2026-0007");
+        savedInvoice.IssuedByUserId.Should().Be(_actor);
+        savedInvoice.RequestPayload.Should().Contain(IceAccountId);
+        savedInvoice.ResponsePayload.Should().Be("""{"id":"doc-1"}""");
+
+        savedOrder.Should().NotBeNull();
+        savedOrder!.State.Should().Be(OrderState.InvoiceIssued);
+        savedOrder.IssuedInvoiceId.Should().Be(savedInvoice.Id);
+        // Snapshots repriced to the live catalog before the freeze.
+        savedOrder.Lines.Single().UnitPriceSnapshot.Should().Be(5m);
+    }
+
+    [HumansFact]
+    public async Task Deposit_lines_post_tax_free_to_the_liability_account()
+    {
+        var order = CampOrder(qty: 2, depositSnapshot: 30m);
+        Arrange(order, IceProduct(unitPrice: 5m, deposit: 30m));
+
+        var input = await CapturedInputAsync(order);
+
+        input.Lines.Should().HaveCount(2);
+        var deposit = input.Lines[1];
+        deposit.AccountId.Should().Be(DepositAccountId);
+        deposit.Taxes.Should().Equal("s_iva_0");
+        deposit.Units.Should().Be(2m);
+        deposit.Price.Should().Be(30m);
+        // The goods line keeps its own rate and its own account.
+        input.Lines[0].AccountId.Should().Be(IceAccountId);
+        input.Lines[0].Taxes.Should().Equal("s_iva_21");
+    }
+
+    [HumansFact]
+    public async Task Deposit_without_a_configured_liability_account_is_refused_before_calling_holded()
+    {
+        _options.DepositLiabilityAccountNum = null;
+        var order = CampOrder(qty: 1, depositSnapshot: 30m);
+        Arrange(order, IceProduct(deposit: 30m));
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*deposit liability account*");
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Order_without_counterparty_under_the_threshold_issues_a_sales_receipt()
+    {
+        // 20 × €5 + 21% = €121, under the €400 simplified-invoice threshold.
+        var order = CampOrder(identified: false);
+        Arrange(order, IceProduct());
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await _holded.Received(1).CreateSalesDocumentAsync(
+            HoldedSalesDocumentKind.SalesReceipt, Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        await _holded.Received(1).ApproveSalesDocumentAsync(
+            HoldedSalesDocumentKind.SalesReceipt, "doc-1", Arg.Any<CancellationToken>());
+        // A receipt has no counterparty, so no contact is created for it.
+        await _holded.DidNotReceive().UpsertContactAsync(
+            Arg.Any<HoldedContactInput>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Order_without_counterparty_over_the_threshold_is_refused()
+    {
+        // 200 × €5 + 21% = €1,210 — a receipt is not lawful at that amount.
+        var order = CampOrder(qty: 200, identified: false);
+        Arrange(order, IceProduct());
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*full factura*");
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Re_issuing_an_issued_order_throws_without_calling_holded()
+    {
+        var order = CampOrder();
+        order.State = OrderState.InvoiceIssued;
+        order.IssuedInvoiceId = Guid.NewGuid();
+        Arrange(order, IceProduct());
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already been invoiced*");
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        await _holded.DidNotReceive().ListAccountingAccountsAsync(Arg.Any<CancellationToken>());
+        await _repo.DidNotReceive().SaveIssuedInvoiceAsync(
+            Arg.Any<Invoice>(), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Product_without_a_revenue_account_is_refused_by_name()
+    {
+        var order = CampOrder();
+        Arrange(order, IceProduct(account: null));
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Ice*");
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Account_missing_from_the_holded_chart_is_refused()
+    {
+        _holded.ListAccountingAccountsAsync(Arg.Any<CancellationToken>())
+            .Returns([Account(DepositAccountNum, DepositAccountId)]);
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{IceAccountNum}*");
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Team_orders_are_never_invoiced()
+    {
+        var order = CampOrder();
+        order.CampSeasonId = null;
+        order.TeamId = Guid.NewGuid();
+        Arrange(order, IceProduct());
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*non-billable*");
+    }
+
+    [HumansFact]
+    public async Task Unconfigured_holded_refuses_issuance_rather_than_silently_freezing_the_order()
+    {
+        _holded.IsConfigured.Returns(false);
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not configured*");
+        await _repo.DidNotReceive().SaveIssuedInvoiceAsync(
+            Arg.Any<Invoice>(), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansTheory]
+    [InlineData(21, "s_iva_21")]
+    [InlineData(10, "s_iva_10")]
+    [InlineData(4, "s_iva_4")]
+    [InlineData(0, "s_iva_0")]
+    public async Task Vat_rate_maps_to_the_holded_sales_tax_key(int vatRate, string expectedKey)
+    {
+        var order = CampOrder(qty: 1);
+        Arrange(order, IceProduct(vat: vatRate));
+
+        var input = await CapturedInputAsync(order);
+
+        input.Lines[0].Taxes.Should().Equal(expectedKey);
+    }
+}

--- a/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
@@ -376,23 +376,33 @@ public class ServiceIssueInvoiceTests
     // Duplicate-issuance guard: search Holded before creating anything
     // ==========================================================================
 
+    /// <summary>A document as Holded reads it back. The defaults match <see cref="CampOrder"/> at
+    /// <see cref="IceProduct"/>'s price: 20 x EUR 5 = 100, +21% VAT = 121.</summary>
+    private static HoldedSalesDocumentDto SalesDoc(
+        string docNumber = "2026-0003", bool? isDraft = null,
+        decimal subtotal = 100m, decimal tax = 21m, decimal total = 121m) => new()
+    {
+        Id = "doc-earlier",
+        DocNumber = docNumber,
+        Subtotal = subtotal,
+        Tax = tax,
+        Total = total,
+        Status = "pending",
+        IsDraft = isDraft,
+        RawJson = """{"id":"doc-earlier"}""",
+    };
+
     /// <summary>Stubs a document already tagged with <paramref name="order"/>'s tag, of
-    /// <paramref name="kind"/>, as a failed earlier attempt would have left behind.</summary>
-    private void ArrangeAlreadyIssued(Order order, HoldedSalesDocumentKind kind, string docId = "doc-earlier")
+    /// <paramref name="kind"/>, as a failed earlier attempt would have left behind. Extra
+    /// <paramref name="thenReads"/> are what successive read-backs return.</summary>
+    private void ArrangeAlreadyIssued(
+        Order order, HoldedSalesDocumentKind kind,
+        HoldedSalesDocumentDto? document = null, params HoldedSalesDocumentDto[] thenReads)
     {
         _holded.FindSalesDocumentIdsByTagAsync(kind, $"humans-order-{order.Id}", Arg.Any<CancellationToken>())
-            .Returns(new List<string> { docId });
-        _holded.GetSalesDocumentAsync(kind, docId, Arg.Any<CancellationToken>())
-            .Returns(new HoldedSalesDocumentDto
-            {
-                Id = docId,
-                DocNumber = "2026-0003",
-                Subtotal = 100m,
-                Tax = 21m,
-                Total = 121m,
-                Status = "pending",
-                RawJson = """{"id":"doc-earlier"}""",
-            });
+            .Returns(new List<string> { "doc-earlier" });
+        _holded.GetSalesDocumentAsync(kind, "doc-earlier", Arg.Any<CancellationToken>())
+            .Returns(document ?? SalesDoc(), thenReads);
     }
 
     [HumansFact]
@@ -478,5 +488,68 @@ public class ServiceIssueInvoiceTests
 
         await _repo.Received(1).SaveIssuedInvoiceAsync(
             Arg.Any<Invoice>(), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task A_recovered_draft_is_approved_before_it_is_adopted()
+    {
+        // Creation succeeded, approval did not. A draft books no revenue and carries no sequential
+        // number, so adopting it as-is would freeze the order with no legal invoice behind it.
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+        ArrangeAlreadyIssued(
+            order, HoldedSalesDocumentKind.Invoice,
+            SalesDoc(docNumber: "", isDraft: true),
+            SalesDoc(docNumber: "2026-0003", isDraft: false));
+        Invoice? saved = null;
+        await _repo.SaveIssuedInvoiceAsync(
+            Arg.Do<Invoice>(i => saved = i), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await _holded.Received(1).ApproveSalesDocumentAsync(
+            HoldedSalesDocumentKind.Invoice, "doc-earlier", Arg.Any<CancellationToken>());
+        // Still no second document.
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        // And the number Holded assigns at approval is the one that gets stored.
+        saved.Should().NotBeNull();
+        saved!.HoldedDocNumber.Should().Be("2026-0003");
+    }
+
+    [HumansFact]
+    public async Task An_already_approved_recovered_document_is_not_approved_again()
+    {
+        var order = CampOrder();
+        Arrange(order, IceProduct());
+        ArrangeAlreadyIssued(order, HoldedSalesDocumentKind.Invoice, SalesDoc(isDraft: false));
+
+        await _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await _holded.DidNotReceive().ApproveSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task A_recovered_document_that_no_longer_matches_the_order_refuses_loudly()
+    {
+        // The order stayed Open after the failed attempt, so the catalog moved under it. Freezing
+        // it against a document that says something else is permanent; a rectificativa is a human
+        // decision.
+        var order = CampOrder();
+        Arrange(order, IceProduct(unitPrice: 9m));
+        ArrangeAlreadyIssued(order, HoldedSalesDocumentKind.Invoice);
+
+        var act = () => _service.IssueInvoiceAsync(order.Id, _actor, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no longer matches*");
+        await _repo.DidNotReceive().SaveIssuedInvoiceAsync(
+            Arg.Any<Invoice>(), Arg.Any<Order>(), Arg.Any<CancellationToken>());
+        await _holded.DidNotReceive().CreateSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<HoldedSalesDocumentInput>(), Arg.Any<CancellationToken>());
+        // A divergent draft is not approved either — that would make the mismatch legal.
+        await _holded.DidNotReceive().ApproveSalesDocumentAsync(
+            Arg.Any<HoldedSalesDocumentKind>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs
@@ -381,16 +381,16 @@ public class ServiceIssueInvoiceTests
     private static HoldedSalesDocumentDto SalesDoc(
         string docNumber = "2026-0003", bool? isDraft = null,
         decimal subtotal = 100m, decimal tax = 21m, decimal total = 121m) => new()
-    {
-        Id = "doc-earlier",
-        DocNumber = docNumber,
-        Subtotal = subtotal,
-        Tax = tax,
-        Total = total,
-        Status = "pending",
-        IsDraft = isDraft,
-        RawJson = """{"id":"doc-earlier"}""",
-    };
+        {
+            Id = "doc-earlier",
+            DocNumber = docNumber,
+            Subtotal = subtotal,
+            Tax = tax,
+            Total = total,
+            Status = "pending",
+            IsDraft = isDraft,
+            RawJson = """{"id":"doc-earlier"}""",
+        };
 
     /// <summary>Stubs a document already tagged with <paramref name="order"/>'s tag, of
     /// <paramref name="kind"/>, as a failed earlier attempt would have left behind. Extra

--- a/tests/Humans.Store.Tests/Services/ServiceStripeReconciliationTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceStripeReconciliationTests.cs
@@ -9,7 +9,9 @@ using Humans.Store.Domain;
 using Humans.Store.Services;
 using Humans.Store.Services.Dtos;
 using Humans.Stripe.Contracts;
+using Humans.Holded.Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
@@ -25,6 +27,8 @@ public class ServiceStripeReconciliationTests
     private readonly IBurnSettingsService _shifts = Substitute.For<IBurnSettingsService>();
     private readonly IStripeService _stripe = Substitute.For<IStripeService>();
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 6, 4, 12, 0));
+    private readonly IHoldedClient _holded = Substitute.For<IHoldedClient>();
+    private readonly StoreSectionOptions _storeOptions = new();
     private readonly Service _service;
 
     public ServiceStripeReconciliationTests()
@@ -33,9 +37,9 @@ public class ServiceStripeReconciliationTests
         // Mapping-chain stubs so GetOrderAsync resolves without throwing.
         _repo.GetAllProductsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new List<Product>());
-        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, string>());
-        _service = new Service(_repo, _audit, _campService, _teams, _clock, _shifts, _stripe, NullLogger<Service>.Instance);
+        _repo.GetProductsByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Product>());
+        _service = new Service(_repo, _audit, _campService, _teams, _clock, _shifts, _stripe, _holded, Options.Create(_storeOptions), NullLogger<Service>.Instance);
     }
 
     private static Order CampOrder(Guid id) => new()

--- a/tests/Humans.Store.Tests/Services/ServiceTeamOrdersTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceTeamOrdersTests.cs
@@ -10,7 +10,9 @@ using Humans.Store.Services;
 using Humans.Store.Services.Dtos;
 using Humans.Stripe.Contracts;
 using Humans.Base.Enums;
+using Humans.Holded.Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
@@ -32,6 +34,8 @@ public class ServiceTeamOrdersTests
     private readonly IBurnSettingsService _shifts = Substitute.For<IBurnSettingsService>();
     private readonly IStripeService _stripe = Substitute.For<IStripeService>();
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 14, 12, 0));
+    private readonly IHoldedClient _holded = Substitute.For<IHoldedClient>();
+    private readonly StoreSectionOptions _storeOptions = new();
     private readonly Service _service;
 
     public ServiceTeamOrdersTests()
@@ -41,7 +45,7 @@ public class ServiceTeamOrdersTests
             .Returns(new Dictionary<Guid, TeamInfo>());
         _campService.GetCampsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new List<CampInfo>());
-        _service = new Service(_repo, _audit, _campService, _teams, _clock, _shifts, _stripe, NullLogger<Service>.Instance);
+        _service = new Service(_repo, _audit, _campService, _teams, _clock, _shifts, _stripe, _holded, Options.Create(_storeOptions), NullLogger<Service>.Instance);
     }
 
     // ==========================================================================

--- a/tests/Humans.Store.Tests/Services/ServiceTeamOrdersTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceTeamOrdersTests.cs
@@ -383,6 +383,28 @@ public class ServiceTeamOrdersTests
     }
 
     [HumansFact]
+    public async Task DeleteOrderAsync_rejects_an_invoiced_order()
+    {
+        // A paid, issued order reads zero-balance, but its store_invoices row references it under a
+        // restrictive foreign key — the delete has to be refused here, not at the database.
+        var orderId = Guid.NewGuid();
+        _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>())
+            .Returns(new Order
+            {
+                Id = orderId,
+                CampSeasonId = Guid.NewGuid(),
+                Year = 2026,
+                State = OrderState.InvoiceIssued,
+                IssuedInvoiceId = Guid.NewGuid(),
+            });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.DeleteOrderAsync(orderId, Guid.NewGuid(), TestContext.Current.CancellationToken));
+
+        await _repo.DidNotReceive().DeleteOrderAsync(orderId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task DeleteOrderAsync_throws_when_order_not_found()
     {
         var orderId = Guid.NewGuid();

--- a/tests/Humans.Store.Tests/Services/ServiceTests.cs
+++ b/tests/Humans.Store.Tests/Services/ServiceTests.cs
@@ -10,7 +10,9 @@ using Humans.Teams.Contracts;
 using Humans.Store.Services.Dtos;
 using Humans.Stripe.Contracts;
 using Humans.Base.Enums;
+using Humans.Holded.Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
@@ -27,6 +29,8 @@ public class ServiceTests
     private readonly IBurnSettingsService _shifts = Substitute.For<IBurnSettingsService>();
     private readonly IStripeService _stripeService = Substitute.For<IStripeService>();
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 14, 12, 0));
+    private readonly IHoldedClient _holded = Substitute.For<IHoldedClient>();
+    private readonly StoreSectionOptions _storeOptions = new();
     private readonly Service _service;
 
     public ServiceTests()
@@ -36,7 +40,7 @@ public class ServiceTests
             .Returns(new Dictionary<Guid, TeamInfo>());
         _campService.GetCampsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new List<CampInfo>());
-        _service = new Service(_repo, _audit, _campService, _teams, _clock, _shifts, _stripeService, NullLogger<Service>.Instance);
+        _service = new Service(_repo, _audit, _campService, _teams, _clock, _shifts, _stripeService, _holded, Options.Create(_storeOptions), NullLogger<Service>.Instance);
     }
 
     // ==========================================================================
@@ -206,8 +210,8 @@ public class ServiceTests
         };
         _repo.GetOrdersForCampSeasonAsync(campSeasonId, Arg.Any<CancellationToken>())
             .Returns([order]);
-        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, string> { [product.Id] = product.Name });
+        _repo.GetProductsByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Product> { product });
 
         var result = await _service.GetOrdersForCampSeasonAsync(campSeasonId, TestContext.Current.CancellationToken);
 
@@ -246,8 +250,8 @@ public class ServiceTests
             }
         };
         _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
-        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, string> { [product.Id] = product.Name });
+        _repo.GetProductsByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Product> { product });
 
         var result = await _service.GetOrderAsync(orderId, TestContext.Current.CancellationToken);
 
@@ -275,8 +279,8 @@ public class ServiceTests
             }
         };
         _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
-        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, string> { [product.Id] = product.Name });
+        _repo.GetProductsByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Product> { product });
         var repriced = MakeProduct(name: "Tent", price: 40m, vat: 10m);
         repriced.Id = product.Id;
         _repo.GetAllProductsForYearAsync(2026, Arg.Any<CancellationToken>())
@@ -308,8 +312,8 @@ public class ServiceTests
             }
         };
         _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
-        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, string> { [product.Id] = product.Name });
+        _repo.GetProductsByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Product> { product });
         var repriced = MakeProduct(name: "Tent", price: 40m, vat: 10m);
         repriced.Id = product.Id;
         _repo.GetAllProductsForYearAsync(2026, Arg.Any<CancellationToken>())
@@ -855,7 +859,8 @@ public class ServiceTests
                 VatRatePercent: 21m,
                 DepositAmountEur: 100m,
                 OrderableUntil: "2026-08-01",
-                IsActive: true),
+                IsActive: true,
+                HoldedRevenueAccountNum: null),
             actor, TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeTrue();
@@ -877,7 +882,8 @@ public class ServiceTests
                 VatRatePercent: 21m,
                 DepositAmountEur: null,
                 OrderableUntil: "not-a-date",
-                IsActive: true),
+                IsActive: true,
+                HoldedRevenueAccountNum: null),
             Guid.NewGuid(), TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeFalse();

--- a/tests/Humans.Store.Tests/Services/SummaryAggregateTests.cs
+++ b/tests/Humans.Store.Tests/Services/SummaryAggregateTests.cs
@@ -9,7 +9,9 @@ using Humans.Store.Domain;
 using Humans.Store.Services;
 using Humans.Stripe.Contracts;
 using Humans.Base.Enums;
+using Humans.Holded.Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
@@ -25,13 +27,15 @@ public class SummaryAggregateTests
     private readonly IBurnSettingsService _shifts = Substitute.For<IBurnSettingsService>();
     private readonly IStripeService _stripe = Substitute.For<IStripeService>();
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 14, 12, 0));
+    private readonly IHoldedClient _holded = Substitute.For<IHoldedClient>();
+    private readonly StoreSectionOptions _storeOptions = new();
     private readonly Service _service;
 
     public SummaryAggregateTests()
     {
         _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, TeamInfo>());
-        _service = new Service(_repo, _audit, _camps, _teams, _clock, _shifts, _stripe, NullLogger<Service>.Instance);
+        _service = new Service(_repo, _audit, _camps, _teams, _clock, _shifts, _stripe, _holded, Options.Create(_storeOptions), NullLogger<Service>.Instance);
     }
 
     [HumansFact]


### PR DESCRIPTION
Refs nobodies-collective/Humans#1029

**The issue stays open.** Every code-side acceptance criterion is implemented; the two that
can only close through a real issuance against the live Holded account (AC5's "first real
invoice's payload dumped", AC6's "revenue appears in the correct `7590000X` accounts after the
nightly sweep") are blocked on the external prerequisites below, and `RecordManualPaymentAsync`
— named in the issue's implementation sketch but in none of its acceptance criteria — is
untouched and still throws `NotSupportedException("Phase 5")`.

## What this does

Store can now issue a camp order's Holded sales document on API **v2**, booking each line to
its item's own revenue account so per-item break-even reads straight off the ledger.

- **`store_products.HoldedRevenueAccountNum`** (`int?`) — the one schema change. StoreAdmin sets
  Acountax's 8-digit chart number per item (`75900001` Bus Tickets, `75900002` ice, …). The
  internal-recharge twin (`75910002`) is **derived** — `ProductDto.InternalRechargeAccountNum`,
  number + 10 000 — never stored, and shown alongside the external number on
  `/Store/Admin/Catalog` so the season-close journal entries have their account to hand.
- **`IssueInvoiceAsync`** — reprices the line snapshots from the live catalog (the #816 freeze
  seam), resolves each product's account, builds the document, **creates and approves** it (a
  Holded draft books nothing), reads it back for its assigned `document_number`, then writes
  `store_invoices` (request + response payloads) and the frozen order in a single
  `SaveChanges`. Re-issue throws before any Holded call.
- **Factura vs factura simplificada** — one code path. Name + address + tax id on the order
  ⇒ full `POST /api/v2/invoices` against an upserted `client` contact. Anything less ⇒
  `POST /api/v2/sales-receipts`, no contact — but only up to
  `Store:SimplifiedInvoiceThresholdEur` (default €400). Above it the details are mandatory and
  issuance is refused rather than silently downgraded.
- **Deposits** — each deposit-bearing line adds a separate `s_iva_0` line booked to
  `Store:DepositLiabilityAccountNum` (fianzas). No configured account ⇒ refuse, because a
  refundable deposit is never income.
- **Reachability** — an "Issue invoice" button on the order page, next to Delete, gated by a new
  Store-admin-only `OrderOperationRequirement.IssueInvoice` (denied on team orders even for
  admins, like `Pay`/`EditCounterparty`).

## Field mapping — verified against v2, not guessed

Locked against `https://api.holded.com/openapi/api2.json` plus **live reads** of the real
account (2026-08-19), which settled the two things a thin probe would have got wrong:

- `items[].account` is the chart account's **24-hex id**, not the 8-digit number — confirmed by
  reading real purchase documents back. So the numbers StoreAdmin holds are resolved against
  `GET /api/v2/accounting-accounts` at issue time; a fresh read also picks up an account
  Acountax created minutes ago. An unknown number refuses issuance by number.
- `items[].taxes` are directional tax **keys** — `GET /api/v2/taxes` confirms `s_iva_21`,
  `s_iva_10`, `s_iva_4`, `s_iva_0` on the sales side (and `s_iva_75` for 7.5%: the decimal
  separator is dropped, not rounded).
- `75900001 Bus Tickets` already exists in the live chart exactly as the issue describes;
  `75900002` does not yet — that's Acountax's task below.

No document was created or approved in the live account.

`IHoldedClient` was already fully on v2, so nothing was re-migrated.

## Duplicate-issuance guard

The local `IssuedInvoiceId` check only sees documents this app finished saving. If create+approve
succeeds and the read-back or `SaveIssuedInvoiceAsync` then fails, the order stays `Open` with no
record of the Holded doc, and a retry issues a **second approved factura** — correctable only by a
factura rectificativa. So issuance now asks Holded before creating anything: a document already
tagged with the order is **adopted**, never re-issued.

- Every store sales document carries the tag `humans-order-{orderId}`. The tag, not the
  human-readable `notes` beside it, is the reference the search matches on: v2's list endpoints
  return `tags` but **not** `notes` (confirmed against `api2.json` and a live `GET /api/v2/purchases`),
  so matching on notes would mean a `GET /{id}` per candidate.
- One new method on `IHoldedClient` — `FindSalesDocumentIdsByTagAsync(kind, tag)`, ids only, no new
  DTO. v2 has no server-side tag filter, so it walks the cursor-paginated list through the existing
  `GetPagedAsync` and matches client-side. A match with no `id` fails the search rather than being
  dropped: an empty result reads as "nothing issued yet".
- Both kinds are searched. The counterparty details decide invoice vs receipt and can be filled in
  between two attempts, so the earlier document may be of the other kind — adopting it is still
  right, because what must not happen is a second approved document.
- The search runs before the revenue-account resolution, so a catalog edited between attempts
  cannot block reconciliation of a document that already exists. Two or more matches means the
  duplicate already happened; the first is adopted (stopping a third) and the rest are logged for
  the rectificativa.

What happens to a recovered document, in order:

1. **Totals are checked against the order.** The order stayed `Open` after the failed attempt, so
   its lines could be edited and its catalog prices could move before the retry. Adopting on the
   tag alone would freeze the order against a document that says something else, permanently. If
   subtotal / tax / total (at 2dp; deposits are tax-0 lines and land in Holded's subtotal) do not
   agree, issuance refuses with both figures spelled out and writes nothing — a correction to an
   issued document is a *factura rectificativa*, and that is a human's decision, not one to
   automate.
2. **A draft is approved.** If creation succeeded and approval did not, the recovered document is
   still a draft: it books no revenue and carries no sequential number, so adopting it as-is would
   leave the order frozen with no legal invoice behind it. `HoldedSalesDocumentDto.IsDraft` (v2's
   `draft`, present on the single-document GET) drives it — a draft is approved and re-read so the
   assigned number is what gets stored. An already-approved document is never re-approved.
3. **The row is written.** No create, no contact upsert. `ResponsePayload` is the document's
   verbatim JSON; `RequestPayload` is an adoption marker.

- **No schema change.** This is why the search was chosen over a persisted issuance claim.

### Payments are no longer clobbered by the save

`SaveIssuedInvoiceAsync` used `ctx.Orders.Update(order)`, which marks the whole detached graph
modified — including the `Payments` read *before* the Holded round-trips. A Stripe webhook settling
a payment mid-issuance was written back to its stale value, with no concurrency token to catch it
(`memory/architecture/no-concurrency-tokens.md`). The order is now attached and only the columns
issuance owns are marked modified: `State`, `IssuedInvoiceId`, `UpdatedAt`, and each line's three
price snapshots. Pre-existing, but the guard's extra round-trips widened the window.

The concurrent-double-submit variant narrows to the window between two in-flight searches, which at
this scale (one StoreAdmin, one button) is not a real path.

## External prerequisites — not code

These are Acountax's or Peter's tasks in the Holded UI. Nothing in this PR waits on them to
merge, but AC5 and AC6 cannot close until they're done:

- [ ] Acountax: create the per-item revenue accounts (`75900002`…) and the matching expense
      sub-accounts on the cost side.
- [ ] Acountax: decide **721 vs 759** (mission income vs *explotación económica*).
- [ ] Acountax: name the **deposit liability account** (fianzas) → set
      `Store:DepositLiabilityAccountNum`. Issuance of any order carrying a deposit is refused
      until this is set.
- [ ] Acountax: rule on the simplified-invoice threshold (€400 general vs €3,000 retail-type
      B2C) → `Store:SimplifiedInvoiceThresholdEur`, defaulted to the conservative €400.
- [ ] Acountax: confirm the account's **VeriFactu** status (v2 exposes `verifactu_status` on
      documents; post-issuance corrections are *factura rectificativa*, never a mutation).
- [ ] Acountax: reclassify the ~10 existing store cost purchase docs onto the new expense
      sub-accounts.
- [ ] Enter the missing water-delivery vendor invoices into Holded.
- [ ] Collect counterparty details (name / address / tax id or passport) from the camps that
      need full facturas — an order over the threshold cannot be issued without them.

## Reuse-first — what was rejected and why

- **`IHoldedService` (the mirror's cross-section read) for account-number → id.**
  `holded_accounts` already stores both, but exposing the Holded id there is new cross-section
  surface on another section's contracts, and a nightly-refreshed mirror can't see an account
  Acountax created this morning. Used the already-public `IHoldedClient.ListAccountingAccountsAsync`
  instead — zero new surface, ~2 calls per issuance out of a 2,000/month budget.
- **Separate `CreateInvoiceAsync` / `CreateSalesReceiptAsync` / `ApproveInvoiceAsync` /
  `ApproveSalesReceiptAsync`** (4 methods, the shape `Store.md` anticipated). The two document
  kinds share one payload and one pipeline, so they became 3 kind-parameterized methods over a
  `HoldedSalesDocumentKind` — the only difference is a path segment.
- **A `Kind` column on `store_invoices`.** The document kind lives in the audited
  `RequestPayload`; the issue names the product column as the one schema change and it stays
  the one schema change.
- **`repo.AddInvoiceAsync` + `repo.UpdateOrderAsync`** (both already existed). Two contexts,
  two `SaveChanges` — an order could end up `InvoiceIssued` without its invoice row, which the
  documented atomic-on-success invariant forbids. `AddInvoiceAsync` had no other caller, so it
  became `SaveIssuedInvoiceAsync(invoice, order)`: one method, net zero added.
- **A new `GetProductsByIdsAsync` alongside `GetProductNamesByIdsAsync`.** Issuance needs the
  account number as well as the name, so the existing method widened to return the products and
  its four callers project the name — caller-side composition, one repo method instead of two.
- **A new `Store/Admin/Orders` screen for the Issue button.** The order page already renders
  admin-only affordances resolved through `OrderAuthorizationHandler`; the button reuses that
  seam and the existing `data-confirm` + nonce'd listener.
- **Hard-coded deposit account and threshold constants.** Both are explicitly Acountax's call in
  the issue and change without a deploy, so they're `StoreSectionOptions`, bound from `Store:*`
  the way `HoldedSectionOptions` binds `Holded:*`.

## Migration

`20260819213719_StoreProductRevenueAccount` (`StoreDbContext`) — one `AddColumn<int>` on
`store_products`, generated by `dotnet ef`, unedited. Snapshot diff is the single new property.

## Tests

- `tests/Humans.Store.Tests/Data/RepositoryTests.cs` — a payment settled mid-issuance survives
  `SaveIssuedInvoiceAsync` while the state flip and repriced snapshots still land.
- `tests/Humans.Store.Tests/Services/ServiceIssueInvoiceTests.cs` (22) — the pre-issue search and
  the adopt-existing path (an earlier document of the other kind, one whose product no longer
  resolves an account, a recovered draft that gets approved and re-read, an already-approved one
  that does not, and a diverged order that refuses loudly and writes nothing), create+approve with
  per-line accounts, the invoice row's payloads, the state freeze and repriced snapshots, tax-0
  deposit lines to the liability account, the receipt/factura branch on both sides of the
  threshold, idempotent re-issue with no Holded call, missing product account, account absent
  from the chart, team orders, unconfigured Holded, and the VAT-rate → tax-key mapping.
- `tests/Humans.Holded.Tests/Services/HoldedClientSalesDocumentTests.cs` (10) — the tag search's
  path and client-side match (and its refusal of an id-less match), the wire shape of
  both endpoints, the approve path, the read-back parse, and the contact payload's `code` /
  `bill_address` (including the omit-when-empty case, so an upsert never blanks a stored address).

`dotnet build Humans.slnx` — 0 warnings, 0 errors. `dotnet test Humans.slnx` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
