### PR TITLE
fix(events): run GDPR erasure through the caching decorator

### DIFF
--- a/src/Sections/Humans.Events/Section.cs
+++ b/src/Sections/Humans.Events/Section.cs
@@ -35,11 +35,10 @@ public sealed class Section : ISection
 
         // Inner Service — Scoped + keyed. Single keyed registration is the
         // concrete Service instance, exposed as IEventService (keyed) for the
-        // decorator and unkeyed IUserDataContributor for GDPR aggregation.
+        // decorator.
         services.AddKeyedScoped<IEventService, EventService>(CachingEventService.InnerServiceKey);
         services.AddScoped<EventService>(sp =>
             (EventService)sp.GetRequiredKeyedService<IEventService>(CachingEventService.InnerServiceKey));
-        services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<EventService>());
         services.AddScoped<ICalendarFeedContributor>(sp => sp.GetRequiredService<EventService>());
 
         // CachingEventService — Singleton so the cache persists across
@@ -58,6 +57,10 @@ public sealed class Section : ISection
         // that backs IEventService (§15e CRITICAL).
         services.AddSingleton<IEventViewInvalidator>(sp =>
             sp.GetRequiredService<CachingEventService>());
+
+        // GDPR fan-out binds to the decorator, not the inner: erasure clears the
+        // person's Host name on events that stay in the guide, and those rows are cached.
+        services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<CachingEventService>());
 
         // Surface Events cache diagnostics on /Debug/CacheStats.
         services.AddSingleton<ICacheStats>(sp => sp.GetRequiredService<CachingEventService>().EventCacheStats);

--- a/src/Sections/Humans.Events/Services/CachingEventService.cs
+++ b/src/Sections/Humans.Events/Services/CachingEventService.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NodaTime;
 using Humans.Events.Contracts;
+using Humans.Gdpr.Contracts;
 
 namespace Humans.Events.Services;
 
@@ -39,7 +40,8 @@ namespace Humans.Events.Services;
 /// </remarks>
 internal sealed class CachingEventService(
     IServiceScopeFactory scopeFactory,
-    ILogger<CachingEventService> logger) : IEventService, IEventViewInvalidator, IHostedService
+    ILogger<CachingEventService> logger)
+    : IEventService, IEventViewInvalidator, IUserDataContributor, IHostedService
 {
     /// <summary>
     /// DI service key under which the undecorated inner <see cref="IEventService"/>
@@ -446,6 +448,23 @@ internal sealed class CachingEventService(
 
     public Task InvalidateGuideSettingsAsync(CancellationToken ct = default) =>
         RefreshSettingsAsync(ct);
+
+    // ==========================================================================
+    // IUserDataContributor — GDPR export + erasure
+    // ==========================================================================
+    // Carried by the decorator, not the inner service: erasure clears the person's
+    // Host name on events that stay in the guide, and those rows are in _eventCache.
+
+    public IReadOnlyDictionary<string, string?> ErasureDeclaration => EventService.Erasure;
+
+    public Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct) =>
+        WithInner(inner => inner.ContributeForUserAsync(userId, ct));
+
+    public async Task EraseForUserAsync(Guid userId, CancellationToken ct)
+    {
+        await WithInner(inner => inner.EraseForUserAsync(userId, ct));
+        await RefreshAllEventsAsync(ct);
+    }
 
     // ==========================================================================
     // Warmup — composition forces the decorator to own IHostedService directly.

--- a/src/Sections/Humans.Events/Services/IEventService.cs
+++ b/src/Sections/Humans.Events/Services/IEventService.cs
@@ -4,6 +4,7 @@ using Humans.Events.Domain;
 using NodaTime;
 using Humans.Events.Contracts;
 using Humans.Base.Interfaces;
+using Humans.Gdpr.Contracts;
 
 namespace Humans.Events.Services;
 
@@ -123,6 +124,13 @@ internal interface IEventService : IApplicationService, IEventServiceRead
     // (part of the moderation workflow). submitterEditUrl is the caller's routing
     // concern; null opts out of the notification.
     Task ApplyModerationAsync(Guid eventId, Guid actorUserId, EventModerationActionType actionType, string? reason, string? submitterEditUrl = null, CancellationToken ct = default);
+
+    // ── GDPR ──────────────────────────────────────────────────────────────
+    // IUserDataContributor is carried by CachingEventService (erasure edits cached
+    // rows); these two are how it reaches the inner service, so they sit here rather
+    // than only on the concrete type.
+    Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct);
+    Task EraseForUserAsync(Guid userId, CancellationToken ct);
 
     // ── Dashboard / Export ────────────────────────────────────────────────
     Task<IReadOnlyList<EventInfo>> GetAllEventsForDashboardAsync(CancellationToken ct = default);

--- a/src/Sections/Humans.Events/Services/Service.cs
+++ b/src/Sections/Humans.Events/Services/Service.cs
@@ -24,7 +24,9 @@ internal sealed class EventService(
     IEmailMessageFactory emailMessages,
     IClock clock,
     ILogger<EventService> logger)
-    : IEventService, IUserDataContributor, ICalendarFeedContributor
+    // IUserDataContributor is implemented by CachingEventService, which delegates here —
+    // erasure edits cached rows, so the fan-out has to run through the decorator.
+    : IEventService, ICalendarFeedContributor
 {
     // EventSettings is owned by Shifts; cross via IBurnSettingsService supplier API (§2c, #719).
 
@@ -843,7 +845,9 @@ internal sealed class EventService(
         return [new UserDataSlice(GdprExportSections.Events, shaped)];
     }
 
-    private static readonly IReadOnlyDictionary<string, string?> Erasure =
+    // internal: CachingEventService carries IUserDataContributor and returns this table
+    // from an uninitialized instance, so it has to be static and reachable from there.
+    internal static readonly IReadOnlyDictionary<string, string?> Erasure =
         new Dictionary<string, string?>(StringComparer.Ordinal)
         {
             [GdprExportSections.Events] =

--- a/tests/Humans.Events.Tests/EventsArchitectureTests.cs
+++ b/tests/Humans.Events.Tests/EventsArchitectureTests.cs
@@ -54,11 +54,11 @@ public class EventsArchitectureTests
     }
 
     [HumansFact]
-    public void EventService_ImplementsIUserDataContributor()
+    public void CachingEventService_ImplementsIUserDataContributor()
     {
-        typeof(IUserDataContributor).IsAssignableFrom(typeof(EventService))
+        typeof(IUserDataContributor).IsAssignableFrom(typeof(CachingEventService))
             .Should().BeTrue(
-                because: "EventService owns event_favourites and event_preferences (user-scoped tables); it must contribute to the GDPR Article 15 export");
+                because: "the section owns event_favourites and event_preferences (user-scoped tables) and must contribute to the GDPR Article 15 export; the decorator carries it because erasure edits rows the cache serves");
     }
 
     [HumansFact]

--- a/tests/Humans.Events.Tests/Services/CachingEventServiceTests.cs
+++ b/tests/Humans.Events.Tests/Services/CachingEventServiceTests.cs
@@ -133,6 +133,24 @@ public sealed class CachingEventServiceTests
         hit.Score.Should().Be(StringSearchExtensions.ExactNameScore);
     }
 
+    [HumansFact]
+    public async Task EraseForUserAsync_RefreshesTheCachedEvents()
+    {
+        // The submitted event stays in the guide with its Host name cleared, so
+        // erasure edits a row the cache is already serving.
+        var before = Approved("Sunset Yoga") with { Host = "Ada" };
+        SeedApproved(before);
+        (await _service.GetApprovedEventByIdAsync(before.Id, TestContext.Current.CancellationToken))!
+            .Host.Should().Be("Ada");
+
+        SeedApproved(before with { Host = null });
+        await _service.EraseForUserAsync(before.SubmitterUserId, TestContext.Current.CancellationToken);
+
+        await _inner.Received(1).EraseForUserAsync(before.SubmitterUserId, Arg.Any<CancellationToken>());
+        (await _service.GetApprovedEventByIdAsync(before.Id, TestContext.Current.CancellationToken))!
+            .Host.Should().BeNull();
+    }
+
     private static ApprovedEventView Approved(string title, string description = "Anything at all") => new(
         Id: Guid.NewGuid(), CampId: null, GuideSharedVenueId: null, SubmitterUserId: Guid.NewGuid(),
         CategoryId: Guid.NewGuid(), CategorySlug: "music", CategoryName: "Music", CategoryIsSensitive: false,

--- a/tests/Humans.Web.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
+++ b/tests/Humans.Web.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
@@ -70,7 +70,8 @@ public class GdprExportDependencyInjectionTests
         SectionType("Humans.Tickets.Services.TicketQueryService"),
         SectionType("Humans.Campaigns.Services.CampaignService"),
         SectionType("Humans.Camps.Services.CampService"),
-        SectionType("Humans.Events.Services.EventService"),
+        // The caching decorator, not EventService: erasure edits cached rows.
+        SectionType("Humans.Events.Services.CachingEventService"),
         SectionType("Humans.AuditLog.Services.AuditLogService"),
         SectionType("Humans.Budget.Services.BudgetService"),
         SectionType("Humans.Agent.Services.AgentService"),


### PR DESCRIPTION
## What

Move Events' `IUserDataContributor` from `EventService` to `CachingEventService`, and refresh the approved-event cache after erasure.

## Why

Erasure clears the person's `Host` display name on events that stay in the guide. Those rows are served from `_eventCache`, so the old registration left a stale name visible until the next warmup.

Follow-up to the Events section-doctor run (#1483), Needs-Peter item 1.

## Existing surface checked

- `IEventViewInvalidator` — rejected: it invalidates guide-settings/views, not the approved-event snapshot; `RefreshAllEventsAsync` is the existing refresh path and is reused as-is.
- `WithInner(...)` — reused for the delegation; no new resolution helper added.
- Two methods added to `IEventService` (`ContributeForUserAsync`, `EraseForUserAsync`) so the decorator reaches the inner service **through the interface** (hard rule: caching decorators may not call repositories). `EventService.Erasure` widened `private` → `internal static` for the same reason.

## UI changes / screenshots

None.

## Checklist

- [x] **Section labeled** — Events.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`**.
- [x] **Issue refs are qualified**.
- [ ] ~~**EF migrations**~~ — none.
- [ ] ~~**NuGet packages updated?**~~ — none.
- [ ] ~~**New project rule?**~~ — none.
- [x] **Reuse-first checked** — see above.
- [x] **Build + test pass locally** — `Humans.Events.Tests` 169/169, `Humans.Web.Tests` GDPR suites green. `Humans.Integration.Tests` needs Postgres, unavailable in this sandbox; CI covers it.
- [ ] ~~**Nav coverage**~~ — no new pages.
- [x] **No magic strings**.
- [x] **Dates/times via NodaTime**.

## Reviewer notes

The regression test discriminates: removing `await RefreshAllEventsAsync(ct);` from `EraseForUserAsync` makes `CachingEventServiceTests.EraseForUserAsync_RefreshesTheCachedEvents` fail.

Three architecture tests constrain the shape and all still pass — `NoTwoContributorsClaimTheSameSection` is why `EventService` drops the marker interface rather than both types carrying it, and `GdprExportDependencyInjectionTests.ExpectedContributorTypes` is updated to name the decorator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FY6HBzp5XZXQS4rgf2dRfb)_