### PR TITLE
Fix ranked ballot resume and validation

### DIFF
--- a/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyAdminController.cs
@@ -383,6 +383,9 @@ internal sealed class SurveyAdminController(
         }
         catch (InvalidOperationException ex)
         {
+            logger.LogWarning(
+                "Ranked availability update rejected for survey {SurveyId}, question {QuestionId}: {Reason}",
+                id, questionId, ex.Message);
             SetError(ex.Message);
         }
         return RedirectToAction(nameof(Results), new { id });

--- a/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
+++ b/src/Sections/Humans.Surveys/Controllers/SurveyController.cs
@@ -488,6 +488,10 @@ internal sealed class SurveyController(
                 {
                     ModelState.AddModelError(id.ToString(), localizer["Survey_QuestionRequired"]);
                 }
+                foreach (var id in result.InvalidAnswers ?? [])
+                {
+                    ModelState.AddModelError(id.ToString(), localizer["Survey_AnswerInvalid"]);
+                }
 
                 route.Save(HttpContext.Session, state);
                 return await RenderPage(state, route, ct);

--- a/src/Sections/Humans.Surveys/Services/ISurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/ISurveyService.cs
@@ -391,7 +391,7 @@ internal sealed class SurveyWizardAnswer
     public int? RatingValue { get; set; }
 }
 
-/// <summary>Where one wizard advance landed. <c>ValidationFailed</c> carries the missing required question ids.</summary>
+/// <summary>Where one wizard advance landed. <c>ValidationFailed</c> carries question-level validation details.</summary>
 internal enum SurveyWizardOutcome
 {
     /// <summary>The survey no longer exists (treat as an invalid link).</summary>
@@ -403,7 +403,7 @@ internal enum SurveyWizardOutcome
     /// <summary>The Human no longer holds active, approved Asociado voting rights.</summary>
     Ineligible,
 
-    /// <summary>Required visible questions are unanswered; the state stays on the posted page.</summary>
+    /// <summary>One or more visible answers are missing or invalid; the state stays on the relevant page.</summary>
     ValidationFailed,
 
     /// <summary>Moved to the previous/next visible page (<c>state.CurrentPage</c> updated).</summary>
@@ -413,5 +413,8 @@ internal enum SurveyWizardOutcome
     Submitted,
 }
 
-/// <summary>Outcome of one wizard advance. <see cref="MissingRequired"/> is empty except on <see cref="SurveyWizardOutcome.ValidationFailed"/>.</summary>
-internal sealed record SurveyWizardAdvanceResult(SurveyWizardOutcome Outcome, IReadOnlyList<Guid> MissingRequired);
+/// <summary>Outcome of one wizard advance. Validation collections are empty except on <see cref="SurveyWizardOutcome.ValidationFailed"/>.</summary>
+internal sealed record SurveyWizardAdvanceResult(
+    SurveyWizardOutcome Outcome,
+    IReadOnlyList<Guid> MissingRequired,
+    IReadOnlyList<Guid>? InvalidAnswers = null);

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -958,12 +958,13 @@ internal sealed class SurveyService(
             var invitation = await repo.GetInvitationByIdAsync(gateInvId, ct);
             if (invitation?.Completed == true)
             {
-                return new SubmissionPreparation([], [], [], AlreadyCompleted: true);
+                return new SubmissionPreparation([], [], [], [], AlreadyCompleted: true);
             }
         }
 
         // Drop answers to questions hidden under full branching (defends against tampered/stale posts).
-        var visibleAnswers = VisibleAnswers(survey, submission.Answers);
+        var visible = VisibleAnswers(survey, submission.Answers);
+        var visibleAnswers = visible.Answers;
         var questions = ToQuestionInputs(survey);
         var answerStates = visibleAnswers.ToDictionary(
             answer => answer.QuestionId,
@@ -978,7 +979,12 @@ internal sealed class SurveyService(
             .ToList();
         var missingRequired = SurveyWizardFlow.RequiredUnanswered(allVisible, answerStates);
 
-        return new SubmissionPreparation(visibleAnswers, questions, missingRequired, AlreadyCompleted: false);
+        return new SubmissionPreparation(
+            visibleAnswers,
+            questions,
+            missingRequired,
+            visible.InvalidAnswers,
+            AlreadyCompleted: false);
     }
 
     private async Task PersistResponseAsync(
@@ -1234,6 +1240,18 @@ internal sealed class SurveyService(
         if (prepared.AlreadyCompleted)
         {
             return new SurveyWizardAdvanceResult(SurveyWizardOutcome.Submitted, []);
+        }
+        if (prepared.InvalidAnswers.Count > 0)
+        {
+            ReplaceWizardAnswers(state, prepared.VisibleAnswers);
+            var invalidIds = prepared.InvalidAnswers.ToHashSet();
+            state.CurrentPage = prepared.Questions
+                .Where(question => question.Id is { } id && invalidIds.Contains(id))
+                .Min(question => question.PageNumber);
+            return new SurveyWizardAdvanceResult(
+                SurveyWizardOutcome.ValidationFailed,
+                [],
+                prepared.InvalidAnswers);
         }
         if (prepared.MissingRequired.Count > 0)
         {
@@ -1876,7 +1894,9 @@ internal sealed class SurveyService(
     /// Keeps only the answers to questions visible under full cascading branching: an answer on a
     /// hidden question neither survives nor counts towards downstream <c>ShowIf</c> conditions.
     /// </summary>
-    private static IReadOnlyList<SurveyAnswerInput> VisibleAnswers(Survey survey, IReadOnlyList<SurveyAnswerInput> answers)
+    private static VisibleAnswerPreparation VisibleAnswers(
+        Survey survey,
+        IReadOnlyList<SurveyAnswerInput> answers)
     {
         var states = answers.ToDictionary(
             a => a.QuestionId,
@@ -1889,7 +1909,8 @@ internal sealed class SurveyService(
             states);
 
         var questions = survey.Questions.ToDictionary(q => q.Id);
-        return answers
+        var invalidAnswers = new List<Guid>();
+        var visibleAnswers = answers
             .Where(a => effective.ContainsKey(a.QuestionId))
             .Where(a => questions.TryGetValue(a.QuestionId, out var question)
                 && question.Type != SurveyQuestionType.Information)
@@ -1906,9 +1927,19 @@ internal sealed class SurveyService(
                         question.GridSelectionMode,
                         a.GridSelections)
                     : null;
-                var normalizedRanked = question.Type == SurveyQuestionType.RankedChoice
-                    ? NormalizeRankedAnswer(question, a.RankedValue)
-                    : null;
+                RankedAnswer? normalizedRanked = null;
+                if (question.Type == SurveyQuestionType.RankedChoice)
+                {
+                    try
+                    {
+                        normalizedRanked = NormalizeRankedAnswer(question, a.RankedValue);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        normalizedRanked = a.RankedValue;
+                        invalidAnswers.Add(a.QuestionId);
+                    }
+                }
                 return a with
                 {
                     GridSelections = normalizedGridSelections?.Count > 0
@@ -1921,12 +1952,18 @@ internal sealed class SurveyService(
                 };
             })
             .ToList();
+        return new VisibleAnswerPreparation(visibleAnswers, invalidAnswers);
     }
+
+    private sealed record VisibleAnswerPreparation(
+        IReadOnlyList<SurveyAnswerInput> Answers,
+        IReadOnlyList<Guid> InvalidAnswers);
 
     private sealed record SubmissionPreparation(
         IReadOnlyList<SurveyAnswerInput> VisibleAnswers,
         IReadOnlyList<QuestionInput> Questions,
         IReadOnlyList<Guid> MissingRequired,
+        IReadOnlyList<Guid> InvalidAnswers,
         bool AlreadyCompleted);
 
     private static List<SurveyAnswer> MapAnswers(Guid responseId, IReadOnlyList<SurveyAnswerInput> answers)

--- a/src/Sections/Humans.Surveys/Services/SurveyService.cs
+++ b/src/Sections/Humans.Surveys/Services/SurveyService.cs
@@ -779,7 +779,8 @@ internal sealed class SurveyService(
                     a.GridSelections?.ToDictionary(
                         kv => kv.Key,
                         kv => (IReadOnlyList<string>)kv.Value,
-                        StringComparer.Ordinal)))
+                        StringComparer.Ordinal),
+                    a.RankedValue))
                 .ToList();
 
         return new SurveyAnswerContext(
@@ -1084,6 +1085,7 @@ internal sealed class SurveyService(
         var visibleBefore = SurveyWizardFlow.VisibleQuestionsOnPage(
             editable.Questions, page, SurveyWizardFlow.ToAnswerStates(state.Answers));
         var posted = postedAnswers.ToDictionary(a => a.QuestionId);
+        var invalidAnswers = new List<Guid>();
 
         foreach (var question in visibleBefore)
         {
@@ -1093,6 +1095,20 @@ internal sealed class SurveyService(
             {
                 state.Answers.Remove(id.ToString());
                 continue;
+            }
+
+            RankedAnswer? rankedValue = null;
+            if (question.Type == SurveyQuestionType.RankedChoice)
+            {
+                try
+                {
+                    rankedValue = NormalizeRankedAnswer(question, answer.RankedValue);
+                }
+                catch (InvalidOperationException)
+                {
+                    rankedValue = answer.RankedValue;
+                    invalidAnswers.Add(id);
+                }
             }
 
             state.Answers[id.ToString()] = new SurveyWizardAnswer
@@ -1105,10 +1121,17 @@ internal sealed class SurveyService(
                     answer.GridSelections),
                 TextValue = string.IsNullOrWhiteSpace(answer.TextValue) ? null : answer.TextValue,
                 RatingValue = answer.RatingValue,
-                RankedValue = question.Type == SurveyQuestionType.RankedChoice
-                    ? NormalizeRankedAnswer(question, answer.RankedValue)
-                    : null,
+                RankedValue = rankedValue,
             };
+        }
+
+        if (invalidAnswers.Count > 0)
+        {
+            state.CurrentPage = page;
+            return new SurveyWizardAdvanceResult(
+                SurveyWizardOutcome.ValidationFailed,
+                [],
+                invalidAnswers);
         }
 
         // A survey may be edited while a respondent has a wizard session open. Re-normalize every

--- a/src/Sections/Humans.Surveys/SurveysResource.ca.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.ca.resx
@@ -62,6 +62,8 @@
   <data name="Survey_PageOf" xml:space="preserve"><value>Pàgina {0} de {1}</value></data>
   <data name="Survey_RequiredAlert" xml:space="preserve"><value>Si us plau, respon les preguntes obligatòries abans de continuar.</value></data>
   <data name="Survey_QuestionRequired" xml:space="preserve"><value>Aquesta pregunta és obligatòria.</value></data>
+  <data name="Survey_ValidationAlert" xml:space="preserve"><value>Revisa les respostes ressaltades abans de continuar.</value></data>
+  <data name="Survey_AnswerInvalid" xml:space="preserve"><value>Revisa aquesta resposta i torna-ho a provar.</value></data>
   <data name="Survey_Back" xml:space="preserve"><value>Enrere</value></data>
   <data name="Survey_Next" xml:space="preserve"><value>Següent</value></data>
   <data name="Survey_Submit" xml:space="preserve"><value>Enviar</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.de.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.de.resx
@@ -62,6 +62,8 @@
   <data name="Survey_PageOf" xml:space="preserve"><value>Seite {0} von {1}</value></data>
   <data name="Survey_RequiredAlert" xml:space="preserve"><value>Bitte beantworte die Pflichtfragen, bevor du fortfährst.</value></data>
   <data name="Survey_QuestionRequired" xml:space="preserve"><value>Diese Frage ist erforderlich.</value></data>
+  <data name="Survey_ValidationAlert" xml:space="preserve"><value>Bitte überprüfe die markierten Antworten, bevor du fortfährst.</value></data>
+  <data name="Survey_AnswerInvalid" xml:space="preserve"><value>Bitte überprüfe diese Antwort und versuche es erneut.</value></data>
   <data name="Survey_Back" xml:space="preserve"><value>Zurück</value></data>
   <data name="Survey_Next" xml:space="preserve"><value>Weiter</value></data>
   <data name="Survey_Submit" xml:space="preserve"><value>Absenden</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.es.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.es.resx
@@ -62,6 +62,8 @@
   <data name="Survey_PageOf" xml:space="preserve"><value>Página {0} de {1}</value></data>
   <data name="Survey_RequiredAlert" xml:space="preserve"><value>Por favor, responde las preguntas obligatorias antes de continuar.</value></data>
   <data name="Survey_QuestionRequired" xml:space="preserve"><value>Esta pregunta es obligatoria.</value></data>
+  <data name="Survey_ValidationAlert" xml:space="preserve"><value>Revisa las respuestas resaltadas antes de continuar.</value></data>
+  <data name="Survey_AnswerInvalid" xml:space="preserve"><value>Revisa esta respuesta e inténtalo de nuevo.</value></data>
   <data name="Survey_Back" xml:space="preserve"><value>Atrás</value></data>
   <data name="Survey_Next" xml:space="preserve"><value>Siguiente</value></data>
   <data name="Survey_Submit" xml:space="preserve"><value>Enviar</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.fr.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.fr.resx
@@ -62,6 +62,8 @@
   <data name="Survey_PageOf" xml:space="preserve"><value>Page {0} sur {1}</value></data>
   <data name="Survey_RequiredAlert" xml:space="preserve"><value>Veuillez répondre aux questions obligatoires avant de continuer.</value></data>
   <data name="Survey_QuestionRequired" xml:space="preserve"><value>Cette question est obligatoire.</value></data>
+  <data name="Survey_ValidationAlert" xml:space="preserve"><value>Veuillez vérifier les réponses signalées avant de continuer.</value></data>
+  <data name="Survey_AnswerInvalid" xml:space="preserve"><value>Veuillez vérifier cette réponse et réessayer.</value></data>
   <data name="Survey_Back" xml:space="preserve"><value>Retour</value></data>
   <data name="Survey_Next" xml:space="preserve"><value>Suivant</value></data>
   <data name="Survey_Submit" xml:space="preserve"><value>Envoyer</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.it.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.it.resx
@@ -62,6 +62,8 @@
   <data name="Survey_PageOf" xml:space="preserve"><value>Pagina {0} di {1}</value></data>
   <data name="Survey_RequiredAlert" xml:space="preserve"><value>Rispondi alle domande obbligatorie prima di continuare.</value></data>
   <data name="Survey_QuestionRequired" xml:space="preserve"><value>Questa domanda è obbligatoria.</value></data>
+  <data name="Survey_ValidationAlert" xml:space="preserve"><value>Controlla le risposte evidenziate prima di continuare.</value></data>
+  <data name="Survey_AnswerInvalid" xml:space="preserve"><value>Controlla questa risposta e riprova.</value></data>
   <data name="Survey_Back" xml:space="preserve"><value>Indietro</value></data>
   <data name="Survey_Next" xml:space="preserve"><value>Avanti</value></data>
   <data name="Survey_Submit" xml:space="preserve"><value>Invia</value></data>

--- a/src/Sections/Humans.Surveys/SurveysResource.resx
+++ b/src/Sections/Humans.Surveys/SurveysResource.resx
@@ -57,6 +57,8 @@
   <data name="Survey_PageOf" xml:space="preserve"><value>Page {0} of {1}</value></data>
   <data name="Survey_RequiredAlert" xml:space="preserve"><value>Please answer the required questions before continuing.</value></data>
   <data name="Survey_QuestionRequired" xml:space="preserve"><value>This question is required.</value></data>
+  <data name="Survey_ValidationAlert" xml:space="preserve"><value>Please check the highlighted answers before continuing.</value></data>
+  <data name="Survey_AnswerInvalid" xml:space="preserve"><value>Please check this answer and try again.</value></data>
   <data name="Survey_Back" xml:space="preserve"><value>Back</value></data>
   <data name="Survey_Next" xml:space="preserve"><value>Next</value></data>
   <data name="Survey_Submit" xml:space="preserve"><value>Submit</value></data>

--- a/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Shared/_SurveyQuestions.cshtml
@@ -7,9 +7,8 @@
 @for (var i = 0; i < Model.Questions.Count; i++)
 {
     var q = Model.Questions[i];
-    var hasError = !ViewData.ModelState.IsValid
-        && ViewData.ModelState.TryGetValue(q.Id.ToString(), out var entry)
-        && entry.Errors.Count > 0;
+    ViewData.ModelState.TryGetValue(q.Id.ToString(), out var entry);
+    var hasError = entry?.Errors.Count > 0;
 
     @if (q.Type == SurveyQuestionType.Information)
     {
@@ -280,7 +279,10 @@
 
         @if (hasError)
         {
-            <div class="text-danger small mt-1">@Localizer["Survey_QuestionRequired"]</div>
+            @foreach (var error in entry!.Errors)
+            {
+                <div class="text-danger small mt-1">@error.ErrorMessage</div>
+            }
         }
     </fieldset>
 }

--- a/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
+++ b/src/Sections/Humans.Surveys/Views/Survey/Page.cshtml
@@ -36,7 +36,7 @@
                 @if (!ViewData.ModelState.IsValid)
                 {
                     <div class="alert alert-danger" role="alert">
-                        @Localizer["Survey_RequiredAlert"]
+                        @Localizer["Survey_ValidationAlert"]
                     </div>
                 }
 

--- a/tests/Humans.Surveys.Tests/Controllers/SurveyAdminControllerTests.cs
+++ b/tests/Humans.Surveys.Tests/Controllers/SurveyAdminControllerTests.cs
@@ -7,10 +7,15 @@ using Humans.Surveys.Services;
 using Humans.Teams.Contracts;
 using Humans.Users.Contracts;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
 using Humans.Surveys.Contracts;
+using Humans.Testing;
+using System.Security.Claims;
 
 namespace Humans.Surveys.Tests.Controllers;
 
@@ -142,6 +147,51 @@ public sealed class SurveyAdminControllerTests
         model.AudienceTeamName.Should().Be("Archived Team");
         await teams.Received(1).GetTeamAsync(teamId, Arg.Any<CancellationToken>());
         await teams.DidNotReceive().GetTeamsAsync(Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task RankedAvailability_logs_a_rejected_update()
+    {
+        var surveyId = Guid.NewGuid();
+        var questionId = Guid.NewGuid();
+        var actorId = Guid.NewGuid();
+        var surveys = Substitute.For<ISurveyService>();
+        surveys.SetRankedAvailabilityAsync(
+                surveyId,
+                questionId,
+                Arg.Any<IReadOnlyList<string>>(),
+                actorId,
+                Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("The vote is still open."));
+        var logger = new CapturingLogger<SurveyAdminController>();
+        var http = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, actorId.ToString())],
+                "test")),
+        };
+        var sut = new SurveyAdminController(
+            surveys,
+            Substitute.For<ITeamServiceRead>(),
+            Substitute.For<IUserServiceRead>(),
+            logger)
+        {
+            ControllerContext = new ControllerContext { HttpContext = http },
+            TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>()),
+        };
+
+        var result = await sut.RankedAvailability(
+            surveyId,
+            questionId,
+            [],
+            Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        var entry = logger.Entries.Should().ContainSingle().Subject;
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.Message.Should().Contain(surveyId.ToString())
+            .And.Contain(questionId.ToString())
+            .And.Contain("The vote is still open.");
     }
 
     private static SurveyAdminController CreateController(

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -1565,6 +1565,7 @@ public class SurveyServiceTests
         var userId = Guid.NewGuid();
         var invitation = InvitationFor(survey.Id, userId);
         var questionId = Guid.NewGuid();
+        var ranked = new RankedAnswer([["a"], ["b"]], ["c"]);
         var draft = new SurveyResponse
         {
             Id = Guid.NewGuid(),
@@ -1574,7 +1575,15 @@ public class SurveyServiceTests
             Anonymity = ResponseAnonymity.Identified,
             Answers = new List<SurveyAnswer>
             {
-                new() { Id = Guid.NewGuid(), QuestionId = questionId, SelectedOptionValues = ["yes"], TextValue = "note", RatingValue = 4 },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    QuestionId = questionId,
+                    SelectedOptionValues = ["yes"],
+                    TextValue = "note",
+                    RatingValue = 4,
+                    RankedValue = ranked,
+                },
             },
         };
 
@@ -1597,6 +1606,7 @@ public class SurveyServiceTests
         answer.SelectedOptionValues.Should().ContainInOrder("yes");
         answer.TextValue.Should().Be("note");
         answer.RatingValue.Should().Be(4);
+        answer.RankedValue.Should().Be(ranked);
     }
 
     [HumansFact]
@@ -2289,6 +2299,36 @@ public class SurveyServiceTests
         result.Outcome.Should().Be(SurveyWizardOutcome.ValidationFailed);
         result.MissingRequired.Should().BeEquivalentTo(new[] { q1Id });
         state.CurrentPage.Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task AdvanceWizardAsync_reports_invalid_ranked_answer_and_preserves_it()
+    {
+        var survey = SurveyWith(SurveyStatus.Open, null, null);
+        var questionId = Guid.NewGuid();
+        var question = RankedQuestion(questionId, survey.Id);
+        question.RankedSettings = RankedQuestionSettings.Default with { AllowEqualRanks = false };
+        survey.Questions = [question];
+        _repo.GetByIdAsync(survey.Id, Arg.Any<CancellationToken>()).Returns(survey);
+        var state = WizardState(survey.Id);
+        var ranked = new RankedAnswer([["a", "b"]], []);
+        var posted = new SurveyAnswerInput(questionId, [], null, null, null, ranked);
+
+        var result = await CreateService().AdvanceWizardAsync(
+            state,
+            page: 1,
+            back: false,
+            [posted],
+            ct: TestContext.Current.CancellationToken);
+
+        result.Outcome.Should().Be(SurveyWizardOutcome.ValidationFailed);
+        result.MissingRequired.Should().BeEmpty();
+        result.InvalidAnswers.Should().ContainSingle().Which.Should().Be(questionId);
+        state.CurrentPage.Should().Be(1);
+        state.Answers[questionId.ToString()].RankedValue.Should().Be(ranked);
+        state.Started.Should().BeFalse();
+        await _repo.DidNotReceive().AddResponseWithAnswersAndSaveAsync(
+            Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]

--- a/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
+++ b/tests/Humans.Surveys.Tests/Services/SurveyServiceTests.cs
@@ -2325,7 +2325,7 @@ public class SurveyServiceTests
         result.MissingRequired.Should().BeEmpty();
         result.InvalidAnswers.Should().ContainSingle().Which.Should().Be(questionId);
         state.CurrentPage.Should().Be(1);
-        state.Answers[questionId.ToString()].RankedValue.Should().Be(ranked);
+        state.Answers[questionId.ToString()].RankedValue.Should().BeEquivalentTo(ranked);
         state.Started.Should().BeFalse();
         await _repo.DidNotReceive().AddResponseWithAnswersAndSaveAsync(
             Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
@@ -2576,6 +2576,43 @@ public class SurveyServiceTests
         state.CurrentPage.Should().Be(1);
         state.Answers[gridId.ToString()].GridSelections.Keys
             .Should().ContainSingle().Which.Should().Be("monday");
+        await _repo.DidNotReceive().AddResponseWithAnswersAndSaveAsync(
+            Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task AdvanceWizardAsync_reports_ranked_answer_invalidated_at_submission_reload()
+    {
+        var questionId = Guid.NewGuid();
+        var initial = SurveyWith(SurveyStatus.Open, null, null);
+        var initialRanked = RankedQuestion(questionId, initial.Id);
+        initialRanked.RankedSettings = RankedQuestionSettings.Default with { AllowEqualRanks = true };
+        initial.Questions = [initialRanked];
+
+        var reloaded = SurveyWith(SurveyStatus.Open, null, null);
+        typeof(Survey).GetProperty(nameof(Survey.Id))!.SetValue(reloaded, initial.Id);
+        var reloadedRanked = RankedQuestion(questionId, reloaded.Id);
+        reloadedRanked.RankedSettings = RankedQuestionSettings.Default with { AllowEqualRanks = false };
+        reloaded.Questions = [reloadedRanked];
+        _repo.GetByIdAsync(initial.Id, Arg.Any<CancellationToken>())
+            .Returns(initial, reloaded);
+
+        var state = WizardState(initial.Id);
+        var ranked = new RankedAnswer([["a", "b"]], []);
+        var posted = new SurveyAnswerInput(questionId, [], null, null, null, ranked);
+
+        var result = await CreateService().AdvanceWizardAsync(
+            state,
+            page: 1,
+            back: false,
+            [posted],
+            ct: TestContext.Current.CancellationToken);
+
+        result.Outcome.Should().Be(SurveyWizardOutcome.ValidationFailed);
+        result.MissingRequired.Should().BeEmpty();
+        result.InvalidAnswers.Should().ContainSingle().Which.Should().Be(questionId);
+        state.CurrentPage.Should().Be(1);
+        state.Answers[questionId.ToString()].RankedValue.Should().BeEquivalentTo(ranked);
         await _repo.DidNotReceive().AddResponseWithAnswersAndSaveAsync(
             Arg.Any<SurveyResponse>(), Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## What

Fixes the credible ranked-voting findings surfaced on the malformed production PR nobodies-collective/Humans#1157:

- resumable invited drafts now restore saved ranked ballots;
- malformed or stale ranked-ballot posts return a localized validation error and preserve the answer instead of throwing;
- rejected post-close availability updates emit a structured warning.

## Why

The production review found two respondent-facing defects in the QA-tested feature. They must land through QA and be exercised there before a correct production promotion is prepared.

## Existing surface checked

No new durable surface. This reuses the existing wizard validation outcome, draft-answer model, controller logger, and section resources. The internal wizard result now distinguishes missing from invalid answers.

## UI changes / screenshots

Validation failures now display the actual localized question error rather than always saying the question is required. No layout change.

## Checklist

- [x] **Section labeled** — `section:surveys`.
- [x] **Targeting `main` on `peterdrier/Humans`**.
- [x] **Branched off QA `main`** (`peterdrier/Humans:main`).
- [x] **Issue refs qualified** — nobodies-collective/Humans#1157.
- [x] **EF migrations** — none.
- [x] **NuGet packages** — none.
- [x] **New project rule** — none.
- [x] **Reuse-first checked** — no new files, public types, endpoints, services, or dependencies.
- [x] **Build + scoped tests pass locally** — Web build; 215 Surveys tests; resource parity; Razor lint.
- [x] **Nav coverage** — no new page.
- [x] **No magic strings** — structured log properties and localized resource keys used.
- [x] **Dates/times and icons** — not applicable.

## Reviewer notes

The malformed nobodies-collective/Humans#1157 must not be merged: its head is the unrelated Budget section-doctor branch. This PR fixes only the ranked-voting review findings on a fresh QA branch.