### PR TITLE
fix(shifts): stop the daily roster silently swallowing signups on a non-active event (nobodies-collective/Humans#896)

### DIFF
--- a/src/Sections/Humans.Shifts/Data/ShiftRepository.Management.cs
+++ b/src/Sections/Humans.Shifts/Data/ShiftRepository.Management.cs
@@ -1,6 +1,7 @@
 using Humans.Shifts.Services.Dtos;
 using Humans.Shifts.Domain;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Shifts.Contracts;
 namespace Humans.Shifts.Data;
@@ -23,15 +24,18 @@ internal sealed partial class ShiftRepository : IShiftManagementRepository
     private readonly IDbContextFactory<ShiftsDbContext> _factory;
     private readonly ShiftsDbContext _dbContext;
     private readonly IClock _clock;
+    private readonly ILogger<ShiftRepository> _logger;
 
     public ShiftRepository(
         IDbContextFactory<ShiftsDbContext> factory,
         ShiftsDbContext dbContext,
-        IClock clock)
+        IClock clock,
+        ILogger<ShiftRepository> logger)
     {
         _factory = factory;
         _dbContext = dbContext;
         _clock = clock;
+        _logger = logger;
     }
 
     // ==========================================================================

--- a/src/Sections/Humans.Shifts/Data/ShiftRepository.Signups.cs
+++ b/src/Sections/Humans.Shifts/Data/ShiftRepository.Signups.cs
@@ -105,23 +105,43 @@ internal sealed partial class ShiftRepository
         ShiftDayUserStatusScope statusScope,
         CancellationToken ct = default)
     {
-        var query = _dbContext.ShiftSignups
+        // Day + status match first, event-scoping applied in memory below — so a
+        // signup dropped purely by event-scoping (rota wired to a non-active
+        // EventSettings, #896) is observable instead of silently vanishing.
+        var dayQuery = _dbContext.ShiftSignups
             .AsNoTracking()
-            .Where(s => s.Shift.Rota.EventSettingsId == eventSettingsId
-                && s.Shift.DayOffset == dayOffset);
+            .Where(s => s.Shift.DayOffset == dayOffset);
 
-        query = statusScope switch
+        dayQuery = statusScope switch
         {
-            ShiftDayUserStatusScope.ConfirmedOnly => query.Where(s => s.Status == SignupStatus.Confirmed),
-            ShiftDayUserStatusScope.PendingOrConfirmed => query.Where(s =>
+            ShiftDayUserStatusScope.ConfirmedOnly => dayQuery.Where(s => s.Status == SignupStatus.Confirmed),
+            ShiftDayUserStatusScope.PendingOrConfirmed => dayQuery.Where(s =>
                 s.Status == SignupStatus.Pending || s.Status == SignupStatus.Confirmed),
-            _ => query.Where(_ => false)
+            _ => dayQuery.Where(_ => false)
         };
 
-        return await query
-            .Select(s => s.UserId)
-            .Distinct()
+        var rows = await dayQuery
+            .Select(s => new { s.Id, s.UserId, RotaEventSettingsId = s.Shift.Rota.EventSettingsId })
             .ToListAsync(ct);
+
+        var userIds = new List<Guid>(rows.Count);
+        foreach (var row in rows)
+        {
+            if (row.RotaEventSettingsId == eventSettingsId)
+            {
+                userIds.Add(row.UserId);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "ShiftSignup {SignupId} for user {UserId} matches day offset {DayOffset} " +
+                    "({StatusScope}) but its rota is scoped to EventSettings {RotaEventSettingsId}, " +
+                    "not the requested event {EventSettingsId} — excluded from the day roster.",
+                    row.Id, row.UserId, dayOffset, statusScope, row.RotaEventSettingsId, eventSettingsId);
+            }
+        }
+
+        return userIds.Distinct().ToList();
     }
 
     // ============================================================

--- a/src/Sections/Humans.Shifts/Docs/data-access.md
+++ b/src/Sections/Humans.Shifts/Docs/data-access.md
@@ -55,6 +55,16 @@ lazy-resolves the read surfaces `ITeamServiceRead`, `IUserServiceRead`,
 `IUserMerge`. Also exposes the Cantina-gating predicates
 (`HasQualifyingCantinaSignupAsync`, `GetOnSiteUserIdsForDayAsync`).
 
+**Event-scoping invariant (day queries).** `ShiftRepository.GetUserIdsForDayAsync`
+matches a signup to a day/status by `Shift.DayOffset` + `Status`, then requires
+`Shift.Rota.EventSettingsId` to equal the requested (active) event before the
+signup counts — a Pending/Confirmed signup on a rota bound to a *different*
+`EventSettings` row (e.g. a duplicate/stale event) is excluded from the day
+cohort, never included cross-event. Every exclusion is logged at Warning
+(signup id, user id, day offset, status scope, both event ids) so a rota
+mis-linked to a non-active event is diagnosable instead of silently dropping
+its volunteers from the Cantina roster (nobodies-collective/Humans#896).
+
 **Shift Summary by Camp.** `BuildSummaryAsync` assembles the
 read-only by-camp shift summary: confirmed signup totals come from
 `IShiftManagementRepository.GetConfirmedUserShiftTotalsAsync` (reads

--- a/tests/Humans.Shifts.Tests/Repositories/ShiftRepositoryManagementTests.cs
+++ b/tests/Humans.Shifts.Tests/Repositories/ShiftRepositoryManagementTests.cs
@@ -2,6 +2,7 @@ using Humans.Shifts.Domain;
 using AwesomeAssertions;
 using Humans.Shifts.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 
@@ -28,7 +29,7 @@ public sealed class ShiftRepositoryManagementTests : IDisposable
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         _shiftsDbContext = new ShiftsDbContext(shiftsOptions);
-        _repo = new ShiftRepository(new TestDbContextFactory<ShiftsDbContext>(shiftsOptions), _shiftsDbContext, _clock);
+        _repo = new ShiftRepository(new TestDbContextFactory<ShiftsDbContext>(shiftsOptions), _shiftsDbContext, _clock, NullLogger<ShiftRepository>.Instance);
     }
 
     public void Dispose() => _shiftsDbContext.Dispose();

--- a/tests/Humans.Shifts.Tests/Repositories/ShiftRepositorySignupTests.cs
+++ b/tests/Humans.Shifts.Tests/Repositories/ShiftRepositorySignupTests.cs
@@ -2,8 +2,11 @@ using Humans.Shifts.Domain;
 using AwesomeAssertions;
 using Humans.Shifts.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
+using NSubstitute;
 
 using Humans.Shifts.Contracts;
 namespace Humans.Shifts.Tests.Repositories;
@@ -27,7 +30,7 @@ public class ShiftRepositorySignupTests : IDisposable
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         _shiftsDbContext = new ShiftsDbContext(shiftsOptions);
-        _repo = new ShiftRepository(new TestDbContextFactory<ShiftsDbContext>(shiftsOptions), _shiftsDbContext, new FakeClock(TestNow));
+        _repo = new ShiftRepository(new TestDbContextFactory<ShiftsDbContext>(shiftsOptions), _shiftsDbContext, new FakeClock(TestNow), NullLogger<ShiftRepository>.Instance);
     }
 
     public void Dispose()
@@ -127,6 +130,61 @@ public class ShiftRepositorySignupTests : IDisposable
         var pendingOrConfirmed = await _repo.GetUserIdsForDayAsync(
             esId, -3, ShiftDayUserStatusScope.PendingOrConfirmed, Xunit.TestContext.Current.CancellationToken);
         pendingOrConfirmed.Should().BeEquivalentTo([user1, user2, pendingUser]);
+    }
+
+    /// <summary>
+    /// Regression for nobodies-collective/Humans#896: a Confirmed all-day build-week
+    /// signup whose rota is wired to a non-active EventSettings must not silently
+    /// vanish from the day query — it stays excluded (the roster is genuinely scoped
+    /// to the active event) but the drop is now logged at Warning so it is
+    /// diagnosable instead of invisible.
+    /// </summary>
+    [HumansFact]
+    public async Task GetUserIdsForDayAsync_LogsWarning_WhenConfirmedSignupExcludedByEventScoping()
+    {
+        var activeEs = Guid.NewGuid();
+        var staleEs = Guid.NewGuid();
+
+        // Same build-week DayOffset (-8) on both events, matching the #896 repro:
+        // the rota is bound to a duplicate/stale EventSettings, not the active one.
+        var shiftOnActiveEvent = SeedShiftWithRota(activeEs, dayOffset: -8);
+        var shiftOnStaleEvent = SeedShiftWithRota(staleEs, dayOffset: -8);
+
+        var onSiteUser = Guid.NewGuid();
+        var droppedUser = Guid.NewGuid();
+
+        _shiftsDbContext.ShiftSignups.Add(MakeSignup(onSiteUser, shiftOnActiveEvent, SignupStatus.Confirmed));
+        var droppedSignup = MakeSignup(droppedUser, shiftOnStaleEvent, SignupStatus.Confirmed);
+        _shiftsDbContext.ShiftSignups.Add(droppedSignup);
+        await _shiftsDbContext.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        // GetUserIdsForDayAsync queries the scoped context directly (not the
+        // factory), so a throwaway factory is fine here — only the logger and the
+        // seeded _shiftsDbContext matter for this assertion.
+        var logger = Substitute.For<ILogger<ShiftRepository>>();
+        var throwawayFactoryOptions = new DbContextOptionsBuilder<ShiftsDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var repo = new ShiftRepository(
+            new TestDbContextFactory<ShiftsDbContext>(throwawayFactoryOptions),
+            _shiftsDbContext,
+            new FakeClock(TestNow),
+            logger);
+
+        var result = await repo.GetUserIdsForDayAsync(
+            activeEs, -8, ShiftDayUserStatusScope.ConfirmedOnly, Xunit.TestContext.Current.CancellationToken);
+
+        // Still scoped to the active event — the roster does not silently mix in a
+        // different event's data.
+        result.Should().BeEquivalentTo([onSiteUser]);
+
+        // But the exclusion is now a loud, diagnosable signal instead of silent.
+        logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Is<Exception?>(e => e == null),
+            Arg.Any<Func<object, Exception?, string>>());
     }
 
     // ── helpers ─────────────────────────────────────────────────────────────

--- a/tests/Humans.Shifts.Tests/Repositories/ShiftRepositorySummaryTests.cs
+++ b/tests/Humans.Shifts.Tests/Repositories/ShiftRepositorySummaryTests.cs
@@ -2,6 +2,7 @@ using Humans.Shifts.Domain;
 using AwesomeAssertions;
 using Humans.Shifts.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 
@@ -37,7 +38,7 @@ public class ShiftRepositorySummaryTests : IDisposable
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         _shiftsDbContext = new ShiftsDbContext(shiftsOptions);
-        _repo = new ShiftRepository(new TestDbContextFactory<ShiftsDbContext>(shiftsOptions), _shiftsDbContext, new FakeClock(TestNow));
+        _repo = new ShiftRepository(new TestDbContextFactory<ShiftsDbContext>(shiftsOptions), _shiftsDbContext, new FakeClock(TestNow), NullLogger<ShiftRepository>.Instance);
     }
 
     public void Dispose()

--- a/tests/Humans.Shifts.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -11,6 +11,7 @@ using Humans.Shifts.Services;
 using Humans.Shifts.Tests.Infrastructure;
 using Humans.Shifts.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Humans.Users.Contracts;
@@ -47,7 +48,7 @@ public sealed class ShiftDashboardMetricsTests : ShiftsTestHarness
             .With<IRoleAssignmentService>()
             .Build();
 
-        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         _service = new ShiftManagementService(
             repo,

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementReadMathTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementReadMathTests.cs
@@ -7,6 +7,7 @@ using Humans.Teams.Contracts;
 using Humans.Shifts.Services;
 using Humans.Shifts.Tests.Infrastructure;
 using Humans.Shifts.Data;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
@@ -51,7 +52,7 @@ public sealed class ShiftManagementReadMathTests : ShiftsTestHarness
             .Build();
 
         _service = new ShiftManagementService(
-            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock),
+            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance),
             AuditLog,
             AdminAuthorization,
             serviceProvider,

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementServiceCoveragePiesTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementServiceCoveragePiesTests.cs
@@ -8,6 +8,7 @@ using Humans.Teams.Contracts;
 using Humans.Shifts.Tests.Infrastructure;
 using Humans.Base.Enums;
 using Humans.Shifts.Data;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Humans.Users.Contracts;
@@ -45,7 +46,7 @@ public sealed class ShiftManagementServiceCoveragePiesTests : ShiftsTestHarness
             .With<IUserService>()
             .Build();
 
-        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         _service = new ShiftManagementService(
             repo,

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementServiceTests.cs
@@ -11,6 +11,7 @@ using Humans.Base.Extensions;
 using Humans.Shifts.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Humans.Users.Contracts;
@@ -61,7 +62,7 @@ public sealed class ShiftManagementServiceTests : ShiftsTestHarness
             .With(_roleAssignmentService)
             .Build();
 
-        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         _service = new ShiftManagementService(
             repo,

--- a/tests/Humans.Shifts.Tests/Services/ShiftManagementWriteGuardTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftManagementWriteGuardTests.cs
@@ -10,6 +10,7 @@ using Humans.Base.Constants;
 using Humans.Base.Enums;
 using Humans.Shifts.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Xunit;
@@ -59,7 +60,7 @@ public sealed class ShiftManagementWriteGuardTests : ShiftsTestHarness
             .Build();
 
         _service = new ShiftManagementService(
-            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock),
+            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance),
             AuditLog,
             AdminAuthorization,
             serviceProvider,

--- a/tests/Humans.Shifts.Tests/Services/ShiftSignupRepositoryActiveCommittedTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSignupRepositoryActiveCommittedTests.cs
@@ -4,6 +4,7 @@ using AwesomeAssertions;
 using Humans.Shifts.Tests.Infrastructure;
 using Humans.Base.Enums;
 using Humans.Shifts.Data;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 
 using Humans.Shifts.Contracts;
@@ -22,7 +23,7 @@ public sealed class ShiftRepositoryActiveCommittedTests : ShiftsTestHarness
     public ShiftRepositoryActiveCommittedTests()
         : base(TestNow)
     {
-        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
     }
 
     [HumansFact]

--- a/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceAutoConfirmIgnoresConsentTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceAutoConfirmIgnoresConsentTests.cs
@@ -43,7 +43,7 @@ public sealed class ShiftSignupServiceAutoConfirmIgnoresConsentTests : ShiftsTes
             .With(roleAssignmentService)
             .Build();
 
-        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         _shiftMgmt = new ShiftManagementService(
             shiftRepo,
@@ -54,7 +54,7 @@ public sealed class ShiftSignupServiceAutoConfirmIgnoresConsentTests : ShiftsTes
             Substitute.For<IShiftViewInvalidator>(),
             Clock);
 
-        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
         _service = new ShiftSignupService(
             _repo,
             Substitute.For<IVolunteerTrackingRepository>(),

--- a/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceCalendarFeedTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceCalendarFeedTests.cs
@@ -31,7 +31,7 @@ public sealed class ShiftSignupServiceCalendarFeedTests : ShiftsTestHarness
             .With(_teamService)
             .Build();
 
-        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
         var shiftMgmt = new ShiftManagementService(
             repo,
             AuditLog,

--- a/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceCoverageGapTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceCoverageGapTests.cs
@@ -48,7 +48,7 @@ public sealed class ShiftSignupServiceCoverageGapTests : ShiftsTestHarness
             .With(roleAssignmentService)
             .Build();
 
-        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
         var shiftMgmt = new ShiftManagementService(
             shiftRepo,
             AuditLog,
@@ -58,7 +58,7 @@ public sealed class ShiftSignupServiceCoverageGapTests : ShiftsTestHarness
             Substitute.For<IShiftViewInvalidator>(),
             Clock);
 
-        var signupRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var signupRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
         _service = new ShiftSignupService(
             signupRepo,
             Substitute.For<IVolunteerTrackingRepository>(),

--- a/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
@@ -37,7 +37,7 @@ public sealed class ShiftSignupServiceEarlyEntryTests : ShiftsTestHarness
             .With(roleAssignmentService)
             .Build();
 
-        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         _shiftMgmt = new ShiftManagementService(
             shiftRepo,
@@ -48,7 +48,7 @@ public sealed class ShiftSignupServiceEarlyEntryTests : ShiftsTestHarness
             Substitute.For<IShiftViewInvalidator>(),
             Clock);
 
-        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
         _service = new ShiftSignupService(
             _repo,
             Substitute.For<IVolunteerTrackingRepository>(),

--- a/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSignupServiceTests.cs
@@ -42,7 +42,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             .With(roleAssignmentService)
             .Build();
 
-        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var shiftRepo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         _shiftMgmt = new ShiftManagementService(
             shiftRepo,
@@ -53,7 +53,7 @@ public sealed class ShiftSignupServiceTests : ShiftsTestHarness
             Substitute.For<IShiftViewInvalidator>(),
             Clock);
 
-        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        _repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
         _service = new ShiftSignupService(
             _repo,
             Substitute.For<IVolunteerTrackingRepository>(),

--- a/tests/Humans.Shifts.Tests/Services/ShiftSummaryServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/ShiftSummaryServiceTests.cs
@@ -9,6 +9,7 @@ using Humans.Shifts.Services;
 using Humans.Shifts.Tests.Infrastructure;
 using Humans.Base.Enums;
 using Humans.Shifts.Data;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Humans.Users.Contracts;
@@ -127,7 +128,7 @@ public sealed class ShiftSummaryServiceTests : ShiftsTestHarness
             .With(_campService)
             .Build();
 
-        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         _service = new ShiftManagementService(
             repo,

--- a/tests/Humans.Shifts.Tests/Services/WorkloadServiceTests.cs
+++ b/tests/Humans.Shifts.Tests/Services/WorkloadServiceTests.cs
@@ -6,6 +6,7 @@ using Humans.Shifts.Services;
 using Humans.Shifts.Tests.Infrastructure;
 using Humans.Base.Enums;
 using Humans.Shifts.Data;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Humans.Users.Contracts;
@@ -27,7 +28,7 @@ public sealed class WorkloadServiceTests : ShiftsTestHarness
 
     public WorkloadServiceTests() : base(Instant.FromUtc(2026, 7, 1, 12, 0))
     {
-        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock);
+        var repo = new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance);
 
         // IShiftView source-of-truth path uses GetRotaAsync only — the inner
         // ShiftViewService also takes signup/availability/tracking repos for

--- a/tests/Humans.Teams.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamRoleServiceTests.cs
@@ -62,7 +62,7 @@ public sealed class TeamRoleServiceTests : TeamsTestHarness
             .With<IUserServiceRead>(userService)
             .Build();
         var shiftManagementService = new ShiftManagementService(
-            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock),
+            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance),
             AuditLog,
             AdminAuthorization,
             serviceProvider,

--- a/tests/Humans.Teams.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Teams.Tests/Services/TeamServiceTests.cs
@@ -81,7 +81,7 @@ public sealed class TeamServiceTests : TeamsTestHarness
             .With<IUserServiceRead>(userService)
             .Build();
         var shiftManagementService = new ShiftManagementService(
-            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock),
+            new ShiftRepository(ShiftsDbFactory, ShiftsDb, Clock, NullLogger<ShiftRepository>.Instance),
             AuditLog,
             AdminAuthorization,
             serviceProvider,


### PR DESCRIPTION
## Summary

Refs nobodies-collective/Humans#896

A Confirmed, correctly-dated all-day signup was reported missing from the Cantina daily roster. The investigation in the issue narrowed it to `ShiftRepository.GetUserIdsForDayAsync` (current location: `src/Sections/Humans.Shifts/Data/ShiftRepository.Signups.cs`, called from `ShiftManagementService.GetOnSiteUserIdsForDayAsync`, consumed by `CantinaRosterService.GetDailyRosterAsync`): the query filters Confirmed/Pending signups by `Shift.DayOffset` **and** `Shift.Rota.EventSettingsId == <active event>` in a single SQL `WHERE`. If a rota is bound to a non-active `EventSettings` row (duplicate/stale event), any signup on it silently disappears from every day query — no error, no log, no trace.

## What changed

`GetUserIdsForDayAsync` now matches day + status first, then partitions the event-scope check **in memory**:
- Signups whose rota *is* scoped to the requested (active) event are returned, same as before.
- Signups that match day+status but belong to a *different* `EventSettings` are still excluded from the result (the roster stays correctly scoped to one event — it never mixes in another event's data), but the exclusion is now logged at `LogWarning` with the signup id, user id, day offset, status scope, and both EventSettings ids.

This makes a rota mis-linked to a non-active event diagnosable from the application logs instead of an invisible drop, without changing the roster's actual on-site cohort for correctly-linked data.

### Decision: signal, not blind-include

The issue asked the fix to either (a) include the signup on the roster anyway, or (b) produce a loud, diagnosable signal. I chose **(b)**. Blindly including any signup that matches day+status regardless of event would reintroduce data from a different (possibly genuinely unrelated, or stale/historical) `EventSettings` row onto the current event's roster — trading one silent-data bug for another. The roster being scoped to exactly one event is a real invariant (`docs/architecture/design-rules.md`); the actual defect here is the rota→event linkage, which is a data-correction call only the owner can make with production access.

## Parked — needs owner

Step 1 of the issue (querying production to compare the affected human's Jun 29 signup's `Shift.Rota.EventSettingsId` against the active `EventSettings.Id`) requires production database access this session does not have. It was **not attempted**. That query still needs to be run by the owner to confirm the root cause on production data (rota wired to a duplicate/stale event vs. some other cause) and to correct the linkage if confirmed.

This PR fixes the silent-swallow behaviour regardless of what that query returns: once the linkage is corrected, the signup will appear on the roster as normal; until then (or for any future recurrence), the drop is now visible in the logs instead of silent.

## Files changed

- `src/Sections/Humans.Shifts/Data/ShiftRepository.Signups.cs` — `GetUserIdsForDayAsync` rewritten (day+status query, in-memory event-scope partition + `LogWarning` on exclusion)
- `src/Sections/Humans.Shifts/Data/ShiftRepository.Management.cs` — added `ILogger<ShiftRepository>` constructor dependency
- `src/Sections/Humans.Shifts/Docs/data-access.md` — documented the event-scoping invariant and the new diagnostic logging
- `tests/Humans.Shifts.Tests/Repositories/ShiftRepositorySignupTests.cs` — new regression test reproducing the #896 drop through the real repository query path, asserting the signup stays excluded *and* the warning fires
- 16 other test files updated only to pass the new `ShiftRepository` constructor argument (`NullLogger<ShiftRepository>.Instance`) — no behavior change

No new public/interface surface: `IShiftManagementRepository.GetUserIdsForDayAsync`'s signature is unchanged; only the internal `ShiftRepository` class gained a constructor dependency (same pattern as `BudgetRepository`, `MailerLite.Data.Repository`).

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors (35 pre-existing warnings, unrelated)
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Humans.Shifts.Tests|FullyQualifiedName~Humans.Teams.Tests"` — 823 passed, 0 failed
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Humans.Cantina.Tests"` — 40 passed, 0 failed
- [x] New regression test `GetUserIdsForDayAsync_LogsWarning_WhenConfirmedSignupExcludedByEventScoping` reproduces the drop and the new warning through the real query path
