### PR TITLE
fix(guide): camp leads can see the guide blocks written for them

### DIFF
--- a/docs/guide/Camps.md
+++ b/docs/guide/Camps.md
@@ -74,7 +74,7 @@ Your camp profile is **persistent year to year** — next year you only update i
 | Barrio Support comms | Barrio Support uses Humans to send communications to camp leads — water schedules, LNT reminders, power obligations. Being registered is how you receive these. |
 | Barrio store (rolling out) | Barrio services — water, ice, tokens — are becoming orderable through a store inside Humans. Details to follow from Production & Logistics. |
 
-## As a [Coordinator](Glossary.md#coordinator) (Camp Coordinator)
+## As a [Coordinator](Glossary.md#coordinator) (Camp Lead)
 
 If you are a **Camp Lead**, you can manage your specific camp. You cannot edit camps you don't lead.
 

--- a/src/Sections/Humans.Guide/Docs/Guide.md
+++ b/src/Sections/Humans.Guide/Docs/Guide.md
@@ -21,7 +21,12 @@
   renderer and optionally stripped at request time by `GuideFilter`.
 - A **parenthetical** is text in parens after `## As a …` (e.g. `## As a
   Board member / Admin (Teams Admin)`) that specifies which domain admin
-  role sees that block.
+  role sees that block. Every parenthetical must be a key in
+  `GuideRolePrivilegeMap` — an unmapped one resolves to no privilege and the
+  block silently reaches nobody it was written for.
+- `Camp Lead` is the one parenthetical that names a **per-camp** role rather
+  than a system role. It maps to the `CampLead` privilege token, which
+  `GuideRoleResolver` sets from `ICampLeadDirectory.IsLeadAnywhereAsync`.
 
 ## Data Model
 
@@ -44,6 +49,7 @@ Unknown stems return 404 (`NotFound.cshtml`). GitHub unavailability on cold cach
 | Anonymous | View Volunteer-scoped blocks only |
 | Any authenticated human | All Anonymous capabilities |
 | Team coordinator (`TeamMember.Role == Coordinator`) | Additionally view Coordinator-scoped blocks |
+| Camp lead (`ICampLeadDirectory.IsLeadAnywhereAsync`) | Additionally view Coordinator-scoped blocks whose parenthetical names `Camp Lead` |
 | Domain admin (system role named in a block's parenthetical) | Additionally view blocks whose parenthetical names their role |
 | Board, Admin | View all blocks on all pages (including all Coordinator blocks via within-file superset rule) |
 | Admin | All Board capabilities. Additionally trigger `POST /Guide/Refresh` |
@@ -63,6 +69,7 @@ Unknown stems return 404 (`NotFound.cshtml`). GitHub unavailability on cold cach
 - Non-Admin users **cannot** trigger `POST /Guide/Refresh`.
 - Anonymous users **cannot** see Coordinator-scoped or Board/Admin-scoped blocks.
 - A domain admin **cannot** see blocks for parentheticals that do not name their role.
+- A camp lead **cannot** see Coordinator blocks that do not name `Camp Lead` — leading a camp is not a general coordinator grant.
 - No user **can** author or edit guide content in-app; GitHub PR is the only authoring path.
 
 ## Triggers
@@ -75,6 +82,7 @@ Unknown stems return 404 (`NotFound.cshtml`). GitHub unavailability on cold cach
 ## Cross-Section Dependencies
 
 - **Teams**: `GuideRoleResolver` calls `ITeamServiceRead.GetTeamsAsync` and determines `IsTeamCoordinator` from the cached `TeamInfo` snapshot (any team where the user holds `TeamMemberRole.Coordinator`) — no direct `TeamMembers` read.
+- **Camps**: `GuideRoleResolver` calls `ICampLeadDirectory.IsLeadAnywhereAsync` for `IsCampLead` — camp lead is a role on a camp season, never a claim, so it cannot come from `IsInRole`. Visibility is "leads *some* camp", the same collapse Teams already makes for coordinators; the guide has no per-camp scope. Not `ICampServiceRead.GetCampUserInfoAsync`: that resolves the first camp where the user is an Active *member* and would miss a lead of a second camp.
 - **Auth/Roles**: `GuideRoleResolver` reads `ClaimsPrincipal.IsInRole` against `RoleNames` constants to build `SystemRoles` set.
 - **Base (inward)**: `IGuideContentSource` / `GitHubGuideContentSource` / `GuideSettings` stay in `Humans.Base`. Despite the name they are not Guide's: the interface is a GitHub-markdown fetcher whose signatures name only `string`, and its consumers are elsewhere — the Agent section's `AgentSectionDocReader` / `AgentFeatureSpecReader` / `CommunityFaqReader` / `AgentDocsHealthCheck`, and Base's `GitHubCommunityKbContentSource`. Shell registers both, and the section consumes the interface inward.
 

--- a/src/Sections/Humans.Guide/Humans.Guide.csproj
+++ b/src/Sections/Humans.Guide/Humans.Guide.csproj
@@ -31,6 +31,7 @@
     -->
     <ProjectReference Include="..\..\Humans.Base\Humans.Base.csproj" />
     <ProjectReference Include="..\Humans.Teams.Contracts\Humans.Teams.Contracts.csproj" />
+    <ProjectReference Include="..\Humans.Camps.Contracts\Humans.Camps.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sections/Humans.Guide/Services/GuideFilter.cs
+++ b/src/Sections/Humans.Guide/Services/GuideFilter.cs
@@ -70,6 +70,9 @@ internal static class GuideFilter
     {
         if (ctx.IsTeamCoordinator) return true;
         if (ctx.SystemRoles.Contains(RoleNames.Board) || ctx.SystemRoles.Contains(RoleNames.Admin)) return true;
+        // Camp lead is not a claim, so it is gated on the parenthetical rather than opening
+        // every Coordinator block the way IsTeamCoordinator does.
+        if (ctx.IsCampLead && paren.Contains(GuideRolePrivilegeMap.CampLead, StringComparer.Ordinal)) return true;
         foreach (var role in paren)
         {
             if (ctx.SystemRoles.Contains(role)) return true;

--- a/src/Sections/Humans.Guide/Services/GuideMarkdownPreprocessor.cs
+++ b/src/Sections/Humans.Guide/Services/GuideMarkdownPreprocessor.cs
@@ -10,7 +10,9 @@ namespace Humans.Guide.Services;
 /// </summary>
 internal sealed class GuideMarkdownPreprocessor
 {
-    private static readonly Regex RoleHeading = new(
+    // Internal so the guard test can hold guide content to the exact heading grammar the
+    // renderer uses, rather than a second copy that can drift from it.
+    internal static readonly Regex RoleHeading = new(
         @"^##\s+As\s+an?\s+(?:\[)?(?<head>Volunteer|Coordinator|Board)[^\n]*?(?:\((?<paren>[^)]+)\))?\s*$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled,
         TimeSpan.FromMilliseconds(250));

--- a/src/Sections/Humans.Guide/Services/GuideRoleContext.cs
+++ b/src/Sections/Humans.Guide/Services/GuideRoleContext.cs
@@ -3,8 +3,9 @@ namespace Humans.Guide.Services;
 internal sealed record GuideRoleContext(
     bool IsAuthenticated,
     bool IsTeamCoordinator,
+    bool IsCampLead,
     IReadOnlySet<string> SystemRoles)
 {
     public static readonly GuideRoleContext Anonymous =
-        new(false, false, new HashSet<string>(StringComparer.Ordinal));
+        new(false, false, false, new HashSet<string>(StringComparer.Ordinal));
 }

--- a/src/Sections/Humans.Guide/Services/GuideRolePrivilegeMap.cs
+++ b/src/Sections/Humans.Guide/Services/GuideRolePrivilegeMap.cs
@@ -5,10 +5,17 @@ namespace Humans.Guide.Services;
 
 /// <summary>
 /// Maps display names that appear in guide-heading parentheticals (e.g. "Camp Admin",
-/// "Consent Coordinator") to the system role constants defined in <see cref="RoleNames"/>.
+/// "Consent Coordinator") to the privilege token the filter matches — a system role
+/// constant from <see cref="RoleNames"/> for every entry but <see cref="CampLead"/>.
 /// </summary>
 internal static class GuideRolePrivilegeMap
 {
+    /// <summary>
+    /// Privilege token for the per-camp lead relationship — a role on a camp season, never a
+    /// claim. <c>GuideRoleResolver</c> sets it from <c>ICampLeadDirectory</c>.
+    /// </summary>
+    public const string CampLead = "CampLead";
+
     private static readonly IReadOnlyDictionary<string, string> DisplayToRole =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -25,16 +32,20 @@ internal static class GuideRolePrivilegeMap
             ["Events Admin"] = RoleNames.EventsAdmin,
             ["Store Admin"] = RoleNames.StoreAdmin,
             ["Consent Coordinator"] = RoleNames.ConsentCoordinator,
-            ["Volunteer Coordinator"] = RoleNames.VolunteerCoordinator
+            ["Volunteer Coordinator"] = RoleNames.VolunteerCoordinator,
+            ["Camp Lead"] = CampLead
         };
 
     /// <summary>
     /// Every system role a parenthetical can name. <see cref="GuideRoleResolver"/> probes
     /// exactly these against the user's claims; deriving the set here is what keeps the two
-    /// from drifting apart.
+    /// from drifting apart. <see cref="CampLead"/> is excluded — no claim carries it.
     /// </summary>
     public static readonly IReadOnlyList<string> MappedRoles =
-        DisplayToRole.Values.Distinct(StringComparer.Ordinal).ToList();
+        DisplayToRole.Values
+            .Where(v => !string.Equals(v, CampLead, StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
 
     public static bool TryResolve(string displayName, [NotNullWhen(true)] out string? systemRole)
     {
@@ -49,7 +60,7 @@ internal static class GuideRolePrivilegeMap
 
     /// <summary>
     /// Parses a guide-heading parenthetical like "Camp Admin, Finance Admin" into the
-    /// matching system-role constants. Unknown tokens are skipped (not thrown).
+    /// matching privilege tokens. Unknown tokens are skipped (not thrown).
     /// </summary>
     public static IReadOnlyList<string> ParseParenthetical(string? paren)
     {

--- a/src/Sections/Humans.Guide/Services/GuideRoleResolver.cs
+++ b/src/Sections/Humans.Guide/Services/GuideRoleResolver.cs
@@ -1,9 +1,12 @@
 using System.Security.Claims;
+using Humans.Camps.Contracts;
 using Humans.Teams.Contracts;
 
 namespace Humans.Guide.Services;
 
-internal sealed class GuideRoleResolver(ITeamServiceRead teamService) : IGuideRoleResolver
+internal sealed class GuideRoleResolver(
+    ITeamServiceRead teamService,
+    ICampLeadDirectory campLeadDirectory) : IGuideRoleResolver
 {
     public async Task<GuideRoleContext> ResolveAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default)
     {
@@ -25,8 +28,14 @@ internal sealed class GuideRoleResolver(ITeamServiceRead teamService) : IGuideRo
 
         var userIdClaim = user.FindFirstValue(ClaimTypes.NameIdentifier);
         var isCoordinator = false;
+        var isCampLead = false;
         if (Guid.TryParse(userIdClaim, out var userId))
         {
+            // Camp lead is a per-camp role, not a claim: the guide's unit of visibility is
+            // "leads some camp this year", the same way IsTeamCoordinator is "coordinates
+            // some team".
+            isCampLead = await campLeadDirectory.IsLeadAnywhereAsync(userId, cancellationToken);
+
             // Answered from the cached TeamInfo snapshot: TeamInfo.Members only
             // contains active (LeftAt is null) memberships, so we just look for
             // any team where the user holds the Coordinator role. Mirrors the
@@ -39,6 +48,7 @@ internal sealed class GuideRoleResolver(ITeamServiceRead teamService) : IGuideRo
         return new GuideRoleContext(
             IsAuthenticated: true,
             IsTeamCoordinator: isCoordinator,
+            IsCampLead: isCampLead,
             SystemRoles: systemRoles);
     }
 }

--- a/tests/Humans.Guide.Tests/GuideArchitectureTests.cs
+++ b/tests/Humans.Guide.Tests/GuideArchitectureTests.cs
@@ -81,6 +81,48 @@ public class GuideArchitectureTests
         GuideFiles.All.Should().BeEquivalentTo(onDisk);
     }
 
+    [HumansFact]
+    public void EveryRoleHeadingParentheticalResolvesToAPrivilege()
+    {
+        // An unmapped parenthetical is silent: the block renders with data-guide-roles=""
+        // and reaches nobody it was written for. "(Camp Coordinator)" sat like that on
+        // Camps.md (nobodies-collective/Humans#1035) until someone read the map.
+        var unmapped = new List<string>();
+
+        foreach (var file in Directory.GetFiles(Path.Combine(LocateRepoRoot(), "docs", "guide"), "*.md"))
+        {
+            foreach (var raw in File.ReadLines(file))
+            {
+                var line = raw.TrimEnd('\r');
+                var match = GuideMarkdownPreprocessor.RoleHeading.Match(line);
+                if (!match.Success || !match.Groups["paren"].Success)
+                {
+                    continue;
+                }
+
+                // "## As a [Coordinator](Glossary.md#coordinator)" — the only parens are a
+                // markdown link destination, so the heading carries no role scope.
+                var open = match.Groups["paren"].Index - 1;
+                if (open >= 1 && line[open - 1] == ']')
+                {
+                    continue;
+                }
+
+                foreach (var token in match.Groups["paren"].Value
+                    .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (!GuideRolePrivilegeMap.TryResolve(token, out _))
+                    {
+                        unmapped.Add($"{Path.GetFileName(file)}: ({token})");
+                    }
+                }
+            }
+        }
+
+        unmapped.Should().BeEmpty(
+            because: "every guide heading parenthetical must name a key in GuideRolePrivilegeMap");
+    }
+
     private static string LocateRepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/Humans.Guide.Tests/Services/GuideFilterTests.cs
+++ b/tests/Humans.Guide.Tests/Services/GuideFilterTests.cs
@@ -24,9 +24,24 @@ public class GuideFilterTests
         <p>Always visible.</p>
         """;
 
+    private const string CampsLike = """
+        <div data-guide-role="coordinator" data-guide-roles="CampLead">
+          <h2>As a Coordinator (Camp Lead)</h2>
+          <p>Camp lead content.</p>
+        </div>
+        <div data-guide-role="boardadmin" data-guide-roles="CampAdmin">
+          <h2>As a Board member / Admin (Camp Admin)</h2>
+          <p>Camp admin content.</p>
+        </div>
+        """;
+
     private static GuideRoleContext Roles(bool isCoord, params string[] systemRoles) =>
-        new(IsAuthenticated: true, IsTeamCoordinator: isCoord,
+        new(IsAuthenticated: true, IsTeamCoordinator: isCoord, IsCampLead: false,
             SystemRoles: new HashSet<string>(systemRoles, StringComparer.Ordinal));
+
+    private static GuideRoleContext CampLeadOnly() =>
+        new(IsAuthenticated: true, IsTeamCoordinator: false, IsCampLead: true,
+            SystemRoles: new HashSet<string>(StringComparer.Ordinal));
 
     [HumansFact]
     public void Apply_Anonymous_KeepsOnlyVolunteerBlock()
@@ -149,6 +164,36 @@ public class GuideFilterTests
         var result = GuideFilter.Apply(coordOnly, Roles(isCoord: false, RoleNames.Admin));
 
         result.Should().Contain("Coord-only content.");
+    }
+
+    [HumansFact]
+    public void Apply_CampLead_SeesCampLeadBlock()
+    {
+        // nobodies-collective/Humans#1035: the Camps Coordinator block is written for camp
+        // leads, who hold no system role — before the CampLead token it reached only Board/Admin.
+        var result = GuideFilter.Apply(CampsLike, CampLeadOnly());
+
+        result.Should().Contain("Camp lead content.");
+        result.Should().NotContain("Camp admin content.");
+    }
+
+    [HumansFact]
+    public void Apply_CampLead_DoesNotSeeUnrelatedCoordinatorBlocks()
+    {
+        // Leading a camp is not a general coordinator grant: only blocks whose parenthetical
+        // names Camp Lead open up.
+        var result = GuideFilter.Apply(Sample, CampLeadOnly());
+
+        result.Should().Contain("Volunteer content.");
+        result.Should().NotContain("Coord content.");
+    }
+
+    [HumansFact]
+    public void Apply_NotACampLead_DoesNotSeeCampLeadBlock()
+    {
+        var result = GuideFilter.Apply(CampsLike, Roles(isCoord: false));
+
+        result.Should().NotContain("Camp lead content.");
     }
 
     [HumansFact]

--- a/tests/Humans.Guide.Tests/Services/GuideMarkdownPreprocessorTests.cs
+++ b/tests/Humans.Guide.Tests/Services/GuideMarkdownPreprocessorTests.cs
@@ -187,9 +187,10 @@ public class GuideMarkdownPreprocessorTests
     {
         // Regression: the heading has a markdown link whose URL is parenthesised,
         // and a trailing role parenthetical. The preprocessor must not mangle
-        // either — the link's URL must survive so Markdig can render it.
+        // either — the link's URL must survive so Markdig can render it, and the
+        // captured parenthetical must be the trailing role, never the link target.
         const string input = """
-            ## As a [Coordinator](Glossary.md#coordinator) (Camp Coordinator)
+            ## As a [Coordinator](Glossary.md#coordinator) (Camp Lead)
 
             Content.
             """;
@@ -197,7 +198,22 @@ public class GuideMarkdownPreprocessorTests
         var result = Preprocessor.Wrap(input);
 
         result.Should().Contain("[Coordinator](Glossary.md#coordinator)");
-        result.Should().Contain("(Camp Coordinator)");
+        result.Should().Contain("(Camp Lead)");
+        result.Should().Contain($"data-guide-roles=\"{GuideRolePrivilegeMap.CampLead}\"");
+    }
+
+    [HumansFact]
+    public void Wrap_ShippedCampsLeadHeading_CarriesTheCampLeadToken()
+    {
+        // End-to-end on the real file: nobodies-collective/Humans#1035 was invisible
+        // precisely because this heading rendered data-guide-roles="".
+        var markdown = File.ReadAllText(
+            Path.Combine(LocateRepoRoot(), "docs", "guide", "Camps.md"));
+
+        var result = Preprocessor.Wrap(markdown);
+
+        result.Should().Contain(
+            $"<div data-guide-role=\"coordinator\" data-guide-roles=\"{GuideRolePrivilegeMap.CampLead}\">");
     }
 
     [HumansFact]

--- a/tests/Humans.Guide.Tests/Services/GuideRolePrivilegeMapTests.cs
+++ b/tests/Humans.Guide.Tests/Services/GuideRolePrivilegeMapTests.cs
@@ -20,6 +20,7 @@ public class GuideRolePrivilegeMapTests
     [InlineData("Ticket Admin", RoleNames.TicketAdmin)]
     [InlineData("Consent Coordinator", RoleNames.ConsentCoordinator)]
     [InlineData("Volunteer Coordinator", RoleNames.VolunteerCoordinator)]
+    [InlineData("Camp Lead", GuideRolePrivilegeMap.CampLead)]
     public void TryResolve_KnownDisplayName_ReturnsSystemRole(string displayName, string expectedRole)
     {
         GuideRolePrivilegeMap.TryResolve(displayName, out var role).Should().BeTrue();
@@ -30,11 +31,19 @@ public class GuideRolePrivilegeMapTests
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("Unknown")]
-    [InlineData("Camp Coordinator")] // A team-coordinator, not a system role
+    [InlineData("Camp Coordinator")] // Not a thing: the domain term is Camp Lead
     public void TryResolve_UnknownOrEmpty_ReturnsFalse(string input)
     {
         GuideRolePrivilegeMap.TryResolve(input, out var role).Should().BeFalse();
         role.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void MappedRoles_ExcludesCampLead()
+    {
+        // MappedRoles is the resolver's IsInRole probe list. Camp lead is a per-camp role,
+        // never a claim, so probing it would be dead work and imply a system role exists.
+        GuideRolePrivilegeMap.MappedRoles.Should().NotContain(GuideRolePrivilegeMap.CampLead);
     }
 
     [HumansFact]

--- a/tests/Humans.Guide.Tests/Services/GuideRoleResolverTests.cs
+++ b/tests/Humans.Guide.Tests/Services/GuideRoleResolverTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using AwesomeAssertions;
+using Humans.Camps.Contracts;
 using Humans.Teams.Contracts;
 using Humans.Base.Constants;
 using Humans.Base.Enums;
@@ -15,13 +16,17 @@ public class GuideRoleResolverTests
 {
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 4, 21, 12, 0));
     private readonly ITeamServiceRead _teamService = Substitute.For<ITeamServiceRead>();
+    private readonly ICampLeadDirectory _campLeads = Substitute.For<ICampLeadDirectory>();
 
     public GuideRoleResolverTests()
     {
-        // Default: empty team cache.
+        // Default: empty team cache, leads no camp.
         _teamService
             .GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, TeamInfo>());
+        _campLeads
+            .IsLeadAnywhereAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(false);
     }
 
     private ClaimsPrincipal PrincipalWithRoles(Guid? userId, params string[] roles)
@@ -39,7 +44,7 @@ public class GuideRoleResolverTests
         return new ClaimsPrincipal(identity);
     }
 
-    private GuideRoleResolver CreateResolver() => new(_teamService);
+    private GuideRoleResolver CreateResolver() => new(_teamService, _campLeads);
 
     private TeamInfo BuildTeam(Guid teamId, params TeamMemberInfo[] members) => new(
         Id: teamId,
@@ -82,7 +87,32 @@ public class GuideRoleResolverTests
 
         result.IsAuthenticated.Should().BeFalse();
         result.IsTeamCoordinator.Should().BeFalse();
+        result.IsCampLead.Should().BeFalse();
         result.SystemRoles.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task Resolve_ActiveCampLead_IsCampLeadTrue()
+    {
+        var userId = Guid.NewGuid();
+        _campLeads.IsLeadAnywhereAsync(userId, Arg.Any<CancellationToken>()).Returns(true);
+
+        var resolver = CreateResolver();
+
+        var result = await resolver.ResolveAsync(PrincipalWithRoles(userId), TestContext.Current.CancellationToken);
+
+        result.IsCampLead.Should().BeTrue();
+        result.IsTeamCoordinator.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task Resolve_NotACampLead_IsCampLeadFalse()
+    {
+        var resolver = CreateResolver();
+
+        var result = await resolver.ResolveAsync(PrincipalWithRoles(Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        result.IsCampLead.Should().BeFalse();
     }
 
     [HumansFact]


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1035

The Camps guide block written for camp leads (`## As a [Coordinator](Glossary.md#coordinator) (Camp Coordinator)`, body opening "If you are a **Camp Lead**, you can manage your specific camp") named a parenthetical that is not a key in `GuideRolePrivilegeMap`. Unmapped parentheticals render `data-guide-roles=""`, so the block reached only Board/Admin via the within-file superset rule — never a camp lead.

## Choice: (a), with the correct name

Option (b) was not available: no existing key covers camp leads. The map holds nothing but `RoleNames` constants, and **camp lead is not a system role** — it is a role held on a camp's season.

- Real camp-lead primitive: `CampSpecialRole.Lead` (`src/Sections/Humans.Camps.Contracts/CampSpecialRole.cs:22`), surfaced cross-section as `ICampLeadDirectory.IsLeadAnywhereAsync` (`src/Sections/Humans.Camps.Contracts/ICampLeadDirectory.cs:18`) — "whether the user is an active lead of any camp in the public year's season".
- The parallel Peter named: team coordinator is `TeamMemberRole.Coordinator`, collapsed by `GuideRoleResolver` into `GuideRoleContext.IsTeamCoordinator` from the cached `TeamInfo` snapshot (`src/Sections/Humans.Guide/Services/GuideRoleResolver.cs:32`).

So the key was added, but keyed on the **domain term** — `Camp Lead`, per `docs/guide/Glossary.md:35` — not the invented "Camp Coordinator", and mapped to a `CampLead` privilege token rather than a role constant. The heading in `docs/guide/Camps.md` was renamed to `(Camp Lead)` to match. No existing key was displaced and no synonym alias was added; the new guard test (below) catches any future heading that reaches for the old wording.

Mechanically: `GuideMarkdownPreprocessor` extracts the trailing parenthetical, `GuideRolePrivilegeMap.ParseParenthetical` maps each comma-token to a privilege token and drops unknown ones, the tokens land in `data-guide-roles`, and `GuideFilter` matches them against the request's `GuideRoleContext`. `CampLead` is excluded from `MappedRoles` (the resolver's `IsInRole` probe list) because no claim carries it — the resolver sets `IsCampLead` from `ICampLeadDirectory` instead, and `GuideFilter.IsCoordinatorVisible` matches the token against that flag.

Camp-lead visibility is gated on the parenthetical rather than opening every Coordinator block the way `IsTeamCoordinator` does: leading a camp is not a general coordinator grant.

## Scoping mismatch

Real. Camp lead is inherently **per-camp** — you lead camp X — but the guide's visibility model has no per-page, let alone per-entity, scope: a block is visible or it is not. The semantics shipped are **"leads any camp in the public year's season"**.

`ICampLeadDirectory.IsLeadAnywhereAsync` is the right primitive rather than the cache-served `ICampServiceRead.GetCampUserInfoAsync`: the latter resolves the *first* camp where the user is an Active member and returns that camp's roles, so a lead of a second camp reads as not-a-lead. The lead query is one indexed `AnyAsync` per authenticated guide render — fine at this scale.

That is the same collapse the guide already makes for teams (`IsTeamCoordinator` is "coordinates *some* team"), and it is harmless here: the block's content is generic how-to for managing your own camp, and every action it describes is separately authorized per camp at the controller. No per-camp scoping was invented in the guide renderer.

## Parenthetical audit

All 46 `## As a …` headings across `docs/guide/` were enumerated; 19 carry a parenthetical. Distinct tokens and their status:

| Token | Status |
|---|---|
| Camp Admin, Teams Admin, Ticket Admin, NoInfo Admin, Human Admin, Finance Admin, Events Admin, Store Admin, Consent Coordinator | mapped |
| Camp Coordinator (`Camps.md`) | **the only unmapped one** — fixed here as `Camp Lead` |

Six further headings match the parenthetical capture only because their markdown link destination is the last parenthesized group (`## As a [Volunteer](Glossary.md#volunteer)` and friends, in `Camps.md`, `Email.md`, `GoogleIntegration.md` ×2, `LegalAndConsent.md`, `Onboarding.md`). Those are link targets, not role scopes; they resolve to nothing, which is the correct outcome for a bare `As a Volunteer` / `As a Coordinator` block. The guard test skips them by detecting the preceding `]`.

## Guard against the class

`GuideArchitectureTests.EveryRoleHeadingParentheticalResolvesToAPrivilege` reads every `docs/guide/*.md` heading through `GuideMarkdownPreprocessor.RoleHeading` — the renderer's own regex, made `internal` so the guard cannot drift from the grammar it checks — and fails on any parenthetical token with no key in the map. Verified: restoring `(Camp Coordinator)` fails it; the shipped tree passes.

## Needs Peter's judgement

- The "leads any camp" semantics above, if you wanted the block scoped tighter. Nothing else in the guide content is ambiguous.
- Unrelated observation, not touched here: `ICampLeadDirectory.IsLeadAnywhereAsync` is documented as "active lead of any camp **in the public year's season**", but `CampRepository.IsLeadAnywhereAsync` (`src/Sections/Humans.Camps/Data/CampRepository.cs:337`) filters on role definition only, with no year predicate. Either the doc or the query is wrong; it is Camps' call, and it predates this PR.

## Deployment note

Guide content is fetched at runtime from `nobodies-collective/Humans@main`, so the `docs/guide/Camps.md` rename only takes effect once this reaches production `main`. Between the fork merge and the promotion the block behaves exactly as it does today (Board/Admin only) — no regression, just a delayed fix.

## Changes

- `GuideRolePrivilegeMap` — `CampLead` token + `Camp Lead` key; excluded from `MappedRoles`
- `GuideRoleContext` — `IsCampLead`
- `GuideRoleResolver` — injects `ICampLeadDirectory`
- `GuideFilter` — `Camp Lead` parenthetical opens the block for camp leads
- `GuideMarkdownPreprocessor` — heading regex `internal` for the guard test
- `Humans.Guide.csproj` — `Humans.Camps.Contracts` reference (peer of the existing `Humans.Teams.Contracts`)
- `docs/guide/Camps.md` — `(Camp Coordinator)` → `(Camp Lead)`
- `Docs/Guide.md` — actor row, invariant, Camps cross-section dependency, parenthetical concept
- Tests — map (2), filter (3), resolver (2), preprocessor (1 new + 1 strengthened), guard (1)

Two of these run against the shipped `docs/guide/Camps.md`, so they fail if the heading regresses: `Wrap_ShippedCampsLeadHeading_CarriesTheCampLeadToken` (proves the regex captures the trailing role parenthetical, not the `](Glossary.md#coordinator)` link target) and the guard test. Both verified failing with `(Camp Coordinator)` restored, passing as shipped.

No new public type, endpoint or DI registration: `ICampLeadDirectory` is an existing contract already registered by `Humans.Camps`.
