### PR TITLE
Legal-name matching in admin/coordinator pickers (scope=manage)

### DIFF
--- a/memory/architecture/person-search.md
+++ b/memory/architecture/person-search.md
@@ -1,6 +1,6 @@
 ---
 name: Person search uses one bit-flag service method and two canonical UI patterns
-description: HARD RULE. All person-search call sites route through `IUserServiceRead.SearchUsersAsync(query, PersonSearchFields, limit)`. UI is one of two patterns — `<vc:human-search>` (inline picker) or `<vc:user-search-result>` (page-style row). Admin-bit fields require admin auth at the controller. Emergency-contact data is never searchable. Shift volunteer search is exempt.
+description: HARD RULE. All person-search call sites route through `IUserServiceRead.SearchUsersAsync(query, PersonSearchFields, limit)`. UI is one of two patterns — `<vc:human-search>` (inline picker) or `<vc:user-search-result>` (page-style row). Admin-bit fields require admin auth at the controller; legal-name matching requires the role-gated managed picker scope. Emergency-contact data is never searchable. Shift volunteer search is exempt.
 ---
 
 Person search shows up across the app — Camp role assignment, team-admin member picker, public profile search page, admin humans list, ticket-transfer recipient lookup, etc. Today they all consolidate behind a single service method and two UI components. Don't fork.
@@ -29,7 +29,7 @@ Task<IReadOnlyList<HumanSearchResult>> SearchUsersAsync(
 **Hard invariants:**
 
 - **Emergency-contact data is never searchable.** Regardless of bit-flag combination. `Profile.EmergencyContactName` / `EmergencyContactPhone` are skipped by every branch of `PersonSearchMatcher`.
-- **Auth boundary is the controller, not the service.** Services are auth-free per design-rules §6. A non-admin endpoint passing `Admin` is a programmer error caught in code review, not a runtime check. The bit-flag is auditable at a glance — every call site reads `PersonSearchFields.X` literally.
+- **Auth boundary is the controller, not the service.** Services are auth-free per design-rules §6. A non-admin endpoint passing `Admin` is a programmer error caught in code review, not a runtime check; `ProfileApiController` additionally fail-closes an unauthorised `scope=manage` request to `PublicAll`. The bit-flag is auditable at a glance — every call site reads `PersonSearchFields.X` literally.
 - **Service returns matches in unspecified order.** Display ordering happens at the controller / view per [`display-sort-in-controllers.md`](display-sort-in-controllers.md). Don't push a `sortBy` parameter into the service.
 - **Limit is a safety cap, not a presentation choice.** It protects against fan-out under broad queries. Controllers may further `.Take(N)` after their own `OrderBy`.
 

--- a/src/Humans.Base/Models/HumanSearchPickerViewModel.cs
+++ b/src/Humans.Base/Models/HumanSearchPickerViewModel.cs
@@ -20,6 +20,8 @@ public class HumanSearchPickerViewModel
     /// <summary>
     /// Search scope passed through to <c>/api/profiles/search</c>.
     /// <see cref="HumanSearchScope.Name"/> narrows to burner-name match;
+    /// <see cref="HumanSearchScope.Manage"/> includes legal-name matching for
+    /// authorized admin/coordinator surfaces;
     /// <see cref="HumanSearchScope.All"/> (default) keeps the broad search.
     /// </summary>
     public HumanSearchScope Scope { get; set; } = HumanSearchScope.All;

--- a/src/Humans.Base/Models/HumanSearchScope.cs
+++ b/src/Humans.Base/Models/HumanSearchScope.cs
@@ -11,4 +11,7 @@ public enum HumanSearchScope
 
     /// <summary>Narrow matching to burner name only.</summary>
     Name,
+
+    /// <summary>Admin/coordinator matching, including legal first and last names.</summary>
+    Manage,
 }

--- a/src/Humans.Base/Views/Shared/Components/HumanSearch/Default.cshtml
+++ b/src/Humans.Base/Views/Shared/Components/HumanSearch/Default.cshtml
@@ -21,9 +21,14 @@
         ? "[]"
         : System.Text.Json.JsonSerializer.Serialize(excludeIds.Select(g => g.ToString()).ToArray());
     // Optional scope passed through to /api/profiles/search. Name narrows matching
-    // to burner name only. All (default) keeps the broad search (bio / city /
-    // interests / CV) so existing callers don't change behavior.
-    var scopeArg = Model.Scope == HumanSearchScope.Name ? "name" : "";
+    // to burner name only; Manage additionally matches legal names. All (default)
+    // keeps the broad public search (bio / city / interests / CV).
+    var scopeArg = Model.Scope switch
+    {
+        HumanSearchScope.Name => "name",
+        HumanSearchScope.Manage => "manage",
+        _ => ""
+    };
     var scopeJson = System.Text.Json.JsonSerializer.Serialize(scopeArg);
     // Optional: allow an exact-email query to resolve a single person (no enumeration leak).
     var allowEmailJson = System.Text.Json.JsonSerializer.Serialize(Model.AllowEmail);

--- a/src/Sections/Humans.Camps/Views/Camp/Members.cshtml
+++ b/src/Sections/Humans.Camps/Views/Camp/Members.cshtml
@@ -110,7 +110,7 @@
                                                              instance-key="@($"role-{role.DefinitionId:N}")"
                                                              placeholder="Search humans…"
                                                              exclude-user-ids="@alreadyInRole"
-                                                             scope="Name" />
+                                                             scope="Manage" />
                                             <button class="btn btn-sm btn-outline-primary" type="submit" title="Assign — adds to camp if not yet a member">
                                                 <i class="fa-solid fa-check"></i>
                                             </button>
@@ -136,7 +136,7 @@
                 <div class="card-body">
                     <form asp-action="AddMember" asp-route-slug="@Model.Slug" method="post" class="input-group">
                         @Html.AntiForgeryToken()
-                        <vc:human-search field-name="userId" scope="Name" />
+                        <vc:human-search field-name="userId" scope="Manage" />
                         <button type="submit" class="btn btn-outline-success" title="Add active member">
                             <i class="fa-solid fa-user-plus"></i>
                         </button>

--- a/src/Sections/Humans.Debug/Views/WidgetGallery/Index.cshtml
+++ b/src/Sections/Humans.Debug/Views/WidgetGallery/Index.cshtml
@@ -915,7 +915,7 @@
                         ("instance-key", "<code>string?</code> — required when multiple instances render on the same page"),
                         ("placeholder", "<code>string?</code> — input placeholder (default \"Search by name…\")"),
                         ("exclude-user-ids", "<code>IEnumerable&lt;Guid&gt;?</code> — hide these users from results"),
-                        ("scope", "<code>HumanSearchScope</code> — <code>Name</code> narrows to burner-name match; <code>All</code> (default) = full-text"),
+                        ("scope", "<code>HumanSearchScope</code> — <code>Name</code> narrows to burner-name match; <code>Manage</code> adds role-gated legal-name matching; <code>All</code> (default) = full-text"),
                         ("selected-user-id", "<code>Guid?</code> — prefill the picker with this user (default null = empty)"),
                         ("allow-email", "<code>bool</code> — when true (default false), an <code>@@</code>-containing query resolves by exact, case-insensitive verified email (0-or-1 result, no enumeration leak); safe on non-admin surfaces"),
                         ("ticket-lookup-url", "<code>string?</code> — when set, the picker also queries this URL (<code>?q=…</code>) in parallel and merges any rows after the profile results; used by the Early Entry card for ticket-barcode lookup (default null = disabled)")

--- a/src/Sections/Humans.Shifts/Helpers/ShiftVolunteerSearchBuilder.cs
+++ b/src/Sections/Humans.Shifts/Helpers/ShiftVolunteerSearchBuilder.cs
@@ -89,7 +89,9 @@ internal sealed class ShiftVolunteerSearchBuilder(
         // returns an arbitrary subset in non-deterministic cache order) and rank by relevance so
         // the closest name match leads. Uncapped — people must be findable (Codex P2, PR #638);
         // cache is ~500 users so the full sort is cheap.
-        var users = (await userService.SearchUsersAsync(query, PersonSearchFields.Name, limit: int.MaxValue))
+        // Both callers are coordinator/admin-gated volunteer-management surfaces;
+        // include legal names without exposing private contact fields.
+        var users = (await userService.SearchUsersAsync(query, PersonSearchFields.ManageAll, limit: int.MaxValue))
             .OrderByRelevance()
             .ToList();
 

--- a/src/Sections/Humans.Teams/Controllers/TeamAdminController.cs
+++ b/src/Sections/Humans.Teams/Controllers/TeamAdminController.cs
@@ -350,11 +350,12 @@ internal sealed class TeamAdminController(
             return Json(Array.Empty<HumanLookupSearchResult>());
         }
 
-        // Name-only — team admins are not global admins, so no contact-data search.
+        // Team management is coordinator/admin-gated: include legal names, but keep
+        // private contact and email fields out of the search scope.
         // Uncapped + relevance-ranked: a hard cap returned an arbitrary subset (the target could be
         // missing) alphabetized; now the best name match leads the scrollable picker.
         var results = await _userService.SearchUsersAsync(
-            q, PersonSearchFields.Name, limit: int.MaxValue);
+            q, PersonSearchFields.ManageAll, limit: int.MaxValue);
 
         var teamInfo = await _teamService.GetTeamAsync(team.Id);
         var existingMemberIds = teamInfo?.Members.Select(m => m.UserId).ToHashSet() ?? [];
@@ -1197,10 +1198,10 @@ internal sealed class TeamAdminController(
             .Select(m => m.UserId)
             .ToHashSet();
 
-        // Name-only for role-picker (no bio/contact data); team admins are not global admins.
-        // Uncapped folded name search over everyone (accent/case-insensitive); relevance-ranked.
+        // Coordinator/admin-gated role picker: include legal names, but no private
+        // contact data. Uncapped folded search is relevance-ranked.
         var allResults = await _userService.SearchUsersAsync(
-            q, PersonSearchFields.Name, limit: int.MaxValue);
+            q, PersonSearchFields.ManageAll, limit: int.MaxValue);
         var nameMatchIds = allResults.Select(r => r.UserId).ToHashSet();
 
         // Team members first, matched by any of:

--- a/src/Sections/Humans.Teams/Views/TeamAdmin/EarlyEntry.cshtml
+++ b/src/Sections/Humans.Teams/Views/TeamAdmin/EarlyEntry.cshtml
@@ -78,7 +78,7 @@
                 <vc:human-search field-name="UserId"
                                  instance-key="team-ee-add"
                                  placeholder="Search by name or ticket #…"
-                                 scope="Name"
+                                 scope="Manage"
                                  ticket-lookup-url="@Url.Action("LookupTicket", "TeamAdmin", new { slug = Model.Slug })" />
             </div>
             <div class="col-md-3">

--- a/src/Sections/Humans.Teams/Views/TeamAdmin/Members.cshtml
+++ b/src/Sections/Humans.Teams/Views/TeamAdmin/Members.cshtml
@@ -180,7 +180,7 @@
                     <vc:human-search field-name="UserId"
                                      instance-key="team-add-member"
                                      placeholder="@Localizer["TeamAdmin_SearchPlaceholder"].Value"
-                                     scope="Name"
+                                     scope="Manage"
                                      exclude-user-ids="@Model.AllMemberUserIds" />
                 </div>
                 <div class="col-md-4">

--- a/src/Sections/Humans.Users/Controllers/ProfileApiController.cs
+++ b/src/Sections/Humans.Users/Controllers/ProfileApiController.cs
@@ -1,6 +1,5 @@
 using Humans.Base.Controllers;
 using Humans.Users.Contracts;
-using Humans.Base.Authorization;
 using Humans.Base.Constants;
 using Humans.Base.Extensions;
 using Humans.Base.Models;

--- a/src/Sections/Humans.Users/Controllers/ProfileApiController.cs
+++ b/src/Sections/Humans.Users/Controllers/ProfileApiController.cs
@@ -1,9 +1,12 @@
 using Humans.Base.Controllers;
 using Humans.Users.Contracts;
+using Humans.Base.Authorization;
+using Humans.Base.Constants;
 using Humans.Base.Extensions;
 using Humans.Base.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 
 namespace Humans.Users.Controllers;
@@ -34,10 +37,13 @@ internal sealed class ProfileApiController(
         if (!q.HasSearchTerm())
             return Ok(Array.Empty<HumanLookupSearchResult>());
 
-        // scope=name → display/burner name only; default → broad public match. Admin bit never set on public endpoint.
+        // scope=name → display/burner name only; default → broad public match.
+        // scope=manage adds legal-name matching, but only for an admin-shaped role.
         var fields = string.Equals(scope, "name", StringComparison.OrdinalIgnoreCase)
             ? PersonSearchFields.Name
-            : PersonSearchFields.PublicAll;
+            : string.Equals(scope, "manage", StringComparison.OrdinalIgnoreCase) && CanUseManageScope(User)
+                ? PersonSearchFields.ManageAll
+                : PersonSearchFields.PublicAll;
 
         // Cover the deleted-user-but-session-still-valid race — fail-closed with 401.
         var (authError, viewer) = await ResolveCurrentUserOrUnauthorizedAsync();
@@ -87,6 +93,20 @@ internal sealed class ProfileApiController(
         // Display sort at controller — memory/architecture/display-sort-in-controllers.md.
         return Ok(response);
     }
+
+    private static bool CanUseManageScope(ClaimsPrincipal user) =>
+        user.IsInRole(RoleNames.Admin)
+        || user.IsInRole(RoleNames.Board)
+        || user.IsInRole(RoleNames.HumanAdmin)
+        || user.IsInRole(RoleNames.TeamsAdmin)
+        || user.IsInRole(RoleNames.CampAdmin)
+        || user.IsInRole(RoleNames.NoInfoAdmin)
+        || user.IsInRole(RoleNames.VolunteerCoordinator)
+        || user.IsInRole(RoleNames.ConsentCoordinator)
+        || user.IsInRole(RoleNames.TicketAdmin)
+        || user.IsInRole(RoleNames.EventsAdmin)
+        || user.IsInRole(RoleNames.FinanceAdmin)
+        || user.IsInRole(RoleNames.StoreAdmin);
 
     // Exact (accent-/case-folded full-string) burner-name collision count, excluding the editing user.
     // Drives the live edit-profile warning. Uncapped — the real number must surface, not the search cap.

--- a/src/Sections/Humans.Users/Docs/authorization.md
+++ b/src/Sections/Humans.Users/Docs/authorization.md
@@ -13,7 +13,7 @@
 | `UsersAdminController.AddRole/EndRole` runtime guards | In-method | `authorizationService.AuthorizeAsync(User, roleName, PolicyNames.RoleAssignmentManage)` — called via the named policy string rather than passing `RoleAssignmentOperationRequirement.Manage` directly (still resolves to the same resource-based handler, owned by `Humans.Auth`) | Resource-based |
 | `ProfileController` email-action runtime guards | In-method | `authorizationService.AuthorizeAsync(User, userId, UserEmailOperations.Edit)` (gating 18 email-edit endpoints) | Resource-based (see handler below) |
 | `ProfileApiController` | Class | `[Authorize]` (authenticated) | — |
-| `ProfileApiController.Search` | Action | `[Authorize]` inherited (`[HttpGet("search")]`) | — (people search; admin bit never set on this endpoint) |
+| `ProfileApiController.Search` | Action | `[Authorize]` inherited (`[HttpGet("search")]`) | `scope=manage` is additionally role-checked for admin-shaped roles and enables legal-name matching; private/admin contact fields remain excluded |
 | `ProfileApiController.BurnerNameCount` | Action | `[Authorize]` inherited (`[HttpGet("burner-name-count")]`) | — (excludes the authenticated viewer; self-exclusion uses session identity, not a caller-supplied id) |
 | `ProfileApiController.GetByUserId` | Action | `[Authorize]` inherited (`[HttpGet("by-userid/{userId:guid}")]`) | — |
 | `UsersAdminController.PurgeHuman` | Action | `Admin` | `PolicyNames.AdminOnly` (override on the class-level `HumanAdminBoardOrAdmin` controller) |

--- a/src/Sections/Humans.Users/Docs/features/profile-search-detail.md
+++ b/src/Sections/Humans.Users/Docs/features/profile-search-detail.md
@@ -105,11 +105,11 @@ The Razor partial renders all user-controlled values (`displayName`, `detail`) v
 
 | Method | Route | Returns | Notes |
 | --- | --- | --- | --- |
-| `GET` | `/api/profiles/search?q={term}&scope={name|...}` | `HumanLookupSearchResult[]` | Existing endpoint. Detail enrichment added by this feature. Uncapped — all matches, relevance-ranked (`OrderByRelevance()`: best name match first, then name). |
+| `GET` | `/api/profiles/search?q={term}&scope={name|manage|...}` | `HumanLookupSearchResult[]` | Existing endpoint. `manage` is role-gated and adds legal-name matching without private contact fields. Detail enrichment added by this feature. Uncapped — all matches, relevance-ranked (`OrderByRelevance()`: best name match first, then name). |
 | `GET` | `/api/profiles/by-userid/{userId:guid}` | `HumanLookupSearchResult` | New. Single-person lookup. 404 if user not found or profile rejected. |
 
 `HumanLookupSearchResult` shape: `{ userId, displayName, detail, profilePictureUrl }`.
 
 ### Extension: ticket-number lookup
 
-The `<vc:human-search>` picker accepts an optional `TicketLookupUrl` on `HumanSearchPickerViewModel`. When set, the client fetches it in parallel with `/api/profiles/search` and merges both result sets into the same dropdown — used by the Team Admin Early Entry card to find a human by ticket barcode (`/TeamAdmin/.../LookupTicket`). The opt-in-attribute rule for extra result sources lives in [`docs/architecture/conventions.md`](../../../../../docs/architecture/conventions.md) under *Current exceptions list*. The profile search endpoints themselves are unchanged.
+The `<vc:human-search>` picker accepts an optional `TicketLookupUrl` on `HumanSearchPickerViewModel`. When set, the client fetches it in parallel with `/api/profiles/search` and merges both result sets into the same dropdown — used by the Team Admin Early Entry card to find a human by ticket barcode (`/TeamAdmin/.../LookupTicket`). The opt-in-attribute rule for extra result sources lives in [`docs/architecture/conventions.md`](../../../../../docs/architecture/conventions.md) under *Current exceptions list*. This ticket lookup is separate from the profile-search `scope` authorization described above; the profile search endpoints themselves are unchanged.

--- a/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
+++ b/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
@@ -84,8 +84,8 @@ Per-window scope flip so admin/coordinator windows match **legal name** (defect 
   hybrid (existing members by DisplayName+Email, candidates by BurnerName) onto the matcher. **Done.**
 - `Shift{Admin,Dashboard}Controller.SearchVolunteers` → `ManageAll` (both are coordinator/admin-gated).
   **Done.**
-- `ProfileApiController.Search`: add a role-checked `scope=manage` → `ManageAll`; point the
-  add-to-team / add-to-barrio / early-entry views at it.
+- `ProfileApiController.Search`: role-checked `scope=manage` → `ManageAll`; the
+  add-to-team / add-to-barrio / early-entry views now request it. **Done.**
 - Web controller tests asserting public endpoints never receive legal-name/admin scope.
 
 ## Out of scope

--- a/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
+++ b/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
@@ -9,7 +9,7 @@
   src/Sections/Humans.Shifts/Controllers/ShiftDashboardController.cs
 -->
 <!-- freshness:flag-on-change
-  Search scope authorization model (LegalName/Admin gating, never-searchable fields) and matcher semantics (resolved name, accent folding, token split). Review when the matcher, PersonSearchFields, or search endpoints change — especially the §Follow-up per-window scope flip landing.
+  Search scope authorization model (LegalName/Admin gating, never-searchable fields) and matcher semantics (resolved name, accent folding, token split). Review when the matcher, PersonSearchFields, or search endpoints change.
 -->
 
 # User search overhaul — match all profile info, exclude board/private

--- a/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
+++ b/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
@@ -81,8 +81,9 @@ per-record matching to it.
 Per-window scope flip so admin/coordinator windows match **legal name** (defect 2):
 
 - `TeamAdminController.SearchUsers` / `SearchMembersForRole` → `ManageAll`; collapse the role-picker
-  hybrid (existing members by DisplayName+Email, candidates by BurnerName) onto the matcher.
-- `Shift{Admin,Dashboard}Controller.SearchVolunteers` → `ManageAll` (confirm each is lead/admin-gated).
+  hybrid (existing members by DisplayName+Email, candidates by BurnerName) onto the matcher. **Done.**
+- `Shift{Admin,Dashboard}Controller.SearchVolunteers` → `ManageAll` (both are coordinator/admin-gated).
+  **Done.**
 - `ProfileApiController.Search`: add a role-checked `scope=manage` → `ManageAll`; point the
   add-to-team / add-to-barrio / early-entry views at it.
 - Web controller tests asserting public endpoints never receive legal-name/admin scope.

--- a/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
+++ b/src/Sections/Humans.Users/Docs/features/user-search-overhaul.md
@@ -14,8 +14,7 @@
 
 # User search overhaul — match all profile info, exclude board/private
 
-**Status:** in progress. This PR lands the matcher + wiring; the per-window legal-name
-scope flip is the tracked follow-up (see §Follow-up).
+**Status:** complete. The matcher, wiring, and per-window legal-name scope flip are live.
 
 ## Problem
 
@@ -66,7 +65,7 @@ NFD + strip combining marks); name matching token-splits the folded query and re
 (order-independent). `CachingUserService` keeps the cache iteration + Guid fast-path and delegates
 per-record matching to it.
 
-## Done in this PR
+## Delivered
 
 - `PersonSearchFields`: `LegalName` + `ManageAll`; `AdminAll` includes `LegalName`.
 - `PersonSearchMatcher` + 23 unit tests (resolved-name fallback, accents, tokens, legal-name
@@ -76,7 +75,7 @@ per-record matching to it.
 - **Net effect now:** resolved-name + accent + token fixes are live in **every** window (defects
   1, 3, 4). The `LegalName`/email scope infrastructure exists, ready for callers to opt in.
 
-## Follow-up (next PR)
+## Per-window scope delivery
 
 Per-window scope flip so admin/coordinator windows match **legal name** (defect 2):
 
@@ -86,7 +85,8 @@ Per-window scope flip so admin/coordinator windows match **legal name** (defect 
   **Done.**
 - `ProfileApiController.Search`: role-checked `scope=manage` → `ManageAll`; the
   add-to-team / add-to-barrio / early-entry views now request it. **Done.**
-- Web controller tests asserting public endpoints never receive legal-name/admin scope.
+- Users controller tests assert public callers fall back to `PublicAll` and authorized
+  admin-shaped roles receive `ManageAll`.
 
 ## Out of scope
 

--- a/tests/Humans.Users.Tests/Controllers/ProfileApiControllerTests.cs
+++ b/tests/Humans.Users.Tests/Controllers/ProfileApiControllerTests.cs
@@ -5,6 +5,7 @@ using Humans.Users.Contracts;
 using Humans.Users.Controllers;
 using NodaTime;
 using Humans.Base.Models;
+using Humans.Base.Constants;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -52,7 +53,7 @@ public class ProfileApiControllerTests
             userStore, null, null, null, null, null, null, null, null);
     }
 
-    private ProfileApiController BuildSut(User? currentUser)
+    private ProfileApiController BuildSut(User? currentUser, params string[] roles)
     {
         if (currentUser is not null)
         {
@@ -67,8 +68,9 @@ public class ProfileApiControllerTests
         var http = new DefaultHttpContext();
         if (currentUser is not null)
         {
-            http.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, currentUser.Id.ToString())
-                ],
+            http.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, currentUser.Id.ToString()),
+                 .. roles.Select(role => new Claim(ClaimTypes.Role, role))],
                 "test"));
         }
 
@@ -159,6 +161,36 @@ public class ProfileApiControllerTests
     // ==========================================================================
     // Search — privacy gate behavior on the per-row detail line.
     // ==========================================================================
+
+    [HumansFact]
+    public async Task Search_manage_scope_uses_legal_name_fields_for_admin_roles()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        _userService.SearchUsersAsync(Arg.Any<string>(), Arg.Any<PersonSearchFields>(),
+                Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
+
+        var sut = BuildSut(viewer, RoleNames.TeamsAdmin);
+
+        await sut.Search("Legal", scope: "manage", ct: Xunit.TestContext.Current.CancellationToken);
+
+        await _userService.Received(1).SearchUsersAsync(
+            "Legal", PersonSearchFields.ManageAll, Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Search_manage_scope_falls_back_to_public_fields_without_admin_role()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        _userService.SearchUsersAsync(Arg.Any<string>(), Arg.Any<PersonSearchFields>(),
+                Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
+
+        var sut = BuildSut(viewer);
+
+        await sut.Search("Legal", scope: "manage", ct: Xunit.TestContext.Current.CancellationToken);
+
+        await _userService.Received(1).SearchUsersAsync(
+            "Legal", PersonSearchFields.PublicAll, Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
 
     [HumansFact]
     public async Task Search_returns_401_when_current_user_resolves_to_null()


### PR DESCRIPTION
Extracted from the 2026-08-25 codex tech-debt loop for separate privacy review — this is the documented follow-up in `user-search-overhaul.md` §Per-window scope delivery (defect 2), not tech debt.

**What it does:**
- New `HumanSearchScope.Manage` on `<vc:human-search>`; `/api/profiles/search?scope=manage` maps to `PersonSearchFields.ManageAll` (Name + Bio + **LegalName**)
- **Fail-closed:** an unauthorized `scope=manage` request silently degrades to `PublicAll` — public/member search never matches legal names
- TeamAdmin `SearchUsers`/`SearchMembersForRole` and Shift admin/dashboard volunteer search → `ManageAll` (all admin/coordinator-gated)
- Add-to-team / add-to-barrio / early-entry picker views request `scope=manage`
- Tests assert public callers fall back to `PublicAll` and authorized roles get `ManageAll`

**⚠️ Two open privacy questions for Peter before merge:**

1. **Role breadth.** `CanUseManageScope` grants legal-name matching to 12 roles: Admin, Board, HumanAdmin, TeamsAdmin, CampAdmin, NoInfoAdmin, VolunteerCoordinator, ConsentCoordinator, TicketAdmin, EventsAdmin, FinanceAdmin, StoreAdmin. The follow-up spec said "role-checked" without enumerating. Some are obvious (FinanceAdmin — receipts; TicketAdmin — ID checks); StoreAdmin/EventsAdmin are debatable. Trim to taste.

2. **Camp-lead gap.** `Camp/Members.cshtml` sends `scope="Manage"` gated by `RolesPanel.CanManage` — which is **resource-based** (camp lead), not role-based. A camp lead holding none of the 12 roles silently degrades to public search, so the picker won't find people by legal name for exactly that screen's audience. Either camp-lead resource authorization needs to satisfy the manage gate, or the Camps view shouldn't request it.

**Validation:** full build 0 errors; all suites green except the pre-existing integration parallel flake (passes in isolation; unrelated — see the host-scoped Serilog issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)