### PR TITLE
feat(surveys): add Grid question type

### DIFF
--- a/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
@@ -60,6 +60,10 @@ internal sealed class SurveyController(
                 resumeState.Answers[a.QuestionId.ToString()] = new SurveyWizardAnswer
                 {
                     SelectedOptionValues = a.SelectedOptionValues.ToList(),
+                    GridSelections = a.GridSelections?.ToDictionary(
+                        kv => kv.Key,
+                        kv => kv.Value.ToList(),
+                        StringComparer.Ordinal) ?? new(StringComparer.Ordinal),
                     TextValue = a.TextValue,
                     RatingValue = a.RatingValue,
                 };
@@ -332,7 +336,19 @@ internal sealed class SurveyController(
     {
         var posted = (model.Answers ?? [])
             .Select(a => new SurveyAnswerInput(
-                a.QuestionId, a.SelectedOptionValues ?? [], a.TextValue, a.RatingValue))
+                a.QuestionId,
+                a.SelectedOptionValues ?? [],
+                a.TextValue,
+                a.RatingValue,
+                (a.GridRows ?? [])
+                    .Where(row => !string.IsNullOrWhiteSpace(row.RowValue))
+                    .GroupBy(row => row.RowValue, StringComparer.Ordinal)
+                    .ToDictionary(
+                        group => group.Key,
+                        group => (IReadOnlyList<string>)group
+                            .SelectMany(row => row.SelectedColumnValues ?? [])
+                            .ToList(),
+                        StringComparer.Ordinal)))
             .ToList();
 
         var result = await surveyService.AdvanceWizardAsync(state, model.Page, model.Back, posted, ct);
@@ -455,7 +471,18 @@ internal sealed class SurveyController(
             Options = q.Options
                 .Select(o => new SurveyPageOption(o.Value, o.Label.Resolve(state.Culture, editable.DefaultCulture)))
                 .ToList(),
+            GridSelectionMode = q.GridSelectionMode,
+            GridRows = (q.GridRows ?? [])
+                .Select(row => new SurveyPageGridRow(
+                    row.Value,
+                    row.Label.Resolve(state.Culture, editable.DefaultCulture)))
+                .ToList(),
             SelectedOptionValues = prior?.SelectedOptionValues ?? [],
+            GridSelections = prior?.GridSelections.ToDictionary(
+                kv => kv.Key,
+                kv => (IReadOnlyList<string>)kv.Value,
+                StringComparer.Ordinal)
+                ?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal),
             TextValue = prior?.TextValue,
             RatingValue = prior?.RatingValue,
         };

--- a/src/Sections/Humans.Surveys/Controllers/SurveysApiController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveysApiController.cs
@@ -76,6 +76,9 @@ internal sealed class SurveysApiController(ISurveyService surveyService, IUserSe
                     ratingMin = q.RatingMin,
                     ratingMax = q.RatingMax,
                     showIf = q.ShowIf,   // structural BranchCondition; option values are the join keys
+                    gridSelectionMode = q.GridSelectionMode?.ToString(),
+                    gridRows = (q.GridRows ?? [])
+                        .Select(row => new { value = row.Value, label = row.Label.Resolve(culture, culture) }),
                     options = q.Options
                         .OrderBy(o => o.Order)
                         .Select(o => new { value = o.Value, label = o.Label.Resolve(culture, culture) }),
@@ -162,6 +165,25 @@ internal sealed class SurveysApiController(ISurveyService surveyService, IUserSe
                 prompt = q.Prompt,
                 type = q.Type.ToString(),
                 optionCounts = q.OptionCounts.Select(o => new { value = o.Value, label = o.Label, count = o.Count, percent = o.Percent }),
+                grid = q.Grid is null
+                    ? null
+                    : new
+                    {
+                        mode = q.Grid.Mode.ToString(),
+                        columns = q.Grid.Columns.Select(column => new { value = column.Value, label = column.Label }),
+                        rows = q.Grid.Rows.Select(row => new
+                        {
+                            value = row.Value,
+                            label = row.Label,
+                            cells = row.Cells.Select(cell => new
+                            {
+                                columnValue = cell.ColumnValue,
+                                columnLabel = cell.ColumnLabel,
+                                count = cell.Count,
+                                percent = cell.Percent,
+                            }),
+                        }),
+                    },
                 ratingDistribution = q.RatingDistribution.Select(b => new { value = b.Value, count = b.Count }),
                 ratingAverage = q.RatingAverage,
                 freeTextAnswers = q.FreeTextAnswers,
@@ -191,6 +213,14 @@ internal sealed class SurveysApiController(ISurveyService surveyService, IUserSe
                         questionId = q.QuestionId,
                         selectedValues = a.SelectedValues,
                         selectedLabels = a.SelectedLabels,
+                        gridSelections = a.GridSelections,
+                        gridSelectionLabels = a.GridSelectionLabels?.Select(selection => new
+                        {
+                            rowValue = selection.RowValue,
+                            rowLabel = selection.RowLabel,
+                            columnValues = selection.ColumnValues,
+                            columnLabels = selection.ColumnLabels,
+                        }),
                         textValue = a.TextValue,
                         ratingValue = a.RatingValue,
                     };

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyAnswerConfiguration.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyAnswerConfiguration.cs
@@ -23,6 +23,16 @@ internal sealed class SurveyAnswerConfiguration : IEntityTypeConfiguration<Surve
                     v => v.Aggregate(0, HashCode.Combine),
                     v => v.ToList()));
 
+        b.Property(a => a.GridSelections).HasColumnType("jsonb")
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, SurveyJson.Options),
+                v => JsonSerializer.Deserialize<Dictionary<string, List<string>>>(v, SurveyJson.Options),
+                new ValueComparer<Dictionary<string, List<string>>?>(
+                    (a, c) => JsonSerializer.Serialize(a, SurveyJson.Options) == JsonSerializer.Serialize(c, SurveyJson.Options),
+                    v => v == null ? 0 : string.GetHashCode(JsonSerializer.Serialize(v, SurveyJson.Options), StringComparison.Ordinal),
+                    v => v == null ? null : JsonSerializer.Deserialize<Dictionary<string, List<string>>>(
+                        JsonSerializer.Serialize(v, SurveyJson.Options), SurveyJson.Options)));
+
         b.Property(a => a.TextValue).HasMaxLength(4000);
 
         // Intra-section FK to the question; Restrict so a question can't be deleted out from under answers.

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyJson.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyJson.cs
@@ -16,6 +16,8 @@ internal static class SurveyJson
 {
     public static readonly JsonSerializerOptions Options = new();
 
+    private sealed record GridRowDocument(string Value, Dictionary<string, string> Label);
+
     /// <summary>Maps a <see cref="LocalizedText"/> property to a jsonb column (culture→text dictionary).</summary>
     public static void LocalizedText<TEntity>(
         EntityTypeBuilder<TEntity> b,
@@ -31,4 +33,27 @@ internal static class SurveyJson
                     (a, c) => a == null ? c == null : a.Equals(c),
                     v => v.GetHashCode(),
                     v => v));
+
+    /// <summary>
+    /// Serializes Grid rows through a persistence-only shape because <see cref="LocalizedText"/>
+    /// deliberately exposes a read-only dictionary and is not directly deserializable by
+    /// <see cref="JsonSerializer"/>.
+    /// </summary>
+    public static string? SerializeGridRows(List<SurveyGridRow>? rows)
+        => rows is null
+            ? null
+            : JsonSerializer.Serialize(
+                rows.Select(row => new GridRowDocument(
+                    row.Value,
+                    new Dictionary<string, string>(row.Label.Values, StringComparer.OrdinalIgnoreCase))),
+                Options);
+
+    public static List<SurveyGridRow>? DeserializeGridRows(string? value)
+        => value is null
+            ? null
+            : JsonSerializer.Deserialize<List<GridRowDocument>>(value, Options)?
+                .Select(row => new SurveyGridRow(
+                    row.Value,
+                    new LocalizedText(row.Label)))
+                .ToList();
 }

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyQuestionConfiguration.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyQuestionConfiguration.cs
@@ -19,6 +19,17 @@ internal sealed class SurveyQuestionConfiguration : IEntityTypeConfiguration<Sur
         SurveyJson.LocalizedText(b, q => q.RatingMaxLabel);
 
         b.Property(q => q.Type).HasConversion<string>().HasMaxLength(20);
+        b.Property(q => q.GridSelectionMode).HasConversion<string>().HasMaxLength(20);
+
+        b.Property(q => q.GridRows)
+            .HasColumnType("jsonb")
+            .HasConversion(
+                v => SurveyJson.SerializeGridRows(v),
+                v => SurveyJson.DeserializeGridRows(v),
+                new ValueComparer<List<SurveyGridRow>?>(
+                    (a, c) => SurveyJson.SerializeGridRows(a) == SurveyJson.SerializeGridRows(c),
+                    v => v == null ? 0 : string.GetHashCode(SurveyJson.SerializeGridRows(v)!, StringComparison.Ordinal),
+                    v => SurveyJson.DeserializeGridRows(SurveyJson.SerializeGridRows(v))));
 
         b.Property(q => q.ShowIf)
             .HasColumnType("jsonb")

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260820085355_AddSurveyGridQuestions.Designer.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260820085355_AddSurveyGridQuestions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Surveys.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Surveys.Data.Migrations
 {
     [DbContext(typeof(SurveysDbContext))]
-    partial class SurveysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820085355_AddSurveyGridQuestions")]
+    partial class AddSurveyGridQuestions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260820085355_AddSurveyGridQuestions.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260820085355_AddSurveyGridQuestions.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Surveys.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSurveyGridQuestions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GridRows",
+                table: "survey_questions",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GridSelectionMode",
+                table: "survey_questions",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GridSelections",
+                table: "survey_answers",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GridRows",
+                table: "survey_questions");
+
+            migrationBuilder.DropColumn(
+                name: "GridSelectionMode",
+                table: "survey_questions");
+
+            migrationBuilder.DropColumn(
+                name: "GridSelections",
+                table: "survey_answers");
+        }
+    }
+}

--- a/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
+++ b/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
@@ -324,6 +324,8 @@ internal sealed partial class SurveyRepository(IDbContextFactory<SurveysDbContex
             keptQuestion.RatingMax = incomingQuestion.RatingMax;
             keptQuestion.RatingMinLabel = incomingQuestion.RatingMinLabel;
             keptQuestion.RatingMaxLabel = incomingQuestion.RatingMaxLabel;
+            keptQuestion.GridSelectionMode = incomingQuestion.GridSelectionMode;
+            keptQuestion.GridRows = incomingQuestion.GridRows;
             keptQuestion.ShowIf = incomingQuestion.ShowIf;
 
             ReconcileOptions(ctx, keptQuestion, incomingQuestion);

--- a/src/Sections/Humans.Surveys/Docs/Surveys.md
+++ b/src/Sections/Humans.Surveys/Docs/Surveys.md
@@ -12,10 +12,10 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 ## Concepts
 
 - A **Survey** is an authored questionnaire with per-culture title/intro/thank-you (`LocalizedText`), a default culture, a status lifecycle (Draft → Open → Closed), an optional open/close window, an audience, and an optional public slug. It owns an ordered graph of questions.
-- A **SurveyQuestion** is one prompt on a page, typed (SingleChoice, MultiChoice, ShortText, LongText, Rating), optionally required, optionally gated by a **`ShowIf` branch condition**. Choice questions own ordered **SurveyQuestionOptions** (stable machine `Value` + `LocalizedText` label).
+- A **SurveyQuestion** is one prompt on a page, typed (SingleChoice, MultiChoice, ShortText, LongText, Rating, Grid), optionally required, optionally gated by a **`ShowIf` branch condition**. Choice questions own ordered **SurveyQuestionOptions** (stable machine `Value` + `LocalizedText` label). Grid questions reuse those options as columns and store localized, stable-keyed rows directly on the question.
 - A **branch condition** (`BranchCondition` + `BranchClause`, jsonb) is skip-logic: a question is visible only when its clauses (combined `All`/`Any`, operators `Is`/`IsNot`/`Answered`/`NotAnswered` over earlier questions' option values) evaluate true. Evaluated by the pure `SurveyBranchingEvaluator`.
 - A **SurveyInvitation** is the per-recipient ledger row for the invited path: one per `(SurveyId, UserId)`. It carries send/reminder funnel state (`SentAt`, `LatestEmailStatus`, `ReminderSentAt`, `Started`, `Completed`) — all flags/timestamps about *participation*, never about *answer content*.
-- A **SurveyResponse** is one submitted (or, for Identified, in-progress) answer set, tagged with its **anonymity tier** and **input method** (UserSpecificLink vs Slug). It owns **SurveyAnswers** (selected option values, free text, or rating).
+- A **SurveyResponse** is one submitted (or, for Identified, in-progress) answer set, tagged with its **anonymity tier** and **input method** (UserSpecificLink vs Slug). It owns **SurveyAnswers** (selected option values, free text, rating, or Grid row-to-column selections).
 - **Anonymity tiers** (`ResponseAnonymity`): **Identified** (linked to the invitee, resumable, the only personal-data tier), **CompletionTracked** (participation counted, answers unlinkable), **Anonymous** (no trace). See Invariants.
 - The **public-slug path** is an anonymous answering route (`/Survey/{slug}`) with no invitation/token; responses are always Anonymous + `InputMethod=Slug`.
 
@@ -58,6 +58,8 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | Prompt / HelpText / RatingMinLabel / RatingMaxLabel | LocalizedText | jsonb |
 | IsRequired | bool | |
 | RatingMin / RatingMax | int? | rating-question range |
+| GridSelectionMode | GridSelectionMode? | string-converted; Single / Multiple for Grid questions |
+| GridRows | List&lt;SurveyGridRow&gt;? | jsonb; ordered stable row `Value` + localized label |
 | ShowIf | BranchCondition? | jsonb skip-logic |
 
 **Index:** `(SurveyId, PageNumber, Order)`.
@@ -71,7 +73,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | Id | Guid | PK |
 | QuestionId | Guid | FK → SurveyQuestion, Cascade |
 | Order | int | |
-| Value | string | max 100; stable machine key (not localised; used as branching/export join key) |
+| Value | string | max 100; stable machine key (not localised; used as branching/export join key, or as a Grid column key) |
 | Label | LocalizedText | jsonb |
 
 ### SurveyInvitation
@@ -121,20 +123,22 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | SelectedOptionValues | List&lt;string&gt; | jsonb; stable option `Value`s |
 | TextValue | string? | max 4000 |
 | RatingValue | int? | |
+| GridSelections | Dictionary&lt;string, List&lt;string&gt;&gt;? | jsonb; stable row key → selected stable column keys |
 
 ### Enums
 
 | Enum | Values |
 |------|--------|
 | SurveyStatus | Draft, Open, Closed |
-| SurveyQuestionType | SingleChoice, MultiChoice, ShortText, LongText, Rating |
+| SurveyQuestionType | SingleChoice, MultiChoice, ShortText, LongText, Rating, Grid |
+| GridSelectionMode | Single, Multiple |
 | ResponseAnonymity | Identified, CompletionTracked, Anonymous |
 | SurveyInputMethod | UserSpecificLink, Slug |
 | SurveyAudienceType | Team, AllActiveMembers, TicketHolders, ShiftParticipants, LoggedInSince |
 | BranchCombine | All, Any |
 | BranchOperator | Is, IsNot, Answered, NotAnswered |
 
-`LocalizedText` (culture → text) and `BranchCondition`/`BranchClause` are section-owned value objects in `src/Sections/Humans.Surveys/Domain/`, all persisted as jsonb.
+`LocalizedText` (culture → text), `SurveyGridRow`, and `BranchCondition`/`BranchClause` are section-owned value objects in `src/Sections/Humans.Surveys/Domain/`; localized text, Grid rows/selections, and branch conditions are persisted as jsonb.
 
 ## Routing
 
@@ -166,6 +170,9 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 - **`Completed` is a boolean with no timestamp** and `survey_invitations` has no `UpdatedAt`: recording *when* a CompletionTracked invitee finished would correlate (user-linked) with the unattributed response's `SubmittedAt` and re-identify them.
 - **Resume is Identified-only.** An in-progress Identified response is a persisted draft (`SubmittedAt is null`), found by `(SurveyId, UserId, SubmittedAt is null)`. CompletionTracked/Anonymous carry no link, are held in session, and **restart** on reopen.
 - **Branching is server-side and authoritative.** A null `ShowIf` is visible; hidden questions are never treated as required; at submit the full branching is re-evaluated and answers to hidden questions are **dropped/rejected** (the client cannot smuggle them). Author-save rejects `ShowIf` forward-references (`SurveyBranchingEvaluator.ValidateNoForwardReferences`).
+- **Grid questions are bounded matrices.** A Grid has at least one localized row, one to five localized columns, and a `Single` or `Multiple` selection mode. Row and column keys are non-blank and unique. A required Grid is complete only when every row has a valid selection; `Single` permits exactly one column per row. Posted selections are normalized against the authored schema before autosave/submission.
+- **Grid questions may be branch targets, never branch sources.** A Grid can carry its own `ShowIf`, but author-save rejects any branch clause that references a Grid question.
+- **Grid result percentages are row-local.** Each cell's percentage uses respondents who answered that row as its denominator. Results retain the current authored matrix. CSV/JSON/Markdown export, the analysis API, and GDPR export retain raw stored row/column keys just as choice exports retain `SelectedOptionValues`, alongside best-effort labels in the survey's default culture; removed definitions fall back to their raw keys instead of hiding historical answers.
 - **Invitation send is idempotent and additive.** Each send resolves the audience, diffs against existing `(SurveyId, UserId)` invitations, and creates+emails only net-new recipients; nobody is double-invited and **sends never revoke**. Requires the survey Open with an audience. Invites are operational (`MessageCategory.System`, always-send) — surveys are never marketing.
 - **Exactly one reminder.** The 7-day reminder fires once per invitee (Open survey, `Completed == false`, `SentAt ≥ 7 days ago`, `ReminderSentAt is null`), stamping `ReminderSentAt` so it never repeats.
 - **Public responses are always Anonymous + `InputMethod=Slug`.** The slug path requires `AllowAnonymous`; reserved slugs `admin`/`answer` are rejected by the builder and 404 on the answer path.

--- a/src/Sections/Humans.Surveys/Docs/features/grid-questions.md
+++ b/src/Sections/Humans.Surveys/Docs/features/grid-questions.md
@@ -1,0 +1,102 @@
+# Grid Survey Questions
+
+## Business context
+
+Survey authors need to ask the same compact question across a series of labelled
+rows, such as date ranges, while offering a small shared set of labelled
+columns. A Grid avoids repeating one question per row and supports both rating-
+like single selections and attendance-like multiple selections.
+
+Requested by Daniel Tenner after discussion with Peter Drier and tracked in
+`nobodies-collective/Humans#1093`.
+
+## User stories and acceptance criteria
+
+### Author a Grid
+
+As a Board/Admin survey author, I can add a **Grid** question with:
+
+- the existing localized prompt and help text;
+- ordered localized rows, each with a stable machine value;
+- one to five ordered localized columns, using the existing question-option
+  shape and stable option values;
+- a mode of either **one choice per row** or **multiple choices per row**.
+
+Rows and columns use the builder's non-sequential collection binding so they can
+be added, removed, and reordered without renumbering posted keys. Save rejects a
+Grid with no mode, no rows, no columns, more than five columns, blank stable
+values, or duplicate row/column values.
+
+Translation pre-fill includes Grid row and column labels and never overwrites
+authored translations.
+
+### Answer a Grid
+
+As a respondent, I see the rows and columns as an accessible table:
+
+- one-choice mode renders one radio group per row;
+- multiple-choice mode renders checkboxes per cell;
+- the table scrolls horizontally on narrow screens without losing its row
+  labels.
+
+When the question is required, every visible row must contain exactly one
+selection in one-choice mode or at least one selection in multiple-choice mode.
+Optional Grids may be partially answered. Server-side capture discards unknown
+rows/columns, de-duplicates selections, and limits one-choice rows to one value.
+
+Identified draft autosave/resume and all anonymity tiers preserve the same
+structured Grid answer.
+
+### Branching
+
+A Grid may carry an existing `ShowIf` condition and therefore be hidden by an
+earlier choice question. Grid answers are not valid branching sources in this
+version; author-save rejects a condition targeting a Grid.
+
+### Results and exports
+
+Admin results show a row/column matrix of per-cell counts and percentages. A
+cell's percentage is based on respondents who answered that row.
+
+The JSON API carries both raw stable row-to-column selections and best-effort
+resolved row/column labels, matching choice exports' raw-value plus label
+pattern. CSV and Markdown keep one column per survey question and encode the raw
+Grid answer as JSON keyed by stable row value, with stable column values in each
+array. Export and GDPR paths never discard stored keys when a live survey's
+current row or column definition no longer contains them; missing labels fall
+back to the raw key. Identified drill-down uses the same best-effort labels.
+
+## Data model
+
+### SurveyQuestion additions
+
+- `Type = Grid`
+- nullable `GridSelectionMode` (`Single` / `Multiple`)
+- nullable `GridRows` jsonb array of `{ Value, Label }`
+
+Existing `SurveyQuestionOption` rows are the Grid columns. The option table,
+builder reconciliation, translation path, and stable-value semantics are reused.
+
+### SurveyAnswer addition
+
+- nullable `GridSelections` jsonb object mapping stable row value to a list of
+  stable column values
+
+The new columns are nullable for existing records and populated only for Grid
+questions. Existing choice, text, and rating answer fields remain unchanged.
+
+## Reuse decisions
+
+- Reused `SurveyQuestionOption` for columns instead of adding a parallel column
+  entity/table.
+- Stored bounded row definitions as question-owned jsonb instead of adding a
+  separately queried row table.
+- Stored structured selections instead of delimiter-encoding row/column pairs
+  into `SelectedOptionValues`.
+- Extended existing internal DTOs/view models and routes; no public/interface
+  surface, service/repository method, package, or DI registration is added.
+
+## Related features
+
+- [`../Surveys.md`](../Surveys.md) — section invariants and complete data model
+- `nobodies-collective/Humans#1093` — product request and acceptance criteria

--- a/src/Sections/Humans.Surveys/Domain/GridSelectionMode.cs
+++ b/src/Sections/Humans.Surveys/Domain/GridSelectionMode.cs
@@ -1,0 +1,8 @@
+namespace Humans.Surveys.Domain;
+
+/// <summary>Whether each Grid row accepts one column or multiple columns.</summary>
+internal enum GridSelectionMode
+{
+    Single = 0,
+    Multiple = 1,
+}

--- a/src/Sections/Humans.Surveys/Domain/SurveyAnswer.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyAnswer.cs
@@ -6,6 +6,7 @@ internal sealed class SurveyAnswer
     public Guid ResponseId { get; init; }
     public Guid QuestionId { get; init; }
     public List<string> SelectedOptionValues { get; set; } = [];   // jsonb
+    public Dictionary<string, List<string>>? GridSelections { get; set; } // jsonb; row value → column values
     public string? TextValue { get; set; }
     public int? RatingValue { get; set; }
     public SurveyResponse Response { get; set; } = null!;

--- a/src/Sections/Humans.Surveys/Domain/SurveyGridRow.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyGridRow.cs
@@ -1,0 +1,4 @@
+namespace Humans.Surveys.Domain;
+
+/// <summary>A Grid row definition: stable machine value plus localized display label.</summary>
+internal sealed record SurveyGridRow(string Value, LocalizedText Label);

--- a/src/Sections/Humans.Surveys/Domain/SurveyQuestion.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyQuestion.cs
@@ -15,6 +15,8 @@ internal sealed class SurveyQuestion
     public int? RatingMax { get; set; }
     public LocalizedText RatingMinLabel { get; set; } = LocalizedText.Empty;
     public LocalizedText RatingMaxLabel { get; set; } = LocalizedText.Empty;
+    public GridSelectionMode? GridSelectionMode { get; set; }
+    public List<SurveyGridRow>? GridRows { get; set; }           // jsonb; null for non-Grid questions
     public BranchCondition? ShowIf { get; set; }
     public Survey Survey { get; set; } = null!;
     public ICollection<SurveyQuestionOption> Options { get; set; } = new List<SurveyQuestionOption>();

--- a/src/Sections/Humans.Surveys/Domain/SurveyQuestionType.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyQuestionType.cs
@@ -1,11 +1,12 @@
 namespace Humans.Surveys.Domain;
 
-/// <summary>Question input kinds. Choice types (<see cref="SingleChoice"/>/<see cref="MultiChoice"/>) carry options and can drive branching.</summary>
+/// <summary>Question input kinds. Choice types carry options and can drive branching; Grid reuses options as columns but cannot drive branching.</summary>
 internal enum SurveyQuestionType
 {
     SingleChoice = 0,
     MultiChoice = 1,
     ShortText = 2,
     LongText = 3,
-    Rating = 4
+    Rating = 4,
+    Grid = 5,
 }

--- a/src/Sections/Humans.Surveys/Models/SurveyCsvExportBuilder.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyCsvExportBuilder.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using Humans.Base.Csv;
 using Humans.Surveys.Services;
 using Humans.Surveys.Domain;
@@ -58,6 +59,13 @@ internal static class SurveyCsvExportBuilder
     {
         SurveyQuestionType.SingleChoice or SurveyQuestionType.MultiChoice =>
             string.Join("|", answer.SelectedValues),
+        SurveyQuestionType.Grid =>
+            JsonSerializer.Serialize(
+                (answer.GridSelections ?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal))
+                .ToDictionary(
+                    selection => selection.Key,
+                    selection => selection.Value,
+                    StringComparer.Ordinal)),
         SurveyQuestionType.Rating =>
             answer.RatingValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
         _ => answer.TextValue ?? string.Empty,

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
@@ -52,15 +52,22 @@ internal sealed class SurveyPageQuestion
     public string RatingMinLabel { get; init; } = string.Empty;
     public string RatingMaxLabel { get; init; } = string.Empty;
     public IReadOnlyList<SurveyPageOption> Options { get; init; } = [];
+    public GridSelectionMode? GridSelectionMode { get; init; }
+    public IReadOnlyList<SurveyPageGridRow> GridRows { get; init; } = [];
 
     // Prior answer (for re-render after a validation failure or a Back navigation).
     public IReadOnlyList<string> SelectedOptionValues { get; init; } = [];
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> GridSelections { get; init; }
+        = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
     public string? TextValue { get; init; }
     public int? RatingValue { get; init; }
 }
 
 /// <summary>One resolved choice option: stable machine <see cref="Value"/> + display <see cref="Label"/>.</summary>
 internal sealed record SurveyPageOption(string Value, string Label);
+
+/// <summary>One resolved Grid row.</summary>
+internal sealed record SurveyPageGridRow(string Value, string Label);
 
 /// <summary>Posted by one wizard page. <see cref="Answers"/> binds via indexed form fields.</summary>
 internal sealed class SurveyPageInputModel
@@ -78,8 +85,16 @@ internal sealed class SurveyPostedAnswer
 {
     public Guid QuestionId { get; set; }
     public List<string> SelectedOptionValues { get; set; } = [];
+    public List<SurveyPostedGridRow> GridRows { get; set; } = [];
     public string? TextValue { get; set; }
     public int? RatingValue { get; set; }
+}
+
+/// <summary>One posted Grid row and its selected column values.</summary>
+internal sealed class SurveyPostedGridRow
+{
+    public string RowValue { get; set; } = string.Empty;
+    public List<string> SelectedColumnValues { get; set; } = [];
 }
 
 /// <summary>The closing thank-you page, with the survey's ThankYou copy resolved for display.</summary>

--- a/src/Sections/Humans.Surveys/Models/SurveyResponsesMarkdownBuilder.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyResponsesMarkdownBuilder.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using Humans.Surveys.Services;
 using Humans.Surveys.Domain;
 using NodaTime.Text;
@@ -57,6 +58,13 @@ internal static class SurveyResponsesMarkdownBuilder
     {
         SurveyQuestionType.SingleChoice or SurveyQuestionType.MultiChoice =>
             Escape(string.Join("|", answer.SelectedValues)),
+        SurveyQuestionType.Grid =>
+            Escape(JsonSerializer.Serialize(
+                (answer.GridSelections ?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal))
+                .ToDictionary(
+                    selection => selection.Key,
+                    selection => selection.Value,
+                    StringComparer.Ordinal))),
         SurveyQuestionType.Rating =>
             answer.RatingValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
         _ => Escape(answer.TextValue ?? string.Empty),

--- a/src/Sections/Humans.Surveys/Models/SurveyResultsBuilder.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyResultsBuilder.cs
@@ -33,6 +33,7 @@ internal static class SurveyResultsBuilder
         Prompt = q.Prompt,
         Type = q.Type,
         OptionCounts = q.OptionCounts,
+        Grid = q.Grid,
         RatingDistribution = q.RatingDistribution,
         RatingAverage = q.RatingAverage is { } avg ? avg.ToString("0.0", CultureInfo.InvariantCulture) : null,
         FreeTextAnswers = q.FreeTextAnswers,
@@ -71,6 +72,7 @@ internal sealed class SurveyResultsQuestionViewModel
     public string Prompt { get; init; } = string.Empty;
     public SurveyQuestionType Type { get; init; }
     public IReadOnlyList<OptionCount> OptionCounts { get; init; } = [];
+    public GridAggregate? Grid { get; init; }
     public IReadOnlyList<RatingBucket> RatingDistribution { get; init; } = [];
     public string? RatingAverage { get; init; }
     public IReadOnlyList<string> FreeTextAnswers { get; init; } = [];

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -96,6 +96,9 @@ internal sealed record SurveyQuestionCardModel(string Key, SurveyQuestionBuilder
 /// <summary>One option row in the builder. Keys are non-sequential indexers (or <c>__QKEY__</c>/<c>__OKEY__</c> placeholders in templates).</summary>
 internal sealed record SurveyOptionRowModel(string QuestionKey, string OptionKey, SurveyOptionBuilderViewModel Option);
 
+/// <summary>One Grid row in the builder. Keys are non-sequential indexers.</summary>
+internal sealed record SurveyGridRowModel(string QuestionKey, string RowKey, SurveyGridRowBuilderViewModel Row);
+
 /// <summary>One show-if clause row in the builder. Keys are non-sequential indexers (or <c>__QKEY__</c>/<c>__CKEY__</c> placeholders in templates).</summary>
 internal sealed record SurveyBranchClauseRowModel(string QuestionKey, string ClauseKey, SurveyBranchClauseBuilderViewModel Clause);
 
@@ -208,9 +211,11 @@ internal sealed class SurveyQuestionBuilderViewModel
     public int? RatingMax { get; set; }
     public Dictionary<string, string> RatingMinLabel { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, string> RatingMaxLabel { get; set; } = new(StringComparer.Ordinal);
+    public GridSelectionMode GridSelectionMode { get; set; } = GridSelectionMode.Single;
     public BranchCombine ShowIfCombine { get; set; } = BranchCombine.All;
     public List<SurveyBranchClauseBuilderViewModel> ShowIfClauses { get; set; } = [];
     public List<SurveyOptionBuilderViewModel> Options { get; set; } = [];
+    public List<SurveyGridRowBuilderViewModel> GridRows { get; set; } = [];
 
     public QuestionInput ToInput(int order) => new(
         Id,
@@ -225,7 +230,9 @@ internal sealed class SurveyQuestionBuilderViewModel
         new LocalizedText(RatingMinLabel),
         new LocalizedText(RatingMaxLabel),
         ToShowIf(),
-        Options.Select((o, i) => o.ToInput(i)).ToList());
+        Options.Select((o, i) => o.ToInput(i)).ToList(),
+        Type == SurveyQuestionType.Grid ? GridSelectionMode : null,
+        Type == SurveyQuestionType.Grid ? GridRows.Select(r => r.ToInput()).ToList() : null);
 
     public static SurveyQuestionBuilderViewModel FromInput(QuestionInput q) => new()
     {
@@ -242,6 +249,8 @@ internal sealed class SurveyQuestionBuilderViewModel
         ShowIfCombine = q.ShowIf?.Combine ?? BranchCombine.All,
         ShowIfClauses = q.ShowIf?.Clauses.Select(SurveyBranchClauseBuilderViewModel.FromClause).ToList() ?? [],
         Options = q.Options.Select(SurveyOptionBuilderViewModel.FromInput).ToList(),
+        GridSelectionMode = q.GridSelectionMode ?? GridSelectionMode.Single,
+        GridRows = q.GridRows?.Select(SurveyGridRowBuilderViewModel.FromInput).ToList() ?? [],
     };
 
     /// <summary>Clauses without a target question (never picked / target removed) are dropped; no clauses ⇒ always visible.</summary>
@@ -290,5 +299,19 @@ internal sealed class SurveyOptionBuilderViewModel
         Id = o.Id,
         Value = o.Value,
         Label = SurveyBuilderViewModel.ToDict(o.Label),
+    };
+}
+
+internal sealed class SurveyGridRowBuilderViewModel
+{
+    public string Value { get; set; } = string.Empty;
+    public Dictionary<string, string> Label { get; set; } = new(StringComparer.Ordinal);
+
+    public GridRowInput ToInput() => new(Value, new LocalizedText(Label));
+
+    public static SurveyGridRowBuilderViewModel FromInput(GridRowInput row) => new()
+    {
+        Value = row.Value,
+        Label = SurveyBuilderViewModel.ToDict(row.Label),
     };
 }

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -33,7 +33,7 @@ internal interface ISurveyService : IApplicationService
 
     /// <summary>
     /// Machine-translates the survey's authored content (title, intro, thank-you, prompts, help,
-    /// rating/option labels) from its default culture into every <paramref name="targetCultures"/>
+    /// rating/option/Grid-row labels) from its default culture into every <paramref name="targetCultures"/>
     /// entry that is still blank — existing text is never overwritten (spec §6.1: pre-fill, then the
     /// author reviews). Returns the number of fields filled; 0 means nothing was missing.
     /// </summary>
@@ -173,7 +173,9 @@ internal sealed record QuestionInput(
     LocalizedText RatingMinLabel,
     LocalizedText RatingMaxLabel,
     BranchCondition? ShowIf,
-    IReadOnlyList<OptionInput> Options);
+    IReadOnlyList<OptionInput> Options,
+    GridSelectionMode? GridSelectionMode = null,
+    IReadOnlyList<GridRowInput>? GridRows = null);
 
 /// <summary>One choice option in the builder graph. <c>Value</c> is the stable machine key.</summary>
 internal sealed record OptionInput(
@@ -181,6 +183,9 @@ internal sealed record OptionInput(
     int Order,
     string Value,
     LocalizedText Label);
+
+/// <summary>One Grid row in the builder graph. <c>Value</c> is the stable machine key.</summary>
+internal sealed record GridRowInput(string Value, LocalizedText Label);
 
 /// <summary>Outcome of a send wave: net-new invitations created, emails queued, and enqueue failures.</summary>
 internal sealed record SendResult(int InvitationsCreated, int EmailsQueued, int Failed);
@@ -223,7 +228,8 @@ internal sealed record SurveyDraftAnswer(
     Guid QuestionId,
     IReadOnlyList<string> SelectedOptionValues,
     string? TextValue,
-    int? RatingValue);
+    int? RatingValue,
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null);
 
 /// <summary>
 /// A finalised wizard submission. Identity columns (<c>UserId</c>/<c>InvitationId</c>) are written on
@@ -247,7 +253,8 @@ internal sealed record SurveyAnswerInput(
     Guid QuestionId,
     IReadOnlyList<string> SelectedOptionValues,
     string? TextValue,
-    int? RatingValue);
+    int? RatingValue,
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null);
 
 /// <summary>
 /// Per-session state of the answering wizard. The Web layer JSON-serialises it into the HTTP session
@@ -273,6 +280,7 @@ internal sealed class SurveyWizardState
 internal sealed class SurveyWizardAnswer
 {
     public List<string> SelectedOptionValues { get; set; } = [];
+    public Dictionary<string, List<string>> GridSelections { get; set; } = new(StringComparer.Ordinal);
     public string? TextValue { get; set; }
     public int? RatingValue { get; set; }
 }
@@ -328,7 +336,7 @@ internal sealed record SurveyFunnel(int LinkStarted, int LinkFinished, int SlugS
 /// One question's aggregate over submitted responses. The populated collection depends on the
 /// question type: <see cref="OptionCounts"/> for choice questions, <see cref="RatingDistribution"/>
 /// plus <see cref="RatingAverage"/> for rating questions, <see cref="FreeTextAnswers"/> for text
-/// questions. The others are empty/null.
+/// questions, and <see cref="Grid"/> for Grid questions. The others are empty/null.
 /// </summary>
 internal sealed record QuestionAggregate(
     Guid QuestionId,
@@ -337,7 +345,8 @@ internal sealed record QuestionAggregate(
     IReadOnlyList<OptionCount> OptionCounts,
     IReadOnlyList<RatingBucket> RatingDistribution,
     double? RatingAverage,
-    IReadOnlyList<string> FreeTextAnswers);
+    IReadOnlyList<string> FreeTextAnswers,
+    GridAggregate? Grid = null);
 
 /// <summary>One choice option's tally. <see cref="Percent"/> is the share of responses to that question (0 when none).</summary>
 internal sealed record OptionCount(string Value, string Label, int Count, double Percent);
@@ -345,11 +354,36 @@ internal sealed record OptionCount(string Value, string Label, int Count, double
 /// <summary>One rating value's tally; empty buckets are included across the question's range.</summary>
 internal sealed record RatingBucket(int Value, int Count);
 
+/// <summary>A Grid question's resolved column schema and per-row cell counts.</summary>
+internal sealed record GridAggregate(
+    GridSelectionMode Mode,
+    IReadOnlyList<SurveyExportOption> Columns,
+    IReadOnlyList<GridAggregateRow> Rows);
+
+/// <summary>One resolved Grid row and its cells.</summary>
+internal sealed record GridAggregateRow(string Value, string Label, IReadOnlyList<GridCellCount> Cells);
+
+/// <summary>One Grid cell tally. Percent is based on respondents who answered the row.</summary>
+internal sealed record GridCellCount(string ColumnValue, string ColumnLabel, int Count, double Percent);
+
 /// <summary>One Identified respondent's drill-down row: stitched display name + their answers.</summary>
 internal sealed record RespondentDetail(Guid UserId, string Name, Instant? SubmittedAt, IReadOnlyList<RespondentAnswer> Answers);
 
 /// <summary>One answer in an Identified respondent's drill-down, with choice labels resolved in the default culture.</summary>
-internal sealed record RespondentAnswer(Guid QuestionId, string Prompt, IReadOnlyList<string> SelectedLabels, string? TextValue, int? RatingValue);
+internal sealed record RespondentAnswer(
+    Guid QuestionId,
+    string Prompt,
+    IReadOnlyList<string> SelectedLabels,
+    string? TextValue,
+    int? RatingValue,
+    IReadOnlyList<ResolvedGridSelection>? GridSelections = null);
+
+/// <summary>One resolved Grid row selection for display/export.</summary>
+internal sealed record ResolvedGridSelection(
+    string RowValue,
+    string RowLabel,
+    IReadOnlyList<string> ColumnValues,
+    IReadOnlyList<string> ColumnLabels);
 
 // ── Export DTOs (co-located; raw per-response, shared by CSV/JSON download and the analysis API) ──
 
@@ -370,10 +404,15 @@ internal sealed record SurveyExportQuestion(
     Guid QuestionId,
     string Prompt,
     SurveyQuestionType Type,
-    IReadOnlyList<SurveyExportOption> Options);
+    IReadOnlyList<SurveyExportOption> Options,
+    GridSelectionMode? GridSelectionMode = null,
+    IReadOnlyList<SurveyExportGridRow>? GridRows = null);
 
 /// <summary>One choice option in the export schema: the stable machine <see cref="Value"/> + its resolved <see cref="Label"/>.</summary>
 internal sealed record SurveyExportOption(string Value, string Label);
+
+/// <summary>One Grid row in the export schema.</summary>
+internal sealed record SurveyExportGridRow(string Value, string Label);
 
 /// <summary>
 /// One exported response. <see cref="UserId"/>/<see cref="UserName"/> are populated only for
@@ -389,10 +428,15 @@ internal sealed record SurveyExportRow(
     string? UserName,
     IReadOnlyList<SurveyExportAnswer> Answers);
 
-/// <summary>One answer in an exported response: choice keys + resolved labels, free text, or a rating.</summary>
+/// <summary>
+/// One answer in an exported response: raw stable keys plus best-effort resolved labels,
+/// free text, or a rating.
+/// </summary>
 internal sealed record SurveyExportAnswer(
     Guid QuestionId,
     IReadOnlyList<string> SelectedValues,
     IReadOnlyList<string> SelectedLabels,
     string? TextValue,
-    int? RatingValue);
+    int? RatingValue,
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null,
+    IReadOnlyList<ResolvedGridSelection>? GridSelectionLabels = null);

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -64,7 +64,9 @@ internal sealed class SurveyService(
                     q.Id, q.PageNumber, q.Order, q.Type, q.Prompt, q.HelpText, q.IsRequired,
                     q.RatingMin, q.RatingMax, q.RatingMinLabel, q.RatingMaxLabel, q.ShowIf,
                     q.Options.OrderBy(o => o.Order)
-                        .Select(o => new OptionInput(o.Id, o.Order, o.Value, o.Label)).ToList()))
+                        .Select(o => new OptionInput(o.Id, o.Order, o.Value, o.Label)).ToList(),
+                    q.GridSelectionMode,
+                    q.GridRows?.Select(row => new GridRowInput(row.Value, row.Label)).ToList()))
                 .ToList());
 
         return new SurveyDetail(s.Id, s.Status, input);
@@ -75,6 +77,7 @@ internal sealed class SurveyService(
         var now = clock.GetCurrentInstant();
         var surveyId = Guid.NewGuid();
         var questions = MapQuestions(surveyId, input);
+        ValidateQuestionConfiguration(questions);
         ValidateBranching(questions);
 
         var survey = new Survey
@@ -109,6 +112,7 @@ internal sealed class SurveyService(
     {
         var now = clock.GetCurrentInstant();
         var questions = MapQuestions(surveyId, input);
+        ValidateQuestionConfiguration(questions);
         ValidateBranching(questions);
 
         var survey = new Survey
@@ -153,6 +157,7 @@ internal sealed class SurveyService(
             MinLabel = Copy(q.RatingMinLabel),
             MaxLabel = Copy(q.RatingMaxLabel),
             Options = q.Options.Select(o => new { Option = o, Label = Copy(o.Label) }).ToList(),
+            GridRows = (q.GridRows ?? []).Select(row => new { Row = row, Label = Copy(row.Label) }).ToList(),
         }).ToList();
 
         var allTexts = new List<Dictionary<string, string>> { title, intro, thankYou };
@@ -160,6 +165,7 @@ internal sealed class SurveyService(
         {
             allTexts.AddRange([q.Prompt, q.Help, q.MinLabel, q.MaxLabel]);
             allTexts.AddRange(q.Options.Select(o => o.Label));
+            allTexts.AddRange(q.GridRows.Select(row => row.Label));
         }
 
         // One batched call per target culture; only fills blanks — never overwrites authored text.
@@ -192,6 +198,7 @@ internal sealed class SurveyService(
                 RatingMinLabel = new LocalizedText(q.MinLabel),
                 RatingMaxLabel = new LocalizedText(q.MaxLabel),
                 Options = q.Options.Select(o => o.Option with { Label = new LocalizedText(o.Label) }).ToList(),
+                GridRows = q.GridRows.Select(row => row.Row with { Label = new LocalizedText(row.Label) }).ToList(),
             }).ToList());
 
         await UpdateAsync(surveyId, input, actorUserId, ct);
@@ -405,7 +412,15 @@ internal sealed class SurveyService(
         var draftAnswers = draft is null
             ? (IReadOnlyList<SurveyDraftAnswer>)[]
             : draft.Answers
-                .Select(a => new SurveyDraftAnswer(a.QuestionId, a.SelectedOptionValues, a.TextValue, a.RatingValue))
+                .Select(a => new SurveyDraftAnswer(
+                    a.QuestionId,
+                    a.SelectedOptionValues,
+                    a.TextValue,
+                    a.RatingValue,
+                    a.GridSelections?.ToDictionary(
+                        kv => kv.Key,
+                        kv => (IReadOnlyList<string>)kv.Value,
+                        StringComparer.Ordinal)))
                 .ToList();
 
         return new SurveyAnswerContext(
@@ -614,6 +629,11 @@ internal sealed class SurveyService(
             state.Answers[id.ToString()] = new SurveyWizardAnswer
             {
                 SelectedOptionValues = answer.SelectedOptionValues.Where(v => !string.IsNullOrEmpty(v)).ToList(),
+                GridSelections = NormalizeGridSelections(
+                    question.GridRows,
+                    question.Options,
+                    question.GridSelectionMode,
+                    answer.GridSelections),
                 TextValue = string.IsNullOrWhiteSpace(answer.TextValue) ? null : answer.TextValue,
                 RatingValue = answer.RatingValue,
             };
@@ -738,9 +758,14 @@ internal sealed class SurveyService(
                 q.Type,
                 q.Options.OrderBy(o => o.Order)
                     .Select(o => new SurveyExportOption(o.Value, o.Label.Resolve(culture, culture)))
-                    .ToList()))
+                    .ToList(),
+                q.GridSelectionMode,
+                q.GridRows?.Select(row => new SurveyExportGridRow(
+                    row.Value,
+                    row.Label.Resolve(culture, culture))).ToList()))
             .ToList();
 
+        var questionsById = survey.Questions.ToDictionary(q => q.Id);
         var optionLabels = survey.Questions.ToDictionary(
             q => q.Id,
             q => q.Options.ToDictionary(o => o.Value, o => o.Label.Resolve(culture, culture), StringComparer.Ordinal));
@@ -773,7 +798,11 @@ internal sealed class SurveyService(
                         a.SelectedOptionValues,
                         ResolveSelectedLabels(a, optionLabels),
                         a.TextValue,
-                        a.RatingValue))
+                        a.RatingValue,
+                        CopyGridSelections(a),
+                        questionsById.TryGetValue(a.QuestionId, out var question)
+                            ? ResolveGridSelections(a, question, culture)
+                            : []))
                     .ToList();
 
                 return new SurveyExportRow(
@@ -820,6 +849,8 @@ internal sealed class SurveyService(
                     : survey.Questions.ToDictionary(
                         q => q.Id,
                         q => q.Options.ToDictionary(o => o.Value, o => o.Label.Resolve(culture, culture), StringComparer.Ordinal));
+                var questionsById = survey?.Questions.ToDictionary(q => q.Id)
+                    ?? new Dictionary<Guid, SurveyQuestion>();
 
                 return new
                 {
@@ -830,6 +861,10 @@ internal sealed class SurveyService(
                     {
                         Question = prompts.GetValueOrDefault(a.QuestionId, string.Empty),
                         SelectedLabels = ResolveSelectedLabels(a, optionLabels),
+                        GridSelections = CopyGridSelections(a),
+                        GridSelectionLabels = questionsById.TryGetValue(a.QuestionId, out var question)
+                            ? ResolveGridSelections(a, question, culture)
+                            : [],
                         a.TextValue,
                         a.RatingValue,
                     }).ToList(),
@@ -885,6 +920,43 @@ internal sealed class SurveyService(
                     return new QuestionAggregate(question.Id, prompt, question.Type, [], distribution, average, []);
                 }
 
+            case SurveyQuestionType.Grid:
+                {
+                    var columns = question.Options
+                        .OrderBy(option => option.Order)
+                        .Select(option => new SurveyExportOption(
+                            option.Value,
+                            option.Label.Resolve(culture, culture)))
+                        .ToList();
+                    var rows = (question.GridRows ?? [])
+                        .Select(row =>
+                        {
+                            var answeredCount = answers.Count(answer =>
+                                answer.GridSelections?.TryGetValue(row.Value, out var selected) == true
+                                && selected.Count > 0);
+                            var cells = columns.Select(column =>
+                            {
+                                var count = answers.Count(answer =>
+                                    answer.GridSelections?.TryGetValue(row.Value, out var selected) == true
+                                    && selected.Contains(column.Value, StringComparer.Ordinal));
+                                var percent = answeredCount == 0
+                                    ? 0d
+                                    : (double)count / answeredCount * 100d;
+                                return new GridCellCount(column.Value, column.Label, count, percent);
+                            }).ToList();
+                            return new GridAggregateRow(
+                                row.Value,
+                                row.Label.Resolve(culture, culture),
+                                cells);
+                        })
+                        .ToList();
+                    var grid = new GridAggregate(
+                        question.GridSelectionMode ?? GridSelectionMode.Single,
+                        columns,
+                        rows);
+                    return new QuestionAggregate(question.Id, prompt, question.Type, [], [], null, [], grid);
+                }
+
             case SurveyQuestionType.ShortText:
             case SurveyQuestionType.LongText:
             default:
@@ -914,6 +986,7 @@ internal sealed class SurveyService(
             q => q.Id,
             q => q.Options.ToDictionary(o => o.Value, o => o.Label.Resolve(culture, culture), StringComparer.Ordinal));
         var prompts = survey.Questions.ToDictionary(q => q.Id, q => q.Prompt.Resolve(culture, culture));
+        var questionsById = survey.Questions.ToDictionary(q => q.Id);
 
         return identified
             .Select(r =>
@@ -926,7 +999,10 @@ internal sealed class SurveyService(
                         prompts.GetValueOrDefault(a.QuestionId, string.Empty),
                         ResolveSelectedLabels(a, optionLabels),
                         a.TextValue,
-                        a.RatingValue))
+                        a.RatingValue,
+                        questionsById.TryGetValue(a.QuestionId, out var question)
+                            ? ResolveGridSelections(a, question, culture)
+                            : []))
                     .ToList();
                 return new RespondentDetail(userId, name, r.SubmittedAt, answers);
             })
@@ -944,6 +1020,37 @@ internal sealed class SurveyService(
             .ToList();
     }
 
+    private static IReadOnlyList<ResolvedGridSelection> ResolveGridSelections(
+        SurveyAnswer answer, SurveyQuestion question, string culture)
+    {
+        if (answer.GridSelections is null) return [];
+
+        var rows = (question.GridRows ?? []).ToDictionary(
+            row => row.Value,
+            row => row.Label.Resolve(culture, culture),
+            StringComparer.Ordinal);
+        var columns = question.Options.ToDictionary(
+            option => option.Value,
+            option => option.Label.Resolve(culture, culture),
+            StringComparer.Ordinal);
+        return answer.GridSelections
+            .Where(selection => selection.Value.Count > 0)
+            .Select(selection => new ResolvedGridSelection(
+                selection.Key,
+                rows.GetValueOrDefault(selection.Key, selection.Key),
+                selection.Value.ToList(),
+                selection.Value
+                    .Select(value => columns.GetValueOrDefault(value, value))
+                    .ToList()))
+            .ToList();
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>>? CopyGridSelections(SurveyAnswer answer)
+        => answer.GridSelections?.ToDictionary(
+            selection => selection.Key,
+            selection => (IReadOnlyList<string>)selection.Value.ToList(),
+            StringComparer.Ordinal);
+
     /// <summary>
     /// Keeps only the answers to questions visible under full cascading branching: an answer on a
     /// hidden question neither survives nor counts towards downstream <c>ShowIf</c> conditions.
@@ -952,7 +1059,7 @@ internal sealed class SurveyService(
     {
         var states = answers.ToDictionary(
             a => a.QuestionId,
-            a => new AnswerState(a.SelectedOptionValues, a.TextValue, a.RatingValue));
+            a => new AnswerState(a.SelectedOptionValues, a.TextValue, a.RatingValue, a.GridSelections));
 
         var effective = SurveyBranchingEvaluator.EffectiveAnswerStates(
             survey.Questions
@@ -960,7 +1067,34 @@ internal sealed class SurveyService(
                 .Select(q => (q.Id, q.ShowIf)),
             states);
 
-        return answers.Where(a => effective.ContainsKey(a.QuestionId)).ToList();
+        var questions = survey.Questions.ToDictionary(q => q.Id);
+        return answers
+            .Where(a => effective.ContainsKey(a.QuestionId))
+            .Where(a => questions.ContainsKey(a.QuestionId))
+            .Select(a =>
+            {
+                var question = questions[a.QuestionId];
+                var normalizedGridSelections = question.Type == SurveyQuestionType.Grid
+                    ? NormalizeGridSelections(
+                        question.GridRows?.Select(row => new GridRowInput(row.Value, row.Label)).ToList(),
+                        question.Options
+                            .OrderBy(option => option.Order)
+                            .Select(option => new OptionInput(option.Id, option.Order, option.Value, option.Label))
+                            .ToList(),
+                        question.GridSelectionMode,
+                        a.GridSelections)
+                    : null;
+                return a with
+                {
+                    GridSelections = normalizedGridSelections?.Count > 0
+                        ? normalizedGridSelections.ToDictionary(
+                                kv => kv.Key,
+                                kv => (IReadOnlyList<string>)kv.Value,
+                                StringComparer.Ordinal)
+                        : null,
+                };
+            })
+            .ToList();
     }
 
     private static List<SurveyAnswer> MapAnswers(Guid responseId, IReadOnlyList<SurveyAnswerInput> answers)
@@ -970,6 +1104,10 @@ internal sealed class SurveyService(
             ResponseId = responseId,
             QuestionId = a.QuestionId,
             SelectedOptionValues = a.SelectedOptionValues.ToList(),
+            GridSelections = a.GridSelections?.ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value.ToList(),
+                StringComparer.Ordinal),
             TextValue = a.TextValue,
             RatingValue = a.RatingValue,
         }).ToList();
@@ -1065,6 +1203,10 @@ internal sealed class SurveyService(
                 RatingMax = q.RatingMax,
                 RatingMinLabel = q.RatingMinLabel,
                 RatingMaxLabel = q.RatingMaxLabel,
+                GridSelectionMode = q.Type == SurveyQuestionType.Grid ? q.GridSelectionMode : null,
+                GridRows = q.Type == SurveyQuestionType.Grid
+                    ? (q.GridRows ?? []).Select(row => new SurveyGridRow(row.Value, row.Label)).ToList()
+                    : null,
                 ShowIf = q.ShowIf,
                 Options = q.Options.Select(o => new SurveyQuestionOption
                 {
@@ -1076,6 +1218,51 @@ internal sealed class SurveyService(
                 }).ToList(),
             };
         }).ToList();
+
+    private static void ValidateQuestionConfiguration(IReadOnlyList<SurveyQuestion> questions)
+    {
+        foreach (var question in questions)
+        {
+            if (question.Type != SurveyQuestionType.Grid) continue;
+
+            if (question.GridSelectionMode is null)
+            {
+                throw new InvalidOperationException($"Grid question {question.Id} must choose a selection mode.");
+            }
+
+            var rows = question.GridRows ?? [];
+            if (rows.Count == 0)
+            {
+                throw new InvalidOperationException($"Grid question {question.Id} must have at least one row.");
+            }
+
+            if (question.Options.Count == 0 || question.Options.Count > 5)
+            {
+                throw new InvalidOperationException($"Grid question {question.Id} must have between one and five columns.");
+            }
+
+            ValidateStableValues(
+                rows.Select(row => row.Value),
+                $"Grid question {question.Id} row");
+            ValidateStableValues(
+                question.Options.Select(option => option.Value),
+                $"Grid question {question.Id} column");
+        }
+
+        static void ValidateStableValues(IEnumerable<string> values, string description)
+        {
+            var materialized = values.ToList();
+            if (materialized.Any(string.IsNullOrWhiteSpace))
+            {
+                throw new InvalidOperationException($"{description} values must not be blank.");
+            }
+
+            if (materialized.Distinct(StringComparer.Ordinal).Count() != materialized.Count)
+            {
+                throw new InvalidOperationException($"{description} values must be unique.");
+            }
+        }
+    }
 
     private static void ValidateBranching(IReadOnlyList<SurveyQuestion> questions)
     {
@@ -1092,6 +1279,51 @@ internal sealed class SurveyService(
             throw new InvalidOperationException(
                 $"A branching Is/IsNot clause has no option values (the condition would be vacuous). Offending question ids: {string.Join(", ", emptyClauses)}.");
         }
+
+        var types = questions.ToDictionary(question => question.Id, question => question.Type);
+        var gridSources = questions
+            .Where(question => question.ShowIf?.Clauses.Any(clause =>
+                types.GetValueOrDefault(clause.QuestionId) == SurveyQuestionType.Grid) == true)
+            .Select(question => question.Id)
+            .ToList();
+        if (gridSources.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Grid questions cannot be branching sources. Offending question ids: {string.Join(", ", gridSources)}.");
+        }
+    }
+
+    private static Dictionary<string, List<string>> NormalizeGridSelections(
+        IReadOnlyList<GridRowInput>? rows,
+        IReadOnlyList<OptionInput> columns,
+        GridSelectionMode? mode,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? selections)
+    {
+        if (rows is null || mode is null || selections is null)
+        {
+            return new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        }
+
+        var rowValues = rows.Select(row => row.Value).ToHashSet(StringComparer.Ordinal);
+        var columnValues = columns.Select(column => column.Value).ToHashSet(StringComparer.Ordinal);
+        var result = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var (rowValue, selectedColumns) in selections)
+        {
+            if (!rowValues.Contains(rowValue)) continue;
+            var valid = selectedColumns
+                .Where(columnValues.Contains)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            if (mode == GridSelectionMode.Single && valid.Count > 1)
+            {
+                valid = valid.Take(1).ToList();
+            }
+
+            if (valid.Count > 0) result[rowValue] = valid;
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/src/Sections/Humans.Surveys/Services/SurveyWizardFlow.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyWizardFlow.cs
@@ -5,16 +5,23 @@ namespace Humans.Surveys.Services;
 
 /// <summary>
 /// One question's captured answer in the wizard, carrying enough to derive both branch visibility
-/// (from <paramref name="Options"/>) and answered-ness (any of options/text/rating present).
+/// (from <paramref name="Options"/>) and answered-ness across every supported answer shape.
 /// </summary>
-internal sealed record AnswerState(IReadOnlyList<string> Options, string? Text, int? Rating)
+internal sealed record AnswerState(
+    IReadOnlyList<string> Options,
+    string? Text,
+    int? Rating,
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? Grid = null)
 {
-    /// <summary>An empty/unanswered state — no option, text, or rating.</summary>
+    /// <summary>An empty/unanswered state.</summary>
     public static AnswerState None { get; } = new([], null, null);
 
-    /// <summary>True when at least one of option/text/rating is present.</summary>
+    /// <summary>True when at least one option, text, rating, or Grid cell is present.</summary>
     public bool IsAnswered =>
-        Options.Any(s => !string.IsNullOrEmpty(s)) || !string.IsNullOrWhiteSpace(Text) || Rating is not null;
+        Options.Any(s => !string.IsNullOrEmpty(s))
+        || !string.IsNullOrWhiteSpace(Text)
+        || Rating is not null
+        || Grid?.Values.Any(values => values.Count > 0) == true;
 }
 
 /// <summary>
@@ -70,14 +77,27 @@ internal static class SurveyWizardFlow
 
     /// <summary>
     /// Ids of the supplied (already visibility-filtered) questions that are required but unanswered,
-    /// in the order given. A question is answered when it has any selected option, text, or rating.
+    /// in the order given. Grid questions additionally require a valid answer for every row.
     /// </summary>
     public static IReadOnlyList<Guid> RequiredUnanswered(
         IReadOnlyList<QuestionInput> visibleQuestions, IReadOnlyDictionary<Guid, AnswerState> answers)
         => visibleQuestions
-            .Where(q => q.Id is { } id && q.IsRequired && !(answers.TryGetValue(id, out var a) && a.IsAnswered))
+            .Where(q => q.Id is { } id && q.IsRequired
+                && !(answers.TryGetValue(id, out var a) && IsAnswered(q, a)))
             .Select(q => q.Id!.Value)
             .ToList();
+
+    private static bool IsAnswered(QuestionInput question, AnswerState answer)
+    {
+        if (question.Type != SurveyQuestionType.Grid) return answer.IsAnswered;
+
+        var rows = question.GridRows ?? [];
+        if (rows.Count == 0 || answer.Grid is null) return false;
+        return rows.All(row =>
+            answer.Grid.TryGetValue(row.Value, out var selected)
+            && selected.Count > 0
+            && (question.GridSelectionMode != GridSelectionMode.Single || selected.Count == 1));
+    }
 
     /// <summary>The nearest page strictly before <paramref name="page"/> that has a visible question, or null at the start.</summary>
     public static int? PreviousVisiblePage(
@@ -108,7 +128,14 @@ internal static class SurveyWizardFlow
         {
             if (Guid.TryParse(key, out var id))
             {
-                result[id] = new AnswerState(a.SelectedOptionValues, a.TextValue, a.RatingValue);
+                result[id] = new AnswerState(
+                    a.SelectedOptionValues,
+                    a.TextValue,
+                    a.RatingValue,
+                    a.GridSelections.ToDictionary(
+                        kv => kv.Key,
+                        kv => (IReadOnlyList<string>)kv.Value,
+                        StringComparer.Ordinal));
             }
         }
 
@@ -123,6 +150,12 @@ internal static class SurveyWizardFlow
                 Guid.Parse(kv.Key),
                 kv.Value.SelectedOptionValues,
                 kv.Value.TextValue,
-                kv.Value.RatingValue))
+                kv.Value.RatingValue,
+                kv.Value.GridSelections.Count == 0
+                    ? null
+                    : kv.Value.GridSelections.ToDictionary(
+                        pair => pair.Key,
+                        pair => (IReadOnlyList<string>)pair.Value,
+                        StringComparer.Ordinal)))
             .ToList();
 }

--- a/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
@@ -122,6 +122,49 @@
                                     </div>
                                     break;
                                 }
+
+                                case SurveyQuestionType.Grid:
+                                {
+                                    var single = q.GridSelectionMode == GridSelectionMode.Single;
+                                    <div class="table-responsive">
+                                        <table class="table table-sm align-middle survey-grid mb-0">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col"><span class="visually-hidden">@q.Prompt</span></th>
+                                                    @foreach (var column in q.Options)
+                                                    {
+                                                        <th scope="col" class="text-center">@column.Label</th>
+                                                    }
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                @for (var rowIndex = 0; rowIndex < q.GridRows.Count; rowIndex++)
+                                                {
+                                                    var row = q.GridRows[rowIndex];
+                                                    q.GridSelections.TryGetValue(row.Value, out var selectedColumns);
+                                                    <tr>
+                                                        <th scope="row">
+                                                            @row.Label
+                                                            <input type="hidden" name="Answers[@i].GridRows[@rowIndex].RowValue" value="@row.Value" />
+                                                        </th>
+                                                        @foreach (var column in q.Options)
+                                                        {
+                                                            var selected = selectedColumns?.Contains(column.Value, StringComparer.Ordinal) == true;
+                                                            <td class="text-center">
+                                                                <input class="form-check-input" type="@(single ? "radio" : "checkbox")"
+                                                                       name="Answers[@i].GridRows[@rowIndex].SelectedColumnValues"
+                                                                       value="@column.Value"
+                                                                       aria-label="@($"{row.Label}: {column.Label}")"
+                                                                       @if (selected) { <text>checked</text> } />
+                                                            </td>
+                                                        }
+                                                    </tr>
+                                                }
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    break;
+                                }
                             }
 
                             @if (hasError)

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -229,9 +229,19 @@
                 const type = card.querySelector('.question-type')?.value;
                 const ratings = card.querySelector('.rating-section');
                 const options = card.querySelector('.options-section');
+                const grid = card.querySelector('.grid-section');
                 const isChoice = type === 'SingleChoice' || type === 'MultiChoice';
-                if (options) options.style.display = isChoice ? '' : 'none';
+                const isGrid = type === 'Grid';
+                if (options) {
+                    options.style.display = isChoice || isGrid ? '' : 'none';
+                    const label = options.querySelector('.options-label');
+                    if (label) label.textContent = isGrid ? 'Columns' : 'Options';
+                    const help = options.querySelector('.grid-column-help');
+                    if (help) help.style.display = isGrid ? '' : 'none';
+                }
+                if (grid) grid.style.display = isGrid ? '' : 'none';
                 if (ratings) ratings.style.display = type === 'Rating' ? '' : 'none';
+                updateGridColumnLimit(card);
             }
 
             function ensureQuestionId(card) {
@@ -242,9 +252,28 @@
             function addOption(card) {
                 const tpl = card.querySelector('.option-template');
                 if (!tpl) return;
+                if (card.querySelector('.question-type')?.value === 'Grid'
+                    && card.querySelectorAll('.options-container .option-row').length >= 5) return;
                 const html = tpl.innerHTML.replaceAll('__OKEY__', freshKey('o'));
                 card.querySelector('.options-container').insertAdjacentHTML('beforeend', html);
                 applyCulture(card.querySelector('.options-container').lastElementChild);
+                updateGridColumnLimit(card);
+            }
+
+            function updateGridColumnLimit(card) {
+                const button = card.querySelector('.add-option');
+                if (!button) return;
+                const isGrid = card.querySelector('.question-type')?.value === 'Grid';
+                const count = card.querySelectorAll('.options-container .option-row').length;
+                button.disabled = isGrid && count >= 5;
+            }
+
+            function addGridRow(card) {
+                const tpl = card.querySelector('.grid-row-template');
+                if (!tpl) return;
+                const html = tpl.innerHTML.replaceAll('__RKEY__', freshKey('r'));
+                card.querySelector('.grid-rows-container').insertAdjacentHTML('beforeend', html);
+                applyCulture(card.querySelector('.grid-rows-container').lastElementChild);
             }
 
             // ── show-if clause editor ────────────────────────────────────────
@@ -264,6 +293,7 @@
                 select.add(new Option('— choose a question —', ''));
                 questionCards().forEach((card, i) => {
                     if (card === ownCard) return;
+                    if (card.querySelector('.question-type')?.value === 'Grid') return;
                     const id = card.querySelector('.question-id')?.value;
                     if (id) select.add(new Option(questionLabel(card, i), id));
                 });
@@ -346,7 +376,13 @@
                 } else if (e.target.classList.contains('add-option')) {
                     addOption(e.target.closest('.question-card'));
                 } else if (e.target.classList.contains('remove-option')) {
+                    const card = e.target.closest('.question-card');
                     e.target.closest('.option-row').remove();
+                    updateGridColumnLimit(card);
+                } else if (e.target.classList.contains('add-grid-row')) {
+                    addGridRow(e.target.closest('.question-card'));
+                } else if (e.target.classList.contains('remove-grid-row')) {
+                    e.target.closest('.grid-row').remove();
                 } else if (e.target.classList.contains('add-clause')) {
                     addClause(e.target.closest('.question-card'));
                 } else if (e.target.classList.contains('remove-clause')) {

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Results.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Results.cshtml
@@ -123,6 +123,45 @@
                     }
                     break;
 
+                case SurveyQuestionType.Grid:
+                    @if (q.Grid is null || q.Grid.Rows.Count == 0 || q.Grid.Columns.Count == 0)
+                    {
+                        <p class="text-muted mb-0">No Grid rows or columns.</p>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-sm align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Row</th>
+                                        @foreach (var column in q.Grid.Columns)
+                                        {
+                                            <th scope="col" class="text-center">@column.Label</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var row in q.Grid.Rows)
+                                    {
+                                        <tr>
+                                            <th scope="row">@row.Label</th>
+                                            @foreach (var cell in row.Cells)
+                                            {
+                                                var pct = (int)Math.Round(cell.Percent);
+                                                <td class="text-center">
+                                                    <strong>@cell.Count</strong>
+                                                    <span class="text-muted small">(@pct%)</span>
+                                                </td>
+                                            }
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                    break;
+
                 default:
                     @if (q.FreeTextAnswers.Count == 0)
                     {
@@ -169,7 +208,16 @@ else
                             {
                                 <dt class="col-sm-4">@a.Prompt</dt>
                                 <dd class="col-sm-8">
-                                    @if (a.SelectedLabels.Count > 0)
+                                    @if (a.GridSelections?.Count > 0)
+                                    {
+                                        <ul class="list-unstyled mb-0">
+                                            @foreach (var selection in a.GridSelections)
+                                            {
+                                                <li><strong>@selection.RowLabel:</strong> @string.Join(", ", selection.ColumnLabels)</li>
+                                            }
+                                        </ul>
+                                    }
+                                    else if (a.SelectedLabels.Count > 0)
                                     {
                                         @string.Join(", ", a.SelectedLabels)
                                     }

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyGridRow.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyGridRow.cshtml
@@ -1,0 +1,18 @@
+@model SurveyGridRowModel
+@{
+    var prefix = $"Questions[{Model.QuestionKey}].GridRows[{Model.RowKey}]";
+}
+<div class="grid-row border rounded p-2 mb-2">
+    <input type="hidden" name="Questions[@Model.QuestionKey].GridRows.Index" value="@Model.RowKey" />
+    <div class="d-flex gap-2 align-items-start">
+        <div class="flex-grow-1">
+            <div class="input-group input-group-sm mb-2">
+                <span class="input-group-text">Value</span>
+                <input type="text" name="@(prefix).Value" class="form-control" value="@Model.Row.Value"
+                       placeholder="stable key, e.g. may-03-09" />
+            </div>
+            <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel($"{prefix}.Label", "Row label", Model.Row.Label))" />
+        </div>
+        <button type="button" class="btn btn-outline-danger btn-sm remove-grid-row" title="Remove row">&times;</button>
+    </div>
+</div>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
@@ -55,7 +55,7 @@
         </div>
 
         <div class="options-section border-top pt-2 mt-2">
-            <label class="form-label small fw-semibold">Options</label>
+            <label class="form-label small fw-semibold options-label">Options</label>
             <div class="options-container">
                 @foreach (var (opt, i) in q.Options.Select((o, i) => (o, i)))
                 {
@@ -66,6 +66,42 @@
                 <partial name="_SurveyOptionRow" model="@(new SurveyOptionRowModel(key, "__OKEY__", new SurveyOptionBuilderViewModel()))" />
             </template>
             <button type="button" class="btn btn-outline-secondary btn-sm add-option">+ Add option</button>
+            <div class="form-text grid-column-help">Grid questions support at most five columns.</div>
+        </div>
+
+        <div class="grid-section border-top pt-2 mt-2">
+            <div class="mb-2">
+                <label class="form-label small fw-semibold" for="grid-mode-@key">Selections per row</label>
+                <select id="grid-mode-@key" name="@(prefix).GridSelectionMode" class="form-select form-select-sm w-auto">
+                    @if (q.GridSelectionMode == GridSelectionMode.Single)
+                    {
+                        <option value="@GridSelectionMode.Single" selected>One choice</option>
+                    }
+                    else
+                    {
+                        <option value="@GridSelectionMode.Single">One choice</option>
+                    }
+                    @if (q.GridSelectionMode == GridSelectionMode.Multiple)
+                    {
+                        <option value="@GridSelectionMode.Multiple" selected>Multiple choices</option>
+                    }
+                    else
+                    {
+                        <option value="@GridSelectionMode.Multiple">Multiple choices</option>
+                    }
+                </select>
+            </div>
+            <label class="form-label small fw-semibold">Rows</label>
+            <div class="grid-rows-container">
+                @foreach (var (row, i) in q.GridRows.Select((row, i) => (row, i)))
+                {
+                    <partial name="_SurveyGridRow" model="@(new SurveyGridRowModel(key, i.ToString(), row))" />
+                }
+            </div>
+            <template class="grid-row-template">
+                <partial name="_SurveyGridRow" model="@(new SurveyGridRowModel(key, "__RKEY__", new SurveyGridRowBuilderViewModel()))" />
+            </template>
+            <button type="button" class="btn btn-outline-secondary btn-sm add-grid-row">+ Add row</button>
         </div>
 
         <div class="border-top pt-2 mt-2 showif-section">

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using Humans.Surveys.Data;
+using Humans.Surveys.Domain;
 using Humans.Integration.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,6 +58,74 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
             new LocalDateTime(2026, 7, 14, 10, 30).InZoneLeniently(Madrid).ToInstant());
         survey.ClosesAt.Should().Be(
             new LocalDateTime(2026, 8, 1, 18, 45, 30).InZoneLeniently(Madrid).ToInstant());
+    }
+
+    [HumansFact(Timeout = 60000)]
+    public async Task Save_binds_and_persists_grid_rows_columns_and_selection_mode()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var createResp = await Client.GetAsync("/Survey/Admin/Create", ct);
+        var token = ExtractAntiForgeryToken(await createResp.Content.ReadAsStringAsync(ct));
+        var questionId = Guid.NewGuid();
+
+        var saveResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", token!),
+            ("Title[en]", $"Grid integration survey {Guid.NewGuid():N}"),
+            ("Questions.Index", "grid"),
+            ("Questions[grid].Id", questionId.ToString()),
+            ("Questions[grid].PageNumber", "1"),
+            ("Questions[grid].Type", nameof(SurveyQuestionType.Grid)),
+            ("Questions[grid].Prompt[en]", "When can you attend?"),
+            ("Questions[grid].IsRequired", "true"),
+            ("Questions[grid].GridSelectionMode", nameof(GridSelectionMode.Multiple)),
+            ("Questions[grid].Options.Index", "morning"),
+            ("Questions[grid].Options[morning].Value", "morning"),
+            ("Questions[grid].Options[morning].Label[en]", "Morning"),
+            ("Questions[grid].Options.Index", "afternoon"),
+            ("Questions[grid].Options[afternoon].Value", "afternoon"),
+            ("Questions[grid].Options[afternoon].Label[en]", "Afternoon"),
+            ("Questions[grid].GridRows.Index", "monday"),
+            ("Questions[grid].GridRows[monday].Value", "monday"),
+            ("Questions[grid].GridRows[monday].Label[en]", "Monday"),
+            ("Questions[grid].GridRows.Index", "tuesday"),
+            ("Questions[grid].GridRows[tuesday].Value", "tuesday"),
+            ("Questions[grid].GridRows[tuesday].Label[en]", "Tuesday")), ct);
+
+        var saveHtml = await saveResp.Content.ReadAsStringAsync(ct);
+        var validationMessages = Regex.Matches(
+                saveHtml,
+                "<li>(?<message>.*?)</li>",
+                RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
+                TimeSpan.FromSeconds(2))
+            .Select(match => match.Groups["message"].Value)
+            .ToList();
+        ((int)saveResp.StatusCode).Should().BeOneOf(
+            [(int)HttpStatusCode.Found, (int)HttpStatusCode.Redirect],
+            $"a valid Grid post should redirect; validation messages were: {string.Join(" | ", validationMessages)}");
+        var idMatch = Regex.Match(
+            saveResp.Headers.Location!.ToString(),
+            "/Survey/Admin/Edit/(?<id>[0-9a-fA-F-]{36})",
+            RegexOptions.ExplicitCapture,
+            TimeSpan.FromSeconds(2));
+        idMatch.Success.Should().BeTrue();
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
+        var surveyId = Guid.Parse(idMatch.Groups["id"].Value);
+        var question = (await db.Surveys.AsNoTracking()
+                .Include(survey => survey.Questions)
+                .ThenInclude(q => q.Options)
+                .SingleAsync(survey => survey.Id == surveyId, ct))
+            .Questions.Should().ContainSingle().Subject;
+
+        question.Id.Should().Be(questionId);
+        question.Type.Should().Be(SurveyQuestionType.Grid);
+        question.IsRequired.Should().BeTrue();
+        question.GridSelectionMode.Should().Be(GridSelectionMode.Multiple);
+        question.GridRows!.Select(row => row.Value).Should().ContainInOrder("monday", "tuesday");
+        question.Options.OrderBy(option => option.Order).Select(option => option.Value)
+            .Should().ContainInOrder("morning", "afternoon");
     }
 
     private static string? ExtractAntiForgeryToken(string html)

--- a/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
+++ b/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NSubstitute;
 using Humans.Users.Contracts;
+using System.Text.Json;
 
 namespace Humans.Surveys.Tests.Controllers;
 
@@ -76,6 +77,33 @@ public class SurveysApiControllerTests
         questions.Should().HaveCount(1);
         questions[0].GetType().GetProperty("type")!.GetValue(questions[0]).Should().Be("SingleChoice");
         questions[0].GetType().GetProperty("prompt")!.GetValue(questions[0]).Should().Be("Pick one");
+    }
+
+    [HumansFact]
+    public async Task Definition_includes_grid_mode_rows_and_columns()
+    {
+        var id = Guid.NewGuid();
+        var questionId = Guid.NewGuid();
+        var editable = new SurveyEditInput(
+            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty, "en", false, null, null, null, null, null, null,
+            [
+                new QuestionInput(
+                    questionId, 1, 0, SurveyQuestionType.Grid, Text("Availability"), LocalizedText.Empty,
+                    true, null, null, LocalizedText.Empty, LocalizedText.Empty, null,
+                    [new OptionInput(Guid.NewGuid(), 0, "morning", Text("Morning"))],
+                    GridSelectionMode.Single,
+                    [new GridRowInput("monday", Text("Monday"))]),
+            ]);
+        _surveys.GetForEditAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new SurveyDetail(id, SurveyStatus.Open, editable));
+
+        var result = await _sut.Definition(id, Xunit.TestContext.Current.CancellationToken);
+
+        var json = JsonSerializer.Serialize(result.Should().BeOfType<OkObjectResult>().Subject.Value);
+        json.Should().Contain(@"""type"":""Grid""");
+        json.Should().Contain(@"""gridSelectionMode"":""Single""");
+        json.Should().Contain(@"""value"":""monday""");
+        json.Should().Contain(@"""label"":""Morning""");
     }
 
     // ── Responses ───────────────────────────────────────────────────────────
@@ -182,6 +210,44 @@ public class SurveysApiControllerTests
         content.ContentType.Should().StartWith("text/markdown");
         content.Content.Should().Contain("| Pick |");
         content.Content.Should().Contain("a\\|b");   // pipe escaped for the MD table
+    }
+
+    [HumansFact]
+    public async Task Responses_projects_resolved_grid_selections()
+    {
+        var id = Guid.NewGuid();
+        var questionId = Guid.NewGuid();
+        var export = new SurveyResponseExport(
+            id, "T", "en",
+            [
+                new SurveyExportQuestion(
+                    questionId, "Availability", SurveyQuestionType.Grid,
+                    [new SurveyExportOption("morning", "Morning")],
+                    GridSelectionMode.Single,
+                    [new SurveyExportGridRow("monday", "Monday")]),
+            ],
+            [
+                Row(
+                    ResponseAnonymity.Anonymous, Submitted, null, null,
+                    new SurveyExportAnswer(
+                        questionId, [], [], null, null,
+                        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+                        {
+                            ["monday"] = ["morning"],
+                        },
+                        [new ResolvedGridSelection("monday", "Monday", ["morning"], ["Morning"])])),
+            ]);
+        _surveys.GetResponseExportAsync(id, Arg.Any<CancellationToken>()).Returns(export);
+
+        var result = await _sut.Responses(
+            id, null, null, 100, null, null, Xunit.TestContext.Current.CancellationToken);
+
+        var json = JsonSerializer.Serialize(result.Should().BeOfType<OkObjectResult>().Subject.Value);
+        json.Should().Contain(@"""gridSelections"":{""monday"":[""morning""]}");
+        json.Should().Contain(@"""rowValue"":""monday""");
+        json.Should().Contain(@"""rowLabel"":""Monday""");
+        json.Should().Contain(@"""columnValues"":[""morning""]");
+        json.Should().Contain(@"""columnLabels"":[""Morning""]");
     }
 
     // ── Aggregates ──────────────────────────────────────────────────────────

--- a/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
@@ -67,4 +67,34 @@ public sealed class SurveyBuilderViewModelTests
         var roundTripped = vm.ToInput(0).ShowIf;
         roundTripped!.Clauses.Single().QuestionId.Should().Be(gate);
     }
+
+    [HumansFact]
+    public void Grid_configuration_round_trips_through_the_builder()
+    {
+        var input = new QuestionInput(
+            Guid.NewGuid(), 1, 0, SurveyQuestionType.Grid,
+            L("Which dates work?"), LocalizedText.Empty, true, null, null,
+            LocalizedText.Empty, LocalizedText.Empty, null,
+            [
+                new OptionInput(Guid.NewGuid(), 0, "morning", L("Morning")),
+                new OptionInput(Guid.NewGuid(), 1, "afternoon", L("Afternoon")),
+            ],
+            GridSelectionMode.Multiple,
+            [
+                new GridRowInput("monday", L("Monday")),
+                new GridRowInput("tuesday", L("Tuesday")),
+            ]);
+
+        var vm = SurveyQuestionBuilderViewModel.FromInput(input);
+        var roundTripped = vm.ToInput(0);
+
+        vm.GridSelectionMode.Should().Be(GridSelectionMode.Multiple);
+        vm.GridRows.Select(row => row.Value).Should().ContainInOrder("monday", "tuesday");
+        roundTripped.GridSelectionMode.Should().Be(GridSelectionMode.Multiple);
+        roundTripped.GridRows!.Select(row => row.Value).Should().ContainInOrder("monday", "tuesday");
+        roundTripped.Options.Select(option => option.Value).Should().ContainInOrder("morning", "afternoon");
+    }
+
+    private static LocalizedText L(string value)
+        => new(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = value });
 }

--- a/tests/Humans.Surveys.Tests/Models/SurveyCsvExportBuilderTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyCsvExportBuilderTests.cs
@@ -18,6 +18,13 @@ public sealed class SurveyCsvExportBuilderTests
     private static SurveyExportQuestion Text(Guid id, string prompt) =>
         new(id, prompt, SurveyQuestionType.ShortText, []);
 
+    private static SurveyExportQuestion Grid(Guid id, string prompt) =>
+        new(
+            id, prompt, SurveyQuestionType.Grid,
+            [new SurveyExportOption("morning", "Morning"), new SurveyExportOption("afternoon", "Afternoon")],
+            GridSelectionMode.Multiple,
+            [new SurveyExportGridRow("monday", "Monday")]);
+
     private static IReadOnlyList<string> Lines(byte[] bytes) =>
         Encoding.UTF8.GetString(bytes)
             .TrimStart('﻿') // exports carry a UTF-8 BOM so Excel detects the encoding
@@ -62,6 +69,39 @@ public sealed class SurveyCsvExportBuilderTests
         // Last column on the single data row is the choice cell — stable values joined by '|', not labels.
         lines[1].Should().EndWith("a|b");
         lines[1].Should().NotContain("Apple");
+    }
+
+    [HumansFact]
+    public void Serializes_grid_selections_as_stable_row_to_column_json()
+    {
+        var gridId = Guid.NewGuid();
+        var export = new SurveyResponseExport(
+            Guid.NewGuid(), "T", "en",
+            [Grid(gridId, "Availability")],
+            [
+                new SurveyExportRow(
+                    Guid.NewGuid(), ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, "en", Submitted, null, null,
+                    [
+                        new SurveyExportAnswer(
+                            gridId, [], [], null, null,
+                            new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+                            {
+                                ["monday"] = ["morning", "afternoon"],
+                            },
+                            [
+                                new ResolvedGridSelection(
+                                    "monday", "Monday",
+                                    ["morning", "afternoon"],
+                                    ["Morning", "Afternoon"]),
+                            ]),
+                    ]),
+            ]);
+
+        var csv = Encoding.UTF8.GetString(SurveyCsvExportBuilder.Build(export));
+
+        csv.Should().Contain(@"{""""monday"""":[""""morning"""",""""afternoon""""]}");
+        csv.Should().NotContain("Monday");
+        csv.Should().NotContain("Morning");
     }
 
     [HumansFact]

--- a/tests/Humans.Surveys.Tests/Models/SurveyResponsesMarkdownBuilderTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyResponsesMarkdownBuilderTests.cs
@@ -16,6 +16,13 @@ public sealed class SurveyResponsesMarkdownBuilderTests
     private static SurveyExportQuestion Text(Guid id, string prompt) =>
         new(id, prompt, SurveyQuestionType.ShortText, []);
 
+    private static SurveyExportQuestion Grid(Guid id, string prompt) =>
+        new(
+            id, prompt, SurveyQuestionType.Grid,
+            [new SurveyExportOption("morning", "Morning")],
+            GridSelectionMode.Single,
+            [new SurveyExportGridRow("monday", "Monday")]);
+
     [HumansFact]
     public void Flattens_multichoice_values_with_pipe_and_uses_values_not_labels()
     {
@@ -47,6 +54,31 @@ public sealed class SurveyResponsesMarkdownBuilderTests
         var dataLine = md.Split('\n')[2];   // header, separator, then the single data row
         dataLine.Should().Contain("line one line \\| two");   // newline → space, pipe → \|
         dataLine.Should().NotContain("\n");
+    }
+
+    [HumansFact]
+    public void Serializes_grid_selections_as_stable_json()
+    {
+        var gridId = Guid.NewGuid();
+        var md = SurveyResponsesMarkdownBuilder.Build(
+            [Grid(gridId, "Availability")],
+            [
+                new SurveyExportRow(
+                    Guid.NewGuid(), ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, "en", Submitted, null, null,
+                    [
+                        new SurveyExportAnswer(
+                            gridId, [], [], null, null,
+                            new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+                            {
+                                ["monday"] = ["morning"],
+                            },
+                            [new ResolvedGridSelection("monday", "Monday", ["morning"], ["Morning"])]),
+                    ]),
+            ]);
+
+        md.Should().Contain(@"{""monday"":[""morning""]}");
+        md.Should().NotContain("Monday");
+        md.Should().NotContain("Morning");
     }
 
     [HumansFact]

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -46,6 +46,20 @@ public class SurveyServiceTests
     private static QuestionInput Q(string prompt, SurveyQuestionType type, int page, int order, params OptionInput[] opts) =>
         new(null, page, order, type, L(prompt), LocalizedText.Empty, false, null, null, LocalizedText.Empty, LocalizedText.Empty, null, opts.ToList());
 
+    private static QuestionInput GridInput(
+        Guid? id = null,
+        int page = 1,
+        int order = 1,
+        GridSelectionMode? mode = GridSelectionMode.Single,
+        IReadOnlyList<OptionInput>? columns = null,
+        IReadOnlyList<GridRowInput>? rows = null) =>
+        new(
+            id, page, order, SurveyQuestionType.Grid, L("Availability"), LocalizedText.Empty,
+            false, null, null, LocalizedText.Empty, LocalizedText.Empty, null,
+            columns ?? [Opt("morning", "Morning", 1), Opt("afternoon", "Afternoon", 2)],
+            mode,
+            rows ?? [new GridRowInput("monday", L("Monday")), new GridRowInput("tuesday", L("Tuesday"))]);
+
     private static SurveyEditInput Input(params QuestionInput[] qs) =>
         new(L("Title"), L("Intro"), L("Thanks"), "en", false, null, null, null, null, null, null, qs.ToList());
 
@@ -75,6 +89,144 @@ public class SurveyServiceTests
         q1.Options.Should().OnlyContain(o => o.QuestionId == q1.Id);
 
         await _audit.Received(1).LogAsync(AuditAction.SurveyCreated, "Survey", id, Arg.Any<string>(), actor);
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_persists_grid_configuration()
+    {
+        Survey? captured = null;
+        _repo.When(r => r.AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>()))
+             .Do(ci => captured = ci.Arg<Survey>());
+
+        await CreateService().CreateAsync(
+            Input(GridInput(mode: GridSelectionMode.Multiple)),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        var grid = captured!.Questions.Should().ContainSingle().Subject;
+        grid.Type.Should().Be(SurveyQuestionType.Grid);
+        grid.GridSelectionMode.Should().Be(GridSelectionMode.Multiple);
+        grid.GridRows!.Select(row => row.Value).Should().ContainInOrder("monday", "tuesday");
+        grid.Options.Select(column => column.Value).Should().ContainInOrder("morning", "afternoon");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_a_grid_with_more_than_five_columns()
+    {
+        var columns = Enumerable.Range(1, 6)
+            .Select(index => Opt($"c{index}", $"Column {index}", index))
+            .ToList();
+
+        var act = async () => await CreateService().CreateAsync(
+            Input(GridInput(columns: columns)),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*between one and five columns*");
+        await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_a_grid_without_rows()
+    {
+        var act = async () => await CreateService().CreateAsync(
+            Input(GridInput(rows: [])),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*at least one row*");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_a_grid_without_a_selection_mode()
+    {
+        var act = async () => await CreateService().CreateAsync(
+            Input(GridInput(mode: null)),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*must choose a selection mode*");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_a_grid_with_a_blank_row_value()
+    {
+        var act = async () => await CreateService().CreateAsync(
+            Input(GridInput(rows: [new GridRowInput(" ", L("Blank"))])),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*row values must not be blank*");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_a_grid_with_duplicate_row_values()
+    {
+        var act = async () => await CreateService().CreateAsync(
+            Input(GridInput(rows:
+            [
+                new GridRowInput("monday", L("Monday")),
+                new GridRowInput("monday", L("Monday again")),
+            ])),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*row values must be unique*");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_a_grid_with_duplicate_column_values()
+    {
+        var act = async () => await CreateService().CreateAsync(
+            Input(GridInput(columns:
+            [
+                Opt("morning", "Morning", 1),
+                Opt("morning", "Morning again", 2),
+            ])),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*column values must be unique*");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_using_a_grid_as_a_branching_source()
+    {
+        var gridId = Guid.NewGuid();
+        var dependentId = Guid.NewGuid();
+        var grid = GridInput(gridId);
+        var dependent = new QuestionInput(
+            dependentId, 2, 1, SurveyQuestionType.ShortText,
+            L("Why?"), LocalizedText.Empty, false, null, null,
+            LocalizedText.Empty, LocalizedText.Empty,
+            new BranchCondition
+            {
+                Clauses =
+                {
+                    new BranchClause
+                    {
+                        QuestionId = gridId,
+                        Operator = BranchOperator.Is,
+                        OptionValues = { "morning" },
+                    },
+                },
+            },
+            []);
+
+        var act = async () => await CreateService().CreateAsync(
+            Input(grid, dependent),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot be branching sources*");
+        await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
     }
 
     private static SurveyEditInput InputWithSlug(string? slug) =>
@@ -208,6 +360,49 @@ public class SurveyServiceTests
         q.Options.Single().Label.Values["es"].Should().Be("es:Good");
         // Empty source fields (intro, thank-you, help, rating labels) are not sent for translation.
         captured.Intro.Values.Should().NotContainKey("de");
+    }
+
+    [HumansFact]
+    public async Task PreFillTranslationsAsync_includes_grid_row_labels()
+    {
+        var survey = SurveyWith(SurveyStatus.Draft, null, null);
+        var questionId = Guid.NewGuid();
+        survey.Questions =
+        [
+            new SurveyQuestion
+            {
+                Id = questionId,
+                SurveyId = survey.Id,
+                PageNumber = 1,
+                Order = 1,
+                Type = SurveyQuestionType.Grid,
+                Prompt = L("Availability"),
+                GridSelectionMode = GridSelectionMode.Single,
+                GridRows = [new SurveyGridRow("monday", L("Monday"))],
+                Options =
+                [
+                    new SurveyQuestionOption
+                    {
+                        Id = Guid.NewGuid(),
+                        QuestionId = questionId,
+                        Order = 1,
+                        Value = "morning",
+                        Label = L("Morning"),
+                    },
+                ],
+            },
+        ];
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        Survey? captured = null;
+        _repo.When(r => r.UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>()))
+            .Do(ci => captured = ci.Arg<Survey>());
+        StubTranslationAsMarker();
+
+        var filled = await CreateService().PreFillTranslationsAsync(
+            survey.Id, ["en", "es"], Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        filled.Should().Be(4); // survey title + question prompt + column label + row label
+        captured!.Questions.Single().GridRows!.Single().Label.Values["es"].Should().Be("es:Monday");
     }
 
     [HumansFact]
@@ -922,6 +1117,28 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task SubmitResponseAsync_stores_null_for_an_unanswered_optional_grid()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        var grid = GridQuestion(Guid.NewGuid(), survey.Id);
+        survey.Questions = [grid];
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        SurveyResponse? captured = null;
+        _repo.When(r => r.AddResponseWithAnswersAndSaveAsync(Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>()))
+            .Do(ci => captured = ci.Arg<SurveyResponse>());
+        var submission = new SurveySubmission(
+            survey.Id, null, null, null,
+            ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, "en",
+            [new SurveyAnswerInput(
+                grid.Id, [], null, null,
+                new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal))]);
+
+        await CreateService().SubmitResponseAsync(submission, TestContext.Current.CancellationToken);
+
+        captured!.Answers.Should().ContainSingle().Which.GridSelections.Should().BeNull();
+    }
+
+    [HumansFact]
     public async Task SubmitResponseAsync_drops_answers_to_questions_hidden_by_branching()
     {
         var gate = Guid.NewGuid();
@@ -1176,6 +1393,62 @@ public class SurveyServiceTests
         state.CurrentPage.Should().Be(1);
     }
 
+    [HumansFact]
+    public async Task AdvanceWizardAsync_normalizes_grid_rows_columns_and_single_selection()
+    {
+        var gridId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        survey.Questions =
+        [
+            new SurveyQuestion
+            {
+                Id = gridId,
+                SurveyId = survey.Id,
+                PageNumber = 1,
+                Order = 1,
+                Type = SurveyQuestionType.Grid,
+                Prompt = L("Availability"),
+                GridSelectionMode = GridSelectionMode.Single,
+                GridRows =
+                [
+                    new SurveyGridRow("monday", L("Monday")),
+                    new SurveyGridRow("tuesday", L("Tuesday")),
+                ],
+                Options =
+                [
+                    new SurveyQuestionOption
+                    {
+                        Id = Guid.NewGuid(), QuestionId = gridId, Order = 1,
+                        Value = "morning", Label = L("Morning"),
+                    },
+                    new SurveyQuestionOption
+                    {
+                        Id = Guid.NewGuid(), QuestionId = gridId, Order = 2,
+                        Value = "afternoon", Label = L("Afternoon"),
+                    },
+                ],
+            },
+        ];
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        var state = WizardState(survey.Id);
+        var posted = new SurveyAnswerInput(
+            gridId, [], null, null,
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+            {
+                ["monday"] = ["morning", "afternoon", "morning"],
+                ["tuesday"] = ["invalid", "afternoon"],
+                ["unknown-row"] = ["morning"],
+            });
+
+        await CreateService().AdvanceWizardAsync(
+            state, 1, back: true, [posted], ct: TestContext.Current.CancellationToken);
+
+        var captured = state.Answers[gridId.ToString()].GridSelections;
+        captured.Keys.Should().BeEquivalentTo("monday", "tuesday");
+        captured["monday"].Should().ContainSingle().Which.Should().Be("morning");
+        captured["tuesday"].Should().ContainSingle().Which.Should().Be("afternoon");
+    }
+
     // ── Results aggregation (Task 6.1) ─────────────────────────────────────────
 
     private static SurveyQuestion ChoiceQuestion(Guid id, Guid surveyId, SurveyQuestionType type, int order, params (string Value, string Label, int Order)[] opts) => new()
@@ -1233,6 +1506,48 @@ public class SurveyServiceTests
 
     private static SurveyAnswer TextAnswer(Guid questionId, string? text) =>
         new() { Id = Guid.NewGuid(), QuestionId = questionId, TextValue = text };
+
+    private static SurveyQuestion GridQuestion(Guid id, Guid surveyId, GridSelectionMode mode = GridSelectionMode.Multiple) => new()
+    {
+        Id = id,
+        SurveyId = surveyId,
+        PageNumber = 1,
+        Order = 1,
+        Type = SurveyQuestionType.Grid,
+        Prompt = L("Availability"),
+        GridSelectionMode = mode,
+        GridRows =
+        [
+            new SurveyGridRow("monday", L("Monday")),
+            new SurveyGridRow("tuesday", L("Tuesday")),
+        ],
+        Options =
+        [
+            new SurveyQuestionOption
+            {
+                Id = Guid.NewGuid(), QuestionId = id, Order = 1,
+                Value = "morning", Label = L("Morning"),
+            },
+            new SurveyQuestionOption
+            {
+                Id = Guid.NewGuid(), QuestionId = id, Order = 2,
+                Value = "afternoon", Label = L("Afternoon"),
+            },
+        ],
+    };
+
+    private static SurveyAnswer GridAnswer(
+        Guid questionId,
+        params (string Row, string[] Columns)[] selections) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            QuestionId = questionId,
+            GridSelections = selections.ToDictionary(
+                selection => selection.Row,
+                selection => selection.Columns.ToList(),
+                StringComparer.Ordinal),
+        };
 
     [HumansFact]
     public async Task GetResultsAsync_returns_null_when_survey_missing()
@@ -1309,6 +1624,43 @@ public class SurveyServiceTests
 
         var text = result.Questions.Single(q => q.QuestionId == textId);
         text.FreeTextAnswers.Should().BeEquivalentTo(new[] { "great", "ok" });
+    }
+
+    [HumansFact]
+    public async Task GetResultsAsync_aggregates_grid_cells_per_row()
+    {
+        var surveyId = Guid.NewGuid();
+        var gridId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(survey, surveyId);
+        survey.Questions = [GridQuestion(gridId, surveyId)];
+        _repo.GetByIdAsync(surveyId, Arg.Any<CancellationToken>()).Returns(survey);
+        var now = _clock.GetCurrentInstant();
+        _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                SubmittedResponse(
+                    surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, now, null,
+                    GridAnswer(gridId, ("monday", ["morning", "afternoon"]), ("tuesday", ["afternoon"]))),
+                SubmittedResponse(
+                    surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug, now, null,
+                    GridAnswer(gridId, ("monday", ["morning"]))),
+            ]);
+        _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, int>());
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
+
+        var result = await CreateService().GetResultsAsync(surveyId, TestContext.Current.CancellationToken);
+
+        var grid = result!.Questions.Should().ContainSingle().Subject.Grid!;
+        grid.Mode.Should().Be(GridSelectionMode.Multiple);
+        var monday = grid.Rows.Single(row => string.Equals(row.Value, "monday", StringComparison.Ordinal));
+        monday.Cells.Single(cell => string.Equals(cell.ColumnValue, "morning", StringComparison.Ordinal)).Count.Should().Be(2);
+        monday.Cells.Single(cell => string.Equals(cell.ColumnValue, "morning", StringComparison.Ordinal)).Percent.Should().Be(100);
+        monday.Cells.Single(cell => string.Equals(cell.ColumnValue, "afternoon", StringComparison.Ordinal)).Percent.Should().Be(50);
+        var tuesday = grid.Rows.Single(row => string.Equals(row.Value, "tuesday", StringComparison.Ordinal));
+        tuesday.Cells.Single(cell => string.Equals(cell.ColumnValue, "afternoon", StringComparison.Ordinal)).Percent.Should().Be(100);
     }
 
     [HumansFact]
@@ -1559,6 +1911,69 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task GetResponseExportAsync_includes_grid_schema_and_resolved_selections()
+    {
+        var surveyId = Guid.NewGuid();
+        var gridId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(survey, surveyId);
+        survey.Questions = [GridQuestion(gridId, surveyId)];
+        _repo.GetByIdAsync(surveyId, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                SubmittedResponse(
+                    surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug,
+                    _clock.GetCurrentInstant(), null,
+                    GridAnswer(gridId, ("monday", ["morning", "afternoon"]))),
+            ]);
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
+
+        var export = await CreateService().GetResponseExportAsync(surveyId, TestContext.Current.CancellationToken);
+
+        var schema = export!.Questions.Should().ContainSingle().Subject;
+        schema.GridSelectionMode.Should().Be(GridSelectionMode.Multiple);
+        schema.GridRows!.Select(row => row.Label).Should().ContainInOrder("Monday", "Tuesday");
+        var answer = export.Rows.Single().Answers.Single();
+        answer.GridSelections!["monday"].Should().ContainInOrder("morning", "afternoon");
+        var selection = answer.GridSelectionLabels.Should().ContainSingle().Subject;
+        selection.RowValue.Should().Be("monday");
+        selection.RowLabel.Should().Be("Monday");
+        selection.ColumnValues.Should().ContainInOrder("morning", "afternoon");
+        selection.ColumnLabels.Should().ContainInOrder("Morning", "Afternoon");
+    }
+
+    [HumansFact]
+    public async Task GetResponseExportAsync_preserves_raw_grid_keys_removed_from_the_current_definition()
+    {
+        var surveyId = Guid.NewGuid();
+        var gridId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(survey, surveyId);
+        survey.Questions = [GridQuestion(gridId, surveyId)];
+        _repo.GetByIdAsync(surveyId, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                SubmittedResponse(
+                    surveyId, ResponseAnonymity.Anonymous, SurveyInputMethod.Slug,
+                    _clock.GetCurrentInstant(), null,
+                    GridAnswer(gridId, ("removed-row", ["removed-column"]))),
+            ]);
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
+
+        var export = await CreateService().GetResponseExportAsync(surveyId, TestContext.Current.CancellationToken);
+
+        var answer = export!.Rows.Single().Answers.Single();
+        answer.GridSelections!["removed-row"].Should().ContainSingle().Which.Should().Be("removed-column");
+        var labels = answer.GridSelectionLabels.Should().ContainSingle().Subject;
+        labels.RowLabel.Should().Be("removed-row");
+        labels.ColumnLabels.Should().ContainSingle().Which.Should().Be("removed-column");
+    }
+
+    [HumansFact]
     public async Task GetResponseExportAsync_orders_rows_by_submitted_at()
     {
         var surveyId = Guid.NewGuid();
@@ -1591,6 +2006,7 @@ public class SurveyServiceTests
         var choiceId = Guid.NewGuid();
         var textId = Guid.NewGuid();
         var ratingId = Guid.NewGuid();
+        var gridId = Guid.NewGuid();
         var survey = SurveyWith(SurveyStatus.Closed, null, null);
         typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(survey, surveyId);
         survey.Title = L("Summer Feedback");
@@ -1599,12 +2015,14 @@ public class SurveyServiceTests
             ChoiceQuestion(choiceId, surveyId, SurveyQuestionType.SingleChoice, 1, ("yes", "Yes", 1), ("no", "No", 2)),
             RatingQuestion(ratingId, surveyId, 2, 1, 5),
             TextQuestion(textId, surveyId, 3),
+            GridQuestion(gridId, surveyId),
         };
         _repo.GetByIdAsync(surveyId, Arg.Any<CancellationToken>()).Returns(survey);
 
         var response = SubmittedResponse(surveyId, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
             _clock.GetCurrentInstant(), userId,
-            ChoiceAnswer(choiceId, "yes"), RatingAnswer(ratingId, 4), TextAnswer(textId, "loved it"));
+            ChoiceAnswer(choiceId, "yes"), RatingAnswer(ratingId, 4), TextAnswer(textId, "loved it"),
+            GridAnswer(gridId, ("removed-row", ["removed-column"])));
         _repo.GetIdentifiedResponsesForUserAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new List<SurveyResponse> { response });
 
@@ -1620,6 +2038,8 @@ public class SurveyServiceTests
         json.Should().Contain("Yes");        // resolved choice label
         json.Should().Contain("loved it");   // free-text value
         json.Should().Contain("4");          // rating value
+        json.Should().Contain("removed-row");
+        json.Should().Contain("removed-column");
     }
 
     [HumansFact]

--- a/tests/Humans.Surveys.Tests/Services/SurveyWizardFlowTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyWizardFlowTests.cs
@@ -16,6 +16,17 @@ public class SurveyWizardFlowTests
         new(id, page, order, type, L("Q"), LocalizedText.Empty, required, null, null,
             LocalizedText.Empty, LocalizedText.Empty, showIf, opts.ToList());
 
+    private static QuestionInput Grid(
+        Guid id,
+        GridSelectionMode mode,
+        bool required = true) =>
+        new(
+            id, 1, 0, SurveyQuestionType.Grid, L("Availability"), LocalizedText.Empty,
+            required, null, null, LocalizedText.Empty, LocalizedText.Empty, null,
+            [Opt("morning"), Opt("afternoon")],
+            mode,
+            [new GridRowInput("monday", L("Monday")), new GridRowInput("tuesday", L("Tuesday"))]);
+
     private static BranchCondition ShowIfIs(Guid q, string value) => new()
     {
         Combine = BranchCombine.All,
@@ -183,5 +194,68 @@ public class SurveyWizardFlowTests
         };
 
         SurveyWizardFlow.RequiredUnanswered(visible, answers).Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void RequiredUnanswered_requires_an_answer_for_every_grid_row()
+    {
+        var id = Guid.NewGuid();
+        var visible = new[] { Grid(id, GridSelectionMode.Multiple) };
+        var incomplete = new Dictionary<Guid, AnswerState>
+        {
+            [id] = new AnswerState(
+                [], null, null,
+                new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+                {
+                    ["monday"] = ["morning"],
+                }),
+        };
+
+        SurveyWizardFlow.RequiredUnanswered(visible, incomplete).Should().ContainSingle().Which.Should().Be(id);
+
+        incomplete[id] = incomplete[id] with
+        {
+            Grid = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+            {
+                ["monday"] = ["morning"],
+                ["tuesday"] = ["afternoon"],
+            },
+        };
+
+        SurveyWizardFlow.RequiredUnanswered(visible, incomplete).Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void RequiredUnanswered_requires_exactly_one_selection_per_row_in_single_mode()
+    {
+        var id = Guid.NewGuid();
+        var visible = new[] { Grid(id, GridSelectionMode.Single) };
+        var answers = new Dictionary<Guid, AnswerState>
+        {
+            [id] = new AnswerState(
+                [], null, null,
+                new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+                {
+                    ["monday"] = ["morning", "afternoon"],
+                    ["tuesday"] = ["afternoon"],
+                }),
+        };
+
+        SurveyWizardFlow.RequiredUnanswered(visible, answers).Should().ContainSingle().Which.Should().Be(id);
+    }
+
+    [HumansFact]
+    public void ToAnswerInputs_keeps_empty_grid_data_null_for_non_grid_answers()
+    {
+        var id = Guid.NewGuid();
+        var answers = new Dictionary<string, SurveyWizardAnswer>(StringComparer.Ordinal)
+        {
+            [id.ToString()] = new() { TextValue = "hello" },
+        };
+
+        var input = SurveyWizardFlow.ToAnswerInputs(answers).Should().ContainSingle().Subject;
+
+        input.TextValue.Should().Be("hello");
+        input.GridSelections.Should().BeNull();
     }
 }


### PR DESCRIPTION
## What

Adds a **Grid** survey question type with localized rows, one to five shared columns, and either single- or multiple-selection mode per row.

Covers authoring, translation pre-fill, answering and resume, validation, results, Identified drill-down, CSV/JSON/Markdown/API exports, GDPR export, persistence, migration, and tests.

Closes nobodies-collective/Humans#1093.

## Why

Survey authors need a compact way to ask the same question across a series of rows (for example dates) without duplicating one question per row.

## Existing surface checked

- Reuses `SurveyQuestionOption` as Grid columns, including ordering, localization, reconciliation, and stable values.
- Extends the existing survey builder, wizard state, answer row, results, exports, API, and GDPR contributor.
- Stores bounded row definitions and structured answers as nullable section-owned jsonb columns.
- No new public contract, service/repository method, route, package, or DI registration.
- Grid questions may be branch targets but not branch sources.

## UI changes / screenshots

The local demo was exercised at `/Survey/grid-question-demo`, including builder save, responsive answering table, required-row error preservation, successful submission, and results matrix. The PR preview can be used for final visual review once CI deploys it.

## Validation

- `Humans.Surveys.Tests`: **149/149 passed**
- `Humans.Integration.Tests`: **292 passed, 1 expected skip**
- Full Release build: **0 warnings, 0 errors**
- Full solution test gate passed
- Real MVC + EF builder/database round-trip integration test passed
- Local PostgreSQL end-to-end submission, results, CSV, and JSON export checks passed
- `dotnet ef migrations has-pending-model-changes --context SurveysDbContext`: clean
- `git diff --check`: clean

Lume independently reviewed the change and reran the focused suite plus the touched controller integration tests. Follow-up fixes preserve raw historical Grid keys in exports, expose best-effort labels separately, retain removed row/column values, persist optional empty Grid answers as `NULL`, and cover the previously missing validation/GDPR cases.

## Checklist

- [x] **Section labeled** — production issue carries the existing feature/database labels; the QA fork currently has no section labels available.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off QA `main`** (`peterdrier/Humans` commit `10402ee8581eb2a55bc2ecaa337bcb6bc76fc89c`).
- [x] **Issue refs are qualified** (`nobodies-collective/Humans#1093`).
- [x] **EF migrations** auto-generated, not hand-edited; all three existing-table columns are nullable.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No.
- [x] **Reuse-first checked** — no unnecessary durable/public surface added.
- [x] **Build + test pass locally**.
- [x] **Nav coverage** — no new page or route; Grid is available through the existing survey builder.
- [x] **No magic strings** — stable row/column values are authored domain data; no new route magic strings.
- [x] **Dates/times via NodaTime**, icons via Font Awesome 6 — no new date/time or icon behavior.

## Reviewer notes

- `SurveysDbContextModelSnapshot.cs` includes generated CLR namespace churn (`Humans.Domain.Entities.*` → `Humans.Surveys.Domain.*`) and an EF product-version bump from 10.0.9 to 10.0.10. The Surveys entities moved namespaces previously; regeneration surfaced that stale metadata. **The migration contains no schema operations beyond the three nullable columns.**
- Exports follow the existing choice-answer fidelity pattern: raw stable keys are retained in `GridSelections`, while `GridSelectionLabels` provides best-effort labels and falls back to raw keys if a live survey definition was edited after submission.
- Issue #1093 is Daniel-authored and currently has no Peter comment. Daniel explicitly instructed us to proceed with this PR despite that process gate.
- Optional single-mode rows retain standard radio behavior: once selected, a row has no explicit clear affordance. This is unchanged from the agreed scope and can be revisited if user feedback calls for it.
