### PR TITLE
skill(section-doctor): cost table as PR comment, compaction telemetry, tiered thread models

### DIFF
--- a/.claude/agents/doctor-reader.md
+++ b/.claude/agents/doctor-reader.md
@@ -1,0 +1,22 @@
+---
+name: doctor-reader
+description: Section-doctor reading thread (Freshness, Tests, History, Comments, Inbox). Dispatched by the section-doctor skill with a thread lens, an inventory slice, and the section's target shape. Not for general use.
+model: opus
+effort: low
+tools: Read, Grep, Glob, Bash
+---
+
+You are one reading thread of a section-doctor run. Your prompt opens with `thread: <Name>` and
+carries your lens, your slice of the section's file inventory, and the section's target shape —
+work strictly within them.
+
+Rules, from `.claude/skills/section-doctor/SKILL.md` Phase 3d:
+
+- Return a **structured findings list plus a disposition for every file you claimed**
+  (`reviewed` / `changed` / `generated`) — never prose narrative.
+- **Never edit anything.** Striking is the main run's job. Your Bash access is for read-only
+  queries (git log, resx/key diffs) only.
+- `reviewed` means the file's names resolve: every code symbol, route and path a doc or comment
+  names has been checked against the tree — not merely that the file was opened.
+- Meet your deadline; an incomplete-but-honest findings list beats a late complete one, because
+  unclaimed files fall back to the main thread, never get dropped.

--- a/.claude/agents/doctor-reviewer.md
+++ b/.claude/agents/doctor-reviewer.md
@@ -1,0 +1,21 @@
+---
+name: doctor-reviewer
+description: Section-doctor second-opinion reviewer — score-blind, default-reject gate for non-mechanical strikes (deletions beyond plainly-dead code, structural moves). Dispatched by the section-doctor skill.
+model: fable
+effort: high
+tools: Read, Grep, Glob, Bash
+---
+
+You are the second-opinion gate on a section-doctor strike. The run proposes a non-mechanical
+change; your default answer is **reject**.
+
+- **Score-blind**: no reforge scores, line counts or metrics enter the verdict. Approve only if
+  you can name the concept that improved in one sentence.
+- Verify the claim yourself from the tree — the proposer's summary is a hypothesis, not evidence.
+  For a deletion, grep the symbol's literal name across `*.cs` and `*.md` and check what the
+  proposer's sweep missed; for a collapse, check the merged form against
+  `docs/architecture/code-review-rules.md` and the section's load-bearing weirdness list.
+- Check what the change makes false nearby: the header comment of every file it cuts from, the
+  doc claims that named what it removed, tests that would still pass if the change were reverted.
+- Reply with the verdict, the one-sentence concept (on approve), or the specific defect (on
+  reject). Never edit anything.

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -607,6 +607,11 @@ detour to avoid it.
 
 ## Phase 5: Bookkeeping
 
+**Re-read Phases 5–7 from this file before writing anything below.** By Phase 5 the run is hours
+past the skill load and may have been auto-compacted; a compaction summary keeps the goals and
+sheds the verbatim mechanics, which is exactly how runs have half-done this bookkeeping. The
+re-read costs a few thousand tokens and re-anchors either way.
+
 **A run's shared-file writes are confined to the sweep commit below.** In the same
 worktree/PR, three bookkeeping writes:
 
@@ -646,19 +651,14 @@ worktree/PR, three bookkeeping writes:
   - **`## File coverage`** — a disposition for every path in the 3a inventory: `reviewed`,
     `changed` or `generated`. Not a summary; the list.
   - **`## Threads`** — one row per thread: how it ran (main / subagent / self-run after a missed
-    deadline), its model, its findings count, and its cost from the Phase 7 report. For each that
-    did not run, why — a silent skip is a failed run, not a quiet one. The model and cost columns
-    are what make "did the cheaper thread lose findings?" answerable across runs
-    (nobodies-collective/Humans#1465); a run that leaves them blank has decided that question for
-    every run after it.
-
-    **A dispatched thread has its own cost; the main-run threads share one.** Phase 3 marks the
-    phase log once, so every main-thread call in it lands in the one `assess` row — spine, Shape
-    and Behavior & bugs together. Write that one figure in each main row and mark it `shared`.
-    Never split it per lens: the split would be invented, and an invented number is worse here
-    than a coarse one. (Phase 4 is the opposite case — it marks per strike item, so its rows are
-    already per-item and need no such caveat.) The Shape/Behavior question is settled by whole-run
-    totals compared across runs (Phase 7), not by attributing turns to lenses that interleave.
+    deadline), its model, and its findings count. For each that
+    did not run, why — a silent skip is a failed run, not a quiet one. The model column plus the
+    PR's cost comment (Phase 7) are what make "did the cheaper thread lose findings?" answerable
+    across runs (nobodies-collective/Humans#1465); a run that leaves the model blank has decided
+    that question for every run after it. **There is no cost column**: per-row dollars are
+    measured after this file is committed and live in one place only — the cost comment, whose
+    subagent rows carry the same thread names. Don't write "see `## Cost`" or any other
+    cost pointer that names a section this file does not have.
 
   `no-derived-aggregates-in-docs` applies to the run file and `health.md` too: never count a
   list the same file carries ("15 contract methods" above the table of them, "52 paths" above
@@ -736,7 +736,7 @@ Body: the opening header paragraph (run/section, run-file link, target-shape lin
 next-up forecast**, read from the `UPCOMING:` line in `$RUNDIR/selection.txt` — "Target shape:
 `Docs/health.md` (new). Likely future sections: A, B, C, D." — never buried lower in the body;
 omitted when the selector was skipped (`--section`) or returned `JUDGMENT REQUIRED`. Then
-assessment summary, worked/skipped bullets, a **`## Cost`** table (below), and a
+assessment summary, worked/skipped bullets, and a
 **`## Needs Peter`** block — terse, numbered, answerable in a word or two, **citing findings by
 number rather than re-describing them** (Phase 5). **The PR body is the authoritative queue while
 the PR is open** (resume reads it from there); the run file's copy carries it forward after merge.
@@ -751,7 +751,10 @@ python .claude/skills/section-doctor/cost-report.py section-doctor/$TS "$RUNDIR/
 It finds this run's own session transcript under `~/.claude/projects` (the model never sees its
 own usage in-band, but the harness logs every API call's tokens there), buckets the main thread
 by the phase log, adds one row per subagent transcript (named by the `thread:` marker its
-prompt opens with), and prints a markdown table with per-row model and API-equivalent $.
+prompt opens with), and prints a markdown table with per-row model and API-equivalent $ — plus
+footer lines reporting the peak main-thread context and any compactions detected (a compaction
+mid-run is exactly when Phase 5's re-read rule earns its keep; if one is reported, say so in the
+run file's retro).
 
 **Rows are named by what the run was doing, not by phase number** — each row takes the label from
 its `mark` line, and the phase id is a trailing column. Phase 4's per-item marks give one row per
@@ -759,13 +762,17 @@ strike, so the largest bucket reads as a breakdown rather than a lump. Whatever 
 are, they are what the reader gets; a run that marks lazily reports lazily.
 
 The table is a **Phase 1 → PR-creation cutoff, not a run total** — the PR
-create/backfill calls and any Phase 8 work land after measurement (the footer says so). Paste
-it as `## Cost` into the PR body and the run file, and fill Phase 5's `## Threads` model/cost
-columns from the same report (both land with the backfill commit). The table stands on its own —
+create/backfill calls and any Phase 8 work land after measurement (the footer says so). **Post it
+as a PR comment immediately after `gh pr create`** (`gh pr comment <PR#> --body-file` — never
+inline shell-quoted; the GitHub MCP comment tool in a cloud run without `gh`). The comment is the
+table's only home: one append-only write adjacent to the create call, costing no push, no CI run
+and no review round. Never paste it into the PR body or the run file — the dual-paste rule this
+replaces was fumbled by three consecutive runs, each differently, because it asked a maybe-compacted
+session to remember two edits hours after reading them. The table stands on its own —
 never compare it against another run's cost or pull in a prior run's figures; cross-run reading is
 Peter's, done over the PRs. The script never fails the run — on any discovery problem it prints
-`Cost: unmeasured (...)`; use that line as the table. Cloud-environment transcript layout is
-unverified — if the first routine run reports unmeasured, note it in Needs-Peter.
+`Cost: unmeasured (...)`; post that line as the comment all the same (a failed measurement leaves
+a visible record, never silence) and note it in Needs-Peter.
 
 Then backfill the real PR number over every `pending` reference (run file header, health history
 row), commit, push again.

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -349,7 +349,11 @@ the wall-clock / token / fragility balance:
   later turn in the run: cache reads on a run that carries Phase 3 to the end are the largest
   line in its bill. **Small context dominates model choice**:
   moving a thread off main saves ~87%, swapping its model ~40%. Each dispatched thread gets an
-  explicit tagged model (table below) and a deadline.
+  explicit tagged model (table below) and a deadline. The tiering runs on capability-per-dollar,
+  not tier names: the judgment-reading threads get **opus at low effort** — on current models the
+  top tier at low effort matches or beats the mid tier at high effort on this kind of reading,
+  and low effort's fewer, more consolidated turns also mean fewer cache-read passes — while the
+  mechanical scans stay **haiku**.
 - **Only the spine and the two judgment threads stay on main** — 3a–3c, Shape, Behavior & bugs,
   and 3e. They are the reading this run exists to do, and a wrong call there costs a real finding.
   Whether they *must* stay is an open measurement, not a settled rule: the figure
@@ -364,6 +368,11 @@ It returns a **structured findings list plus a disposition for every file it cla
 prose, and **never edits anything** — striking is Phase 4's job on main. Prompt line one is
 `thread: <Name>` so the cost report can name the row.
 
+**`opus low` rows dispatch as the `doctor-reader` agent type** (`.claude/agents/doctor-reader.md`)
+— an agent definition is the only place effort can be pinned; a bare Agent call's `model`
+parameter cannot set it. Haiku rows use the plain model tag (default effort). Where the
+environment lacks the agent type, fall back to the plain model tag and note it in `## Threads`.
+
 **A dispatched thread that misses its deadline does not block the strike loop:** work its
 checklist on the main thread and label it self-run in the run file. That is the degrade path —
 files are never silently dropped, because the coverage block still demands a disposition for
@@ -373,13 +382,13 @@ each one.
 |---|---|---|
 | **Shape** | `/simplify`'s method against the target: shape mismatches, duplicated pipelines, pass-throughs, over-general options, dead and over-exposed surface, per-method external-caller counts | main |
 | **Behavior & bugs** | Does it do what it claims? Walk each flow against the target's invariants. Where the section consumes authored content (markdown, resx, templates, seed data), run the **real shipped content through the real pipeline** — a defect whose trigger is the shape of an input file is invisible to every code-reading thread | main |
-| **Freshness** | The section's docs vs code: claims that no longer hold, `freshness:triggers` globs that still resolve, and triggers that watch *everything the doc asserts about* — including another section's file where the doc names it. A fixed claim gets swept everywhere it appears | subagent (sonnet) |
+| **Freshness** | The section's docs vs code: claims that no longer hold, `freshness:triggers` globs that still resolve, and triggers that watch *everything the doc asserts about* — including another section's file where the doc names it. A fixed claim gets swept everywhere it appears | subagent (opus low) |
 | **Conformance** | `docs/architecture/section-conformance.yml` — the per-section rules nothing enforces yet. Detectors are mechanical; the judgment is what to do about a hit | background + subagent (haiku) |
-| **Tests** | The invariant coverage matrix — every invariant, negative access rule and trigger in the target mapped to a pinning test; redundant and asserting-the-mock tests | subagent (sonnet) |
+| **Tests** | The invariant coverage matrix — every invariant, negative access rule and trigger in the target mapped to a pinning test; redundant and asserting-the-mock tests | subagent (opus low) |
 | **Prose & surface** | InspectCode Tier 1/2; docs that are 500 words where 50 would do; dead resources, missing translations, resource keys not prefixed with the section name (`resource-key-prefix`, cleanup — report the count, don't backfill unless the run is *for* that); nav quality — dead ends, missing backlinks, discoverability from `AdminNavTree` | background + subagent (haiku) |
-| **History** | Prose narrating a prior state: a deleted/renamed project or type, a migration/lane number, "used to live in X", "the first section to Y", a dated run post-mortem, rationale for a decision no longer contested. **Cut test: keep only if it changes what a reader does** — a live constraint, a non-obvious invariant, a landmine that bites if reverted. A load-bearing "why" moves to the issue, linked, not narrated in the file | subagent (sonnet) |
-| **Comments** | Every comment in the section's inventory, rewritten or deleted. Cut what restates the next line, decision history, hedging, reassurance addressed to the next agent. **Cut test: a comment survives only if it carries something the code cannot say** | subagent (sonnet) |
-| **Inbox** | Section-tagged `debt-ledger.yml` items, open GitHub issues, in-app issues. Work or rank them — and **review** the open issues for validity / consistency / freshness / spec quality (below); off-section finds go to the run's sweep queue as `debt:`, never written to the ledger directly | subagent (sonnet) |
+| **History** | Prose narrating a prior state: a deleted/renamed project or type, a migration/lane number, "used to live in X", "the first section to Y", a dated run post-mortem, rationale for a decision no longer contested. **Cut test: keep only if it changes what a reader does** — a live constraint, a non-obvious invariant, a landmine that bites if reverted. A load-bearing "why" moves to the issue, linked, not narrated in the file | subagent (opus low) |
+| **Comments** | Every comment in the section's inventory, rewritten or deleted. Cut what restates the next line, decision history, hedging, reassurance addressed to the next agent. **Cut test: a comment survives only if it carries something the code cannot say** | subagent (opus low) |
+| **Inbox** | Section-tagged `debt-ledger.yml` items, open GitHub issues, in-app issues. Work or rank them — and **review** the open issues for validity / consistency / freshness / spec quality (below); off-section finds go to the run's sweep queue as `debt:`, never written to the ledger directly | subagent (opus low) |
 
 **Every thread that does not run says so in the run file, with why.** A silent skip leaves a whole
 dimension unmeasured with nothing flagging it. A thread earns removal from this table only when
@@ -524,7 +533,9 @@ executed after it. Budget checks are real
    never report it as covered by CI. Never propose a CI job for that project, and never count its
    tests as a coverage gap — the rule above settles it.
 4. Non-mechanical changes (deletions beyond plainly-dead code, structural moves) → second-opinion
-   reviewer subagent, opus-tier, score-blind, default-reject: "name the concept that improved in
+   reviewer subagent — the `doctor-reviewer` agent type (`.claude/agents/doctor-reviewer.md`,
+   fable; fall back to a plain opus subagent with its prompt where the type or model is
+   unavailable) — score-blind, default-reject: "name the concept that improved in
    one sentence." Reject → rework once; second reject → revert, record.
 5. **Doc fixes sweep the claim — by literal string, repo-wide**: when a strike removes or
    renames a route, type, method or path, or fixes a claim naming one, grep the whole repo for

--- a/.claude/skills/section-doctor/cost-report.py
+++ b/.claude/skills/section-doctor/cost-report.py
@@ -7,7 +7,8 @@ Finds this run's own session transcript under ~/.claude/projects (the file that
 mentions the run branch and was modified after the run started), sums per-API-call
 token usage bucketed by the phase boundaries in the phase log, adds one row per
 subagent transcript (named by its `thread:` marker where it has one), and prints a
-markdown table with per-row model and API-equivalent cost.
+markdown table with per-row model and API-equivalent cost, followed by footer lines
+reporting the peak main-thread context and any mid-run compactions detected.
 
 Rows are named by what the run was DOING, not by phase number: each phase-log line
 is `<iso-ts> <phase-id> <label>` and the label becomes the row. Phase 4 writes one
@@ -24,11 +25,14 @@ import re
 import sys
 from datetime import datetime
 
-# $/MTok: fresh input, output, cache write, cache read (API list rates)
+# $/MTok: fresh input, output, cache write, cache read (API list rates).
+# Order matters: rate() takes the first substring match, so "sonnet-5" ($2/$10)
+# must precede the plain "sonnet" (4.6, $3/$15) fallback.
 RATES = {
     "fable": (10, 50, 12.50, 1.00),
     "mythos": (10, 50, 12.50, 1.00),
     "opus": (5, 25, 6.25, 0.50),
+    "sonnet-5": (2, 10, 2.50, 0.20),
     "sonnet": (3, 15, 3.75, 0.30),
     "haiku": (1, 5, 1.25, 0.10),
 }
@@ -94,6 +98,7 @@ def add(bucket, model, u):
     for key in RATES:
         if key in (model or ""):
             bucket.setdefault("models", set()).add(key)
+            break  # first match only, mirroring rate()
     fresh = u.get("input_tokens", 0)
     out = u.get("output_tokens", 0)
     cw = u.get("cache_creation_input_tokens", 0)
@@ -132,6 +137,7 @@ def main():
         b["first"] = min(b["first"], t)
         return b
 
+    contexts = []  # (label, context tokens) per main-thread call, time-ordered
     for t, model, u in usage_entries(own):
         # entries before the phase log belong to whatever the session did earlier
         # (interactive invocation) — not to this run
@@ -139,6 +145,8 @@ def main():
             continue
         pid, label = phase_at(ts(t), phases)
         add(row(f"main:{pid}:{label}", pid, label, ts(t)), model, u)
+        contexts.append((label, sum(u.get(k, 0) for k in (
+            "input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"))))
 
     for p in glob.glob(own[: -len(".jsonl")] + "/subagents/*.jsonl"):
         if os.path.getmtime(p) < run_start:
@@ -177,6 +185,25 @@ def main():
         "API-equivalent $, list rates; run under subscription quota. "
         "Measured Phase 1 to PR creation; PR create/backfill and Phase 8 excluded."
     )
+
+    # Context telemetry: where the run's context peaked, and whether it was
+    # compacted mid-run. Compaction is detected from the usage data itself — a
+    # sustained drop of >50% and >100k tokens between consecutive main-thread
+    # calls (a one-call dip, e.g. a small utility request, does not count).
+    if contexts:
+        peak_label, peak_ctx = max(contexts, key=lambda c: c[1])
+        print()
+        print(f"Peak main-thread context: {peak_ctx:,} tokens ({peak_label}).")
+        compactions = []
+        for i in range(1, len(contexts)):
+            prev, cur = contexts[i - 1][1], contexts[i][1]
+            sustained = i + 1 >= len(contexts) or contexts[i + 1][1] < prev
+            if cur < prev * 0.5 and prev - cur > 100_000 and sustained:
+                compactions.append(contexts[i][0])
+        if compactions:
+            print(f"Compactions detected: {len(compactions)} ({', '.join(compactions)}).")
+        else:
+            print("Compactions detected: none.")
 
 
 if __name__ == "__main__":

--- a/docs/superpowers/specs/2026-08-17-section-doctor-design.md
+++ b/docs/superpowers/specs/2026-08-17-section-doctor-design.md
@@ -264,7 +264,7 @@ The plan is advisory — run-day findings can extend a section's stay.
   real `date` reads, never estimates. Doc fixes sweep the claim across `docs/guide/` and sibling
   docs; UI-affecting strikes get runtime verification in the running app. Non-mechanical changes
   (deletions beyond dead code, structural moves) get a second-opinion reviewer subagent
-  (opus-tier, score-blind, default-reject — refactor-swarm posture).
+  (fable-tier, score-blind, default-reject — refactor-swarm posture).
 - **5 Bookkeeping** — exactly two writes, both conflict-free: the `health.md` history row and
   this run's own `docs/health/runs/<date>-<Section>.md` (all in the worktree, same PR). No
   shared file is touched; daily runs never write `maintenance-log.md`.


### PR DESCRIPTION
Peter-authorized edits to the section-doctor skill files, from the cost/model discussion around #1537, #1538, #1545.

## Why

Three consecutive runs fumbled the "paste the cost table into the PR body **and** the run file" rule, each differently: #1537 lost the table entirely (no `unmeasured` line either), #1538 hit only the run file, #1545 only the PR body — while every disk-derived obligation (phase log, `$TS` branch, run file) survived. That signature points at mid-run compaction shedding verbatim instructions loaded hours earlier, not at sloppiness.

## Commit 1 — cost comment + telemetry

- **Phase 7**: the cost table posts as a **PR comment** right after `gh pr create` — one append-only write, adjacent to the create call, no push/CI/review cost, single home. `Cost: unmeasured (...)` posts as the comment too, so a failed measurement leaves a record instead of silence.
- **Phase 5**: the `## Threads` table drops its cost column (the comment's subagent rows carry the same thread names — no more "see `## Cost`" pointing at a section that doesn't exist). New rule: **re-read Phases 5–7 from the file before bookkeeping**, re-anchoring a maybe-compacted session.
- **cost-report.py**:
  - Footer lines: peak main-thread context, and compactions detected from the usage data itself (sustained >50% / >100k context drop between consecutive calls; a one-call utility dip doesn't count). This answers "did this run compact, and where" per run.
  - **Sonnet 5 rates** ($2/$10) matched before the Sonnet 4.6 fallback ($3/$15) — Claude Code's `sonnet` alias resolves to Sonnet 5 on the Anthropic API, so prior reports overpriced sonnet thread rows ~50%. Model labels now first-match ("sonnet-5", not "sonnet+sonnet-5").
  - Verified against a synthetic transcript: rates, peak, real-compaction detection, and dip rejection all correct.

## Commit 2 — tiered thread models

- Reading threads (Freshness, Tests, History, Comments, Inbox): sonnet → **opus at low effort**. Top tier at low effort matches or beats mid tier at high effort on judgment reading; fewer turns also mean fewer cache-read passes. Mechanical scans stay haiku.
- Second-opinion reviewer: opus → **fable** — the cheapest, highest-leverage judgment call in a run ($3.03 in the Surveys run, and it stopped a wrong design from shipping).
- Effort is only settable in an agent definition (a bare Agent-tool `model` param can't carry it — per the Agent SDK subagents doc), so two registered agent types are added: `.claude/agents/doctor-reader.md` (opus, low) and `doctor-reviewer.md` (fable, high) — the repo's first frontmattered agent definitions; the existing three are prompt docs. The skill falls back to plain model tags where a type is unavailable.
- Design spec's reviewer line trued up (`opus-tier` → `fable-tier`).

## Not included (deliberate)

- **Spine model**: the main thread runs on the session's model, which the scheduled routine sets — a fable-spine trial is a routine-config change (≈2× the dominant cache-read bucket at list rates), Peter's call, not a skill edit.
- **Phase 2 selector** stays sonnet — rare path, light judgment.

Docs/skill-only change: no build or tests per scoped-inner-loop; cost-report.py exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
