### PR TITLE
feat(surveys): customize and preview invitation copy

### DIFF
--- a/src/Humans.Base/Extensions/HtmlHelperExtensions.cs
+++ b/src/Humans.Base/Extensions/HtmlHelperExtensions.cs
@@ -1,6 +1,4 @@
 using System.Text.Encodings.Web;
-using Ganss.Xss;
-using Markdig;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -17,30 +15,9 @@ public static class HtmlHelperExtensions
         return writer.ToString().Replace("'", "\\'", StringComparison.Ordinal);
     }
 
-    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
-        .UseAdvancedExtensions()
-        .UseSoftlineBreakAsHardlineBreak()
-        .Build();
-
     public static IHtmlContent SanitizedMarkdown(this IHtmlHelper html, string? markdown)
     {
         ArgumentNullException.ThrowIfNull(html);
-
-        if (string.IsNullOrWhiteSpace(markdown))
-        {
-            return HtmlString.Empty;
-        }
-
-        var rendered = Markdown.ToHtml(markdown, MarkdownPipeline);
-        var sanitizer = new HtmlSanitizer();
-
-        // Allow task list checkboxes rendered by Markdig's UseTaskLists extension
-        sanitizer.AllowedTags.Add("input");
-        sanitizer.AllowedAttributes.Add("type");
-        sanitizer.AllowedAttributes.Add("checked");
-        sanitizer.AllowedAttributes.Add("disabled");
-
-        var sanitized = sanitizer.Sanitize(rendered);
-        return new HtmlString(sanitized);
+        return new HtmlString(SanitizedMarkdownRenderer.Render(markdown));
     }
 }

--- a/src/Humans.Base/Extensions/SanitizedMarkdownRenderer.cs
+++ b/src/Humans.Base/Extensions/SanitizedMarkdownRenderer.cs
@@ -1,0 +1,39 @@
+using Ganss.Xss;
+using Markdig;
+
+namespace Humans.Base.Extensions;
+
+/// <summary>
+/// Canonical Markdown-to-HTML rendering for authored content displayed by Humans.
+/// </summary>
+public static class SanitizedMarkdownRenderer
+{
+    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .UseSoftlineBreakAsHardlineBreak()
+        .Build();
+
+    public static string Render(string? markdown, bool allowImages = true)
+    {
+        if (string.IsNullOrWhiteSpace(markdown))
+        {
+            return string.Empty;
+        }
+
+        var rendered = Markdown.ToHtml(markdown, MarkdownPipeline);
+        var sanitizer = new HtmlSanitizer();
+
+        // Allow task list checkboxes rendered by Markdig's UseTaskLists extension.
+        sanitizer.AllowedTags.Add("input");
+        sanitizer.AllowedAttributes.Add("type");
+        sanitizer.AllowedAttributes.Add("checked");
+        sanitizer.AllowedAttributes.Add("disabled");
+
+        if (!allowImages)
+        {
+            sanitizer.AllowedTags.Remove("img");
+        }
+
+        return sanitizer.Sanitize(rendered);
+    }
+}

--- a/src/Sections/Humans.Email.Contracts/IEmailMessageFactory.cs
+++ b/src/Sections/Humans.Email.Contracts/IEmailMessageFactory.cs
@@ -48,8 +48,19 @@ public interface IEmailMessageFactory
     /// <summary>Term renewal reminder (Governance).</summary>
     EmailMessage TermRenewalReminder(string userEmail, string userName, string tierName, string expiresAt, string? culture = null);
 
-    /// <summary>Survey invitation — operational (System category, always-send). <paramref name="answerToken"/> is the invite token; the URL is built by the renderer.</summary>
-    EmailMessage SurveyInvitation(string userEmail, string userName, string surveyTitle, string answerToken, string? culture = null);
+    /// <summary>
+    /// Survey invitation — operational (System category, always-send).
+    /// <paramref name="answerToken"/> is the invite token; the URL is built by the renderer.
+    /// Blank custom copy retains the standard localized wording.
+    /// </summary>
+    EmailMessage SurveyInvitation(
+        string userEmail,
+        string userName,
+        string surveyTitle,
+        string answerToken,
+        string? culture = null,
+        string? customSubject = null,
+        string? customMessage = null);
 
     /// <summary>Survey reminder — single nudge for an unfinished invitation (System category).</summary>
     EmailMessage SurveyReminder(string userEmail, string userName, string surveyTitle, string answerToken, string? culture = null);

--- a/src/Sections/Humans.Email.Contracts/IEmailPreviewServiceRead.cs
+++ b/src/Sections/Humans.Email.Contracts/IEmailPreviewServiceRead.cs
@@ -1,0 +1,23 @@
+using Humans.Base.Interfaces;
+
+namespace Humans.Email.Contracts;
+
+/// <summary>
+/// Read-only rendering seam for displaying an always-send system email exactly as the outbox
+/// would wrap it, without enqueueing or recording delivery activity.
+/// </summary>
+public interface IEmailPreviewServiceRead : IApplicationService
+{
+    /// <summary>
+    /// Applies the canonical branded email wrapper to a system message.
+    /// Opt-outable messages are rejected because their exact wrapper requires a recipient-specific
+    /// unsubscribe URL from the send path.
+    /// </summary>
+    RenderedEmailPreview RenderSystemMessage(EmailMessage message);
+}
+
+/// <summary>A fully wrapped, side-effect-free system email preview.</summary>
+public sealed record RenderedEmailPreview(
+    string RecipientEmail,
+    string Subject,
+    string HtmlBody);

--- a/src/Sections/Humans.Email/Controllers/EmailController.cs
+++ b/src/Sections/Humans.Email/Controllers/EmailController.cs
@@ -168,6 +168,7 @@ internal sealed class EmailController(
     [HttpGet("EmailPreview")]
     public IActionResult EmailPreview(
         [FromServices] IEmailRenderer renderer,
+        [FromServices] IEmailBodyComposer bodyComposer,
         [FromServices] IOptions<EmailSettings> emailSettings)
     {
         var settings = emailSettings.Value;
@@ -177,7 +178,14 @@ internal sealed class EmailController(
         {
             var (name, email) = Personas[culture];
             var ctx = new PreviewContext(culture, name, email, settings);
-            previews[culture] = PreviewDefinitions.Select(build => build(renderer, ctx)).ToList();
+            previews[culture] = PreviewDefinitions
+                .Select(build => build(renderer, ctx))
+                .Select(item =>
+                {
+                    item.Body = bodyComposer.Compose(item.Body).HtmlBody;
+                    return item;
+                })
+                .ToList();
         }
 
         return View(new EmailPreviewViewModel { Previews = previews, FromAddress = settings.FromAddress });

--- a/src/Sections/Humans.Email/Docs/Email.md
+++ b/src/Sections/Humans.Email/Docs/Email.md
@@ -14,7 +14,7 @@ Transactional email outbox: queue, render, deliver, retry, pause/resume. Backs c
 
 - An **Outbox Message** is a single queued email record with recipient, subject, rendered HTML body, status, retry metadata, and optional links to `User` / `CampaignGrant` / `ShiftSignup`.
 - The **Outbox Pause Flag** is a `SystemSetting` row keyed `IsEmailSendingPaused` that, when `"true"`, causes `ProcessEmailOutboxJob` to skip all delivery attempts on its next tick. Resuming flips it back to `"false"`.
-- **Email Body Composition** happens entirely inside the section: `IEmailBodyComposer` / `BrandedEmailBodyComposer` are internal, as are `IEmailRenderer` / `EmailRenderer` and the two transports. Business code outside the section never sees any of them — it builds an `EmailMessage` through `IEmailMessageFactory` and hands it to `IEmailService`, both on `Humans.Email.Contracts`.
+- **Email Body Composition** happens entirely inside the section: `IEmailBodyComposer` / `BrandedEmailBodyComposer` are internal, as are `IEmailRenderer` / `EmailRenderer` and the two transports. Business code outside the section builds an `EmailMessage` through `IEmailMessageFactory` and hands it to `IEmailService`. Authorized UI previews can pass an always-send system message to the read-only `IEmailPreviewServiceRead`; it returns the exact canonical branded wrapper without enqueueing it.
 - **Delivery** is performed by `EmailOutboxProcessor` (section) via `IEmailTransport` (`SmtpEmailTransport` in prod, `StubEmailTransport` in dev/test). `ProcessEmailOutboxJob` (`Humans.Email/Jobs/`) is the Hangfire scheduler shim that calls it through `IEmailOutboxProcessor`. `IImmediateOutboxProcessor` (`HangfireImmediateOutboxProcessor`, `Humans.Email/Contracts/`) is the trigger for time-sensitive templates that need to fire the next job run immediately rather than wait for the recurring tick.
 - **One `IEmailService` implementation exists:** `OutboxEmailService` (Application, default — writes to the outbox). DI binds `IEmailService` to `OutboxEmailService`.
 
@@ -102,6 +102,7 @@ Per design-rules §8, each `system_settings` key is owned by its consuming secti
 - Admin retry resets a row to `Status = Queued`, `RetryCount = 0`, `LastError = null`, `NextRetryAt = null`, `PickedUpAt = null`.
 - Recipient addresses ending in `@localhost` or `@ticketstub.local` are short-circuit-marked `Sent` without contacting the transport (test addresses; sending real mail to them would damage sender reputation).
 - `IEmailBodyComposer` is a section-internal abstraction so `OutboxEmailService` stays free of `IHostEnvironment`/configuration dependencies; the implementation (`BrandedEmailBodyComposer`) is section-internal too. `IImmediateOutboxProcessor` (`HangfireImmediateOutboxProcessor`) lives in `Humans.Email/Contracts/`.
+- `IEmailPreviewServiceRead` is the only cross-section seam for side-effect-free final-body rendering. It delegates to the same internal `IEmailBodyComposer` as the outbox and accepts only always-send system messages; opt-outable messages require recipient-specific unsubscribe policy and are rejected.
 - The Email section does **not** contribute to the GDPR export (`IUserDataContributor`). User-scoped outbox history is exposed only through the `/Profile/Me/Outbox` and `/Users/Admin/{id}/Outbox` views.
 
 ## Negative Access Rules
@@ -147,6 +148,13 @@ Per design-rules §8, each `system_settings` key is owned by its consuming secti
 - **`Humans.Email.Contracts` — everything consumed from outside the section:**
   - `IEmailService` + `EmailMessage` — the one transport entry point, called by nine `Humans.Application` services, six `Humans.Infrastructure` jobs and six moved sections.
   - `IEmailMessageFactory` — the typed builders those callers use to construct an `EmailMessage`.
+    `SurveyInvitation` accepts optional plain-text custom subject/message values from Surveys; the
+    internal renderer trims and safely encodes them while retaining the existing template, generated
+    answer link, System category, and localized standard-copy fallback.
+  - `IEmailPreviewServiceRead` + `RenderedEmailPreview` — read-only final-body rendering for
+    authorized cross-section preview pages. It applies the same internal branded composer as the
+    outbox, creates no outbox row, and deliberately rejects opt-outable categories whose exact
+    footer depends on recipient-specific send policy.
   - `IEmailOutboxServiceRead` + `EmailOutboxMessageDto` — per-human outbox history for Shell's `/Profile/Me/Outbox` and `/Users/Admin/{id}/Outbox`.
   - `IEmailOutboxProcessor` / `IEmailOutboxRetention` — what `ProcessEmailOutboxJob` / `CleanupEmailOutboxJob` drive. Both jobs moved out of Base into the section at G5 lane 5b-1 (initially under `Contracts/`, then into their own `Humans.Email/Jobs/` folder at nobodies-collective/Humans#1353's Jobs/ carve-out), so these two have no consumer outside the section any more and could move inward in a later pass.
   - `IImmediateOutboxProcessor` — was on the leaf for the opposite reason: Base *implemented* it. `HangfireImmediateOutboxProcessor` followed the job out of Base at the same lane and still lives under `Humans.Email/Contracts/` — the #1353 Jobs/ carve-out is for `IRecurringJob` implementors and `*Job`-named Hangfire jobs, and this type is neither — so both sides are now section-side.

--- a/src/Sections/Humans.Email/EmailResource.ca.resx
+++ b/src/Sections/Humans.Email/EmailResource.ca.resx
@@ -379,10 +379,11 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} eliminacions de compte pendents</value><comment>{0} = count</comment></data>
   <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Hola {0},&lt;/p&gt;
-&lt;p&gt;Estàs convidat/da a completar l'enquesta &lt;strong&gt;{1}&lt;/strong&gt;. Només et portarà uns minuts.&lt;/p&gt;
+{3}
 &lt;p&gt;&lt;a href="{2}"&gt;Obre l'enquesta&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;Gràcies,&lt;br/&gt;El Nobodies Collective&lt;/p&gt;</value></data>
   <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Si us plau, completa: {0}</value></data>
+  <data name="Email_SurveyInvitation_DefaultMessage" xml:space="preserve"><value>Estàs convidat/da a completar l'enquesta &lt;strong&gt;{0}&lt;/strong&gt;. Només et portarà uns minuts.</value></data>
   <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Hola {0},&lt;/p&gt;
 &lt;p&gt;Només un recordatori que l'enquesta &lt;strong&gt;{1}&lt;/strong&gt; encara espera la teva resposta.&lt;/p&gt;

--- a/src/Sections/Humans.Email/EmailResource.de.resx
+++ b/src/Sections/Humans.Email/EmailResource.de.resx
@@ -379,10 +379,11 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} Kontol&#xF6;schungen ausstehend</value><comment>{0} = count</comment></data>
   <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Hallo {0},&lt;/p&gt;
-&lt;p&gt;du bist eingeladen, die Umfrage &lt;strong&gt;{1}&lt;/strong&gt; auszufüllen. Es dauert nur ein paar Minuten.&lt;/p&gt;
+{3}
 &lt;p&gt;&lt;a href="{2}"&gt;Umfrage öffnen&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;Vielen Dank,&lt;br/&gt;Das Nobodies Collective&lt;/p&gt;</value></data>
   <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Bitte ausfüllen: {0}</value></data>
+  <data name="Email_SurveyInvitation_DefaultMessage" xml:space="preserve"><value>du bist eingeladen, die Umfrage &lt;strong&gt;{0}&lt;/strong&gt; auszufüllen. Es dauert nur ein paar Minuten.</value></data>
   <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Hallo {0},&lt;/p&gt;
 &lt;p&gt;nur eine Erinnerung, dass die Umfrage &lt;strong&gt;{1}&lt;/strong&gt; noch auf deine Antwort wartet.&lt;/p&gt;

--- a/src/Sections/Humans.Email/EmailResource.es.resx
+++ b/src/Sections/Humans.Email/EmailResource.es.resx
@@ -154,10 +154,13 @@
   <data name="Email_SurveyInvitation_Body" xml:space="preserve">
     <value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Hola {0},&lt;/p&gt;
-&lt;p&gt;Te invitamos a completar la encuesta &lt;strong&gt;{1}&lt;/strong&gt;. Solo te llevará unos minutos.&lt;/p&gt;
+{3}
 &lt;p&gt;&lt;a href="{2}"&gt;Abrir la encuesta&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;Gracias,&lt;br/&gt;Nobodies Collective&lt;/p&gt;</value>
-    <comment>{0} = user name, {1} = survey title, {2} = answer URL</comment>
+    <comment>{0} = user name, {1} = survey title, {2} = answer URL, {3} = encoded invitation message HTML</comment>
+  </data>
+  <data name="Email_SurveyInvitation_DefaultMessage" xml:space="preserve">
+    <value>Te invitamos a completar la encuesta &lt;strong&gt;{0}&lt;/strong&gt;. Solo te llevará unos minutos.</value>
   </data>
   <data name="Email_SurveyReminder_Body" xml:space="preserve">
     <value>&lt;h2&gt;{1}&lt;/h2&gt;

--- a/src/Sections/Humans.Email/EmailResource.fr.resx
+++ b/src/Sections/Humans.Email/EmailResource.fr.resx
@@ -379,10 +379,11 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} suppressions de compte en attente</value><comment>{0} = count</comment></data>
   <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Bonjour {0},&lt;/p&gt;
-&lt;p&gt;Vous êtes invité à compléter le sondage &lt;strong&gt;{1}&lt;/strong&gt;. Cela ne prend que quelques minutes.&lt;/p&gt;
+{3}
 &lt;p&gt;&lt;a href="{2}"&gt;Ouvrir le sondage&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;Merci,&lt;br/&gt;Nobodies Collective&lt;/p&gt;</value></data>
   <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Merci de compléter : {0}</value></data>
+  <data name="Email_SurveyInvitation_DefaultMessage" xml:space="preserve"><value>Vous êtes invité à compléter le sondage &lt;strong&gt;{0}&lt;/strong&gt;. Cela ne prend que quelques minutes.</value></data>
   <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Bonjour {0},&lt;/p&gt;
 &lt;p&gt;Petit rappel : le sondage &lt;strong&gt;{1}&lt;/strong&gt; attend toujours votre réponse.&lt;/p&gt;

--- a/src/Sections/Humans.Email/EmailResource.it.resx
+++ b/src/Sections/Humans.Email/EmailResource.it.resx
@@ -379,10 +379,11 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} eliminazioni di account in sospeso</value><comment>{0} = count</comment></data>
   <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Ciao {0},&lt;/p&gt;
-&lt;p&gt;Sei invitato a completare il sondaggio &lt;strong&gt;{1}&lt;/strong&gt;. Bastano pochi minuti.&lt;/p&gt;
+{3}
 &lt;p&gt;&lt;a href="{2}"&gt;Apri il sondaggio&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;Grazie,&lt;br/&gt;Il Nobodies Collective&lt;/p&gt;</value></data>
   <data name="Email_SurveyInvitation_Subject" xml:space="preserve"><value>Completa: {0}</value></data>
+  <data name="Email_SurveyInvitation_DefaultMessage" xml:space="preserve"><value>Sei invitato a completare il sondaggio &lt;strong&gt;{0}&lt;/strong&gt;. Bastano pochi minuti.</value></data>
   <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Ciao {0},&lt;/p&gt;
 &lt;p&gt;Solo un promemoria: il sondaggio &lt;strong&gt;{1}&lt;/strong&gt; è ancora in attesa della tua risposta.&lt;/p&gt;

--- a/src/Sections/Humans.Email/EmailResource.resx
+++ b/src/Sections/Humans.Email/EmailResource.resx
@@ -87,9 +87,10 @@
 &lt;p&gt;Best regards,&lt;br/&gt;The Humans Team&lt;/p&gt;</value><comment>{0} = user name, {1} = reason HTML (or empty), {2} = admin email</comment></data>
   <data name="Email_SurveyInvitation_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Hi {0},&lt;/p&gt;
-&lt;p&gt;You're invited to complete the survey &lt;strong&gt;{1}&lt;/strong&gt;. It only takes a few minutes.&lt;/p&gt;
+{3}
 &lt;p&gt;&lt;a href="{2}"&gt;Open the survey&lt;/a&gt;&lt;/p&gt;
-&lt;p&gt;Thank you,&lt;br/&gt;The Nobodies Collective&lt;/p&gt;</value><comment>{0} = user name, {1} = survey title, {2} = answer URL</comment></data>
+&lt;p&gt;Thank you,&lt;br/&gt;The Nobodies Collective&lt;/p&gt;</value><comment>{0} = user name, {1} = survey title, {2} = answer URL, {3} = encoded invitation message HTML</comment></data>
+  <data name="Email_SurveyInvitation_DefaultMessage" xml:space="preserve"><value>You're invited to complete the survey &lt;strong&gt;{0}&lt;/strong&gt;. It only takes a few minutes.</value><comment>{0} = HTML-encoded survey title</comment></data>
   <data name="Email_SurveyReminder_Body" xml:space="preserve"><value>&lt;h2&gt;{1}&lt;/h2&gt;
 &lt;p&gt;Hi {0},&lt;/p&gt;
 &lt;p&gt;Just a reminder that the survey &lt;strong&gt;{1}&lt;/strong&gt; is still waiting for your response.&lt;/p&gt;

--- a/src/Sections/Humans.Email/Section.cs
+++ b/src/Sections/Humans.Email/Section.cs
@@ -45,6 +45,7 @@ public sealed class Section : ISection
 
         services.AddScoped<IEmailRenderer, EmailRenderer>();
         services.AddSingleton<IEmailBodyComposer, BrandedEmailBodyComposer>();
+        services.AddSingleton<IEmailPreviewServiceRead, EmailPreviewService>();
         services.AddScoped<IEmailMessageFactory, EmailMessageFactory>();
         services.AddScoped<IEmailService, OutboxEmailService>();
 

--- a/src/Sections/Humans.Email/Services/EmailMessageFactory.cs
+++ b/src/Sections/Humans.Email/Services/EmailMessageFactory.cs
@@ -92,9 +92,17 @@ internal sealed class EmailMessageFactory(IEmailRenderer renderer) : IEmailMessa
             "term_renewal_reminder", MessageCategory.Governance);
     }
 
-    public EmailMessage SurveyInvitation(string userEmail, string userName, string surveyTitle, string answerToken, string? culture = null)
+    public EmailMessage SurveyInvitation(
+        string userEmail,
+        string userName,
+        string surveyTitle,
+        string answerToken,
+        string? culture = null,
+        string? customSubject = null,
+        string? customMessage = null)
     {
-        var content = renderer.RenderSurveyInvitation(userName, surveyTitle, answerToken, culture);
+        var content = renderer.RenderSurveyInvitation(
+            userName, surveyTitle, answerToken, culture, customSubject, customMessage);
         return new EmailMessage(userEmail, userName, content.Subject, content.HtmlBody,
             "survey_invitation", MessageCategory.System);
     }

--- a/src/Sections/Humans.Email/Services/EmailPreviewService.cs
+++ b/src/Sections/Humans.Email/Services/EmailPreviewService.cs
@@ -1,0 +1,23 @@
+using Humans.Email.Contracts;
+using Humans.Users.Contracts;
+
+namespace Humans.Email.Services;
+
+/// <summary>
+/// Produces a side-effect-free preview through the same canonical body composer used by the outbox.
+/// </summary>
+internal sealed class EmailPreviewService(IEmailBodyComposer bodyComposer) : IEmailPreviewServiceRead
+{
+    public RenderedEmailPreview RenderSystemMessage(EmailMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (message.Category is not null and not MessageCategory.System)
+        {
+            throw new InvalidOperationException(
+                "Only always-send system emails can be previewed without recipient-specific send policy.");
+        }
+
+        var body = bodyComposer.Compose(message.HtmlBody);
+        return new RenderedEmailPreview(message.RecipientEmail, message.Subject, body.HtmlBody);
+    }
+}

--- a/src/Sections/Humans.Email/Services/EmailRenderer.cs
+++ b/src/Sections/Humans.Email/Services/EmailRenderer.cs
@@ -133,10 +133,31 @@ internal sealed class EmailRenderer(
             Lf("Email_TermRenewalReminder_Subject", tierName),
             Lf("Email_TermRenewalReminder_Body", HtmlEncode(userName), HtmlEncode(tierName), HtmlEncode(expiresAt), _settings.BaseUrl)));
 
-    public EmailContent RenderSurveyInvitation(string userName, string surveyTitle, string answerToken, string? culture = null)
-        => RenderLocalized(culture, () => new EmailContent(
-            Lf("Email_SurveyInvitation_Subject", surveyTitle),
-            Lf("Email_SurveyInvitation_Body", HtmlEncode(userName), HtmlEncode(surveyTitle), BuildSurveyAnswerUrl(answerToken))));
+    public EmailContent RenderSurveyInvitation(
+        string userName,
+        string surveyTitle,
+        string answerToken,
+        string? culture = null,
+        string? customSubject = null,
+        string? customMessage = null)
+        => RenderLocalized(culture, () =>
+        {
+            var subject = string.IsNullOrWhiteSpace(customSubject)
+                ? Lf("Email_SurveyInvitation_Subject", surveyTitle)
+                : customSubject.Trim();
+            var messageHtml = string.IsNullOrWhiteSpace(customMessage)
+                ? $"<p>{Lf("Email_SurveyInvitation_DefaultMessage", HtmlEncode(surveyTitle))}</p>"
+                : $"<p>{HtmlEncode(customMessage.Trim()).Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal).Replace("\n", "<br />", StringComparison.Ordinal)}</p>";
+
+            return new EmailContent(
+                subject,
+                Lf(
+                    "Email_SurveyInvitation_Body",
+                    HtmlEncode(userName),
+                    HtmlEncode(surveyTitle),
+                    BuildSurveyAnswerUrl(answerToken),
+                    messageHtml));
+        });
 
     public EmailContent RenderSurveyReminder(string userName, string surveyTitle, string answerToken, string? culture = null)
         => RenderLocalized(culture, () => new EmailContent(

--- a/src/Sections/Humans.Email/Services/EmailRenderer.cs
+++ b/src/Sections/Humans.Email/Services/EmailRenderer.cs
@@ -2,6 +2,7 @@ using Humans.Users.Contracts;
 using System.Globalization;
 using Humans.Email.Contracts;
 using Humans.Base.Configuration;
+using Humans.Base.Extensions;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 
@@ -147,7 +148,7 @@ internal sealed class EmailRenderer(
                 : customSubject.Trim();
             var messageHtml = string.IsNullOrWhiteSpace(customMessage)
                 ? $"<p>{Lf("Email_SurveyInvitation_DefaultMessage", HtmlEncode(surveyTitle))}</p>"
-                : $"<p>{HtmlEncode(customMessage.Trim()).Replace("\r\n", "\n", StringComparison.Ordinal).Replace("\r", "\n", StringComparison.Ordinal).Replace("\n", "<br />", StringComparison.Ordinal)}</p>";
+                : SanitizedMarkdownRenderer.Render(customMessage.Trim(), allowImages: false);
 
             return new EmailContent(
                 subject,

--- a/src/Sections/Humans.Email/Services/IEmailRenderer.cs
+++ b/src/Sections/Humans.Email/Services/IEmailRenderer.cs
@@ -80,8 +80,17 @@ internal interface IEmailRenderer
     /// </summary>
     EmailContent RenderTermRenewalReminder(string userName, string tierName, string expiresAt, string? culture = null);
 
-    /// <summary>Survey invitation — links to the tokenised answering wizard.</summary>
-    EmailContent RenderSurveyInvitation(string userName, string surveyTitle, string answerToken, string? culture = null);
+    /// <summary>
+    /// Survey invitation — links to the tokenised answering wizard and optionally replaces the
+    /// standard localized subject/message with safely rendered author copy.
+    /// </summary>
+    EmailContent RenderSurveyInvitation(
+        string userName,
+        string surveyTitle,
+        string answerToken,
+        string? culture = null,
+        string? customSubject = null,
+        string? customMessage = null);
 
     /// <summary>Survey reminder — single nudge for an unfinished invitation.</summary>
     EmailContent RenderSurveyReminder(string userName, string surveyTitle, string answerToken, string? culture = null);

--- a/src/Sections/Humans.Email/Views/Email/EmailPreview.cshtml
+++ b/src/Sections/Humans.Email/Views/Email/EmailPreview.cshtml
@@ -70,7 +70,7 @@
                                     <strong>Subject:</strong> @email.Subject
                                 </div>
                                 <div class="email-preview-frame p-0">
-                                    <iframe srcdoc="@WrapInEmailTemplate(email.Body)" class="w-100 border-0" style="height: 450px;"></iframe>
+                                    <iframe srcdoc="@email.Body" class="w-100 border-0" style="height: 450px;"></iframe>
                                 </div>
                             </div>
                         </div>
@@ -80,34 +80,6 @@
         </div>
     }
 </div>
-
-@functions {
-    string WrapInEmailTemplate(string content)
-    {
-        var html = $@"<!DOCTYPE html>
-<html>
-<head>
-    <meta charset=""utf-8"">
-    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
-    <style>
-        body {{ font-family: 'Source Sans 3', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #3d2b1f; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #faf6f0; }}
-        h2 {{ color: #3d2b1f; font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif; font-weight: 600; }}
-        a {{ color: #8b6914; }}
-        ul {{ padding-left: 20px; }}
-        .footer {{ margin-top: 30px; padding-top: 20px; border-top: 1px solid #c9a96e; font-size: 12px; color: #6b5a4e; }}
-    </style>
-</head>
-<body>
-{content}
-    <div class=""footer"">
-        <p>Humans &mdash; Nobodies Collective<br/>
-        <a href=""https://humans.nobodies.team"">https://humans.nobodies.team</a></p>
-    </div>
-</body>
-</html>";
-        return html;
-    }
-}
 
 <style>
     .email-preview-frame iframe {

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -158,6 +158,36 @@ internal sealed class SurveyAdminController(
         return RedirectToAction(nameof(Send), new { id });
     }
 
+    [HttpGet("Preview/{id:guid}/Email")]
+    public async Task<IActionResult> PreviewEmail(
+        Guid id,
+        [FromServices] ISurveyPreviewEmailService previewEmailService,
+        CancellationToken ct)
+    {
+        var actorId = GetCurrentUserId();
+        if (actorId is null) return Forbid();
+
+        try
+        {
+            var message = await previewEmailService.PreviewForUserAsync(id, actorId.Value, ct);
+            return View("EmailPreview", new SurveyEmailPreviewViewModel
+            {
+                SurveyId = id,
+                Recipient = message.RecipientEmail,
+                Subject = message.Subject,
+                HtmlBody = message.HtmlBody,
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning(
+                "Survey email preview rejected for survey {SurveyId}, user {UserId}: {Reason}",
+                id, actorId, ex.Message);
+            SetError(ex.Message);
+            return RedirectToAction(nameof(Edit), new { id });
+        }
+    }
+
     [HttpPost("Save")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Save(SurveyBuilderViewModel model, string? submitAction, CancellationToken ct)

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyConfiguration.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyConfiguration.cs
@@ -14,6 +14,8 @@ internal sealed class SurveyConfiguration : IEntityTypeConfiguration<Survey>
         SurveyJson.LocalizedText(b, s => s.Title);
         SurveyJson.LocalizedText(b, s => s.Intro);
         SurveyJson.LocalizedText(b, s => s.ThankYou);
+        SurveyJson.LocalizedText(b, s => s.InvitationEmailSubject);
+        SurveyJson.LocalizedText(b, s => s.InvitationEmailMessage);
 
         b.Property(s => s.DefaultCulture).HasMaxLength(10).IsRequired();
         b.Property(s => s.Status).HasConversion<string>().HasMaxLength(20);

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260822103412_AddSurveyInvitationEmailCopy.Designer.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260822103412_AddSurveyInvitationEmailCopy.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Surveys.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Surveys.Data.Migrations
 {
     [DbContext(typeof(SurveysDbContext))]
-    partial class SurveysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260822103412_AddSurveyInvitationEmailCopy")]
+    partial class AddSurveyInvitationEmailCopy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260822103412_AddSurveyInvitationEmailCopy.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260822103412_AddSurveyInvitationEmailCopy.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Surveys.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSurveyInvitationEmailCopy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InvitationEmailMessage",
+                table: "surveys",
+                type: "jsonb",
+                nullable: false,
+                defaultValueSql: "'{}'::jsonb");
+
+            migrationBuilder.AddColumn<string>(
+                name: "InvitationEmailSubject",
+                table: "surveys",
+                type: "jsonb",
+                nullable: false,
+                defaultValueSql: "'{}'::jsonb");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InvitationEmailMessage",
+                table: "surveys");
+
+            migrationBuilder.DropColumn(
+                name: "InvitationEmailSubject",
+                table: "surveys");
+        }
+    }
+}

--- a/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
+++ b/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
@@ -48,6 +48,8 @@ internal sealed partial class SurveyRepository(IDbContextFactory<SurveysDbContex
         existing.Title = survey.Title;
         existing.Intro = survey.Intro;
         existing.ThankYou = survey.ThankYou;
+        existing.InvitationEmailSubject = survey.InvitationEmailSubject;
+        existing.InvitationEmailMessage = survey.InvitationEmailMessage;
         existing.DefaultCulture = survey.DefaultCulture;
         existing.AllowAnonymous = survey.AllowAnonymous;
         // Status is owned by Open/Close (SetStatusAsync) — authoring updates never change it.

--- a/src/Sections/Humans.Surveys/Docs/Surveys.md
+++ b/src/Sections/Humans.Surveys/Docs/Surveys.md
@@ -11,7 +11,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 
 ## Concepts
 
-- A **Survey** is an authored questionnaire with per-culture title/intro/thank-you (`LocalizedText`), a default culture, a status lifecycle (Draft → Open → Closed), an optional open/close window, an audience, and an optional public slug. It owns an ordered graph of questions.
+- A **Survey** is an authored questionnaire with per-culture title/intro/thank-you and optional invitation email subject/message (`LocalizedText`), a default culture, a status lifecycle (Draft → Open → Closed), an optional open/close window, an audience, and an optional public slug. It owns an ordered graph of questions.
 - A **SurveyQuestion** is one prompt on a page, typed (SingleChoice, MultiChoice, ShortText, LongText, Rating, Grid), optionally required, optionally gated by a **`ShowIf` branch condition**. Choice questions own ordered **SurveyQuestionOptions** (stable machine `Value` + `LocalizedText` label). Grid questions reuse those options as columns and store localized, stable-keyed rows directly on the question.
 - A **branch condition** (`BranchCondition` + `BranchClause`, jsonb) is skip-logic: a question is visible only when its clauses (combined `All`/`Any`, operators `Is`/`IsNot`/`Answered`/`NotAnswered` over earlier questions' option values) evaluate true. Evaluated by the pure `SurveyBranchingEvaluator`.
 - A **SurveyInvitation** is the per-recipient ledger row for the invited path: one per `(SurveyId, UserId)`. It carries send/reminder funnel state (`SentAt`, `LatestEmailStatus`, `ReminderSentAt`, `Started`, `Completed`) — all flags/timestamps about *participation*, never about *answer content*.
@@ -29,6 +29,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 |----------|------|-------|
 | Id | Guid | PK |
 | Title / Intro / ThankYou | LocalizedText | jsonb (culture → text); default `'{}'::jsonb` |
+| InvitationEmailSubject / InvitationEmailMessage | LocalizedText | optional custom initial-invitation copy; jsonb default `'{}'::jsonb` means use standard localized wording |
 | DefaultCulture | string | max 10; fallback culture for resolution |
 | AllowAnonymous | bool | gates the anonymity selector and the public slug |
 | Status | SurveyStatus | string-converted; Draft / Open / Closed |
@@ -186,6 +187,11 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
   `IEmailMessageFactory.SurveyInvitation` + `IEmailService.SendAsync`. Its seven-day signed token has a
   distinct Data Protection purpose, retains the recipient's resolved culture, and redirects
   `/Survey/Answer` to the protected preview route; no `SurveyInvitation` row is created.
+- **Invitation copy is optional, localized, and plain text.** Authors may replace the initial
+  invitation subject and message, while Humans retains the greeting, survey-title heading, generated
+  answer-link button, sign-off, template key, and System routing policy. Blank custom fields preserve
+  the standard localized wording. Messages are HTML-encoded with line breaks preserved; Markdown,
+  raw HTML, author-provided links, and reminder customization are not supported.
 - **Exactly one reminder.** The 7-day reminder fires once per invitee (Open survey, `Completed == false`, `SentAt ≥ 7 days ago`, `ReminderSentAt is null`), stamping `ReminderSentAt` so it never repeats.
 - **Public responses are always Anonymous + `InputMethod=Slug`.** The slug path requires `AllowAnonymous`; reserved slugs `admin`/`answer` are rejected by the builder and 404 on the answer path.
 <!-- wheat: docs/plans/2026-06-27-post-event-app-feedback-survey.md §1.2, §3, §4 -->

--- a/src/Sections/Humans.Surveys/Docs/Surveys.md
+++ b/src/Sections/Humans.Surveys/Docs/Surveys.md
@@ -28,7 +28,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | Property | Type | Notes |
 |----------|------|-------|
 | Id | Guid | PK |
-| Title / Intro / ThankYou | LocalizedText | jsonb (culture → text); default `'{}'::jsonb` |
+| Title / Intro / ThankYou | LocalizedText | jsonb (culture → text); default `'{}'::jsonb`. Intro is raw Markdown rendered only through the shared sanitized-Markdown helper. |
 | InvitationEmailSubject / InvitationEmailMessage | LocalizedText | optional custom initial-invitation copy; jsonb default `'{}'::jsonb` means use standard localized wording |
 | DefaultCulture | string | max 10; fallback culture for resolution |
 | AllowAnonymous | bool | gates the anonymity selector and the public slug |

--- a/src/Sections/Humans.Surveys/Docs/features/survey-intro-markdown.md
+++ b/src/Sections/Humans.Surveys/Docs/features/survey-intro-markdown.md
@@ -1,0 +1,49 @@
+# Survey intro Markdown
+
+## Business context
+
+Survey authors need introductory copy that remains readable when it contains multiple paragraphs,
+emphasis, links, or lists. Previously the respondent intro rendered as a single HTML-encoded text
+run, so even authored line breaks were collapsed by the browser.
+
+## User stories and acceptance criteria
+
+- A Board or Admin authors each localized survey intro through Humans' existing Markdown editor.
+- The editor stores raw Markdown in the existing localized `Survey.Intro` value; no schema or data
+  migration is required.
+- The respondent intro and protected survey preview render through
+  `Html.SanitizedMarkdown(...)`, the same shared Markdig and HTML-sanitizer path used elsewhere in
+  Humans.
+- Ordinary line breaks are visible because the shared Markdown pipeline treats soft line breaks as
+  hard line breaks.
+- Existing plain-text introductions remain valid and render as ordinary paragraphs.
+- Unsafe HTML, including scripts, is removed before the rendered result is returned as HTML.
+- `Save + translate missing` continues to treat intro content as plain text for translation; authors
+  must review generated translations to ensure Markdown punctuation, especially links, was
+  preserved.
+
+## Existing shared pattern
+
+The feature deliberately reuses:
+
+- `<markdown-editor>` from `Humans.Base`, including its toolbar, preview, help, graceful textarea
+  fallback, CSP nonce handling, and one-time asset loading;
+- `Html.SanitizedMarkdown(...)`, which owns the Markdig pipeline and Ganss HTML sanitization;
+- `[MarkdownContent]` on the resolved `SurveyIntroViewModel.Intro` string to document the rendering
+  contract.
+
+The builder refreshes a culture's CodeMirror instance after its hidden localized editor becomes
+visible. No new Markdown renderer, sanitizer, JavaScript library, or package is introduced.
+
+## Non-goals
+
+- A separate Survey-only Markdown dialect.
+- Rich-text or WYSIWYG storage.
+- Formatting survey titles, question prompts, answer options, or thank-you copy.
+- Guaranteeing machine translation preserves Markdown without human review.
+
+## Related features
+
+- [Custom survey invitation email copy](survey-invitation-email-copy.md)
+- [Survey preview and preview email](survey-preview.md)
+- [Survey section invariants](../Surveys.md)

--- a/src/Sections/Humans.Surveys/Docs/features/survey-invitation-email-copy.md
+++ b/src/Sections/Humans.Surveys/Docs/features/survey-invitation-email-copy.md
@@ -11,10 +11,10 @@ survey title, secure answer-link button, sign-off, routing policy, and branded e
 
 ## User stories and acceptance criteria
 
-- A Board or Admin can optionally author a localized invitation email subject and plain-text message
+- A Board or Admin can optionally author a localized invitation email subject and Markdown-formatted message
   in the existing survey builder language tabs.
 - The subject is a single line of at most 200 characters per culture.
-- The message is at most 4,000 characters per culture. Line breaks are preserved.
+- The message is at most 4,000 characters per culture. Line breaks and basic Markdown formatting are preserved.
 - Blank subject or message values use the existing localized standard wording for that part.
 - Existing surveys therefore retain their current invitation output without a data backfill.
 - `Save + translate missing` treats both fields like the other localized survey content and never
@@ -26,7 +26,8 @@ survey title, secure answer-link button, sign-off, routing policy, and branded e
 - The email preview obtains its final HTML through Email's read-only preview contract, so it uses
   the same canonical branded wrapper as the outbox rather than copying email CSS into Surveys.
 - `Send preview email to me` uses the same factory and renderer inputs as a real invitation.
-- Author text is HTML-encoded. It is never interpreted as Markdown or raw HTML.
+- Author Markdown is rendered through the shared sanitized-Markdown renderer. Unsafe HTML is removed and
+  images are not included in invitation emails.
 - Reminder email copy is unchanged.
 
 ## Data model
@@ -47,12 +48,13 @@ accepts optional custom subject/message values after its existing arguments and 
 existing `survey_invitation` renderer. No new email type, transport path, template key, category, or
 service is introduced.
 
-The renderer trims custom copy, HTML-encodes the message, converts line breaks to `<br />`, and retains
-the existing generated survey URL. A blank custom value selects the standard localized resource text.
+The renderer trims custom copy, passes the message through Base's canonical sanitized-Markdown renderer
+with images disabled, and retains the existing generated survey URL. The same renderer supplies both
+preview and delivered emails. A blank custom value selects the standard localized resource text.
 
 ## Non-goals
 
-- Markdown, arbitrary links, HTML, images, attachments, or WYSIWYG editing.
+- Images, attachments, arbitrary HTML, or WYSIWYG editing.
 - Custom reminder copy.
 - Reusable template libraries, audience variants, or campaign analytics.
 - Changes to translation or deployment infrastructure.

--- a/src/Sections/Humans.Surveys/Docs/features/survey-invitation-email-copy.md
+++ b/src/Sections/Humans.Surveys/Docs/features/survey-invitation-email-copy.md
@@ -1,0 +1,64 @@
+# Custom survey invitation email copy
+
+## Business context
+
+Board and Admin survey authors need invitation emails that explain why a survey matters, particularly
+for time-sensitive operational questions such as choosing event dates. The standard invitation remains
+a useful fallback, but a fixed subject and generic sentence are not compelling enough for every survey.
+
+This feature customizes only the initial survey invitation. Humans retains ownership of the greeting,
+survey title, secure answer-link button, sign-off, routing policy, and branded email frame.
+
+## User stories and acceptance criteria
+
+- A Board or Admin can optionally author a localized invitation email subject and plain-text message
+  in the existing survey builder language tabs.
+- The subject is a single line of at most 200 characters per culture.
+- The message is at most 4,000 characters per culture. Line breaks are preserved.
+- Blank subject or message values use the existing localized standard wording for that part.
+- Existing surveys therefore retain their current invitation output without a data backfill.
+- `Save + translate missing` treats both fields like the other localized survey content and never
+  overwrites authored translations.
+- Initial invitations resolve the survey title and custom copy in the recipient's supported preferred
+  culture, with the survey default culture as fallback.
+- The shared Preview menu opens either the respondent survey preview or a side-effect-free rendered
+  email preview in a new tab.
+- The email preview obtains its final HTML through Email's read-only preview contract, so it uses
+  the same canonical branded wrapper as the outbox rather than copying email CSS into Surveys.
+- `Send preview email to me` uses the same factory and renderer inputs as a real invitation.
+- Author text is HTML-encoded. It is never interpreted as Markdown or raw HTML.
+- Reminder email copy is unchanged.
+
+## Data model
+
+`Survey` owns two additional `LocalizedText` values, each stored as a non-null `jsonb` column with an
+empty-object default:
+
+- `InvitationEmailSubject`
+- `InvitationEmailMessage`
+
+The empty-object default is the backward-compatible representation for existing surveys and means
+"use the standard localized copy."
+
+## Email contract and rendering
+
+The existing `IEmailMessageFactory.SurveyInvitation` method remains the typed cross-section seam. It
+accepts optional custom subject/message values after its existing arguments and forwards them to the
+existing `survey_invitation` renderer. No new email type, transport path, template key, category, or
+service is introduced.
+
+The renderer trims custom copy, HTML-encodes the message, converts line breaks to `<br />`, and retains
+the existing generated survey URL. A blank custom value selects the standard localized resource text.
+
+## Non-goals
+
+- Markdown, arbitrary links, HTML, images, attachments, or WYSIWYG editing.
+- Custom reminder copy.
+- Reusable template libraries, audience variants, or campaign analytics.
+- Changes to translation or deployment infrastructure.
+
+## Related features
+
+- [nobodies-collective/Humans#1110](https://github.com/nobodies-collective/Humans/issues/1110)
+- [Survey preview and preview email](survey-preview.md)
+- [Survey section invariants](../Surveys.md)

--- a/src/Sections/Humans.Surveys/Docs/features/survey-preview.md
+++ b/src/Sections/Humans.Surveys/Docs/features/survey-preview.md
@@ -19,13 +19,24 @@ risks creating misleading invitation/funnel data and makes authoring unnecessari
 - Page navigation is read-only. The final Submit button is disabled and every preview page states that
   answers and activity are not saved.
 
+### Preview the invitation email
+
+- The survey list, builder, and Send page use a shared Preview dropdown with **Preview survey** and
+  **Preview email** choices; both open in a new browser tab.
+- The email preview is side-effect-free and shows the subject and rendered invitation body for the
+  currently authenticated user's notification email and preferred culture.
+- It uses the same typed message factory, signed preview link, and Email-owned branded body composer
+  as `Send preview email to me`, including the real header, footer, and environment banner, but does
+  not enqueue an outbox message.
+
 ### Send a preview email to myself
 
 - A Board or Admin can queue a preview email from the Send page or from the preview notice shown on
   the intro, question, and thank-you pages.
 - The recipient is the currently authenticated user's canonical notification email.
-- The message uses the same localized survey-invitation template, subject, routing category, branded
-  wrapping, and outbox transport as a regular invitation.
+- The message uses the same localized survey-invitation template, authored custom subject/message
+  (or standard-copy fallbacks), routing category, branded wrapping, and outbox transport as a regular
+  invitation.
 - Its signed link preserves the recipient's resolved culture and opens the protected preview instead of
   the answering flow.
 - Sending or following a preview email creates no invitation, response, draft, reminder, completion,
@@ -39,6 +50,7 @@ All preview rendering and send actions are under the existing `BoardOrAdmin`-pro
 - `GET /Survey/Admin/Preview/{id}`
 - `GET /Survey/Admin/Preview/{id}/Page`
 - `GET /Survey/Admin/Preview/{id}/ThankYou`
+- `GET /Survey/Admin/Preview/{id}/Email`
 - `POST /Survey/Admin/Preview/{id}/Email`
 
 The regular `/Survey/Answer?t=...` entry route recognizes a distinct, seven-day Data Protection

--- a/src/Sections/Humans.Surveys/Domain/LocalizedText.cs
+++ b/src/Sections/Humans.Surveys/Domain/LocalizedText.cs
@@ -21,6 +21,14 @@ internal sealed class LocalizedText : IEquatable<LocalizedText>
         return string.Empty;
     }
 
+    /// <summary>Requested culture → default culture → "".</summary>
+    public string ResolveOptional(string culture, string defaultCulture)
+    {
+        if (_values.TryGetValue(culture, out var v) && !string.IsNullOrEmpty(v)) return v;
+        if (_values.TryGetValue(defaultCulture, out var d) && !string.IsNullOrEmpty(d)) return d;
+        return string.Empty;
+    }
+
     public bool HasCulture(string culture) => _values.TryGetValue(culture, out var v) && !string.IsNullOrEmpty(v);
 
     public bool Equals(LocalizedText? other) =>

--- a/src/Sections/Humans.Surveys/Domain/Survey.cs
+++ b/src/Sections/Humans.Surveys/Domain/Survey.cs
@@ -8,6 +8,8 @@ internal sealed class Survey
     public LocalizedText Title { get; set; } = LocalizedText.Empty;
     public LocalizedText Intro { get; set; } = LocalizedText.Empty;
     public LocalizedText ThankYou { get; set; } = LocalizedText.Empty;
+    public LocalizedText InvitationEmailSubject { get; set; } = LocalizedText.Empty;
+    public LocalizedText InvitationEmailMessage { get; set; } = LocalizedText.Empty;
     public string DefaultCulture { get; set; } = "en";
     public bool AllowAnonymous { get; set; }
     public SurveyStatus Status { get; set; } = SurveyStatus.Draft;

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -12,6 +12,15 @@ internal sealed class SurveyAdminIndexViewModel
     public IReadOnlyList<SurveySummary> Surveys { get; init; } = [];
 }
 
+/// <summary>Side-effect-free preview of the current user's survey invitation email.</summary>
+internal sealed class SurveyEmailPreviewViewModel
+{
+    public Guid SurveyId { get; init; }
+    public string Recipient { get; init; } = string.Empty;
+    public string Subject { get; init; } = string.Empty;
+    public string HtmlBody { get; init; } = string.Empty;
+}
+
 /// <summary>A team choice for the audience picker.</summary>
 internal sealed record SurveyTeamOption(Guid Id, string Name);
 
@@ -96,7 +105,8 @@ internal sealed record SurveyLocalizedFieldModel(
     string NamePrefix,
     string Label,
     IReadOnlyDictionary<string, string> Values,
-    bool Multiline = false);
+    bool Multiline = false,
+    int? MaxLength = null);
 
 /// <summary>One question card in the builder. <paramref name="Key"/> is the non-sequential indexer key (or the <c>__QKEY__</c> placeholder in the JS template).</summary>
 internal sealed record SurveyQuestionCardModel(string Key, SurveyQuestionBuilderViewModel Question);
@@ -127,6 +137,8 @@ internal sealed class SurveyBuilderViewModel
     public Dictionary<string, string> Title { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, string> Intro { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, string> ThankYou { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, string> InvitationEmailSubject { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, string> InvitationEmailMessage { get; set; } = new(StringComparer.Ordinal);
 
     public string DefaultCulture { get; set; } = CultureCatalog.DefaultCultureCode;
     public bool AllowAnonymous { get; set; }
@@ -161,6 +173,8 @@ internal sealed class SurveyBuilderViewModel
         new LocalizedText(Title),
         new LocalizedText(Intro),
         new LocalizedText(ThankYou),
+        new LocalizedText(InvitationEmailSubject),
+        new LocalizedText(InvitationEmailMessage),
         string.IsNullOrWhiteSpace(DefaultCulture) ? CultureCatalog.DefaultCultureCode : DefaultCulture,
         AllowAnonymous,
         ToInstant(OpensAt, zone),
@@ -181,6 +195,8 @@ internal sealed class SurveyBuilderViewModel
             Title = ToDict(e.Title),
             Intro = ToDict(e.Intro),
             ThankYou = ToDict(e.ThankYou),
+            InvitationEmailSubject = ToDict(e.InvitationEmailSubject),
+            InvitationEmailMessage = ToDict(e.InvitationEmailMessage),
             DefaultCulture = e.DefaultCulture,
             AllowAnonymous = e.AllowAnonymous,
             OpensAt = FromInstant(e.OpensAt, zone),

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -1,3 +1,4 @@
+using Humans.Base.Attributes;
 using Humans.Base.Extensions;
 using Humans.Surveys.Services;
 using Humans.Surveys.Domain;
@@ -35,6 +36,7 @@ internal sealed class SurveyIntroViewModel
 {
     public string Token { get; init; } = string.Empty;
     public string Title { get; init; } = string.Empty;
+    [MarkdownContent]
     public string Intro { get; init; } = string.Empty;
 
     /// <summary>The currently-selected language; the form posts it back so the wizard runs in it.</summary>
@@ -106,7 +108,8 @@ internal sealed record SurveyLocalizedFieldModel(
     string Label,
     IReadOnlyDictionary<string, string> Values,
     bool Multiline = false,
-    int? MaxLength = null);
+    int? MaxLength = null,
+    bool Markdown = false);
 
 /// <summary>One question card in the builder. <paramref name="Key"/> is the non-sequential indexer key (or the <c>__QKEY__</c> placeholder in the JS template).</summary>
 internal sealed record SurveyQuestionCardModel(string Key, SurveyQuestionBuilderViewModel Question);

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -32,8 +32,8 @@ internal interface ISurveyService : IApplicationService
     Task UpdateAsync(Guid surveyId, SurveyEditInput input, Guid actorUserId, CancellationToken ct = default);
 
     /// <summary>
-    /// Machine-translates the survey's authored content (title, intro, thank-you, prompts, help,
-    /// rating/option/Grid-row labels) from its default culture into every <paramref name="targetCultures"/>
+    /// Machine-translates the survey's authored content (title, intro, thank-you, invitation copy,
+    /// prompts, help, rating/option/Grid-row labels) from its default culture into every <paramref name="targetCultures"/>
     /// entry that is still blank — existing text is never overwritten (spec §6.1: pre-fill, then the
     /// author reviews). Returns the number of fields filled; 0 means nothing was missing.
     /// </summary>
@@ -152,6 +152,8 @@ internal sealed record SurveyEditInput(
     LocalizedText Title,
     LocalizedText Intro,
     LocalizedText ThankYou,
+    LocalizedText InvitationEmailSubject,
+    LocalizedText InvitationEmailMessage,
     string DefaultCulture,
     bool AllowAnonymous,
     Instant? OpensAt,

--- a/src/Sections/Humans.Surveys/Services/SurveyPreviewEmailService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyPreviewEmailService.cs
@@ -7,6 +7,7 @@ namespace Humans.Surveys.Services;
 
 internal interface ISurveyPreviewEmailService : IOrchestrator
 {
+    Task<RenderedEmailPreview> PreviewForUserAsync(Guid surveyId, Guid userId, CancellationToken ct = default);
     Task<string> SendToUserAsync(Guid surveyId, Guid userId, CancellationToken ct = default);
 }
 
@@ -20,26 +21,22 @@ internal sealed class SurveyPreviewEmailService(
     IUserServiceRead userService,
     IEmailService emailService,
     IEmailMessageFactory emailMessages,
+    IEmailPreviewServiceRead emailPreviews,
     SurveyPreviewTokenProvider previewTokens,
     ILogger<SurveyPreviewEmailService> logger) : ISurveyPreviewEmailService
 {
+    public async Task<RenderedEmailPreview> PreviewForUserAsync(
+        Guid surveyId,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        var message = await BuildForUserAsync(surveyId, userId, ct);
+        return emailPreviews.RenderSystemMessage(message);
+    }
+
     public async Task<string> SendToUserAsync(Guid surveyId, Guid userId, CancellationToken ct = default)
     {
-        var detail = await surveyService.GetForEditAsync(surveyId, ct)
-            ?? throw new InvalidOperationException("Survey not found.");
-        var survey = detail.Editable;
-        var emails = await userEmailService.GetNotificationTargetEmailsAsync([userId], ct);
-        if (!emails.TryGetValue(userId, out var email))
-            throw new InvalidOperationException("Your account has no notification email.");
-
-        var user = await userService.GetUserInfoAsync(userId, ct);
-        var name = user?.BurnerName ?? string.Empty;
-        var culture = user?.PreferredLanguage.IsSupportedCultureCode() == true
-            ? user.PreferredLanguage
-            : survey.DefaultCulture;
-        var title = survey.Title.Resolve(survey.DefaultCulture, survey.DefaultCulture);
-        var token = previewTokens.Create(surveyId, culture);
-        var message = emailMessages.SurveyInvitation(email, name, title, token, culture);
+        var message = await BuildForUserAsync(surveyId, userId, ct);
 
         try
         {
@@ -57,6 +54,31 @@ internal sealed class SurveyPreviewEmailService(
         logger.LogInformation(
             "Survey {SurveyId} preview email queued for requesting user {UserId}",
             surveyId, userId);
-        return email;
+        return message.RecipientEmail;
+    }
+
+    private async Task<EmailMessage> BuildForUserAsync(
+        Guid surveyId,
+        Guid userId,
+        CancellationToken ct)
+    {
+        var detail = await surveyService.GetForEditAsync(surveyId, ct)
+            ?? throw new InvalidOperationException("Survey not found.");
+        var survey = detail.Editable;
+        var emails = await userEmailService.GetNotificationTargetEmailsAsync([userId], ct);
+        if (!emails.TryGetValue(userId, out var email))
+            throw new InvalidOperationException("Your account has no notification email.");
+
+        var user = await userService.GetUserInfoAsync(userId, ct);
+        var name = user?.BurnerName ?? string.Empty;
+        var culture = user?.PreferredLanguage.IsSupportedCultureCode() == true
+            ? user.PreferredLanguage
+            : survey.DefaultCulture;
+        var title = survey.Title.Resolve(culture, survey.DefaultCulture);
+        var customSubject = survey.InvitationEmailSubject.Resolve(culture, survey.DefaultCulture);
+        var customMessage = survey.InvitationEmailMessage.Resolve(culture, survey.DefaultCulture);
+        var token = previewTokens.Create(surveyId, culture);
+        return emailMessages.SurveyInvitation(
+            email, name, title, token, culture, customSubject, customMessage);
     }
 }

--- a/src/Sections/Humans.Surveys/Services/SurveyPreviewEmailService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyPreviewEmailService.cs
@@ -75,8 +75,8 @@ internal sealed class SurveyPreviewEmailService(
             ? user.PreferredLanguage
             : survey.DefaultCulture;
         var title = survey.Title.Resolve(culture, survey.DefaultCulture);
-        var customSubject = survey.InvitationEmailSubject.Resolve(culture, survey.DefaultCulture);
-        var customMessage = survey.InvitationEmailMessage.Resolve(culture, survey.DefaultCulture);
+        var customSubject = survey.InvitationEmailSubject.ResolveOptional(culture, survey.DefaultCulture);
+        var customMessage = survey.InvitationEmailMessage.ResolveOptional(culture, survey.DefaultCulture);
         var token = previewTokens.Create(surveyId, culture);
         return emailMessages.SurveyInvitation(
             email, name, title, token, culture, customSubject, customMessage);

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -320,8 +320,8 @@ internal sealed class SurveyService(
                 : survey.DefaultCulture;
             var name = user?.BurnerName ?? string.Empty;
             var title = survey.Title.Resolve(culture, survey.DefaultCulture);
-            var customSubject = survey.InvitationEmailSubject.Resolve(culture, survey.DefaultCulture);
-            var customMessage = survey.InvitationEmailMessage.Resolve(culture, survey.DefaultCulture);
+            var customSubject = survey.InvitationEmailSubject.ResolveOptional(culture, survey.DefaultCulture);
+            var customMessage = survey.InvitationEmailMessage.ResolveOptional(culture, survey.DefaultCulture);
             var token = tokenProvider.Create(inv.Id);
             var msg = emailMessages.SurveyInvitation(
                 email, name, title, token, culture, customSubject, customMessage);

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -36,6 +36,9 @@ internal sealed class SurveyService(
     ISurveyInviteTokenProvider tokenProvider,
     IGoogleTranslationService translation) : ISurveyService, ISurveyReminderSender, IUserDataContributor
 {
+    private const int InvitationEmailSubjectMaxLength = 200;
+    private const int InvitationEmailMessageMaxLength = 4000;
+
     public async Task<IReadOnlyList<SurveySummary>> GetSummariesAsync(CancellationToken ct = default)
     {
         var surveys = await repo.GetAllSummariesAsync(ct);
@@ -56,7 +59,8 @@ internal sealed class SurveyService(
         if (s is null) return null;
 
         var input = new SurveyEditInput(
-            s.Title, s.Intro, s.ThankYou, s.DefaultCulture, s.AllowAnonymous, s.OpensAt, s.ClosesAt,
+            s.Title, s.Intro, s.ThankYou, s.InvitationEmailSubject, s.InvitationEmailMessage,
+            s.DefaultCulture, s.AllowAnonymous, s.OpensAt, s.ClosesAt,
             s.AudienceType, s.AudienceTeamId, s.AudienceLoggedInSince, s.PublicSlug,
             ToQuestionInputs(s));
 
@@ -67,6 +71,9 @@ internal sealed class SurveyService(
     {
         ValidateAudienceConfiguration(
             input.AudienceType, input.AudienceTeamId, input.AudienceLoggedInSince, requireAudience: false);
+        var invitationEmailSubject = NormalizeLocalizedText(input.InvitationEmailSubject);
+        var invitationEmailMessage = NormalizeLocalizedText(input.InvitationEmailMessage);
+        ValidateInvitationEmailCopy(invitationEmailSubject, invitationEmailMessage);
         var now = clock.GetCurrentInstant();
         var surveyId = Guid.NewGuid();
         var questions = MapQuestions(surveyId, input);
@@ -79,6 +86,8 @@ internal sealed class SurveyService(
             Title = input.Title,
             Intro = input.Intro,
             ThankYou = input.ThankYou,
+            InvitationEmailSubject = invitationEmailSubject,
+            InvitationEmailMessage = invitationEmailMessage,
             DefaultCulture = input.DefaultCulture,
             AllowAnonymous = input.AllowAnonymous,
             Status = SurveyStatus.Draft,
@@ -105,6 +114,9 @@ internal sealed class SurveyService(
     {
         ValidateAudienceConfiguration(
             input.AudienceType, input.AudienceTeamId, input.AudienceLoggedInSince, requireAudience: false);
+        var invitationEmailSubject = NormalizeLocalizedText(input.InvitationEmailSubject);
+        var invitationEmailMessage = NormalizeLocalizedText(input.InvitationEmailMessage);
+        ValidateInvitationEmailCopy(invitationEmailSubject, invitationEmailMessage);
         var now = clock.GetCurrentInstant();
         var questions = MapQuestions(surveyId, input);
         ValidateQuestionConfiguration(questions);
@@ -116,6 +128,8 @@ internal sealed class SurveyService(
             Title = input.Title,
             Intro = input.Intro,
             ThankYou = input.ThankYou,
+            InvitationEmailSubject = invitationEmailSubject,
+            InvitationEmailMessage = invitationEmailMessage,
             DefaultCulture = input.DefaultCulture,
             AllowAnonymous = input.AllowAnonymous,
             OpensAt = input.OpensAt,
@@ -144,6 +158,8 @@ internal sealed class SurveyService(
         var title = Copy(e.Title);
         var intro = Copy(e.Intro);
         var thankYou = Copy(e.ThankYou);
+        var invitationEmailSubject = Copy(e.InvitationEmailSubject);
+        var invitationEmailMessage = Copy(e.InvitationEmailMessage);
         var questions = e.Questions.Select(q => new
         {
             Question = q,
@@ -155,7 +171,14 @@ internal sealed class SurveyService(
             GridRows = (q.GridRows ?? []).Select(row => new { Row = row, Label = Copy(row.Label) }).ToList(),
         }).ToList();
 
-        var allTexts = new List<Dictionary<string, string>> { title, intro, thankYou };
+        var allTexts = new List<Dictionary<string, string>>
+        {
+            title,
+            intro,
+            thankYou,
+            invitationEmailSubject,
+            invitationEmailMessage,
+        };
         foreach (var q in questions)
         {
             allTexts.AddRange([q.Prompt, q.Help, q.MinLabel, q.MaxLabel]);
@@ -184,6 +207,7 @@ internal sealed class SurveyService(
 
         var input = new SurveyEditInput(
             new LocalizedText(title), new LocalizedText(intro), new LocalizedText(thankYou),
+            new LocalizedText(invitationEmailSubject), new LocalizedText(invitationEmailMessage),
             e.DefaultCulture, e.AllowAnonymous, e.OpensAt, e.ClosesAt,
             e.AudienceType, e.AudienceTeamId, e.AudienceLoggedInSince, e.PublicSlug,
             questions.Select(q => q.Question with
@@ -264,8 +288,6 @@ internal sealed class SurveyService(
 
         var emails = await userEmailService.GetNotificationTargetEmailsAsync(netNew, ct);
         var users = await userService.GetUserInfosAsync(netNew, ct);
-        var title = survey.Title.Resolve(survey.DefaultCulture, survey.DefaultCulture);
-
         var invitationsCreated = 0;
         var emailsQueued = 0;
         var failed = 0;
@@ -292,10 +314,17 @@ internal sealed class SurveyService(
             await repo.AddInvitationAndSaveAsync(inv, ct);
             invitationsCreated++;
 
-            var culture = users.TryGetValue(userId, out var user) ? user.PreferredLanguage : survey.DefaultCulture;
+            var preferredCulture = users.TryGetValue(userId, out var user) ? user.PreferredLanguage : null;
+            var culture = preferredCulture.IsSupportedCultureCode()
+                ? preferredCulture!
+                : survey.DefaultCulture;
             var name = user?.BurnerName ?? string.Empty;
+            var title = survey.Title.Resolve(culture, survey.DefaultCulture);
+            var customSubject = survey.InvitationEmailSubject.Resolve(culture, survey.DefaultCulture);
+            var customMessage = survey.InvitationEmailMessage.Resolve(culture, survey.DefaultCulture);
             var token = tokenProvider.Create(inv.Id);
-            var msg = emailMessages.SurveyInvitation(email, name, title, token, culture);
+            var msg = emailMessages.SurveyInvitation(
+                email, name, title, token, culture, customSubject, customMessage);
 
             try
             {
@@ -1351,6 +1380,45 @@ internal sealed class SurveyService(
         if (type == SurveyAudienceType.LoggedInSince && loggedInSince is null)
             return "A cutoff date is required for the Logged in since audience.";
         return null;
+    }
+
+    private static LocalizedText NormalizeLocalizedText(LocalizedText text)
+        => new(text.Values.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value?.Trim() ?? string.Empty,
+            StringComparer.OrdinalIgnoreCase));
+
+    private static void ValidateInvitationEmailCopy(
+        LocalizedText subject,
+        LocalizedText message)
+    {
+        var multilineSubject = subject.Values.FirstOrDefault(
+            pair => pair.Value.Contains('\r', StringComparison.Ordinal)
+                    || pair.Value.Contains('\n', StringComparison.Ordinal));
+        if (!string.IsNullOrEmpty(multilineSubject.Key))
+        {
+            throw new InvalidOperationException(
+                $"Survey invitation email subjects must be a single line ({multilineSubject.Key}).");
+        }
+
+        ValidateLocalizedLength(
+            subject,
+            InvitationEmailSubjectMaxLength,
+            "Survey invitation email subjects");
+        ValidateLocalizedLength(
+            message,
+            InvitationEmailMessageMaxLength,
+            "Survey invitation email messages");
+
+        static void ValidateLocalizedLength(LocalizedText text, int maxLength, string description)
+        {
+            var offender = text.Values.FirstOrDefault(pair => pair.Value.Length > maxLength);
+            if (!string.IsNullOrEmpty(offender.Key))
+            {
+                throw new InvalidOperationException(
+                    $"{description} must be {maxLength} characters or fewer ({offender.Key}).");
+            }
+        }
     }
 
     /// <summary>Maps builder input to tracked entities, assigning new ids where the input id is null.</summary>

--- a/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
@@ -21,8 +21,6 @@
             <p class="form-text mt-0 mb-2">@q.HelpText</p>
         }
 
-        <input type="hidden" name="Answers[@i].QuestionId" value="@q.Id" />
-
         @switch (q.Type)
         {
             case SurveyQuestionType.SingleChoice:
@@ -130,6 +128,12 @@
                 break;
             }
         }
+
+        @* Keep this after the visible answer control. Bootstrap floats legend and applies
+           `legend + * { clear: left }`; an invisible input in that position prevents the
+           first checkbox/radio/table from clearing the legend. Field order does not affect
+           MVC's indexed answer binding. *@
+        <input type="hidden" name="Answers[@i].QuestionId" value="@q.Id" />
 
         @if (hasError)
         {

--- a/src/Sections/Humans.Surveys/Views/Survey/Intro.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Survey/Intro.cshtml
@@ -28,7 +28,7 @@
 
                 @if (!string.IsNullOrWhiteSpace(Model.Intro))
                 {
-                    <div class="mb-4">@Model.Intro</div>
+                    <div class="mb-4 survey-intro">@Html.SanitizedMarkdown(Model.Intro)</div>
                 }
 
                 @{

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -29,10 +29,7 @@
     @if (!Model.IsNew)
     {
         <div class="d-flex align-items-center gap-2">
-            <a asp-controller="SurveyAdmin" asp-action="Preview" asp-route-id="@Model.Id"
-               class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
-                <i class="fa-solid fa-eye me-1"></i>Preview
-            </a>
+            <partial name="_SurveyPreviewMenu" model="@Model.Id!.Value" />
             <span class="badge @(Model.Status == SurveyStatus.Open ? "bg-success" : Model.Status == SurveyStatus.Closed ? "bg-secondary" : "bg-warning text-dark")">@Model.Status</span>
             @if (Model.Status != SurveyStatus.Open)
             {
@@ -144,6 +141,20 @@
                     <input type="text" asp-for="PublicSlug" class="form-control form-control-sm" placeholder="e.g. feedback-2026" />
                 </div>
             </div>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-header py-2"><strong>Invitation email</strong></div>
+        <div class="card-body">
+            <p class="small text-muted mb-2">
+                Customize the initial invitation. Humans adds the greeting, survey title, survey-link button,
+                and sign-off. Leave either field blank to use the standard wording.
+            </p>
+            <partial name="_SurveyLocalizedField"
+                     model="@(new SurveyLocalizedFieldModel(nameof(Model.InvitationEmailSubject), "Email subject", Model.InvitationEmailSubject, MaxLength: 200))" />
+            <partial name="_SurveyLocalizedField"
+                     model="@(new SurveyLocalizedFieldModel(nameof(Model.InvitationEmailMessage), "Email message", Model.InvitationEmailMessage, Multiline: true, MaxLength: 4000))" />
         </div>
     </div>
 

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -78,7 +78,7 @@
         <div class="card-header py-2"><strong>Survey</strong></div>
         <div class="card-body">
             <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel(nameof(Model.Title), "Title", Model.Title))" />
-            <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel(nameof(Model.Intro), "Intro", Model.Intro, Multiline: true))" />
+            <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel(nameof(Model.Intro), "Intro", Model.Intro, Multiline: true, Markdown: true))" />
             <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel(nameof(Model.ThankYou), "Thank-you", Model.ThankYou, Multiline: true))" />
 
             <div class="row g-3 mt-1">
@@ -211,6 +211,14 @@
                 });
             }
 
+            function refreshVisibleMarkdownEditors() {
+                requestAnimationFrame(() => {
+                    document.querySelectorAll(
+                        '.survey-culture-field[data-culture="' + activeCulture + '"] .CodeMirror'
+                    ).forEach(el => el.CodeMirror?.refresh());
+                });
+            }
+
             function cultureInput(group, culture) {
                 return group.querySelector('.survey-culture-field[data-culture="' + culture + '"] input, ' +
                                            '.survey-culture-field[data-culture="' + culture + '"] textarea');
@@ -241,6 +249,7 @@
                     t.classList.toggle('btn-outline-secondary', t !== tab);
                 });
                 applyCulture();
+                refreshVisibleMarkdownEditors();
                 updateMissingBadges();
             }));
 

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -149,12 +149,13 @@
         <div class="card-body">
             <p class="small text-muted mb-2">
                 Customize the initial invitation. Humans adds the greeting, survey title, survey-link button,
-                and sign-off. Leave either field blank to use the standard wording.
+                and sign-off. The message supports Markdown formatting, but not images. Leave either field
+                blank to use the standard wording.
             </p>
             <partial name="_SurveyLocalizedField"
                      model="@(new SurveyLocalizedFieldModel(nameof(Model.InvitationEmailSubject), "Email subject", Model.InvitationEmailSubject, MaxLength: 200))" />
             <partial name="_SurveyLocalizedField"
-                     model="@(new SurveyLocalizedFieldModel(nameof(Model.InvitationEmailMessage), "Email message", Model.InvitationEmailMessage, Multiline: true, MaxLength: 4000))" />
+                     model="@(new SurveyLocalizedFieldModel(nameof(Model.InvitationEmailMessage), "Email message", Model.InvitationEmailMessage, Multiline: true, Markdown: true, MaxLength: 4000))" />
         </div>
     </div>
 

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/EmailPreview.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/EmailPreview.cshtml
@@ -1,0 +1,37 @@
+@model SurveyEmailPreviewViewModel
+
+@{
+    ViewData["Title"] = "Survey email preview";
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-controller="SurveyAdmin" asp-action="Index">Surveys</a></li>
+        <li class="breadcrumb-item"><a asp-controller="SurveyAdmin" asp-action="Edit" asp-route-id="@Model.SurveyId">Edit survey</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Email preview</li>
+    </ol>
+</nav>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Survey email preview</h1>
+    <span class="badge bg-secondary">Preview only</span>
+</div>
+
+<p class="text-muted">
+    This is the invitation that would be sent to the currently logged-in user.
+</p>
+
+<div class="card">
+    <div class="card-header small">
+        <div><strong>To:</strong> @Model.Recipient</div>
+        <div><strong>Subject:</strong> @Model.Subject</div>
+    </div>
+    <div class="card-body p-0">
+        <iframe srcdoc="@Model.HtmlBody"
+                title="Survey invitation email preview"
+                class="w-100 border-0"
+                style="height: 600px;"
+                sandbox></iframe>
+    </div>
+</div>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
@@ -57,8 +57,7 @@
                         <td class="text-end">@s.ResponseCount</td>
                         <td class="text-end">@(s.InvitedCount > 0 ? $"{rate}%" : "—")</td>
                         <td class="text-end">
-                            <a asp-controller="SurveyAdmin" asp-action="Preview" asp-route-id="@s.Id"
-                               class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">Preview</a>
+                            <partial name="_SurveyPreviewMenu" model="@s.Id" />
                             <a asp-controller="SurveyAdmin" asp-action="Edit" asp-route-id="@s.Id" class="btn btn-outline-primary btn-sm">Edit</a>
                             <a asp-controller="SurveyAdmin" asp-action="Send" asp-route-id="@s.Id" class="btn btn-outline-secondary btn-sm">Send</a>
                             <a asp-controller="SurveyAdmin" asp-action="Results" asp-route-id="@s.Id" class="btn btn-outline-secondary btn-sm">Results</a>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
@@ -47,10 +47,7 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">@(string.IsNullOrWhiteSpace(Model.Title) ? "(untitled)" : Model.Title)</h1>
     <div class="d-flex align-items-center gap-2">
-        <a asp-controller="SurveyAdmin" asp-action="Preview" asp-route-id="@Model.Id"
-           class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
-            <i class="fa-solid fa-eye me-1"></i>Preview survey
-        </a>
+        <partial name="_SurveyPreviewMenu" model="@Model.Id" />
         <form asp-controller="SurveyAdmin" asp-action="SendPreviewEmail" asp-route-id="@Model.Id" method="post" class="d-inline">
             @Html.AntiForgeryToken()
             <button type="submit" class="btn btn-outline-primary btn-sm">

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyLocalizedField.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyLocalizedField.cshtml
@@ -12,17 +12,29 @@
     {
         var name = $"{Model.NamePrefix}[{culture}]";
         Model.Values.TryGetValue(culture, out var value);
-        <div class="survey-culture-field input-group input-group-sm mb-1" data-culture="@culture"
-             style="@(culture == active ? "" : "display:none")">
-            <span class="input-group-text" style="min-width:3.5rem;">@culture.ToDisplayLanguageName()</span>
-            @if (Model.Multiline)
-            {
-                <textarea name="@name" class="form-control" rows="2" maxlength="@Model.MaxLength">@value</textarea>
-            }
-            else
-            {
-                <input type="text" name="@name" class="form-control" value="@value" maxlength="@Model.MaxLength" />
-            }
-        </div>
+        @if (Model.Markdown)
+        {
+            <div class="survey-culture-field mb-2" data-culture="@culture"
+                 style="@(culture == active ? "" : "display:none")">
+                <div class="small text-muted mb-1">@culture.ToDisplayLanguageName()</div>
+                <markdown-editor name="@name" value="@value" rows="4"
+                                 maxlength="@(Model.MaxLength ?? 0)" />
+            </div>
+        }
+        else
+        {
+            <div class="survey-culture-field input-group input-group-sm mb-1" data-culture="@culture"
+                 style="@(culture == active ? "" : "display:none")">
+                <span class="input-group-text" style="min-width:3.5rem;">@culture.ToDisplayLanguageName()</span>
+                @if (Model.Multiline)
+                {
+                    <textarea name="@name" class="form-control" rows="2" maxlength="@Model.MaxLength">@value</textarea>
+                }
+                else
+                {
+                    <input type="text" name="@name" class="form-control" value="@value" maxlength="@Model.MaxLength" />
+                }
+            </div>
+        }
     }
 </div>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyLocalizedField.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyLocalizedField.cshtml
@@ -17,11 +17,11 @@
             <span class="input-group-text" style="min-width:3.5rem;">@culture.ToDisplayLanguageName()</span>
             @if (Model.Multiline)
             {
-                <textarea name="@name" class="form-control" rows="2">@value</textarea>
+                <textarea name="@name" class="form-control" rows="2" maxlength="@Model.MaxLength">@value</textarea>
             }
             else
             {
-                <input type="text" name="@name" class="form-control" value="@value" />
+                <input type="text" name="@name" class="form-control" value="@value" maxlength="@Model.MaxLength" />
             }
         </div>
     }

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyPreviewMenu.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyPreviewMenu.cshtml
@@ -1,0 +1,22 @@
+@model Guid
+
+<div class="dropdown d-inline-block">
+    <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button"
+            data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="fa-solid fa-eye me-1"></i>Preview
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end">
+        <li>
+            <a asp-controller="SurveyAdmin" asp-action="Preview" asp-route-id="@Model"
+               class="dropdown-item" target="_blank" rel="noopener">
+                <i class="fa-solid fa-list-check fa-fw me-1"></i>Preview survey
+            </a>
+        </li>
+        <li>
+            <a asp-controller="SurveyAdmin" asp-action="PreviewEmail" asp-route-id="@Model"
+               class="dropdown-item" target="_blank" rel="noopener">
+                <i class="fa-solid fa-envelope fa-fw me-1"></i>Preview email
+            </a>
+        </li>
+    </ul>
+</div>

--- a/tests/Humans.Base.Tests/Extensions/SanitizedMarkdownRendererTests.cs
+++ b/tests/Humans.Base.Tests/Extensions/SanitizedMarkdownRendererTests.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+using Humans.Base.Extensions;
+
+namespace Humans.Base.Tests.Extensions;
+
+public sealed class SanitizedMarkdownRendererTests
+{
+    [HumansFact]
+    public void Render_returns_empty_for_blank_markdown()
+    {
+        SanitizedMarkdownRenderer.Render(" ").Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void Render_preserves_markdown_and_removes_unsafe_html()
+    {
+        var html = SanitizedMarkdownRenderer.Render(
+            "**Important**\n\n- First\n- Second\n\n<script>alert('x')</script>");
+
+        html.Should().Contain("<strong>Important</strong>");
+        html.Should().Contain("<li>First</li>");
+        html.Should().NotContain("<script>");
+    }
+
+    [HumansFact]
+    public void Render_can_remove_images_for_email_content()
+    {
+        var html = SanitizedMarkdownRenderer.Render(
+            "Before ![poster](https://example.com/poster.png) after",
+            allowImages: false);
+
+        html.Should().NotContain("<img");
+        html.Should().NotContain("poster.png");
+    }
+}

--- a/tests/Humans.Email.Tests/Services/EmailMessageFactoryTests.cs
+++ b/tests/Humans.Email.Tests/Services/EmailMessageFactoryTests.cs
@@ -82,6 +82,29 @@ public sealed class EmailMessageFactoryTests
     }
 
     [HumansFact]
+    public void SurveyInvitation_forwards_custom_copy_and_preserves_policy()
+    {
+        var msg = _factory.SurveyInvitation(
+            "a@x.com",
+            "Alice",
+            "Availability",
+            "token",
+            "fr",
+            "Choose a date",
+            "Tell us what works.");
+
+        msg.TemplateName.Should().Be("survey_invitation");
+        msg.Category.Should().Be(MessageCategory.System);
+        _renderer.Received(1).RenderSurveyInvitation(
+            "Alice",
+            "Availability",
+            "token",
+            "fr",
+            "Choose a date",
+            "Tell us what works.");
+    }
+
+    [HumansFact]
     public void FacilitatedMessage_WithContactInfo_SetsReplyToSender()
     {
         var msg = _factory.FacilitatedMessage(

--- a/tests/Humans.Email.Tests/Services/EmailPreviewServiceTests.cs
+++ b/tests/Humans.Email.Tests/Services/EmailPreviewServiceTests.cs
@@ -1,0 +1,43 @@
+using AwesomeAssertions;
+using Humans.Email.Contracts;
+using Humans.Email.Services;
+using Humans.Users.Contracts;
+using NSubstitute;
+
+namespace Humans.Email.Tests.Services;
+
+public sealed class EmailPreviewServiceTests
+{
+    [HumansFact]
+    public void RenderSystemMessage_uses_the_canonical_body_composer()
+    {
+        var composer = Substitute.For<IEmailBodyComposer>();
+        composer.Compose("<p>Invitation</p>").Returns(("<html>Branded invitation</html>", "Invitation"));
+        var sut = new EmailPreviewService(composer);
+        var message = new EmailMessage(
+            "tester@example.com", "Tester", "Survey subject", "<p>Invitation</p>",
+            "survey_invitation", MessageCategory.System);
+
+        var preview = sut.RenderSystemMessage(message);
+
+        preview.Should().Be(new RenderedEmailPreview(
+            "tester@example.com", "Survey subject", "<html>Branded invitation</html>"));
+        composer.Received(1).Compose("<p>Invitation</p>");
+    }
+
+    [HumansFact]
+    public void RenderSystemMessage_rejects_opt_outable_messages()
+    {
+        var composer = Substitute.For<IEmailBodyComposer>();
+        var sut = new EmailPreviewService(composer);
+        var message = new EmailMessage(
+            "tester@example.com", "Tester", "Team update", "<p>Update</p>",
+            "added_to_team", MessageCategory.TeamUpdates);
+
+        var action = () => sut.RenderSystemMessage(message);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*recipient-specific send policy*");
+        composer.DidNotReceive().Compose(Arg.Any<string>(), Arg.Any<string?>());
+    }
+}

--- a/tests/Humans.Email.Tests/Services/EmailRendererTests.cs
+++ b/tests/Humans.Email.Tests/Services/EmailRendererTests.cs
@@ -11,7 +11,7 @@ namespace Humans.Email.Tests.Services;
 public sealed class EmailRendererTests
 {
     [HumansFact]
-    public void SurveyInvitation_custom_copy_is_trimmed_encoded_and_preserves_line_breaks()
+    public void SurveyInvitation_custom_copy_renders_sanitized_markdown_without_images()
     {
         var renderer = CreateRenderer();
 
@@ -21,14 +21,18 @@ public sealed class EmailRendererTests
             "token + value",
             "en",
             "  Help choose our dates  ",
-            "  First line\r\n<script>alert('x')</script>\nLast line  ");
+            "  **Choose carefully.**\r\n\r\n- Friday\r\n- Saturday\r\n\r\n[Details](https://example.com)\r\n\r\n![Poster](https://example.com/poster.png)\r\n<script>alert('x')</script>  ");
 
         content.Subject.Should().Be("Help choose our dates");
         content.HtmlBody.Should().Contain("Daniel &lt;Admin&gt;");
         content.HtmlBody.Should().Contain("<h2>Dates &amp; places</h2>");
-        content.HtmlBody.Should().Contain(
-            "<p>First line<br />&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;<br />Last line</p>");
+        content.HtmlBody.Should().Contain("<p><strong>Choose carefully.</strong></p>");
+        content.HtmlBody.Should().Contain("<ul>");
+        content.HtmlBody.Should().Contain("<li>Friday</li>");
+        content.HtmlBody.Should().Contain("<a href=\"https://example.com\">Details</a>");
         content.HtmlBody.Should().NotContain("<script>");
+        content.HtmlBody.Should().NotContain("<img");
+        content.HtmlBody.Should().NotContain("poster.png");
         content.HtmlBody.Should().Contain(
             "https://humans.example/Survey/Answer?t=token%20%2B%20value");
     }

--- a/tests/Humans.Email.Tests/Services/EmailRendererTests.cs
+++ b/tests/Humans.Email.Tests/Services/EmailRendererTests.cs
@@ -1,0 +1,70 @@
+using AwesomeAssertions;
+using Humans.Base.Configuration;
+using Humans.Email.Services;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Humans.Email.Tests.Services;
+
+public sealed class EmailRendererTests
+{
+    [HumansFact]
+    public void SurveyInvitation_custom_copy_is_trimmed_encoded_and_preserves_line_breaks()
+    {
+        var renderer = CreateRenderer();
+
+        var content = renderer.RenderSurveyInvitation(
+            "Daniel <Admin>",
+            "Dates & places",
+            "token + value",
+            "en",
+            "  Help choose our dates  ",
+            "  First line\r\n<script>alert('x')</script>\nLast line  ");
+
+        content.Subject.Should().Be("Help choose our dates");
+        content.HtmlBody.Should().Contain("Daniel &lt;Admin&gt;");
+        content.HtmlBody.Should().Contain("<h2>Dates &amp; places</h2>");
+        content.HtmlBody.Should().Contain(
+            "<p>First line<br />&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;<br />Last line</p>");
+        content.HtmlBody.Should().NotContain("<script>");
+        content.HtmlBody.Should().Contain(
+            "https://humans.example/Survey/Answer?t=token%20%2B%20value");
+    }
+
+    [HumansFact]
+    public void SurveyInvitation_blank_custom_copy_retains_standard_localized_wording()
+    {
+        var renderer = CreateRenderer();
+
+        var content = renderer.RenderSurveyInvitation(
+            "Daniel", "Test Survey", "token", "en", " ", null);
+
+        content.Subject.Should().Be("Please complete: Test Survey");
+        content.HtmlBody.Should().Contain(
+            "<p>You're invited to complete <strong>Test Survey</strong>.</p>");
+    }
+
+    private static EmailRenderer CreateRenderer()
+    {
+        var strings = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Email_SurveyInvitation_Subject"] = "Please complete: {0}",
+            ["Email_SurveyInvitation_DefaultMessage"] = "You're invited to complete <strong>{0}</strong>.",
+            ["Email_SurveyInvitation_Body"] =
+                "<h2>{1}</h2><p>Hi {0},</p>{3}<p><a href=\"{2}\">Open the survey</a></p>",
+        };
+        var localizer = Substitute.For<IStringLocalizer<EmailResource>>();
+        localizer[Arg.Any<string>()].Returns(call =>
+        {
+            var key = call.Arg<string>();
+            return new LocalizedString(key, strings.GetValueOrDefault(key, key));
+        });
+
+        return new EmailRenderer(
+            Options.Create(new EmailSettings { BaseUrl = "https://humans.example" }),
+            localizer,
+            NullLogger<EmailRenderer>.Instance);
+    }
+}

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -371,6 +371,56 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
             .And.Contain("culture=fr");
     }
 
+    [HumansFact(Timeout = 60000)]
+    public async Task Preview_question_controls_clear_the_legend_before_hidden_binding_fields()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var token = await GetCreateTokenAsync();
+
+        var saveResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", token),
+            ("Title[en]", $"Preview controls {Guid.NewGuid():N}"),
+            ("Questions.Index", "choices"),
+            ("Questions[choices].Id", Guid.NewGuid().ToString()),
+            ("Questions[choices].PageNumber", "1"),
+            ("Questions[choices].Type", nameof(SurveyQuestionType.MultiChoice)),
+            ("Questions[choices].Prompt[en]", "Choose days"),
+            ("Questions[choices].Options.Index", "friday"),
+            ("Questions[choices].Options[friday].Value", "friday"),
+            ("Questions[choices].Options[friday].Label[en]", "Friday"),
+            ("Questions.Index", "grid"),
+            ("Questions[grid].Id", Guid.NewGuid().ToString()),
+            ("Questions[grid].PageNumber", "1"),
+            ("Questions[grid].Type", nameof(SurveyQuestionType.Grid)),
+            ("Questions[grid].Prompt[en]", "Choose times"),
+            ("Questions[grid].GridSelectionMode", nameof(GridSelectionMode.Multiple)),
+            ("Questions[grid].Options.Index", "morning"),
+            ("Questions[grid].Options[morning].Value", "morning"),
+            ("Questions[grid].Options[morning].Label[en]", "Morning"),
+            ("Questions[grid].GridRows.Index", "saturday"),
+            ("Questions[grid].GridRows[saturday].Value", "saturday"),
+            ("Questions[grid].GridRows[saturday].Label[en]", "Saturday")), ct);
+        var surveyId = ExtractSurveyId(saveResp);
+
+        var preview = await Client.GetAsync($"/Survey/Admin/Preview/{surveyId}/Page?page=1", ct);
+        preview.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await preview.Content.ReadAsStringAsync(ct);
+
+        var firstCheckbox = html.IndexOf("id=\"q0_friday\"", StringComparison.Ordinal);
+        var choiceBindingField = html.IndexOf("name=\"Answers[0].QuestionId\"", StringComparison.Ordinal);
+        firstCheckbox.Should().BeGreaterThan(-1);
+        choiceBindingField.Should().BeGreaterThan(firstCheckbox,
+            because: "the first visible choice must immediately follow and clear Bootstrap's floated legend");
+
+        var gridTable = html.IndexOf("class=\"table table-sm align-middle survey-grid", StringComparison.Ordinal);
+        var gridBindingField = html.IndexOf("name=\"Answers[1].QuestionId\"", StringComparison.Ordinal);
+        gridTable.Should().BeGreaterThan(-1);
+        gridBindingField.Should().BeGreaterThan(gridTable,
+            because: "the visible Grid table must clear the legend before the hidden binding field");
+        html.Should().Contain("Morning").And.Contain("Saturday");
+    }
+
     private async Task<string> GetCreateTokenAsync()
     {
         var createResp = await Client.GetAsync(

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -130,6 +130,40 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
     }
 
     [HumansFact(Timeout = 60000)]
+    public async Task Save_updates_invitation_email_copy_on_an_existing_survey()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var createToken = await GetCreateTokenAsync();
+
+        var createResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", createToken),
+            ("Title[en]", $"Invitation update {Guid.NewGuid():N}"),
+            ("InvitationEmailSubject[en]", "Initial subject"),
+            ("InvitationEmailMessage[en]", "Initial message")), ct);
+        var surveyId = ExtractSurveyId(createResp);
+
+        var editResp = await Client.GetAsync($"/Survey/Admin/Edit/{surveyId}", ct);
+        var editToken = ExtractAntiForgeryToken(await editResp.Content.ReadAsStringAsync(ct));
+        var updateResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", editToken!),
+            ("Id", surveyId.ToString()),
+            ("Title[en]", "Invitation update"),
+            ("InvitationEmailSubject[en]", "Choose our weekend"),
+            ("InvitationEmailMessage[en]", "**Tell us what works.**")), ct);
+
+        ((int)updateResp.StatusCode).Should().BeOneOf(
+            (int)HttpStatusCode.Found, (int)HttpStatusCode.Redirect);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
+        var survey = await db.Surveys.AsNoTracking()
+            .SingleAsync(candidate => candidate.Id == surveyId, ct);
+        survey.InvitationEmailSubject.Resolve("en", "en").Should().Be("Choose our weekend");
+        survey.InvitationEmailMessage.Resolve("en", "en").Should().Be("**Tell us what works.**");
+    }
+
+    [HumansFact(Timeout = 60000)]
     public async Task Save_binds_and_persists_grid_rows_columns_and_selection_mode()
     {
         await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);

--- a/tests/Humans.Integration.Tests/Controllers/SurveyPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyPageRenderTests.cs
@@ -57,6 +57,24 @@ public class SurveyPageRenderTests(HumansTestDatabase database) : IntegrationTes
     }
 
     [HumansFact(Timeout = 60000)]
+    public async Task Public_survey_intro_renders_sanitized_markdown_and_preserves_line_breaks()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var slug = $"render-test-{Guid.NewGuid():N}";
+        await SeedOpenPublicSurveyAsync(
+            slug,
+            ct,
+            intro: "First line\nSecond line\n\n**Important**\n\n<script>alert('unsafe')</script>");
+
+        var html = await (await Client.GetAsync($"/Survey/{slug}", ct))
+            .Content.ReadAsStringAsync(ct);
+
+        html.Should().Contain("First line<br>");
+        html.Should().Contain("<strong>Important</strong>");
+        html.Should().NotContain("alert('unsafe')");
+    }
+
+    [HumansFact(Timeout = 60000)]
     public async Task Closed_survey_renders_the_closed_page_rather_than_the_wizard()
     {
         var ct = Xunit.TestContext.Current.CancellationToken;
@@ -120,8 +138,28 @@ public class SurveyPageRenderTests(HumansTestDatabase database) : IntegrationTes
         }
     }
 
+    [HumansFact(Timeout = 60000)]
+    public async Task Admin_survey_builder_renders_the_shared_markdown_editor_for_intro()
+    {
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var slug = $"render-test-{Guid.NewGuid():N}";
+        var surveyId = await SeedOpenPublicSurveyAsync(slug, ct);
+
+        var html = await (await Client.GetAsync($"/Survey/Admin/Edit/{surveyId}", ct))
+            .Content.ReadAsStringAsync(ct);
+
+        html.Should().Contain("name=\"Intro[en]\"");
+        html.Should().Contain("easymde@2.21.0");
+        html.Should().Contain("new EasyMDE");
+        html.Should().NotContain("<markdown-editor");
+    }
+
     private async Task<Guid> SeedOpenPublicSurveyAsync(
-        string slug, CancellationToken ct, SurveyStatus status = SurveyStatus.Open)
+        string slug,
+        CancellationToken ct,
+        SurveyStatus status = SurveyStatus.Open,
+        string intro = "Intro copy")
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
@@ -130,7 +168,7 @@ public class SurveyPageRenderTests(HumansTestDatabase database) : IntegrationTes
         {
             Id = Guid.NewGuid(),
             Title = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = "Render test survey" }),
-            Intro = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = "Intro copy" }),
+            Intro = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = intro }),
             ThankYou = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = "Thanks" }),
             DefaultCulture = "en",
             AllowAnonymous = true,

--- a/tests/Humans.Integration.Tests/Controllers/SurveyPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyPageRenderTests.cs
@@ -139,7 +139,7 @@ public class SurveyPageRenderTests(HumansTestDatabase database) : IntegrationTes
     }
 
     [HumansFact(Timeout = 60000)]
-    public async Task Admin_survey_builder_renders_the_shared_markdown_editor_for_intro()
+    public async Task Admin_survey_builder_renders_the_shared_markdown_editor_for_intro_and_email_message()
     {
         var ct = Xunit.TestContext.Current.CancellationToken;
         await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
@@ -150,6 +150,7 @@ public class SurveyPageRenderTests(HumansTestDatabase database) : IntegrationTes
             .Content.ReadAsStringAsync(ct);
 
         html.Should().Contain("name=\"Intro[en]\"");
+        html.Should().Contain("name=\"InvitationEmailMessage[en]\"");
         html.Should().Contain("easymde@2.21.0");
         html.Should().Contain("new EasyMDE");
         html.Should().NotContain("<markdown-editor");

--- a/tests/Humans.Surveys.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Surveys.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -97,6 +97,8 @@ public sealed class SurveyAdminControllerTests
             Text("Team survey"),
             LocalizedText.Empty,
             LocalizedText.Empty,
+            LocalizedText.Empty,
+            LocalizedText.Empty,
             "en",
             false,
             null,
@@ -158,6 +160,8 @@ public sealed class SurveyAdminControllerTests
         new(
             Text(title),
             string.IsNullOrEmpty(intro) ? LocalizedText.Empty : Text(intro),
+            LocalizedText.Empty,
+            LocalizedText.Empty,
             LocalizedText.Empty,
             "en",
             allowAnonymous,

--- a/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
+++ b/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
@@ -59,7 +59,9 @@ public class SurveysApiControllerTests
         var id = Guid.NewGuid();
         var qId = Guid.NewGuid();
         var editable = new SurveyEditInput(
-            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty, "en", false, null, null, null, null, null, null,
+            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty,
+            LocalizedText.Empty, LocalizedText.Empty,
+            "en", false, null, null, null, null, null, null,
             [
                 new QuestionInput(qId, 1, 0, SurveyQuestionType.SingleChoice, Text("Pick one"), LocalizedText.Empty,
                     true, null, null, LocalizedText.Empty, LocalizedText.Empty, null,
@@ -85,7 +87,9 @@ public class SurveysApiControllerTests
         var id = Guid.NewGuid();
         var questionId = Guid.NewGuid();
         var editable = new SurveyEditInput(
-            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty, "en", false, null, null, null, null, null, null,
+            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty,
+            LocalizedText.Empty, LocalizedText.Empty,
+            "en", false, null, null, null, null, null, null,
             [
                 new QuestionInput(
                     questionId, 1, 0, SurveyQuestionType.Grid, Text("Availability"), LocalizedText.Empty,

--- a/tests/Humans.Surveys.Tests/Domain/LocalizedTextTests.cs
+++ b/tests/Humans.Surveys.Tests/Domain/LocalizedTextTests.cs
@@ -22,6 +22,19 @@ public class LocalizedTextTests
     }
 
     [HumansFact]
+    public void ResolveOptional_does_not_fall_back_to_an_unrelated_culture()
+    {
+        var t = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = string.Empty,
+            ["es"] = "Hola",
+        });
+
+        t.ResolveOptional("fr", "en").Should().BeEmpty();
+        t.ResolveOptional("es", "en").Should().Be("Hola");
+    }
+
+    [HumansFact]
     public void Empty_resolves_to_empty_string_and_equality_is_by_value()
     {
         LocalizedText.Empty.Resolve("en", "en").Should().BeEmpty();

--- a/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
@@ -9,6 +9,38 @@ namespace Humans.Surveys.Tests.Models;
 public sealed class SurveyBuilderViewModelTests
 {
     [HumansFact]
+    public void Invitation_email_copy_round_trips_through_the_builder()
+    {
+        var detail = new SurveyDetail(
+            Guid.NewGuid(),
+            SurveyStatus.Draft,
+            new SurveyEditInput(
+                L("Survey"),
+                LocalizedText.Empty,
+                LocalizedText.Empty,
+                L("Choose a date"),
+                L("Tell us what works."),
+                "en",
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                []));
+
+        var vm = SurveyBuilderViewModel.FromDetail(
+            detail, [], NodaTime.DateTimeZone.Utc);
+        var roundTripped = vm.ToEditInput(NodaTime.DateTimeZone.Utc);
+
+        roundTripped.InvitationEmailSubject.Resolve("en", "en")
+            .Should().Be("Choose a date");
+        roundTripped.InvitationEmailMessage.Resolve("en", "en")
+            .Should().Be("Tell us what works.");
+    }
+
+    [HumansFact]
     public void ToInput_maps_clause_rows_to_a_branch_condition()
     {
         var gate = Guid.NewGuid();

--- a/tests/Humans.Surveys.Tests/Services/SurveyPreviewEmailServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyPreviewEmailServiceTests.cs
@@ -13,6 +13,58 @@ namespace Humans.Surveys.Tests.Services;
 public sealed class SurveyPreviewEmailServiceTests
 {
     [HumansFact]
+    public async Task PreviewForUserAsync_returns_the_rendered_message_without_sending_it()
+    {
+        var surveyId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var surveys = Substitute.For<ISurveyService>();
+        var userEmails = Substitute.For<IUserEmailService>();
+        var users = Substitute.For<IUserServiceRead>();
+        var emailService = Substitute.For<IEmailService>();
+        var messages = Substitute.For<IEmailMessageFactory>();
+        var emailPreviews = Substitute.For<IEmailPreviewServiceRead>();
+        var previewTokens = new SurveyPreviewTokenProvider(
+            DataProtectionProvider.Create("survey-preview-page-tests"));
+        var editable = new SurveyEditInput(
+            Text("Volunteer survey"), LocalizedText.Empty, LocalizedText.Empty,
+            Text("Choose our gathering dates"), Text("Tell us which weekends work for you."),
+            "en",
+            false, null, null, null, null, null, null, []);
+        surveys.GetForEditAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(new SurveyDetail(surveyId, SurveyStatus.Draft, editable));
+        userEmails.GetNotificationTargetEmailsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string> { [userId] = "tester@example.com" });
+        users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new UserInfo(
+                userId, "Tester", false, "en", null, Instant.FromUnixTimeSeconds(0),
+                null, null, null, null, null, false, null, false, null, null, null,
+                null, null, null, [], [], [], null, []));
+        var rendered = new EmailMessage(
+            "tester@example.com", "Tester", "Choose our gathering dates",
+            "<h2>Volunteer survey</h2><p>Tell us which weekends work for you.</p>",
+            "survey_invitation", MessageCategory.System);
+        messages.SurveyInvitation(
+                "tester@example.com", "Tester", "Volunteer survey", Arg.Any<string>(), "en",
+                "Choose our gathering dates", "Tell us which weekends work for you.")
+            .Returns(rendered);
+        var wrapped = new RenderedEmailPreview(
+            "tester@example.com", "Choose our gathering dates", "<html>Branded preview</html>");
+        emailPreviews.RenderSystemMessage(rendered).Returns(wrapped);
+        var sut = new SurveyPreviewEmailService(
+            surveys, userEmails, users, emailService, messages, emailPreviews, previewTokens,
+            NullLogger<SurveyPreviewEmailService>.Instance);
+
+        var preview = await sut.PreviewForUserAsync(
+            surveyId, userId, Xunit.TestContext.Current.CancellationToken);
+
+        preview.Should().Be(wrapped);
+        emailPreviews.Received(1).RenderSystemMessage(rendered);
+        await emailService.DidNotReceive().SendAsync(
+            Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task SendToUserAsync_uses_invitation_template_without_creating_an_invitation()
     {
         var surveyId = Guid.NewGuid();
@@ -22,10 +74,13 @@ public sealed class SurveyPreviewEmailServiceTests
         var users = Substitute.For<IUserServiceRead>();
         var emailService = Substitute.For<IEmailService>();
         var messages = Substitute.For<IEmailMessageFactory>();
+        var emailPreviews = Substitute.For<IEmailPreviewServiceRead>();
         var previewTokens = new SurveyPreviewTokenProvider(
             DataProtectionProvider.Create("survey-preview-email-tests"));
         var editable = new SurveyEditInput(
-            Text("Volunteer survey"), LocalizedText.Empty, LocalizedText.Empty, "en",
+            Text("Volunteer survey"), LocalizedText.Empty, LocalizedText.Empty,
+            Text("Choose our gathering dates"), Text("Tell us which weekends work for you."),
+            "en",
             false, null, null, null, null, null, null, []);
         surveys.GetForEditAsync(surveyId, Arg.Any<CancellationToken>())
             .Returns(new SurveyDetail(surveyId, SurveyStatus.Draft, editable));
@@ -47,7 +102,9 @@ public sealed class SurveyPreviewEmailServiceTests
                 "Tester",
                 "Volunteer survey",
                 Arg.Do<string>(token => capturedToken = token),
-                "fr")
+                "fr",
+                "Choose our gathering dates",
+                "Tell us which weekends work for you.")
             .Returns(rendered);
         var sut = new SurveyPreviewEmailService(
             surveys,
@@ -55,6 +112,7 @@ public sealed class SurveyPreviewEmailServiceTests
             users,
             emailService,
             messages,
+            emailPreviews,
             previewTokens,
             NullLogger<SurveyPreviewEmailService>.Instance);
 

--- a/tests/Humans.Surveys.Tests/Services/SurveyPreviewEmailServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyPreviewEmailServiceTests.cs
@@ -131,6 +131,65 @@ public sealed class SurveyPreviewEmailServiceTests
             Arg.Any<IReadOnlyList<SurveyAnswerInput>>(), Arg.Any<CancellationToken>());
     }
 
+    [HumansFact]
+    public async Task PreviewForUserAsync_leaves_optional_copy_blank_when_only_an_unrelated_culture_exists()
+    {
+        var surveyId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var surveys = Substitute.For<ISurveyService>();
+        var userEmails = Substitute.For<IUserEmailService>();
+        var users = Substitute.For<IUserServiceRead>();
+        var emailService = Substitute.For<IEmailService>();
+        var messages = Substitute.For<IEmailMessageFactory>();
+        var emailPreviews = Substitute.For<IEmailPreviewServiceRead>();
+        var previewTokens = new SurveyPreviewTokenProvider(
+            DataProtectionProvider.Create("survey-preview-language-fallback-tests"));
+        var spanishOnlySubject = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = string.Empty,
+            ["es"] = "Elige una fecha",
+        });
+        var spanishOnlyMessage = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = string.Empty,
+            ["es"] = "Dinos qué te conviene.",
+        });
+        var editable = new SurveyEditInput(
+            Text("Volunteer survey"), LocalizedText.Empty, LocalizedText.Empty,
+            spanishOnlySubject, spanishOnlyMessage, "en",
+            false, null, null, null, null, null, null, []);
+        surveys.GetForEditAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(new SurveyDetail(surveyId, SurveyStatus.Draft, editable));
+        userEmails.GetNotificationTargetEmailsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string> { [userId] = "tester@example.com" });
+        users.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new UserInfo(
+                userId, "Tester", false, "fr", null, Instant.FromUnixTimeSeconds(0),
+                null, null, null, null, null, false, null, false, null, null, null,
+                null, null, null, [], [], [], null, []));
+        var rendered = new EmailMessage(
+            "tester@example.com", "Tester", "Standard French subject", "<p>Standard French body</p>",
+            "survey_invitation", MessageCategory.System);
+        messages.SurveyInvitation(
+                "tester@example.com", "Tester", "Volunteer survey", Arg.Any<string>(), "fr",
+                string.Empty, string.Empty)
+            .Returns(rendered);
+        emailPreviews.RenderSystemMessage(rendered)
+            .Returns(new RenderedEmailPreview(
+                "tester@example.com", rendered.Subject, rendered.HtmlBody));
+        var sut = new SurveyPreviewEmailService(
+            surveys, userEmails, users, emailService, messages, emailPreviews, previewTokens,
+            NullLogger<SurveyPreviewEmailService>.Instance);
+
+        await sut.PreviewForUserAsync(
+            surveyId, userId, Xunit.TestContext.Current.CancellationToken);
+
+        messages.Received(1).SurveyInvitation(
+            "tester@example.com", "Tester", "Volunteer survey", Arg.Any<string>(), "fr",
+            string.Empty, string.Empty);
+    }
+
     private static LocalizedText Text(string en) =>
         new(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = en });
 }

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -796,6 +796,51 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task SendInvitesAsync_leaves_optional_copy_blank_when_only_an_unrelated_culture_exists()
+    {
+        var teamId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Open, SurveyAudienceType.Team, teamId);
+        survey.InvitationEmailSubject = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = string.Empty,
+            ["es"] = "Elige una fecha",
+        });
+        survey.InvitationEmailMessage = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = string.Empty,
+            ["es"] = "Dinos qué te conviene.",
+        });
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _teamService.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(TeamWith(teamId, userId));
+        _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns(new HashSet<Guid>());
+        _userEmailService.GetNotificationTargetEmailsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string> { [userId] = "human@example.org" });
+        _userService.GetUserInfosAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo>
+                {
+                    [userId] = UserInfoWithName(userId, "Étincelle", "fr"),
+                }));
+
+        await CreateService().SendInvitesAsync(
+            survey.Id, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        _emailMessages.Received(1).SurveyInvitation(
+            "human@example.org",
+            "Étincelle",
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            "fr",
+            string.Empty,
+            string.Empty);
+    }
+
+    [HumansFact]
     public async Task SendInvitesAsync_marks_failed_when_email_send_throws()
     {
         var teamId = Guid.NewGuid();

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -62,7 +62,10 @@ public class SurveyServiceTests
             rows ?? [new GridRowInput("monday", L("Monday")), new GridRowInput("tuesday", L("Tuesday"))]);
 
     private static SurveyEditInput Input(params QuestionInput[] qs) =>
-        new(L("Title"), L("Intro"), L("Thanks"), "en", false, null, null, null, null, null, null, qs.ToList());
+        new(
+            L("Title"), L("Intro"), L("Thanks"),
+            LocalizedText.Empty, LocalizedText.Empty,
+            "en", false, null, null, null, null, null, null, qs.ToList());
 
     [HumansFact]
     public async Task CreateAsync_persists_draft_with_questions_options_and_creator()
@@ -90,6 +93,59 @@ public class SurveyServiceTests
         q1.Options.Should().OnlyContain(o => o.QuestionId == q1.Id);
 
         await _audit.Received(1).LogAsync(AuditAction.SurveyCreated, "Survey", id, Arg.Any<string>(), actor);
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_persists_trimmed_invitation_email_copy()
+    {
+        Survey? captured = null;
+        _repo.When(r => r.AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>()))
+             .Do(ci => captured = ci.Arg<Survey>());
+        var input = Input() with
+        {
+            InvitationEmailSubject = L("  Help choose our dates  "),
+            InvitationEmailMessage = L("  Tell us what works.  "),
+        };
+
+        await CreateService().CreateAsync(
+            input, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        captured!.InvitationEmailSubject.Resolve("en", "en").Should().Be("Help choose our dates");
+        captured.InvitationEmailMessage.Resolve("en", "en").Should().Be("Tell us what works.");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_multiline_or_overlong_invitation_subjects()
+    {
+        var multiline = Input() with { InvitationEmailSubject = L("First\nSecond") };
+        var overlong = Input() with { InvitationEmailSubject = L(new string('x', 201)) };
+
+        var multilineAct = async () => await CreateService().CreateAsync(
+            multiline, Guid.NewGuid(), TestContext.Current.CancellationToken);
+        var overlongAct = async () => await CreateService().CreateAsync(
+            overlong, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await multilineAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*single line*");
+        await overlongAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*200 characters or fewer*");
+        await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_rejects_overlong_invitation_messages()
+    {
+        var input = Input() with
+        {
+            InvitationEmailMessage = L(new string('x', 4001)),
+        };
+
+        var act = async () => await CreateService().CreateAsync(
+            input, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*4000 characters or fewer*");
+        await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -243,11 +299,17 @@ public class SurveyServiceTests
     }
 
     private static SurveyEditInput InputWithSlug(string? slug) =>
-        new(L("Title"), L("Intro"), L("Thanks"), "en", true, null, null, null, null, null, slug, []);
+        new(
+            L("Title"), L("Intro"), L("Thanks"),
+            LocalizedText.Empty, LocalizedText.Empty,
+            "en", true, null, null, null, null, null, slug, []);
 
     private static SurveyEditInput InputWithAudience(
         SurveyAudienceType audience, Guid? teamId = null, Instant? loggedInSince = null) =>
-        new(L("Title"), L("Intro"), L("Thanks"), "en", false, null, null,
+        new(
+            L("Title"), L("Intro"), L("Thanks"),
+            LocalizedText.Empty, LocalizedText.Empty,
+            "en", false, null, null,
             audience, teamId, loggedInSince, null, []);
 
     [HumansTheory]
@@ -334,7 +396,11 @@ public class SurveyServiceTests
             new List<OptionInput> { Opt("yes", "Yes", 1) });
         var q2 = new QuestionInput(q2Id, 1, 2, SurveyQuestionType.SingleChoice, L("Q2"), LocalizedText.Empty, false, null, null,
             LocalizedText.Empty, LocalizedText.Empty, null, new List<OptionInput> { Opt("yes", "Yes", 1) });
-        var input = new SurveyEditInput(L("T"), L("I"), L("Ty"), "en", false, null, null, null, null, null, null, new List<QuestionInput> { q1, q2 });
+        var input = new SurveyEditInput(
+            L("T"), L("I"), L("Ty"),
+            LocalizedText.Empty, LocalizedText.Empty,
+            "en", false, null, null, null, null, null, null,
+            new List<QuestionInput> { q1, q2 });
 
         var act = async () => await CreateService().UpdateAsync(Guid.NewGuid(), input, Guid.NewGuid(), TestContext.Current.CancellationToken);
 
@@ -470,6 +536,26 @@ public class SurveyServiceTests
         await _repo.DidNotReceive().UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
         await _translation.DidNotReceive().TranslateAsync(
             Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task PreFillTranslationsAsync_includes_invitation_subject_and_message()
+    {
+        var survey = SurveyWith(SurveyStatus.Draft, null, null);
+        survey.InvitationEmailSubject = L("Choose a date");
+        survey.InvitationEmailMessage = L("Tell us what works.");
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        Survey? captured = null;
+        _repo.When(r => r.UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>()))
+             .Do(ci => captured = ci.Arg<Survey>());
+        StubTranslationAsMarker();
+
+        var filled = await CreateService().PreFillTranslationsAsync(
+            survey.Id, ["en", "fr"], Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        filled.Should().Be(3); // title + invitation subject + invitation message
+        captured!.InvitationEmailSubject.Values["fr"].Should().Be("fr:Choose a date");
+        captured.InvitationEmailMessage.Values["fr"].Should().Be("fr:Tell us what works.");
     }
 
     // ── Invitations ──────────────────────────────────────────────────────────
@@ -657,6 +743,56 @@ public class SurveyServiceTests
         await _repo.DidNotReceive().AddInvitationAndSaveAsync(Arg.Is<SurveyInvitation>(i => i.UserId == a), Arg.Any<CancellationToken>());
         await _emailService.Received(2).SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>());
         await _audit.Received(1).LogAsync(AuditAction.SurveyInvitesSent, "Survey", survey.Id, Arg.Any<string>(), Arg.Any<Guid>());
+    }
+
+    [HumansFact]
+    public async Task SendInvitesAsync_resolves_title_and_custom_copy_in_each_recipient_culture()
+    {
+        var teamId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Open, SurveyAudienceType.Team, teamId);
+        survey.Title = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = "Availability",
+            ["fr"] = "Disponibilités",
+        });
+        survey.InvitationEmailSubject = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = "Choose a date",
+            ["fr"] = "Choisissez une date",
+        });
+        survey.InvitationEmailMessage = new LocalizedText(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["en"] = "Tell us what works.",
+            ["fr"] = "Dites-nous ce qui vous convient.",
+        });
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _teamService.GetTeamAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(TeamWith(teamId, userId));
+        _repo.GetInvitedUserIdsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns(new HashSet<Guid>());
+        _userEmailService.GetNotificationTargetEmailsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string> { [userId] = "human@example.org" });
+        _userService.GetUserInfosAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo>
+                {
+                    [userId] = UserInfoWithName(userId, "Étincelle", "fr"),
+                }));
+
+        await CreateService().SendInvitesAsync(
+            survey.Id, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        _emailMessages.Received(1).SurveyInvitation(
+            "human@example.org",
+            "Étincelle",
+            "Disponibilités",
+            Arg.Any<string>(),
+            "fr",
+            "Choisissez une date",
+            "Dites-nous ce qui vous convient.");
     }
 
     [HumansFact]
@@ -894,8 +1030,8 @@ public class SurveyServiceTests
         rows.Single(r => r.UserId == unknown).Name.Should().Be(unknown.ToString());
     }
 
-    private static UserInfo UserInfoWithName(Guid id, string burnerName) => new(
-        id, burnerName, false, "en", null, Instant.MinValue, null, null, null, null, null,
+    private static UserInfo UserInfoWithName(Guid id, string burnerName, string culture = "en") => new(
+        id, burnerName, false, culture, null, Instant.MinValue, null, null, null, null, null,
         false, null, false, null, null, null, null, null, null,
         [], [], [], null, []);
 


### PR DESCRIPTION
## What

Adds localized, customizable survey invitation subjects and Markdown messages, with a canonical branded email preview alongside the existing survey preview. Also renders survey intro copy through the existing sanitized Markdown path and fixes two preview/edit regressions found during local browser testing.

Closes nobodies-collective/Humans#1110

## Why

Survey invitations currently use fixed generic copy, which makes event-date and other time-sensitive surveys less compelling and harder to verify before sending. Authors need focused control over the subject/message without introducing a general template system or bypassing Humans' existing email rendering and safety paths.

Daniel approved the product scope, and Peter explicitly approved the implementation—including the Markdown addition—in nobodies-collective/Humans#1110 on August 22, 2026.

## Existing surface checked

- Reuses Survey `LocalizedText`, culture tabs, translation-prefill flow, and existing JSONB mapping.
- Extends the existing typed `IEmailMessageFactory.SurveyInvitation` contract rather than adding a parallel sending path.
- Reuses Email's canonical branded body composer through a narrow read-only preview contract; the Email gallery now uses the same composer too.
- Reuses the existing `<markdown-editor>` authoring pattern and sanitized Markdown renderer. Images and unsafe HTML are removed.
- Reuses the existing survey preview menu and preview-only request flow.

## UI changes / screenshots

- Survey builder gains localized **Email subject** and **Email message** fields.
- **Preview** is a dropdown with **Preview survey** and **Preview email**, both opening in a new tab.
- Survey intro and invitation message fields support the app's existing Markdown authoring experience.
- Manually browser-tested locally with an existing survey and a synthetic Grid survey, including save/reload, preview rendering, fallback copy, first-choice checkbox alignment, and Grid visibility.

## Checklist

- [x] **Section labeled** — issue carries `section:surveys` and `section:email`; this PR carries the matching QA-fork labels.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork). No direct commits to `main`.
- [x] **Branched off `origin/main`** — branch is based on current `peterdrier/Humans:main` (`04126b4af`; locally named `qa/main`).
- [x] **Issue refs are qualified** (`nobodies-collective/Humans#1110`).
- [x] **EF migrations** are auto-generated, not hand-edited. No data backfill is required; existing surveys retain fallback copy.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No.
- [x] **Reuse-first checked** — the read-only Email preview seam removes duplicated branded-wrapper markup instead of creating a third copy.
- [x] **Build + test pass locally**: solution build passed with 0 warnings/errors; complete locale-normalized solution tests passed serially. Integration: 308 passed, 1 skipped; Surveys: 171 passed; Email: 70 passed; Base: 161 passed.
- [x] **Nav coverage** — both previews are reachable from the survey builder/index controls; no orphan page.
- [x] **No magic strings** — existing constants/typed contracts used where applicable.
- [x] **Dates/times via NodaTime**, icons via Font Awesome 6 — no new date/time behavior; existing FA icons used.

## Reviewer notes

- The migration adds two optional localized JSONB columns. Because QA preview databases are cloned when a PR first opens, please test against the fresh PR environment rather than an older preview database.
- Initial invitation custom copy resolves using recipient culture with survey-default fallback. Blank fields preserve the old localized wording. Reminder copy is unchanged.
- The preview and actual initial invitation share the same message factory/renderer path; preview performs no enqueue/send.
- The last two commits are regression fixes discovered through real controller/browser testing: invitation copy now persists on edit, and preview answer controls no longer let Bootstrap's `legend + *` rule displace the first checkbox or hide a Grid table.
