### PR TITLE
test(vc-tags): delete NotContain(<vc:) assertions superseded by the static check

### DIFF
--- a/tests/Humans.Integration.Tests/Controllers/AdminLayoutRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/AdminLayoutRenderTests.cs
@@ -120,9 +120,6 @@ public partial class AdminLayoutRenderTests(HumansTestDatabase database) : Integ
                 $"GET {url}: _AdminLayout's <partial name=\"_LoginPartial\" /> did not render — "
                 + $"an unresolved partial is silent, not an error ({site})");
 
-            // <vc:temp-data-alerts /> is bound by Humans.Web's own _ViewImports; unbound, it
-            // survives into the body as literal markup the browser drops.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered ({site})");
             html.Should().NotContain("<partial ", $"GET {url} left a <partial> tag helper unbound ({site})");
         }
     }

--- a/tests/Humans.Integration.Tests/Controllers/AuditLogPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/AuditLogPageRenderTests.cs
@@ -59,10 +59,6 @@ public class AuditLogPageRenderTests(HumansTestDatabase database) : IntegrationT
             // because it ships no resource set to assert raw keys against.
             html.Should().NotContain("<page-header", $"GET {url} left <page-header> unbound");
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup, which the browser silently drops.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
             // element for a type reference; that also renders as inert markup.
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");
@@ -133,8 +129,6 @@ public class AuditLogPageRenderTests(HumansTestDatabase database) : IntegrationT
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(marker,
                 $"GET {url}: the seeded audit row must reach the page — an unbound <vc:audit-log> renders nothing");
-            html.Should().NotContain("<vc:audit-log",
-                $"GET {url}: the audit history widget must bind, not ship as literal markup");
             html.Should().NotContain("audit-log-view-component",
                 $"GET {url}: a ReSharper-rewritten vc tag is inert markup too");
         }
@@ -176,8 +170,6 @@ public class AuditLogPageRenderTests(HumansTestDatabase database) : IntegrationT
         var html = await response.Content.ReadAsStringAsync(ct);
         html.Should().Contain(marker,
             $"GET {url}: the seeded audit row must reach the panel — an unbound <vc:audit-log> renders nothing");
-        html.Should().NotContain("<vc:audit-log",
-            $"GET {url}: the widget must bind, not ship as literal markup");
     }
 
     /// <summary>

--- a/tests/Humans.Integration.Tests/Controllers/BudgetPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/BudgetPageRenderTests.cs
@@ -124,10 +124,6 @@ public class BudgetPageRenderTests(HumansTestDatabase database) : IntegrationTes
 
             var html = await response.Content.ReadAsStringAsync(ct);
 
-            // A view component element that the section's _ViewImports failed to bind renders
-            // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // The fallback for a key the carve missed is the key itself.
             html.Should().NotContain("Budget_", $"GET {url} rendered a raw resource key");
         }

--- a/tests/Humans.Integration.Tests/Controllers/CalendarPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CalendarPageRenderTests.cs
@@ -115,10 +115,6 @@ public class CalendarPageRenderTests(HumansTestDatabase database) : IntegrationT
 
             var html = await response.Content.ReadAsStringAsync(ct);
 
-            // A view component element that the section's _ViewImports failed to bind renders
-            // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // The fallback for a key the carve missed is the key itself.
             html.Should().NotContain("Calendar_", $"GET {url} rendered a raw resource key");
         }
@@ -211,8 +207,6 @@ public class CalendarPageRenderTests(HumansTestDatabase database) : IntegrationT
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var html = await response.Content.ReadAsStringAsync(ct);
-        html.Should().NotContain("<vc:user-calendar",
-            "Shell must import the Calendar tag helper, not just the namespace");
         html.Should().Contain("Calendar Feed", "the component renders its own card header");
     }
 

--- a/tests/Humans.Integration.Tests/Controllers/CampaignPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CampaignPageRenderTests.cs
@@ -105,10 +105,6 @@ public class CampaignPageRenderTests(HumansTestDatabase database) : IntegrationT
 
             var html = await response.Content.ReadAsStringAsync(ct);
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper's rename refactoring rewrites <vc:name> to <name-view-component>,
             // which is equally inert (the "<vc:*> rename hazard" in G5-SECTION-TEMPLATE.md).
             html.Should().NotContain("-view-component", $"GET {url} left a renamed view-component tag unrendered");

--- a/tests/Humans.Integration.Tests/Controllers/CampsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CampsPageRenderTests.cs
@@ -81,10 +81,6 @@ public class CampsPageRenderTests(HumansTestDatabase database) : IntegrationTest
 
             var html = await response.Content.ReadAsStringAsync(ct);
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // The fallback for a key the carve missed is the key itself.
             html.Should().NotContain("Camp_", $"GET {url} rendered a raw Camps resource key");
             html.Should().NotContain("CampCard_", $"GET {url} rendered a raw CampCard key");
@@ -135,26 +131,6 @@ public class CampsPageRenderTests(HumansTestDatabase database) : IntegrationTest
         // Shell's own renderer of the same key, which is why it stayed behind.
         var shellPage = await (await Client.GetAsync("/", ct)).Content.ReadAsStringAsync(ct);
         shellPage.Should().NotContain("Camp_Plural");
-    }
-
-    /// <summary>
-    /// Shell's profile page renders the section's <c>&lt;vc:my-camps&gt;</c>. The component is
-    /// <c>public</c> under <c>Humans.Camps/Contracts/</c> so MVC's default provider discovers
-    /// it and the tag helper is generated at compile time — but only if Shell's
-    /// <c>_ViewImports</c> carries <c>@@addTagHelper *, Humans.Camps</c>. Without that line the
-    /// element survives into the response as inert markup, which is a green build, a 200, and a
-    /// missing widget.
-    /// </summary>
-    [HumansFact(Timeout = 120000)]
-    public async Task A_shell_page_renders_the_sections_view_component()
-    {
-        var ct = Xunit.TestContext.Current.CancellationToken;
-        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
-
-        var html = await (await Client.GetAsync("/Profile", ct)).Content.ReadAsStringAsync(ct);
-
-        html.Should().NotContain("<vc:my-camps",
-            because: "Shell must resolve the moved component, not ship its tag");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/CantinaPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CantinaPageRenderTests.cs
@@ -61,10 +61,6 @@ public class CantinaPageRenderTests(HumansTestDatabase database) : IntegrationTe
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own resolved copy");
 
-            // A view component element that the section's _ViewImports failed to bind renders
-            // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
             // element for a type reference; that also renders as inert markup.
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");

--- a/tests/Humans.Integration.Tests/Controllers/CityPlanningPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CityPlanningPageRenderTests.cs
@@ -66,10 +66,6 @@ public class CityPlanningPageRenderTests(HumansTestDatabase database) : Integrat
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own resolved copy");
 
-            // A view component element that the section's _ViewImports failed to bind renders
-            // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // The fallback for a key the carve missed is the key itself.
             html.Should().NotContain("CityPlanning_", $"GET {url} rendered a raw resource key");
             html.Should().NotContain("ContainerMap_", $"GET {url} rendered a raw resource key");

--- a/tests/Humans.Integration.Tests/Controllers/ConsentPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/ConsentPageRenderTests.cs
@@ -106,7 +106,6 @@ public class ConsentPageRenderTests(HumansTestDatabase database) : IntegrationTe
 
     private static void AssertRenderedCleanly(string html, string what)
     {
-        html.Should().NotContain("<vc:", $"{what} left a view-component tag unrendered");
         html.Should().NotContain("-view-component", $"{what} has a renamed view-component element");
         foreach (var prefix in CarvedPrefixes)
         {

--- a/tests/Humans.Integration.Tests/Controllers/DebugPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/DebugPageRenderTests.cs
@@ -78,9 +78,6 @@ public class DebugPageRenderTests(HumansTestDatabase database) : IntegrationTest
             // positive marker it emits is asserted on /Debug/Translations below.
             html.Should().NotContain("<page-header", $"GET {url} left a tag helper unrendered");
 
-            // Same failure mode for a view component element.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
             // element for a type reference; that also renders as inert markup.
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");

--- a/tests/Humans.Integration.Tests/Controllers/DevelopmentPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/DevelopmentPageRenderTests.cs
@@ -132,7 +132,6 @@ public class DevelopmentPageRenderTests(HumansTestDatabase database) : Integrati
         // response as its own start tag, so the page is a 200 with correct-looking source and a
         // missing widget.
         html.Should().NotContain("<page-header", $"GET {url} left a tag helper unrendered");
-        html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
         // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the element
         // for a type reference; that also renders as inert markup.
         html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");

--- a/tests/Humans.Integration.Tests/Controllers/EarlyEntryPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/EarlyEntryPageRenderTests.cs
@@ -61,9 +61,6 @@ public class EarlyEntryPageRenderTests(HumansTestDatabase database) : Integratio
         html.Should().NotContain("No early entry grants",
             because: "the empty branch would render none of the markup this test guards");
 
-        // A view component element the section's _ViewImports failed to bind renders as
-        // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-        html.Should().NotContain("<vc:", $"GET {RosterUrl} left a view-component tag unrendered");
         html.Should().NotContain("-view-component", $"GET {RosterUrl} has a rewritten vc tag");
     }
 

--- a/tests/Humans.Integration.Tests/Controllers/EmailPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/EmailPageRenderTests.cs
@@ -82,10 +82,6 @@ public class EmailPageRenderTests(HumansTestDatabase database) : IntegrationTest
 
             var html = await response.Content.ReadAsStringAsync(ct);
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper's rename refactoring rewrites <vc:name> to <name-view-component>,
             // which is equally inert (the "<vc:*> rename hazard" in G5-SECTION-TEMPLATE.md).
             html.Should().NotContain("-view-component", $"GET {url} left a renamed view-component tag unrendered");

--- a/tests/Humans.Integration.Tests/Controllers/FeedbackPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/FeedbackPageRenderTests.cs
@@ -92,10 +92,6 @@ public class FeedbackPageRenderTests(HumansTestDatabase database) : IntegrationT
 
         var html = await response.Content.ReadAsStringAsync(ct);
 
-        // A view component element that the section's _ViewImports failed to bind renders
-        // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-        html.Should().NotContain("<vc:", "GET /Feedback left a view-component tag unrendered");
-
         // The fallback for a key the carve missed is the key itself.
         html.Should().NotContain("Feedback_", "GET /Feedback rendered a raw resource key");
         html.Should().NotContain("Enum_Feedback", "GET /Feedback rendered a raw enum resource key");
@@ -123,7 +119,6 @@ public class FeedbackPageRenderTests(HumansTestDatabase database) : IntegrationT
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync(ct);
 
-        html.Should().NotContain("<vc:", "the detail partial left <vc:human> unrendered");
         html.Should().NotContain("Feedback_", "the detail partial rendered a raw resource key");
         html.Should().Contain("Conversation");
         html.Should().Contain("Thanks, reproduced.");

--- a/tests/Humans.Integration.Tests/Controllers/FinancePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/FinancePageRenderTests.cs
@@ -49,10 +49,6 @@ public class FinancePageRenderTests(HumansTestDatabase database) : IntegrationTe
         {
             html.Should().Contain($"href=\"{href}\"", $"the index must link to {href}");
         }
-
-        // A view-component element the section's _ViewImports failed to bind renders as literal
-        // markup: 200, correct-looking source, nothing on the page.
-        html.Should().NotContain("<vc:", "a view-component tag was left unrendered");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/GatePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/GatePageRenderTests.cs
@@ -121,10 +121,6 @@ public class GatePageRenderTests(HumansTestDatabase database) : IntegrationTestB
 
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own copy");
-
-            // A view component element that the section's _ViewImports failed to bind renders
-            // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
         }
     }
 

--- a/tests/Humans.Integration.Tests/Controllers/GoogleIntegrationPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/GoogleIntegrationPageRenderTests.cs
@@ -76,7 +76,6 @@ public class GoogleIntegrationPageRenderTests(HumansTestDatabase database) : Int
 
             var html = await response.Content.ReadAsStringAsync(ct);
 
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
             html.Should().NotContain("-view-component", $"GET {url} has a ReSharper-rewritten vc tag");
             html.Should().NotContain("GoogleAccounts_",
                 $"GET {url} rendered a raw resource key — the resx carve missed one, or a type bound the wrong localizer");

--- a/tests/Humans.Integration.Tests/Controllers/GovernancePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/GovernancePageRenderTests.cs
@@ -105,7 +105,6 @@ public class GovernancePageRenderTests(HumansTestDatabase database) : Integratio
 
     private static void AssertRenderedCleanly(string html, string what)
     {
-        html.Should().NotContain("<vc:", $"{what} left a view-component tag unrendered");
         html.Should().NotContain("-view-component", $"{what} has a renamed view-component element");
         foreach (var prefix in CarvedPrefixes)
         {

--- a/tests/Humans.Integration.Tests/Controllers/GuidePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/GuidePageRenderTests.cs
@@ -96,10 +96,6 @@ public class GuidePageRenderTests(HumansTestDatabase database) : IntegrationTest
             html.Should().Contain("Common questions",
                 $"GET {url} must render the sidebar's Common questions group");
 
-            // A view-component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // An unbound AuthorizeViewTagHelper leaks its attribute into the response instead
             // of gating the element.
             html.Should().NotContain("authorize-policy",
@@ -145,6 +141,5 @@ public class GuidePageRenderTests(HumansTestDatabase database) : IntegrationTest
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         var html = await response.Content.ReadAsStringAsync(ct);
         html.Should().Contain("That guide page does not exist");
-        html.Should().NotContain("<vc:");
     }
 }

--- a/tests/Humans.Integration.Tests/Controllers/HomePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/HomePageRenderTests.cs
@@ -26,7 +26,6 @@ public class HomePageRenderTests(HumansTestDatabase database) : IntegrationTestB
 
     private static void AssertRenderedCleanly(string html, string what)
     {
-        html.Should().NotContain("<vc:", $"{what} left a view-component tag unrendered");
         html.Should().NotContain("-view-component", $"{what} has a renamed view-component element");
         foreach (var prefix in CarvedPrefixes)
         {

--- a/tests/Humans.Integration.Tests/Controllers/IssuePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/IssuePageRenderTests.cs
@@ -101,10 +101,6 @@ public class IssuePageRenderTests(HumansTestDatabase database) : IntegrationTest
 
         var html = await response.Content.ReadAsStringAsync(ct);
 
-        // A view component element the section's _ViewImports failed to bind renders as
-        // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-        html.Should().NotContain("<vc:", "GET /Issues left a view-component tag unrendered");
-
         // The fallback for a key the carve missed is the key itself.
         html.Should().NotContain("Issue_", "GET /Issues rendered a raw resource key");
         html.Should().NotContain("Enum_Issue", "GET /Issues rendered a raw enum resource key");
@@ -131,7 +127,6 @@ public class IssuePageRenderTests(HumansTestDatabase database) : IntegrationTest
 
         var html = await response.Content.ReadAsStringAsync(ct);
 
-        html.Should().NotContain("<vc:");
         html.Should().NotContain("Issue_", "GET /Issues/New rendered a raw resource key");
         html.Should().NotContain("Enum_Issue", "GET /Issues/New rendered a raw enum resource key");
 
@@ -156,7 +151,6 @@ public class IssuePageRenderTests(HumansTestDatabase database) : IntegrationTest
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync(ct);
 
-        html.Should().NotContain("<vc:", "the detail partial left <vc:human> unrendered");
         html.Should().NotContain("Issue_", "the detail partial rendered a raw resource key");
         html.Should().Contain("Conversation");
         html.Should().Contain("Thanks, reproduced.");

--- a/tests/Humans.Integration.Tests/Controllers/MailerLitePageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/MailerLitePageRenderTests.cs
@@ -60,10 +60,6 @@ public class MailerLitePageRenderTests(HumansTestDatabase database) : Integratio
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own copy");
 
-            // A section can only addTagHelper against Humans.UI; a component element the
-            // section's _ViewImports failed to bind survives into the body as its own
-            // element name — 200, correct-looking source, nothing on screen.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten <vc:> element");
 
             // _ViewStart's Layout = "_AdminLayout" resolves into Humans.Web across

--- a/tests/Humans.Integration.Tests/Controllers/MonitorPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/MonitorPageRenderTests.cs
@@ -52,7 +52,6 @@ public class MonitorPageRenderTests(HumansTestDatabase database) : IntegrationTe
         // tag (step 12, Debug's case). This is what a missing @addTagHelper in the section's
         // own _ViewImports looks like.
         html.Should().NotContain("<page-header", $"GET {url} left <page-header> unbound");
-        html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
         html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");
     }
 
@@ -97,7 +96,6 @@ public class MonitorPageRenderTests(HumansTestDatabase database) : IntegrationTe
         html.Should().Contain(marker,
             $"GET {url}: the seeded sync row must reach the page — an unbound <vc:audit-log> renders nothing");
         html.Should().Contain("reader", $"GET {url} must render the sync layout's Role column");
-        html.Should().NotContain("<vc:audit-log", $"GET {url}: the widget must bind, not ship as literal markup");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/NotificationPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/NotificationPageRenderTests.cs
@@ -104,10 +104,6 @@ public class NotificationPageRenderTests(HumansTestDatabase database) : Integrat
 
         var html = await response.Content.ReadAsStringAsync(ct);
 
-        // A view component element the section's _ViewImports failed to bind renders as
-        // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-        html.Should().NotContain("<vc:", "GET /Notifications left a view-component tag unrendered");
-
         // The fallback for a key the carve missed is the key itself.
         html.Should().NotContain("Notification_", "GET /Notifications rendered a raw resource key");
 
@@ -132,7 +128,6 @@ public class NotificationPageRenderTests(HumansTestDatabase database) : Integrat
 
         var html = await response.Content.ReadAsStringAsync(ct);
 
-        html.Should().NotContain("<vc:");
         html.Should().NotContain("Notification_", "the popup partial rendered a raw resource key");
         html.Should().Contain("Notifications");   // Notification_Popup_Title
         html.Should().Contain(ActionableTitle);

--- a/tests/Humans.Integration.Tests/Controllers/OnboardingPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/OnboardingPageRenderTests.cs
@@ -45,7 +45,6 @@ public class OnboardingPageRenderTests(HumansTestDatabase database) : Integratio
 
     private static void AssertRenderedCleanly(string html, string what)
     {
-        html.Should().NotContain("<vc:", $"{what} left a view-component tag unrendered");
         html.Should().NotContain("-view-component", $"{what} has a renamed view-component element");
         foreach (var prefix in CarvedPrefixes)
         {

--- a/tests/Humans.Integration.Tests/Controllers/ScannerPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/ScannerPageRenderTests.cs
@@ -62,10 +62,6 @@ public class ScannerPageRenderTests(HumansTestDatabase database) : IntegrationTe
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own resolved copy");
 
-            // A view component element that the section's _ViewImports failed to bind renders
-            // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // The fallback for a key the carve missed is the key itself.
             html.Should().NotContain("Scanner_", $"GET {url} rendered a raw resource key");
         }
@@ -88,7 +84,6 @@ public class ScannerPageRenderTests(HumansTestDatabase database) : IntegrationTe
         var html = await response.Content.ReadAsStringAsync(ct);
         html.Should().Contain("no-such-barcode");
         html.Should().NotContain("Scanner_", "the not-found copy is a carved key");
-        html.Should().NotContain("<vc:");
     }
 
     [HumansFact(Timeout = 120000)]

--- a/tests/Humans.Integration.Tests/Controllers/SearchPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SearchPageRenderTests.cs
@@ -63,10 +63,6 @@ public class SearchPageRenderTests(HumansTestDatabase database) : IntegrationTes
             // localizer — is the key itself.
             html.Should().NotContain("Search_", $"GET {url} rendered a raw resource key");
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
             // element for a type reference; that also renders as inert markup.
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");

--- a/tests/Humans.Integration.Tests/Controllers/ShiftsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/ShiftsPageRenderTests.cs
@@ -127,10 +127,6 @@ public class ShiftsPageRenderTests(HumansTestDatabase database) : IntegrationTes
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own copy");
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
             // element for a type reference; that also renders as inert markup.
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");
@@ -161,7 +157,6 @@ public class ShiftsPageRenderTests(HumansTestDatabase database) : IntegrationTes
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var html = await response.Content.ReadAsStringAsync(ct);
-        html.Should().NotContain("<vc:", "GET /Shifts left a view-component tag unrendered");
         html.Should().Contain("id=\"sectionHelp-Shifts\"",
             "the access-matrix modal is what the page's Learn-more button targets");
     }

--- a/tests/Humans.Integration.Tests/Controllers/StoreControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/StoreControllerTests.cs
@@ -147,8 +147,6 @@ public class StoreControllerTests(HumansTestDatabase database) : IntegrationTest
         var html = await response.Content.ReadAsStringAsync(ct);
         html.Should().Contain(marker,
             $"GET {url}: the seeded price-change row must reach the panel");
-        html.Should().NotContain("<vc:audit-log",
-            $"GET {url}: the widget must bind, not ship as literal markup");
     }
 
     private async Task<int> SeedActiveProductAsync(string name)

--- a/tests/Humans.Integration.Tests/Controllers/TeamsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/TeamsPageRenderTests.cs
@@ -76,10 +76,6 @@ public class TeamsPageRenderTests(HumansTestDatabase database) : IntegrationTest
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own copy");
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
             // element for a type reference; that also renders as inert markup.
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");

--- a/tests/Humans.Integration.Tests/Controllers/TicketsPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/TicketsPageRenderTests.cs
@@ -81,10 +81,6 @@ public class TicketsPageRenderTests(HumansTestDatabase database) : IntegrationTe
             var html = await response.Content.ReadAsStringAsync(ct);
             html.Should().Contain(copy, $"GET {url} must render its own copy");
 
-            // A view component element the section's _ViewImports failed to bind renders as
-            // literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-            html.Should().NotContain("<vc:", $"GET {url} left a view-component tag unrendered");
-
             // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
             // element for a type reference; that also renders as inert markup.
             html.Should().NotContain("-view-component", $"GET {url} has a rewritten vc tag");
@@ -133,7 +129,6 @@ public class TicketsPageRenderTests(HumansTestDatabase database) : IntegrationTe
         html.Should().Contain("Back");                                 // Common_Back, from SharedResource
         html.Should().NotContain("TicketTransfer_", "a carved key rendered as its own name");
         html.Should().NotContain("Common_", "a shared key rendered as its own name");
-        html.Should().NotContain("<vc:");
     }
 
     [HumansFact(Timeout = 120000)]
@@ -210,7 +205,6 @@ public class TicketsPageRenderTests(HumansTestDatabase database) : IntegrationTe
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var html = await response.Content.ReadAsStringAsync(ct);
-        html.Should().NotContain("<vc:ticket-stub", "Shell must import the Tickets tag helper, not just the namespace");
         html.Should().Contain("Sample Human", "the stub card renders its attendee name");
     }
 

--- a/tests/Humans.Integration.Tests/Controllers/TourPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/TourPageRenderTests.cs
@@ -28,7 +28,6 @@ public class TourPageRenderTests(HumansTestDatabase database) : IntegrationTestB
         html.Should().Contain("Communicate");
         html.Should().Contain("Humans for your burn");
         html.Should().Contain("href=\"/About\"");
-        html.Should().NotContain("<vc:", because: "an unresolved view component tag renders as inert literal markup");
     }
 
     [HumansFact(Timeout = 60000)]

--- a/tests/Humans.Integration.Tests/Controllers/UsersPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/UsersPageRenderTests.cs
@@ -428,10 +428,6 @@ public class UsersPageRenderTests(HumansTestDatabase database) : IntegrationTest
 
     private static void AssertRenderedCleanly(string html, string what)
     {
-        // A view-component element the section's _ViewImports failed to bind renders
-        // as literal <vc:…> markup: 200, correct-looking source, nothing on the page.
-        html.Should().NotContain("<vc:", $"{what} left a view-component tag unrendered");
-
         // ReSharper rewrites <vc:name> to <name-view-component> when it mistakes the
         // element for a type reference; that also renders as inert markup.
         html.Should().NotContain("-view-component", $"{what} has a rewritten vc tag");

--- a/tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs
+++ b/tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs
@@ -63,18 +63,18 @@ public class ViewComponentTagHelperBindingTests
 
         var failures = new List<string>();
 
-        foreach (var (path, tag) in callSites)
+        foreach (var (path, tag, line) in callSites)
         {
             if (!components.TryGetValue(tag, out var component))
             {
-                failures.Add($"{path}: <vc:{tag}> does not name any known view component — it can never resolve");
+                failures.Add($"{path}:{line}: <vc:{tag}> does not name any known view component — it can never resolve");
                 continue;
             }
 
             if (!component.IsPublic)
             {
                 failures.Add(
-                    $"{path}: <vc:{tag}> names {component.TypeName}, which is not public — Razor "
+                    $"{path}:{line}: <vc:{tag}> names {component.TypeName}, which is not public — Razor "
                     + "never generates a tag helper call for it, so it ships as inert literal markup");
                 continue;
             }
@@ -82,7 +82,7 @@ public class ViewComponentTagHelperBindingTests
             if (!ImportsAssembly(path, src, component.AssemblyName))
             {
                 failures.Add(
-                    $"{path}: <vc:{tag}> is not covered by an @addTagHelper *, {component.AssemblyName} "
+                    $"{path}:{line}: <vc:{tag}> is not covered by an @addTagHelper *, {component.AssemblyName} "
                     + "directive in its folder chain — it ships as inert literal markup");
             }
         }
@@ -169,14 +169,14 @@ public class ViewComponentTagHelperBindingTests
         @"@\*.*?\*@", RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
     /// <summary>
-    /// Every distinct <c>&lt;vc:name</c> call site in one view, tag name only. Razor comments
-    /// are stripped first — <c>_ViewImports.cshtml</c> files routinely document a component's
-    /// binding inside a <c>@* ... *@</c> block (e.g. "invoked by name, not a tag helper"), and
-    /// that documentation is not a real call site.
+    /// Every distinct <c>&lt;vc:name</c> call site in one view, tag name plus its 1-based line
+    /// number. Razor comments are stripped first — <c>_ViewImports.cshtml</c> files routinely
+    /// document a component's binding inside a <c>@* ... *@</c> block (e.g. "invoked by name,
+    /// not a tag helper"), and that documentation is not a real call site.
     /// </summary>
-    private static IEnumerable<(string Path, string Tag)> CallSites(string path)
+    private static IEnumerable<(string Path, string Tag, int Line)> CallSites(string path)
     {
-        var text = RazorComment.Replace(File.ReadAllText(path), string.Empty);
+        var text = StripComments(File.ReadAllText(path));
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var index = text.IndexOf(CallSiteMarker, StringComparison.Ordinal);
 
@@ -189,11 +189,22 @@ public class ViewComponentTagHelperBindingTests
 
             var tag = text[start..end];
             if (tag.Length > 0 && seen.Add(tag))
-                yield return (path, tag);
+                yield return (path, tag, LineNumber(text, index));
 
             index = text.IndexOf(CallSiteMarker, end, StringComparison.Ordinal);
         }
     }
+
+    /// <summary>The 1-based line number of <paramref name="index"/> within <paramref name="text"/>.</summary>
+    private static int LineNumber(string text, int index) =>
+        1 + text.AsSpan(0, index).Count('\n');
+
+    /// <summary>
+    /// Strips <c>@* ... *@</c> comments, keeping every newline the comment contained so line
+    /// numbers computed on the result still match the original file.
+    /// </summary>
+    private static string StripComments(string text) =>
+        RazorComment.Replace(text, m => new string('\n', m.Value.Count(c => c == '\n')));
 
     // Razor applies every _ViewImports.cshtml from the project root down to the view's folder.
     // Comments are stripped first for the same reason call sites are: several _ViewImports
@@ -215,7 +226,7 @@ public class ViewComponentTagHelperBindingTests
     }
 
     private static string ActiveDirectives(string importsPath) =>
-        RazorComment.Replace(File.ReadAllText(importsPath), string.Empty);
+        StripComments(File.ReadAllText(importsPath));
 
     private static IEnumerable<string> RazorFiles(string srcRoot) =>
         Directory


### PR DESCRIPTION
Fixes nobodies-collective/Humans#1031

## Context

#1031 asked for a build-time check that fails when a `.cshtml` contains a `<vc:…>` tag whose
component can never resolve, plus deletion of the ten `NotContain("<vc:")` runtime assertions
once that check is green (step 4 of the issue).

A scope check against `origin/main` found that check already exists:
`tests/Humans.Web.Tests/Architecture/ViewComponentTagHelperBindingTests.cs`, added in **PR #1412**
(filed against #1055, a different but adjacent issue). It is a reflection + file-scan test, not an
analyzer — #1412's own remarks record the same reasoning #1031 lays out (Roslyn never sees
`.cshtml`, so a Roslyn analyzer can't reach this). It:

- scans every `.cshtml` under `src/` recursively, with no per-project opt-in,
- strips `@*…*@` Razor comments before scanning (both at call sites and in `_ViewImports.cshtml`),
- discovers every public view component by reflection across every section assembly plus
  `Humans.Web` and `Humans.Base`,
- fails with the offending file and tag name when a `<vc:…>` names an unknown component, a
  non-public component, or a component whose assembly isn't opened via `@addTagHelper` in the
  view's folder chain.

What #1412 never did is step 4's cleanup. The ten assertions the issue named had grown to **47**
`html.Should().NotContain("<vc:", …)` call sites across **33** `*PageRenderTests.cs` files by the
time this PR was filed. This PR is that cleanup — no new checker, no analyzer.

## Equivalence evidence (why this is safe to delete)

The runtime assertion and the static check guard the same failure mode, but from different
angles: the runtime assertion catches a tag that survived into rendered HTML on a page a test
actually requested; the static check catches a tag that cannot resolve at all, independent of
whether anything requests the page. Verified before deleting anything:

- **Coverage is a strict superset.** The runtime assertions only ever covered pages a render test
  happened to `GET`. The static test scans every `.cshtml` under `src/` unconditionally, so it
  covers every page the runtime assertions covered plus every page that has no render test at
  all — including the exact gap #1031 called out (Agent, Events, Store never carried the
  assertion despite using `<vc:>`).
- **Resolution is a compile-time property, not a runtime one.** Whether `<vc:foo>` resolves is
  decided by Razor at compile time from the component's visibility and the view's
  `@addTagHelper` chain — it does not depend on request data, signed-in persona, or which
  branch of the view executes. So a tag that resolves for the static check resolves identically
  for every runtime request, and vice versa. I read all 47 call sites (including the
  component-specific ones — `<vc:audit-log>`, `<vc:user-calendar>`, `<vc:my-camps>`,
  `<vc:ticket-stub>`, `<vc:human>`) and confirmed none of them depend on anything the static
  check can't see.
- **One sibling assertion is *not* redundant, and I left every instance of it alone.** Many of
  these tests also assert `NotContain("-view-component", …)`, guarding a *different* failure
  mode: ReSharper's rename refactoring rewrites `<vc:name>` to `<name-view-component>` in the
  `.cshtml` source itself (G5-SECTION-TEMPLATE.md, "The `<vc:*>` rename hazard"). Once that
  rewrite has happened, the source no longer contains the literal substring `<vc:` at all, so the
  static test's scanner (which keys off `<vc:`) has nothing to flag — the call site has silently
  vanished, not failed to resolve. Only a runtime assertion on rendered content can catch that.
  I did not touch any `-view-component` assertion.

I found no case where a `NotContain("<vc:", …)` assertion depended on something the static check
misses, so all 47 were deleted — none were kept back.

## What changed

- **47 `NotContain("<vc:", …)` assertions deleted** across 33 `*PageRenderTests.cs` /
  `StoreControllerTests.cs` files in `tests/Humans.Integration.Tests/Controllers/`. Where the
  assertion was the *only* thing a test method did
  (`CampsPageRenderTests.A_shell_page_renders_the_sections_view_component`, which only asserted
  `NotContain("<vc:my-camps", …)` with no positive assertion), the whole method is deleted rather
  than left as an empty shell. Every other deletion left its test method with its other
  assertions (positive `Contain` checks, resource-key checks, the sibling
  `-view-component` check, etc.) intact.
- **Line-number reporting added** to the static test (issue AC: "naming the file and line";
  the landed version only named the file). `CallSites` now yields a 1-based line number
  alongside the path and tag, and every failure message is `{path}:{line}: …`. Comment-stripping
  was changed to preserve embedded newlines (`StripComments`, shared by both the call-site scan
  and the `_ViewImports` directive scan) so line numbers survive a multi-line `@* … *@` block
  being stripped ahead of the match. Verified by temporarily breaking a real `@addTagHelper`
  line and confirming the failure pointed at the exact source line of the affected `<vc:my-camps>`
  call site, then reverting.

## Not in scope for this PR

- `AuditLogPageRenderTests.Every_audit_log_call_site_sits_under_a_view_imports_that_binds_it` is a
  second, hand-rolled static scan (predates #1412) that is now also fully subsumed by the general
  static check. It doesn't use `NotContain("<vc:")`, so it's outside this PR's stated scope
  (deleting the 47 named assertions); flagging it here as a follow-up rather than pulling it in.
- `docs/sections/G5-SECTION-TEMPLATE.md` still references `NotContain("<vc:")` as the expected
  per-lane pattern in its historical "proven: …" narrative (the issue's own "Key files" section
  flagged this doc, not as an AC). It's a large historical narrative doc describing how each past
  G5 section move was done; rewriting those references is a bigger, separate editorial pass I did
  not take on here.

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 errors.
- `dotnet test Humans.slnx -v quiet` — full suite green, including
  `Humans.Web.Tests` (525 passed) and `Humans.Integration.Tests` (295 passed, 1 skipped, 0 failed).
- Deliberately broke a real `@addTagHelper *, Humans.Camps` line and confirmed the static test
  fails naming the exact file and line of the affected call site, then reverted.
