### PR TITLE
chore(claude): set Concise output style in repo settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "outputStyle": "Concise",
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/skills/finish/SKILL.md
+++ b/.claude/skills/finish/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: finish
+description: End-of-session cleanup for coding and project work. Use when the user says "finish", "wrap up", "done for now", or any variation of ending a work session.
+---
+
+# Finish — Session Closer
+
+Close out a Claude Code session so nothing falls through the cracks when context is lost.
+
+## Scope Rule
+
+Only check repos that were **active in this session**. Use conversation memory to determine which repos were touched. The current working directory always counts.
+
+**Your lane is what THIS session did. Nothing else exists.** Peter runs 5–10 Claudes in parallel, so the repo is full of other sessions' branches, worktrees, PRs, and commits. Reporting any of it is noise he has to read and discard — and worse, it reads as *his* loose ends when it isn't.
+
+Never mention:
+
+- Branches, worktrees, or PRs this session didn't create or work on
+- Commits on `main` that landed from elsewhere ("main has moved to X", "N commits came in while we worked")
+- Open PRs this session never touched, even to say they're untouched
+- Other sessions' running agents or background work
+- Anything you noticed in passing and "left alone" — leaving it alone means not mentioning it either
+
+The test for every line: **did this session do it?** If no, cut it. A shorter close that covers only your own work is the correct output, not an incomplete one.
+
+This applies to the git checks too. `git status` and `git log` will surface other sessions' activity; read past it. Report your own uncommitted work, your own unpushed commits, your own branch state — and if this session's work is fully landed and clean, say exactly that and stop.
+
+## Flow
+
+### 1. Git Hygiene (each active repo)
+
+Run `git status`, `git diff --stat`, `git log --oneline -5` as **separate Bash calls** (not chained with `&&`). Report:
+
+- Uncommitted changes (staged/unstaged)
+- Untracked files
+- Unpushed commits
+- Branch state (on main? feature branch that needs merging/pushing?)
+
+Don't auto-fix. Present state and ask if Peter wants to commit now or defer.
+
+### 2. Context Capture
+
+Scan for things that should survive this session:
+
+- Corrections Peter made and durable rules that surfaced — capture as `memory/<bucket>/<name>.md` atoms + `INDEX.md` line per `memory/META.md` (goes on this session's branch, never direct to main)
+- Architectural or process decisions not yet recorded
+
+If everything was already captured during the session, say so.
+
+### 3. Session Outcomes
+
+Brief factual summary in chat:
+- Shipped/built/fixed
+- Started but unfinished
+- Discussed but not acted on
+
+### 4. Loose Ends
+
+List open items from this session — tasks deferred, background agents **this session** started that are still running, promises made. Frame as: "These are still open."
+
+If this session left nothing open, say so in one line. Don't pad the section with work that belongs to another lane.
+
+### 5. Clean Close
+
+One-line summary + confirmation it's safe to close. E.g.:
+> "3 commits pushed, PR #N open. You're clean — close whenever."
+
+## Tone
+
+- Fast and light. No guilt about unfinished items.
+- If energy is clearly low, minimize: git check + loose ends only.
+- Acknowledge one win, always.
+
+## Not This
+
+- Not a planning session — don't set tomorrow's priorities
+- Not a code review — just check state is clean

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Membership management system for Nobodies Collective (Spanish nonprofit). Manage
 
 @docs/architecture/peters-hard-rules.md
 
+**Peter's working rules — how to behave while working (think-before-coding, simplicity first, surgical changes, brevity). Same authority and same no-LLM-edits policy as the hard rules:**
+
+@docs/architecture/peters-working-rules.md
+
 **Every section is its own project** — `src/Sections/Humans.<Section>/` (+ an optional `.Contracts` leaf), per nobodies-collective/Humans#866 (G5), all 42 of them. A section owns its `DbContext`, migrations and tables end-to-end (`Domain/`, `Services/`, `Data/`, `Controllers/`, `Views/`, its own `<Section>Resource` resx set) and registers its own DI from `Section.cs : ISection`. There is no shared `HumansDbContext` — deleted in nobodies-collective/Humans#858; every table belongs to exactly one section context.
 
 The old four-layer hub projects are gone: `src/Humans.Domain`, `src/Humans.Application`, `src/Humans.Infrastructure` and `src/Humans.UI` were all deleted over the course of G5. **The layers are roles now, not projects,** and three kinds of project are left:

--- a/docs/architecture/peters-working-rules.md
+++ b/docs/architecture/peters-working-rules.md
@@ -1,0 +1,70 @@
+# Working Rules from Peter
+
+Behavioral rules for any agent working in this repo, ported from Peter's global rules so they apply everywhere the repo is cloned (including cloud sessions). Like the hard rules, these are Peter's words — not to be edited by an LLM.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Fix at the Source, Not the Symptom
+
+When something is broken, the fix lives in code, configuration, or re-provisioning — not in hand-editing runtime state (databases, deployed config, caches, generated files) or in bypass flags (`--no-verify`, suppressing errors, deleting "stuck" state to make a process restart cleanly). Surgical workarounds make the red light go away while leaving the real problem unsolved or hidden somewhere worse. If the only path forward you can see goes through manual state edits or bypass flags, **stop and ask** — never present them as one option among several. Offering a forbidden shortcut as a menu item is itself the violation. Token budget is not a reason to take the short path; "broken" is sometimes the correct state to leave something in until the upstream fix is made.
+
+## General Rules
+
+- **Never use 15 words where 5 will do.** This applies to chat replies, commit messages, PR bodies, code comments, and docs — everything you write, not just code. Lead with the answer or the status; drop the rationale unless it changes my decision. Don't restate something back to me that I just read. One line per item, not one paragraph. Write it short the first time — consolidating 7 lines to 3 after I complain means it should have been 3 to begin with.
+- When I ask a question, ONLY answer the question. Do not make code changes, refactor, or implement anything unless explicitly asked.
+- Keep changes minimal and simple. Do not over-engineer, add unnecessary abstractions, or refactor beyond what was requested. When in doubt, choose the simpler approach.
+- Only use `AskUserQuestion` for genuine multi-option decision points (architecture choices, triage actions). Do NOT use it for simple confirmations, yes/no, or "ready to submit?" — just use plain text for those.


### PR DESCRIPTION
Cloud sessions (claude.ai/code) only load config cloned with the repo — the Concise output style was a user-level setting on Peter's machine and never reached them, so cloud sessions produced verbose output. Setting `outputStyle` in the checked-in `.claude/settings.json` makes it apply everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)