### PR TITLE
Split expense Decision card into Coordinator and Finance Admin cards

### DIFF
--- a/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
@@ -70,9 +70,11 @@
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Assumpte</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Presentat</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Presentat per</value></data>
+  <data name="Expenses_CoordinatorDecision" xml:space="preserve"><value>Decisió del coordinador</value></data>
   <data name="Expenses_Endorse" xml:space="preserve"><value>Avala</value></data>
   <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Vols avalar aquest informe de despeses?</value></data>
   <data name="Expenses_FileFirst" xml:space="preserve"><value>Presenta el teu primer informe</value></data>
+  <data name="Expenses_FinanceAdminDecision" xml:space="preserve"><value>Decisió de l'administrador financer</value></data>
   <data name="Expenses_IouHeader" xml:space="preserve"><value>El que el col·lectiu et deu</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Deute amb tu (saldo de Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Article</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.de.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.de.resx
@@ -70,9 +70,11 @@
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Betreff</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Eingereicht</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Eingereicht von</value></data>
+  <data name="Expenses_CoordinatorDecision" xml:space="preserve"><value>Entscheidung des Koordinators</value></data>
   <data name="Expenses_Endorse" xml:space="preserve"><value>Befürworten</value></data>
   <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Diese Spesenabrechnung befürworten?</value></data>
   <data name="Expenses_FileFirst" xml:space="preserve"><value>Reiche deine erste Abrechnung ein</value></data>
+  <data name="Expenses_FinanceAdminDecision" xml:space="preserve"><value>Entscheidung der Finanzverwaltung</value></data>
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Was das Kollektiv dir schuldet</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Dir geschuldet (Holded-Saldo)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Position</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.es.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.es.resx
@@ -70,9 +70,11 @@
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Asunto</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Enviado</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Enviado por</value></data>
+  <data name="Expenses_CoordinatorDecision" xml:space="preserve"><value>Decisión del coordinador</value></data>
   <data name="Expenses_Endorse" xml:space="preserve"><value>Avalar</value></data>
   <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>¿Avalar este informe de gastos?</value></data>
   <data name="Expenses_FileFirst" xml:space="preserve"><value>Presenta tu primer informe</value></data>
+  <data name="Expenses_FinanceAdminDecision" xml:space="preserve"><value>Decisión del administrador financiero</value></data>
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Lo que el colectivo te debe</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Te debe (saldo en Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Concepto</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
@@ -70,9 +70,11 @@
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Objet</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Soumise</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Soumise par</value></data>
+  <data name="Expenses_CoordinatorDecision" xml:space="preserve"><value>Décision du coordinateur</value></data>
   <data name="Expenses_Endorse" xml:space="preserve"><value>Valider</value></data>
   <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Valider cette note de frais ?</value></data>
   <data name="Expenses_FileFirst" xml:space="preserve"><value>Déposez votre première note</value></data>
+  <data name="Expenses_FinanceAdminDecision" xml:space="preserve"><value>Décision de l'administrateur financier</value></data>
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Ce que le collectif vous doit</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Dû à vous (solde Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Article</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.it.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.it.resx
@@ -70,9 +70,11 @@
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Oggetto</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Presentata</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Presentata da</value></data>
+  <data name="Expenses_CoordinatorDecision" xml:space="preserve"><value>Decisione del coordinatore</value></data>
   <data name="Expenses_Endorse" xml:space="preserve"><value>Avalla</value></data>
   <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Avallare questa nota spese?</value></data>
   <data name="Expenses_FileFirst" xml:space="preserve"><value>Presenta la tua prima nota</value></data>
+  <data name="Expenses_FinanceAdminDecision" xml:space="preserve"><value>Decisione dell'amministratore finanziario</value></data>
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Quanto il collettivo ti deve</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Dovuto a te (saldo Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Voce</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.resx
@@ -70,9 +70,11 @@
   <data name="Expenses_ColSubject" xml:space="preserve"><value>Subject</value></data>
   <data name="Expenses_ColSubmitted" xml:space="preserve"><value>Submitted</value></data>
   <data name="Expenses_ColSubmittedBy" xml:space="preserve"><value>Submitted by</value></data>
+  <data name="Expenses_CoordinatorDecision" xml:space="preserve"><value>Coordinator Decision</value></data>
   <data name="Expenses_Endorse" xml:space="preserve"><value>Endorse</value></data>
   <data name="Expenses_EndorseConfirm" xml:space="preserve"><value>Endorse this expense report?</value></data>
   <data name="Expenses_FileFirst" xml:space="preserve"><value>File your first report</value></data>
+  <data name="Expenses_FinanceAdminDecision" xml:space="preserve"><value>Finance Admin Decision</value></data>
   <data name="Expenses_IouHeader" xml:space="preserve"><value>What the collective owes you</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Owed to you (Holded balance)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Item</value></data>

--- a/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
+++ b/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
@@ -122,9 +122,6 @@ internal sealed class ExpenseDetailViewModel
     /// <summary>Coordinator rejection is available, under the same conditions as <see cref="CanEndorse"/>.</summary>
     public bool CanCoordinatorReject { get; init; }
 
-    /// <summary>Any decision at all is on offer — drives whether the decision card renders.</summary>
-    public bool HasDecision => CanApprove || CanFinanceReject || CanEndorse || CanCoordinatorReject;
-
     /// <summary>Budget categories offered by the approval form's override; empty unless <see cref="CanApprove"/>.</summary>
     public IReadOnlyList<BudgetCategoryOption> Categories { get; init; } = [];
 }

--- a/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
@@ -197,11 +197,48 @@
         @* Every decision on a report is taken here rather than from a queue row, so nobody
            approves a report without the lines and receipts on screen (peterdrier/Humans#1447).
            A finance admin looking at a Submitted report can both endorse and approve it — the
-           authorization handler has always granted them the coordinator's operations. *@
-        @if (Model.HasDecision)
+           authorization handler has always granted them the coordinator's operations — so they
+           see both cards; a coordinator sees only theirs. The cards follow workflow order:
+           the coordinator endorses first, then finance decides and may override the cap. *@
+        @if (Model.CanEndorse || Model.CanCoordinatorReject)
         {
             <div class="card mb-3 border-primary">
-                <div class="card-header bg-primary-subtle"><strong><i class="fa-solid fa-gavel me-1"></i>Decision</strong></div>
+                <div class="card-header bg-primary-subtle"><strong><i class="fa-solid fa-gavel me-1"></i>@Localizer["Expenses_CoordinatorDecision"]</strong></div>
+                <div class="card-body">
+                    @if (Model.CanEndorse)
+                    {
+                        <form asp-action="Endorse" asp-route-id="@r.Id" method="post" class="mb-3">
+                            @Html.AntiForgeryToken()
+                            <div class="mb-2">
+                                <label class="form-label" for="endorse-max">@Localizer["Expenses_MaxAmount"]</label>
+                                <input type="number" class="form-control" id="endorse-max" name="MaxAmount"
+                                       step="0.01" min="0.01"
+                                       value="@(r.MaxAmount?.ToString("F2", System.Globalization.CultureInfo.InvariantCulture))">
+                            </div>
+                            <button type="submit" class="btn btn-outline-success w-100"
+                                    data-confirm="@Localizer["Expenses_EndorseConfirm"].Value">
+                                <i class="fa-solid fa-check me-1"></i>@Localizer["Expenses_Endorse"]
+                            </button>
+                        </form>
+                    }
+
+                    @* Finance admins reject from their own card below, so this button only
+                       renders for an actual coordinator. *@
+                    @if (Model.CanCoordinatorReject && !Model.CanFinanceReject)
+                    {
+                        <button type="button" class="btn btn-outline-danger w-100"
+                                data-bs-toggle="modal" data-bs-target="#rejectModal">
+                            <i class="fa-solid fa-xmark me-1"></i>@Localizer["Expenses_Reject"]
+                        </button>
+                    }
+                </div>
+            </div>
+        }
+
+        @if (Model.CanApprove || Model.CanFinanceReject)
+        {
+            <div class="card mb-3 border-primary">
+                <div class="card-header bg-primary-subtle"><strong><i class="fa-solid fa-gavel me-1"></i>@Localizer["Expenses_FinanceAdminDecision"]</strong></div>
                 <div class="card-body">
                     @if (Model.CanApprove)
                     {
@@ -236,24 +273,7 @@
                         </form>
                     }
 
-                    @if (Model.CanEndorse)
-                    {
-                        <form asp-action="Endorse" asp-route-id="@r.Id" method="post" class="mb-3">
-                            @Html.AntiForgeryToken()
-                            <div class="mb-2">
-                                <label class="form-label" for="endorse-max">@Localizer["Expenses_MaxAmount"]</label>
-                                <input type="number" class="form-control" id="endorse-max" name="MaxAmount"
-                                       step="0.01" min="0.01"
-                                       value="@(r.MaxAmount?.ToString("F2", System.Globalization.CultureInfo.InvariantCulture))">
-                            </div>
-                            <button type="submit" class="btn btn-outline-success w-100"
-                                    data-confirm="@Localizer["Expenses_EndorseConfirm"].Value">
-                                <i class="fa-solid fa-check me-1"></i>@Localizer["Expenses_Endorse"]
-                            </button>
-                        </form>
-                    }
-
-                    @if (Model.CanFinanceReject || Model.CanCoordinatorReject)
+                    @if (Model.CanFinanceReject)
                     {
                         <button type="button" class="btn btn-outline-danger w-100"
                                 data-bs-toggle="modal" data-bs-target="#rejectModal">


### PR DESCRIPTION
On `/Expenses/{id}`, a finance admin viewing a Submitted report got one "Decision" card holding Approve, Endorse, and Reject — two green buttons and two identical **Max amount** fields with nothing saying which form each belonged to, or that the admin's cap overrides the coordinator's and blank clears it.

Split the card by role, in workflow order:

- **Coordinator Decision** — Endorse + max amount cap. Reject renders here only for a pure coordinator.
- **Finance Admin Decision** — Approve + max amount (override) + category override + Reject.

A coordinator sees only their card; a finance admin on a Submitted report sees both, making the endorse→approve hierarchy visible. The shared reject modal is unchanged. New card headers are localized in all six languages; the now-unused `HasDecision` view-model property is removed.

No behavior change — same forms, same actions, same authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)