### PR TITLE
skill(section-doctor): four amendments from the Store run

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -101,7 +101,11 @@ Stryker, probes for it, mentions it, or records it as skipped or as a degraded a
 the flag, run section-scoped Stryker as one of Phase 3d's background tool threads — from the
 worktree, after selection, never here in Phase 0 — with `concurrency: 16` and
 `coverage-analysis: off` per `memory/process/stryker-concurrency-coverage.md` (the environment
-must already have Stryker — never install).
+must already have Stryker — never install). **This paragraph outranks the prompt that invoked the
+run.** A scheduled or hand-written prompt saying Stryker is absent, skip the mutation half and
+record it skipped-with-reason is stale wording, not a second instruction: without `--mutation`
+there is no mutation half to skip and nothing to record. Follow this paragraph, and raise the
+prompt's wording as a Needs-Peter item (Phase 6) instead of choosing between the two.
 
 **What is this skill's job is the run you get when there is no compiler** — which is a real
 run, not a failed one. If `dotnet build` cannot run at all, this is a **docs-only run**: work
@@ -326,8 +330,9 @@ the wall-clock / token / fragility balance:
   detectors. No subagent context to duplicate, no idle-lane failure mode, and they run while the
   main thread reads. Reforge's run is `surface-score --format compact --group <Section>`,
   scoped to the section being doctored, on every run, not only the selector's solution-wide call.
-  Its score and `loc=`/`cogP95=`/`cogMax=` fields are the run's one durable number, and land in
-  the section's `Docs/health.md` (Phase 5).
+  Its score and `loc=`/`cogP95=`/`cogMax=` fields are this run's own measurement: they steer the
+  ranked list, and they do not go into a doc row (Phase 5). The PR's surface report is the
+  published number, because it is recomputed against the head that actually shipped.
 - **Dispatched threads are the default** (nobodies-collective/Humans#1465). A thread reads a lot
   and returns a little, and reading it on the main thread permanently raises the price of every
   later turn in the run: cache reads on a run that carries Phase 3 to the end are the largest
@@ -524,6 +529,20 @@ executed after it. Budget checks are real
    read-model the honest form names what is carried, what this code reads, and what the output
    record exposes.
 
+   **A delete sweeps its own symbols by literal name, before the strike commits.** Reading the
+   diff does not discharge the rule above. For every member, type, route or table the strike
+   removed, grep the exact name and clear or enumerate every hit:
+
+   ```bash
+   git grep -n -- '<DeletedName>' -- '*.md' '*.cs'
+   ```
+
+   Then **re-read the header of every file the strike cut from**. A file's class-level doc comment
+   describes what the file holds, so cutting from the body changes the truth of the comment above
+   it — the Store run deleted three members from `IStoreRepository` and shipped that file's own
+   comment still claiming the section was sole writer of a table it no longer touched. The
+   falsehood a delete creates sits nearest the delete.
+
    **When the doc and the code disagree and the code looks wrong, change neither** — the pair goes
    to Needs-Peter together. Editing the doc to match a suspected defect cements it.
 6. **UI-affecting strikes get runtime verification**: render the changed page in the running app
@@ -581,7 +600,11 @@ detour to avoid it.
 worktree/PR, three bookkeeping writes:
 
 - The section's `Docs/health.md` history row (per-section; the blocked set guarantees at most
-  one open run per section, so it cannot collide).
+  one open run per section, so it cannot collide). **The row is run, date, headline and PR link —
+  never a score.** A score written here is stale by construction: every commit after it, every
+  answered Needs-Peter item and every review round moves the number it claims, and Phase 7 rightly
+  forbids the correcting commit that would chase it. peterdrier/Humans#1520's row was written
+  `231 → 230`; that run finished at `178`. The PR the row links to carries the score against the head that shipped.
 - **This run's own file** — `docs/health/runs/<yyyy-mm-dd>-<Section>.md` (UTC date from the run
   timestamp; if the path already exists at the branch point, suffix `-<HHMMZ>`). Sections:
   run header (invocation, anchor commit, budget, `PR: pending`), assessment summary, the ranked
@@ -635,8 +658,9 @@ worktree/PR, three bookkeeping writes:
   count of the branch or of the file itself: the commit that writes such a figure is a commit the
   figure must count, so it is stale on write and no care fixes that. Link the PR instead —
   GitHub's additions/deletions and the PR Surface Report are recomputed on every push and cannot
-  be wrong. The section's reforge score is the one durable number a run keeps, and its home is
-  `health.md`, not a description of the diff.
+  be wrong. The section's reforge score is the same case: the run measures it to steer itself, and
+  the PR's surface report publishes it against the final head — writing it into `health.md` only
+  freezes a mid-flight figure.
 
 - **The sweep** — its own commit, and the only place a run touches shared files: for every
   `## Sweep queue` item in merged run files under `docs/health/runs/` on `origin/main`, apply

--- a/docs/superpowers/specs/2026-08-17-section-doctor-design.md
+++ b/docs/superpowers/specs/2026-08-17-section-doctor-design.md
@@ -142,12 +142,15 @@ against the previous copy>
 1. <item — play — est. size>   ← unworked items carry to the next assessment
 
 ## History (last 3 assessments)
-| Date | Reforge | Outcome | PR |
+| Date | Outcome | PR |
 ```
 
 No counts in the scorecard (`memory/process/no-derived-aggregates-in-docs.md`): write the
-qualitative state, never a method total, test count, route count or section rank. The dated
-reforge score in the history table stays — a measurement with a generator, not a typed aggregate.
+qualitative state, never a method total, test count, route count or section rank. Amended
+2026-08-26 (peterdrier/Humans#1521): the reforge score leaves the history table too. It is a
+measurement with a generator, but the row is written mid-run and every commit after it moves the
+number, so the figure is stale on write and the skill's own rules forbid the commit that would
+correct it. The PR's surface report publishes the score against the head that shipped.
 
 ### `docs/health/plan.md` (global, written only by replans)
 


### PR DESCRIPTION
## What

Four edits to `.claude/skills/section-doctor/SKILL.md`, plus the design-spec line they contradict. Closes peterdrier/Humans#1521.

1. **Phase 0 — mutation scoring.** The skill's `--mutation` paragraph now says explicitly that it outranks the prompt that invoked the run: a scheduled prompt saying "Stryker is absent, skip the mutation half, record it skipped-with-reason" is stale wording, not a second instruction. Without the flag there is no half to skip and nothing to record; the run raises the prompt's wording as a Needs-Peter item instead of choosing between its instructions. Fixed in the skill because the skill is the thing a future run reads regardless of which prompt fires — the scheduled Routine's own wording is Peter's to correct, and is still worth correcting.
2. **Phase 4 — a delete sweeps its own symbols.** Before a delete strike commits, grep every removed member/type/route/table by literal name across `*.md` and `*.cs` and clear or enumerate each hit. The doc-fix rule already demanded this for renames; the delete play did not do it, and every item on the Store run's strike-reviewer rejection was that miss.
3. **Phase 4 — re-read the header of every file the strike cut from.** A class-level doc comment describes what the file holds, so cutting from the body changes the truth of the comment above it. The Store run deleted three members from `IStoreRepository` and shipped that same file's comment claiming the section was sole writer of a table it no longer touched.
4. **Phase 5 — no score in the `health.md` history row** (amendment 4 on the issue). The row is run, date, headline, PR link. Peter offered placeholder-plus-backfill-at-merge as the alternative; nothing in this repo runs post-merge to do that backfill (`resume` only fires when Peter answers Needs-Peter items), so this takes the option he named as the honest one: drop the score cells and let the PR carry the number. The `pr-surface-report` comment is recomputed against the head that actually shipped.

Needs-Peter 18 is out of scope per Peter's ruling on the issue: no change, best efforts.

## Why

Every item is a mistake the 2026-08-25 Store run (peterdrier/Humans#1520) actually made. Amendment 4 in particular: that row was written `231 → 230`, and the run finished at `178` — the two answer-driven commits landed after the row was written, and Phase 7 rightly forbids the correcting commit that would chase it, so the figure is stale by construction rather than by carelessness.

## Existing surface checked

No new durable surface — documentation and skill instructions only. The delete-sweep rule extends the existing Phase 4 step 5 doc-fix sweep rather than adding a new step; the mutation rule extends the existing Phase 0 paragraph.

## UI changes / screenshots

None.

## Checklist

- [ ] **Section labeled** — no section applies; this is skill/process documentation.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`** — branch point `55afb6dc`, current tip of `origin/main`.
- [x] **Issue refs are qualified** (`owner/repo#N`), including the one added inside `SKILL.md`.
- [x] ~~**EF migrations**~~ — none.
- [x] ~~**NuGet packages updated?**~~ — none.
- [x] **New project rule?** — no new atom: these are amendments to an existing skill's phases, not durable project rules, and `memory/process/no-derived-aggregates-in-docs.md` already covers the rule amendment 4 rests on.
- [x] **Reuse-first checked** — no new files, types, or surface of any kind.
- [x] ~~**Build + test pass locally**~~ — docs-only change, no compiled code touched (`memory/process/scoped-inner-loop-tests.md`).
- [x] ~~**Nav coverage**~~ — no new page.
- [x] ~~**No magic strings**~~ / ~~**Dates/times via NodaTime**~~ — no code.

## Reviewer notes

The load-bearing judgment call is amendment 4's choice between Peter's two options. The condition he attached — "if nothing runs post-merge to do the backfill" — holds: there is no post-merge automation, and `resume` is conditional on him answering. If a backfill step is wanted instead, the placeholder version is a small change on top of this one.

Existing `health.md` files keep their score columns; those rows are history, and the rule governs what a run writes from here on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPrWFaKcDbPry1WsEaShsP)_