### PR TITLE
test(users): mutate ProfileCompletion again — it was silently dropped, not moved

### DIFF
--- a/tests/Humans.Users.Tests/stryker-profiles-contracts-config.json
+++ b/tests/Humans.Users.Tests/stryker-profiles-contracts-config.json
@@ -1,0 +1,22 @@
+{
+  "stryker-config": {
+    "project": "Humans.Users.Contracts.csproj",
+    "test-runner": "mtp",
+    "coverage-analysis": "off",
+    "mutation-level": "Standard",
+    "mutate": [
+      "**/ProfileCompletion.cs"
+    ],
+    "concurrency": 16,
+    "reporters": [
+      "ClearText",
+      "Json",
+      "Html"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    }
+  }
+}


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1052

## What was actually stale

`tests/Humans.Application.Tests/stryker-profiles-config.json` had already been renamed to `tests/Humans.Users.Tests/stryker-profiles-config.json` and repointed at `Humans.Users.csproj` by #1359 (landed 2026-08-18), as an incidental fix while distributing `Humans.Application.Tests`. That pass correctly:

- dropped `**/FullProfile.cs` — that machinery was deleted outright in #561, long before this issue existed
- collapsed `**/Authorization/UserEmail/*.cs` → `**/Authorization/UserEmail*.cs` (files moved from a `UserEmail/` subfolder to flat `UserEmail*.cs` names)
- collapsed `**/Services/Profile/*.cs` + `**/Services/Profiles/*.cs` → `**/Services/Profile*.cs`

...but it silently **dropped** `**/Helpers/ProfileCompletion.cs` instead of following it. That file didn't move into `Humans.Users` — it moved into `Humans.Users.Contracts/ProfileCompletion.cs` (carved out during #866 lane 2, before #1359 even ran). It's real weighted-scoring logic (~90 lines, two overloads) with its own test file (`tests/Humans.Users.Tests/Helpers/ProfileCompletionTests.cs`), so it needed its own Stryker config — Stryker.NET mutates exactly one target project per config, and `Humans.Users.Contracts.csproj` is a different project than `Humans.Users.csproj`.

## Change

Added `tests/Humans.Users.Tests/stryker-profiles-contracts-config.json`, targeting `Humans.Users.Contracts.csproj` with `mutate: ["**/ProfileCompletion.cs"]`. The existing `tests/Humans.Users.Tests/stryker-profiles-config.json` needed no edits — it was already correct.

## Verification — every glob checked against the tree, not assumed

| config | glob | files matched |
|---|---|---|
| `stryker-profiles-config.json` | `**/Authorization/UserEmail*.cs` | 3 (`UserEmailAuthorizationHandler.cs`, `UserEmailOperationRequirement.cs`, `UserEmailOperations.cs`) |
| `stryker-profiles-config.json` | `**/Services/Profile*.cs` | 2 (`ProfileEditorService.cs`, `ProfileService.cs`) |
| `stryker-profiles-contracts-config.json` | `**/ProfileCompletion.cs` | 1 |

## Confirming Stryker runs (both `concurrency: 16`, `coverage-analysis: off`, house default)

- **`stryker-profiles-config.json`** (Humans.Users.csproj): 118 mutants tested (58 killed / 60 survived) → **49.15%**. `UserEmailOperations.cs`/`UserEmailOperationRequirement.cs` legitimately produced zero mutants (trivial marker/constant classes, nothing mutable) — the mutation weight sits in `UserEmailAuthorizationHandler.cs` (6 mutants) and the two `Profile*Service.cs` files (68 + 44 mutants).
- **`stryker-profiles-contracts-config.json`** (Humans.Users.Contracts.csproj): 114 mutants tested (58 killed / 56 survived) → **50.88%**, all concentrated in `ProfileCompletion.cs` as intended.

Both runs are non-trivial, live mutant counts — the config is confirmed to actually mutate code, not the silent-zero failure mode this issue exists to catch.

## Needs new interface surface — owner approval required

None.
