### PR TITLE
doctor(Events): first pass — dead favourite surface + four duplicated rules

### DIFF
--- a/docs/health/runs/2026-08-24-Events.md
+++ b/docs/health/runs/2026-08-24-Events.md
@@ -1,0 +1,399 @@
+# doctor(Events) — 2026-08-24
+
+## Header
+
+- Invocation: unattended daily run, no arguments (routine-fired)
+- Anchor commit: `origin/main` @ `4d5c18e9`
+- Budget: 2.5h
+- Branch: `section-doctor/2026-08-24T131359Z`
+- PR: peterdrier/Humans#PENDING
+- 2026-08-24 13:14Z session: dotnet SDK 10.0.400, reforge and dotnet-ef available.
+  Stryker not installed — Tests-thread mutation-score half skipped with reason.
+- **Verification caveat, read this first:** `origin/main` @ `4d5c18e9` does not
+  build from a clean tree in this environment — 9 Razor errors in
+  `src/Humans.Base/Views/Shared/{_Pager,_Table}.cshtml`, reproduced in a
+  pristine detached worktree of untouched `origin/main`. See Needs Peter #3.
+  Every strike below was built and tested green (0 errors, 170/170
+  `Humans.Events.Tests`) at the moment it was made, and one full
+  `dotnet test Humans.slnx` ran 45 test projects with **zero test failures**.
+  The clean-build failure only surfaced after this run deleted `obj/`+`bin/`,
+  and it is not attributable to this diff (which touches no Razor file).
+
+## Assessment summary
+
+Events is the largest never-doctored section (score=258, loc=6367, cogP95=9,
+cogMax=35): six controllers, one service of 870 lines, a §15 caching decorator
+that is also its own `IHostedService`, seven owned tables and a six-language
+resource set. It answers six question-shapes — Programme, Mine, Propose,
+Decide, Configure, Publish — and the shape pressure is real: **Programme is
+answered five separate ways** (Browse, Schedule, the JSON API, the CSV export
+and the print guide), each re-deriving occurrence expansion and camp-name
+resolution from scratch, and **Propose runs two near-identical form pipelines**
+(individual and barrio).
+
+The material findings split three ways. Dead surface: a favourite
+toggle/exists pair with no live caller. Duplication: the same four rules
+written out between three and twelve times each. Two genuine defects, both
+Needs Peter because the fix shape is a real fork and both change observable
+behaviour — the GDPR-erasure cache-coherence hole and the PriorityRank-0
+bulk-template round-trip failure.
+
+## Ranked findings
+
+1. **GDPR erasure bypasses the cache.** `Section.cs` registers
+   `services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<EventService>())`
+   — the **inner** service, not the `CachingEventService` decorator. An
+   erasure therefore deletes the rows and leaves the decorator's projection
+   serving the erased user's events until the next unrelated invalidation.
+   Fix shape is a fork (rebind the contributor to the decorator vs. have the
+   contributor call the invalidator), and either way it changes observable
+   behaviour. — **Needs Peter #1** (bug)
+2. **A PriorityRank of 0 does not round-trip through the bulk template.**
+   `BuildBulkUploadTemplateAsync` writes existing submissions back out as the
+   camp's next upload; `PriorityRank == 0` means "unranked" on the print-guide
+   sort (`o.PriorityRank == 0 ? int.MaxValue : o.PriorityRank`) but is written
+   to the CSV as the literal `0`, which `ValidateBulkRows` reads back as a
+   rank. Invariant #6 in `Docs/health.md` ("bulk CSV import is all-or-nothing,
+   and its template round-trips") does not hold. — **Needs Peter #2** (bug)
+3. `IEventRepository.FavouriteExistsAsync` has **zero callers** (reforge
+   `callers`, fully-qualified). — **delete** (dead surface) — *struck*
+4. `IEventService.ToggleFavouriteAsync`'s only caller is its own
+   `CachingEventService` pass-through; the favourites JSON API uses
+   `AddFavouriteAsync`/`RemoveFavouriteAsync`. — **delete** — *struck*
+5. `EventsExportController` injects `IUserServiceRead` **twice** (once for
+   itself, once for the base) and resolves a submitter per event inside the
+   CSV loop, when `EventsLookupHelpers.LoadSubmittersAsync` already exists for
+   exactly that. — **cut + dedup** — *struck*
+6. Gate-relative day-offset resolution exists **three times**:
+   `EventsApiController.ComputeDayOffset`, `EventsDashboardController.ComputeDayOffset`
+   and `EventOccurrenceExpander.ResolveDayOffset`. Identical behaviour, one
+   nullable-tolerant. — **dedup** — *struck*
+7. Camp display-name resolution (`Active?.Name ?? Slug`) is written out at
+   **twelve sites across five controllers**, in three private helper shapes.
+   — **dedup** — *struck*
+8. `EventsController` hand-rolls the day-offset option list **three times**,
+   twice byte-identical to `EventsLookupHelpers.BuildEventDayOptions`, which
+   `EventsModerationController` already calls. — **dedup** — *struck*
+9. **The occurrence-expansion guard** (`gate.HasValue && tz != null ? …
+   GetOccurrenceInstants(…) : [StartAt]`) is written out at **five sites**,
+   with a sixth variant guarding only `tz`. It cannot be deduped mechanically
+   because the three types that carry `GetOccurrenceInstants` — `Event`,
+   `EventInfo` and `ApprovedEventView` — are three hand-mirrored copies of the
+   same method with no shared shape (each carries a "Mirrors …" comment
+   admitting it). — **collapse**, queued, not struck: it needs a shared shape
+   on the three types, which is public surface.
+10. **Comments thread: 86 CUT/SHORTEN verdicts, ≈211 lines** — mostly
+    `/// Unique identifier.`-class doc noise across the eight `Domain/` types,
+    plus thirteen 3-line `// ====` ASCII banners in `CachingEventService`
+    (rest of the codebase uses the single-line `// ── Label ──` form).
+    Five of these are **factual corrections, not size reductions**, and are
+    the part worth keeping: `IEventRepository.cs:15` names
+    `IShiftManagementService` (no such type; it is `IBurnSettingsService`);
+    `EventGuideDbContext.cs:21-22` says `event_settings` lives on
+    `UsersDbContext` (it is on `ShiftsDbContext`); and three broken
+    `<see cref>` targets (`EventGuideSettings.cs:7`,
+    `EventModerationActionType.cs:21` — stale pre-G5 `Entities.*` namespace —
+    and `EventsModerationViewModels.cs:91`). Silent today because
+    `GenerateDocumentationFile` is set nowhere in the repo. **Not struck** —
+    the clean-build failure landed before this batch; queued.
+11. `EventsModerationController` has **no test file**, and the `[Authorize]`
+    policies on the six controllers are pinned by no test. — **test gap**,
+    queued.
+12. Three per-section absence tests would be candidates for deletion under
+    `memory/architecture/no-tests-for-absences.md` — but **that rule lives in
+    unmerged PR #1482 and does not exist in this worktree**. Recorded, not
+    acted on.
+
+Independence check: pass. #1 came from reading `Section.cs`'s DI against the
+decorator's invalidation surface; #2 from walking invariant #6 of the target
+written in 3c against `ValidateBulkRows`; #3/#4 from `reforge callers` on
+fully-qualified signatures; #5–#9 from the Programme/Propose collapse pressure
+named in the 3c target *before* any scan. Not a scanner verdict list.
+
+## File coverage
+
+Every path in the 3a inventory has a disposition here (114 files).
+
+| Path | Disposition | Thread |
+|---|---|---|
+| `src/Sections/Humans.Events.Contracts/ApprovedEventView.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events.Contracts/EventGuideSettingsView.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events.Contracts/EventSearchHit.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events.Contracts/EventStatus.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events.Contracts/Humans.Events.Contracts.csproj` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events.Contracts/IEventServiceRead.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Contracts/FavouriteButtonModel.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Controllers/EventsAdminController.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Controllers/EventsApiController.cs` | changed | Shape (Strikes 3, 4) |
+| `src/Sections/Humans.Events/Controllers/EventsController.cs` | changed | Shape (Strikes 4, 5) |
+| `src/Sections/Humans.Events/Controllers/EventsDashboardController.cs` | changed | Shape (Strikes 3, 4) |
+| `src/Sections/Humans.Events/Controllers/EventsExportController.cs` | changed | Shape (Strikes 2, 4) |
+| `src/Sections/Humans.Events/Controllers/EventsModerationController.cs` | changed | Shape (Strike 4) |
+| `src/Sections/Humans.Events/Data/Configurations/EventCategoryConfiguration.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/Configurations/EventConfiguration.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/Configurations/EventFavouriteConfiguration.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/Configurations/EventGuideSettingsConfiguration.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/Configurations/EventModerationActionConfiguration.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/Configurations/EventPreferenceConfiguration.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/Configurations/EventVenueConfiguration.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/EventGuideDbContext.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/EventGuideDbContextFactory.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Data/IEventRepository.cs` | changed | Shape (Strike 1) |
+| `src/Sections/Humans.Events/Data/Migrations/20260715112050_BaselineEventGuide.Designer.cs` | reviewed | Conformance |
+| `src/Sections/Humans.Events/Data/Migrations/20260715112050_BaselineEventGuide.cs` | reviewed | Conformance |
+| `src/Sections/Humans.Events/Data/Migrations/EventGuideDbContextModelSnapshot.cs` | reviewed | Conformance |
+| `src/Sections/Humans.Events/Data/Repository.cs` | changed | Shape (Strike 1) |
+| `src/Sections/Humans.Events/Docs/2026-06-08-camp-events-card-design.md` | reviewed | Freshness |
+| `src/Sections/Humans.Events/Docs/2026-06-09-events-admin-edit-design.md` | reviewed | Freshness |
+| `src/Sections/Humans.Events/Docs/Events.md` | reviewed | Freshness |
+| `src/Sections/Humans.Events/Docs/authorization.md` | reviewed | Freshness |
+| `src/Sections/Humans.Events/Docs/data-access.md` | reviewed | Freshness |
+| `src/Sections/Humans.Events/Docs/events-bulk-upload-sample.csv` | reviewed | Freshness |
+| `src/Sections/Humans.Events/Docs/features/Events-feature.md` | reviewed | Freshness |
+| `src/Sections/Humans.Events/Docs/health.md` | changed | Phase 3c (new) |
+| `src/Sections/Humans.Events/Domain/Event.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/Domain/EventCategory.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/Domain/EventFavourite.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/Domain/EventGuideSettings.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/Domain/EventModerationAction.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/Domain/EventModerationActionType.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/Domain/EventPreference.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/Domain/EventVenue.cs` | reviewed | Comments |
+| `src/Sections/Humans.Events/EventsResource.ca.resx` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/EventsResource.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/EventsResource.de.resx` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/EventsResource.es.resx` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/EventsResource.fr.resx` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/EventsResource.it.resx` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/EventsResource.resx` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Filters/EventsFeatureFilter.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Helpers/EventsLookupHelpers.cs` | changed | Shape (Strike 4) |
+| `src/Sections/Humans.Events/Helpers/EventsTimeHelpers.cs` | changed | Shape (Strike 3) |
+| `src/Sections/Humans.Events/Humans.Events.csproj` | reviewed | Conformance |
+| `src/Sections/Humans.Events/Models/BarrioEventViewModels.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Models/EventsAdminViewModels.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Models/EventsApiModels.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Models/EventsCardViewModel.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Models/EventsDashboardViewModel.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Models/EventsModerationViewModels.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Models/IndividualEventViewModels.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Properties/AssemblyInfo.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Section.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/SectionAdminNav.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/SectionNav.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/SectionPolicies.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/BulkEventCsvParser.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/BulkEventCsvRecord.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/CachingEventService.cs` | changed | Shape (Strike 1) |
+| `src/Sections/Humans.Events/Services/Dtos/BulkEventImport.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/Dtos/CampEventOverlap.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/Dtos/EventInfo.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/EventConflictDetector.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/EventOccurrenceExpander.cs` | changed | Shape (Strike 3) |
+| `src/Sections/Humans.Events/Services/EventRecurrenceDays.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/IEventService.cs` | changed | Shape (Strike 1) |
+| `src/Sections/Humans.Events/Services/IEventViewInvalidator.cs` | reviewed | Shape |
+| `src/Sections/Humans.Events/Services/Service.cs` | changed | Shape (Strike 1) |
+| `src/Sections/Humans.Events/ViewComponents/EventsCardViewComponent.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/ViewComponents/EventsSearchResultViewComponent.cs` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Events/BarrioEventForm.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Events/Browse.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Events/IndividualEventForm.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Events/MySubmissions.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Events/Schedule.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsAdmin/Categories.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsAdmin/CategoryForm.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsAdmin/Settings.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsAdmin/VenueForm.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsAdmin/Venues.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsAdmin/_ViewStart.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsDashboard/Index.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsExport/Index.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsExport/PrintGuide.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsModeration/AdminEventForm.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/EventsModeration/Index.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Shared/Components/EventsCard/Default.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Shared/Components/EventsSearchResult/Default.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/Shared/_FavouriteButton.cshtml` | reviewed | Prose & surface |
+| `src/Sections/Humans.Events/Views/_ViewImports.cshtml` | reviewed | Prose & surface |
+| `tests/Humans.Events.Tests/Controllers/EventsApiControllerTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Controllers/EventsControllerTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Data/RepositoryTests.cs` | changed | Tests (Strike 1) |
+| `tests/Humans.Events.Tests/Domain/EventTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/EventsArchitectureTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Humans.Events.Tests.csproj` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Services/BulkEventCsvParserTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Services/CachingEventServiceTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Services/EventConflictDetectorTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Services/EventOccurrenceExpanderTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Services/ServiceCalendarFeedTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/Services/ServiceTests.cs` | changed | Tests (Strike 1) |
+| `tests/Humans.Events.Tests/ViewComponents/EventsCardViewComponentTests.cs` | reviewed | Tests |
+| `tests/Humans.Events.Tests/ViewComponents/EventsSearchResultViewComponentTests.cs` | reviewed | Tests |
+## Threads
+
+| Thread | How | Model | Findings | Cost | Notes |
+|---|---|---|---|---|---|
+| Spine + Shape + Behavior & bugs (3a–3c, 3e) | main | opus-5 | #1,#2,#5–#9 | $12.38 (phase3 bucket) | Phase 3 marked once — the shared bucket for every main-thread reading lens |
+| Comments | dispatched sub-agent | sonnet | #10 | $19.98 | Full 114-file walk; 86 CUT/SHORTEN verdicts with exact replacements, 5 of them factual corrections |
+| History | dispatched sub-agent | sonnet | (#10) | $5.64 | ~30 decision-history comments folded into the Comments verdict set; the `Events.md` history block itself passes the cut test |
+| Freshness | dispatched sub-agent | sonnet | (#10) | $4.65 | `Events.md`, `authorization.md`, `data-access.md` read against the code; the five wrong doc claims surfaced through the Comments walk, not here |
+| Tests | dispatched sub-agent | sonnet | #11,#12 | $4.13 | **Stryker skipped — not installed in this environment and out of scope by instruction.** Mutation-score half not run; invariant matrix walked instead |
+| Conformance | dispatched sub-agent | haiku | none | $1.26 | `section-conformance.yml` rows pass — resource-key prefix, table prefix (`event_*`), canonical layer folders, one baseline migration |
+| Prose & surface | dispatched sub-agent | haiku | none | $1.11 | 20 `.cshtml` + the 6-language resx set reviewed; no dead resource keys, nav targets all resolve |
+| Inbox | dispatched sub-agent — **returned nothing usable** | sonnet | — | $1.06 | GitHub MCP is scoped to `peterdrier/Humans`; Events issues live in `nobodies-collective/Humans`. `search_issues` returns 0 there **silently** rather than erroring, so the thread cannot tell "no issues" from "wrong repo". See Needs Peter #4 |
+
+The `assess` row of `## Cost` is the shared bucket for every main-thread
+reading lens; splitting turn-by-turn cost per lens would be an invented number.
+
+## Worked
+
+- **Strike 1 (delete, dead surface — findings #3, #4):** Removed
+  `IEventRepository.FavouriteExistsAsync` and the `ToggleFavouriteAsync` pair
+  (repository, service, interface, caching pass-through). The two repository
+  tests and four service tests that pinned the whole-event/day-offset match
+  rule *through* Toggle were **rewritten against the live
+  `RemoveFavouriteAsync`/`AddFavouriteIfAbsentAsync`**, not deleted — deleting
+  them would have dropped the only pin on "a day-specific reference also
+  matches the whole-event row". Commit `da1dd284`.
+- **Strike 2 (cut + dedup — finding #5):** `EventsExportController` now takes
+  one `IUserServiceRead` and reads the base's `UserService`; the CSV export
+  resolves submitters once via `LoadSubmittersAsync` over the distinct
+  camp-less submitter ids. Commit `d7b19672`.
+- **Strike 3 (dedup — finding #6):** One `ComputeDayOffset` in
+  `EventsTimeHelpers`; three private copies deleted. Commit `5cf0962c`.
+- **Strike 4 (dedup — finding #7):** One `EventsLookupHelpers.ResolveCampName`;
+  twelve call sites point at it and the two surviving private helpers are thin
+  adapters (by-id lookup, non-null call sites). Commit `3e4f8745`.
+- **Strike 5 (dedup — finding #8):** `EventsController`'s three hand-rolled
+  day-option loops replaced with `BuildEventDayOptions`. Commit `83cda71c`.
+
+Net: 6 files smaller, 209 lines deleted against 167 added, one new
+section-owned helper method (`ResolveCampName`) and one moved one
+(`ComputeDayOffset`). No new public surface, no migration, no behaviour change.
+
+## Skipped
+
+- **Findings #1 and #2** — the two real defects. Both are Needs Peter: each
+  has a genuine fork in the fix shape and each changes observable behaviour,
+  which this run does not do unattended.
+- **Finding #9** (occurrence-expansion guard) — the mechanical dedup is
+  blocked by three hand-mirrored `GetOccurrenceInstants` methods on three
+  types. Collapsing them means a shared shape on public DTOs. Queued.
+- **Finding #10** (86 comment verdicts, including the five factual doc
+  corrections) — **not struck because the environment's clean build broke
+  mid-run** (see Needs Peter #3) and this run does not push code it cannot
+  build. The verdict list is complete with exact replacements and is the
+  cheapest first item for the next Events run.
+- **Finding #11** (no `EventsModerationController` tests, unpinned
+  `[Authorize]` policies) — same reason; queued.
+- **Finding #12** — the rule it would act under is not in this tree.
+- **Sections passed over as blocked:** none. No open `section-doctor/…` PRs at
+  branch point; the one open PR (#1482) touches no Events file.
+
+## Retro
+
+- **Selector rubric:** picked Events as the highest-score never-doctored
+  section (258). Right call — it is where the duplication actually is, and
+  four of the five strikes were only visible *because* the 3c target named
+  "Programme is answered five ways" before any tool ran.
+- **Wasted motion:** yes, and it cost the back half of the run. Deleting
+  `obj/`+`bin/` to clear what looked like build corruption was the wrong
+  reflex: it converted a working incremental build into a clean build that
+  cannot succeed in this environment, and it is what stopped strikes at five.
+  The diagnosis that mattered — reproducing the same 9 errors on a pristine
+  detached worktree of `origin/main` — should have come *first*, and would
+  have cost one build instead of the tree.
+- **Assessment missed:** the Comments sub-agent found five wrong factual
+  claims in production doc comments that the main-thread Freshness read did
+  not — including a `DbContext` ownership claim that contradicts Shifts' own
+  docs. Doc comments inside code files are not covered by the Freshness lens's
+  usual `Docs/` sweep, and this run only caught them by dispatching a lens
+  that reads every comment in the section.
+- **Target diff:** the section had no prior `health.md`; today's is the first
+  snapshot. Nothing to diff. The six question-shapes and eight invariants are
+  recorded for the next run to diff against.
+
+## Needs Peter
+
+- [ ] 1 — **Bug: GDPR erasure bypasses the Events cache.**
+  `src/Sections/Humans.Events/Section.cs` binds `IUserDataContributor` to
+  `EventService` (the inner service), so an erasure deletes rows while
+  `CachingEventService`'s projection keeps serving the erased user's events.
+  Two fix shapes, and it is your call which: (a) rebind the contributor to the
+  decorator so the existing invalidation path runs, or (b) have the erasure
+  path call `IEventViewInvalidator` explicitly. (a) is smaller; (b) keeps the
+  contributor off the decorator's `IHostedService` lifetime.
+- [ ] 2 — **Bug: `PriorityRank == 0` does not round-trip through the bulk
+  template.** The print guide treats 0 as "unranked"
+  (`o.PriorityRank == 0 ? int.MaxValue : o.PriorityRank`), but
+  `BuildBulkUploadTemplateAsync` writes the literal `0` and `ValidateBulkRows`
+  reads it back as a rank. Fork: write blank for 0 in the template (changes
+  the CSV shape camps see), or make 0 and blank equivalent on read (changes
+  validation). Invariant #6 in the new `Docs/health.md` is currently false.
+- [ ] 3 — **`origin/main` does not build from a clean tree in this
+  environment.** `4d5c18e9`, freshly checked out into a detached worktree,
+  fails with 9 Razor errors in `src/Humans.Base/Views/Shared/_Pager.cshtml`
+  and `_Table.cshtml` — the signature of `Views/Shared/_ViewImports.cshtml`
+  not being applied (`<partial>` and `asp-*` unrecognised; `RZ1021` follows).
+  `global.json` pins `10.0.100` with `rollForward: latestFeature` and this
+  sandbox resolves **10.0.400**, which is the most likely cause; CI presumably
+  runs a 10.0.1xx SDK and is green. Two things follow: unattended runs cannot
+  verify a full `dotnet test Humans.slnx` here, and the `rollForward` is
+  loose enough that a contributor on a current SDK hits the same wall.
+- [ ] 4 — **Unattended runs cannot review a section's open issues.** GitHub
+  access in this session is scoped to `peterdrier/Humans`, but issues live on
+  `nobodies-collective/Humans`. `search_issues` against the issues repo
+  returns **0 results silently** rather than erroring, so the Inbox thread
+  looks like it ran and found nothing. Either widen the scope for these runs
+  or the skill should state the Inbox thread is unavailable in cloud sessions.
+
+## Sweep queue
+
+- debt: Events — three types (`Event`, `EventInfo`, `ApprovedEventView`) carry
+  three hand-mirrored copies of `GetOccurrenceInstants`, each labelled
+  "Mirrors …" in its own doc comment. The guard around them is written out at
+  five call sites and cannot be deduped until the three share a shape.
+- debt: Events — `EventService` is 870 lines against a `maxClassLoc` of 740,
+  and holds the section's two highest-complexity methods (`ValidateBulkRows`
+  CC 35, `BulkImportAsync` CC 33) plus a 114-line
+  `BuildBulkUploadTemplateAsync`. The bulk-import trio is one cohesive
+  concern and would split cleanly.
+- debt: Events — `EventsModerationController` has no test file, and no test
+  pins the `[Authorize]` policy on any of the six Events controllers.
+- debt: Events — `CachingEventService` uses thirteen 3-line `// ====` ASCII
+  banners where the rest of the codebase uses the single-line `// ── Label ──`
+  form; and five doc comments in the section state facts that are wrong
+  (`IShiftManagementService`, `event_settings` on `UsersDbContext`, three
+  broken `<see cref>` targets). Full verdict list with exact replacements is
+  in finding #10 above.
+
+## Cost
+
+| Component | Phase | Model | Fresh in | Out | Cache write | Cache read | ~$ |
+|---|---|---|---|---|---|---|---|
+| worktree | phase1 | opus | 10 | 1,687 | 6,346 | 457,736 | 0.31 |
+| select section | phase2 | opus | 20 | 3,389 | 60,725 | 969,490 | 0.95 |
+| assess | phase3 | opus | 158 | 96,785 | 496,267 | 13,718,792 | 12.38 |
+| Freshness (subagent) | phase3 | sonnet | 160 | 1,964 | 532,344 | 8,730,989 | 4.65 |
+| Conformance (subagent) | phase3 | haiku | 802 | 3,255 | 419,888 | 7,145,341 | 1.26 |
+| Tests (subagent) | phase3 | sonnet | 152 | 3,780 | 360,200 | 9,067,358 | 4.13 |
+| Prose & surface (subagent) | phase3 | haiku | 830 | 5,205 | 316,836 | 6,901,428 | 1.11 |
+| History (subagent) | phase3 | sonnet | 254 | 8,011 | 287,852 | 14,803,878 | 5.64 |
+| Comments (subagent) | phase3 | sonnet | 544 | 4,989 | 1,929,336 | 42,231,668 | 19.98 |
+| Inbox (subagent) | phase3 | sonnet | 44 | 148 | 156,396 | 1,562,469 | 1.06 |
+| strike: dead favourite surface | phase4 | opus | 156 | 51,679 | 111,561 | 12,781,586 | 8.38 |
+| strikes 2–5 + bookkeeping | phase4/5 | opus | 84 | 18,817 | 68,110 | 4,821,546 | 3.31 |
+| **total** | | | 3,214 | 199,709 | 4,745,861 | 123,192,281 | **63.15** |
+
+API-equivalent $, list rates; run under subscription quota. Measured Phase 1 to
+PR creation; PR create/backfill and Phase 8 excluded.
+
+Against the 2026-08-23 Onboarding baseline (nobodies-collective/Humans#1465:
+$93.30 / 746 calls / 184k median context): **$63.15, ~32% under**, on the
+largest never-doctored section. The dispatched-thread split is where the money
+went — seven sub-agents cost $37.83 of the $63.15, and the Comments thread
+alone ($19.98) is the single largest line in the run. It earned it: it is the
+only thread that found the five wrong factual claims, and the only one whose
+output survives this run intact as the next run's first work item. The Inbox
+thread's $1.06 bought nothing and could not have — see Needs Peter #4.

--- a/docs/health/runs/2026-08-24-Events.md
+++ b/docs/health/runs/2026-08-24-Events.md
@@ -6,7 +6,7 @@
 - Anchor commit: `origin/main` @ `4d5c18e9`
 - Budget: 2.5h
 - Branch: `section-doctor/2026-08-24T131359Z`
-- PR: peterdrier/Humans#PENDING
+- PR: peterdrier/Humans#1483
 - 2026-08-24 13:14Z session: dotnet SDK 10.0.400, reforge and dotnet-ef available.
   Stryker not installed — Tests-thread mutation-score half skipped with reason.
 - **Verification caveat, read this first:** `origin/main` @ `4d5c18e9` does not

--- a/src/Sections/Humans.Events/Controllers/EventsApiController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsApiController.cs
@@ -14,6 +14,7 @@ using Humans.Events.Contracts;
 using Humans.Events.Services.Dtos;
 using Humans.Users.Contracts;
 using static Humans.Events.Helpers.EventsTimeHelpers;
+using static Humans.Events.Helpers.EventsLookupHelpers;
 
 namespace Humans.Events.Controllers;
 
@@ -50,7 +51,7 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
             if (categorySlug != null && !string.Equals(e.CategorySlug, categorySlug, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var campName = ResolveCampName(e.CampId, campsById);
+            var campName = ResolveCampNameById(e.CampId, campsById);
             var submitterName = ResolveSubmitterName(e, submitterInfoById);
 
             foreach (var occurrenceStart in gateOpeningDate.HasValue && tz != null ? e.GetOccurrenceInstants(gateOpeningDate.Value, tz) : (IReadOnlyList<Instant>)[e.StartAt])
@@ -78,7 +79,7 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
 
         var gateOpeningDate = eventSettings?.GateOpeningDate;
         var campsById = await LoadCampsByIdAsync(gateOpeningDate?.Year);
-        var campName = ResolveCampName(e.CampId, campsById);
+        var campName = ResolveCampNameById(e.CampId, campsById);
         var submitterName = e.CampId == null
             ? (await UserService.GetUserInfoAsync(e.SubmitterUserId))?.BurnerName
             : null;
@@ -100,10 +101,9 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
             .Select(g =>
             {
                 var camp = campsById.GetValueOrDefault(g.Key);
-                var seasonName = camp?.Active?.Name;
                 return new GuideCampApiDto(
                     g.Key,
-                    seasonName ?? camp?.Slug,
+                    ResolveCampName(camp),
                     camp?.Slug);
             })
             .ToList();
@@ -126,7 +126,7 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
 
         var campsById = await LoadCampsByIdAsync(gateOpeningDate?.Year);
         var camp = campsById.GetValueOrDefault(id);
-        var campName = camp?.Active?.Name ?? camp?.Slug;
+        var campName = ResolveCampName(camp);
 
         return Ok(new GuideCampDetailApiDto(
             id,
@@ -216,7 +216,7 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
         var results = favourites.SelectMany(f =>
         {
             var e = f.Event;
-            var campName = ResolveCampName(e.CampId, campsById);
+            var campName = ResolveCampNameById(e.CampId, campsById);
             var submitterName = ResolveSubmitterName(e, submitterInfoById);
 
             // One entry per favourited occurrence (day-specific favourites
@@ -281,12 +281,8 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
         return camps1.ToDictionary(c => c.Id);
     }
 
-    private static string? ResolveCampName(Guid? campId, IReadOnlyDictionary<Guid, CampInfo> campsById)
-    {
-        if (campId is null) return null;
-        var camp = campsById.GetValueOrDefault(campId.Value);
-        return camp?.Active?.Name ?? camp?.Slug;
-    }
+    private static string? ResolveCampNameById(Guid? campId, IReadOnlyDictionary<Guid, CampInfo> campsById)
+        => campId is null ? null : ResolveCampName(campsById.GetValueOrDefault(campId.Value));
 
     // Individual events only — the published-guide host falls back to the submitter's burner name.
     private static string? ResolveSubmitterName(ApprovedEventView e, IReadOnlyDictionary<Guid, UserInfo> submitterInfoById)

--- a/src/Sections/Humans.Events/Controllers/EventsApiController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsApiController.cs
@@ -13,6 +13,7 @@ using NodaTime.Text;
 using Humans.Events.Contracts;
 using Humans.Events.Services.Dtos;
 using Humans.Users.Contracts;
+using static Humans.Events.Helpers.EventsTimeHelpers;
 
 namespace Humans.Events.Controllers;
 
@@ -334,12 +335,5 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
             locationNote,
             campId == null ? (host ?? submitterName) : host,
             priorityRank);
-    }
-
-    private static int ComputeDayOffset(Instant instant, LocalDate? gateOpeningDate, DateTimeZone? tz)
-    {
-        if (gateOpeningDate == null) return 0;
-        var eventDate = tz != null ? instant.InZone(tz).Date : LocalDate.FromDateTime(instant.ToDateTimeUtc());
-        return Period.Between(gateOpeningDate.Value, eventDate, PeriodUnits.Days).Days;
     }
 }

--- a/src/Sections/Humans.Events/Controllers/EventsController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsController.cs
@@ -469,19 +469,7 @@ internal sealed class EventsController(
         var categories = await guide.GetActiveCategoriesAsync();
         var venues = await guide.GetActiveVenuesAsync();
 
-        var eventDays = new List<EventDayOptionViewModel>();
-        if (eventSettings != null)
-        {
-            for (var offset = 0; offset <= eventSettings.EventEndOffset; offset++)
-            {
-                var date = eventSettings.GateOpeningDate.PlusDays(offset);
-                eventDays.Add(new EventDayOptionViewModel
-                {
-                    DayOffset = offset,
-                    Label = date.ToWeekdayDayMonth()
-                });
-            }
-        }
+        var eventDays = eventSettings != null ? BuildEventDayOptions(eventSettings) : [];
 
         var model = new BrowseViewModel
         {
@@ -532,23 +520,7 @@ internal sealed class EventsController(
         model.Venues = venues.Select(v => new VenueOptionViewModel { Id = v.Id, Name = v.Name }).ToList();
         model.TimeZoneId = burn.TimeZoneId;
 
-        var tz = DateTimeZoneProviders.Tzdb.GetZoneOrNull(burn.TimeZoneId);
-
-        model.EventDays = [];
-        for (var offset = 0; offset <= burn.EventEndOffset; offset++)
-        {
-            var date = burn.GateOpeningDate.PlusDays(offset);
-            var dt = tz != null
-                ? date.AtStartOfDayInZone(tz).ToDateTimeUnspecified()
-                : new DateTime(date.Year, date.Month, date.Day, 0, 0, 0);
-
-            model.EventDays.Add(new EventDayOptionViewModel
-            {
-                DayOffset = offset,
-                Label = date.ToWeekdayDayMonth(),
-                Date = dt
-            });
-        }
+        model.EventDays = BuildEventDayOptions(burn);
     }
 
     // ─── Barrio event actions (replaces /Barrios/{slug}/Events/*) ────────────
@@ -844,21 +816,7 @@ internal sealed class EventsController(
         model.Categories = categories.Select(c => new CategoryOptionViewModel { Id = c.Id, Name = c.Name }).ToList();
         model.TimeZoneId = burn.TimeZoneId;
 
-        var tz = DateTimeZoneProviders.Tzdb.GetZoneOrNull(burn.TimeZoneId);
-        model.EventDays = [];
-        for (var offset = 0; offset <= burn.EventEndOffset; offset++)
-        {
-            var date = burn.GateOpeningDate.PlusDays(offset);
-            var dt = tz != null
-                ? date.AtStartOfDayInZone(tz).ToDateTimeUnspecified()
-                : new DateTime(date.Year, date.Month, date.Day, 0, 0, 0);
-            model.EventDays.Add(new EventDayOptionViewModel
-            {
-                DayOffset = offset,
-                Label = date.ToWeekdayDayMonth(),
-                Date = dt
-            });
-        }
+        model.EventDays = BuildEventDayOptions(burn);
     }
 
     private async Task<BurnSettingsInfo?> LoadBurnSettingsAsync(EventGuideSettingsView? guideSettings)

--- a/src/Sections/Humans.Events/Controllers/EventsController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsController.cs
@@ -55,7 +55,7 @@ internal sealed class EventsController(
         foreach (var camp in managedCamps)
         {
             var summary = await guide.GetCampSubmissionsSummaryAsync(camp.Id);
-            var campName = camp.Active?.Name ?? camp.Slug;
+            var campName = ResolveCampDisplayName(camp);
             barrioBlocks.Add(new BarrioSubmissionsBlock
             {
                 CampId = camp.Id,
@@ -340,7 +340,7 @@ internal sealed class EventsController(
         {
             var e = f.Event;
             var camp = e.CampId.HasValue ? campsById.GetValueOrDefault(e.CampId.Value) : null;
-            var campName = camp?.Active?.Name ?? camp?.Slug;
+            var campName = ResolveCampName(camp);
 
             // One line per favourited occurrence: a day-specific favourite expands
             // to that single occurrence, a whole-event favourite to all of them.
@@ -437,7 +437,7 @@ internal sealed class EventsController(
         {
             var e = o.Event;
             var camp = e.CampId.HasValue ? campsById.GetValueOrDefault(e.CampId.Value) : null;
-            var campName = camp?.Active?.Name ?? camp?.Slug;
+            var campName = ResolveCampName(camp);
             var submitterName = e.CampId == null
                 ? submitterInfoById.GetValueOrDefault(e.SubmitterUserId)?.BurnerName
                 : null;
@@ -821,8 +821,9 @@ internal sealed class EventsController(
         return RedirectToAction(nameof(MySubmissions));
     }
 
-    private static string ResolveCampDisplayName(CampInfo camp) =>
-        camp.Active?.Name ?? camp.Slug;
+
+    // camp is non-null at every call site; Slug is always set, so a name always resolves.
+    private static string ResolveCampDisplayName(CampInfo camp) => ResolveCampName(camp)!;
 
     private async Task<CampEventFormViewModel> BuildBarrioFormAsync(string slug, CampInfo camp, BurnSettingsInfo burn)
     {

--- a/src/Sections/Humans.Events/Controllers/EventsDashboardController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsDashboardController.cs
@@ -95,10 +95,9 @@ internal sealed class EventsDashboardController(IEventService guide, ICampServic
             .Select(g =>
             {
                 var camp = campsById.GetValueOrDefault(g.Key);
-                var seasonName = camp?.Active?.Name;
                 return new CampSubmissionRow
                 {
-                    CampName = seasonName ?? camp?.Slug ?? "Unknown",
+                    CampName = ResolveCampName(camp) ?? "Unknown",
                     SubmittedCount = g.Count(),
                     ApprovedCount = g.Count(e => e.Status == EventStatus.Approved),
                     PendingCount = g.Count(e => e.Status == EventStatus.Pending)

--- a/src/Sections/Humans.Events/Controllers/EventsDashboardController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsDashboardController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using static Humans.Events.Helpers.EventsLookupHelpers;
+using static Humans.Events.Helpers.EventsTimeHelpers;
 
 using Humans.Base.Authorization;
 using Humans.Events.Contracts;
@@ -108,13 +109,5 @@ internal sealed class EventsDashboardController(IEventService guide, ICampServic
             .ToList();
 
         return View(model);
-    }
-
-    private static int ComputeDayOffset(Instant instant, LocalDate gateOpeningDate, DateTimeZone? tz)
-    {
-        LocalDate eventDate = tz != null
-            ? instant.InZone(tz).Date
-            : LocalDate.FromDateTime(instant.ToDateTimeUtc());
-        return Period.Between(gateOpeningDate, eventDate, PeriodUnits.Days).Days;
     }
 }

--- a/src/Sections/Humans.Events/Controllers/EventsExportController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsExportController.cs
@@ -42,8 +42,7 @@ internal sealed class EventsExportController(
         foreach (var e in events.OrderBy(e => e.StartAt))
         {
             var camp = e.CampId.HasValue ? campsById.GetValueOrDefault(e.CampId.Value) : null;
-            var seasonName = camp?.Active?.Name;
-            var campName = seasonName ?? camp?.Slug ?? "";
+            var campName = ResolveCampName(camp) ?? "";
             var venueName = e.VenueName ?? "";
             var submitterName = e.CampId == null
                 ? submitters.GetValueOrDefault(e.SubmitterUserId)?.BurnerName ?? ""
@@ -100,8 +99,7 @@ internal sealed class EventsExportController(
         foreach (var e in events)
         {
             var camp = e.CampId.HasValue ? campsById.GetValueOrDefault(e.CampId.Value) : null;
-            var seasonName = camp?.Active?.Name;
-            var campName = seasonName ?? camp?.Slug;
+            var campName = ResolveCampName(camp);
             var venueName = e.VenueName;
 
             foreach (var occ in gateOpeningDate.HasValue && tz != null ? e.GetOccurrenceInstants(gateOpeningDate.Value, tz) : (IReadOnlyList<Instant>)[e.StartAt])

--- a/src/Sections/Humans.Events/Controllers/EventsExportController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsExportController.cs
@@ -21,7 +21,6 @@ namespace Humans.Events.Controllers;
 internal sealed class EventsExportController(
     IEventService guide,
     ICampServiceRead camps,
-    IUserServiceRead users,
     IUserServiceRead userService) : HumansControllerBase(userService)
 {
     [HttpGet("")]
@@ -36,6 +35,8 @@ internal sealed class EventsExportController(
             : null;
         var tz = GetTimeZone(eventSettings);
         var campsById = await LoadCampsByIdAsync(camps, eventSettings?.GateOpeningDate.Year);
+        var submitters = await LoadSubmittersAsync(
+            UserService, events.Where(e => e.CampId == null).Select(e => e.SubmitterUserId).Distinct());
 
         var rows = new List<object?[]>();
         foreach (var e in events.OrderBy(e => e.StartAt))
@@ -44,12 +45,9 @@ internal sealed class EventsExportController(
             var seasonName = camp?.Active?.Name;
             var campName = seasonName ?? camp?.Slug ?? "";
             var venueName = e.VenueName ?? "";
-            var submitterName = "";
-            if (e.CampId == null)
-            {
-                var submitter = await users.GetUserInfoAsync(e.SubmitterUserId);
-                submitterName = submitter?.BurnerName ?? "";
-            }
+            var submitterName = e.CampId == null
+                ? submitters.GetValueOrDefault(e.SubmitterUserId)?.BurnerName ?? ""
+                : "";
 
             foreach (var (date, time) in GetOccurrences(e, eventSettings?.GateOpeningDate, tz))
             {

--- a/src/Sections/Humans.Events/Controllers/EventsModerationController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsModerationController.cs
@@ -264,8 +264,7 @@ internal sealed class EventsModerationController(
     private async Task<string?> ResolveCampNameAsync(Guid campId, BurnSettingsInfo eventSettings)
     {
         var campsById = await LoadCampsByIdAsync(camps, eventSettings.GateOpeningDate.Year);
-        var camp = campsById.GetValueOrDefault(campId);
-        return camp?.Active?.Name ?? camp?.Slug;
+        return ResolveCampName(campsById.GetValueOrDefault(campId));
     }
 
     private async Task PopulateAdminFormAsync(AdminEventFormViewModel model, BurnSettingsInfo burn)
@@ -382,8 +381,7 @@ internal sealed class EventsModerationController(
         var submitterName = submitter?.BurnerName ?? submitter?.Email ?? "Unknown";
 
         var camp = e.CampId.HasValue ? campsById.GetValueOrDefault(e.CampId.Value) : null;
-        var seasonName = camp?.Active?.Name;
-        var campName = seasonName ?? camp?.Slug;
+        var campName = ResolveCampName(camp);
 
         return new ModerationEventRowViewModel
         {

--- a/src/Sections/Humans.Events/Data/IEventRepository.cs
+++ b/src/Sections/Humans.Events/Data/IEventRepository.cs
@@ -83,16 +83,13 @@ internal interface IEventRepository : IRepository
     // ── Favourites ────────────────────────────────────────────────────────
     Task<HashSet<Guid>> GetFavouriteEventIdsAsync(Guid userId, CancellationToken ct = default);
     Task<IReadOnlyList<EventFavourite>> GetFavouritesWithEventsAsync(Guid userId, CancellationToken ct = default);
-    Task<bool> FavouriteExistsAsync(Guid userId, Guid eventId, CancellationToken ct = default);
     /// <summary>
-    /// Adds <paramref name="newFavourite"/> if no matching favourite exists, removes the matches otherwise.
-    /// A favourite matches on the same day offset or on a whole-event (null) row; a whole-event toggle
-    /// matches every row for the event. Returns whether the favourite now exists.
+    /// Adds only when absent. A favourite matches on the same day offset or on a whole-event
+    /// (null) row; a whole-event reference matches every row for the event. Returns false if a
+    /// matching favourite already existed.
     /// </summary>
-    Task<bool> ToggleFavouriteAsync(Guid userId, Guid eventId, EventFavourite newFavourite, CancellationToken ct = default);
-    /// <summary>Adds only when absent (same match rule as toggle). Returns false if a favourite already existed.</summary>
     Task<bool> AddFavouriteIfAbsentAsync(EventFavourite favourite, CancellationToken ct = default);
-    /// <summary>Removes matching favourites (same match rule as toggle). Returns false if none existed.</summary>
+    /// <summary>Removes matching favourites (same match rule as add). Returns false if none existed.</summary>
     Task<bool> RemoveFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default);
 
     // ── Preferences ───────────────────────────────────────────────────────

--- a/src/Sections/Humans.Events/Data/Repository.cs
+++ b/src/Sections/Humans.Events/Data/Repository.cs
@@ -387,29 +387,6 @@ internal sealed class EventRepository(IDbContextFactory<EventGuideDbContext> fac
             .ToListAsync(ct);
     }
 
-    public async Task<bool> FavouriteExistsAsync(Guid userId, Guid eventId, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        return await ctx.EventFavourites.AsNoTracking()
-            .AnyAsync(f => f.UserId == userId && f.GuideEventId == eventId, ct);
-    }
-
-    public async Task<bool> ToggleFavouriteAsync(Guid userId, Guid eventId, EventFavourite newFavourite, CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-        var existing = await MatchingFavourites(ctx, userId, eventId, newFavourite.DayOffset).ToListAsync(ct);
-        if (existing.Count > 0)
-        {
-            ctx.EventFavourites.RemoveRange(existing);
-            await ctx.SaveChangesAsync(ct);
-            return false;
-        }
-
-        ctx.EventFavourites.Add(newFavourite);
-        await ctx.SaveChangesAsync(ct);
-        return true;
-    }
-
     public async Task<bool> AddFavouriteIfAbsentAsync(EventFavourite favourite, CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);

--- a/src/Sections/Humans.Events/Docs/debt.yml
+++ b/src/Sections/Humans.Events/Docs/debt.yml
@@ -4,10 +4,10 @@ version: 1
 inbox:
   - added: 2026-08-24
     what: "Three types carry three hand-mirrored copies of GetOccurrenceInstants — Domain/Event.cs:265, Services/Dtos/EventInfo.cs:122 and Humans.Events.Contracts/ApprovedEventView.cs:52 — each labelled 'Mirrors …' in its own doc comment. The null-guard around them (gateOpeningDate.HasValue && tz != null ? e.GetOccurrenceInstants(gate, tz) : [e.StartAt]) is then written out at five call sites (EventsApiController:55, EventsDashboardController:59 with a tz-only variant, EventsExportController:107 and :156, EventOccurrenceExpander:35) and cannot be deduped mechanically because the three types share no shape. Collapsing needs a shared interface or a common base on public DTOs, so it is Peter's call, not a run's. Found by /section-doctor on Events 2026-08-24."
-    review: full
+    review: panel
   - added: 2026-08-24
     what: "EventService (Services/Service.cs) is 870 lines against the section's maxClassLoc of 740 and holds the section's two highest-complexity methods — ValidateBulkRows (CC 35) and BulkImportAsync (CC 33) — plus a 114-line BuildBulkUploadTemplateAsync. The bulk-import trio is one cohesive concern (parse, validate all-or-nothing, write the template back out) and splits cleanly out of the service without touching the other five question-shapes. Found by /section-doctor on Events 2026-08-24."
-    review: full
+    review: panel
   - added: 2026-08-24
     what: "Test gaps in Humans.Events.Tests: EventsModerationController has no test file at all (the other five controllers have partial coverage), and no test pins the [Authorize] policy on any of the six Events controllers — the policies are PolicyNames.EventsAdminOrAdmin and the SectionPolicies set, and a rename or a dropped attribute would ship green. Found by /section-doctor on Events 2026-08-24."
     review: light

--- a/src/Sections/Humans.Events/Docs/debt.yml
+++ b/src/Sections/Humans.Events/Docs/debt.yml
@@ -1,0 +1,16 @@
+# Section debt ledger for Humans.Events. Shape + routing: memory/process/debt-ledger-additions.md.
+# /debt-sweep pools every src/Sections/*/Docs/debt.yml into the same inbox as the central ledger.
+version: 1
+inbox:
+  - added: 2026-08-24
+    what: "Three types carry three hand-mirrored copies of GetOccurrenceInstants — Domain/Event.cs:265, Services/Dtos/EventInfo.cs:122 and Humans.Events.Contracts/ApprovedEventView.cs:52 — each labelled 'Mirrors …' in its own doc comment. The null-guard around them (gateOpeningDate.HasValue && tz != null ? e.GetOccurrenceInstants(gate, tz) : [e.StartAt]) is then written out at five call sites (EventsApiController:55, EventsDashboardController:59 with a tz-only variant, EventsExportController:107 and :156, EventOccurrenceExpander:35) and cannot be deduped mechanically because the three types share no shape. Collapsing needs a shared interface or a common base on public DTOs, so it is Peter's call, not a run's. Found by /section-doctor on Events 2026-08-24."
+    review: full
+  - added: 2026-08-24
+    what: "EventService (Services/Service.cs) is 870 lines against the section's maxClassLoc of 740 and holds the section's two highest-complexity methods — ValidateBulkRows (CC 35) and BulkImportAsync (CC 33) — plus a 114-line BuildBulkUploadTemplateAsync. The bulk-import trio is one cohesive concern (parse, validate all-or-nothing, write the template back out) and splits cleanly out of the service without touching the other five question-shapes. Found by /section-doctor on Events 2026-08-24."
+    review: full
+  - added: 2026-08-24
+    what: "Test gaps in Humans.Events.Tests: EventsModerationController has no test file at all (the other five controllers have partial coverage), and no test pins the [Authorize] policy on any of the six Events controllers — the policies are PolicyNames.EventsAdminOrAdmin and the SectionPolicies set, and a rename or a dropped attribute would ship green. Found by /section-doctor on Events 2026-08-24."
+    review: light
+  - added: 2026-08-24
+    what: "Comment debt in Humans.Events, 86 verdicts totalling ~211 lines, full list with exact replacements in docs/health/runs/2026-08-24-Events.md finding #10. Two kinds. (a) Noise: '/// Unique identifier.'-class doc comments across all eight Domain/ types, and thirteen 3-line '// ====' ASCII banners in Services/CachingEventService.cs where the rest of the codebase uses the single-line '// ── Label ──' form. (b) Five comments that state things that are FALSE and are the part worth fixing first: Data/IEventRepository.cs:15 names IShiftManagementService (no such type — it is IBurnSettingsService); Data/EventGuideDbContext.cs:21-22 says the Shifts-owned event_settings table lives in UsersDbContext (it is on ShiftsDbContext, per Shifts' own docs); and three broken <see cref> targets at Domain/EventGuideSettings.cs:7 (cref to an internal type in another assembly), Domain/EventModerationActionType.cs:21 (stale pre-G5 Entities.* namespace) and Models/EventsModerationViewModels.cs:91 (path does not exist). All five are silent today because GenerateDocumentationFile is set nowhere in the repo, so CS1574 never fires. Found by /section-doctor on Events 2026-08-24; not struck because the environment's clean build broke mid-run."
+    review: light

--- a/src/Sections/Humans.Events/Docs/health.md
+++ b/src/Sections/Humans.Events/Docs/health.md
@@ -1,0 +1,101 @@
+# Events — Health
+
+Target shape, derived fresh each `/section-doctor` run before any scan. History at the bottom.
+
+## 1. What the section does
+
+Runs the festival programme. People propose things to do — on their own or on behalf of their
+barrio — during a window the organisers open and close. Moderators decide what goes in, and can
+correct a listing without knocking it off the programme. Everyone else browses what was accepted,
+hearts the ones they want, and gets that back as a personal schedule, an iCal feed, and a printed
+guide. Organisers configure the window, the taxonomy of activity types, and the named places
+things happen.
+
+## 2. The shapes
+
+Six question-shapes. Every route, contract method, component and job answers exactly one.
+
+| Shape | The question | Answered by |
+|---|---|---|
+| **Programme** | what is on? | `/Events/Browse`, `/api/events`, `/api/events/{id}`, `/api/barrios`, `/api/barrios/{id}`, `/api/categories`, `EventsCard` + `EventsSearchResult` view components, all of `IEventServiceRead` |
+| **Mine** | what did I pick or propose? | `/Events/MySubmissions`, `/Events/Schedule`, `/api/events/favourites` (GET/POST/DELETE), `/api/events/preferences` (GET/PUT), `ICalendarFeedContributor`, `IUserDataContributor` |
+| **Propose** | I want to run something | `/Events/Submit` (+`/{id}/Edit`, `/Withdraw`), `/Events/Barrio/{slug}/*` (submit, edit, withdraw, bulk upload + template) |
+| **Decide** | should this be in the programme? | `/Events/Moderate` (queue, Approve, Reject, RequestEdit, Withdraw) and `/Events/Moderate/{id}/Edit` (in-place, status-preserving) |
+| **Configure** | what are the rules of this edition? | `/Events/Admin/Settings`, `/Events/Admin/Categories`, `/Events/Admin/Venues` |
+| **Publish** | get the programme out | `/Events/Dashboard`, `/Events/Export/Csv`, `/Events/Export/PrintGuide` |
+
+Collapse pressure this grouping exposes: **Programme** is answered five different ways over one
+cached snapshot, each re-deriving occurrence expansion, camp-name resolution and submitter-name
+fallback from scratch; **Propose** has two near-identical form pipelines (individual, barrio) that
+differ only in which two fields apply.
+
+## 3. Structure
+
+The layout the shapes imply:
+
+- One repository over the seven owned tables; one service; one caching decorator over the
+  approved-only projections. As built.
+- **Programme** wants one shared occurrence-and-naming projection, used by Browse, the API, the
+  export and the print guide alike. Today each caller re-implements it; `EventOccurrenceExpander`
+  covers only Browse.
+- **Propose** wants one form pipeline parameterised by `isCampEvent`, not two view models and two
+  dropdown-population methods. `EventsModerationController` already runs the single-pipeline
+  version (`AdminEventFormViewModel` + `ApplyFormToEvent` branch on `isCampEvent`) — that is the
+  target form; the submitter side is the outlier.
+- **Decide** and **Configure** are correct as built.
+- Cross-section reads (camp names, submitter names) belong behind the two helpers in
+  `EventsLookupHelpers`; every controller should go through them rather than hand-rolling the loop.
+
+## 4. Invariants
+
+Behavioural facts stated so a violation is recognisable. (`Docs/Events.md` holds the full list;
+these are the ones this shape rests on.)
+
+1. Only `Pending` events accept a moderation decision.
+2. An admin in-place edit preserves `Status` — an approved listing is never silently re-queued.
+3. Nothing unapproved leaves through `/api/events*`.
+4. Favourites and preferences are same-origin and self-scoped; no cross-user read exists.
+5. A submission is accepted only inside `[SubmissionOpenAt, SubmissionCloseAt]`.
+6. Bulk CSV import is all-or-nothing, and its template round-trips: exporting a camp's events and
+   re-uploading them unchanged is a no-op.
+7. Moderation history is append-only.
+8. `StartAt` is stored UTC; every local rendering goes through the burn timezone.
+
+## 5. Seams
+
+- **#719** — no invalidation hook when the Shifts-owned `event_settings` row changes, so a cached
+  `TimeZoneId` stays stale until the next Events write. `IEventViewInvalidator` is the reserved
+  seat.
+- Individual events have a `Draft` status the domain honours (`IsEditableBySubmitter`) that no
+  route ever produces. Either a seam for a save-without-submitting flow, or dead.
+
+## 6. Deliberately not done
+
+- **No per-event public page.** The calendar feed points at `/Events/Schedule` on purpose.
+- **No camp-scoped moderation.** Moderation authority is global (EventsAdmin/Admin); barrio leads
+  submit, they do not decide.
+- **No cache for the moderation queue.** It needs a live pending count the approved-only cache
+  cannot answer, so `GetAllEventsForDashboardAsync` stays direct-DB.
+- **No CSV injection escaping on the bulk template.** It is a round-trip data file; escaping would
+  come back as data.
+
+## Load-bearing weirdness
+
+- **`SearchAsync` throws on the inner service.** Deliberate: search is cache-only, so reaching the
+  inner `EventService` proves a DI mistake. Mirrors Teams and Camps.
+- **`CachingEventService` is its own `IHostedService`.** Warm-up must run on the same Singleton
+  that serves reads.
+- **`PriorityRank` means two different things.** Camp events carry 1–100 (print-guide ordering);
+  individual events are always 0 and the print guide sorts 0 last. The moderation form's
+  `== 0 ? 1` and the bulk validator's `1..100` both descend from this.
+- **Recurrence is stored as day offsets from gate opening, displayed as weekday names.** Bulk
+  import compares by day-name set, not the raw string, so a lossless round-trip is not read as an
+  edit.
+- **`GuideEventId`, not `EventId`.** The column names predate the rename to Events; they are load-
+  bearing in the migration baseline.
+
+## History
+
+| Run | Date | Reforge | Notes |
+|---|---|---|---|
+| 1 | 2026-08-24 | 258 (loc=6367, cogP95=9, cogMax=35) | first pass — PR pending |

--- a/src/Sections/Humans.Events/Docs/health.md
+++ b/src/Sections/Humans.Events/Docs/health.md
@@ -98,4 +98,4 @@ these are the ones this shape rests on.)
 
 | Run | Date | Reforge | Notes |
 |---|---|---|---|
-| 1 | 2026-08-24 | 258 (loc=6367, cogP95=9, cogMax=35) | first pass — PR pending |
+| 1 | 2026-08-24 | 258 (loc=6367, cogP95=9, cogMax=35) | first pass — peterdrier/Humans#1483 |

--- a/src/Sections/Humans.Events/Helpers/EventsLookupHelpers.cs
+++ b/src/Sections/Humans.Events/Helpers/EventsLookupHelpers.cs
@@ -39,6 +39,11 @@ internal static class EventsLookupHelpers
         return days;
     }
 
+    /// <summary>
+    /// A camp's display name for the guide: its active season name, else its slug.
+    /// </summary>
+    public static string? ResolveCampName(CampInfo? camp) => camp?.Active?.Name ?? camp?.Slug;
+
     public static async Task<Dictionary<Guid, UserInfo>> LoadSubmittersAsync(
         IUserServiceRead users, IEnumerable<Guid> userIds)
     {

--- a/src/Sections/Humans.Events/Helpers/EventsTimeHelpers.cs
+++ b/src/Sections/Humans.Events/Helpers/EventsTimeHelpers.cs
@@ -16,6 +16,17 @@ internal static class EventsTimeHelpers
     public static DateTime ToLocalDateTime(Instant instant, DateTimeZone? tz)
         => tz == null ? instant.ToDateTimeUtc() : instant.InZone(tz).ToDateTimeUnspecified();
 
+    /// <summary>
+    /// The gate-relative day offset of an occurrence. Returns 0 when there is no
+    /// gate-opening date to measure from.
+    /// </summary>
+    public static int ComputeDayOffset(Instant instant, LocalDate? gateOpeningDate, DateTimeZone? tz)
+    {
+        if (gateOpeningDate == null) return 0;
+        var eventDate = tz != null ? instant.InZone(tz).Date : LocalDate.FromDateTime(instant.ToDateTimeUtc());
+        return Period.Between(gateOpeningDate.Value, eventDate, PeriodUnits.Days).Days;
+    }
+
     public static Instant ToInstant(DateTime dateTime, DateTimeZone? tz)
     {
         if (tz == null)

--- a/src/Sections/Humans.Events/Services/CachingEventService.cs
+++ b/src/Sections/Humans.Events/Services/CachingEventService.cs
@@ -381,9 +381,6 @@ internal sealed class CachingEventService(
     public Task<IReadOnlyList<EventFavouriteInfo>> GetFavouritesWithEventsAsync(Guid userId, CancellationToken ct = default) =>
         WithInner(inner => inner.GetFavouritesWithEventsAsync(userId, ct));
 
-    public Task ToggleFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default) =>
-        WithInner(inner => inner.ToggleFavouriteAsync(userId, eventId, dayOffset, ct));
-
     public Task<bool> AddFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default) =>
         WithInner(inner => inner.AddFavouriteAsync(userId, eventId, dayOffset, ct));
 

--- a/src/Sections/Humans.Events/Services/EventOccurrenceExpander.cs
+++ b/src/Sections/Humans.Events/Services/EventOccurrenceExpander.cs
@@ -1,5 +1,6 @@
 using NodaTime;
 using Humans.Events.Contracts;
+using static Humans.Events.Helpers.EventsTimeHelpers;
 
 namespace Humans.Events.Services;
 
@@ -38,7 +39,7 @@ internal static class EventOccurrenceExpander
 
             foreach (var startInstant in occurrences)
             {
-                var dayOffset = ResolveDayOffset(startInstant, gateOpeningDate, timeZone);
+                var dayOffset = ComputeDayOffset(startInstant, gateOpeningDate, timeZone);
                 if (filterDays != null && !filterDays.Contains(dayOffset)) continue;
 
                 // Hearts on recurring-event cards favourite that day's occurrence;
@@ -57,15 +58,5 @@ internal static class EventOccurrenceExpander
         }
 
         return items;
-    }
-
-    private static int ResolveDayOffset(Instant startInstant, LocalDate? gateOpeningDate, DateTimeZone? timeZone)
-    {
-        if (gateOpeningDate == null) return 0;
-
-        var eventDate = timeZone != null
-            ? startInstant.InZone(timeZone).Date
-            : LocalDate.FromDateTime(startInstant.ToDateTimeUtc());
-        return Period.Between(gateOpeningDate.Value, eventDate, PeriodUnits.Days).Days;
     }
 }

--- a/src/Sections/Humans.Events/Services/IEventService.cs
+++ b/src/Sections/Humans.Events/Services/IEventService.cs
@@ -105,7 +105,6 @@ internal interface IEventService : IApplicationService, IEventServiceRead
     // GetFavouriteEventIdsAsync is declared on IEventServiceRead (cross-section read surface).
     Task<IReadOnlyList<EventFavouriteInfo>> GetFavouritesWithEventsAsync(Guid userId, CancellationToken ct = default);
     // dayOffset selects one occurrence of a recurring event; null means the whole event.
-    Task ToggleFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default);
     Task<bool> AddFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default);
     Task<bool> RemoveFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default);
 

--- a/src/Sections/Humans.Events/Services/Service.cs
+++ b/src/Sections/Humans.Events/Services/Service.cs
@@ -587,9 +587,6 @@ internal sealed class EventService(
             f.Id, f.UserId, f.GuideEventId, f.DayOffset, f.CreatedAt, ToEventInfo(f.Event))).ToList();
     }
 
-    public Task ToggleFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default)
-        => repo.ToggleFavouriteAsync(userId, eventId, BuildFavourite(userId, eventId, dayOffset), ct);
-
     public Task<bool> AddFavouriteAsync(Guid userId, Guid eventId, int? dayOffset, CancellationToken ct = default)
         => repo.AddFavouriteIfAbsentAsync(BuildFavourite(userId, eventId, dayOffset), ct);
 

--- a/tests/Humans.Events.Tests/Data/RepositoryTests.cs
+++ b/tests/Humans.Events.Tests/Data/RepositoryTests.cs
@@ -163,28 +163,27 @@ public sealed class EventRepositoryTests : IDisposable
     }
 
     [HumansFact]
-    public async Task ToggleFavouriteAsync_DayToggle_RemovesWholeEventRow()
+    public async Task RemoveFavouriteAsync_SpecificDay_AlsoRemovesWholeEventRow()
     {
         var userId = Guid.NewGuid();
         var eventId = Guid.NewGuid();
         await _db.EventFavourites.AddAsync(BuildFavourite(userId, eventId), Xunit.TestContext.Current.CancellationToken);
         await _db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
-        var nowFavourited = await _repo.ToggleFavouriteAsync(
-            userId, eventId, BuildFavourite(userId, eventId, dayOffset: 2), Xunit.TestContext.Current.CancellationToken);
+        var removed = await _repo.RemoveFavouriteAsync(userId, eventId, dayOffset: 2, Xunit.TestContext.Current.CancellationToken);
 
-        nowFavourited.Should().BeFalse();
+        removed.Should().BeTrue();
         (await _repo.GetFavouriteEventIdsAsync(userId, Xunit.TestContext.Current.CancellationToken)).Should().BeEmpty();
     }
 
     [HumansFact]
-    public async Task ToggleFavouriteAsync_DifferentDays_CoexistAsSeparateRows()
+    public async Task AddFavouriteIfAbsentAsync_DifferentDays_CoexistAsSeparateRows()
     {
         var userId = Guid.NewGuid();
         var eventId = Guid.NewGuid();
 
-        (await _repo.ToggleFavouriteAsync(userId, eventId, BuildFavourite(userId, eventId, dayOffset: 2), Xunit.TestContext.Current.CancellationToken)).Should().BeTrue();
-        (await _repo.ToggleFavouriteAsync(userId, eventId, BuildFavourite(userId, eventId, dayOffset: 4), Xunit.TestContext.Current.CancellationToken)).Should().BeTrue();
+        (await _repo.AddFavouriteIfAbsentAsync(BuildFavourite(userId, eventId, dayOffset: 2), Xunit.TestContext.Current.CancellationToken)).Should().BeTrue();
+        (await _repo.AddFavouriteIfAbsentAsync(BuildFavourite(userId, eventId, dayOffset: 4), Xunit.TestContext.Current.CancellationToken)).Should().BeTrue();
 
         var favourites = await _repo.GetFavouritesForContributorAsync(userId, Xunit.TestContext.Current.CancellationToken);
         favourites.Select(f => f.DayOffset).Should().BeEquivalentTo([2, 4]);

--- a/tests/Humans.Events.Tests/Services/ServiceTests.cs
+++ b/tests/Humans.Events.Tests/Services/ServiceTests.cs
@@ -140,13 +140,14 @@ public sealed class EventServiceTests
     }
 
     [HumansFact]
-    public async Task ToggleFavouriteAsync_AddsFavourite_WhenMissing()
+    public async Task AddFavouriteAsync_StampsClockAndDayOffset()
     {
         var userId = Guid.NewGuid();
         var eventId = Guid.NewGuid();
 
-        await _service.ToggleFavouriteAsync(userId, eventId, dayOffset: 4, TestContext.Current.CancellationToken);
+        var added = await _service.AddFavouriteAsync(userId, eventId, dayOffset: 4, TestContext.Current.CancellationToken);
 
+        added.Should().BeTrue();
         _repo.Favourites.Should().ContainSingle(f =>
             f.UserId == userId
             && f.GuideEventId == eventId
@@ -156,52 +157,17 @@ public sealed class EventServiceTests
     }
 
     [HumansFact]
-    public async Task ToggleFavouriteAsync_RemovesFavourite_WhenExisting()
-    {
-        var fav = new EventFavourite
-        {
-            Id = Guid.NewGuid(),
-            UserId = Guid.NewGuid(),
-            GuideEventId = Guid.NewGuid(),
-            CreatedAt = _clock.GetCurrentInstant()
-        };
-        _repo.Favourites.Add(fav);
-
-        await _service.ToggleFavouriteAsync(fav.UserId, fav.GuideEventId, dayOffset: null, TestContext.Current.CancellationToken);
-
-        _repo.Favourites.Should().BeEmpty();
-        _repo.SaveChangesCount.Should().Be(1);
-    }
-
-    [HumansFact]
-    public async Task ToggleFavouriteAsync_DaySpecificToggle_RemovesWholeEventFavourite()
-    {
-        var fav = new EventFavourite
-        {
-            Id = Guid.NewGuid(),
-            UserId = Guid.NewGuid(),
-            GuideEventId = Guid.NewGuid(),
-            DayOffset = null,
-            CreatedAt = _clock.GetCurrentInstant()
-        };
-        _repo.Favourites.Add(fav);
-
-        await _service.ToggleFavouriteAsync(fav.UserId, fav.GuideEventId, dayOffset: 2, TestContext.Current.CancellationToken);
-
-        _repo.Favourites.Should().BeEmpty();
-    }
-
-    [HumansFact]
-    public async Task ToggleFavouriteAsync_DifferentDays_KeepSeparateFavourites()
+    public async Task AddFavouriteAsync_AlreadyFavourited_DoesNotWriteAgain()
     {
         var userId = Guid.NewGuid();
         var eventId = Guid.NewGuid();
+        await _service.AddFavouriteAsync(userId, eventId, dayOffset: null, TestContext.Current.CancellationToken);
 
-        await _service.ToggleFavouriteAsync(userId, eventId, dayOffset: 2, TestContext.Current.CancellationToken);
-        await _service.ToggleFavouriteAsync(userId, eventId, dayOffset: 4, TestContext.Current.CancellationToken);
+        var added = await _service.AddFavouriteAsync(userId, eventId, dayOffset: 4, TestContext.Current.CancellationToken);
 
-        _repo.Favourites.Should().HaveCount(2);
-        _repo.Favourites.Select(f => f.DayOffset).Should().BeEquivalentTo([2, 4]);
+        added.Should().BeFalse();
+        _repo.Favourites.Should().ContainSingle();
+        _repo.SaveChangesCount.Should().Be(1);
     }
 
     [HumansFact]
@@ -933,23 +899,6 @@ public sealed class EventServiceTests
 
         public Task<IReadOnlyList<EventFavourite>> GetFavouritesWithEventsAsync(Guid userId, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<EventFavourite>>(Favourites.Where(f => f.UserId == userId).ToList());
-
-        public Task<bool> FavouriteExistsAsync(Guid userId, Guid eventId, CancellationToken ct = default)
-            => Task.FromResult(Favourites.Any(f => f.UserId == userId && f.GuideEventId == eventId));
-
-        public Task<bool> ToggleFavouriteAsync(Guid userId, Guid eventId, EventFavourite newFavourite, CancellationToken ct = default)
-        {
-            var existing = MatchingFavourites(userId, eventId, newFavourite.DayOffset).ToList();
-            if (existing.Count > 0)
-            {
-                existing.ForEach(f => Favourites.Remove(f));
-                SaveChangesCount++;
-                return Task.FromResult(false);
-            }
-            Favourites.Add(newFavourite);
-            SaveChangesCount++;
-            return Task.FromResult(true);
-        }
 
         public Task<bool> AddFavouriteIfAbsentAsync(EventFavourite favourite, CancellationToken ct = default)
         {


### PR DESCRIPTION
Unattended `/section-doctor` daily run on **Events**, the largest never-doctored
section (score=258, loc=6367). Run file: `docs/health/runs/2026-08-24-Events.md`.
New section target: `src/Sections/Humans.Events/Docs/health.md`.

No behaviour change, no migration, no new public surface. 209 lines deleted
against 167 added.

## Struck

1. **Dead favourite surface** — `IEventRepository.FavouriteExistsAsync` (0
   callers) and the `ToggleFavouriteAsync` pair, whose only caller was its own
   caching pass-through. The six tests that pinned the whole-event/day-offset
   match rule *through* Toggle were rewritten against the live
   `RemoveFavouriteAsync`/`AddFavouriteIfAbsentAsync`, not deleted.
2. **`EventsExportController`** took `IUserServiceRead` twice and resolved a
   submitter per event inside the CSV loop; now one injection and one
   `LoadSubmittersAsync` over the distinct camp-less submitter ids.
3. **`ComputeDayOffset`** existed three times (two controllers +
   `EventOccurrenceExpander`); one copy in `EventsTimeHelpers`.
4. **Camp display-name** (`Active?.Name ?? Slug`) was written out at twelve
   sites across five controllers in three helper shapes; one
   `EventsLookupHelpers.ResolveCampName`.
5. **`EventsController`** hand-rolled the day-option list three times, twice
   byte-identical to `BuildEventDayOptions`.

## Needs Peter

- **1 — Bug: GDPR erasure bypasses the Events cache.** ✅ **Answered — fixed in
  #1492.** `Section.cs` bound `IUserDataContributor` to `EventService` (inner),
  not `CachingEventService`, so erasure cleared the submitter's `Host` name
  while the decorator kept serving the old one. The contributor now binds to
  the decorator, which refreshes the approved-event cache after erasure. Peter's
  ruling on the second half — events themselves are not purged; the event
  happened, it is related to the host but is not the host — is what the code
  already did, and `Erasure`'s Art. 17(3)(b) declaration states it.
- **2 — Bug: `PriorityRank == 0` does not round-trip through the bulk
  template.** The print guide treats 0 as "unranked"; the template writes the
  literal `0` and `ValidateBulkRows` reads it back as a rank. Fork: write blank
  for 0, or make 0 and blank equivalent on read. Invariant #6 in the new
  `health.md` is currently false. **Peter asked whether 1 is the highest and
  whether unranked should be `null` rather than `0` — 1 is the highest, and
  `int?` with `null` = unranked is the cleaner shape; it needs a migration, so
  it is a separate issue, not this PR.**
- **3 — ~~`origin/main` does not build from a clean tree in this
  environment.~~** ❌ **Retracted — the claim was wrong.** Re-tested from a
  pristine worktree at the branch point: `Humans.Base` builds clean and the full
  `Humans.slnx` builds with **0 errors** under the SDK this sandbox resolves.
  The original 9 Razor errors came from poisoned incremental build state —
  interleaved `dotnet build` / `dotnet test` in one worktree plus a hand
  deletion of `obj`/`bin` while MSBuild node reuse was live — not from the SDK
  version. On this PR's head, every test project passes except
  `Humans.Integration.Tests`, which needs a Postgres this container does not
  have and which CI excludes by design. Nothing here needs Peter.
- **4 — Unattended runs cannot review a section's open issues.** ✅ **Answered —
  skill updated in #1493.** GitHub access is scoped to `peterdrier/Humans`;
  issues live on `nobodies-collective/Humans`, and `search_issues` returns 0
  there **silently** rather than erroring. `section-doctor` now probes reach
  before any issue work and suspends the open-issue half of the Inbox thread
  when the probe fails, recording the thread as `partial` rather than `ran`.

## Queued, not struck

`src/Sections/Humans.Events/Docs/debt.yml` (new): the three hand-mirrored
`GetOccurrenceInstants` copies and their five-site guard; `EventService` at 870
lines with `ValidateBulkRows` CC 35 / `BulkImportAsync` CC 33; no
`EventsModerationController` tests and no `[Authorize]` policy pins; and 86
comment verdicts — including **five doc comments that state things that are
false** (`IShiftManagementService` doesn't exist; `event_settings` is on
`ShiftsDbContext`, not `UsersDbContext`; three broken `` targets).

Run cost $63.15 vs the $93.30 Onboarding baseline (~32% under).