### PR TITLE
audit(users): re-verify HUM_USER_DISPLAYNAME warnings after G5 move (#1053)

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -120,25 +120,31 @@ themes:
     title: User.DisplayName reads (HUM_USER_DISPLAYNAME)
     detect: "build:HUM_USER_DISPLAYNAME"
     review: light
-    last_swept: 2026-06-13
-    remaining: 20
+    last_swept: 2026-08-20
+    remaining: 19
     notes: >-
-      ACTIONABLE = 0 (audited every site, sweep 2026-06-13). All 20 sites that
-      fire HUM_USER_DISPLAYNAME are legitimate consumers per the obsolete
-      message: creation-time writes (AccountController.CreateExternalLoginUser,
-      AccountProvisioningService ×2), BurnerName-fallback derivation
-      (UserInfo.cs, CachingUserService.WithUserFields/RehydrateUser),
-      write-side sync (UserInfoSaveChangesInterceptor), repository
-      merge/purge/delete labels (UserRepository ×6), GDPR export
-      (UserService GdprExport shape), GDPR-anonymized sentinel state
-      (UserStateClassifier), and debug/dev seeders (DevPersonaSeeder ×2,
-      DevelopmentDashboardSeeder, GateTerminalAccountSeeder). Rendering-caller
-      debt was already migrated (#691). DETECT OVERCOUNTS: build:HUM_USER_DISPLAYNAME
-      counts all 20 firing sites, but legit consumers cannot be silenced
-      without a forbidden pragma, so the count floors at ~20 and can never
-      reach 0. remaining bumped 12->20 to match the detect; treat it as the
-      irreducible legit floor, not a backlog. PARKED — re-check only if a new
-      rendering caller of User.DisplayName appears (the analyzer will flag it).
+      ACTIONABLE = 0 (re-audited every site against a full clean rebuild,
+      #1053, 2026-08-20 — the section's G5 move into its own project gave the
+      analyzer a compilation unit to fire against on every clean build, which
+      is what surfaced the count for a full-rebuild audience). All 19 sites
+      that fire HUM_USER_DISPLAYNAME are still legitimate consumers per the
+      obsolete message: creation-time writes (ExternalLoginService.CreateUserAsync,
+      AccountProvisioningService ×2, dev/system seeders ×4), BurnerName-fallback
+      derivation (UserInfo.cs, CachingUserService.WithUserFields), write-side
+      sync (UserInfoSaveChangesInterceptor ×2, UserRepository.UpdateDisplayNameAsync),
+      repository merge/purge/delete labels (UserRepository ×5 more), GDPR
+      export (UserService.ContributeForUserAsync), and GDPR-anonymized
+      sentinel state (UserStateEvaluator). Full site table in
+      peterdrier/Humans PR for #1053. Count dropped 20->19 since the
+      2026-06-13 sweep because CachingUserService.RehydrateUser (one of the
+      two BurnerName-derivation sites back then) no longer exists — folded
+      into WithUserFields at some point since, not because a site was
+      silenced. Rendering-caller debt was already migrated (#691). DETECT
+      OVERCOUNTS: build:HUM_USER_DISPLAYNAME counts all 19 firing sites, but
+      legit consumers cannot be silenced without a forbidden pragma, so the
+      count floors at ~19 and can never reach 0. Treat it as the irreducible
+      legit floor, not a backlog. PARKED — re-check only if a new rendering
+      caller of User.DisplayName appears (the analyzer will flag it).
       Peter 2026-06-13: LEAVE parked in the ledger; the [Obsolete] warning
       independently guards against new misuse.
   - id: cs0618-pragma-nav-reads

--- a/src/Sections/Humans.Users/Data/Repositories/UserRepository.cs
+++ b/src/Sections/Humans.Users/Data/Repositories/UserRepository.cs
@@ -95,6 +95,7 @@ internal sealed partial class UserRepository : IUserRepository
 
     // Writes — User
 
+    /// <summary>Keeps the legacy fallback column synced to BurnerName so merge/purge/GDPR labels stay accurate if the Profile is later gone.</summary>
     public async Task<bool> UpdateDisplayNameAsync(
         Guid userId, string displayName, CancellationToken ct = default)
     {


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1053

## Summary

Re-audited every `HUM_USER_DISPLAYNAME` warning site against a **full clean rebuild** (`dotnet clean` + `dotnet build Humans.slnx`) of the whole solution, per the issue's definition of done.

**Actual count is 19, not 31.** The issue title's "31" and a prior in-session (lost) recon pass's "22" both predate this build. A fresh clean rebuild today surfaces exactly 19 unique `HUM_USER_DISPLAYNAME` sites, and that count matches — site for site — the categories the 2026-06-13 debt-sweep already audited and parked (`docs/architecture/debt-ledger.yml`, `obsolete-user-displayname`), modulo one site (`CachingUserService.RehydrateUser`) that no longer exists (folded into `WithUserFields` since). **All 19 are legitimate** per `memory/architecture/burnername-is-the-display-name.md`'s consumer list — no real violations found.

## Classification table (19 sites, full-rebuild verified)

| Site | Verdict | Why |
|---|---|---|
| `Users.Contracts/UserInfo.cs:389` | Legitimate | Resolver implementation — this *is* the code that computes `UserInfo.BurnerName` from the legacy fallback. |
| `Users/Data/CachingUserService.cs:320` | Legitimate | Resolver implementation (`WithUserFields`) — same BurnerName resolution, cache-refresh path. |
| `Users/Data/Repositories/UserRepository.cs:107` (`UpdateDisplayNameAsync`) | Legitimate | Write-side sync: keeps the legacy fallback column mirrored to the current BurnerName so the merge/purge/GDPR labels below stay accurate instead of showing a stale account-creation name. Added a one-line doc comment — the least self-evident of the 19. |
| `Users/Data/Repositories/UserRepository.cs:259` (`AnonymizeForMergeAsync`) | Legitimate | Repository merge-tombstone label ("Merged User"). |
| `Users/Data/Repositories/UserRepository.cs:467, 476` (`PurgeAsync`) | Legitimate | Repository purge-tombstone label ("Purged (...)"). |
| `Users/Data/Repositories/UserRepository.cs:520, 523` (`ApplyExpiredDeletionAnonymizationAsync`) | Legitimate | Repository GDPR-anonymization tombstone label. |
| `Users/Data/UserInfoSaveChangesInterceptor.cs:161` (×2, read+write) | Legitimate | Cloning `User` entity fields for cache-invalidation diffing (`CloneUserInfoFields`) — infrastructure, not rendering. |
| `Users/Domain/UserStateEvaluator.cs:20` | Legitimate | Comparing against the GDPR-anonymized sentinel value to derive `UserState` — state classification, not rendering. |
| `Users/Services/AccountProvisioningService.cs:64` (`FindOrCreateUserByEmailAsync`) | Legitimate | Creation-time fallback: seeds legacy `DisplayName` on new-user construction (import/ticket/MailerLite path). |
| `Users/Services/AccountProvisioningService.cs:132` (`CompleteMagicLinkSignupAsync`) | Legitimate | Creation-time fallback: seeds legacy `DisplayName` from the entered BurnerName on magic-link signup. |
| `Users/Services/ExternalLoginService.cs:215` (`CreateUserAsync`) | Legitimate | Creation-time fallback: seeds legacy `DisplayName` on OAuth signup. |
| `Users/Services/UserService.cs:933` (`ContributeForUserAsync`) | Legitimate | GDPR data export — the field is legitimately part of the exported account record. |
| `Development/Services/DevPersonaSeeder.cs:104, 323` | Legitimate | Dev-only persona/guest seeders — explicitly named in the analyzer's own message + Directory.Build.props rationale. |
| `Development/Services/DevelopmentDashboardSeeder.cs:258` | Legitimate | Dev-only dashboard fixture seeder. |
| `Tickets/Services/GateTerminalAccountSeeder.cs:90` | Legitimate | System-account provisioning (gate terminal), same creation-time-fallback shape as the Users creation sites. |

Zero real violations. No rendering-path reads found (that debt was already migrated in #691).

## Why the build isn't "warning-quiet"

The issue's DoD says legitimate sites are "suppressed or recorded." Per-site suppression (`#pragma`, `[SuppressMessage]`) is a **hard rule violation** — `memory/process/no-analyzer-suppressions.md` names `HUM_USER_DISPLAYNAME` explicitly in its scope. `Directory.Build.props` already documents Peter's deliberate decision (2026-06-13 sweep) to keep this warning **visible** in production projects specifically so a *new* rendering-path violation gets caught — silencing the legitimate 19 would silence that guard too. So the correct action here is "recorded," not "suppressed," and the build is not warning-quiet by design. This matches the issue's own escape hatch: "the outcome may correctly be 'all N are legitimate, record that and move on'."

## What changed

- `docs/architecture/debt-ledger.yml` — refreshed the existing `obsolete-user-displayname` theme entry: `last_swept` 2026-06-13 → 2026-08-20, `remaining` 20 → 19, notes updated with the current per-site breakdown and the `RehydrateUser` count explanation.
- `src/Sections/Humans.Users/Data/Repositories/UserRepository.cs` — one-line doc comment on `UpdateDisplayNameAsync` explaining the write-side-sync rationale (the only one of the 19 sites whose purpose wasn't already evident from surrounding code/method names).

No other code changes — nothing here needed a fix.

## Rejected options

- **Suppress via pragma/`[SuppressMessage]`** — forbidden by `no-analyzer-suppressions.md` for this exact diagnostic id.
- **`[Grandfathered]` attribute** — doesn't apply; `HUM_USER_DISPLAYNAME` is a plain C# `[Obsolete]`-with-`DiagnosticId` warning, not one of the custom HUM#### Roslyn analyzers that support `[Grandfathered]`.
- **Comment every one of the 19 sites** — most already read unambiguously from their method name/context (`PurgeAsync`, `AnonymizeForMergeAsync`, `ContributeForUserAsync`, dev-seeder classes). Added a comment only where the rationale wasn't obvious (`UpdateDisplayNameAsync`), per surgical-fix / minimal-diff discipline.
- **Rewrite the memory atom's consumer list** — already accurate; the 19 sites map cleanly onto its existing categories (resolver implementations, debug screens n/a here, infrastructure mutations, creation-time fallback, GDPR export/anonymization). No gap found worth a doc change beyond the ledger refresh.

## Needs new interface surface — owner approval required

None. No site needed new surface.
