### PR TITLE
section-doctor: drop the cost baseline comparison; forecast in the PR header, persisted

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -89,8 +89,9 @@ is recoverable with `git rev-parse --abbrev-ref HEAD` at any point in the run.
 
 Getting a toolchain is the *environment's* job, not this skill's — a local run and the
 scheduled cloud run both start with the SDK, `dotnet-ef` and reforge already there. Never
-install one. Stryker is **not** part of that toolchain: when `dotnet stryker` is unavailable,
-skip the mutation-score half of the Tests thread and record it skipped-with-reason.
+install one. Mutation scoring (Stryker) is **off, deliberately, until Peter turns it back on**:
+no run installs it, probes for it, or records it as skipped — the Tests thread is the invariant
+matrix and test-quality work only.
 
 **What is this skill's job is the run you get when there is no compiler** — which is a real
 run, not a failed one. If `dotnet build` cannot run at all, this is a **docs-only run**: work
@@ -171,6 +172,7 @@ remains only for the re-doctor judgment below:
 ```bash
 python .claude/skills/section-doctor/select-section.py --prs "$RUNDIR/prs.json" \
   | tee "$RUNDIR/selection.txt"
+exit "${PIPESTATUS[0]}"   # tee would otherwise mask the selector's exit code (2/3 below)
 ```
 
 It computes the **blocked set** (sections named by open `section-doctor/` PRs' titles,
@@ -297,7 +299,7 @@ Each thread is a lens over the **same complete inventory**, and each reports a d
 every file it claims. They run concurrently, but *how* a thread runs follows from what it is —
 the wall-clock / token / fragility balance:
 
-- **Tool threads run as background commands** — Stryker, InspectCode, reforge, conformance
+- **Tool threads run as background commands** — InspectCode, reforge, conformance
   detectors. No subagent context to duplicate, no idle-lane failure mode, and they run while the
   main thread reads. Reforge's run is `surface-score --format compact --group <Section>`,
   scoped to the section being doctored, on every run, not only the selector's solution-wide call.
@@ -334,7 +336,7 @@ each one.
 | **Behavior & bugs** | Does it do what it claims? Walk each flow against the target's invariants. Where the section consumes authored content (markdown, resx, templates, seed data), run the **real shipped content through the real pipeline** — a defect whose trigger is the shape of an input file is invisible to every code-reading thread | main |
 | **Freshness** | The section's docs vs code: claims that no longer hold, `freshness:triggers` globs that still resolve, and triggers that watch *everything the doc asserts about* — including another section's file where the doc names it. A fixed claim gets swept everywhere it appears | subagent (sonnet) |
 | **Conformance** | `docs/architecture/section-conformance.yml` — the per-section rules nothing enforces yet. Detectors are mechanical; the judgment is what to do about a hit | background + subagent (haiku) |
-| **Tests** | Mutation score (Stryker, section-scoped — only when Stryker is installed); the invariant coverage matrix — every invariant, negative access rule and trigger in the target mapped to a pinning test; redundant and asserting-the-mock tests | background + subagent (sonnet) |
+| **Tests** | The invariant coverage matrix — every invariant, negative access rule and trigger in the target mapped to a pinning test; redundant and asserting-the-mock tests | subagent (sonnet) |
 | **Prose & surface** | InspectCode Tier 1/2; docs that are 500 words where 50 would do; dead resources, missing translations, resource keys not prefixed with the section name (`resource-key-prefix`, cleanup — report the count, don't backfill unless the run is *for* that); nav quality — dead ends, missing backlinks, discoverability from `AdminNavTree` | background + subagent (haiku) |
 | **History** | Prose narrating a prior state: a deleted/renamed project or type, a migration/lane number, "used to live in X", "the first section to Y", a dated run post-mortem, rationale for a decision no longer contested. **Cut test: keep only if it changes what a reader does** — a live constraint, a non-obvious invariant, a landmine that bites if reverted. A load-bearing "why" moves to the issue, linked, not narrated in the file | subagent (sonnet) |
 | **Comments** | Every comment in the section's inventory, rewritten or deleted. Cut what restates the next line, decision history, hedging, reassurance addressed to the next agent. **Cut test: a comment survives only if it carries something the code cannot say** | subagent (sonnet) |
@@ -349,10 +351,7 @@ several runs record it as "ran, found nothing".
 - **Behavior & bugs** — read the section's auth paths by hand. A doc-code contradiction on gating
   is invisible to grep and to every other thread.
 - **Tests** — always build the invariant matrix, including when the section looks well tested; the
-  gaps it finds are the invariants nobody thought to doubt. A new test that does not move the
-  mutants it was written for is not passing, it is undiscriminating — re-run the tool thread
-  against new tests before the PR. Stryker's `--coverage-analysis` is config-only, not a CLI flag,
-  and a section-scoped run must exclude `Data/Migrations` or migration bodies swamp the score.
+  gaps it finds are the invariants nobody thought to doubt.
 - **Freshness** — a doc claiming a test that does not exist is a doc to fix, never a test to
   write. That instinct has fired twice (#1465, #1480) and both times the test would have been
   an absence assertion — `memory/architecture/no-tests-for-absences.md`. A trigger that
@@ -604,7 +603,7 @@ worktree/PR, three bookkeeping writes:
 
   `no-derived-aggregates-in-docs` applies to the run file and `health.md` too: never count a
   list the same file carries ("15 contract methods" above the table of them, "52 paths" above
-  the coverage list). Measurements with a generator — Stryker scores, reforge — stay. A typed
+  the coverage list). Measurements with a generator — reforge scores — stay. A typed
   self-count that is wrong points a refactor at the wrong method.
 
   **The run file never describes its own diff.** No size block, no insertions/deletions, no line

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -169,7 +169,8 @@ MCP tools: `[{number, headRefName, title, files: [paths]}]` for all open PRs.
 remains only for the re-doctor judgment below:
 
 ```bash
-python .claude/skills/section-doctor/select-section.py --prs "$RUNDIR/prs.json"
+python .claude/skills/section-doctor/select-section.py --prs "$RUNDIR/prs.json" \
+  | tee "$RUNDIR/selection.txt"
 ```
 
 It computes the **blocked set** (sections named by open `section-doctor/` PRs' titles,
@@ -184,9 +185,11 @@ build also serves Phase 3/4), runs `reforge surface-score --format compact`, and
 mid-sized sections; the biggest and smallest get their turn once the middle has been worked.
 It prints `SECTION:` / `TIER:` / `RATIONALE:` plus the full ranked table for the run file, and
 an **`UPCOMING:`** line — the next 4 sections a repeat of this maths would pick, assuming each
-pick blocks itself and nothing else changes. That forecast is purely informational (it goes in
-the PR body, Phase 7): it is not stored, no later run reads or honours it, and tomorrow's run
-recomputing differently is expected. The script falls back to a LOC ranking (flagged in its
+pick blocks itself and nothing else changes. The `tee` to `$RUNDIR/selection.txt` is what lets
+Phase 7 read that line hours later, after the selector's output has left context — without it the
+forecast silently drops out of the PR body. The forecast is purely informational (it goes in the
+PR body's header, Phase 7): no later run reads or honours it, and tomorrow's run recomputing
+differently is expected. The script falls back to a LOC ranking (flagged in its
 output) when reforge is unusable. Act on its verdicts — never re-derive the maths in-band:
 
 - **`ALL BLOCKED`** (exit 3): report the open PRs and stop. This is the one path that removes the
@@ -308,8 +311,8 @@ the wall-clock / token / fragility balance:
   explicit tagged model (table below) and a deadline.
 - **Only the spine and the two judgment threads stay on main** — 3a–3c, Shape, Behavior & bugs,
   and 3e. They are the reading this run exists to do, and a wrong call there costs a real finding.
-  Whether they *must* stay is an open measurement, not a settled rule: the run-over-run figure
-  that answers it is the whole-run total against the baseline (Phase 7), because Phase 3's
+  Whether they *must* stay is an open measurement, not a settled rule: the figure
+  that answers it is the whole-run total, compared run over run (Phase 7), because Phase 3's
   main-thread cost is one shared bucket and does not split per lens. Don't move them on a hunch
   in either direction — move them on a run that dispatched them and came out cheaper without
   losing findings.
@@ -597,7 +600,7 @@ worktree/PR, three bookkeeping writes:
     Never split it per lens: the split would be invented, and an invented number is worse here
     than a coarse one. (Phase 4 is the opposite case — it marks per strike item, so its rows are
     already per-item and need no such caveat.) The Shape/Behavior question is settled by whole-run
-    totals against the baseline (Phase 7), not by attributing turns to lenses that interleave.
+    totals compared across runs (Phase 7), not by attributing turns to lenses that interleave.
 
   `no-derived-aggregates-in-docs` applies to the run file and `health.md` too: never count a
   list the same file carries ("15 contract methods" above the table of them, "52 paths" above
@@ -670,10 +673,11 @@ git push -u origin section-doctor/$TS
 gh pr create --repo peterdrier/Humans --base main --title "doctor(<Section>): <headline>" --body ...
 ```
 
-Body: assessment summary, worked/skipped bullets, a one-line **next-up forecast** from Phase 2's
-`UPCOMING:` output — "Next 5 (non-binding): 1. <today's section> (this run) 2. … 5. …; each run
-recomputes live, so tomorrow may differ" — omitted when the selector was skipped (`--section`) or
-returned `JUDGMENT REQUIRED`, a **`## Cost`** table (below), and a
+Body: the opening header paragraph (run/section, run-file link, target-shape link) **ends with the
+next-up forecast**, read from the `UPCOMING:` line in `$RUNDIR/selection.txt` — "Target shape:
+`Docs/health.md` (new). Likely future sections: A, B, C, D." — never buried lower in the body;
+omitted when the selector was skipped (`--section`) or returned `JUDGMENT REQUIRED`. Then
+assessment summary, worked/skipped bullets, a **`## Cost`** table (below), and a
 **`## Needs Peter`** block — terse, numbered, answerable in a word or two, **citing findings by
 number rather than re-describing them** (Phase 5). **The PR body is the authoritative queue while
 the PR is open** (resume reads it from there); the run file's copy carries it forward after merge.
@@ -698,9 +702,9 @@ are, they are what the reader gets; a run that marks lazily reports lazily.
 The table is a **Phase 1 → PR-creation cutoff, not a run total** — the PR
 create/backfill calls and any Phase 8 work land after measurement (the footer says so). Paste
 it as `## Cost` into the PR body and the run file, and fill Phase 5's `## Threads` model/cost
-columns from the same report (both land with the backfill commit). Compare the total against the
-2026-08-23 Onboarding baseline of **$93.30 / 746 calls / 184k median context**
-(nobodies-collective/Humans#1465) and say in one line whether dispatch moved it. The script never fails the run — on any discovery problem it prints
+columns from the same report (both land with the backfill commit). The table stands on its own —
+never compare it against another run's cost or pull in a prior run's figures; cross-run reading is
+Peter's, done over the PRs. The script never fails the run — on any discovery problem it prints
 `Cost: unmeasured (...)`; use that line as the table. Cloud-environment transcript layout is
 unverified — if the first routine run reports unmeasured, note it in Needs-Peter.
 


### PR DESCRIPTION
Two fixes Peter requested off the PR #1513 run:

1. **No more Onboarding-baseline comparison.** Phase 7 told every run to compare its cost against the 2026-08-23 Onboarding baseline ($93.30 / 746 calls / 184k context) — daily waste. Removed; the cost table now stands alone and cross-run reading is Peter's, over the PRs. The two dangling "against the baseline" references in 3d and Phase 5 now say "compared across runs".
2. **The next-5 forecast reliably lands, and lands up top.** Phase 2 now tees the selector output to `$RUNDIR/selection.txt` so the `UPCOMING:` line survives to Phase 7 (#1499 lost its forecast because it didn't — its own Needs-Peter item 11). Phase 7 now puts it at the end of the PR body's opening paragraph — "Target shape: `Docs/health.md` (new). Likely future sections: A, B, C, D." — instead of buried under Skipped (#1513).

Skill-only change; Peter-directed edit of `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)