### PR TITLE
feat(expenses): one Holded purchase doc per receipt

### DIFF
--- a/src/Sections/Humans.Expenses/Contracts/ExpenseLineDto.cs
+++ b/src/Sections/Humans.Expenses/Contracts/ExpenseLineDto.cs
@@ -13,4 +13,8 @@ public sealed record ExpenseLineDto
     /// excluded from the report total and from the Holded push — reviewed, never booked.</summary>
     public Guid? ParentLineId { get; init; }
     public required int SortOrder { get; init; }
+    /// <summary>The Holded purchase document this line booked to (one doc per bookable line).
+    /// Null until pushed, on proof rows, and on lines the authorized cap zeroed out. Reports
+    /// pushed before per-line docs carry their single doc id on the report instead.</summary>
+    public string? HoldedDocId { get; init; }
 }

--- a/src/Sections/Humans.Expenses/Contracts/ExpenseReportDto.cs
+++ b/src/Sections/Humans.Expenses/Contracts/ExpenseReportDto.cs
@@ -25,7 +25,17 @@ public sealed record ExpenseReportDto
     public string? LastRejectionReason { get; init; }
     public Guid? LastRejectedByUserId { get; init; }
     public Instant? LastRejectedAt { get; init; }
+    /// <summary>Legacy single-doc pushes only (pre per-line docs); new pushes set
+    /// <see cref="ExpenseLineDto.HoldedDocId"/> per line. Read via <see cref="HoldedDocIds"/>.</summary>
     public string? HoldedDocId { get; init; }
+    /// <summary>Every Holded purchase document this report booked to: the legacy report-level doc
+    /// when present, else the per-line docs in line order. Empty means not (yet) in Holded.</summary>
+    public IReadOnlyList<string> HoldedDocIds => HoldedDocId is not null
+        ? [HoldedDocId]
+        : Lines.Where(l => l.HoldedDocId is not null)
+            .OrderBy(l => l.SortOrder)
+            .Select(l => l.HoldedDocId!)
+            .ToList();
     public string? HoldedContactId { get; init; }
     public int? HoldedSupplierAccountNum { get; init; }
     public required Instant CreatedAt { get; init; }

--- a/src/Sections/Humans.Expenses/Data/Configurations/ExpenseLineConfiguration.cs
+++ b/src/Sections/Humans.Expenses/Data/Configurations/ExpenseLineConfiguration.cs
@@ -15,6 +15,8 @@ internal sealed class ExpenseLineConfiguration : IEntityTypeConfiguration<Expens
         b.Property(x => x.Description).HasMaxLength(500).IsRequired();
         b.Property(x => x.Amount).HasColumnType("decimal(12,2)");
 
+        b.Property(x => x.HoldedDocId).HasMaxLength(64);
+
         b.Property(x => x.LineType)
             .HasConversion<string>()
             .HasMaxLength(20)

--- a/src/Sections/Humans.Expenses/Data/ExpenseReportMapper.cs
+++ b/src/Sections/Humans.Expenses/Data/ExpenseReportMapper.cs
@@ -39,6 +39,7 @@ internal static class ExpenseReportMapper
             LineType = l.LineType,
             AttachmentId = l.AttachmentId,
             ParentLineId = l.ParentLineId,
+            HoldedDocId = l.HoldedDocId,
             Attachment = l.Attachment is null
                 ? null
                 : new ExpenseAttachmentDto

--- a/src/Sections/Humans.Expenses/Data/ExpenseRepository.cs
+++ b/src/Sections/Humans.Expenses/Data/ExpenseRepository.cs
@@ -418,15 +418,16 @@ internal sealed class ExpenseRepository(IDbContextFactory<ExpensesDbContext> fac
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task SetHoldedDocIdAsync(
-        Guid reportId, string holdedDocId, Instant updatedAt,
+    public async Task SetLineHoldedDocIdAsync(
+        Guid lineId, string holdedDocId, Instant updatedAt,
         CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
-        var r = await ctx.ExpenseReports.FirstOrDefaultAsync(x => x.Id == reportId, ct);
-        if (r is null) return;
-        r.HoldedDocId = holdedDocId;
-        r.UpdatedAt = updatedAt;
+        var line = await ctx.ExpenseLines.FirstOrDefaultAsync(x => x.Id == lineId, ct);
+        if (line is null) return;
+        line.HoldedDocId = holdedDocId;
+        var r = await ctx.ExpenseReports.FirstOrDefaultAsync(x => x.Id == line.ExpenseReportId, ct);
+        if (r is not null) r.UpdatedAt = updatedAt;
         await ctx.SaveChangesAsync(ct);
     }
 

--- a/src/Sections/Humans.Expenses/Data/IExpenseRepository.cs
+++ b/src/Sections/Humans.Expenses/Data/IExpenseRepository.cs
@@ -117,16 +117,16 @@ internal interface IExpenseRepository : IRepository
     Task MarkAttachmentPushedAsync(
         Guid attachmentId, NodaTime.Instant pushedAt, CancellationToken ct = default);
     /// <summary>
-    /// Persists the freshly-issued Holded document id on the report. Caller
-    /// invokes this immediately after <c>IHoldedClient.CreatePurchaseDocumentAsync</c>
-    /// returns — that way a transient failure during attachment upload (which runs
-    /// after) does not cause the outbox event to retry the create call and produce
-    /// a duplicate Holded document. Marking the outbox event processed is a
-    /// separate <see cref="MarkOutboxProcessedAsync"/> call that runs only after
-    /// the full create + upload chain succeeds.
+    /// Persists the freshly-issued Holded document id on the line. Caller invokes
+    /// this immediately after <c>IHoldedClient.CreatePurchaseDocumentAsync</c>
+    /// returns for that line — that way a transient failure later in the push
+    /// (attachment upload, the next line's doc) does not cause the outbox event to
+    /// retry the create call and produce a duplicate Holded document. Marking the
+    /// outbox event processed is a separate <see cref="MarkOutboxProcessedAsync"/>
+    /// call that runs only after every line's create + upload + approve succeeds.
     /// </summary>
-    Task SetHoldedDocIdAsync(
-        Guid reportId, string holdedDocId, NodaTime.Instant updatedAt,
+    Task SetLineHoldedDocIdAsync(
+        Guid lineId, string holdedDocId, NodaTime.Instant updatedAt,
         CancellationToken ct = default);
     /// <summary>
     /// Persists the Holded contact id and (optionally) the resolved 400000xx supplier-account

--- a/src/Sections/Humans.Expenses/Data/Migrations/20260828140457_ExpenseLineHoldedDocId.Designer.cs
+++ b/src/Sections/Humans.Expenses/Data/Migrations/20260828140457_ExpenseLineHoldedDocId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Expenses.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Expenses.Data.Migrations
 {
     [DbContext(typeof(ExpensesDbContext))]
-    partial class ExpensesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828140457_ExpenseLineHoldedDocId")]
+    partial class ExpenseLineHoldedDocId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Expenses/Data/Migrations/20260828140457_ExpenseLineHoldedDocId.cs
+++ b/src/Sections/Humans.Expenses/Data/Migrations/20260828140457_ExpenseLineHoldedDocId.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Expenses.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExpenseLineHoldedDocId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "HoldedDocId",
+                table: "expense_lines",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HoldedDocId",
+                table: "expense_lines");
+        }
+    }
+}

--- a/src/Sections/Humans.Expenses/Docs/Expenses.md
+++ b/src/Sections/Humans.Expenses/Docs/Expenses.md
@@ -35,7 +35,7 @@ Members submit expense reports for reimbursement. Finance Admin reviews and appr
 | BudgetCategoryId | Guid | FK → Budget.BudgetCategory (cross-domain, scalar only) |
 | BudgetYearId | Guid | FK → Budget.BudgetYear (cross-domain, scalar only) |
 | Status | ExpenseReportStatus | see enum below |
-| Note | string? | optional submitter-written **Subject**; becomes the Holded document `Description` |
+| Note | string? | optional submitter-written **Subject**; stays in Humans — the Holded docs' `Description` is each line's description plus a report reference |
 | PayeeName | string | snapshotted at submit |
 | PayeeIban | string | snapshotted at submit, refreshable from `/Expenses/{id}/Iban` until approval; MUST be masked in all log/audit output |
 | Total | decimal | sum of line amounts — the receipts total, not what is paid |
@@ -45,7 +45,7 @@ Members submit expense reports for reimbursement. Finance Admin reviews and appr
 | CoordinatorEndorsedAt | Instant? | |
 | ApprovedByUserId | Guid? | scalar FK |
 | ApprovedAt | Instant? | |
-| HoldedDocId | string? | Holded purchase document id |
+| HoldedDocId | string? | **Legacy** single-doc pushes only (pre per-line docs); never set by new pushes — read via `ExpenseReportDto.HoldedDocIds`, which folds it with the per-line ids |
 | HoldedContactId | string? | Holded contact id for this submitter; set on first push; links to creditor cache |
 | HoldedSupplierAccountNum | int? | 40000000–41999999 supplier-account number (supplierRecord.num), cached at push time |
 | LastRejectionReason / LastRejectedByUserId / LastRejectedAt | — | last rejection details |
@@ -67,6 +67,7 @@ Members submit expense reports for reimbursement. Finance Admin reviews and appr
 | AttachmentId | Guid? | FK → expense_attachments |
 | ParentLineId | Guid? | self-FK → expense_lines; non-null marks a proof row backing that Invoice line |
 | SortOrder | int | |
+| HoldedDocId | string? | the Holded purchase doc this line booked to (one doc per bookable line); null until pushed, on proof rows, and on lines the cap zeroed out |
 
 ### ExpenseAttachment
 
@@ -136,7 +137,8 @@ Append-on-approve, drained by `HoldedExpenseOutboxJob`. Fields: `EventType` (Cre
 - **Every decision is taken from `/Expenses/{id}`**, never from a queue row, so a report cannot be approved, rejected or endorsed without its lines and receipts on screen. `/Expenses/Review` lists and links; it carries no decision controls.
 - `/Expenses/Review` is one queue for three audiences, scoped by the viewer: a finance admin sees every non-draft, non-withdrawn report; anyone else sees their own plus those booked to a budget category they coordinate. Drafts and withdrawals never appear — they belong to `/Expenses`.
 - Payable is `min(Total, MaxAmount)` (`ExpenseReportDto.Payable`). Owed/paid math, the review queue, and the detail view all read the payable; `Total` renders only as the receipts total.
-- A capped report pushes to Holded with one extra negative line ("Authorized maximum €X — adjustment", amount `MaxAmount − Total`, same account as the receipt lines) so the purchase document totals the payable. No adjustment line when the report is uncapped or the cap is at or above `Total`.
+- **The push books one Holded purchase document per bookable line**, in `SortOrder`, each carrying that line's description (plus a report reference in the doc description), amount, category account, and its one attachment. Proof rows get neither doc lines nor uploads. Reports pushed before per-line docs keep their single report-level `HoldedDocId`; a re-queue of one resumes onto that doc (remaining uploads + approve) and never mints per-line docs beside it.
+- **The authorized cap allocates greedily in `SortOrder`** (`PayableAllocation` — the push, the detail view, and the audit message all read the same allocation): each line books in full until the payable runs out. The line the cap lands inside books its receipt at face value plus a negative "Authorized maximum €X — adjustment" line on the same account, so that doc totals what the cap lets it book while still matching its attached receipt. A line entirely past the cap gets **no doc and no upload** — Holded holds no record of it — and the skip is named in the `ExpenseHoldedPushed` audit entry and badged on the detail view's lines table (trimmed lines show "books X of Y" there too, from endorsement onward). Where the reduction lands is presentation only: the whole report books to one category account. No adjustment or skip when the report is uncapped or the cap is at or above `Total`.
 - `Profile.Iban` must be non-null at submit time. `PayeeIban` is snapshotted at that moment. A later profile-level IBAN change (`/Profile`) never touches an in-flight report. A change made through **the report's own** `/Expenses/{id}/Iban` page does: while the report is `Submitted` or `CoordinatorEndorsed` it rewrites that report's `PayeeIban` too, because the point of the page is fixing the payment before it goes out. `Draft` has no snapshot to fix (submit takes it), and `Approved` / `Withdrawn` are never touched — approval has already queued the Holded push. Clearing the IBAN is **refused** on `Submitted` / `CoordinatorEndorsed`: a report awaiting payment needs one, and half-applying would leave profile and snapshot disagreeing about who gets paid. The form stops offering the removal on those statuses too (`ExpenseIbanViewModel.CanRemoveIban`), so the page never invites what the service will reject.
 - The `/Expenses/{id}` **Payee** card renders the report's own `PayeeName` (unmasked legal name) and masked `PayeeIban` — the submit-time snapshot, i.e. who Holded actually pays. It is scoped to the submitter and finance admins (`ExpenseDetailViewModel.CanSeePayee`); a coordinator endorsing a report does not see it, because the legal name is unmasked and burner names are the norm elsewhere. The card never shows the *viewer's* own IBAN on someone else's report: what it renders is always the *report submitter's* state, and the Set/Change IBAN buttons render for the submitter and for whoever the `Edit` grant covers (the `Iban` action Forbids everyone else).
 - **A report belongs to its `SubmitterUserId`; whoever is changing it is only the actor.** Everything payee-shaped reads the submitter's profile, never the acting user's — `SubmitAsync` snapshots the submitter's IBAN and legal name, and the `Iban` page writes the submitter's profile. The actor appears only where it means the actor: `ExpenseAttachment.UploadedByUserId` and the audit entries.

--- a/src/Sections/Humans.Expenses/Domain/ExpenseLine.cs
+++ b/src/Sections/Humans.Expenses/Domain/ExpenseLine.cs
@@ -14,6 +14,11 @@ internal sealed class ExpenseLine
     /// excluded from the report total and from the Holded push — reviewed, never booked.</summary>
     public Guid? ParentLineId { get; set; }
     public int SortOrder { get; set; }
+    /// <summary>The Holded purchase document this line booked to — each bookable line gets its own
+    /// doc, carrying its one receipt. Null until pushed, and always null on proof rows and on lines
+    /// the authorized cap zeroed out. Reports pushed before per-line docs carry the single doc id
+    /// on <see cref="ExpenseReport.HoldedDocId"/> instead.</summary>
+    public string? HoldedDocId { get; set; }
 
     public ExpenseAttachment? Attachment { get; set; }
 }

--- a/src/Sections/Humans.Expenses/Domain/ExpenseReport.cs
+++ b/src/Sections/Humans.Expenses/Domain/ExpenseReport.cs
@@ -24,6 +24,8 @@ internal sealed class ExpenseReport
     public string? LastRejectionReason { get; set; }
     public Guid? LastRejectedByUserId { get; set; }
     public Instant? LastRejectedAt { get; set; }
+    /// <summary>Legacy single-doc pushes only (pre per-line docs). New pushes create one doc per
+    /// bookable line and write <see cref="ExpenseLine.HoldedDocId"/>; this is never set again.</summary>
     public string? HoldedDocId { get; set; }
     /// <summary>Holded contact id for this submitter (set on first push). Links to creditor balance + payments.</summary>
     public string? HoldedContactId { get; set; }

--- a/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.ca.resx
@@ -84,6 +84,8 @@
   <data name="Expenses_IouHeader" xml:space="preserve"><value>El que el col·lectiu et deu</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Deute amb tu (saldo de Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Article</value></data>
+  <data name="Expenses_LineBooksOf" xml:space="preserve"><value>Comptabilitza {0} de {1} — màxim autoritzat</value></data>
+  <data name="Expenses_LineNotBooked" xml:space="preserve"><value>No comptabilitzat — màxim autoritzat assolit</value></data>
   <data name="Expenses_MaxAmount" xml:space="preserve"><value>Import màxim</value></data>
   <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Els meus informes de despeses</value></data>
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nou informe</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.de.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.de.resx
@@ -84,6 +84,8 @@
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Was das Kollektiv dir schuldet</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Dir geschuldet (Holded-Saldo)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Position</value></data>
+  <data name="Expenses_LineBooksOf" xml:space="preserve"><value>Verbucht {0} von {1} — genehmigtes Maximum</value></data>
+  <data name="Expenses_LineNotBooked" xml:space="preserve"><value>Nicht verbucht — genehmigtes Maximum erreicht</value></data>
   <data name="Expenses_MaxAmount" xml:space="preserve"><value>Höchstbetrag</value></data>
   <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Meine Spesenabrechnungen</value></data>
   <data name="Expenses_NewReport" xml:space="preserve"><value>Neue Abrechnung</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.es.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.es.resx
@@ -84,6 +84,8 @@
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Lo que el colectivo te debe</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Te debe (saldo en Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Concepto</value></data>
+  <data name="Expenses_LineBooksOf" xml:space="preserve"><value>Contabiliza {0} de {1} — máximo autorizado</value></data>
+  <data name="Expenses_LineNotBooked" xml:space="preserve"><value>No contabilizado — máximo autorizado alcanzado</value></data>
   <data name="Expenses_MaxAmount" xml:space="preserve"><value>Importe máximo</value></data>
   <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Mis informes de gastos</value></data>
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nuevo informe</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.fr.resx
@@ -84,6 +84,8 @@
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Ce que le collectif vous doit</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Dû à vous (solde Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Article</value></data>
+  <data name="Expenses_LineBooksOf" xml:space="preserve"><value>Comptabilise {0} sur {1} — maximum autorisé</value></data>
+  <data name="Expenses_LineNotBooked" xml:space="preserve"><value>Non comptabilisé — maximum autorisé atteint</value></data>
   <data name="Expenses_MaxAmount" xml:space="preserve"><value>Montant maximum</value></data>
   <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Mes notes de frais</value></data>
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nouvelle note</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.it.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.it.resx
@@ -84,6 +84,8 @@
   <data name="Expenses_IouHeader" xml:space="preserve"><value>Quanto il collettivo ti deve</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Dovuto a te (saldo Holded)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Voce</value></data>
+  <data name="Expenses_LineBooksOf" xml:space="preserve"><value>Contabilizza {0} di {1} — massimo autorizzato</value></data>
+  <data name="Expenses_LineNotBooked" xml:space="preserve"><value>Non contabilizzato — massimo autorizzato raggiunto</value></data>
   <data name="Expenses_MaxAmount" xml:space="preserve"><value>Importo massimo</value></data>
   <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>Le mie note spese</value></data>
   <data name="Expenses_NewReport" xml:space="preserve"><value>Nuova nota</value></data>

--- a/src/Sections/Humans.Expenses/ExpensesResource.resx
+++ b/src/Sections/Humans.Expenses/ExpensesResource.resx
@@ -84,6 +84,8 @@
   <data name="Expenses_IouHeader" xml:space="preserve"><value>What the collective owes you</value></data>
   <data name="Expenses_IouOwed" xml:space="preserve"><value>Owed to you (Holded balance)</value></data>
   <data name="Expenses_LedgerColItem" xml:space="preserve"><value>Item</value></data>
+  <data name="Expenses_LineBooksOf" xml:space="preserve"><value>Books {0} of {1} — authorized maximum</value></data>
+  <data name="Expenses_LineNotBooked" xml:space="preserve"><value>Not booked — authorized maximum reached</value></data>
   <data name="Expenses_MaxAmount" xml:space="preserve"><value>Max amount</value></data>
   <data name="Expenses_MyReportsTitle" xml:space="preserve"><value>My Expense Reports</value></data>
   <data name="Expenses_NewReport" xml:space="preserve"><value>New Report</value></data>

--- a/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
+++ b/src/Sections/Humans.Expenses/Models/ExpensesViewModels.cs
@@ -28,7 +28,7 @@ internal sealed class ExpensesIndexViewModel
     /// <summary>Unbound although a report already reached Holded — auto-bind failed and only a manual
     /// bind clears it (nobodies-collective/Humans#972). Unbound with no pushed report is just "not yet".</summary>
     public bool CreditorBindingFailed =>
-        BoundAccountNum is null && Reports.Any(r => r.HoldedDocId is not null);
+        BoundAccountNum is null && Reports.Any(r => r.HoldedDocIds.Count > 0);
 
     /// <summary>True when this user is a coordinator for any budget-year team, regardless of queue depth.</summary>
     public bool IsCoordinator { get; init; }

--- a/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
@@ -95,9 +95,8 @@ internal sealed class ExpenseReportService(
             // at outbox-drain time), so it contributes to the creditor balance from Approved onward.
             // Approved is the report's terminal state — paid/unpaid is read from the account ledger, never the report.
             memberRegisteredTotal = memberReports
-                .Where(r => r.HoldedDocIds.Count > 0
-                         && r.Status is ExpenseReportStatus.Approved)
-                .Sum(r => r.Payable);
+                .Where(r => r.Status is ExpenseReportStatus.Approved)
+                .Sum(RegisteredAmount);
 
             owed = status?.OwedToMember ?? 0m;
             totalPaid = status?.TotalPaid ?? 0m;
@@ -127,6 +126,18 @@ internal sealed class ExpenseReportService(
                 : null,
         };
     }
+
+    /// <summary>
+    /// What of this report is actually booked in Holded right now. A legacy report-level doc always
+    /// carried the whole payable; per-line docs count only the lines whose doc exists, so a push that
+    /// failed partway (retrying) doesn't overstate the member's registered total against the ledger.
+    /// </summary>
+    private static decimal RegisteredAmount(ExpenseReportDto report) =>
+        report.HoldedDocId is not null
+            ? report.Payable
+            : PayableAllocation.Allocate(report)
+                .Where(a => a.Line.HoldedDocId is not null)
+                .Sum(a => a.Booked);
 
     private ExpenseHoldedSyncState ResolveSyncState(HoldedExpenseOutboxEvent? outboxEvent)
     {
@@ -1410,10 +1421,17 @@ internal sealed class ExpenseReportService(
                 await holdedClient.ApprovePurchaseDocumentAsync(holdedDocId, ct);
         }
 
-        var summary = pushedDocIds.Count == 1
-            ? $"Pushed to Holded as purchase document {pushedDocIds[0]}."
-            : $"Pushed to Holded as purchase documents {string.Join(", ", pushedDocIds)}.";
-        return notes.Count == 0 ? summary : $"{summary} {string.Join(" ", notes)}";
+        var summary = pushedDocIds.Count switch
+        {
+            0 => "No purchase documents pushed to Holded.",
+            1 => $"Pushed to Holded as purchase document {pushedDocIds[0]}.",
+            _ => $"Pushed to Holded as purchase documents {string.Join(", ", pushedDocIds)}.",
+        };
+        var full = notes.Count == 0 ? summary : $"{summary} {string.Join(" ", notes)}";
+        // AuditLogEntry.Description caps at 4,000 chars (job-name prefix included) and a failed
+        // insert is swallowed, so an oversized summary loses the audit entry entirely.
+        const int maxSummaryLength = 3500;
+        return full.Length <= maxSummaryLength ? full : full[..(maxSummaryLength - 1)] + "…";
     }
 
     /// <summary>

--- a/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
+++ b/src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
@@ -91,11 +91,11 @@ internal sealed class ExpenseReportService(
                 report.HoldedSupplierAccountNum, ct);
 
             var memberReports = await repo.GetForSubmitterAsync(report.SubmitterUserId, ct);
-            // A report with a HoldedDocId is booked as a payable in Holded (the purchase doc is created
+            // A report with Holded docs is booked as payables in Holded (the purchase docs are created
             // at outbox-drain time), so it contributes to the creditor balance from Approved onward.
             // Approved is the report's terminal state — paid/unpaid is read from the account ledger, never the report.
             memberRegisteredTotal = memberReports
-                .Where(r => r.HoldedDocId is not null
+                .Where(r => r.HoldedDocIds.Count > 0
                          && r.Status is ExpenseReportStatus.Approved)
                 .Sum(r => r.Payable);
 
@@ -109,7 +109,7 @@ internal sealed class ExpenseReportService(
 
         return new ExpenseHoldedTimeline
         {
-            RegisteredInHolded = report.HoldedDocId is not null,
+            RegisteredInHolded = report.HoldedDocIds.Count > 0,
             OwedToMember = owed,
             MemberRegisteredTotal = memberRegisteredTotal,
             OtherAmount = Math.Max(0m, owed - memberRegisteredTotal),
@@ -1273,90 +1273,20 @@ internal sealed class ExpenseReportService(
         // the category has no active mapping; the doc still creates, just unbooked.
         var holdedAccountId = await holdedFinance.GetHoldedAccountIdForCategoryAsync(report.BudgetCategoryId, ct);
 
-        // Proof rows back an invoice line for review only — they are not booked and their
-        // files are not uploaded. What Holded gets is the invoice itself.
-        var bookableLines = report.Lines
-            .Where(l => l.ParentLineId is null)
-            .OrderBy(l => l.SortOrder)
-            .ToList();
-
-        var docLines = bookableLines
-            .Select(l => new HoldedPurchaseDocumentLineInput
-            {
-                Description = l.Description,
-                Amount = l.Amount,
-                AccountId = holdedAccountId,
-            })
-            .ToList();
-
-        // The receipts are booked in full and a negative line brings the doc down to the authorized
-        // cap, so the payable matches what was approved without rewriting the receipt lines.
-        if (report.Payable < report.Total)
+        // 2–4. One purchase doc per bookable line, each carrying its one receipt. A report pushed
+        // before per-line docs carries a report-level doc id instead: that push resumes onto its
+        // single doc rather than minting per-line duplicates next to it.
+        string pushedSummary;
+        if (!string.IsNullOrEmpty(report.HoldedDocId))
         {
-            docLines.Add(new HoldedPurchaseDocumentLineInput
-            {
-                Description =
-                    $"Authorized maximum €{report.Payable.ToString("0.00", CultureInfo.InvariantCulture)} — adjustment",
-                Amount = report.Payable - report.Total,
-                AccountId = holdedAccountId,
-            });
-        }
-
-        var input = new HoldedPurchaseDocumentInput
-        {
-            ContactId = holdedContactId,
-            ContactName = submitterName,
-            Date = report.SubmittedAt ?? report.CreatedAt,
-            Description = report.Note ?? "",
-            Lines = docLines,
-        };
-
-        // 2. Create the purchase doc (idempotent on HoldedDocId).
-        string holdedDocId;
-        if (string.IsNullOrEmpty(report.HoldedDocId))
-        {
-            holdedDocId = await holdedClient.CreatePurchaseDocumentAsync(input, ct);
-            await repo.SetHoldedDocIdAsync(report.Id, holdedDocId, now, ct);
+            await ResumeLegacySingleDocPushAsync(report, report.HoldedDocId, now, ct);
+            pushedSummary = $"Pushed to Holded as purchase document {report.HoldedDocId}.";
         }
         else
         {
-            holdedDocId = report.HoldedDocId;
+            pushedSummary = await PushPerLineDocsAsync(
+                report, submitterName, holdedContactId, holdedAccountId, now, ct);
         }
-
-        // 3. Upload attachments. Each upload is recorded so a re-run — after a failure partway
-        // through this loop, or after a finance admin requeues the event — resumes instead of
-        // adding a second copy of every earlier file to the same doc.
-        foreach (var line in bookableLines)
-        {
-            if (line.AttachmentId is null || line.Attachment is null) continue;
-            if (line.Attachment.HoldedUploadedAt is not null) continue;
-
-            var bytes = await fileStorage.TryReadAsync(
-                AttachmentKey(line.Attachment.Id, line.Attachment.Extension), ct);
-            if (bytes is null)
-                throw new InvalidOperationException(
-                    $"Attachment file for {line.Attachment.Id}{line.Attachment.Extension} could not be read from storage.");
-            using var stream = new MemoryStream(bytes, writable: false);
-            await holdedClient.UploadAttachmentAsync(
-                holdedDocId,
-                new HoldedAttachmentInput
-                {
-                    FileName = line.Attachment.OriginalFileName,
-                    ContentType = line.Attachment.ContentType,
-                    Content = stream,
-                },
-                ct);
-            await repo.MarkAttachmentPushedAsync(line.Attachment.Id, now, ct);
-        }
-
-        // 4. Approve the doc — POST /purchases only creates a draft, and nothing else approves it,
-        // so an unapproved doc never books to the ledger. Checked first via GetPurchaseDocumentAsync's
-        // ApprovedAt, mirroring how Store decides whether a sales document still needs approving
-        // (Humans.Store/Services/Service.cs, IsDraft check before ApproveSalesDocumentAsync) — so a
-        // re-drain that reaches an already-approved doc does not throw the event into permanent failure.
-        var currentDoc = await holdedClient.GetPurchaseDocumentAsync(holdedDocId, ct);
-        if (currentDoc.ApprovedAt is null)
-            await holdedClient.ApprovePurchaseDocumentAsync(holdedDocId, ct);
 
         // 5. Resolve supplierRecord.num (now that a payable exists) and persist the contact link.
         // Best-effort: the doc is already created, so a failure here must NOT fail the outbox event
@@ -1394,9 +1324,149 @@ internal sealed class ExpenseReportService(
         await auditLogService.LogAsync(
             AuditAction.ExpenseHoldedPushed,
             AuditEntityTypes.Report, report.Id,
-            $"Pushed to Holded as purchase document {holdedDocId}.",
+            pushedSummary,
             OutboxJobName);
     }
+
+    /// <summary>
+    /// One purchase doc per bookable line, in <c>SortOrder</c>: create (idempotent on the line's
+    /// <c>HoldedDocId</c>), upload its one receipt (idempotent on <c>HoldedUploadedAt</c>), approve
+    /// (idempotent on the doc's <c>ApprovedAt</c> — POST /purchases only creates a draft, and an
+    /// unapproved doc never books to the ledger). A line the cap trims books its receipt at face
+    /// value plus a negative adjustment line on the same account; a line the cap zeroed out gets no
+    /// doc and no upload — the skip is named in the returned audit summary, since Holded then holds
+    /// no record of that receipt at all.
+    /// </summary>
+    private async Task<string> PushPerLineDocsAsync(
+        ExpenseReportDto report,
+        string submitterName,
+        string holdedContactId,
+        string? holdedAccountId,
+        Instant now,
+        CancellationToken ct)
+    {
+        var allocations = PayableAllocation.Allocate(report);
+
+        var pushedDocIds = new List<string>();
+        var notes = new List<string>();
+        foreach (var allocation in allocations)
+        {
+            var line = allocation.Line;
+            if (allocation.Booked <= 0m)
+            {
+                if (allocation.Skipped)
+                    notes.Add(
+                        $"'{line.Description}' ({Euro(line.Amount)}) not booked — authorized maximum reached.");
+                continue;
+            }
+
+            var holdedDocId = line.HoldedDocId;
+            if (string.IsNullOrEmpty(holdedDocId))
+            {
+                var docLines = new List<HoldedPurchaseDocumentLineInput>
+                {
+                    new()
+                    {
+                        Description = line.Description,
+                        Amount = line.Amount,
+                        AccountId = holdedAccountId,
+                    },
+                };
+                // The receipt books at face value so the doc matches its attachment; the negative
+                // line brings the doc down to what the cap lets this line book.
+                if (allocation.Trimmed)
+                {
+                    docLines.Add(new HoldedPurchaseDocumentLineInput
+                    {
+                        Description = $"Authorized maximum {Euro(report.Payable)} — adjustment",
+                        Amount = allocation.Booked - line.Amount,
+                        AccountId = holdedAccountId,
+                    });
+                }
+
+                holdedDocId = await holdedClient.CreatePurchaseDocumentAsync(
+                    new HoldedPurchaseDocumentInput
+                    {
+                        ContactId = holdedContactId,
+                        ContactName = submitterName,
+                        Date = report.SubmittedAt ?? report.CreatedAt,
+                        // The report's Note stays in Humans — the doc's breadcrumb back to its
+                        // report is what the accountant needs, not member↔reviewer context.
+                        Description = $"{line.Description} — expense report {report.Id}",
+                        Lines = docLines,
+                    }, ct);
+                await repo.SetLineHoldedDocIdAsync(line.Id, holdedDocId, now, ct);
+            }
+            pushedDocIds.Add(holdedDocId);
+
+            if (allocation.Trimmed)
+                notes.Add(
+                    $"'{line.Description}' booked {Euro(allocation.Booked)} of {Euro(line.Amount)} (authorized maximum).");
+
+            await UploadLineAttachmentAsync(line, holdedDocId, now, ct);
+
+            var currentDoc = await holdedClient.GetPurchaseDocumentAsync(holdedDocId, ct);
+            if (currentDoc.ApprovedAt is null)
+                await holdedClient.ApprovePurchaseDocumentAsync(holdedDocId, ct);
+        }
+
+        var summary = pushedDocIds.Count == 1
+            ? $"Pushed to Holded as purchase document {pushedDocIds[0]}."
+            : $"Pushed to Holded as purchase documents {string.Join(", ", pushedDocIds)}.";
+        return notes.Count == 0 ? summary : $"{summary} {string.Join(" ", notes)}";
+    }
+
+    /// <summary>
+    /// Finishes a push that started before per-line docs: the report-level doc already exists in
+    /// Holded (possibly with some receipts on it), so upload what is still missing and approve —
+    /// never create a second payable next to it.
+    /// </summary>
+    private async Task ResumeLegacySingleDocPushAsync(
+        ExpenseReportDto report, string holdedDocId, Instant now, CancellationToken ct)
+    {
+        foreach (var line in report.Lines
+                     .Where(l => l.ParentLineId is null)
+                     .OrderBy(l => l.SortOrder))
+        {
+            await UploadLineAttachmentAsync(line, holdedDocId, now, ct);
+        }
+
+        var currentDoc = await holdedClient.GetPurchaseDocumentAsync(holdedDocId, ct);
+        if (currentDoc.ApprovedAt is null)
+            await holdedClient.ApprovePurchaseDocumentAsync(holdedDocId, ct);
+    }
+
+    /// <summary>
+    /// Uploads the line's receipt to the given doc. Each upload is recorded so a re-run — after a
+    /// failure partway through the push, or after a finance admin requeues the event — resumes
+    /// instead of adding a second copy of every earlier file.
+    /// </summary>
+    private async Task UploadLineAttachmentAsync(
+        ExpenseLineDto line, string holdedDocId, Instant now, CancellationToken ct)
+    {
+        if (line.AttachmentId is null || line.Attachment is null) return;
+        if (line.Attachment.HoldedUploadedAt is not null) return;
+
+        var bytes = await fileStorage.TryReadAsync(
+            AttachmentKey(line.Attachment.Id, line.Attachment.Extension), ct);
+        if (bytes is null)
+            throw new InvalidOperationException(
+                $"Attachment file for {line.Attachment.Id}{line.Attachment.Extension} could not be read from storage.");
+        using var stream = new MemoryStream(bytes, writable: false);
+        await holdedClient.UploadAttachmentAsync(
+            holdedDocId,
+            new HoldedAttachmentInput
+            {
+                FileName = line.Attachment.OriginalFileName,
+                ContentType = line.Attachment.ContentType,
+                Content = stream,
+            },
+            ct);
+        await repo.MarkAttachmentPushedAsync(line.Attachment.Id, now, ct);
+    }
+
+    private static string Euro(decimal amount) =>
+        $"€{amount.ToString("0.00", CultureInfo.InvariantCulture)}";
 
     /// <summary>
     /// The service-side half of the edit gate (the resource-based handler is the first half). For

--- a/src/Sections/Humans.Expenses/Services/PayableAllocation.cs
+++ b/src/Sections/Humans.Expenses/Services/PayableAllocation.cs
@@ -1,0 +1,38 @@
+using Humans.Expenses.Contracts;
+
+namespace Humans.Expenses.Services;
+
+/// <summary>
+/// How the authorized cap distributes over the bookable lines: each line books in full, in
+/// <c>SortOrder</c>, until the payable runs out — the line the cap lands inside is trimmed, and
+/// every line after it is skipped. Where the reduction lands is presentation only (the whole
+/// report books to one category account), so greedy-in-order is as correct as anything and keeps
+/// each Holded doc matching its receipt. The push, the detail view, and the audit message all
+/// read this one allocation so they can never disagree.
+/// </summary>
+internal static class PayableAllocation
+{
+    internal sealed record LineAllocation(ExpenseLineDto Line, decimal Booked)
+    {
+        /// <summary>The cap landed inside this line: it books, but below the receipt amount.</summary>
+        internal bool Trimmed => Booked > 0m && Booked < Line.Amount;
+
+        /// <summary>The cap was spent before this line: no Holded doc, no attachment upload.</summary>
+        internal bool Skipped => Booked <= 0m && Line.Amount > 0m;
+    }
+
+    internal static IReadOnlyList<LineAllocation> Allocate(ExpenseReportDto report)
+    {
+        var remaining = report.Payable;
+        var allocations = new List<LineAllocation>();
+        foreach (var line in report.Lines
+                     .Where(l => l.ParentLineId is null)
+                     .OrderBy(l => l.SortOrder))
+        {
+            var booked = Math.Max(0m, Math.Min(line.Amount, remaining));
+            remaining -= booked;
+            allocations.Add(new LineAllocation(line, booked));
+        }
+        return allocations;
+    }
+}

--- a/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
+++ b/src/Sections/Humans.Expenses/Views/Expenses/Detail.cshtml
@@ -99,6 +99,11 @@
                         </thead>
                         <tbody>
                             @{
+                                // Per-line cap allocation — the same greedy-in-order split the Holded push
+                                // books, so what the reviewer authorizes here is exactly what pushes later.
+                                var cappedAllocations = r.Payable < r.Total
+                                    ? PayableAllocation.Allocate(r).ToDictionary(a => a.Line.Id)
+                                    : null;
                                 var proofsByParent = r.Lines.Where(l => l.ParentLineId is not null)
                                     .GroupBy(l => l.ParentLineId!.Value)
                                     .ToDictionary(g => g.Key, g => g.OrderBy(l => l.SortOrder).ToList());
@@ -149,7 +154,21 @@
                                         }
                                         @line.Description
                                     </td>
-                                    <td class="text-end">@line.Amount.ToEuro()</td>
+                                    <td class="text-end">
+                                        @line.Amount.ToEuro()
+                                        @if (cappedAllocations is not null
+                                             && cappedAllocations.TryGetValue(line.Id, out var alloc))
+                                        {
+                                            @if (alloc.Trimmed)
+                                            {
+                                                <div><span class="badge bg-warning text-dark">@Localizer["Expenses_LineBooksOf", alloc.Booked.ToEuro(), line.Amount.ToEuro()]</span></div>
+                                            }
+                                            else if (alloc.Skipped)
+                                            {
+                                                <div><span class="badge bg-secondary">@Localizer["Expenses_LineNotBooked"]</span></div>
+                                            }
+                                        }
+                                    </td>
                                     <td>@{ await AttachmentCell(line); }</td>
                                 </tr>
                                 @if (line.LineType == ExpenseLineType.Invoice)
@@ -393,20 +412,20 @@
                                    Holded" there invites a duplicate. *@
                                 <span class="small text-muted ms-1">
                                     Given up after @sync.RetryCount attempt@(sync.RetryCount == 1 ? "" : "s").
-                                    @if (string.IsNullOrEmpty(Model.Report.HoldedDocId))
+                                    @if (Model.Report.HoldedDocIds.Count == 0)
                                     {
                                         @:This report is not in Holded.
                                     }
                                     else
                                     {
-                                        @:Document @Model.Report.HoldedDocId exists in Holded but the push did not finish — its receipts may be missing. Re-queue rather than creating a second payable.
+                                        @:@(Model.Report.HoldedDocIds.Count == 1 ? "Document" : "Documents") @string.Join(", ", Model.Report.HoldedDocIds) exist@(Model.Report.HoldedDocIds.Count == 1 ? "s" : "") in Holded but the push did not finish — receipts or further documents may be missing. Re-queue rather than creating a second payable.
                                     }
                                 </span>
                                 break;
                             case ExpenseHoldedSyncState.Pushed:
                                 <span class="badge text-bg-success">Pushed</span>
                                 <span class="small text-muted ms-1">
-                                    @(sync.SettledAt is { } at ? at.ToDateTime() : "")@(string.IsNullOrEmpty(Model.Report.HoldedDocId) ? "" : $" — document {Model.Report.HoldedDocId}")
+                                    @(sync.SettledAt is { } at ? at.ToDateTime() : "")@(Model.Report.HoldedDocIds.Count == 0 ? "" : $" — {(Model.Report.HoldedDocIds.Count == 1 ? "document" : "documents")} {string.Join(", ", Model.Report.HoldedDocIds)}")
                                 </span>
                                 break;
                             case ExpenseHoldedSyncState.NotConfigured:
@@ -457,7 +476,7 @@
                             Change below if needed.
                         </p>
                     }
-                    else if (Model.HasCreditorContact && string.IsNullOrEmpty(Model.Report.HoldedDocId))
+                    else if (Model.HasCreditorContact && Model.Report.HoldedDocIds.Count == 0)
                     {
                         <p class="small mb-2 text-muted">
                             <i class="fa-solid fa-circle-info me-1"></i>This member has a Holded contact; its 400000xx

--- a/src/Sections/Humans.Finance/Docs/expense-reimbursement-process.md
+++ b/src/Sections/Humans.Finance/Docs/expense-reimbursement-process.md
@@ -32,8 +32,17 @@ Happy path. When something needs fixing it gets more complicated.
    This step is the expected route, not an enforced gate: the treasurer can approve straight from
    Submitted when there is a rush, and the approval's audit entry records that they did.
 3. **The treasurer (finance admin) also approves it.**
-4. **The report is uploaded to Holded** for the accountant, and because math. The member gets a
-   Holded contact with a creditor account. A member without a contact yet is created as an
+4. **The report is uploaded to Holded** for the accountant, and because math. **One purchase
+   document per receipt**: each invoice/receipt on the report becomes its own Holded purchase doc
+   carrying that one attachment, so what the accountant registers matches the underlying legal
+   documents one-to-one. The report's subject/note stays in Humans — each doc's description is its
+   receipt's description plus a reference back to the report. When the approvers capped the payout
+   below the receipts total, the receipts book in order until the cap runs out: the receipt the cap
+   lands inside books at face value with a negative "authorized maximum" adjustment on the same
+   account, and any receipt entirely past the cap is **not booked at all** — nothing is reimbursed
+   for it, so Holded holds no record of it (the report's own audit trail and detail view say so).
+   The member gets a Holded contact with a creditor account. A member without a contact yet is
+   created as an
    *acreedor* (contact type `creditor`), which Holded mints in the **410 series** (e.g. `41000004`)
    — deliberately apart from the **400-series** *proveedores*, the ordinary vendors paid by direct
    invoice. Members onboarded before this carry a 400-series account and keep it; the binding, not

--- a/tests/Humans.Expenses.Tests/Data/ExpenseRepositoryTests.cs
+++ b/tests/Humans.Expenses.Tests/Data/ExpenseRepositoryTests.cs
@@ -431,20 +431,25 @@ public class ExpenseRepositoryTests
     }
 
     [HumansFact]
-    public async Task SetHoldedDocIdAsync_PersistsHoldedDocIdAndUpdatedAt()
+    public async Task SetLineHoldedDocIdAsync_PersistsLineDocIdAndReportUpdatedAt()
     {
         // Persistence is intentionally separate from outbox-event marking — the
-        // service writes HoldedDocId immediately after the Holded create call and
-        // marks the outbox event processed only after the full upload chain succeeds
-        // (idempotency: a retry after a failed upload reuses the persisted doc id).
+        // service writes the line's HoldedDocId immediately after the Holded create call and
+        // marks the outbox event processed only after every line's create + upload + approve
+        // succeeds (idempotency: a retry after a failed upload reuses the persisted doc id).
         var report = MakeReport(status: ExpenseReportStatus.Approved);
         await Seed(report);
+        var lineId = Guid.NewGuid();
+        await _sut.AddLineAsync(report.Id,
+            new ExpenseLine { Id = lineId, Description = "x", Amount = 10m }, Xunit.TestContext.Current.CancellationToken);
         var updatedAt = Instant.FromUtc(2026, 5, 5, 1, 0);
 
-        await _sut.SetHoldedDocIdAsync(report.Id, "doc-123", updatedAt, Xunit.TestContext.Current.CancellationToken);
+        await _sut.SetLineHoldedDocIdAsync(lineId, "doc-123", updatedAt, Xunit.TestContext.Current.CancellationToken);
 
         var loaded = await _sut.GetByIdAsync(report.Id, Xunit.TestContext.Current.CancellationToken);
-        loaded!.HoldedDocId.Should().Be("doc-123");
+        loaded!.Lines.Single(l => l.Id == lineId).HoldedDocId.Should().Be("doc-123");
+        loaded.HoldedDocId.Should().BeNull();
+        loaded.HoldedDocIds.Should().Equal("doc-123");
         loaded.UpdatedAt.Should().Be(updatedAt);
     }
 

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceHoldedOutboxTests.cs
@@ -102,23 +102,40 @@ public class ExpenseReportServiceHoldedOutboxTests
 
     // ─── helpers ──────────────────────────────────────────────────────────────
 
-    private static ExpenseReportDto MakeReport(string? holdedDocId = null) => new()
+    /// <summary>One bookable line ("Wood", €50) — the minimum a real approved report carries, so
+    /// the per-line push has a doc to create. Tests that need other shapes override Lines.</summary>
+    private static ExpenseReportDto MakeReport(string? holdedDocId = null)
     {
-        Id = Guid.NewGuid(),
-        SubmitterUserId = SubmitterId,
-        BudgetCategoryId = CategoryId,
-        BudgetYearId = Guid.NewGuid(),
-        Status = ExpenseReportStatus.Approved,
-        PayeeName = "Alice Smith",
-        PayeeIban = "",
-        Total = 0m,
-        SubmittedAt = Instant.FromUtc(2026, 5, 1, 10, 0),
-        CreatedAt = Instant.FromUtc(2026, 5, 1, 9, 0),
-        UpdatedAt = Instant.FromUtc(2026, 5, 1, 9, 0),
-        Note = "Team expenses",
-        HoldedDocId = holdedDocId,
-        Lines = new List<ExpenseLineDto>(),
-    };
+        var reportId = Guid.NewGuid();
+        return new()
+        {
+            Id = reportId,
+            SubmitterUserId = SubmitterId,
+            BudgetCategoryId = CategoryId,
+            BudgetYearId = Guid.NewGuid(),
+            Status = ExpenseReportStatus.Approved,
+            PayeeName = "Alice Smith",
+            PayeeIban = "",
+            Total = 50m,
+            SubmittedAt = Instant.FromUtc(2026, 5, 1, 10, 0),
+            CreatedAt = Instant.FromUtc(2026, 5, 1, 9, 0),
+            UpdatedAt = Instant.FromUtc(2026, 5, 1, 9, 0),
+            Note = "Team expenses",
+            HoldedDocId = holdedDocId,
+            Lines = new List<ExpenseLineDto>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    ExpenseReportId = reportId,
+                    Description = "Wood",
+                    Amount = 50m,
+                    LineType = ExpenseLineType.Receipt,
+                    SortOrder = 1,
+                },
+            },
+        };
+    }
 
     /// <summary>A two-line report whose attachments carry the given push stamps — the shape the
     /// attachment-idempotency tests need.</summary>
@@ -222,14 +239,15 @@ public class ExpenseReportServiceHoldedOutboxTests
 
         await _sut.DrainHoldedOutboxAsync(BatchSize, Xunit.TestContext.Current.CancellationToken);
 
+        // The report's Note stays in Humans; the doc's description is the line plus the report ref.
         await _holdedClient.Received(1).CreatePurchaseDocumentAsync(
             Arg.Is<HoldedPurchaseDocumentInput>(i =>
                 string.Equals(i.ContactName, "Alice Smith", StringComparison.Ordinal) &&
-                string.Equals(i.Description, "Team expenses", StringComparison.Ordinal)),
+                string.Equals(i.Description, $"Wood — expense report {report.Id}", StringComparison.Ordinal)),
             Arg.Any<CancellationToken>());
 
-        await _repo.Received(1).SetHoldedDocIdAsync(
-            report.Id, holdedDocId, Now, Arg.Any<CancellationToken>());
+        await _repo.Received(1).SetLineHoldedDocIdAsync(
+            report.Lines[0].Id, holdedDocId, Now, Arg.Any<CancellationToken>());
         await _repo.Received(1).MarkOutboxProcessedAsync(
             outboxEvent.Id, Now, Arg.Any<CancellationToken>());
     }
@@ -438,14 +456,14 @@ public class ExpenseReportServiceHoldedOutboxTests
         };
 
         var outboxEvent = MakeEvent(report.Id, HoldedExpenseOutboxEventType.CreateIncomingDoc);
-        const string holdedDocId = "holded-doc-with-attachments";
 
         _repo.GetUnprocessedOutboxAsync(Arg.Any<Instant>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([outboxEvent]);
         _repo.GetByIdAsync(report.Id, Arg.Any<CancellationToken>())
             .Returns(report);
+        // One doc per line — each receipt lands on its own line's doc.
         _holdedClient.CreatePurchaseDocumentAsync(Arg.Any<HoldedPurchaseDocumentInput>(), Arg.Any<CancellationToken>())
-            .Returns(holdedDocId);
+            .Returns("doc-line-a", "doc-line-b");
 
         _fileStorage.TryReadAsync(
                 $"uploads/expense-attachments/{attachment1.Id}.pdf",
@@ -459,17 +477,19 @@ public class ExpenseReportServiceHoldedOutboxTests
         await _sut.DrainHoldedOutboxAsync(BatchSize, Xunit.TestContext.Current.CancellationToken);
 
         await _holdedClient.Received(1).UploadAttachmentAsync(
-            holdedDocId,
+            "doc-line-a",
             Arg.Is<HoldedAttachmentInput>(a => a.FileName == "receipt1.pdf" && a.ContentType == "application/pdf"),
             Arg.Any<CancellationToken>());
 
         await _holdedClient.Received(1).UploadAttachmentAsync(
-            holdedDocId,
+            "doc-line-b",
             Arg.Is<HoldedAttachmentInput>(a => a.FileName == "receipt2.jpg" && a.ContentType == "image/jpeg"),
             Arg.Any<CancellationToken>());
 
-        await _repo.Received(1).SetHoldedDocIdAsync(
-            report.Id, holdedDocId, Now, Arg.Any<CancellationToken>());
+        await _repo.Received(1).SetLineHoldedDocIdAsync(
+            report.Lines[0].Id, "doc-line-a", Now, Arg.Any<CancellationToken>());
+        await _repo.Received(1).SetLineHoldedDocIdAsync(
+            report.Lines[1].Id, "doc-line-b", Now, Arg.Any<CancellationToken>());
         await _repo.Received(1).MarkOutboxProcessedAsync(
             outboxEvent.Id, Now, Arg.Any<CancellationToken>());
     }
@@ -498,8 +518,8 @@ public class ExpenseReportServiceHoldedOutboxTests
 
         await _holdedClient.DidNotReceiveWithAnyArgs()
             .UploadAttachmentAsync(null!, null!, Arg.Any<CancellationToken>());
-        await _repo.Received(1).SetHoldedDocIdAsync(
-            report.Id, "doc-no-att", Now, Arg.Any<CancellationToken>());
+        await _repo.Received(1).SetLineHoldedDocIdAsync(
+            report.Lines[0].Id, "doc-no-att", Now, Arg.Any<CancellationToken>());
         await _repo.Received(1).MarkOutboxProcessedAsync(
             outboxEvent.Id, Now, Arg.Any<CancellationToken>());
     }
@@ -549,11 +569,11 @@ public class ExpenseReportServiceHoldedOutboxTests
     }
 
     [HumansFact]
-    public async Task CreateIncomingDoc_HoldedDocIdAlreadySet_SkipsCreateAndOnlyMarksProcessed()
+    public async Task CreateIncomingDoc_LegacyReportLevelDocId_ResumesOntoItInsteadOfCreatingPerLineDocs()
     {
-        // Idempotency guard: if a previous retry already issued the Holded document
-        // (and persisted HoldedDocId early) but failed during the attachment upload
-        // loop, the next drain pass must NOT call CreatePurchaseDocumentAsync again.
+        // A report pushed before per-line docs carries its single doc id on the report. The
+        // resume must NOT call CreatePurchaseDocumentAsync — that would mint per-line payables
+        // next to the doc Holded already has.
         var report = MakeReport(holdedDocId: "doc-prev-retry");
         var outboxEvent = MakeEvent(report.Id, HoldedExpenseOutboxEventType.CreateIncomingDoc);
 
@@ -567,9 +587,148 @@ public class ExpenseReportServiceHoldedOutboxTests
         await _holdedClient.DidNotReceiveWithAnyArgs()
             .CreatePurchaseDocumentAsync(null!, Arg.Any<CancellationToken>());
         await _repo.DidNotReceiveWithAnyArgs()
-            .SetHoldedDocIdAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
+            .SetLineHoldedDocIdAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
         await _repo.Received(1).MarkOutboxProcessedAsync(
             outboxEvent.Id, Now, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task CreateIncomingDoc_LineDocIdAlreadySet_SkipsCreateForThatLineOnly()
+    {
+        // Idempotency on re-drain: a line whose doc a previous attempt already issued (and
+        // persisted early) is not created again; the lines after it still get theirs.
+        var report = MakeReport();
+        var pushedLine = report.Lines[0] with { HoldedDocId = "doc-line-a" };
+        var pendingLine = pushedLine with
+        {
+            Id = Guid.NewGuid(),
+            Description = "Screws",
+            SortOrder = 2,
+            HoldedDocId = null,
+        };
+        report = report with { Total = 100m, Lines = [pushedLine, pendingLine] };
+        var outboxEvent = MakeEvent(report.Id, HoldedExpenseOutboxEventType.CreateIncomingDoc);
+
+        _repo.GetUnprocessedOutboxAsync(Arg.Any<Instant>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([outboxEvent]);
+        _repo.GetByIdAsync(report.Id, Arg.Any<CancellationToken>())
+            .Returns(report);
+        _holdedClient.CreatePurchaseDocumentAsync(Arg.Any<HoldedPurchaseDocumentInput>(), Arg.Any<CancellationToken>())
+            .Returns("doc-line-b");
+
+        await _sut.DrainHoldedOutboxAsync(BatchSize, Xunit.TestContext.Current.CancellationToken);
+
+        await _holdedClient.Received(1).CreatePurchaseDocumentAsync(
+            Arg.Is<HoldedPurchaseDocumentInput>(i => i.Lines[0].Description == "Screws"),
+            Arg.Any<CancellationToken>());
+        await _repo.Received(1).SetLineHoldedDocIdAsync(
+            pendingLine.Id, "doc-line-b", Now, Arg.Any<CancellationToken>());
+        await _repo.DidNotReceive().SetLineHoldedDocIdAsync(
+            pushedLine.Id, Arg.Any<string>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+        await _repo.Received(1).MarkOutboxProcessedAsync(
+            outboxEvent.Id, Now, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task CreateIncomingDoc_CapInsideAMultiLineReport_TrimsTheLastDocAndSkipsTheRest()
+    {
+        // 3×100 with a 250 cap: two full docs, the third trimmed to 50 via a negative adjustment
+        // on the same account; with a fourth receipt it would get no doc at all.
+        ExpenseLineDto Line(string description, int sortOrder) => new()
+        {
+            Id = Guid.NewGuid(),
+            ExpenseReportId = Guid.NewGuid(),
+            Description = description,
+            Amount = 100m,
+            LineType = ExpenseLineType.Receipt,
+            SortOrder = sortOrder,
+        };
+        var report = MakeReport() with
+        {
+            Total = 300m,
+            MaxAmount = 250m,
+            Lines = [Line("A", 1), Line("B", 2), Line("C", 3)],
+        };
+        var outboxEvent = MakeEvent(report.Id, HoldedExpenseOutboxEventType.CreateIncomingDoc);
+
+        _repo.GetUnprocessedOutboxAsync(Arg.Any<Instant>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([outboxEvent]);
+        _repo.GetByIdAsync(report.Id, Arg.Any<CancellationToken>())
+            .Returns(report);
+        _holdedFinance.GetHoldedAccountIdForCategoryAsync(CategoryId, Arg.Any<CancellationToken>())
+            .Returns("holded-acc-629001");
+        _holdedClient.CreatePurchaseDocumentAsync(Arg.Any<HoldedPurchaseDocumentInput>(), Arg.Any<CancellationToken>())
+            .Returns("doc-a", "doc-b", "doc-c");
+
+        await _sut.DrainHoldedOutboxAsync(BatchSize, Xunit.TestContext.Current.CancellationToken);
+
+        await _holdedClient.Received(3).CreatePurchaseDocumentAsync(
+            Arg.Any<HoldedPurchaseDocumentInput>(), Arg.Any<CancellationToken>());
+        await _holdedClient.Received(1).CreatePurchaseDocumentAsync(
+            Arg.Is<HoldedPurchaseDocumentInput>(i =>
+                i.Lines.Count == 1 && i.Lines[0].Description == "A" && i.Lines[0].Amount == 100m),
+            Arg.Any<CancellationToken>());
+        await _holdedClient.Received(1).CreatePurchaseDocumentAsync(
+            Arg.Is<HoldedPurchaseDocumentInput>(i =>
+                i.Lines.Count == 2 &&
+                i.Lines[0].Description == "C" && i.Lines[0].Amount == 100m &&
+                i.Lines[1].Amount == -50m &&
+                string.Equals(i.Lines[1].Description, "Authorized maximum €250.00 — adjustment", StringComparison.Ordinal) &&
+                string.Equals(i.Lines[1].AccountId, "holded-acc-629001", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>());
+        // The trim is named in the audit entry alongside the doc ids.
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.ExpenseHoldedPushed, Arg.Any<string>(), report.Id,
+            Arg.Is<string>(s =>
+                s.Contains("doc-a, doc-b, doc-c") &&
+                s.Contains("'C' booked €50.00 of €100.00")),
+            Arg.Any<string>(), null, null);
+    }
+
+    [HumansFact]
+    public async Task CreateIncomingDoc_ReceiptFullyOverTheCap_GetsNoDocNoUploadAndIsNamedInTheAudit()
+    {
+        // The cap is spent before the second receipt: Holded holds no record of it at all, so
+        // the skip must be loud — named in the audit entry, never silent.
+        var line1 = MakeLineWithAttachment(Guid.NewGuid(), "first.pdf", 0, holdedUploadedAt: null)
+            with
+        { Amount = 100m };
+        var line2 = MakeLineWithAttachment(Guid.NewGuid(), "second.pdf", 1, holdedUploadedAt: null)
+            with
+        { Amount = 100m };
+        var report = MakeReport() with
+        {
+            Total = 200m,
+            MaxAmount = 100m,
+            Lines = [line1, line2],
+        };
+        var outboxEvent = MakeEvent(report.Id, HoldedExpenseOutboxEventType.CreateIncomingDoc);
+
+        _repo.GetUnprocessedOutboxAsync(Arg.Any<Instant>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns([outboxEvent]);
+        _repo.GetByIdAsync(report.Id, Arg.Any<CancellationToken>())
+            .Returns(report);
+        _holdedClient.CreatePurchaseDocumentAsync(Arg.Any<HoldedPurchaseDocumentInput>(), Arg.Any<CancellationToken>())
+            .Returns("doc-first");
+        _fileStorage.TryReadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new byte[] { 1, 2, 3 });
+
+        await _sut.DrainHoldedOutboxAsync(BatchSize, Xunit.TestContext.Current.CancellationToken);
+
+        await _holdedClient.Received(1).CreatePurchaseDocumentAsync(
+            Arg.Any<HoldedPurchaseDocumentInput>(), Arg.Any<CancellationToken>());
+        await _holdedClient.DidNotReceive().UploadAttachmentAsync(
+            Arg.Any<string>(),
+            Arg.Is<HoldedAttachmentInput>(a => a.FileName == "second.pdf"),
+            Arg.Any<CancellationToken>());
+        await _repo.Received(1).MarkOutboxProcessedAsync(
+            outboxEvent.Id, Now, Arg.Any<CancellationToken>());
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.ExpenseHoldedPushed, Arg.Any<string>(), report.Id,
+            Arg.Is<string>(s =>
+                s.Contains("doc-first") &&
+                s.Contains("'second.pdf' (€100.00) not booked — authorized maximum reached.")),
+            Arg.Any<string>(), null, null);
     }
 
     // ─── UpdateIncomingDocTag: v2 has no tag-update endpoint, so this now just drains ──────────
@@ -615,7 +774,7 @@ public class ExpenseReportServiceHoldedOutboxTests
 
         await _repo.Received(1).IncrementOutboxRetryAsync(
             outboxEvent.Id, "timeout", Arg.Any<Instant>(), Arg.Any<CancellationToken>());
-        await _repo.DidNotReceiveWithAnyArgs().SetHoldedDocIdAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
+        await _repo.DidNotReceiveWithAnyArgs().SetLineHoldedDocIdAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
         await _repo.DidNotReceiveWithAnyArgs().MarkOutboxProcessedAsync(Guid.Empty, default, Arg.Any<CancellationToken>());
         await _repo.DidNotReceiveWithAnyArgs()
             .MarkOutboxFailedPermanentlyAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
@@ -958,7 +1117,7 @@ public class ExpenseReportServiceHoldedOutboxTests
             Arg.Any<string>(),
             Now,
             Arg.Any<CancellationToken>());
-        await _repo.DidNotReceiveWithAnyArgs().SetHoldedDocIdAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
+        await _repo.DidNotReceiveWithAnyArgs().SetLineHoldedDocIdAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
         await _repo.DidNotReceiveWithAnyArgs().MarkOutboxProcessedAsync(Guid.Empty, default, Arg.Any<CancellationToken>());
         await _repo.DidNotReceiveWithAnyArgs().IncrementOutboxRetryAsync(Guid.Empty, null!, default, Arg.Any<CancellationToken>());
     }

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
@@ -1985,7 +1985,8 @@ public sealed class ExpenseReportServiceTests
         SetupUserAndProfile(userId, "Alice Tester", "ES9121000418450200051332");
         var reportId = await SeedApprovedReportWithAttachmentAsync(userId, category.Id);
         await _expenseRepo.SetHoldedContactLinkAsync(reportId, "c1", 40000007, FakeNow, Xunit.TestContext.Current.CancellationToken);
-        await _expenseRepo.SetHoldedDocIdAsync(reportId, "doc-1", FakeNow, Xunit.TestContext.Current.CancellationToken);
+        var seededLineId = (await _sut.GetAsync(reportId, Xunit.TestContext.Current.CancellationToken))!.Lines[0].Id;
+        await _expenseRepo.SetLineHoldedDocIdAsync(seededLineId, "doc-1", FakeNow, Xunit.TestContext.Current.CancellationToken);
 
         _holdedFinance.GetCreditorStatusAsync(40000007, Arg.Any<CancellationToken>())
             .Returns(new HoldedCreditorStatus(40000007, Balance: -200m, OwedToMember: 200m,
@@ -2010,7 +2011,8 @@ public sealed class ExpenseReportServiceTests
         SetupUserAndProfile(userId, "Alice Tester", "ES9121000418450200051332");
         var reportId = await SeedApprovedReportWithAttachmentAsync(userId, category.Id, maxAmount: 30m);
         await _expenseRepo.SetHoldedContactLinkAsync(reportId, "c1", 40000007, FakeNow, Xunit.TestContext.Current.CancellationToken);
-        await _expenseRepo.SetHoldedDocIdAsync(reportId, "doc-1", FakeNow, Xunit.TestContext.Current.CancellationToken);
+        var seededLineId = (await _sut.GetAsync(reportId, Xunit.TestContext.Current.CancellationToken))!.Lines[0].Id;
+        await _expenseRepo.SetLineHoldedDocIdAsync(seededLineId, "doc-1", FakeNow, Xunit.TestContext.Current.CancellationToken);
 
         _holdedFinance.GetCreditorStatusAsync(40000007, Arg.Any<CancellationToken>())
             .Returns(new HoldedCreditorStatus(40000007, Balance: -30m, OwedToMember: 30m,
@@ -2032,7 +2034,8 @@ public sealed class ExpenseReportServiceTests
         SetupUserAndProfile(userId, "Alice Tester", "ES9121000418450200051332");
         var reportId = await SeedApprovedReportWithAttachmentAsync(userId, category.Id);
         await _expenseRepo.SetHoldedContactLinkAsync(reportId, "c1", 40000007, FakeNow, Xunit.TestContext.Current.CancellationToken);
-        await _expenseRepo.SetHoldedDocIdAsync(reportId, "doc-1", FakeNow, Xunit.TestContext.Current.CancellationToken);
+        var seededLineId = (await _sut.GetAsync(reportId, Xunit.TestContext.Current.CancellationToken))!.Lines[0].Id;
+        await _expenseRepo.SetLineHoldedDocIdAsync(seededLineId, "doc-1", FakeNow, Xunit.TestContext.Current.CancellationToken);
 
         _holdedFinance.GetCreditorStatusAsync(40000007, Arg.Any<CancellationToken>())
             .Returns(new HoldedCreditorStatus(40000007, Balance: -50m, OwedToMember: 50m,

--- a/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Expenses.Tests/Services/ExpenseReportServiceTests.cs
@@ -2027,6 +2027,41 @@ public sealed class ExpenseReportServiceTests
     }
 
     [HumansFact]
+    public async Task GetHoldedTimelineAsync_RegisteredTotal_CountsOnlyLinesWhoseDocExists()
+    {
+        // A per-line push that failed partway: line A's doc was created, line B's wasn't yet.
+        // Only A's 40 € is booked in Holded, so the registered total must not claim B's 60 € too.
+        var userId = Guid.NewGuid();
+        var (_, category) = SetupActiveYear();
+        SetupUserAndProfile(userId, "Alice Tester", "ES9121000418450200051332");
+
+        var reportId = await _sut.CreateDraftAsync(userId, userId, category.Id, null, Xunit.TestContext.Current.CancellationToken);
+        var lineAId = await _sut.AddLineAsync(reportId, userId, false, "A", 40m, ct: Xunit.TestContext.Current.CancellationToken);
+        var lineBId = await _sut.AddLineAsync(reportId, userId, false, "B", 60m, ct: Xunit.TestContext.Current.CancellationToken);
+        foreach (var lineId in new[] { lineAId, lineBId })
+        {
+            await using var stream = new MemoryStream([7, 8, 9]);
+            await _sut.AttachFileToLineAsync(
+                reportId, userId, false, lineId, "receipt.pdf", "application/pdf", stream, Xunit.TestContext.Current.CancellationToken);
+        }
+        (await _sut.SubmitAsync(reportId, userId, false, Xunit.TestContext.Current.CancellationToken)).Should().BeTrue();
+        (await _sut.ApproveAsync(reportId, Guid.NewGuid(), null, null, Xunit.TestContext.Current.CancellationToken)).Should().BeTrue();
+
+        await _expenseRepo.SetHoldedContactLinkAsync(reportId, "c1", 40000007, FakeNow, Xunit.TestContext.Current.CancellationToken);
+        await _expenseRepo.SetLineHoldedDocIdAsync(lineAId, "doc-a", FakeNow, Xunit.TestContext.Current.CancellationToken);
+
+        _holdedFinance.GetCreditorStatusAsync(40000007, Arg.Any<CancellationToken>())
+            .Returns(new HoldedCreditorStatus(40000007, Balance: -40m, OwedToMember: 40m,
+                LastPaymentDate: null, TotalPaid: 0m));
+
+        var report = await _sut.GetAsync(reportId, Xunit.TestContext.Current.CancellationToken);
+        var timeline = await _sut.GetHoldedTimelineAsync(report!, Xunit.TestContext.Current.CancellationToken);
+
+        timeline!.MemberRegisteredTotal.Should().Be(40m);
+        timeline.OtherAmount.Should().Be(0m);
+    }
+
+    [HumansFact]
     public async Task GetHoldedTimelineAsync_CarriesPaidTotalAndDate()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
## What

The Holded push now books **one purchase document per bookable expense line**, each carrying its one invoice/receipt attachment, instead of one document per report. Per Peter's design discussion in-session (accounting accuracy: each registered doc matches one legal document).

## Why

- One Holded doc ↔ one legal document is what the gestor expects to register; the receipt sits on the doc it belongs to.
- SEPA booking already pays a member's open docs oldest-first, so multiple payables per report reconcile fine with one transfer.

Design decisions settled with Peter:

- **Cap allocation is greedy in line order** (`PayableAllocation`, shared by push, detail view, and audit so they can never disagree). The line the cap lands inside books its receipt at face value plus a negative "Authorized maximum €X — adjustment" line on the same account (doc still matches its attachment); receipts entirely past the cap get **no doc and no upload**, named in the `ExpenseHoldedPushed` audit entry and badged on the detail view's lines table from the moment a cap exists — visible at review time, not just after the push. Placement is presentation-only since the whole report books to one category account.
- **The report's note stays in Humans** — each doc's description is the line description plus a report reference.
- **Legacy reports** pushed as a single doc keep their report-level `HoldedDocId`; a re-queue resumes onto that doc (remaining uploads + approve) and never mints per-line docs beside it. `ExpenseReportDto.HoldedDocIds` folds both shapes for readers (timeline, sync card, creditor-bind card).

## Existing surface checked

- Reused the existing outbox drain, retry/backoff, per-attachment `HoldedUploadedAt` resume tracking, and the approve-if-draft pattern — per-line now instead of per-report.
- `IExpenseRepository.SetHoldedDocIdAsync` (report-level) is **replaced** by `SetLineHoldedDocIdAsync` — net-zero on the internal repository interface; no writer for the legacy column remains.
- New durable surface: `ExpenseLineDto.HoldedDocId` + computed `ExpenseReportDto.HoldedDocIds` on the existing DTOs (read-model enrichment, no new interface methods), and internal `PayableAllocation`.

## UI changes / screenshots

`/Expenses/{id}`: capped reports badge each line with "Books €X of €Y — authorized maximum" / "Not booked — authorized maximum reached" (localized, 6 cultures); the finance-admin sync and creditor cards read the folded doc-id list.

## Checklist

- [x] **Section labeled** — Expenses/Finance.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`**.
- [x] **Issue refs are qualified** — none referenced.
- [x] **EF migrations** auto-generated (`ExpenseLineHoldedDocId`, nullable string(64) on `expense_lines`, Expenses context only); ef-migration-reviewer gate passed.
- [x] ~~**NuGet packages updated?**~~ None.
- [x] ~~**New project rule?**~~ None surfaced.
- [x] **Reuse-first checked** (see above).
- [x] **Build + test pass locally** — full suite green except `Humans.Integration.Tests`, which needs Docker/Testcontainers and cannot run in this environment (per Peter: they only run on his dev box; CI covers the rest).
- [x] **Nav coverage** — no new pages.
- [x] **No magic strings** — resource keys + existing audit-action enums.
- [x] **Dates/times via NodaTime**.

## Reviewer notes

- Docs updated in the same PR: `Finance/Docs/expense-reimbursement-process.md` step 4 (business process) and `Expenses/Docs/Expenses.md` (data model + invariants).
- The GDPR export shapes its fields explicitly and doesn't include doc ids — unchanged.
- Zero-`Payable` edge: cap validation floors at €0.01, so "no docs at all" is theoretical; the audit summary still copes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vu1Fk4YKfT6suR9uwg4J9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu1Fk4YKfT6suR9uwg4J9Q)_