### PR TITLE
feat(events): PriorityRank is int?, null = unranked

### DIFF
--- a/src/Sections/Humans.Events.Contracts/ApprovedEventView.cs
+++ b/src/Sections/Humans.Events.Contracts/ApprovedEventView.cs
@@ -41,7 +41,7 @@ public sealed record ApprovedEventView(
     int DurationMinutes,
     bool IsRecurring,
     string? RecurrenceDays,
-    int PriorityRank,
+    int? PriorityRank,
     Instant SubmittedAt,
     Instant LastUpdatedAt)
 {

--- a/src/Sections/Humans.Events/Controllers/EventsApiController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsApiController.cs
@@ -308,7 +308,7 @@ internal sealed class EventsApiController(IEventService guide, ICampServiceRead 
     private static GuideEventApiDto BuildEventDto(
         Guid id, string title, string description, Guid categoryId, string categoryName, string categorySlug,
         bool categoryIsSensitive, Guid? campId, Guid? guideSharedVenueId, string? venueName, string? locationNote,
-        string? host, int durationMinutes, bool isRecurring, int priorityRank,
+        string? host, int durationMinutes, bool isRecurring, int? priorityRank,
         Instant startAt, int dayOffset, string? campName, string? submitterName)
     {
         return new GuideEventApiDto(

--- a/src/Sections/Humans.Events/Controllers/EventsController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsController.cs
@@ -174,7 +174,6 @@ internal sealed class EventsController(
             DurationMinutes = durationMinutes,
             IsRecurring = model.IsRecurring,
             RecurrenceDays = model.IsRecurring ? model.RecurrenceDays : null,
-            PriorityRank = 0
         };
         guideEvent.Submit(clock);
 

--- a/src/Sections/Humans.Events/Controllers/EventsExportController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsExportController.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Humans.Base.Csv;
 using Humans.Base.Extensions;
 using Humans.Camps.Contracts;
@@ -63,7 +64,7 @@ internal sealed class EventsExportController(
                     time,
                     e.DurationMinutes,
                     e.IsRecurring ? "Yes" : "No",
-                    e.PriorityRank,
+                    e.PriorityRank?.ToString(CultureInfo.InvariantCulture) ?? "",
                     e.Status.ToString(),
                     ToLocalDateTime(e.SubmittedAt, tz).ToInvariantTimestamp(),
                     e.Host ?? "",
@@ -121,7 +122,7 @@ internal sealed class EventsExportController(
         if (maxSlots.HasValue && maxSlots.Value > 0)
         {
             allOccurrences = allOccurrences
-                .OrderBy(o => o.PriorityRank == 0 ? int.MaxValue : o.PriorityRank)
+                .OrderBy(o => o.PriorityRank ?? int.MaxValue)
                 .ThenBy(o => o.StartAt)
                 .Take(maxSlots.Value)
                 .ToList();
@@ -181,6 +182,6 @@ internal sealed class EventsExportController(
         public string? LocationNote { get; set; }
         public DateTime StartAt { get; set; }
         public int DurationMinutes { get; set; }
-        public int PriorityRank { get; set; }
+        public int? PriorityRank { get; set; }
     }
 }

--- a/src/Sections/Humans.Events/Controllers/EventsModerationController.cs
+++ b/src/Sections/Humans.Events/Controllers/EventsModerationController.cs
@@ -183,7 +183,7 @@ internal sealed class EventsModerationController(
             Host = guideEvent.Host,
             IsRecurring = guideEvent.IsRecurring,
             RecurrenceDays = guideEvent.RecurrenceDays,
-            PriorityRank = guideEvent.PriorityRank == 0 ? 1 : guideEvent.PriorityRank
+            PriorityRank = guideEvent.PriorityRank
         };
 
         if (guideEvent.CampId.HasValue)

--- a/src/Sections/Humans.Events/Data/Migrations/20260828042714_PriorityRankNullable.Designer.cs
+++ b/src/Sections/Humans.Events/Data/Migrations/20260828042714_PriorityRankNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Events.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Events.Data.Migrations
 {
     [DbContext(typeof(EventGuideDbContext))]
-    partial class EventGuideDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828042714_PriorityRankNullable")]
+    partial class PriorityRankNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Events/Data/Migrations/20260828042714_PriorityRankNullable.cs
+++ b/src/Sections/Humans.Events/Data/Migrations/20260828042714_PriorityRankNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Events.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class PriorityRankNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "PriorityRank",
+                table: "events",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "PriorityRank",
+                table: "events",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Sections/Humans.Events/Docs/Events.md
+++ b/src/Sections/Humans.Events/Docs/Events.md
@@ -42,7 +42,7 @@ Event programming: submission, moderation, browsing, export, and preference mana
 | RecurrenceDays | string? | comma-separated day offsets, e.g. "0,1,2" |
 | LocationNote | string? | max 120 |
 | Host | string? | max 40; optional display name for the person running the event |
-| PriorityRank | int | 0 = unprioritised; lower = higher priority in print guide |
+| PriorityRank | int? | null = unranked; lower = higher priority in print guide |
 | Status | EventStatus | enum (see below) |
 | AdminNotes | string? | moderator-only notes |
 | SubmittedAt | Instant | set on first Submit(); updated on resubmit |

--- a/src/Sections/Humans.Events/Docs/health.md
+++ b/src/Sections/Humans.Events/Docs/health.md
@@ -85,9 +85,9 @@ these are the ones this shape rests on.)
   inner `EventService` proves a DI mistake. Mirrors Teams and Camps.
 - **`CachingEventService` is its own `IHostedService`.** Warm-up must run on the same Singleton
   that serves reads.
-- **`PriorityRank` means two different things.** Camp events carry 1–100 (print-guide ordering);
-  individual events are always 0 and the print guide sorts 0 last. The moderation form's
-  `== 0 ? 1` and the bulk validator's `1..100` both descend from this.
+- **`PriorityRank` is camp-events-only.** Camp events carry 1–100 (print-guide ordering) or
+  null = unranked (sorted last); individual events are always null. The bulk validator's `1..100`
+  applies only when a value is present; blank round-trips as blank.
 - **Recurrence is stored as day offsets from gate opening, displayed as weekday names.** Bulk
   import compares by day-name set, not the raw string, so a lossless round-trip is not read as an
   edit.

--- a/src/Sections/Humans.Events/Domain/Event.cs
+++ b/src/Sections/Humans.Events/Domain/Event.cs
@@ -81,9 +81,9 @@ internal sealed class Event
     public string? RecurrenceDays { get; set; }
 
     /// <summary>
-    /// Submitter-assigned priority for print guide selection (1 = highest).
+    /// Submitter-assigned priority for print guide selection (1 = highest; null = unranked).
     /// </summary>
-    public int PriorityRank { get; set; }
+    public int? PriorityRank { get; set; }
 
     /// <summary>
     /// Current moderation status.
@@ -225,7 +225,7 @@ internal sealed class Event
     public void ApplyBarrioEdit(
         Guid categoryId, string title, string description,
         Instant startAt, int durationMinutes, string? locationNote, string? host,
-        bool isRecurring, string? recurrenceDays, int priorityRank)
+        bool isRecurring, string? recurrenceDays, int? priorityRank)
     {
         CategoryId = categoryId;
         Title = title;

--- a/src/Sections/Humans.Events/Models/BarrioEventViewModels.cs
+++ b/src/Sections/Humans.Events/Models/BarrioEventViewModels.cs
@@ -29,7 +29,7 @@ internal sealed class CampEventRowViewModel
     public DateTime StartAt { get; set; }
     public int DurationMinutes { get; set; }
     public EventStatus Status { get; set; }
-    public int PriorityRank { get; set; }
+    public int? PriorityRank { get; set; }
     public bool CanEdit { get; set; }
     public bool CanWithdraw { get; set; }
 
@@ -94,7 +94,7 @@ internal sealed class CampEventFormViewModel
     [Required]
     [Range(1, 100)]
     [Display(Name = "Priority Rank")]
-    public int PriorityRank { get; set; } = 1;
+    public int? PriorityRank { get; set; }
 
     // Dropdown data
     public List<CategoryOptionViewModel> Categories { get; set; } = [];

--- a/src/Sections/Humans.Events/Models/EventsApiModels.cs
+++ b/src/Sections/Humans.Events/Models/EventsApiModels.cs
@@ -13,7 +13,7 @@ internal sealed record GuideEventApiDto(
     GuideEventVenueApiDto? Venue,
     string? LocationNote,
     string? Host,
-    int PriorityRank);
+    int? PriorityRank);
 
 internal sealed record GuideEventCategoryApiDto(
     Guid Id,

--- a/src/Sections/Humans.Events/Models/EventsModerationViewModels.cs
+++ b/src/Sections/Humans.Events/Models/EventsModerationViewModels.cs
@@ -32,7 +32,7 @@ internal sealed class ModerationEventRowViewModel
     public string? LocationNote { get; set; }
     public bool IsRecurring { get; set; }
     public string? RecurrenceDays { get; set; }
-    public int PriorityRank { get; set; }
+    public int? PriorityRank { get; set; }
     public DateTime SubmittedAt { get; set; }
     public EventStatus Status { get; set; }
     public List<ModerationHistoryItemViewModel> History { get; set; } = [];
@@ -149,10 +149,10 @@ internal sealed class AdminEventFormViewModel
     [Display(Name = "Recurrence Days")]
     public string? RecurrenceDays { get; set; }
 
-    // Camp events only.
+    // Camp events only; blank = unranked.
     [Range(1, 100)]
     [Display(Name = "Priority Rank")]
-    public int PriorityRank { get; set; } = 1;
+    public int? PriorityRank { get; set; }
 
     [MaxLength(500)]
     [Display(Name = "Edit note (optional)")]

--- a/src/Sections/Humans.Events/Services/BulkEventCsvParser.cs
+++ b/src/Sections/Humans.Events/Services/BulkEventCsvParser.cs
@@ -62,8 +62,12 @@ internal static class BulkEventCsvParser
 
             if (!int.TryParse(record.DurationMinutes, CultureInfo.InvariantCulture, out var duration))
                 errors.Add($"Row {fileRow}: DurationMinutes is not an integer.");
-            if (!int.TryParse(record.PriorityRank, CultureInfo.InvariantCulture, out var priority))
-                errors.Add($"Row {fileRow}: PriorityRank is not an integer.");
+            int? priority = null;
+            if (!string.IsNullOrWhiteSpace(record.PriorityRank))
+            {
+                if (int.TryParse(record.PriorityRank, CultureInfo.InvariantCulture, out var parsedPriority)) priority = parsedPriority;
+                else errors.Add($"Row {fileRow}: PriorityRank is not an integer.");
+            }
 
             var isRecurring = string.Equals(record.IsRecurring, "true", StringComparison.OrdinalIgnoreCase);
 

--- a/src/Sections/Humans.Events/Services/Dtos/BulkEventImport.cs
+++ b/src/Sections/Humans.Events/Services/Dtos/BulkEventImport.cs
@@ -17,7 +17,7 @@ internal sealed record BulkCsvRow(
     string? Host,
     bool IsRecurring,
     string? RecurrenceDays,
-    int PriorityRank);
+    int? PriorityRank);
 
 /// <summary>Per-row validation failure surfaced back to the uploader.</summary>
 internal sealed record BulkImportRowError(int RowNumber, string Title, IReadOnlyList<string> Errors);

--- a/src/Sections/Humans.Events/Services/Dtos/EventInfo.cs
+++ b/src/Sections/Humans.Events/Services/Dtos/EventInfo.cs
@@ -95,7 +95,7 @@ internal sealed record EventInfo(
     int DurationMinutes,
     bool IsRecurring,
     string? RecurrenceDays,
-    int PriorityRank,
+    int? PriorityRank,
     EventStatus Status,
     Instant SubmittedAt,
     Instant LastUpdatedAt,

--- a/src/Sections/Humans.Events/Services/Service.cs
+++ b/src/Sections/Humans.Events/Services/Service.cs
@@ -459,7 +459,7 @@ internal sealed class EventService(
                 Host = e.Host ?? string.Empty,
                 IsRecurring = e.IsRecurring ? "true" : "false",
                 RecurrenceDays = recDays,
-                PriorityRank = e.PriorityRank.ToString(CultureInfo.InvariantCulture),
+                PriorityRank = e.PriorityRank?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             });
         }
 
@@ -535,7 +535,7 @@ internal sealed class EventService(
             else if (row.DurationMinutes % 15 != 0)
                 rowErrors.Add("DurationMinutes must be a multiple of 15.");
 
-            if (row.PriorityRank < 1 || row.PriorityRank > 100)
+            if (row.PriorityRank is { } rank && (rank < 1 || rank > 100))
                 rowErrors.Add("PriorityRank must be between 1 and 100.");
 
             if (row.Id.HasValue)

--- a/src/Sections/Humans.Events/Views/EventsModeration/Index.cshtml
+++ b/src/Sections/Humans.Events/Views/EventsModeration/Index.cshtml
@@ -131,7 +131,7 @@ else
                                         <dd class="col-sm-9">Day offsets: @evt.RecurrenceDays</dd>
                                     }
 
-                                    @if (evt.PriorityRank > 0)
+                                    @if (evt.PriorityRank is not null)
                                     {
                                         <dt class="col-sm-3">Priority Rank</dt>
                                         <dd class="col-sm-9">@evt.PriorityRank</dd>

--- a/tests/Humans.Events.Tests/Services/BulkEventCsvParserTests.cs
+++ b/tests/Humans.Events.Tests/Services/BulkEventCsvParserTests.cs
@@ -24,6 +24,27 @@ public sealed class BulkEventCsvParserTests
     }
 
     [HumansFact]
+    public void Parse_BlankPriorityRank_IsUnranked()
+    {
+        var csv = $"{Header}\n,Camp,,Title,Desc,Workshop,2026-07-08,09:30,60,,,false,,\n";
+
+        var rows = BulkEventCsvParser.Parse(csv);
+
+        rows.Should().ContainSingle();
+        rows[0].PriorityRank.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void Parse_NonNumericPriorityRank_IsAnError()
+    {
+        var csv = $"{Header}\n,Camp,,Title,Desc,Workshop,2026-07-08,09:30,60,,,false,,high\n";
+
+        var act = () => BulkEventCsvParser.Parse(csv);
+
+        act.Should().Throw<FormatException>().WithMessage("*PriorityRank is not an integer*");
+    }
+
+    [HumansFact]
     public void Parse_ColumnsInAnyOrder_MatchedByHeaderName()
     {
         var csv = "Title,Category,Date,StartTime,DurationMinutes,IsRecurring,PriorityRank,Description\n" +

--- a/tests/Humans.Events.Tests/Services/ServiceTests.cs
+++ b/tests/Humans.Events.Tests/Services/ServiceTests.cs
@@ -481,6 +481,37 @@ public sealed class EventServiceTests
     }
 
     [HumansFact]
+    public async Task BulkImportAsync_UnrankedRow_IsAcceptedAndStaysUnranked()
+    {
+        var campId = Guid.NewGuid();
+        _repo.Categories.Add(new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true });
+
+        var result = await _service.BulkImportAsync(
+            campId, Guid.NewGuid(), [Row(priority: null)],
+            new LocalDate(2026, 7, 8), 6, DateTimeZone.Utc, TestContext.Current.CancellationToken);
+
+        result.HasErrors.Should().BeFalse();
+        _repo.Events.Should().ContainSingle().Which.PriorityRank.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task BulkTemplate_UnrankedEvent_RoundTripsAsUnranked()
+    {
+        var campId = Guid.NewGuid();
+        var category = new EventCategory { Id = Guid.NewGuid(), Name = "Workshop", Slug = "workshop", IsActive = true };
+        _repo.Categories.Add(category);
+        var existing = ExistingEvent(campId, category.Id, EventStatus.Approved);
+        existing.Category = category;
+        existing.PriorityRank = null;
+        _repo.Events.Add(existing);
+
+        var bytes = await _service.BuildBulkUploadTemplateAsync(campId, "Fire Barrio", TestContext.Current.CancellationToken);
+        var rows = BulkEventCsvParser.Parse(HumansCsv.Utf8WithBom.GetString(bytes).TrimStart('\uFEFF'));
+
+        rows.Should().ContainSingle().Which.PriorityRank.Should().BeNull();
+    }
+
+    [HumansFact]
     public async Task BulkImportAsync_UnchangedExistingRow_IsNoOp()
     {
         var campId = Guid.NewGuid();
@@ -659,7 +690,7 @@ public sealed class EventServiceTests
         Guid? id = null, string title = "My Event", string description = "Desc",
         string category = "Workshop", string date = "2026-07-08", string startTime = "09:30",
         int duration = 60, string? location = null, string? host = null,
-        bool isRecurring = false, string? recurrenceDays = null, int priority = 1, int rowNumber = 2)
+        bool isRecurring = false, string? recurrenceDays = null, int? priority = 1, int rowNumber = 2)
         => new(rowNumber, id, title, description, category, date, startTime, duration, location, host, isRecurring, recurrenceDays, priority);
 
     private Event ExistingEvent(Guid campId, Guid categoryId, EventStatus status)


### PR DESCRIPTION
## What

`Event.PriorityRank` becomes `int?` with `null` = unranked (1 = highest). Closes peterdrier/Humans#1494.

- New individual events are no longer seeded with `PriorityRank = 0` — the property stays null.
- Moderation edit form prefills the actual stored value (the old `== 0 ? 1 : …` coercion silently rewrote unranked events to rank 1 on save).
- Print-guide selection sorts unranked last (`?? int.MaxValue`); CSV export emits blank for unranked.
- Bulk CSV import: blank `PriorityRank` parses as null and round-trips through the exported template; the 1–100 range validation applies only when a value is present; non-numeric still errors.
- Barrio submission form keeps `PriorityRank` required; the camp admin form allows blank (= unranked) and drops the `= 1` default.
- Schema-only migration `PriorityRankNullable` (AlterColumn to nullable) in the Events context, 100% auto-generated.

## Why

`0` was doing double duty as "unranked", which leaked into sorting (0 sorts as top priority) and into the moderation form's coercion hack. Null makes unranked explicit end to end.

## Existing surface checked

- `ApprovedEventView` (Contracts) carries the property; Calendar consumes the type but not `PriorityRank` — Calendar tests pass unchanged.
- No new public surface: existing DTOs/view models changed in place to `int?`.

## Checklist

- [x] Migration auto-generated (`dotnet ef migrations add PriorityRankNullable --context EventGuideDbContext …`), schema-only; ef-migration-reviewer agent verdict: **PASS** (`has-pending-model-changes` clean, chain clean, snapshot regen artifacts benign).
- [x] Tests: Events 174/174 green (incl. new blank/round-trip/validation cases); Calendar 79/79; full `Humans.slnx` suite green except `Humans.Integration.Tests` (offline by design).
- [x] Docs updated: `Events.md` schema row, `health.md` surprises entry.
- [x] No new localization keys (admin-side views only).

## Reviewer notes

**Existing `PriorityRank = 0` rows — Peter's call, decided:** the rows stay at 0. The event they ranked is over, so their sort position no longer matters; next year's events start at null and behave correctly. No data migration, no backfill screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGodsbtme5y3oa6oHw1NAB