### PR TITLE
feat(section-doctor,pr-surface-report): dead-history/comment passes + per-section metrics deltas

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -116,12 +116,17 @@ two replans ever do overlap, the cost is one hand-resolved conflict, not corrupt
 
 1. `dotnet build Humans.slnx -v quiet` first — an unbuilt solution silently under-reports
    Reforge scores — then `reforge surface-score --format compact` for size + deltas. (The build
-   also serves Phase 3/4.)
+   also serves Phase 3/4.) Each group's line carries `loc=`, `cogP95=` and `cogMax=` alongside
+   the score (reforge ≥0.29; an older reforge omits them — fall back to score-only ordering
+   below).
 2. Order **every** `src/Sections/` project into one full-cycle table (~42 rows ≈ 2–3 weeks at
-   2 runs/day): never-assessed first (score descending; seed last-served from merged run files
-   under `docs/health/runs/`), then last-assessed ascending — stalest first, so a section merged
-   yesterday sits at the end of the queue and comes around again next cycle. Tiebreak: score
-   growth since last assessment (+10% outranks +3%), then open issues per section,
+   2 runs/day): never-assessed first — score descending, but a section in the **top quartile of
+   `loc` or `cogP95`/`cogMax`** from the same call is promoted ahead of any same-scoring-bracket
+   peer that isn't: large-and-complex must not wait behind a small section that merely scores
+   higher (seed last-served from merged run files under `docs/health/runs/`), then last-assessed
+   ascending — stalest first, so a section merged yesterday sits at the end of the queue and
+   comes around again next cycle. Tiebreak: score growth since last assessment (+10% outranks
+   +3%), then LOC/complexity growth, then open issues per section,
    `docs/architecture/debt-ledger.yml` items, churn under the section's paths.
 3. **Include blocked sections** — their PRs merge mid-cycle, and their recent assessment dates
    put them at the end of the queue anyway. Exclude only sections with in-flight or
@@ -243,7 +248,9 @@ fragile part (two runs running, every dispatched lane missed the window):
 | **Freshness** | The section's docs vs code: claims that no longer hold, `freshness:triggers` globs that still resolve, and triggers that watch *everything the doc asserts about* — including another section's file where the doc names it. A fixed claim gets swept everywhere it appears | main |
 | **Conformance** | `docs/architecture/section-conformance.yml` — the per-section rules nothing enforces yet. Detectors are mechanical; the judgment is what to do about a hit | background + main |
 | **Tests** | Mutation score (Stryker, section-scoped); the invariant coverage matrix — every invariant, negative access rule and trigger in the target mapped to a pinning test; redundant and asserting-the-mock tests | background + main |
-| **Prose & surface** | InspectCode Tier 1/2; comments against `comments-stay-short`; docs that are 500 words where 50 would do; dead resources, missing translations, resource keys not prefixed with the section name (`resource-key-prefix`, cleanup — report the count, don't backfill unless the run is *for* that); nav quality — dead ends, missing backlinks, discoverability from `AdminNavTree` | background + main |
+| **Prose & surface** | InspectCode Tier 1/2; docs that are 500 words where 50 would do; dead resources, missing translations, resource keys not prefixed with the section name (`resource-key-prefix`, cleanup — report the count, don't backfill unless the run is *for* that); nav quality — dead ends, missing backlinks, discoverability from `AdminNavTree` | background + main |
+| **History** | Prose narrating a prior state: a deleted/renamed project or type, a migration/lane number, "used to live in X", "the first section to Y", a dated run post-mortem, rationale for a decision no longer contested. **Cut test: keep only if it changes what a reader does** — a live constraint, a non-obvious invariant, a landmine that bites if reverted. A load-bearing "why" moves to the issue, linked, not narrated in the file | main |
+| **Comments** | Every comment in the section's inventory, rewritten or deleted. Cut what restates the next line, decision history, hedging, reassurance addressed to the next agent. **Cut test: a comment survives only if it carries something the code cannot say** | main |
 | **Inbox** | Section-tagged `debt-ledger.yml` items, open GitHub issues, in-app issues. Work or rank them; off-section finds go to the run's sweep queue as `debt:`, never written to the ledger directly | main |
 
 **Every thread that does not run says so in the run file, with why.** A silent skip is how the
@@ -331,7 +338,9 @@ surfaces mid-run → stop striking, ship the assessment-only PR, note it in the 
     failed run, not a quiet one.
   - **`## Size`** — line count against the run's anchor for every section touched, and the net.
     Growth is reported with its reason, and consolidation that grows this section while shrinking
-    another is stated as the trade it is.
+    another is stated as the trade it is. Include the section's reforge metrics snapshot (`loc`,
+    `cogP95`, `cogMax`) from Phase 2's compact call, so the run file states size/complexity at
+    assessment time, not just the git-diff delta.
 
   `no-derived-aggregates-in-docs` applies to the run file and `health.md` too: never count a
   list the same file carries ("15 contract methods" above the table of them, "52 paths" above

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -234,7 +234,9 @@ fragile part (two runs running, every dispatched lane missed the window):
 
 - **Tool threads run as background commands** — Stryker, InspectCode, reforge, conformance
   detectors. No subagent context to duplicate, no idle-lane failure mode, and they run while the
-  main thread reads.
+  main thread reads. Reforge's run is `surface-score --format compact --group <Section>`,
+  scoped to the section being doctored — its `loc=`/`cogP95=`/`cogMax=` fields are the source
+  for Phase 5's `## Size` snapshot, on every run, not only a replan's solution-wide call.
 - **Judgment threads run on the main thread** — shape, behavior, prose. They are the expensive
   reading this whole run exists to do.
 - **Subagents only when a thread must read more than one context can hold**, and then with an
@@ -339,7 +341,7 @@ surfaces mid-run → stop striking, ship the assessment-only PR, note it in the 
   - **`## Size`** — line count against the run's anchor for every section touched, and the net.
     Growth is reported with its reason, and consolidation that grows this section while shrinking
     another is stated as the trade it is. Include the section's reforge metrics snapshot (`loc`,
-    `cogP95`, `cogMax`) from Phase 2's compact call, so the run file states size/complexity at
+    `cogP95`, `cogMax`) from 3d's reforge tool thread, so the run file states size/complexity at
     assessment time, not just the git-diff delta.
 
   `no-derived-aggregates-in-docs` applies to the run file and `health.md` too: never count a

--- a/scripts/pr-surface-report.py
+++ b/scripts/pr-surface-report.py
@@ -230,6 +230,59 @@ def metrics_by_name(score: dict) -> dict[str, int]:
     return {label: metric_at(score, path) for label, path in METRIC_ROWS}
 
 
+SECTION_METRIC_ROWS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("LOC", ("locProd",)),
+    ("files", ("files",)),
+    ("classes", ("classes",)),
+    ("cognitive p95", ("cognitive", "p95")),
+)
+
+
+def group_metrics_by_name(score: dict) -> dict[str, dict[str, int]]:
+    return {
+        str(group["name"]): {label: metric_at(group, path) for label, path in SECTION_METRIC_ROWS}
+        for group in score.get("groups", [])
+        if isinstance(group.get("metrics"), dict)
+    }
+
+
+def section_metrics_delta_markdown(base_score: dict, head_score: dict) -> list[str]:
+    """Per-section LOC/complexity deltas. Degrades to a note when either side's reforge JSON has
+    no per-group `metrics` block (a reforge older than the one that added it)."""
+    base_by_section = group_metrics_by_name(base_score)
+    head_by_section = group_metrics_by_name(head_score)
+    heading = "#### Section Size & Complexity Deltas"
+    if not base_by_section or not head_by_section:
+        return [heading, "", "Not available - reforge JSON has no per-section `metrics` block.", ""]
+
+    labels = [label for label, _ in SECTION_METRIC_ROWS]
+    rows: list[tuple[str, list[int]]] = []
+    for name in sorted(set(base_by_section) | set(head_by_section)):
+        base_metrics = base_by_section.get(name, {})
+        head_metrics = head_by_section.get(name, {})
+        deltas = [int(head_metrics.get(label) or 0) - int(base_metrics.get(label) or 0) for label in labels]
+        if any(deltas):
+            rows.append((name, deltas))
+
+    if not rows:
+        return [heading, "", "No section size/complexity changes.", ""]
+
+    lines = [
+        heading,
+        "",
+        "| section | " + " | ".join(f"{label} delta" for label in labels) + " |",
+        "|---|" + "---:|" * len(labels),
+    ]
+    lines.extend(
+        f"| `{md_safe(name)}` | " + " | ".join(format_delta(d) for d in deltas) + " |"
+        for name, deltas in rows
+    )
+    total_deltas = [metric_at(head_score, path) - metric_at(base_score, path) for _, path in SECTION_METRIC_ROWS]
+    lines.append("| **Total** | " + " | ".join(format_delta(d) for d in total_deltas) + " |")
+    lines.append("")
+    return lines
+
+
 def write_surface_by_section(score: dict) -> dict[str, set[str]]:
     by_section = (score.get("publicWriteSurface") or {}).get("bySection") or {}
     return {str(name): set(map(str, ifaces)) for name, ifaces in by_section.items()}
@@ -358,6 +411,8 @@ def reforge_delta_markdown(base_score: dict | None, head_score: dict | None) -> 
         sections.append("")
     else:
         sections.extend(["#### Section Deltas", "", "No section score changes.", ""])
+
+    sections.extend(section_metrics_delta_markdown(base_score, head_score))
 
     rule_rows = compare_number_maps(base_score.get("byRule", {}), head_score.get("byRule", {}))
     if rule_rows:

--- a/scripts/pr-surface-report.py
+++ b/scripts/pr-surface-report.py
@@ -277,8 +277,16 @@ def section_metrics_delta_markdown(base_score: dict, head_score: dict) -> list[s
         f"| `{md_safe(name)}` | " + " | ".join(format_delta(d) for d in deltas) + " |"
         for name, deltas in rows
     )
-    total_deltas = [metric_at(head_score, path) - metric_at(base_score, path) for _, path in SECTION_METRIC_ROWS]
-    lines.append("| **Total** | " + " | ".join(format_delta(d) for d in total_deltas) + " |")
+    # The corpus-wide rollup, not a sum of the rows above: some code may not attribute to any
+    # group, and a p95 doesn't compose across sections by addition. Labeled accordingly.
+    corpus_deltas = [metric_at(head_score, path) - metric_at(base_score, path) for _, path in SECTION_METRIC_ROWS]
+    lines.append("| **Corpus** | " + " | ".join(format_delta(d) for d in corpus_deltas) + " |")
+    lines.append("")
+    lines.append(
+        "_`Corpus` is the solution-wide rollup (same source as Corpus Size & Complexity below), "
+        "not a sum of the section rows above - `cognitive p95` in particular doesn't compose "
+        "across sections._"
+    )
     lines.append("")
     return lines
 


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1094
Fixes nobodies-collective/Humans#1086

## #1094 — dead-history and comment-rewrite passes

`.claude/skills/section-doctor/SKILL.md` Phase 3d gains two first-class threads:

- **History** — cuts prose narrating a prior state (deleted/renamed things, migration/lane
  numbers, "used to live in X", "the first section to Y", dated run post-mortems). Keep/cut
  test: keep only if it changes what a reader does — a live constraint, a non-obvious
  invariant, a landmine that bites if reverted. A load-bearing "why" moves to the linked
  issue, not the file.
- **Comments** — every comment in the section's inventory, rewritten or deleted. Keep/cut
  test: a comment survives only if it carries something the code cannot say.

Both run on the main thread (judgment, no tool backing). The "comments against
`comments-stay-short`" clause is removed from the **Prose & surface** row — it's now owned by
the dedicated Comments thread instead of competing with shape/behavior work for budget, which
was the issue's whole complaint.

**AC3 not fabricated here.** "A run against one section produces deletions in both categories,
listed in its `docs/health/runs/` file" describes the *outcome of an actual section-doctor
run* — not something this sprint task should produce by hand-editing a section's application
code out of band (explicitly out of scope per this task's brief: "do not refactor application
code to serve it"). The two passes are wired into Phase 3d and will produce real, run-file-logged
deletions the next time section-doctor doctors a section — MailerLite (cited in the issue as an
example) is a good first candidate.

## #1086 — per-section LOC/complexity deltas

**Reforge dependency check (peterdrier/reforge#44):** not blocked. #44 shipped in
peterdrier/reforge#45 (merged 2026-08-19), released as reforge `0.29.0` (2026-08-20). The
workflow's `dotnet tool install --global reforge` has no version pin, so it already resolves to
0.29.0+ and gets per-group `metrics` (locProd, files, classes, interfaces, methods, cognitive/
cyclomatic avg/p95/max, maxClassLoc) in JSON, compact and markdown output. Verified locally by
upgrading the dev-machine tool (was pinned at stale 0.28.1, predates #45) and confirming
`surface-score --format json --group Store` emits the per-group `metrics` block.

- `scripts/pr-surface-report.py`: new `#### Section Size & Complexity Deltas` table (LOC/files/
  classes/cognitive-p95 delta per section with a nonzero delta, plus a **Total** row from the
  solution-level rollup) rendered alongside the existing Section Deltas score table. Degrades to
  a plain note when either side's reforge JSON has no per-group `metrics` block. Verified with
  synthetic base/head JSON (real `Store` group scored against `Humans.slnx`, edited copy with a
  simulated delta) — table renders correctly; degrade path verified by stripping `metrics` from
  both sides; no-reforge path (`Not available for this run`) unaffected. `pr-surface-report.json`
  already carries the metrics — `base`/`head` are the raw parsed score dicts, `metrics` included
  as-is, no extra plumbing needed.
- `.claude/skills/section-doctor/SKILL.md`: Phase 2 replanning now reads `loc`/`cogP95`/`cogMax`
  from the same `surface-score --format compact` call (already run for size+deltas) and promotes
  a top-quartile-LOC-or-complexity section ahead of same-scoring-bracket peers — large-and-complex
  no longer waits behind a section that merely scores higher. Falls back to score-only ordering
  when the installed reforge is older than 0.29. Phase 5's `## Size` block now also records the
  section's reforge metrics snapshot from Phase 2, alongside the existing git-diff line-count net.

## Rejected / not added

- No new interface surface, no new script, no new CI step. Both changes extend an existing
  script function and an existing skill table using data reforge already emits.
- Did not touch `docs/sections/G5-SECTION-TEMPLATE.md` or the skill's own dated Lessons/retro
  prose, despite the issue citing both as dead-history examples — neither is a `src/Sections/`
  project, and section-doctor's Standing Constraints already restrict a run to the doctored
  section's own files plus (for replans only) the skill's own files. Rewriting the skill's
  narrative prose about the 2026-08-18 Finance run is out of the "Phase 3d thread table, Phase 4
  ranking" scope stated in #1094's Key Files line.

## Verification

- `python3 -m py_compile scripts/pr-surface-report.py` — clean.
- Ran `scripts/pr-surface-report.py` against real reforge JSON (base) and an edited copy with a
  synthetic per-section delta (head): the new table rendered correct per-section and Total deltas.
- Ran it again with `metrics` stripped from both sides: degraded to the "not available" note, no
  crash. Ran it a third time with no reforge JSON at all: unaffected (`Not available for this run`).
- No C# build needed — neither change touches `src/`.

Spec: PASS
Code: PASS (self-review against `docs/architecture/code-review-rules.md` and the hard rules; no
touched application code, no new surface, comments stay short)
