### PR TITLE
feat(surveys): add ranked-choice voting

### DIFF
--- a/src/Sections/Humans.Surveys/Contracts/SurveyDefinitionSnapshot.cs
+++ b/src/Sections/Humans.Surveys/Contracts/SurveyDefinitionSnapshot.cs
@@ -31,7 +31,9 @@ public sealed record SurveyDefinitionQuestion(
     GridSelectionMode? GridSelectionMode,
     IReadOnlyList<SurveyExportGridRow> GridRows,
     IReadOnlyList<SurveyDefinitionImage> Images,
-    IReadOnlyList<SurveyExportOption> Options);
+    IReadOnlyList<SurveyExportOption> Options,
+    SurveyRankedSettings? RankedSettings = null,
+    IReadOnlyList<string>? RankedUnavailableOptionValues = null);
 
 /// <summary>An Information question's image: an app-relative URL plus its resolved captions.</summary>
 public sealed record SurveyDefinitionImage(Guid Id, string Url, string Label, string AltText);

--- a/src/Sections/Humans.Surveys/Contracts/SurveyQuestionType.cs
+++ b/src/Sections/Humans.Surveys/Contracts/SurveyQuestionType.cs
@@ -13,4 +13,5 @@ public enum SurveyQuestionType
     Rating = 4,
     Grid = 5,
     Information = 6,
+    RankedChoice = 7,
 }

--- a/src/Sections/Humans.Surveys/Contracts/SurveyReadModels.cs
+++ b/src/Sections/Humans.Surveys/Contracts/SurveyReadModels.cs
@@ -74,7 +74,8 @@ public sealed record RespondentAnswer(
     IReadOnlyList<string> SelectedLabels,
     string? TextValue,
     int? RatingValue,
-    IReadOnlyList<ResolvedGridSelection>? GridSelections = null);
+    IReadOnlyList<ResolvedGridSelection>? GridSelections = null,
+    ResolvedRankedBallot? RankedBallot = null);
 
 /// <summary>One resolved Grid row selection for display/export.</summary>
 public sealed record ResolvedGridSelection(
@@ -82,6 +83,11 @@ public sealed record ResolvedGridSelection(
     string RowLabel,
     IReadOnlyList<string> ColumnValues,
     IReadOnlyList<string> ColumnLabels);
+
+/// <summary>A ranked ballot with candidate labels resolved for human-readable drill-down.</summary>
+public sealed record ResolvedRankedBallot(
+    IReadOnlyList<IReadOnlyList<string>> RankGroups,
+    IReadOnlyList<string> Rejected);
 
 // ── Export DTOs (co-located; raw per-response, shared by CSV/JSON download and the analysis API) ──
 
@@ -104,13 +110,26 @@ public sealed record SurveyExportQuestion(
     SurveyQuestionType Type,
     IReadOnlyList<SurveyExportOption> Options,
     GridSelectionMode? GridSelectionMode = null,
-    IReadOnlyList<SurveyExportGridRow>? GridRows = null);
+    IReadOnlyList<SurveyExportGridRow>? GridRows = null,
+    SurveyRankedSettings? RankedSettings = null,
+    IReadOnlyList<string>? RankedUnavailableOptionValues = null);
 
 /// <summary>One choice option in the export schema: the stable machine <see cref="Value"/> + its resolved <see cref="Label"/>.</summary>
 public sealed record SurveyExportOption(string Value, string Label);
 
 /// <summary>One Grid row in the export schema.</summary>
 public sealed record SurveyExportGridRow(string Value, string Label);
+
+/// <summary>Public, stable settings for a ranked-choice question.</summary>
+public sealed record SurveyRankedSettings(
+    bool AllowEqualRanks,
+    bool AllowReject,
+    string OfficialMethod);
+
+/// <summary>A raw ranked ballot using stable option values.</summary>
+public sealed record SurveyRankedBallot(
+    IReadOnlyList<IReadOnlyList<string>> RankGroups,
+    IReadOnlyList<string> Rejected);
 
 /// <summary>
 /// One exported response. <see cref="UserId"/>/<see cref="UserName"/> are populated only for
@@ -137,4 +156,5 @@ public sealed record SurveyExportAnswer(
     string? TextValue,
     int? RatingValue,
     IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null,
-    IReadOnlyList<ResolvedGridSelection>? GridSelectionLabels = null);
+    IReadOnlyList<ResolvedGridSelection>? GridSelectionLabels = null,
+    SurveyRankedBallot? RankedBallot = null);

--- a/src/Sections/Humans.Surveys/Contracts/SurveyResponsesMarkdownBuilder.cs
+++ b/src/Sections/Humans.Surveys/Contracts/SurveyResponsesMarkdownBuilder.cs
@@ -63,6 +63,8 @@ public static class SurveyResponsesMarkdownBuilder
                     selection => selection.Key,
                     selection => selection.Value,
                     StringComparer.Ordinal))),
+        SurveyQuestionType.RankedChoice =>
+            answer.RankedBallot is null ? string.Empty : Escape(JsonSerializer.Serialize(answer.RankedBallot)),
         SurveyQuestionType.Rating =>
             answer.RatingValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
         _ => Escape(answer.TextValue ?? string.Empty),

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -7,6 +7,8 @@ using Humans.Base.Authorization;
 using Humans.Base.Extensions;
 using Humans.Surveys.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using Humans.Users.Contracts;
@@ -24,7 +26,8 @@ internal sealed class SurveyAdminController(
     ISurveyService surveyService,
     ITeamServiceRead teamService,
     IUserServiceRead userService,
-    ILogger<SurveyAdminController> logger) : HumansControllerBase(userService)
+    ILogger<SurveyAdminController> logger,
+    IWebHostEnvironment? environment = null) : HumansControllerBase(userService)
 {
     private static readonly DateTimeZone Zone = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
 
@@ -36,7 +39,22 @@ internal sealed class SurveyAdminController(
             .OrderBy(s => s.Status)
             .ThenBy(s => s.Title, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        ViewData["CanSeedRankedDemo"] = IsDevelopment();
         return View(new SurveyAdminIndexViewModel { Surveys = ordered });
+    }
+
+    [HttpPost("SeedRankedDemo")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SeedRankedDemo(CancellationToken ct)
+    {
+        if (!IsDevelopment()) return NotFound();
+        var actorId = GetCurrentUserId();
+        if (actorId is null) return Forbid();
+        var created = await surveyService.SeedRankedVotingDemoAsync(actorId.Value, ct);
+        SetSuccess(created == 0
+            ? "Ranked-voting demo surveys already exist."
+            : $"Created {created} ranked-voting demo surveys.");
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpGet("Create")]
@@ -338,6 +356,33 @@ internal sealed class SurveyAdminController(
         return View(SurveyResultsBuilder.Build(results));
     }
 
+    [HttpPost("Results/{id:guid}/RankedAvailability")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RankedAvailability(
+        Guid id,
+        Guid questionId,
+        List<string>? unavailableValues,
+        CancellationToken ct)
+    {
+        var actorId = GetCurrentUserId();
+        if (actorId is null) return Forbid();
+        try
+        {
+            await surveyService.SetRankedAvailabilityAsync(
+                id,
+                questionId,
+                unavailableValues ?? [],
+                actorId.Value,
+                ct);
+            SetSuccess("Candidate availability updated; ranked results were recalculated.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            SetError(ex.Message);
+        }
+        return RedirectToAction(nameof(Results), new { id });
+    }
+
     [HttpGet("Results/{id:guid}/Export.csv")]
     public async Task<IActionResult> ExportCsv(Guid id, CancellationToken ct)
     {
@@ -380,5 +425,8 @@ internal sealed class SurveyAdminController(
             .Select(t => new SurveyTeamOption(t.Id, t.Name))
             .ToList();
     }
+
+    private bool IsDevelopment() => environment is not null
+        && string.Equals(environment.EnvironmentName, Environments.Development, StringComparison.Ordinal);
 
 }

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -92,6 +92,7 @@ internal sealed class SurveyAdminController(
             Culture = resolvedCulture,
             AllowAnonymous = editable.AllowAnonymous,
             ShowAnonymitySelector = editable.AllowAnonymous,
+            IsAsociadoVote = editable.IsAsociadoVote,
             IsPreview = true,
             PreviewSurveyId = detail.Id,
         };
@@ -322,6 +323,7 @@ internal sealed class SurveyAdminController(
             AudienceLoggedInSince = detail.Editable.AudienceLoggedInSince?.InZone(Zone).Date,
             NewRecipientCount = newRecipientCount,
             Invitations = statuses.OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase).ToList(),
+            IsAsociadoVote = detail.Editable.IsAsociadoVote,
         };
         return View(vm);
     }

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -73,6 +73,7 @@ internal sealed class SurveyAdminController(
         if (detail is null) return NotFound();
 
         var vm = SurveyBuilderViewModel.FromDetail(detail, await LoadTeamsAsync(ct), Zone);
+        vm.HasSavedAnswers = await surveyService.HasSavedAnswersAsync(id, ct);
         return View("Builder", vm);
     }
 
@@ -222,7 +223,7 @@ internal sealed class SurveyAdminController(
 
         if (!ModelState.IsValid)
         {
-            model.Teams = await LoadTeamsAsync(ct);
+            await PrepareBuilderForRenderAsync(model, ct);
             return View("Builder", model);
         }
 
@@ -244,7 +245,7 @@ internal sealed class SurveyAdminController(
         {
             logger.LogWarning("Survey save rejected for {SurveyId}: {Reason}", model.Id, ex.Message);
             ModelState.AddModelError(string.Empty, ex.Message);
-            model.Teams = await LoadTeamsAsync(ct);
+            await PrepareBuilderForRenderAsync(model, ct);
             return View("Builder", model);
         }
 
@@ -426,6 +427,15 @@ internal sealed class SurveyAdminController(
             .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
             .Select(t => new SurveyTeamOption(t.Id, t.Name))
             .ToList();
+    }
+
+    private async Task PrepareBuilderForRenderAsync(
+        SurveyBuilderViewModel model,
+        CancellationToken ct)
+    {
+        model.Teams = await LoadTeamsAsync(ct);
+        model.HasSavedAnswers = model.Id is { } id
+            && await surveyService.HasSavedAnswersAsync(id, ct);
     }
 
 }

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -7,8 +7,6 @@ using Humans.Base.Authorization;
 using Humans.Base.Extensions;
 using Humans.Surveys.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using Humans.Users.Contracts;
@@ -26,8 +24,7 @@ internal sealed class SurveyAdminController(
     ISurveyService surveyService,
     ITeamServiceRead teamService,
     IUserServiceRead userService,
-    ILogger<SurveyAdminController> logger,
-    IWebHostEnvironment? environment = null) : HumansControllerBase(userService)
+    ILogger<SurveyAdminController> logger) : HumansControllerBase(userService)
 {
     private static readonly DateTimeZone Zone = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
 
@@ -39,22 +36,7 @@ internal sealed class SurveyAdminController(
             .OrderBy(s => s.Status)
             .ThenBy(s => s.Title, StringComparer.OrdinalIgnoreCase)
             .ToList();
-        ViewData["CanSeedRankedDemo"] = IsDevelopment();
         return View(new SurveyAdminIndexViewModel { Surveys = ordered });
-    }
-
-    [HttpPost("SeedRankedDemo")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> SeedRankedDemo(CancellationToken ct)
-    {
-        if (!IsDevelopment()) return NotFound();
-        var actorId = GetCurrentUserId();
-        if (actorId is null) return Forbid();
-        var created = await surveyService.SeedRankedVotingDemoAsync(actorId.Value, ct);
-        SetSuccess(created == 0
-            ? "Ranked-voting demo surveys already exist."
-            : $"Created {created} ranked-voting demo surveys.");
-        return RedirectToAction(nameof(Index));
     }
 
     [HttpGet("Create")]
@@ -425,8 +407,5 @@ internal sealed class SurveyAdminController(
             .Select(t => new SurveyTeamOption(t.Id, t.Name))
             .ToList();
     }
-
-    private bool IsDevelopment() => environment is not null
-        && string.Equals(environment.EnvironmentName, Environments.Development, StringComparison.Ordinal);
 
 }

--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -39,6 +39,26 @@ internal sealed class SurveyAdminController(
         return View(new SurveyAdminIndexViewModel { Surveys = ordered });
     }
 
+    [HttpGet("Official/{id:guid}")]
+    public async Task<IActionResult> Official(Guid id, CancellationToken ct)
+    {
+        var userId = GetCurrentUserId();
+        if (userId is null) return Forbid();
+
+        var link = await surveyService.GetOfficialLinkAsync(id, userId.Value, ct);
+        if (link?.InvitationToken is { } token)
+        {
+            return RedirectToAction(nameof(SurveyController.Answer), "Survey", new { t = token });
+        }
+        if (link?.PublicSlug is { } slug)
+        {
+            return RedirectToAction(nameof(SurveyController.Public), "Survey", new { slug });
+        }
+
+        SetError("No active survey link is available for you.");
+        return RedirectToAction(nameof(Send), new { id });
+    }
+
     [HttpGet("Create")]
     public async Task<IActionResult> Create(CancellationToken ct)
     {

--- a/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
@@ -77,6 +77,7 @@ internal sealed class SurveyController(
                         StringComparer.Ordinal) ?? new(StringComparer.Ordinal),
                     TextValue = a.TextValue,
                     RatingValue = a.RatingValue,
+                    RankedValue = a.RankedValue,
                 };
             }
 
@@ -246,6 +247,7 @@ internal sealed class SurveyController(
                             pair => pair.Key,
                             pair => pair.Value.ToList(),
                             StringComparer.Ordinal),
+                    RankedValue = answer.RankedValue,
                 };
             }
         }
@@ -446,7 +448,8 @@ internal sealed class SurveyController(
                         group => (IReadOnlyList<string>)group
                             .SelectMany(row => row.SelectedColumnValues ?? [])
                             .ToList(),
-                        StringComparer.Ordinal)))
+                        StringComparer.Ordinal),
+                ToRankedAnswer(a.RankedOptions)))
             .ToList();
 
         var result = await surveyService.AdvanceWizardAsync(state, model.Page, model.Back, posted, ct);
@@ -478,6 +481,34 @@ internal sealed class SurveyController(
                 route.Save(HttpContext.Session, state);
                 return RedirectToAction(route.PageAction, route.PageRouteValues);
         }
+    }
+
+    private static RankedAnswer? ToRankedAnswer(IReadOnlyList<SurveyPostedRankedOption>? rows)
+    {
+        if (rows is null || rows.Count == 0) return null;
+        var ranked = rows
+            .Select(row => new
+            {
+                Row = row,
+                Rank = int.TryParse(
+                    row.Selection,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var rank) && rank > 0
+                        ? (int?)rank
+                        : null,
+            })
+            .Where(item => item.Rank is not null && !string.IsNullOrWhiteSpace(item.Row.OptionValue))
+            .GroupBy(item => item.Rank!.Value)
+            .OrderBy(group => group.Key)
+            .Select(group => (IReadOnlyList<string>)group.Select(item => item.Row.OptionValue).ToList())
+            .ToList();
+        var rejected = rows
+            .Where(row => string.Equals(row.Selection, "reject", StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(row.OptionValue))
+            .Select(row => row.OptionValue)
+            .ToList();
+        return ranked.Count == 0 && rejected.Count == 0 ? null : new RankedAnswer(ranked, rejected);
     }
 
     /// <summary>

--- a/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
@@ -51,6 +51,11 @@ internal sealed class SurveyController(
 
         var editable = ctx.Definition.Editable;
 
+        if (!ctx.IsEligible)
+        {
+            return View("Closed", new SurveyClosedViewModel { Reason = "ineligible-asociado" });
+        }
+
         if (!IsAnswerable(ctx.Definition))
         {
             return View("Closed", new SurveyClosedViewModel { Reason = "closed" });
@@ -96,6 +101,7 @@ internal sealed class SurveyController(
             AllowAnonymous = editable.AllowAnonymous,
             ShowAnonymitySelector = editable.AllowAnonymous,
             HasResumableDraft = ctx.HasResumableDraft,
+            IsAsociadoVote = editable.IsAsociadoVote,
         };
         return View("Intro", vm);
     }
@@ -111,6 +117,11 @@ internal sealed class SurveyController(
         }
 
         var editable = ctx.Definition.Editable;
+
+        if (!ctx.IsEligible)
+        {
+            return View("Closed", new SurveyClosedViewModel { Reason = "ineligible-asociado" });
+        }
 
         // Re-gate on the POST: the intro may have been loaded just before the window closed.
         if (!IsAnswerable(ctx.Definition))
@@ -398,6 +409,12 @@ internal sealed class SurveyController(
         {
             return View("Closed", new SurveyClosedViewModel { Reason = "closed" });
         }
+        if (editable.IsAsociadoVote
+            && (state.UserId is not { } userId
+                || !await surveyService.IsEligibleAsociadoAsync(userId, ct)))
+        {
+            return View("Closed", new SurveyClosedViewModel { Reason = "ineligible-asociado" });
+        }
 
         var answerStates = SurveyWizardFlow.ToAnswerStates(state.Answers);
 
@@ -461,6 +478,10 @@ internal sealed class SurveyController(
 
             case SurveyWizardOutcome.Closed:
                 return View("Closed", new SurveyClosedViewModel { Reason = "closed" });
+
+            case SurveyWizardOutcome.Ineligible:
+                route.Clear(HttpContext.Session);
+                return View("Closed", new SurveyClosedViewModel { Reason = "ineligible-asociado" });
 
             case SurveyWizardOutcome.ValidationFailed:
                 foreach (var id in result.MissingRequired)

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyAnswerConfiguration.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyAnswerConfiguration.cs
@@ -34,6 +34,24 @@ internal sealed class SurveyAnswerConfiguration : IEntityTypeConfiguration<Surve
                     v => v == null ? null : JsonSerializer.Deserialize<Dictionary<string, List<string>>>(
                         JsonSerializer.Serialize(v, SurveyJson.Options), SurveyJson.Options)));
 
+        b.Property(a => a.RankedValue).HasColumnType("jsonb")
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, SurveyJson.Options),
+                v => JsonSerializer.Deserialize<RankedAnswer>(v, SurveyJson.Options),
+                new ValueComparer<RankedAnswer?>(
+                    (a, c) => JsonSerializer.Serialize(a, SurveyJson.Options)
+                        == JsonSerializer.Serialize(c, SurveyJson.Options),
+                    v => v == null
+                        ? 0
+                        : string.GetHashCode(
+                            JsonSerializer.Serialize(v, SurveyJson.Options),
+                            StringComparison.Ordinal),
+                    v => v == null
+                        ? null
+                        : JsonSerializer.Deserialize<RankedAnswer>(
+                            JsonSerializer.Serialize(v, SurveyJson.Options),
+                            SurveyJson.Options)));
+
         b.Property(a => a.TextValue).HasMaxLength(4000);
 
         // Intra-section FK to the question; Restrict so a question can't be deleted out from under answers.

--- a/src/Sections/Humans.Surveys/Data/Configurations/SurveyQuestionConfiguration.cs
+++ b/src/Sections/Humans.Surveys/Data/Configurations/SurveyQuestionConfiguration.cs
@@ -42,6 +42,44 @@ internal sealed class SurveyQuestionConfiguration : IEntityTypeConfiguration<Sur
                     v => v == null ? 0 : string.GetHashCode(SurveyJson.SerializeInformationImages(v)!, StringComparison.Ordinal),
                     v => SurveyJson.DeserializeInformationImages(SurveyJson.SerializeInformationImages(v))));
 
+        b.Property(q => q.RankedSettings)
+            .HasColumnType("jsonb")
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, SurveyJson.Options),
+                v => JsonSerializer.Deserialize<RankedQuestionSettings>(v, SurveyJson.Options),
+                new ValueComparer<RankedQuestionSettings?>(
+                    (a, c) => JsonSerializer.Serialize(a, SurveyJson.Options)
+                        == JsonSerializer.Serialize(c, SurveyJson.Options),
+                    v => v == null
+                        ? 0
+                        : string.GetHashCode(
+                            JsonSerializer.Serialize(v, SurveyJson.Options),
+                            StringComparison.Ordinal),
+                    v => v == null
+                        ? null
+                        : JsonSerializer.Deserialize<RankedQuestionSettings>(
+                            JsonSerializer.Serialize(v, SurveyJson.Options),
+                            SurveyJson.Options)));
+
+        b.Property(q => q.RankedUnavailableOptionValues)
+            .HasColumnType("jsonb")
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, SurveyJson.Options),
+                v => JsonSerializer.Deserialize<List<string>>(v, SurveyJson.Options),
+                new ValueComparer<List<string>?>(
+                    (a, c) => JsonSerializer.Serialize(a, SurveyJson.Options)
+                        == JsonSerializer.Serialize(c, SurveyJson.Options),
+                    v => v == null
+                        ? 0
+                        : string.GetHashCode(
+                            JsonSerializer.Serialize(v, SurveyJson.Options),
+                            StringComparison.Ordinal),
+                    v => v == null
+                        ? null
+                        : JsonSerializer.Deserialize<List<string>>(
+                            JsonSerializer.Serialize(v, SurveyJson.Options),
+                            SurveyJson.Options)));
+
         b.Property(q => q.ShowIf)
             .HasColumnType("jsonb")
             .HasConversion(

--- a/src/Sections/Humans.Surveys/Data/ISurveyRepository.cs
+++ b/src/Sections/Humans.Surveys/Data/ISurveyRepository.cs
@@ -35,6 +35,9 @@ internal partial interface ISurveyRepository : IRepository
     /// <summary>Current status of a survey, or null if it does not exist. Read-only.</summary>
     Task<SurveyStatus?> GetStatusAsync(Guid id, CancellationToken ct = default);
 
+    /// <summary>True when any draft or submitted answer has been saved for the survey.</summary>
+    Task<bool> HasSavedAnswersAsync(Guid surveyId, CancellationToken ct = default);
+
     /// <summary>Sets a survey's status and stamps <c>UpdatedAt</c>. No-op if the survey does not exist.</summary>
     Task SetStatusAsync(Guid id, SurveyStatus status, Instant updatedAt, CancellationToken ct = default);
 

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260828160544_AddRankedChoiceVoting.Designer.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260828160544_AddRankedChoiceVoting.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Surveys.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Surveys.Data.Migrations
 {
     [DbContext(typeof(SurveysDbContext))]
-    partial class SurveysDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828160544_AddRankedChoiceVoting")]
+    partial class AddRankedChoiceVoting
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Surveys/Data/Migrations/20260828160544_AddRankedChoiceVoting.cs
+++ b/src/Sections/Humans.Surveys/Data/Migrations/20260828160544_AddRankedChoiceVoting.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Surveys.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRankedChoiceVoting : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAsociadoVote",
+                table: "surveys",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RankedSettings",
+                table: "survey_questions",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RankedUnavailableOptionValues",
+                table: "survey_questions",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RankedValue",
+                table: "survey_answers",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAsociadoVote",
+                table: "surveys");
+
+            migrationBuilder.DropColumn(
+                name: "RankedSettings",
+                table: "survey_questions");
+
+            migrationBuilder.DropColumn(
+                name: "RankedUnavailableOptionValues",
+                table: "survey_questions");
+
+            migrationBuilder.DropColumn(
+                name: "RankedValue",
+                table: "survey_answers");
+        }
+    }
+}

--- a/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
+++ b/src/Sections/Humans.Surveys/Data/SurveyRepository.cs
@@ -53,6 +53,7 @@ internal sealed partial class SurveyRepository(IDbContextFactory<SurveysDbContex
         existing.InvitationEmailMessage = survey.InvitationEmailMessage;
         existing.DefaultCulture = survey.DefaultCulture;
         existing.AllowAnonymous = survey.AllowAnonymous;
+        existing.IsAsociadoVote = survey.IsAsociadoVote;
         // Status is owned by Open/Close (SetStatusAsync) — authoring updates never change it.
         existing.OpensAt = survey.OpensAt;
         existing.ClosesAt = survey.ClosesAt;
@@ -75,6 +76,14 @@ internal sealed partial class SurveyRepository(IDbContextFactory<SurveysDbContex
             .Where(s => s.Id == id)
             .Select(s => (SurveyStatus?)s.Status)
             .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<bool> HasSavedAnswersAsync(Guid surveyId, CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.SurveyAnswers
+            .AsNoTracking()
+            .AnyAsync(answer => answer.Response.SurveyId == surveyId, ct);
     }
 
     public async Task SetStatusAsync(Guid id, SurveyStatus status, Instant updatedAt, CancellationToken ct = default)
@@ -463,6 +472,8 @@ internal sealed partial class SurveyRepository(IDbContextFactory<SurveysDbContex
             keptQuestion.GridSelectionMode = incomingQuestion.GridSelectionMode;
             keptQuestion.GridRows = incomingQuestion.GridRows;
             keptQuestion.InformationImages = incomingQuestion.InformationImages;
+            keptQuestion.RankedSettings = incomingQuestion.RankedSettings;
+            keptQuestion.RankedUnavailableOptionValues = incomingQuestion.RankedUnavailableOptionValues;
             keptQuestion.ShowIf = incomingQuestion.ShowIf;
 
             ReconcileOptions(ctx, keptQuestion, incomingQuestion);

--- a/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
+++ b/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
@@ -12,7 +12,8 @@ tracked by nobodies-collective/Humans#86.
 
 ## V1 decisions
 
-- RankedChoice is available only in a survey marked **Asociado vote**.
+- RankedChoice is available in ordinary surveys as well as surveys marked
+  **Asociado vote**.
 - An Asociado vote is Identified-only and may contain mixed question types.
 - An Asociado vote always targets the current active Asociados audience; current
   eligibility is still rechecked when each invitee answers and submits.

--- a/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
+++ b/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
@@ -12,8 +12,8 @@ tracked by nobodies-collective/Humans#86.
 
 ## V1 decisions
 
-- A survey containing RankedChoice questions contains no other question types.
-- Ranked ballots are Identified only.
+- RankedChoice is available only in a survey marked **Asociado vote**.
+- An Asociado vote is Identified-only and may contain mixed question types.
 - Equal ranks are enabled by default.
 - Reject is optional and means unacceptable, not vetoed.
 - Preference tiers are ranked > unranked > rejected.
@@ -21,8 +21,9 @@ tracked by nobodies-collective/Humans#86.
 - Condorcet check and Borda are post-close sensitivity analysis.
 - IRV, Baldwin, and Coombs are deferred.
 - Authored option order is the disclosed final exact tie-break.
-- Results are embargoed until the survey closes.
-- A closed RankedChoice survey cannot reopen.
+- Every question's answer-derived results are embargoed until an Asociado vote
+  closes; ordinary surveys retain live results.
+- A closed Asociado vote cannot reopen.
 
 ## Counting
 
@@ -53,14 +54,17 @@ the all-options outcome and the current available-only outcome.
 
 ## Result embargo
 
-While Open, Board/Admin may see participation only: eligible, started,
-completed, outstanding, response rate, and reminder status. No answer-derived
-data is available through results pages, exports, Backdoor endpoints,
-raw-response views, or respondent drill-down.
+Ordinary surveys keep the existing default: anyone authorized to use Surveys
+results may see them while Open.
 
-This is a survey-level lifecycle rule, which is why v1 prohibits mixing ranked
-and non-ranked questions. The builder explains the embargo and no-reopen rule
-when RankedChoice is selected.
+While an Asociado vote is Open, Board/Admin may see participation only:
+eligible, started, completed, outstanding, response rate, and reminder status.
+No answer-derived data from any question type is available through results
+pages, exports, Backdoor endpoints, raw-response views, or respondent
+drill-down.
+
+The builder explains the Identified-only, embargo, and no-reopen consequences
+when Asociado vote is selected. RankedChoice requires that mode.
 
 ## Data model
 
@@ -70,6 +74,10 @@ Planned question settings:
 - allow Reject;
 - official method;
 - unavailable option values.
+
+Planned survey setting:
+
+- whether the survey is an Asociado vote.
 
 Planned answer data:
 

--- a/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
+++ b/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
@@ -52,6 +52,12 @@ recount and compresses remaining ranks. The stored ballot is unchanged.
 Availability changes are reversible and audited. Closed results preserve both
 the all-options outcome and the current available-only outcome.
 
+When a head-to-head preference cycle is present, the results page names the
+cycle and explains that removing an unavailable option can break it and change
+the winner even when the previous winner remains available. The explanation
+links to the public voting-method note at
+`https://nobodies.team/event-dates-2027-voting-method.html#preference-cycles-and-availability`.
+
 ## Result embargo
 
 Ordinary surveys keep the existing default: anyone authorized to use Surveys

--- a/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
+++ b/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
@@ -14,6 +14,8 @@ tracked by nobodies-collective/Humans#86.
 
 - RankedChoice is available only in a survey marked **Asociado vote**.
 - An Asociado vote is Identified-only and may contain mixed question types.
+- An Asociado vote always targets the current active Asociados audience; current
+  eligibility is still rechecked when each invitee answers and submits.
 - Equal ranks are enabled by default.
 - Reject is optional and means unacceptable, not vetoed.
 - Preference tiers are ranked > unranked > rejected.

--- a/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
+++ b/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
@@ -1,0 +1,85 @@
+# Ranked-choice voting
+
+## Business context
+
+The 2027 event-date decision needs one authenticated ballot per eligible
+Asociado. Similar dates should be allowed to tie, dates may be explicitly
+unacceptable, and dates that later prove unavailable must be removable from the
+count without rewriting ballots.
+
+This feature belongs to Surveys. It is not the formal bylaw/quorum voting system
+tracked by nobodies-collective/Humans#86.
+
+## V1 decisions
+
+- A survey containing RankedChoice questions contains no other question types.
+- Ranked ballots are Identified only.
+- Equal ranks are enabled by default.
+- Reject is optional and means unacceptable, not vetoed.
+- Preference tiers are ranked > unranked > rejected.
+- Ranked Pairs (Tideman) is the precommitted official method.
+- Condorcet check and Borda are post-close sensitivity analysis.
+- IRV, Baldwin, and Coombs are deferred.
+- Authored option order is the disclosed final exact tie-break.
+- Results are embargoed until the survey closes.
+- A closed RankedChoice survey cannot reopen.
+
+## Counting
+
+Pairwise comparison records strict preferences only. Equal-ranked, equally
+unranked, and equally rejected options contribute no preference; indifference
+is not half a vote.
+
+Ranked Pairs sorts victories by:
+
+1. descending margin;
+2. descending winning votes;
+3. winning option authored position;
+4. losing option authored position.
+
+It locks each victory unless the edge creates a cycle. Condorcet check reports a
+candidate that strictly defeats every other active candidate, or the smallest
+visible cycle. Borda assigns `m-1` through `0` points and averages the occupied
+positions for every tied tier, including distinct unranked and rejected tiers.
+Exact Borda totals use rational arithmetic.
+
+## Availability
+
+Authored candidates, cast ballots, and post-vote availability are separate
+state. Excluding an unavailable option removes it from each ballot for the
+recount and compresses remaining ranks. The stored ballot is unchanged.
+Availability changes are reversible and audited. Closed results preserve both
+the all-options outcome and the current available-only outcome.
+
+## Result embargo
+
+While Open, Board/Admin may see participation only: eligible, started,
+completed, outstanding, response rate, and reminder status. No answer-derived
+data is available through results pages, exports, Backdoor endpoints,
+raw-response views, or respondent drill-down.
+
+This is a survey-level lifecycle rule, which is why v1 prohibits mixing ranked
+and non-ranked questions. The builder explains the embargo and no-reopen rule
+when RankedChoice is selected.
+
+## Data model
+
+Planned question settings:
+
+- allow equal ranks;
+- allow Reject;
+- official method;
+- unavailable option values.
+
+Planned answer data:
+
+- ordered rank groups of stable option values;
+- a distinct rejected-option set.
+
+Counting-affecting authoring state freezes after the first saved answer,
+including a draft/autosave.
+
+## Related
+
+- [Survey section invariants](../Surveys.md)
+- nobodies-collective/Humans#1151

--- a/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
+++ b/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
@@ -24,7 +24,11 @@ tracked by nobodies-collective/Humans#86.
 - Every question's answer-derived results are embargoed until an Asociado vote
   closes; ordinary surveys retain live results.
 - A closed Asociado vote cannot reopen.
-- Asociado-vote mode is locked once the survey opens.
+- The entire Asociado-vote definition and audience are locked once the survey
+  opens; post-close ranked-option availability remains the only mutable recount
+  input.
+- Eligibility is checked against current active, approved Asociado status at
+  entry, while answering, and again at final submission.
 
 ## Counting
 
@@ -70,8 +74,10 @@ No answer-derived data from any question type is available through results
 pages, exports, Backdoor endpoints, raw-response views, or respondent
 drill-down.
 
-The builder explains the Identified-only, embargo, and no-reopen consequences
-when Asociado vote is selected. RankedChoice requires that mode.
+The builder presents Asociado-vote mode as a separate binding-vote section and
+explains the Identified-only, eligibility, whole-definition lock, embargo, and
+no-reopen consequences before opening. Respondents see a binding-vote notice on
+the intro and question pages. RankedChoice requires that mode.
 
 ## Data model
 

--- a/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
+++ b/src/Sections/Humans.Surveys/Docs/features/ranked-choice-voting.md
@@ -24,6 +24,7 @@ tracked by nobodies-collective/Humans#86.
 - Every question's answer-derived results are embargoed until an Asociado vote
   closes; ordinary surveys retain live results.
 - A closed Asociado vote cannot reopen.
+- Asociado-vote mode is locked once the survey opens.
 
 ## Counting
 
@@ -91,7 +92,8 @@ Planned answer data:
 - a distinct rejected-option set.
 
 Counting-affecting authoring state freezes after the first saved answer,
-including a draft/autosave.
+including a draft/autosave. The builder visibly disables the ranked settings
+at that point instead of allowing an edit that the server will reject.
 
 ## Related
 

--- a/src/Sections/Humans.Surveys/Domain/RankedAnswer.cs
+++ b/src/Sections/Humans.Surveys/Domain/RankedAnswer.cs
@@ -1,0 +1,5 @@
+namespace Humans.Surveys.Domain;
+
+internal sealed record RankedAnswer(
+    IReadOnlyList<IReadOnlyList<string>> RankGroups,
+    IReadOnlyList<string> Rejected);

--- a/src/Sections/Humans.Surveys/Domain/RankedQuestionSettings.cs
+++ b/src/Sections/Humans.Surveys/Domain/RankedQuestionSettings.cs
@@ -1,0 +1,15 @@
+namespace Humans.Surveys.Domain;
+
+internal enum RankedVotingMethod
+{
+    RankedPairs,
+}
+
+internal sealed record RankedQuestionSettings(
+    bool AllowEqualRanks,
+    bool AllowReject,
+    RankedVotingMethod OfficialMethod)
+{
+    public static RankedQuestionSettings Default { get; } =
+        new(AllowEqualRanks: true, AllowReject: false, RankedVotingMethod.RankedPairs);
+}

--- a/src/Sections/Humans.Surveys/Domain/Survey.cs
+++ b/src/Sections/Humans.Surveys/Domain/Survey.cs
@@ -13,6 +13,7 @@ internal sealed class Survey
     public LocalizedText InvitationEmailMessage { get; set; } = LocalizedText.Empty;
     public string DefaultCulture { get; set; } = "en";
     public bool AllowAnonymous { get; set; }
+    public bool? IsAsociadoVote { get; set; }
     public SurveyStatus Status { get; set; } = SurveyStatus.Draft;
     public Instant? OpensAt { get; set; }
     public Instant? ClosesAt { get; set; }

--- a/src/Sections/Humans.Surveys/Domain/SurveyAnswer.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyAnswer.cs
@@ -7,6 +7,7 @@ internal sealed class SurveyAnswer
     public Guid QuestionId { get; init; }
     public List<string> SelectedOptionValues { get; set; } = [];   // jsonb
     public Dictionary<string, List<string>>? GridSelections { get; set; } // jsonb; row value → column values
+    public RankedAnswer? RankedValue { get; set; } // jsonb; ordered rank groups + rejected values
     public string? TextValue { get; set; }
     public int? RatingValue { get; set; }
     public SurveyResponse Response { get; set; } = null!;

--- a/src/Sections/Humans.Surveys/Domain/SurveyAudienceType.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyAudienceType.cs
@@ -10,5 +10,6 @@ internal enum SurveyAudienceType
     AllActiveMembers = 1,
     TicketHolders = 2,
     ShiftParticipants = 3,
-    LoggedInSince = 4
+    LoggedInSince = 4,
+    Asociados = 5
 }

--- a/src/Sections/Humans.Surveys/Domain/SurveyQuestion.cs
+++ b/src/Sections/Humans.Surveys/Domain/SurveyQuestion.cs
@@ -20,6 +20,8 @@ internal sealed class SurveyQuestion
     public GridSelectionMode? GridSelectionMode { get; set; }
     public List<SurveyGridRow>? GridRows { get; set; }           // jsonb; null for non-Grid questions
     public List<SurveyInformationImage>? InformationImages { get; set; } // jsonb; null for non-Information items
+    public RankedQuestionSettings? RankedSettings { get; set; } // jsonb; null for non-RankedChoice questions
+    public List<string>? RankedUnavailableOptionValues { get; set; } // jsonb; post-close availability
     public BranchCondition? ShowIf { get; set; }
     public Survey Survey { get; set; } = null!;
     public ICollection<SurveyQuestionOption> Options { get; set; } = new List<SurveyQuestionOption>();

--- a/src/Sections/Humans.Surveys/Models/SurveyCsvExportBuilder.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyCsvExportBuilder.cs
@@ -66,6 +66,8 @@ internal static class SurveyCsvExportBuilder
                     selection => selection.Key,
                     selection => selection.Value,
                     StringComparer.Ordinal)),
+        SurveyQuestionType.RankedChoice =>
+            answer.RankedBallot is null ? string.Empty : JsonSerializer.Serialize(answer.RankedBallot),
         SurveyQuestionType.Rating =>
             answer.RatingValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
         _ => answer.TextValue ?? string.Empty,

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
@@ -41,6 +41,7 @@ internal static class SurveyPageViewModelFactory
             NextPreviewPage = isPreview && step >= 0 && step < pages.Count - 1 ? pages[step + 1] : null,
             Page = state.CurrentPage,
             Title = editable.Title.Resolve(state.Culture, editable.DefaultCulture),
+            IsAsociadoVote = editable.IsAsociadoVote,
             StepNumber = step < 0 ? 1 : step + 1,
             TotalSteps = pages.Count,
             CanGoBack = step > 0,

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModelFactory.cs
@@ -93,6 +93,9 @@ internal static class SurveyPageViewModelFactory
                 ?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal),
             TextValue = prior?.TextValue,
             RatingValue = prior?.RatingValue,
+            RankedValue = prior?.RankedValue,
+            RankedAllowEqualRanks = question.RankedSettings?.AllowEqualRanks ?? true,
+            RankedAllowReject = question.RankedSettings?.AllowReject ?? false,
         };
     }
 }

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
@@ -73,6 +73,9 @@ internal sealed class SurveyPageQuestion
         = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
     public string? TextValue { get; init; }
     public int? RatingValue { get; init; }
+    public RankedAnswer? RankedValue { get; init; }
+    public bool RankedAllowEqualRanks { get; init; }
+    public bool RankedAllowReject { get; init; }
 }
 
 /// <summary>One resolved choice option: stable machine <see cref="Value"/> + display <see cref="Label"/>.</summary>
@@ -109,6 +112,7 @@ internal sealed class SurveyPostedAnswer
     public List<SurveyPostedGridRow> GridRows { get; set; } = [];
     public string? TextValue { get; set; }
     public int? RatingValue { get; set; }
+    public List<SurveyPostedRankedOption> RankedOptions { get; set; } = [];
 }
 
 /// <summary>One posted Grid row and its selected column values.</summary>
@@ -116,6 +120,12 @@ internal sealed class SurveyPostedGridRow
 {
     public string RowValue { get; set; } = string.Empty;
     public List<string> SelectedColumnValues { get; set; } = [];
+}
+
+internal sealed class SurveyPostedRankedOption
+{
+    public string OptionValue { get; set; } = string.Empty;
+    public string? Selection { get; set; }
 }
 
 /// <summary>The closing thank-you page, with the survey's ThankYou copy resolved for display.</summary>

--- a/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyPageViewModels.cs
@@ -33,6 +33,7 @@ internal sealed class SurveyPageViewModel
     public int Page { get; init; }
 
     public string Title { get; init; } = string.Empty;
+    public bool IsAsociadoVote { get; init; }
 
     /// <summary>1-based position of this page among the visible pages.</summary>
     public int StepNumber { get; init; }

--- a/src/Sections/Humans.Surveys/Models/SurveyResultsBuilder.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyResultsBuilder.cs
@@ -32,6 +32,8 @@ internal static class SurveyResultsBuilder
             SelectedResponseCount = scoped.SelectedResponseCount,
             Questions = view.Questions.Select(BuildQuestion).ToList(),
             Respondents = view.IdentifiedRespondents.Select(BuildRespondent).ToList(),
+            IsEmbargoed = scoped.IsEmbargoed,
+            RankedQuestions = scoped.RankedQuestions ?? new Dictionary<Guid, RankedQuestionResult>(),
         };
     }
 
@@ -74,6 +76,9 @@ internal sealed class SurveyResultsViewModel
     public IReadOnlyList<SurveyResultsQuestionViewModel> Questions { get; init; } = [];
     public IReadOnlyList<SurveyResultsRespondentViewModel> Respondents { get; init; } = [];
     public bool ShowIdentifiedRespondents => Scope != SurveyResultsScope.Anonymous;
+    public bool IsEmbargoed { get; init; }
+    public IReadOnlyDictionary<Guid, RankedQuestionResult> RankedQuestions { get; init; }
+        = new Dictionary<Guid, RankedQuestionResult>();
 }
 
 /// <summary>One question's display aggregate. Populated collection depends on <see cref="Type"/> (reused from the service DTO).</summary>

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -61,6 +61,9 @@ internal sealed class SurveyIntroViewModel
     /// <summary>True when the invitee already has answers in progress (Identified resume).</summary>
     public bool HasResumableDraft { get; init; }
 
+    /// <summary>True when this is a binding, identified Asociado vote.</summary>
+    public bool IsAsociadoVote { get; init; }
+
     /// <summary>True for the protected, side-effect-free Board/Admin preview flow.</summary>
     public bool IsPreview { get; init; }
 
@@ -95,6 +98,7 @@ internal sealed class SurveySendViewModel
     public LocalDate? AudienceLoggedInSince { get; init; }
     public int NewRecipientCount { get; init; }
     public IReadOnlyList<SurveyInviteStatus> Invitations { get; init; } = [];
+    public bool IsAsociadoVote { get; init; }
 
     public bool CanSend => Status == SurveyStatus.Open && AudienceType is not null && NewRecipientCount > 0;
 }
@@ -171,6 +175,7 @@ internal sealed class SurveyBuilderViewModel
     public bool HasSavedAnswers { get; set; }
 
     public bool IsNew => Id is null;
+    public bool IsDefinitionLocked => !IsNew && IsAsociadoVote && Status != SurveyStatus.Draft;
 
     // datetime-local <input> values (empty when unset).
     public string OpensAtInput => FormatLocal(OpensAt);

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -113,7 +113,10 @@ internal sealed record SurveyLocalizedFieldModel(
     bool Markdown = false);
 
 /// <summary>One question card in the builder. <paramref name="Key"/> is the non-sequential indexer key (or the <c>__QKEY__</c> placeholder in the JS template).</summary>
-internal sealed record SurveyQuestionCardModel(string Key, SurveyQuestionBuilderViewModel Question);
+internal sealed record SurveyQuestionCardModel(
+    string Key,
+    SurveyQuestionBuilderViewModel Question,
+    bool RankedDefinitionLocked = false);
 
 /// <summary>One option row in the builder. Keys are non-sequential indexers (or <c>__QKEY__</c>/<c>__OKEY__</c> placeholders in templates).</summary>
 internal sealed record SurveyOptionRowModel(string QuestionKey, string OptionKey, SurveyOptionBuilderViewModel Option);
@@ -165,6 +168,7 @@ internal sealed class SurveyBuilderViewModel
     // Render-only (not bound back).
     public IReadOnlyList<string> Cultures { get; } = CultureCatalog.SupportedCultureCodes;
     public IReadOnlyList<SurveyTeamOption> Teams { get; set; } = [];
+    public bool HasSavedAnswers { get; set; }
 
     public bool IsNew => Id is null;
 

--- a/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
+++ b/src/Sections/Humans.Surveys/Models/SurveyViewModels.cs
@@ -152,6 +152,7 @@ internal sealed class SurveyBuilderViewModel
 
     public string DefaultCulture { get; set; } = CultureCatalog.DefaultCultureCode;
     public bool AllowAnonymous { get; set; }
+    public bool IsAsociadoVote { get; set; }
     public LocalDateTime? OpensAt { get; set; }
     public LocalDateTime? ClosesAt { get; set; }
     public SurveyAudienceType? AudienceType { get; set; }
@@ -193,7 +194,8 @@ internal sealed class SurveyBuilderViewModel
         AudienceType == SurveyAudienceType.Team ? AudienceTeamId : null,
         AudienceType == SurveyAudienceType.LoggedInSince ? ToStartOfDayInstant(AudienceLoggedInSince, zone) : null,
         string.IsNullOrWhiteSpace(PublicSlug) ? null : PublicSlug,
-        ToQuestionInputsInPageOrder());
+        ToQuestionInputsInPageOrder(),
+        IsAsociadoVote);
 
     private IReadOnlyList<QuestionInput> ToQuestionInputsInPageOrder()
     {
@@ -221,6 +223,7 @@ internal sealed class SurveyBuilderViewModel
             InvitationEmailMessage = ToDict(e.InvitationEmailMessage),
             DefaultCulture = e.DefaultCulture,
             AllowAnonymous = e.AllowAnonymous,
+            IsAsociadoVote = e.IsAsociadoVote,
             OpensAt = FromInstant(e.OpensAt, zone),
             ClosesAt = FromInstant(e.ClosesAt, zone),
             AudienceType = e.AudienceType,
@@ -258,6 +261,8 @@ internal sealed class SurveyQuestionBuilderViewModel
     public Dictionary<string, string> RatingMinLabel { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, string> RatingMaxLabel { get; set; } = new(StringComparer.Ordinal);
     public GridSelectionMode? GridSelectionMode { get; set; }
+    public bool RankedAllowEqualRanks { get; set; } = true;
+    public bool RankedAllowReject { get; set; }
     public BranchCombine ShowIfCombine { get; set; } = BranchCombine.All;
     public List<SurveyBranchClauseBuilderViewModel> ShowIfClauses { get; set; } = [];
     public List<SurveyOptionBuilderViewModel> Options { get; set; } = [];
@@ -282,6 +287,12 @@ internal sealed class SurveyQuestionBuilderViewModel
         Type == SurveyQuestionType.Grid ? GridRows.Select(r => r.ToInput()).ToList() : null,
         Type == SurveyQuestionType.Information
             ? InformationImages.Select(image => image.ToInput()).ToList()
+            : null,
+        Type == SurveyQuestionType.RankedChoice
+            ? new RankedQuestionSettings(
+                RankedAllowEqualRanks,
+                RankedAllowReject,
+                RankedVotingMethod.RankedPairs)
             : null);
 
     public static SurveyQuestionBuilderViewModel FromInput(QuestionInput q) => new()
@@ -304,6 +315,8 @@ internal sealed class SurveyQuestionBuilderViewModel
         InformationImages = q.InformationImages?
             .Select(SurveyInformationImageBuilderViewModel.FromInput)
             .ToList() ?? [],
+        RankedAllowEqualRanks = q.RankedSettings?.AllowEqualRanks ?? true,
+        RankedAllowReject = q.RankedSettings?.AllowReject ?? false,
     };
 
     /// <summary>Clauses without a target question (never picked / target removed) are dropped; no clauses ⇒ always visible.</summary>

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -61,6 +61,12 @@ internal interface ISurveyService : IApplicationService, ISurveyAnalysisRead
     /// <summary>Per-invite delivery/participation status for the admin Send page, with display names stitched in. Unsorted — caller sorts.</summary>
     Task<IReadOnlyList<SurveyInviteStatus>> GetInviteStatusesAsync(Guid surveyId, CancellationToken ct = default);
 
+    /// <summary>The current Human's official entry link for an Open survey: their unspent invitation, or the public slug fallback.</summary>
+    Task<SurveyOfficialLink?> GetOfficialLinkAsync(
+        Guid surveyId,
+        Guid userId,
+        CancellationToken ct = default);
+
     /// <summary>
     /// Job-driven sweep: sends the one-time 7-day reminder to every invitee of an Open survey who
     /// hasn't completed and hasn't already been reminded (<c>SentAt</c> ≥ 7 days ago). Stamps
@@ -156,6 +162,8 @@ internal interface ISurveyService : IApplicationService, ISurveyAnalysisRead
         CancellationToken ct = default);
 
 }
+
+internal sealed record SurveyOfficialLink(string? InvitationToken, string? PublicSlug);
 
 internal sealed record SurveyScopedResults(
     SurveyResultsView Results,

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -23,6 +23,9 @@ internal interface ISurveyService : IApplicationService, ISurveyAnalysisRead
     /// <summary>Loads a survey's full editable graph for the builder, or null if not found.</summary>
     Task<SurveyDetail?> GetForEditAsync(Guid surveyId, CancellationToken ct = default);
 
+    /// <summary>Whether any draft or submitted answer has frozen counting-affecting ranked settings.</summary>
+    Task<bool> HasSavedAnswersAsync(Guid surveyId, CancellationToken ct = default);
+
     /// <summary>Creates a Draft survey from the builder input; returns the new survey id.</summary>
     Task<Guid> CreateAsync(SurveyEditInput input, Guid actorUserId, CancellationToken ct = default);
 

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -84,6 +84,9 @@ internal interface ISurveyService : IApplicationService, ISurveyAnalysisRead
     /// </summary>
     Task<SurveyAnswerContext?> ResolveAnswerContextAsync(string token, CancellationToken ct = default);
 
+    /// <summary>Whether the Human currently holds active, approved Asociado voting rights.</summary>
+    Task<bool> IsEligibleAsociadoAsync(Guid userId, CancellationToken ct = default);
+
     /// <summary>
     /// Creates (or, idempotently, returns the existing) Identified in-progress draft response for the
     /// Human. Identified is the only resumable tier. The participation id may name an emailed invitation
@@ -296,7 +299,8 @@ internal sealed record SurveyAnswerContext(
     Guid UserId,
     SurveyDetail Definition,
     IReadOnlyList<SurveyDraftAnswer> DraftAnswers,
-    bool HasResumableDraft);
+    bool HasResumableDraft,
+    bool IsEligible = true);
 
 /// <summary>
 /// A survey resolved from its public slug: the survey id plus the reused editable definition
@@ -395,6 +399,9 @@ internal enum SurveyWizardOutcome
 
     /// <summary>The survey is not Open or is outside its answer window.</summary>
     Closed,
+
+    /// <summary>The Human no longer holds active, approved Asociado voting rights.</summary>
+    Ineligible,
 
     /// <summary>Required visible questions are unanswered; the state stays on the posted page.</summary>
     ValidationFailed,

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -155,7 +155,6 @@ internal interface ISurveyService : IApplicationService, ISurveyAnalysisRead
         Guid actorUserId,
         CancellationToken ct = default);
 
-    Task<int> SeedRankedVotingDemoAsync(Guid actorUserId, CancellationToken ct = default);
 }
 
 internal sealed record SurveyScopedResults(
@@ -171,6 +170,8 @@ internal sealed record RankedQuestionResult(
     RankedMethodResult CurrentOfficialResult,
     IReadOnlyList<RankedMethodResult> Methods,
     IReadOnlyList<PairwiseContest> Pairwise,
+    IReadOnlyList<string> OriginalPreferenceCycle,
+    IReadOnlyList<string> CurrentPreferenceCycle,
     IReadOnlyList<string> UnavailableValues);
 
 internal sealed record RankedCandidateResult(

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -147,12 +147,39 @@ internal interface ISurveyService : IApplicationService, ISurveyAnalysisRead
         Guid surveyId,
         SurveyResultsScope scope,
         CancellationToken ct = default);
+
+    Task SetRankedAvailabilityAsync(
+        Guid surveyId,
+        Guid questionId,
+        IReadOnlyList<string> unavailableValues,
+        Guid actorUserId,
+        CancellationToken ct = default);
+
+    Task<int> SeedRankedVotingDemoAsync(Guid actorUserId, CancellationToken ct = default);
 }
 
 internal sealed record SurveyScopedResults(
     SurveyResultsView Results,
     int SelectedResponseCount,
-    SurveyResultsScope Scope);
+    SurveyResultsScope Scope,
+    bool IsEmbargoed = false,
+    IReadOnlyDictionary<Guid, RankedQuestionResult>? RankedQuestions = null);
+
+internal sealed record RankedQuestionResult(
+    IReadOnlyList<RankedCandidateResult> Candidates,
+    RankedMethodResult OriginalOfficialResult,
+    RankedMethodResult CurrentOfficialResult,
+    IReadOnlyList<RankedMethodResult> Methods,
+    IReadOnlyList<PairwiseContest> Pairwise,
+    IReadOnlyList<string> UnavailableValues);
+
+internal sealed record RankedCandidateResult(
+    string Value,
+    string Label,
+    bool IsAvailable,
+    int RejectionCount,
+    double RejectionPercent);
+internal sealed record RankedMethodResult(string Method, string? WinnerValue, string? WinnerLabel, bool TieBreakUsed);
 
 internal enum SurveyResultsScope
 {
@@ -181,7 +208,8 @@ internal sealed record SurveyEditInput(
     Guid? AudienceTeamId,
     Instant? AudienceLoggedInSince,
     string? PublicSlug,
-    IReadOnlyList<QuestionInput> Questions);
+    IReadOnlyList<QuestionInput> Questions,
+    bool IsAsociadoVote = false);
 
 /// <summary>One question in the builder graph.</summary>
 internal sealed record QuestionInput(
@@ -200,7 +228,9 @@ internal sealed record QuestionInput(
     IReadOnlyList<OptionInput> Options,
     GridSelectionMode? GridSelectionMode = null,
     IReadOnlyList<GridRowInput>? GridRows = null,
-    IReadOnlyList<InformationImageInput>? InformationImages = null);
+    IReadOnlyList<InformationImageInput>? InformationImages = null,
+    RankedQuestionSettings? RankedSettings = null,
+    IReadOnlyList<string>? RankedUnavailableOptionValues = null);
 
 /// <summary>One choice option in the builder graph. <c>Value</c> is the stable machine key.</summary>
 internal sealed record OptionInput(
@@ -278,7 +308,8 @@ internal sealed record SurveyDraftAnswer(
     IReadOnlyList<string> SelectedOptionValues,
     string? TextValue,
     int? RatingValue,
-    IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null);
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null,
+    RankedAnswer? RankedValue = null);
 
 /// <summary>
 /// A finalised wizard submission. Identity columns (<c>UserId</c>/<c>InvitationId</c>) are written on
@@ -303,7 +334,8 @@ internal sealed record SurveyAnswerInput(
     IReadOnlyList<string> SelectedOptionValues,
     string? TextValue,
     int? RatingValue,
-    IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null);
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? GridSelections = null,
+    RankedAnswer? RankedValue = null);
 
 /// <summary>
 /// Per-session state of the answering wizard. The Web layer JSON-serialises it into the HTTP session
@@ -338,6 +370,7 @@ internal sealed class SurveyWizardAnswer
 {
     public List<string> SelectedOptionValues { get; set; } = [];
     public Dictionary<string, List<string>> GridSelections { get; set; } = new(StringComparer.Ordinal);
+    public RankedAnswer? RankedValue { get; set; }
     public string? TextValue { get; set; }
     public int? RatingValue { get; set; }
 }

--- a/src/Sections/Humans.Surveys/Services/RankedChoiceCounter.cs
+++ b/src/Sections/Humans.Surveys/Services/RankedChoiceCounter.cs
@@ -1,0 +1,459 @@
+using System.Numerics;
+
+namespace Humans.Surveys.Services;
+
+internal sealed record RankedBallot(
+    IReadOnlyList<IReadOnlyList<string>> RankGroups,
+    IReadOnlySet<string> Rejected);
+
+internal sealed record PairwiseContest(
+    string First,
+    string Second,
+    int PreferFirst,
+    int PreferSecond);
+
+internal sealed record RankedPairwiseMatrix(IReadOnlyList<PairwiseContest> Contests);
+
+internal sealed record RankedPairsLock(
+    string Winner,
+    string Loser,
+    int Margin,
+    int WinningVotes,
+    bool Locked);
+
+internal sealed record RankedPairsResult(
+    string? Winner,
+    IReadOnlyList<RankedPairsLock> Locks,
+    bool TieBreakUsed);
+
+internal sealed record CondorcetResult(
+    string? Winner,
+    IReadOnlyList<string> SmallestCycle);
+
+internal readonly record struct RankedFraction : IComparable<RankedFraction>
+{
+    public static RankedFraction Zero => new(BigInteger.Zero, BigInteger.One);
+
+    public RankedFraction(BigInteger numerator, BigInteger denominator)
+    {
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator));
+        }
+
+        var divisor = BigInteger.GreatestCommonDivisor(BigInteger.Abs(numerator), denominator);
+        Numerator = numerator / divisor;
+        Denominator = denominator / divisor;
+    }
+
+    public BigInteger Numerator { get; }
+    public BigInteger Denominator { get; }
+
+    public static RankedFraction operator +(RankedFraction left, RankedFraction right) =>
+        new(
+            left.Numerator * right.Denominator + right.Numerator * left.Denominator,
+            left.Denominator * right.Denominator);
+
+    public static bool operator <(RankedFraction left, RankedFraction right) =>
+        left.CompareTo(right) < 0;
+
+    public static bool operator >(RankedFraction left, RankedFraction right) =>
+        left.CompareTo(right) > 0;
+
+    public static bool operator <=(RankedFraction left, RankedFraction right) =>
+        left.CompareTo(right) <= 0;
+
+    public static bool operator >=(RankedFraction left, RankedFraction right) =>
+        left.CompareTo(right) >= 0;
+
+    public int CompareTo(RankedFraction other) =>
+        (Numerator * other.Denominator).CompareTo(other.Numerator * Denominator);
+
+    public override string ToString() =>
+        Denominator == BigInteger.One ? Numerator.ToString() : $"{Numerator}/{Denominator}";
+}
+
+internal sealed record BordaScore(string Candidate, RankedFraction Score);
+
+internal sealed record BordaResult(
+    string? Winner,
+    IReadOnlyList<BordaScore> Scores,
+    bool TieBreakUsed);
+
+internal static class RankedChoiceCounter
+{
+    public static RankedPairwiseMatrix BuildPairwise(
+        IReadOnlyList<string> authoredCandidates,
+        IReadOnlyList<RankedBallot> ballots,
+        IReadOnlySet<string>? activeCandidates = null)
+    {
+        var candidates = GetCandidates(authoredCandidates, activeCandidates);
+        var preferences = ballots.Select(ballot => BuildPreferences(ballot, candidates)).ToList();
+        var contests = new List<PairwiseContest>();
+
+        for (var first = 0; first < candidates.Count; first++)
+        {
+            for (var second = first + 1; second < candidates.Count; second++)
+            {
+                var preferFirst = 0;
+                var preferSecond = 0;
+
+                foreach (var preference in preferences)
+                {
+                    var comparison = preference[candidates[first]].CompareTo(preference[candidates[second]]);
+                    if (comparison < 0)
+                    {
+                        preferFirst++;
+                    }
+                    else if (comparison > 0)
+                    {
+                        preferSecond++;
+                    }
+                }
+
+                contests.Add(new PairwiseContest(
+                    candidates[first],
+                    candidates[second],
+                    preferFirst,
+                    preferSecond));
+            }
+        }
+
+        return new RankedPairwiseMatrix(contests);
+    }
+
+    public static RankedPairsResult CountRankedPairs(
+        IReadOnlyList<string> authoredCandidates,
+        RankedPairwiseMatrix matrix,
+        IReadOnlySet<string>? activeCandidates = null)
+    {
+        var candidates = GetCandidates(authoredCandidates, activeCandidates);
+        if (candidates.Count == 0)
+        {
+            return new RankedPairsResult(null, [], false);
+        }
+
+        var order = candidates
+            .Select((candidate, index) => (candidate, index))
+            .ToDictionary(item => item.candidate, item => item.index, StringComparer.Ordinal);
+        var victories = matrix.Contests
+            .Where(contest => order.ContainsKey(contest.First) && order.ContainsKey(contest.Second))
+            .Where(contest => contest.PreferFirst != contest.PreferSecond)
+            .Select(contest => contest.PreferFirst > contest.PreferSecond
+                ? new Victory(
+                    contest.First,
+                    contest.Second,
+                    contest.PreferFirst - contest.PreferSecond,
+                    contest.PreferFirst)
+                : new Victory(
+                    contest.Second,
+                    contest.First,
+                    contest.PreferSecond - contest.PreferFirst,
+                    contest.PreferSecond))
+            .OrderByDescending(victory => victory.Margin)
+            .ThenByDescending(victory => victory.WinningVotes)
+            .ThenBy(victory => order[victory.Winner])
+            .ThenBy(victory => order[victory.Loser])
+            .ToList();
+
+        var tieBreakUsed = victories
+            .GroupBy(victory => (victory.Margin, victory.WinningVotes))
+            .Any(group => group.Count() > 1);
+        var edges = candidates.ToDictionary(
+            candidate => candidate,
+            _ => new HashSet<string>(StringComparer.Ordinal),
+            StringComparer.Ordinal);
+        var locks = new List<RankedPairsLock>();
+
+        foreach (var victory in victories)
+        {
+            var locked = !HasPath(edges, victory.Loser, victory.Winner);
+            if (locked)
+            {
+                edges[victory.Winner].Add(victory.Loser);
+            }
+
+            locks.Add(new RankedPairsLock(
+                victory.Winner,
+                victory.Loser,
+                victory.Margin,
+                victory.WinningVotes,
+                locked));
+        }
+
+        var destinations = edges.Values.SelectMany(values => values).ToHashSet(StringComparer.Ordinal);
+        var sources = candidates.Where(candidate => !destinations.Contains(candidate)).ToList();
+        tieBreakUsed |= sources.Count > 1;
+
+        return new RankedPairsResult(sources[0], locks, tieBreakUsed);
+    }
+
+    public static CondorcetResult CheckCondorcet(
+        IReadOnlyList<string> authoredCandidates,
+        RankedPairwiseMatrix matrix,
+        IReadOnlySet<string>? activeCandidates = null)
+    {
+        var candidates = GetCandidates(authoredCandidates, activeCandidates);
+        var edges = candidates.ToDictionary(
+            candidate => candidate,
+            _ => new HashSet<string>(StringComparer.Ordinal),
+            StringComparer.Ordinal);
+
+        foreach (var contest in matrix.Contests)
+        {
+            if (!edges.ContainsKey(contest.First) || !edges.ContainsKey(contest.Second))
+            {
+                continue;
+            }
+
+            if (contest.PreferFirst > contest.PreferSecond)
+            {
+                edges[contest.First].Add(contest.Second);
+            }
+            else if (contest.PreferSecond > contest.PreferFirst)
+            {
+                edges[contest.Second].Add(contest.First);
+            }
+        }
+
+        var winner = candidates.FirstOrDefault(candidate =>
+            candidates.All(other =>
+                string.Equals(candidate, other, StringComparison.Ordinal) ||
+                edges[candidate].Contains(other)));
+
+        return new CondorcetResult(winner, winner is null ? FindSmallestCycle(candidates, edges) : []);
+    }
+
+    public static BordaResult CountBorda(
+        IReadOnlyList<string> authoredCandidates,
+        IReadOnlyList<RankedBallot> ballots,
+        IReadOnlySet<string>? activeCandidates = null)
+    {
+        var candidates = GetCandidates(authoredCandidates, activeCandidates);
+        if (candidates.Count == 0)
+        {
+            return new BordaResult(null, [], false);
+        }
+
+        var totals = candidates.ToDictionary(
+            candidate => candidate,
+            _ => RankedFraction.Zero,
+            StringComparer.Ordinal);
+
+        foreach (var ballot in ballots)
+        {
+            var groups = BuildBordaGroups(ballot, candidates);
+            var position = 0;
+
+            foreach (var group in groups)
+            {
+                var pointSum = BigInteger.Zero;
+                for (var offset = 0; offset < group.Count; offset++)
+                {
+                    pointSum += candidates.Count - 1 - (position + offset);
+                }
+
+                var score = new RankedFraction(pointSum, group.Count);
+                foreach (var candidate in group)
+                {
+                    totals[candidate] += score;
+                }
+
+                position += group.Count;
+            }
+        }
+
+        var order = candidates
+            .Select((candidate, index) => (candidate, index))
+            .ToDictionary(item => item.candidate, item => item.index, StringComparer.Ordinal);
+        var scores = totals
+            .Select(item => new BordaScore(item.Key, item.Value))
+            .OrderByDescending(item => item.Score)
+            .ThenBy(item => order[item.Candidate])
+            .ToList();
+        var tieBreakUsed = scores
+            .GroupBy(score => score.Score)
+            .Any(group => group.Count() > 1);
+
+        return new BordaResult(scores[0].Candidate, scores, tieBreakUsed);
+    }
+
+    private static IReadOnlyList<string> GetCandidates(
+        IReadOnlyList<string> authoredCandidates,
+        IReadOnlySet<string>? activeCandidates)
+    {
+        if (authoredCandidates.Count != authoredCandidates.Distinct(StringComparer.Ordinal).Count())
+        {
+            throw new ArgumentException("Candidate values must be unique.", nameof(authoredCandidates));
+        }
+
+        return authoredCandidates
+            .Where(candidate => activeCandidates is null || activeCandidates.Contains(candidate))
+            .ToList();
+    }
+
+    private static Dictionary<string, int> BuildPreferences(
+        RankedBallot ballot,
+        IReadOnlyList<string> candidates)
+    {
+        var candidateSet = candidates.ToHashSet(StringComparer.Ordinal);
+        var preferences = new Dictionary<string, int>(StringComparer.Ordinal);
+        var rank = 0;
+
+        foreach (var group in ballot.RankGroups)
+        {
+            var activeGroup = group.Where(candidateSet.Contains).Distinct(StringComparer.Ordinal).ToList();
+            foreach (var candidate in activeGroup)
+            {
+                preferences.TryAdd(candidate, rank);
+            }
+
+            if (activeGroup.Count > 0)
+            {
+                rank++;
+            }
+        }
+
+        var unrankedRank = rank;
+        var rejectedRank = rank + 1;
+        foreach (var candidate in candidates)
+        {
+            if (!preferences.ContainsKey(candidate))
+            {
+                preferences[candidate] = ballot.Rejected.Contains(candidate)
+                    ? rejectedRank
+                    : unrankedRank;
+            }
+        }
+
+        return preferences;
+    }
+
+    private static IReadOnlyList<IReadOnlyList<string>> BuildBordaGroups(
+        RankedBallot ballot,
+        IReadOnlyList<string> candidates)
+    {
+        var candidateSet = candidates.ToHashSet(StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var groups = new List<IReadOnlyList<string>>();
+
+        foreach (var rankGroup in ballot.RankGroups)
+        {
+            var group = rankGroup
+                .Where(candidateSet.Contains)
+                .Where(seen.Add)
+                .ToList();
+            if (group.Count > 0)
+            {
+                groups.Add(group);
+            }
+        }
+
+        var rejected = candidates
+            .Where(candidate => !seen.Contains(candidate) && ballot.Rejected.Contains(candidate))
+            .ToList();
+        var unranked = candidates
+            .Where(candidate => !seen.Contains(candidate) && !ballot.Rejected.Contains(candidate))
+            .ToList();
+
+        if (unranked.Count > 0)
+        {
+            groups.Add(unranked);
+        }
+
+        if (rejected.Count > 0)
+        {
+            groups.Add(rejected);
+        }
+
+        return groups;
+    }
+
+    private static bool HasPath(
+        IReadOnlyDictionary<string, HashSet<string>> edges,
+        string start,
+        string destination)
+    {
+        var pending = new Stack<string>();
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        pending.Push(start);
+
+        while (pending.TryPop(out var current))
+        {
+            if (string.Equals(current, destination, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (!visited.Add(current))
+            {
+                continue;
+            }
+
+            foreach (var next in edges[current])
+            {
+                pending.Push(next);
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<string> FindSmallestCycle(
+        IReadOnlyList<string> candidates,
+        IReadOnlyDictionary<string, HashSet<string>> edges)
+    {
+        IReadOnlyList<string> smallest = [];
+
+        foreach (var start in candidates)
+        {
+            foreach (var next in edges[start])
+            {
+                var path = FindShortestPath(edges, next, start);
+                if (path.Count == 0)
+                {
+                    continue;
+                }
+
+                var cycle = new[] { start }.Concat(path).ToList();
+                if (smallest.Count == 0 || cycle.Count < smallest.Count)
+                {
+                    smallest = cycle;
+                }
+            }
+        }
+
+        return smallest;
+    }
+
+    private static IReadOnlyList<string> FindShortestPath(
+        IReadOnlyDictionary<string, HashSet<string>> edges,
+        string start,
+        string destination)
+    {
+        var pending = new Queue<IReadOnlyList<string>>();
+        var visited = new HashSet<string>(StringComparer.Ordinal) { start };
+        pending.Enqueue([start]);
+
+        while (pending.TryDequeue(out var path))
+        {
+            var current = path[^1];
+            if (string.Equals(current, destination, StringComparison.Ordinal))
+            {
+                return path;
+            }
+
+            foreach (var next in edges[current])
+            {
+                if (visited.Add(next))
+                {
+                    pending.Enqueue([.. path, next]);
+                }
+            }
+        }
+
+        return [];
+    }
+
+    private sealed record Victory(string Winner, string Loser, int Margin, int WinningVotes);
+}

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -62,6 +62,29 @@ internal sealed class SurveyService(
             responses.GetValueOrDefault(s.Id))).ToList();
     }
 
+    public async Task<SurveyOfficialLink?> GetOfficialLinkAsync(
+        Guid surveyId,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        var survey = await repo.GetByIdAsync(surveyId, ct);
+        if (survey?.Status != SurveyStatus.Open) return null;
+
+        var invitation = (await repo.GetInvitationsAsync(surveyId, ct))
+            .FirstOrDefault(candidate =>
+                candidate.UserId == userId
+                && candidate.SentAt is not null
+                && !candidate.Completed);
+        if (invitation is not null)
+        {
+            return new SurveyOfficialLink(tokenProvider.Create(invitation.Id), null);
+        }
+
+        return string.IsNullOrWhiteSpace(survey.PublicSlug)
+            ? null
+            : new SurveyOfficialLink(null, survey.PublicSlug);
+    }
+
     /// <summary>
     /// The machine-readable question graph behind <c>/api/backdoor/surveys/{id}</c>. Built on
     /// <see cref="GetForEditAsync"/> so there is one read path, then flattened: localized text

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -1613,13 +1613,13 @@ internal sealed class SurveyService(
                         Question = prompts.GetValueOrDefault(a.QuestionId, string.Empty),
                         SelectedLabels = ResolveSelectedLabels(a, optionLabels),
                         GridSelections = CopyGridSelections(a),
-                         GridSelectionLabels = questionsById.TryGetValue(a.QuestionId, out var question)
+                        GridSelectionLabels = questionsById.TryGetValue(a.QuestionId, out var question)
                              ? ResolveGridSelections(a, question, culture)
                              : [],
-                         RankedBallot = CopyRankedBallot(a),
-                         RankedBallotLabels = ResolveRankedBallot(a, optionLabels),
-                         a.TextValue,
-                         a.RatingValue,
+                        RankedBallot = CopyRankedBallot(a),
+                        RankedBallotLabels = ResolveRankedBallot(a, optionLabels),
+                        a.TextValue,
+                        a.RatingValue,
                     }).ToList(),
                 };
             })

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -107,9 +107,11 @@ internal sealed class SurveyService(
                             $"/{image.StoragePath!.TrimStart('/')}",
                             image.Label.Resolve(culture, culture),
                             image.AltText.Resolve(culture, culture)))],
-                    [.. q.Options
-                        .OrderBy(o => o.Order)
-                        .Select(o => new SurveyExportOption(o.Value, o.Label.Resolve(culture, culture)))]))]);
+                     [.. q.Options
+                         .OrderBy(o => o.Order)
+                         .Select(o => new SurveyExportOption(o.Value, o.Label.Resolve(culture, culture)))],
+                     ToRankedSettings(q.RankedSettings),
+                     q.RankedUnavailableOptionValues?.ToList()))]);
     }
 
     private static SurveyBranchCondition? ToBranchCondition(BranchCondition? condition) =>
@@ -129,7 +131,8 @@ internal sealed class SurveyService(
             s.Title, s.Intro, s.ThankYou, s.InvitationEmailSubject, s.InvitationEmailMessage,
             s.DefaultCulture, s.AllowAnonymous, s.OpensAt, s.ClosesAt,
             s.AudienceType, s.AudienceTeamId, s.AudienceLoggedInSince, s.PublicSlug,
-            ToQuestionInputs(s));
+            ToQuestionInputs(s),
+            s.IsAsociadoVote == true);
 
         return new SurveyDetail(s.Id, s.Status, input);
     }
@@ -150,6 +153,7 @@ internal sealed class SurveyService(
             questions = MapQuestions(surveyId, prepared.Input);
             ValidateQuestionConfiguration(questions);
             ValidateBranching(questions);
+            ValidateVoteConfiguration(input, questions);
         }
         catch
         {
@@ -167,6 +171,7 @@ internal sealed class SurveyService(
             InvitationEmailMessage = invitationEmailMessage,
             DefaultCulture = input.DefaultCulture,
             AllowAnonymous = input.AllowAnonymous,
+            IsAsociadoVote = input.IsAsociadoVote,
             Status = SurveyStatus.Draft,
             OpensAt = input.OpensAt,
             ClosesAt = input.ClosesAt,
@@ -195,7 +200,15 @@ internal sealed class SurveyService(
         return surveyId;
     }
 
-    public async Task UpdateAsync(Guid surveyId, SurveyEditInput input, Guid actorUserId, CancellationToken ct = default)
+    public Task UpdateAsync(Guid surveyId, SurveyEditInput input, Guid actorUserId, CancellationToken ct = default)
+        => UpdateCoreAsync(surveyId, input, actorUserId, allowRankedAvailabilityChanges: false, ct);
+
+    private async Task UpdateCoreAsync(
+        Guid surveyId,
+        SurveyEditInput input,
+        Guid actorUserId,
+        bool allowRankedAvailabilityChanges,
+        CancellationToken ct)
     {
         ValidateAudienceConfiguration(
             input.AudienceType, input.AudienceTeamId, input.AudienceLoggedInSince, requireAudience: false);
@@ -210,8 +223,25 @@ internal sealed class SurveyService(
         try
         {
             questions = MapQuestions(surveyId, prepared.Input);
+            if (!allowRankedAvailabilityChanges)
+            {
+                var existingById = existing.Questions.ToDictionary(question => question.Id);
+                foreach (var question in questions.Where(question => question.Type == SurveyQuestionType.RankedChoice))
+                {
+                    if (existingById.TryGetValue(question.Id, out var persisted))
+                    {
+                        question.RankedUnavailableOptionValues =
+                            persisted.RankedUnavailableOptionValues?.ToList();
+                    }
+                }
+            }
             ValidateQuestionConfiguration(questions);
             ValidateBranching(questions);
+            ValidateVoteConfiguration(input, questions);
+            if (await repo.HasSavedAnswersAsync(surveyId, ct))
+            {
+                ValidateRankedDefinitionFrozen(existing.Questions, questions);
+            }
         }
         catch
         {
@@ -229,6 +259,7 @@ internal sealed class SurveyService(
             InvitationEmailMessage = invitationEmailMessage,
             DefaultCulture = input.DefaultCulture,
             AllowAnonymous = input.AllowAnonymous,
+            IsAsociadoVote = input.IsAsociadoVote,
             OpensAt = input.OpensAt,
             ClosesAt = input.ClosesAt,
             AudienceType = input.AudienceType,
@@ -271,6 +302,8 @@ internal sealed class SurveyService(
             changes.Add($"default culture ({existing.DefaultCulture} → {updated.DefaultCulture})");
         if (existing.AllowAnonymous != updated.AllowAnonymous)
             changes.Add(updated.AllowAnonymous ? "anonymous responses enabled" : "anonymous responses disabled");
+        if ((existing.IsAsociadoVote == true) != (updated.IsAsociadoVote == true))
+            changes.Add(updated.IsAsociadoVote == true ? "Asociado vote enabled" : "Asociado vote disabled");
         if (existing.OpensAt != updated.OpensAt) changes.Add("opens-at");
         if (existing.ClosesAt != updated.ClosesAt) changes.Add("closes-at");
         if (existing.AudienceType != updated.AudienceType)
@@ -284,6 +317,25 @@ internal sealed class SurveyService(
 
         var oldQuestions = existing.Questions.ToDictionary(q => q.Id);
         var newQuestions = updated.Questions.ToDictionary(q => q.Id);
+        foreach (var question in newQuestions.Values.Where(q => q.Type == SurveyQuestionType.RankedChoice))
+        {
+            if (!oldQuestions.TryGetValue(question.Id, out var oldQuestion)) continue;
+            var oldUnavailable = (oldQuestion.RankedUnavailableOptionValues ?? [])
+                .ToHashSet(StringComparer.Ordinal);
+            var newUnavailable = (question.RankedUnavailableOptionValues ?? [])
+                .ToHashSet(StringComparer.Ordinal);
+            var addedUnavailable = newUnavailable.Except(oldUnavailable, StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToList();
+            var restored = oldUnavailable.Except(newUnavailable, StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToList();
+            if (addedUnavailable.Count > 0)
+                changes.Add($"ranked options unavailable ({string.Join(", ", addedUnavailable)})");
+            if (restored.Count > 0)
+                changes.Add($"ranked options restored ({string.Join(", ", restored)})");
+        }
+
         var added = newQuestions.Keys.Count(id => !oldQuestions.ContainsKey(id));
         var removed = oldQuestions.Keys.Count(id => !newQuestions.ContainsKey(id));
         var edited = newQuestions.Values.Count(q =>
@@ -307,6 +359,9 @@ internal sealed class SurveyService(
         || !old.RatingMinLabel.Equals(updated.RatingMinLabel)
         || !old.RatingMaxLabel.Equals(updated.RatingMaxLabel)
         || old.GridSelectionMode != updated.GridSelectionMode
+        || old.RankedSettings != updated.RankedSettings
+        || !(old.RankedUnavailableOptionValues ?? [])
+            .SequenceEqual(updated.RankedUnavailableOptionValues ?? [], StringComparer.Ordinal)
         || !OptionsEqual(old.Options, updated.Options);
 
     private static bool OptionsEqual(ICollection<SurveyQuestionOption> old, ICollection<SurveyQuestionOption> updated) =>
@@ -401,7 +456,8 @@ internal sealed class SurveyService(
                     Label = new LocalizedText(image.Label),
                     AltText = new LocalizedText(image.AltText),
                 }).ToList(),
-            }).ToList());
+            }).ToList(),
+            e.IsAsociadoVote);
 
         await UpdateAsync(surveyId, input, actorUserId, ct);
         logger.LogInformation(
@@ -420,6 +476,13 @@ internal sealed class SurveyService(
         var status = await repo.GetStatusAsync(surveyId, ct)
             ?? throw new InvalidOperationException("Survey not found.");
         if (status == SurveyStatus.Open) return;
+        if (status == SurveyStatus.Closed)
+        {
+            var survey = await repo.GetByIdAsync(surveyId, ct)
+                ?? throw new InvalidOperationException("Survey not found.");
+            if (survey.IsAsociadoVote == true)
+                throw new InvalidOperationException("A closed Asociado vote cannot be reopened.");
+        }
 
         await repo.SetStatusAsync(surveyId, SurveyStatus.Open, clock.GetCurrentInstant(), ct);
         await auditLog.LogAsync(AuditAction.SurveyOpened, AuditEntityTypes.Survey, surveyId, "Opened survey", actorUserId);
@@ -835,7 +898,8 @@ internal sealed class SurveyService(
                 answer.SelectedOptionValues,
                 answer.TextValue,
                 answer.RatingValue,
-                answer.GridSelections));
+                answer.GridSelections,
+                answer.RankedValue));
         var allVisible = SurveyWizardFlow.OrderedPages(questions)
             .SelectMany(page => SurveyWizardFlow.VisibleQuestionsOnPage(questions, page, answerStates))
             .ToList();
@@ -964,6 +1028,9 @@ internal sealed class SurveyService(
                     answer.GridSelections),
                 TextValue = string.IsNullOrWhiteSpace(answer.TextValue) ? null : answer.TextValue,
                 RatingValue = answer.RatingValue,
+                RankedValue = question.Type == SurveyQuestionType.RankedChoice
+                    ? NormalizeRankedAnswer(question, answer.RankedValue)
+                    : null,
             };
         }
 
@@ -1086,8 +1153,11 @@ internal sealed class SurveyService(
         return new SurveyWizardAdvanceResult(SurveyWizardOutcome.Submitted, []);
     }
 
-    public async Task<SurveyResultsView?> GetResultsAsync(Guid surveyId, CancellationToken ct = default) =>
-        (await GetScopedResultsAsync(surveyId, SurveyResultsScope.Combined, ct))?.Results;
+    public async Task<SurveyResultsView?> GetResultsAsync(Guid surveyId, CancellationToken ct = default)
+    {
+        var scoped = await GetScopedResultsAsync(surveyId, SurveyResultsScope.Combined, ct);
+        return scoped is { IsEmbargoed: false } ? scoped.Results : null;
+    }
 
     public async Task<SurveyScopedResults?> GetScopedResultsAsync(
         Guid surveyId,
@@ -1099,6 +1169,7 @@ internal sealed class SurveyService(
 
         var culture = survey.DefaultCulture;
         var responses = await repo.GetResponsesForResultsAsync(surveyId, ct);
+        var embargoed = survey.IsAsociadoVote == true && survey.Status != SurveyStatus.Closed;
         var selectedResponses = responses
             .Where(response => MatchesScope(response.Anonymity, scope))
             .ToList();
@@ -1112,11 +1183,13 @@ internal sealed class SurveyService(
                 .Count(invitation => invitation.SentAt.HasValue && invitation.Completed);
         var responseRate = invitedCount == 0 ? 0d : (double)completedInvitationCount / invitedCount;
 
-        var questions = survey.Questions
-            .Where(q => q.Type != SurveyQuestionType.Information)
-            .OrderBy(q => q.PageNumber).ThenBy(q => q.Order)
-            .Select(q => BuildQuestionAggregate(q, selectedResponses, culture))
-            .ToList();
+        var questions = embargoed
+            ? []
+            : survey.Questions
+                .Where(q => q.Type != SurveyQuestionType.Information)
+                .OrderBy(q => q.PageNumber).ThenBy(q => q.Order)
+                .Select(q => BuildQuestionAggregate(q, selectedResponses, culture))
+                .ToList();
 
         var funnel = new SurveyFunnel(
             LinkStarted: await repo.GetStartedInvitationCountAsync(surveyId, ct),
@@ -1124,7 +1197,16 @@ internal sealed class SurveyService(
             SlugStarted: survey.PublicStartedCount,
             SlugFinished: responses.Count(r => r.InputMethod == SurveyInputMethod.Slug));
 
-        var identified = await BuildIdentifiedRespondentsAsync(survey, responses, culture, ct);
+        var identified = embargoed
+            ? []
+            : await BuildIdentifiedRespondentsAsync(survey, responses, culture, ct);
+        var rankedQuestions = embargoed
+            ? new Dictionary<Guid, RankedQuestionResult>()
+            : survey.Questions
+                .Where(question => question.Type == SurveyQuestionType.RankedChoice)
+                .ToDictionary(
+                    question => question.Id,
+                    question => BuildRankedQuestionResult(question, selectedResponses, culture));
 
         return new SurveyScopedResults(
             new SurveyResultsView(
@@ -1137,8 +1219,263 @@ internal sealed class SurveyService(
                 funnel,
                 questions,
                 identified),
-            selectedResponses.Count,
-            scope);
+            embargoed ? 0 : selectedResponses.Count,
+            scope,
+            embargoed,
+            rankedQuestions);
+    }
+
+    private static RankedQuestionResult BuildRankedQuestionResult(
+        SurveyQuestion question,
+        IReadOnlyList<SurveyResponse> responses,
+        string culture)
+    {
+        var options = question.Options.OrderBy(option => option.Order).ToList();
+        var authored = options.Select(option => option.Value).ToList();
+        var unavailable = (question.RankedUnavailableOptionValues ?? [])
+            .Where(value => authored.Contains(value, StringComparer.Ordinal))
+            .ToHashSet(StringComparer.Ordinal);
+        var active = authored.Where(value => !unavailable.Contains(value)).ToHashSet(StringComparer.Ordinal);
+        var labels = options.ToDictionary(
+            option => option.Value,
+            option => option.Label.Resolve(culture, culture),
+            StringComparer.Ordinal);
+        var ballots = responses
+            .SelectMany(response => response.Answers)
+            .Where(answer => answer.QuestionId == question.Id && answer.RankedValue is not null)
+            .Select(answer => new RankedBallot(
+                answer.RankedValue!.RankGroups,
+                answer.RankedValue.Rejected.ToHashSet(StringComparer.Ordinal)))
+            .ToList();
+        RankedMethodResult Method(string name, string? winner, bool tieBreak) => new(
+            name,
+            winner,
+            winner is null ? null : labels.GetValueOrDefault(winner, winner),
+            tieBreak);
+
+        (RankedPairwiseMatrix Matrix, RankedMethodResult Official, IReadOnlyList<RankedMethodResult> Methods)
+            Count(IReadOnlySet<string>? candidates)
+        {
+            var matrix = RankedChoiceCounter.BuildPairwise(authored, ballots, candidates);
+            var rankedPairs = RankedChoiceCounter.CountRankedPairs(authored, matrix, candidates);
+            var condorcet = RankedChoiceCounter.CheckCondorcet(authored, matrix, candidates);
+            var borda = RankedChoiceCounter.CountBorda(authored, ballots, candidates);
+            var official = Method("Ranked Pairs (official)", rankedPairs.Winner, rankedPairs.TieBreakUsed);
+            return (
+                matrix,
+                official,
+                [
+                    official,
+                    Method("Condorcet check", condorcet.Winner, false),
+                    Method("Borda Count", borda.Winner, borda.TieBreakUsed),
+                ]);
+        }
+
+        var original = Count(null);
+        var current = Count(active);
+
+        return new RankedQuestionResult(
+            options.Select(option => new RankedCandidateResult(
+                option.Value,
+                labels[option.Value],
+                !unavailable.Contains(option.Value),
+                ballots.Count(ballot => ballot.Rejected.Contains(option.Value)),
+                ballots.Count == 0
+                    ? 0d
+                    : 100d * ballots.Count(ballot => ballot.Rejected.Contains(option.Value)) / ballots.Count))
+                .ToList(),
+            original.Official,
+            current.Official,
+            current.Methods,
+            current.Matrix.Contests,
+            unavailable.ToList());
+    }
+
+    public async Task SetRankedAvailabilityAsync(
+        Guid surveyId,
+        Guid questionId,
+        IReadOnlyList<string> unavailableValues,
+        Guid actorUserId,
+        CancellationToken ct = default)
+    {
+        var detail = await GetForEditAsync(surveyId, ct)
+            ?? throw new InvalidOperationException("Survey not found.");
+        if (detail.Status != SurveyStatus.Closed)
+            throw new InvalidOperationException("Candidate availability can only change after the vote closes.");
+        var question = detail.Editable.Questions.FirstOrDefault(candidate => candidate.Id == questionId);
+        if (question?.Type != SurveyQuestionType.RankedChoice)
+            throw new InvalidOperationException("Ranked-choice question not found.");
+        var known = question.Options.Select(option => option.Value).ToHashSet(StringComparer.Ordinal);
+        var normalized = unavailableValues
+            .Where(known.Contains)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var updatedQuestions = detail.Editable.Questions
+            .Select(candidate => candidate.Id == questionId
+                ? candidate with { RankedUnavailableOptionValues = normalized }
+                : candidate)
+            .ToList();
+        await UpdateCoreAsync(
+            surveyId,
+            detail.Editable with { Questions = updatedQuestions },
+            actorUserId,
+            allowRankedAvailabilityChanges: true,
+            ct);
+    }
+
+    public async Task<int> SeedRankedVotingDemoAsync(Guid actorUserId, CancellationToken ct = default)
+    {
+        const string prefix = "[Demo] Ranked vote";
+        if ((await GetSummariesAsync(ct)).Any(summary => summary.Title.StartsWith(prefix, StringComparison.Ordinal)))
+            return 0;
+
+        var voters = (await userService.GetAllUserInfosAsync(ct))
+            .Where(user => user.IsApproved && !user.IsGdprAnonymized && !user.IsDeletionPending && !user.IsMerged)
+            .Take(8)
+            .ToList();
+        if (voters.Count == 0)
+            throw new InvalidOperationException("No active local users are available for demo ballots.");
+
+        static LocalizedText Text(string value) => new(
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = value });
+        static QuestionInput RankingQuestion(Guid id) => new(
+            id, 1, 0, SurveyQuestionType.RankedChoice,
+            Text("Which weekend should we choose?"),
+            Text("Rank any dates you support. Unranked dates remain acceptable; Reject means unacceptable."),
+            true, null, null, LocalizedText.Empty, LocalizedText.Empty, null,
+            [
+                new OptionInput(Guid.NewGuid(), 0, "sep-12", Text("12–13 September")),
+                new OptionInput(Guid.NewGuid(), 1, "sep-19", Text("19–20 September")),
+                new OptionInput(Guid.NewGuid(), 2, "sep-26", Text("26–27 September")),
+                new OptionInput(Guid.NewGuid(), 3, "oct-03", Text("3–4 October")),
+            ],
+            RankedSettings: new RankedQuestionSettings(true, true, RankedVotingMethod.RankedPairs));
+
+        SurveyEditInput Demo(string title, Guid questionId) => new(
+            Text(title),
+            Text("Local fixture for reviewing ranked voting and the Asociado-vote result embargo."),
+            Text("Your vote has been recorded."),
+            LocalizedText.Empty,
+            LocalizedText.Empty,
+            "en",
+            false,
+            null,
+            null,
+            SurveyAudienceType.Asociados,
+            null,
+            null,
+            null,
+            [RankingQuestion(questionId)],
+            true);
+
+        var openEmptyId = await CreateAsync(Demo($"{prefix} — open, no responses", Guid.NewGuid()), actorUserId, ct);
+        await OpenAsync(openEmptyId, actorUserId, ct);
+
+        var openPartialQuestion = Guid.NewGuid();
+        var openPartialId = await CreateAsync(
+            Demo($"{prefix} — open, partial participation", openPartialQuestion), actorUserId, ct);
+        await OpenAsync(openPartialId, actorUserId, ct);
+        await SeedDemoResponsesAsync(
+            openPartialId,
+            openPartialQuestion,
+            voters,
+            [
+                new RankedAnswer([["sep-12"], ["sep-19"], ["sep-26"]], ["oct-03"]),
+                new RankedAnswer([["sep-19"], ["sep-26"], ["sep-12"]], []),
+            ],
+            includeStartedDraft: true,
+            ct);
+
+        var closedQuestion = Guid.NewGuid();
+        var closedId = await CreateAsync(
+            Demo($"{prefix} — closed, Condorcet cycle", closedQuestion), actorUserId, ct);
+        await OpenAsync(closedId, actorUserId, ct);
+        await SeedDemoResponsesAsync(
+            closedId,
+            closedQuestion,
+            voters,
+            [
+                new RankedAnswer([["sep-12"], ["sep-19"], ["sep-26"], ["oct-03"]], []),
+                new RankedAnswer([["sep-12"], ["sep-19"], ["sep-26"], ["oct-03"]], []),
+                new RankedAnswer([["sep-19"], ["sep-26"], ["sep-12"], ["oct-03"]], []),
+                new RankedAnswer([["sep-19"], ["sep-26"], ["sep-12"], ["oct-03"]], []),
+                new RankedAnswer([["sep-26"], ["sep-12"], ["sep-19"], ["oct-03"]], []),
+                new RankedAnswer([["sep-26"], ["sep-12"], ["sep-19"], ["oct-03"]], []),
+            ],
+            includeStartedDraft: false,
+            ct);
+        await CloseAsync(closedId, actorUserId, ct);
+        await SetRankedAvailabilityAsync(closedId, closedQuestion, ["sep-12"], actorUserId, ct);
+
+        return 3;
+    }
+
+    private async Task SeedDemoResponsesAsync(
+        Guid surveyId,
+        Guid questionId,
+        IReadOnlyList<UserInfo> voters,
+        IReadOnlyList<RankedAnswer> ballots,
+        bool includeStartedDraft,
+        CancellationToken ct)
+    {
+        var now = clock.GetCurrentInstant();
+        var count = Math.Min(ballots.Count, voters.Count);
+        for (var index = 0; index < count; index++)
+        {
+            var invitation = new SurveyInvitation
+            {
+                Id = Guid.NewGuid(),
+                SurveyId = surveyId,
+                UserId = voters[index].Id,
+                CreatedAt = now,
+                SentAt = now,
+                Started = true,
+            };
+            await repo.AddInvitationAndSaveAsync(invitation, ct);
+            var draft = new SurveyResponse
+            {
+                Id = Guid.NewGuid(),
+                SurveyId = surveyId,
+                InvitationId = invitation.Id,
+                UserId = voters[index].Id,
+                Anonymity = ResponseAnonymity.Identified,
+                InputMethod = SurveyInputMethod.UserSpecificLink,
+                Culture = "en",
+            };
+            await repo.AddResponseAsync(draft, ct);
+            await repo.FinalizeIdentifiedResponseAsync(
+                invitation.Id,
+                draft.Id,
+                MapAnswers(draft.Id, [new SurveyAnswerInput(questionId, [], null, null, null, ballots[index])]),
+                now,
+                SurveyInputMethod.UserSpecificLink,
+                "en",
+                ct);
+        }
+
+        if (includeStartedDraft && voters.Count > count)
+        {
+            var invitation = new SurveyInvitation
+            {
+                Id = Guid.NewGuid(),
+                SurveyId = surveyId,
+                UserId = voters[count].Id,
+                CreatedAt = now,
+                SentAt = now,
+                Started = true,
+            };
+            await repo.AddInvitationAndSaveAsync(invitation, ct);
+            await repo.AddResponseAsync(new SurveyResponse
+            {
+                Id = Guid.NewGuid(),
+                SurveyId = surveyId,
+                InvitationId = invitation.Id,
+                UserId = voters[count].Id,
+                Anonymity = ResponseAnonymity.Identified,
+                InputMethod = SurveyInputMethod.UserSpecificLink,
+                Culture = "en",
+            }, ct);
+        }
     }
 
     private static bool MatchesScope(ResponseAnonymity anonymity, SurveyResultsScope scope) => scope switch
@@ -1152,6 +1489,7 @@ internal sealed class SurveyService(
     {
         var survey = await repo.GetByIdAsync(surveyId, ct);
         if (survey is null) return null;
+        if (survey.IsAsociadoVote == true && survey.Status != SurveyStatus.Closed) return null;
 
         var culture = survey.DefaultCulture;
         var responses = await repo.GetResponsesForResultsAsync(surveyId, ct);
@@ -1170,9 +1508,11 @@ internal sealed class SurveyService(
                     .Select(o => new SurveyExportOption(o.Value, o.Label.Resolve(culture, culture)))
                     .ToList(),
                 q.GridSelectionMode,
-                q.GridRows?.Select(row => new SurveyExportGridRow(
-                    row.Value,
-                    row.Label.Resolve(culture, culture))).ToList()))
+                 q.GridRows?.Select(row => new SurveyExportGridRow(
+                     row.Value,
+                     row.Label.Resolve(culture, culture))).ToList(),
+                 ToRankedSettings(q.RankedSettings),
+                 q.RankedUnavailableOptionValues?.ToList()))
             .ToList();
 
         var questionsById = survey.Questions.ToDictionary(q => q.Id);
@@ -1210,9 +1550,10 @@ internal sealed class SurveyService(
                         a.TextValue,
                         a.RatingValue,
                         CopyGridSelections(a),
-                        questionsById.TryGetValue(a.QuestionId, out var question)
-                            ? ResolveGridSelections(a, question, culture)
-                            : []))
+                         questionsById.TryGetValue(a.QuestionId, out var question)
+                             ? ResolveGridSelections(a, question, culture)
+                             : [],
+                         CopyRankedBallot(a)))
                     .ToList();
 
                 return new SurveyExportRow(
@@ -1272,11 +1613,13 @@ internal sealed class SurveyService(
                         Question = prompts.GetValueOrDefault(a.QuestionId, string.Empty),
                         SelectedLabels = ResolveSelectedLabels(a, optionLabels),
                         GridSelections = CopyGridSelections(a),
-                        GridSelectionLabels = questionsById.TryGetValue(a.QuestionId, out var question)
-                            ? ResolveGridSelections(a, question, culture)
-                            : [],
-                        a.TextValue,
-                        a.RatingValue,
+                         GridSelectionLabels = questionsById.TryGetValue(a.QuestionId, out var question)
+                             ? ResolveGridSelections(a, question, culture)
+                             : [],
+                         RankedBallot = CopyRankedBallot(a),
+                         RankedBallotLabels = ResolveRankedBallot(a, optionLabels),
+                         a.TextValue,
+                         a.RatingValue,
                     }).ToList(),
                 };
             })
@@ -1431,9 +1774,10 @@ internal sealed class SurveyService(
                         ResolveSelectedLabels(a, optionLabels),
                         a.TextValue,
                         a.RatingValue,
-                        questionsById.TryGetValue(a.QuestionId, out var question)
-                            ? ResolveGridSelections(a, question, culture)
-                            : []))
+                         questionsById.TryGetValue(a.QuestionId, out var question)
+                             ? ResolveGridSelections(a, question, culture)
+                             : [],
+                         ResolveRankedBallot(a, optionLabels)))
                     .ToList();
                 return new RespondentDetail(userId, name, r.SubmittedAt, answers);
             })
@@ -1481,6 +1825,37 @@ internal sealed class SurveyService(
             selection => (IReadOnlyList<string>)selection.Value.ToList(),
             StringComparer.Ordinal);
 
+    private static SurveyRankedSettings? ToRankedSettings(RankedQuestionSettings? settings)
+        => settings is null
+            ? null
+            : new SurveyRankedSettings(
+                settings.AllowEqualRanks,
+                settings.AllowReject,
+                settings.OfficialMethod.ToString());
+
+    private static SurveyRankedBallot? CopyRankedBallot(SurveyAnswer answer)
+        => answer.RankedValue is null
+            ? null
+            : new SurveyRankedBallot(
+                [.. answer.RankedValue.RankGroups.Select(group => (IReadOnlyList<string>)[.. group])],
+                [.. answer.RankedValue.Rejected]);
+
+    private static ResolvedRankedBallot? ResolveRankedBallot(
+        SurveyAnswer answer,
+        IReadOnlyDictionary<Guid, Dictionary<string, string>> optionLabels)
+    {
+        if (answer.RankedValue is null) return null;
+
+        var labels = optionLabels.GetValueOrDefault(answer.QuestionId);
+        string Resolve(string value) =>
+            labels is not null && labels.TryGetValue(value, out var label) ? label : value;
+
+        return new ResolvedRankedBallot(
+            [.. answer.RankedValue.RankGroups
+                .Select(group => (IReadOnlyList<string>)[.. group.Select(Resolve)])],
+            [.. answer.RankedValue.Rejected.Select(Resolve)]);
+    }
+
     private static IReadOnlyList<QuestionInput> ToQuestionInputs(Survey survey)
         => survey.Questions
             .OrderBy(question => question.PageNumber)
@@ -1518,7 +1893,9 @@ internal sealed class SurveyService(
                         image.StoragePath,
                         image.ContentType,
                         image.FileName))
-                    .ToList()))
+                    .ToList(),
+                question.RankedSettings,
+                question.RankedUnavailableOptionValues))
             .ToList();
 
     private static void ReplaceWizardAnswers(
@@ -1538,6 +1915,7 @@ internal sealed class SurveyService(
                     ?? new Dictionary<string, List<string>>(StringComparer.Ordinal),
                 TextValue = answer.TextValue,
                 RatingValue = answer.RatingValue,
+                RankedValue = answer.RankedValue,
             };
         }
     }
@@ -1550,7 +1928,7 @@ internal sealed class SurveyService(
     {
         var states = answers.ToDictionary(
             a => a.QuestionId,
-            a => new AnswerState(a.SelectedOptionValues, a.TextValue, a.RatingValue, a.GridSelections));
+            a => new AnswerState(a.SelectedOptionValues, a.TextValue, a.RatingValue, a.GridSelections, a.RankedValue));
 
         var effective = SurveyBranchingEvaluator.EffectiveAnswerStates(
             survey.Questions
@@ -1576,6 +1954,9 @@ internal sealed class SurveyService(
                         question.GridSelectionMode,
                         a.GridSelections)
                     : null;
+                var normalizedRanked = question.Type == SurveyQuestionType.RankedChoice
+                    ? NormalizeRankedAnswer(question, a.RankedValue)
+                    : null;
                 return a with
                 {
                     GridSelections = normalizedGridSelections?.Count > 0
@@ -1584,6 +1965,7 @@ internal sealed class SurveyService(
                                 kv => (IReadOnlyList<string>)kv.Value,
                                 StringComparer.Ordinal)
                         : null,
+                    RankedValue = normalizedRanked,
                 };
             })
             .ToList();
@@ -1608,6 +1990,7 @@ internal sealed class SurveyService(
                 StringComparer.Ordinal),
             TextValue = a.TextValue,
             RatingValue = a.RatingValue,
+            RankedValue = a.RankedValue,
         }).ToList();
 
     private static IReadOnlyList<SurveyDraftAnswer> MapDraftAnswers(SurveyResponse draft)
@@ -1620,7 +2003,8 @@ internal sealed class SurveyService(
                 answer.GridSelections?.ToDictionary(
                     pair => pair.Key,
                     pair => (IReadOnlyList<string>)pair.Value,
-                    StringComparer.Ordinal)))
+                    StringComparer.Ordinal),
+                answer.RankedValue))
             .ToList();
 
     /// <summary>
@@ -1641,6 +2025,16 @@ internal sealed class SurveyService(
 
             case SurveyAudienceType.AllActiveMembers:
                 return (await ActiveMemberIdsAsync(ct)).ToHashSet();
+
+            case SurveyAudienceType.Asociados:
+                return (await userService.GetAllUserInfosAsync(ct))
+                    .Where(user => user.IsApproved
+                        && user.Profile?.MembershipTier == MembershipTier.Asociado
+                        && !user.IsGdprAnonymized
+                        && !user.IsDeletionPending
+                        && !user.IsMerged)
+                    .Select(user => user.Id)
+                    .ToHashSet();
 
             case SurveyAudienceType.TicketHolders:
                 {
@@ -1936,6 +2330,12 @@ internal sealed class SurveyService(
                         image.Label,
                         image.AltText)).ToList()
                     : null,
+                RankedSettings = q.Type == SurveyQuestionType.RankedChoice
+                    ? q.RankedSettings ?? RankedQuestionSettings.Default
+                    : null,
+                RankedUnavailableOptionValues = q.Type == SurveyQuestionType.RankedChoice
+                    ? (q.RankedUnavailableOptionValues ?? []).Distinct(StringComparer.Ordinal).ToList()
+                    : null,
                 ShowIf = q.ShowIf,
                 Options = q.Options.Select(o => new SurveyQuestionOption
                 {
@@ -1955,6 +2355,12 @@ internal sealed class SurveyService(
             if (question.Type == SurveyQuestionType.Information)
             {
                 ValidateInformationQuestion(question);
+                continue;
+            }
+
+            if (question.Type == SurveyQuestionType.RankedChoice)
+            {
+                ValidateRankedQuestion(question);
                 continue;
             }
 
@@ -2019,6 +2425,21 @@ internal sealed class SurveyService(
             ValidateStableValues(question.Options.Select(option => option.Value), $"Grid question {question.Id} column");
         }
 
+        static void ValidateRankedQuestion(SurveyQuestion question)
+        {
+            if (question.Options.Count < 2)
+                throw new InvalidOperationException($"Ranked-choice question {question.Id} must have at least two options.");
+            ValidateStableValues(
+                question.Options.OrderBy(option => option.Order).Select(option => option.Value),
+                $"Ranked-choice question {question.Id} option");
+            if (question.RankedSettings is null
+                || !Enum.IsDefined(question.RankedSettings.OfficialMethod))
+            {
+                throw new InvalidOperationException(
+                    $"Ranked-choice question {question.Id} must have valid ranking settings.");
+            }
+        }
+
         static void ValidateStableValues(IEnumerable<string> values, string description)
         {
             var materialized = values.ToList();
@@ -2054,14 +2475,112 @@ internal sealed class SurveyService(
         var nonAnswerSources = questions
             .Where(question => question.ShowIf?.Clauses.Any(clause =>
                 types.GetValueOrDefault(clause.QuestionId) is
-                    SurveyQuestionType.Grid or SurveyQuestionType.Information) == true)
+                    SurveyQuestionType.Grid or SurveyQuestionType.Information or SurveyQuestionType.RankedChoice) == true)
             .Select(question => question.Id)
             .ToList();
         if (nonAnswerSources.Count > 0)
         {
             throw new InvalidOperationException(
-                $"Grid questions and Information items cannot be branching sources. Offending question ids: {string.Join(", ", nonAnswerSources)}.");
+                $"Grid, RankedChoice, and Information questions cannot be branching sources. Offending question ids: {string.Join(", ", nonAnswerSources)}.");
         }
+    }
+
+    private static void ValidateVoteConfiguration(
+        SurveyEditInput input,
+        IReadOnlyList<SurveyQuestion> questions)
+    {
+        var hasRanked = questions.Any(question => question.Type == SurveyQuestionType.RankedChoice);
+        if (hasRanked && !input.IsAsociadoVote)
+            throw new InvalidOperationException("Ranked-choice questions require Asociado vote mode.");
+        if (!input.IsAsociadoVote) return;
+        if (input.AllowAnonymous)
+            throw new InvalidOperationException("Asociado votes must use identified responses.");
+        if (!string.IsNullOrWhiteSpace(input.PublicSlug))
+            throw new InvalidOperationException("Asociado votes cannot have a public link.");
+    }
+
+    private static void ValidateRankedDefinitionFrozen(
+        IEnumerable<SurveyQuestion> existing,
+        IEnumerable<SurveyQuestion> updated)
+    {
+        var oldRanked = existing
+            .Where(question => question.Type == SurveyQuestionType.RankedChoice)
+            .OrderBy(question => question.PageNumber).ThenBy(question => question.Order)
+            .ToList();
+        var newRanked = updated
+            .Where(question => question.Type == SurveyQuestionType.RankedChoice)
+            .OrderBy(question => question.PageNumber).ThenBy(question => question.Order)
+            .ToList();
+        if (oldRanked.Count != newRanked.Count)
+            throw new InvalidOperationException("Ranked-choice questions cannot be added or removed after voting starts.");
+        for (var index = 0; index < oldRanked.Count; index++)
+        {
+            var before = oldRanked[index];
+            var after = newRanked[index];
+            var beforeValues = before.Options.OrderBy(option => option.Order).Select(option => option.Value);
+            var afterValues = after.Options.OrderBy(option => option.Order).Select(option => option.Value);
+            if (before.Id != after.Id
+                || !beforeValues.SequenceEqual(afterValues, StringComparer.Ordinal)
+                || before.RankedSettings != after.RankedSettings)
+            {
+                throw new InvalidOperationException(
+                    "Ranked-choice candidates, order, and settings cannot change after the first saved answer.");
+            }
+        }
+    }
+
+    private static RankedAnswer? NormalizeRankedAnswer(QuestionInput question, RankedAnswer? answer)
+    {
+        if (answer is null) return null;
+        var authored = question.Options.OrderBy(option => option.Order).Select(option => option.Value).ToList();
+        return NormalizeRankedAnswer(authored, question.RankedSettings, answer);
+    }
+
+    private static RankedAnswer? NormalizeRankedAnswer(SurveyQuestion question, RankedAnswer? answer)
+    {
+        if (answer is null) return null;
+        var authored = question.Options.OrderBy(option => option.Order).Select(option => option.Value).ToList();
+        return NormalizeRankedAnswer(authored, question.RankedSettings, answer);
+    }
+
+    private static RankedAnswer? NormalizeRankedAnswer(
+        IReadOnlyList<string> authored,
+        RankedQuestionSettings? settings,
+        RankedAnswer answer)
+    {
+        settings ??= RankedQuestionSettings.Default;
+        var known = authored.ToHashSet(StringComparer.Ordinal);
+        var suppliedKnownValues = answer.RankGroups
+            .SelectMany(group => group)
+            .Concat(answer.Rejected)
+            .Where(known.Contains)
+            .ToList();
+        if (suppliedKnownValues.Distinct(StringComparer.Ordinal).Count() != suppliedKnownValues.Count)
+            throw new InvalidOperationException("A ranked-choice option may appear only once in a ballot.");
+
+        var authoredPositions = authored
+            .Select((value, index) => (value, index))
+            .ToDictionary(pair => pair.value, pair => pair.index, StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var groups = new List<IReadOnlyList<string>>();
+        foreach (var group in answer.RankGroups)
+        {
+            var valid = group
+                .Where(value => known.Contains(value) && seen.Add(value))
+                .OrderBy(value => authoredPositions[value])
+                .ToList();
+            if (!settings.AllowEqualRanks && valid.Count > 1)
+                throw new InvalidOperationException("This ranked-choice question does not allow equal ranks.");
+            if (valid.Count > 0) groups.Add(valid);
+        }
+
+        var rejected = answer.Rejected
+            .Where(value => known.Contains(value) && seen.Add(value))
+            .OrderBy(value => authoredPositions[value])
+            .ToList();
+        if (!settings.AllowReject && rejected.Count > 0)
+            throw new InvalidOperationException("This ranked-choice question does not allow rejection.");
+        return groups.Count == 0 && rejected.Count == 0 ? null : new RankedAnswer(groups, rejected);
     }
 
     private static Dictionary<string, List<string>> NormalizeGridSelections(

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -2429,6 +2429,8 @@ internal sealed class SurveyService(
         if (hasRanked && !input.IsAsociadoVote)
             throw new InvalidOperationException("Ranked-choice questions require Asociado vote mode.");
         if (!input.IsAsociadoVote) return;
+        if (input.AudienceType != SurveyAudienceType.Asociados)
+            throw new InvalidOperationException("Asociado votes must target the Asociados audience.");
         if (input.AllowAnonymous)
             throw new InvalidOperationException("Asociado votes must use identified responses.");
         if (!string.IsNullOrWhiteSpace(input.PublicSlug))

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -160,6 +160,9 @@ internal sealed class SurveyService(
         return new SurveyDetail(s.Id, s.Status, input);
     }
 
+    public Task<bool> HasSavedAnswersAsync(Guid surveyId, CancellationToken ct = default)
+        => repo.HasSavedAnswersAsync(surveyId, ct);
+
     public async Task<Guid> CreateAsync(SurveyEditInput input, Guid actorUserId, CancellationToken ct = default)
     {
         ValidateAudienceConfiguration(
@@ -241,6 +244,12 @@ internal sealed class SurveyService(
         var now = clock.GetCurrentInstant();
         var existing = await repo.GetByIdAsync(surveyId, ct)
             ?? throw new InvalidOperationException("Survey not found.");
+        if (existing.Status != SurveyStatus.Draft
+            && (existing.IsAsociadoVote == true) != input.IsAsociadoVote)
+        {
+            throw new InvalidOperationException(
+                "Asociado vote mode cannot change after the survey has opened.");
+        }
         var prepared = await PrepareInformationImagesAsync(surveyId, input, existing, ct);
         List<SurveyQuestion> questions;
         try

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -179,7 +179,7 @@ internal sealed class SurveyService(
             questions = MapQuestions(surveyId, prepared.Input);
             ValidateQuestionConfiguration(questions);
             ValidateBranching(questions);
-            ValidateVoteConfiguration(input, questions);
+            ValidateVoteConfiguration(input);
         }
         catch
         {
@@ -276,7 +276,7 @@ internal sealed class SurveyService(
             }
             ValidateQuestionConfiguration(questions);
             ValidateBranching(questions);
-            ValidateVoteConfiguration(input, questions);
+            ValidateVoteConfiguration(input);
             if (await repo.HasSavedAnswersAsync(surveyId, ct))
             {
                 ValidateRankedDefinitionFrozen(existing.Questions, questions);
@@ -2421,13 +2421,8 @@ internal sealed class SurveyService(
         }
     }
 
-    private static void ValidateVoteConfiguration(
-        SurveyEditInput input,
-        IReadOnlyList<SurveyQuestion> questions)
+    private static void ValidateVoteConfiguration(SurveyEditInput input)
     {
-        var hasRanked = questions.Any(question => question.Type == SurveyQuestionType.RankedChoice);
-        if (hasRanked && !input.IsAsociadoVote)
-            throw new InvalidOperationException("Ranked-choice questions require Asociado vote mode.");
         if (!input.IsAsociadoVote) return;
         if (input.AudienceType != SurveyAudienceType.Asociados)
             throw new InvalidOperationException("Asociado votes must target the Asociados audience.");

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -1253,7 +1253,11 @@ internal sealed class SurveyService(
             winner is null ? null : labels.GetValueOrDefault(winner, winner),
             tieBreak);
 
-        (RankedPairwiseMatrix Matrix, RankedMethodResult Official, IReadOnlyList<RankedMethodResult> Methods)
+        (
+            RankedPairwiseMatrix Matrix,
+            RankedMethodResult Official,
+            IReadOnlyList<RankedMethodResult> Methods,
+            IReadOnlyList<string> PreferenceCycle)
             Count(IReadOnlySet<string>? candidates)
         {
             var matrix = RankedChoiceCounter.BuildPairwise(authored, ballots, candidates);
@@ -1268,7 +1272,8 @@ internal sealed class SurveyService(
                     official,
                     Method("Condorcet check", condorcet.Winner, false),
                     Method("Borda Count", borda.Winner, borda.TieBreakUsed),
-                ]);
+                ],
+                condorcet.SmallestCycle);
         }
 
         var original = Count(null);
@@ -1288,6 +1293,8 @@ internal sealed class SurveyService(
             current.Official,
             current.Methods,
             current.Matrix.Contests,
+            original.PreferenceCycle,
+            current.PreferenceCycle,
             unavailable.ToList());
     }
 
@@ -1321,161 +1328,6 @@ internal sealed class SurveyService(
             actorUserId,
             allowRankedAvailabilityChanges: true,
             ct);
-    }
-
-    public async Task<int> SeedRankedVotingDemoAsync(Guid actorUserId, CancellationToken ct = default)
-    {
-        const string prefix = "[Demo] Ranked vote";
-        if ((await GetSummariesAsync(ct)).Any(summary => summary.Title.StartsWith(prefix, StringComparison.Ordinal)))
-            return 0;
-
-        var voters = (await userService.GetAllUserInfosAsync(ct))
-            .Where(user => user.IsApproved && !user.IsGdprAnonymized && !user.IsDeletionPending && !user.IsMerged)
-            .Take(8)
-            .ToList();
-        if (voters.Count == 0)
-            throw new InvalidOperationException("No active local users are available for demo ballots.");
-
-        static LocalizedText Text(string value) => new(
-            new Dictionary<string, string>(StringComparer.Ordinal) { ["en"] = value });
-        static QuestionInput RankingQuestion(Guid id) => new(
-            id, 1, 0, SurveyQuestionType.RankedChoice,
-            Text("Which weekend should we choose?"),
-            Text("Rank any dates you support. Unranked dates remain acceptable; Reject means unacceptable."),
-            true, null, null, LocalizedText.Empty, LocalizedText.Empty, null,
-            [
-                new OptionInput(Guid.NewGuid(), 0, "sep-12", Text("12–13 September")),
-                new OptionInput(Guid.NewGuid(), 1, "sep-19", Text("19–20 September")),
-                new OptionInput(Guid.NewGuid(), 2, "sep-26", Text("26–27 September")),
-                new OptionInput(Guid.NewGuid(), 3, "oct-03", Text("3–4 October")),
-            ],
-            RankedSettings: new RankedQuestionSettings(true, true, RankedVotingMethod.RankedPairs));
-
-        SurveyEditInput Demo(string title, Guid questionId) => new(
-            Text(title),
-            Text("Local fixture for reviewing ranked voting and the Asociado-vote result embargo."),
-            Text("Your vote has been recorded."),
-            LocalizedText.Empty,
-            LocalizedText.Empty,
-            "en",
-            false,
-            null,
-            null,
-            SurveyAudienceType.Asociados,
-            null,
-            null,
-            null,
-            [RankingQuestion(questionId)],
-            true);
-
-        var openEmptyId = await CreateAsync(Demo($"{prefix} — open, no responses", Guid.NewGuid()), actorUserId, ct);
-        await OpenAsync(openEmptyId, actorUserId, ct);
-
-        var openPartialQuestion = Guid.NewGuid();
-        var openPartialId = await CreateAsync(
-            Demo($"{prefix} — open, partial participation", openPartialQuestion), actorUserId, ct);
-        await OpenAsync(openPartialId, actorUserId, ct);
-        await SeedDemoResponsesAsync(
-            openPartialId,
-            openPartialQuestion,
-            voters,
-            [
-                new RankedAnswer([["sep-12"], ["sep-19"], ["sep-26"]], ["oct-03"]),
-                new RankedAnswer([["sep-19"], ["sep-26"], ["sep-12"]], []),
-            ],
-            includeStartedDraft: true,
-            ct);
-
-        var closedQuestion = Guid.NewGuid();
-        var closedId = await CreateAsync(
-            Demo($"{prefix} — closed, Condorcet cycle", closedQuestion), actorUserId, ct);
-        await OpenAsync(closedId, actorUserId, ct);
-        await SeedDemoResponsesAsync(
-            closedId,
-            closedQuestion,
-            voters,
-            [
-                new RankedAnswer([["sep-12"], ["sep-19"], ["sep-26"], ["oct-03"]], []),
-                new RankedAnswer([["sep-12"], ["sep-19"], ["sep-26"], ["oct-03"]], []),
-                new RankedAnswer([["sep-19"], ["sep-26"], ["sep-12"], ["oct-03"]], []),
-                new RankedAnswer([["sep-19"], ["sep-26"], ["sep-12"], ["oct-03"]], []),
-                new RankedAnswer([["sep-26"], ["sep-12"], ["sep-19"], ["oct-03"]], []),
-                new RankedAnswer([["sep-26"], ["sep-12"], ["sep-19"], ["oct-03"]], []),
-            ],
-            includeStartedDraft: false,
-            ct);
-        await CloseAsync(closedId, actorUserId, ct);
-        await SetRankedAvailabilityAsync(closedId, closedQuestion, ["sep-12"], actorUserId, ct);
-
-        return 3;
-    }
-
-    private async Task SeedDemoResponsesAsync(
-        Guid surveyId,
-        Guid questionId,
-        IReadOnlyList<UserInfo> voters,
-        IReadOnlyList<RankedAnswer> ballots,
-        bool includeStartedDraft,
-        CancellationToken ct)
-    {
-        var now = clock.GetCurrentInstant();
-        var count = Math.Min(ballots.Count, voters.Count);
-        for (var index = 0; index < count; index++)
-        {
-            var invitation = new SurveyInvitation
-            {
-                Id = Guid.NewGuid(),
-                SurveyId = surveyId,
-                UserId = voters[index].Id,
-                CreatedAt = now,
-                SentAt = now,
-                Started = true,
-            };
-            await repo.AddInvitationAndSaveAsync(invitation, ct);
-            var draft = new SurveyResponse
-            {
-                Id = Guid.NewGuid(),
-                SurveyId = surveyId,
-                InvitationId = invitation.Id,
-                UserId = voters[index].Id,
-                Anonymity = ResponseAnonymity.Identified,
-                InputMethod = SurveyInputMethod.UserSpecificLink,
-                Culture = "en",
-            };
-            await repo.AddResponseAsync(draft, ct);
-            await repo.FinalizeIdentifiedResponseAsync(
-                invitation.Id,
-                draft.Id,
-                MapAnswers(draft.Id, [new SurveyAnswerInput(questionId, [], null, null, null, ballots[index])]),
-                now,
-                SurveyInputMethod.UserSpecificLink,
-                "en",
-                ct);
-        }
-
-        if (includeStartedDraft && voters.Count > count)
-        {
-            var invitation = new SurveyInvitation
-            {
-                Id = Guid.NewGuid(),
-                SurveyId = surveyId,
-                UserId = voters[count].Id,
-                CreatedAt = now,
-                SentAt = now,
-                Started = true,
-            };
-            await repo.AddInvitationAndSaveAsync(invitation, ct);
-            await repo.AddResponseAsync(new SurveyResponse
-            {
-                Id = Guid.NewGuid(),
-                SurveyId = surveyId,
-                InvitationId = invitation.Id,
-                UserId = voters[count].Id,
-                Anonymity = ResponseAnonymity.Identified,
-                InputMethod = SurveyInputMethod.UserSpecificLink,
-                Culture = "en",
-            }, ct);
-        }
     }
 
     private static bool MatchesScope(ResponseAnonymity anonymity, SurveyResultsScope scope) => scope switch

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -244,6 +244,13 @@ internal sealed class SurveyService(
         var now = clock.GetCurrentInstant();
         var existing = await repo.GetByIdAsync(surveyId, ct)
             ?? throw new InvalidOperationException("Survey not found.");
+        if (existing.IsAsociadoVote == true
+            && existing.Status != SurveyStatus.Draft
+            && !allowRankedAvailabilityChanges)
+        {
+            throw new InvalidOperationException(
+                "An Asociado vote cannot be edited after it has opened.");
+        }
         if (existing.Status != SurveyStatus.Draft
             && (existing.IsAsociadoVote == true) != input.IsAsociadoVote)
         {
@@ -408,6 +415,11 @@ internal sealed class SurveyService(
     {
         var detail = await GetForEditAsync(surveyId, ct)
             ?? throw new InvalidOperationException("Survey not found.");
+        if (detail.Editable.IsAsociadoVote && detail.Status != SurveyStatus.Draft)
+        {
+            throw new InvalidOperationException(
+                "An Asociado vote cannot be edited after it has opened.");
+        }
         var e = detail.Editable;
         var source = e.DefaultCulture;
 
@@ -750,8 +762,12 @@ internal sealed class SurveyService(
 
         var definition = await GetForEditAsync(invitation.SurveyId, ct);
         if (definition is null) return null;
+        var isEligible = !definition.Editable.IsAsociadoVote
+            || await IsEligibleAsociadoAsync(invitation.UserId, ct);
 
-        var draft = await repo.GetDraftResponseAsync(invitation.SurveyId, invitation.UserId, ct);
+        var draft = isEligible
+            ? await repo.GetDraftResponseAsync(invitation.SurveyId, invitation.UserId, ct)
+            : null;
         var draftAnswers = draft is null
             ? (IReadOnlyList<SurveyDraftAnswer>)[]
             : draft.Answers
@@ -772,8 +788,12 @@ internal sealed class SurveyService(
             invitation.UserId,
             definition,
             draftAnswers,
-            HasResumableDraft: draft is not null);
+            HasResumableDraft: draft is not null,
+            IsEligible: isEligible);
     }
+
+    public async Task<bool> IsEligibleAsociadoAsync(Guid userId, CancellationToken ct = default)
+        => IsEligibleAsociado(await userService.GetUserInfoAsync(userId, ct));
 
     public async Task<Guid> StartIdentifiedDraftAsync(
         Guid surveyId,
@@ -783,6 +803,13 @@ internal sealed class SurveyService(
         string culture,
         CancellationToken ct = default)
     {
+        var survey = await repo.GetByIdAsync(surveyId, ct);
+        if (survey?.IsAsociadoVote == true && !await IsEligibleAsociadoAsync(userId, ct))
+        {
+            throw new InvalidOperationException(
+                "Only an active, approved Asociado may answer this vote.");
+        }
+
         // Idempotent: one in-progress Identified draft per Human, regardless of entry path.
         var existing = await repo.GetDraftResponseAsync(surveyId, userId, ct);
         if (existing is not null)
@@ -909,6 +936,19 @@ internal sealed class SurveyService(
         {
             throw new InvalidOperationException("Survey is not open for responses.");
         }
+        if (survey.IsAsociadoVote == true)
+        {
+            if (submission.Anonymity != ResponseAnonymity.Identified || submission.UserId is not { } userId)
+            {
+                throw new InvalidOperationException(
+                    "Asociado votes require an identified eligible Asociado.");
+            }
+            if (!await IsEligibleAsociadoAsync(userId, ct))
+            {
+                throw new InvalidOperationException(
+                    "Only an active, approved Asociado may answer this vote.");
+            }
+        }
 
         // Same authoritative posture for the duplicate gate: a completed invitation can't submit
         // again on the tracked tiers (Anonymous never flips Completed, so it is unaffected).
@@ -1033,6 +1073,11 @@ internal sealed class SurveyService(
         if (!SurveyWizardFlow.IsAnswerable(definition.Status, editable.OpensAt, editable.ClosesAt, clock.GetCurrentInstant()))
         {
             return new SurveyWizardAdvanceResult(SurveyWizardOutcome.Closed, []);
+        }
+        if (editable.IsAsociadoVote
+            && (state.UserId is not { } userId || !await IsEligibleAsociadoAsync(userId, ct)))
+        {
+            return new SurveyWizardAdvanceResult(SurveyWizardOutcome.Ineligible, []);
         }
 
         // Only accept answers for questions actually visible on the posted page (re-evaluated server-side).
@@ -1912,11 +1957,7 @@ internal sealed class SurveyService(
 
             case SurveyAudienceType.Asociados:
                 return (await userService.GetAllUserInfosAsync(ct))
-                    .Where(user => user.IsApproved
-                        && user.Profile?.MembershipTier == MembershipTier.Asociado
-                        && !user.IsGdprAnonymized
-                        && !user.IsDeletionPending
-                        && !user.IsMerged)
+                    .Where(IsEligibleAsociado)
                     .Select(user => user.Id)
                     .ToHashSet();
 
@@ -1975,6 +2016,17 @@ internal sealed class SurveyService(
             .Select(u => u.Id)
             .ToList();
     }
+
+    private static bool IsEligibleAsociado(UserInfo? user)
+        => user is
+        {
+            IsApproved: true,
+            Profile.MembershipTier: MembershipTier.Asociado,
+            IsGdprAnonymized: false,
+            IsDeletionPending: false,
+            IsMerged: false,
+            State: UserState.Active,
+        };
 
     private static void ValidateAudienceConfiguration(
         SurveyAudienceType? type, Guid? teamId, Instant? loggedInSince, bool requireAudience)

--- a/src/Sections/Humans.Surveys/Services/SurveyWizardFlow.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyWizardFlow.cs
@@ -12,7 +12,8 @@ internal sealed record AnswerState(
     IReadOnlyList<string> Options,
     string? Text,
     int? Rating,
-    IReadOnlyDictionary<string, IReadOnlyList<string>>? Grid = null)
+    IReadOnlyDictionary<string, IReadOnlyList<string>>? Grid = null,
+    RankedAnswer? Ranked = null)
 {
     /// <summary>An empty/unanswered state.</summary>
     public static AnswerState None { get; } = new([], null, null);
@@ -22,7 +23,8 @@ internal sealed record AnswerState(
         Options.Any(s => !string.IsNullOrEmpty(s))
         || !string.IsNullOrWhiteSpace(Text)
         || Rating is not null
-        || Grid?.Values.Any(values => values.Count > 0) == true;
+        || Grid?.Values.Any(values => values.Count > 0) == true
+        || Ranked is { } ranked && (ranked.RankGroups.Any(group => group.Count > 0) || ranked.Rejected.Count > 0);
 }
 
 /// <summary>
@@ -137,7 +139,8 @@ internal static class SurveyWizardFlow
                     a.GridSelections.ToDictionary(
                         kv => kv.Key,
                         kv => (IReadOnlyList<string>)kv.Value,
-                        StringComparer.Ordinal));
+                        StringComparer.Ordinal),
+                    a.RankedValue);
             }
         }
 
@@ -158,6 +161,7 @@ internal static class SurveyWizardFlow
                     : kv.Value.GridSelections.ToDictionary(
                         pair => pair.Key,
                         pair => (IReadOnlyList<string>)pair.Value,
-                        StringComparer.Ordinal)))
+                        StringComparer.Ordinal),
+                kv.Value.RankedValue))
             .ToList();
 }

--- a/src/Sections/Humans.Surveys/SurveysResource.ca.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.ca.resx
@@ -41,6 +41,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Survey_TransparencyNote" xml:space="preserve"><value>Les teves respostes poden ser revisades i analitzades, fins i tot mitjançant eines automatitzades, per millorar el col·lectiu.</value></data>
+  <data name="Survey_AsociadoVote_Heading" xml:space="preserve"><value>Votació vinculant d'Asociados</value></data>
+  <data name="Survey_AsociadoVote_Body" xml:space="preserve"><value>Aquesta és una votació identificada i vinculant de l'associació. Humans comprova que actualment ets un Asociado actiu i aprovat abans de permetre't participar i de nou quan envies el vot. Els resultats romanen segellats fins que es tanca la votació. Envia únicament el teu propi vot meditat; un vot enviat no es pot substituir.</value></data>
+  <data name="Survey_AsociadoVote_PageReminder" xml:space="preserve"><value>El teu vot identificat forma part d'una decisió vinculant de l'associació. La teva elegibilitat es tornarà a comprovar quan l'enviïs.</value></data>
+  <data name="Survey_AsociadoIneligible_Heading" xml:space="preserve"><value>No tens dret a votar</value></data>
+  <data name="Survey_AsociadoIneligible_Body" xml:space="preserve"><value>Aquesta votació vinculant està restringida a les persones que actualment són Asociados actius i aprovats. Si creus que el teu registre de membre és incorrecte, posa't en contacte amb la Junta abans que es tanqui el període de votació.</value></data>
   <data name="Survey_TitleFallback" xml:space="preserve"><value>Enquesta</value></data>
   <data name="Survey_ResumeNotice" xml:space="preserve"><value>Tens respostes en curs — continua on ho vas deixar.</value></data>
   <data name="Survey_Language" xml:space="preserve"><value>Idioma</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.ca.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.ca.resx
@@ -69,4 +69,8 @@
   <data name="Survey_InvalidLink_Body" xml:space="preserve"><value>L'enllaç de l'enquesta no és vàlid o ha caducat. Si creus que és un error, demana un enllaç nou.</value></data>
   <data name="Survey_ThankYou_Heading" xml:space="preserve"><value>Gràcies</value></data>
   <data name="Survey_ThankYouFallback" xml:space="preserve"><value>Gràcies per la teva resposta.</value></data>
+  <data name="Survey_Ranked_Option" xml:space="preserve"><value>Opció</value></data>
+  <data name="Survey_Ranked_Rank" xml:space="preserve"><value>Posició</value></data>
+  <data name="Survey_Ranked_Reject" xml:space="preserve"><value>Rebutjar</value></data>
+  <data name="Survey_Ranked_Unranked" xml:space="preserve"><value>Sense classificar</value></data>
 </root>

--- a/src/Sections/Humans.Surveys/SurveysResource.de.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.de.resx
@@ -41,6 +41,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Survey_TransparencyNote" xml:space="preserve"><value>Deine Antworten können überprüft und analysiert werden, auch durch automatisierte Tools, um das Kollektiv zu verbessern.</value></data>
+  <data name="Survey_AsociadoVote_Heading" xml:space="preserve"><value>Verbindliche Asociado-Abstimmung</value></data>
+  <data name="Survey_AsociadoVote_Body" xml:space="preserve"><value>Dies ist eine identifizierte, verbindliche Abstimmung des Vereins. Humans prüft vor deiner Teilnahme und erneut beim Absenden, ob du derzeit ein aktiver, bestätigter Asociado bist. Die Ergebnisse bleiben bis zum Ende der Abstimmung unter Verschluss. Gib nur deinen eigenen, wohlüberlegten Stimmzettel ab; ein abgegebener Stimmzettel kann nicht ersetzt werden.</value></data>
+  <data name="Survey_AsociadoVote_PageReminder" xml:space="preserve"><value>Dein identifizierter Stimmzettel ist Teil einer verbindlichen Vereinsentscheidung. Deine Stimmberechtigung wird beim Absenden erneut geprüft.</value></data>
+  <data name="Survey_AsociadoIneligible_Heading" xml:space="preserve"><value>Du bist nicht stimmberechtigt</value></data>
+  <data name="Survey_AsociadoIneligible_Body" xml:space="preserve"><value>Diese verbindliche Abstimmung ist Personen vorbehalten, die derzeit aktive, bestätigte Asociados sind. Wenn du glaubst, dass dein Mitgliedsstatus falsch erfasst ist, wende dich bitte vor Ende des Abstimmungszeitraums an den Vorstand.</value></data>
   <data name="Survey_TitleFallback" xml:space="preserve"><value>Umfrage</value></data>
   <data name="Survey_ResumeNotice" xml:space="preserve"><value>Du hast Antworten in Bearbeitung — mach dort weiter, wo du aufgehört hast.</value></data>
   <data name="Survey_Language" xml:space="preserve"><value>Sprache</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.de.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.de.resx
@@ -69,4 +69,8 @@
   <data name="Survey_InvalidLink_Body" xml:space="preserve"><value>Der Umfrage-Link ist ungültig oder abgelaufen. Wenn du denkst, dass das ein Fehler ist, fordere bitte einen neuen Link an.</value></data>
   <data name="Survey_ThankYou_Heading" xml:space="preserve"><value>Vielen Dank</value></data>
   <data name="Survey_ThankYouFallback" xml:space="preserve"><value>Vielen Dank für deine Antwort.</value></data>
+  <data name="Survey_Ranked_Option" xml:space="preserve"><value>Option</value></data>
+  <data name="Survey_Ranked_Rank" xml:space="preserve"><value>Rang</value></data>
+  <data name="Survey_Ranked_Reject" xml:space="preserve"><value>Ablehnen</value></data>
+  <data name="Survey_Ranked_Unranked" xml:space="preserve"><value>Nicht gereiht</value></data>
 </root>

--- a/src/Sections/Humans.Surveys/SurveysResource.es.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.es.resx
@@ -69,4 +69,8 @@
   <data name="Survey_InvalidLink_Body" xml:space="preserve"><value>El enlace de la encuesta no es válido o ha caducado. Si crees que es un error, solicita un enlace nuevo.</value></data>
   <data name="Survey_ThankYou_Heading" xml:space="preserve"><value>Gracias</value></data>
   <data name="Survey_ThankYouFallback" xml:space="preserve"><value>Gracias por tu respuesta.</value></data>
+  <data name="Survey_Ranked_Option" xml:space="preserve"><value>Opción</value></data>
+  <data name="Survey_Ranked_Rank" xml:space="preserve"><value>Posición</value></data>
+  <data name="Survey_Ranked_Reject" xml:space="preserve"><value>Rechazar</value></data>
+  <data name="Survey_Ranked_Unranked" xml:space="preserve"><value>Sin clasificar</value></data>
 </root>

--- a/src/Sections/Humans.Surveys/SurveysResource.es.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.es.resx
@@ -41,6 +41,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Survey_TransparencyNote" xml:space="preserve"><value>Tus respuestas pueden ser revisadas y analizadas, incluso mediante herramientas automatizadas, para mejorar el colectivo.</value></data>
+  <data name="Survey_AsociadoVote_Heading" xml:space="preserve"><value>Votación vinculante de Asociados</value></data>
+  <data name="Survey_AsociadoVote_Body" xml:space="preserve"><value>Esta es una votación identificada y vinculante de la asociación. Humans comprueba que actualmente eres un Asociado activo y aprobado antes de permitirte participar y de nuevo cuando envías tu voto. Los resultados permanecen sellados hasta que cierre la votación. Envía únicamente tu propio voto meditado; un voto enviado no puede sustituirse.</value></data>
+  <data name="Survey_AsociadoVote_PageReminder" xml:space="preserve"><value>Tu voto identificado forma parte de una decisión vinculante de la asociación. Tu elegibilidad volverá a comprobarse cuando lo envíes.</value></data>
+  <data name="Survey_AsociadoIneligible_Heading" xml:space="preserve"><value>No tienes derecho a votar</value></data>
+  <data name="Survey_AsociadoIneligible_Body" xml:space="preserve"><value>Esta votación vinculante está restringida a quienes actualmente son Asociados activos y aprobados. Si crees que tu registro de membresía es incorrecto, ponte en contacto con la Junta antes de que cierre el periodo de votación.</value></data>
   <data name="Survey_TitleFallback" xml:space="preserve"><value>Encuesta</value></data>
   <data name="Survey_ResumeNotice" xml:space="preserve"><value>Tienes respuestas en curso — continúa donde lo dejaste.</value></data>
   <data name="Survey_Language" xml:space="preserve"><value>Idioma</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.fr.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.fr.resx
@@ -69,4 +69,8 @@
   <data name="Survey_InvalidLink_Body" xml:space="preserve"><value>Le lien de l'enquête est invalide ou a expiré. Si vous pensez qu'il s'agit d'une erreur, demandez un nouveau lien.</value></data>
   <data name="Survey_ThankYou_Heading" xml:space="preserve"><value>Merci</value></data>
   <data name="Survey_ThankYouFallback" xml:space="preserve"><value>Merci pour votre réponse.</value></data>
+  <data name="Survey_Ranked_Option" xml:space="preserve"><value>Option</value></data>
+  <data name="Survey_Ranked_Rank" xml:space="preserve"><value>Rang</value></data>
+  <data name="Survey_Ranked_Reject" xml:space="preserve"><value>Rejeter</value></data>
+  <data name="Survey_Ranked_Unranked" xml:space="preserve"><value>Non classé</value></data>
 </root>

--- a/src/Sections/Humans.Surveys/SurveysResource.fr.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.fr.resx
@@ -41,6 +41,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Survey_TransparencyNote" xml:space="preserve"><value>Vos réponses peuvent être examinées et analysées, y compris par des outils automatisés, afin d'améliorer le collectif.</value></data>
+  <data name="Survey_AsociadoVote_Heading" xml:space="preserve"><value>Vote contraignant des Asociados</value></data>
+  <data name="Survey_AsociadoVote_Body" xml:space="preserve"><value>Il s'agit d'un vote identifié et contraignant de l'association. Humans vérifie que vous êtes actuellement un Asociado actif et approuvé avant de vous autoriser à participer, puis à nouveau lors de l'envoi de votre bulletin. Les résultats restent scellés jusqu'à la clôture du vote. N'envoyez que votre propre bulletin mûrement réfléchi ; un bulletin envoyé ne peut pas être remplacé.</value></data>
+  <data name="Survey_AsociadoVote_PageReminder" xml:space="preserve"><value>Votre bulletin identifié fait partie d'une décision contraignante de l'association. Votre droit de vote sera vérifié à nouveau lors de l'envoi.</value></data>
+  <data name="Survey_AsociadoIneligible_Heading" xml:space="preserve"><value>Vous n'avez pas le droit de voter</value></data>
+  <data name="Survey_AsociadoIneligible_Body" xml:space="preserve"><value>Ce vote contraignant est réservé aux personnes qui sont actuellement des Asociados actifs et approuvés. Si vous pensez que votre statut de membre est incorrect, veuillez contacter le Conseil avant la clôture de la période de vote.</value></data>
   <data name="Survey_TitleFallback" xml:space="preserve"><value>Enquête</value></data>
   <data name="Survey_ResumeNotice" xml:space="preserve"><value>Vous avez des réponses en cours — reprenez là où vous vous étiez arrêté·e.</value></data>
   <data name="Survey_Language" xml:space="preserve"><value>Langue</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.it.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.it.resx
@@ -69,4 +69,8 @@
   <data name="Survey_InvalidLink_Body" xml:space="preserve"><value>Il link del sondaggio non è valido o è scaduto. Se pensi che sia un errore, richiedi un nuovo link.</value></data>
   <data name="Survey_ThankYou_Heading" xml:space="preserve"><value>Grazie</value></data>
   <data name="Survey_ThankYouFallback" xml:space="preserve"><value>Grazie per la tua risposta.</value></data>
+  <data name="Survey_Ranked_Option" xml:space="preserve"><value>Opzione</value></data>
+  <data name="Survey_Ranked_Rank" xml:space="preserve"><value>Posizione</value></data>
+  <data name="Survey_Ranked_Reject" xml:space="preserve"><value>Rifiuta</value></data>
+  <data name="Survey_Ranked_Unranked" xml:space="preserve"><value>Non classificata</value></data>
 </root>

--- a/src/Sections/Humans.Surveys/SurveysResource.it.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.it.resx
@@ -41,6 +41,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Survey_TransparencyNote" xml:space="preserve"><value>Le tue risposte possono essere esaminate e analizzate, anche tramite strumenti automatizzati, per migliorare il collettivo.</value></data>
+  <data name="Survey_AsociadoVote_Heading" xml:space="preserve"><value>Votazione vincolante degli Asociados</value></data>
+  <data name="Survey_AsociadoVote_Body" xml:space="preserve"><value>Questa è una votazione identificata e vincolante dell'associazione. Humans verifica che tu sia attualmente un Asociado attivo e approvato prima di consentirti di partecipare e di nuovo quando invii la scheda. I risultati restano secretati fino alla chiusura della votazione. Invia solo la tua scheda personale e ponderata; una scheda inviata non può essere sostituita.</value></data>
+  <data name="Survey_AsociadoVote_PageReminder" xml:space="preserve"><value>La tua scheda identificata fa parte di una decisione vincolante dell'associazione. La tua idoneità sarà verificata nuovamente al momento dell'invio.</value></data>
+  <data name="Survey_AsociadoIneligible_Heading" xml:space="preserve"><value>Non hai diritto di voto</value></data>
+  <data name="Survey_AsociadoIneligible_Body" xml:space="preserve"><value>Questa votazione vincolante è riservata alle persone che sono attualmente Asociados attivi e approvati. Se ritieni che il tuo stato di membro sia errato, contatta il Consiglio prima della chiusura del periodo di votazione.</value></data>
   <data name="Survey_TitleFallback" xml:space="preserve"><value>Sondaggio</value></data>
   <data name="Survey_ResumeNotice" xml:space="preserve"><value>Hai risposte in corso — continua da dove avevi lasciato.</value></data>
   <data name="Survey_Language" xml:space="preserve"><value>Lingua</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.resx
@@ -64,4 +64,8 @@
   <data name="Survey_InvalidLink_Body" xml:space="preserve"><value>The survey link you used is invalid or has expired. If you think this is a mistake, please request a new link.</value></data>
   <data name="Survey_ThankYou_Heading" xml:space="preserve"><value>Thank you</value></data>
   <data name="Survey_ThankYouFallback" xml:space="preserve"><value>Thank you for your response.</value></data>
+  <data name="Survey_Ranked_Option" xml:space="preserve"><value>Option</value></data>
+  <data name="Survey_Ranked_Rank" xml:space="preserve"><value>Rank</value></data>
+  <data name="Survey_Ranked_Reject" xml:space="preserve"><value>Reject</value></data>
+  <data name="Survey_Ranked_Unranked" xml:space="preserve"><value>Unranked</value></data>
 </root>

--- a/src/Sections/Humans.Surveys/SurveysResource.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.resx
@@ -36,6 +36,11 @@
   <!-- Common / Shared          -->
   <!-- ======================== -->
   <data name="Survey_TransparencyNote" xml:space="preserve"><value>Your responses may be reviewed and analysed, including by automated tooling, to improve the collective.</value></data>
+  <data name="Survey_AsociadoVote_Heading" xml:space="preserve"><value>Binding Asociado vote</value></data>
+  <data name="Survey_AsociadoVote_Body" xml:space="preserve"><value>This is an identified, binding association vote. Humans verifies that you are currently an active, approved Asociado before allowing you to participate and again when you submit. Results remain sealed until voting closes. Submit only your own considered ballot; a submitted ballot cannot be replaced.</value></data>
+  <data name="Survey_AsociadoVote_PageReminder" xml:space="preserve"><value>Your identified ballot forms part of a binding association decision. Your eligibility will be checked again when you submit.</value></data>
+  <data name="Survey_AsociadoIneligible_Heading" xml:space="preserve"><value>You are not eligible to vote</value></data>
+  <data name="Survey_AsociadoIneligible_Body" xml:space="preserve"><value>This binding vote is restricted to people who are currently active, approved Asociados. If you believe your membership record is incorrect, please contact the Board before the voting period closes.</value></data>
   <data name="Survey_TitleFallback" xml:space="preserve"><value>Survey</value></data>
   <data name="Survey_ResumeNotice" xml:space="preserve"><value>You have answers in progress — continue where you left off.</value></data>
   <data name="Survey_Language" xml:space="preserve"><value>Language</value></data>

--- a/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
@@ -210,6 +210,66 @@
                 </div>
                 break;
             }
+
+            case SurveyQuestionType.RankedChoice:
+            {
+                var ranks = new Dictionary<string, int>(StringComparer.Ordinal);
+                if (q.RankedValue is not null)
+                {
+                    for (var rankIndex = 0; rankIndex < q.RankedValue.RankGroups.Count; rankIndex++)
+                    {
+                        foreach (var value in q.RankedValue.RankGroups[rankIndex])
+                        {
+                            ranks[value] = rankIndex + 1;
+                        }
+                    }
+                }
+                var rejected = q.RankedValue?.Rejected.ToHashSet(StringComparer.Ordinal)
+                    ?? new HashSet<string>(StringComparer.Ordinal);
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle mb-0 survey-ranked-choice"
+                           data-equal-ranks="@(q.RankedAllowEqualRanks ? "true" : "false")">
+                        <thead>
+                            <tr>
+                                <th scope="col">@Localizer["Survey_Ranked_Option"]</th>
+                                <th scope="col">@Localizer["Survey_Ranked_Rank"]</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @for (var optionIndex = 0; optionIndex < q.Options.Count; optionIndex++)
+                            {
+                                var option = q.Options[optionIndex];
+                                ranks.TryGetValue(option.Value, out var selectedRank);
+                                <tr>
+                                    <th scope="row">
+                                        @option.Label
+                                        <input type="hidden"
+                                               name="Answers[@answerIndex].RankedOptions[@optionIndex].OptionValue"
+                                               value="@option.Value" />
+                                    </th>
+                                    <td>
+                                        <select class="form-select form-select-sm ranked-selection"
+                                                name="Answers[@answerIndex].RankedOptions[@optionIndex].Selection">
+                                            <option value="">@Localizer["Survey_Ranked_Unranked"]</option>
+                                            @for (var rank = 1; rank <= q.Options.Count; rank++)
+                                            {
+                                                <option value="@rank" selected="@(selectedRank == rank ? "selected" : null)">@rank</option>
+                                            }
+                                            @if (q.RankedAllowReject)
+                                            {
+                                                <option value="reject" selected="@(rejected.Contains(option.Value) ? "selected" : null)">
+                                                    @Localizer["Survey_Ranked_Reject"]
+                                                </option>
+                                            }
+                                        </select>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+                break;
+            }
         }
 
         @* Keep this after the visible answer control. Bootstrap floats legend and applies
@@ -224,3 +284,17 @@
         }
     </fieldset>
 }
+
+<script>
+document.addEventListener('change', function (event) {
+    const table = event.target.closest('.survey-ranked-choice');
+    if (!table || !event.target.classList.contains('ranked-selection')) return;
+    if (table.dataset.equalRanks === 'false' && /^\d+$/.test(event.target.value)) {
+        table.querySelectorAll('.ranked-selection').forEach(select => {
+            if (select !== event.target && select.value === event.target.value) {
+                select.value = '';
+            });
+        }
+    }
+});
+</script>

--- a/src/Sections/Humans.Surveys/Views/Survey/Closed.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Survey/Closed.cshtml
@@ -7,6 +7,7 @@
     {
         "closed" => ("Survey_Closed_Heading", "Survey_Closed_Body"),
         "empty" => ("Survey_NothingToAnswer_Heading", "Survey_NothingToAnswer_Body"),
+        "ineligible-asociado" => ("Survey_AsociadoIneligible_Heading", "Survey_AsociadoIneligible_Body"),
         _ => ("Survey_InvalidLink_Heading", "Survey_InvalidLink_Body"),
     };
     var heading = Localizer[headingKey];

--- a/src/Sections/Humans.Surveys/Views/Survey/Intro.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Survey/Intro.cshtml
@@ -26,6 +26,16 @@
                     </div>
                 }
 
+                @if (Model.IsAsociadoVote)
+                {
+                    <div class="alert alert-warning" role="alert">
+                        <h2 class="h6 alert-heading">
+                            <i class="fa-solid fa-scale-balanced me-1"></i>@Localizer["Survey_AsociadoVote_Heading"]
+                        </h2>
+                        <p class="mb-0">@Localizer["Survey_AsociadoVote_Body"]</p>
+                    </div>
+                }
+
                 @if (!string.IsNullOrWhiteSpace(Model.Intro))
                 {
                     <div class="mb-4 survey-intro">@Html.SanitizedMarkdown(Model.Intro)</div>

--- a/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
@@ -24,6 +24,15 @@
                                  "Answers and activity are not saved. Conditional questions are shown so they can be inspected."))" />
                 }
 
+                @if (Model.IsAsociadoVote)
+                {
+                    <div class="alert alert-warning small" role="note">
+                        <i class="fa-solid fa-scale-balanced me-1"></i>
+                        <strong>@Localizer["Survey_AsociadoVote_Heading"]</strong>
+                        @Localizer["Survey_AsociadoVote_PageReminder"]
+                    </div>
+                }
+
                 @if (!ViewData.ModelState.IsValid)
                 {
                     <div class="alert alert-danger" role="alert">

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -321,16 +321,24 @@
 
             function applyVoteMode() {
                 if (asociadoVote.checked) {
+                    audienceType.value = 'Asociados';
                     allowAnon.checked = false;
                     allowAnon.disabled = true;
                     publicSlug.value = '';
                     publicSlug.disabled = true;
+                    applyAudienceVisibility();
                 } else {
                     allowAnon.disabled = false;
                     publicSlug.disabled = false;
                 }
             }
 
+            audienceType.addEventListener('change', function () {
+                if (asociadoVote.checked && audienceType.value !== 'Asociados') {
+                    audienceType.value = 'Asociados';
+                    applyAudienceVisibility();
+                }
+            });
             asociadoVote.addEventListener('change', applyVoteMode);
             applyVoteMode();
 

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -12,6 +12,7 @@
         SurveyAudienceType.TicketHolders => "Current ticket holders",
         SurveyAudienceType.ShiftParticipants => "Humans with shifts",
         SurveyAudienceType.LoggedInSince => "Humans logged in since a date",
+        SurveyAudienceType.Asociados => "All active Asociados",
         _ => audience.ToString(),
     };
 }
@@ -31,7 +32,8 @@
         <div class="d-flex align-items-center gap-2">
             <partial name="_SurveyPreviewMenu" model="@Model.Id!.Value" />
             <span class="badge @(Model.Status == SurveyStatus.Open ? "bg-success" : Model.Status == SurveyStatus.Closed ? "bg-secondary" : "bg-warning text-dark")">@Model.Status</span>
-            @if (Model.Status != SurveyStatus.Open)
+            @if (Model.Status != SurveyStatus.Open
+                && !(Model.Status == SurveyStatus.Closed && Model.IsAsociadoVote))
             {
                 <form asp-controller="SurveyAdmin" asp-action="Open" asp-route-id="@Model.Id" method="post" class="d-inline">
                     @Html.AntiForgeryToken()
@@ -106,6 +108,15 @@
                         <input type="checkbox" class="form-check-input" id="allowAnon" asp-for="AllowAnonymous" />
                         <label class="form-check-label small" for="allowAnon">Allow anonymous responses</label>
                     </div>
+                </div>
+            </div>
+
+            <div class="form-check mt-3">
+                <input type="checkbox" class="form-check-input" id="asociadoVote" asp-for="IsAsociadoVote" />
+                <label class="form-check-label fw-semibold" for="asociadoVote">Asociado vote</label>
+                <div class="form-text">
+                    Identified responses only. While open, only participation statistics are visible;
+                    all answer-derived results are embargoed until close, and the vote cannot then be reopened.
                 </div>
             </div>
 
@@ -259,6 +270,9 @@
             const audienceType = document.querySelector('select[name="AudienceType"]');
             const audienceTeamField = document.getElementById('audience-team-field');
             const loggedInSinceField = document.getElementById('logged-in-since-field');
+            const asociadoVote = document.getElementById('asociadoVote');
+            const allowAnon = document.getElementById('allowAnon');
+            const publicSlug = document.querySelector('input[name="PublicSlug"]');
 
             function applyAudienceVisibility() {
                 audienceTeamField.style.display = audienceType.value === 'Team' ? '' : 'none';
@@ -268,6 +282,21 @@
             audienceType.addEventListener('change', applyAudienceVisibility);
             applyAudienceVisibility();
 
+            function applyVoteMode() {
+                if (asociadoVote.checked) {
+                    allowAnon.checked = false;
+                    allowAnon.disabled = true;
+                    publicSlug.value = '';
+                    publicSlug.disabled = true;
+                } else {
+                    allowAnon.disabled = false;
+                    publicSlug.disabled = false;
+                }
+            }
+
+            asociadoVote.addEventListener('change', applyVoteMode);
+            applyVoteMode();
+
             // ── question cards ───────────────────────────────────────────────
             function applyTypeVisibility(card) {
                 const type = card.querySelector('.question-type')?.value;
@@ -276,7 +305,9 @@
                 const grid = card.querySelector('.grid-section');
                 const information = card.querySelector('.information-section');
                 const required = card.querySelector('.required-section');
-                const isChoice = type === 'SingleChoice' || type === 'MultiChoice';
+                const ranked = card.querySelector('.ranked-section');
+                const isRanked = type === 'RankedChoice';
+                const isChoice = type === 'SingleChoice' || type === 'MultiChoice' || isRanked;
                 const isGrid = type === 'Grid';
                 const isInformation = type === 'Information';
                 if (options) {
@@ -289,6 +320,7 @@
                 if (grid) grid.style.display = isGrid ? '' : 'none';
                 if (ratings) ratings.style.display = type === 'Rating' ? '' : 'none';
                 if (information) information.style.display = isInformation ? '' : 'none';
+                if (ranked) ranked.style.display = isRanked ? '' : 'none';
                 if (required) required.style.display = isInformation ? 'none' : '';
                 updateGridColumnLimit(card);
                 updateInformationImageLimit(card);

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -112,11 +112,24 @@
             </div>
 
             <div class="form-check mt-3">
-                <input type="checkbox" class="form-check-input" id="asociadoVote" asp-for="IsAsociadoVote" />
+                @if (!Model.IsNew && Model.Status != SurveyStatus.Draft)
+                {
+                    <input type="hidden" name="IsAsociadoVote" value="@(Model.IsAsociadoVote ? "true" : "false")" />
+                    <input type="checkbox" class="form-check-input" id="asociadoVote"
+                           checked="@(Model.IsAsociadoVote ? "checked" : null)" disabled />
+                }
+                else
+                {
+                    <input type="checkbox" class="form-check-input" id="asociadoVote" asp-for="IsAsociadoVote" />
+                }
                 <label class="form-check-label fw-semibold" for="asociadoVote">Asociado vote</label>
                 <div class="form-text">
                     Identified responses only. While open, only participation statistics are visible;
                     all answer-derived results are embargoed until close, and the vote cannot then be reopened.
+                    @if (!Model.IsNew && Model.Status != SurveyStatus.Draft)
+                    {
+                        <strong>This setting is locked because the survey has opened.</strong>
+                    }
                 </div>
             </div>
 
@@ -175,12 +188,12 @@
     <div id="questions-container">
         @foreach (var (q, i) in Model.Questions.Select((q, i) => (q, i)))
         {
-            <partial name="_SurveyQuestionCard" model="@(new SurveyQuestionCardModel(i.ToString(), q))" />
+            <partial name="_SurveyQuestionCard" model="@(new SurveyQuestionCardModel(i.ToString(), q, Model.HasSavedAnswers))" />
         }
     </div>
 
     <template id="question-template">
-        <partial name="_SurveyQuestionCard" model="@(new SurveyQuestionCardModel("__QKEY__", new SurveyQuestionBuilderViewModel()))" />
+        <partial name="_SurveyQuestionCard" model="@(new SurveyQuestionCardModel("__QKEY__", new SurveyQuestionBuilderViewModel(), Model.HasSavedAnswers))" />
     </template>
 
     <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mt-3">

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Builder.cshtml
@@ -37,7 +37,10 @@
             {
                 <form asp-controller="SurveyAdmin" asp-action="Open" asp-route-id="@Model.Id" method="post" class="d-inline">
                     @Html.AntiForgeryToken()
-                    <button type="submit" class="btn btn-success btn-sm">Open</button>
+                    <button type="submit" class="btn btn-success btn-sm"
+                            data-confirm="@(Model.IsAsociadoVote
+                                ? "Open this binding Asociado vote? Once opened, its questions, wording, settings, dates, audience and invitation copy cannot be edited; once closed, it cannot be reopened."
+                                : "Open this survey so it can receive responses?")">Open</button>
                 </form>
             }
             @if (Model.Status == SurveyStatus.Open)
@@ -55,6 +58,16 @@
 
 <div asp-validation-summary="All" class="alert alert-danger" role="alert" style="@(ViewData.ModelState.IsValid ? "display:none" : "")"></div>
 
+@if (Model.IsDefinitionLocked)
+{
+    <div class="alert alert-warning" role="alert">
+        <strong>This binding Asociado vote is locked.</strong>
+        Once it opened, its questions, wording, settings, dates, audience and invitation copy became
+        read-only. You may still preview it, close it, inspect participation, and—after close—mark ranked
+        options unavailable for recounting.
+    </div>
+}
+
 <form asp-controller="SurveyAdmin" asp-action="Save" method="post" enctype="multipart/form-data"
       id="survey-builder-form" class="pb-5">
     @Html.AntiForgeryToken()
@@ -63,6 +76,7 @@
         <input type="hidden" asp-for="Id" />
     }
     <input type="hidden" asp-for="Status" />
+    <fieldset class="border-0 p-0 m-0 w-100" disabled="@(Model.IsDefinitionLocked ? "disabled" : null)">
 
     @* One culture is edited at a time; the badge counts fields still missing vs the default language. *@
     <div class="d-flex flex-wrap align-items-center gap-1 mb-2" id="culture-tabs">
@@ -111,27 +125,33 @@
                 </div>
             </div>
 
-            <div class="form-check mt-3">
-                @if (!Model.IsNew && Model.Status != SurveyStatus.Draft)
-                {
-                    <input type="hidden" name="IsAsociadoVote" value="@(Model.IsAsociadoVote ? "true" : "false")" />
-                    <input type="checkbox" class="form-check-input" id="asociadoVote"
-                           checked="@(Model.IsAsociadoVote ? "checked" : null)" disabled />
-                }
-                else
-                {
-                    <input type="checkbox" class="form-check-input" id="asociadoVote" asp-for="IsAsociadoVote" />
-                }
-                <label class="form-check-label fw-semibold" for="asociadoVote">Asociado vote</label>
-                <div class="form-text">
-                    Identified responses only. While open, only participation statistics are visible;
-                    all answer-derived results are embargoed until close, and the vote cannot then be reopened.
+            <section class="border border-warning rounded p-3 mt-3" aria-labelledby="asociado-vote-heading">
+                <h2 class="h6" id="asociado-vote-heading">Asociado vote</h2>
+                <div class="alert alert-warning small" role="note">
+                    <i class="fa-solid fa-circle-info me-1"></i>
+                    Use this only for a binding association decision. Review every question, option, date,
+                    translation, audience setting and invitation carefully before opening. Opening is
+                    irreversible: the complete survey becomes read-only, and after it closes it cannot be reopened.
+                </div>
+                <div class="form-check">
                     @if (!Model.IsNew && Model.Status != SurveyStatus.Draft)
                     {
-                        <strong>This setting is locked because the survey has opened.</strong>
+                        <input type="hidden" name="IsAsociadoVote" value="@(Model.IsAsociadoVote ? "true" : "false")" />
+                        <input type="checkbox" class="form-check-input" id="asociadoVote"
+                               checked="@(Model.IsAsociadoVote ? "checked" : null)" disabled />
                     }
+                    else
+                    {
+                        <input type="checkbox" class="form-check-input" id="asociadoVote" asp-for="IsAsociadoVote" />
+                    }
+                    <label class="form-check-label fw-semibold" for="asociadoVote">This is a binding Asociado vote</label>
+                    <div class="form-text">
+                        Only active, approved Asociados may answer. Ballots are identified. While open, only
+                        participation statistics are visible; all answer-derived results are sealed until close.
+                        Once opened, the survey cannot be edited. Once closed, it cannot be reopened.
+                    </div>
                 </div>
-            </div>
+            </section>
 
             <div class="row g-3 mt-1">
                 <div class="col-md-3">
@@ -196,6 +216,9 @@
         <partial name="_SurveyQuestionCard" model="@(new SurveyQuestionCardModel("__QKEY__", new SurveyQuestionBuilderViewModel(), Model.HasSavedAnswers))" />
     </template>
 
+    </fieldset>
+    @if (!Model.IsDefinitionLocked)
+    {
     <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mt-3">
         <button type="button" class="btn btn-outline-secondary btn-sm" id="add-question">+ Add question</button>
         <div class="d-flex flex-column flex-sm-row flex-wrap gap-2">
@@ -209,6 +232,7 @@
             <button type="submit" class="btn btn-primary">Save survey</button>
         </div>
     </div>
+    }
 </form>
 
 @section Scripts {
@@ -558,7 +582,7 @@
             }
 
             // ── events ───────────────────────────────────────────────────────
-            document.getElementById('add-question').addEventListener('click', function () {
+            document.getElementById('add-question')?.addEventListener('click', function () {
                 addQuestion(null);
             });
 

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
@@ -52,7 +52,18 @@
                                 @(string.IsNullOrWhiteSpace(s.Title) ? "(untitled)" : s.Title)
                             </a>
                         </td>
-                        <td><span class="badge @StatusBadge(s.Status)">@s.Status</span></td>
+                        <td>
+                            @if (s.Status == SurveyStatus.Open)
+                            {
+                                <a asp-controller="SurveyAdmin" asp-action="Official" asp-route-id="@s.Id"
+                                   class="badge @StatusBadge(s.Status) text-decoration-none"
+                                   title="Open the official survey link">@s.Status</a>
+                            }
+                            else
+                            {
+                                <span class="badge @StatusBadge(s.Status)">@s.Status</span>
+                            }
+                        </td>
                         <td class="text-end">@s.InvitedCount</td>
                         <td class="text-end">@s.ResponseCount</td>
                         <td class="text-end">@(s.InvitedCount > 0 ? $"{rate}%" : "—")</td>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
@@ -68,3 +68,10 @@
         </table>
     </div>
 </div>
+@if (ViewData["CanSeedRankedDemo"] as bool? == true)
+{
+    <form asp-action="SeedRankedDemo" method="post" class="mb-3">
+        @Html.AntiForgeryToken()
+        <button type="submit" class="btn btn-outline-secondary btn-sm">Create ranked-voting demo surveys</button>
+    </form>
+}

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Index.cshtml
@@ -68,10 +68,3 @@
         </table>
     </div>
 </div>
-@if (ViewData["CanSeedRankedDemo"] as bool? == true)
-{
-    <form asp-action="SeedRankedDemo" method="post" class="mb-3">
-        @Html.AntiForgeryToken()
-        <button type="submit" class="btn btn-outline-secondary btn-sm">Create ranked-voting demo surveys</button>
-    </form>
-}

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Results.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Results.cshtml
@@ -24,13 +24,24 @@
     <h1 class="mb-0">@(string.IsNullOrWhiteSpace(Model.Title) ? "(untitled)" : Model.Title)</h1>
     <div class="d-flex align-items-center gap-2">
         <span class="badge @StatusBadge(Model.Status)">@Model.Status</span>
-        <a asp-controller="SurveyAdmin" asp-action="ExportCsv" asp-route-id="@Model.SurveyId" class="btn btn-outline-secondary btn-sm">Download CSV</a>
-        <a asp-controller="SurveyAdmin" asp-action="ExportJson" asp-route-id="@Model.SurveyId" class="btn btn-outline-secondary btn-sm">Download JSON</a>
+        @if (!Model.IsEmbargoed)
+        {
+            <a asp-controller="SurveyAdmin" asp-action="ExportCsv" asp-route-id="@Model.SurveyId" class="btn btn-outline-secondary btn-sm">Download CSV</a>
+            <a asp-controller="SurveyAdmin" asp-action="ExportJson" asp-route-id="@Model.SurveyId" class="btn btn-outline-secondary btn-sm">Download JSON</a>
+        }
     </div>
 </div>
 
 <vc:temp-data-alerts />
 
+@if (Model.IsEmbargoed)
+{
+    <div class="alert alert-info">
+        This is an Asociado vote. Answer-derived results, exports, and respondent details become available only after the vote closes.
+    </div>
+}
+else
+{
 <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-4">
     <div>
         <strong>Question results:</strong>
@@ -51,6 +62,7 @@
         </a>
     </div>
 </div>
+}
 
 <div class="row g-3 mb-4">
     <div class="col-sm-4">
@@ -91,6 +103,8 @@
     </div>
 </div>
 
+@if (!Model.IsEmbargoed)
+{
 <h2 class="h5">Questions</h2>
 @if (Model.Questions.Count == 0)
 {
@@ -103,6 +117,122 @@
         <div class="card-body">
             @switch (q.Type)
             {
+                case SurveyQuestionType.RankedChoice:
+                    @if (!Model.RankedQuestions.TryGetValue(q.QuestionId, out var ranked))
+                    {
+                        <p class="text-muted mb-0">No ranked ballots.</p>
+                    }
+                    else
+                    {
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <div class="text-muted small">Original official result — all authored options</div>
+                                        <div class="h5 mb-0">@(ranked.OriginalOfficialResult.WinnerLabel ?? "No winner")</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <div class="text-muted small">Current official result — available options</div>
+                                        <div class="h5 mb-0">@(ranked.CurrentOfficialResult.WinnerLabel ?? "No winner")</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        @if (!string.Equals(
+                            ranked.OriginalOfficialResult.WinnerValue,
+                            ranked.CurrentOfficialResult.WinnerValue,
+                            StringComparison.Ordinal))
+                        {
+                            <div class="alert alert-warning py-2">
+                                Excluding unavailable options changes the official winner.
+                            </div>
+                        }
+
+                        <h4 class="h6">Sensitivity analysis — current available options</h4>
+                        <div class="table-responsive mb-3">
+                            <table class="table table-sm align-middle">
+                                <thead><tr><th>Method</th><th>Winner</th><th>Notes</th></tr></thead>
+                                <tbody>
+                                @foreach (var method in ranked.Methods)
+                                {
+                                    <tr class="@(method.Method.StartsWith("Ranked Pairs", StringComparison.Ordinal) ? "table-primary" : "")">
+                                        <th scope="row">@method.Method</th>
+                                        <td>@(method.WinnerLabel ?? "No unique winner")</td>
+                                        <td>@(method.TieBreakUsed ? "Authored-order tie-break applied" : "")</td>
+                                    </tr>
+                                }
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <details class="mb-3">
+                            <summary>Pairwise comparisons</summary>
+                            <div class="table-responsive mt-2">
+                                <table class="table table-sm">
+                                    <thead><tr><th>Pair</th><th>Votes</th></tr></thead>
+                                    <tbody>
+                                    @foreach (var contest in ranked.Pairwise)
+                                    {
+                                        var first = ranked.Candidates.First(candidate => candidate.Value == contest.First).Label;
+                                        var second = ranked.Candidates.First(candidate => candidate.Value == contest.Second).Label;
+                                        <tr><td>@first vs @second</td><td>@contest.PreferFirst – @contest.PreferSecond</td></tr>
+                                    }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </details>
+
+                        <h4 class="h6">Rejections</h4>
+                        <div class="table-responsive mb-3">
+                            <table class="table table-sm">
+                                <thead><tr><th>Option</th><th>Rejected</th><th>Status</th></tr></thead>
+                                <tbody>
+                                @foreach (var candidate in ranked.Candidates)
+                                {
+                                    <tr>
+                                        <td>@candidate.Label</td>
+                                        <td>@candidate.RejectionCount (@Math.Round(candidate.RejectionPercent)%)</td>
+                                        <td>
+                                            @if (!candidate.IsAvailable)
+                                            {
+                                                <span class="badge text-bg-warning">No longer available</span>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                                </tbody>
+                            </table>
+                        </div>
+
+                        @if (Model.Status == SurveyStatus.Closed)
+                        {
+                            <form asp-action="RankedAvailability" asp-route-id="@Model.SurveyId" method="post">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="questionId" value="@q.QuestionId" />
+                                <fieldset>
+                                    <legend class="h6">Unavailable options</legend>
+                                    <p class="form-text">Exclude dates or choices that are no longer available, without changing saved ballots.</p>
+                                    @foreach (var candidate in ranked.Candidates)
+                                    {
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox"
+                                                   id="unavailable-@q.QuestionId-@candidate.Value"
+                                                   name="unavailableValues" value="@candidate.Value"
+                                                   checked="@(!candidate.IsAvailable ? "checked" : null)" />
+                                            <label class="form-check-label" for="unavailable-@q.QuestionId-@candidate.Value">@candidate.Label</label>
+                                        </div>
+                                    }
+                                    <button type="submit" class="btn btn-outline-primary btn-sm mt-2">Recalculate</button>
+                                </fieldset>
+                            </form>
+                        }
+                    }
+                    break;
+
                 case SurveyQuestionType.SingleChoice:
                 case SurveyQuestionType.MultiChoice:
                     @if (q.OptionCounts.Count == 0)
@@ -240,6 +370,21 @@
                                                 }
                                             </ul>
                                         }
+                                        else if (a.RankedBallot is { } ballot)
+                                        {
+                                            <ol class="mb-0 ps-3">
+                                                @foreach (var group in ballot.RankGroups)
+                                                {
+                                                    <li>@string.Join(" = ", group)</li>
+                                                }
+                                            </ol>
+                                            @if (ballot.Rejected.Count > 0)
+                                            {
+                                                <div class="small text-danger mt-1">
+                                                    <strong>Rejected:</strong> @string.Join(", ", ballot.Rejected)
+                                                </div>
+                                            }
+                                        }
                                         else if (a.SelectedLabels.Count > 0)
                                         {
                                             @string.Join(", ", a.SelectedLabels)
@@ -265,6 +410,7 @@
             }
         </div>
     }
+}
 }
 
 <div class="mt-3">

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Results.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Results.cshtml
@@ -142,6 +142,35 @@ else
                                 </div>
                             </div>
                         </div>
+                        var originalCycleLabels = ranked.OriginalPreferenceCycle
+                            .Select(value => ranked.Candidates
+                                .FirstOrDefault(candidate => string.Equals(candidate.Value, value, StringComparison.Ordinal))
+                                ?.Label ?? value)
+                            .ToList();
+                        var currentCycleLabels = ranked.CurrentPreferenceCycle
+                            .Select(value => ranked.Candidates
+                                .FirstOrDefault(candidate => string.Equals(candidate.Value, value, StringComparison.Ordinal))
+                                ?.Label ?? value)
+                            .ToList();
+                        @if (currentCycleLabels.Count > 0 || originalCycleLabels.Count > 0)
+                        {
+                            var showingCurrentCycle = currentCycleLabels.Count > 0;
+                            var cycleLabels = showingCurrentCycle ? currentCycleLabels : originalCycleLabels;
+                            <div class="alert alert-info">
+                                <strong>Preference cycle detected in the @(showingCurrentCycle ? "available-options" : "all-options") count:</strong>
+                                @string.Join(" → ", cycleLabels).
+                                @if (showingCurrentCycle)
+                                {
+                                    <text>Like rock–paper–scissors, each option beats another but is beaten by a third. No option beats every other option head-to-head, so Ranked Pairs resolves the cycle by locking the strongest victories without creating a loop.</text>
+                                }
+                                else
+                                {
+                                    <text>Like rock–paper–scissors, each option beat another but was beaten by a third. Removing an unavailable option breaks this cycle. The remaining options are then compared directly, so the winner can change even when the previous winner is still available.</text>
+                                }
+                                <a href="https://nobodies.team/event-dates-2027-voting-method.html#preference-cycles-and-availability"
+                                   target="_blank" rel="noopener noreferrer">Why availability changes can look counter-intuitive</a>.
+                            </div>
+                        }
                         @if (!string.Equals(
                             ranked.OriginalOfficialResult.WinnerValue,
                             ranked.CurrentOfficialResult.WinnerValue,

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/Send.cshtml
@@ -91,13 +91,19 @@
         @if (Model.Status != SurveyStatus.Open)
         {
             <p class="text-muted">The survey must be <strong>Open</strong> before invitations can be sent.</p>
-            @if (Model.AudienceType is not null && Model.NewRecipientCount > 0)
+            @if (Model.Status == SurveyStatus.Closed && Model.IsAsociadoVote)
+            {
+                <p class="text-muted mb-0">A closed Asociado vote cannot be reopened.</p>
+            }
+            else if (Model.AudienceType is not null && Model.NewRecipientCount > 0)
             {
                 <form asp-controller="SurveyAdmin" asp-action="Open" asp-route-id="@Model.Id" method="post" class="d-inline">
                     @Html.AntiForgeryToken()
                     <input type="hidden" name="continueToSend" value="true" />
                     <button type="submit" class="btn btn-success"
-                            data-confirm="Open this survey so it can receive responses?">
+                            data-confirm="@(Model.IsAsociadoVote
+                                ? "Open this binding Asociado vote? Once opened, its definition and audience cannot be edited; once closed, it cannot be reopened."
+                                : "Open this survey so it can receive responses?")">
                         Open survey
                     </button>
                 </form>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
@@ -110,6 +110,25 @@
             <div class="form-text grid-column-help">Grid questions support at most five columns.</div>
         </div>
 
+        <div class="ranked-section border-top pt-2 mt-2">
+            <div class="alert alert-info small py-2">
+                Ranked choice uses Ranked Pairs (Tideman) as the official method.
+                If two outcomes remain tied, the option listed earlier wins.
+            </div>
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="ranked-equal-@key"
+                       name="@(prefix).RankedAllowEqualRanks" value="true"
+                       @(q.RankedAllowEqualRanks ? "checked" : null) />
+                <label class="form-check-label small" for="ranked-equal-@key">Allow equal ranks</label>
+            </div>
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="ranked-reject-@key"
+                       name="@(prefix).RankedAllowReject" value="true"
+                       @(q.RankedAllowReject ? "checked" : null) />
+                <label class="form-check-label small" for="ranked-reject-@key">Include a Reject option</label>
+            </div>
+        </div>
+
         <div class="grid-section border-top pt-2 mt-2">
             <div class="mb-2">
                 <label class="form-label small fw-semibold" for="grid-mode-@key">Selections per row</label>

--- a/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
+++ b/src/Sections/Humans.Surveys/Views/SurveyAdmin/_SurveyQuestionCard.cshtml
@@ -115,18 +115,43 @@
                 Ranked choice uses Ranked Pairs (Tideman) as the official method.
                 If two outcomes remain tied, the option listed earlier wins.
             </div>
-            <div class="form-check">
-                <input type="checkbox" class="form-check-input" id="ranked-equal-@key"
-                       name="@(prefix).RankedAllowEqualRanks" value="true"
-                       @(q.RankedAllowEqualRanks ? "checked" : null) />
-                <label class="form-check-label small" for="ranked-equal-@key">Allow equal ranks</label>
-            </div>
-            <div class="form-check">
-                <input type="checkbox" class="form-check-input" id="ranked-reject-@key"
-                       name="@(prefix).RankedAllowReject" value="true"
-                       @(q.RankedAllowReject ? "checked" : null) />
-                <label class="form-check-label small" for="ranked-reject-@key">Include a Reject option</label>
-            </div>
+            @if (Model.RankedDefinitionLocked)
+            {
+                <input type="hidden" name="@(prefix).RankedAllowEqualRanks"
+                       value="@(q.RankedAllowEqualRanks ? "true" : "false")" />
+                <input type="hidden" name="@(prefix).RankedAllowReject"
+                       value="@(q.RankedAllowReject ? "true" : "false")" />
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="ranked-equal-@key"
+                           checked="@(q.RankedAllowEqualRanks ? "checked" : null)" disabled />
+                    <label class="form-check-label small" for="ranked-equal-@key">Allow equal ranks</label>
+                </div>
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="ranked-reject-@key"
+                           checked="@(q.RankedAllowReject ? "checked" : null)" disabled />
+                    <label class="form-check-label small" for="ranked-reject-@key">Include a Reject option</label>
+                </div>
+                <div class="form-text">
+                    Ranked candidates, order, and settings are locked because an answer has been saved.
+                </div>
+            }
+            else
+            {
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="ranked-equal-@key"
+                           name="@(prefix).RankedAllowEqualRanks" value="true"
+                           checked="@(q.RankedAllowEqualRanks ? "checked" : null)" />
+                    <input type="hidden" name="@(prefix).RankedAllowEqualRanks" value="false" />
+                    <label class="form-check-label small" for="ranked-equal-@key">Allow equal ranks</label>
+                </div>
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="ranked-reject-@key"
+                           name="@(prefix).RankedAllowReject" value="true"
+                           checked="@(q.RankedAllowReject ? "checked" : null)" />
+                    <input type="hidden" name="@(prefix).RankedAllowReject" value="false" />
+                    <label class="form-check-label small" for="ranked-reject-@key">Include a Reject option</label>
+                </div>
+            }
         </div>
 
         <div class="grid-section border-top pt-2 mt-2">

--- a/tests/Humans.Surveys.Tests/Models/SurveyCsvExportBuilderTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyCsvExportBuilderTests.cs
@@ -106,6 +106,40 @@ public sealed class SurveyCsvExportBuilderTests
     }
 
     [HumansFact]
+    public void Serializes_ranked_ballot_as_stable_value_json()
+    {
+        var questionId = Guid.NewGuid();
+        var export = new SurveyResponseExport(
+            Guid.NewGuid(), "T", "en",
+            [
+                new SurveyExportQuestion(
+                    questionId,
+                    "Rank dates",
+                    SurveyQuestionType.RankedChoice,
+                    [new SurveyExportOption("a", "Apple"), new SurveyExportOption("b", "Banana")]),
+            ],
+            [
+                new SurveyExportRow(
+                    Guid.NewGuid(), ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                    "en", Submitted, Guid.NewGuid(), "Sparkle",
+                    [
+                        new SurveyExportAnswer(
+                            questionId, [], [], null, null,
+                            RankedBallot: new SurveyRankedBallot([["a"]], ["b"])),
+                    ]),
+            ]);
+
+        var csv = Encoding.UTF8.GetString(SurveyCsvExportBuilder.Build(export));
+
+        csv.Should().Contain("RankGroups");
+        csv.Should().Contain("Rejected");
+        csv.Should().Contain(@"""""a""""");
+        csv.Should().Contain(@"""""b""""");
+        csv.Should().NotContain("Apple");
+        csv.Should().NotContain("Banana");
+    }
+
+    [HumansFact]
     public void Leaves_identity_columns_blank_for_non_identified_row()
     {
         var textId = Guid.NewGuid();

--- a/tests/Humans.Surveys.Tests/Models/SurveyResponsesMarkdownBuilderTests.cs
+++ b/tests/Humans.Surveys.Tests/Models/SurveyResponsesMarkdownBuilderTests.cs
@@ -83,6 +83,34 @@ public sealed class SurveyResponsesMarkdownBuilderTests
     }
 
     [HumansFact]
+    public void Serializes_ranked_ballot_as_stable_value_json()
+    {
+        var questionId = Guid.NewGuid();
+        var md = SurveyResponsesMarkdownBuilder.Build(
+            [
+                new SurveyExportQuestion(
+                    questionId,
+                    "Rank dates",
+                    SurveyQuestionType.RankedChoice,
+                    [new SurveyExportOption("a", "Apple"), new SurveyExportOption("b", "Banana")]),
+            ],
+            [
+                new SurveyExportRow(
+                    Guid.NewGuid(), ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                    "en", Submitted, Guid.NewGuid(), "Sparkle",
+                    [
+                        new SurveyExportAnswer(
+                            questionId, [], [], null, null,
+                            RankedBallot: new SurveyRankedBallot([["a"]], ["b"])),
+                    ]),
+            ]);
+
+        md.Should().Contain(@"{""RankGroups"":[[""a""]],""Rejected"":[""b""]}");
+        md.Should().NotContain("Apple");
+        md.Should().NotContain("Banana");
+    }
+
+    [HumansFact]
     public void Leaves_user_name_blank_for_non_identified_row()
     {
         var textId = Guid.NewGuid();

--- a/tests/Humans.Surveys.Tests/Services/RankedChoiceCounterTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/RankedChoiceCounterTests.cs
@@ -1,0 +1,173 @@
+using AwesomeAssertions;
+using Humans.Surveys.Services;
+
+namespace Humans.Surveys.Tests.Services;
+
+public class RankedChoiceCounterTests
+{
+    private static readonly IReadOnlyList<string> Candidates = ["A", "B", "C"];
+
+    [HumansFact]
+    public void Pairwise_treats_ranked_as_better_than_unranked_and_rejected()
+    {
+        var matrix = RankedChoiceCounter.BuildPairwise(
+            Candidates,
+            [Ballot([["A"]], "C")]);
+
+        Contest(matrix, "A", "B").Should().Be((1, 0));
+        Contest(matrix, "A", "C").Should().Be((1, 0));
+        Contest(matrix, "B", "C").Should().Be((1, 0));
+    }
+
+    [HumansFact]
+    public void Pairwise_records_no_preference_inside_equal_rank_or_bottom_tier()
+    {
+        var matrix = RankedChoiceCounter.BuildPairwise(
+            ["A", "B", "C", "D"],
+            [Ballot([["A", "B"]], "C", "D")]);
+
+        Contest(matrix, "A", "B").Should().Be((0, 0));
+        Contest(matrix, "C", "D").Should().Be((0, 0));
+    }
+
+    [HumansFact]
+    public void Ranked_pairs_resolves_a_condorcet_cycle()
+    {
+        var ballots = Repeat(3, Ballot([["A"], ["B"], ["C"]]))
+            .Concat(Repeat(2, Ballot([["B"], ["C"], ["A"]])))
+            .Concat(Repeat(2, Ballot([["C"], ["A"], ["B"]])))
+            .ToList();
+        var matrix = RankedChoiceCounter.BuildPairwise(Candidates, ballots);
+
+        var result = RankedChoiceCounter.CountRankedPairs(Candidates, matrix);
+
+        result.Winner.Should().Be("A");
+        result.Locks.Should().ContainEquivalentOf(new RankedPairsLock("C", "A", 1, 4, false));
+    }
+
+    [HumansFact]
+    public void Ranked_pairs_uses_authored_pair_order_for_equal_strength_victories()
+    {
+        var matrix = new RankedPairwiseMatrix(
+        [
+            new PairwiseContest("A", "B", 3, 1),
+            new PairwiseContest("A", "C", 1, 3),
+            new PairwiseContest("B", "C", 3, 1),
+        ]);
+
+        var result = RankedChoiceCounter.CountRankedPairs(Candidates, matrix);
+
+        result.Locks.Select(item => (item.Winner, item.Loser)).Should().Equal(
+            ("A", "B"),
+            ("B", "C"),
+            ("C", "A"));
+        result.TieBreakUsed.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void Condorcet_returns_the_candidate_who_beats_every_other_candidate()
+    {
+        var matrix = RankedChoiceCounter.BuildPairwise(
+            Candidates,
+            [
+                Ballot([["A"], ["B"], ["C"]]),
+                Ballot([["A"], ["C"], ["B"]]),
+                Ballot([["B"], ["A"], ["C"]]),
+            ]);
+
+        var result = RankedChoiceCounter.CheckCondorcet(Candidates, matrix);
+
+        result.Winner.Should().Be("A");
+        result.SmallestCycle.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void Condorcet_reports_the_smallest_visible_cycle()
+    {
+        var matrix = new RankedPairwiseMatrix(
+        [
+            new PairwiseContest("A", "B", 2, 1),
+            new PairwiseContest("A", "C", 1, 2),
+            new PairwiseContest("B", "C", 2, 1),
+        ]);
+
+        var result = RankedChoiceCounter.CheckCondorcet(Candidates, matrix);
+
+        result.Winner.Should().BeNull();
+        result.SmallestCycle.Should().HaveCount(4);
+        result.SmallestCycle[0].Should().Be(result.SmallestCycle[^1]);
+    }
+
+    [HumansFact]
+    public void Borda_averages_every_tied_tier_and_keeps_reject_below_unranked()
+    {
+        var result = RankedChoiceCounter.CountBorda(
+            ["A", "B", "C", "D", "E"],
+            [Ballot([["A"], ["B", "C"]], "E")]);
+
+        Score(result, "A").Should().Be("4");
+        Score(result, "B").Should().Be("5/2");
+        Score(result, "C").Should().Be("5/2");
+        Score(result, "D").Should().Be("1");
+        Score(result, "E").Should().Be("0");
+    }
+
+    [HumansFact]
+    public void Availability_removes_candidates_without_mutating_ballots()
+    {
+        var ballots = new[]
+        {
+            Ballot([["A"], ["B"], ["C"]]),
+            Ballot([["B"], ["C"], ["A"]]),
+        };
+        var active = new HashSet<string>(["A", "C"], StringComparer.Ordinal);
+
+        var matrix = RankedChoiceCounter.BuildPairwise(Candidates, ballots, active);
+        var borda = RankedChoiceCounter.CountBorda(Candidates, ballots, active);
+
+        matrix.Contests.Should().ContainSingle();
+        matrix.Contests[0].First.Should().Be("A");
+        matrix.Contests[0].Second.Should().Be("C");
+        borda.Scores.Select(score => score.Candidate).Should().Equal("A", "C");
+        ballots[0].RankGroups.SelectMany(group => group).Should().Contain("B");
+    }
+
+    [HumansFact]
+    public void Empty_and_single_candidate_counts_are_defined()
+    {
+        RankedChoiceCounter.CountRankedPairs(
+                [],
+                new RankedPairwiseMatrix([]))
+            .Winner.Should().BeNull();
+
+        var matrix = RankedChoiceCounter.BuildPairwise(["A"], []);
+        RankedChoiceCounter.CountRankedPairs(["A"], matrix).Winner.Should().Be("A");
+        RankedChoiceCounter.CheckCondorcet(["A"], matrix).Winner.Should().Be("A");
+        RankedChoiceCounter.CountBorda(["A"], []).Winner.Should().Be("A");
+    }
+
+    private static RankedBallot Ballot(
+        IReadOnlyList<IReadOnlyList<string>> groups,
+        params string[] rejected) =>
+        new(groups, rejected.ToHashSet(StringComparer.Ordinal));
+
+    private static IEnumerable<RankedBallot> Repeat(int count, RankedBallot ballot) =>
+        Enumerable.Repeat(ballot, count);
+
+    private static (int First, int Second) Contest(
+        RankedPairwiseMatrix matrix,
+        string first,
+        string second)
+    {
+        var contest = matrix.Contests.Single(item =>
+            string.Equals(item.First, first, StringComparison.Ordinal) &&
+            string.Equals(item.Second, second, StringComparison.Ordinal));
+        return (contest.PreferFirst, contest.PreferSecond);
+    }
+
+    private static string Score(BordaResult result, string candidate) =>
+        result.Scores
+            .Single(score => string.Equals(score.Candidate, candidate, StringComparison.Ordinal))
+            .Score
+            .ToString();
+}

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -3384,10 +3384,14 @@ public class SurveyServiceTests
         survey.IsAsociadoVote = true;
         var questionId = Guid.NewGuid();
         var question = RankedQuestion(questionId, survey.Id);
-        question.RankedUnavailableOptionValues = ["a"];
+        question.RankedUnavailableOptionValues = ["b"];
         survey.Questions = [question];
         var responses = new[]
         {
+            SubmittedResponse(
+                survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                _clock.GetCurrentInstant(), Guid.NewGuid(),
+                RankedAnswerFor(questionId, [["a"], ["b"]], "c")),
             SubmittedResponse(
                 survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
                 _clock.GetCurrentInstant(), Guid.NewGuid(),
@@ -3395,11 +3399,15 @@ public class SurveyServiceTests
             SubmittedResponse(
                 survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
                 _clock.GetCurrentInstant(), Guid.NewGuid(),
-                RankedAnswerFor(questionId, [["a"], ["b"], ["c"]], "c")),
+                RankedAnswerFor(questionId, [["b"], ["c"], ["a"]])),
             SubmittedResponse(
                 survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
                 _clock.GetCurrentInstant(), Guid.NewGuid(),
                 RankedAnswerFor(questionId, [["b"], ["c"], ["a"]])),
+            SubmittedResponse(
+                survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                _clock.GetCurrentInstant(), Guid.NewGuid(),
+                RankedAnswerFor(questionId, [["c"], ["a"], ["b"]])),
         };
         _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
         _repo.GetResponsesForResultsAsync(survey.Id, Arg.Any<CancellationToken>())
@@ -3414,12 +3422,15 @@ public class SurveyServiceTests
 
         var ranked = scoped!.RankedQuestions![questionId];
         ranked.OriginalOfficialResult.WinnerValue.Should().Be("a");
-        ranked.CurrentOfficialResult.WinnerValue.Should().Be("b");
+        ranked.CurrentOfficialResult.WinnerValue.Should().Be("c");
+        ranked.OriginalPreferenceCycle.Should().HaveCount(4);
+        ranked.OriginalPreferenceCycle[0].Should().Be(ranked.OriginalPreferenceCycle[^1]);
+        ranked.CurrentPreferenceCycle.Should().BeEmpty();
         ranked.Methods.Select(method => method.Method).Should().Equal(
             "Ranked Pairs (official)", "Condorcet check", "Borda Count");
         ranked.Candidates.Single(candidate => string.Equals(candidate.Value, "c", StringComparison.Ordinal))
             .RejectionCount.Should().Be(1);
-        ranked.Candidates.Single(candidate => string.Equals(candidate.Value, "a", StringComparison.Ordinal))
+        ranked.Candidates.Single(candidate => string.Equals(candidate.Value, "b", StringComparison.Ordinal))
             .IsAvailable.Should().BeFalse();
     }
 }

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -3375,11 +3375,29 @@ public class SurveyServiceTests
         var ordinary = async () => await service.CreateAsync(
             Input(ranked), Guid.NewGuid(), TestContext.Current.CancellationToken);
         var anonymousVote = async () => await service.CreateAsync(
-            Input(ranked) with { IsAsociadoVote = true, AllowAnonymous = true },
+            Input(ranked) with
+            {
+                IsAsociadoVote = true,
+                AudienceType = SurveyAudienceType.Asociados,
+                AllowAnonymous = true,
+            },
             Guid.NewGuid(),
             TestContext.Current.CancellationToken);
         var publicVote = async () => await service.CreateAsync(
-            Input(ranked) with { IsAsociadoVote = true, PublicSlug = "vote" },
+            Input(ranked) with
+            {
+                IsAsociadoVote = true,
+                AudienceType = SurveyAudienceType.Asociados,
+                PublicSlug = "vote",
+            },
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        var wrongAudience = async () => await service.CreateAsync(
+            Input(ranked) with
+            {
+                IsAsociadoVote = true,
+                AudienceType = SurveyAudienceType.AllActiveMembers,
+            },
             Guid.NewGuid(),
             TestContext.Current.CancellationToken);
 
@@ -3389,6 +3407,8 @@ public class SurveyServiceTests
             .WithMessage("*identified*");
         await publicVote.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*public link*");
+        await wrongAudience.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Asociados audience*");
         await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
     }
 
@@ -3481,7 +3501,11 @@ public class SurveyServiceTests
 
         var act = async () => await CreateService().UpdateAsync(
             survey.Id,
-            Input(changed) with { IsAsociadoVote = true },
+            Input(changed) with
+            {
+                IsAsociadoVote = true,
+                AudienceType = SurveyAudienceType.Asociados,
+            },
             Guid.NewGuid(),
             TestContext.Current.CancellationToken);
 
@@ -3493,7 +3517,7 @@ public class SurveyServiceTests
     [HumansFact]
     public async Task SetRankedAvailabilityAsync_is_post_close_only_and_audits_stable_values()
     {
-        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        var survey = SurveyWith(SurveyStatus.Closed, SurveyAudienceType.Asociados, null);
         survey.IsAsociadoVote = true;
         var questionId = Guid.NewGuid();
         var question = RankedQuestion(questionId, survey.Id);

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -70,6 +70,20 @@ public class SurveyServiceTests
             mode,
             rows ?? [new GridRowInput("monday", L("Monday")), new GridRowInput("tuesday", L("Tuesday"))]);
 
+    private static QuestionInput RankedInput(
+        Guid? id = null,
+        bool allowEqualRanks = true,
+        bool allowReject = true,
+        IReadOnlyList<OptionInput>? options = null) =>
+        new(
+            id, 1, 1, SurveyQuestionType.RankedChoice, L("Rank dates"), LocalizedText.Empty,
+            true, null, null, LocalizedText.Empty, LocalizedText.Empty, null,
+            options ?? [Opt("a", "A", 1), Opt("b", "B", 2), Opt("c", "C", 3)],
+            RankedSettings: new RankedQuestionSettings(
+                allowEqualRanks,
+                allowReject,
+                RankedVotingMethod.RankedPairs));
+
     private static SurveyEditInput Input(params QuestionInput[] qs) =>
         new(
             L("Title"), L("Intro"), L("Thanks"),
@@ -2462,6 +2476,44 @@ public class SurveyServiceTests
     private static SurveyAnswer TextAnswer(Guid questionId, string? text) =>
         new() { Id = Guid.NewGuid(), QuestionId = questionId, TextValue = text };
 
+    private static SurveyQuestion RankedQuestion(Guid id, Guid surveyId) => new()
+    {
+        Id = id,
+        SurveyId = surveyId,
+        PageNumber = 1,
+        Order = 1,
+        Type = SurveyQuestionType.RankedChoice,
+        Prompt = L("Rank dates"),
+        IsRequired = true,
+        RankedSettings = RankedQuestionSettings.Default with { AllowReject = true },
+        Options =
+        [
+            new SurveyQuestionOption
+            {
+                Id = Guid.NewGuid(), QuestionId = id, Order = 1, Value = "a", Label = L("A"),
+            },
+            new SurveyQuestionOption
+            {
+                Id = Guid.NewGuid(), QuestionId = id, Order = 2, Value = "b", Label = L("B"),
+            },
+            new SurveyQuestionOption
+            {
+                Id = Guid.NewGuid(), QuestionId = id, Order = 3, Value = "c", Label = L("C"),
+            },
+        ],
+    };
+
+    private static SurveyAnswer RankedAnswerFor(
+        Guid questionId,
+        IReadOnlyList<IReadOnlyList<string>> groups,
+        params string[] rejected) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            QuestionId = questionId,
+            RankedValue = new RankedAnswer(groups, rejected),
+        };
+
     private static SurveyQuestion GridQuestion(Guid id, Guid surveyId, GridSelectionMode mode = GridSelectionMode.Multiple) => new()
     {
         Id = id,
@@ -3017,6 +3069,43 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task GetResponseExportAsync_includes_ranked_schema_availability_and_raw_ballot()
+    {
+        var surveyId = Guid.NewGuid();
+        var questionId = Guid.NewGuid();
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(survey, surveyId);
+        survey.IsAsociadoVote = true;
+        var question = RankedQuestion(questionId, surveyId);
+        question.RankedUnavailableOptionValues = ["c"];
+        survey.Questions = [question];
+        _repo.GetByIdAsync(surveyId, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetResponsesForResultsAsync(surveyId, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                SubmittedResponse(
+                    surveyId,
+                    ResponseAnonymity.Identified,
+                    SurveyInputMethod.UserSpecificLink,
+                    _clock.GetCurrentInstant(),
+                    Guid.NewGuid(),
+                    RankedAnswerFor(questionId, [["a", "b"]], "c")),
+            ]);
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(new Dictionary<Guid, UserInfo>()));
+
+        var export = await CreateService().GetResponseExportAsync(surveyId, TestContext.Current.CancellationToken);
+
+        var schema = export!.Questions.Should().ContainSingle().Subject;
+        schema.RankedSettings.Should().Be(new SurveyRankedSettings(true, true, "RankedPairs"));
+        schema.RankedUnavailableOptionValues.Should().ContainSingle().Which.Should().Be("c");
+        var ballot = export.Rows.Single().Answers.Single().RankedBallot!;
+        ballot.RankGroups.Should().ContainSingle()
+            .Which.Should().ContainInOrder("a", "b");
+        ballot.Rejected.Should().ContainSingle().Which.Should().Be("c");
+    }
+
+    [HumansFact]
     public async Task GetResponseExportAsync_preserves_raw_grid_keys_removed_from_the_current_definition()
     {
         var surveyId = Guid.NewGuid();
@@ -3153,5 +3242,184 @@ public class SurveyServiceTests
         slices.Should().ContainSingle();
         await _repo.Received(1).GetIdentifiedResponsesForUserAsync(userId, Arg.Any<CancellationToken>());
         await _repo.DidNotReceive().GetResponsesForResultsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_ranked_choice_requires_identified_asociado_vote_mode()
+    {
+        var ranked = RankedInput();
+        var service = CreateService();
+
+        var ordinary = async () => await service.CreateAsync(
+            Input(ranked), Guid.NewGuid(), TestContext.Current.CancellationToken);
+        var anonymousVote = async () => await service.CreateAsync(
+            Input(ranked) with { IsAsociadoVote = true, AllowAnonymous = true },
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        var publicVote = async () => await service.CreateAsync(
+            Input(ranked) with { IsAsociadoVote = true, PublicSlug = "vote" },
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await ordinary.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*require Asociado vote*");
+        await anonymousVote.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*identified*");
+        await publicVote.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*public link*");
+        await _repo.DidNotReceive().AddAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task OpenAsync_rejects_reopening_a_closed_asociado_vote()
+    {
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        survey.IsAsociadoVote = true;
+        _repo.GetStatusAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(SurveyStatus.Closed);
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+
+        var act = async () => await CreateService().OpenAsync(
+            survey.Id, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot be reopened*");
+        await _repo.DidNotReceive().SetStatusAsync(
+            Arg.Any<Guid>(), Arg.Any<SurveyStatus>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Open_asociado_vote_exposes_participation_but_embargoes_answer_results_and_exports()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        survey.IsAsociadoVote = true;
+        var questionId = Guid.NewGuid();
+        survey.Questions = [TextQuestion(questionId, survey.Id, 1)];
+        var response = SubmittedResponse(
+            survey.Id,
+            ResponseAnonymity.Identified,
+            SurveyInputMethod.UserSpecificLink,
+            _clock.GetCurrentInstant(),
+            Guid.NewGuid(),
+            TextAnswer(questionId, "secret"));
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetResponsesForResultsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns([response]);
+        _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, int> { [survey.Id] = 4 });
+        _repo.GetStartedInvitationCountAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(2);
+
+        var service = CreateService();
+        var scoped = await service.GetScopedResultsAsync(
+            survey.Id, SurveyResultsScope.Combined, TestContext.Current.CancellationToken);
+        var publicResults = await service.GetResultsAsync(survey.Id, TestContext.Current.CancellationToken);
+        var export = await service.GetResponseExportAsync(survey.Id, TestContext.Current.CancellationToken);
+
+        scoped!.IsEmbargoed.Should().BeTrue();
+        scoped.Results.ResponseCount.Should().Be(1);
+        scoped.Results.InvitedCount.Should().Be(4);
+        scoped.Results.Questions.Should().BeEmpty();
+        scoped.Results.IdentifiedRespondents.Should().BeEmpty();
+        scoped.RankedQuestions.Should().BeEmpty();
+        publicResults.Should().BeNull();
+        export.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task UpdateAsync_freezes_ranked_candidates_order_and_settings_after_first_saved_answer()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        survey.IsAsociadoVote = true;
+        var questionId = Guid.NewGuid();
+        survey.Questions = [RankedQuestion(questionId, survey.Id)];
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.HasSavedAnswersAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(true);
+        var changed = RankedInput(
+            questionId,
+            allowEqualRanks: false,
+            options: [Opt("b", "B", 1), Opt("a", "A", 2), Opt("c", "C", 3)]);
+
+        var act = async () => await CreateService().UpdateAsync(
+            survey.Id,
+            Input(changed) with { IsAsociadoVote = true },
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot change after the first saved answer*");
+        await _repo.DidNotReceive().UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SetRankedAvailabilityAsync_is_post_close_only_and_audits_stable_values()
+    {
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        survey.IsAsociadoVote = true;
+        var questionId = Guid.NewGuid();
+        var question = RankedQuestion(questionId, survey.Id);
+        question.RankedUnavailableOptionValues = ["b"];
+        survey.Questions = [question];
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        Survey? captured = null;
+        _repo.When(repo => repo.UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>()))
+            .Do(call => captured = call.Arg<Survey>());
+        var actor = Guid.NewGuid();
+
+        await CreateService().SetRankedAvailabilityAsync(
+            survey.Id, questionId, ["c", "unknown"], actor, TestContext.Current.CancellationToken);
+
+        captured!.Questions.Single().RankedUnavailableOptionValues.Should().Equal("c");
+        await _audit.Received(1).LogAsync(
+            AuditAction.SurveyUpdated,
+            AuditEntityTypes.Survey,
+            survey.Id,
+            Arg.Is<string>(value => value.Contains("unavailable (c)", StringComparison.Ordinal)
+                && value.Contains("restored (b)", StringComparison.Ordinal)),
+            actor);
+    }
+
+    [HumansFact]
+    public async Task Closed_ranked_results_preserve_original_and_recount_available_options()
+    {
+        var survey = SurveyWith(SurveyStatus.Closed, null, null);
+        survey.IsAsociadoVote = true;
+        var questionId = Guid.NewGuid();
+        var question = RankedQuestion(questionId, survey.Id);
+        question.RankedUnavailableOptionValues = ["a"];
+        survey.Questions = [question];
+        var responses = new[]
+        {
+            SubmittedResponse(
+                survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                _clock.GetCurrentInstant(), Guid.NewGuid(),
+                RankedAnswerFor(questionId, [["a"], ["b"], ["c"]])),
+            SubmittedResponse(
+                survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                _clock.GetCurrentInstant(), Guid.NewGuid(),
+                RankedAnswerFor(questionId, [["a"], ["b"], ["c"]], "c")),
+            SubmittedResponse(
+                survey.Id, ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink,
+                _clock.GetCurrentInstant(), Guid.NewGuid(),
+                RankedAnswerFor(questionId, [["b"], ["c"], ["a"]])),
+        };
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetResponsesForResultsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns(responses);
+        _repo.GetInvitedCountsBySurveyAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, int>());
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, UserInfo>());
+
+        var scoped = await CreateService().GetScopedResultsAsync(
+            survey.Id, SurveyResultsScope.Combined, TestContext.Current.CancellationToken);
+
+        var ranked = scoped!.RankedQuestions![questionId];
+        ranked.OriginalOfficialResult.WinnerValue.Should().Be("a");
+        ranked.CurrentOfficialResult.WinnerValue.Should().Be("b");
+        ranked.Methods.Select(method => method.Method).Should().Equal(
+            "Ranked Pairs (official)", "Condorcet check", "Borda Count");
+        ranked.Candidates.Single(candidate => string.Equals(candidate.Value, "c", StringComparison.Ordinal))
+            .RejectionCount.Should().Be(1);
+        ranked.Candidates.Single(candidate => string.Equals(candidate.Value, "a", StringComparison.Ordinal))
+            .IsAvailable.Should().BeFalse();
     }
 }

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -824,6 +824,45 @@ public class SurveyServiceTests
             new User { Id = id, PreferredLanguage = "en", LastLoginAt = lastLogin, State = state },
             [], [], [], null, []);
 
+    private static UserInfo Asociado(Guid id, MembershipTier tier = MembershipTier.Asociado)
+    {
+        var profile = UserFixtures.Profile(
+            burnerName: "Voter",
+            firstName: "Eligible",
+            lastName: "Human",
+            isApproved: true,
+            membershipTier: tier);
+        return new UserInfo(
+            Id: id,
+            BurnerName: profile.BurnerName,
+            IsGdprAnonymized: false,
+            PreferredLanguage: "en",
+            FallbackPictureUrl: null,
+            CreatedAt: Instant.MinValue,
+            LastLoginAt: null,
+            LastConsentReminderSentAt: null,
+            DeletionRequestedAt: null,
+            DeletionScheduledFor: null,
+            DeletionEligibleAfter: null,
+            UnsubscribedFromCampaigns: false,
+            ICalToken: null,
+            SuppressScheduleChangeEmails: false,
+            MagicLinkSentAt: null,
+            ContactSource: null,
+            ExternalSourceId: null,
+            MergedToUserId: null,
+            MergedAt: null,
+            IdentityEmailColumn: null,
+            UserEmails: [],
+            EventParticipations: [],
+            ExternalLogins: [],
+            Profile: profile,
+            CommunicationPreferences: [])
+        {
+            State = UserState.Active,
+        };
+    }
+
     private static TeamInfo TeamWith(Guid teamId, params Guid[] memberUserIds) => new(
         teamId, "Team", null, "team",
         IsActive: true, IsSystemTeam: false, SystemTeamType.None, RequiresApproval: false,
@@ -1588,6 +1627,29 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task ResolveAnswerContextAsync_rejects_a_non_asociado_from_an_asociado_vote()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, SurveyAudienceType.Asociados, null);
+        survey.IsAsociadoVote = true;
+        var userId = Guid.NewGuid();
+        var invitation = InvitationFor(survey.Id, userId);
+        _tokenProvider.Resolve("vote").Returns(invitation.Id);
+        _repo.GetInvitationByIdAsync(invitation.Id, Arg.Any<CancellationToken>()).Returns(invitation);
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Asociado(userId, MembershipTier.Colaborador));
+
+        var ctx = await CreateService().ResolveAnswerContextAsync(
+            "vote", TestContext.Current.CancellationToken);
+
+        ctx.Should().NotBeNull();
+        ctx.IsEligible.Should().BeFalse();
+        ctx.HasResumableDraft.Should().BeFalse();
+        await _repo.DidNotReceive().GetDraftResponseAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task ResolvePublicContextAsync_returns_null_for_unknown_slug()
     {
         _repo.GetIdByPublicSlugAsync("missing", Arg.Any<CancellationToken>()).Returns((Guid?)null);
@@ -1882,6 +1944,34 @@ public class SurveyServiceTests
             "en",
             Arg.Any<CancellationToken>());
         await _repo.DidNotReceive().AddResponseWithAnswersAndSaveAsync(Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SubmitResponseAsync_rechecks_asociado_eligibility_before_finalising()
+    {
+        var survey = SurveyForSubmit(out var questionId, out _);
+        survey.IsAsociadoVote = true;
+        var userId = Guid.NewGuid();
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Asociado(userId, MembershipTier.Colaborador));
+        var submission = new SurveySubmission(
+            survey.Id, Guid.NewGuid(), userId, Guid.NewGuid(),
+            ResponseAnonymity.Identified, SurveyInputMethod.UserSpecificLink, "en",
+            [Ans(questionId, "yes")]);
+
+        var act = async () => await CreateService().SubmitResponseAsync(
+            submission, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*active, approved Asociado*");
+        await _repo.DidNotReceive().FinalizeIdentifiedResponseAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyList<SurveyAnswer>>(),
+            Arg.Any<Instant>(),
+            Arg.Any<SurveyInputMethod>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -3320,7 +3410,7 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
-    public async Task UpdateAsync_cannot_change_asociado_vote_mode_after_opening()
+    public async Task UpdateAsync_cannot_edit_an_asociado_vote_after_opening()
     {
         var survey = SurveyWith(SurveyStatus.Open, null, null);
         survey.IsAsociadoVote = true;
@@ -3333,7 +3423,7 @@ public class SurveyServiceTests
             TestContext.Current.CancellationToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*cannot change after the survey has opened*");
+            .WithMessage("*cannot be edited after it has opened*");
         await _repo.DidNotReceive().UpdateAsync(
             Arg.Any<Survey>(), Arg.Any<CancellationToken>());
     }
@@ -3396,7 +3486,7 @@ public class SurveyServiceTests
             TestContext.Current.CancellationToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*cannot change after the first saved answer*");
+            .WithMessage("*cannot be edited after it has opened*");
         await _repo.DidNotReceive().UpdateAsync(Arg.Any<Survey>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -3367,13 +3367,31 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
-    public async Task CreateAsync_ranked_choice_requires_identified_asociado_vote_mode()
+    public async Task CreateAsync_allows_ranked_choice_in_an_ordinary_survey()
+    {
+        Survey? captured = null;
+        _repo.When(repository => repository.AddAsync(
+                Arg.Any<Survey>(),
+                Arg.Any<CancellationToken>()))
+            .Do(call => captured = call.Arg<Survey>());
+
+        await CreateService().CreateAsync(
+            Input(RankedInput()),
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        captured.Should().NotBeNull();
+        captured!.IsAsociadoVote.Should().BeFalse();
+        captured.Questions.Should().ContainSingle()
+            .Which.Type.Should().Be(SurveyQuestionType.RankedChoice);
+    }
+
+    [HumansFact]
+    public async Task CreateAsync_asociado_vote_requires_identified_restricted_configuration()
     {
         var ranked = RankedInput();
         var service = CreateService();
 
-        var ordinary = async () => await service.CreateAsync(
-            Input(ranked), Guid.NewGuid(), TestContext.Current.CancellationToken);
         var anonymousVote = async () => await service.CreateAsync(
             Input(ranked) with
             {
@@ -3401,8 +3419,6 @@ public class SurveyServiceTests
             Guid.NewGuid(),
             TestContext.Current.CancellationToken);
 
-        await ordinary.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*require Asociado vote*");
         await anonymousVote.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*identified*");
         await publicVote.Should().ThrowAsync<InvalidOperationException>()

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -1461,6 +1461,38 @@ public class SurveyServiceTests
         rows.Single(r => r.UserId == unknown).Name.Should().Be(unknown.ToString());
     }
 
+    [HumansFact]
+    public async Task GetOfficialLinkAsync_uses_the_current_humans_unspent_invitation()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        survey.PublicSlug = "public-fallback";
+        var userId = Guid.NewGuid();
+        var invitation = InvitationFor(survey.Id, userId);
+        invitation.SentAt = _clock.GetCurrentInstant();
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        _repo.GetInvitationsAsync(survey.Id, Arg.Any<CancellationToken>())
+            .Returns([invitation]);
+        _tokenProvider.Create(invitation.Id).Returns("official-token");
+
+        var link = await CreateService().GetOfficialLinkAsync(
+            survey.Id, userId, TestContext.Current.CancellationToken);
+
+        link.Should().Be(new SurveyOfficialLink("official-token", null));
+    }
+
+    [HumansFact]
+    public async Task GetOfficialLinkAsync_falls_back_to_the_public_slug()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        survey.PublicSlug = "public-survey";
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+
+        var link = await CreateService().GetOfficialLinkAsync(
+            survey.Id, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        link.Should().Be(new SurveyOfficialLink(null, "public-survey"));
+    }
+
     private static UserInfo UserInfoWithName(Guid id, string burnerName, string culture = "en") => new(
         id, burnerName, false, culture, null, Instant.MinValue, null, null, null, null, null,
         false, null, false, null, null, null, null, null, null,

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -3320,6 +3320,25 @@ public class SurveyServiceTests
     }
 
     [HumansFact]
+    public async Task UpdateAsync_cannot_change_asociado_vote_mode_after_opening()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        survey.IsAsociadoVote = true;
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+
+        var act = async () => await CreateService().UpdateAsync(
+            survey.Id,
+            Input() with { IsAsociadoVote = false },
+            Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot change after the survey has opened*");
+        await _repo.DidNotReceive().UpdateAsync(
+            Arg.Any<Survey>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task Open_asociado_vote_exposes_participation_but_embargoes_answer_results_and_exports()
     {
         var survey = SurveyWith(SurveyStatus.Open, null, null);


### PR DESCRIPTION
## What

Adds complete ranked-choice voting for identified Asociado votes, with Ranked Pairs as the official method, Condorcet/Borda sensitivity results, post-close availability recounts, and a survey-wide result embargo until close.

Closes nobodies-collective/Humans#1151.

## Why

The Asociados event-date vote needs tied rankings, optional explicit rejection, deterministic Condorcet counting, and the ability to remove dates that later prove unavailable without changing stored ballots.

## Existing surface checked

- Extended the existing Surveys builder, wizard, results, export, Backdoor, GDPR, repository, and audit paths rather than adding a parallel voting subsystem.
- Counting remains in the Surveys service layer; `SurveyResultsBuilder` stays presentation-only.
- Reused existing identified invitations/responses, status transitions, export builders, and development persona flow.
- Public read DTOs were extended deliberately so closed ranked ballots and settings remain machine-readable.

## UI changes / local review

A Development-only button on `/Survey/Admin` creates three local fixtures:

1. open with no responses;
2. open with two completed ballots plus one started draft (participation visible, answers embargoed);
3. closed Condorcet-cycle vote with `12–13 September` unavailable, demonstrating an original Ranked Pairs winner of `12–13 September` and a current winner of `19–20 September`.

The isolated local review app/database were exercised through the normal service and HTTP paths, including the availability form and identified ballot drill-down.

## Checklist

- [x] **Section labeled** — `section:surveys`.
- [x] **Targeting `main` on `peterdrier/Humans`**.
- [x] **Branched off current QA main** (`qa/main` in Daniel's checkout).
- [x] **Issue refs are qualified**.
- [x] **EF migrations** — generated by EF in `Humans.Surveys`; no hand edits; pending-model check is clean.
- [x] **NuGet packages updated?** No.
- [x] **New project rule?** No.
- [x] **Reuse-first checked**.
- [x] **Build + scoped tests pass locally** — full solution build passes; Surveys tests pass 207/207; relevant integration render test passes; fresh-database migration test passes.
- [x] **Nav coverage** — no new production page; the fixture action is intentionally Development-only on the existing Surveys index.
- [x] **No magic strings** — stable ballot values are persisted input data; method names are typed internally.
- [x] **Dates/times via NodaTime**, icons via Font Awesome 6.

## Reviewer notes

- Asociado vote is a survey-level mode: all answer-derived data is embargoed until close, all questions remain identified-only, and Closed → Open is forbidden.
- RankedChoice questions require Asociado-vote mode, but an Asociado vote may contain mixed question types.
- Candidate order/settings freeze on the first saved answer, including drafts. Availability is a separate, reversible, audited post-close setting.
- V1 deliberately defers IRV, Baldwin, and Coombs because their equal-rank semantics were not specified. Ranked Pairs is official; Condorcet and Borda are sensitivity checks.
- A full local solution test run exposed unrelated existing/environment failures: one Shifts date-format assertion (`Tue Jun 30` vs `Tue 30 Jun`) and transient Integration/Testcontainers failures while Docker ran out of disk. After pruning unused build cache, the ranked render and fresh-database migration tests pass independently.
