### PR TITLE
Sprint queue on GitHub: tracking-issue template + batch-worker unattended mode

### DIFF
--- a/.claude/agents/batch-worker.md
+++ b/.claude/agents/batch-worker.md
@@ -154,7 +154,8 @@ failure would leave the failing implementation on the branch and carry it into t
 - **Review gate exhausted (3 iterations, Phase 2 / 2.5 / 3)** — unchanged from the rules above:
   **STOP.** The batch is blocked at that issue. Do not skip it, do not move to the next issue, do
   not open a PR. Record the failing criterion in Needs-Peter and in the batch report. A blocked
-  batch leaves its branch pushed and its checkbox unticked for a human to pick up.
+  batch leaves its branch pushed and its checkbox unticked for a human to pick up; nothing
+  re-dispatches it on its own, since the orchestrator chooses the batch (§ Input).
 
 If a gate fires after that issue already has a commit — the escape valve missed it during
 exploration and caught it during implementation — `git revert` or reset that issue's commits before
@@ -170,17 +171,11 @@ Two mechanical differences from a local run:
   - **Phase 4 PR creation** — `create_pull_request` (owner `peterdrier`, repo `Humans`, base
     `main`) replaces `gh pr create`. Push with plain `git push -u origin <branch>` first; only the
     PR call needs the MCP tool.
-  - **Open-PR list** (claim / blocked set) — `list_pull_requests` + `pull_request_read`
-    (`get_files`), assembled into the JSON shape `section-doctor` Phase 2 uses:
-    `[{number, headRefName, title, files: [paths]}]`.
   - **Tracking issue** — `issue_write` (method `update`) to tick a batch checkbox or append to the
     Needs-Peter block; `issue_read` to re-read it first, since another run may have edited it.
 - **Branch names must be `claude/`-prefixed** (`claude/sprint-<date>-batch-<n>`). That prefix is
   always accepted on push; other names are checked against branch protection, others' commits, and
   others' open PRs, and are rejected on any of them.
-
-Claim the batch before doing any work, by the blocked-set rule in
-`docs/sprints/TRACKING-ISSUE-TEMPLATE.md` — first unchecked batch whose branch has no open PR.
 
 ## Report Format
 

--- a/.claude/agents/batch-worker.md
+++ b/.claude/agents/batch-worker.md
@@ -141,24 +141,40 @@ When this agent runs from a sprint routine rather than a session Peter is watchi
 one to escalate to: routine runs are fully autonomous with no permission prompts. The stop-and-
 report rules above still hold, but "the orchestrator escalates to Peter" is not available.
 
-**Every stop degrades to: skip the item, append to Needs-Peter, keep going.** Never to shipping
-the change. Specifically:
+**Pre-implementation gates degrade to: skip the item, append to Needs-Peter, keep going.**
+**Post-commit review failures stay hard stops.** The distinction is whether code is already
+committed: Phase 1 step 5 commits each issue before Phase 2 reviews it, so a "skip" after a review
+failure would leave the failing implementation on the branch and carry it into the batch PR.
 
 - **Phase 1 escape valve (privilege / spec change)** — do not implement, do not commit. Append to
   the sprint issue's Needs-Peter block with the concern, the lines that would change, who gains
   what capability, and move to the next issue in the work order. The batch continues.
 - **Unauthorized author** — `/sprint` marks these `GATED` at plan time and they should never reach
   you. If one does, skip it and record that the gate leaked.
-- **Review gate exhausted (3 iterations)** — unchanged: the batch stops at that issue. Record the
-  failing criterion in Needs-Peter as well as the batch report.
+- **Review gate exhausted (3 iterations, Phase 2 / 2.5 / 3)** — unchanged from the rules above:
+  **STOP.** The batch is blocked at that issue. Do not skip it, do not move to the next issue, do
+  not open a PR. Record the failing criterion in Needs-Peter and in the batch report. A blocked
+  batch leaves its branch pushed and its checkbox unticked for a human to pick up.
+
+If a gate fires after that issue already has a commit — the escape valve missed it during
+exploration and caught it during implementation — `git revert` or reset that issue's commits before
+continuing, so the skipped work never reaches the PR.
 
 A skipped item leaves the batch checkbox unticked and is named in the PR body. Peter's answers are
 applied later by a `resume` run, as in `section-doctor`.
 
 Two mechanical differences from a local run:
 
-- **`gh` is unavailable.** Use the GitHub MCP tools instead — for the open-PR list, build the same
-  JSON shape `section-doctor` Phase 2 uses: `[{number, headRefName, title, files: [paths]}]`.
+- **`gh` is unavailable.** Use the GitHub MCP tools for every GitHub operation, overriding the
+  `gh` invocations named above:
+  - **Phase 4 PR creation** — `create_pull_request` (owner `peterdrier`, repo `Humans`, base
+    `main`) replaces `gh pr create`. Push with plain `git push -u origin <branch>` first; only the
+    PR call needs the MCP tool.
+  - **Open-PR list** (claim / blocked set) — `list_pull_requests` + `pull_request_read`
+    (`get_files`), assembled into the JSON shape `section-doctor` Phase 2 uses:
+    `[{number, headRefName, title, files: [paths]}]`.
+  - **Tracking issue** — `issue_write` (method `update`) to tick a batch checkbox or append to the
+    Needs-Peter block; `issue_read` to re-read it first, since another run may have edited it.
 - **Branch names must be `claude/`-prefixed** (`claude/sprint-<date>-batch-<n>`). That prefix is
   always accepted on push; other names are checked against branch protection, others' commits, and
   others' open PRs, and are rejected on any of them.

--- a/.claude/agents/batch-worker.md
+++ b/.claude/agents/batch-worker.md
@@ -135,6 +135,37 @@ Self-reviewed against CODE_REVIEW_RULES.md. No critical issues.
 - **One commit per issue, plus fix commits.** Keep the history clean so individual issues can be traced.
 - **If the user sends a message, STOP and answer immediately.** Do not continue working while there's an unanswered question.
 
+## Unattended Mode (routine-fired cloud runs)
+
+When this agent runs from a sprint routine rather than a session Peter is watching, there is no
+one to escalate to: routine runs are fully autonomous with no permission prompts. The stop-and-
+report rules above still hold, but "the orchestrator escalates to Peter" is not available.
+
+**Every stop degrades to: skip the item, append to Needs-Peter, keep going.** Never to shipping
+the change. Specifically:
+
+- **Phase 1 escape valve (privilege / spec change)** — do not implement, do not commit. Append to
+  the sprint issue's Needs-Peter block with the concern, the lines that would change, who gains
+  what capability, and move to the next issue in the work order. The batch continues.
+- **Unauthorized author** — `/sprint` marks these `GATED` at plan time and they should never reach
+  you. If one does, skip it and record that the gate leaked.
+- **Review gate exhausted (3 iterations)** — unchanged: the batch stops at that issue. Record the
+  failing criterion in Needs-Peter as well as the batch report.
+
+A skipped item leaves the batch checkbox unticked and is named in the PR body. Peter's answers are
+applied later by a `resume` run, as in `section-doctor`.
+
+Two mechanical differences from a local run:
+
+- **`gh` is unavailable.** Use the GitHub MCP tools instead — for the open-PR list, build the same
+  JSON shape `section-doctor` Phase 2 uses: `[{number, headRefName, title, files: [paths]}]`.
+- **Branch names must be `claude/`-prefixed** (`claude/sprint-<date>-batch-<n>`). That prefix is
+  always accepted on push; other names are checked against branch protection, others' commits, and
+  others' open PRs, and are rejected on any of them.
+
+Claim the batch before doing any work, by the blocked-set rule in
+`docs/sprints/TRACKING-ISSUE-TEMPLATE.md` — first unchecked batch whose branch has no open PR.
+
 ## Report Format
 
 When the batch completes (success or failure), output a structured report:

--- a/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
+++ b/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
@@ -1,0 +1,77 @@
+# Sprint Tracking Issue — Template
+
+The queue for an unattended sprint run. `/sprint` (local) writes one of these to
+`peterdrier/Humans`; a routine fires a cloud session that works it.
+
+Modelled on [`section-doctor`](../../.claude/skills/section-doctor/SKILL.md) — claim via
+blocked set, escalate via Needs-Peter, one PR per batch. Deviate only with a reason.
+
+## Issue shape
+
+- **Title:** `sprint(YYYY-MM-DD): <n> batches, <m> issues`
+- **Labels:** `sprint`, `sprint:YYYY-MM-DD`
+- **Repo:** `peterdrier/Humans` only. Upstream issues are mirrored in by `/sprint`
+  (body **and** comments verbatim, per
+  [`issue-fetch-protocol`](../../memory/process/issue-fetch-protocol.md)) with a
+  `nobodies-collective/Humans#N` backref. Closing the upstream original stays manual.
+
+## Body
+
+```markdown
+## Batches
+
+- [ ] **Batch 1 — <name>** · `claude/sprint-YYYY-MM-DD-batch-1`
+  1. peterdrier/Humans#NNN — <title> · author: <login> · gate: <clear|GATED:reason>
+  2. peterdrier/Humans#NNN — <title> · author: <login> · gate: clear
+- [ ] **Batch 2 — <name>** · `claude/sprint-YYYY-MM-DD-batch-2`
+  1. ...
+
+## File partition
+
+Batch 1: src/Sections/Humans.<X>/**
+Batch 2: src/Sections/Humans.<Y>/**
+
+## Needs-Peter
+
+_(appended by runs; each entry dated, one line of context + the question)_
+```
+
+Every issue reference is qualified — [`issue-refs-qualified`](../../memory/process/issue-refs-qualified.md).
+
+## Batching rules
+
+**Batches must be file-disjoint.** Concurrent batches open concurrent PRs that must merge in
+any order (`nobodies-collective/Humans#1069`). Two batches that touch the same paths belong in
+one batch, sequenced. Record the partition in the body so a run can verify it.
+
+Size to the existing shape: small related issues group into one batch; a large issue is its own
+batch, split across subagents by the worker.
+
+## Claiming
+
+A run picks the **first unchecked batch whose branch has no open PR**. Compute the blocked set
+exactly as `section-doctor` Phase 2 does — from open PRs, not from a label, so a died-mid-run
+batch is reclaimable without cleanup. Never work a batch whose PR is already open.
+
+## Gates — unattended
+
+No one is at the gate: a routine run has no permission prompts. Every stop in
+[`batch-worker`](../../.claude/agents/batch-worker.md) degrades to **skip the item, append to
+Needs-Peter, keep going** — never to shipping the change.
+
+- **Unauthorized author** (not `peterdrier` / `swombat`) — `/sprint` marks the item `GATED`
+  at plan time; the run skips it. Never worked unattended without per-issue approval.
+- **Privilege change** —
+  [`privilege-changes-need-explicit-approval`](../../memory/process/privilege-changes-need-explicit-approval.md).
+  Skip, record which users would gain what.
+- **Spec change from `fb:` feedback** —
+  [`triage-protocol`](../../memory/process/triage-protocol.md). Skip, record the delta.
+
+A skipped item leaves its batch checkbox unticked and names the skip in the PR body.
+
+## Completion
+
+One PR per batch → `main` on `peterdrier/Humans`, branch `claude/sprint-<date>-batch-<n>`
+(the `claude/` prefix is always accepted; other names are checked against protection and
+others' commits). Tick the box on merge-ready, not on push. Sprint issue closes when every
+box is ticked or every remainder sits in Needs-Peter.

--- a/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
+++ b/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
@@ -47,11 +47,13 @@ one batch, sequenced. Record the partition in the body so a run can verify it.
 Size to the existing shape: small related issues group into one batch; a large issue is its own
 batch, split across subagents by the worker.
 
-## Claiming
+## Batch selection
 
-A run picks the **first unchecked batch whose branch has no open PR**. Compute the blocked set
-exactly as `section-doctor` Phase 2 does — from open PRs, not from a label, so a died-mid-run
-batch is reclaimable without cleanup. Never work a batch whose PR is already open.
+**The batch is an input, not a discovery.** The orchestrator passes the worker its batch number
+and work order (see [`batch-worker`](../../.claude/agents/batch-worker.md) § Input); a run never
+scans the tracking issue for the next unclaimed batch. So there is no claim, no lock, no blocked
+set, and no reclaim rule — two runs cannot race for the same batch, and a batch that stops for a
+human is simply not dispatched again until someone dispatches it.
 
 ## Gates — unattended
 

--- a/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
+++ b/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
@@ -55,9 +55,11 @@ batch is reclaimable without cleanup. Never work a batch whose PR is already ope
 
 ## Gates — unattended
 
-No one is at the gate: a routine run has no permission prompts. Every stop in
-[`batch-worker`](../../.claude/agents/batch-worker.md) degrades to **skip the item, append to
-Needs-Peter, keep going** — never to shipping the change.
+No one is at the gate: a routine run has no permission prompts. **Pre-implementation** gates in
+[`batch-worker`](../../.claude/agents/batch-worker.md) degrade to **skip the item, append to
+Needs-Peter, keep going** — never to shipping the change. **Post-commit review failures stay hard
+stops:** a batch whose spec, reuse or code review is still failing after 3 iterations is blocked,
+opens no PR, and waits for a human.
 
 - **Unauthorized author** (not `peterdrier` / `swombat`) — `/sprint` marks the item `GATED`
   at plan time; the run skips it. Never worked unattended without per-issue approval.
@@ -67,7 +69,8 @@ Needs-Peter, keep going** — never to shipping the change.
 - **Spec change from `fb:` feedback** —
   [`triage-protocol`](../../memory/process/triage-protocol.md). Skip, record the delta.
 
-A skipped item leaves its batch checkbox unticked and names the skip in the PR body.
+A skipped item leaves its batch checkbox unticked and names the skip in the PR body. If a gate
+fires after the item already has a commit, its commits are reverted before the run continues.
 
 ## Completion
 


### PR DESCRIPTION
## What

Moves the sprint queue off the gitignored `local/sprint-*.md` plan file and onto a GitHub tracking issue, so a routine-fired cloud session can pick work up with no local state. Adds `docs/sprints/TRACKING-ISSUE-TEMPLATE.md` and an Unattended Mode section to `.claude/agents/batch-worker.md`.

Groundwork only — `/sprint` and `/execute-sprint` are personal skills outside this repo and are not touched here. Follow-up spec: peterdrier/Humans#1468.

## Why

Cloud sessions don't read `~/.claude/skills/` and start from a fresh container, so `local/` (gitignored, `.gitignore:134`) is invisible to them. The queue has to live somewhere both a local `/sprint` run and an unattended cloud run can reach.

Rather than invent conventions, this reuses `section-doctor`'s, which already runs as a scheduled cloud job:

- **Needs-Peter block plus a later `resume` run** in place of escalation, since a routine run has no permission prompts and no one at the gate.
- **One PR per batch**, which also checkpoints a sprint whose session dies partway.
- **File-disjoint batches**, per the concurrency contract in `nobodies-collective/Humans#1069`.

## Existing surface checked

No new durable code surface — two docs, one of them an edit to an existing agent file. Considered and rejected: a second `batch-worker-unattended.md` agent (would duplicate ~90% of the existing file); a new `docs/process/` tree (`docs/sprints/` mirrors the existing `docs/sections/SECTION-TEMPLATE.md` convention).

An earlier revision added a claim/blocked-set rule so a run could select its own batch. Review found two independent failure modes in it (indefinite reclaim of a blocked batch; a concurrent-claim race), and both traced back to the mechanism rather than its edges — the orchestrator already passes the worker its batch (`batch-worker` § Input), so nothing needs to self-select. Removed in f596a105 along with the open-PR-list reconstruction that existed only to serve it.

## Checklist

- [x] **Section labeled** — Infrastructure / process.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`**.
- [x] **Issue refs are qualified** (`owner/repo#N`).
- ~~**EF migrations**~~ — none.
- ~~**NuGet packages updated?**~~ — none.
- [x] **New project rule?** — none yet. The durable rules here (file-disjoint batching, unattended gate degradation) stay in the template while the process is unproven; they become `memory/` atoms once `/sprint` actually writes one of these and the shape holds.
- [x] **Reuse-first checked** — see above.
- ~~**Build + test pass locally**~~ — docs only, no code touched.
- ~~**Nav coverage**~~ — no pages.
- ~~**No magic strings**~~ / ~~**NodaTime / Font Awesome**~~ — no code.

## Reviewer notes

One decision worth a second opinion:

**Gates degrade to skip rather than stop — but only before implementation.** An unattended run that stops dead on a privilege-change escape valve accomplishes nothing and reports to nobody, so pre-implementation gates skip the item and record it. Post-commit review failures stay hard stops, because Phase 1 commits each issue before Phase 2 reviews it and a skip there would carry failing code into the batch PR. `nobodies-collective/Humans#398` is the incident this path exists to prevent, so the failure direction matters more than throughput.

The other open question — whether file-disjoint batching is stricter than it needs to be for sprints that mostly run serially — is carried in peterdrier/Humans#1468 for Peter.