### PR TITLE
feat(camps): mark a season Full as an informational status label

### DIFF
--- a/src/Sections/Humans.Camps/Controllers/CampController.cs
+++ b/src/Sections/Humans.Camps/Controllers/CampController.cs
@@ -649,6 +649,31 @@ internal sealed class CampController(
     }
 
     [Authorize]
+    [HttpPost("{slug}/MarkFull/{seasonId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> MarkFull(string slug, Guid seasonId)
+    {
+        var (errorResult, _, camp) = await ResolveCampManagementAsync(slug);
+        if (errorResult is not null)
+        {
+            return errorResult;
+        }
+
+        try
+        {
+            await _campService.MarkSeasonFullAsync(seasonId);
+            SetSuccess("Season marked as full. New join requests are now blocked.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning(ex, "Marking camp season full failed for camp {CampId}, slug {Slug}, and season {SeasonId}", camp.Id, slug, seasonId);
+            SetError(ex.Message);
+        }
+
+        return RedirectToAction(nameof(Details), new { slug });
+    }
+
+    [Authorize]
     [HttpPost("{slug}/Rejoin/{seasonId:guid}")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Rejoin(string slug, Guid seasonId)

--- a/src/Sections/Humans.Camps/Controllers/CampController.cs
+++ b/src/Sections/Humans.Camps/Controllers/CampController.cs
@@ -473,7 +473,9 @@ internal sealed class CampController(
                 .OrderBy(MemberName, StringComparer.OrdinalIgnoreCase).ToList();
         }
 
-        var openSeason = camp.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
+        // Full is informational only (Peter, 2026-08-20) — it must not disable camp
+        // management, so role management stays available on a Full season too.
+        var openSeason = camp.Seasons.FirstOrDefault(s => s.Status is CampSeasonStatus.Active or CampSeasonStatus.Full);
         viewModel.RolesPanel = openSeason is null
             ? null
             : await BuildRolesPanelAsync(camp.Slug, openSeason, canManage: true, ct);
@@ -661,7 +663,7 @@ internal sealed class CampController(
 
         try
         {
-            await _campService.SetSeasonStatusAsync(seasonId, CampSeasonStatus.Full);
+            await _campService.SetSeasonStatusAsync(camp.Id, seasonId, CampSeasonStatus.Full);
             SetSuccess("Season marked as full.");
         }
         catch (InvalidOperationException ex)
@@ -1045,7 +1047,7 @@ internal sealed class CampController(
         var (errorResult, user, camp) = await ResolveCampManagementAsync(slug);
         if (errorResult is not null) return errorResult;
 
-        var openSeason = camp.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
+        var openSeason = camp.Seasons.FirstOrDefault(s => s.Status is CampSeasonStatus.Active or CampSeasonStatus.Full);
         var outcome = openSeason is null
             ? AssignCampRoleOutcome.SeasonNotFound
             : await campRoleService.AssignAsync(openSeason.Id, roleDefinitionId, campMemberId, user.Id, ct);

--- a/src/Sections/Humans.Camps/Controllers/CampController.cs
+++ b/src/Sections/Humans.Camps/Controllers/CampController.cs
@@ -661,8 +661,8 @@ internal sealed class CampController(
 
         try
         {
-            await _campService.MarkSeasonFullAsync(seasonId);
-            SetSuccess("Season marked as full. New join requests are now blocked.");
+            await _campService.SetSeasonStatusAsync(seasonId, CampSeasonStatus.Full);
+            SetSuccess("Season marked as full.");
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Sections/Humans.Camps/Docs/Camps.md
+++ b/src/Sections/Humans.Camps/Docs/Camps.md
@@ -149,7 +149,7 @@ Four controllers serve this section. The MVC URL surface is dual-routed under `/
 | `/Camps/{slug}/Edit` | `CampController` | Lead-only edit of season copy / images / leads (links through to Members for role/membership management) |
 | `/Camps/{slug}/Edit/Members` | `CampController.Members` | Lead-only members + roles management (pending requests, active members, role assignments) |
 | `/Camps/Register` | `CampController` | New camp registration |
-| `/Camps/{slug}/OptIn/{year}`, `.../Withdraw/{seasonId}`, `.../Rejoin/{seasonId}` | `CampController` | Per-season participation toggles |
+| `/Camps/{slug}/OptIn/{year}`, `.../Withdraw/{seasonId}`, `.../Rejoin/{seasonId}`, `.../MarkFull/{seasonId}` | `CampController` | Per-season participation toggles |
 | `/Camps/{slug}/Members/*` | `CampController` | Member request/approve/reject/remove/leave |
 | `/Camps/{slug}/Roles/*` | `CampController` | Per-camp role assignment/unassignment |
 | `/Camps/{slug}/Images/*` | `CampController` | Image upload/delete/reorder |
@@ -174,7 +174,7 @@ Admin pages live under `/Camps/Admin/*` — never `/Admin/Camps/*` (per `docs/ar
 |-------|--------------|
 | Anyone (including anonymous) | Browse the camps directory, view camp details and season details |
 | Any authenticated human | Register a new camp (which creates a new season in Pending status). Request to join a camp for its open season; withdraw their own pending request; leave their own active membership. |
-| Camp lead | Edit their camp's details, manage season registrations, manage co-leads, upload/manage images, manage historical names. Approve / reject pending membership requests for their camp. Remove active members. Add an active member directly to their camp (lead-driven shortcut). Assign / unassign per-camp role assignments for their camp. |
+| Camp lead | Edit their camp's details, manage season registrations, manage co-leads, upload/manage images, manage historical names. Approve / reject pending membership requests for their camp. Remove active members. Add an active member directly to their camp (lead-driven shortcut). Assign / unassign per-camp role assignments for their camp. Mark their camp's Active season Full, closing it to new join requests. |
 | CampAdmin, Admin | All camp lead capabilities on all camps. Approve/reject season registrations. Reactivate a Full or Withdrawn season. Manage camp settings (public year, open seasons, name lock dates). Update registration info copy. View withdrawn seasons on the admin dashboard. Export camp data as CSV. Manage the role-definition catalogue (create, edit, deactivate, reactivate). View the role-staffing compliance matrix. |
 | Team/sub-team coordinator | View the read-only role-staffing compliance matrix at `/Camps/Admin/Compliance` (via `CampComplianceAccess`) — no camp-management authority. |
 | Admin | Delete camps |
@@ -182,7 +182,8 @@ Admin pages live under `/Camps/Admin/*` — never `/Admin/Camps/*` (per `docs/ar
 ## Invariants
 
 - Each camp has a unique slug used for URL routing.
-- Camp season status follows: Pending then Active, Full, Rejected, or Withdrawn. Only CampAdmin can approve or reject a season.
+- Camp season status follows: Pending then Active, Full, Rejected, or Withdrawn. Only CampAdmin can approve or reject a season. A camp lead or CampAdmin can mark an Active season Full (`MarkSeasonFullAsync`); only CampAdmin can reactivate a Full (or Withdrawn) season back to Active/Pending.
+- A `Full` season blocks new membership requests — `RequestCampMembershipAsync` only matches an `Active` season for the public year. Existing `Active`/`Pending` members are unaffected; only new requests are blocked.
 - Only camp leads or CampAdmin can edit a camp.
 - Camp images are stored on disk via the shared `IFileStorage` abstraction (key prefix `uploads/camps/{campId}/`); metadata and display order are tracked per camp.
 - **Name-lock + historical-name auto-log:** renaming a season (`ChangeSeasonNameAsync`) is rejected once the season's `NameLockDate` has passed (today ≥ `NameLockDate`). Before the lock date, a rename auto-records the *old* name as a `CampHistoricalName` with `Source = NameChange` and writes a `CampNameChanged` audit entry.

--- a/src/Sections/Humans.Camps/Docs/Camps.md
+++ b/src/Sections/Humans.Camps/Docs/Camps.md
@@ -174,7 +174,7 @@ Admin pages live under `/Camps/Admin/*` — never `/Admin/Camps/*` (per `docs/ar
 |-------|--------------|
 | Anyone (including anonymous) | Browse the camps directory, view camp details and season details |
 | Any authenticated human | Register a new camp (which creates a new season in Pending status). Request to join a camp for its open season; withdraw their own pending request; leave their own active membership. |
-| Camp lead | Edit their camp's details, manage season registrations, manage co-leads, upload/manage images, manage historical names. Approve / reject pending membership requests for their camp. Remove active members. Add an active member directly to their camp (lead-driven shortcut). Assign / unassign per-camp role assignments for their camp. Mark their camp's Active season Full, closing it to new join requests. |
+| Camp lead | Edit their camp's details, manage season registrations, manage co-leads, upload/manage images, manage historical names. Approve / reject pending membership requests for their camp. Remove active members. Add an active member directly to their camp (lead-driven shortcut). Assign / unassign per-camp role assignments for their camp. Mark their camp's Active season Full — an informational label only, shown to visitors, that does not block join requests. |
 | CampAdmin, Admin | All camp lead capabilities on all camps. Approve/reject season registrations. Reactivate a Full or Withdrawn season. Manage camp settings (public year, open seasons, name lock dates). Update registration info copy. View withdrawn seasons on the admin dashboard. Export camp data as CSV. Manage the role-definition catalogue (create, edit, deactivate, reactivate). View the role-staffing compliance matrix. |
 | Team/sub-team coordinator | View the read-only role-staffing compliance matrix at `/Camps/Admin/Compliance` (via `CampComplianceAccess`) — no camp-management authority. |
 | Admin | Delete camps |
@@ -182,8 +182,8 @@ Admin pages live under `/Camps/Admin/*` — never `/Admin/Camps/*` (per `docs/ar
 ## Invariants
 
 - Each camp has a unique slug used for URL routing.
-- Camp season status follows: Pending then Active, Full, Rejected, or Withdrawn. Only CampAdmin can approve or reject a season. A camp lead or CampAdmin can mark an Active season Full (`MarkSeasonFullAsync`); only CampAdmin can reactivate a Full (or Withdrawn) season back to Active/Pending.
-- A `Full` season blocks new membership requests — `RequestCampMembershipAsync` only matches an `Active` season for the public year. Existing `Active`/`Pending` members are unaffected; only new requests are blocked.
+- Camp season status follows: Pending then Active, Full, Rejected, or Withdrawn. Only CampAdmin can approve or reject a season. A camp lead or CampAdmin can set an Active season's status to Full (`CampService.SetSeasonStatusAsync` → `CampSeason.SetStatus`, a plain field flip with no transition validation); only CampAdmin can reactivate a Full (or Withdrawn) season back to Active/Pending.
+- **`Full` is informational only — it does not gate join requests.** It tells visitors the camp currently looks full; `RequestCampMembershipAsync` still matches `Active` **or** `Full` for the public year, because Humans doesn't yet know everyone who is actually in the camp (Peter, 2026-08-20). Don't reintroduce a block here — that reading of the issue was explicitly overridden.
 - Only camp leads or CampAdmin can edit a camp.
 - Camp images are stored on disk via the shared `IFileStorage` abstraction (key prefix `uploads/camps/{campId}/`); metadata and display order are tracked per camp.
 - **Name-lock + historical-name auto-log:** renaming a season (`ChangeSeasonNameAsync`) is rejected once the season's `NameLockDate` has passed (today ≥ `NameLockDate`). Before the lock date, a rename auto-records the *old* name as a `CampHistoricalName` with `Source = NameChange` and writes a `CampNameChanged` audit entry.

--- a/src/Sections/Humans.Camps/Domain/CampSeason.cs
+++ b/src/Sections/Humans.Camps/Domain/CampSeason.cs
@@ -117,11 +117,16 @@ internal sealed class CampSeason
         UpdatedAt = now;
     }
 
-    public void MarkFull(Instant now)
+    /// <summary>
+    /// Direct status flip with no transition validation. For informational status
+    /// labels only (e.g. Active -> Full, which does not gate anything — see
+    /// CampService.SetSeasonStatusAsync). Approve/Reject/Withdraw/Reactivate keep
+    /// their own guarded transitions and side effects; don't route those through
+    /// this method.
+    /// </summary>
+    public void SetStatus(CampSeasonStatus status, Instant now)
     {
-        EnsureStatus(CampSeasonStatus.Active, "mark full");
-
-        Status = CampSeasonStatus.Full;
+        Status = status;
         UpdatedAt = now;
     }
 

--- a/src/Sections/Humans.Camps/Domain/CampSeason.cs
+++ b/src/Sections/Humans.Camps/Domain/CampSeason.cs
@@ -117,6 +117,14 @@ internal sealed class CampSeason
         UpdatedAt = now;
     }
 
+    public void MarkFull(Instant now)
+    {
+        EnsureStatus(CampSeasonStatus.Active, "mark full");
+
+        Status = CampSeasonStatus.Full;
+        UpdatedAt = now;
+    }
+
     public void Withdraw(Instant now)
     {
         if (Status != CampSeasonStatus.Pending && Status != CampSeasonStatus.Active)

--- a/src/Sections/Humans.Camps/Services/CachingCampService.cs
+++ b/src/Sections/Humans.Camps/Services/CachingCampService.cs
@@ -245,6 +245,12 @@ internal sealed class CachingCampService(
         await InvalidateBySeasonAsync(seasonId, cancellationToken);
     }
 
+    public async Task MarkSeasonFullAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    {
+        await WithInner(inner => inner.MarkSeasonFullAsync(seasonId, cancellationToken));
+        await InvalidateBySeasonAsync(seasonId, cancellationToken);
+    }
+
     public async Task<CampUpdateResult> UpdateCampAsync(
         CampUpdateInput input, CancellationToken cancellationToken = default)
     {

--- a/src/Sections/Humans.Camps/Services/CachingCampService.cs
+++ b/src/Sections/Humans.Camps/Services/CachingCampService.cs
@@ -245,9 +245,10 @@ internal sealed class CachingCampService(
         await InvalidateBySeasonAsync(seasonId, cancellationToken);
     }
 
-    public async Task SetSeasonStatusAsync(Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default)
+    public async Task SetSeasonStatusAsync(
+        Guid scopedCampId, Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default)
     {
-        await WithInner(inner => inner.SetSeasonStatusAsync(seasonId, status, cancellationToken));
+        await WithInner(inner => inner.SetSeasonStatusAsync(scopedCampId, seasonId, status, cancellationToken));
         await InvalidateBySeasonAsync(seasonId, cancellationToken);
     }
 

--- a/src/Sections/Humans.Camps/Services/CachingCampService.cs
+++ b/src/Sections/Humans.Camps/Services/CachingCampService.cs
@@ -245,9 +245,9 @@ internal sealed class CachingCampService(
         await InvalidateBySeasonAsync(seasonId, cancellationToken);
     }
 
-    public async Task MarkSeasonFullAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    public async Task SetSeasonStatusAsync(Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default)
     {
-        await WithInner(inner => inner.MarkSeasonFullAsync(seasonId, cancellationToken));
+        await WithInner(inner => inner.SetSeasonStatusAsync(seasonId, status, cancellationToken));
         await InvalidateBySeasonAsync(seasonId, cancellationToken);
     }
 

--- a/src/Sections/Humans.Camps/Services/CampService.cs
+++ b/src/Sections/Humans.Camps/Services/CampService.cs
@@ -647,6 +647,32 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
         }
     }
 
+    public async Task MarkSeasonFullAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var year = 0;
+        var campId = Guid.Empty;
+
+        var found = await _repo.UpdateSeasonAsync(seasonId, season =>
+        {
+            season.MarkFull(now);
+            year = season.Year;
+            campId = season.CampId;
+        }, cancellationToken);
+
+        if (!found)
+        {
+            throw new InvalidOperationException("Season not found.");
+        }
+
+        await _auditLog.LogAsync(
+            AuditAction.CampSeasonStatusChanged, nameof(CampSeason), seasonId,
+            $"Season {year} marked as full",
+            "CampService",
+            relatedEntityId: campId, relatedEntityType: nameof(Camp));
+
+    }
+
     public async Task ReactivateSeasonAsync(Guid seasonId, CancellationToken cancellationToken = default)
     {
         var now = _clock.GetCurrentInstant();
@@ -1091,14 +1117,17 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
         var settings = await GetSettingsAsync(cancellationToken);
         var camp = await _repo.GetByIdAsync(campId, cancellationToken);
         var season = camp?.Seasons.FirstOrDefault(s =>
-            s.Year == settings.PublicYear
-            && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full));
+            s.Year == settings.PublicYear && s.Status == CampSeasonStatus.Active);
         if (season is null)
         {
+            var isFull = camp?.Seasons.Any(s =>
+                s.Year == settings.PublicYear && s.Status == CampSeasonStatus.Full) == true;
             return new CampMemberRequestResult(
                 Guid.Empty,
                 CampMemberRequestOutcome.NoOpenSeason,
-                "Camp is not open for membership this year.",
+                isFull
+                    ? "This camp is full and not accepting new members this year."
+                    : "Camp is not open for membership this year.",
                 CampMemberRequestNoticeLevel.Error);
         }
 

--- a/src/Sections/Humans.Camps/Services/CampService.cs
+++ b/src/Sections/Humans.Camps/Services/CampService.cs
@@ -647,17 +647,21 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
         }
     }
 
-    public async Task SetSeasonStatusAsync(Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default)
+    public async Task SetSeasonStatusAsync(
+        Guid scopedCampId, Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default)
     {
         var now = _clock.GetCurrentInstant();
         var year = 0;
-        var campId = Guid.Empty;
 
         var found = await _repo.UpdateSeasonAsync(seasonId, season =>
         {
+            if (season.CampId != scopedCampId)
+            {
+                throw new InvalidOperationException("Season does not belong to the specified camp.");
+            }
+
             season.SetStatus(status, now);
             year = season.Year;
-            campId = season.CampId;
         }, cancellationToken);
 
         if (!found)
@@ -669,7 +673,7 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
             AuditAction.CampSeasonStatusChanged, nameof(CampSeason), seasonId,
             $"Season {year} status set to {status}",
             "CampService",
-            relatedEntityId: campId, relatedEntityType: nameof(Camp));
+            relatedEntityId: scopedCampId, relatedEntityType: nameof(Camp));
 
     }
 
@@ -1298,7 +1302,9 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
             return AddCampMemberOutcome.InvalidUser;
 
         var camp = await _repo.GetByIdAsync(campId, cancellationToken);
-        var openSeason = camp?.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
+        // Full is informational only (Peter, 2026-08-20) — it must not block camp
+        // management, so a Full season is still usable here.
+        var openSeason = camp?.Seasons.FirstOrDefault(s => s.Status is CampSeasonStatus.Active or CampSeasonStatus.Full);
         if (openSeason is null)
             return AddCampMemberOutcome.NoActiveSeason;
 
@@ -1311,7 +1317,9 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
         CancellationToken cancellationToken = default)
     {
         var camp = await _repo.GetByIdAsync(campId, cancellationToken);
-        var openSeason = camp?.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
+        // Full is informational only (Peter, 2026-08-20) — it must not block camp
+        // management, so a Full season is still usable here.
+        var openSeason = camp?.Seasons.FirstOrDefault(s => s.Status is CampSeasonStatus.Active or CampSeasonStatus.Full);
         if (openSeason is null)
             return AssignCampRoleOutcome.SeasonNotFound;
 

--- a/src/Sections/Humans.Camps/Services/CampService.cs
+++ b/src/Sections/Humans.Camps/Services/CampService.cs
@@ -647,7 +647,7 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
         }
     }
 
-    public async Task MarkSeasonFullAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    public async Task SetSeasonStatusAsync(Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default)
     {
         var now = _clock.GetCurrentInstant();
         var year = 0;
@@ -655,7 +655,7 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
 
         var found = await _repo.UpdateSeasonAsync(seasonId, season =>
         {
-            season.MarkFull(now);
+            season.SetStatus(status, now);
             year = season.Year;
             campId = season.CampId;
         }, cancellationToken);
@@ -667,7 +667,7 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
 
         await _auditLog.LogAsync(
             AuditAction.CampSeasonStatusChanged, nameof(CampSeason), seasonId,
-            $"Season {year} marked as full",
+            $"Season {year} status set to {status}",
             "CampService",
             relatedEntityId: campId, relatedEntityType: nameof(Camp));
 
@@ -1116,18 +1116,18 @@ internal sealed class CampService : ICampService, ICampLeadDirectory, ICampSeedi
     {
         var settings = await GetSettingsAsync(cancellationToken);
         var camp = await _repo.GetByIdAsync(campId, cancellationToken);
+        // Active AND Full both accept requests — Full is an informational label the lead
+        // sets to say "we look full," not an enforcement gate. Humans doesn't yet know
+        // everyone actually in the camp, so people still need to be able to request/join.
         var season = camp?.Seasons.FirstOrDefault(s =>
-            s.Year == settings.PublicYear && s.Status == CampSeasonStatus.Active);
+            s.Year == settings.PublicYear
+            && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full));
         if (season is null)
         {
-            var isFull = camp?.Seasons.Any(s =>
-                s.Year == settings.PublicYear && s.Status == CampSeasonStatus.Full) == true;
             return new CampMemberRequestResult(
                 Guid.Empty,
                 CampMemberRequestOutcome.NoOpenSeason,
-                isFull
-                    ? "This camp is full and not accepting new members this year."
-                    : "Camp is not open for membership this year.",
+                "Camp is not open for membership this year.",
                 CampMemberRequestNoticeLevel.Error);
         }
 

--- a/src/Sections/Humans.Camps/Services/ICampService.cs
+++ b/src/Sections/Humans.Camps/Services/ICampService.cs
@@ -36,8 +36,11 @@ internal interface ICampService : ICampServiceRead, IApplicationService
     Task RejectSeasonAsync(Guid seasonId, Guid reviewedByUserId, string notes, CancellationToken cancellationToken = default);
     Task WithdrawSeasonAsync(Guid seasonId, CancellationToken cancellationToken = default);
     Task ReactivateSeasonAsync(Guid seasonId, CancellationToken cancellationToken = default);
-    /// <summary>Camp lead or CampAdmin marks an Active season Full, closing it to new join requests.</summary>
-    Task MarkSeasonFullAsync(Guid seasonId, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Camp lead or CampAdmin sets a season's status directly (currently used to toggle
+    /// Full on/off). Informational only — does not gate join requests or anything else.
+    /// </summary>
+    Task SetSeasonStatusAsync(Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default);
     // Camp updates
     Task<CampUpdateResult> UpdateCampAsync(CampUpdateInput input, CancellationToken cancellationToken = default);
     Task DeleteCampAsync(Guid campId, CancellationToken cancellationToken = default);

--- a/src/Sections/Humans.Camps/Services/ICampService.cs
+++ b/src/Sections/Humans.Camps/Services/ICampService.cs
@@ -39,8 +39,11 @@ internal interface ICampService : ICampServiceRead, IApplicationService
     /// <summary>
     /// Camp lead or CampAdmin sets a season's status directly (currently used to toggle
     /// Full on/off). Informational only — does not gate join requests or anything else.
+    /// Throws if the season does not belong to <paramref name="scopedCampId"/>, matching the
+    /// scoping pattern used by ApproveCampMemberAsync/RejectCampMemberAsync/RemoveCampMemberAsync.
     /// </summary>
-    Task SetSeasonStatusAsync(Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default);
+    Task SetSeasonStatusAsync(
+        Guid scopedCampId, Guid seasonId, CampSeasonStatus status, CancellationToken cancellationToken = default);
     // Camp updates
     Task<CampUpdateResult> UpdateCampAsync(CampUpdateInput input, CancellationToken cancellationToken = default);
     Task DeleteCampAsync(Guid campId, CancellationToken cancellationToken = default);

--- a/src/Sections/Humans.Camps/Services/ICampService.cs
+++ b/src/Sections/Humans.Camps/Services/ICampService.cs
@@ -36,6 +36,8 @@ internal interface ICampService : ICampServiceRead, IApplicationService
     Task RejectSeasonAsync(Guid seasonId, Guid reviewedByUserId, string notes, CancellationToken cancellationToken = default);
     Task WithdrawSeasonAsync(Guid seasonId, CancellationToken cancellationToken = default);
     Task ReactivateSeasonAsync(Guid seasonId, CancellationToken cancellationToken = default);
+    /// <summary>Camp lead or CampAdmin marks an Active season Full, closing it to new join requests.</summary>
+    Task MarkSeasonFullAsync(Guid seasonId, CancellationToken cancellationToken = default);
     // Camp updates
     Task<CampUpdateResult> UpdateCampAsync(CampUpdateInput input, CancellationToken cancellationToken = default);
     Task DeleteCampAsync(Guid campId, CancellationToken cancellationToken = default);

--- a/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
+++ b/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
@@ -363,15 +363,18 @@
                                     You are a lead for @Model.Membership.OpenSeasonYear.
                                 </div>
                             }
-                            else if (Model.CurrentSeason is { Status: CampSeasonStatus.Full } && Model.CurrentSeason.Year == Model.PublicYear)
-                            {
-                                <div class="alert alert-secondary py-2 mb-0">
-                                    <i class="fa-solid fa-ban me-1"></i>
-                                    This camp is full and not accepting new members for @Model.Membership.OpenSeasonYear.
-                                </div>
-                            }
                             else
                             {
+                                @* Full is informational only — it tells visitors the camp looks full, it
+                                   does not block a request. Humans doesn't yet know everyone actually in
+                                   the camp, so people still need to be able to request/join. *@
+                                @if (Model.CurrentSeason is { Status: CampSeasonStatus.Full } && Model.CurrentSeason.Year == Model.PublicYear)
+                                {
+                                    <div class="alert alert-secondary py-2 mb-2">
+                                        <i class="fa-solid fa-circle-info me-1"></i>
+                                        This camp says it's full for @Model.Membership.OpenSeasonYear — you can still request to join.
+                                    </div>
+                                }
                                 <form asp-controller="Camp" asp-action="RequestMembership" asp-route-slug="@Model.Slug" method="post">
                                     @Html.AntiForgeryToken()
                                     <button type="submit" class="btn btn-outline-primary w-100">
@@ -449,7 +452,7 @@
                         {
                             <form asp-controller="Camp" asp-action="MarkFull" asp-route-slug="@Model.Slug" asp-route-seasonId="@s.Id" method="post">
                                 @Html.AntiForgeryToken()
-                                <button type="submit" class="btn btn-outline-warning w-100" data-confirm="Mark this season full? New join requests will be blocked until the season is reactivated.">
+                                <button type="submit" class="btn btn-outline-warning w-100" data-confirm="Mark this season full? This just tells visitors you look full — people can still request to join.">
                                     <i class="fa-solid fa-ban me-1"></i> Mark Season Full
                                 </button>
                             </form>

--- a/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
+++ b/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
@@ -363,7 +363,7 @@
                                     You are a lead for @Model.Membership.OpenSeasonYear.
                                 </div>
                             }
-                            else if (Model.CurrentSeason?.Status == CampSeasonStatus.Full)
+                            else if (Model.CurrentSeason is { Status: CampSeasonStatus.Full } && Model.CurrentSeason.Year == Model.PublicYear)
                             {
                                 <div class="alert alert-secondary py-2 mb-0">
                                     <i class="fa-solid fa-ban me-1"></i>

--- a/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
+++ b/src/Sections/Humans.Camps/Views/Camp/Details.cshtml
@@ -363,6 +363,13 @@
                                     You are a lead for @Model.Membership.OpenSeasonYear.
                                 </div>
                             }
+                            else if (Model.CurrentSeason?.Status == CampSeasonStatus.Full)
+                            {
+                                <div class="alert alert-secondary py-2 mb-0">
+                                    <i class="fa-solid fa-ban me-1"></i>
+                                    This camp is full and not accepting new members for @Model.Membership.OpenSeasonYear.
+                                </div>
+                            }
                             else
                             {
                                 <form asp-controller="Camp" asp-action="RequestMembership" asp-route-slug="@Model.Slug" method="post">
@@ -435,6 +442,15 @@
                                 @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-outline-warning w-100" data-confirm="Are you sure you want to withdraw from this season?">
                                     <i class="fa-solid fa-right-from-bracket me-1"></i> Withdraw Season
+                                </button>
+                            </form>
+                        }
+                        @if ((Model.IsCurrentUserLead || Model.IsCurrentUserCampAdmin) && s.Status == CampSeasonStatus.Active)
+                        {
+                            <form asp-controller="Camp" asp-action="MarkFull" asp-route-slug="@Model.Slug" asp-route-seasonId="@s.Id" method="post">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn-outline-warning w-100" data-confirm="Mark this season full? New join requests will be blocked until the season is reactivated.">
+                                    <i class="fa-solid fa-ban me-1"></i> Mark Season Full
                                 </button>
                             </form>
                         }

--- a/tests/Humans.Camps.Tests/Domain/CampSeasonTests.cs
+++ b/tests/Humans.Camps.Tests/Domain/CampSeasonTests.cs
@@ -67,30 +67,21 @@ public class CampSeasonTests
         season.UpdatedAt.Should().Be(Now);
     }
 
-    [HumansFact]
-    public void MarkFull_FromActive_SetsFull()
-    {
-        var season = CreateSeason(CampSeasonStatus.Active);
-
-        season.MarkFull(Now);
-
-        season.Status.Should().Be(CampSeasonStatus.Full);
-        season.UpdatedAt.Should().Be(Now);
-    }
-
     [HumansTheory]
-    [InlineData(CampSeasonStatus.Pending)]
-    [InlineData(CampSeasonStatus.Full)]
-    [InlineData(CampSeasonStatus.Rejected)]
-    [InlineData(CampSeasonStatus.Withdrawn)]
-    public void MarkFull_FromNonActiveStatus_Throws(CampSeasonStatus source)
+    [InlineData(CampSeasonStatus.Active, CampSeasonStatus.Full)]
+    [InlineData(CampSeasonStatus.Full, CampSeasonStatus.Active)]
+    [InlineData(CampSeasonStatus.Pending, CampSeasonStatus.Rejected)]
+    public void SetStatus_SetsStatusUnconditionally(CampSeasonStatus source, CampSeasonStatus target)
     {
+        // No transition validation — SetStatus is a plain field flip, used for the
+        // informational Full label. Guarded transitions (Approve/Reject/Withdraw/
+        // Reactivate) keep their own methods and are unaffected.
         var season = CreateSeason(source);
 
-        var action = () => season.MarkFull(Now);
+        season.SetStatus(target, Now);
 
-        action.Should().Throw<InvalidOperationException>()
-            .WithMessage($"Cannot mark full a season with status {source}.");
+        season.Status.Should().Be(target);
+        season.UpdatedAt.Should().Be(Now);
     }
 
     [HumansTheory]

--- a/tests/Humans.Camps.Tests/Domain/CampSeasonTests.cs
+++ b/tests/Humans.Camps.Tests/Domain/CampSeasonTests.cs
@@ -67,6 +67,32 @@ public class CampSeasonTests
         season.UpdatedAt.Should().Be(Now);
     }
 
+    [HumansFact]
+    public void MarkFull_FromActive_SetsFull()
+    {
+        var season = CreateSeason(CampSeasonStatus.Active);
+
+        season.MarkFull(Now);
+
+        season.Status.Should().Be(CampSeasonStatus.Full);
+        season.UpdatedAt.Should().Be(Now);
+    }
+
+    [HumansTheory]
+    [InlineData(CampSeasonStatus.Pending)]
+    [InlineData(CampSeasonStatus.Full)]
+    [InlineData(CampSeasonStatus.Rejected)]
+    [InlineData(CampSeasonStatus.Withdrawn)]
+    public void MarkFull_FromNonActiveStatus_Throws(CampSeasonStatus source)
+    {
+        var season = CreateSeason(source);
+
+        var action = () => season.MarkFull(Now);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage($"Cannot mark full a season with status {source}.");
+    }
+
     [HumansTheory]
     [InlineData(CampSeasonStatus.Pending)]
     [InlineData(CampSeasonStatus.Active)]

--- a/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
@@ -799,7 +799,7 @@ public sealed class CampServiceTests : CampsTestHarness
         var camp = await CreateTestCamp();
         await ApproveLatestSeasonAsync(camp.Id);
         var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
-        await _service.SetSeasonStatusAsync(season.Id, CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
+        await _service.SetSeasonStatusAsync(camp.Id, season.Id, CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId, "Alice");
 
@@ -1064,6 +1064,47 @@ public sealed class CampServiceTests : CampsTestHarness
     }
 
     [HumansFact]
+    public async Task AddCampMemberToActiveSeason_FullSeason_StillAdds()
+    {
+        // Full is informational only (Peter, 2026-08-20) — camp management must keep
+        // working on a Full season, so this must still succeed.
+        var camp = new Camp { Id = Guid.NewGuid(), Slug = "full-add-camp" };
+        var season = new CampSeason { Id = Guid.NewGuid(), CampId = camp.Id, Year = 2026, Status = CampSeasonStatus.Full };
+        var targetUserId = Guid.NewGuid();
+        var actorUserId = Guid.NewGuid();
+        CampsDb.Camps.Add(camp);
+        CampsDb.CampSeasons.Add(season);
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var result = await _service.AddCampMemberToActiveSeasonAsync(camp.Id, targetUserId, actorUserId, Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().Be(AddCampMemberOutcome.Added);
+    }
+
+    [HumansFact]
+    public async Task AddMemberAndAssignRoleInActiveSeason_FullSeason_StillAssigns()
+    {
+        // Full is informational only (Peter, 2026-08-20) — camp management must keep
+        // working on a Full season, so this must still succeed.
+        var camp = new Camp { Id = Guid.NewGuid(), Slug = "full-role-camp" };
+        var season = new CampSeason { Id = Guid.NewGuid(), CampId = camp.Id, Year = 2026, Status = CampSeasonStatus.Full };
+        var targetUserId = Guid.NewGuid();
+        var actorUserId = Guid.NewGuid();
+        var roleDefinitionId = Guid.NewGuid();
+        CampsDb.Camps.Add(camp);
+        CampsDb.CampSeasons.Add(season);
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        _campRoleService.AssignAsync(
+                season.Id, roleDefinitionId, Arg.Any<Guid>(), actorUserId, Arg.Any<CancellationToken>())
+            .Returns(AssignCampRoleOutcome.Assigned);
+
+        var result = await _service.AddMemberAndAssignRoleInActiveSeasonAsync(
+            camp.Id, roleDefinitionId, targetUserId, actorUserId, Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().Be(AssignCampRoleOutcome.Assigned);
+    }
+
+    [HumansFact]
     public async Task AddMemberAndAssignRoleInActiveSeason_uses_existing_active_member_without_audit()
     {
         var camp = new Camp { Id = Guid.NewGuid(), Slug = "test-camp-2" };
@@ -1277,7 +1318,7 @@ public sealed class CampServiceTests : CampsTestHarness
         await ApproveLatestSeasonAsync(camp.Id);
         var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
 
-        await _service.SetSeasonStatusAsync(season.Id, CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
+        await _service.SetSeasonStatusAsync(camp.Id, season.Id, CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
 
         var updated = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id, Xunit.TestContext.Current.CancellationToken);
         updated.Status.Should().Be(CampSeasonStatus.Full);
@@ -1291,9 +1332,24 @@ public sealed class CampServiceTests : CampsTestHarness
     [HumansFact]
     public async Task SetSeasonStatusAsync_SeasonNotFound_Throws()
     {
-        var action = () => _service.SetSeasonStatusAsync(Guid.NewGuid(), CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
+        var action = () => _service.SetSeasonStatusAsync(Guid.NewGuid(), Guid.NewGuid(), CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
 
         await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not found*");
+    }
+
+    [HumansFact]
+    public async Task SetSeasonStatusAsync_WrongCamp_Throws()
+    {
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        await ApproveLatestSeasonAsync(camp.Id);
+        var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
+
+        // Same scoping pattern as ApproveCampMemberAsync/RejectCampMemberAsync/RemoveCampMemberAsync:
+        // a caller authorized against a different camp must not be able to flip this season's status.
+        var action = () => _service.SetSeasonStatusAsync(Guid.NewGuid(), season.Id, CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*does not belong*");
     }
 
     [HumansFact]

--- a/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
@@ -790,22 +790,26 @@ public sealed class CampServiceTests : CampsTestHarness
     }
 
     [HumansFact]
-    public async Task RequestCampMembershipAsync_FullSeason_ReturnsNoOpenSeasonAndBlocksRequest()
+    public async Task RequestCampMembershipAsync_FullSeason_StillAcceptsRequest()
     {
+        // Full is informational only (Peter, 2026-08-20 PR #1427 correction) — it tells
+        // visitors the camp looks full, it does not gate join requests. Humans doesn't
+        // yet know everyone actually in the camp.
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
         await ApproveLatestSeasonAsync(camp.Id);
         var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
-        await _service.MarkSeasonFullAsync(season.Id, Xunit.TestContext.Current.CancellationToken);
+        await _service.SetSeasonStatusAsync(season.Id, CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId, "Alice");
 
         var result = await _service.RequestCampMembershipAsync(camp.Id, userId, Xunit.TestContext.Current.CancellationToken);
 
-        result.Outcome.Should().Be(CampMemberRequestOutcome.NoOpenSeason);
-        result.Message.Should().Be("This camp is full and not accepting new members this year.");
-        result.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Error);
-        (await CampsDb.CampMembers.AsNoTracking().AnyAsync(m => m.UserId == userId, Xunit.TestContext.Current.CancellationToken)).Should().BeFalse();
+        result.Outcome.Should().Be(CampMemberRequestOutcome.Created);
+        result.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Success);
+        var member = await CampsDb.CampMembers.AsNoTracking().FirstAsync(m => m.Id == result.CampMemberId, Xunit.TestContext.Current.CancellationToken);
+        member.Status.Should().Be(CampMemberStatus.Pending);
+        member.UserId.Should().Be(userId);
     }
 
     [HumansFact]
@@ -1266,14 +1270,14 @@ public sealed class CampServiceTests : CampsTestHarness
     }
 
     [HumansFact]
-    public async Task MarkSeasonFullAsync_ActiveSeason_SetsFullAndAudits()
+    public async Task SetSeasonStatusAsync_SetsStatusAndAudits()
     {
         await SeedSettingsAsync();
         var camp = await CreateTestCamp();
         await ApproveLatestSeasonAsync(camp.Id);
         var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
 
-        await _service.MarkSeasonFullAsync(season.Id, Xunit.TestContext.Current.CancellationToken);
+        await _service.SetSeasonStatusAsync(season.Id, CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
 
         var updated = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id, Xunit.TestContext.Current.CancellationToken);
         updated.Status.Should().Be(CampSeasonStatus.Full);
@@ -1285,15 +1289,11 @@ public sealed class CampServiceTests : CampsTestHarness
     }
 
     [HumansFact]
-    public async Task MarkSeasonFullAsync_NonActiveSeason_Throws()
+    public async Task SetSeasonStatusAsync_SeasonNotFound_Throws()
     {
-        await SeedSettingsAsync();
-        var camp = await CreateTestCamp();
-        var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
+        var action = () => _service.SetSeasonStatusAsync(Guid.NewGuid(), CampSeasonStatus.Full, Xunit.TestContext.Current.CancellationToken);
 
-        var action = () => _service.MarkSeasonFullAsync(season.Id, Xunit.TestContext.Current.CancellationToken);
-
-        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*mark full*");
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not found*");
     }
 
     [HumansFact]

--- a/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Camps.Tests/Services/CampServiceTests.cs
@@ -790,6 +790,25 @@ public sealed class CampServiceTests : CampsTestHarness
     }
 
     [HumansFact]
+    public async Task RequestCampMembershipAsync_FullSeason_ReturnsNoOpenSeasonAndBlocksRequest()
+    {
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        await ApproveLatestSeasonAsync(camp.Id);
+        var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
+        await _service.MarkSeasonFullAsync(season.Id, Xunit.TestContext.Current.CancellationToken);
+        var userId = Guid.NewGuid();
+        await SeedUserAsync(userId, "Alice");
+
+        var result = await _service.RequestCampMembershipAsync(camp.Id, userId, Xunit.TestContext.Current.CancellationToken);
+
+        result.Outcome.Should().Be(CampMemberRequestOutcome.NoOpenSeason);
+        result.Message.Should().Be("This camp is full and not accepting new members this year.");
+        result.NoticeLevel.Should().Be(CampMemberRequestNoticeLevel.Error);
+        (await CampsDb.CampMembers.AsNoTracking().AnyAsync(m => m.UserId == userId, Xunit.TestContext.Current.CancellationToken)).Should().BeFalse();
+    }
+
+    [HumansFact]
     public async Task RequestCampMembershipAsync_AlreadyPending_IsIdempotent()
     {
         await SeedSettingsAsync();
@@ -1244,6 +1263,37 @@ public sealed class CampServiceTests : CampsTestHarness
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task MarkSeasonFullAsync_ActiveSeason_SetsFullAndAudits()
+    {
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        await ApproveLatestSeasonAsync(camp.Id);
+        var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
+
+        await _service.MarkSeasonFullAsync(season.Id, Xunit.TestContext.Current.CancellationToken);
+
+        var updated = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.Id == season.Id, Xunit.TestContext.Current.CancellationToken);
+        updated.Status.Should().Be(CampSeasonStatus.Full);
+
+        await AuditLog.Received(1).LogAsync(
+            AuditAction.CampSeasonStatusChanged,
+            nameof(CampSeason), season.Id,
+            Arg.Any<string>(), "CampService", camp.Id, nameof(Camp));
+    }
+
+    [HumansFact]
+    public async Task MarkSeasonFullAsync_NonActiveSeason_Throws()
+    {
+        await SeedSettingsAsync();
+        var camp = await CreateTestCamp();
+        var season = await CampsDb.CampSeasons.AsNoTracking().FirstAsync(s => s.CampId == camp.Id, Xunit.TestContext.Current.CancellationToken);
+
+        var action = () => _service.MarkSeasonFullAsync(season.Id, Xunit.TestContext.Current.CancellationToken);
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*mark full*");
     }
 
     [HumansFact]


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1070

## Summary

`CampSeasonStatus.Full` was declared and reachable in the state machine docs, but nothing in the app could set it — `SetSeasonFullAsync` was deleted as zero-caller dead code in `b4710bf01`. This restores the capability.

- Camp lead **or** CampAdmin can manually set an `Active` season's status to `Full` (no auto-flip on member count).
- **`Full` is an informational label, not an enforcement gate.** It tells visitors the camp currently looks full. It does **not** block join requests — `RequestCampMembershipAsync` still matches `Active` *or* `Full`, unchanged from before this PR. The Details page shows an informational banner on a Full season, but the "Request to join" button stays.
- `Full → Active` reactivation is unchanged: still CampAdmin-only via `CampAdminController.Reactivate`.
- Existing members (Active/Pending) are untouched by setting a season Full.

**Correction (Peter, 2026-08-20):** the first version of this PR blocked new join requests on a Full season, reading the issue as "Full closes the season to new members." Peter overrode that reading:

> I did NOT say that full = do not allow further requests.. Full is a message to people that the camp is no longer accepting applications. That does not mean that humans yet knows everyone in the camp. Also, it should be CampSeason.SetStatus(Full) not MarkFull. otherwise you're wasting 4 methods because of an enum.

The blocking behavior and the `MarkFull`-shaped domain/service methods have been reverted/replaced accordingly.

## Changes

- `CampSeason.SetStatus(CampSeasonStatus status, Instant now)` — a single generic status setter, no per-transition validation. Replaces the one-off `MarkFull` method. `Approve`/`Reject`/`Withdraw`/`Reactivate` keep their own guarded methods with their own side effects (review fields, notifications) — unaffected.
- `ICampService.SetSeasonStatusAsync(Guid scopedCampId, Guid seasonId, CampSeasonStatus status, ...)` / `CampService.SetSeasonStatusAsync` — repo mutation via `CampSeason.SetStatus` + `CampSeasonStatusChanged` audit entry. Scoped to `scopedCampId`, matching the `ApproveCampMemberAsync`/`RejectCampMemberAsync`/`RemoveCampMemberAsync` pattern (review finding 1, below).
- `CachingCampService.SetSeasonStatusAsync` — pass-through + `InvalidateBySeasonAsync`, matching the sibling season-transition methods.
- `CampController.MarkFull` — `POST /Camps/{slug}/MarkFull/{seasonId}` action (route name kept stable), calls `SetSeasonStatusAsync(camp.Id, seasonId, CampSeasonStatus.Full)`. Authorized via the existing `ResolveCampManagementAsync` (`CampOperationRequirement.Manage` = camp lead or CampAdmin/Admin) — the same gate `Withdraw`/`Rejoin` already use. No new role, no widened authorization.
- Camp-management call sites (Members role panel, `AssignRole`, `AddCampMemberToActiveSeasonAsync`, `AddMemberAndAssignRoleInActiveSeasonAsync`) now accept `Status is Active or Full` instead of `Active` only, so marking a season Full no longer disables camp management (review finding 4, below).
- `Details.cshtml` — "Mark Season Full" button next to Withdraw/Rejoin; an informational banner shown alongside (not instead of) the "Request to join" button when the season is Full.
- `src/Sections/Humans.Camps/Docs/Camps.md` — updated routes table, Actors & Roles, and Invariants; explicitly notes Full does not gate requests, with the 2026-08-20 correction referenced so it isn't reintroduced.

## Reuse considered / rejected

- **Authorization**: reused `CampOperationRequirement.Manage` / `ResolveCampManagementAsync` as-is — the same gate already used for `Withdraw`/`Rejoin`/`Edit`. No new policy, no new role.
- **One setter, not a method family**: per Peter's direction, `CampSeason.SetStatus` is the single enum-taking setter rather than a `MarkFull`/`MarkOpen`/`MarkClosed`-shaped family. It's additive to (not a replacement for) `Approve`/`Reject`/`Withdraw`/`Reactivate`, which carry real side effects beyond a status flip.
- Did **not** touch the other `Active or Full` status checks in `CampApiController`, `Camp.cs`, `CampAdminPageBuilder`, `CampRoleService`, or the compliance matrix — those already correctly include Full for visibility purposes and needed no change either time.

## Tests

- `CampSeasonTests`: `SetStatus_SetsStatusUnconditionally` (theory — no transition validation).
- `CampServiceTests`: `SetSeasonStatusAsync_SetsStatusAndAudits`, `SetSeasonStatusAsync_SeasonNotFound_Throws`, `SetSeasonStatusAsync_WrongCamp_Throws` (finding 1), `RequestCampMembershipAsync_FullSeason_StillAcceptsRequest` (was a "blocks request" test; flipped to prove Full still accepts joins per the correction), `AddCampMemberToActiveSeason_FullSeason_StillAdds`, `AddMemberAndAssignRoleInActiveSeason_FullSeason_StillAssigns` (finding 4).
- Full `Humans.Camps.Tests` suite: 228 passed, 1 skipped (pre-existing), 0 failed.
- `dotnet build Humans.slnx -v quiet`: 0 errors.

No schema change — `CampSeasonStatus.Full` already existed in the enum.

## Codex review findings (this PR)

Four findings from Codex review, all replied in-thread and threads resolved:

| # | Finding | Verdict |
|---|---|---|
| 1 | Scope the season mutation to the authorized camp | **Fixed** — `SetSeasonStatusAsync` now takes `scopedCampId`, throws if the season belongs to a different camp. |
| 2 | Make the Full check atomic with membership insertion | **WONTFIX (moot)** — Full no longer blocks anything, so there's no check left to race. |
| 3 | Restrict the status flip to Active seasons | **Declined** — Peter: "it should be CampSeason.SetStatus(Full) not MarkFull. otherwise you're wasting 4 methods because of an enum." Per-transition validation is exactly the method-family he rejected. |
| 4 | Keep camp management available after marking Full | **Fixed** — role panel, `AssignRole`, `AddCampMemberToActiveSeasonAsync`, `AddMemberAndAssignRoleInActiveSeasonAsync` now accept Active or Full. |

Note: `Withdraw`/`Rejoin` (`CampController`) call `WithdrawSeasonAsync(seasonId)`/`ReactivateSeasonAsync(seasonId)` with the same unscoped-by-campId shape finding 1 fixed for `MarkFull`. Pre-existing, out of scope for this PR — not touched here.
