### PR TITLE
fix(surveys): address production review findings

### DIFF
--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -70,7 +70,7 @@ internal sealed class SurveyAdminController(
         if (detail is null) return NotFound();
 
         var editable = detail.Editable;
-        var resolvedCulture = ResolvePreviewCulture(culture, editable.DefaultCulture);
+        var resolvedCulture = SurveyPageViewModelFactory.ResolveCulture(culture, editable.DefaultCulture);
         var vm = new SurveyIntroViewModel
         {
             Title = editable.Title.Resolve(resolvedCulture, editable.DefaultCulture),
@@ -96,7 +96,7 @@ internal sealed class SurveyAdminController(
             return RedirectToAction(nameof(PreviewThankYou), new { id, culture });
 
         var selectedPage = page is not null && pages.Contains(page.Value) ? page.Value : pages[0];
-        var resolvedCulture = ResolvePreviewCulture(culture, editable.DefaultCulture);
+        var resolvedCulture = SurveyPageViewModelFactory.ResolveCulture(culture, editable.DefaultCulture);
         var state = new SurveyWizardState
         {
             SurveyId = id,
@@ -120,7 +120,7 @@ internal sealed class SurveyAdminController(
         if (detail is null) return NotFound();
 
         var editable = detail.Editable;
-        var resolvedCulture = ResolvePreviewCulture(culture, editable.DefaultCulture);
+        var resolvedCulture = SurveyPageViewModelFactory.ResolveCulture(culture, editable.DefaultCulture);
         var thankYou = editable.ThankYou.Resolve(resolvedCulture, editable.DefaultCulture);
         var vm = new SurveyThankYouViewModel
         {
@@ -136,7 +136,7 @@ internal sealed class SurveyAdminController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SendPreviewEmail(
         Guid id,
-        [FromServices] SurveyPreviewEmailService previewEmailService,
+        [FromServices] ISurveyPreviewEmailService previewEmailService,
         CancellationToken ct)
     {
         var actorId = GetCurrentUserId();
@@ -356,10 +356,4 @@ internal sealed class SurveyAdminController(
             .ToList();
     }
 
-    private static string ResolvePreviewCulture(string? requested, string surveyDefault)
-    {
-        if (requested.IsSupportedCultureCode()) return requested!;
-        if (surveyDefault.IsSupportedCultureCode()) return surveyDefault;
-        return CultureCatalog.DefaultCultureCode;
-    }
 }

--- a/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
@@ -2,7 +2,6 @@ using Humans.Base.Controllers;
 using System.Globalization;
 using Humans.Surveys.Services;
 using Humans.Surveys.Domain;
-using Humans.Base.Extensions;
 using Humans.Surveys.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -117,7 +116,7 @@ internal sealed class SurveyController(
 
         // When the survey forbids anonymity, the only tier is Identified.
         var anonymity = editable.AllowAnonymous ? model.Anonymity : ResponseAnonymity.Identified;
-        var culture = ResolveCulture(model.Culture, editable.DefaultCulture);
+        var culture = SurveyPageViewModelFactory.ResolveCulture(model.Culture, editable.DefaultCulture);
 
         var state = BuildState(ctx, anonymity, culture);
         state.Started = true;
@@ -203,7 +202,7 @@ internal sealed class SurveyController(
             return View("Closed", new SurveyClosedViewModel { Reason = "closed" });
         }
 
-        var resolvedCulture = ResolveCulture(culture, editable.DefaultCulture);
+        var resolvedCulture = SurveyPageViewModelFactory.ResolveCulture(culture, editable.DefaultCulture);
         var state = new SurveyWizardState
         {
             SurveyId = ctx.SurveyId,
@@ -433,13 +432,8 @@ internal sealed class SurveyController(
 
     /// <summary>Picks a supported display culture, defaulting to the current UI culture then the survey's default.</summary>
     private static string ResolveCulture(string surveyDefault)
-        => ResolveCulture(CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, surveyDefault);
-
-    private static string ResolveCulture(string? requested, string surveyDefault)
-    {
-        if (requested.IsSupportedCultureCode()) return requested!;
-        if (surveyDefault.IsSupportedCultureCode()) return surveyDefault;
-        return CultureCatalog.DefaultCultureCode;
-    }
+        => SurveyPageViewModelFactory.ResolveCulture(
+            CultureInfo.CurrentUICulture.TwoLetterISOLanguageName,
+            surveyDefault);
 
 }

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
@@ -1,3 +1,4 @@
+using Humans.Base.Extensions;
 using Humans.Surveys.Services;
 
 namespace Humans.Surveys.Models;
@@ -8,6 +9,13 @@ namespace Humans.Surveys.Models;
 /// </summary>
 internal static class SurveyPageViewModelFactory
 {
+    public static string ResolveCulture(string? requested, string surveyDefault)
+    {
+        if (requested.IsSupportedCultureCode()) return requested!;
+        if (surveyDefault.IsSupportedCultureCode()) return surveyDefault;
+        return CultureCatalog.DefaultCultureCode;
+    }
+
     public static SurveyPageViewModel Build(
         SurveyWizardState state,
         SurveyEditInput editable,

--- a/src/Sections/Humans.Surveys/Section.cs
+++ b/src/Sections/Humans.Surveys/Section.cs
@@ -37,7 +37,7 @@ public sealed class Section : ISection
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<SurveyService>());
         services.AddScoped<ISurveyInviteTokenProvider, SurveyInviteTokenProvider>();
         services.AddScoped<SurveyPreviewTokenProvider>();
-        services.AddScoped<SurveyPreviewEmailService>();
+        services.AddScoped<ISurveyPreviewEmailService, SurveyPreviewEmailService>();
 
         // Survey analysis API key. Missing/empty key is a runtime 503 at the filter, not a startup failure.
         services.Configure<SurveyApiSettings>(opts =>

--- a/src/Sections/Humans.Surveys/Services/SurveyPreviewEmailService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyPreviewEmailService.cs
@@ -1,8 +1,14 @@
 using Humans.Email.Contracts;
 using Humans.Base.Extensions;
+using Humans.Base.Interfaces;
 using Humans.Users.Contracts;
 
 namespace Humans.Surveys.Services;
+
+internal interface ISurveyPreviewEmailService : IOrchestrator
+{
+    Task<string> SendToUserAsync(Guid surveyId, Guid userId, CancellationToken ct = default);
+}
 
 /// <summary>
 /// Sends a side-effect-free survey invitation preview to the requesting Board/Admin user. It reuses
@@ -15,7 +21,7 @@ internal sealed class SurveyPreviewEmailService(
     IEmailService emailService,
     IEmailMessageFactory emailMessages,
     SurveyPreviewTokenProvider previewTokens,
-    ILogger<SurveyPreviewEmailService> logger)
+    ILogger<SurveyPreviewEmailService> logger) : ISurveyPreviewEmailService
 {
     public async Task<string> SendToUserAsync(Guid surveyId, Guid userId, CancellationToken ct = default)
     {

--- a/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
@@ -1,0 +1,139 @@
+@model Humans.Surveys.Models.SurveyPageViewModel
+
+@for (var i = 0; i < Model.Questions.Count; i++)
+{
+    var q = Model.Questions[i];
+    var hasError = !ViewData.ModelState.IsValid
+        && ViewData.ModelState.TryGetValue(q.Id.ToString(), out var entry)
+        && entry.Errors.Count > 0;
+
+    <fieldset class="mb-4 @(hasError ? "border-start border-danger border-3 ps-3" : string.Empty)">
+        <legend class="form-label fw-semibold">
+            @q.Prompt
+            @if (q.IsRequired)
+            {
+                <span class="text-danger" aria-hidden="true">*</span>
+            }
+        </legend>
+
+        @if (!string.IsNullOrWhiteSpace(q.HelpText))
+        {
+            <p class="form-text mt-0 mb-2">@q.HelpText</p>
+        }
+
+        <input type="hidden" name="Answers[@i].QuestionId" value="@q.Id" />
+
+        @switch (q.Type)
+        {
+            case SurveyQuestionType.SingleChoice:
+                foreach (var opt in q.Options)
+                {
+                    var sel = q.SelectedOptionValues.Contains(opt.Value, StringComparer.Ordinal);
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio"
+                               id="q@(i)_@opt.Value" name="Answers[@i].SelectedOptionValues"
+                               value="@opt.Value" @(sel ? "checked" : null) />
+                        <label class="form-check-label" for="q@(i)_@opt.Value">@opt.Label</label>
+                    </div>
+                }
+                break;
+
+            case SurveyQuestionType.MultiChoice:
+                foreach (var opt in q.Options)
+                {
+                    var sel = q.SelectedOptionValues.Contains(opt.Value, StringComparer.Ordinal);
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox"
+                               id="q@(i)_@opt.Value" name="Answers[@i].SelectedOptionValues"
+                               value="@opt.Value" @(sel ? "checked" : null) />
+                        <label class="form-check-label" for="q@(i)_@opt.Value">@opt.Label</label>
+                    </div>
+                }
+                break;
+
+            case SurveyQuestionType.ShortText:
+                <input class="form-control" type="text"
+                       name="Answers[@i].TextValue" value="@q.TextValue" />
+                break;
+
+            case SurveyQuestionType.LongText:
+                <textarea class="form-control" rows="4" name="Answers[@i].TextValue">@q.TextValue</textarea>
+                break;
+
+            case SurveyQuestionType.Rating:
+            {
+                var min = q.RatingMin ?? 1;
+                var max = q.RatingMax ?? 5;
+                <div class="d-flex flex-wrap align-items-center gap-3">
+                    @if (!string.IsNullOrWhiteSpace(q.RatingMinLabel))
+                    {
+                        <span class="form-text mb-0">@q.RatingMinLabel</span>
+                    }
+                    <div class="btn-group" role="group" aria-label="Rating">
+                        @for (var n = min; n <= max; n++)
+                        {
+                            var checkedRating = q.RatingValue == n;
+                            <input type="radio" class="btn-check"
+                                   id="q@(i)_r@(n)" name="Answers[@i].RatingValue"
+                                   value="@n" autocomplete="off" @(checkedRating ? "checked" : null) />
+                            <label class="btn btn-outline-primary" for="q@(i)_r@(n)">@n</label>
+                        }
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(q.RatingMaxLabel))
+                    {
+                        <span class="form-text mb-0">@q.RatingMaxLabel</span>
+                    }
+                </div>
+                break;
+            }
+
+            case SurveyQuestionType.Grid:
+            {
+                var single = q.GridSelectionMode == GridSelectionMode.Single;
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle survey-grid mb-0">
+                        <thead>
+                            <tr>
+                                <th scope="col"><span class="visually-hidden">@q.Prompt</span></th>
+                                @foreach (var column in q.Options)
+                                {
+                                    <th scope="col" class="text-center">@column.Label</th>
+                                }
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @for (var rowIndex = 0; rowIndex < q.GridRows.Count; rowIndex++)
+                            {
+                                var row = q.GridRows[rowIndex];
+                                q.GridSelections.TryGetValue(row.Value, out var selectedColumns);
+                                <tr>
+                                    <th scope="row">
+                                        @row.Label
+                                        <input type="hidden" name="Answers[@i].GridRows[@rowIndex].RowValue" value="@row.Value" />
+                                    </th>
+                                    @foreach (var column in q.Options)
+                                    {
+                                        var selected = selectedColumns?.Contains(column.Value, StringComparer.Ordinal) == true;
+                                        <td class="text-center">
+                                            <input class="form-check-input" type="@(single ? "radio" : "checkbox")"
+                                                   name="Answers[@i].GridRows[@rowIndex].SelectedColumnValues"
+                                                   value="@column.Value"
+                                                   aria-label="@($"{row.Label}: {column.Label}")"
+                                                   @if (selected) { <text>checked</text> } />
+                                        </td>
+                                    }
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+                break;
+            }
+        }
+
+        @if (hasError)
+        {
+            <div class="text-danger small mt-1">@Localizer["Survey_QuestionRequired"]</div>
+        }
+    </fieldset>
+}

--- a/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
@@ -56,143 +56,15 @@
                         <input type="hidden" name="Culture" value="@Model.PreviewCulture" />
                     }
 
-                    @for (var i = 0; i < Model.Questions.Count; i++)
+                    @if (Model.IsPreview)
                     {
-                        var q = Model.Questions[i];
-                        var hasError = !ViewData.ModelState.IsValid
-                            && ViewData.ModelState.TryGetValue(q.Id.ToString(), out var entry)
-                            && entry.Errors.Count > 0;
-
-                        <fieldset class="mb-4 @(hasError ? "border-start border-danger border-3 ps-3" : string.Empty)"
-                                  disabled="@(Model.IsPreview ? "disabled" : null)">
-                            <legend class="form-label fw-semibold">
-                                @q.Prompt
-                                @if (q.IsRequired)
-                                {
-                                    <span class="text-danger" aria-hidden="true">*</span>
-                                }
-                            </legend>
-
-                            @if (!string.IsNullOrWhiteSpace(q.HelpText))
-                            {
-                                <p class="form-text mt-0 mb-2">@q.HelpText</p>
-                            }
-
-                            <input type="hidden" name="Answers[@i].QuestionId" value="@q.Id" />
-
-                            @switch (q.Type)
-                            {
-                                case SurveyQuestionType.SingleChoice:
-                                    foreach (var opt in q.Options)
-                                    {
-                                        var sel = q.SelectedOptionValues.Contains(opt.Value, StringComparer.Ordinal);
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio"
-                                                   id="q@(i)_@opt.Value" name="Answers[@i].SelectedOptionValues"
-                                                   value="@opt.Value" @(sel ? "checked" : null) />
-                                            <label class="form-check-label" for="q@(i)_@opt.Value">@opt.Label</label>
-                                        </div>
-                                    }
-                                    break;
-
-                                case SurveyQuestionType.MultiChoice:
-                                    foreach (var opt in q.Options)
-                                    {
-                                        var sel = q.SelectedOptionValues.Contains(opt.Value, StringComparer.Ordinal);
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="checkbox"
-                                                   id="q@(i)_@opt.Value" name="Answers[@i].SelectedOptionValues"
-                                                   value="@opt.Value" @(sel ? "checked" : null) />
-                                            <label class="form-check-label" for="q@(i)_@opt.Value">@opt.Label</label>
-                                        </div>
-                                    }
-                                    break;
-
-                                case SurveyQuestionType.ShortText:
-                                    <input class="form-control" type="text"
-                                           name="Answers[@i].TextValue" value="@q.TextValue" />
-                                    break;
-
-                                case SurveyQuestionType.LongText:
-                                    <textarea class="form-control" rows="4" name="Answers[@i].TextValue">@q.TextValue</textarea>
-                                    break;
-
-                                case SurveyQuestionType.Rating:
-                                {
-                                    var min = q.RatingMin ?? 1;
-                                    var max = q.RatingMax ?? 5;
-                                    <div class="d-flex flex-wrap align-items-center gap-3">
-                                        @if (!string.IsNullOrWhiteSpace(q.RatingMinLabel))
-                                        {
-                                            <span class="form-text mb-0">@q.RatingMinLabel</span>
-                                        }
-                                        <div class="btn-group" role="group" aria-label="Rating">
-                                            @for (var n = min; n <= max; n++)
-                                            {
-                                                var checkedRating = q.RatingValue == n;
-                                                <input type="radio" class="btn-check"
-                                                       id="q@(i)_r@(n)" name="Answers[@i].RatingValue"
-                                                       value="@n" autocomplete="off" @(checkedRating ? "checked" : null) />
-                                                <label class="btn btn-outline-primary" for="q@(i)_r@(n)">@n</label>
-                                            }
-                                        </div>
-                                        @if (!string.IsNullOrWhiteSpace(q.RatingMaxLabel))
-                                        {
-                                            <span class="form-text mb-0">@q.RatingMaxLabel</span>
-                                        }
-                                    </div>
-                                    break;
-                                }
-
-                                case SurveyQuestionType.Grid:
-                                {
-                                    var single = q.GridSelectionMode == GridSelectionMode.Single;
-                                    <div class="table-responsive">
-                                        <table class="table table-sm align-middle survey-grid mb-0">
-                                            <thead>
-                                                <tr>
-                                                    <th scope="col"><span class="visually-hidden">@q.Prompt</span></th>
-                                                    @foreach (var column in q.Options)
-                                                    {
-                                                        <th scope="col" class="text-center">@column.Label</th>
-                                                    }
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                @for (var rowIndex = 0; rowIndex < q.GridRows.Count; rowIndex++)
-                                                {
-                                                    var row = q.GridRows[rowIndex];
-                                                    q.GridSelections.TryGetValue(row.Value, out var selectedColumns);
-                                                    <tr>
-                                                        <th scope="row">
-                                                            @row.Label
-                                                            <input type="hidden" name="Answers[@i].GridRows[@rowIndex].RowValue" value="@row.Value" />
-                                                        </th>
-                                                        @foreach (var column in q.Options)
-                                                        {
-                                                            var selected = selectedColumns?.Contains(column.Value, StringComparer.Ordinal) == true;
-                                                            <td class="text-center">
-                                                                <input class="form-check-input" type="@(single ? "radio" : "checkbox")"
-                                                                       name="Answers[@i].GridRows[@rowIndex].SelectedColumnValues"
-                                                                       value="@column.Value"
-                                                                       aria-label="@($"{row.Label}: {column.Label}")"
-                                                                       @if (selected) { <text>checked</text> } />
-                                                            </td>
-                                                        }
-                                                    </tr>
-                                                }
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                    break;
-                                }
-                            }
-
-                            @if (hasError)
-                            {
-                                <div class="text-danger small mt-1">@Localizer["Survey_QuestionRequired"]</div>
-                            }
+                        <fieldset class="border-0 p-0 m-0" disabled="disabled">
+                            <partial name="_SurveyQuestions" model="Model" />
                         </fieldset>
+                    }
+                    else
+                    {
+                        <partial name="_SurveyQuestions" model="Model" />
                     }
 
                     <div class="d-flex justify-content-between mt-4">


### PR DESCRIPTION
## What

Address the three automated production-review findings on nobodies-collective/Humans#1109 before the survey-preview release proceeds.

This follow-up to peterdrier/Humans#1449:

- marks the preview-email coordinator with an internal `IOrchestrator` interface and registers/injects that interface;
- reuses one shared survey culture resolver from both survey controllers;
- removes the expression-driven Razor `disabled` attribute by rendering preview questions inside an explicitly disabled fieldset.

## Why

The production review correctly identified one blocking role-marker violation and two maintainability/Razor-rule violations. These should land through QA rather than being bypassed or patched directly in production.

## Existing surface checked

- Reused `IOrchestrator`; no public contract was added.
- Extended the existing internal `SurveyPageViewModelFactory` rather than adding another culture helper.
- Extracted the existing question markup into one shared partial so preview and live answering still render exactly the same controls without duplicating the full question switch.

## UI changes / screenshots

No intended visual change. Preview answer controls remain disabled and excluded from requests; live answering remains enabled. The existing HTTP integration regression test renders the preview through `SurveyAdminController` and verifies that the disabled fieldset contains the named answer controls.

## Checklist

- [x] **Section labeled** — upstream issue nobodies-collective/Humans#1108 carries `section:surveys`; the QA repository has no equivalent section label.
- [x] **Targeting `main` on `peterdrier/Humans`** from a same-repository feature branch.
- [x] **Branched from current `peterdrier/Humans:main`** at `be157cd1`.
- [x] **Issue/PR refs qualified**.
- [x] **EF migrations** — none.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No; this applies existing role-marker, reuse-first, and Razor boolean-attribute rules.
- [x] **Reuse-first checked** — existing marker, model factory, and respondent markup reused.
- [x] **Build + tests**:
  - full solution build: 0 warnings, 0 errors
  - Surveys tests: 164 passed
  - preview HTTP integration regression: passed
  - full solution: all section suites passed; integration 303 passed / 1 skipped, with the known parallel-sensitive missing-database startup test failing in-suite and passing immediately in isolation
  - `git diff --check`: passed
- [x] **Nav coverage** — no new page or route.
- [x] **No magic strings**, date/time, or icon changes.

## Reviewer notes

Once this is squash-merged into QA, nobodies-collective/Humans#1109 will automatically update from `peterdrier/Humans:main`. The three production review threads should remain open until the corrected QA commit is visible on that PR.