### PR TITLE
fix(finance): green for positive, red for negative money figures

### DIFF
--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -714,6 +714,15 @@ a:hover {
     color: var(--h-sage-dark) !important;
 }
 
+/* Finance: sign-based coloring for monetary figures — green = positive, red = negative, never the reverse. */
+.finance-positive {
+    color: var(--h-sage-dark) !important;
+}
+
+.finance-negative {
+    color: var(--h-rust) !important;
+}
+
 .text-warning {
     color: var(--h-amber) !important;
 }

--- a/src/Sections/Humans.Finance/Views/Finance/CreditorStatement.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/CreditorStatement.cshtml
@@ -29,7 +29,7 @@
     <div class="col-md-4">
         <div class="card text-center"><div class="card-body">
             <h6 class="card-subtitle mb-2 text-muted">Balance</h6>
-            <span class="fs-4 @(owedBalance > 0 ? "text-danger" : "")">@owedBalance.ToEuro()</span>
+            <span class="fs-4 @(owedBalance > 0 ? "finance-positive" : owedBalance < 0 ? "finance-negative" : "")">@owedBalance.ToEuro()</span>
             <div class="text-muted small mt-1">positive = owed to the member</div>
         </div></div>
     </div>

--- a/src/Sections/Humans.Finance/Views/Finance/Creditors.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/Creditors.cshtml
@@ -185,7 +185,7 @@ else
                     <td class="text-end">
                         @if (r.Balance is { } bal)
                         {
-                            <span class="@(bal > 0 ? "text-danger fw-semibold" : "")">@bal.ToEuro()</span>
+                            <span class="@(bal > 0 ? "finance-positive fw-semibold" : bal < 0 ? "finance-negative fw-semibold" : "")">@bal.ToEuro()</span>
                         }
                         else
                         {


### PR DESCRIPTION
Positive owed-to-member balances rendered in `text-danger` (red), reading backwards against the universal green=positive/red=negative convention.

- New semantic `finance-positive` / `finance-negative` CSS classes in `site.css` (following the existing `.text-success`/`.text-danger` token pattern).
- Applied to `Finance/Creditors` balance column and `Finance/CreditorStatement` balance card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)