### PR TITLE
feat(users): show user state on NameBackfill admin screen

### DIFF
--- a/src/Sections/Humans.Users/Contracts/IUserNameSyncService.cs
+++ b/src/Sections/Humans.Users/Contracts/IUserNameSyncService.cs
@@ -23,6 +23,7 @@ public interface IUserNameSyncService : IApplicationService
 public sealed record UnsyncedNameRow(
     Guid UserId,
     string Email,
+    UserState State,
     string ProfileBurnerName,
     string ProfileLegalName,
     bool BurnerNameMissing,

--- a/src/Sections/Humans.Users/Services/UserNameSyncService.cs
+++ b/src/Sections/Humans.Users/Services/UserNameSyncService.cs
@@ -38,6 +38,7 @@ internal sealed class UserNameSyncService(
             rows.Add(new UnsyncedNameRow(
                 user.Id,
                 emailByUser.TryGetValue(user.Id, out var email) ? email : string.Empty,
+                user.State,
                 profile.BurnerName,
                 $"{profile.FirstName} {profile.LastName}".Trim(),
                 burnerMissing,

--- a/src/Sections/Humans.Users/Views/UserNameBackfillAdmin/Index.cshtml
+++ b/src/Sections/Humans.Users/Views/UserNameBackfillAdmin/Index.cshtml
@@ -46,6 +46,7 @@
         @{
             var backfillTable = TableModel.For(Model.UnsyncedRows)
                 .Column("Email", r => r.Email)
+                .Column("Status", r => r.State.ToString())
                 .Column("Burner name", r => r.ProfileBurnerName)
                 .Column("Legal name", r => r.ProfileLegalName)
                 .Column("Missing", r => (r.BurnerNameMissing, r.LegalNameMissing) switch


### PR DESCRIPTION
The NameBackfill list includes merged/deleted users but gave no indication of lifecycle state, making it unclear why rows are there. Adds a **Status** column (`users.State`: Bare/Active/DeletePending/Suspended/Rejected/Deleted/Merged/AdminSuspended) to the table.

- `UnsyncedNameRow` gains `UserState State`, populated from the User entity already in hand.
- Admin view — no localization keys per `localization-admin-exempt`.
- `tests/Humans.Users.Tests`: 560 passed.

Known separately: some merged users still carry email addresses — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)