### PR TITLE
doctor(Campaigns): first pass — prose drift cleared, invariants tested

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -400,3 +400,9 @@ inbox:
   - added: 2026-08-27
     what: "docs/architecture/design-rules.md:340 says contributors \"read through their own IDbContextFactory<TContext>\" and names AgentService as an example; AgentRepository takes a scoped AgentDbContext by injection. The conclusion (sequential is no longer a correctness requirement) is right; the stated mechanism is not — the accurate invariant is that no two contributors share a context instance (finding 25, /section-doctor on Gdpr 2026-08-27)."
     review: panel
+  - added: 2026-08-28
+    what: "docs/architecture/freshness-catalog.yml has no Settings entry — add one covering src/Sections/Humans.Settings/** and src/Sections/Humans.Settings.Contracts/** (finding 14, /section-doctor on Settings 2026-08-28)."
+    review: light
+  - added: 2026-08-28
+    what: "docs/architecture/dependency-graph.md predates the Monitor carve-out — DriveMon is still styled :::google and no Monitor section appears (finding 20, /section-doctor on Settings 2026-08-28)."
+    review: light

--- a/docs/guide/Campaigns.md
+++ b/docs/guide/Campaigns.md
@@ -4,9 +4,11 @@
   src/Sections/Humans.Campaigns/Domain/**
   src/Sections/Humans.Campaigns/Data/Configurations/**
   src/Sections/Humans.Campaigns/Views/**
+  src/Sections/Humans.Campaigns.Contracts/**
   src/Sections/Humans.Users/Views/Unsubscribe/**
   src/Sections/Humans.Users/Controllers/UnsubscribeController.cs
   src/Sections/Humans.Users/Services/UnsubscribeService.cs
+  src/Sections/Humans.Users.Contracts/MessageCategory.cs
 -->
 <!-- freshness:flag-on-change
   Campaign lifecycle (Draft/Active/Completed), code import, wave send, grant assignment, unsubscribe flow, and My Codes profile section. Review when campaign views, services, or entities change.

--- a/docs/health/runs/2026-08-29-Campaigns.md
+++ b/docs/health/runs/2026-08-29-Campaigns.md
@@ -84,7 +84,7 @@ diff stats carry the totals).
 ## Retro
 
 - **Selector/rubric**: fair pick. Campaigns' 176 overweights Contracts surface that turned out
-  justified (two consumers, narrow DTOs); the real sickness was prose drift, which no score sees.
+  justified (a small consumer set, narrow DTOs); the real sickness was prose drift, which no score sees.
 - **Wasted motion**: the Freshness subagent misattributed a sort to GetAllAsync (read the
   neighboring method's line), costing a main-thread re-verify; InspectCode is absent in the cloud
   image so Prose ran haiku-only. Remote naming cost a detour (finding 45).

--- a/docs/health/runs/2026-08-29-Campaigns.md
+++ b/docs/health/runs/2026-08-29-Campaigns.md
@@ -8,8 +8,8 @@
 ## Assessment summary
 
 First doctoring of Campaigns (never-doctored tier, reforge 176, median pick; Camps blocked
-by open doctor PR #1561). The section's code is in good shape — small, layered correctly,
-50 grandfather-free files — but its prose had drifted hard: docs and comments named services,
+by open doctor PR peterdrier/Humans#1561). The section's code is in good shape — small,
+layered correctly, nothing grandfathered — but its prose had drifted hard: docs and comments named services,
 navigations, indexes and test guards that no longer exist, and the test project missed the
 section's actual invariants (redemption matching, the merge fold, GDPR paths) while
 double-covering wave email pass-through. Two real behavior findings: the import flash message
@@ -37,9 +37,9 @@ C=Comments, P=Prose, B=Behavior(main), S=Shape(main).
 14. H1–H4 Contracts csproj comment block rewrite (wrong projects/counts/lanes) — **done**
 15. C14+C15+H13 "sixteen members"/"pre-G5" stale counts — **done**
 16. P1 Detail.cshtml duplicates EnumBadgeMap badge colors — **done** (EnumBadgeMap.For; Queued gains text-dark from the shared map)
-17. T11 MarkGrantsRedeemedAsync logic untested — **done** (6 repo tests)
-18. T16 ReassignGrantsToUserAsync untested in CI — **done** (3 repo tests)
-19. T12 grant-read status filtering untested — **done** (2 repo tests)
+17. T11 MarkGrantsRedeemedAsync logic untested — **done** (repo tests: case-insensitivity, Draft exclusion, already-redeemed, newest-wins, N-same-code, blank codes)
+18. T16 ReassignGrantsToUserAsync untested in CI — **done** (repo tests: clean move, target-wins, same-campaign dedup)
+19. T12 grant-read status filtering untested — **done** (repo tests for both per-user reads)
 20. T5+T6 per-grant failure isolation untested (wave+retry) — **done**
 21. T1 SendWave Active guard untested — **done**
 22. T18 enum stability test one-directional — **done** (BeEquivalentTo)
@@ -61,7 +61,7 @@ C=Comments, P=Prose, B=Behavior(main), S=Shape(main).
 38. F9+F10 freshness triggers don't watch asserted-about files — **done** (globs added)
 39. T3+T4+T7+T8+T13+T14+T15+T17+T2 remaining test gaps — **partial**: T3 (case-insensitive dedupe), T4 (ImportOrder sequence), T7 (no partial wave), T14 (outbox write-back), T15 (GDPR export/erase) done; T8 (wave skip paths — needs harness support for email-less users), T13 (GetCodeTrackingAsync — largest untested read, ~1h on its own), T17 (resend failure paths — entangled with finding 13's pending ruling), T2 (absence pin) skipped on budget/dependency.
 40. H12/H16/H17 keep-or-ask — **kept** (dated design records pin live decisions)
-41. Inbox: no Campaigns-tagged issues; open #1562/#1554 are skill-infra, out of section (keep); ledger's deferred `GetCodeTrackingSummaries` db-sort item stands — no recommendations
+41. Inbox: no Campaigns-tagged issues; open peterdrier/Humans#1562 / peterdrier/Humans#1554 are skill-infra, out of section (keep); ledger's deferred `GetCodeTrackingSummaries` db-sort item stands — no recommendations
 42. T9 skipped: asserts an absence (`no-tests-for-absences`)
 43. T19 optional arch test (concrete controller injection) — skipped, low value
 44. UI verification gate: findings 11/16 changed rendered markup; a cloud run has no browser against a live instance, so verification is build + razor-lint + render tests. **Needs Peter**: eyeball Detail on the PR preview deploy.
@@ -69,8 +69,9 @@ C=Comments, P=Prose, B=Behavior(main), S=Shape(main).
 
 ## Worked
 
-Findings 1–12, 14–38, plus the done half of 39. Six commits: section docs, code comments,
-Detail view, import counts, two test batches (32 → 50 section tests, all green).
+Findings 1–12, 14–38, plus the done half of 39, committed by concern: section docs, code
+comments, Detail view, import counts, two test batches (section suite green; the PR's own
+diff stats carry the totals).
 
 ## Skipped
 

--- a/docs/health/runs/2026-08-29-Campaigns.md
+++ b/docs/health/runs/2026-08-29-Campaigns.md
@@ -1,0 +1,168 @@
+# Section-doctor run — Campaigns — 2026-08-29
+
+- Invocation: unattended daily (scheduled), no args
+- Branch: `section-doctor/2026-08-29T191609Z`, anchored at `443fe3731f00` (fork main)
+- Budget: 2.5h strike window from 19:16Z; cloud run (repo root, no worktree)
+- PR: pending
+
+## Assessment summary
+
+First doctoring of Campaigns (never-doctored tier, reforge 176, median pick; Camps blocked
+by open doctor PR #1561). The section's code is in good shape — small, layered correctly,
+50 grandfather-free files — but its prose had drifted hard: docs and comments named services,
+navigations, indexes and test guards that no longer exist, and the test project missed the
+section's actual invariants (redemption matching, the merge fold, GDPR paths) while
+double-covering wave email pass-through. Two real behavior findings: the import flash message
+reported input line count instead of the import result, and Resend buttons rendered for
+TicketAdmin users whose POST could only 403. One judgment call queued for Peter (finding 13).
+
+## Ranked findings
+
+Numbers are final finding numbers, assigned once. Sources: F=Freshness, T=Tests, H=History,
+C=Comments, P=Prose, B=Behavior(main), S=Shape(main).
+
+1. F5+C8+C9+C10 false ordering claims on ICampaignServiceRead + ICampaignRepository (GetAllAsync, both grant reads) — **done** (docs now say unordered, callers sort)
+2. C2+H7 Reassign comment "no unique index" is false — **done**
+3. C1 misplaced Reassign `<summary>` stacked on DeleteGrantsForUserAsync — **done**
+4. C7+H5+H6 comments narrate nonexistent/obsolete User nav — **done**
+5. F1 Campaigns.md names ITeamService.GetActiveTeamOptionsAsync/GetTeamMembersAsync (don't exist) — **done** (ITeamServiceRead.GetTeamsAsync/GetTeamAsync)
+6. F2 Campaigns.md INotificationService → INotificationEmitter — **done**
+7. F3 data-access.md lists ICommunicationPreferenceService (not injected) — **done**
+8. F4 feature doc "manual or auto" complete — **done** (manual only)
+9. F6 Campaigns.md "(controller enforces)" — **done** (service-enforced)
+10. C17 _ViewImports claims GateArchitectureTests guards this section — **done** (deleted)
+11. B3/P2 Resend buttons rendered for TicketAdmin who gets 403 — **done** (gated with isAdmin)
+12. B1 ImportCodes flash "Imported {lines} codes" counts input lines not imported — **done** (service returns (imported, skipped); message reports both)
+13. B2 ResendToGrantAsync flips grant to Queued (CampaignService.cs:514) before resolving user/email; a throw at either lookup strands the grant Queued, invisible to RetryAllFailed — **needs Peter**: reorder the flip after resolution, or catch-and-flip-to-Failed? Two defensible shapes.
+14. H1–H4 Contracts csproj comment block rewrite (wrong projects/counts/lanes) — **done**
+15. C14+C15+H13 "sixteen members"/"pre-G5" stale counts — **done**
+16. P1 Detail.cshtml duplicates EnumBadgeMap badge colors — **done** (EnumBadgeMap.For; Queued gains text-dark from the shared map)
+17. T11 MarkGrantsRedeemedAsync logic untested — **done** (6 repo tests)
+18. T16 ReassignGrantsToUserAsync untested in CI — **done** (3 repo tests)
+19. T12 grant-read status filtering untested — **done** (2 repo tests)
+20. T5+T6 per-grant failure isolation untested (wave+retry) — **done**
+21. T1 SendWave Active guard untested — **done**
+22. T18 enum stability test one-directional — **done** (BeEquivalentTo)
+23. T20+T21 redundant wave email assertions — **done** (merged into one pass-through test)
+24. T24 unused Humans.Shifts.Contracts ref in test csproj — **done** (verified unused, removed)
+25. C3 line-number refs in CampaignGrantConfiguration comment — **done**
+26. C4+C5+C6 DbContext: wrong migrations path, bare #750, cref UsersDbContext — **done**
+27. C11+C12+H8 "after the Campaigns migration lands" stale tense — **done**
+28. C13 IUserService → IUserServiceRead in comments — **done**
+29. C16+H9 SectionAdminNav dead path docs/sections/Campaigns.md — **done** (Docs/Campaigns.md)
+30. C18 "(step 12)" unresolvable — **done** (dropped)
+31. C19+H19 bare issue refs #546/#750 — **done** (qualified)
+32. C20+C21 comments restating next line (Domain navs, Detail.cshtml section banners) — **done** (deleted)
+33. H10+H11 "has been removed"/"is gone" narration in Campaigns.md — **done** (present-state wording)
+34. H14+H15 csproj prior-state clauses — **done** (trimmed)
+35. F7 docs say DisplayName; code sends BurnerName — **done**
+36. F8 feature-doc stats list wrong — **done**
+37. F12 feature-doc diagram narrates removed navs — **done** (bare-FK annotations)
+38. F9+F10 freshness triggers don't watch asserted-about files — **done** (globs added)
+39. T3+T4+T7+T8+T13+T14+T15+T17+T2 remaining test gaps — **partial**: T3 (case-insensitive dedupe), T4 (ImportOrder sequence), T7 (no partial wave), T14 (outbox write-back), T15 (GDPR export/erase) done; T8 (wave skip paths — needs harness support for email-less users), T13 (GetCodeTrackingAsync — largest untested read, ~1h on its own), T17 (resend failure paths — entangled with finding 13's pending ruling), T2 (absence pin) skipped on budget/dependency.
+40. H12/H16/H17 keep-or-ask — **kept** (dated design records pin live decisions)
+41. Inbox: no Campaigns-tagged issues; open #1562/#1554 are skill-infra, out of section (keep); ledger's deferred `GetCodeTrackingSummaries` db-sort item stands — no recommendations
+42. T9 skipped: asserts an absence (`no-tests-for-absences`)
+43. T19 optional arch test (concrete controller injection) — skipped, low value
+44. UI verification gate: findings 11/16 changed rendered markup; a cloud run has no browser against a live instance, so verification is build + razor-lint + render tests. **Needs Peter**: eyeball Detail on the PR preview deploy.
+45. Skill amendment (Phase 7): the push snippet assumes `origin` = peterdrier/Humans, but this cloud container cloned nobodies-collective as `origin`; the run added a `fork` remote and pushed there. **Needs Peter**: proposed edit — Phase 7 derives the push remote from the PR target instead of naming `origin`.
+
+## Worked
+
+Findings 1–12, 14–38, plus the done half of 39. Six commits: section docs, code comments,
+Detail view, import counts, two test batches (32 → 50 section tests, all green).
+
+## Skipped
+
+- Camps: blocked by open doctor PR peterdrier/Humans#1561 (selection, not a finding).
+- Findings 13, 42, 43, and the skipped half of 39 — reasons on each entry above.
+- Reforge surface items (readServiceInterfaceMethod=12 on grant reads, missingWriteSurface=10,
+  longMethod SendWaveAsync): structural; none met the strike bar for a first pass and none is a
+  defect — left for a future run with the section's history in hand.
+
+## Retro
+
+- **Selector/rubric**: fair pick. Campaigns' 176 overweights Contracts surface that turned out
+  justified (two consumers, narrow DTOs); the real sickness was prose drift, which no score sees.
+- **Wasted motion**: the Freshness subagent misattributed a sort to GetAllAsync (read the
+  neighboring method's line), costing a main-thread re-verify; InspectCode is absent in the cloud
+  image so Prose ran haiku-only. Remote naming cost a detour (finding 45).
+- **Missed by assessment, revealed by striking**: the unused Shifts.Contracts test reference —
+  no thread lens looks at csproj ItemGroups against usings; the Tests thread caught it only
+  because it read the csproj for context. A context compaction hit mid-run (during Phase 4);
+  the ranked-list checkpoint in $RUNDIR carried state across it as designed.
+- **Target diff**: first run on this section — no previous target; `Docs/health.md` created new.
+
+## Needs Peter
+
+- [ ] 13 — ResendToGrantAsync: reorder the Queued flip after user/email resolution, or flip to Failed on throw?
+- [ ] 44 — eyeball Detail.cshtml (badges, admin-gated Resend) on the preview deploy
+- [ ] 45 — Phase 7 skill edit: derive push remote from PR target, not `origin`
+
+## Sweep queue
+
+- debt: several sections' csproj comments still name the pre-G5 `Humans.Interfaces` project (off-section for this run) → `docs/architecture/debt-ledger.yml`
+
+## File coverage
+
+| Path | Disposition |
+|---|---|
+| docs/guide/Campaigns.md | changed |
+| src/Sections/Humans.Campaigns.Contracts/CampaignCodeTrackingDtos.cs | reviewed |
+| src/Sections/Humans.Campaigns.Contracts/Humans.Campaigns.Contracts.csproj | changed |
+| src/Sections/Humans.Campaigns.Contracts/ICampaignService.cs | changed |
+| src/Sections/Humans.Campaigns.Contracts/ICampaignServiceRead.cs | changed |
+| src/Sections/Humans.Campaigns/Controllers/CampaignController.cs | changed |
+| src/Sections/Humans.Campaigns/Data/CampaignRepository.cs | changed |
+| src/Sections/Humans.Campaigns/Data/CampaignsDbContext.cs | changed |
+| src/Sections/Humans.Campaigns/Data/CampaignsDbContextFactory.cs | reviewed |
+| src/Sections/Humans.Campaigns/Data/Configurations/CampaignCodeConfiguration.cs | reviewed |
+| src/Sections/Humans.Campaigns/Data/Configurations/CampaignConfiguration.cs | reviewed |
+| src/Sections/Humans.Campaigns/Data/Configurations/CampaignGrantConfiguration.cs | changed |
+| src/Sections/Humans.Campaigns/Data/ICampaignRepository.cs | changed |
+| src/Sections/Humans.Campaigns/Data/Migrations/20260809125024_BaselineCampaigns.Designer.cs | generated |
+| src/Sections/Humans.Campaigns/Data/Migrations/20260809125024_BaselineCampaigns.cs | generated |
+| src/Sections/Humans.Campaigns/Data/Migrations/CampaignsDbContextModelSnapshot.cs | generated |
+| src/Sections/Humans.Campaigns/Docs/Campaigns.md | changed |
+| src/Sections/Humans.Campaigns/Docs/authorization.md | reviewed |
+| src/Sections/Humans.Campaigns/Docs/data-access.md | changed |
+| src/Sections/Humans.Campaigns/Docs/features/Campaigns-feature.md | changed |
+| src/Sections/Humans.Campaigns/Docs/health.md | changed (created this run) |
+| src/Sections/Humans.Campaigns/Domain/Campaign.cs | changed |
+| src/Sections/Humans.Campaigns/Domain/CampaignCode.cs | changed |
+| src/Sections/Humans.Campaigns/Domain/CampaignGrant.cs | reviewed |
+| src/Sections/Humans.Campaigns/Domain/CampaignStatus.cs | reviewed |
+| src/Sections/Humans.Campaigns/Humans.Campaigns.csproj | changed |
+| src/Sections/Humans.Campaigns/Models/CampaignViewModels.cs | reviewed |
+| src/Sections/Humans.Campaigns/Properties/AssemblyInfo.cs | reviewed |
+| src/Sections/Humans.Campaigns/Section.cs | changed |
+| src/Sections/Humans.Campaigns/SectionAdminNav.cs | changed |
+| src/Sections/Humans.Campaigns/Services/CampaignService.cs | changed |
+| src/Sections/Humans.Campaigns/Services/Dtos/CampaignDtos.cs | reviewed |
+| src/Sections/Humans.Campaigns/Views/Campaign/Create.cshtml | reviewed |
+| src/Sections/Humans.Campaigns/Views/Campaign/Detail.cshtml | changed |
+| src/Sections/Humans.Campaigns/Views/Campaign/Edit.cshtml | reviewed |
+| src/Sections/Humans.Campaigns/Views/Campaign/Index.cshtml | reviewed |
+| src/Sections/Humans.Campaigns/Views/Campaign/SendWave.cshtml | reviewed |
+| src/Sections/Humans.Campaigns/Views/Campaign/_ViewStart.cshtml | reviewed |
+| src/Sections/Humans.Campaigns/Views/_ViewImports.cshtml | changed |
+| tests/Humans.Campaigns.Tests/Architecture/CampaignsArchitectureTests.cs | changed |
+| tests/Humans.Campaigns.Tests/Controllers/CampaignControllerTests.cs | reviewed |
+| tests/Humans.Campaigns.Tests/Data/CampaignRepositoryTests.cs | changed (created this run) |
+| tests/Humans.Campaigns.Tests/Enums/EnumStringStabilityTests.cs | changed |
+| tests/Humans.Campaigns.Tests/Humans.Campaigns.Tests.csproj | changed |
+| tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs | changed |
+
+## Threads
+
+| Thread | How it ran | Model | Findings |
+|---|---|---|---|
+| Shape | main thread | fable | 0 standalone (folded into 3c target) |
+| Behavior & bugs | main thread | fable | 3 |
+| Freshness | subagent | doctor-reader (opus low) | 12 |
+| Tests | subagent | doctor-reader (opus low) | 24 |
+| History | subagent | doctor-reader (opus low) | 19 |
+| Comments | subagent | doctor-reader (opus low) | 23 |
+| Prose & surface | subagent | haiku | 2 — InspectCode absent in the cloud image, so haiku-only |
+| Conformance | self-run, main thread | fable | 0 (both detectors clean) |
+| Inbox | self-run, main thread | fable | 0 recommendations (2 open repo issues reviewed, both skill-infra; in-app issues unreachable from cloud) |

--- a/docs/health/runs/2026-08-29-Campaigns.md
+++ b/docs/health/runs/2026-08-29-Campaigns.md
@@ -3,7 +3,7 @@
 - Invocation: unattended daily (scheduled), no args
 - Branch: `section-doctor/2026-08-29T191609Z`, anchored at `443fe3731f00` (fork main)
 - Budget: 2.5h strike window from 19:16Z; cloud run (repo root, no worktree)
-- PR: pending
+- PR: peterdrier/Humans#1564
 
 ## Assessment summary
 

--- a/docs/health/runs/2026-08-29-Campaigns.md
+++ b/docs/health/runs/2026-08-29-Campaigns.md
@@ -70,7 +70,7 @@ C=Comments, P=Prose, B=Behavior(main), S=Shape(main).
 ## Worked
 
 Findings 1–12, 14–38, plus the done half of 39, committed by concern: section docs, code
-comments, Detail view, import counts, two test batches (section suite green; the PR's own
+comments, Detail view, import counts, test batches (section suite green; the PR's own
 diff stats carry the totals).
 
 ## Skipped

--- a/src/Sections/Humans.Agent/Docs/debt.yml
+++ b/src/Sections/Humans.Agent/Docs/debt.yml
@@ -5,3 +5,6 @@ inbox:
   - added: 2026-08-28
     what: "Test gaps from the invariant matrix (finding 14, /section-doctor on Agent 2026-08-28): (a) enabled gate — no test asserts the widget hides when Enabled=false (the other half, POST /Agent/Ask → 503, is pinned by AgentControllerTests.Ask_accepts_a_message_at_exactly_the_cap); (b) DailyTokenCap is set in every fixture but never exceeded — the third cap of invariant 3 has no reject test; (c) anonymous → 401 unpinned anywhere; (d) nothing asserts the tool catalog AgentPromptAssembler advertises equals AgentToolNames.All; (e) AgentFeatureSpecReader has no path-traversal negative test (CommunityFaqReader does); (f) an abuse-flagged message is never driven through AskAsync to a RefusalReason row."
     review: light
+  - added: 2026-08-28
+    what: "AgentService.RunTurnAsync is 210 LOC / CC 42 and AnthropicClient.StreamAsync 153 LOC / CC 42 (reforge). Both are the load-bearing streaming loops the target shape blesses (manual enumerator for error-path billing; SSE block assembly); recorded so the score is not mistaken for unexamined debt (/section-doctor on Agent 2026-08-28)."
+    review: light

--- a/src/Sections/Humans.Campaigns.Contracts/Humans.Campaigns.Contracts.csproj
+++ b/src/Sections/Humans.Campaigns.Contracts/Humans.Campaigns.Contracts.csproj
@@ -1,30 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    Campaigns' cross-section surface, carved into its own leaf project because two of its
-    consumers are still in Base: TicketSyncService and TicketQueryService
-    (Humans.Application) mark redeemed discount codes and build the code-tracking dashboard.
-    A Contracts/ *folder* inside Humans.Campaigns would therefore make Base reference a
-    section and cycle (design §15.5b, memory/architecture/section-project-cycle-fix.md).
+    Campaigns' cross-section surface as a leaf project: Humans.Tickets (redemption sync +
+    code-tracking dashboard), Humans.Users (profile "My Codes" + admin detail) and
+    Humans.Email (outbox delivery-status writeback) consume it, and section-to-leaf edges
+    keep the graph acyclic (design §15.5b, memory/architecture/section-project-cycle-fix.md).
 
-    The grant Sent/Failed mirror is no longer a Base consumer and was already mis-attributed
-    here: the body moved into Humans.Email's EmailOutboxProcessor at Email's own G5 move, and
-    the ProcessEmailOutboxJob shim that used to name it followed it into
-    Humans.Email/Contracts/ at G5 lane 5b-1. Humans.Email references this leaf directly, and
-    the section-to-leaf edge is what keeps the graph acyclic.
+    It holds only the five members outsiders call — the three ICampaignServiceRead reads
+    plus MarkGrantsRedeemedAsync and UpdateGrantEmailStatusAsync. Campaign/code CRUD, wave
+    sending, resend/retry and the whole admin page surface have no consumer outside the
+    section and stay internal to Humans.Campaigns.
 
-    It holds the four members other assemblies actually call — two grant reads for the
-    profile and admin-detail pages, and the two writes above — out of ICampaignService's
-    twenty. Campaign/code CRUD, wave sending, the resend and retry paths and the whole admin
-    page surface have no consumer outside the section and stay internal to Humans.Campaigns.
-
-    References Humans.Interfaces and nothing else — it is below Humans.Application, so this
-    cannot cycle. EmailOutboxStatus, the Email section's enum, appears in CampaignGrantSummary
-    and UpdateGrantEmailStatusAsync; it keeps the Humans.Base.Enums namespace but lives in
-    the Humans.Interfaces assembly since G5 lane 3a-1, so the separate Humans.Domain reference
-    went with that project when lane 3b deleted it. The delivery state is
-    Base vocabulary the section re-exports rather than owns, so it does not move onto the
-    leaf the way Budget's own enums did.
+    References Humans.Base and nothing else. EmailOutboxStatus (Humans.Base.Enums) appears
+    in CampaignGrantSummary and UpdateGrantEmailStatusAsync — Base vocabulary the leaf
+    re-exports rather than owns.
   -->
 
   <ItemGroup>

--- a/src/Sections/Humans.Campaigns.Contracts/Humans.Campaigns.Contracts.csproj
+++ b/src/Sections/Humans.Campaigns.Contracts/Humans.Campaigns.Contracts.csproj
@@ -6,7 +6,7 @@
     Humans.Email (outbox delivery-status writeback) consume it, and section-to-leaf edges
     keep the graph acyclic (design §15.5b, memory/architecture/section-project-cycle-fix.md).
 
-    It holds only the five members outsiders call — the three ICampaignServiceRead reads
+    It holds only the members outsiders call — the ICampaignServiceRead reads
     plus MarkGrantsRedeemedAsync and UpdateGrantEmailStatusAsync. Campaign/code CRUD, wave
     sending, resend/retry and the whole admin page surface have no consumer outside the
     section and stay internal to Humans.Campaigns.

--- a/src/Sections/Humans.Campaigns.Contracts/ICampaignService.cs
+++ b/src/Sections/Humans.Campaigns.Contracts/ICampaignService.cs
@@ -35,9 +35,8 @@ public sealed record CampaignGrantSummary(
 /// </summary>
 /// <remarks>
 /// The section's own controller takes the internal <c>CampaignService</c>
-/// directly, so campaign/code CRUD, activation, wave sending, resend and retry —
-/// the other sixteen members of the pre-G5 <c>ICampaignService</c> — are not
-/// public at all (design §15 step 5).
+/// directly, so campaign/code CRUD, activation, wave sending, resend and retry
+/// are not public at all (design §15 step 5).
 /// </remarks>
 public interface ICampaignService : ICampaignServiceRead, IApplicationService
 {

--- a/src/Sections/Humans.Campaigns.Contracts/ICampaignServiceRead.cs
+++ b/src/Sections/Humans.Campaigns.Contracts/ICampaignServiceRead.cs
@@ -18,15 +18,15 @@ public interface ICampaignServiceRead
     Task<CampaignCodeTrackingData> GetCodeTrackingAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Returns campaign grants for a user where the campaign is Active or Completed,
-    /// ordered by AssignedAt descending.
+    /// Returns campaign grants for a user where the campaign is Active or
+    /// Completed. Unordered — callers sort.
     /// </summary>
     Task<IReadOnlyList<CampaignGrantSummary>> GetActiveOrCompletedGrantsForUserAsync(
         Guid userId, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns all campaign grants for a user (any campaign status),
-    /// ordered by AssignedAt descending. Used for admin detail views.
+    /// Returns all campaign grants for a user (any campaign status). Unordered —
+    /// callers sort. Used for admin detail views.
     /// </summary>
     Task<IReadOnlyList<CampaignGrantSummary>> GetAllGrantsForUserAsync(
         Guid userId, CancellationToken ct = default);

--- a/src/Sections/Humans.Campaigns/Controllers/CampaignController.cs
+++ b/src/Sections/Humans.Campaigns/Controllers/CampaignController.cs
@@ -149,8 +149,10 @@ internal sealed class CampaignController(CampaignService campaignService, IUserS
             return RedirectToAction(nameof(Detail), new { id });
         }
 
-        await campaignService.ImportCodesAsync(id, codes);
-        SetSuccess($"Imported {codes.Count} codes.");
+        var (imported, skipped) = await campaignService.ImportCodesAsync(id, codes);
+        SetSuccess(skipped > 0
+            ? $"Imported {imported} codes; skipped {skipped} duplicates."
+            : $"Imported {imported} codes.");
         return RedirectToAction(nameof(Detail), new { id });
     }
 

--- a/src/Sections/Humans.Campaigns/Data/CampaignRepository.cs
+++ b/src/Sections/Humans.Campaigns/Data/CampaignRepository.cs
@@ -9,8 +9,7 @@ namespace Humans.Campaigns.Data;
 /// <summary>
 /// EF-backed implementation of <see cref="ICampaignRepository"/>. The only
 /// non-test file that touches <c>DbContext.Campaigns</c>,
-/// <c>DbContext.CampaignCodes</c>, or <c>DbContext.CampaignGrants</c> after
-/// the Campaigns migration lands.
+/// <c>DbContext.CampaignCodes</c>, or <c>DbContext.CampaignGrants</c>.
 /// Uses <see cref="IDbContextFactory{TContext}"/> so the repository can be
 /// registered as Singleton while <c>CampaignsDbContext</c> remains Scoped.
 /// </summary>
@@ -22,9 +21,8 @@ internal sealed class CampaignRepository(IDbContextFactory<CampaignsDbContext> f
 
     public async Task<Campaign?> GetByIdAsync(Guid id, CancellationToken ct = default)
     {
-        // Grants' User navigation is cross-domain and tagged obsolete in the
-        // entity; we don't include it here. Consumers that need display names
-        // for recipients resolve via IUserService keyed off CampaignGrant.UserId.
+        // CampaignGrant carries a bare UserId — no nav to include. Consumers that
+        // need recipient display names resolve them via IUserServiceRead.
         await using var ctx = await factory.CreateDbContextAsync(ct);
         return await ctx.Campaigns
             .Include(c => c.Codes)
@@ -75,8 +73,8 @@ internal sealed class CampaignRepository(IDbContextFactory<CampaignsDbContext> f
     public async Task<IReadOnlyList<CampaignCodeTrackingGrantRow>> GetCodeTrackingGrantRowsAsync(
         CancellationToken ct = default)
     {
-        // Projected flat rows — no cross-domain .Include on CampaignGrant.User;
-        // recipient display names are resolved by the service via IUserService.
+        // Projected flat rows; recipient display names are resolved by the
+        // service via IUserServiceRead.
         await using var ctx = await factory.CreateDbContextAsync(ct);
         return await ctx.CampaignGrants
             .AsNoTracking()
@@ -378,10 +376,8 @@ internal sealed class CampaignRepository(IDbContextFactory<CampaignsDbContext> f
             else
             {
                 src.UserId = targetUserId;
-                // Track this campaign so a hypothetical second source row on the
-                // same campaign also drops (defensive — current schema has no
-                // unique index, but the service contract is one grant per user
-                // per campaign).
+                // Track this campaign so a second source row on the same campaign
+                // drops instead of violating the unique (CampaignId, UserId) index.
                 targetCampaignIdSet.Add(src.CampaignId);
             }
         }

--- a/src/Sections/Humans.Campaigns/Data/CampaignsDbContext.cs
+++ b/src/Sections/Humans.Campaigns/Data/CampaignsDbContext.cs
@@ -9,15 +9,15 @@ namespace Humans.Campaigns.Data;
 /// (nobodies-collective/Humans#858): maps only <c>campaigns</c>,
 /// <c>campaign_codes</c> and <c>campaign_grants</c>, with its own
 /// <c>__EFMigrationsHistory_Campaigns</c> table and migrations under
-/// <c>Migrations/Campaigns/</c>. Same database, same connection — the split is
+/// <c>Data/Migrations/</c>. Same database, same connection — the split is
 /// a code-side partition of the EF model.
 /// </summary>
 /// <remarks>
-/// Internal-sealed like every section context (issue #750): repositories
-/// are the only consumers. Configurations are applied explicitly (not by
-/// assembly scanning) so this model can never accrete another section's tables.
-/// Grant recipients and campaign creators are bare Guid references, so the
-/// Identity tables stay in <see cref="UsersDbContext"/> and are deliberately
+/// Internal-sealed like every section context (nobodies-collective/Humans#750):
+/// repositories are the only consumers. Configurations are applied explicitly
+/// (not by assembly scanning) so this model can never accrete another section's
+/// tables. Grant recipients and campaign creators are bare Guid references, so
+/// the Identity tables stay in <c>UsersDbContext</c> and are deliberately
 /// absent here.
 /// </remarks>
 internal sealed class CampaignsDbContext(DbContextOptions<CampaignsDbContext> options)

--- a/src/Sections/Humans.Campaigns/Data/Configurations/CampaignGrantConfiguration.cs
+++ b/src/Sections/Humans.Campaigns/Data/Configurations/CampaignGrantConfiguration.cs
@@ -18,9 +18,9 @@ internal sealed class CampaignGrantConfiguration : IEntityTypeConfiguration<Camp
         builder.Property(g => g.RedeemedAt);
 
         // UserId is a bare cross-section Guid column — no FK constraint, no nav.
-        // Explicit index: replaces the convention index that died with the FK.
-        // CampaignRepository filters UserId alone (:160,173,327,350,380) and the
-        // unique (CampaignId, UserId) cannot serve a UserId-only lookup.
+        // Explicit index: the repository's grant-by-user reads, GDPR export/erase
+        // and the merge fold all filter UserId alone, which the unique
+        // (CampaignId, UserId) index cannot serve.
         builder.HasIndex(g => g.UserId);
         builder.HasIndex(g => new { g.CampaignId, g.UserId }).IsUnique();
         builder.HasIndex(g => g.CampaignCodeId).IsUnique();

--- a/src/Sections/Humans.Campaigns/Data/ICampaignRepository.cs
+++ b/src/Sections/Humans.Campaigns/Data/ICampaignRepository.cs
@@ -9,7 +9,7 @@ namespace Humans.Campaigns.Data;
 /// <summary>
 /// Repository for the Campaigns section's tables: <c>campaigns</c>,
 /// <c>campaign_codes</c>, and <c>campaign_grants</c>. The only non-test file
-/// that writes to these DbSets after the Campaigns migration lands.
+/// that writes to these DbSets.
 /// </summary>
 internal interface ICampaignRepository : IRepository
 {
@@ -36,7 +36,7 @@ internal interface ICampaignRepository : IRepository
     /// </summary>
     Task<Campaign?> FindForMutationWithCodesAsync(Guid id, CancellationToken ct = default);
 
-    /// <summary>All campaigns ordered by CreatedAt descending, with codes and grants.</summary>
+    /// <summary>All campaigns with codes and grants; unordered — the list view sorts.</summary>
     Task<List<Campaign>> GetAllAsync(CancellationToken ct = default);
 
     /// <summary>
@@ -94,7 +94,7 @@ internal interface ICampaignRepository : IRepository
 
     /// <summary>
     /// Returns active/completed campaign grants for a user, with campaign
-    /// and code included, ordered AssignedAt desc. Read-only.
+    /// and code included; unordered — callers sort. Read-only.
     /// </summary>
     Task<IReadOnlyList<CampaignGrant>> GetActiveOrCompletedGrantsForUserAsync(
         Guid userId, CancellationToken ct = default);
@@ -161,6 +161,9 @@ internal interface ICampaignRepository : IRepository
     // Account-merge fold
     // ==========================================================================
 
+    /// <summary>GDPR Art. 17: removes every grant held by the user.</summary>
+    Task<int> DeleteGrantsForUserAsync(Guid userId, CancellationToken ct = default);
+
     /// <summary>
     /// Re-FKs <c>campaign_grants.UserId</c> from
     /// <paramref name="sourceUserId"/> to <paramref name="targetUserId"/>.
@@ -174,9 +177,6 @@ internal interface ICampaignRepository : IRepository
     /// Returns the count of grants attributed to
     /// <paramref name="targetUserId"/> after the move.
     /// </summary>
-    /// <summary>GDPR Art. 17: removes every grant held by the user.</summary>
-    Task<int> DeleteGrantsForUserAsync(Guid userId, CancellationToken ct = default);
-
     Task<int> ReassignGrantsToUserAsync(
         Guid sourceUserId,
         Guid targetUserId,
@@ -212,7 +212,7 @@ internal sealed record CampaignCodeTrackingSummaryRow(
 
 /// <summary>
 /// One grant per row, used by <see cref="ICampaignRepository.GetCodeTrackingGrantRowsAsync"/>.
-/// The owning service stitches recipient display names via <c>IUserService</c>
+/// The owning service stitches recipient display names via <c>IUserServiceRead</c>
 /// so no cross-domain navigation is read at the repository layer.
 /// </summary>
 internal sealed record CampaignCodeTrackingGrantRow(

--- a/src/Sections/Humans.Campaigns/Docs/Campaigns.md
+++ b/src/Sections/Humans.Campaigns/Docs/Campaigns.md
@@ -73,7 +73,7 @@ Records the assignment of a specific code to a specific user.
 **Indexes:** unique `(CampaignCodeId)` (one grant per code) and unique `(CampaignId, UserId)` (one grant per user per campaign).
 
 **Aggregate-local navs:** `CampaignGrant.Campaign`, `CampaignGrant.Code`.
-Cross-domain nav `CampaignGrant.OutboxMessages` (Email) has been removed — Email outbox rows reference the grant by bare FK only, resolved through the Email section's services. Campaigns code never traversed it; email delivery goes through `IEmailOutboxService`.
+Campaigns holds no nav to Email's outbox rows — they reference the grant by bare FK and are resolved through the Email section's services; email delivery goes through `IEmailService`.
 
 ### CampaignStatus
 
@@ -95,7 +95,7 @@ Stored as string (`HasConversion<string>()`, max length 20).
 ## Invariants
 
 - Campaign status follows: Draft then Active then Completed. `ActivateAsync` requires Draft + at least one code; `CompleteAsync` requires Active; `SendWaveAsync` requires Active.
-- Vendor-generated codes can only be created while the campaign is in Draft status (controller enforces). CSV code import has no service-side status guard — the Campaign Detail view exposes the import form in both Draft and Active.
+- Vendor-generated codes can only be created while the campaign is in Draft status (service-enforced — `GenerateAndImportDiscountCodesAsync` returns `NotDraft`). CSV code import has no service-side status guard — the Campaign Detail view exposes the import form in both Draft and Active.
 - Each code is unique per campaign (DB-enforced via unique `(CampaignId, Code)` index) and can be assigned to at most one human (DB-enforced via unique `CampaignCodeId` on grants).
 - Each human can hold at most one grant per campaign (DB-enforced via unique `(CampaignId, UserId)` on grants).
 - Wave allocation pulls available codes ordered by `CampaignCode.ImportOrder` so batch order is stable and reproducible.
@@ -111,20 +111,21 @@ Stored as string (`HasConversion<string>()`, max length 20).
 
 ## Triggers
 
-- When a campaign wave is sent (`SendWaveAsync`), emails are queued to the outbox via `IEmailService.SendAsync(IEmailMessageFactory.CampaignCode(...))` for each eligible human, and a `CampaignReceived` in-app notification is dispatched (best-effort) to every recipient who actually received a grant.
+- When a campaign wave is sent (`SendWaveAsync`), emails are queued to the outbox via `IEmailService.SendAsync(IEmailMessageFactory.CampaignCode(...))` for each eligible human, and a `CampaignReceived` in-app notification is dispatched (best-effort, via `INotificationEmitter`) to every recipient who actually received a grant.
 - Legacy campaign-only unsubscribe tokens map to `MessageCategory.Marketing`, which is opt-outable; `ICommunicationPreferenceService.UpdatePreferenceAsync` flips that preference as normal. There is no live path to a `CampaignCodes` unsubscribe token — `OutboxEmailService` never generates one for an always-on category — and `UpdatePreferenceAsync`/`GuestController.CanUpdatePreference` would refuse the change regardless. (The legacy `User.UnsubscribedFromCampaigns` boolean still exists on the entity for GDPR export but is not read by any active gate.)
 - When `TicketSyncService` detects a granted code redeemed in a ticket purchase, it calls `ICampaignService.MarkGrantsRedeemedAsync` to set `CampaignGrant.RedeemedAt`.
 - When an enqueue throws during `SendWaveAsync` or `RetryAllFailedAsync`, the single offending grant is flipped to `Failed` so the next pass of `RetryAllFailedAsync` can pick it up.
-- When an account merge accepts, `IUserMerge.ReassignAsync` (implemented by `CampaignService`) re-FKs `CampaignGrant.UserId` from source to target (collapsing duplicates where target already holds a grant for the same campaign). Called only by `IAccountMergeService.AcceptAsync` (Profiles section).
+- When an account merge accepts, `IUserMerge.ReassignAsync` (implemented by `CampaignService`) re-FKs `CampaignGrant.UserId` from source to target (collapsing duplicates where target already holds a grant for the same campaign). Called only by `IAccountMergeService.AcceptAsync` (Users section).
 
 ## Cross-Section Dependencies
 
 - **Tickets:** `ITicketDiscountCodes` (`Humans.Tickets.Contracts`) — TicketAdmin can generate discount codes via the ticket vendor integration; Campaigns asks Tickets for codes through this leaf rather than reaching past it into the Base vendor port. Generation is invoked from the Campaign Detail page, not from the Tickets section.
 - **Email:** `IEmailService.SendAsync` with `IEmailMessageFactory.CampaignCode` — composes and queues the campaign-code email through the outbox.
-- **Profiles / Users:** `IUserEmailService.GetNotificationTargetEmailsAsync(IReadOnlyCollection<Guid>)` — resolves notification targets for grant emails; `IUserServiceRead.GetUserInfoAsync` / `GetUserInfosAsync` — recipient `DisplayName` for the email payload and code-tracking display; `IUnsubscribeService` (Users section, `Humans.Users.Services.UnsubscribeService`) processes the public `/Unsubscribe/{token}` endpoint, validating legacy campaign-only tokens (mapped to `MessageCategory.Marketing`) before delegating opt-out to `ICommunicationPreferenceService.UpdatePreferenceAsync` — `CampaignService` itself does not call `ICommunicationPreferenceService`.
-- **Notifications:** `INotificationService.SendAsync` — `CampaignReceived` in-app notifications for wave recipients.
-- **Teams:** `ITeamService.GetActiveTeamOptionsAsync` (Send Wave team picker) and `ITeamService.GetTeamMembersAsync` (team-scoped wave targeting).
-- **Profiles:** Called by `IAccountMergeService` (Profiles section) — `IUserMerge.ReassignAsync` (implemented by `CampaignService`) re-FKs `CampaignGrant` from source to target during account merge fold.
+- **Users:** `IUserEmailService.GetNotificationTargetEmailsAsync(IReadOnlyCollection<Guid>)` — resolves notification targets for grant emails; `IUserServiceRead.GetUserInfoAsync` / `GetUserInfosAsync` — recipient `BurnerName` for the email payload and code-tracking display; `IUnsubscribeService` (Users section, `Humans.Users.Services.UnsubscribeService`) processes the public `/Unsubscribe/{token}` endpoint, validating legacy campaign-only tokens (mapped to `MessageCategory.Marketing`) before delegating opt-out to `ICommunicationPreferenceService.UpdatePreferenceAsync` — `CampaignService` itself does not call `ICommunicationPreferenceService`.
+- **Notifications:** `INotificationEmitter.SendAsync` — `CampaignReceived` in-app notifications for wave recipients.
+- **Teams:** `ITeamServiceRead.GetTeamsAsync` (Send Wave team picker; active teams filtered in the service) and `GetTeamAsync` → `TeamInfo.Members` (team-scoped wave targeting).
+- **Users (merge fold):** Called by `IAccountMergeService.AcceptAsync` (Users section) — `IUserMerge.ReassignAsync` (implemented by `CampaignService`) re-FKs `CampaignGrant` from source to target during account merge fold.
+- **Gdpr:** implements `IUserDataContributor` (`Humans.Gdpr.Contracts`) — grant export slice and hard-delete erasure.
 
 ## Architecture
 
@@ -135,8 +136,8 @@ Stored as string (`HasConversion<string>()`, max length 20).
 - `CampaignService` lives in `Humans.Campaigns.Services` and depends only on Application-layer abstractions.
 - `ICampaignRepository` (interface `src/Sections/Humans.Campaigns/Data/ICampaignRepository.cs`, impl `src/Sections/Humans.Campaigns/Data/CampaignRepository.cs`) is the only file that touches this section's tables via `DbContext`.
 - **Decorator decision — no caching decorator.** Admin-only, low write/read volume.
-- **Cross-section reads** route through `ITeamService.GetActiveTeamOptionsAsync` / `GetTeamMembersAsync` and `IUserEmailService.GetNotificationTargetEmailsAsync`, `IUserServiceRead.GetUserInfoAsync` / `GetUserInfosAsync` for display data. Outbound email queueing goes through `IEmailService.SendAsync` with `IEmailMessageFactory.CampaignCode` (the outbox service owns the email_outbox_messages table and applies opt-out/unsubscribe policy itself — `CampaignService` does not call `ICommunicationPreferenceService`).
-- **Cross-domain navs removed:** `Campaign.CreatedByUserId` and `CampaignGrant.UserId` are bare Guid columns — no `CreatedByUser` / `User` nav property, and since G5 no DB-level FK constraint either: the section assembly cannot name `User`, so `CampaignConfiguration` / `CampaignGrantConfiguration` declare no relationship at all. All callers — including `TicketQueryService.GetCodeTrackingDataAsync` via `ICampaignService.GetCodeTrackingAsync` — resolve display names through `IUserService`. `CampaignGrant.OutboxMessages` (Email) is also gone — Email outbox rows reference the grant by bare FK only.
+- **Cross-section reads** route through `ITeamServiceRead.GetTeamsAsync` / `GetTeamAsync` and `IUserEmailService.GetNotificationTargetEmailsAsync`, `IUserServiceRead.GetUserInfoAsync` / `GetUserInfosAsync` for display data. Outbound email queueing goes through `IEmailService.SendAsync` with `IEmailMessageFactory.CampaignCode` (the outbox service owns the email_outbox_messages table and applies opt-out/unsubscribe policy itself — `CampaignService` does not call `ICommunicationPreferenceService`).
+- **No cross-domain navs:** `Campaign.CreatedByUserId` and `CampaignGrant.UserId` are bare Guid columns — no `CreatedByUser` / `User` nav property and no DB-level FK constraint: the section assembly cannot name `User`, so `CampaignConfiguration` / `CampaignGrantConfiguration` declare no relationship at all. All callers — including `TicketQueryService.GetCodeTrackingDataAsync` via `ICampaignService.GetCodeTrackingAsync` — resolve display names through `IUserServiceRead`.
 - **Architecture test** — `tests/Humans.Campaigns.Tests/Architecture/CampaignsArchitectureTests.cs`, alongside the cross-cutting analyzer coverage (`HUM0009`, `HUM0034`; `HUM0024` and `HUM0021` were retired in nobodies-collective/Humans#1278).
 
 ### Touch-and-clean guidance

--- a/src/Sections/Humans.Campaigns/Docs/data-access.md
+++ b/src/Sections/Humans.Campaigns/Docs/data-access.md
@@ -18,10 +18,9 @@ Repository: `ICampaignRepository`.
 | CampaignGrants | R/W |
 
 Cross-section calls via `ITeamServiceRead`, `IUserEmailService`,
-`IUserServiceRead`, `INotificationEmitter`,
-`ICommunicationPreferenceService`, `IEmailService`, `IEmailMessageFactory`,
-`ITicketDiscountCodes` (Tickets Contracts leaf — grant-wave discount code
-generation), plus `IClock`. Implements `ICampaignService` (which extends
+`IUserServiceRead`, `INotificationEmitter`, `IEmailService`,
+`IEmailMessageFactory`, `ITicketDiscountCodes` (Tickets Contracts leaf —
+grant-wave discount code generation), plus `IClock`. Implements `ICampaignService` (which extends
 `ICampaignServiceRead`), `IUserDataContributor`, `IUserMerge`. No
 `IMemoryCache`.
 

--- a/src/Sections/Humans.Campaigns/Docs/features/Campaigns-feature.md
+++ b/src/Sections/Humans.Campaigns/Docs/features/Campaigns-feature.md
@@ -3,6 +3,7 @@
   src/Sections/Humans.Campaigns.Contracts/**
   src/Sections/Humans.Users/Services/UnsubscribeService.cs
   src/Sections/Humans.Users/Controllers/UnsubscribeController.cs
+  src/Sections/Humans.Email/Services/OutboxEmailService.cs
 -->
 <!-- freshness:flag-on-change
   Campaign workflow, wave-send eligibility, unsubscribe behavior, or self-service code lookup may have shifted; verify states/routes/auth still match.
@@ -28,7 +29,7 @@ Draft → Active → Completed
 
 Transitions:
 - **Activate**: moves from Draft → Active (requires at least one imported code)
-- **Complete**: moves from Active → Completed (manual or auto)
+- **Complete**: moves from Active → Completed (manual Admin action; there is no auto-complete path)
 
 ## Wave Send
 
@@ -50,7 +51,7 @@ Route: `/Campaigns/Admin` — Admin role, except the detail page and API code ge
 
 Pages:
 - Campaign list with status and code/grant counts
-- Campaign detail: stats (total codes, assigned, sent, failed), grant table
+- Campaign detail: stats (total codes, available, sent, failed, redeemed), grant table
 - Create / Edit campaign form (title, description, email subject, email body template, optional reply-to address)
 - Import codes (CSV upload) or generate codes via the ticket vendor API
 - Activate / Send Wave / Complete actions
@@ -80,8 +81,8 @@ Humans can view their campaign codes on their profile page. The profile page sho
 Campaign 1──n CampaignCode
 Campaign 1──n CampaignGrant
 CampaignCode 1──1 CampaignGrant (once assigned)
-CampaignGrant n──1 User
-CampaignGrant 1──n EmailOutboxMessage
+CampaignGrant n──1 User            (bare Guid FK — no nav, no DB constraint)
+CampaignGrant 1──n EmailOutboxMessage  (Email-side bare FK — no nav on CampaignGrant)
 ```
 
 ## Ticket Vendor Integration

--- a/src/Sections/Humans.Campaigns/Docs/health.md
+++ b/src/Sections/Humans.Campaigns/Docs/health.md
@@ -50,8 +50,8 @@ Nothing here wants splitting; the service is ~700 lines over eight coherent shap
 - CampaignCodes mail is always-on: no opt-out check, no unsubscribe link/header.
 - Template substitution (`{{Code}}`, `{{Name}}`) HTML-encodes values — done in Email's
   renderer, not here; this section forwards raw values.
-- Only Admin mutates; TicketAdmin may view detail and generate vendor codes; members see
-  only their own grants.
+- Mutations are Admin-only, with one exception: vendor-code generation is
+  TicketAdminOrAdmin. TicketAdmin may also view detail; members see only their own grants.
 - Redemption matching: case-insensitive, unredeemed grants on Active/Completed campaigns,
   newest campaign wins on multi-campaign code collision, N same-code redemptions consume N
   distinct grants.

--- a/src/Sections/Humans.Campaigns/Docs/health.md
+++ b/src/Sections/Humans.Campaigns/Docs/health.md
@@ -1,0 +1,98 @@
+# Campaigns — Target Shape
+
+Regenerated every section-doctor run (Phase 3c), before any scan. History table at the bottom.
+
+## 1. What the section does
+
+An admin creates a bulk code-distribution effort, loads unique one-per-person codes into it
+(CSV upload, or generated through the ticket vendor while still in draft), turns it on, and
+sends codes out team by team: each send assigns a free code to every team member who doesn't
+already hold one and emails it to them. Failed deliveries can be retried one at a time or all
+at once. Recipients see their codes on their own profile; admins see per-campaign delivery and
+redemption counts, updated when the ticket system spots a code being used. When the effort is
+over the admin closes it. Grants follow the person through account merges, appear in their
+GDPR export, and are hard-deleted on erasure.
+
+## 2. The shapes
+
+| Shape | Members | Notes |
+|---|---|---|
+| Campaign CRUD | Create, Edit, GetById, GetAll (admin list) | form-shaped; validation = three required strings |
+| Lifecycle | Activate, Complete | one-way Draft → Active → Completed |
+| Code loading | ImportCodesAsync (CSV), GenerateAndImportDiscountCodesAsync (vendor) | both funnel into per-campaign `ImportOrder` sequence |
+| Wave send | PreviewWaveSendAsync, SendWaveAsync, GetSendWavePageAsync | team-scoped; grant + email per eligible member |
+| Delivery repair | ResendToGrantAsync, RetryAllFailedAsync | both re-enqueue through the same email factory |
+| Grant reads | GetActiveOrCompletedGrantsForUserAsync, GetAllGrantsForUserAsync, GetCodeTrackingAsync | the cross-section read surface (`ICampaignServiceRead`) |
+| Inbound writes | MarkGrantsRedeemedAsync (ticket sync), UpdateGrantEmailStatusAsync (outbox processor) | the two cross-section writes on `ICampaignService` |
+| Platform roles | IUserDataContributor (export + erase), IUserMerge (grant re-FK) | GDPR and merge fold |
+
+Question-shapes: "manage a campaign" (CRUD + lifecycle + loading), "get codes to people"
+(wave + repair), "who has what" (grant reads), "record what happened elsewhere" (inbound
+writes), "platform obligations" (GDPR/merge).
+
+## 3. Structure
+
+The layout those shapes imply is what exists: one controller (admin pages), one service
+holding all rules, one repository as sole table-toucher, a Contracts leaf carrying only the
+five members outsiders call, DTOs per page. No caching decorator (admin-only, cold paths).
+Nothing here wants splitting; the service is ~700 lines over eight coherent shapes.
+
+## 4. Invariants
+
+- Status walks Draft → Active → Completed, one way. Activate needs ≥1 code; Complete needs
+  Active; SendWave needs Active; vendor generation needs Draft (service-enforced).
+- A code is unique per campaign (DB unique `(CampaignId, Code)`); granted to at most one
+  person (DB unique `CampaignCodeId` on grants); a person holds at most one grant per
+  campaign (DB unique `(CampaignId, UserId)`).
+- Wave allocation orders by `ImportOrder` — batch order stable and reproducible.
+- Per-grant commit during wave/retry: one enqueue failure flips only that grant to Failed.
+- A wave aborts before granting anything when available codes < eligible members.
+- CampaignCodes mail is always-on: no opt-out check, no unsubscribe link/header.
+- Template substitution (`{{Code}}`, `{{Name}}`) HTML-encodes values — done in Email's
+  renderer, not here; this section forwards raw values.
+- Only Admin mutates; TicketAdmin may view detail and generate vendor codes; members see
+  only their own grants.
+- Redemption matching: case-insensitive, unredeemed grants on Active/Completed campaigns,
+  newest campaign wins on multi-campaign code collision, N same-code redemptions consume N
+  distinct grants.
+
+## 5. Seams
+
+None. No specified-but-unbuilt work found in the section docs, feature spec, or issue
+backlog at assessment time.
+
+## 6. Deliberately not done
+
+- **No caching decorator** — admin-only, low volume (Campaigns.md records the decision).
+- **No `ICommunicationPreferenceService` call in wave send** — CampaignCodes is always-on,
+  confirmed intended (nobodies-collective/Humans#1032); don't "add the missing opt-out check".
+- **No `UpdatedAt` stamp in `ReassignGrantsToUserAsync`** — the parameter exists for merge-fold
+  signature parity and is deliberately discarded; the entity has no such column.
+- **No service-side status guard on CSV import** — import is open in Draft and Active by
+  design (post-activation top-up); only vendor generation is Draft-only.
+- **No localization** — the whole UI is admin-side (`/Campaigns/Admin`), exempt; the section
+  ships no resx set at all, and `_ViewImports` documents that.
+
+## Load-bearing weirdness
+
+- `CreatedByUserId` / `CampaignGrant.UserId` are bare Guids — no nav, no FK constraint —
+  because the section assembly cannot name `User` since G5. Display names resolve through
+  `IUserServiceRead`; don't reintroduce a relationship.
+- The controller injects the concrete `CampaignService`, not an interface — deliberate
+  (design §15 step 5): the in-section surface stays internal, only the five cross-assembly
+  members live on `ICampaignService`/`ICampaignServiceRead`.
+- Repository is Singleton over `IDbContextFactory` (context per call) — the section's §15b
+  pattern; the architecture test pins it.
+- `ImportOrder` is a per-campaign monotonic int assigned at import, not an identity column —
+  it exists solely to make wave allocation reproducible.
+- The email body template is *markdown carrying `{{...}}` placeholders*; rendering and
+  HTML-encoding happen in Email's outbox service so all mail encodes consistently — tests
+  pin that raw values are forwarded.
+- `EnumStringStabilityTests` lives in this test project (not the central one) because
+  `CampaignStatus` is internal post-G5; renaming an enum member needs a data migration.
+
+## History
+
+| Run | Date | Headline | PR |
+|---|---|---|---|
+| 1 | 2026-08-29 | First doctoring: comment/doc drift cleared, contract claims aligned with code | pending |

--- a/src/Sections/Humans.Campaigns/Docs/health.md
+++ b/src/Sections/Humans.Campaigns/Docs/health.md
@@ -95,4 +95,4 @@ backlog at assessment time.
 
 | Run | Date | Headline | PR |
 |---|---|---|---|
-| 1 | 2026-08-29 | First doctoring: comment/doc drift cleared, contract claims aligned with code | pending |
+| 1 | 2026-08-29 | First doctoring: comment/doc drift cleared, contract claims aligned with code | peterdrier/Humans#1564 |

--- a/src/Sections/Humans.Campaigns/Docs/health.md
+++ b/src/Sections/Humans.Campaigns/Docs/health.md
@@ -33,9 +33,9 @@ writes), "platform obligations" (GDPR/merge).
 ## 3. Structure
 
 The layout those shapes imply is what exists: one controller (admin pages), one service
-holding all rules, one repository as sole table-toucher, a Contracts leaf carrying only the
-five members outsiders call, DTOs per page. No caching decorator (admin-only, cold paths).
-Nothing here wants splitting; the service is ~700 lines over eight coherent shapes.
+holding all rules, one repository as sole table-toucher, a Contracts leaf carrying only
+the members outsiders call, DTOs per page. No caching decorator (admin-only, cold paths).
+Nothing here wants splitting; the service maps one coherent shape per question above.
 
 ## 4. Invariants
 

--- a/src/Sections/Humans.Campaigns/Docs/health.md
+++ b/src/Sections/Humans.Campaigns/Docs/health.md
@@ -17,13 +17,13 @@ GDPR export, and are hard-deleted on erasure.
 
 | Shape | Members | Notes |
 |---|---|---|
-| Campaign CRUD | Create, Edit, GetById, GetAll (admin list) | form-shaped; validation = three required strings |
+| Campaign CRUD | Create, Edit, GetById, GetAll (admin list) | form-shaped; validation is required-string checks only |
 | Lifecycle | Activate, Complete | one-way Draft → Active → Completed |
 | Code loading | ImportCodesAsync (CSV), GenerateAndImportDiscountCodesAsync (vendor) | both funnel into per-campaign `ImportOrder` sequence |
 | Wave send | PreviewWaveSendAsync, SendWaveAsync, GetSendWavePageAsync | team-scoped; grant + email per eligible member |
 | Delivery repair | ResendToGrantAsync, RetryAllFailedAsync | both re-enqueue through the same email factory |
 | Grant reads | GetActiveOrCompletedGrantsForUserAsync, GetAllGrantsForUserAsync, GetCodeTrackingAsync | the cross-section read surface (`ICampaignServiceRead`) |
-| Inbound writes | MarkGrantsRedeemedAsync (ticket sync), UpdateGrantEmailStatusAsync (outbox processor) | the two cross-section writes on `ICampaignService` |
+| Inbound writes | MarkGrantsRedeemedAsync (ticket sync), UpdateGrantEmailStatusAsync (outbox processor) | the cross-section writes on `ICampaignService` |
 | Platform roles | IUserDataContributor (export + erase), IUserMerge (grant re-FK) | GDPR and merge fold |
 
 Question-shapes: "manage a campaign" (CRUD + lifecycle + loading), "get codes to people"
@@ -79,7 +79,7 @@ backlog at assessment time.
   because the section assembly cannot name `User` since G5. Display names resolve through
   `IUserServiceRead`; don't reintroduce a relationship.
 - The controller injects the concrete `CampaignService`, not an interface — deliberate
-  (design §15 step 5): the in-section surface stays internal, only the five cross-assembly
+  (design §15 step 5): the in-section surface stays internal; only the cross-assembly
   members live on `ICampaignService`/`ICampaignServiceRead`.
 - Repository is Singleton over `IDbContextFactory` (context per call) — the section's §15b
   pattern; the architecture test pins it.

--- a/src/Sections/Humans.Campaigns/Domain/Campaign.cs
+++ b/src/Sections/Humans.Campaigns/Domain/Campaign.cs
@@ -17,7 +17,6 @@ internal sealed class Campaign
     public Instant CreatedAt { get; set; }
     public Guid CreatedByUserId { get; set; }
 
-    // Navigation.
     public ICollection<CampaignCode> Codes { get; } = new List<CampaignCode>();
     public ICollection<CampaignGrant> Grants { get; } = new List<CampaignGrant>();
 }

--- a/src/Sections/Humans.Campaigns/Domain/CampaignCode.cs
+++ b/src/Sections/Humans.Campaigns/Domain/CampaignCode.cs
@@ -10,7 +10,6 @@ internal sealed class CampaignCode
     public int ImportOrder { get; set; }
     public Instant ImportedAt { get; set; }
 
-    // Navigation
     public Campaign Campaign { get; set; } = null!;
     public CampaignGrant? Grant { get; set; }
 }

--- a/src/Sections/Humans.Campaigns/Humans.Campaigns.csproj
+++ b/src/Sections/Humans.Campaigns/Humans.Campaigns.csproj
@@ -12,10 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-      Microsoft.NET.Sdk.Web adds these to ImplicitUsings; Microsoft.NET.Sdk.Razor does not.
-      Declaring them keeps the files moved out of Humans.Web byte-identical to their originals.
-    -->
+    <!-- Microsoft.NET.Sdk.Web adds these to ImplicitUsings; Microsoft.NET.Sdk.Razor does not. -->
     <Using Include="Microsoft.AspNetCore.Http" />
     <Using Include="Microsoft.AspNetCore.Routing" />
     <Using Include="Microsoft.Extensions.Logging" />
@@ -31,8 +28,8 @@
     <ProjectReference Include="..\Humans.Gdpr.Contracts\Humans.Gdpr.Contracts.csproj" />
     <!--
       Tickets' contracts leaf: CampaignService asks Tickets for discount codes
-      (ITicketDiscountCodes) rather than reaching past it into the Base vendor port, which
-      is what it used to do. Acyclic — the pair goes through leaves in both directions
+      (ITicketDiscountCodes) rather than reaching past it into the Base vendor port.
+      Acyclic — the pair goes through leaves in both directions
       (Humans.Tickets -> Humans.Campaigns.Contracts) and Humans.Campaigns.Contracts names
       no Tickets type.
     -->

--- a/src/Sections/Humans.Campaigns/Section.cs
+++ b/src/Sections/Humans.Campaigns/Section.cs
@@ -23,8 +23,8 @@ public sealed class Section : ISection
     {
         services.AddSectionDbContext<CampaignsDbContext>(sentinelTable: "campaigns");
 
-        // §15 repository pattern (issue #546): Singleton + IDbContextFactory (§15b) so the
-        // repository owns context lifetime.
+        // §15 repository pattern (nobodies-collective/Humans#546): Singleton +
+        // IDbContextFactory (§15b) so the repository owns context lifetime.
         services.AddSingleton<ICampaignRepository, CampaignRepository>();
         services.AddScoped<CampaignService>();
         services.AddScoped<ICampaignService>(sp => sp.GetRequiredService<CampaignService>());

--- a/src/Sections/Humans.Campaigns/SectionAdminNav.cs
+++ b/src/Sections/Humans.Campaigns/SectionAdminNav.cs
@@ -10,7 +10,7 @@ internal sealed class SectionAdminNav : ISectionAdminNav
     [
         new("Tickets", [
             // Campaigns distribute ticket-vendor discount codes (email is just the
-            // delivery channel) — Tickets, not Messaging. See docs/sections/Campaigns.md.
+            // delivery channel) — Tickets, not Messaging. See Docs/Campaigns.md.
             new("Campaigns", "Campaign", "Index", null, null, "fa-solid fa-bullhorn", PolicyNames.AdminOnly, Weight: 40)
         ], Weight: 0)
     ];

--- a/src/Sections/Humans.Campaigns/Services/CampaignService.cs
+++ b/src/Sections/Humans.Campaigns/Services/CampaignService.cs
@@ -220,7 +220,7 @@ internal sealed class CampaignService(
     public Task<Guid?> GetCampaignIdForGrantAsync(Guid grantId, CancellationToken ct = default) =>
         repository.GetCampaignIdForGrantAsync(grantId, ct);
 
-    public async Task ImportCodesAsync(Guid campaignId, IEnumerable<string> codes, CancellationToken ct = default)
+    public async Task<(int Imported, int Skipped)> ImportCodesAsync(Guid campaignId, IEnumerable<string> codes, CancellationToken ct = default)
     {
         var campaign = await repository.FindForMutationWithCodesAsync(campaignId, ct)
             ?? throw new InvalidOperationException($"Campaign {campaignId} not found.");
@@ -265,6 +265,8 @@ internal sealed class CampaignService(
         logger.LogInformation(
             "Campaign {CampaignId}: imported {Imported} codes, skipped {Skipped} duplicates",
             campaignId, imported, skipped);
+
+        return (imported, skipped);
     }
 
     private async Task ImportGeneratedCodesAsync(Guid campaignId, IReadOnlyList<string> codes,

--- a/src/Sections/Humans.Campaigns/Services/CampaignService.cs
+++ b/src/Sections/Humans.Campaigns/Services/CampaignService.cs
@@ -18,7 +18,7 @@ namespace Humans.Campaigns.Services;
 /// <summary>
 /// The Campaigns section's service. Implements the cross-assembly
 /// <see cref="ICampaignService"/> contract; the section's own controller injects this
-/// concrete type for the sixteen members that stay inside (design §15 step 5).
+/// concrete type for the members that stay inside the section (design §15 step 5).
 /// </summary>
 internal sealed class CampaignService(
     ICampaignRepository repository,

--- a/src/Sections/Humans.Campaigns/Views/Campaign/Detail.cshtml
+++ b/src/Sections/Humans.Campaigns/Views/Campaign/Detail.cshtml
@@ -13,20 +13,13 @@
     var codesRedeemed = Model.Stats.CodesRedeemed;
     var totalGrants = Model.Stats.TotalGrants;
     var redemptionPct = totalGrants > 0 ? (int)Math.Round(100.0 * codesRedeemed / totalGrants) : 0;
-    var statusClass = Model.Campaign.Status switch
-    {
-        CampaignStatus.Draft => "bg-secondary",
-        CampaignStatus.Active => "bg-success",
-        CampaignStatus.Completed => "bg-info",
-        _ => "bg-secondary"
-    };
     var isAdmin = (await AuthService.AuthorizeAsync(User, PolicyNames.AdminOnly)).Succeeded;
     var canGenerateCodes = (await AuthService.AuthorizeAsync(User, PolicyNames.TicketAdminOrAdmin)).Succeeded;
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
-        <h1>@Model.Campaign.Title <span class="badge @statusClass fs-6">@Model.Campaign.Status</span></h1>
+        <h1>@Model.Campaign.Title <span class="badge @EnumBadgeMap.For(Model.Campaign.Status) fs-6">@Model.Campaign.Status</span></h1>
         @if (!string.IsNullOrWhiteSpace(Model.Campaign.Description))
         {
             <div class="text-muted mb-0">@Html.SanitizedMarkdown(Model.Campaign.Description)</div>
@@ -47,8 +40,6 @@
     </div>
 </div>
 
-
-@* Action buttons *@
 <div class="d-flex flex-wrap gap-2 mb-4">
     @if (isAdmin && Model.Campaign.Status == CampaignStatus.Active)
     {
@@ -115,7 +106,6 @@
     }
 </div>
 
-@* Stats cards *@
 <div class="row mb-4">
     <div class="col-md-3">
         <div class="card text-center">
@@ -151,7 +141,6 @@
     </div>
 </div>
 
-@* Redemption stats *@
 @if (totalGrants > 0)
 {
     <div class="alert alert-info mb-4">
@@ -160,7 +149,6 @@
     </div>
 }
 
-@* Grants table *@
 <div class="card">
     <div class="card-header">Grants</div>
     <div class="card-body p-0">
@@ -188,14 +176,7 @@
             Func<CampaignGrantSummary, IHtmlContent> emailStatusCell = @<text>
                 @if (item.LatestEmailStatus.HasValue)
                 {
-                    var emailStatusClass = item.LatestEmailStatus switch
-                    {
-                        EmailOutboxStatus.Queued => "bg-warning",
-                        EmailOutboxStatus.Sent => "bg-success",
-                        EmailOutboxStatus.Failed => "bg-danger",
-                        _ => "bg-secondary"
-                    };
-                    <span class="badge @emailStatusClass">@item.LatestEmailStatus</span>
+                    <span class="badge @EnumBadgeMap.For(item.LatestEmailStatus.Value)">@item.LatestEmailStatus</span>
                     @if (item.LatestEmailAt.HasValue)
                     {
                         <small class="text-muted ms-1">@item.LatestEmailAt.Value.ToDateTime()</small>
@@ -206,14 +187,18 @@
                     <span class="text-muted">-</span>
                 }
             </text>;
+            @* POST Resend is AdminOnly; don't render a button TicketAdmin can only 403 on. *@
             Func<CampaignGrantSummary, IHtmlContent> resendCell =
                 @<text>
-                    <form asp-action="Resend" asp-route-grantId="@item.Id" method="post" class="d-inline">
-                        @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-outline-secondary btn-sm">
-                            <i class="fa-solid fa-rotate-right me-1"></i>Resend
-                        </button>
-                    </form>
+                    @if (isAdmin)
+                    {
+                        <form asp-action="Resend" asp-route-grantId="@item.Id" method="post" class="d-inline">
+                            @Html.AntiForgeryToken()
+                            <button type="submit" class="btn btn-outline-secondary btn-sm">
+                                <i class="fa-solid fa-rotate-right me-1"></i>Resend
+                            </button>
+                        </form>
+                    }
                 </text>;
             var grantsTable = TableModel.For(rows)
                 .Template("Human", humanCell)

--- a/src/Sections/Humans.Campaigns/Views/_ViewImports.cshtml
+++ b/src/Sections/Humans.Campaigns/Views/_ViewImports.cshtml
@@ -1,6 +1,6 @@
 @* A section RCL does NOT inherit the host's Views/_ViewImports.cshtml. Omitting a line
    here ships broken markup with a green build and no runtime error — see design §1/§2.
-   Guarded by CampaignPageRenderTests (step 12). *@
+   Guarded by CampaignPageRenderTests. *@
 @using Humans.Base.Extensions
 @using Humans.Campaigns
 @using Humans.Campaigns.Contracts
@@ -15,7 +15,6 @@
 @using NodaTime
 @* No localizer of either kind: Campaigns' views carry no Localizer[…] call and
    SharedResource has no Campaign_ key, so the section ships no resource set at all
-   (§15.3b — Finance and Gate are the other two). GateArchitectureTests' structural
-   guard is the backstop if someone adds copy. *@
+   (§15.3b — Finance and Gate are the other two). *@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Humans.Base

--- a/tests/Humans.Campaigns.Tests/Architecture/CampaignsArchitectureTests.cs
+++ b/tests/Humans.Campaigns.Tests/Architecture/CampaignsArchitectureTests.cs
@@ -9,11 +9,8 @@ namespace Humans.Campaigns.Tests.Architecture;
 /// (nobodies-collective/Humans#866, G5).
 /// </summary>
 /// <remarks>
-/// Replaces <c>Humans.Application.Tests/Architecture/CampaignsArchitectureTests.cs</c>. Its
-/// <c>CampaignService_DoesNotReferenceEntityFrameworkCore</c> test is gone: it asserted that
-/// <c>Humans.Application</c> carries no EF reference, and the section assembly holds the
-/// repository and legitimately does — so over there the assertion is either false or vacuous.
-/// Keeping the service off the DbSets is HUM0025's job now.
+/// No EF-reference assertion here: the section assembly holds the repository and
+/// legitimately references EF. Keeping the service off the DbSets is HUM0025's job.
 /// </remarks>
 public class CampaignsArchitectureTests
 {

--- a/tests/Humans.Campaigns.Tests/Data/CampaignRepositoryTests.cs
+++ b/tests/Humans.Campaigns.Tests/Data/CampaignRepositoryTests.cs
@@ -1,0 +1,283 @@
+using AwesomeAssertions;
+using Humans.Campaigns.Contracts;
+using Humans.Campaigns.Data;
+using Humans.Campaigns.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NodaTime;
+using NodaTime.Testing;
+
+namespace Humans.Campaigns.Tests.Data;
+
+/// <summary>
+/// Repository-level guards for the grant matching and account-merge logic that
+/// lives in <see cref="CampaignRepository"/> rather than the service:
+/// <c>MarkGrantsRedeemedAsync</c> (ticket-sync redemption matching),
+/// <c>ReassignGrantsToUserAsync</c> (merge fold), and the status filtering of
+/// the two per-user grant reads.
+/// </summary>
+public sealed class CampaignRepositoryTests
+{
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 31, 12, 0));
+
+    private readonly TestDbContextFactory<CampaignsDbContext> _factory =
+        new(new DbContextOptionsBuilder<CampaignsDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options);
+
+    private readonly CampaignsDbContext _db;
+    private readonly CampaignRepository _repository;
+
+    public CampaignRepositoryTests()
+    {
+        _db = _factory.CreateDbContext();
+        _repository = new CampaignRepository(_factory);
+    }
+
+    // ==========================================================================
+    // MarkGrantsRedeemedAsync
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task MarkGrantsRedeemedAsync_MatchesCodesCaseInsensitively()
+    {
+        var campaign = await SeedCampaignAsync(CampaignStatus.Active);
+        var grant = await SeedGrantAsync(campaign, "AbC-123");
+
+        var count = await _repository.MarkGrantsRedeemedAsync(
+            [new DiscountCodeRedemption("abc-123", _clock.GetCurrentInstant())],
+            Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(1);
+        (await ReloadGrantAsync(grant.Id)).RedeemedAt.Should().Be(_clock.GetCurrentInstant());
+    }
+
+    [HumansFact]
+    public async Task MarkGrantsRedeemedAsync_IgnoresDraftCampaignGrants()
+    {
+        var campaign = await SeedCampaignAsync(CampaignStatus.Draft);
+        var grant = await SeedGrantAsync(campaign, "DRAFT-CODE");
+
+        var count = await _repository.MarkGrantsRedeemedAsync(
+            [new DiscountCodeRedemption("DRAFT-CODE", _clock.GetCurrentInstant())],
+            Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(0);
+        (await ReloadGrantAsync(grant.Id)).RedeemedAt.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task MarkGrantsRedeemedAsync_SkipsAlreadyRedeemedGrants()
+    {
+        var earlier = Instant.FromUtc(2026, 1, 1, 0, 0);
+        var campaign = await SeedCampaignAsync(CampaignStatus.Completed);
+        var grant = await SeedGrantAsync(campaign, "USED", redeemedAt: earlier);
+
+        var count = await _repository.MarkGrantsRedeemedAsync(
+            [new DiscountCodeRedemption("USED", _clock.GetCurrentInstant())],
+            Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(0);
+        (await ReloadGrantAsync(grant.Id)).RedeemedAt.Should().Be(earlier);
+    }
+
+    [HumansFact]
+    public async Task MarkGrantsRedeemedAsync_SameCodeInTwoCampaigns_NewestCampaignWins()
+    {
+        var older = await SeedCampaignAsync(CampaignStatus.Active, Instant.FromUtc(2025, 1, 1, 0, 0));
+        var newer = await SeedCampaignAsync(CampaignStatus.Active, Instant.FromUtc(2026, 1, 1, 0, 0));
+        var olderGrant = await SeedGrantAsync(older, "SHARED");
+        var newerGrant = await SeedGrantAsync(newer, "SHARED");
+
+        var count = await _repository.MarkGrantsRedeemedAsync(
+            [new DiscountCodeRedemption("SHARED", _clock.GetCurrentInstant())],
+            Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(1);
+        (await ReloadGrantAsync(newerGrant.Id)).RedeemedAt.Should().NotBeNull();
+        (await ReloadGrantAsync(olderGrant.Id)).RedeemedAt.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task MarkGrantsRedeemedAsync_NRedemptionsOfSameCode_RedeemNDistinctGrants()
+    {
+        var first = await SeedCampaignAsync(CampaignStatus.Active);
+        var second = await SeedCampaignAsync(CampaignStatus.Active);
+        var grantA = await SeedGrantAsync(first, "MULTI");
+        var grantB = await SeedGrantAsync(second, "MULTI");
+
+        var count = await _repository.MarkGrantsRedeemedAsync(
+            [
+                new DiscountCodeRedemption("MULTI", _clock.GetCurrentInstant()),
+                new DiscountCodeRedemption("MULTI", _clock.GetCurrentInstant())
+            ],
+            Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(2);
+        (await ReloadGrantAsync(grantA.Id)).RedeemedAt.Should().NotBeNull();
+        (await ReloadGrantAsync(grantB.Id)).RedeemedAt.Should().NotBeNull();
+    }
+
+    [HumansFact]
+    public async Task MarkGrantsRedeemedAsync_BlankCodes_RedeemNothing()
+    {
+        var campaign = await SeedCampaignAsync(CampaignStatus.Active);
+        await SeedGrantAsync(campaign, "REAL");
+
+        var count = await _repository.MarkGrantsRedeemedAsync(
+            [new DiscountCodeRedemption("", _clock.GetCurrentInstant())],
+            Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(0);
+    }
+
+    // ==========================================================================
+    // ReassignGrantsToUserAsync
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task ReassignGrantsToUserAsync_MovesGrantsToTarget()
+    {
+        var source = Guid.NewGuid();
+        var target = Guid.NewGuid();
+        var campaign = await SeedCampaignAsync(CampaignStatus.Active);
+        var grant = await SeedGrantAsync(campaign, "MOVE", userId: source);
+
+        var count = await _repository.ReassignGrantsToUserAsync(
+            source, target, _clock.GetCurrentInstant(), Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(1);
+        (await ReloadGrantAsync(grant.Id)).UserId.Should().Be(target);
+    }
+
+    [HumansFact]
+    public async Task ReassignGrantsToUserAsync_TargetAlreadyGrantedOnCampaign_TargetWinsSourceRowDrops()
+    {
+        var source = Guid.NewGuid();
+        var target = Guid.NewGuid();
+        var campaign = await SeedCampaignAsync(CampaignStatus.Active);
+        var sourceGrant = await SeedGrantAsync(campaign, "SRC", userId: source);
+        var targetGrant = await SeedGrantAsync(campaign, "TGT", userId: target);
+
+        var count = await _repository.ReassignGrantsToUserAsync(
+            source, target, _clock.GetCurrentInstant(), Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(1);
+        (await _db.CampaignGrants.AsNoTracking()
+            .SingleOrDefaultAsync(g => g.Id == sourceGrant.Id, Xunit.TestContext.Current.CancellationToken))
+            .Should().BeNull();
+        (await ReloadGrantAsync(targetGrant.Id)).UserId.Should().Be(target);
+    }
+
+    [HumansFact]
+    public async Task ReassignGrantsToUserAsync_SecondSourceRowOnSameCampaign_Drops()
+    {
+        // Pre-index data could hold two source grants on one campaign; moving
+        // both would violate the unique (CampaignId, UserId) index, so the
+        // second must drop. The in-memory provider doesn't enforce the index —
+        // this pins the dedup logic, not the constraint.
+        var source = Guid.NewGuid();
+        var target = Guid.NewGuid();
+        var campaign = await SeedCampaignAsync(CampaignStatus.Active);
+        await SeedGrantAsync(campaign, "DUP-1", userId: source);
+        await SeedGrantAsync(campaign, "DUP-2", userId: source);
+
+        var count = await _repository.ReassignGrantsToUserAsync(
+            source, target, _clock.GetCurrentInstant(), Xunit.TestContext.Current.CancellationToken);
+
+        count.Should().Be(1);
+        (await _db.CampaignGrants.AsNoTracking()
+            .CountAsync(g => g.UserId == source, Xunit.TestContext.Current.CancellationToken))
+            .Should().Be(0);
+    }
+
+    // ==========================================================================
+    // Grant reads — campaign-status filtering
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetActiveOrCompletedGrantsForUserAsync_ExcludesDraftCampaignGrants()
+    {
+        var userId = Guid.NewGuid();
+        var draft = await SeedCampaignAsync(CampaignStatus.Draft);
+        var active = await SeedCampaignAsync(CampaignStatus.Active);
+        var completed = await SeedCampaignAsync(CampaignStatus.Completed);
+        await SeedGrantAsync(draft, "D", userId: userId);
+        var activeGrant = await SeedGrantAsync(active, "A", userId: userId);
+        var completedGrant = await SeedGrantAsync(completed, "C", userId: userId);
+
+        var grants = await _repository.GetActiveOrCompletedGrantsForUserAsync(
+            userId, Xunit.TestContext.Current.CancellationToken);
+
+        grants.Select(g => g.Id).Should().BeEquivalentTo([activeGrant.Id, completedGrant.Id]);
+    }
+
+    [HumansFact]
+    public async Task GetAllGrantsForUserAsync_ReturnsAllStatuses_OnlyForThatUser()
+    {
+        var userId = Guid.NewGuid();
+        var draft = await SeedCampaignAsync(CampaignStatus.Draft);
+        var active = await SeedCampaignAsync(CampaignStatus.Active);
+        var draftGrant = await SeedGrantAsync(draft, "D", userId: userId);
+        var activeGrant = await SeedGrantAsync(active, "A", userId: userId);
+        await SeedGrantAsync(active, "OTHER", userId: Guid.NewGuid());
+
+        var grants = await _repository.GetAllGrantsForUserAsync(
+            userId, Xunit.TestContext.Current.CancellationToken);
+
+        grants.Select(g => g.Id).Should().BeEquivalentTo([draftGrant.Id, activeGrant.Id]);
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private async Task<Campaign> SeedCampaignAsync(CampaignStatus status, Instant? createdAt = null)
+    {
+        var campaign = new Campaign
+        {
+            Id = Guid.NewGuid(),
+            Title = "Repo Campaign",
+            EmailSubject = "Subject",
+            EmailBodyTemplate = "Body",
+            Status = status,
+            CreatedAt = createdAt ?? _clock.GetCurrentInstant(),
+            CreatedByUserId = Guid.NewGuid()
+        };
+        _db.Campaigns.Add(campaign);
+        await _db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+        _db.ChangeTracker.Clear();
+        return campaign;
+    }
+
+    private async Task<CampaignGrant> SeedGrantAsync(
+        Campaign campaign, string code, Guid? userId = null, Instant? redeemedAt = null)
+    {
+        var codeRow = new CampaignCode
+        {
+            Id = Guid.NewGuid(),
+            CampaignId = campaign.Id,
+            Code = code,
+            ImportedAt = _clock.GetCurrentInstant()
+        };
+        var grant = new CampaignGrant
+        {
+            Id = Guid.NewGuid(),
+            CampaignId = campaign.Id,
+            CampaignCodeId = codeRow.Id,
+            UserId = userId ?? Guid.NewGuid(),
+            AssignedAt = _clock.GetCurrentInstant(),
+            RedeemedAt = redeemedAt
+        };
+        _db.CampaignCodes.Add(codeRow);
+        _db.CampaignGrants.Add(grant);
+        await _db.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+        _db.ChangeTracker.Clear();
+        return grant;
+    }
+
+    private async Task<CampaignGrant> ReloadGrantAsync(Guid grantId) =>
+        await _db.CampaignGrants.AsNoTracking()
+            .SingleAsync(g => g.Id == grantId, Xunit.TestContext.Current.CancellationToken);
+}

--- a/tests/Humans.Campaigns.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Campaigns.Tests/Enums/EnumStringStabilityTests.cs
@@ -26,12 +26,9 @@ public class EnumStringStabilityTests
 
     private static void AssertNames(Type enumType, string[] expectedNames)
     {
-        var actualNames = Enum.GetNames(enumType);
-        foreach (var expected in expectedNames)
-        {
-            actualNames.Should().Contain(expected,
-                $"enum {enumType.Name} member '{expected}' is stored as a string in the DB. " +
-                "If you renamed it, create a DB migration to UPDATE the old values.");
-        }
+        Enum.GetNames(enumType).Should().BeEquivalentTo(expectedNames,
+            $"enum {enumType.Name} members are stored as strings in the DB. " +
+            "If you renamed one, create a DB migration to UPDATE the old values; " +
+            "if you added or removed one, update this expected list.");
     }
 }

--- a/tests/Humans.Campaigns.Tests/Humans.Campaigns.Tests.csproj
+++ b/tests/Humans.Campaigns.Tests/Humans.Campaigns.Tests.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\..\src\Sections\Humans.Teams.Contracts\Humans.Teams.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Sections\Humans.Users.Contracts\Humans.Users.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Humans.Base\Humans.Base.csproj" />
-    <ProjectReference Include="..\..\src\Sections\Humans.Shifts.Contracts\Humans.Shifts.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
@@ -428,27 +428,42 @@ public sealed class CampaignServiceTests
     }
 
     [HumansFact]
-    public async Task SendWaveAsync_PassesTemplateBodyAndSubjectToEmailService()
+    public async Task SendWaveAsync_NotActive_Throws()
     {
-        var campaign = await SeedActiveCampaignWithCodesAsync(["CODE-1"],
-            emailSubject: "Hi {{Name}}, your code",
-            emailBodyTemplate: "<p>Hi {{Name}}, your code is {{Code}}</p>");
+        var campaign = await SeedCampaignAsync();
 
-        var user = SeedUser(displayName: "Charlie");
-        var team = SeedTeam("Gamma");
-        SeedTeamMember(team.Id, user.Id);
+        var act = () => _service.SendWaveAsync(campaign.Id, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Active*");
+    }
+
+    [HumansFact]
+    public async Task SendWaveAsync_EnqueueFailure_FailsThatGrantOnly()
+    {
+        var campaign = await SeedActiveCampaignWithCodesAsync(["ISO-1", "ISO-2"]);
+
+        var user1 = SeedUser(displayName: "First");
+        var user2 = SeedUser(displayName: "Second");
+        var team = SeedTeam("Kappa");
+        SeedTeamMember(team.Id, user1.Id);
+        SeedTeamMember(team.Id, user2.Id);
         await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
 
-        await _service.SendWaveAsync(campaign.Id, team.Id, Xunit.TestContext.Current.CancellationToken);
+        _emailService.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromException(new InvalidOperationException("enqueue down")),
+                Task.CompletedTask);
 
-        // CampaignService delegates rendering to IEmailService: it must pass through
-        // the raw template subject/body + code so OutboxEmailService can render it.
-        _emailMessages.Received(1).CampaignCode(
-            Arg.Is<CampaignCodeEmailRequest>(r =>
-                r.Subject == "Hi {{Name}}, your code"
-                && r.MarkdownBody == "<p>Hi {{Name}}, your code is {{Code}}</p>"
-                && r.Code == "CODE-1"
-                && r.RecipientName == "Charlie"));
+        var count = await _service.SendWaveAsync(campaign.Id, team.Id, Xunit.TestContext.Current.CancellationToken);
+
+        // Both grants exist — the enqueue failure flips only its own grant to
+        // Failed (where RetryAllFailedAsync picks it up) without aborting the wave.
+        count.Should().Be(2);
+        var grants = await CampaignsDb.CampaignGrants.AsNoTracking().ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        grants.Should().HaveCount(2);
+        grants.Count(g => g.LatestEmailStatus == EmailOutboxStatus.Failed).Should().Be(1);
+        grants.Count(g => g.LatestEmailStatus == EmailOutboxStatus.Queued).Should().Be(1);
     }
 
     [HumansFact]
@@ -491,12 +506,14 @@ public sealed class CampaignServiceTests
     }
 
     [HumansFact]
-    public async Task SendWaveAsync_PassesRawCodeAndRecipientToEmailService()
+    public async Task SendWaveAsync_PassesRawTemplateAndRecipientToEmailService()
     {
-        // HTML-encoding of values happens inside OutboxEmailService (owner of the
-        // outbox table) — CampaignService must forward raw values to it so that
-        // encoding is applied consistently across all email templates.
+        // Rendering and HTML-encoding happen inside OutboxEmailService (owner of
+        // the outbox table) — CampaignService must forward the raw template
+        // subject/body and raw code/name values so encoding is applied
+        // consistently across all email templates.
         var campaign = await SeedActiveCampaignWithCodesAsync(["A<B>C"],
+            emailSubject: "Hi {{Name}}, your code",
             emailBodyTemplate: "<p>Code: {{Code}}, Name: {{Name}}</p>");
 
         var user = SeedUser(displayName: "O'Brien & Co");
@@ -508,7 +525,9 @@ public sealed class CampaignServiceTests
 
         _emailMessages.Received(1).CampaignCode(
             Arg.Is<CampaignCodeEmailRequest>(r =>
-                r.Code == "A<B>C"
+                r.Subject == "Hi {{Name}}, your code"
+                && r.MarkdownBody == "<p>Code: {{Code}}, Name: {{Name}}</p>"
+                && r.Code == "A<B>C"
                 && r.RecipientName == "O'Brien & Co"));
     }
 
@@ -576,6 +595,40 @@ public sealed class CampaignServiceTests
         ClearAllTrackers();
         var retriedGrant = await CampaignsDb.CampaignGrants.FindAsync(grants[0].Id, Xunit.TestContext.Current.CancellationToken);
         retriedGrant!.LatestEmailStatus.Should().Be(EmailOutboxStatus.Queued);
+    }
+
+    [HumansFact]
+    public async Task RetryAllFailedAsync_ReEnqueueFailure_LeavesThatGrantFailedOnly()
+    {
+        var campaign = await SeedActiveCampaignWithCodesAsync(["RE-1", "RE-2"]);
+
+        var user1 = SeedUser(displayName: "RetryUser1");
+        var user2 = SeedUser(displayName: "RetryUser2");
+        var team = SeedTeam("Lambda");
+        SeedTeamMember(team.Id, user1.Id);
+        SeedTeamMember(team.Id, user2.Id);
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+
+        await _service.SendWaveAsync(campaign.Id, team.Id, Xunit.TestContext.Current.CancellationToken);
+
+        var grants = await CampaignsDb.CampaignGrants.ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        grants[0].LatestEmailStatus = EmailOutboxStatus.Failed;
+        grants[1].LatestEmailStatus = EmailOutboxStatus.Failed;
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+
+        _emailService.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromException(new InvalidOperationException("enqueue down")),
+                Task.CompletedTask);
+
+        await _service.RetryAllFailedAsync(campaign.Id, Xunit.TestContext.Current.CancellationToken);
+
+        // One re-enqueue threw and flipped its grant back to Failed; the other
+        // grant's retry still went through.
+        ClearAllTrackers();
+        var refreshed = await CampaignsDb.CampaignGrants.AsNoTracking().ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        refreshed.Count(g => g.LatestEmailStatus == EmailOutboxStatus.Failed).Should().Be(1);
+        refreshed.Count(g => g.LatestEmailStatus == EmailOutboxStatus.Queued).Should().Be(1);
     }
 
     // ==========================================================================

--- a/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
@@ -149,8 +149,10 @@ public sealed class CampaignServiceTests
     {
         var campaign = await SeedCampaignAsync();
 
-        await _service.ImportCodesAsync(campaign.Id, ["CODE1", "CODE2", "CODE1", "CODE3"], Xunit.TestContext.Current.CancellationToken);
+        var (imported, skipped) = await _service.ImportCodesAsync(campaign.Id, ["CODE1", "CODE2", "CODE1", "CODE3"], Xunit.TestContext.Current.CancellationToken);
 
+        imported.Should().Be(3);
+        skipped.Should().Be(1);
         var codes = await CampaignsDb.CampaignCodes
             .Where(c => c.CampaignId == campaign.Id)
             .ToListAsync(Xunit.TestContext.Current.CancellationToken);
@@ -166,8 +168,10 @@ public sealed class CampaignServiceTests
         // First import
         await _service.ImportCodesAsync(campaign.Id, ["CODE1", "CODE2"], Xunit.TestContext.Current.CancellationToken);
         // Second import with overlap
-        await _service.ImportCodesAsync(campaign.Id, ["CODE2", "CODE3"], Xunit.TestContext.Current.CancellationToken);
+        var (imported, skipped) = await _service.ImportCodesAsync(campaign.Id, ["CODE2", "CODE3"], Xunit.TestContext.Current.CancellationToken);
 
+        imported.Should().Be(1);
+        skipped.Should().Be(1);
         var codes = await CampaignsDb.CampaignCodes
             .Where(c => c.CampaignId == campaign.Id)
             .ToListAsync(Xunit.TestContext.Current.CancellationToken);

--- a/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Campaigns.Tests/Services/CampaignServiceTests.cs
@@ -6,6 +6,7 @@ using Humans.Teams.Contracts;
 using Humans.Tickets.Contracts;
 using Humans.Campaigns.Data;
 using Humans.Campaigns.Domain;
+using Humans.Gdpr.Contracts;
 using Humans.Base.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -149,7 +150,8 @@ public sealed class CampaignServiceTests
     {
         var campaign = await SeedCampaignAsync();
 
-        var (imported, skipped) = await _service.ImportCodesAsync(campaign.Id, ["CODE1", "CODE2", "CODE1", "CODE3"], Xunit.TestContext.Current.CancellationToken);
+        // "code1" duplicates "CODE1": dedupe is case-insensitive.
+        var (imported, skipped) = await _service.ImportCodesAsync(campaign.Id, ["CODE1", "CODE2", "code1", "CODE3"], Xunit.TestContext.Current.CancellationToken);
 
         imported.Should().Be(3);
         skipped.Should().Be(1);
@@ -176,6 +178,22 @@ public sealed class CampaignServiceTests
             .Where(c => c.CampaignId == campaign.Id)
             .ToListAsync(Xunit.TestContext.Current.CancellationToken);
         codes.Should().HaveCount(3);
+    }
+
+    [HumansFact]
+    public async Task ImportCodesAsync_AssignsSequentialImportOrder_ContinuingFromExistingMax()
+    {
+        var campaign = await SeedCampaignAsync();
+
+        await _service.ImportCodesAsync(campaign.Id, ["FIRST", "SECOND"], Xunit.TestContext.Current.CancellationToken);
+        await _service.ImportCodesAsync(campaign.Id, ["THIRD"], Xunit.TestContext.Current.CancellationToken);
+
+        var codes = await CampaignsDb.CampaignCodes
+            .Where(c => c.CampaignId == campaign.Id)
+            .OrderBy(c => c.ImportOrder)
+            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        codes.Select(c => (c.Code, c.ImportOrder))
+            .Should().ContainInOrder(("FIRST", 1), ("SECOND", 2), ("THIRD", 3));
     }
 
     [HumansFact]
@@ -503,6 +521,9 @@ public sealed class CampaignServiceTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*Not enough codes*");
+
+        // The throw happens before any grant is created — no partial wave.
+        (await CampaignsDb.CampaignGrants.CountAsync(Xunit.TestContext.Current.CancellationToken)).Should().Be(0);
     }
 
     [HumansFact]
@@ -670,8 +691,89 @@ public sealed class CampaignServiceTests
     }
 
     // ==========================================================================
+    // UpdateGrantEmailStatusAsync (email outbox processor write-back)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task UpdateGrantEmailStatusAsync_KnownGrant_UpdatesStatusAndTimestamp()
+    {
+        var grant = await SeedGrantForUserAsync(Guid.NewGuid());
+        var sentAt = Clock.GetCurrentInstant() + Duration.FromHours(1);
+
+        var updated = await _service.UpdateGrantEmailStatusAsync(
+            grant.Id, EmailOutboxStatus.Sent, sentAt, Xunit.TestContext.Current.CancellationToken);
+
+        updated.Should().BeTrue();
+        ClearAllTrackers();
+        var refreshed = await CampaignsDb.CampaignGrants.FindAsync(grant.Id, Xunit.TestContext.Current.CancellationToken);
+        refreshed!.LatestEmailStatus.Should().Be(EmailOutboxStatus.Sent);
+        refreshed.LatestEmailAt.Should().Be(sentAt);
+    }
+
+    [HumansFact]
+    public async Task UpdateGrantEmailStatusAsync_UnknownGrant_ReturnsFalse()
+    {
+        var updated = await _service.UpdateGrantEmailStatusAsync(
+            Guid.NewGuid(), EmailOutboxStatus.Sent, Clock.GetCurrentInstant(), Xunit.TestContext.Current.CancellationToken);
+
+        updated.Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // GDPR export and erase
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task ContributeForUserAsync_ReturnsGrantSliceForThatUserOnly()
+    {
+        var userId = Guid.NewGuid();
+        await SeedGrantForUserAsync(userId);
+        await SeedGrantForUserAsync(Guid.NewGuid());
+
+        var slices = await _service.ContributeForUserAsync(userId, Xunit.TestContext.Current.CancellationToken);
+
+        var slice = slices.Should().ContainSingle().Which;
+        slice.SectionName.Should().Be(GdprExportSections.CampaignGrants);
+        ((System.Collections.IEnumerable)slice.Data!).Cast<object>().Should().ContainSingle();
+    }
+
+    [HumansFact]
+    public async Task EraseForUserAsync_DeletesOnlyThatUsersGrants()
+    {
+        var userId = Guid.NewGuid();
+        var otherId = Guid.NewGuid();
+        await SeedGrantForUserAsync(userId);
+        var kept = await SeedGrantForUserAsync(otherId);
+
+        await _service.EraseForUserAsync(userId, Xunit.TestContext.Current.CancellationToken);
+
+        ClearAllTrackers();
+        var remaining = await CampaignsDb.CampaignGrants.ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        remaining.Should().ContainSingle().Which.Id.Should().Be(kept.Id);
+    }
+
+    // ==========================================================================
     // Helpers
     // ==========================================================================
+
+    private async Task<CampaignGrant> SeedGrantForUserAsync(Guid userId)
+    {
+        var campaign = await SeedActiveCampaignWithCodesAsync([$"G-{Guid.NewGuid():N}"]);
+        var code = await CampaignsDb.CampaignCodes
+            .FirstAsync(c => c.CampaignId == campaign.Id, Xunit.TestContext.Current.CancellationToken);
+        var grant = new CampaignGrant
+        {
+            Id = Guid.NewGuid(),
+            CampaignId = campaign.Id,
+            CampaignCodeId = code.Id,
+            UserId = userId,
+            AssignedAt = Clock.GetCurrentInstant()
+        };
+        CampaignsDb.CampaignGrants.Add(grant);
+        await SaveAllAsync(Xunit.TestContext.Current.CancellationToken);
+        ClearAllTrackers();
+        return grant;
+    }
 
     private async Task<Campaign> SeedCampaignAsync(
         CampaignStatus status = CampaignStatus.Draft,


### PR DESCRIPTION
Section-doctor daily run on **Campaigns** (unattended, 2026-08-29). Run file: [`docs/health/runs/2026-08-29-Campaigns.md`](https://github.com/peterdrier/Humans/blob/section-doctor/2026-08-29T191609Z/docs/health/runs/2026-08-29-Campaigns.md). Target shape: [`Docs/health.md`](https://github.com/peterdrier/Humans/blob/section-doctor/2026-08-29T191609Z/src/Sections/Humans.Campaigns/Docs/health.md) (new). Likely future sections: Budget, Feedback, Consent, Gate.

## What

First doctoring of Campaigns. The code is small and correctly layered; the prose had drifted hard — docs and comments named services, navigations, indexes and test guards that no longer exist — and the test project missed the section's actual invariants while double-covering wave email pass-through. Two behavior fixes and one judgment call queued below.

## Why

Daily section-doctor rotation (never-doctored tier, median reforge pick; Camps blocked by open doctor PR peterdrier/Humans#1561).

## Existing surface checked

No new durable surface. `ImportCodesAsync` gained a return value (internal-only — it is not on the Contracts interface); the Detail view now reuses `EnumBadgeMap` instead of hand-rolled badge-class switches; one unused ProjectReference removed.

## UI changes / screenshots

Detail view only: header and email-status badges now come from `EnumBadgeMap` (Queued gains `text-dark`), and the per-grant Resend button renders only for AdminOnly users (its POST already was AdminOnly — TicketAdmin saw a button that could only 403). Cloud run has no browser; please eyeball on the preview deploy (finding 44).

## Worked / skipped

- Findings 1–12, 14–38 + half of 39: doc/comment drift cleared across 26 files; import flash message reports real imported/skipped counts; Resend gated; tests 32 → 50 (redemption matching, merge fold, GDPR export/erase, per-grant failure isolation, ImportOrder, outbox write-back).
- Skipped: findings 13 (needs ruling), 39-rest (T8/T13/T17/T2 — budget/dependency), 42 (`no-tests-for-absences`), 43 (low). Sweep applied queued Agent/Settings debt items.

## Needs Peter

1. Finding 13 — `ResendToGrantAsync` flips the grant to Queued before resolving user/email; a throw strands it Queued, invisible to Retry All Failed. Reorder the flip, or catch-and-flip-to-Failed?
2. Finding 44 — eyeball Detail.cshtml (badges, admin-gated Resend) on the preview deploy.
3. Finding 45 — skill Phase 7 edit: derive the push remote from the PR target instead of assuming `origin` (this cloud container names nobodies-collective `origin`).

## Checklist

- [ ] **Section labeled** — no Campaigns label exists in the label set; left for a maintainer.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`** (fork main, `443fe3731f00`).
- [x] **Issue refs are qualified** where crossing repo boundaries.
- ~~EF migrations~~ — none.
- ~~NuGet packages updated~~ — none.
- ~~New project rule~~ — none.
- [x] **Reuse-first checked** — EnumBadgeMap reuse is the point of finding 16; no new public surface.
- [x] **Build + test pass locally** — full `dotnet test Humans.slnx` green (Integration.Tests self-skips in cloud, by design); `dotnet format whitespace --verify-no-changes` clean.
- [x] **Nav coverage** — no new pages.
- [x] **No magic strings** — n/a to the diff.
- [x] **Dates/times via NodaTime**, icons via Font Awesome 6.

## Reviewer notes

The diff is wide but shallow: most of it is prose corrections traced to code, one file at a time. The behavioral changes are confined to `CampaignController.ImportCodes` (flash message), `CampaignService.ImportCodesAsync` (return type), and `Detail.cshtml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpKHveJr3nGqYhk1LV8ddm)_