### PR TITLE
Surveys: add information blocks with labelled image tabs

### DIFF
--- a/src/Humans.Base/TagHelpers/MarkdownEditorTagHelper.cs
+++ b/src/Humans.Base/TagHelpers/MarkdownEditorTagHelper.cs
@@ -153,6 +153,7 @@ public class MarkdownEditorTagHelper(
         // Force class/rows/optional attributes onto the textarea regardless of asp-for shape.
         textarea.Attributes["class"] = cssClasses;
         textarea.Attributes["rows"] = Rows.ToString(CultureInfo.InvariantCulture);
+        textarea.Attributes["data-humans-markdown-editor"] = "true";
         if (Required)
         {
             textarea.Attributes["required"] = "required";
@@ -204,27 +205,28 @@ public class MarkdownEditorTagHelper(
             output.Content.AppendHtml(
                 $"<style{styleNonceAttr}>.editor-toolbar{{white-space:nowrap;overflow-x:auto;overflow-y:hidden;}}</style>");
 
-            // Render the help modal partial once per request so callers don't have to.
-            ((IViewContextAware)htmlHelper).Contextualize(ViewContext);
-            var modalHtml = await htmlHelper.PartialAsync("_MarkdownHelp");
-            using var modalWriter = new StringWriter(CultureInfo.InvariantCulture);
-            modalHtml.WriteTo(modalWriter, HtmlEncoder.Default);
-            output.Content.AppendHtml(modalWriter.ToString());
-        }
-
-        // Encode the textarea id for use inside a JS string literal.
-        var jsIdLiteral = JavaScriptEncoder.Default.Encode(uniqueId);
-
-        // Inline init script — defers EasyMDE construction until the asset script has loaded.
-        // We stamp the CSP nonce directly because this <script> is emitted as raw HTML via
-        // AppendHtml and never re-parsed by NonceTagHelper.
-        var initScript = $@"<script{nonceAttr}>
+            // Expose one shared initializer so client-side templates can upgrade Markdown
+            // textareas after inserting them into the DOM. Scripts contained inside HTML
+            // assigned through innerHTML do not execute, so per-element inline scripts alone
+            // are not sufficient for dynamic forms such as the survey builder.
+            output.Content.AppendHtml($@"<script{nonceAttr}>
 (function() {{
-    function initMde() {{
-        if (typeof EasyMDE === 'undefined') {{ return false; }}
-        var el = document.getElementById('{jsIdLiteral}');
-        if (!el || el.dataset.mdeInitialized === 'true') {{ return true; }}
-        el.dataset.mdeInitialized = 'true';
+    function editorElements(root) {{
+        if (!root) {{ return []; }}
+        var elements = [];
+        if (root.matches && root.matches('textarea[data-humans-markdown-editor=""true""]')) {{
+            elements.push(root);
+        }}
+        if (root.querySelectorAll) {{
+            elements.push.apply(
+                elements,
+                root.querySelectorAll('textarea[data-humans-markdown-editor=""true""]'));
+        }}
+        return elements;
+    }}
+
+    function createEditor(el) {{
+        if (!el || el.dataset.mdeInitialized === 'true') {{ return; }}
         try {{
             new EasyMDE({{
                 element: el,
@@ -255,10 +257,50 @@ public class MarkdownEditorTagHelper(
                     }}, className: 'fa-solid fa-circle-question', title: 'Markdown help' }}
                 ]
             }});
+            el.dataset.mdeInitialized = 'true';
         }} catch (e) {{
             // Leave the bare textarea in place on failure.
             console.warn('EasyMDE initialization failed', e);
         }}
+    }}
+
+    function init(root) {{
+        var attempts = 0;
+        function tryInit() {{
+            attempts++;
+            if (typeof EasyMDE === 'undefined') {{
+                if (attempts <= 50) {{ setTimeout(tryInit, 100); }}
+                return;
+            }}
+            editorElements(root || document).forEach(createEditor);
+        }}
+        tryInit();
+    }}
+
+    window.HumansMarkdownEditor = {{ init: init }};
+}})();
+</script>");
+
+            // Render the help modal partial once per request so callers don't have to.
+            ((IViewContextAware)htmlHelper).Contextualize(ViewContext);
+            var modalHtml = await htmlHelper.PartialAsync("_MarkdownHelp");
+            using var modalWriter = new StringWriter(CultureInfo.InvariantCulture);
+            modalHtml.WriteTo(modalWriter, HtmlEncoder.Default);
+            output.Content.AppendHtml(modalWriter.ToString());
+        }
+
+        // Encode the textarea id for use inside a JS string literal.
+        var jsIdLiteral = JavaScriptEncoder.Default.Encode(uniqueId);
+
+        // Inline init script for server-rendered editors. Dynamic forms call the same shared
+        // initializer after inserting their template content.
+        var initScript = $@"<script{nonceAttr}>
+(function() {{
+    function initMde() {{
+        if (!window.HumansMarkdownEditor) {{ return false; }}
+        var el = document.getElementById('{jsIdLiteral}');
+        if (!el) {{ return true; }}
+        window.HumansMarkdownEditor.init(el);
         return true;
     }}
 

--- a/src/Sections/Humans.Surveys/Controllers/SurveysApiController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveysApiController.cs
@@ -72,6 +72,9 @@ internal sealed class SurveysApiController(ISurveyService surveyService, IUserSe
                     order = q.Order,
                     type = q.Type.ToString(),
                     prompt = q.Prompt.Resolve(culture, culture),
+                    markdown = q.Type == SurveyQuestionType.Information
+                        ? q.HelpText.Resolve(culture, culture)
+                        : null,
                     required = q.IsRequired,
                     ratingMin = q.RatingMin,
                     ratingMax = q.RatingMax,
@@ -79,6 +82,15 @@ internal sealed class SurveysApiController(ISurveyService surveyService, IUserSe
                     gridSelectionMode = q.GridSelectionMode?.ToString(),
                     gridRows = (q.GridRows ?? [])
                         .Select(row => new { value = row.Value, label = row.Label.Resolve(culture, culture) }),
+                    images = (q.InformationImages ?? [])
+                        .Where(image => !string.IsNullOrWhiteSpace(image.StoragePath))
+                        .Select(image => new
+                        {
+                            id = image.Id,
+                            url = $"/{image.StoragePath!.TrimStart('/')}",
+                            label = image.Label.Resolve(culture, culture),
+                            altText = image.AltText.Resolve(culture, culture),
+                        }),
                     options = q.Options
                         .OrderBy(o => o.Order)
                         .Select(o => new { value = o.Value, label = o.Label.Resolve(culture, culture) }),

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyJson.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyJson.cs
@@ -17,6 +17,13 @@ internal static class SurveyJson
     public static readonly JsonSerializerOptions Options = new();
 
     private sealed record GridRowDocument(string Value, Dictionary<string, string> Label);
+    private sealed record InformationImageDocument(
+        Guid Id,
+        string StoragePath,
+        string ContentType,
+        string FileName,
+        Dictionary<string, string> Label,
+        Dictionary<string, string> AltText);
 
     /// <summary>Maps a <see cref="LocalizedText"/> property to a jsonb column (culture→text dictionary).</summary>
     public static void LocalizedText<TEntity>(
@@ -55,5 +62,31 @@ internal static class SurveyJson
                 .Select(row => new SurveyGridRow(
                     row.Value,
                     new LocalizedText(row.Label)))
+                .ToList();
+
+    public static string? SerializeInformationImages(List<SurveyInformationImage>? images)
+        => images is null
+            ? null
+            : JsonSerializer.Serialize(
+                images.Select(image => new InformationImageDocument(
+                    image.Id,
+                    image.StoragePath,
+                    image.ContentType,
+                    image.FileName,
+                    new Dictionary<string, string>(image.Label.Values, StringComparer.OrdinalIgnoreCase),
+                    new Dictionary<string, string>(image.AltText.Values, StringComparer.OrdinalIgnoreCase))),
+                Options);
+
+    public static List<SurveyInformationImage>? DeserializeInformationImages(string? value)
+        => value is null
+            ? null
+            : JsonSerializer.Deserialize<List<InformationImageDocument>>(value, Options)?
+                .Select(image => new SurveyInformationImage(
+                    image.Id,
+                    image.StoragePath,
+                    image.ContentType,
+                    image.FileName,
+                    new LocalizedText(image.Label),
+                    new LocalizedText(image.AltText)))
                 .ToList();
 }

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyQuestionConfiguration.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyQuestionConfiguration.cs
@@ -31,6 +31,16 @@ internal sealed class SurveyQuestionConfiguration : IEntityTypeConfiguration<Sur
                     v => v == null ? 0 : string.GetHashCode(SurveyJson.SerializeGridRows(v)!, StringComparison.Ordinal),
                     v => SurveyJson.DeserializeGridRows(SurveyJson.SerializeGridRows(v))));
 
+        b.Property(q => q.InformationImages)
+            .HasColumnType("jsonb")
+            .HasConversion(
+                v => SurveyJson.SerializeInformationImages(v),
+                v => SurveyJson.DeserializeInformationImages(v),
+                new ValueComparer<List<SurveyInformationImage>?>(
+                    (a, c) => SurveyJson.SerializeInformationImages(a) == SurveyJson.SerializeInformationImages(c),
+                    v => v == null ? 0 : string.GetHashCode(SurveyJson.SerializeInformationImages(v)!, StringComparison.Ordinal),
+                    v => SurveyJson.DeserializeInformationImages(SurveyJson.SerializeInformationImages(v))));
+
         b.Property(q => q.ShowIf)
             .HasColumnType("jsonb")
             .HasConversion(

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260823081703_AddSurveyInformationBlocks.Designer.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260823081703_AddSurveyInformationBlocks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Surveys.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Surveys.Data.Migrations
 {
     [DbContext(typeof(SurveysDbContext))]
-    partial class SurveysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823081703_AddSurveyInformationBlocks")]
+    partial class AddSurveyInformationBlocks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260823081703_AddSurveyInformationBlocks.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260823081703_AddSurveyInformationBlocks.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Surveys.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSurveyInformationBlocks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InformationImages",
+                table: "survey_questions",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InformationImages",
+                table: "survey_questions");
+        }
+    }
+}

--- a/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
+++ b/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
@@ -334,6 +334,7 @@ internal sealed partial class SurveyRepository(IDbContextFactory<SurveysDbContex
             keptQuestion.RatingMaxLabel = incomingQuestion.RatingMaxLabel;
             keptQuestion.GridSelectionMode = incomingQuestion.GridSelectionMode;
             keptQuestion.GridRows = incomingQuestion.GridRows;
+            keptQuestion.InformationImages = incomingQuestion.InformationImages;
             keptQuestion.ShowIf = incomingQuestion.ShowIf;
 
             ReconcileOptions(ctx, keptQuestion, incomingQuestion);

--- a/src/Sections/Humans.Surveys/Docs/Surveys.md
+++ b/src/Sections/Humans.Surveys/Docs/Surveys.md
@@ -12,7 +12,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 ## Concepts
 
 - A **Survey** is an authored questionnaire with per-culture title/intro/thank-you and optional invitation email subject/message (`LocalizedText`), a default culture, a status lifecycle (Draft → Open → Closed), an optional open/close window, an audience, and an optional public slug. It owns an ordered graph of questions.
-- A **SurveyQuestion** is one prompt on a page, typed (SingleChoice, MultiChoice, ShortText, LongText, Rating, Grid), optionally required, optionally gated by a **`ShowIf` branch condition**. Choice questions own ordered **SurveyQuestionOptions** (stable machine `Value` + `LocalizedText` label). Grid questions reuse those options as columns and store localized, stable-keyed rows directly on the question.
+- A **SurveyQuestion** is one ordered item on a page, typed (SingleChoice, MultiChoice, ShortText, LongText, Rating, Grid, Information), optionally required, optionally gated by a **`ShowIf` branch condition**. Choice questions own ordered **SurveyQuestionOptions** (stable machine `Value` + `LocalizedText` label). Grid questions reuse those options as columns and store localized, stable-keyed rows directly on the question. Information items reuse Prompt as an optional heading and HelpText as sanitized Markdown, and may carry up to five labelled public images.
 - A **branch condition** (`BranchCondition` + `BranchClause`, jsonb) is skip-logic: a question is visible only when its clauses (combined `All`/`Any`, operators `Is`/`IsNot`/`Answered`/`NotAnswered` over earlier questions' option values) evaluate true. Evaluated by the pure `SurveyBranchingEvaluator`.
 - A **SurveyInvitation** is the per-recipient ledger row for the invited path: one per `(SurveyId, UserId)`. It carries send/reminder funnel state (`SentAt`, `LatestEmailStatus`, `ReminderSentAt`, `Started`, `Completed`) — all flags/timestamps about *participation*, never about *answer content*.
 - A **SurveyResponse** is one submitted (or, for Identified, in-progress) answer set, tagged with its **anonymity tier** and **input method** (UserSpecificLink vs Slug). It owns **SurveyAnswers** (selected option values, free text, rating, or Grid row-to-column selections).
@@ -61,6 +61,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | RatingMin / RatingMax | int? | rating-question range |
 | GridSelectionMode | GridSelectionMode? | string-converted; Single / Multiple for Grid questions |
 | GridRows | List&lt;SurveyGridRow&gt;? | jsonb; ordered stable row `Value` + localized label |
+| InformationImages | List&lt;SurveyInformationImage&gt;? | nullable jsonb; up to five public storage keys with localized label and alt text |
 | ShowIf | BranchCondition? | jsonb skip-logic |
 
 **Index:** `(SurveyId, PageNumber, Order)`.
@@ -131,7 +132,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | Enum | Values |
 |------|--------|
 | SurveyStatus | Draft, Open, Closed |
-| SurveyQuestionType | SingleChoice, MultiChoice, ShortText, LongText, Rating, Grid |
+| SurveyQuestionType | SingleChoice, MultiChoice, ShortText, LongText, Rating, Grid, Information |
 | GridSelectionMode | Single, Multiple |
 | ResponseAnonymity | Identified, CompletionTracked, Anonymous |
 | SurveyInputMethod | UserSpecificLink, Slug |
@@ -139,7 +140,7 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 | BranchCombine | All, Any |
 | BranchOperator | Is, IsNot, Answered, NotAnswered |
 
-`LocalizedText` (culture → text), `SurveyGridRow`, and `BranchCondition`/`BranchClause` are section-owned value objects in `src/Sections/Humans.Surveys/Domain/`; localized text, Grid rows/selections, and branch conditions are persisted as jsonb.
+`LocalizedText` (culture → text), `SurveyGridRow`, `SurveyInformationImage`, and `BranchCondition`/`BranchClause` are section-owned value objects in `src/Sections/Humans.Surveys/Domain/`; localized text, Grid rows/selections, Information images, and branch conditions are persisted as jsonb.
 
 ## Routing
 
@@ -177,6 +178,8 @@ First-party, GDPR-compliant surveys: author typed/branching multi-language surve
 - **Grid questions are bounded matrices.** A Grid has at least one localized row, one to five localized columns, and a `Single` or `Multiple` selection mode. Row and column keys are non-blank and unique. A required Grid is complete only when every row has a valid selection; `Single` permits exactly one column per row. Posted selections are normalized against the authored schema before autosave/submission.
 - **Grid questions may be branch targets, never branch sources.** A Grid can carry its own `ShowIf`, but author-save rejects any branch clause that references a Grid question.
 - **Grid result percentages are row-local.** Each cell's percentage uses respondents who answered that row as its denominator. Results retain the current authored matrix. CSV/JSON/Markdown export, the analysis API, and GDPR export retain raw stored row/column keys just as choice exports retain `SelectedOptionValues`, alongside best-effort labels in the survey's default culture; removed definitions fall back to their raw keys instead of hiding historical answers.
+- **Information items are context, not answers.** They share question ordering, paging, translation, preview, and conditional visibility, but are never required, never branch sources, emit no answer input, and are omitted from results and response exports. Markdown uses the shared sanitizer. Images are public `IFileStorage` objects under `uploads/surveys/`, capped at five, and their builder upload form warns that URLs can be shared outside the survey.
+- **Question help text is sanitized Markdown.** Existing plain text remains valid; respondent and preview rendering use the shared Markdown renderer/sanitizer. Prompts remain plain text.
 - **Invitation send is idempotent and additive.** Each send resolves the audience, diffs against existing `(SurveyId, UserId)` invitations, and creates+emails only net-new recipients; nobody is double-invited and **sends never revoke**. The Send page previews that exact net-new count, not the raw audience size. Requires the survey Open with a valid audience configuration (`Team` requires a team; `LoggedInSince` requires a cutoff date). Invites are operational (`MessageCategory.System`, always-send) — surveys are never marketing.
 - **Survey preview is side-effect-free and status-independent.** Board/Admin authors may preview Draft,
   Open, or Closed surveys through the respondent views. Preview page navigation is GET-only, displays

--- a/src/Sections/Humans.Surveys/Docs/features/survey-information-blocks.md
+++ b/src/Sections/Humans.Surveys/Docs/features/survey-information-blocks.md
@@ -18,6 +18,10 @@ questions. It supports:
 - zero to five images, each with a localized tab label and localized alt text;
 - the existing page ordering and `ShowIf` visibility rule.
 
+The Markdown field uses the shared EasyMDE editor for both server-rendered and newly inserted items.
+Question cards can be inserted after any existing card and moved up or down; their posted DOM order
+becomes the persisted survey question order.
+
 Information items are never required and cannot be branching sources. They must contain Markdown or
 at least one image. Image labels and alt text must contain authored text.
 

--- a/src/Sections/Humans.Surveys/Docs/features/survey-information-blocks.md
+++ b/src/Sections/Humans.Surveys/Docs/features/survey-information-blocks.md
@@ -19,8 +19,8 @@ questions. It supports:
 - the existing page ordering and `ShowIf` visibility rule.
 
 The Markdown field uses the shared EasyMDE editor for both server-rendered and newly inserted items.
-Question cards can be inserted after any existing card and moved up or down; their posted DOM order
-becomes the persisted survey question order.
+Question cards can be inserted after any existing card and moved up or down within their page. Their
+posted DOM order becomes the persisted order within that page.
 
 Information items are never required and cannot be branching sources. They must contain Markdown or
 at least one image. Image labels and alt text must contain authored text.
@@ -55,8 +55,10 @@ Bytes use the shared `IFileStorage` under:
 `uploads/surveys/{surveyId}/{questionId}/{imageId}.{extension}`
 
 No private download endpoint or new storage abstraction is introduced. Replacing an image writes a
-fresh key before the database update; removed/replaced files are deleted after persistence succeeds.
-New files are cleaned up best-effort if validation or persistence fails.
+fresh key before the database update. Newly written files are cleaned up best-effort if validation or
+persistence fails. Removed/replaced files are retained: deleting them during an ordinary update can
+race with another in-flight editor that still references the previous key. A future storage
+maintenance job may garbage-collect keys after proving they are no longer referenced.
 
 ## Results, exports, and API
 

--- a/src/Sections/Humans.Surveys/Docs/features/survey-information-blocks.md
+++ b/src/Sections/Humans.Surveys/Docs/features/survey-information-blocks.md
@@ -1,0 +1,77 @@
+# Survey Information Blocks
+
+## Business context
+
+Survey respondents sometimes need evidence immediately before answering a question—for example
+fire-risk, temperature, and rainfall forecasts before choosing event dates. The survey intro cannot
+serve this need because it is a separate wizard screen.
+
+Tracked in `nobodies-collective/Humans#1119`.
+
+## Authoring
+
+A Board/Admin author can add an **Information** item to the same ordered, paged collection as
+questions. It supports:
+
+- an optional localized heading, stored in the existing `SurveyQuestion.Prompt`;
+- localized Markdown, stored in the existing `SurveyQuestion.HelpText`;
+- zero to five images, each with a localized tab label and localized alt text;
+- the existing page ordering and `ShowIf` visibility rule.
+
+Information items are never required and cannot be branching sources. They must contain Markdown or
+at least one image. Image labels and alt text must contain authored text.
+
+The builder posts as `multipart/form-data`. It explicitly warns:
+
+> Uploaded image URLs are public and may be shared outside this survey.
+
+Uploads accept JPEG, PNG, and WebP files up to 10 MB each.
+
+## Respondent and preview rendering
+
+Live answering and protected admin preview share the existing survey-page projection and partial:
+
+- Markdown renders through `Html.SanitizedMarkdown(...)`;
+- the same authored HelpText field now renders through that sanitizer for ordinary questions too,
+  so the builder's shared Markdown editor has consistent semantics;
+- one image renders as a labelled figure;
+- multiple images render as accessible Bootstrap tabs;
+- a `<noscript>` vertical figure list keeps every image available without JavaScript.
+
+Information items remain part of page visibility and navigation, but emit no answer fields.
+
+## Persistence and file lifecycle
+
+The bounded image collection is stored in nullable `SurveyQuestion.InformationImages` JSONB. Each
+record contains an id, public storage key, content type, original filename, localized label, and
+localized alt text.
+
+Bytes use the shared `IFileStorage` under:
+
+`uploads/surveys/{surveyId}/{questionId}/{imageId}.{extension}`
+
+No private download endpoint or new storage abstraction is introduced. Replacing an image writes a
+fresh key before the database update; removed/replaced files are deleted after persistence succeeds.
+New files are cleaned up best-effort if validation or persistence fails.
+
+## Results, exports, and API
+
+Information items do not appear as answer columns or aggregates and cannot acquire persisted
+answers. The definition API includes their Markdown and public image metadata so external survey
+definition consumers can retain the authored flow.
+
+## Reuse decisions
+
+- Reused `SurveyQuestion` for ordering, paging, localization, and branching.
+- Reused `Prompt` and `HelpText` rather than adding another localized text column.
+- Used one nullable JSONB property rather than a seventh Survey-owned table for a collection capped
+  at five.
+- Reused the shared Markdown sanitizer, Bootstrap tabs, and `IFileStorage`.
+- Extended existing create/update, preview, answering, results, export, and API paths; no endpoint,
+  service method, repository method, interface, package, or DI registration was added.
+
+## Related
+
+- [Survey section invariants](../Surveys.md)
+- [Survey intro Markdown](survey-intro-markdown.md)
+- `nobodies-collective/Humans#1119`

--- a/src/Sections/Humans.Surveys/Domain/SurveyInformationImage.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyInformationImage.cs
@@ -1,0 +1,13 @@
+namespace Humans.Surveys.Domain;
+
+/// <summary>
+/// One publicly served image attached to an Information survey item. Persisted as part of the
+/// question's JSONB document because the collection is small (at most five) and aggregate-local.
+/// </summary>
+internal sealed record SurveyInformationImage(
+    Guid Id,
+    string StoragePath,
+    string ContentType,
+    string FileName,
+    LocalizedText Label,
+    LocalizedText AltText);

--- a/src/Sections/Humans.Surveys/Domain/SurveyQuestion.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyQuestion.cs
@@ -17,6 +17,7 @@ internal sealed class SurveyQuestion
     public LocalizedText RatingMaxLabel { get; set; } = LocalizedText.Empty;
     public GridSelectionMode? GridSelectionMode { get; set; }
     public List<SurveyGridRow>? GridRows { get; set; }           // jsonb; null for non-Grid questions
+    public List<SurveyInformationImage>? InformationImages { get; set; } // jsonb; null for non-Information items
     public BranchCondition? ShowIf { get; set; }
     public Survey Survey { get; set; } = null!;
     public ICollection<SurveyQuestionOption> Options { get; set; } = new List<SurveyQuestionOption>();

--- a/src/Sections/Humans.Surveys/Domain/SurveyQuestionType.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyQuestionType.cs
@@ -1,6 +1,9 @@
 namespace Humans.Surveys.Domain;
 
-/// <summary>Question input kinds. Choice types carry options and can drive branching; Grid reuses options as columns but cannot drive branching.</summary>
+/// <summary>
+/// Survey item kinds. Information carries no answer; choice types carry options and can drive
+/// branching; Grid reuses options as columns but cannot drive branching.
+/// </summary>
 internal enum SurveyQuestionType
 {
     SingleChoice = 0,
@@ -9,4 +12,5 @@ internal enum SurveyQuestionType
     LongText = 3,
     Rating = 4,
     Grid = 5,
+    Information = 6,
 }

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
@@ -76,6 +76,14 @@ internal static class SurveyPageViewModelFactory
                     row.Value,
                     row.Label.Resolve(state.Culture, editable.DefaultCulture)))
                 .ToList(),
+            InformationImages = (question.InformationImages ?? [])
+                .Where(image => !string.IsNullOrWhiteSpace(image.StoragePath))
+                .Select(image => new SurveyPageInformationImage(
+                    image.Id ?? Guid.Empty,
+                    $"/{image.StoragePath!.TrimStart('/')}",
+                    image.Label.Resolve(state.Culture, editable.DefaultCulture),
+                    image.AltText.Resolve(state.Culture, editable.DefaultCulture)))
+                .ToList(),
             SelectedOptionValues = prior?.SelectedOptionValues ?? [],
             GridSelections = prior?.GridSelections.ToDictionary(
                 kv => kv.Key,

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
@@ -1,3 +1,4 @@
+using Humans.Base.Attributes;
 using Humans.Surveys.Domain;
 
 namespace Humans.Surveys.Models;
@@ -53,6 +54,7 @@ internal sealed class SurveyPageQuestion
     public Guid Id { get; init; }
     public SurveyQuestionType Type { get; init; }
     public string Prompt { get; init; } = string.Empty;
+    [MarkdownContent]
     public string HelpText { get; init; } = string.Empty;
     public bool IsRequired { get; init; }
     public int? RatingMin { get; init; }
@@ -62,6 +64,7 @@ internal sealed class SurveyPageQuestion
     public IReadOnlyList<SurveyPageOption> Options { get; init; } = [];
     public GridSelectionMode? GridSelectionMode { get; init; }
     public IReadOnlyList<SurveyPageGridRow> GridRows { get; init; } = [];
+    public IReadOnlyList<SurveyPageInformationImage> InformationImages { get; init; } = [];
 
     // Prior answer (for re-render after a validation failure or a Back navigation).
     public IReadOnlyList<string> SelectedOptionValues { get; init; } = [];
@@ -76,6 +79,9 @@ internal sealed record SurveyPageOption(string Value, string Label);
 
 /// <summary>One resolved Grid row.</summary>
 internal sealed record SurveyPageGridRow(string Value, string Label);
+
+/// <summary>One resolved, publicly served image in an Information survey item.</summary>
+internal sealed record SurveyPageInformationImage(Guid Id, string Url, string Label, string AltText);
 
 /// <summary>Pure presentation model for the shared author-preview notice.</summary>
 internal sealed record SurveyPreviewNoticeModel(

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -192,7 +192,19 @@ internal sealed class SurveyBuilderViewModel
         AudienceType == SurveyAudienceType.Team ? AudienceTeamId : null,
         AudienceType == SurveyAudienceType.LoggedInSince ? ToStartOfDayInstant(AudienceLoggedInSince, zone) : null,
         string.IsNullOrWhiteSpace(PublicSlug) ? null : PublicSlug,
-        Questions.Select((q, i) => q.ToInput(i)).ToList());
+        ToQuestionInputsInPageOrder());
+
+    private IReadOnlyList<QuestionInput> ToQuestionInputsInPageOrder()
+    {
+        var nextOrderByPage = new Dictionary<int, int>();
+        return Questions.Select(question =>
+        {
+            var page = question.PageNumber <= 0 ? 1 : question.PageNumber;
+            var order = nextOrderByPage.GetValueOrDefault(page);
+            nextOrderByPage[page] = order + 1;
+            return question.ToInput(order);
+        }).ToList();
+    }
 
     public static SurveyBuilderViewModel FromDetail(SurveyDetail detail, IReadOnlyList<SurveyTeamOption> teams, DateTimeZone zone)
     {

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -120,6 +120,12 @@ internal sealed record SurveyOptionRowModel(string QuestionKey, string OptionKey
 /// <summary>One Grid row in the builder. Keys are non-sequential indexers.</summary>
 internal sealed record SurveyGridRowModel(string QuestionKey, string RowKey, SurveyGridRowBuilderViewModel Row);
 
+/// <summary>One Information image row in the builder. Keys are non-sequential indexers.</summary>
+internal sealed record SurveyInformationImageRowModel(
+    string QuestionKey,
+    string ImageKey,
+    SurveyInformationImageBuilderViewModel Image);
+
 /// <summary>One show-if clause row in the builder. Keys are non-sequential indexers (or <c>__QKEY__</c>/<c>__CKEY__</c> placeholders in templates).</summary>
 internal sealed record SurveyBranchClauseRowModel(string QuestionKey, string ClauseKey, SurveyBranchClauseBuilderViewModel Clause);
 
@@ -243,6 +249,7 @@ internal sealed class SurveyQuestionBuilderViewModel
     public List<SurveyBranchClauseBuilderViewModel> ShowIfClauses { get; set; } = [];
     public List<SurveyOptionBuilderViewModel> Options { get; set; } = [];
     public List<SurveyGridRowBuilderViewModel> GridRows { get; set; } = [];
+    public List<SurveyInformationImageBuilderViewModel> InformationImages { get; set; } = [];
 
     public QuestionInput ToInput(int order) => new(
         Id,
@@ -259,7 +266,10 @@ internal sealed class SurveyQuestionBuilderViewModel
         ToShowIf(),
         Options.Select((o, i) => o.ToInput(i)).ToList(),
         Type == SurveyQuestionType.Grid ? GridSelectionMode : null,
-        Type == SurveyQuestionType.Grid ? GridRows.Select(r => r.ToInput()).ToList() : null);
+        Type == SurveyQuestionType.Grid ? GridRows.Select(r => r.ToInput()).ToList() : null,
+        Type == SurveyQuestionType.Information
+            ? InformationImages.Select(image => image.ToInput()).ToList()
+            : null);
 
     public static SurveyQuestionBuilderViewModel FromInput(QuestionInput q) => new()
     {
@@ -278,6 +288,9 @@ internal sealed class SurveyQuestionBuilderViewModel
         Options = q.Options.Select(SurveyOptionBuilderViewModel.FromInput).ToList(),
         GridSelectionMode = q.GridSelectionMode ?? Humans.Surveys.Domain.GridSelectionMode.Single,
         GridRows = q.GridRows?.Select(SurveyGridRowBuilderViewModel.FromInput).ToList() ?? [],
+        InformationImages = q.InformationImages?
+            .Select(SurveyInformationImageBuilderViewModel.FromInput)
+            .ToList() ?? [],
     };
 
     /// <summary>Clauses without a target question (never picked / target removed) are dropped; no clauses ⇒ always visible.</summary>
@@ -289,6 +302,35 @@ internal sealed class SurveyQuestionBuilderViewModel
             .ToList();
         return clauses.Count == 0 ? null : new BranchCondition { Combine = ShowIfCombine, Clauses = clauses };
     }
+}
+
+internal sealed class SurveyInformationImageBuilderViewModel
+{
+    public Guid? Id { get; set; }
+    public Dictionary<string, string> Label { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, string> AltText { get; set; } = new(StringComparer.Ordinal);
+    public string? ExistingStoragePath { get; set; }
+    public string? ExistingFileName { get; set; }
+    public IFormFile? Upload { get; set; }
+
+    public InformationImageInput ToInput() => new(
+        Id,
+        new LocalizedText(Label),
+        new LocalizedText(AltText),
+        ExistingStoragePath,
+        FileName: ExistingFileName,
+        Upload: Upload is { Length: > 0 }
+            ? new SurveyImageUpload(Upload.OpenReadStream(), Upload.ContentType, Upload.FileName, Upload.Length)
+            : null);
+
+    public static SurveyInformationImageBuilderViewModel FromInput(InformationImageInput image) => new()
+    {
+        Id = image.Id,
+        Label = SurveyBuilderViewModel.ToDict(image.Label),
+        AltText = SurveyBuilderViewModel.ToDict(image.AltText),
+        ExistingStoragePath = image.StoragePath,
+        ExistingFileName = image.FileName,
+    };
 }
 
 /// <summary>One structured show-if clause: an earlier question, an operator, and (for Is/IsNot) the option values to match.</summary>

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -180,7 +180,8 @@ internal sealed record QuestionInput(
     BranchCondition? ShowIf,
     IReadOnlyList<OptionInput> Options,
     GridSelectionMode? GridSelectionMode = null,
-    IReadOnlyList<GridRowInput>? GridRows = null);
+    IReadOnlyList<GridRowInput>? GridRows = null,
+    IReadOnlyList<InformationImageInput>? InformationImages = null);
 
 /// <summary>One choice option in the builder graph. <c>Value</c> is the stable machine key.</summary>
 internal sealed record OptionInput(
@@ -191,6 +192,21 @@ internal sealed record OptionInput(
 
 /// <summary>One Grid row in the builder graph. <c>Value</c> is the stable machine key.</summary>
 internal sealed record GridRowInput(string Value, LocalizedText Label);
+
+/// <summary>
+/// One Information-item image. Existing persisted metadata is populated on reads; a new upload is
+/// populated only for the duration of an authoring save.
+/// </summary>
+internal sealed record InformationImageInput(
+    Guid? Id,
+    LocalizedText Label,
+    LocalizedText AltText,
+    string? StoragePath = null,
+    string? ContentType = null,
+    string? FileName = null,
+    SurveyImageUpload? Upload = null);
+
+internal sealed record SurveyImageUpload(Stream Content, string ContentType, string FileName, long Length);
 
 /// <summary>Outcome of a send wave: net-new invitations created, emails queued, and enqueue failures.</summary>
 internal sealed record SendResult(int InvitationsCreated, int EmailsQueued, int Failed);

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -1562,7 +1562,12 @@ internal sealed class SurveyService(
                             FileName = persisted.FileName,
                             Upload = null,
                         });
+                        continue;
                     }
+
+                    throw new InvalidOperationException(
+                        "Select an image file for every image row. " +
+                        "If a previous save failed, select the file again.");
                 }
 
                 preparedQuestions.Add(question with

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -189,7 +189,6 @@ internal sealed class SurveyService(
             await DeleteFilesBestEffortAsync(prepared.NewStoragePaths, CancellationToken.None);
             throw;
         }
-        await DeleteFilesBestEffortAsync(prepared.RemovedStoragePaths, CancellationToken.None);
         await auditLog.LogAsync(AuditAction.SurveyUpdated, AuditEntityTypes.Survey, surveyId, "Updated survey", actorUserId);
     }
 
@@ -1504,7 +1503,6 @@ internal sealed class SurveyService(
             .SelectMany(question => question.InformationImages ?? [])
             .ToDictionary(image => image.Id)
             ?? new Dictionary<Guid, SurveyInformationImage>();
-        var keptExistingPaths = new HashSet<string>(StringComparer.Ordinal);
         var newStoragePaths = new List<string>();
         var preparedQuestions = new List<QuestionInput>(input.Questions.Count);
 
@@ -1557,7 +1555,6 @@ internal sealed class SurveyService(
                     if (requested.Id is { } existingId
                         && existingImages.TryGetValue(existingId, out var persisted))
                     {
-                        keptExistingPaths.Add(persisted.StoragePath);
                         preparedImages.Add(requested with
                         {
                             StoragePath = persisted.StoragePath,
@@ -1589,15 +1586,9 @@ internal sealed class SurveyService(
             throw;
         }
 
-        var removedStoragePaths = existingImages.Values
-            .Select(image => image.StoragePath)
-            .Where(path => !keptExistingPaths.Contains(path) && !newStoragePaths.Contains(path, StringComparer.Ordinal))
-            .ToList();
-
         return new PreparedInformationImages(
             input with { Questions = preparedQuestions },
-            newStoragePaths,
-            removedStoragePaths);
+            newStoragePaths);
     }
 
     private static void ValidateInformationImage(SurveyImageUpload upload)
@@ -1640,8 +1631,7 @@ internal sealed class SurveyService(
 
     private sealed record PreparedInformationImages(
         SurveyEditInput Input,
-        IReadOnlyList<string> NewStoragePaths,
-        IReadOnlyList<string> RemovedStoragePaths);
+        IReadOnlyList<string> NewStoragePaths);
 
     /// <summary>Maps builder input to tracked entities, assigning new ids where the input id is null.</summary>
     private static List<SurveyQuestion> MapQuestions(Guid surveyId, SurveyEditInput input)

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -10,6 +10,7 @@ using Humans.Surveys.Contracts;
 using Humans.Teams.Contracts;
 using Humans.Tickets.Contracts;
 using Humans.Base.Enums;
+using Humans.Base.Interfaces;
 using Humans.Surveys.Domain;
 using NodaTime;
 
@@ -34,10 +35,17 @@ internal sealed class SurveyService(
     IEmailService emailService,
     IEmailMessageFactory emailMessages,
     ISurveyInviteTokenProvider tokenProvider,
-    IGoogleTranslationService translation) : ISurveyService, ISurveyReminderSender, IUserDataContributor
+    IGoogleTranslationService translation,
+    IFileStorage fileStorage) : ISurveyService, ISurveyReminderSender, IUserDataContributor
 {
     private const int InvitationEmailSubjectMaxLength = 200;
     private const int InvitationEmailMessageMaxLength = 4000;
+    private const int MaxInformationImages = 5;
+    private const long MaxInformationImageBytes = 10 * 1024 * 1024;
+    private static readonly HashSet<string> AllowedInformationImageContentTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "image/jpeg", "image/png", "image/webp" };
+    private static readonly HashSet<string> AllowedInformationImageExtensions =
+        new(StringComparer.OrdinalIgnoreCase) { ".jpg", ".jpeg", ".png", ".webp" };
 
     public async Task<IReadOnlyList<SurveySummary>> GetSummariesAsync(CancellationToken ct = default)
     {
@@ -76,9 +84,19 @@ internal sealed class SurveyService(
         ValidateInvitationEmailCopy(invitationEmailSubject, invitationEmailMessage);
         var now = clock.GetCurrentInstant();
         var surveyId = Guid.NewGuid();
-        var questions = MapQuestions(surveyId, input);
-        ValidateQuestionConfiguration(questions);
-        ValidateBranching(questions);
+        var prepared = await PrepareInformationImagesAsync(surveyId, input, existing: null, ct);
+        List<SurveyQuestion> questions;
+        try
+        {
+            questions = MapQuestions(surveyId, prepared.Input);
+            ValidateQuestionConfiguration(questions);
+            ValidateBranching(questions);
+        }
+        catch
+        {
+            await DeleteFilesBestEffortAsync(prepared.NewStoragePaths, CancellationToken.None);
+            throw;
+        }
 
         var survey = new Survey
         {
@@ -103,7 +121,15 @@ internal sealed class SurveyService(
             Questions = questions,
         };
 
-        await repo.AddAsync(survey, ct);
+        try
+        {
+            await repo.AddAsync(survey, ct);
+        }
+        catch
+        {
+            await DeleteFilesBestEffortAsync(prepared.NewStoragePaths, CancellationToken.None);
+            throw;
+        }
         logger.LogInformation("Survey {SurveyId} created by {UserId}", surveyId, actorUserId);
         await auditLog.LogAsync(AuditAction.SurveyCreated, AuditEntityTypes.Survey, surveyId,
             $"Created survey '{survey.Title.Resolve(survey.DefaultCulture, survey.DefaultCulture)}'", actorUserId);
@@ -118,9 +144,21 @@ internal sealed class SurveyService(
         var invitationEmailMessage = NormalizeLocalizedText(input.InvitationEmailMessage);
         ValidateInvitationEmailCopy(invitationEmailSubject, invitationEmailMessage);
         var now = clock.GetCurrentInstant();
-        var questions = MapQuestions(surveyId, input);
-        ValidateQuestionConfiguration(questions);
-        ValidateBranching(questions);
+        var existing = await repo.GetByIdAsync(surveyId, ct)
+            ?? throw new InvalidOperationException("Survey not found.");
+        var prepared = await PrepareInformationImagesAsync(surveyId, input, existing, ct);
+        List<SurveyQuestion> questions;
+        try
+        {
+            questions = MapQuestions(surveyId, prepared.Input);
+            ValidateQuestionConfiguration(questions);
+            ValidateBranching(questions);
+        }
+        catch
+        {
+            await DeleteFilesBestEffortAsync(prepared.NewStoragePaths, CancellationToken.None);
+            throw;
+        }
 
         var survey = new Survey
         {
@@ -142,7 +180,16 @@ internal sealed class SurveyService(
             Questions = questions,
         };
 
-        await repo.UpdateAsync(survey, ct);
+        try
+        {
+            await repo.UpdateAsync(survey, ct);
+        }
+        catch
+        {
+            await DeleteFilesBestEffortAsync(prepared.NewStoragePaths, CancellationToken.None);
+            throw;
+        }
+        await DeleteFilesBestEffortAsync(prepared.RemovedStoragePaths, CancellationToken.None);
         await auditLog.LogAsync(AuditAction.SurveyUpdated, AuditEntityTypes.Survey, surveyId, "Updated survey", actorUserId);
     }
 
@@ -169,6 +216,12 @@ internal sealed class SurveyService(
             MaxLabel = Copy(q.RatingMaxLabel),
             Options = q.Options.Select(o => new { Option = o, Label = Copy(o.Label) }).ToList(),
             GridRows = (q.GridRows ?? []).Select(row => new { Row = row, Label = Copy(row.Label) }).ToList(),
+            InformationImages = (q.InformationImages ?? []).Select(image => new
+            {
+                Image = image,
+                Label = Copy(image.Label),
+                AltText = Copy(image.AltText),
+            }).ToList(),
         }).ToList();
 
         var allTexts = new List<Dictionary<string, string>>
@@ -184,6 +237,8 @@ internal sealed class SurveyService(
             allTexts.AddRange([q.Prompt, q.Help, q.MinLabel, q.MaxLabel]);
             allTexts.AddRange(q.Options.Select(o => o.Label));
             allTexts.AddRange(q.GridRows.Select(row => row.Label));
+            allTexts.AddRange(q.InformationImages.Select(image => image.Label));
+            allTexts.AddRange(q.InformationImages.Select(image => image.AltText));
         }
 
         // One batched call per target culture; only fills blanks — never overwrites authored text.
@@ -218,6 +273,11 @@ internal sealed class SurveyService(
                 RatingMaxLabel = new LocalizedText(q.MaxLabel),
                 Options = q.Options.Select(o => o.Option with { Label = new LocalizedText(o.Label) }).ToList(),
                 GridRows = q.GridRows.Select(row => row.Row with { Label = new LocalizedText(row.Label) }).ToList(),
+                InformationImages = q.InformationImages.Select(image => image.Image with
+                {
+                    Label = new LocalizedText(image.Label),
+                    AltText = new LocalizedText(image.AltText),
+                }).ToList(),
             }).ToList());
 
         await UpdateAsync(surveyId, input, actorUserId, ct);
@@ -687,6 +747,7 @@ internal sealed class SurveyService(
 
         foreach (var question in visibleBefore)
         {
+            if (question.Type == SurveyQuestionType.Information) continue;
             var id = question.Id!.Value;
             if (!posted.TryGetValue(id, out var answer))
             {
@@ -831,6 +892,7 @@ internal sealed class SurveyService(
         var responseRate = invitedCount == 0 ? 0d : (double)responseCount / invitedCount;
 
         var questions = survey.Questions
+            .Where(q => q.Type != SurveyQuestionType.Information)
             .OrderBy(q => q.PageNumber).ThenBy(q => q.Order)
             .Select(q => BuildQuestionAggregate(q, responses, culture))
             .ToList();
@@ -864,6 +926,7 @@ internal sealed class SurveyService(
         var responses = await repo.GetResponsesForResultsAsync(surveyId, ct);
 
         var orderedQuestions = survey.Questions
+            .Where(q => q.Type != SurveyQuestionType.Information)
             .OrderBy(q => q.PageNumber).ThenBy(q => q.Order)
             .ToList();
 
@@ -1195,6 +1258,15 @@ internal sealed class SurveyService(
                 question.GridSelectionMode,
                 question.GridRows?
                     .Select(row => new GridRowInput(row.Value, row.Label))
+                    .ToList(),
+                question.InformationImages?
+                    .Select(image => new InformationImageInput(
+                        image.Id,
+                        image.Label,
+                        image.AltText,
+                        image.StoragePath,
+                        image.ContentType,
+                        image.FileName))
                     .ToList()))
             .ToList();
 
@@ -1238,7 +1310,8 @@ internal sealed class SurveyService(
         var questions = survey.Questions.ToDictionary(q => q.Id);
         return answers
             .Where(a => effective.ContainsKey(a.QuestionId))
-            .Where(a => questions.ContainsKey(a.QuestionId))
+            .Where(a => questions.TryGetValue(a.QuestionId, out var question)
+                && question.Type != SurveyQuestionType.Information)
             .Select(a =>
             {
                 var question = questions[a.QuestionId];
@@ -1421,6 +1494,155 @@ internal sealed class SurveyService(
         }
     }
 
+    private async Task<PreparedInformationImages> PrepareInformationImagesAsync(
+        Guid surveyId,
+        SurveyEditInput input,
+        Survey? existing,
+        CancellationToken ct)
+    {
+        var existingImages = existing?.Questions
+            .SelectMany(question => question.InformationImages ?? [])
+            .ToDictionary(image => image.Id)
+            ?? new Dictionary<Guid, SurveyInformationImage>();
+        var keptExistingPaths = new HashSet<string>(StringComparer.Ordinal);
+        var newStoragePaths = new List<string>();
+        var preparedQuestions = new List<QuestionInput>(input.Questions.Count);
+
+        try
+        {
+            foreach (var question in input.Questions)
+            {
+                var questionId = question.Id ?? Guid.NewGuid();
+                if (question.Type != SurveyQuestionType.Information)
+                {
+                    preparedQuestions.Add(question with
+                    {
+                        Id = questionId,
+                        InformationImages = null,
+                    });
+                    continue;
+                }
+
+                var requestedImages = question.InformationImages ?? [];
+                if (requestedImages.Count > MaxInformationImages)
+                {
+                    throw new InvalidOperationException(
+                        $"An Information item can have at most {MaxInformationImages} images.");
+                }
+
+                var preparedImages = new List<InformationImageInput>(requestedImages.Count);
+                foreach (var requested in requestedImages)
+                {
+                    if (requested.Upload is { } upload)
+                    {
+                        ValidateInformationImage(upload);
+                        // Replacements get a fresh key so a failed database save cannot delete or
+                        // overwrite the still-authoritative existing file.
+                        var imageId = Guid.NewGuid();
+                        var extension = Path.GetExtension(upload.FileName);
+                        var storagePath = $"uploads/surveys/{surveyId}/{questionId}/{imageId}{extension}";
+                        await fileStorage.SaveAsync(storagePath, upload.Content, ct);
+                        newStoragePaths.Add(storagePath);
+                        preparedImages.Add(requested with
+                        {
+                            Id = imageId,
+                            StoragePath = storagePath,
+                            ContentType = upload.ContentType,
+                            FileName = upload.FileName,
+                            Upload = null,
+                        });
+                        continue;
+                    }
+
+                    if (requested.Id is { } existingId
+                        && existingImages.TryGetValue(existingId, out var persisted))
+                    {
+                        keptExistingPaths.Add(persisted.StoragePath);
+                        preparedImages.Add(requested with
+                        {
+                            StoragePath = persisted.StoragePath,
+                            ContentType = persisted.ContentType,
+                            FileName = persisted.FileName,
+                            Upload = null,
+                        });
+                    }
+                }
+
+                preparedQuestions.Add(question with
+                {
+                    Id = questionId,
+                    IsRequired = false,
+                    RatingMin = null,
+                    RatingMax = null,
+                    RatingMinLabel = LocalizedText.Empty,
+                    RatingMaxLabel = LocalizedText.Empty,
+                    Options = [],
+                    GridSelectionMode = null,
+                    GridRows = null,
+                    InformationImages = preparedImages,
+                });
+            }
+        }
+        catch
+        {
+            await DeleteFilesBestEffortAsync(newStoragePaths, CancellationToken.None);
+            throw;
+        }
+
+        var removedStoragePaths = existingImages.Values
+            .Select(image => image.StoragePath)
+            .Where(path => !keptExistingPaths.Contains(path) && !newStoragePaths.Contains(path, StringComparer.Ordinal))
+            .ToList();
+
+        return new PreparedInformationImages(
+            input with { Questions = preparedQuestions },
+            newStoragePaths,
+            removedStoragePaths);
+    }
+
+    private static void ValidateInformationImage(SurveyImageUpload upload)
+    {
+        if (upload.Length <= 0)
+        {
+            throw new InvalidOperationException("The selected image is empty.");
+        }
+        if (!AllowedInformationImageContentTypes.Contains(upload.ContentType))
+        {
+            throw new InvalidOperationException("Only JPEG, PNG, and WebP images are allowed.");
+        }
+        if (upload.Length > MaxInformationImageBytes)
+        {
+            throw new InvalidOperationException("Each Information image must be under 10 MB.");
+        }
+        if (!AllowedInformationImageExtensions.Contains(Path.GetExtension(upload.FileName)))
+        {
+            throw new InvalidOperationException(
+                "Image filenames must end in .jpg, .jpeg, .png, or .webp.");
+        }
+    }
+
+    private async Task DeleteFilesBestEffortAsync(
+        IEnumerable<string> storagePaths,
+        CancellationToken ct)
+    {
+        foreach (var storagePath in storagePaths.Distinct(StringComparer.Ordinal))
+        {
+            try
+            {
+                await fileStorage.DeleteAsync(storagePath, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to delete survey Information image {StoragePath}", storagePath);
+            }
+        }
+    }
+
+    private sealed record PreparedInformationImages(
+        SurveyEditInput Input,
+        IReadOnlyList<string> NewStoragePaths,
+        IReadOnlyList<string> RemovedStoragePaths);
+
     /// <summary>Maps builder input to tracked entities, assigning new ids where the input id is null.</summary>
     private static List<SurveyQuestion> MapQuestions(Guid surveyId, SurveyEditInput input)
         => input.Questions.Select(q =>
@@ -1444,6 +1666,15 @@ internal sealed class SurveyService(
                 GridRows = q.Type == SurveyQuestionType.Grid
                     ? (q.GridRows ?? []).Select(row => new SurveyGridRow(row.Value, row.Label)).ToList()
                     : null,
+                InformationImages = q.Type == SurveyQuestionType.Information
+                    ? (q.InformationImages ?? []).Select(image => new SurveyInformationImage(
+                        image.Id!.Value,
+                        image.StoragePath!,
+                        image.ContentType!,
+                        image.FileName!,
+                        image.Label,
+                        image.AltText)).ToList()
+                    : null,
                 ShowIf = q.ShowIf,
                 Options = q.Options.Select(o => new SurveyQuestionOption
                 {
@@ -1460,6 +1691,45 @@ internal sealed class SurveyService(
     {
         foreach (var question in questions)
         {
+            if (question.Type == SurveyQuestionType.Information)
+            {
+                if (question.IsRequired)
+                {
+                    throw new InvalidOperationException(
+                        $"Information item {question.Id} cannot be required.");
+                }
+
+                var images = question.InformationImages ?? [];
+                if (images.Count > MaxInformationImages)
+                {
+                    throw new InvalidOperationException(
+                        $"Information item {question.Id} can have at most {MaxInformationImages} images.");
+                }
+
+                if (!question.HelpText.Values.Values.Any(value => !string.IsNullOrWhiteSpace(value))
+                    && images.Count == 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Information item {question.Id} must contain Markdown or at least one image.");
+                }
+
+                if (images.Any(image =>
+                    !image.Label.Values.Values.Any(value => !string.IsNullOrWhiteSpace(value))))
+                {
+                    throw new InvalidOperationException(
+                        $"Every image in Information item {question.Id} must have a label.");
+                }
+
+                if (images.Any(image =>
+                    !image.AltText.Values.Values.Any(value => !string.IsNullOrWhiteSpace(value))))
+                {
+                    throw new InvalidOperationException(
+                        $"Every image in Information item {question.Id} must have alt text.");
+                }
+
+                continue;
+            }
+
             if (question.Type != SurveyQuestionType.Grid) continue;
 
             if (question.GridSelectionMode is null
@@ -1519,15 +1789,16 @@ internal sealed class SurveyService(
         }
 
         var types = questions.ToDictionary(question => question.Id, question => question.Type);
-        var gridSources = questions
+        var nonAnswerSources = questions
             .Where(question => question.ShowIf?.Clauses.Any(clause =>
-                types.GetValueOrDefault(clause.QuestionId) == SurveyQuestionType.Grid) == true)
+                types.GetValueOrDefault(clause.QuestionId) is
+                    SurveyQuestionType.Grid or SurveyQuestionType.Information) == true)
             .Select(question => question.Id)
             .ToList();
-        if (gridSources.Count > 0)
+        if (nonAnswerSources.Count > 0)
         {
             throw new InvalidOperationException(
-                $"Grid questions cannot be branching sources. Offending question ids: {string.Join(", ", gridSources)}.");
+                $"Grid questions and Information items cannot be branching sources. Offending question ids: {string.Join(", ", nonAnswerSources)}.");
         }
     }
 

--- a/src/Sections/Humans.Surveys/Services/SurveyWizardFlow.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyWizardFlow.cs
@@ -82,7 +82,8 @@ internal static class SurveyWizardFlow
     public static IReadOnlyList<Guid> RequiredUnanswered(
         IReadOnlyList<QuestionInput> visibleQuestions, IReadOnlyDictionary<Guid, AnswerState> answers)
         => visibleQuestions
-            .Where(q => q.Id is { } id && q.IsRequired
+            .Where(q => q.Type != SurveyQuestionType.Information
+                && q.Id is { } id && q.IsRequired
                 && !(answers.TryGetValue(id, out var a) && IsAnswered(q, a)))
             .Select(q => q.Id!.Value)
             .ToList();

--- a/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
@@ -60,7 +60,10 @@
                              role="tabpanel"
                              aria-labelledby="@(tabGroupId)-tab-@imageIndex"
                              tabindex="0">
-                            <img src="@image.Url" alt="@image.AltText" class="img-fluid rounded" />
+                            <figure class="mb-0">
+                                <img src="@image.Url" alt="@image.AltText" class="img-fluid rounded" />
+                                <figcaption class="small text-muted mt-1">@image.Label</figcaption>
+                            </figure>
                         </div>
                     }
                 </div>

--- a/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
@@ -7,6 +7,79 @@
         && ViewData.ModelState.TryGetValue(q.Id.ToString(), out var entry)
         && entry.Errors.Count > 0;
 
+    @if (q.Type == SurveyQuestionType.Information)
+    {
+        var tabGroupId = $"information-{q.Id:N}";
+        <section class="mb-4 survey-information-block"
+                 aria-labelledby="@(!string.IsNullOrWhiteSpace(q.Prompt) ? $"{tabGroupId}-heading" : null)">
+            @if (!string.IsNullOrWhiteSpace(q.Prompt))
+            {
+                <h2 class="h5" id="@(tabGroupId)-heading">@q.Prompt</h2>
+            }
+            @if (!string.IsNullOrWhiteSpace(q.HelpText))
+            {
+                <div class="survey-information-markdown">@Html.SanitizedMarkdown(q.HelpText)</div>
+            }
+
+            @if (q.InformationImages.Count == 1)
+            {
+                var image = q.InformationImages[0];
+                <figure class="mt-3">
+                    <img src="@image.Url" alt="@image.AltText" class="img-fluid rounded" />
+                    <figcaption class="small text-muted mt-1">@image.Label</figcaption>
+                </figure>
+            }
+            else if (q.InformationImages.Count > 1)
+            {
+                <ul class="nav nav-tabs flex-nowrap overflow-x-auto mt-3"
+                    id="@(tabGroupId)-tabs" role="tablist">
+                    @for (var imageIndex = 0; imageIndex < q.InformationImages.Count; imageIndex++)
+                    {
+                        var image = q.InformationImages[imageIndex];
+                        var active = imageIndex == 0;
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link text-nowrap @(active ? "active" : "")"
+                               id="@(tabGroupId)-tab-@imageIndex"
+                               data-bs-toggle="tab"
+                               href="#@(tabGroupId)-panel-@imageIndex"
+                               role="tab"
+                               aria-controls="@(tabGroupId)-panel-@imageIndex"
+                               aria-selected="@(active ? "true" : "false")">
+                                @image.Label
+                            </a>
+                        </li>
+                    }
+                </ul>
+                <div class="tab-content border border-top-0 rounded-bottom p-3">
+                    @for (var imageIndex = 0; imageIndex < q.InformationImages.Count; imageIndex++)
+                    {
+                        var image = q.InformationImages[imageIndex];
+                        var active = imageIndex == 0;
+                        <div class="tab-pane fade @(active ? "show active" : "")"
+                             id="@(tabGroupId)-panel-@imageIndex"
+                             role="tabpanel"
+                             aria-labelledby="@(tabGroupId)-tab-@imageIndex"
+                             tabindex="0">
+                            <img src="@image.Url" alt="@image.AltText" class="img-fluid rounded" />
+                        </div>
+                    }
+                </div>
+                <noscript>
+                    <div class="mt-3">
+                        @foreach (var image in q.InformationImages)
+                        {
+                            <figure>
+                                <img src="@image.Url" alt="@image.AltText" class="img-fluid rounded" />
+                                <figcaption class="small text-muted mt-1">@image.Label</figcaption>
+                            </figure>
+                        }
+                    </div>
+                </noscript>
+            }
+        </section>
+        continue;
+    }
+
     <fieldset class="mb-4 @(hasError ? "border-start border-danger border-3 ps-3" : string.Empty)">
         <legend class="form-label fw-semibold">
             @q.Prompt
@@ -18,7 +91,9 @@
 
         @if (!string.IsNullOrWhiteSpace(q.HelpText))
         {
-            <p class="form-text mt-0 mb-2">@q.HelpText</p>
+            <div class="form-text mt-0 mb-2 survey-question-help">
+                @Html.SanitizedMarkdown(q.HelpText)
+            </div>
         }
 
         @switch (q.Type)

--- a/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
@@ -1,5 +1,9 @@
 @model Humans.Surveys.Models.SurveyPageViewModel
 
+@{
+    var nextAnswerIndex = 0;
+}
+
 @for (var i = 0; i < Model.Questions.Count; i++)
 {
     var q = Model.Questions[i];
@@ -83,6 +87,7 @@
         continue;
     }
 
+    var answerIndex = nextAnswerIndex++;
     <fieldset class="mb-4 @(hasError ? "border-start border-danger border-3 ps-3" : string.Empty)">
         <legend class="form-label fw-semibold">
             @q.Prompt
@@ -107,9 +112,9 @@
                     var sel = q.SelectedOptionValues.Contains(opt.Value, StringComparer.Ordinal);
                     <div class="form-check">
                         <input class="form-check-input" type="radio"
-                               id="q@(i)_@opt.Value" name="Answers[@i].SelectedOptionValues"
+                               id="q@(answerIndex)_@opt.Value" name="Answers[@answerIndex].SelectedOptionValues"
                                value="@opt.Value" @(sel ? "checked" : null) />
-                        <label class="form-check-label" for="q@(i)_@opt.Value">@opt.Label</label>
+                        <label class="form-check-label" for="q@(answerIndex)_@opt.Value">@opt.Label</label>
                     </div>
                 }
                 break;
@@ -120,20 +125,20 @@
                     var sel = q.SelectedOptionValues.Contains(opt.Value, StringComparer.Ordinal);
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox"
-                               id="q@(i)_@opt.Value" name="Answers[@i].SelectedOptionValues"
+                               id="q@(answerIndex)_@opt.Value" name="Answers[@answerIndex].SelectedOptionValues"
                                value="@opt.Value" @(sel ? "checked" : null) />
-                        <label class="form-check-label" for="q@(i)_@opt.Value">@opt.Label</label>
+                        <label class="form-check-label" for="q@(answerIndex)_@opt.Value">@opt.Label</label>
                     </div>
                 }
                 break;
 
             case SurveyQuestionType.ShortText:
                 <input class="form-control" type="text"
-                       name="Answers[@i].TextValue" value="@q.TextValue" />
+                       name="Answers[@answerIndex].TextValue" value="@q.TextValue" />
                 break;
 
             case SurveyQuestionType.LongText:
-                <textarea class="form-control" rows="4" name="Answers[@i].TextValue">@q.TextValue</textarea>
+                <textarea class="form-control" rows="4" name="Answers[@answerIndex].TextValue">@q.TextValue</textarea>
                 break;
 
             case SurveyQuestionType.Rating:
@@ -150,9 +155,9 @@
                         {
                             var checkedRating = q.RatingValue == n;
                             <input type="radio" class="btn-check"
-                                   id="q@(i)_r@(n)" name="Answers[@i].RatingValue"
+                                   id="q@(answerIndex)_r@(n)" name="Answers[@answerIndex].RatingValue"
                                    value="@n" autocomplete="off" @(checkedRating ? "checked" : null) />
-                            <label class="btn btn-outline-primary" for="q@(i)_r@(n)">@n</label>
+                            <label class="btn btn-outline-primary" for="q@(answerIndex)_r@(n)">@n</label>
                         }
                     </div>
                     @if (!string.IsNullOrWhiteSpace(q.RatingMaxLabel))
@@ -185,14 +190,14 @@
                                 <tr>
                                     <th scope="row">
                                         @row.Label
-                                        <input type="hidden" name="Answers[@i].GridRows[@rowIndex].RowValue" value="@row.Value" />
+                                        <input type="hidden" name="Answers[@answerIndex].GridRows[@rowIndex].RowValue" value="@row.Value" />
                                     </th>
                                     @foreach (var column in q.Options)
                                     {
                                         var selected = selectedColumns?.Contains(column.Value, StringComparer.Ordinal) == true;
                                         <td class="text-center">
                                             <input class="form-check-input" type="@(single ? "radio" : "checkbox")"
-                                                   name="Answers[@i].GridRows[@rowIndex].SelectedColumnValues"
+                                                   name="Answers[@answerIndex].GridRows[@rowIndex].SelectedColumnValues"
                                                    value="@column.Value"
                                                    aria-label="@($"{row.Label}: {column.Label}")"
                                                    @if (selected) { <text>checked</text> } />
@@ -211,7 +216,7 @@
            `legend + * { clear: left }`; an invisible input in that position prevents the
            first checkbox/radio/table from clearing the legend. Field order does not affect
            MVC's indexed answer binding. *@
-        <input type="hidden" name="Answers[@i].QuestionId" value="@q.Id" />
+        <input type="hidden" name="Answers[@answerIndex].QuestionId" value="@q.Id" />
 
         @if (hasError)
         {

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -372,6 +372,46 @@
             // ── show-if clause editor ────────────────────────────────────────
             function questionCards() { return Array.from(container.querySelectorAll('.question-card')); }
 
+            function updateQuestionControls() {
+                const cards = questionCards();
+                cards.forEach((card, index) => {
+                    const label = card.querySelector('.question-position-label');
+                    const up = card.querySelector('.move-question-up');
+                    const down = card.querySelector('.move-question-down');
+                    if (label) label.textContent = 'Question ' + (index + 1);
+                    if (up) up.disabled = index === 0;
+                    if (down) down.disabled = index === cards.length - 1;
+                });
+            }
+
+            function addQuestion(afterCard) {
+                const html = qTemplate.innerHTML.replaceAll('__QKEY__', freshKey('q'));
+                let card;
+                if (afterCard) {
+                    afterCard.insertAdjacentHTML('afterend', html);
+                    card = afterCard.nextElementSibling;
+                } else {
+                    container.insertAdjacentHTML('beforeend', html);
+                    card = container.lastElementChild;
+                }
+                initCard(card);
+                applyCulture(card);
+                window.HumansMarkdownEditor?.init(card);
+                updateQuestionControls();
+            }
+
+            function moveQuestion(button, direction) {
+                const card = button.closest('.question-card');
+                const sibling = direction < 0 ? card.previousElementSibling : card.nextElementSibling;
+                if (!sibling) return;
+                if (direction < 0) {
+                    container.insertBefore(card, sibling);
+                } else {
+                    container.insertBefore(sibling, card);
+                }
+                updateQuestionControls();
+            }
+
             function questionLabel(card, index) {
                 // The first localized field on a card is its Prompt.
                 const prompt = card.querySelector('.survey-localized-field');
@@ -461,11 +501,7 @@
 
             // ── events ───────────────────────────────────────────────────────
             document.getElementById('add-question').addEventListener('click', function () {
-                const html = qTemplate.innerHTML.replaceAll('__QKEY__', freshKey('q'));
-                container.insertAdjacentHTML('beforeend', html);
-                const card = container.lastElementChild;
-                initCard(card);
-                applyCulture(card);
+                addQuestion(null);
             });
 
             container.addEventListener('click', function (e) {
@@ -474,6 +510,13 @@
                     const id = card.querySelector('.question-id')?.value;
                     card.remove();
                     if (id) removeClauseRowsReferencing(id);
+                    updateQuestionControls();
+                } else if (e.target.closest('.move-question-up')) {
+                    moveQuestion(e.target, -1);
+                } else if (e.target.closest('.move-question-down')) {
+                    moveQuestion(e.target, 1);
+                } else if (e.target.closest('.add-question-after')) {
+                    addQuestion(e.target.closest('.question-card'));
                 } else if (e.target.classList.contains('add-option')) {
                     addOption(e.target.closest('.question-card'));
                 } else if (e.target.classList.contains('remove-option')) {
@@ -559,6 +602,7 @@
             });
 
             questionCards().forEach(initCard);
+            updateQuestionControls();
             applyCulture();
             updateMissingBadges();
         })();

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -53,7 +53,8 @@
 
 <div asp-validation-summary="All" class="alert alert-danger" role="alert" style="@(ViewData.ModelState.IsValid ? "display:none" : "")"></div>
 
-<form asp-controller="SurveyAdmin" asp-action="Save" method="post" id="survey-builder-form">
+<form asp-controller="SurveyAdmin" asp-action="Save" method="post" enctype="multipart/form-data"
+      id="survey-builder-form" class="pb-5">
     @Html.AntiForgeryToken()
     @if (!Model.IsNew)
     {
@@ -171,9 +172,9 @@
         <partial name="_SurveyQuestionCard" model="@(new SurveyQuestionCardModel("__QKEY__", new SurveyQuestionBuilderViewModel()))" />
     </template>
 
-    <div class="d-flex justify-content-between mt-3">
+    <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mt-3">
         <button type="button" class="btn btn-outline-secondary btn-sm" id="add-question">+ Add question</button>
-        <div class="d-flex gap-2">
+        <div class="d-flex flex-column flex-sm-row flex-wrap gap-2">
             <button type="submit" name="submitAction" value="save-translate" class="btn btn-outline-primary"
                     title="Saves, then machine-translates fields still missing in other languages from the default language. Existing text is never overwritten — review before opening.">
                 Save + translate missing
@@ -273,8 +274,11 @@
                 const ratings = card.querySelector('.rating-section');
                 const options = card.querySelector('.options-section');
                 const grid = card.querySelector('.grid-section');
+                const information = card.querySelector('.information-section');
+                const required = card.querySelector('.required-section');
                 const isChoice = type === 'SingleChoice' || type === 'MultiChoice';
                 const isGrid = type === 'Grid';
+                const isInformation = type === 'Information';
                 if (options) {
                     options.style.display = isChoice || isGrid ? '' : 'none';
                     const label = options.querySelector('.options-label');
@@ -284,7 +288,10 @@
                 }
                 if (grid) grid.style.display = isGrid ? '' : 'none';
                 if (ratings) ratings.style.display = type === 'Rating' ? '' : 'none';
+                if (information) information.style.display = isInformation ? '' : 'none';
+                if (required) required.style.display = isInformation ? 'none' : '';
                 updateGridColumnLimit(card);
+                updateInformationImageLimit(card);
             }
 
             function ensureQuestionId(card) {
@@ -319,6 +326,24 @@
                 card.querySelector('.grid-rows-container').insertAdjacentHTML('beforeend', html);
                 applyCulture(card.querySelector('.grid-rows-container').lastElementChild);
                 updateMoveButtons(card.querySelector('.grid-rows-container'), '.grid-row', 'grid-row');
+            }
+
+            function addInformationImage(card) {
+                const tpl = card.querySelector('.information-image-template');
+                const list = card.querySelector('.information-images-container');
+                if (!tpl || !list || list.querySelectorAll('.information-image-row').length >= 5) return;
+                const html = tpl.innerHTML.replaceAll('__IKEY__', freshKey('i'));
+                list.insertAdjacentHTML('beforeend', html);
+                applyCulture(list.lastElementChild);
+                updateInformationImageLimit(card);
+                updateMoveButtons(list, '.information-image-row', 'information-image');
+            }
+
+            function updateInformationImageLimit(card) {
+                const button = card.querySelector('.add-information-image');
+                if (!button) return;
+                button.disabled = card.querySelectorAll(
+                    '.information-images-container .information-image-row').length >= 5;
             }
 
             function updateMoveButtons(list, itemSelector, classPrefix) {
@@ -361,7 +386,8 @@
                 select.add(new Option('— choose a question —', ''));
                 questionCards().forEach((card, i) => {
                     if (card === ownCard) return;
-                    if (card.querySelector('.question-type')?.value === 'Grid') return;
+                    const type = card.querySelector('.question-type')?.value;
+                    if (type === 'Grid' || type === 'Information') return;
                     const id = card.querySelector('.question-id')?.value;
                     if (id) select.add(new Option(questionLabel(card, i), id));
                 });
@@ -426,6 +452,11 @@
                 });
                 updateMoveButtons(card.querySelector('.options-container'), '.option-row', 'option');
                 updateMoveButtons(card.querySelector('.grid-rows-container'), '.grid-row', 'grid-row');
+                updateMoveButtons(
+                    card.querySelector('.information-images-container'),
+                    '.information-image-row',
+                    'information-image');
+                updateInformationImageLimit(card);
             }
 
             // ── events ───────────────────────────────────────────────────────
@@ -456,6 +487,24 @@
                     moveCollectionItem(e.target, 1, '.option-row', '.options-container', 'option');
                 } else if (e.target.classList.contains('add-grid-row')) {
                     addGridRow(e.target.closest('.question-card'));
+                } else if (e.target.classList.contains('add-information-image')) {
+                    addInformationImage(e.target.closest('.question-card'));
+                } else if (e.target.classList.contains('remove-information-image')) {
+                    const card = e.target.closest('.question-card');
+                    e.target.closest('.information-image-row').remove();
+                    updateInformationImageLimit(card);
+                    updateMoveButtons(
+                        card.querySelector('.information-images-container'),
+                        '.information-image-row',
+                        'information-image');
+                } else if (e.target.closest('.move-information-image-up')) {
+                    moveCollectionItem(
+                        e.target, -1, '.information-image-row',
+                        '.information-images-container', 'information-image');
+                } else if (e.target.closest('.move-information-image-down')) {
+                    moveCollectionItem(
+                        e.target, 1, '.information-image-row',
+                        '.information-images-container', 'information-image');
                 } else if (e.target.classList.contains('remove-grid-row')) {
                     const card = e.target.closest('.question-card');
                     e.target.closest('.grid-row').remove();

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -372,15 +372,22 @@
             // ── show-if clause editor ────────────────────────────────────────
             function questionCards() { return Array.from(container.querySelectorAll('.question-card')); }
 
+            function questionPage(card) {
+                const value = Number.parseInt(card.querySelector('.question-page-number')?.value || '1', 10);
+                return Number.isFinite(value) && value > 0 ? value : 1;
+            }
+
             function updateQuestionControls() {
                 const cards = questionCards();
                 cards.forEach((card, index) => {
                     const label = card.querySelector('.question-position-label');
                     const up = card.querySelector('.move-question-up');
                     const down = card.querySelector('.move-question-down');
+                    const samePageCards = cards.filter(candidate => questionPage(candidate) === questionPage(card));
+                    const pageIndex = samePageCards.indexOf(card);
                     if (label) label.textContent = 'Question ' + (index + 1);
-                    if (up) up.disabled = index === 0;
-                    if (down) down.disabled = index === cards.length - 1;
+                    if (up) up.disabled = pageIndex === 0;
+                    if (down) down.disabled = pageIndex === samePageCards.length - 1;
                 });
             }
 
@@ -395,6 +402,9 @@
                     card = container.lastElementChild;
                 }
                 initCard(card);
+                if (afterCard) {
+                    card.querySelector('.question-page-number').value = questionPage(afterCard);
+                }
                 applyCulture(card);
                 window.HumansMarkdownEditor?.init(card);
                 updateQuestionControls();
@@ -402,12 +412,15 @@
 
             function moveQuestion(button, direction) {
                 const card = button.closest('.question-card');
-                const sibling = direction < 0 ? card.previousElementSibling : card.nextElementSibling;
-                if (!sibling) return;
+                const samePageCards = questionCards()
+                    .filter(candidate => questionPage(candidate) === questionPage(card));
+                const index = samePageCards.indexOf(card);
+                const target = samePageCards[index + direction];
+                if (!target) return;
                 if (direction < 0) {
-                    container.insertBefore(card, sibling);
+                    container.insertBefore(card, target);
                 } else {
-                    container.insertBefore(sibling, card);
+                    container.insertBefore(card, target.nextElementSibling);
                 }
                 updateQuestionControls();
             }
@@ -572,6 +585,8 @@
             container.addEventListener('change', function (e) {
                 if (e.target.classList.contains('question-type')) {
                     applyTypeVisibility(e.target.closest('.question-card'));
+                } else if (e.target.classList.contains('question-page-number')) {
+                    updateQuestionControls();
                 } else if (e.target.classList.contains('showif-mode')) {
                     const card = e.target.closest('.question-card');
                     const conditional = e.target.value === 'conditional';

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyInformationImageRow.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyInformationImageRow.cshtml
@@ -1,0 +1,39 @@
+@model SurveyInformationImageRowModel
+@{
+    var prefix = $"Questions[{Model.QuestionKey}].InformationImages[{Model.ImageKey}]";
+    var image = Model.Image;
+}
+<div class="information-image-row border rounded p-2 mb-2">
+    <input type="hidden" name="Questions[@Model.QuestionKey].InformationImages.Index" value="@Model.ImageKey" />
+    <input type="hidden" name="@(prefix).Id" value="@image.Id" />
+    <input type="hidden" name="@(prefix).ExistingStoragePath" value="@image.ExistingStoragePath" />
+    <input type="hidden" name="@(prefix).ExistingFileName" value="@image.ExistingFileName" />
+
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-stretch align-items-md-start gap-2 mb-2">
+        <div class="flex-grow-1" style="min-width:0">
+            @if (!string.IsNullOrWhiteSpace(image.ExistingStoragePath))
+            {
+                <a href="/@image.ExistingStoragePath.TrimStart('/')" target="_blank" rel="noopener">
+                    @(string.IsNullOrWhiteSpace(image.ExistingFileName) ? "View current image" : image.ExistingFileName)
+                </a>
+                <div class="form-text">Choose a new file below to replace it.</div>
+            }
+            <input type="file" name="@(prefix).Upload" class="form-control form-control-sm mt-1"
+                   accept="image/jpeg,image/png,image/webp" />
+        </div>
+        <div class="btn-group btn-group-sm align-self-start" role="group" aria-label="Image order and removal">
+            <button type="button" class="btn btn-outline-secondary move-information-image-up" aria-label="Move image up">
+                <i class="fa-solid fa-arrow-up" aria-hidden="true"></i>
+            </button>
+            <button type="button" class="btn btn-outline-secondary move-information-image-down" aria-label="Move image down">
+                <i class="fa-solid fa-arrow-down" aria-hidden="true"></i>
+            </button>
+            <button type="button" class="btn btn-outline-danger remove-information-image">Remove</button>
+        </div>
+    </div>
+
+    <partial name="_SurveyLocalizedField"
+             model="@(new SurveyLocalizedFieldModel($"{prefix}.Label", "Tab label", image.Label))" />
+    <partial name="_SurveyLocalizedField"
+             model="@(new SurveyLocalizedFieldModel($"{prefix}.AltText", "Image alt text", image.AltText))" />
+</div>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
@@ -32,7 +32,9 @@
         <div class="row g-2 mb-2">
             <div class="col-auto">
                 <label class="form-label small mb-0">Page</label>
-                <input type="number" min="1" name="@(prefix).PageNumber" class="form-control form-control-sm" style="width:5rem;" value="@(q.PageNumber <= 0 ? 1 : q.PageNumber)" />
+                <input type="number" min="1" name="@(prefix).PageNumber"
+                       class="form-control form-control-sm question-page-number"
+                       style="width:5rem;" value="@(q.PageNumber <= 0 ? 1 : q.PageNumber)" />
             </div>
             <div class="col-auto">
                 <label class="form-label small mb-0">Type</label>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
@@ -9,9 +9,24 @@
     @* Always rendered: new questions get a client-generated id (Builder JS) so show-if clauses can
        reference them before the first save — the service honours supplied ids. *@
     <input type="hidden" name="@(prefix).Id" value="@q.Id" class="question-id" />
-    <div class="card-header d-flex justify-content-between align-items-center py-2">
-        <strong class="small text-muted">Question</strong>
-        <button type="button" class="btn btn-outline-danger btn-sm remove-question">Remove</button>
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2 py-2">
+        <strong class="small text-muted question-position-label">Question</strong>
+        <div class="d-flex flex-wrap gap-1">
+            <div class="btn-group btn-group-sm" role="group" aria-label="Question order">
+                <button type="button" class="btn btn-outline-secondary move-question-up"
+                        title="Move question up" aria-label="Move question up">
+                    <i class="fa-solid fa-arrow-up" aria-hidden="true"></i>
+                </button>
+                <button type="button" class="btn btn-outline-secondary move-question-down"
+                        title="Move question down" aria-label="Move question down">
+                    <i class="fa-solid fa-arrow-down" aria-hidden="true"></i>
+                </button>
+            </div>
+            <button type="button" class="btn btn-outline-secondary btn-sm add-question-after">
+                + Add below
+            </button>
+            <button type="button" class="btn btn-outline-danger btn-sm remove-question">Remove</button>
+        </div>
     </div>
     <div class="card-body">
         <div class="row g-2 mb-2">

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
@@ -28,7 +28,7 @@
                     }
                 </select>
             </div>
-            <div class="col-auto align-self-end">
+            <div class="col-auto align-self-end required-section">
                 <div class="form-check">
                     <input type="checkbox" class="form-check-input" id="req-@key" name="@(prefix).IsRequired" value="true" @(q.IsRequired ? "checked" : null) />
                     <label class="form-check-label small" for="req-@key">Required</label>
@@ -36,8 +36,32 @@
             </div>
         </div>
 
-        <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel($"{prefix}.Prompt", "Prompt", q.Prompt))" />
-        <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel($"{prefix}.HelpText", "Help text (optional)", q.HelpText, Multiline: true))" />
+        <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel($"{prefix}.Prompt", "Prompt / optional information heading", q.Prompt))" />
+        <partial name="_SurveyLocalizedField" model="@(new SurveyLocalizedFieldModel($"{prefix}.HelpText", "Help text / information Markdown", q.HelpText, Multiline: true, Markdown: true))" />
+
+        <div class="information-section border-top pt-2 mt-2">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <label class="form-label small fw-semibold mb-0">Images</label>
+                <span class="small text-muted">Up to five, shown as labelled tabs.</span>
+            </div>
+            <div class="alert alert-warning small py-2">
+                Uploaded image URLs are public and may be shared outside this survey.
+            </div>
+            <div class="information-images-container">
+                @foreach (var (image, i) in q.InformationImages.Select((image, i) => (image, i)))
+                {
+                    <partial name="_SurveyInformationImageRow"
+                             model="@(new SurveyInformationImageRowModel(key, i.ToString(), image))" />
+                }
+            </div>
+            <template class="information-image-template">
+                <partial name="_SurveyInformationImageRow"
+                         model="@(new SurveyInformationImageRowModel(key, "__IKEY__", new SurveyInformationImageBuilderViewModel()))" />
+            </template>
+            <button type="button" class="btn btn-outline-secondary btn-sm add-information-image">
+                + Add image
+            </button>
+        </div>
 
         <div class="rating-section border-top pt-2 mt-2">
             <div class="row g-2">

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
+using Humans.Base.Interfaces;
 using Humans.Surveys.Data;
 using Humans.Surveys.Domain;
 using Humans.Surveys.Services;
@@ -229,6 +231,79 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
         question.GridRows!.Select(row => row.Value).Should().ContainInOrder("monday", "tuesday");
         question.Options.OrderBy(option => option.Order).Select(option => option.Value)
             .Should().ContainInOrder("morning", "afternoon");
+    }
+
+    [HumansFact(Timeout = 60000)]
+    public async Task Save_uploads_and_preview_renders_an_information_block()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var token = await GetCreateTokenAsync();
+        var questionId = Guid.NewGuid();
+        using var form = new MultipartFormDataContent();
+        AddField("__RequestVerificationToken", token);
+        AddField("Title[en]", $"Information integration survey {Guid.NewGuid():N}");
+        AddField("Questions.Index", "information");
+        AddField("Questions[information].Id", questionId.ToString());
+        AddField("Questions[information].PageNumber", "1");
+        AddField("Questions[information].Type", nameof(SurveyQuestionType.Information));
+        AddField("Questions[information].Prompt[en]", "Conditions");
+        AddField("Questions[information].HelpText[en]", "**Read this before choosing.**");
+        AddField("Questions[information].InformationImages.Index", "fire");
+        AddField("Questions[information].InformationImages[fire].Label[en]", "Fire risk");
+        AddField("Questions[information].InformationImages[fire].AltText[en]", "Fire risk forecast table");
+        var fireFile = new ByteArrayContent([0x89, 0x50, 0x4E, 0x47]);
+        fireFile.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        form.Add(fireFile, "Questions[information].InformationImages[fire].Upload", "fire-risk.png");
+        AddField("Questions[information].InformationImages.Index", "rain");
+        AddField("Questions[information].InformationImages[rain].Label[en]", "Rain");
+        AddField("Questions[information].InformationImages[rain].AltText[en]", "Rain forecast table");
+        var rainFile = new ByteArrayContent([0x89, 0x50, 0x4E, 0x47]);
+        rainFile.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        form.Add(rainFile, "Questions[information].InformationImages[rain].Upload", "rain.png");
+
+        var saveResp = await Client.PostAsync("/Survey/Admin/Save", form, ct);
+        var surveyId = ExtractSurveyId(saveResp);
+
+        List<string> storagePaths;
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
+            var question = (await db.Surveys.AsNoTracking()
+                    .Include(survey => survey.Questions)
+                    .SingleAsync(survey => survey.Id == surveyId, ct))
+                .Questions.Should().ContainSingle().Subject;
+            question.Type.Should().Be(SurveyQuestionType.Information);
+            question.IsRequired.Should().BeFalse();
+            question.InformationImages.Should().HaveCount(2);
+            question.InformationImages.Select(image => image.Label.Resolve("en", "en"))
+                .Should().ContainInOrder("Fire risk", "Rain");
+            question.InformationImages.Select(image => image.AltText.Resolve("en", "en"))
+                .Should().ContainInOrder("Fire risk forecast table", "Rain forecast table");
+            storagePaths = question.InformationImages.Select(image => image.StoragePath).ToList();
+        }
+
+        var preview = await Client.GetAsync(
+            $"/Survey/Admin/Preview/{surveyId}/Page?page=1", ct);
+        preview.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await preview.Content.ReadAsStringAsync(ct);
+        html.Should().Contain("<strong>Read this before choosing.</strong>");
+        html.Should().Contain("Fire risk");
+        html.Should().Contain("Rain");
+        html.Should().Contain("data-bs-toggle=\"tab\"");
+        html.Should().ContainAll(storagePaths.Select(storagePath => $"/{storagePath}"));
+        html.Should().NotContain("name=\"Answers[0].QuestionId\"");
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var fileStorage = scope.ServiceProvider.GetRequiredService<IFileStorage>();
+            foreach (var storagePath in storagePaths)
+            {
+                await fileStorage.DeleteAsync(storagePath, CancellationToken.None);
+            }
+        }
+
+        void AddField(string name, string value) => form.Add(new StringContent(value), name);
     }
 
     [HumansFact(Timeout = 60000)]

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -234,6 +234,61 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
     }
 
     [HumansFact(Timeout = 60000)]
+    public async Task Save_persists_the_posted_question_order()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
+        var ct = Xunit.TestContext.Current.CancellationToken;
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var createToken = await GetCreateTokenAsync();
+
+        var createResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", createToken),
+            ("Title[en]", $"Question order {Guid.NewGuid():N}"),
+            ("Questions.Index", "first"),
+            ("Questions[first].Id", firstId.ToString()),
+            ("Questions[first].PageNumber", "1"),
+            ("Questions[first].Type", nameof(SurveyQuestionType.ShortText)),
+            ("Questions[first].Prompt[en]", "First"),
+            ("Questions.Index", "second"),
+            ("Questions[second].Id", secondId.ToString()),
+            ("Questions[second].PageNumber", "1"),
+            ("Questions[second].Type", nameof(SurveyQuestionType.ShortText)),
+            ("Questions[second].Prompt[en]", "Second")), ct);
+        var surveyId = ExtractSurveyId(createResp);
+
+        var editResp = await Client.GetAsync($"/Survey/Admin/Edit/{surveyId}", ct);
+        var editToken = ExtractAntiForgeryToken(await editResp.Content.ReadAsStringAsync(ct));
+        var reorderResp = await Client.PostAsync("/Survey/Admin/Save", BuildForm(
+            ("__RequestVerificationToken", editToken!),
+            ("Id", surveyId.ToString()),
+            ("Title[en]", "Question order updated"),
+            ("Questions.Index", "second"),
+            ("Questions[second].Id", secondId.ToString()),
+            ("Questions[second].PageNumber", "1"),
+            ("Questions[second].Type", nameof(SurveyQuestionType.ShortText)),
+            ("Questions[second].Prompt[en]", "Second"),
+            ("Questions.Index", "first"),
+            ("Questions[first].Id", firstId.ToString()),
+            ("Questions[first].PageNumber", "1"),
+            ("Questions[first].Type", nameof(SurveyQuestionType.ShortText)),
+            ("Questions[first].Prompt[en]", "First")), ct);
+
+        ((int)reorderResp.StatusCode).Should().BeOneOf(
+            (int)HttpStatusCode.Found, (int)HttpStatusCode.Redirect);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
+        var questionIds = await db.SurveyQuestions.AsNoTracking()
+            .Where(question => question.SurveyId == surveyId)
+            .OrderBy(question => question.Order)
+            .Select(question => question.Id)
+            .ToListAsync(ct);
+
+        questionIds.Should().ContainInOrder(secondId, firstId);
+    }
+
+    [HumansFact(Timeout = 60000)]
     public async Task Save_uploads_and_preview_renders_an_information_block()
     {
         await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -295,6 +295,7 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
         var ct = Xunit.TestContext.Current.CancellationToken;
         var token = await GetCreateTokenAsync();
         var questionId = Guid.NewGuid();
+        var answerQuestionId = Guid.NewGuid();
         using var form = new MultipartFormDataContent();
         AddField("__RequestVerificationToken", token);
         AddField("Title[en]", $"Information integration survey {Guid.NewGuid():N}");
@@ -316,6 +317,12 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
         var rainFile = new ByteArrayContent([0x89, 0x50, 0x4E, 0x47]);
         rainFile.Headers.ContentType = new MediaTypeHeaderValue("image/png");
         form.Add(rainFile, "Questions[information].InformationImages[rain].Upload", "rain.png");
+        AddField("Questions.Index", "answer");
+        AddField("Questions[answer].Id", answerQuestionId.ToString());
+        AddField("Questions[answer].PageNumber", "1");
+        AddField("Questions[answer].Type", nameof(SurveyQuestionType.ShortText));
+        AddField("Questions[answer].Prompt[en]", "Which date works?");
+        AddField("Questions[answer].IsRequired", "true");
 
         var saveResp = await Client.PostAsync("/Survey/Admin/Save", form, ct);
         var surveyId = ExtractSurveyId(saveResp);
@@ -324,10 +331,12 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
         using (var scope = Factory.Services.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<SurveysDbContext>();
-            var question = (await db.Surveys.AsNoTracking()
+            var questions = (await db.Surveys.AsNoTracking()
                     .Include(survey => survey.Questions)
                     .SingleAsync(survey => survey.Id == surveyId, ct))
-                .Questions.Should().ContainSingle().Subject;
+                .Questions;
+            questions.Should().HaveCount(2);
+            var question = questions.Single(candidate => candidate.Id == questionId);
             question.Type.Should().Be(SurveyQuestionType.Information);
             question.IsRequired.Should().BeFalse();
             question.InformationImages.Should().HaveCount(2);
@@ -349,7 +358,9 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
         html.Should().Contain("<figcaption class=\"small text-muted mt-1\">Fire risk</figcaption>");
         html.Should().Contain("<figcaption class=\"small text-muted mt-1\">Rain</figcaption>");
         html.Should().ContainAll(storagePaths.Select(storagePath => $"/{storagePath}"));
-        html.Should().NotContain("name=\"Answers[0].QuestionId\"");
+        html.Should().Contain($"name=\"Answers[0].QuestionId\" value=\"{answerQuestionId}\"");
+        html.Should().Contain("name=\"Answers[0].TextValue\"");
+        html.Should().NotContain("name=\"Answers[1].QuestionId\"");
 
         using (var scope = Factory.Services.CreateScope())
         {

--- a/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -346,6 +346,8 @@ public class SurveyAdminControllerTests(HumansTestDatabase database) : Integrati
         html.Should().Contain("Fire risk");
         html.Should().Contain("Rain");
         html.Should().Contain("data-bs-toggle=\"tab\"");
+        html.Should().Contain("<figcaption class=\"small text-muted mt-1\">Fire risk</figcaption>");
+        html.Should().Contain("<figcaption class=\"small text-muted mt-1\">Rain</figcaption>");
         html.Should().ContainAll(storagePaths.Select(storagePath => $"/{storagePath}"));
         html.Should().NotContain("name=\"Answers[0].QuestionId\"");
 

--- a/tests/Humans.Integration.Tests/Controllers/SurveyPageRenderTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/SurveyPageRenderTests.cs
@@ -139,7 +139,7 @@ public class SurveyPageRenderTests(HumansTestDatabase database) : IntegrationTes
     }
 
     [HumansFact(Timeout = 60000)]
-    public async Task Admin_survey_builder_renders_the_shared_markdown_editor_for_intro_and_email_message()
+    public async Task Admin_survey_builder_renders_shared_markdown_editors_and_dynamic_question_controls()
     {
         var ct = Xunit.TestContext.Current.CancellationToken;
         await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
@@ -153,6 +153,12 @@ public class SurveyPageRenderTests(HumansTestDatabase database) : IntegrationTes
         html.Should().Contain("name=\"InvitationEmailMessage[en]\"");
         html.Should().Contain("easymde@2.21.0");
         html.Should().Contain("new EasyMDE");
+        html.Should().Contain("data-humans-markdown-editor=\"true\"");
+        html.Should().Contain("window.HumansMarkdownEditor");
+        html.Should().Contain("window.HumansMarkdownEditor?.init(card)");
+        html.Should().Contain("move-question-up");
+        html.Should().Contain("move-question-down");
+        html.Should().Contain("add-question-after");
         html.Should().NotContain("<markdown-editor");
     }
 

--- a/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
+++ b/tests/Humans.Surveys.Tests/Controllers/SurveysApiControllerTests.cs
@@ -110,6 +110,43 @@ public class SurveysApiControllerTests
         json.Should().Contain(@"""label"":""Morning""");
     }
 
+    [HumansFact]
+    public async Task Definition_includes_information_markdown_and_public_images()
+    {
+        var id = Guid.NewGuid();
+        var editable = new SurveyEditInput(
+            Text("My Survey"), LocalizedText.Empty, LocalizedText.Empty,
+            LocalizedText.Empty, LocalizedText.Empty,
+            "en", false, null, null, null, null, null, null,
+            [
+                new QuestionInput(
+                    Guid.NewGuid(), 1, 0, SurveyQuestionType.Information,
+                    Text("Forecast"), Text("**Read this first**"),
+                    false, null, null, LocalizedText.Empty, LocalizedText.Empty, null, [],
+                    InformationImages:
+                    [
+                        new InformationImageInput(
+                            Guid.NewGuid(),
+                            Text("Fire risk"),
+                            Text("Fire risk table"),
+                            "uploads/surveys/fire.png",
+                            "image/png",
+                            "fire.png"),
+                    ]),
+            ]);
+        _surveys.GetForEditAsync(id, Arg.Any<CancellationToken>())
+            .Returns(new SurveyDetail(id, SurveyStatus.Open, editable));
+
+        var result = await _sut.Definition(id, Xunit.TestContext.Current.CancellationToken);
+
+        var json = JsonSerializer.Serialize(result.Should().BeOfType<OkObjectResult>().Subject.Value);
+        json.Should().Contain(@"""type"":""Information""");
+        json.Should().Contain(@"""markdown"":""**Read this first**""");
+        json.Should().Contain(@"""url"":""/uploads/surveys/fire.png""");
+        json.Should().Contain(@"""label"":""Fire risk""");
+        json.Should().Contain(@"""altText"":""Fire risk table""");
+    }
+
     // ── Responses ───────────────────────────────────────────────────────────
 
     [HumansFact]

--- a/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
@@ -168,6 +168,30 @@ public sealed class SurveyBuilderViewModelTests
         mapped.AltText.Resolve("en", "en").Should().Be("Temperature forecast table");
     }
 
+    [HumansFact]
+    public void ToEditInput_uses_the_posted_question_list_order()
+    {
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var vm = new SurveyBuilderViewModel
+        {
+            Title = new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = "Survey" },
+            Questions =
+            [
+                new SurveyQuestionBuilderViewModel { Id = secondId, Prompt = Dict("Second") },
+                new SurveyQuestionBuilderViewModel { Id = firstId, Prompt = Dict("First") },
+            ],
+        };
+
+        var questions = vm.ToEditInput(NodaTime.DateTimeZone.Utc).Questions;
+
+        questions.Select(question => question.Id).Should().ContainInOrder(secondId, firstId);
+        questions.Select(question => question.Order).Should().ContainInOrder(0, 1);
+    }
+
     private static LocalizedText L(string value)
-        => new(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = value });
+        => new(Dict(value));
+
+    private static Dictionary<string, string> Dict(string value)
+        => new(StringComparer.Ordinal) { ["en"] = value };
 }

--- a/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
@@ -169,24 +169,26 @@ public sealed class SurveyBuilderViewModelTests
     }
 
     [HumansFact]
-    public void ToEditInput_uses_the_posted_question_list_order()
+    public void ToEditInput_uses_the_posted_question_list_order_within_each_page()
     {
         var firstId = Guid.NewGuid();
         var secondId = Guid.NewGuid();
+        var thirdId = Guid.NewGuid();
         var vm = new SurveyBuilderViewModel
         {
             Title = new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = "Survey" },
             Questions =
             [
-                new SurveyQuestionBuilderViewModel { Id = secondId, Prompt = Dict("Second") },
-                new SurveyQuestionBuilderViewModel { Id = firstId, Prompt = Dict("First") },
+                new SurveyQuestionBuilderViewModel { Id = secondId, PageNumber = 2, Prompt = Dict("Second") },
+                new SurveyQuestionBuilderViewModel { Id = firstId, PageNumber = 1, Prompt = Dict("First") },
+                new SurveyQuestionBuilderViewModel { Id = thirdId, PageNumber = 2, Prompt = Dict("Third") },
             ],
         };
 
         var questions = vm.ToEditInput(NodaTime.DateTimeZone.Utc).Questions;
 
-        questions.Select(question => question.Id).Should().ContainInOrder(secondId, firstId);
-        questions.Select(question => question.Order).Should().ContainInOrder(0, 1);
+        questions.Select(question => question.Id).Should().ContainInOrder(secondId, firstId, thirdId);
+        questions.Select(question => question.Order).Should().ContainInOrder(0, 0, 1);
     }
 
     private static LocalizedText L(string value)

--- a/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyBuilderViewModelTests.cs
@@ -138,6 +138,36 @@ public sealed class SurveyBuilderViewModelTests
         vm.ToInput(0).GridSelectionMode.Should().BeNull();
     }
 
+    [HumansFact]
+    public void Information_images_round_trip_through_the_builder()
+    {
+        var imageId = Guid.NewGuid();
+        var input = new QuestionInput(
+            Guid.NewGuid(), 1, 0, SurveyQuestionType.Information,
+            L("Weather context"), L("**Forecast details**"), false, null, null,
+            LocalizedText.Empty, LocalizedText.Empty, null, [],
+            InformationImages:
+            [
+                new InformationImageInput(
+                    imageId,
+                    L("Temperature"),
+                    L("Temperature forecast table"),
+                    "uploads/surveys/survey/question/image.png",
+                    "image/png",
+                    "temperature.png"),
+            ]);
+
+        var vm = SurveyQuestionBuilderViewModel.FromInput(input);
+        var roundTripped = vm.ToInput(0);
+
+        var image = vm.InformationImages.Should().ContainSingle().Subject;
+        image.ExistingStoragePath.Should().Be("uploads/surveys/survey/question/image.png");
+        var mapped = roundTripped.InformationImages.Should().ContainSingle().Subject;
+        mapped.Id.Should().Be(imageId);
+        mapped.Label.Resolve("en", "en").Should().Be("Temperature");
+        mapped.AltText.Resolve("en", "en").Should().Be("Temperature forecast table");
+    }
+
     private static LocalizedText L(string value)
         => new(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = value });
 }

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -206,7 +206,7 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
-    public async Task UpdateAsync_deletes_removed_information_image_after_persisting()
+    public async Task UpdateAsync_does_not_delete_a_removed_image_that_a_concurrent_editor_may_restore()
     {
         var survey = SurveyWith(SurveyStatus.Draft, null, null);
         var questionId = Guid.NewGuid();
@@ -242,8 +242,8 @@ public class SurveyServiceTests
             survey.Id, Input(updated), Guid.NewGuid(), TestContext.Current.CancellationToken);
 
         await _repo.Received(1).UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
-        await _fileStorage.Received(1).DeleteAsync(
-            "uploads/surveys/old.png", Arg.Any<CancellationToken>());
+        await _fileStorage.DidNotReceive().DeleteAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -10,6 +10,7 @@ using Humans.Surveys.Services;
 using Humans.Teams.Contracts;
 using Humans.Tickets.Contracts;
 using Humans.Base.Enums;
+using Humans.Base.Interfaces;
 using Humans.Surveys.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -34,11 +35,12 @@ public class SurveyServiceTests
     private readonly IEmailMessageFactory _emailMessages = Substitute.For<IEmailMessageFactory>();
     private readonly ISurveyInviteTokenProvider _tokenProvider = Substitute.For<ISurveyInviteTokenProvider>();
     private readonly IGoogleTranslationService _translation = Substitute.For<IGoogleTranslationService>();
+    private readonly IFileStorage _fileStorage = Substitute.For<IFileStorage>();
 
     private SurveyService CreateService(ILogger<SurveyService>? logger = null) => new(
         _repo, _audit, _clock, logger ?? NullLogger<SurveyService>.Instance,
         _teamService, _userService, _ticketService, _shiftView,
-        _userEmailService, _emailService, _emailMessages, _tokenProvider, _translation);
+        _userEmailService, _emailService, _emailMessages, _tokenProvider, _translation, _fileStorage);
 
     private static LocalizedText L(string en) => new(new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = en });
 
@@ -165,6 +167,83 @@ public class SurveyServiceTests
         grid.GridSelectionMode.Should().Be(GridSelectionMode.Multiple);
         grid.GridRows!.Select(row => row.Value).Should().ContainInOrder("monday", "tuesday");
         grid.Options.Select(column => column.Value).Should().ContainInOrder("morning", "afternoon");
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_saves_and_persists_an_information_image()
+    {
+        Survey? captured = null;
+        _repo.When(r => r.AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>()))
+            .Do(call => captured = call.Arg<Survey>());
+        var questionId = Guid.NewGuid();
+        await using var content = new MemoryStream([1, 2, 3]);
+        var information = new QuestionInput(
+            questionId, 1, 0, SurveyQuestionType.Information,
+            L("Conditions"), L("Use this context before choosing."), true, null, null,
+            LocalizedText.Empty, LocalizedText.Empty, null, [],
+            InformationImages:
+            [
+                new InformationImageInput(
+                    null,
+                    L("Fire risk"),
+                    L("Fire risk forecast table"),
+                    Upload: new SurveyImageUpload(content, "image/png", "fire-risk.png", 3)),
+            ]);
+
+        await CreateService().CreateAsync(
+            Input(information), Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        var saved = captured!.Questions.Should().ContainSingle().Subject;
+        saved.Type.Should().Be(SurveyQuestionType.Information);
+        saved.IsRequired.Should().BeFalse();
+        saved.Options.Should().BeEmpty();
+        var image = saved.InformationImages.Should().ContainSingle().Subject;
+        image.StoragePath.Should().StartWith($"uploads/surveys/{captured.Id}/{questionId}/");
+        image.StoragePath.Should().EndWith(".png");
+        image.Label.Resolve("en", "en").Should().Be("Fire risk");
+        await _fileStorage.Received(1).SaveAsync(
+            image.StoragePath, content, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task UpdateAsync_deletes_removed_information_image_after_persisting()
+    {
+        var survey = SurveyWith(SurveyStatus.Draft, null, null);
+        var questionId = Guid.NewGuid();
+        survey.Questions =
+        [
+            new SurveyQuestion
+            {
+                Id = questionId,
+                SurveyId = survey.Id,
+                PageNumber = 1,
+                Type = SurveyQuestionType.Information,
+                HelpText = L("Context"),
+                InformationImages =
+                [
+                    new SurveyInformationImage(
+                        Guid.NewGuid(),
+                        "uploads/surveys/old.png",
+                        "image/png",
+                        "old.png",
+                        L("Old"),
+                        L("Old data")),
+                ],
+            },
+        ];
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        var updated = new QuestionInput(
+            questionId, 1, 0, SurveyQuestionType.Information,
+            LocalizedText.Empty, L("Updated context"), false, null, null,
+            LocalizedText.Empty, LocalizedText.Empty, null, [],
+            InformationImages: []);
+
+        await CreateService().UpdateAsync(
+            survey.Id, Input(updated), Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await _repo.Received(1).UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+        await _fileStorage.Received(1).DeleteAsync(
+            "uploads/surveys/old.png", Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -1954,6 +2033,43 @@ public class SurveyServiceTests
         var result = await CreateService().GetResultsAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task Information_items_are_omitted_from_results_and_response_exports()
+    {
+        var surveyId = Guid.NewGuid();
+        var informationId = Guid.NewGuid();
+        var answerId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(survey, surveyId);
+        survey.Questions =
+        [
+            new SurveyQuestion
+            {
+                Id = informationId,
+                SurveyId = surveyId,
+                PageNumber = 1,
+                Order = 0,
+                Type = SurveyQuestionType.Information,
+                Prompt = L("Forecast"),
+                HelpText = L("Context"),
+            },
+            TextQuestion(answerId, surveyId, 1),
+        ];
+        _repo.GetByIdAsync(surveyId, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SurveyResponse>());
+        _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, int>());
+
+        var results = await CreateService().GetResultsAsync(
+            surveyId, TestContext.Current.CancellationToken);
+        var export = await CreateService().GetResponseExportAsync(
+            surveyId, TestContext.Current.CancellationToken);
+
+        results!.Questions.Should().ContainSingle().Which.QuestionId.Should().Be(answerId);
+        export!.Questions.Should().ContainSingle().Which.QuestionId.Should().Be(answerId);
     }
 
     [HumansFact]

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -247,6 +247,30 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task CreateAsync_rejects_an_image_row_without_an_upload()
+    {
+        var information = new QuestionInput(
+            Guid.NewGuid(), 1, 0, SurveyQuestionType.Information,
+            L("Conditions"), L("Context"), false, null, null,
+            LocalizedText.Empty, LocalizedText.Empty, null, [],
+            InformationImages:
+            [
+                new InformationImageInput(
+                    null,
+                    L("Fire risk"),
+                    L("Fire risk forecast table")),
+            ]);
+
+        var act = async () => await CreateService().CreateAsync(
+            Input(information), Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*select the file again*");
+        await _repo.DidNotReceive().AddAsync(
+            Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task CreateAsync_rejects_a_grid_with_more_than_five_columns()
     {
         var columns = Enumerable.Range(1, 6)

--- a/tests/Humans.Surveys.Tests/Services/SurveyWizardFlowTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyWizardFlowTests.cs
@@ -197,6 +197,18 @@ public class SurveyWizardFlowTests
     }
 
     [HumansFact]
+    public void RequiredUnanswered_never_requires_an_information_item()
+    {
+        var information = Q(
+            Guid.NewGuid(), 1, 1, SurveyQuestionType.Information, required: true);
+
+        SurveyWizardFlow.RequiredUnanswered(
+                [information],
+                new Dictionary<Guid, AnswerState>())
+            .Should().BeEmpty();
+    }
+
+    [HumansFact]
     public void RequiredUnanswered_requires_an_answer_for_every_grid_row()
     {
         var id = Guid.NewGuid();


### PR DESCRIPTION
## What

Adds ordered survey information blocks with localized, sanitized Markdown and up to five labelled public images displayed as tabs. Implements nobodies-collective/Humans#1119.

## Why

Survey respondents need supporting evidence such as fire-risk, temperature, and rain tables immediately before the questions those data inform; the survey introduction is on a separate screen.

## Existing surface checked

Reuses survey question ordering, paging and conditional display; existing localized `Prompt`/`HelpText`; `SurveyService` create/update; repository reconciliation; `Html.SanitizedMarkdown`; Bootstrap tabs; and `IFileStorage`. No new endpoint, package, DI registration, repository method, or standalone service was added.

## UI changes / screenshots

- Builder supports Markdown plus ordered, labelled JPEG/PNG/WebP uploads (maximum five, 10 MB each).
- The upload form explicitly warns that uploaded file URLs are public and shareable outside the survey.
- Preview/respondent rendering uses horizontally scrollable tabs, with a vertical no-JavaScript fallback.
- Tested at 390×844: no page-level horizontal overflow; upload controls and save actions stack; image tabs scroll and remain interactive in preview.

## Checklist

- [x] **Section labeled** — issue and PR carry `section:surveys`.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off the QA fork's `main`** (`qa/main` locally; identical at branch point).
- [x] **Issue refs are qualified** (`nobodies-collective/Humans#1119`).
- [x] **EF migration** was auto-generated and has no pending model changes.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No.
- [x] **Reuse-first checked** — existing survey, Markdown, Bootstrap, and file-storage surfaces were reused.
- [ ] **Build + test pass locally** — full solution build passes; Survey tests (182) and focused Survey Admin integration tests pass. The full parallel solution run hit the pre-existing `MissingDatabase_StillRefusesToStart_AndLogsOneClearFatalLineNamingIt` startup-test flake; that test passes in isolation.
- [x] **Nav coverage** — no new page; the new item is available in the existing survey builder.
- [x] **No magic strings** — enum/`nameof()` used where applicable.
- [x] **Dates/times via NodaTime, icons via Font Awesome 6** — no new date/time handling; existing FA icons used.

## Reviewer notes

The migration adds one nullable JSONB column (`InformationImages`) to survey questions. Information blocks never create answers, cannot be required or used as branch sources, and are excluded defensively from results and exports. Failed new uploads are cleaned up best-effort; removed/replaced files are retained to avoid stale-editor races and may be garbage-collected later by a reference-aware maintenance job.

The multi-image integration test also guards that preview tab triggers render as links rather than disabled buttons inside the preview fieldset.

