### PR TITLE
fix(surveys): CompletionTracked submissions throw on every submit

### DIFF
--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -924,7 +924,7 @@ internal sealed class SurveyService(
         var submission = new SurveySubmission(
             state.SurveyId,
             state.InvitationId,
-            state.Anonymity == ResponseAnonymity.Identified ? state.UserId : null,
+            state.Anonymity == ResponseAnonymity.Anonymous ? null : state.UserId,
             state.DraftResponseId,
             state.Anonymity,
             state.InputMethod,

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -660,6 +660,10 @@ internal sealed class SurveyService(
     public async Task SubmitResponseAsync(SurveySubmission submission, CancellationToken ct = default)
     {
         var prepared = await PrepareSubmissionAsync(submission, ct);
+        if (prepared.AlreadyCompleted)
+        {
+            throw new InvalidOperationException("This invitation has already submitted a response.");
+        }
         if (prepared.MissingRequired.Count > 0)
         {
             throw new InvalidOperationException("Required survey questions are unanswered.");
@@ -689,7 +693,7 @@ internal sealed class SurveyService(
             var invitation = await repo.GetInvitationByIdAsync(gateInvId, ct);
             if (invitation?.Completed == true)
             {
-                throw new InvalidOperationException("This invitation has already submitted a response.");
+                return new SubmissionPreparation([], [], [], AlreadyCompleted: true);
             }
         }
 
@@ -708,7 +712,7 @@ internal sealed class SurveyService(
             .ToList();
         var missingRequired = SurveyWizardFlow.RequiredUnanswered(allVisible, answerStates);
 
-        return new SubmissionPreparation(visibleAnswers, questions, missingRequired);
+        return new SubmissionPreparation(visibleAnswers, questions, missingRequired, AlreadyCompleted: false);
     }
 
     private async Task PersistResponseAsync(
@@ -931,6 +935,10 @@ internal sealed class SurveyService(
             state.Culture,
             SurveyWizardFlow.ToAnswerInputs(state.Answers));
         var prepared = await PrepareSubmissionAsync(submission, ct);
+        if (prepared.AlreadyCompleted)
+        {
+            return new SurveyWizardAdvanceResult(SurveyWizardOutcome.Submitted, []);
+        }
         if (prepared.MissingRequired.Count > 0)
         {
             ReplaceWizardAnswers(state, prepared.VisibleAnswers);
@@ -1431,7 +1439,8 @@ internal sealed class SurveyService(
     private sealed record SubmissionPreparation(
         IReadOnlyList<SurveyAnswerInput> VisibleAnswers,
         IReadOnlyList<QuestionInput> Questions,
-        IReadOnlyList<Guid> MissingRequired);
+        IReadOnlyList<Guid> MissingRequired,
+        bool AlreadyCompleted);
 
     private static List<SurveyAnswer> MapAnswers(Guid responseId, IReadOnlyList<SurveyAnswerInput> answers)
         => answers.Select(a => new SurveyAnswer

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -1983,6 +1983,27 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task AdvanceWizardAsync_submits_completion_tracked_response_and_completes_invitation()
+    {
+        var survey = SurveyForWizard(out var q1Id, out var q2Id);
+        var invitationId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var state = WizardState(survey.Id, invitationId);
+        state.Anonymity = ResponseAnonymity.CompletionTracked;
+        state.UserId = userId;
+        state.Answers[q1Id.ToString()] = new SurveyWizardAnswer { SelectedOptionValues = ["yes"] };
+        state.CurrentPage = 2;
+        state.Started = true;
+
+        var result = await CreateService().AdvanceWizardAsync(
+            state, 2, back: false, [TextAns(q2Id, "done")], ct: TestContext.Current.CancellationToken);
+
+        result.Outcome.Should().Be(SurveyWizardOutcome.Submitted);
+        await _repo.Received(1).FinalizeCompletionTrackedResponseAsync(
+            invitationId, userId, Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task AdvanceWizardAsync_returns_closed_when_survey_not_open()
     {
         var survey = SurveyForWizard(out var q1Id, out _);

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -1852,7 +1852,8 @@ public class SurveyServiceTests
 
         var act = async () => await CreateService().SubmitResponseAsync(submission, TestContext.Current.CancellationToken);
 
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("This invitation has already submitted a response.");
         await _repo.DidNotReceive().AddResponseWithAnswersAndSaveAsync(Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
         await _repo.DidNotReceive().FinalizeCompletionTrackedResponseAsync(
             Arg.Any<Guid>(),
@@ -2001,6 +2002,29 @@ public class SurveyServiceTests
         result.Outcome.Should().Be(SurveyWizardOutcome.Submitted);
         await _repo.Received(1).FinalizeCompletionTrackedResponseAsync(
             invitationId, userId, Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task AdvanceWizardAsync_returns_submitted_when_invitation_already_completed()
+    {
+        var survey = SurveyForWizard(out var q1Id, out var q2Id);
+        var invitation = InvitationFor(survey.Id, Guid.NewGuid());
+        invitation.Completed = true;
+        var state = WizardState(survey.Id, invitation.Id);
+        state.Anonymity = ResponseAnonymity.CompletionTracked;
+        state.UserId = invitation.UserId;
+        state.Answers[q1Id.ToString()] = new SurveyWizardAnswer { SelectedOptionValues = ["yes"] };
+        state.CurrentPage = 2;
+        state.Started = true;
+        _repo.GetInvitationByIdAsync(invitation.Id, Arg.Any<CancellationToken>()).Returns(invitation);
+
+        var result = await CreateService().AdvanceWizardAsync(
+            state, 2, back: false, [TextAns(q2Id, "done")], ct: TestContext.Current.CancellationToken);
+
+        result.Outcome.Should().Be(SurveyWizardOutcome.Submitted);
+        await _repo.DidNotReceive().FinalizeCompletionTrackedResponseAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
+        await _repo.DidNotReceive().AddResponseWithAnswersAndSaveAsync(Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]


### PR DESCRIPTION
## Fix 1: CompletionTracked submissions threw on every submit

### Symptom
Production `InvalidOperationException` on every CompletionTracked survey submission — both invited and public-slug routes. `SurveyController.SubmitPage` → `ProcessPage` → `AdvanceWizardAsync` → `PersistResponseAsync`.

### Cause
`AdvanceWizardAsync` built the submission with `state.Anonymity == ResponseAnonymity.Identified ? state.UserId : null` — nulling `UserId` for CompletionTracked too. `PersistResponseAsync`'s CompletionTracked branch requires a non-null `submission.UserId` and threw.

History: bug entered in the original feature commit d29c8bb30, incidentally fixed during peterdrier/Humans#1463's review rounds, reintroduced when those rounds were reverted in 945fcdeca3.

### Fix
One-line ternary flip: only null `UserId` for `Anonymous`. Safe — `PersistResponseAsync`'s CompletionTracked branch already forces the persisted `SurveyResponse.UserId` to `null` regardless of what's passed in; the submission's `UserId` is used only by `FinalizeCompletionTrackedResponseAsync` to locate the `survey_invitations` row and flip its `Completed` flag. No identity is written to the stored response.

### Test
Added `AdvanceWizardAsync_submits_completion_tracked_response_and_completes_invitation` — drives a CompletionTracked wizard submit through `AdvanceWizardAsync` and asserts it succeeds and calls `FinalizeCompletionTrackedResponseAsync` with the invitation/user ids.

## Fix 2: already-completed invitation returned a 500 instead of the thank-you page

### Symptom
Same flow, same PR: a double-click or refresh of the final wizard step on a tracked invitation that had already submitted threw an unhandled 500 instead of landing the respondent on the thank-you page.

### Cause
`PrepareSubmissionAsync` threw `InvalidOperationException("This invitation has already submitted a response.")` on an already-completed tracked invitation. `SubmitResponseAsync` is supposed to throw there (service-level contract), but `AdvanceWizardAsync` shares the same helper and let the exception propagate unhandled instead of returning a normal wizard outcome.

### Fix
`SubmissionPreparation` gained an `AlreadyCompleted` flag; `PrepareSubmissionAsync` returns it instead of throwing. `SubmitResponseAsync` checks the flag and throws the same message as before (contract unchanged). `AdvanceWizardAsync` checks the flag and returns `SurveyWizardOutcome.Submitted` — the controller already clears the session and redirects to the thank-you action for that outcome, so no controller change was needed.

### Test
Added `AdvanceWizardAsync_returns_submitted_when_invitation_already_completed` (asserts `Submitted` outcome and no persist calls) and strengthened `SubmitResponseAsync_throws_when_invitation_already_completed` with a `WithMessage` assertion on the preserved exception text.

## Verification (both fixes)
- `dotnet build Humans.slnx -v quiet` — 0 errors
- `dotnet test tests/Humans.Surveys.Tests/Humans.Surveys.Tests.csproj -v quiet` — 191/191 passed
- `dotnet format whitespace Humans.slnx --verify-no-changes --no-restore --include src/Sections/Humans.Surveys tests/Humans.Surveys.Tests` — clean
