### PR TITLE
fix(web): fail loudly and legibly when the database is unreachable at startup

### DIFF
--- a/docs/deploy/preview-unavailable.html
+++ b/docs/deploy/preview-unavailable.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Preview environment not ready</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1.5rem; color: #1a1a1a; }
+  h1 { font-size: 1.4rem; }
+  code { background: #f0f0f0; padding: 0.1rem 0.35rem; border-radius: 3px; }
+  ul { padding-left: 1.2rem; }
+  li { margin-bottom: 0.5rem; }
+</style>
+</head>
+<body>
+<h1>This preview environment isn't up yet</h1>
+<p>
+  No app container answered this hostname. That's expected right after a PR is opened or
+  pushed to, and usually one of these:
+</p>
+<ul>
+  <li>
+    <strong>Database not cloned yet.</strong> Every PR preview needs its own database
+    (<code>humans_pr_&lt;N&gt;</code>), cloned by the <code>preview-db</code> GitHub Actions
+    workflow on the self-hosted runner. If that job is still queued or running, the app
+    container starts, fails fast, and exits until the database exists.
+    Check the PR's <strong>Actions</strong> tab for the <code>preview-db</code> run.
+  </li>
+  <li>
+    <strong>PR not deployed, or the URL is wrong.</strong> If Coolify has never deployed an
+    app for this PR, there's nothing to boot at all. Check the PR number in the URL
+    (<code>https://&lt;pr_id&gt;.n.burn.camp</code>) and that the PR is actually open.
+  </li>
+  <li>
+    <strong>PR closed.</strong> Its preview environment is torn down when the PR closes —
+    this hostname will never resolve to a running app again.
+  </li>
+  <li>
+    <strong>Something else crashed on boot.</strong> Check the container logs for a
+    <code>FATAL</code> line — startup failures always log one, naming what went wrong.
+  </li>
+</ul>
+<p>
+  See <a href="https://github.com/nobodies-collective/Humans/issues/1060">nobodies-collective/Humans#1060</a>
+  for the background on this page.
+</p>
+</body>
+</html>

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -842,25 +842,84 @@ foreach (var contributor in SectionDiscoveryExtensions.DiscoverImplementations<I
 
 // DB migrations run via DatabaseMigrationHostedService during StartAsync, before Hangfire takes locks.
 
-if (!app.Environment.IsEnvironment("Testing"))
-{
-    // Force IGlobalConfiguration resolution so JobStorage.Current is set before RecurringJob.AddOrUpdate uses it.
-    app.Services.GetRequiredService<IGlobalConfiguration>();
-    app.UseHumansRecurringJobs();
-}
-
+// Widened to also cover the Hangfire block below (nobodies-collective/Humans#1060): a preview
+// env whose database doesn't exist yet fails here first — every recurring-job registration
+// throws the same connection error, but each is caught and logged as a WARNING by
+// UseHumansRecurringJobs (a legitimate concern there: a stale distributed lock must not stop
+// the app booting). That warning is loud but incidental; the real fatal cause is whichever of
+// this block or DatabaseMigrationHostedService.StartingAsync (run inside RunAsync) throws
+// first, and previously only the RunAsync half was caught here.
 try
 {
+    if (!app.Environment.IsEnvironment("Testing"))
+    {
+        // Force IGlobalConfiguration resolution so JobStorage.Current is set before RecurringJob.AddOrUpdate uses it.
+        app.Services.GetRequiredService<IGlobalConfiguration>();
+        app.UseHumansRecurringJobs();
+    }
+
     await app.RunAsync();
 }
 catch (Exception ex)
 {
-    Log.Fatal(ex, "Application terminated unexpectedly");
+    LogStartupFailure(ex, builder.Configuration);
     throw;
 }
 finally
 {
     Log.CloseAndFlush();
+}
+
+/// <summary>
+/// One clear FATAL line for a startup crash, naming the database when the cause is a
+/// Postgres connectivity failure (nobodies-collective/Humans#1060) — e.g. a PR preview
+/// deployed before <c>preview-db.yml</c> cloned <c>humans_pr_{N}</c>. Falls back to the
+/// generic message for anything else, so a startup failure is never silently unlabeled.
+/// </summary>
+static void LogStartupFailure(Exception ex, IConfiguration configuration)
+{
+    var pgEx = FindException<NpgsqlException>(ex);
+    if (pgEx is null)
+    {
+        Log.Fatal(ex, "Application terminated unexpectedly");
+        return;
+    }
+
+    var connectionString = configuration.GetConnectionString("DefaultConnection");
+    var database = connectionString is not null
+        ? new NpgsqlConnectionStringBuilder(connectionString).Database
+        : null;
+
+    if (pgEx is PostgresException { SqlState: PostgresErrorCodes.InvalidCatalogName })
+    {
+        Log.Fatal(ex, "Application terminated unexpectedly: database {Database} does not exist", database);
+    }
+    else
+    {
+        Log.Fatal(ex, "Application terminated unexpectedly: database {Database} is unreachable", database);
+    }
+}
+
+/// <summary>Walks <paramref name="ex"/>'s InnerException chain (and AggregateException branches) for the first match.</summary>
+static T? FindException<T>(Exception? ex) where T : Exception
+{
+    for (; ex is not null; ex = ex.InnerException)
+    {
+        if (ex is T match)
+            return match;
+
+        if (ex is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.InnerExceptions)
+            {
+                var found = FindException<T>(inner);
+                if (found is not null)
+                    return found;
+            }
+        }
+    }
+
+    return null;
 }
 
 static async Task WriteDetailedHealthResponse(HttpContext context, HealthReport report)

--- a/tests/Humans.Integration.Tests/Infrastructure/ApiVersionDatabaseIndependenceTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/ApiVersionDatabaseIndependenceTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Humans.Integration.Tests.Infrastructure;
+
+/// <summary>
+/// Coverage for nobodies-collective/Humans#1060 criterion 4: <c>/api/version</c> must stay
+/// answerable without a database, so it remains a usable liveness probe rather than another
+/// 404 when something DB-related is unhealthy. The endpoint already reads only assembly
+/// metadata, so this pins that against regression — a database outage after boot must never
+/// take it down with everything else.
+/// </summary>
+public sealed class ApiVersionDatabaseIndependenceTests(HumansTestDatabase database)
+{
+    [HumansFact]
+    public async Task ApiVersion_RespondsAfterDatabaseBecomesUnreachable()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var dbName = $"test_{Guid.NewGuid():N}";
+        var connectionString = await database.CloneTemplateAsync(dbName, ct);
+
+        await using var factory = new HumansWebApplicationFactory(connectionString);
+        await factory.InitializeAsync();
+        using var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        // Sanity: the endpoint works while the database is healthy.
+        var healthy = await client.GetAsync("/api/version", ct);
+        healthy.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Drop the database out from under the already-running app — the shape of a
+        // database that disappears after boot (restart, credential rotation, network
+        // partition). If /api/version ever gained a database dependency, this is what
+        // would catch it: everything else on the site would degrade too, but the
+        // liveness probe must not.
+        await database.DropDatabaseAsync(dbName, ct);
+
+        var afterOutage = await client.GetAsync("/api/version", ct);
+        afterOutage.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Humans.Integration.Tests/Infrastructure/HumansTestDatabase.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/HumansTestDatabase.cs
@@ -98,6 +98,14 @@ public sealed class HumansTestDatabase : IAsyncLifetime
     private string ConnectionStringFor(string name) =>
         new NpgsqlConnectionStringBuilder(_adminConnectionString) { Database = name }.ConnectionString;
 
+    /// <summary>
+    /// A connection string naming a database that is never created — the container is
+    /// reachable but the catalog isn't, the shape of a PR preview whose
+    /// <c>preview-db.yml</c> clone hasn't run yet (nobodies-collective/Humans#1060).
+    /// Never touches the server.
+    /// </summary>
+    public string ConnectionStringForMissingDatabase(string name) => ConnectionStringFor(name);
+
     private async Task ExecuteAdminAsync(string sql, CancellationToken ct)
     {
         await using var connection = new NpgsqlConnection(_adminConnectionString);

--- a/tests/Humans.Integration.Tests/Infrastructure/MissingDatabaseStartupTests.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/MissingDatabaseStartupTests.cs
@@ -1,0 +1,40 @@
+using AwesomeAssertions;
+using Serilog.Events;
+using Xunit;
+
+namespace Humans.Integration.Tests.Infrastructure;
+
+/// <summary>
+/// Coverage for nobodies-collective/Humans#1060: a preview env whose <c>preview-db.yml</c>
+/// clone hasn't run yet must fail with a clear, database-naming FATAL log line — not just the
+/// incidental Hangfire warning from <see cref="Humans.Web.Extensions.RecurringJobExtensions"/>
+/// — and it must still refuse to start (no graceful degradation).
+/// </summary>
+public sealed class MissingDatabaseStartupTests(HumansTestDatabase database)
+{
+    [HumansFact]
+    public async Task MissingDatabase_StillRefusesToStart_AndLogsOneClearFatalLineNamingIt()
+    {
+        // Reachable Postgres server, but this catalog was never created — exactly what a
+        // preview host looks like before the preview-db workflow clones humans_pr_{N}.
+        var missingDatabaseName = $"humans_missing_{Guid.NewGuid():N}";
+        var connectionString = database.ConnectionStringForMissingDatabase(missingDatabaseName);
+
+        await using var factory = new HumansWebApplicationFactory(connectionString);
+
+        // Criterion 5: the app must still refuse to start — no quiet tolerance of a
+        // missing database, in preview or anywhere else.
+        await Assert.ThrowsAnyAsync<Exception>(async () => await factory.InitializeAsync());
+
+        // Criterion 3: the real cause must be legible as one clear FATAL line naming the
+        // database. Before Program.cs's LogStartupFailure, this line read the generic
+        // "Application terminated unexpectedly" with the database name buried only in the
+        // attached exception, not the rendered message — this assertion fails against that
+        // text.
+        var fatalEvents = Humans.Base.Logging.InMemoryLogSink.Instance.GetEvents(minLevel: LogEventLevel.Fatal);
+        fatalEvents.Should().Contain(
+            e => e.RenderMessage().Contains(missingDatabaseName, StringComparison.Ordinal),
+            "a startup failure caused by a missing database must name it in a FATAL log line, " +
+            "not just in an attached exception a dashboard may collapse");
+    }
+}


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1060

## Problem

Preview DBs (`humans_pr_{N}`) are cloned by a self-hosted-runner workflow that can queue behind Coolify's push-triggered deploy. When that happens the app boots with no database, crashes, and the proxy shows a bare `404 page not found` — indistinguishable from a typo, an undeployed PR, or a closed PR's torn-down environment. The real cause (`database "humans_pr_1306" does not exist`) was visible only in container logs, and the loudest log line there was a **warning** from Hangfire recurring-job registration, not the actual fatal cause.

## What changed (in-repo)

**`src/Humans.Web/Program.cs`** — criteria 3 & 5:

- Widened the top-level `try` to also cover the `IGlobalConfiguration`/`UseHumansRecurringJobs()` block, which previously ran *outside* any try/catch (an uncaught exception there — from Hangfire's eager Postgres connection — would have crashed with no `Log.Fatal` at all).
- Replaced the generic `Log.Fatal(ex, "Application terminated unexpectedly")` with `LogStartupFailure`, a local function that walks the exception chain for a `Npgsql(Postgres)Exception`, extracts the target database name from the connection string, and logs **one clear FATAL line naming it** — distinguishing "database does not exist" (`SqlState 3D000`) from a generic unreachable-database failure. Falls back to the old generic message for anything else.
- Nothing about *whether* the app starts changed — same crash-and-exit on a missing/unreachable database, in production and everywhere else. This is a logging-quality fix, not a tolerance change (see explicit non-goal below).

**`/api/version`** (criterion 4) — already had zero database dependency (it only reads assembly metadata), so no code change was needed there. Added regression coverage:

- `tests/.../MissingDatabaseStartupTests.cs` — boots the app against a real, reachable Postgres server whose target database was never created. Asserts the host still refuses to start (criterion 5) **and** that a FATAL log event's rendered message contains the missing database's name (criterion 3). Verified this is a genuine red→green test: reverting the `LogStartupFailure` change to the old generic message turns it red.
- `tests/.../ApiVersionDatabaseIndependenceTests.cs` — boots normally, confirms `/api/version` is 200, then drops the underlying database out from under the running app and confirms `/api/version` is still 200 (criterion 4, as a live regression guard against the endpoint or the request pipeline ever gaining a database dependency).

**`docs/deploy/preview-unavailable.html`** — a static page for the proxy to serve instead of the bare `404 page not found`, listing the possible causes (DB not cloned yet, PR not deployed / bad URL, PR closed, or some other boot crash — check the container's FATAL log line). This can only give generic guidance since a static file can't know *which* of those applies to a given hostname — see below.

## Out-of-repo: Coolify proxy configuration

Criteria 1 and 2 ("names the missing database and the reason" / "distinguishes database-missing from PR-not-deployed from PR-closed") are a proxy-layer concern: when the database is missing, the app is deliberately down (criterion 5), so it cannot serve its own error page — nothing is listening on the port. Only Coolify/Traefik, sitting in front of the (absent) container, can answer at all.

What to configure, and where:

- **Coolify's custom error page for the `*.n.burn.camp` preview domain** (Traefik `errors` middleware / Coolify's per-application "Custom Error Pages" setting): point it at `docs/deploy/preview-unavailable.html` from this repo (served as a static asset from wherever Coolify's proxy config expects — e.g. a small nginx/static container, or Traefik's `errorPage` service). This alone replaces the bare 404 with the generic explanation and is a one-time, static config change.
- **To actually distinguish "database missing" from "PR not deployed" / "PR closed" per request** needs dynamic logic Coolify's proxy doesn't have out of the box, since that requires cross-referencing: (a) whether Coolify has an application/environment for this PR number at all (absent ⇒ never deployed, or the URL is wrong), (b) whether that environment was recently torn down (present in history but deleted ⇒ closed), and (c) if an environment exists but its container is unhealthy, the container's logs for the FATAL line this PR now guarantees exists (present ⇒ database name + reason). That's a small diagnostic script/service Coolify would call as its error handler (e.g. a Traefik `forwardAuth`/error-page backend that shells out to the Coolify API + `docker logs`), which is Coolify/infra configuration outside this repository.

**Bottom line: criteria 1 and 2 are only partially satisfied by this PR** (the static page replaces the bare 404 with a generic, actionable explanation) — the per-request "which specific reason" distinction is out-of-repo Coolify/proxy work as scoped in the issue itself ("this belongs at the proxy/Coolify layer, not inside the app").

## Non-goal check

This PR does not make the app tolerate a missing database. `MissingDatabaseStartupTests` proves the app still crashes on a missing database, in every environment — the change is entirely about what gets logged when it does.
