### PR TITLE
fix(holded): end_date is exclusive on the ledger-entries API

### DIFF
--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -499,9 +499,12 @@ internal sealed class HoldedClient : IHoldedClient
         LocalDate from, LocalDate to, int? accountNum = null, CancellationToken ct = default)
     {
         const int pageSafetyCap = 100; // 20 000 lines/window — far above a small nonprofit's volume
+        // end_date is EXCLUSIVE on the live API (probed 2026-08-25: entry 2439 dated 25/08/2026 is
+        // absent with end_date=2026-08-25, present with end_date=2026-08-26) — bump by a day so this
+        // method's own contract of an inclusive `to` holds and callers stay untouched.
         var query =
             $"/api/v2/ledger-entries?start_date={LocalDatePattern.Iso.Format(from)}" +
-            $"&end_date={LocalDatePattern.Iso.Format(to)}&limit=200";
+            $"&end_date={LocalDatePattern.Iso.Format(to.PlusDays(1))}&limit=200";
         if (accountNum is { } num)
             query += $"&account={num}";
 

--- a/src/Sections/Humans.Holded/Services/HoldedClient.cs
+++ b/src/Sections/Humans.Holded/Services/HoldedClient.cs
@@ -499,9 +499,7 @@ internal sealed class HoldedClient : IHoldedClient
         LocalDate from, LocalDate to, int? accountNum = null, CancellationToken ct = default)
     {
         const int pageSafetyCap = 100; // 20 000 lines/window — far above a small nonprofit's volume
-        // end_date is EXCLUSIVE on the live API (probed 2026-08-25: entry 2439 dated 25/08/2026 is
-        // absent with end_date=2026-08-25, present with end_date=2026-08-26) — bump by a day so this
-        // method's own contract of an inclusive `to` holds and callers stay untouched.
+        // end_date is exclusive on the live API — send to+1 so the inclusive-`to` contract holds.
         var query =
             $"/api/v2/ledger-entries?start_date={LocalDatePattern.Iso.Format(from)}" +
             $"&end_date={LocalDatePattern.Iso.Format(to.PlusDays(1))}&limit=200";

--- a/tests/Humans.Holded.Tests/Services/HoldedClientReadTests.cs
+++ b/tests/Humans.Holded.Tests/Services/HoldedClientReadTests.cs
@@ -245,6 +245,27 @@ public class HoldedClientReadTests
     }
 
     [HumansFact]
+    public async Task ListLedgerEntries_sends_end_date_one_day_past_the_inclusive_to()
+    {
+        // end_date is exclusive on the live API (probed 2026-08-25: an entry dated 25/08/2026 is
+        // absent with end_date=2026-08-25, present with end_date=2026-08-26), so the request must
+        // carry to+1 day for this method's own `to` parameter to stay inclusive.
+        string? capturedQuery = null;
+        var handler = new StubHandler(req =>
+        {
+            capturedQuery = req.RequestUri!.Query;
+            return Respond(HttpStatusCode.OK, """{"items":[],"cursor":null,"has_more":false}""");
+        });
+
+        var client = Make(handler);
+        await client.ListLedgerEntriesAsync(
+            new LocalDate(2026, 8, 20), new LocalDate(2026, 8, 25),
+            ct: Xunit.TestContext.Current.CancellationToken);
+
+        capturedQuery.Should().Contain("end_date=2026-08-26");
+    }
+
+    [HumansFact]
     public async Task ListLedgerEntries_surfaces_an_unreadable_line_as_permanent_not_a_raw_parse_throw()
     {
         // Fail the page rather than drop the line: creditor and account balances are summed from


### PR DESCRIPTION
## Summary
- Holded's v2 `GET /api/v2/ledger-entries` treats `end_date` as EXCLUSIVE. Live probe (2026-08-25): entry 2439 dated 25/08/2026 — `start_date=2026-08-20&end_date=2026-08-25` returns 0 entries; `end_date=2026-08-26` returns it.
- Both sync call sites (`Services/Service.cs`) pass `today` as the inclusive `to`, so same-day ledger entries never reached the mirror while account balances already included them — producing phantom Holded-vs-local balance mismatches.
- `ListLedgerEntriesAsync` now requests `end_date={to+1 day}` so its own inclusive-`to` contract holds; callers are unchanged.

## Test plan
- [x] Added `ListLedgerEntries_sends_end_date_one_day_past_the_inclusive_to` asserting the request URL carries `end_date=2026-08-26` for `to=2026-08-25`.
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors.
- [x] `dotnet test tests/Humans.Holded.Tests -v quiet` — 94/94 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)