### PR TITLE
feat(skills): execute-sprint cloud skill + per-batch expense reporting

### DIFF
--- a/.claude/agents/batch-worker.md
+++ b/.claude/agents/batch-worker.md
@@ -29,7 +29,7 @@ For each issue in the work order (sequentially, never parallel):
 
    b. **Spec change derived from user feedback.** The issue body includes an `fb:` feedback reference AND the change alters what the system does or allows beyond a mechanical fix — adds/removes a workflow step, changes eligibility rules, changes what data is shown or collected, adds a new public endpoint, changes a default behavior, removes a consent step. Per `memory/process/triage-protocol.md`.
 
-   When you stop, report: the specific concern, the line(s) that would need to change, a one-line summary of what changes for whom, and (if a privilege change) which user(s) would gain the capability. The orchestrator escalates to Peter; you do not. The pre-flight gate in `/execute-sprint` Step 2.5 should have caught these — if you're hitting this path, either the gate missed something or the spec was misleading. Either way, the worker is not the layer that decides.
+   When you stop, report: the specific concern, the line(s) that would need to change, a one-line summary of what changes for whom, and (if a privilege change) which user(s) would gain the capability. The orchestrator escalates to Peter; you do not. The orchestrator's pre-flight gates should have caught these — if you're hitting this path, either a gate missed something or the spec was misleading. Either way, the worker is not the layer that decides.
 
    Mechanical fixes from user feedback (typos, broken links, error-message wording, layout glitches, hidden stack traces, missing icons) do NOT trigger this — only spec/policy/capability changes do.
 4. Run `dotnet build Humans.slnx` — fix any build errors before proceeding.
@@ -137,45 +137,41 @@ Self-reviewed against CODE_REVIEW_RULES.md. No critical issues.
 
 ## Unattended Mode (routine-fired cloud runs)
 
-When this agent runs from a sprint routine rather than a session Peter is watching, there is no
-one to escalate to: routine runs are fully autonomous with no permission prompts. The stop-and-
-report rules above still hold, but "the orchestrator escalates to Peter" is not available.
+When this agent runs from a sprint routine rather than a session Peter is watching
+(dispatched by the [`execute-sprint`](../skills/execute-sprint/SKILL.md) project skill), there
+is no one to escalate to: routine runs are fully autonomous with no permission prompts. The
+stop-and-report rules above still hold, but "the orchestrator escalates to Peter" is not
+available — escalation means recording, and the split of duties tightens:
 
-**Pre-implementation gates degrade to: skip the item, append to Needs-Peter, keep going.**
-**Post-commit review failures stay hard stops.** The distinction is whether code is already
-committed: Phase 1 step 5 commits each issue before Phase 2 reviews it, so a "skip" after a review
-failure would leave the failing implementation on the branch and carry it into the batch PR.
+**The worker implements, commits, and reports. The orchestrator owns everything GitHub-side** —
+push, PR creation, ticking the tracking-issue checkbox, appending to its Needs-Peter block.
+Phase 4 does not apply: stop after the last commit and put the PR body content in your report.
+You need no GitHub access at all in this mode (`gh` is unavailable in cloud sessions anyway);
+never touch the tracking issue yourself.
 
-- **Phase 1 escape valve (privilege / spec change)** — do not implement, do not commit. Append to
-  the sprint issue's Needs-Peter block with the concern, the lines that would change, who gains
-  what capability, and move to the next issue in the work order. The batch continues.
-- **Unauthorized author** — `/sprint` marks these `GATED` at plan time and they should never reach
-  you. If one does, skip it and record that the gate leaked.
+**Pre-implementation gates degrade to: skip the item, record it in your report for Needs-Peter,
+keep going.** **Post-commit review failures stay hard stops.** The distinction is whether code is
+already committed: Phase 1 step 5 commits each issue before Phase 2 reviews it, so a "skip" after
+a review failure would leave the failing implementation on the branch and carry it into the batch PR.
+
+- **Phase 1 escape valve (privilege / spec change)** — do not implement, do not commit. Record
+  the concern, the lines that would change, and who gains what capability; move to the next issue
+  in the work order. The batch continues.
+- **Unauthorized author** — `plan-sprint` marks these `GATED` at plan time and the orchestrator
+  never hands them to you. If one reaches you anyway, skip it and record that the gate leaked.
 - **Review gate exhausted (3 iterations, Phase 2 / 2.5 / 3)** — unchanged from the rules above:
-  **STOP.** The batch is blocked at that issue. Do not skip it, do not move to the next issue, do
-  not open a PR. Record the failing criterion in Needs-Peter and in the batch report. A blocked
-  batch leaves its branch pushed and its checkbox unticked for a human to pick up; nothing
-  re-dispatches it on its own, since the orchestrator chooses the batch (§ Input).
+  **STOP.** The batch is blocked at that issue. Do not skip it, do not move to the next issue.
+  Report `BLOCKED` with the failing criterion; the orchestrator opens no PR for the batch and
+  nothing re-dispatches it on its own, since the batch is an input, not a discovery (§ Input,
+  and the template's § Batch selection).
 
 If a gate fires after that issue already has a commit — the escape valve missed it during
 exploration and caught it during implementation — `git revert` or reset that issue's commits before
 continuing, so the skipped work never reaches the PR.
 
-A skipped item leaves the batch checkbox unticked and is named in the PR body. Peter's answers are
-applied later by a `resume` run, as in `section-doctor`.
-
-Two mechanical differences from a local run:
-
-- **`gh` is unavailable.** Use the GitHub MCP tools for every GitHub operation, overriding the
-  `gh` invocations named above:
-  - **Phase 4 PR creation** — `create_pull_request` (owner `peterdrier`, repo `Humans`, base
-    `main`) replaces `gh pr create`. Push with plain `git push -u origin <branch>` first; only the
-    PR call needs the MCP tool.
-  - **Tracking issue** — `issue_write` (method `update`) to tick a batch checkbox or append to the
-    Needs-Peter block; `issue_read` to re-read it first, since another run may have edited it.
-- **Branch names must be `claude/`-prefixed** (`claude/sprint-<date>-batch-<n>`). That prefix is
-  always accepted on push; other names are checked against branch protection, others' commits, and
-  others' open PRs, and are rejected on any of them.
+A skipped item leaves the batch checkbox unticked and is named in the PR body (by the
+orchestrator, from your report). Peter's answers are applied later by a `resume` run, as in
+`section-doctor`.
 
 ## Report Format
 

--- a/.claude/skills/execute-sprint/SKILL.md
+++ b/.claude/skills/execute-sprint/SKILL.md
@@ -26,7 +26,9 @@ Ground rules (template + [`batch-worker`](../../agents/batch-worker.md) Unattend
 
 1. `mkdir -p local` (gitignored, absent in a fresh clone) and record the start:
    `date -u +%Y-%m-%dT%H:%M:%SZ > local/.run-start`.
-2. `git fetch origin main --quiet`.
+2. `git fetch origin main --quiet`, then `git checkout --detach origin/main` — the gate below
+   and every batch branch start from the fetched baseline, never from whatever the clone happens
+   to have checked out (the tree is disposable).
 3. Toolchain gate: `dotnet build Humans.slnx -v quiet` must pass on `origin/main` before any
    batch is worked. If the build cannot run at all, comment that on the tracking issue and
    stop — an unattended run cannot fix its own environment, and there is no docs-only fallback
@@ -63,15 +65,19 @@ Parallel batches are a growth step — do not add them until several sequential 
 
 1. `git checkout -B claude/sprint-<date>-batch-<n> origin/main`. If that branch already exists
    on origin with **no open PR** — a prior run died between push and PR — this run replaces it:
-   push with `--force-with-lease` at step 5 (that content never reached review; without this
-   the re-push is rejected as non-fast-forward and the batch can never complete).
+   `git fetch origin claude/sprint-<date>-batch-<n>` first (the lease needs the remote ref's
+   fetched value or it rejects with `stale info`), then push with `--force-with-lease` at
+   step 5. That content never reached review; without this the re-push is rejected as
+   non-fast-forward and the batch can never complete.
 2. Fetch every `gate: clear` issue in the batch — body **and** comments — via MCP into
    `local/issue-<N>.txt` / `local/issue-<N>-comments.txt`. Comments are part of the spec;
    Peter's comments override the OP body.
 3. **Staleness pre-check per issue:** `git log origin/main --oneline --grep "#<N>"` plus a
    merged-PR search via MCP. A hit means *probably shipped* — verify the acceptance criteria
    against the tree; if all are met, comment the per-criterion file:line evidence on the issue
-   and close it via MCP. Never silently skip, never burn a worker discovering it.
+   and close it via MCP. Never silently skip, never burn a worker discovering it. If staleness
+   clears **every** issue in the batch, the batch is done — no worker, no empty PR: tick its box
+   with a note that all items had already shipped.
 4. Dispatch **one batch-worker subagent** for the batch, per
    [`.claude/agents/batch-worker.md`](../../agents/batch-worker.md) — Unattended Mode applies.
    Prompt contains: batch number/name, work order, spec file paths (worker reads the files),
@@ -86,9 +92,11 @@ Parallel batches are a growth step — do not add them until several sequential 
      `Fixes peterdrier/Humans#<N>`; skipped items are named with the reason; the batch's cost
      row (Step 4) is appended once measured. A `BLOCKED` batch gets no PR — its branch stays
      pushed for a human.
-6. Update the tracking issue via MCP: tick the batch checkbox once the PR is open and the
-   worker's review gates passed; append any new Needs-Peter entries (dated, one line of
-   context + the question).
+6. Update the tracking issue via MCP: tick the batch checkbox **only when nothing was
+   skipped** — every item shipped or was closed as already-done, PR open, review gates passed.
+   If any item was skipped (GATED, escape valve, blocked), the box stays unticked per the
+   template and each skipped item goes to Needs-Peter (dated, one line of context + the
+   question) — the sprint issue can still close with remainders sitting there.
 
 **Migration-flagged batches:** work only if `dotnet ef` runs in this environment and the
 migration generates cleanly; otherwise skip the whole batch to Needs-Peter. Never hand-edit a

--- a/.claude/skills/execute-sprint/SKILL.md
+++ b/.claude/skills/execute-sprint/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: execute-sprint
+description: "Use when a sprint tracking issue (label `sprint`) on peterdrier/Humans needs working — routine-fired cloud runs, or any unattended session told to execute the sprint queue."
+---
+
+# Execute Sprint — Unattended Cloud Runs
+
+Cloud-side half of the sprint process (peterdrier/Humans#1468). `/sprint` runs locally,
+Peter approves which batches go up, and it publishes a tracking issue per
+[`docs/sprints/TRACKING-ISSUE-TEMPLATE.md`](../../../docs/sprints/TRACKING-ISSUE-TEMPLATE.md).
+A routine fires a .NET cloud session on that issue; this skill claims and works batches.
+The local swarm variant is Peter's personal skill — this file is the unattended path only.
+
+Ground rules (template + [`batch-worker`](../../agents/batch-worker.md) Unattended Mode):
+
+- **No one is at the gate.** Every stop degrades to *skip the item, append to Needs-Peter,
+  keep going* — never to shipping the change.
+- **`gh` is unavailable.** GitHub MCP tools for all issue/PR API work; plain git for the tree.
+- **Branches are `claude/sprint-<date>-batch-<n>`** — the `claude/` prefix is always accepted
+  on push; other names are rejected on branch protection, others' commits, or others' open PRs.
+- **Never merge anything.** The run ends at PRs open, boxes ticked, report posted.
+- **Only `gate: clear` items are worked.** A `GATED` item is skipped and named in the PR body,
+  whatever the reason on it says.
+
+## Step 0: Setup
+
+1. `mkdir -p local` (gitignored, absent in a fresh clone) and record the start:
+   `date -u +%Y-%m-%dT%H:%M:%SZ > local/.run-start`.
+2. `git fetch origin main --quiet`.
+3. Toolchain gate: `dotnet build Humans.slnx -v quiet` must pass on `origin/main` before any
+   batch is claimed. If the build cannot run at all, comment that on the tracking issue and
+   stop — an unattended run cannot fix its own environment, and there is no docs-only fallback
+   for implementation work.
+
+## Step 1: Find the tracking issue
+
+- Routine-fired: the issue arrives wrapped in `<routine-fire-payload>` — use that issue number.
+- Otherwise: the newest open issue labeled `sprint` on `peterdrier/Humans`.
+
+Parse the body: batches (checkbox, name, branch, numbered issues with author + gate status),
+the `## File partition` block, the `## Needs-Peter` block. All refs are qualified
+(`owner/repo#N`); an unqualified ref is a plan error — skip that item to Needs-Peter.
+
+## Step 2: Claim a batch
+
+1. Open-PR list via MCP, as the JSON shape section-doctor Phase 2 uses:
+   `[{number, headRefName, title, files: [paths]}]`.
+2. Blocked set = batches whose branch already has an open PR. **Claim = first unchecked,
+   unblocked batch.** A batch that died mid-run has no open PR and is reclaimable with no
+   cleanup; never work a batch whose PR is already open.
+3. Nothing claimable → comment on the tracking issue (one line per batch: ticked / PR #N open /
+   all-GATED) and stop.
+
+## Step 3: Work the claimed batch
+
+One batch at a time; when a batch's PR is open, return to Step 2 for the next claimable one.
+Parallel batches are a growth step — do not add them until several sequential runs are clean.
+
+1. `git checkout -B claude/sprint-<date>-batch-<n> origin/main`.
+2. Fetch every `gate: clear` issue in the batch — body **and** comments — via MCP into
+   `local/issue-<N>.txt` / `local/issue-<N>-comments.txt`. Comments are part of the spec;
+   Peter's comments override the OP body.
+3. **Staleness pre-check per issue:** `git log origin/main --oneline --grep "#<N>"` plus a
+   merged-PR search via MCP. A hit means *probably shipped* — verify the acceptance criteria
+   against the tree; if all are met, comment the per-criterion file:line evidence on the issue
+   and close it via MCP. Never silently skip, never burn a worker discovering it.
+4. Dispatch **one batch-worker subagent** for the batch, per
+   [`.claude/agents/batch-worker.md`](../../agents/batch-worker.md) — Unattended Mode applies.
+   Prompt contains: batch number/name, work order, spec file paths (worker reads the files),
+   branch name, sprint date, and the instruction that every escape valve degrades to
+   skip + record. Model explicit and tagged in the name (`batch-<n>-sonnet`): sonnet by
+   default, opus-tier only where the batch carries architecture or deletion judgment.
+   The worker implements and commits sequentially, one commit per issue; it never pushes.
+5. Orchestrator pushes and opens the PR via MCP:
+   - Title: `sprint(<date>) batch <n>: <name>`.
+   - Body: one line per issue — completed issues get the qualified closing keyword
+     `Fixes peterdrier/Humans#<N>`; skipped items are named with the reason; the batch's cost
+     row (Step 4) is appended once measured.
+6. Update the tracking issue via MCP: tick the batch checkbox once the PR is open and the
+   worker's review gates passed; append any new Needs-Peter entries (dated, one line of
+   context + the question).
+
+**Migration-flagged batches:** work only if `dotnet ef` runs in this environment and the
+migration generates cleanly; otherwise skip the whole batch to Needs-Peter. Never hand-edit a
+migration, never author a data migration.
+
+## Step 4: Expense report
+
+Work is done in subagents, so the accounting is per batch. After the last batch:
+
+```bash
+python .claude/skills/execute-sprint/cost-report.py <date> "$(cat local/.run-start)"
+```
+
+The script finds this session's transcript, buckets the main thread as `orchestrator`, and
+assigns each subagent transcript to its batch (the batch branch name appears in the worker's
+prompt). It prints the component table with API-equivalent $. It never fails the run — on any
+discovery problem it prints `Cost: unmeasured (...)`; cloud transcript layout is unverified,
+so if the first runs report unmeasured, add that to Needs-Peter.
+
+Post one **run report comment** on the tracking issue:
+
+1. Headline table — one row per batch:
+
+   | Batch | Issues | ~$ |
+   |---|---|---|
+   | 1 | peterdrier/Humans#1401, #1405, #1406 | 12.45 |
+   | orchestrator | — | 1.10 |
+   | **total** | | **13.55** |
+
+2. The script's component/token-class table.
+3. **Mini cost analysis — a short paragraph, not an essay:** where the money went (cache read
+   vs output vs fresh input; which component dominated), and any glaring issue — a worker
+   costing >2× the batch median, cache-write share suggesting context churn or re-reads,
+   orchestrator cost rivaling a worker (too much in-band work), anything that looks like
+   polling. If there is nothing glaring, say so in one line.
+
+Also append each batch's own row to its PR body.
+
+## Step 5: End of run
+
+The run is complete when every batch is ticked, PR-blocked, or GATED/Needs-Peter — and the run
+report comment is posted. Leftover Needs-Peter items are worked later by a `resume` run
+applying Peter's answers, as in section-doctor. Do not loop waiting for CI; do not merge.
+
+## Routine setup (documentation — configured on claude.ai, not in this repo)
+
+- **Trigger:** new issue on `peterdrier/Humans` with label `sprint`.
+- **Environment:** .NET cloud instance (the build gate in Step 0 depends on it).
+- **Prompt:** must reference the payload explicitly or the fire text is treated as inert, e.g.:
+  *"A sprint tracking issue was just created — its number is in `<routine-fire-payload>`.
+  Invoke the `execute-sprint` project skill on it."*

--- a/.claude/skills/execute-sprint/SKILL.md
+++ b/.claude/skills/execute-sprint/SKILL.md
@@ -8,7 +8,7 @@ description: "Use when a sprint tracking issue (label `sprint`) on peterdrier/Hu
 Cloud-side half of the sprint process (peterdrier/Humans#1468). [`plan-sprint`](../plan-sprint/SKILL.md)
 runs locally, Peter approves which batches go up, and it publishes a tracking issue per
 [`docs/sprints/TRACKING-ISSUE-TEMPLATE.md`](../../../docs/sprints/TRACKING-ISSUE-TEMPLATE.md).
-A routine fires a .NET cloud session on that issue; this skill claims and works batches —
+A routine fires a .NET cloud session on that issue; this skill works its batches —
 it is the unattended path only.
 
 Ground rules (template + [`batch-worker`](../../agents/batch-worker.md) Unattended Mode):
@@ -28,7 +28,7 @@ Ground rules (template + [`batch-worker`](../../agents/batch-worker.md) Unattend
    `date -u +%Y-%m-%dT%H:%M:%SZ > local/.run-start`.
 2. `git fetch origin main --quiet`.
 3. Toolchain gate: `dotnet build Humans.slnx -v quiet` must pass on `origin/main` before any
-   batch is claimed. If the build cannot run at all, comment that on the tracking issue and
+   batch is worked. If the build cannot run at all, comment that on the tracking issue and
    stop — an unattended run cannot fix its own environment, and there is no docs-only fallback
    for implementation work.
 
@@ -41,19 +41,23 @@ Parse the body: batches (checkbox, name, branch, numbered issues with author + g
 the `## File partition` block, the `## Needs-Peter` block. All refs are qualified
 (`owner/repo#N`); an unqualified ref is a plan error — skip that item to Needs-Peter.
 
-## Step 2: Claim a batch
+## Step 2: Determine the work list
 
-1. Open-PR list via MCP, as the JSON shape section-doctor Phase 2 uses:
-   `[{number, headRefName, title, files: [paths]}]`.
-2. Blocked set = batches whose branch already has an open PR. **Claim = first unchecked,
-   unblocked batch.** A batch that died mid-run has no open PR and is reclaimable with no
-   cleanup; never work a batch whose PR is already open.
-3. Nothing claimable → comment on the tracking issue (one line per batch: ticked / PR #N open /
-   all-GATED) and stop.
+**The batch is an input, not a discovery** (template § Batch selection) — no claim, no lock, no
+blocked set:
 
-## Step 3: Work the claimed batch
+- **Routine-fired on issue creation:** every batch is fresh — the work list is all batches, in
+  body order.
+- **Manual dispatch** ("run batch N of sprint issue #X"): the named batch(es) only. A batch that
+  stopped for a human is never re-dispatched on the run's own initiative.
 
-One batch at a time; when a batch's PR is open, return to Step 2 for the next claimable one.
+Idempotence only (not discovery): a batch whose box is already ticked, or whose branch already
+has an open PR, is skipped and noted. Nothing on the work list → comment why on the tracking
+issue and stop.
+
+## Step 3: Work the batches
+
+One batch at a time, in work-list order; when a batch's PR is open, move to the next.
 Parallel batches are a growth step — do not add them until several sequential runs are clean.
 
 1. `git checkout -B claude/sprint-<date>-batch-<n> origin/main`.
@@ -71,11 +75,13 @@ Parallel batches are a growth step — do not add them until several sequential 
    skip + record. Model explicit and tagged in the name (`batch-<n>-sonnet`): sonnet by
    default, opus-tier only where the batch carries architecture or deletion judgment.
    The worker implements and commits sequentially, one commit per issue; it never pushes.
-5. Orchestrator pushes and opens the PR via MCP:
+5. Orchestrator pushes and opens the PR via MCP (the worker never touches GitHub — its report
+   carries the PR body content):
    - Title: `sprint(<date>) batch <n>: <name>`.
-   - Body: one line per issue — completed issues get the qualified closing keyword
+   - Body: from the worker's report — completed issues get the qualified closing keyword
      `Fixes peterdrier/Humans#<N>`; skipped items are named with the reason; the batch's cost
-     row (Step 4) is appended once measured.
+     row (Step 4) is appended once measured. A `BLOCKED` batch gets no PR — its branch stays
+     pushed for a human.
 6. Update the tracking issue via MCP: tick the batch checkbox once the PR is open and the
    worker's review gates passed; append any new Needs-Peter entries (dated, one line of
    context + the question).
@@ -119,7 +125,8 @@ Also append each batch's own row to its PR body.
 
 ## Step 5: End of run
 
-The run is complete when every batch is ticked, PR-blocked, or GATED/Needs-Peter — and the run
+The run is complete when every batch on the work list is ticked, reported blocked (no PR), or
+skipped to Needs-Peter — and the run
 report comment is posted. Leftover Needs-Peter items are worked later by a `resume` run
 applying Peter's answers, as in section-doctor. Do not loop waiting for CI; do not merge.
 

--- a/.claude/skills/execute-sprint/SKILL.md
+++ b/.claude/skills/execute-sprint/SKILL.md
@@ -5,11 +5,11 @@ description: "Use when a sprint tracking issue (label `sprint`) on peterdrier/Hu
 
 # Execute Sprint — Unattended Cloud Runs
 
-Cloud-side half of the sprint process (peterdrier/Humans#1468). `/sprint` runs locally,
-Peter approves which batches go up, and it publishes a tracking issue per
+Cloud-side half of the sprint process (peterdrier/Humans#1468). [`plan-sprint`](../plan-sprint/SKILL.md)
+runs locally, Peter approves which batches go up, and it publishes a tracking issue per
 [`docs/sprints/TRACKING-ISSUE-TEMPLATE.md`](../../../docs/sprints/TRACKING-ISSUE-TEMPLATE.md).
-A routine fires a .NET cloud session on that issue; this skill claims and works batches.
-The local swarm variant is Peter's personal skill — this file is the unattended path only.
+A routine fires a .NET cloud session on that issue; this skill claims and works batches —
+it is the unattended path only.
 
 Ground rules (template + [`batch-worker`](../../agents/batch-worker.md) Unattended Mode):
 

--- a/.claude/skills/execute-sprint/SKILL.md
+++ b/.claude/skills/execute-sprint/SKILL.md
@@ -52,15 +52,19 @@ blocked set:
   stopped for a human is never re-dispatched on the run's own initiative.
 
 Idempotence only (not discovery): a batch whose box is already ticked, or whose branch already
-has an open PR, is skipped and noted. Nothing on the work list → comment why on the tracking
-issue and stop.
+has an open PR, is skipped and noted. So is a batch whose items are **all `GATED`** — nothing
+in it can be worked unattended; it stays unticked, no worker, no empty PR. Nothing on the work
+list → comment why on the tracking issue and stop.
 
 ## Step 3: Work the batches
 
 One batch at a time, in work-list order; when a batch's PR is open, move to the next.
 Parallel batches are a growth step — do not add them until several sequential runs are clean.
 
-1. `git checkout -B claude/sprint-<date>-batch-<n> origin/main`.
+1. `git checkout -B claude/sprint-<date>-batch-<n> origin/main`. If that branch already exists
+   on origin with **no open PR** — a prior run died between push and PR — this run replaces it:
+   push with `--force-with-lease` at step 5 (that content never reached review; without this
+   the re-push is rejected as non-fast-forward and the batch can never complete).
 2. Fetch every `gate: clear` issue in the batch — body **and** comments — via MCP into
    `local/issue-<N>.txt` / `local/issue-<N>-comments.txt`. Comments are part of the spec;
    Peter's comments override the OP body.

--- a/.claude/skills/execute-sprint/cost-report.py
+++ b/.claude/skills/execute-sprint/cost-report.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Cost report for an execute-sprint run (Step 4).
+
+Usage: python cost-report.py <sprint-date> <run-start-iso>
+
+Finds this run's own session transcript under ~/.claude/projects (the file that
+mentions a `claude/sprint-<date>-batch-` branch and was modified after the run
+started), sums per-API-call token usage, and prints a markdown table with
+API-equivalent cost: the main thread as `orchestrator`, each subagent transcript
+assigned to the batch whose branch name appears in it.
+
+Adapted from .claude/skills/section-doctor/cost-report.py (phase buckets swapped
+for batch grouping). Exits 0 with "Cost: unmeasured (...)" on any discovery
+failure — never fail the run.
+"""
+import glob
+import json
+import os
+import re
+import sys
+from datetime import datetime
+
+# $/MTok: fresh input, output, cache write, cache read (API list rates)
+RATES = {
+    "fable": (10, 50, 12.50, 1.00),
+    "mythos": (10, 50, 12.50, 1.00),
+    "opus": (5, 25, 6.25, 0.50),
+    "sonnet": (3, 15, 3.75, 0.30),
+    "haiku": (1, 5, 1.25, 0.10),
+}
+
+
+def rate(model):
+    for key, r in RATES.items():
+        if key in (model or ""):
+            return r
+    return RATES["opus"]
+
+
+def ts(s):
+    return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+
+
+def usage_entries(path):
+    for line in open(path, encoding="utf-8", errors="ignore"):
+        try:
+            j = json.loads(line)
+        except ValueError:
+            continue
+        u = (j.get("message") or {}).get("usage")
+        if u:
+            yield j.get("timestamp"), (j.get("message") or {}).get("model"), u
+
+
+def add(bucket, model, u):
+    r = rate(model)
+    fresh = u.get("input_tokens", 0)
+    out = u.get("output_tokens", 0)
+    cw = u.get("cache_creation_input_tokens", 0)
+    cr = u.get("cache_read_input_tokens", 0)
+    b = bucket.setdefault("tok", [0, 0, 0, 0])
+    for i, v in enumerate((fresh, out, cw, cr)):
+        b[i] += v
+    bucket["usd"] = bucket.get("usd", 0) + (
+        fresh * r[0] + out * r[1] + cw * r[2] + cr * r[3]
+    ) / 1e6
+
+
+def main():
+    date, run_start_iso = sys.argv[1], sys.argv[2]
+    run_start = ts(run_start_iso.strip())
+    branch_prefix = f"claude/sprint-{date}-batch-"
+    batch_re = re.compile(re.escape(branch_prefix) + r"(\d+)")
+
+    own = None
+    for p in glob.glob(os.path.expanduser("~/.claude/projects/*/*.jsonl")):
+        try:
+            if os.path.getmtime(p) >= run_start and branch_prefix in open(
+                p, encoding="utf-8", errors="ignore"
+            ).read():
+                own = p
+                break
+        except OSError:
+            pass
+    if not own:
+        print("Cost: unmeasured (no session transcript found under ~/.claude/projects)")
+        return
+
+    rows = {}  # label -> {tok, usd}
+    for t, model, u in usage_entries(own):
+        # entries before .run-start belong to whatever the session did earlier
+        if not t or ts(t) < run_start:
+            continue
+        add(rows.setdefault("orchestrator", {}), model, u)
+
+    for p in glob.glob(own[: -len(".jsonl")] + "/subagents/*.jsonl"):
+        if os.path.getmtime(p) < run_start:
+            continue
+        m = batch_re.search(open(p, encoding="utf-8", errors="ignore").read())
+        agent_id = os.path.basename(p)[len("agent-") : -len(".jsonl")]
+        label = f"batch-{m.group(1)}" if m else f"agent:{agent_id}"
+        for _, model, u in usage_entries(p):
+            add(rows.setdefault(label, {}), model, u)
+
+    print("| Component | Fresh in | Out | Cache write | Cache read | ~$ |")
+    print("|---|---|---|---|---|---|")
+    total = [0, 0, 0, 0]
+    usd = 0.0
+    for label in sorted(rows):
+        b = rows[label]
+        f, o, cw, cr = b["tok"]
+        print(f"| {label} | {f:,} | {o:,} | {cw:,} | {cr:,} | {b['usd']:.2f} |")
+        for i, v in enumerate((f, o, cw, cr)):
+            total[i] += v
+        usd += b["usd"]
+    print(
+        f"| **total** | {total[0]:,} | {total[1]:,} | {total[2]:,} | {total[3]:,} "
+        f"| **{usd:.2f}** |"
+    )
+    print()
+    print(
+        "API-equivalent $, list rates. Measured from local/.run-start to report time; "
+        "the report comment itself lands after measurement."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:  # never fail the run over bookkeeping
+        print(f"Cost: unmeasured ({e})")

--- a/.claude/skills/plan-sprint/SKILL.md
+++ b/.claude/skills/plan-sprint/SKILL.md
@@ -40,8 +40,9 @@ gh issue list --repo peterdrier/Humans --state open --limit 200 --json number,ti
 ```bash
 git fetch origin --quiet; git fetch upstream --quiet
 git log --oneline upstream/main..origin/main
-gh pr list --repo peterdrier/Humans --state open --json number,title,headRefName
-gh pr list --repo peterdrier/Humans --state merged --limit 10 --json number,title,mergedAt,headRefName
+gh pr list --repo peterdrier/Humans --state open --limit 200 --json number,title,headRefName
+gh pr list --repo peterdrier/Humans --state merged --limit 50 --json number,title,mergedAt,headRefName
+# default --limit is 30 — too low to classify the pipeline; raise if either returns its cap
 ```
 
 | Stage | Detection | For planning |

--- a/.claude/skills/plan-sprint/SKILL.md
+++ b/.claude/skills/plan-sprint/SKILL.md
@@ -29,8 +29,10 @@ Issues live on two repos (`memory/process/issue-home-routing.md`): **upstream**
 (bugs/tech-debt/agent-created). Sweep both; qualify every ref (`owner/repo#N`) in all output.
 
 ```bash
-gh issue list --repo nobodies-collective/Humans --state open --limit 50 --json number,title,body,labels,createdAt,comments,author
-gh issue list --repo peterdrier/Humans --state open --limit 50 --json number,title,body,labels,createdAt,comments,author
+gh issue list --repo nobodies-collective/Humans --state open --limit 200 --json number,title,body,labels,createdAt,comments,author
+gh issue list --repo peterdrier/Humans --state open --limit 200 --json number,title,body,labels,createdAt,comments,author
+# --limit is a hard cap, not a page size — if a repo ever returns exactly 200, raise it and re-run
+
 ```
 
 **Pipeline status** (origin = QA, upstream = production):

--- a/.claude/skills/plan-sprint/SKILL.md
+++ b/.claude/skills/plan-sprint/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: plan-sprint
+description: "Use when planning a Humans sprint — grooming the backlog into work batches and publishing the Peter-approved subset as a cloud sprint tracking issue. Runs locally with gh access to both repos."
+argument-hint: "[quick] [section:<name>] [migrations]"
+---
+
+# Plan Sprint (Humans)
+
+Groom open issues into assessed, file-disjoint work batches; write the plan to
+`local/sprint-{date}.md`; then — **only for the batches Peter explicitly approves** — publish a
+tracking issue per [`docs/sprints/TRACKING-ISSUE-TEMPLATE.md`](../../../docs/sprints/TRACKING-ISSUE-TEMPLATE.md)
+that fires the cloud [`execute-sprint`](../execute-sprint/SKILL.md) routine.
+
+Project-specific replacement for Peter's global `/sprint` (peterdrier/Humans#1468) — do not use
+the global one on this repo. Runs locally: it needs `gh` against both repos, which cloud
+sessions don't have.
+
+## Arguments
+
+- *(none)* — full backlog analysis with batch proposals
+- `quick` — skip research, use each issue's existing `## Sprint Metadata` / labels only
+- `section:<name>` — focus on one section (bare name accepted)
+- `migrations` — only show items that need EF Core migrations
+
+## Step 1: Gather data
+
+Issues live on two repos (`memory/process/issue-home-routing.md`): **upstream**
+`nobodies-collective/Humans` (community feedback/direction) and **origin** `peterdrier/Humans`
+(bugs/tech-debt/agent-created). Sweep both; qualify every ref (`owner/repo#N`) in all output.
+
+```bash
+gh issue list --repo nobodies-collective/Humans --state open --limit 50 --json number,title,body,labels,createdAt,comments,author
+gh issue list --repo peterdrier/Humans --state open --limit 50 --json number,title,body,labels,createdAt,comments,author
+```
+
+**Pipeline status** (origin = QA, upstream = production):
+
+```bash
+git fetch origin --quiet; git fetch upstream --quiet
+git log --oneline upstream/main..origin/main
+gh pr list --repo peterdrier/Humans --state open --json number,title,headRefName
+gh pr list --repo peterdrier/Humans --state merged --limit 10 --json number,title,mergedAt,headRefName
+```
+
+| Stage | Detection | For planning |
+|-------|-----------|--------------|
+| **Open** | No PR, not in any commit | Available — batch it |
+| **In Review** | Open PR on origin | In-flight — don't re-batch |
+| **In QA** | Merged to origin, not in upstream | Done coding — don't batch |
+| **Shipped** | In upstream/main or issue closed | Done — surface for closing |
+
+**Only a closing verb counts** (`Closes|Fixes|Resolves|Implements|Finishes #NNN`). A bare
+`#NNN`, `Refs`, `Part of`, "9 of 10 criteria; issue stays open" — the issue is still open; when
+verb and disclaimer disagree, the disclaimer wins. Upstream issues never auto-close from fork
+merges — list finished-but-open ones as **Done but still open — close these**, with evidence.
+
+**Sequence and pace:** `blocked-by: owner/repo#NNN` in a body excludes the issue until the
+blocker closes (at most one issue per sequence per sprint). `pace:N` labels cap that group at N
+per sprint; overflow goes to Unbatched with the reason.
+
+## Step 2: Assess each item
+
+Use an existing non-stale `## Sprint Metadata` section if the body has one; otherwise assess.
+
+**Business importance:** Critical (blocking users / data loss / security / prod broken) · High
+(active user pain, coordinator blocker, deadline) · Medium (UX, requested feature, prevention) ·
+Low (nice-to-have, tech debt). Weight `/triage`-originated community reports higher.
+
+**Size:** XS (<30 min) · S (≤2 h) · M (2–6 h) · L (6–16 h) · XL (16+ h).
+
+**Tier** (drives worker model + review depth): XS→`direct`, S→`lightweight`, M→`standard`,
+L/XL→`thorough`; override when complexity doesn't match size.
+
+**Author + gate status** — record for every issue (`memory/process/issue-fetch-protocol.md`):
+`peterdrier`/`swombat` → `gate: clear`; anyone else → `gate: GATED:unauthorized-author`. GATED
+items batch normally but never dispatch unattended; a comment from Peter giving direction counts
+as approval — cite it and mark `gate: clear (per comment YYYY-MM-DD)`.
+
+**Privilege / spec-change carve-out.** Capability grants ([`memory/process/privilege-changes-need-explicit-approval.md`](../../../memory/process/privilege-changes-need-explicit-approval.md))
+and `fb:`-derived spec changes ([`memory/process/triage-protocol.md`](../../../memory/process/triage-protocol.md))
+are never `direct`/`lightweight`: owner-authored with explicit approval → `thorough` +
+`🔒 privilege change — owner-authored` flag; otherwise → a separate **Needs Owner Review**
+section, body verbatim, never batched.
+
+**Owner-operated work** (host/environment/third-party console/manual ops — nothing would show in
+a diff) gets its own section *above* the batches, never a lane.
+
+**Section:** the `section:*` labels are authoritative (`gh label list --repo
+nobodies-collective/Humans --limit 200 --search "section:"`). First label = primary; extras =
+secondary (the batch touches all of them). Missing label = infer for grouping + list in a
+**Missing section label** footer. Cross-cutting buckets (`section:infra`, `section:ui`) don't
+predict file overlap — check bodies.
+
+**Migration?** `yes`/`no`/`maybe`. Every section owns its own DbContext and migrations folder,
+so migrations serialize **within** a section only — two sections' migrations are independent.
+
+## Step 3: Group and batch
+
+Bucket by primary section; sort by importance then size. **Default one section per batch** —
+same project, same DbContext, file-disjoint by construction. Mix sections only for: a
+cross-cutting sweep, a seam (two sections meeting at one interface), or the `direct`-tier quick-
+fixes batch.
+
+**A lane is a queue of PRs, not issues.** Bundle by default — one unit = one agent session = one
+PR = as many issues as sensibly fit; multiple schema changes in one section are ONE migration.
+Split only for: independently rejectable decisions, ship-first bugs, L/XL items, a deliberate
+two-step rollout, or different subsystems inside one section. State units per batch:
+`**Units:** U1 = #a + #b · U2 = #c`.
+
+**Batch ordering:** Critical/High first; `direct` issues collapse into one early "Quick fixes"
+batch; migrations serialize within a section only; **never plan stacked branches** — every batch
+branches off `origin/main`; if one needs another's code, sequence it across sprints or design it
+file-disjoint.
+
+Batch format:
+
+```
+### Batch {N}: {name}
+**Priority:** … · **Total effort:** … · **Migration:** … · **Section:** … (+secondaries)
+
+| # | Title | Author | Gate | Biz | Size | Tier | Migration |
+|---|-------|--------|------|-----|------|------|-----------|
+
+**Work order:** 1. … 2. …
+**Units:** …
+**Files:** {the path globs this batch owns — feeds the tracking issue's partition block}
+**Rationale / Parallel-safe / Depends on:** …
+```
+
+## Step 4: Write the plan
+
+`local/sprint-{YYYY-MM-DD}.md` (gitignored): summary (totals, pipeline counts, by-section),
+in-flight list, batches in execution order, Unbatched (every open item appears somewhere, each
+with a reason — owner-operated, blocked, sequenced, paced, needs investigation, in-flight, on
+hold; "too large" is not a reason), Needs Design Session footer, sequence chains.
+
+## Step 5: Publish the cloud queue (Peter-gated — HARD GATE)
+
+**The plan is a proposal; the queue is Peter's decision.** Never publish every batch by default,
+never treat silence as a go — creating the labeled issue IS the dispatch trigger, so nothing is
+created until the selection is explicit.
+
+1. Present the batch list — one line per batch (number, name, issues, size, gate flags) — and
+   ask which batches go to the cloud queue. Recommend the smallest low-risk batch(es) to start.
+   Gating question: its own message, banner it in long sessions.
+2. For each approved batch:
+   - **Mirror upstream issues into the fork** — the cloud session cannot reach
+     `nobodies-collective` issues. `gh api` the body and every comment; create the mirror on
+     `peterdrier/Humans` verbatim (body, then a `## Comments (mirrored)` section), first line
+     `Mirrored from nobodies-collective/Humans#N.` The tracking issue references the mirror's
+     number. Mirrors never get the `sprint` label.
+   - **Re-verify gate status** per issue; Peter can flip a GATED item here — record
+     `gate: clear (approved YYYY-MM-DD)`.
+   - **Verify approved batches are file-disjoint** (their `**Files:**` globs must not overlap —
+     concurrent PRs must merge in any order) and build the `## File partition` block.
+3. Ensure labels: `gh label create sprint --repo peterdrier/Humans` and
+   `gh label create "sprint:{date}" --repo peterdrier/Humans` (ignore already-exists).
+4. Create the tracking issue per the template — title `sprint(YYYY-MM-DD): <n> batches, <m>
+   issues`, both labels, complete body — in ONE `gh issue create` call. The routine fires on
+   creation of the labeled issue, so the body must be finished at creation.
+5. Report the issue URL. Unapproved batches stay local-only in the plan file — never carried
+   into the tracking issue in any form.

--- a/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
+++ b/docs/sprints/TRACKING-ISSUE-TEMPLATE.md
@@ -1,16 +1,17 @@
 # Sprint Tracking Issue — Template
 
-The queue for an unattended sprint run. `/sprint` (local) writes one of these to
-`peterdrier/Humans`; a routine fires a cloud session that works it.
+The queue for an unattended sprint run. [`plan-sprint`](../../.claude/skills/plan-sprint/SKILL.md)
+(local, Peter-gated) writes one of these to `peterdrier/Humans`; a routine fires a cloud session
+that works it via [`execute-sprint`](../../.claude/skills/execute-sprint/SKILL.md).
 
-Modelled on [`section-doctor`](../../.claude/skills/section-doctor/SKILL.md) — claim via
-blocked set, escalate via Needs-Peter, one PR per batch. Deviate only with a reason.
+Modelled on [`section-doctor`](../../.claude/skills/section-doctor/SKILL.md) — escalate via
+Needs-Peter, one PR per batch. Deviate only with a reason.
 
 ## Issue shape
 
 - **Title:** `sprint(YYYY-MM-DD): <n> batches, <m> issues`
 - **Labels:** `sprint`, `sprint:YYYY-MM-DD`
-- **Repo:** `peterdrier/Humans` only. Upstream issues are mirrored in by `/sprint`
+- **Repo:** `peterdrier/Humans` only. Upstream issues are mirrored in by `plan-sprint`
   (body **and** comments verbatim, per
   [`issue-fetch-protocol`](../../memory/process/issue-fetch-protocol.md)) with a
   `nobodies-collective/Humans#N` backref. Closing the upstream original stays manual.
@@ -63,7 +64,7 @@ Needs-Peter, keep going** — never to shipping the change. **Post-commit review
 stops:** a batch whose spec, reuse or code review is still failing after 3 iterations is blocked,
 opens no PR, and waits for a human.
 
-- **Unauthorized author** (not `peterdrier` / `swombat`) — `/sprint` marks the item `GATED`
+- **Unauthorized author** (not `peterdrier` / `swombat`) — `plan-sprint` marks the item `GATED`
   at plan time; the run skips it. Never worked unattended without per-issue approval.
 - **Privilege change** —
   [`privilege-changes-need-explicit-approval`](../../memory/process/privilege-changes-need-explicit-approval.md).


### PR DESCRIPTION
## Summary

Both halves of the sprint pipeline as **project skills** (peterdrier/Humans#1468; global `/sprint` is not used on this repo), plus post-#1467 cleanup of the batch-worker/template.

- **`.claude/skills/plan-sprint/SKILL.md`** — local planning: sweeps both repos, assesses (importance/size/tier/author/gate/migration), builds file-disjoint batches, writes `local/sprint-<date>.md`, then **Step 5 hard gate**: Peter selects which batches go to the cloud queue before anything is published. Publish = mirror upstream issues into the fork (body + comments verbatim + backref), mark non-`peterdrier`/`swombat` authors `GATED`, create the tracking issue per the template in one labeled `gh issue create` (creation fires the routine).
- **`.claude/skills/execute-sprint/SKILL.md`** — routine-fired unattended runs, on the **batch-as-input model**: routine fire = all batches in body order; manual dispatch = named batch only; no claim/lock/blocked set. Build gate on main before work, staleness pre-check per issue, one batch-worker subagent per batch (Unattended Mode), one PR per batch on `claude/sprint-<date>-batch-<n>`, orchestrator ticks boxes + appends Needs-Peter. Sequential only until a few runs are clean.
- **`.claude/skills/execute-sprint/cost-report.py`** — per-batch expense accounting (adapted from section-doctor's): `orchestrator` + per-batch subagent buckets by branch-name mention. Run posts a report comment on the tracking issue: `Batch | Issues | ~$` table, token-class breakdown, short analysis of where the $ went + anything glaring. Smoke-tested against synthetic transcripts.
- **Fixes to #1467's files** (merged in): batch-worker Unattended Mode had the *worker* ticking tracking-issue checkboxes, appending Needs-Peter, and creating PRs via guessed MCP tool names — now the worker implements/commits/reports only and the orchestrator owns everything GitHub-side; template's "claim via blocked set" line contradicted its own § Batch selection — removed; `/sprint` refs updated to `plan-sprint`.

Done outside this PR: `sprint` label created on peterdrier/Humans.

## Notes

- The repo `execute-sprint` shadows the personal `~/.claude/skills/execute-sprint` when working locally in this repo; rename the personal one if that bites.
- Cloud transcript layout is unverified; a first-run `Cost: unmeasured` goes to Needs-Peter per the skill.
- Routine (trigger: new issue labeled `sprint`, .NET instance) is claude.ai config — documented at the bottom of the execute-sprint skill.

Refs peterdrier/Humans#1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
