### PR TITLE
Sort identified survey respondents by response time

### DIFF
--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -1330,6 +1330,8 @@ internal sealed class SurveyService(
     {
         var identified = responses
             .Where(r => r.Anonymity == ResponseAnonymity.Identified && r.UserId.HasValue)
+            .OrderBy(r => r.SubmittedAt)
+            .ThenBy(r => r.Id)
             .ToList();
         if (identified.Count == 0) return [];
 

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -2599,6 +2599,46 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task GetResultsAsync_orders_identified_respondents_by_submission_time()
+    {
+        var surveyId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(survey, surveyId);
+        survey.Questions = new List<SurveyQuestion>();
+        _repo.GetByIdAsync(surveyId, Arg.Any<CancellationToken>()).Returns(survey);
+
+        var now = _clock.GetCurrentInstant();
+        var earlierUser = Guid.NewGuid();
+        var laterUser = Guid.NewGuid();
+        _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(new List<SurveyResponse>
+            {
+                SubmittedResponse(
+                    surveyId, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                    now, laterUser),
+                SubmittedResponse(
+                    surveyId, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                    now - Duration.FromMinutes(5), earlierUser),
+            });
+        _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, int>());
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo>
+                {
+                    [earlierUser] = UserInfoWithName(earlierUser, "Earlier"),
+                    [laterUser] = UserInfoWithName(laterUser, "Later"),
+                }));
+
+        var result = await CreateService().GetResultsAsync(surveyId, TestContext.Current.CancellationToken);
+
+        result!.IdentifiedRespondents.Select(respondent => respondent.Name)
+            .Should().ContainInOrder("Earlier", "Later");
+        result.IdentifiedRespondents.Select(respondent => respondent.SubmittedAt)
+            .Should().BeInAscendingOrder();
+    }
+
+    [HumansFact]
     public async Task GetResultsAsync_builds_funnel_from_started_count_public_count_and_input_method_splits()
     {
         var surveyId = Guid.NewGuid();


### PR DESCRIPTION
## What

Sort the identified respondent drill-down chronologically by submission time, with response ID as a deterministic tie-breaker. Adds service-level coverage for out-of-order repository results.

Follow-up to nobodies-collective/Humans#1137.

## Why

The results page currently inherits repository ordering, so identified responses can appear in a seemingly random order.

## Existing surface checked

Reuses `SurveyService.BuildIdentifiedRespondentsAsync`; no new durable surface.

## UI changes / screenshots

The existing accordion is unchanged; only its item ordering changes.

## Checklist

- [x] **Section labeled** — Surveys.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off QA `main`**.
- [x] **Issue refs are qualified**.
- [x] **EF migrations** — none.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No.
- [x] **Reuse-first checked** — existing service path extended without new surface.
- [x] **Build + test pass locally**: full build and solution tests passed; the known intermittent missing-database startup test also passed in isolation and in the final integration run.
- [x] **Nav coverage** — no new page.
- [x] **No magic strings** — not applicable.
- [x] **Dates/times via NodaTime** — ordering uses the existing `Instant` submission timestamp.

## Reviewer notes

Ordering is oldest response first, matching the chronological ordering already used by survey exports. Equal timestamps are ordered by response ID for stability.
