### PR TITLE
test(resources): gate every section resx set for translation parity

### DIFF
--- a/src/Humans.Base/Models/TranslationsGalleryViewModel.cs
+++ b/src/Humans.Base/Models/TranslationsGalleryViewModel.cs
@@ -47,7 +47,11 @@ public sealed record TranslationRow(
 
 public static class TranslationsGalleryModelBuilder
 {
-    public static TranslationsGalleryViewModel Build(IStringLocalizer<SharedResource> localizer)
+    /// <summary>
+    /// Untyped <see cref="IStringLocalizer"/> so this builds the gallery for any resource
+    /// set, not just <see cref="SharedResource"/> (nobodies-collective/Humans#1095).
+    /// </summary>
+    public static TranslationsGalleryViewModel Build(IStringLocalizer localizer)
     {
         var languages = CultureCatalog.SupportedCultureCodes
             .Where(c => !string.Equals(c, CultureCatalog.DefaultCultureCode, StringComparison.Ordinal))

--- a/tests/Humans.Web.Tests/Resources/SectionResourceParityTests.cs
+++ b/tests/Humans.Web.Tests/Resources/SectionResourceParityTests.cs
@@ -1,0 +1,66 @@
+using AwesomeAssertions;
+using Humans.Base.Models;
+using Humans.Web.Extensions;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Humans.Web.Tests.Resources;
+
+/// <summary>
+/// Resx parity gate for every section's own <c>&lt;Section&gt;Resource</c> set — the
+/// section-scoped sibling of <see cref="SharedResourceParityTests"/>
+/// (nobodies-collective/Humans#1095). Derives the set from
+/// <see cref="SectionDiscoveryExtensions.SectionResourceTypes"/>, so a section added or
+/// renamed later needs no edit here.
+/// </summary>
+public class SectionResourceParityTests
+{
+    [HumansFact]
+    public void EverySectionResourceSetHasEveryBaseKeyInEveryNonBaseCulture()
+    {
+        var factory = new ResourceManagerStringLocalizerFactory(
+            Options.Create(new LocalizationOptions()), NullLoggerFactory.Instance);
+
+        var resourceTypes = SectionDiscoveryExtensions.SectionResourceTypes();
+
+        // Guards the loop below against covering nothing: an empty set means section
+        // discovery itself is broken, not that no section carries strings.
+        resourceTypes.Should().NotBeEmpty(
+            "SectionResourceTypes() must find every active section's <Section>Resource marker");
+
+        var failures = new List<string>();
+
+        foreach (var resourceType in resourceTypes)
+        {
+            var localizer = factory.Create(resourceType);
+            var gallery = TranslationsGalleryModelBuilder.Build(localizer);
+
+            // Same vacuous-pass guard as SharedResourceParityTests: a resx the localizer
+            // can't find yields zero keys, zero gaps, and a silent pass over this set.
+            if (gallery.TotalKeys == 0)
+            {
+                failures.Add($"{resourceType.Name}: resolved 0 keys — localizer could not find its resx");
+                continue;
+            }
+
+            var missingByCulture = gallery.Groups
+                .SelectMany(g => g.Rows)
+                .SelectMany(row => gallery.Languages
+                    .Where(culture => row.Values[culture] is null)
+                    .Select(culture => (Culture: culture, row.Key)))
+                .GroupBy(x => x.Culture, x => x.Key, StringComparer.Ordinal)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderBy(key => key, StringComparer.Ordinal).ToList(),
+                    StringComparer.Ordinal);
+
+            failures.AddRange(missingByCulture.Select(kv =>
+                $"{resourceType.Name}.{kv.Key} missing {kv.Value.Count}: [{string.Join(", ", kv.Value)}]"));
+        }
+
+        failures.Should().BeEmpty(
+            "every section resx set must translate every base key in every supported culture; " +
+            "found: " + string.Join("; ", failures));
+    }
+}


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1095

## Problem

`SharedResourceParityTests.EveryNonBaseCultureHasEveryBaseKey` only gates `SharedResource`. Since G5 (#866) there are 25 section `<Section>Resource` sets (`src/Sections/Humans.*/*Resource.resx`), none of them gated — a section can drop a translation key from `.es`/`.ca`/`.de`/`.fr`/`.it` and it silently falls back to English at runtime, same 200, green build.

## Fix

- `TranslationsGalleryModelBuilder.Build` (`src/Humans.Base/Models/TranslationsGalleryViewModel.cs`) is generalized from `IStringLocalizer<SharedResource>` to plain `IStringLocalizer` — it only ever used the untyped members (`GetAllStrings`), so this is the blocker the issue names, resolved with no behavior change for the two existing callers (`SharedResourceParityTests`, `DebugController.Translations`), both of which pass `IStringLocalizer<SharedResource>`, still assignable.
- New test `SectionResourceParityTests.EverySectionResourceSetHasEveryBaseKeyInEveryNonBaseCulture` (`tests/Humans.Web.Tests/Resources/SectionResourceParityTests.cs`) loops `SectionDiscoveryExtensions.SectionResourceTypes()` — the same reflection the boot diagnostic in `Program.cs:602` already uses — builds an `IStringLocalizer` per section resource type via `ResourceManagerStringLocalizerFactory`, runs it through `TranslationsGalleryModelBuilder.Build`, and asserts no non-base culture is missing a base key. Failures name the resource type, culture, and exact missing keys.
- Vacuous-pass guard: a resource type resolving 0 keys (localizer can't find its resx) is reported as its own failure rather than silently passing with zero gaps — same failure mode the existing `SharedResource` test guards against with its 500-key floor, but expressed as "0 keys is always wrong" since a per-set literal floor across 25 sets would need updating every time any section's resx changes.

## Reuse rejected / considered

- **Per-set MemberData `[HumansTheory]`** instead of one aggregating `[HumansFact]`: rejected — `Type` as theory data has historically flaky xUnit serialization, and one aggregating fact produces one clear failure message naming every gap across every section, matching the existing `SharedResourceParityTests` style.
- **Hard-coded per-section minimum key counts**: rejected — 25 literals that go stale on every resx edit; `TotalKeys == 0` catches the actual failure mode (localizer can't resolve the manifest) without pinning a number.
- Reused `SectionDiscoveryExtensions.SectionResourceTypes()` as-is (no new discovery helper) and `TranslationsGalleryModelBuilder` as-is (generalized signature only, no new type).

## Proof the gate catches the failure it exists to prevent

Removed the `Agent_ConversationBackToHistory` key from `AgentResource.es.resx`, ran the new test:

```
Expected failures to be empty because every section resx set must translate every base key
in every supported culture; found: AgentResource.es missing 1: [Agent_ConversationBackToHistory]
```

Restored the key; `git diff` on that file is empty; full `Resources` test suite (3 tests) green again.

## Needs new interface surface — owner approval required

`TranslationsGalleryModelBuilder.Build`'s public signature changed from `IStringLocalizer<SharedResource>` to `IStringLocalizer`. This is the exact generalization the issue asks for ("whoever generalises `TranslationsGalleryModelBuilder` off its `SharedResource`-typed localizer") and is source/binary compatible for both existing callers — flagging for visibility per process, not because I'm blocked on it.

## Out of scope

The issue names a second half — generalizing `/Debug/Translations` itself to render every section's set, not just `SharedResource`'s — as "the other half of the same gap," explicitly scoped to whoever does the `Build` generalization, not as a hard requirement of this fix. This PR does the generalization the test needs; the gallery page's own UI/routing for a per-section view is a separate, larger change (new route or query param, section picker) that I left out to keep this PR to the parity gate. Filing as a follow-up if wanted.

## Testing

- `dotnet build Humans.slnx -v quiet` — green
- `dotnet test tests/Humans.Web.Tests` (526 tests) — green
- `dotnet test tests/Humans.Base.Tests` (156 tests) — green
- `dotnet test tests/Humans.Integration.Tests --filter FullyQualifiedName~DebugPageRenderTests` (5 tests, exercises `/Debug/Translations` end to end) — green
