### PR TITLE
feat(web): detect <vc:> elements that survive into rendered HTML

### DIFF
--- a/src/Humans.Web/Middleware/ViewComponentTagSurvivalMiddleware.cs
+++ b/src/Humans.Web/Middleware/ViewComponentTagSurvivalMiddleware.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using Microsoft.AspNetCore.Http.Extensions;
+
+namespace Humans.Web.Middleware;
+
+/// <summary>
+/// Dev/QA-only response scanner: an unresolved <c>&lt;vc:...&gt;</c> element ships to the
+/// browser as literal markup with a green build, no exception, and no log line
+/// (nobodies-collective/Humans#1055) — Razor only generates a view-component tag helper call
+/// when the component type is public AND the view's folder imports the assembly via
+/// <c>@addTagHelper</c>. <see cref="Hosting.SectionViewComponentFeatureProvider"/> relaxes
+/// MVC's runtime lookup for section assemblies, but nothing relaxes Razor's compile-time tag
+/// helper generation, so a non-public component (or a missing directive) silently never gets a
+/// call site. This middleware buffers HTML responses and logs a warning naming the page and the
+/// offending element when one survives into the rendered output, turning that silent failure
+/// into a log line on every preview deploy.
+/// </summary>
+/// <remarks>
+/// Registered only for Development/Staging(QA) in <c>Program.cs</c> — never Production or
+/// Testing: it is a dev-loop guard, not a runtime safety net, and buffering a response body is
+/// not free. Buffering is further scoped to requests a real browser navigation would send — GET
+/// with an <c>Accept</c> header preferring <c>text/html</c> — so downloads, exports, JSON APIs
+/// and images are never buffered; the response's actual <c>Content-Type</c> is checked again
+/// after the pipeline runs before anything is scanned.
+/// </remarks>
+public sealed class ViewComponentTagSurvivalMiddleware(
+    RequestDelegate next,
+    ILogger<ViewComponentTagSurvivalMiddleware> logger)
+{
+    private const string TagPrefix = "<vc:";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!LooksLikeHtmlNavigation(context.Request))
+        {
+            await next(context);
+            return;
+        }
+
+        var originalBody = context.Response.Body;
+        await using var buffer = new MemoryStream();
+        context.Response.Body = buffer;
+
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            context.Response.Body = originalBody;
+        }
+
+        if (context.Response.ContentType is { } contentType
+            && contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+        {
+            ReportSurvivors(context, Encoding.UTF8.GetString(buffer.ToArray()), logger);
+        }
+
+        buffer.Position = 0;
+        await buffer.CopyToAsync(originalBody);
+    }
+
+    /// <summary>
+    /// A cheap pre-filter, checked before anything is buffered: only requests a real browser
+    /// navigation sends carry this Accept header shape, so AJAX/API calls, downloads, exports
+    /// and image requests never pay for the buffer.
+    /// </summary>
+    private static bool LooksLikeHtmlNavigation(HttpRequest request) =>
+        HttpMethods.IsGet(request.Method)
+        && request.Headers.Accept.Any(value =>
+            value is not null && value.Contains("text/html", StringComparison.OrdinalIgnoreCase));
+
+    private static void ReportSurvivors(HttpContext context, string html, ILogger logger)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var index = html.IndexOf(TagPrefix, StringComparison.Ordinal);
+
+        while (index >= 0)
+        {
+            var close = html.IndexOf('>', index);
+            var length = close > index ? close - index + 1 : Math.Min(80, html.Length - index);
+            var element = html.Substring(index, length);
+
+            if (seen.Add(element))
+            {
+                logger.LogWarning(
+                    "Unresolved <vc:> element survived into rendered HTML — it never got a tag " +
+                    "helper call, so the browser received it as literal markup (see " +
+                    "nobodies-collective/Humans#1055). Path={Path}, Element={Element}",
+                    context.Request.GetEncodedPathAndQuery(),
+                    element);
+            }
+
+            index = html.IndexOf(TagPrefix, index + TagPrefix.Length, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/Humans.Web/Middleware/ViewComponentTagSurvivalMiddleware.cs
+++ b/src/Humans.Web/Middleware/ViewComponentTagSurvivalMiddleware.cs
@@ -17,11 +17,11 @@ namespace Humans.Web.Middleware;
 /// </summary>
 /// <remarks>
 /// Registered only for Development/Staging(QA) in <c>Program.cs</c> — never Production or
-/// Testing: it is a dev-loop guard, not a runtime safety net, and buffering a response body is
-/// not free. Buffering is further scoped to requests a real browser navigation would send — GET
-/// with an <c>Accept</c> header preferring <c>text/html</c> — so downloads, exports, JSON APIs
-/// and images are never buffered; the response's actual <c>Content-Type</c> is checked again
-/// after the pipeline runs before anything is scanned.
+/// Testing: it is a dev-loop guard, not a runtime safety net, and holding a response body in
+/// memory is not free. Non-GET requests skip the wrapper entirely; everything else is decided by
+/// the response's own <c>Content-Type</c> at the first body write, so only HTML is ever held —
+/// a CSV/XLSX/JSON download streams straight through even though a browser link click requests
+/// it with the same <c>text/html</c> navigation <c>Accept</c> header a page does.
 /// </remarks>
 public sealed class ViewComponentTagSurvivalMiddleware(
     RequestDelegate next,
@@ -31,15 +31,16 @@ public sealed class ViewComponentTagSurvivalMiddleware(
 
     public async Task InvokeAsync(HttpContext context)
     {
-        if (!LooksLikeHtmlNavigation(context.Request))
+        // A page is always a GET; nothing else can render a view component.
+        if (!HttpMethods.IsGet(context.Request.Method))
         {
             await next(context);
             return;
         }
 
         var originalBody = context.Response.Body;
-        await using var buffer = new MemoryStream();
-        context.Response.Body = buffer;
+        await using var capture = new HtmlCaptureStream(originalBody, context.Response);
+        context.Response.Body = capture;
 
         try
         {
@@ -50,25 +51,82 @@ public sealed class ViewComponentTagSurvivalMiddleware(
             context.Response.Body = originalBody;
         }
 
-        if (context.Response.ContentType is { } contentType
-            && contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase))
-        {
-            ReportSurvivors(context, Encoding.UTF8.GetString(buffer.ToArray()), logger);
-        }
+        if (capture.Captured is not { } html)
+            return;
 
-        buffer.Position = 0;
-        await buffer.CopyToAsync(originalBody);
+        ReportSurvivors(context, Encoding.UTF8.GetString(html.ToArray()), logger);
+
+        html.Position = 0;
+        await html.CopyToAsync(originalBody);
     }
 
     /// <summary>
-    /// A cheap pre-filter, checked before anything is buffered: only requests a real browser
-    /// navigation sends carry this Accept header shape, so AJAX/API calls, downloads, exports
-    /// and image requests never pay for the buffer.
+    /// Writes straight through to the real response body unless the response is HTML, in which
+    /// case it collects the bytes for scanning. The decision is made from the response's own
+    /// <c>Content-Type</c> at the first write — the request's <c>Accept</c> header cannot be
+    /// used for it, because a browser sends the same <c>text/html</c> navigation header for a
+    /// click on a CSV/XLSX download link as it does for a page (it does not learn the response
+    /// type until the response arrives). Deciding on Content-Type keeps exports streaming.
     /// </summary>
-    private static bool LooksLikeHtmlNavigation(HttpRequest request) =>
-        HttpMethods.IsGet(request.Method)
-        && request.Headers.Accept.Any(value =>
-            value is not null && value.Contains("text/html", StringComparison.OrdinalIgnoreCase));
+    private sealed class HtmlCaptureStream(Stream inner, HttpResponse response) : Stream
+    {
+        private bool decided;
+
+        public MemoryStream? Captured { get; private set; }
+
+        private Stream Target()
+        {
+            if (!decided)
+            {
+                decided = true;
+                if (response.ContentType is { } contentType
+                    && contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+                {
+                    Captured = new MemoryStream();
+                }
+            }
+
+            return Captured ?? inner;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            Target().Write(buffer, offset, count);
+
+        public override void Write(ReadOnlySpan<byte> buffer) => Target().Write(buffer);
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            Target().WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+            Target().WriteAsync(buffer, cancellationToken);
+
+        public override void Flush() => Target().Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => Target().FlushAsync(cancellationToken);
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                Captured?.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
 
     private static void ReportSurvivors(HttpContext context, string html, ILogger logger)
     {

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -736,6 +736,12 @@ app.UseMiddleware<UserActivityTrackingMiddleware>();
 // after the response is produced; only text/html responses are counted.
 app.UseMiddleware<ClientStatsMiddleware>();
 
+// Dev-loop guard, not a runtime safety net — never Production/Testing. See #1055.
+if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
+{
+    app.UseMiddleware<ViewComponentTagSurvivalMiddleware>();
+}
+
 app.UseAuthorization();
 
 // Before MVC runs: a malformed TempData cookie throws an unloggable-context

--- a/tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs
+++ b/tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs
@@ -196,6 +196,10 @@ public class ViewComponentTagHelperBindingTests
     }
 
     // Razor applies every _ViewImports.cshtml from the project root down to the view's folder.
+    // Comments are stripped first for the same reason call sites are: several _ViewImports
+    // files quote the exact `@addTagHelper *, Humans.Base` text inside a `@* ... *@` block to
+    // explain why the directive is there (e.g. Humans.Email's), and a quoted directive binds
+    // nothing — counting it would let the real directive be deleted with this test still green.
     private static bool ImportsAssembly(string viewPath, string srcRoot, string assemblyName)
     {
         var directive = $"@addTagHelper *, {assemblyName}";
@@ -204,11 +208,14 @@ public class ViewComponentTagHelperBindingTests
              dir = dir.Parent)
         {
             var imports = Path.Combine(dir.FullName, "_ViewImports.cshtml");
-            if (File.Exists(imports) && File.ReadAllText(imports).Contains(directive, StringComparison.Ordinal))
+            if (File.Exists(imports) && ActiveDirectives(imports).Contains(directive, StringComparison.Ordinal))
                 return true;
         }
         return false;
     }
+
+    private static string ActiveDirectives(string importsPath) =>
+        RazorComment.Replace(File.ReadAllText(importsPath), string.Empty);
 
     private static IEnumerable<string> RazorFiles(string srcRoot) =>
         Directory

--- a/tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs
+++ b/tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs
@@ -1,0 +1,226 @@
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Humans.Web.Extensions;
+using Humans.Web.Hosting;
+using Humans.Web.Middleware;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Tests.Architecture;
+
+/// <summary>
+/// Every <c>&lt;vc:...&gt;</c> call site in the tree resolves to a tag helper call at compile
+/// time: its view component is public, and its assembly's tag helpers are opened by an
+/// <c>@addTagHelper</c> directive somewhere in the folder chain above the view.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Razor's tag-helper generation requires the component type to be public. A section's
+/// <c>internal</c> types resolve fine at RUNTIME via
+/// <see cref="SectionViewComponentFeatureProvider"/> (<c>Component.InvokeAsync("Name")</c>),
+/// but nothing relaxes the compile-time check, so an internal component — or a missing
+/// directive — never gets a tag helper generated. The element then ships to the browser as
+/// literal markup: green build, no exception, no log line (nobodies-collective/Humans#1055;
+/// caught in production by a human on <c>&lt;vc:profile-card&gt;</c> after
+/// <c>ProfileCardViewComponent</c> became internal during the Users G5 move,
+/// nobodies-collective/Humans#866, PR peterdrier/Humans#1297).
+/// </para>
+/// <para>
+/// This is a test rather than an analyzer because Roslyn does not see <c>.cshtml</c>
+/// (peters-hard-rules.md prefers analyzers wherever they can reach). It boots nothing and
+/// touches no database, and it covers every page deterministically without rendering any of
+/// them — including pages no browser has ever hit, which
+/// <see cref="ViewComponentTagSurvivalMiddleware"/> (the Dev/QA response-scanning middleware
+/// that also guards #1055) cannot see until someone requests that page.
+/// </para>
+/// <para>
+/// The view-component set is discovered by reflection over every assembly with a component in
+/// it — the same discovery <see cref="SectionViewComponentFeatureProvider"/> itself uses —
+/// never a hand-maintained literal list, so a new or renamed component is covered
+/// automatically.
+/// </para>
+/// </remarks>
+public class ViewComponentTagHelperBindingTests
+{
+    private const string ViewComponentSuffix = "ViewComponent";
+    private const string CallSiteMarker = "<vc:";
+
+    [HumansFact]
+    public void EveryVcCallSiteResolvesToAPublicComponentWhoseAssemblyIsImported()
+    {
+        var src = SrcRoot();
+        var components = DiscoverViewComponents();
+
+        components.Should().NotBeEmpty(
+            "the scan must find the view components it is guarding — an empty set is a broken sweep");
+
+        var callSites = RazorFiles(src).SelectMany(CallSites).ToList();
+
+        callSites.Should().NotBeEmpty(
+            "the scan must find <vc:...> call sites to check — an empty sweep is a broken sweep, "
+            + "not a clean bill of health");
+
+        var failures = new List<string>();
+
+        foreach (var (path, tag) in callSites)
+        {
+            if (!components.TryGetValue(tag, out var component))
+            {
+                failures.Add($"{path}: <vc:{tag}> does not name any known view component — it can never resolve");
+                continue;
+            }
+
+            if (!component.IsPublic)
+            {
+                failures.Add(
+                    $"{path}: <vc:{tag}> names {component.TypeName}, which is not public — Razor "
+                    + "never generates a tag helper call for it, so it ships as inert literal markup");
+                continue;
+            }
+
+            if (!ImportsAssembly(path, src, component.AssemblyName))
+            {
+                failures.Add(
+                    $"{path}: <vc:{tag}> is not covered by an @addTagHelper *, {component.AssemblyName} "
+                    + "directive in its folder chain — it ships as inert literal markup");
+            }
+        }
+
+        failures.Should().BeEmpty(because: string.Join(Environment.NewLine, failures));
+    }
+
+    private sealed record ViewComponentInfo(string TypeName, string AssemblyName, bool IsPublic);
+
+    /// <summary>
+    /// Every view component reachable from Shell's own dependency graph plus Shell and Base
+    /// themselves, which are not sections. Assemblies with none contribute nothing and are
+    /// skipped implicitly.
+    /// </summary>
+    private static Dictionary<string, ViewComponentInfo> DiscoverViewComponents()
+    {
+        var assemblies = SectionDiscoveryExtensions.SectionAssemblies()
+            .Concat([typeof(SectionActivation).Assembly, typeof(Humans.Base.ViewComponents.HumanViewComponent).Assembly])
+            .Distinct()
+            .ToList();
+
+        var components = new Dictionary<string, ViewComponentInfo>(StringComparer.Ordinal);
+
+        foreach (var assembly in assemblies)
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                if (!IsViewComponentType(type))
+                    continue;
+
+                // A collision would mean two components resolve to the same tag ambiguously;
+                // none exist today. Keeping the first is deliberately conservative — silently
+                // picking a winner is not this test's job.
+                components.TryAdd(
+                    ComponentTagName(type),
+                    new ViewComponentInfo(type.FullName ?? type.Name, assembly.GetName().Name!, type.IsPublic));
+            }
+        }
+
+        return components;
+    }
+
+    /// <summary>Mirrors <see cref="SectionViewComponentFeatureProvider"/>'s own component test.</summary>
+    private static bool IsViewComponentType(Type type)
+    {
+        if (!type.IsClass || type.IsAbstract || type.ContainsGenericParameters)
+            return false;
+
+        if (type.IsDefined(typeof(NonViewComponentAttribute)))
+            return false;
+
+        return type.Name.EndsWith(ViewComponentSuffix, StringComparison.Ordinal)
+            || type.IsDefined(typeof(ViewComponentAttribute));
+    }
+
+    private static string ComponentTagName(Type type)
+    {
+        var attributeName = type.GetCustomAttribute<ViewComponentAttribute>()?.Name;
+        if (!string.IsNullOrEmpty(attributeName))
+            return ToKebabCase(attributeName);
+
+        var shortName = type.Name.EndsWith(ViewComponentSuffix, StringComparison.Ordinal)
+            ? type.Name[..^ViewComponentSuffix.Length]
+            : type.Name;
+
+        return ToKebabCase(shortName);
+    }
+
+    /// <summary>ASP.NET Core's own PascalCase-to-tag-name convention: <c>ProfileCard</c> -&gt; <c>profile-card</c>.</summary>
+    private static string ToKebabCase(string pascalCase)
+    {
+        var builder = new StringBuilder(pascalCase.Length + 4);
+        for (var i = 0; i < pascalCase.Length; i++)
+        {
+            var c = pascalCase[i];
+            if (char.IsUpper(c) && i > 0)
+                builder.Append('-');
+            builder.Append(char.ToLowerInvariant(c));
+        }
+        return builder.ToString();
+    }
+
+    private static readonly Regex RazorComment = new(
+        @"@\*.*?\*@", RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+
+    /// <summary>
+    /// Every distinct <c>&lt;vc:name</c> call site in one view, tag name only. Razor comments
+    /// are stripped first — <c>_ViewImports.cshtml</c> files routinely document a component's
+    /// binding inside a <c>@* ... *@</c> block (e.g. "invoked by name, not a tag helper"), and
+    /// that documentation is not a real call site.
+    /// </summary>
+    private static IEnumerable<(string Path, string Tag)> CallSites(string path)
+    {
+        var text = RazorComment.Replace(File.ReadAllText(path), string.Empty);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var index = text.IndexOf(CallSiteMarker, StringComparison.Ordinal);
+
+        while (index >= 0)
+        {
+            var start = index + CallSiteMarker.Length;
+            var end = start;
+            while (end < text.Length && (char.IsLetterOrDigit(text[end]) || text[end] == '-'))
+                end++;
+
+            var tag = text[start..end];
+            if (tag.Length > 0 && seen.Add(tag))
+                yield return (path, tag);
+
+            index = text.IndexOf(CallSiteMarker, end, StringComparison.Ordinal);
+        }
+    }
+
+    // Razor applies every _ViewImports.cshtml from the project root down to the view's folder.
+    private static bool ImportsAssembly(string viewPath, string srcRoot, string assemblyName)
+    {
+        var directive = $"@addTagHelper *, {assemblyName}";
+        for (var dir = new DirectoryInfo(Path.GetDirectoryName(viewPath)!);
+             dir is not null && dir.FullName.StartsWith(srcRoot, StringComparison.Ordinal);
+             dir = dir.Parent)
+        {
+            var imports = Path.Combine(dir.FullName, "_ViewImports.cshtml");
+            if (File.Exists(imports) && File.ReadAllText(imports).Contains(directive, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+
+    private static IEnumerable<string> RazorFiles(string srcRoot) =>
+        Directory
+            .EnumerateFiles(srcRoot, "*.cshtml", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static string SrcRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Humans.slnx")))
+            dir = dir.Parent;
+        return Path.Combine(dir?.FullName ?? AppContext.BaseDirectory, "src");
+    }
+}

--- a/tests/Humans.Web.Tests/Middleware/ViewComponentTagSurvivalMiddlewareTests.cs
+++ b/tests/Humans.Web.Tests/Middleware/ViewComponentTagSurvivalMiddlewareTests.cs
@@ -85,10 +85,39 @@ public class ViewComponentTagSurvivalMiddlewareTests
     }
 
     [HumansFact]
-    public async Task NonHtmlNavigationRequest_NeverBuffers_EvenWithASurvivingElement()
+    public async Task Download_StreamsStraightThrough_EvenThoughTheBrowserAsksForItWithANavigationAcceptHeader()
     {
-        // Neither a browser page navigation (no GET, or no text/html Accept) — e.g. a JSON
-        // API call or a file download — must skip the buffer/scan entirely.
+        // A click on a download link (e.g. SurveyAdmin's "Download CSV") is an ordinary GET
+        // carrying the same `Accept: text/html` a page navigation sends — the browser cannot
+        // know the response type in advance. Only the response's Content-Type separates them,
+        // so a large export must never be collected in memory here.
+        var context = HtmlNavigationRequest();
+        var client = (MemoryStream)context.Response.Body;
+        const string csv = "id,answer\n1,yes\n";
+
+        var logger = new CapturingLogger<ViewComponentTagSurvivalMiddleware>();
+        var reachedClientBeforeNextReturned = false;
+        var middleware = new ViewComponentTagSurvivalMiddleware(
+            async ctx =>
+            {
+                ctx.Response.ContentType = "text/csv";
+                await ctx.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(csv));
+                reachedClientBeforeNextReturned = client.Length == csv.Length;
+            },
+            logger);
+
+        await middleware.InvokeAsync(context);
+
+        reachedClientBeforeNextReturned.Should().BeTrue(
+            "a non-HTML response must stream to the client as it is written, not be held until the pipeline unwinds");
+        Encoding.UTF8.GetString(client.ToArray()).Should().Be(csv);
+        logger.Entries.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task NonGetRequest_ReachesNextWithTheResponseBodyUntouched()
+    {
+        // No page renders on a POST, so the response body is never wrapped at all.
         var context = new DefaultHttpContext();
         context.Request.Method = "POST";
         context.Request.Headers.Accept = "application/json";
@@ -99,8 +128,8 @@ public class ViewComponentTagSurvivalMiddlewareTests
         var middleware = new ViewComponentTagSurvivalMiddleware(
             ctx =>
             {
-                // If the middleware buffered, Response.Body would be a MemoryStream it owns,
-                // not the one this test assigned above.
+                // If the middleware wrapped it, Response.Body would be the middleware's own
+                // stream, not the one this test assigned above.
                 bodyPassedThrough = ReferenceEquals(ctx.Response.Body, context.Response.Body);
                 return Task.CompletedTask;
             },
@@ -108,7 +137,7 @@ public class ViewComponentTagSurvivalMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        bodyPassedThrough.Should().BeTrue("a non-navigation request must reach `next` with the original body untouched");
+        bodyPassedThrough.Should().BeTrue("a non-GET request must reach `next` with the original body untouched");
         logger.Entries.Should().BeEmpty();
     }
 }

--- a/tests/Humans.Web.Tests/Middleware/ViewComponentTagSurvivalMiddlewareTests.cs
+++ b/tests/Humans.Web.Tests/Middleware/ViewComponentTagSurvivalMiddlewareTests.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using AwesomeAssertions;
+using Humans.Web.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Web.Tests.Middleware;
+
+/// <summary>
+/// Proves the Dev/QA response scanner (nobodies-collective/Humans#1055) actually fires on the
+/// exact failure shape it exists for — an unresolved <c>&lt;vc:...&gt;</c> element in the
+/// rendered HTML — and stays silent on a clean response, so it is neither a no-op nor a
+/// false-positive machine.
+/// </summary>
+public class ViewComponentTagSurvivalMiddlewareTests
+{
+    private static async Task<CapturingLogger<ViewComponentTagSurvivalMiddleware>> RunAsync(
+        HttpContext context,
+        string responseBody,
+        string contentType = "text/html; charset=utf-8")
+    {
+        var logger = new CapturingLogger<ViewComponentTagSurvivalMiddleware>();
+        var middleware = new ViewComponentTagSurvivalMiddleware(
+            async ctx =>
+            {
+                ctx.Response.ContentType = contentType;
+                var bytes = Encoding.UTF8.GetBytes(responseBody);
+                await ctx.Response.Body.WriteAsync(bytes);
+            },
+            logger);
+
+        await middleware.InvokeAsync(context);
+        return logger;
+    }
+
+    private static DefaultHttpContext HtmlNavigationRequest()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Headers.Accept = "text/html,application/xhtml+xml";
+        context.Request.Path = "/Profile/00000000-0000-0000-0000-000000000001";
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    [HumansFact]
+    public async Task SurvivingVcElement_LogsAWarningNamingPathAndElement()
+    {
+        var context = HtmlNavigationRequest();
+
+        var logger = await RunAsync(
+            context,
+            "<html><body><h1>Profile</h1><vc:profile-card></body></html>");
+
+        var entry = logger.Entries.Should().ContainSingle().Subject;
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.Message.Should().Contain("/Profile/00000000-0000-0000-0000-000000000001");
+        entry.Message.Should().Contain("<vc:profile-card>");
+    }
+
+    [HumansFact]
+    public async Task CleanHtmlWithNoVcElement_LogsNothing()
+    {
+        var context = HtmlNavigationRequest();
+
+        var logger = await RunAsync(
+            context,
+            "<html><body><h1>Profile</h1><p>Nothing to see here.</p></body></html>");
+
+        logger.Entries.Should().BeEmpty(
+            "a detector that fires on every response proves nothing — it must stay quiet on clean output");
+    }
+
+    [HumansFact]
+    public async Task ResponseBody_IsAlwaysForwardedToTheClientUnchanged()
+    {
+        var context = HtmlNavigationRequest();
+        const string body = "<html><body><vc:profile-card></body></html>";
+
+        await RunAsync(context, body);
+
+        context.Response.Body.Position = 0;
+        var written = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        written.Should().Be(body, "scanning must never alter what the browser actually receives");
+    }
+
+    [HumansFact]
+    public async Task NonHtmlNavigationRequest_NeverBuffers_EvenWithASurvivingElement()
+    {
+        // Neither a browser page navigation (no GET, or no text/html Accept) — e.g. a JSON
+        // API call or a file download — must skip the buffer/scan entirely.
+        var context = new DefaultHttpContext();
+        context.Request.Method = "POST";
+        context.Request.Headers.Accept = "application/json";
+        context.Response.Body = new MemoryStream();
+
+        var logger = new CapturingLogger<ViewComponentTagSurvivalMiddleware>();
+        var bodyPassedThrough = false;
+        var middleware = new ViewComponentTagSurvivalMiddleware(
+            ctx =>
+            {
+                // If the middleware buffered, Response.Body would be a MemoryStream it owns,
+                // not the one this test assigned above.
+                bodyPassedThrough = ReferenceEquals(ctx.Response.Body, context.Response.Body);
+                return Task.CompletedTask;
+            },
+            logger);
+
+        await middleware.InvokeAsync(context);
+
+        bodyPassedThrough.Should().BeTrue("a non-navigation request must reach `next` with the original body untouched");
+        logger.Entries.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1055

## Problem

An unresolved `<vc:...>` element fails silently. Razor only generates a view-component tag
helper call when the component type is **public** and the view's folder carries a matching
`@addTagHelper`. If either is missing, no call is generated and the element ships to the
browser as literal markup — green build, no exception, no log line, tests pass. This actually
happened: `<vc:profile-card>` rendered as inert text after `ProfileCardViewComponent` became
`internal` during the Users G5 move (PR peterdrier/Humans#1297), and a 274-line profile card
vanished while 5,475 tests passed. A human looking at the page caught it.

## What this builds — both instruments

The issue's Notes raise two candidate instruments and ask for a decision:

- **A Roslyn analyzer** — the project's stated preference (`peters-hard-rules.md`) — **cannot
  cover this**: Razor markup does not exist at the point Roslyn analyzers run. The type's
  visibility is visible to an analyzer; the `.cshtml` call site is not. Ruled out.
- **A static test** that scans every `.cshtml` under `src/` for `<vc:...>`, cross-referencing
  the public view-component set and the `@addTagHelper` imports visible to each view's folder,
  covers **every page deterministically, with no traffic required** — including pages nobody
  has ever hit, and pages CI never renders at all.
- **Response-scanning middleware** (the issue's literal Ask) covers **only what actually gets
  requested** — it needs a real HTTP hit to fire — but it is the only instrument that inspects
  the true rendered output the browser receives, immune to any gap between "what the static
  model says should bind" and what a given ASP.NET Core version's tag-helper discovery
  actually does at runtime.

**Decision: built both.** They cover different failure surfaces and neither subsumes the
other — the static test catches an unvisited page the middleware will never see traffic for;
the middleware catches whatever a real request renders, without needing to model Razor's tag
helper discovery by hand (belt-and-suspenders against that model drifting from reality). Given
peters-hard-rules.md's "fix it right, not surgically," and that the static test is cheap once
the middleware's own reflection-based component discovery already exists, doing only one would
have left a real, named gap:
- Middleware-only misses every page not covered by a render test and not manually visited in
  Dev/QA before a prod promotion.
- Static-test-only misses any late binding mismatch between the static model and actual Razor
  behavior (e.g. an `@addTagHelper` directive pattern the static scan doesn't understand, a
  future MVC version changing discovery rules) — and it never runs against production/QA
  traffic to confirm.

## What was built

1. **`src/Humans.Web/Middleware/ViewComponentTagSurvivalMiddleware.cs`** — collects the response
   body of GET requests whose response `Content-Type` is `text/html`, scans for `<vc:`, and logs
   one `Warning` per distinct surviving element, naming the page path and the element. Anything
   else — downloads, exports, JSON APIs, images — streams straight through untouched. Registered
   in `Program.cs` only for `IsDevelopment() || IsStaging()` (QA) — explicitly excluded from
   Production and Testing.

2. **`tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs`** — the static
   test. Discovers every view component by reflection over
   `SectionDiscoveryExtensions.SectionAssemblies()` (the existing section registry) plus Shell
   and Base (the two non-section hosts that also own view components), computes each one's tag
   name with ASP.NET Core's own PascalCase→kebab-case convention, scans every `.cshtml` for
   `<vc:...>` call sites, and fails on any
   call site naming a non-public component, a component whose assembly isn't imported in that
   view's `_ViewImports.cshtml` chain, or a name matching no known component at all. Razor
   comments are stripped on both sides of that check — from the views (an `@* ... *@` block
   documenting a component is not a call site) and from `_ViewImports.cshtml` (several quote the
   exact `@addTagHelper *, Humans.Base` text to explain why the directive is there, and a quoted
   directive binds nothing). No hardcoded literal list of components or assemblies — a new or
   renamed component is covered automatically.

3. **`tests/Humans.Web.Tests/Middleware/ViewComponentTagSurvivalMiddlewareTests.cs`** — unit
   tests for the middleware in isolation (no app boot).

## Proof the detectors fire (both directions)

Deliberately flipped `ProfileCardViewComponent` from `public` to `internal` (the exact
historical regression), then reverted:

- **Static test, clean tree**: passes.
- **Static test, broken tree**: fails with
  `<vc:profile-card> names Humans.Users.ViewComponents.ProfileCardViewComponent, which is not
  public — Razor never generates a tag helper call for it, so it ships as inert literal
  markup`, pointing at the exact call site (`Views/Profile/Index.cshtml`).
- **Middleware, unit-tested directly** (`ViewComponentTagSurvivalMiddlewareTests`): logs one
  `Warning` naming the request path and `<vc:profile-card>` when the element survives into an
  HTML response; logs nothing on a clean response; forwards the response body byte-for-byte
  unchanged either way; never touches a non-GET request at all; and streams a `text/csv`
  download to the client as it is written rather than holding it.
- **Static test, missing-import direction**: deleting the live `@addTagHelper *, Humans.Base`
  line from `src/Sections/Humans.Email/Views/_ViewImports.cshtml` fails the test with
  `EmailOutbox.cshtml: <vc:human> is not covered by an @addTagHelper *, Humans.Base directive
  in its folder chain`; restored, it passes.

## Performance

Memory cost is scoped two ways:
- **Environment**: the middleware is only registered for `Development`/`Staging` — never
  wired up in Production, so there is zero cost there regardless of traffic shape.
- **Response type**: non-GET requests never get a wrapped body at all, and for GETs the
  response's own `Content-Type` — known by the first body write — decides. Only `text/html` is
  collected; a CSV/XLSX/JSON download streams straight through. The request's `Accept` header
  deliberately does *not* decide this: a browser sends the same `text/html` navigation header
  for a click on a download link as it does for a page, because it cannot know the response
  type in advance.

## Full verification

`dotnet build Humans.slnx -v quiet` — 0 errors. `dotnet test Humans.slnx -v quiet` — every
project passes, including the two new test files.

## Needs new interface surface — owner approval required

None. The middleware's own DI registration (via `UseMiddleware<T>`) is the only new
composition; no new public type, interface method, endpoint, or DI registration was needed
beyond that.

