### PR TITLE
skill(section-doctor): match blocked sections case-insensitively

### DIFF
--- a/.claude/skills/section-doctor/select-section.py
+++ b/.claude/skills/section-doctor/select-section.py
@@ -93,13 +93,24 @@ def main():
         if os.path.isdir(os.path.join(SECTIONS_DIR, d)) and d.startswith("Humans.") and not d.endswith(".Contracts")
     )
 
+    # PR titles spell the section however the run wrote it (`doctor(expenses)`); the pool is
+    # spelled from the directory (`Expenses`). Map titles onto the pool's spelling so the
+    # membership test below actually excludes the section.
+    canonical = {s.casefold(): s for s in pool}
+
     blocked, warnings = {}, []
     for pr in prs:
         if not (pr.get("headRefName") or "").startswith("section-doctor/"):
             continue
         m = re.match(r"doctor\(([^)]+)\)", pr.get("title") or "")
         if m:
-            blocked[m.group(1).strip()] = pr["number"]
+            named = m.group(1).strip()
+            section = canonical.get(named.casefold())
+            if section is None:
+                warnings.append("open run PR #%s names section %r, which is not a src/Sections project "
+                                "-- blocking nothing" % (pr.get("number"), named))
+                continue
+            blocked[section] = pr["number"]
         else:
             touched = sorted({s for s in map(path_section, pr_files(pr)) if s})
             for s in touched:


### PR DESCRIPTION
## What

`select-section.py` keyed its blocked set on the section name as spelled in the open run PR's title (`doctor(expenses)`) but built the pool from directory names (`Expenses`), so the case-sensitive membership test never matched and no section was ever actually blocked. Title names now resolve onto the pool's spelling through a casefolded lookup.

Closes peterdrier/Humans#1539

## Why

Two concurrent doctor runs could land on the same section, and a section with an open doctor PR got picked again while that PR was still in review — observed live in peterdrier/Humans#1538, which printed `blocked=expenses (#1537)` and then selected `SECTION: Expenses` in the same run.

A title naming something that is not a `src/Sections` project also silently blocked nothing; that case now emits a warning instead.

## Existing surface checked

No new durable surface. The fix is local to `main()` in `select-section.py` — one `canonical` lookup dict built from the already-computed `pool`, reusing the existing `warnings` list for the unmatched-name case.

## Checklist

- [ ] **Section labeled** — ~~n/a: tooling change under `.claude/skills/`, no section.~~
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`**.
- [x] **Issue refs are qualified** (`peterdrier/Humans#1539`).
- [x] **EF migrations** — ~~none.~~
- [x] **NuGet packages updated?** — ~~no.~~
- [x] **New project rule?** — ~~no new rule; this is a bug fix to existing tooling.~~
- [x] **Reuse-first checked** — no new files, types, or helpers.
- [x] **Build + test pass locally** — ~~no C# touched; verified by running the selector directly (below).~~
- [x] **Nav coverage** — ~~no pages.~~
- [x] **No magic strings** — n/a.
- [x] **Dates/times via NodaTime** — n/a.

## Reviewer notes

Verified against a fixture reproducing the live failure — an open `section-doctor/expenses-…` PR titled `doctor(expenses): …` plus one titled `doctor(NotASection): …`:

```
$ select-section.py --prs prs.json --blocked-only
blocked: Expenses (#1537)
WARNING: open run PR #1540 names section 'NotASection', which is not a src/Sections project -- blocking nothing

$ select-section.py --prs prs.json --no-build
pool=43 blocked=Expenses (#1537) feature-active=none
SECTION: Gate
```

`Expenses` no longer appears in either tier table. `path_section`-derived names (the fallback branch for unparseable titles, and the feature-active set) already come from directory names, so they need no normalisation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hdd31R7jevVAZ6ppwfyicX)_