### PR TITLE
doctor skill: cut main-thread context cost before the big sections

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -496,9 +496,11 @@ run file is not the verdict; write the verdict.
 `mkdir -p "$RUNDIR/assessment"` (Phase 0 created only `$RUNDIR`), then write the assessment's
 outputs there — the ranked list (finding numbers,
 one-line descriptions, source thread, intended play) as `ranked-list.md`, each thread's findings
-list beside it (one file per thread), and the independence verdict. Once the list is on disk a
-compaction can no longer lose findings, and everything Phases 4–6 need is re-readable for a few
-K tokens.
+list beside it (one file per thread), the independence verdict, the 3a inventory with each
+path's disposition so far, and the thread-status table (how each thread ran, its model, its
+findings count) — everything Phase 5's `## File coverage` and `## Threads` blocks will need.
+Once all of it is on disk a compaction can no longer lose findings or coverage state, and
+everything Phases 4–6 need is re-readable for a few K tokens.
 
 The 3e→4 boundary is the run's context shed. Phases 4–6 are where most of a run's turns happen,
 and they need the checkpoint files, 3c's target and the strike's own files — not the hundreds of
@@ -530,7 +532,9 @@ subagent does not inherit the run's cwd, and on a local machine a relative path 
 another session's checkout — and the rules of this phase it will touch (the doc-sweep and
 delete-sweep rules, the resx/XML rule, the build-output rule). It edits and validates under
 `$WORKTREE` only, runs **no git commands**, and returns a diff summary; the main thread reviews
-the diff and commits. Judgment strikes — `collapse`, `rearch`, any deletion whose safety depends on
+the diff and commits. Its prompt opens `thread: strike <what>` — the same `<what>` as the item's
+phase-log mark — so the cost report names its row per 3d's convention instead of falling back to
+an opaque agent filename. Judgment strikes — `collapse`, `rearch`, any deletion whose safety depends on
 cross-file context — and every reviewer gate (step 4) stay on the main thread. The split is per
 strike *class*, never blanket: cross-file context on main is what catches the miscounts a
 narrowly-briefed executor cannot see.

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -524,10 +524,12 @@ executed after it. Budget checks are real
 **Mechanical strike classes execute in subagents; judgment stays on main.** A strike whose whole
 scope is named by its checkpoint entry — dead-code deletion, doc-drift fixes, comment strikes,
 mechanical renames — dispatches to a per-strike **sonnet** executor subagent, given only the
-strike's checkpoint text, its target file paths, and the rules of this phase it will touch (the
-doc-sweep and delete-sweep rules, the resx/XML rule, the build-output rule). It edits, builds,
-runs the targeted tests, and returns a diff summary; the main thread reviews the diff and
-commits. Judgment strikes — `collapse`, `rearch`, any deletion whose safety depends on
+strike's checkpoint text, its target file paths — **absolute, rooted at `$WORKTREE`**; a
+subagent does not inherit the run's cwd, and on a local machine a relative path can land in
+another session's checkout — and the rules of this phase it will touch (the doc-sweep and
+delete-sweep rules, the resx/XML rule, the build-output rule). It edits and validates under
+`$WORKTREE` only, runs **no git commands**, and returns a diff summary; the main thread reviews
+the diff and commits. Judgment strikes — `collapse`, `rearch`, any deletion whose safety depends on
 cross-file context — and every reviewer gate (step 4) stay on the main thread. The split is per
 strike *class*, never blanket: cross-file context on main is what catches the miscounts a
 narrowly-briefed executor cannot see.

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -274,8 +274,8 @@ Pass 2) — an "ideal shape" that restates the reforge score is the failure this
 prevent.
 
 Phase 2's selector script already built the solution on a normal run; only when it was skipped
-(`--section`) start `dotnet build Humans.slnx -v quiet` in the background now — reforge needs a
-built solution and 3d's tool threads need the build. Do not look at its output until 3d.
+(`--section`) start `dotnet build Humans.slnx -v quiet -clp:ErrorsOnly` in the background now —
+reforge needs a built solution and 3d's tool threads need the build. Do not look at its output until 3d.
 
 ### 3a. Inventory — every file, assigned
 
@@ -493,7 +493,8 @@ plus one sentence naming which items came from the target rather than a scan. Ev
 run file is not the verdict; write the verdict.
 
 **Checkpoint, then shed the assessment.** The last required 3e step, before any strike executes:
-write the assessment's outputs to `$RUNDIR/assessment/` — the ranked list (finding numbers,
+`mkdir -p "$RUNDIR/assessment"` (Phase 0 created only `$RUNDIR`), then write the assessment's
+outputs there — the ranked list (finding numbers,
 one-line descriptions, source thread, intended play) as `ranked-list.md`, each thread's findings
 list beside it (one file per thread), and the independence verdict. Once the list is on disk a
 compaction can no longer lose findings, and everything Phases 4–6 need is re-readable for a few
@@ -550,7 +551,7 @@ Per item (one item or tight cluster per commit):
    `docs/architecture/code-review-rules.md`'s hard-reject list and the section's own load-bearing
    weirdness, and where a linter owns that shape (`.claude/razor-lint.sh` for views) run it on the
    changed file rather than trusting it to fire later.
-3. `dotnet build Humans.slnx -v quiet`; targeted tests for the touched area.
+3. `dotnet build Humans.slnx -v quiet -clp:ErrorsOnly`; targeted tests for the touched area.
 
    **A test the run adds is only covered if some CI job actually runs it — check the filters, not
    the suite.** Before writing "CI is the gate" about a new test, resolve its assembly against
@@ -608,7 +609,8 @@ Per item (one item or tight cluster per commit):
 6. **UI-affecting strikes get runtime verification**: render the changed page in the running app
    (`dotnet run` + browser/test-site) before the PR — a green build does not prove a cshtml/JS
    change works.
-7. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet` before each push;
+7. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet -clp:ErrorsOnly`
+   before each push;
    push every 3–5 items. When a reviewer gate could not be obtained, say so in the commit message
    as well as the run file — a commit that lands unreviewed should say so where the diff is read.
 

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -92,6 +92,10 @@ is recoverable with `git rev-parse --abbrev-ref HEAD` at any point in the run.
   holds the output DLLs and the build burns MSB3026 retry rounds on locked files. One at a time.
 - Resolve every asserted path from the worktree root. A bare basename test reports a live file
   missing and invites a repo-wide "fix" for a file that was never gone.
+- Build/test output stays out of the transcript: every `dotnet build` / `dotnet test` takes
+  `-v quiet -clp:ErrorsOnly` per `memory/process/dotnet-verbosity-quiet.md`; if output is still
+  long, redirect to a file under `$RUNDIR` and Read it — never pipe through `tail`/`head`/`grep`.
+  Every line of build noise in the transcript is re-read by every later turn of the run.
 
 Getting a toolchain is the *environment's* job, not this skill's — a local run and the
 scheduled cloud run both start with the SDK, `dotnet-ef` and reforge already there. Never
@@ -154,12 +158,15 @@ RUNDIR="${TMPDIR:-/tmp}/section-doctor/$TS"   # re-derive; nothing carries over 
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) phase1 worktree" >> "$RUNDIR/phase-log"
 ```
 
-**Write the line out in full at every phase boundary, through Phase 7.** Shell state does not
+**Write the line out in full at every phase boundary, through Phase 7 — always the full
+`$(date -u +%Y-%m-%dT%H:%M:%SZ) <mark>` form.** The leading timestamp is what buckets the
+spend: `cost-report.py` skips any line that does not start with one, so a bare `phase4 …`
+mark silently folds that phase's cost into the row above it. Shell state does not
 survive between tool calls — a `mark()` helper defined here is gone by the next call, and so are
 `$RUNDIR`, `$TS` and `$WORKTREE`. Re-derive the path (or paste it literally) each time rather than
 relying on a variable set in an earlier call:
 
-| Phase | Line to append |
+| Phase | Mark (after the timestamp) |
 |---|---|
 | 2 | `phase2 select section` |
 | 3 | `phase3 assess` |
@@ -485,6 +492,22 @@ way, as a literal line — `Independence check: pass` or `Independence check: fa
 plus one sentence naming which items came from the target rather than a scan. Evidence in the
 run file is not the verdict; write the verdict.
 
+**Checkpoint, then shed the assessment.** The last required 3e step, before any strike executes:
+write the assessment's outputs to `$RUNDIR/assessment/` — the ranked list (finding numbers,
+one-line descriptions, source thread, intended play) as `ranked-list.md`, each thread's findings
+list beside it (one file per thread), and the independence verdict. Once the list is on disk a
+compaction can no longer lose findings, and everything Phases 4–6 need is re-readable for a few
+K tokens.
+
+The 3e→4 boundary is the run's context shed. Phases 4–6 are where most of a run's turns happen,
+and they need the checkpoint files, 3c's target and the strike's own files — not the hundreds of
+K of assessment reads behind them. From here, disk is the authoritative state: work each strike
+from its checkpoint entry, re-read `$RUNDIR/assessment/` rather than relying on scrollback, and
+treat a compaction at or after this boundary as costing nothing — the state it sheds is on disk.
+Never re-read a whole file to answer a question a targeted reforge query answers ("who calls
+this", "where is this defined"), and never re-open a file only to confirm what a checkpointed
+finding already states.
+
 ## Phase 4: Strike
 
 Work the ranked list until budget exhausted. **Drain the list — stopping early with strikeable
@@ -496,7 +519,20 @@ subtrees into dead code, so it precedes deletion; deletion is near-zero risk and
 everything downstream of it. A `collapse` or `rearch` item routinely outranks a `delete` one —
 a wrong abstraction costs every future session, a dead local costs one grep — but it is still
 executed after it. Budget checks are real
-`date` reads between items, never estimates. Per item (one item or tight cluster per commit):
+`date` reads between items, never estimates.
+
+**Mechanical strike classes execute in subagents; judgment stays on main.** A strike whose whole
+scope is named by its checkpoint entry — dead-code deletion, doc-drift fixes, comment strikes,
+mechanical renames — dispatches to a per-strike **sonnet** executor subagent, given only the
+strike's checkpoint text, its target file paths, and the rules of this phase it will touch (the
+doc-sweep and delete-sweep rules, the resx/XML rule, the build-output rule). It edits, builds,
+runs the targeted tests, and returns a diff summary; the main thread reviews the diff and
+commits. Judgment strikes — `collapse`, `rearch`, any deletion whose safety depends on
+cross-file context — and every reviewer gate (step 4) stay on the main thread. The split is per
+strike *class*, never blanket: cross-file context on main is what catches the miscounts a
+narrowly-briefed executor cannot see.
+
+Per item (one item or tight cluster per commit):
 
 1. Pick the play. `/simplify`'s *method* is absorbed into Phase 3 — do not call the skill from a
    run: it is audit-gated (its approval gate is a merged audit PR, then one item per PR) and that

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -531,7 +531,9 @@ strike's checkpoint text, its target file paths — **absolute, rooted at `$WORK
 subagent does not inherit the run's cwd, and on a local machine a relative path can land in
 another session's checkout — and the rules of this phase it will touch (the doc-sweep and
 delete-sweep rules, the resx/XML rule, the build-output rule). It edits and validates under
-`$WORKTREE` only, runs **no git commands**, and returns a diff summary; the main thread reviews
+`$WORKTREE` only, runs **no git commands** — where a handed rule prescribes `git grep` (the
+delete sweep), the executor runs the same search with the Grep tool or `rg -n` rooted at
+`$WORKTREE` instead — and returns a diff summary; the main thread reviews
 **`git diff` in the worktree, never the executor's own summary,** and commits. One executor at a
 time — Phase 0's one-build-per-worktree rule applies to them too. Its prompt's whole first line,
 nothing after it, is the `thread: strike <what>` marker — the same `<what>` as the item's

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -274,7 +274,7 @@ Pass 2) — an "ideal shape" that restates the reforge score is the failure this
 prevent.
 
 Phase 2's selector script already built the solution on a normal run; only when it was skipped
-(`--section`) start `dotnet build Humans.slnx -v quiet -clp:ErrorsOnly` in the background now —
+(`--section`) start `dotnet build Humans.slnx -v quiet` in the background now —
 reforge needs a built solution and 3d's tool threads need the build. Do not look at its output until 3d.
 
 ### 3a. Inventory — every file, assigned
@@ -532,7 +532,9 @@ subagent does not inherit the run's cwd, and on a local machine a relative path 
 another session's checkout — and the rules of this phase it will touch (the doc-sweep and
 delete-sweep rules, the resx/XML rule, the build-output rule). It edits and validates under
 `$WORKTREE` only, runs **no git commands**, and returns a diff summary; the main thread reviews
-the diff and commits. Its prompt opens `thread: strike <what>` — the same `<what>` as the item's
+**`git diff` in the worktree, never the executor's own summary,** and commits. One executor at a
+time — Phase 0's one-build-per-worktree rule applies to them too. Its prompt's whole first line,
+nothing after it, is the `thread: strike <what>` marker — the same `<what>` as the item's
 phase-log mark — so the cost report names its row per 3d's convention instead of falling back to
 an opaque agent filename. Judgment strikes — `collapse`, `rearch`, any deletion whose safety depends on
 cross-file context — and every reviewer gate (step 4) stay on the main thread. The split is per
@@ -555,7 +557,7 @@ Per item (one item or tight cluster per commit):
    `docs/architecture/code-review-rules.md`'s hard-reject list and the section's own load-bearing
    weirdness, and where a linter owns that shape (`.claude/razor-lint.sh` for views) run it on the
    changed file rather than trusting it to fire later.
-3. `dotnet build Humans.slnx -v quiet -clp:ErrorsOnly`; targeted tests for the touched area.
+3. `dotnet build Humans.slnx -v quiet`; targeted tests for the touched area.
 
    **A test the run adds is only covered if some CI job actually runs it — check the filters, not
    the suite.** Before writing "CI is the gate" about a new test, resolve its assembly against
@@ -613,7 +615,7 @@ Per item (one item or tight cluster per commit):
 6. **UI-affecting strikes get runtime verification**: render the changed page in the running app
    (`dotnet run` + browser/test-site) before the PR — a green build does not prove a cshtml/JS
    change works.
-7. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet -clp:ErrorsOnly`
+7. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet`
    before each push;
    push every 3–5 items. When a reviewer gate could not be obtained, say so in the commit message
    as well as the run file — a commit that lands unreviewed should say so where the diff is read.

--- a/.claude/skills/section-doctor/cost-report.py
+++ b/.claude/skills/section-doctor/cost-report.py
@@ -57,9 +57,12 @@ def read_phase_log(path):
     The label says what the run was doing; it is the row name. Older logs carry no
     label, so the id stands in for one. A line without a parseable leading timestamp
     cannot be bucketed: it is skipped and counted, and the footer reports the count —
-    its phase's spend folds into the preceding row."""
+    its phase's spend folds into the preceding row. A skipped line BEFORE the first
+    valid mark is worse: run_start then derives from a later mark, so the spend before
+    it is excluded from the total, not folded — flagged separately."""
     out = []
     skipped = 0
+    skipped_before_first = False
     for line in open(path, encoding="utf-8"):
         parts = line.split(None, 2)
         if len(parts) < 2:
@@ -68,9 +71,11 @@ def read_phase_log(path):
             t = ts(parts[0])
         except ValueError:
             skipped += 1
+            if not out:
+                skipped_before_first = True
             continue
         out.append((t, parts[1], parts[2].strip() if len(parts) > 2 else parts[1]))
-    return sorted(out), skipped
+    return sorted(out), skipped, skipped_before_first
 
 
 def phase_at(t, phases):
@@ -123,7 +128,7 @@ def add(bucket, model, u):
 
 def main():
     branch, phase_log = sys.argv[1], sys.argv[2]
-    phases, skipped_marks = read_phase_log(phase_log)
+    phases, skipped_marks, skipped_before_first = read_phase_log(phase_log)
     if not phases:
         print("Cost: unmeasured (phase log has no timestamped marks)")
         return
@@ -204,6 +209,11 @@ def main():
             f"Warning: {skipped_marks} phase-log line(s) without a leading timestamp "
             "skipped — that spend is folded into the preceding row."
         )
+        if skipped_before_first:
+            print(
+                "A skipped line preceded the first timestamped mark: usage before "
+                "that mark is excluded entirely, so the total underreports the run."
+            )
 
     # Context telemetry: where the run's context peaked, and whether it was
     # compacted mid-run. Compaction is detected from the usage data itself — a

--- a/.claude/skills/section-doctor/cost-report.py
+++ b/.claude/skills/section-doctor/cost-report.py
@@ -99,10 +99,11 @@ def usage_entries(path):
 
 
 def thread_name(path):
-    """The `thread: <Name>` marker a dispatched Phase 3d prompt opens with (SKILL.md §3d)."""
+    """The `thread: <Name>` marker a dispatched prompt opens with — Phase 3d threads and
+    Phase 4 strike executors (`thread: strike <what>`) alike (SKILL.md §3d, §4)."""
     with open(path, encoding="utf-8", errors="ignore") as f:
         for line in list(f)[:3]:  # the prompt is the first record; don't match a later mention
-            m = re.search(r'thread:\s*([A-Za-z][A-Za-z &]*)', line)
+            m = re.search(r'thread:\s*([A-Za-z][\w &:-]*)', line)
             if m:
                 return m.group(1).strip()
     return None

--- a/.claude/skills/section-doctor/cost-report.py
+++ b/.claude/skills/section-doctor/cost-report.py
@@ -103,7 +103,10 @@ def thread_name(path):
     Phase 4 strike executors (`thread: strike <what>`) alike (SKILL.md §3d, §4)."""
     with open(path, encoding="utf-8", errors="ignore") as f:
         for line in list(f)[:3]:  # the prompt is the first record; don't match a later mention
-            m = re.search(r'thread:\s*([A-Za-z][\w &:-]*)', line)
+            # capture to the end of the marker's logical line: stop at a real newline,
+            # a JSON escape (\n inside a jsonl-encoded prompt), or a closing quote —
+            # punctuation like / . ' + in a strike name is part of the name
+            m = re.search(r'thread:\s*([A-Za-z][^"\\\n]*)', line)
             if m:
                 return m.group(1).strip()
     return None

--- a/.claude/skills/section-doctor/cost-report.py
+++ b/.claude/skills/section-doctor/cost-report.py
@@ -14,7 +14,9 @@ Rows are named by what the run was DOING, not by phase number: each phase-log li
 is `<iso-ts> <phase-id> <label>` and the label becomes the row. Phase 4 writes one
 line per strike item, so the strike rows break down per item rather than collapsing
 into one bucket. The phase id is a trailing column. A line with no label falls back
-to its id, so an older phase log still reports.
+to its id, so an older phase log still reports. A line without a parseable leading
+timestamp is skipped (and counted in a footer warning) rather than corrupting the
+bucketing or failing the report.
 
 Exits 0 with "Cost: unmeasured (...)" on any discovery failure — never fail the run.
 """
@@ -50,17 +52,25 @@ def ts(s):
 
 
 def read_phase_log(path):
-    """`<iso-ts> <phase-id> [label...]` -> [(start_ts, phase_id, label)], time-ordered.
+    """`<iso-ts> <phase-id> [label...]` -> ([(start_ts, phase_id, label)], skipped), time-ordered.
 
     The label says what the run was doing; it is the row name. Older logs carry no
-    label, so the id stands in for one."""
+    label, so the id stands in for one. A line without a parseable leading timestamp
+    cannot be bucketed: it is skipped and counted, and the footer reports the count —
+    its phase's spend folds into the preceding row."""
     out = []
+    skipped = 0
     for line in open(path, encoding="utf-8"):
         parts = line.split(None, 2)
         if len(parts) < 2:
             continue
-        out.append((ts(parts[0]), parts[1], parts[2].strip() if len(parts) > 2 else parts[1]))
-    return sorted(out)
+        try:
+            t = ts(parts[0])
+        except ValueError:
+            skipped += 1
+            continue
+        out.append((t, parts[1], parts[2].strip() if len(parts) > 2 else parts[1]))
+    return sorted(out), skipped
 
 
 def phase_at(t, phases):
@@ -113,7 +123,10 @@ def add(bucket, model, u):
 
 def main():
     branch, phase_log = sys.argv[1], sys.argv[2]
-    phases = read_phase_log(phase_log)
+    phases, skipped_marks = read_phase_log(phase_log)
+    if not phases:
+        print("Cost: unmeasured (phase log has no timestamped marks)")
+        return
     run_start = phases[0][0]
 
     own = None
@@ -185,6 +198,12 @@ def main():
         "API-equivalent $, list rates; run under subscription quota. "
         "Measured Phase 1 to PR creation; PR create/backfill and Phase 8 excluded."
     )
+    if skipped_marks:
+        print()
+        print(
+            f"Warning: {skipped_marks} phase-log line(s) without a leading timestamp "
+            "skipped — that spend is folded into the preceding row."
+        )
 
     # Context telemetry: where the run's context peaked, and whether it was
     # compacted mid-run. Compaction is detected from the usage data itself — a

--- a/.claude/skills/section-doctor/cost-report.py
+++ b/.claude/skills/section-doctor/cost-report.py
@@ -222,7 +222,9 @@ def main():
     # Context telemetry: where the run's context peaked, and whether it was
     # compacted mid-run. Compaction is detected from the usage data itself — a
     # sustained drop of >50% and >100k tokens between consecutive main-thread
-    # calls (a one-call dip, e.g. a small utility request, does not count).
+    # calls. Sustained means the NEXT call also stays below the same threshold:
+    # a one-call dip (a small utility request between two full-context calls,
+    # e.g. 200k -> 10k -> 199k) rebounds above it and does not count.
     if contexts:
         peak_label, peak_ctx = max(contexts, key=lambda c: c[1])
         print()
@@ -230,7 +232,7 @@ def main():
         compactions = []
         for i in range(1, len(contexts)):
             prev, cur = contexts[i - 1][1], contexts[i][1]
-            sustained = i + 1 >= len(contexts) or contexts[i + 1][1] < prev
+            sustained = i + 1 >= len(contexts) or contexts[i + 1][1] < prev * 0.5
             if cur < prev * 0.5 and prev - cur > 100_000 and sustained:
                 compactions.append(contexts[i][0])
         if compactions:

--- a/docs/superpowers/specs/2026-08-17-section-doctor-design.md
+++ b/docs/superpowers/specs/2026-08-17-section-doctor-design.md
@@ -432,3 +432,14 @@ and a `## Size` block whose subject was the diff containing it.
     skip, a Phase 6 lesson, a Phase 7 measurement gap — takes the next unused number as it is
     written, and no number is reused. One prose description per finding, where it was first
     written; every other mention cites the number.
+26. **3e checkpoints to disk before any strike, and mechanical strikes dispatch per class
+    (#1562, 2026-08-28).** The 3e→4 boundary is the run's context shed: the last 3e step persists
+    the ranked list, each thread's findings, the independence verdict, the 3a inventory with
+    dispositions, and the thread-status table under `$RUNDIR/assessment/`, so a compaction at or
+    after this point costs nothing the disk doesn't already hold. From Phase 4, a strike whose
+    whole scope is named by its checkpoint entry — dead-code deletion, doc-drift fixes, comment
+    strikes, mechanical renames — dispatches to a per-strike sonnet executor; judgment strikes
+    (`collapse`, `rearch`, cross-file-context deletions) and every reviewer gate stay on main,
+    which reviews `git diff` in the worktree, never the executor's own summary. Reversal
+    criterion: if executors lose findings the main thread would have caught, revert to running
+    Phase 4 entirely on main.


### PR DESCRIPTION
Fixes peterdrier/Humans#1562.

All four pieces, edits to `.claude/skills/section-doctor/SKILL.md` + `cost-report.py`:

1. **Checkpoint at 3e, then shed context.** New required 3e step: ranked list, per-thread findings, and the independence verdict go to `$RUNDIR/assessment/` before any strike. The 3e→4 boundary is named as the run's context shed — Phases 4–6 work from disk, not scrollback, so a compaction after 3e loses nothing.
2. **Strike-executor subagents, per strike class.** Mechanical classes (dead-code deletion, doc-drift, comments, renames) dispatch to per-strike sonnet executors given only the checkpoint text + target files + the phase rules they touch; judgment strikes (`collapse`, `rearch`, cross-file-dependent deletions) and all reviewer gating stay on main.
3. **Output hygiene.** Phase 0 shell rule: `-v quiet -clp:ErrorsOnly` per `memory/process/dotnet-verbosity-quiet.md`, long output redirected to `$RUNDIR` and Read; 3e adds "reforge query over whole-file re-read".
4. **Phase-log timestamps.** Phase 1 now states every mark is the full `$(date -u …) <mark>` form and the table column is renamed to make the timestamp non-optional. `cost-report.py` skips (and counts, with a footer warning) lines lacking a parseable timestamp instead of dying to "Cost: unmeasured", and reports clearly on an all-bad log.

Verified: `cost-report.py` tested against a synthetic phase-log with mixed timestamped/untimestamped lines and an all-untimestamped log — correct bucketing, footer warning, and clean fallback. Docs/skill change only, no build impact.

Last acceptance criterion (next run's cache-read well below Camps' ~70M) is verified by the next section-doctor run, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JouM5p2PXGoRM3f3fZ8S1Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01JouM5p2PXGoRM3f3fZ8S1Z)_