### PR TITLE
doctor(skill): name the run session after the section it picked

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -222,6 +222,19 @@ Take the selected section (or `--section`, which skips the selector but never th
 set — check it with `select-section.py --prs "$RUNDIR/prs.json" --blocked-only`). Sections
 are `src/Sections/` projects only.
 
+**Name the run after the section, here.** A scheduled run opens a session titled after the
+routine, so every day's run is called `section-doctor-daily` and they are told apart only by
+their start time. This is the first moment the section is known, so rename the session now —
+`set_session_title` on the claude-code-remote MCP server, with this session's own id from
+`get_session` (call it with no `session_id` and it describes the caller):
+
+    section-doctor: <Section> — <yyyy-mm-dd>
+
+Skip it without comment when either tool is unavailable — an interactive run is already
+titled by whatever the human typed, and a rename is a convenience, never a gate. Do not
+rename again later: the title is how the run is found in a list, and a title that moves is
+worse than a generic one.
+
 **A low reforge score is not evidence the section is healthy.** The score measures structure, never
 correctness — the lowest-scoring section in the solution was failing open on access control. Nothing
 in the ranking rubric surfaces that, so never read a good score as a reason to look less hard.


### PR DESCRIPTION
## What

Adds one step to the end of Phase 2 of `.claude/skills/section-doctor/SKILL.md`: once the selector has picked a section, rename the session to `section-doctor: <Section> — <yyyy-mm-dd>`.

A scheduled run's session is titled after the routine, so every day's run shows as `section-doctor-daily` in the session list and they can only be told apart by start time. Phase 2 is the first moment the section is known, so that is where the rename goes.

Mechanism is `set_session_title` on the claude-code-remote MCP server, with the caller's own id from `get_session` (called with no `session_id`, it describes the caller). The routine already has that MCP server connected.

Two guards in the text: skip silently if either tool is unavailable — an interactive run is already titled by whatever the human typed, and a rename is a convenience, never a gate — and do not rename again later, because a title that moves is worse than a generic one.

Verified live before writing it: this run's own session was renamed from `⚡ section-doctor-daily` to `section-doctor: Notifications — 2026-08-26` and the change took.

## Why

Asked for by Peter, after looking at a session list where the routine's runs were distinguishable only by timestamp.

**On the "Only Peter edits this file" rule at the top of the skill:** that rule stops a *run* from amending its own instructions. This is Peter directing the change and reviewing it as a PR, which is the sanctioned path, not a run applying its own lesson.

## Existing surface checked

No new durable surface. One paragraph of instruction added to an existing phase; no script, no new file, no code.

## Checklist

- [x] ~~**Section labeled**~~ — not a section change; this is skill instructions.
- [x] **Targeting `main` on `peterdrier/Humans`**.
- [x] **Branched off `origin/main`** (`a15f5431`).
- [x] ~~**Issue refs are qualified**~~ — no issue refs.
- [x] ~~**EF migrations**~~ — none.
- [x] ~~**NuGet packages updated?**~~ — none.
- [x] ~~**New project rule?**~~ — none; this is a phase step in an existing skill, not a durable rule needing a `memory/` atom.
- [x] **Reuse-first checked** — uses the MCP tools already available to the routine; nothing added.
- [ ] ~~**Build + test pass locally**~~ — **not run, deliberately.** The diff is one markdown file under `.claude/skills/`; no compiled code is touched, so `dotnet build` / `dotnet test` exercise nothing related to it. Flagging rather than ticking a gate I did not run.
- [x] ~~**Nav coverage**~~ — no page.
- [x] ~~**No magic strings**~~ — no code.
- [x] ~~**Dates/times via NodaTime**~~ — no code. The date in the title format is the run's own date, written by the run.

## Reviewer notes

The same problem applies to any routine that picks its subject at runtime — `execute-sprint` is the obvious other one. This PR deliberately does not touch it: worth doing, but it is a separate skill and a separate call.

One open detail: the rename dropped the `⚡` prefix the old title carried. I could not tell whether that glyph is stored in the title or added by the UI for routine-fired sessions. If it is stored and you want it kept, the format string in the skill should carry it explicitly.

---
_Generated by [Claude Code](https://claude.ai/code/session_015oYk5N6gZu4fq51nHarGKb)_