### PR TITLE
section-doctor: non-binding next-5 forecast in the PR body

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -183,8 +183,11 @@ build also serves Phase 3/4), runs `reforge surface-score --format compact`, and
 **median** of the ranked never-doctored tier — middle-out: the process proves itself on
 mid-sized sections; the biggest and smallest get their turn once the middle has been worked.
 It prints `SECTION:` / `TIER:` / `RATIONALE:` plus the full ranked table for the run file, and
-falls back to a LOC ranking (flagged in its output) when reforge is unusable. Act on its
-verdicts — never re-derive the maths in-band:
+an **`UPCOMING:`** line — the next 4 sections a repeat of this maths would pick, assuming each
+pick blocks itself and nothing else changes. That forecast is purely informational (it goes in
+the PR body, Phase 7): it is not stored, no later run reads or honours it, and tomorrow's run
+recomputing differently is expected. The script falls back to a LOC ranking (flagged in its
+output) when reforge is unusable. Act on its verdicts — never re-derive the maths in-band:
 
 - **`ALL BLOCKED`** (exit 3): report the open PRs and stop. This is the one path that removes the
   worktree immediately (Phase 9) — nothing has been written yet, so it is clean and
@@ -644,7 +647,10 @@ git push -u origin section-doctor/$TS
 gh pr create --repo peterdrier/Humans --base main --title "doctor(<Section>): <headline>" --body ...
 ```
 
-Body: assessment summary, worked/skipped bullets, a **`## Cost`** table (below), and a
+Body: assessment summary, worked/skipped bullets, a one-line **next-up forecast** from Phase 2's
+`UPCOMING:` output — "Next 5 (non-binding): 1. <today's section> (this run) 2. … 5. …; each run
+recomputes live, so tomorrow may differ" — omitted when the selector was skipped (`--section`) or
+returned `JUDGMENT REQUIRED`, a **`## Cost`** table (below), and a
 **`## Needs Peter`** block — terse, numbered, answerable in a word or two, **citing findings by
 number rather than re-describing them** (Phase 5). **The PR body is the authoritative queue while
 the PR is open** (resume reads it from there); the run file's copy carries it forward after merge.

--- a/.claude/skills/section-doctor/select-section.py
+++ b/.claude/skills/section-doctor/select-section.py
@@ -163,13 +163,29 @@ def main():
         return 2
 
     # Feature-active sections sink to the tier bottom: median over the rest, unless only they remain.
-    ranked = sorted((s for s in never if s not in active), key=score) or sorted(never, key=score)
-    pick = ranked[(len(ranked) - 1) // 2]
+    def median_pick(tier):
+        ranked = sorted((s for s in tier if s not in active), key=score) or sorted(tier, key=score)
+        return ranked[(len(ranked) - 1) // 2]
+
+    pick = median_pick(never)
     print("\nSECTION: %s" % pick)
     print("TIER: never-doctored")
     print("RATIONALE: median (lower-middle) of %d never-doctored section(s) by %s after setting"
-          % (len(ranked), "reforge score" if "fallback" not in source else "loc"))
+          % (len([s for s in never if s not in active]) or len(never),
+             "reforge score" if "fallback" not in source else "loc"))
     print("  aside %d feature-active; pool %d, blocked %d." % (len([s for s in never if s in active]), len(pool), len(blocked)))
+
+    # Non-binding forecast: the next 4 picks if nothing else changes (each pick blocks itself).
+    # Purely informational for the PR body; never stored, and later runs recompute from scratch.
+    upcoming, future = [], [s for s in never if s != pick]
+    while len(upcoming) < 4 and future:
+        nxt = median_pick(future)
+        upcoming.append(nxt)
+        future.remove(nxt)
+    line = ", ".join(upcoming) if upcoming else "none"
+    if len(upcoming) < 4:
+        line += " -- never-doctored tier exhausts; then previously-doctored (judgment)"
+    print("UPCOMING: %s" % line)
     return 0
 
 


### PR DESCRIPTION
Selector now prints an `UPCOMING:` line — the next 4 sections a repeat of the median maths would pick (each pick blocks itself, nothing else changes). Phase 7 puts it in the PR body as a "Next 5 (non-binding)" FYI line; omitted on `--section` and `JUDGMENT REQUIRED` runs.

Purely informational: not stored, no later run reads it, tomorrow may compute differently.

Tested against the current tree: today Notifications; then Surveys, MailerLite, Events, Expenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)