### PR TITLE
docs(email): data-access entry + dependency-graph node for EmailOutboxProcessor

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -157,6 +157,7 @@ graph LR
     AdminDash[AdminDashboardService]:::dashboard
 
     EmailOutbox[EmailOutboxService]:::email
+    EmailOutboxProc[EmailOutboxProcessor]:::email
     NotifEmitter[NotificationEmitter]:::notifications
     NotifInbox[NotificationInboxService]:::notifications
     NotifMeter[NotificationMeterProvider]:::notifications
@@ -505,6 +506,8 @@ graph LR
 
     %% Email (admin outbox — pause flag lives in Settings)
     EmailOutbox --> SettingsSvc
+    EmailOutboxProc --> Campaign
+    EmailOutboxProc --> Metrics
 
     %% Settings' carry screen reads the Shifts rows it copies from (#1104).
     %% Temporary: retires with the carry screen.

--- a/src/Sections/Humans.Email/Docs/data-access.md
+++ b/src/Sections/Humans.Email/Docs/data-access.md
@@ -25,6 +25,21 @@ pause flag).
 `IsEmailSendingPaused` key through `ISystemSettingsService`. Cross-section
 calls via `ISystemSettingsService`, plus `IClock`. No `IMemoryCache`.
 
+### EmailOutboxProcessor (Scoped)
+
+Repository: `IEmailOutboxRepository`.
+
+| Table | R/W |
+|-------|-----|
+| EmailOutboxMessages | R/W |
+
+Drains the outbox queue (design §15 step 6b): claims a processing batch,
+sends via the section-internal `IEmailTransport`, and records each outcome.
+Checks the pause flag through `IEmailOutboxService.IsEmailPausedAsync` before
+each run. Cross-section calls via `ICampaignService` (mirrors campaign-grant
+email status after send — `[CrossSectionWrite]`-marked) and `IHumansMetrics` /
+`IMeters`, plus `IClock`. No `IMemoryCache`.
+
 ### OutboxEmailService (Scoped)
 
 Repository: `IEmailOutboxRepository`.


### PR DESCRIPTION
## What

Closes peterdrier/Humans#1523 — the remaining half. Adds the `EmailOutboxProcessor` H3 to `src/Sections/Humans.Email/Docs/data-access.md` and its node + cross-section edges (`ICampaignService`, `IHumansMetrics`/`IMeters`) to the Mermaid in `docs/architecture/dependency-graph.md`. `HumanLifecycleService`'s entry already landed on main.

## Why

The two freshness checks un-hidden by peterdrier/Humans#1520 were red on real gaps; these entries turn them green again (97 Mermaid nodes, 106 service headings, verified with gawk).

## Existing surface checked

No new durable surface — docs only.

## Checklist

- [x] **Section labeled** — issue carries `section:email` / `section:users`.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`**, not `upstream/main`.
- [x] **Issue refs are qualified** (`owner/repo#N`).
- ~~EF migrations~~ — none, docs only.
- ~~NuGet packages updated?~~ — none.
- ~~New project rule?~~ — none.
- [x] **Reuse-first checked** — no new surface.
- ~~Build + test pass locally~~ — docs-only change, no build needed (`memory/process/scoped-inner-loop-tests.md`); both freshness checks pass.
- ~~Nav coverage~~ — no pages.
- ~~No magic strings~~ — n/a.
- ~~Dates/times via NodaTime, icons via FA6~~ — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGodsbtme5y3oa6oHw1NAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGodsbtme5y3oa6oHw1NAB)_