### PR TITLE
feat(events): publish a scored search hit, matching Teams/Camps/Shifts

### DIFF
--- a/docs/features/global/global-search.md
+++ b/docs/features/global/global-search.md
@@ -79,7 +79,7 @@ The feature is deliberately scoped to matching **confined to each entity's own p
 - **Camps** match on the public-year `CampSeason.Name` only.
 - **Shifts** (rotas) match on `Rota.Name` only.
 - Teams, Camps, Shifts, and Humans additionally match by pasting the entity's own id (a `Guid.TryParse` fast-path scored as an exact match). For humans the pasted UserId resolves against the cached snapshot (`CachingUserService`) and is reported as a `User ID` match; rejected profiles are excluded, and `ExactName` queries skip id resolution so a GUID-shaped burner name matches by name, never by id collision.
-- **Events** match on `Event.Title` or `Event.Description` and are filtered to `Status = Approved` only. Events are the one deliberate exception to matching on the name/title field alone: the orchestrator reuses `IEventServiceRead.GetApprovedEventsAsync` (the same call the public Browse page makes), which filters Title + Description in memory over the approved-event cache, because event copy is short and free-form so description text is often the load-bearing name signal users remember. Rows are still scored by Title via the standard exact/prefix/contains rubric; rows that only matched via Description fall through to a contains-tier score so they're still surfaced (just ranked below title hits).
+- **Events** match on `Event.Title` or `Event.Description` and are filtered to `Status = Approved` only, via `IEventServiceRead.SearchAsync` — event copy is short and free-form so description text is often the load-bearing name signal users remember. A Title match scores via the standard exact/prefix/contains rubric; a Description-only match uses the same three tiers halved (50/40/30) so it's still surfaced but always ranks below every Title match, and orders sensibly against other description-only hits instead of tying (nobodies-collective/Humans#1062).
 - Humans, Teams, Camps **and Events** match in-memory against the cached snapshots (`CachingUserService` / `CachingTeamService` / `CachingCampService` / `CachingEventService`) — case-insensitive contains, accent-folded for humans; search never hits the DB for these four buckets. **Shifts is the only DB-backed bucket**, running case-insensitive Postgres `EF.Functions.ILike` per `memory/feedback_ef_ilike_not_toupper.md`.
 
 ### US-GS.4: A text query surfaces the public-visibility set, never more
@@ -133,15 +133,15 @@ SearchController
          ├── ITeamServiceRead.SearchAsync(query, max)                                         → IReadOnlyList<TeamSearchHit>
          ├── ICampServiceRead.SearchAsync(query, max)                                         → IReadOnlyList<CampSearchHit>
          ├── IShiftManagementService.SearchAsync(query, max)                                  → IReadOnlyList<RotaSearchHit>
-         └── IEventServiceRead.GetApprovedEventsAsync(…, q: query, …)  (skipped when Features:Events is off)  → IReadOnlyList<Event>
+         └── IEventServiceRead.SearchAsync(query, max)  (skipped when Features:Events is off)  → IReadOnlyList<EventSearchHit>
 ```
 
-Humans, Teams, and Camps are served entirely from their caching decorators' warm in-memory snapshots — the inner `TeamService` / `CampService` `SearchAsync` throw `NotSupportedException` and the DB-search repository methods are gone. **Events is cache-backed too:** `IEventServiceRead` is registered as the `CachingEventService` singleton (`Section.cs:55`), whose `GetApprovedEventsAsync` filters the approved-event cache in memory with `Contains(…, OrdinalIgnoreCase)` — no DB round trip per search. **Shifts is the only bucket that reaches Postgres**, running the case-insensitive `ILike` filter against the name field with `EscapeLikePattern` to defang `%` / `_` / `\` in user input. Section services map their domain entities to type-specific search-hit DTOs (`TeamSearchHit`, `CampSearchHit`, `RotaSearchHit`) so the orchestrator never has to traverse cross-domain navigation properties to render a row.
+Humans, Teams, Camps and Events are served entirely from their caching decorators' warm in-memory snapshots — the inner `TeamService` / `CampService` / `EventService` `SearchAsync` throw `NotSupportedException` and the DB-search repository methods are gone. `IEventServiceRead` is registered as the `CachingEventService` singleton (`Section.cs:55`), whose `SearchAsync` filters the approved-event cache in memory with `Contains(…, OrdinalIgnoreCase)` — no DB round trip per search. **Shifts is the only bucket that reaches Postgres**, running the case-insensitive `ILike` filter against the name field with `EscapeLikePattern` to defang `%` / `_` / `\` in user input. Section services map their domain entities to type-specific search-hit DTOs (`TeamSearchHit`, `CampSearchHit`, `RotaSearchHit`, `EventSearchHit`) so the orchestrator never has to traverse cross-domain navigation properties to render a row.
 
 Every hit arrives pre-scored by the section that produced it, against one shared rubric —
 `StringSearchExtensions.NameMatchScore` in `Humans.Base` (humans use `PersonSearchMatcher`, which
-adds tiers for token-prefix and non-name-field matches). Events is the exception: it publishes no
-scored search-hit type, so the orchestrator still scores that one bucket off `Title`
+adds tiers for token-prefix and non-name-field matches; Events halves the rubric's three tiers for
+a Description-only match, per US-GS.3). No bucket scores in the orchestrator any more
 (nobodies-collective/Humans#1062).
 
 | Match shape     | Score |
@@ -162,6 +162,7 @@ Counts reflect every match — there is no cap, so the chip count is the true nu
 | `TeamSearchHit (TeamId, Name, Score)` | `ITeamServiceRead.SearchAsync` | Key + ordering → `GlobalSearchResult` |
 | `CampSearchHit (CampId, Name, Score)` | `ICampServiceRead.SearchAsync` | Key + ordering → `GlobalSearchResult` |
 | `RotaSearchHit (RotaId, Name, Score)` | `IShiftManagementService.SearchAsync` | Key + ordering → `GlobalSearchResult` |
+| `EventSearchHit (EventId, Title, Score)` | `IEventServiceRead.SearchAsync` | Key + ordering → `GlobalSearchResult` |
 | `GlobalSearchResult (Type, Key, SortKey, Score)` | Orchestrator | `Key` is a `Guid` for every bucket; view passes it to the owning section's `<vc:…-search-result>` |
 | `GlobalSearchResults (Query, Humans, Teams, Camps, Shifts, Events)` | `ISearchService` | View-model / view |
 

--- a/src/Sections/Humans.Events.Contracts/EventSearchHit.cs
+++ b/src/Sections/Humans.Events.Contracts/EventSearchHit.cs
@@ -1,0 +1,21 @@
+namespace Humans.Events.Contracts;
+
+/// <summary>
+/// One approved event that matched a global-search query. Returned by
+/// <c>IEventServiceRead.SearchAsync</c>, already scored by this section — the
+/// orchestrator ranks by <see cref="Score"/> and passes <see cref="EventId"/> to
+/// <c>&lt;vc:events-search-result&gt;</c>, which fetches everything it renders
+/// (nobodies-collective/Humans#1062). Matches Title or Description: a Title match
+/// scores via the shared exact/prefix/contains tiers
+/// (<c>StringSearchExtensions.NameMatchScore</c>, 100/80/60); a Description-only
+/// match uses the same three tiers halved (50/40/30) so it always ranks below every
+/// Title match while still being ordered sensibly against other description hits.
+/// </summary>
+/// <param name="EventId">The matched event's id; the key the row's view component is invoked with.</param>
+/// <param name="Title">Display title. Ordering only — the orchestrator uses it as an
+/// alphabetical tiebreak and never renders it.</param>
+/// <param name="Score">Match strength — see the tiering rules above.</param>
+public record EventSearchHit(
+    Guid EventId,
+    string Title,
+    int Score);

--- a/src/Sections/Humans.Events.Contracts/IEventServiceRead.cs
+++ b/src/Sections/Humans.Events.Contracts/IEventServiceRead.cs
@@ -32,4 +32,14 @@ public interface IEventServiceRead
 
     /// <summary>The event ids the given user has favourited.</summary>
     Task<HashSet<Guid>> GetFavouriteEventIdsAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Approved events whose Title or Description contains <paramref name="query"/>
+    /// (case-insensitive), each scored by this section — see <see cref="EventSearchHit"/>
+    /// for the tiering. Capped at <paramref name="max"/>; returned in unspecified order —
+    /// the global search orchestrator ranks. Served from the approved-only cache. Used by
+    /// the global /Search page (<c>SearchService</c>); nobodies-collective/Humans#1062.
+    /// </summary>
+    Task<IReadOnlyList<EventSearchHit>> SearchAsync(
+        string query, int max, CancellationToken ct = default);
 }

--- a/src/Sections/Humans.Events/Services/CachingEventService.cs
+++ b/src/Sections/Humans.Events/Services/CachingEventService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using Humans.Events.Services.Dtos;
 using Humans.Base.Caching;
+using Humans.Base.Extensions;
 using Humans.Base.Interfaces.Caching;
 using Humans.Shifts.Contracts;
 using Humans.Base.Threading;
@@ -326,6 +327,49 @@ internal sealed class CachingEventService(
     private static bool MatchesQuery(ApprovedEventView view, string q) =>
         view.Title.Contains(q, StringComparison.OrdinalIgnoreCase) ||
         view.Description.Contains(q, StringComparison.OrdinalIgnoreCase);
+
+    // Served entirely from the cached approved-event snapshot — search must never hit the DB
+    // (mirrors CachingTeamService.SearchAsync / CachingCampService.SearchAsync).
+    public async Task<IReadOnlyList<EventSearchHit>> SearchAsync(
+        string query, int max, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query) || max <= 0)
+            return [];
+
+        await EnsureLoadedAsync(ct);
+
+        var trimmed = query.Trim();
+
+        // GUID paste → jump straight to that event, mirroring the by-id path
+        // (nobodies-collective/Humans#1062, matching Teams/Camps/Shifts).
+        if (Guid.TryParse(trimmed, out var id))
+        {
+            return _eventCache.TryGet(id, out var byId)
+                ? [new EventSearchHit(byId.Id, byId.Title, StringSearchExtensions.ExactNameScore)]
+                : [];
+        }
+
+        return _eventCache.Values
+            .Where(e => MatchesQuery(e, trimmed))
+            // Deterministic Take(max) for global search; controller re-ranks by score before
+            // display (mirrors ShiftRepository.SearchVolunteerVisibleRotasAsync).
+            .OrderBy(e => e.Title, StringComparer.OrdinalIgnoreCase)
+            .Take(max)
+            .Select(e => new EventSearchHit(e.Id, e.Title, ScoreEventMatch(e, trimmed)))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Title match scores via the shared exact/prefix/contains tiers (100/80/60).
+    /// A Description-only match uses the same three tiers halved (50/40/30), so it
+    /// always ranks below every Title match while description-only rows still order
+    /// sensibly against each other instead of tying (nobodies-collective/Humans#1062).
+    /// </summary>
+    private static int ScoreEventMatch(ApprovedEventView view, string query)
+    {
+        var titleScore = view.Title.NameMatchScore(query);
+        return titleScore > 0 ? titleScore : view.Description.NameMatchScore(query) / 2;
+    }
 
     // ==========================================================================
     // Favourites — per-user, pass-through (not in projection scope)

--- a/src/Sections/Humans.Events/Services/Service.cs
+++ b/src/Sections/Humans.Events/Services/Service.cs
@@ -565,6 +565,18 @@ internal sealed class EventService(
         return ev is null ? null : ToApprovedEventView(ev);
     }
 
+    // Event search is served from the cached approved-event snapshot in
+    // CachingEventService — it must never hit the DB. Reaching the inner service
+    // means a DI registration mistake. Mirrors CachingTeamService.SearchAsync /
+    // CachingCampService.SearchAsync (search is cache-only; there is no repository search).
+    public Task<IReadOnlyList<EventSearchHit>> SearchAsync(
+        string query, int max, CancellationToken ct = default) =>
+        throw new NotSupportedException(
+            "Event search runs against the cached approved-event snapshot in " +
+            "CachingEventService. If this is being called on the inner Service it " +
+            "indicates a DI registration mistake — IEventServiceRead must resolve to " +
+            "the caching decorator.");
+
     public Task<HashSet<Guid>> GetFavouriteEventIdsAsync(Guid userId, CancellationToken ct = default)
         => repo.GetFavouriteEventIdsAsync(userId, ct);
 

--- a/src/Sections/Humans.Search/Services/SearchService.cs
+++ b/src/Sections/Humans.Search/Services/SearchService.cs
@@ -1,4 +1,3 @@
-using Humans.Base.Extensions;
 using Humans.Camps.Contracts;
 using Humans.Events.Contracts;
 using Humans.Shifts.Contracts;
@@ -11,7 +10,6 @@ namespace Humans.Search.Services;
 
 /// <summary>
 /// Per-entity-field search orchestrator (no cross-modal traversal): each section matches and scores its own hits, this returns five buckets of keys (unsorted).
-/// Events is the one bucket still scored here — it publishes no scored search hit (nobodies-collective/Humans#1062).
 /// See docs/features/global/global-search.md. Display ordering lives in SearchController.
 /// </summary>
 internal sealed class SearchService(
@@ -116,26 +114,13 @@ internal sealed class SearchService(
     private async Task<IReadOnlyList<GlobalSearchResult>> SearchEventsAsync(
         string query, int limit, CancellationToken ct)
     {
-        // Reuse the public Browse query — Approved-only, filtered server-side by title/description.
-        // Scoring stays here, unlike the other three buckets: Events publishes no scored search hit
-        // to move it onto (nobodies-collective/Humans#1062). Rows that only matched via Description
-        // score 0 on Title and fall through to the contains tier so they still appear.
-        var hits = await eventService.GetApprovedEventsAsync(
-            campId: null, venueId: null, categoryId: null,
-            q: query, excludedSlugs: Array.Empty<string>(), ct);
-
+        var hits = await eventService.SearchAsync(query, limit, ct);
         return hits
-            .Select(e =>
-            {
-                var titleScore = e.Title.NameMatchScore(query);
-                return new GlobalSearchResult(
-                    Type: SearchResultType.Event,
-                    Key: e.Id,
-                    SortKey: e.Title,
-                    Score: titleScore > 0 ? titleScore : StringSearchExtensions.ContainsNameScore);
-            })
-            .OrderByDescending(r => r.Score) // arch:db-sort-ok top-N relevance selector
-            .Take(limit)
+            .Select(e => new GlobalSearchResult(
+                Type: SearchResultType.Event,
+                Key: e.EventId,
+                SortKey: e.Title,
+                Score: e.Score))
             .ToList();
     }
 }

--- a/tests/Humans.Events.Tests/Services/CachingEventServiceTests.cs
+++ b/tests/Humans.Events.Tests/Services/CachingEventServiceTests.cs
@@ -1,0 +1,142 @@
+using AwesomeAssertions;
+using Humans.Base.Extensions;
+using Humans.Events.Contracts;
+using Humans.Events.Services;
+using Humans.Events.Services.Dtos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Events.Tests.Services;
+
+/// <summary>
+/// Covers <see cref="CachingEventService.SearchAsync"/> — Events' scored search hit
+/// (nobodies-collective/Humans#1062). Served entirely from the approved-event cache warmed
+/// off the substitute inner <see cref="IEventService"/>; no DB involved.
+/// </summary>
+public sealed class CachingEventServiceTests
+{
+    private readonly IEventService _inner = Substitute.For<IEventService>();
+    private readonly CachingEventService _service;
+
+    public CachingEventServiceTests()
+    {
+        _inner.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<EventCategoryManageInfo>>([]));
+        _inner.GetAllVenuesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<EventVenueManageInfo>>([]));
+        _inner.GetGuideSettingsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<EventGuideSettingsView?>(null));
+
+        var services = new ServiceCollection();
+        services.AddKeyedScoped<IEventService>(
+            CachingEventService.InnerServiceKey, (_, _) => _inner);
+        var provider = services.BuildServiceProvider();
+
+        _service = new CachingEventService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<CachingEventService>.Instance);
+    }
+
+    private void SeedApproved(params ApprovedEventView[] events) =>
+        _inner.GetApprovedEventsAsync(
+                null, null, null, null, Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ApprovedEventView>>(events));
+
+    [HumansFact]
+    public async Task SearchAsync_TitleExactMatch_ScoresTheExactTier()
+    {
+        SeedApproved(Approved("Sunset Yoga"));
+
+        var hits = await _service.SearchAsync("Sunset Yoga", 10, TestContext.Current.CancellationToken);
+
+        hits.Should().ContainSingle().Which.Score.Should().Be(StringSearchExtensions.ExactNameScore);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_TitlePrefixMatch_ScoresThePrefixTier()
+    {
+        SeedApproved(Approved("Sunset Yoga Session"));
+
+        var hits = await _service.SearchAsync("Sunset", 10, TestContext.Current.CancellationToken);
+
+        hits.Should().ContainSingle().Which.Score.Should().Be(StringSearchExtensions.PrefixNameScore);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_TitleContainsMatch_ScoresTheContainsTier()
+    {
+        SeedApproved(Approved("Morning Sunset Yoga"));
+
+        var hits = await _service.SearchAsync("Sunset", 10, TestContext.Current.CancellationToken);
+
+        hits.Should().ContainSingle().Which.Score.Should().Be(StringSearchExtensions.ContainsNameScore);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_DescriptionOnlyMatch_StillAppears_RankedBelowEveryTitleMatch()
+    {
+        // Title misses entirely; only the description carries the match. It must still
+        // surface, and its score must stay below the lowest title tier (Contains, 60) so a
+        // description-only hit never outranks a real title match.
+        SeedApproved(
+            Approved("Meditation Circle", description: "Guided breathing for beginners"),
+            Approved("Sunrise Hike", description: "A gentle Sunset walk up the ridge"));
+
+        var hits = await _service.SearchAsync("Sunset", 10, TestContext.Current.CancellationToken);
+
+        var hit = hits.Should().ContainSingle().Subject;
+        hit.Title.Should().Be("Sunrise Hike");
+        hit.Score.Should().BeLessThan(StringSearchExtensions.ContainsNameScore).And.BeGreaterThan(0);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_DescriptionOnlyMatches_TierAmongThemselves_ExactAboveContains()
+    {
+        SeedApproved(
+            Approved("Alpha", description: "Sunset"), // description exact match
+            Approved("Beta", description: "A calm Sunset walk")); // description contains match
+
+        var hits = await _service.SearchAsync("Sunset", 10, TestContext.Current.CancellationToken);
+
+        hits.Should().HaveCount(2);
+        var exact = hits.Single(h => string.Equals(h.Title, "Alpha", StringComparison.Ordinal)).Score;
+        var contains = hits.Single(h => string.Equals(h.Title, "Beta", StringComparison.Ordinal)).Score;
+        exact.Should().BeGreaterThan(contains);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_HonoursTheLimit()
+    {
+        SeedApproved(
+            Approved("Alpha Sunset"),
+            Approved("Beta Sunset"),
+            Approved("Gamma Sunset"));
+
+        var hits = await _service.SearchAsync("Sunset", 2, TestContext.Current.CancellationToken);
+
+        hits.Should().HaveCount(2);
+    }
+
+    [HumansFact]
+    public async Task SearchAsync_GuidQuery_JumpsStraightToThatEvent()
+    {
+        var wanted = Approved("Anything");
+        SeedApproved(wanted, Approved("Something Else"));
+
+        var hits = await _service.SearchAsync(wanted.Id.ToString(), 10, TestContext.Current.CancellationToken);
+
+        var hit = hits.Should().ContainSingle().Subject;
+        hit.EventId.Should().Be(wanted.Id);
+        hit.Score.Should().Be(StringSearchExtensions.ExactNameScore);
+    }
+
+    private static ApprovedEventView Approved(string title, string description = "Anything at all") => new(
+        Id: Guid.NewGuid(), CampId: null, GuideSharedVenueId: null, SubmitterUserId: Guid.NewGuid(),
+        CategoryId: Guid.NewGuid(), CategorySlug: "music", CategoryName: "Music", CategoryIsSensitive: false,
+        VenueName: null, Title: title, Description: description, LocationNote: null, Host: null,
+        StartAt: Instant.FromUtc(2026, 8, 1, 10, 0), DurationMinutes: 60, IsRecurring: false, RecurrenceDays: null,
+        PriorityRank: 0, SubmittedAt: Instant.FromUtc(2026, 8, 1, 10, 0), LastUpdatedAt: Instant.FromUtc(2026, 8, 1, 10, 0));
+}

--- a/tests/Humans.Search.Tests/Services/SearchServiceTests.cs
+++ b/tests/Humans.Search.Tests/Services/SearchServiceTests.cs
@@ -7,7 +7,6 @@ using Humans.Users.Contracts;
 using Humans.Search.Services;
 using Humans.Search.Services.Dtos;
 using Microsoft.Extensions.Configuration;
-using NodaTime;
 using NSubstitute;
 using Xunit;
 
@@ -19,22 +18,22 @@ namespace Humans.Search.Tests.Services;
 /// can see: the field mask the human bucket asks for (<see cref="PersonSearchFields.PublicAll"/>
 /// — the only search-time privacy filter this service owns), and the key/sort-key mapping
 /// that is all this section keeps of another section's row
-/// (nobodies-collective/Humans#1062). Name-match scoring now belongs to each section and is
-/// pinned there; the Events bucket is the exception and is still scored here.
+/// (nobodies-collective/Humans#1062). Name-match scoring belongs to each section (including
+/// Events, since #1062's Events follow-up) and is pinned where it lives.
 ///
 /// <para>
 /// Per the 2026-08-07 ruling on nobodies-collective/Humans#985, search is not an
 /// authorization boundary: a hit is a routing convenience and the destination page enforces
 /// visibility. The per-section text-query filters that this service depends on are pinned
 /// where they live — <c>CachingTeamServiceTests</c>, <c>CachingCampServiceTests</c>,
-/// <c>ShiftManagementServiceTests</c> and <c>ShiftRepositoryRotaSearchVisibilityTests</c>.
+/// <c>CachingEventServiceTests</c>, <c>ShiftManagementServiceTests</c> and
+/// <c>ShiftRepositoryRotaSearchVisibilityTests</c>.
 /// </para>
 /// </summary>
 public sealed class SearchServiceTests
 {
     private const int ScoreExact = 100;
     private const int ScorePrefix = 80;
-    private const int ScoreContains = 60;
 
     private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
     private readonly ITeamServiceRead _teams = Substitute.For<ITeamServiceRead>();
@@ -48,7 +47,7 @@ public sealed class SearchServiceTests
         StubTeams(new TeamSearchHit(Guid.NewGuid(), "Kitchen", ScoreExact));
         StubCamps(new CampSearchHit(Guid.NewGuid(), "Kitchen", ScoreExact));
         StubRotas(new RotaSearchHit(Guid.NewGuid(), "Kitchen", ScoreExact));
-        StubEvents(MakeEvent("Kitchen Takeover", "Food"));
+        StubEvents(new EventSearchHit(Guid.NewGuid(), "Kitchen Takeover", ScoreExact));
     }
 
     // ==========================================================================
@@ -145,9 +144,8 @@ public sealed class SearchServiceTests
             Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
         await _shifts.Received(onlyType == SearchResultType.Shift ? 1 : 0).SearchAsync(
             Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
-        await _events.Received(onlyType == SearchResultType.Event ? 1 : 0).GetApprovedEventsAsync(
-            Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<string?>(),
-            Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+        await _events.Received(onlyType == SearchResultType.Event ? 1 : 0).SearchAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -169,13 +167,15 @@ public sealed class SearchServiceTests
     [HumansFact]
     public async Task SearchAsync_CarriesEachSectionsOwnScore_WithoutRescoring()
     {
-        // Teams/Camps/Shifts score their own hits (nobodies-collective/Humans#1062). A score
-        // that contradicts the name proves this service takes the section's word for it.
+        // Teams/Camps/Shifts/Events score their own hits (nobodies-collective/Humans#1062). A
+        // score that contradicts the name proves this service takes the section's word for it.
         StubTeams(new TeamSearchHit(Guid.NewGuid(), "Nothing Like The Query", ScorePrefix));
+        StubEvents(new EventSearchHit(Guid.NewGuid(), "Nothing Like The Query", ScorePrefix));
 
         var results = await Build().SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
 
         results.Teams.Should().ContainSingle().Which.Score.Should().Be(ScorePrefix);
+        results.Events.Should().ContainSingle().Which.Score.Should().Be(ScorePrefix);
     }
 
     [HumansFact]
@@ -187,8 +187,8 @@ public sealed class SearchServiceTests
         StubTeams(new TeamSearchHit(teamId, "Kitchen Crew", ScorePrefix));
         StubCamps(new CampSearchHit(campId, "Garden of Joy", ScorePrefix));
         StubRotas(new RotaSearchHit(rotaId, "Garden", ScoreExact));
-        var eventHit = MakeEvent("Fire & Ice", "Performance");
-        StubEvents(eventHit);
+        var eventId = Guid.NewGuid();
+        StubEvents(new EventSearchHit(eventId, "Fire & Ice", ScorePrefix));
 
         var results = await Build().SearchAsync("Garden", ct: TestContext.Current.CancellationToken);
 
@@ -205,7 +205,7 @@ public sealed class SearchServiceTests
         rota.SortKey.Should().Be("Garden");
 
         var ev = results.Events.Should().ContainSingle().Subject;
-        ev.Key.Should().Be(eventHit.Id);
+        ev.Key.Should().Be(eventId);
         ev.SortKey.Should().Be("Fire & Ice");
     }
 
@@ -307,33 +307,8 @@ public sealed class SearchServiceTests
             .SearchAsync("Kitchen", ct: TestContext.Current.CancellationToken);
 
         results.Events.Should().BeEmpty();
-        await _events.DidNotReceive().GetApprovedEventsAsync(
-            Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<string?>(),
-            Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
-    }
-
-    [HumansFact]
-    public async Task SearchAsync_EventTitleMisses_FallsBackToTheContainsTier_SoDescriptionMatchesStillSurface()
-    {
-        // The Events bucket is filtered server-side on title OR description; a row that only
-        // matched the description scores 0 on Title and must not be dropped like a team would be.
-        StubEvents(
-            MakeEvent("Sunset Yoga", "Yoga"),
-            MakeEvent("Meditation Circle", "Wellbeing"));
-
-        var results = await Build().SearchAsync("Meditation", ct: TestContext.Current.CancellationToken);
-
-        results.Events.Should().SatisfyRespectively(
-            titleMatch =>
-            {
-                titleMatch.SortKey.Should().Be("Meditation Circle");
-                titleMatch.Score.Should().Be(ScorePrefix);
-            },
-            descriptionOnly =>
-            {
-                descriptionOnly.SortKey.Should().Be("Sunset Yoga");
-                descriptionOnly.Score.Should().Be(ScoreContains);
-            });
+        await _events.DidNotReceive().SearchAsync(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     // ==========================================================================
@@ -366,35 +341,10 @@ public sealed class SearchServiceTests
         _shifts.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<RotaSearchHit>>(hits));
 
-    private void StubEvents(params ApprovedEventView[] hits) =>
-        _events.GetApprovedEventsAsync(
-                Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<string?>(),
-                Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<ApprovedEventView>>(hits));
+    private void StubEvents(params EventSearchHit[] hits) =>
+        _events.SearchAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<EventSearchHit>>(hits));
 
     private static HumanSearchResult MakeHuman(string burnerName) =>
         new(Guid.NewGuid(), Guid.NewGuid(), burnerName, null, "Name", null, null, ScoreExact);
-
-    private static ApprovedEventView MakeEvent(string title, string categoryName) =>
-        new(
-            Guid.NewGuid(),
-            CampId: null,
-            GuideSharedVenueId: null,
-            SubmitterUserId: Guid.NewGuid(),
-            CategoryId: Guid.NewGuid(),
-            CategorySlug: categoryName.ToLowerInvariant(),
-            categoryName,
-            CategoryIsSensitive: false,
-            VenueName: null,
-            title,
-            Description: "Anything at all",
-            LocationNote: null,
-            Host: null,
-            StartAt: Instant.FromUtc(2026, 7, 4, 18, 0),
-            DurationMinutes: 60,
-            IsRecurring: false,
-            RecurrenceDays: null,
-            PriorityRank: 0,
-            SubmittedAt: Instant.FromUtc(2026, 6, 1, 12, 0),
-            LastUpdatedAt: Instant.FromUtc(2026, 6, 1, 12, 0));
 }


### PR DESCRIPTION
## Summary
- Events was the last global-search bucket scored in `Humans.Search` instead of its own section — fixes the last remaining gap from nobodies-collective/Humans#1062.
- `IEventServiceRead.SearchAsync(query, max, ct)` returns `EventSearchHit(EventId, Title, Score)`, served entirely from `CachingEventService`'s existing approved-event cache (no DB round trip, mirrors `CachingTeamService`/`CachingCampService`). The inner `EventService.SearchAsync` throws `NotSupportedException` like its Team/Camp counterparts.
- Scoring: a Title match uses the shared exact/prefix/contains rubric (100/80/60). A Description-only match uses the same three tiers **halved** (50/40/30) — it still surfaces, always ranks below every Title match, and no longer ties with other description-only hits.
- `SearchService.SearchEventsAsync` is now the same three-line projection as the other three buckets — no scoring left in `Humans.Search`.
- `Features:Events` behavior unchanged (still gates the bucket before the section is even called).

## Reuse-first notes
- Reused the existing approved-event cache (`CachingEventService`'s `_eventCache`) rather than adding a new cache or hitting the DB — same mechanism `GetApprovedEventsAsync`/`GetApprovedEventByIdAsync` already use.
- Reused `StringSearchExtensions.NameMatchScore` (shared, no section vocabulary) rather than adding Events-specific scoring constants to `Humans.Base`.
- Kept the GUID-paste fast path (jump straight to the event, `ExactNameScore`) for shape parity with Teams/Camps/Shifts, since it's part of the established `SearchAsync` contract shape across all three siblings, and `GetApprovedEventByIdAsync` already made it a one-line addition.
- Did not touch `EventsSearchResultViewComponent` — it already fetches by id from the cache and needed no change.

## Judgment calls
- **Description-tier scores (50/40/30)**: no existing precedent for multi-field scoring in this codebase (Teams/Camps/Shifts only ever match one field). Chose "halve the standard tiers" so Description matches keep their own internal exact > prefix > contains ordering while staying strictly below the weakest Title tier (Contains = 60 > Description-exact = 50).
- **Section-level ordering before `Take(max)`**: alphabetical by Title, matching the established pattern in `CachingTeamService`/`CachingCampService`/`ShiftRepository.SearchVolunteerVisibleRotasAsync` ("deterministic Take(max) for global search; controller re-ranks by score before display").

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet` — full solution green
- [x] New `CachingEventServiceTests`: title exact/prefix/contains tiers, description-only match appears and ranks below title matches, description-only tiering among themselves, limit honoured, GUID-paste jump
- [x] Updated `SearchServiceTests` to stub `IEventServiceRead.SearchAsync` instead of `GetApprovedEventsAsync`
- [x] `GlobalSearchSectionRenderTests` (including the "tripling rows costs no extra query" cache test) still passes unchanged

Refs nobodies-collective/Humans#1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)