### PR TITLE
feat(freshness): verify and repair dead trigger globs inside the sweep

### DIFF
--- a/.claude/skills/freshness-sweep/SKILL.md
+++ b/.claude/skills/freshness-sweep/SKILL.md
@@ -57,12 +57,59 @@ Path/branch collision: error; instruct `git worktree list` / `git worktree remov
 
 Abort on validation failure → Phase 8.
 
+## Phase 3.5: Verify and repair trigger globs
+
+Runs BEFORE Phase 4 computes the dirty list, so a glob repaired this run also
+fires as dirty in this same run — nobodies-collective/Humans#1021. A dead
+`freshness:triggers` entry (a glob or literal path that no longer resolves to
+any file) is **silent by construction**: it makes its doc look *clean*
+instead of *unchecked*, so the doc drops out of the dirty list before Phase 4
+ever runs and nobody notices. Two sweeps (2026-08-08, 2026-08-10) found large
+batches of these ad hoc, with a throwaway verifier, *after* the dirty list had
+already been computed from the broken globs — this phase exists so the sweep
+catches and repairs its own dead triggers as a matter of course, not as
+someone remembering to go look.
+
+1. From inside the worktree, run:
+   ```bash
+   bash docs/scripts/freshness-checks/verify-triggers.sh
+   ```
+   This walks every `.md` under the catalog's `editorial_trees` (honoring
+   `ignore:`), expands every `freshness:triggers` entry as a real glob
+   (`**`/`*`-aware — never a literal `test -e` per line, which under-reports:
+   the 2026-08-08 sweep's throwaway verifier compared globs literally and
+   missed the last 5 of 64 dead paths, caught only in PR review) as well as
+   every literal path, and for each dead one:
+   - **Repairs it in place** when the new location is unambiguous — a single
+     `find` hit by basename, which is also how a section-project move
+     resolves (a section's uniquely-named file or directory has exactly one
+     hit under its new `src/Sections/Humans.<Section>/**` home, no
+     section-specific logic needed). Emits `REPAIRED <doc> | <old> -> <new>`.
+   - **Leaves it and flags it** when no single unambiguous target exists
+     (zero or multiple `find` hits — never guessed). Emits
+     `UNRESOLVED <doc> | <old>` and `FORCE-DIRTY <doc>`.
+2. The script already edited the doc files for every `REPAIRED` line — those
+   are real content changes and ride in the sweep's own PR like any other
+   regen (memory/process/freshness-sweep-owns-its-verifier.md). Nothing
+   further to do for them.
+3. Carry the `UNRESOLVED` list and the `FORCE-DIRTY` doc list forward:
+   - Into **Phase 4**: union the `FORCE-DIRTY` docs into the dirty list,
+     regardless of whether anything in the diff window matches them — an
+     unresolved dead trigger means the doc needs a human-legible review this
+     run, not silent skipping.
+   - Into **Phase 6**: the report's new "Dead trigger globs" section (see
+     below).
+4. Mechanical catalog entries are unaffected by this phase — Phase 3's
+   existing "warn on trigger glob matching no files" already covers them;
+   this phase is the editorial-doc counterpart the issue exists to add.
+
 ## Phase 4: Match dirty entries
 
 1. `--full`/fallback: every candidate dirty.
 2. `git diff --name-only <previous-anchor>..upstream/main` → glob-match against each entry's triggers.
 3. `--scope <glob>`: filter to mechanical entries whose `id` matches.
-4. Empty dirty list → "No entries dirty — nothing to refresh." → Phase 8.
+4. Union in the Phase 3.5 `FORCE-DIRTY` set (editorial docs with an unresolved dead trigger) — always dirty this run regardless of diff match.
+5. Empty dirty list → "No entries dirty — nothing to refresh." → Phase 8.
 
 ## Phase 5: Dispatch updates (≤3 concurrent subagents)
 
@@ -206,7 +253,9 @@ A prune-analysis subagent's manifest may surface **medium-confidence wheat** (th
 
 ## Phase 6: Aggregate and write report
 
-Overwrite `docs/freshness/last-report.md`: timestamp header; anchor/mode/counts summary; "Updated automatically" bullets (`id — summary`); "Pruned" section (file, lines removed, evidence) from Phase 5.5, including a **"Wheat migrated"** sub-list (`source §section → destination`, with the code symbol that verified it); "Flagged for human review" (file, triggers, reason — subjective prose only, never concrete broken facts, which are fixed inline); "Proposed for review" ("None — all candidates resolved this sweep" unless a question to Peter is pending); "Questions" (anything you asked Peter inline this sweep); "Skipped (errors)". Previous-anchor = `none` on first run or `--full`. No files changed → "Nothing to update." → Phase 8. Otherwise stage all changes + report.
+Overwrite `docs/freshness/last-report.md`: timestamp header; anchor/mode/counts summary; "Updated automatically" bullets (`id — summary`); **"Dead trigger globs"** section from Phase 3.5 — a `Repaired` sub-list (`doc — old → new`, one per `REPAIRED` line) and an `Unresolved` sub-list (`doc — old`, one per `UNRESOLVED` line, each noting it was force-included in this run's dirty list); "Pruned" section (file, lines removed, evidence) from Phase 5.5, including a **"Wheat migrated"** sub-list (`source §section → destination`, with the code symbol that verified it); "Flagged for human review" (file, triggers, reason — subjective prose only, never concrete broken facts, which are fixed inline); "Proposed for review" ("None — all candidates resolved this sweep" unless a question to Peter is pending); "Questions" (anything you asked Peter inline this sweep); "Skipped (errors)". Previous-anchor = `none` on first run or `--full`. No files changed → "Nothing to update." → Phase 8. Otherwise stage all changes + report.
+
+Unresolved dead triggers are a record, not a delivery — like every other item needing Peter's judgment they also go through Phase 7.5 inline, phrased as a one-line decision each (e.g. "1. `Auth.md`'s `Authorization/Requirements/**` trigger is dead — Requirement classes now live per-section under each `Authorization/`; retarget to `src/Sections/*/Authorization/**Requirement.cs`, or drop the trigger?").
 
 **The report is the durable RECORD, not the delivery channel.** Every item that needs Peter's judgment — flagged drift that is a genuine judgment call, open questions, uncertain prune wheat — is delivered to him **inline** in Phase 7.5, not parked in the report for him to find later. Assume he never opens the report. Writing a review item only into the report and ending the run is a process failure.
 
@@ -281,7 +330,8 @@ Only after Phase 7.5 is resolved. `cd $REPO_ROOT && git worktree remove $WORKTRE
 | Marker validation error | That doc → "Skipped (errors)"; others continue |
 | Subagent fails | That entry skipped; recorded in "Skipped (errors)" |
 | Duplicate target in catalog | Schema validation rejects at parse time |
-| Trigger glob matches nothing | Warning only |
+| Mechanical trigger glob matches nothing | Warning only (Phase 3) |
+| Editorial trigger glob/literal matches nothing | Repaired or force-dirtied by Phase 3.5, never silently skipped |
 | Push / PR creation fails | Worktree retained; fix manually |
 
 ## Constraints

--- a/docs/features/global/expires-on-deadline.md
+++ b/docs/features/global/expires-on-deadline.md
@@ -1,5 +1,5 @@
 <!-- freshness:triggers
-  src/Humans.Base/Architecture/ExpiresOnAttribute.cs
+  src/Humans.Base/Attributes/ExpiresOnAttribute.cs
   src/Humans.Analyzers/ExpiresOnAnalyzer.cs
   Directory.Build.props
 -->

--- a/docs/features/global/gdpr-export.md
+++ b/docs/features/global/gdpr-export.md
@@ -3,7 +3,7 @@
   src/Sections/Humans.Gdpr/**
   src/Sections/Humans.Gdpr.Contracts/**
   src/Sections/Humans.Users/Controllers/ProfileController.cs
-  src/Humans.Web/Controllers/GuestController.cs
+  src/Sections/Humans.Onboarding/Controllers/GuestController.cs
   src/Sections/Humans.Users/Services/ProfileService.cs
   src/Sections/Humans.Users/Services/UserService.cs
   src/Sections/Humans.Consent/Services/ConsentService.cs

--- a/docs/guide/Onboarding.md
+++ b/docs/guide/Onboarding.md
@@ -1,6 +1,6 @@
 <!-- freshness:triggers
   src/Humans.Web/Views/Account/**
-  src/Humans.Web/Views/Guest/**
+  src/Sections/Humans.Onboarding/Views/Guest/**
   src/Humans.Web/Views/Home/**
   src/Sections/Humans.Users/Views/Profile/Edit.cshtml
   src/Sections/Humans.Shifts/Views/ShiftProfile/ShiftInfo.cshtml
@@ -8,7 +8,7 @@
   src/Sections/Humans.Onboarding/Views/OnboardingReview/Index.cshtml
   src/Sections/Humans.Onboarding/Views/OnboardingReview/Detail.cshtml
   src/Humans.Web/Controllers/AccountController.cs
-  src/Humans.Web/Controllers/GuestController.cs
+  src/Sections/Humans.Onboarding/Controllers/GuestController.cs
   src/Humans.Web/Controllers/HomeController.cs
   src/Sections/Humans.Onboarding/Controllers/OnboardingReviewController.cs
   src/Sections/Humans.Onboarding/Services/**

--- a/docs/guide/SigningIn.md
+++ b/docs/guide/SigningIn.md
@@ -2,7 +2,7 @@
   src/Humans.Web/Controllers/AccountController.cs
   src/Humans.Web/Views/Account/**
   src/Sections/Humans.Auth/Services/MagicLinkService.cs
-  src/Humans.Web/Controllers/GuestController.cs
+  src/Sections/Humans.Onboarding/Controllers/GuestController.cs
 -->
 <!-- freshness:flag-on-change
   Login options, magic-link expiry/single-use/confirm-button mechanics, and the enumeration-safe "check your email" message. Review when AccountController, Account views, or MagicLinkService change.

--- a/docs/scripts/freshness-checks/diff-mode.sh
+++ b/docs/scripts/freshness-checks/diff-mode.sh
@@ -20,6 +20,9 @@
 #      entries dirty (docs aren't src/, so no triggers should fire).
 #   7. Every freshness:triggers glob in every editorial doc resolves to at
 #      least one real file.
+#   8. trigger_is_dead (the function test 7 relies on) is proven in BOTH
+#      directions with synthetic input, not just whatever today's real docs
+#      happen to contain (nobodies-collective/Humans#1021).
 #
 # Test 7 exists because a dead trigger glob is SILENT: it makes a doc look
 # *clean* rather than *unchecked*, so the doc drops out of the sweep's dirty
@@ -35,6 +38,7 @@
 set -euo pipefail
 
 CATALOG="docs/architecture/freshness-catalog.yml"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PASS=0
 FAIL=0
 
@@ -43,56 +47,13 @@ if [ ! -f "$CATALOG" ]; then
   exit 1
 fi
 
-# Every editorial doc the sweep is responsible for, derived FROM the catalog's
-# editorial_trees rather than hardcoded here. Entries are either a directory to
-# walk (docs/sections/, src/Sections/, …) or a single file listed on its own
-# (docs/architecture/design-rules.md, docs/seed-data.md, …).
-#
-# Read the list from the catalog so this check cannot drift away from it. An
-# earlier hardcoded version walked only the four directories and silently skipped
-# all six individually-listed files — so a dead glob in design-rules.md or
-# seed-data.md still produced a green "all trigger globs resolve", which is the
-# exact failure test 7 exists to catch.
-editorial_docs() {
-  awk '/^editorial_trees:/{f=1;next} f&&/^[a-z_]+:/{f=0} f' "$CATALOG" \
-    | grep -E '^[[:space:]]+- ' \
-    | sed 's/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]*$//' \
-    | while IFS= read -r entry; do
-        [ -z "$entry" ] && continue
-        if [ -f "$entry" ]; then
-          echo "$entry"
-        elif [ -d "${entry%/}" ]; then
-          find "${entry%/}" -name '*.md' \
-               -not -name 'SECTION-TEMPLATE.md' -not -name 'G5-SECTION-TEMPLATE.md' \
-               -not -name 'README.md' -not -name 'GettingStarted.md' -not -name 'Glossary.md' \
-               -not -path '*/obj/*' -not -path '*/bin/*' \
-               -not -path '*/Docs/20*.md' \
-               -not -name 'health.md' 2>/dev/null
-        else
-          # Unresolved entry: emit nothing here — test 3 reports it via
-          # editorial_entries_unresolved. The explicit `:` matters: without an
-          # else branch the `if` returns the failed `[ -d ]` status, which under
-          # `set -e` aborts the whole script mid-run instead of failing a test.
-          :
-        fi
-      done
-}
-
-# Catalog editorial_trees entries that resolve to nothing. A warning here is not
-# enough: if an individually listed file such as docs/seed-data.md is renamed,
-# editorial_docs simply omits it, the remaining ~140 docs still clear test 3's
-# thresholds, and tests 4 and 7 never inspect the missing file — so the script
-# exits green while the catalog points at nothing. Test 3 fails on any output.
-editorial_entries_unresolved() {
-  awk '/^editorial_trees:/{f=1;next} f&&/^[a-z_]+:/{f=0} f' "$CATALOG" \
-    | grep -E '^[[:space:]]+- ' \
-    | sed 's/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]*$//' \
-    | while IFS= read -r entry; do
-        if [ -n "$entry" ] && [ ! -f "$entry" ] && [ ! -d "${entry%/}" ]; then
-          echo "$entry"
-        fi
-      done
-}
+# editorial_docs, editorial_entries_unresolved, doc_trigger_lines and
+# trigger_is_dead live in lib-editorial-docs.sh, shared with
+# verify-triggers.sh (nobodies-collective/Humans#1021) so this script's
+# definition of "the editorial doc set" and "a dead trigger" cannot drift
+# from the one the sweep itself uses to repair them.
+# shellcheck source=./lib-editorial-docs.sh
+source "$SCRIPT_DIR/lib-editorial-docs.sh"
 
 # ─── Test 1: Catalog parses (structural smoke) ────────────────────────
 N_MECHANICAL=$(grep -cE '^\s+- id:\s+' "$CATALOG" || echo 0)
@@ -124,8 +85,11 @@ while IFS= read -r line; do
   if $in_triggers && [[ "$line" =~ ^[[:space:]]+-[[:space:]]+\"(.+)\"[[:space:]]*$ ]]; then
     glob="${BASH_REMATCH[1]}"
     total=$((total+1))
-    matches=( $glob )
-    if [ ${#matches[@]} -eq 0 ]; then
+    # trigger_is_dead (lib-editorial-docs.sh) branches on wildcard vs literal —
+    # mechanical entries mix both (e.g. "Directory.Packages.props" alongside
+    # "**/*.csproj"), and a plain `matches=( $glob )` word-splits a literal to
+    # itself regardless of whether the file exists, same blind spot test 7 had.
+    if trigger_is_dead "$glob"; then
       echo "  [test 2]: ZERO MATCH glob: $glob"
       bad=$((bad+1))
     fi
@@ -268,18 +232,17 @@ else
 fi
 
 # ─── Test 7: Every editorial trigger glob resolves to a real file ─────
-# The one check that can see a dead trigger. See the header note.
+# The one check that can see a dead trigger. See the header note. Uses the
+# shared doc_trigger_lines/trigger_is_dead from lib-editorial-docs.sh — the
+# same functions verify-triggers.sh uses to repair these, so a fix to the
+# detection logic can't land in one script and not the other.
 dead_globs=0
 dead_docs=0
 checked_docs=0
 for f in $(editorial_docs); do
-  # `|| true` is load-bearing: under `set -o pipefail` the grep returns 1 for a
-  # doc with no trigger marker, which aborted the whole script at the first such
-  # file and left every doc after it unchecked while test 7 printed nothing at
-  # all. Silence from a test is not a pass.
-  triggers=$(awk '/<!-- freshness:triggers/,/^-->/' "$f" 2>/dev/null \
-             | { grep -vE '^\s*<!--|^-->' || true; } \
-             | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  # `doc_trigger_lines` already `|| true`-guards the no-marker case — see its
+  # definition for why that matters under `set -o pipefail`.
+  triggers=$(doc_trigger_lines "$f")
   if [ -z "$triggers" ]; then continue; fi
   checked_docs=$((checked_docs+1))
   doc_dead=0
@@ -287,28 +250,11 @@ for f in $(editorial_docs); do
   while IFS= read -r glob; do
     [ -z "$glob" ] && continue
     doc_total=$((doc_total+1))
-    # A trigger is either a wildcard pattern or a literal path, and they need
-    # different checks. `matches=( $glob )` only detects a dead *pattern* (via
-    # nullglob); a literal path with no wildcard word-splits to itself, so the
-    # array always has one element and the check passes whether or not the file
-    # exists. That is how 307 dead literal triggers across 65 docs survived
-    # every sweep while test 7 reported green — the same class of bug as a dead
-    # glob, one layer down. Branch on the wildcard.
     # Both branches must END on a successful command. Under `set -euo pipefail`
     # a trailing `cond && assign` returns non-zero whenever cond is false, which
     # aborts the whole script mid-test — the same way a bare trailing `if` once
     # killed everything after test 2. Use explicit if/else, never `&&`.
-    trigger_dead=0
-    case "$glob" in
-      *'*'*)
-        matches=( $glob )
-        if [ ${#matches[@]} -eq 0 ]; then trigger_dead=1; else trigger_dead=0; fi
-        ;;
-      *)
-        if [ -e "$glob" ]; then trigger_dead=0; else trigger_dead=1; fi
-        ;;
-    esac
-    if [ "$trigger_dead" -eq 1 ]; then
+    if trigger_is_dead "$glob"; then
       echo "  [test 7]: DEAD trigger in $f -> $glob"
       dead_globs=$((dead_globs+1))
       doc_dead=$((doc_dead+1))
@@ -327,6 +273,36 @@ if [ "$dead_globs" -eq 0 ]; then
   PASS=$((PASS+1))
 else
   echo "FAIL [test 7]: $dead_globs dead triggers across $dead_docs of $checked_docs docs"
+  FAIL=$((FAIL+1))
+fi
+
+# ─── Test 8: Synthetic proof — trigger_is_dead sees BOTH directions ───────
+# Test 7 only ever exercises trigger_is_dead against docs' CURRENT triggers —
+# whatever happens to be alive or dead in the repo today. That proves nothing
+# about the function itself: every dead trigger test 7 finds gets repaired
+# and stops proving the "reports a real failure" direction tomorrow, and if
+# every trigger in the repo happened to be alive, test 7 would never have
+# exercised the dead-detection branch at all (nobodies-collective/Humans#1021
+# — "a test that only ever sees passing input proves nothing"). This test is
+# independent of doc content: it feeds trigger_is_dead synthetic real and
+# fake paths directly, one pair per branch (wildcard, literal), and asserts
+# each direction explicitly.
+real_glob="docs/architecture/**"          # real dir — must NOT be reported dead
+dead_glob="src/Humans.NoSuchSection.DoesNotExist/**"   # never existed — must be reported dead
+real_literal="$CATALOG"                   # real file — must NOT be reported dead
+dead_literal="docs/architecture/this-file-does-not-exist-1021.md"  # must be reported dead
+
+t8_fail=""
+if trigger_is_dead "$real_glob"; then t8_fail="$t8_fail glob-real-passed-as-dead"; fi
+if ! trigger_is_dead "$dead_glob"; then t8_fail="$t8_fail glob-dead-passed-as-real"; fi
+if trigger_is_dead "$real_literal"; then t8_fail="$t8_fail literal-real-passed-as-dead"; fi
+if ! trigger_is_dead "$dead_literal"; then t8_fail="$t8_fail literal-dead-passed-as-real"; fi
+
+if [ -z "$t8_fail" ]; then
+  echo "PASS [test 8]: trigger_is_dead proves both directions (glob + literal, real + dead)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [test 8]: trigger_is_dead direction check(s) broken:$t8_fail"
   FAIL=$((FAIL+1))
 fi
 

--- a/docs/scripts/freshness-checks/lib-editorial-docs.sh
+++ b/docs/scripts/freshness-checks/lib-editorial-docs.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Shared helpers for freshness-check scripts: enumerate the editorial doc set
+# from the catalog's editorial_trees (filtered by its ignore: list), and the
+# per-doc trigger extraction / dead-glob detection used to verify them.
+# Sourced by diff-mode.sh and verify-triggers.sh so neither definition can
+# drift from the other (nobodies-collective/Humans#1021) — a walk hardcoded
+# in one script and reused nowhere else is exactly how a second script's
+# editorial coverage silently falls behind the catalog.
+#
+# Requires the caller to `CATALOG=...` before sourcing.
+
+# Catalog's `ignore:` list, one glob pattern per line.
+ignore_patterns() {
+  awk '/^ignore:/{f=1;next} f&&/^[a-z_]+:/{f=0} f' "$CATALOG" \
+    | grep -E '^[[:space:]]+- ' | sed 's/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+# True (0) if $1 matches any catalog ignore pattern. `case` glob matching
+# treats `*` as unbounded (it matches `/` too), so a catalog pattern written
+# as `docs/plans/**` behaves the same as `docs/plans/*` here — both match any
+# depth, which is what the catalog author intends by using `**`.
+path_ignored() {
+  local path="$1" pat
+  while IFS= read -r pat; do
+    [ -z "$pat" ] && continue
+    case "$path" in
+      $pat) return 0 ;;
+    esac
+  done < <(ignore_patterns)
+  return 1
+}
+
+# Every editorial doc the sweep is responsible for, derived FROM the catalog's
+# editorial_trees rather than hardcoded here. Entries are either a directory to
+# walk (docs/sections/, src/Sections/, …) or a single file listed on its own
+# (docs/architecture/design-rules.md, docs/seed-data.md, …).
+#
+# Read the list from the catalog so this check cannot drift away from it. An
+# earlier hardcoded version walked only the four directories and silently skipped
+# all six individually-listed files — so a dead glob in design-rules.md or
+# seed-data.md still produced a green "all trigger globs resolve", which is the
+# exact failure test 7 exists to catch.
+#
+# Every candidate is also run through the catalog's `ignore:` list (path_ignored
+# above) — the find-level `-not -name`/`-not -path` clauses below cover the
+# common cases directly (they run inside `find`, which is faster over a big
+# tree), but `path_ignored` is the one filter that cannot drift from the
+# catalog: e.g. `src/Sections/*/Docs/data-access.md` is ignore-listed but has
+# no matching `-not` clause below, and would otherwise be walked.
+editorial_docs() {
+  awk '/^editorial_trees:/{f=1;next} f&&/^[a-z_]+:/{f=0} f' "$CATALOG" \
+    | grep -E '^[[:space:]]+- ' \
+    | sed 's/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]*$//' \
+    | while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+        if [ -f "$entry" ]; then
+          path_ignored "$entry" || echo "$entry"
+        elif [ -d "${entry%/}" ]; then
+          find "${entry%/}" -name '*.md' \
+               -not -name 'SECTION-TEMPLATE.md' -not -name 'G5-SECTION-TEMPLATE.md' \
+               -not -name 'README.md' -not -name 'GettingStarted.md' -not -name 'Glossary.md' \
+               -not -path '*/obj/*' -not -path '*/bin/*' \
+               -not -path '*/Docs/20*.md' \
+               -not -name 'health.md' 2>/dev/null \
+            | while IFS= read -r f; do path_ignored "$f" || echo "$f"; done
+        else
+          # Unresolved entry: emit nothing here — test 3 reports it via
+          # editorial_entries_unresolved. The explicit `:` matters: without an
+          # else branch the `if` returns the failed `[ -d ]` status, which under
+          # `set -e` aborts the whole script mid-run instead of failing a test.
+          :
+        fi
+      done
+}
+
+# Catalog editorial_trees entries that resolve to nothing. A warning here is not
+# enough: if an individually listed file such as docs/seed-data.md is renamed,
+# editorial_docs simply omits it, the remaining docs still clear test 3's
+# thresholds, and tests 4 and 7 never inspect the missing file — so the script
+# exits green while the catalog points at nothing. Test 3 fails on any output.
+editorial_entries_unresolved() {
+  awk '/^editorial_trees:/{f=1;next} f&&/^[a-z_]+:/{f=0} f' "$CATALOG" \
+    | grep -E '^[[:space:]]+- ' \
+    | sed 's/^[[:space:]]*-[[:space:]]*//; s/[[:space:]]*$//' \
+    | while IFS= read -r entry; do
+        if [ -n "$entry" ] && [ ! -f "$entry" ] && [ ! -d "${entry%/}" ]; then
+          echo "$entry"
+        fi
+      done
+}
+
+# Extract the raw freshness:triggers glob/literal entries from one doc, one
+# per output line, trimmed. Empty output means the doc carries no marker.
+# `|| true` is load-bearing: a doc with no marker makes `grep -v` return 1,
+# which under a caller's `set -o pipefail` would otherwise abort mid-walk and
+# leave every doc after it unchecked (docs/freshness/last-report.md,
+# 2026-08-18 sweep, "the checker's own silence is not evidence").
+doc_trigger_lines() {
+  awk '/<!-- freshness:triggers/,/^-->/' "$1" 2>/dev/null \
+    | { grep -vE '^\s*<!--|^-->' || true; } \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+# True (0 / dead) if the glob/literal trigger $1 resolves to zero real files.
+# A trigger is either a wildcard pattern or a literal path, and they need
+# different checks: `matches=( $glob )` only detects a dead *pattern* (via
+# `shopt -s nullglob`, which the caller must have set) — a literal path with
+# no wildcard word-splits to itself, so the array always has one element and
+# the check would pass whether or not the file exists. That mismatch let 307
+# dead literal triggers across 65 docs survive every sweep while a
+# pattern-only check reported green (docs/freshness/last-report.md,
+# 2026-08-18 sweep) — the same class of bug as a dead glob, one layer down.
+trigger_is_dead() {
+  local glob="$1"
+  case "$glob" in
+    *'*'*)
+      local matches=( $glob )
+      [ ${#matches[@]} -eq 0 ]
+      ;;
+    *)
+      [ ! -e "$glob" ]
+      ;;
+  esac
+}

--- a/docs/scripts/freshness-checks/verify-triggers.sh
+++ b/docs/scripts/freshness-checks/verify-triggers.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Verify every freshness:triggers entry across the catalog's editorial_trees
+# docs; auto-repair the ones with an unambiguous new target in place; report
+# the rest. This is the mechanism nobodies-collective/Humans#1021 asked for:
+# a dead trigger glob makes a doc look CLEAN instead of UNCHECKED — it
+# silently matches zero files, so the doc never enters the sweep's dirty
+# list. Two sweeps (2026-08-08, 2026-08-10) found large batches of these ad
+# hoc, with a throwaway verifier, AFTER the dirty list had already been
+# computed from the broken globs — so the sweep that found them had already
+# skipped the affected docs that run.
+#
+# Called from /freshness-sweep Phase 3.5, BEFORE Phase 4 computes the dirty
+# list, so a glob this script repairs fires as dirty in the same run.
+#
+# Usage (run from repo root):
+#   bash docs/scripts/freshness-checks/verify-triggers.sh [--check]
+#
+# Default mode REPAIRS: rewrites resolvable dead trigger lines in the doc
+# files themselves. --check reports only and makes no edits (a dry run —
+# diff-mode.sh test 7 already covers read-only verification by hand; this
+# flag exists for scripting a preview of what this script would change).
+#
+# Exit code is always 0 — this is sweep hygiene, not a CI gate (per the
+# issue's Problem/Motivation: "a dead trigger glob doesn't break anything at
+# runtime ... caught and repaired by the sweep itself, not gated in CI").
+# Callers read stdout, not the exit code.
+#
+# Output, one line per finding:
+#   REPAIRED <doc> | <old> -> <new>
+#   UNRESOLVED <doc> | <old>
+# then a summary line:
+#   SUMMARY repaired=<n> unresolved=<n> docs_forced_dirty=<n>
+# followed by one line per doc carrying >=1 UNRESOLVED trigger:
+#   FORCE-DIRTY <doc>
+# Phase 4 unions FORCE-DIRTY docs into its dirty list regardless of whether
+# anything in the diff window matches — an unresolved dead trigger means the
+# doc needs a human-legible review this run, not silent skipping.
+
+set -uo pipefail  # deliberately no -e: one bad doc must not silence the rest
+                   # (docs/freshness/last-report.md, 2026-08-18 sweep — "the
+                   # checker's own silence is not evidence").
+
+CATALOG="docs/architecture/freshness-catalog.yml"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./lib-editorial-docs.sh
+source "$SCRIPT_DIR/lib-editorial-docs.sh"
+
+if [ ! -f "$CATALOG" ]; then
+  echo "ERROR: $CATALOG not found. Run from repo root." >&2
+  exit 1
+fi
+
+MODE="repair"
+if [ "${1:-}" = "--check" ]; then MODE="check"; fi
+
+shopt -s globstar nullglob
+
+# Resolve a dead trigger to its unambiguous new target, or print nothing.
+#
+# Wildcard triggers (contain `*`): anchor on the last static directory
+# segment before the first `*` (e.g. "Guest" in
+# src/Humans.Web/Views/Guest/**), find it by basename anywhere under src/,
+# and reattach the original wildcard suffix. Literal triggers: anchor on the
+# basename and find it the same way.
+#
+# "Unambiguous" means exactly one hit — zero or multiple is left unresolved,
+# never guessed. This is also how "the section-project equivalent" resolves:
+# a section's uniquely-named directory or file has exactly one hit under its
+# new src/Sections/Humans.<X>/ home, so no section-specific logic is needed —
+# it falls out of the same basename search the literal case uses.
+resolve_target() {
+  local glob="$1" prefix suffix seg hits n base
+  case "$glob" in
+    *'*'*)
+      prefix="${glob%%\**}"
+      suffix="${glob#"$prefix"}"
+      seg="${prefix%/}"; seg="${seg##*/}"
+      [ -z "$seg" ] && return
+      hits=$(find src -type d -name "$seg" -not -path '*/obj/*' -not -path '*/bin/*' 2>/dev/null)
+      n=$(printf '%s\n' "$hits" | sed '/^$/d' | wc -l)
+      [ "$n" -ne 1 ] && return
+      echo "${hits}/${suffix}"
+      ;;
+    *)
+      base="${glob##*/}"
+      hits=$(find src -name "$base" -not -path '*/obj/*' -not -path '*/bin/*' 2>/dev/null)
+      n=$(printf '%s\n' "$hits" | sed '/^$/d' | wc -l)
+      [ "$n" -ne 1 ] && return
+      echo "$hits"
+      ;;
+  esac
+}
+
+# Rewrite the first not-yet-touched line in $1 whose trimmed content equals
+# $2, to $3, preserving the original leading whitespace. awk (not sed) so the
+# old/new strings never need regex escaping — both routinely contain `*`,
+# `.` and `/`.
+repair_line() {
+  local file="$1" old="$2" new="$3"
+  awk -v old="$old" -v new="$new" '
+    {
+      line = $0
+      trimmed = line
+      sub(/^[ \t]+/, "", trimmed)
+      sub(/[ \t]+$/, "", trimmed)
+      if (!done && trimmed == old) {
+        match(line, /^[ \t]*/)
+        indent = substr(line, RSTART, RLENGTH)
+        print indent new
+        done = 1
+        next
+      }
+      print line
+    }
+  ' "$file" > "$file.verify-triggers.tmp" && mv "$file.verify-triggers.tmp" "$file"
+}
+
+repaired=0
+unresolved=0
+declare -A dirty_docs
+
+for f in $(editorial_docs); do
+  triggers=$(doc_trigger_lines "$f")
+  [ -z "$triggers" ] && continue
+  while IFS= read -r glob; do
+    [ -z "$glob" ] && continue
+    if trigger_is_dead "$glob"; then
+      target=$(resolve_target "$glob")
+      if [ -n "$target" ]; then
+        echo "REPAIRED $f | $glob -> $target"
+        repaired=$((repaired + 1))
+        if [ "$MODE" = "repair" ]; then
+          repair_line "$f" "$glob" "$target"
+        fi
+      else
+        echo "UNRESOLVED $f | $glob"
+        unresolved=$((unresolved + 1))
+        dirty_docs["$f"]=1
+      fi
+    fi
+  done <<< "$triggers"
+done
+
+echo "SUMMARY repaired=$repaired unresolved=$unresolved docs_forced_dirty=${#dirty_docs[@]}"
+for d in "${!dirty_docs[@]}"; do
+  echo "FORCE-DIRTY $d"
+done
+
+exit 0

--- a/src/Sections/Humans.Scanner/Docs/features/gate-terminal-login.md
+++ b/src/Sections/Humans.Scanner/Docs/features/gate-terminal-login.md
@@ -2,8 +2,8 @@
   src/Humans.Web/Controllers/AccountController.cs
   src/Sections/Humans.Tickets/Controllers/TicketsOnsiteAdminController.cs
   src/Humans.Web/Views/Account/GateLogin.cshtml
-  src/Humans.Web/Views/Tickets/Admin/Gate.cshtml
-  src/Humans.Web/Hosting/GateTerminalAccountSeeder.cs
+  src/Sections/Humans.Tickets/Views/Tickets/Admin/Gate.cshtml
+  src/Sections/Humans.Tickets/Services/GateTerminalAccountSeeder.cs
   src/Humans.Web/Services/GateLoginThrottle.cs
   src/Humans.Base/Constants/SystemUserIds.cs
   src/Humans.Base/Authorization/PolicyNames.cs

--- a/src/Sections/Humans.Tickets/Docs/features/ticket-vendor-integration.md
+++ b/src/Sections/Humans.Tickets/Docs/features/ticket-vendor-integration.md
@@ -2,8 +2,8 @@
   src/Sections/Humans.Tickets/**
   src/Sections/Humans.Tickets.Contracts/**
   src/Sections/Humans.TicketTailor/**
-  src/Humans.Web/Controllers/WelcomeController.cs
-  src/Humans.Web/Views/Welcome/**
+  src/Sections/Humans.Onboarding/Controllers/WelcomeController.cs
+  src/Sections/Humans.Onboarding/Views/Welcome/**
   src/Sections/Humans.Campaigns/Domain/CampaignGrant.cs
   src/Sections/Humans.Tickets.Contracts/TicketConstants.cs
   src/Sections/Humans.Stripe/**


### PR DESCRIPTION
## Summary

Fixes nobodies-collective/Humans#1021

A dead `freshness:triggers` entry is silent by construction: it makes a doc look **clean** instead of **unchecked**, so the doc drops out of the sweep's dirty list before anyone notices. Two sweeps (2026-08-08, 2026-08-10) found large batches of these ad hoc, with a throwaway verifier, *after* the dirty list had already been computed from the broken globs.

This PR builds the verification + repair into the sweep itself, and extends the by-hand harness:

- **New `docs/scripts/freshness-checks/lib-editorial-docs.sh`** — the editorial-doc enumeration (`editorial_docs`, `editorial_entries_unresolved`) plus the shared `doc_trigger_lines` / `trigger_is_dead` glob-aware dead-trigger check, factored out so `diff-mode.sh` and the new repair script can't drift from each other's definition of "the editorial doc set" or "a dead trigger". Also adds `path_ignored`, which now honors the catalog's `ignore:` list generically (closing a real gap: `src/Sections/*/Docs/data-access.md` — 38 files — was ignore-listed but not excluded by the old hardcoded walk).
- **New `docs/scripts/freshness-checks/verify-triggers.sh`** — walks every `.md` under the catalog's `editorial_trees`, expands every `freshness:triggers` entry as a real glob/literal, and for each dead one either repairs it in place (single `find` hit by basename — which is also how a section-project move resolves, since a section's uniquely-named file/dir has exactly one hit under its new `src/Sections/Humans.<Section>/` home) or leaves it and reports it as `UNRESOLVED` + `FORCE-DIRTY`. Exit code is always 0 — this is sweep hygiene, not a CI gate.
- **`.claude/skills/freshness-sweep/SKILL.md`** — new **Phase 3.5: Verify and repair trigger globs**, inserted between Phase 3 (discovery) and Phase 4 (dirty-list computation), so a glob repaired this run also fires as dirty in this same run. Phase 4 now unions in the `FORCE-DIRTY` set. Phase 6's report template gets a new "Dead trigger globs" section (Repaired / Unresolved sub-lists), and unresolved items are called out as another Phase 7.5 inline-decision item.
- **`docs/scripts/freshness-checks/diff-mode.sh`** — sources the shared lib instead of duplicating it; Test 7 (editorial) now shares `trigger_is_dead`; **Test 2** (mechanical) is fixed to use the same shared check — it had the identical "literal-path-always-passes" blind spot Test 7 used to have (mechanical triggers mix literals like `Directory.Packages.props` with globs); new **Test 8** proves `trigger_is_dead` in both directions with synthetic real/dead glob and literal pairs, independent of whatever today's real docs happen to contain (a test that only ever sees passing/failing input by accident proves nothing about the check itself).

### Proof — ran the verifier over the real repo tree

`bash docs/scripts/freshness-checks/verify-triggers.sh` found **16 dead triggers across 13 docs**. 9 had an unambiguous single-`find`-hit target and were auto-repaired (applied to the 6 affected doc files, included in this PR); 7 are genuinely ambiguous or fully renamed (e.g. `AdminNavTree.cs` was split into `AdminNavComposition.cs` + 31 per-section `SectionAdminNav.cs` files; `Authorization/Requirements/**` was distributed into each section's own `Authorization/` folder with no `Requirements/` subfolder) and are correctly left `UNRESOLVED` + `FORCE-DIRTY` for a real sweep run to review. Re-running afterward confirms idempotency: `repaired=0, unresolved=7`.

`bash docs/scripts/freshness-checks/diff-mode.sh`: 7/8 tests pass; Test 7 correctly still fails, reporting exactly those same 7 remaining dead triggers (real, unrepaired findings — this script is diagnostic, not a CI gate, per the issue).

### Acceptance criteria

- [x] Every `freshness:triggers` entry under `editorial_trees` expanded as a real glob (`**`/`*`-aware), not compared literally
- [x] Dead globs with an unambiguous new target repaired automatically (demonstrated: 9/16)
- [x] Unresolved dead globs reported (`UNRESOLVED`/`FORCE-DIRTY` output → Phase 6 report section) and their docs forced dirty (Phase 4 union)
- [x] Verification (Phase 3.5) runs before the dirty list is computed (Phase 4)
- [x] Catalog's `ignore:` list honored generically (`path_ignored`)
- [x] `**` pattern on a real dir passes / on a deleted dir is reported — proven by synthetic Test 8, not just today's real doc content
- [x] `diff-mode.sh` covers editorial docs (already true; kept, now shares logic with the repair script)
- [x] (comment) Test 3's editorial walk is catalog-driven (was already fixed in a prior sweep — verified by inspection and by running the script)
- [x] (comment) `N_TREES` reports the real count (was already fixed in a prior sweep — verified: reports 10, not 0)

## Test plan

- [x] `bash docs/scripts/freshness-checks/diff-mode.sh` — 7/8 pass, Test 7 shows the true remaining 7 dead triggers
- [x] `bash docs/scripts/freshness-checks/verify-triggers.sh` — repairs applied, idempotent on re-run
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
