### PR TITLE
doctor(Finance): the section moved; its docs, comments and tests catch up

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -400,3 +400,9 @@ inbox:
   - added: 2026-08-27
     what: "docs/architecture/design-rules.md:340 says contributors \"read through their own IDbContextFactory<TContext>\" and names AgentService as an example; AgentRepository takes a scoped AgentDbContext by injection. The conclusion (sequential is no longer a correctness requirement) is right; the stated mechanism is not — the accurate invariant is that no two contributors share a context instance (finding 25, /section-doctor on Gdpr 2026-08-27)."
     review: panel
+  - added: 2026-08-28
+    what: "docs/architecture/freshness-catalog.yml has no entry for src/Sections/Humans.Settings/** or src/Sections/Humans.Settings.Contracts/**, so drift there is never caught by a freshness sweep (finding 14, /section-doctor on Settings 2026-08-28)."
+    review: light
+  - added: 2026-08-28
+    what: "docs/architecture/dependency-graph.md predates the Monitor carve-out — DriveMon is still styled :::google with no Monitor section in the diagram (finding 20, /section-doctor on Settings 2026-08-28)."
+    review: light

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -132,7 +132,7 @@ graph LR
     HumanLifecycle[HumanLifecycleService]:::onboarding
     Feedback[FeedbackService]:::feedback
     Budget[BudgetService]:::budget
-    Finance[HoldedFinanceService]:::finance
+    Finance[Finance.Service]:::finance
     Holded[HoldedService]:::holded
 
     User[UserService]:::users

--- a/docs/features/global/gdpr-export.md
+++ b/docs/features/global/gdpr-export.md
@@ -89,7 +89,7 @@ change.
 │    AuditLogService           BudgetService        │
 │    SurveyService             AgentService         │
 │    CachingEventService       IssuesService        │
-│    ExpenseReportService      HoldedFinanceService │
+│    ExpenseReportService      Finance.Service      │
 │    GateService               GoogleSyncLogService │
 │    EmailOutboxService                             │
 │    MailerLiteGdprContributor BackdoorApiKeyService │
@@ -160,8 +160,8 @@ service has no data for this user are omitted.
 | `AgentConversations` | `AgentService` | Array of `{ Id, StartedAt, LastMessageAt, Locale, MessageCount, Messages: [{ Role, Content, CreatedAt, Model, RefusalReason, HandedOffToFeedbackId }] }` — the user's AI assistant conversations with full message history. |
 | `ExpenseReports` | `ExpenseReportService` | Array of `{ Id, Status, Note, PayeeName, PayeeIban (masked), Total, SubmittedAt, ApprovedAt, CreatedAt, Lines: [{ Id, Description, Amount, LineType, SortOrder, Attachment? }] }` — the user's expense reports including line items and attachment metadata; null when the user has no reports. |
 | `ExpenseAuditLog` | `ExpenseReportService` | Single object `{ MaskedIban, Entries: [{ Action, EntityType, EntityId, Description, OccurredAt }] }` covering all expense-related audit events (submit, endorse, approve, reject, IBAN set/remove/reveal, etc.); null when the user has no expense audit entries. |
-| `HoldedCreditorAccount` | `HoldedFinanceService` | Single object `{ SupplierAccountNum, HoldedContactId, Source }` — the user's Holded creditor account binding; null when no binding exists. |
-| `SepaPayouts` | `HoldedFinanceService` | Array of `{ GeneratedAt, FileName, SupplierAccountNum, CreditorName, Iban (masked), Amount }` — every SEPA credit transfer paid to the user, oldest first; empty when they have never been paid. Retained after erasure on the fiscal basis. |
+| `HoldedCreditorAccount` | `Finance.Service` | Single object `{ SupplierAccountNum, HoldedContactId, Source }` — the user's Holded creditor account binding; null when no binding exists. |
+| `SepaPayouts` | `Finance.Service` | Array of `{ GeneratedAt, FileName, SupplierAccountNum, CreditorName, Iban (masked), Amount }` — every SEPA credit transfer paid to the user, oldest first; empty when they have never been paid. Retained after erasure on the fiscal basis. |
 | `SurveyResponses` | `SurveyService` | Array of `{ Survey, SubmittedAt, Culture, Answers[] }` where each answer has `{ Question, SelectedLabels, TextValue, RatingValue }`. |
 | `GateScans` | `GateService` | Array of `{ OccurredAt, Verdict, Role, LaneId }` — the user's own gate activity, as guest or as scanner (`Role` is "Guest" or "Scanner"). Data-minimized: no barcode, no other person's identifiers. |
 | `GoogleSyncLog` | `GoogleSyncLogService` | Array of `{ Action, OccurredAt, Description, ResourceName, UserEmail, Role, Source, Success, ErrorMessage }` — every Workspace sync row attributed to the human, merge tombstones followed. |

--- a/docs/health/runs/2026-09-06-Finance.md
+++ b/docs/health/runs/2026-09-06-Finance.md
@@ -83,8 +83,8 @@ every screen masks it (finding 1).
     binding; two contacts on one number would show the other's name. Generation already keys by
     contact id. Note only — the read contract carries no user id.
 25. **Two open Tour doctor PRs** (peterdrier/Humans#1610, #1611) — the earlier run had not opened
-    its PR when the later one selected, so the blocked set could not see it. Skill issue filed on
-    peterdrier/Humans.
+    its PR when the later one selected, so the blocked set could not see it. Skill issue filed:
+    peterdrier/Humans#1612.
 
 Independence check: pass — findings 1, 14, 15, 16 and 24 came from the target before any thread
 returned.

--- a/docs/health/runs/2026-09-06-Finance.md
+++ b/docs/health/runs/2026-09-06-Finance.md
@@ -1,0 +1,278 @@
+# section-doctor — Finance — 2026-09-06
+
+- Invocation: unattended daily run (cloud), no arguments; Phase 8 skipped per the stored prompt.
+- Anchor commit: `10199a23` (origin/main at branch point); branch `section-doctor/2026-09-06T161637Z`.
+- Budget: standard daily (~2.5 h).
+- PR: pending
+
+## Assessment summary
+
+Second doctoring of Finance. The selector returned JUDGMENT REQUIRED (every eligible section
+previously doctored); Finance was the pick on staleness and change volume — its first run was the
+oldest still standing, and since then the section shipped SEPA payout generation and booking, GDPR
+export and erasure, and the read/write interface split the first target had named as its seam.
+The target was regenerated to match: two new shapes (E and F), the seam removed, the Holded
+write-boundary statement corrected after reading the code (audit entries mask the IBAN; erasure
+deletes the binding and nothing else).
+
+The code is sound: no defect on any path the target names. What accumulated is the same sediment
+the first run found, one layer newer — docs that counted things, narrated the moves that made the
+section what it is, listed files as manifests and carried a phantom migration; comments that
+restated the next line or told a lane story; three named invariants with no test, and one test that
+pinned an absence. One spec-vs-reality contradiction is real and is Peter's to settle: the creditor
+statement renders a member's IBAN raw while every doc says the raw value lives in two places and
+every screen masks it (finding 1).
+
+## Findings (ranked, 3e)
+
+1. **Raw IBAN on the creditor statement** — `Views/Finance/CreditorStatement.cshtml:64` renders
+   `@c.Iban` unmasked; `Finance.md`, `sepa-payout.md` and the target say every screen masks it and
+   the raw value lives in "exactly two places". Either the view masks or the docs stop claiming.
+   Queued to Peter — personal-data display is not a unilateral call. Independent of the threads.
+2. **`Finance.md` stale claims** — two self-counts of actions, a Migrations line three short, a
+   phantom `HoldedActuals` migration, four-vs-six owned tables, an Actors row crediting the
+   FinanceAdmin with Budget's capabilities, a trigger block missing two files it asserts about.
+   Struck.
+3. **`authorization.md` route list** omitted the three SEPA routes. Replaced with "every action on
+   the class". Struck.
+4. **`data-access.md`** headed by a class name that no longer exists, "one method / other
+   methods" wording, read-split migration narration. Struck.
+5. **`Finance.md` narrated prior state** — "What exists (Feature N)" manifests, the `HoldedSyncJob`
+   lane story, the squash story, "23 actions … pre-G5", the ledger-mirror move told twice, a
+   "Done:" changelog, a "Today vs Planned" with no Planned. Struck.
+6. **Process doc Status** said steps 9–11 were on QA; `SepaTransferBooking` is on `upstream/main`.
+   Restated as current. Struck.
+7. **`sepa-payout.md`** "now genuinely means". Struck; its "two places" claim rides with #1.
+8. **Wrong comments** — "No I/O since that read" over a repo read; "archived locally" where
+   nothing archives; a `TODO(probe)` on a deep link in use since Feature 1. Struck.
+9. **Narrated-move comments** in the controller, architecture tests, `Section.cs`, the csproj and
+   `HoldedDocSyncState.cs`. Struck.
+10. **Restating comments** in `Service.cs` — a class summary naming four of the shapes, four
+    comments restating the next line, one repeating its XML doc. Struck.
+11. **Four unpinned invariants** — `IsDraft == null` ⇒ not approved; stored `Xml`/`Checksum` equal
+    the bytes returned; erasure keeps the payouts slice; the statement view flips the sign. Three
+    tests added; the sign flip lives in view arithmetic with no render test in the section's project
+    and went to `Docs/debt.yml`.
+12. **Two test deletions** — `Sync_DocsMissingFromHolded_AreNeverDeleted` asserted an absence
+    against a repository that exposes no delete; a Fact duplicated the `JustOutsideTheBlock`
+    theory. Reviewer ACCEPT on both; retired and folded.
+13. **`ContractsDoNotReExposeTheHoldedConnector`** is an assembly-reference absence test.
+    Retiring an architecture test needs Peter (peterdrier/Humans#1600). Queued.
+14. **`HoldedConnectorVm.ArchivedMappings` is dead by invariant** — `IsActive` is never cleared
+    and `Holded.cshtml`'s own footer says so. The honest fix drops the column, which is schema;
+    a test pins the current rendering. Recorded in `Docs/debt.yml`, not struck.
+15. **`HoldedAccounts.cshtml` `?? 62900100` fallback** duplicated the controller's constant on a
+    path that always sets `ViewBag.BlockStart`. Reviewer ACCEPT; cut.
+16. **`GroupBy(...).First()` over a DB-unique key** in `Service.cs`, silent. Now `ToDictionary`.
+    Reviewer ACCEPT; collapsed.
+17. **"Pre-v2 row" tooltip** named a version boundary to a treasurer. Reworded.
+18. **`SepaOptions.cs` at the project root** trips `section-file-layout`; Holded and Store carry
+    the same shape. A move is structural and the rule may be what is wrong. Queued to Peter.
+19. **Central debt-ledger row 2026-08-05** names `HoldedFinanceService`; the class is `Service`
+    and the work is still open. Ledger rows are the sweep's to edit — sweep queue.
+20. **stryker `break: 0`** — the mutation gate cannot fail. Repo policy; queued to Peter.
+21. **No Finance rows in `freshness-catalog.yml`**; freshness rests on the per-doc trigger blocks.
+    Queued to Peter.
+22. **Prior run's Needs-Peter 6** (a conformance rule for trigger blocks that watch nothing they
+    assert about) has now shown up twice on this section. Items 2, 3, 4 of that list are resolved
+    (`DropDeadHoldedColumns` shipped; read split shipped; the tuple is documented). Queued to Peter
+    to decide.
+23. **Budget's `NoActiveYear.cshtml`** still has no `/Finance/*` links — already in Budget's
+    `debt.yml` from 2026-08-18. Nothing to re-queue.
+24. **`GetCreditorLedgerAsync` resolves the header contact by account number**, not through the
+    binding; two contacts on one number would show the other's name. Generation already keys by
+    contact id. Note only — the read contract carries no user id.
+25. **Two open Tour doctor PRs** (peterdrier/Humans#1610, #1611) — the earlier run had not opened
+    its PR when the later one selected, so the blocked set could not see it. Skill issue filed on
+    peterdrier/Humans.
+
+Independence check: pass — findings 1, 14, 15, 16 and 24 came from the target before any thread
+returned.
+
+Not findings, verified: `HoldedDocSyncVm.StaleAfter` matches the Holded section's cron;
+Expenses views render no raw IBAN; `GetConnectorOverview_MakesNoHoldedApiCall` is a legitimate
+call-path absence and stays.
+
+## Worked
+
+- **Docs** (findings 2–7): `Finance.md`, `authorization.md`, `data-access.md`,
+  `expense-reimbursement-process.md`, `features/sepa-payout.md` now describe the section as it is —
+  no counts, no manifests, no moves, no phantom migration, a trigger block that names both
+  cross-section files it asserts about, and a cross-section read-interface table.
+- **Comments and view text** (8, 9, 10, 17): wrong, restating and narrated-move comments cut from
+  `Service.cs`, `FinanceController.cs`, `FinanceArchitectureTests.cs`, `Section.cs`, the csproj and
+  `HoldedDocSyncState.cs`; two treasurer-facing strings reworded.
+- **Tests** (11, 12): three invariant-pinning tests added; one absence test retired with the
+  premise in the commit message; one duplicate folded into the theory it duplicated.
+- **Code** (15, 16): a dead view fallback cut; a silent `GroupBy…First()` made a `ToDictionary`.
+- **Literal sweep**: the class name `HoldedFinanceService` was fixed in `gdpr-export.md`, the
+  dependency graph and Holded's `data-access.md`. Dated design and plan documents keep it — they are
+  records. The central debt-ledger row goes through the sweep queue.
+- **Target**: `Docs/health.md` regenerated and diffed (see Retro).
+- **Section ledger**: `Docs/debt.yml` created with findings 11 (sign flip) and 14.
+
+## Skipped + why
+
+- Finding 1 — personal-data display; which side moves is Peter's call.
+- Finding 13 — retiring an architecture test is gated on peterdrier/Humans#1600.
+- Finding 14 — the fix is a Finance migration (drop `IsActive`); schema is out of remit, and cutting
+  the view branch alone would leave the column and the test pinning it.
+- Finding 18 — a structural move under a rule that may itself be wrong.
+- Findings 20, 21, 22 — repo policy and catalog ownership, not section work.
+- Finding 24 — fixing it needs a user id on the read contract: surface addition.
+- Finding 11's sign flip — no render-test harness in the section's test project; recorded as debt
+  rather than adding one.
+- The IBAN "exactly two places" sentences (`Finance.md`, `sepa-payout.md`) were left as written
+  because they are the doc side of finding 1.
+
+## Retro (Phase 6)
+
+- **Selector.** JUDGMENT REQUIRED across eighteen previously-doctored sections; Finance was the
+  right pick — oldest surviving run, most shipped since. The blocked set was built from open PRs
+  only and so let the Tour run duplicate itself (finding 25, issue filed).
+- **Wasted motion.** The two haiku threads cost a re-check each: Prose returned a
+  self-contradicting finding and no word counts; Conformance ran two of three rules and main filled
+  the third from the yml. The Inbox thread asserted a prior item still open that a shipped migration
+  closes. Each is a mechanical thread whose output needed the reading it was meant to save.
+- **What striking revealed.** The docs' worst claims were the ones that counted or listed — every
+  count was wrong and every manifest stale — which is what `no-derived-aggregates-in-docs` predicts.
+  The one real spec-vs-reality delta (finding 1) was invisible to the freshness lens and came from
+  writing the target's invariants down and then reading the view.
+- **Target diff.** The section moved: two shapes the previous target did not have, the previous
+  seam shipped, and the previous target's own claims about erasure and audit entries were wrong
+  against the code. Corrected in place; the history table gained its row.
+
+## Needs Peter
+
+- [ ] 1 — `CreditorStatement.cshtml:64` renders a member's IBAN raw; the docs say every screen
+  masks it. Mask the view, or amend the docs' "exactly two places" claim?
+- [ ] 13 — retire `ContractsDoNotReExposeTheHoldedConnector` (assembly-reference absence test), or
+  keep architecture tests exempt from `no-tests-for-absences`? Same question as peterdrier/Humans#1600.
+- [ ] 18 — `SepaOptions.cs` (and `HoldedSectionOptions.cs`, `StoreSectionOptions.cs`) at the
+  project root against `section-file-layout`: move them, or widen the rule to `*Options.cs`?
+- [ ] 20 — `tests/Humans.Finance.Tests/stryker-config.json` `break: 0` means the mutation gate
+  cannot fail. Intentional?
+- [ ] 21 — `freshness-catalog.yml` carries no Finance rows. Add them, or is the per-doc trigger
+  block the intended mechanism for sections?
+- [ ] 22 — the prior run's Needs-Peter 6 (a conformance rule: a trigger block must name what its doc
+  asserts about) has now bitten twice. Adopt, or drop the ask?
+- [ ] Lesson, Phase 2 — the blocked set is built from open PRs, so a run that has not yet opened its
+  PR is invisible to the next run's selector (finding 25). Proposed: also block sections whose
+  `section-doctor/<TS>` branch exists on origin within the last N hours.
+- [ ] Lesson, Phase 3d — haiku mechanical threads (Prose, Conformance) returned incomplete or
+  self-contradicting output twice in one run. Proposed: the dispatch preamble asks each mechanical
+  thread to echo the rule list it ran and a per-rule result, so an omission is visible without
+  re-reading.
+- [ ] Lesson, Phase 3d — the Inbox thread reports carry-forward items as still open on the strength
+  of the prior run file alone. Proposed: carry-forward status is main's to verify against code
+  (migrations, symbols) before ranking.
+
+## Sweep queue
+
+- `debt: docs/architecture/debt-ledger.yml — the 2026-08-05 [ExternalWrite] entry names HoldedFinanceService.EnsureCreditorContactAsync / CreateExpenseAccountAsync; the class is Service (Humans.Finance.Services). The work itself is still open — only BookSepaTransferAsync carries [ExternalWrite] today. Rename in place, do not re-add (finding 19, 2026-09-06-Finance).`
+
+## File coverage
+
+| Path | Disposition |
+|---|---|
+| `src/Sections/Humans.Finance.Contracts/CreditorContactSource.cs` | reviewed |
+| `src/Sections/Humans.Finance.Contracts/CreditorLedgerLine.cs` | reviewed |
+| `src/Sections/Humans.Finance.Contracts/HoldedCreditorAdminDtos.cs` | reviewed |
+| `src/Sections/Humans.Finance.Contracts/HoldedCreditorStatus.cs` | reviewed |
+| `src/Sections/Humans.Finance.Contracts/HoldedDtos.cs` | reviewed |
+| `src/Sections/Humans.Finance.Contracts/Humans.Finance.Contracts.csproj` | reviewed |
+| `src/Sections/Humans.Finance.Contracts/IHoldedFinanceService.cs` | reviewed |
+| `src/Sections/Humans.Finance.Contracts/IHoldedFinanceServiceRead.cs` | reviewed |
+| `src/Sections/Humans.Finance/Controllers/FinanceController.cs` | changed |
+| `src/Sections/Humans.Finance/Data/Configurations/HoldedCategoryMapConfiguration.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Configurations/HoldedCreditorContactConfiguration.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Configurations/HoldedDocSyncStateConfiguration.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Configurations/HoldedExpenseDocConfiguration.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Configurations/SepaPayoutFileConfiguration.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Configurations/SepaPayoutTransferConfiguration.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/FinanceDbContext.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/FinanceDbContextFactory.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/IHoldedRepository.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260715103643_BaselineFinance.Designer.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260715103643_BaselineFinance.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260810195350_HoldedExpenseDocIsApproved.Designer.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260810195350_HoldedExpenseDocIsApproved.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260810204942_HoldedMirrorMovesToHoldedSection.Designer.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260810204942_HoldedMirrorMovesToHoldedSection.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260818210635_DropDeadHoldedColumns.Designer.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260818210635_DropDeadHoldedColumns.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260825005739_SepaPayoutFiles.Designer.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260825005739_SepaPayoutFiles.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260825153612_SepaTransferBooking.Designer.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/20260825153612_SepaTransferBooking.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Migrations/FinanceDbContextModelSnapshot.cs` | reviewed |
+| `src/Sections/Humans.Finance/Data/Repository.cs` | reviewed |
+| `src/Sections/Humans.Finance/Docs/Finance.md` | changed |
+| `src/Sections/Humans.Finance/Docs/authorization.md` | changed |
+| `src/Sections/Humans.Finance/Docs/data-access.md` | changed |
+| `src/Sections/Humans.Finance/Docs/expense-reimbursement-process.md` | changed |
+| `src/Sections/Humans.Finance/Docs/features/sepa-payout.md` | changed |
+| `src/Sections/Humans.Finance/Docs/health.md` | generated |
+| `src/Sections/Humans.Finance/Domain/HoldedCategoryMap.cs` | reviewed |
+| `src/Sections/Humans.Finance/Domain/HoldedCreditorContact.cs` | reviewed |
+| `src/Sections/Humans.Finance/Domain/HoldedDocSyncState.cs` | changed |
+| `src/Sections/Humans.Finance/Domain/HoldedExpenseDoc.cs` | reviewed |
+| `src/Sections/Humans.Finance/Domain/HoldedMatchSource.cs` | reviewed |
+| `src/Sections/Humans.Finance/Domain/HoldedMatchStatus.cs` | reviewed |
+| `src/Sections/Humans.Finance/Domain/SepaPayoutFile.cs` | reviewed |
+| `src/Sections/Humans.Finance/Domain/SepaPayoutTransfer.cs` | reviewed |
+| `src/Sections/Humans.Finance/Humans.Finance.csproj` | changed |
+| `src/Sections/Humans.Finance/Models/CreditorAccountRowVm.cs` | reviewed |
+| `src/Sections/Humans.Finance/Models/HoldedConnectorVm.cs` | reviewed |
+| `src/Sections/Humans.Finance/Models/SepaPayoutModels.cs` | reviewed |
+| `src/Sections/Humans.Finance/Properties/AssemblyInfo.cs` | reviewed |
+| `src/Sections/Humans.Finance/Resources/pain.001.001.09.xsd` | reviewed |
+| `src/Sections/Humans.Finance/Section.cs` | changed |
+| `src/Sections/Humans.Finance/SectionAdminNav.cs` | reviewed |
+| `src/Sections/Humans.Finance/SectionPolicies.cs` | reviewed |
+| `src/Sections/Humans.Finance/SepaOptions.cs` | reviewed |
+| `src/Sections/Humans.Finance/Services/HoldedMatcher.cs` | reviewed |
+| `src/Sections/Humans.Finance/Services/IHoldedFinanceAdminService.cs` | reviewed |
+| `src/Sections/Humans.Finance/Services/SepaPaymentFileBuilder.cs` | reviewed |
+| `src/Sections/Humans.Finance/Services/SepaSchema.cs` | reviewed |
+| `src/Sections/Humans.Finance/Services/SepaText.cs` | reviewed |
+| `src/Sections/Humans.Finance/Services/Service.cs` | changed |
+| `src/Sections/Humans.Finance/Views/Finance/CreditorStatement.cshtml` | reviewed |
+| `src/Sections/Humans.Finance/Views/Finance/Creditors.cshtml` | reviewed |
+| `src/Sections/Humans.Finance/Views/Finance/Holded.cshtml` | changed |
+| `src/Sections/Humans.Finance/Views/Finance/HoldedAccounts.cshtml` | changed |
+| `src/Sections/Humans.Finance/Views/Finance/HoldedUnmatched.cshtml` | reviewed |
+| `src/Sections/Humans.Finance/Views/Finance/Sepa.cshtml` | reviewed |
+| `src/Sections/Humans.Finance/Views/Finance/_ViewStart.cshtml` | reviewed |
+| `src/Sections/Humans.Finance/Views/_ViewImports.cshtml` | reviewed |
+| `tests/Humans.Finance.Tests/FinanceArchitectureTests.cs` | changed |
+| `tests/Humans.Finance.Tests/FinanceControllerTests.cs` | reviewed |
+| `tests/Humans.Finance.Tests/HoldedMatcherTests.cs` | reviewed |
+| `tests/Humans.Finance.Tests/Humans.Finance.Tests.csproj` | reviewed |
+| `tests/Humans.Finance.Tests/RepositoryTests.cs` | reviewed |
+| `tests/Humans.Finance.Tests/SepaPaymentFileBuilderTests.cs` | reviewed |
+| `tests/Humans.Finance.Tests/ServiceTests.cs` | changed |
+| `tests/Humans.Finance.Tests/stryker-config.json` | reviewed |
+
+Outside the inventory, changed by the literal sweep: `docs/features/global/gdpr-export.md`,
+`docs/architecture/dependency-graph.md`, `src/Sections/Humans.Holded/Docs/data-access.md`.
+Created: `src/Sections/Humans.Finance/Docs/debt.yml`.
+
+## Threads
+
+| Thread | How | Model | Findings |
+|---|---|---|---|
+| Shape | main | (main session) | target §2 |
+| Behavior & bugs | main | (main session) | 4 (findings 14, 15, 16, 24) |
+| Inbox | subagent | doctor-reader (opus, low) | 6 |
+| Conformance | subagent | haiku | 1 (ran two of three rules; main filled the third) |
+| Prose & surface | subagent | haiku | 2 (one self-contradicting, discarded; no word counts returned) |
+| Freshness | subagent | doctor-reader (opus, low) | 11 |
+| Tests | subagent | doctor-reader (opus, low) | 10 |
+| History | subagent | doctor-reader (opus, low) | 20 |
+| Comments | subagent | doctor-reader (opus, low) | 9 |
+| Reviewer | subagent | doctor-reviewer | 4 gated, 4 ACCEPT |
+
+Reforge ran as a background command (Finance 579, `BookSepaTransferAsync` the section's largest
+method). Every dispatched thread returned before deadline; none self-run. Inbox's GitHub scope was
+peterdrier/Humans only; in-app issues were not read (no database in the container).

--- a/docs/health/runs/2026-09-06-Finance.md
+++ b/docs/health/runs/2026-09-06-Finance.md
@@ -3,7 +3,7 @@
 - Invocation: unattended daily run (cloud), no arguments; Phase 8 skipped per the stored prompt.
 - Anchor commit: `10199a23` (origin/main at branch point); branch `section-doctor/2026-09-06T161637Z`.
 - Budget: standard daily (~2.5 h).
-- PR: pending
+- PR: peterdrier/Humans#1613
 
 ## Assessment summary
 

--- a/memory/process/debt-ledger-additions.md
+++ b/memory/process/debt-ledger-additions.md
@@ -9,7 +9,8 @@
 | Debt | Goes to |
 |---|---|
 | One-off whose fix is inside a single `src/Sections/Humans.<X>/` — **any** section, not only the one you are working in | that section's [`src/Sections/Humans.<X>/Docs/debt.yml`](../../src/Sections) — create it if absent |
-| One-off spanning sections, or in `Humans.Base` / `Humans.Web` / `tests/` / infrastructure | `inbox:` in [`docs/architecture/debt-ledger.yml`](../../docs/architecture/debt-ledger.yml) |
+| One-off spanning sections, or in `Humans.Base` / `Humans.Web` / infrastructure, or in shared test scaffolding (`tests/Humans.Testing`, `tests/Humans.Application.Tests`) | `inbox:` in [`docs/architecture/debt-ledger.yml`](../../docs/architecture/debt-ledger.yml) |
+| One-off inside a section's own test project (`tests/Humans.<X>.Tests`) | that section's `Docs/debt.yml` — the project is section-owned, not infrastructure |
 | Recurring class (a pattern with multiple sites, usually analyzer- or baseline-backed) | `themes:` in the central ledger |
 
 Section files keep the central ledger readable and put the debt where the next reader of that section will meet it. The central ledger stays the home of rotation state — `themes:` is global by construction, and `/debt-sweep` pools every section file into the same inbox at pick time, so routing changes where an item is written, never whether it is served.

--- a/src/Sections/Humans.Agent/Docs/debt.yml
+++ b/src/Sections/Humans.Agent/Docs/debt.yml
@@ -5,3 +5,6 @@ inbox:
   - added: 2026-08-28
     what: "Test gaps from the invariant matrix (finding 14, /section-doctor on Agent 2026-08-28): (a) enabled gate — no test asserts the widget hides when Enabled=false (the other half, POST /Agent/Ask → 503, is pinned by AgentControllerTests.Ask_accepts_a_message_at_exactly_the_cap); (b) DailyTokenCap is set in every fixture but never exceeded — the third cap of invariant 3 has no reject test; (c) anonymous → 401 unpinned anywhere; (d) nothing asserts the tool catalog AgentPromptAssembler advertises equals AgentToolNames.All; (e) AgentFeatureSpecReader has no path-traversal negative test (CommunityFaqReader does); (f) an abuse-flagged message is never driven through AskAsync to a RefusalReason row."
     review: light
+  - added: 2026-08-28
+    what: "AgentService.RunTurnAsync (210 LOC, CC 42) and AnthropicClient.StreamAsync (153 LOC, CC 42) are the section's two most complex methods — the load-bearing streaming loops the target shape blesses (manual enumerator for error-path billing; SSE block assembly). Recorded so the score is not mistaken for unexamined debt. Found by /section-doctor on Agent 2026-08-28."
+    review: light

--- a/src/Sections/Humans.Finance/Controllers/FinanceController.cs
+++ b/src/Sections/Humans.Finance/Controllers/FinanceController.cs
@@ -12,17 +12,10 @@ using Humans.Users.Contracts;
 namespace Humans.Finance.Controllers;
 
 /// <summary>
-/// Finance's own pages: Holded account provisioning, the unmatched-document queue and the
-/// creditor-account admin (<c>/Finance/HoldedAccounts</c>, <c>/Finance/HoldedUnmatched</c>,
-/// <c>/Finance/Creditors*</c>, <c>/Finance/HoldedSync/Run</c>).
+/// Finance's own pages: the Holded connector, account provisioning, the unmatched-document queue,
+/// creditor accounts and SEPA payouts. Budget's admin surface shares the <c>Finance</c> route
+/// prefix from its own <c>BudgetAdminController</c>.
 /// </summary>
-/// <remarks>
-/// The other 23 actions that used to share this class are Budget CRUD — years, groups,
-/// categories, line items, cash flow, audit log — and are now
-/// <c>Humans.Budget</c>'s <c>BudgetAdminController</c>, keeping the same <c>[Route("Finance")]</c>
-/// prefix so no URL moved. Dragging them in here would have put Budget's whole admin surface
-/// inside the Finance section (nobodies-collective/Humans#866, G5).
-/// </remarks>
 [Authorize(Policy = PolicyNames.FinanceAdminOrAdmin)]
 [Route("Finance")]
 internal sealed class FinanceController(

--- a/src/Sections/Humans.Finance/Docs/Finance.md
+++ b/src/Sections/Humans.Finance/Docs/Finance.md
@@ -18,7 +18,7 @@ Finance is the **treasurer's reality side** of the money story. Budget owns plan
 
 The end-to-end *business* process — how a reimbursement actually moves from expense report through the bank and back to a zero balance, including the manual steps and external parties — is [`expense-reimbursement-process.md`](expense-reimbursement-process.md). This file stays about code invariants.
 
-Three things live here: the Holded purchase-doc sync and its attribution to budget categories; creditor bindings and the balances derived from the Holded section's ledger mirror ([Feature 2](#feature-2--creditor-reads-over-the-holded-sections-mirror)); and SEPA payout generation and booking ([Feature 3](#feature-3--sepa-payout-of-creditor-balances), [`features/sepa-payout.md`](features/sepa-payout.md)). The Budget surface on the same `/Finance` prefix is Budget's — see Routing.
+What lives here: the Holded purchase-doc sync and its attribution to budget categories; creditor bindings and the balances derived from the Holded section's ledger mirror ([Feature 2](#feature-2--creditor-reads-over-the-holded-sections-mirror)); and SEPA payout generation and booking ([Feature 3](#feature-3--sepa-payout-of-creditor-balances), [`features/sepa-payout.md`](features/sepa-payout.md)). The Budget surface on the same `/Finance` prefix is Budget's — see Routing.
 
 ## Concepts
 

--- a/src/Sections/Humans.Finance/Docs/Finance.md
+++ b/src/Sections/Humans.Finance/Docs/Finance.md
@@ -4,7 +4,9 @@
   src/Sections/Humans.Holded/Services/HoldedClient.cs
   src/Sections/Humans.Holded/Services/Service.cs
   src/Sections/Humans.Holded/Jobs/HoldedSyncJob.cs
+  src/Sections/Humans.Holded/SectionJobs.cs
   src/Sections/Humans.Budget/Controllers/BudgetAdminController.cs
+  src/Sections/Humans.Expenses/Services/ExpenseReportService.cs
 -->
 <!-- freshness:flag-on-change
   FinanceController routes or auth policy (FinanceAdminOrAdmin) — review when FinanceController or the section's cross-section contracts (IBudgetServiceRead, IHoldedService, IUserServiceRead) change. Holded attribution logic (Account → Tag → Unmatched) and the provisioning model reviewed when HoldedMatcher, IHoldedFinanceService, or HoldedCategoryMap change.
@@ -16,15 +18,7 @@ Finance is the **treasurer's reality side** of the money story. Budget owns plan
 
 The end-to-end *business* process — how a reimbursement actually moves from expense report through the bank and back to a zero balance, including the manual steps and external parties — is [`expense-reimbursement-process.md`](expense-reimbursement-process.md). This file stays about code invariants.
 
-## Today vs Planned
-
-**Today — treasurer surface over Budget** (built, *not this section*): the Budget years/groups/categories/line-items/cash-flow surface under the same `/Finance` prefix is `Humans.Budget`'s `BudgetAdminController` — see [`Budget.md`](../../Humans.Budget/Docs/Budget.md). It shares only the URL prefix and the `FinanceAdminOrAdmin` policy.
-
-**Today — Holded actuals integration** (built, Feature 1): Finance-owned entities (`HoldedExpenseDoc`, `HoldedCategoryMap`, `HoldedDocSyncState`) with a dedicated repository, `IHoldedFinanceService` implemented by `Service`, a nightly sync job, and treasurer UI pages for account provisioning and unmatched-doc resolution. Actuals displayed on the budget year detail view.
-
-**Today — Holded creditor reads** (built, Feature 2): the daybook journal-line mirror itself belongs to the **Holded** section; Finance derives creditor balance, owed and payments from it (no balance/payment tables of its own, no live API call on page load), and `GetCreditorStatusAsync` / `GetCreditorLedgerAsync` expose that read surface to Expenses. See [Feature 2](#feature-2--creditor-reads-over-the-holded-sections-mirror) below.
-
-**Today — SEPA payout** (built, Feature 3): `/Finance/Creditors` selects payable creditor balances and `POST /Finance/Sepa/Generate` streams a pain.001.001.09 credit-transfer file for the bank; `/Finance/Sepa` then books each transfer's payment into Holded against the member's open purchase documents. Balance-based, not report-based: nothing in Expenses moves. See [Feature 3](#feature-3--sepa-payout-of-creditor-balances) and [`features/sepa-payout.md`](features/sepa-payout.md).
+Three things live here: the Holded purchase-doc sync and its attribution to budget categories; creditor bindings and the balances derived from the Holded section's ledger mirror ([Feature 2](#feature-2--creditor-reads-over-the-holded-sections-mirror)); and SEPA payout generation and booking ([Feature 3](#feature-3--sepa-payout-of-creditor-balances), [`features/sepa-payout.md`](features/sepa-payout.md)). The Budget surface on the same `/Finance` prefix is Budget's — see Routing.
 
 ## Concepts
 
@@ -109,7 +103,7 @@ contact, three write paths with different collision remedies, and no unique inde
 
 **Table:** `holded_doc_sync_state` (singleton, `Id = 1`, lazy-created)
 
-Fields: `LastSyncAt`, `Status` (`Idle / Running / Error` string), `LastError`, `StatusChangedAt`, `LastSyncedDocCount`. Status of the purchase-doc sync only — the ledger mirror (`holded_ledger_lines`, kind-keyed sync states) moved to the **Holded section** (`src/Sections/Humans.Holded/Docs/Holded.md`); Finance reads it via `IHoldedService`.
+Fields: `LastSyncAt`, `Status` (`Idle / Running / Error` string), `LastError`, `StatusChangedAt`, `LastSyncedDocCount`. Status of the purchase-doc sync only — the ledger mirror and its own sync states are the **Holded section**'s (`src/Sections/Humans.Holded/Docs/Holded.md`); Finance reads it via `IHoldedService`.
 
 ### SepaPayoutFile
 
@@ -163,7 +157,7 @@ Stored as string via `HasConversion<string>()`.
 | Account | Attributed via the line's booked Holded account |
 | Tag | Attributed via a normalized tag fallback |
 
-`HoldedDocSyncState.Status` is a plain string (`Idle` / `Running` / `Error`), not an enum — the `HoldedSyncStatus` enum moved to the Holded section with the ledger mirror.
+`HoldedDocSyncState.Status` is a plain string (`Idle` / `Running` / `Error`), not an enum.
 
 ## Routing
 
@@ -194,7 +188,7 @@ Every `/Finance/*` route is gated on `PolicyNames.FinanceAdminOrAdmin`, declared
 
 | Actor | Capabilities |
 |-------|--------------|
-| FinanceAdmin, Admin | Full access to all `/Finance/*` routes. View budget data, manage years/groups/categories/line items, trigger ticketing sync. Provision Holded accounts, trigger Holded sync, inspect unmatched docs. |
+| FinanceAdmin, Admin | Every `/Finance/*` route: provision Holded accounts, run the sync, work the unmatched queue, bind and unbind creditors, generate and book SEPA payouts. |
 | Department coordinator | None — Finance routes are FinanceAdmin-only. |
 | Any other authenticated human | None |
 
@@ -203,7 +197,7 @@ Every `/Finance/*` route is gated on `PolicyNames.FinanceAdminOrAdmin`, declared
 - A purchase doc is attributed **as a whole, by its first product line's** booked account (plus the union of doc-level and line-level tags), and its full `Total` lands on that one category. A multi-line doc booked across several Holded accounts is not split; line-level attribution is a deliberate later refinement (`Service.MapDoc`).
 - Actuals are keyed on the **calendar year** of the doc's Europe/Madrid date, matched against `BudgetYear.Year` parsed as an integer (`FinanceController` → `GetActualsForYearAsync` → `HoldedRepository.GetMatchedForYearAsync`). A budget year whose `Year` string is not a plain number, or that does not run January–December, shows no actuals.
 - Only `FinanceAdmin` or `Admin` may access any `/Finance/*` route (`[Authorize(Policy = PolicyNames.FinanceAdminOrAdmin)]` on `FinanceController`).
-- `FinanceController` performs no budget mutations at all — its ten actions are the Holded, creditor and SEPA-payout surface. Budget CRUD on the same prefix is `Humans.Budget`'s `BudgetAdminController`.
+- `FinanceController` performs no budget mutations at all — its actions are the Holded, creditor and SEPA-payout surface. Budget CRUD on the same prefix is `Humans.Budget`'s `BudgetAdminController`.
 - `/Finance/Holded` issues **no** Holded HTTP call. Every figure comes from `holded_doc_sync_state`, `holded_category_map`, `holded_expense_docs` and `holded_creditor_contacts`; the mirror's own health (API budget, ledger sweeps, chart of accounts) is `/Holded`'s and is linked, not restated. Pinned by `GetConnectorOverview_MakesNoHoldedApiCall`.
 - The doc sync counts as **stale** at 36 h — the nightly job's 24 h cadence plus half a day of grace — and never having run counts as stale too: budget actuals and the unmatched queue are equally wrong either way, so both raise the same alarm.
 - The sync job pulls all purchase docs from Holded each cycle (full-pull). Upsert is keyed on `HoldedDocId`; `CreatedAt` is preserved across re-syncs.
@@ -263,7 +257,7 @@ Every `/Finance/*` route is gated on `PolicyNames.FinanceAdminOrAdmin`, declared
 
 ## Cross-Section Dependencies
 
-Derived from `Humans.Finance.csproj`'s project references — four contracts leaves, no section projects:
+Derived from `Humans.Finance.csproj`'s project references — contracts leaves only, no section projects:
 
 - **Budget** (`Humans.Budget.Contracts`): `IBudgetServiceRead.GetActiveYearAsync`, for the categories the provisioning plan is built from. Read-only.
 - **Holded** (`Humans.Holded.Contracts`): `IHoldedService` for cached ledger lines and account balances, and `IHoldedClient` for the live contact/account calls the provisioning and bind paths make.
@@ -274,56 +268,33 @@ No Tickets dependency: the cash-flow view that had one is Budget's. Budget never
 
 ## Architecture
 
-**Status:** (A) — Finance has its own service, an owned repository, and an EF migration.
-**G5 (own project, `src/Sections/Humans.Finance` + `src/Sections/Humans.Finance.Contracts`) — 2026-08-09.**
+**Status:** (A) — own project (`src/Sections/Humans.Finance` + `src/Sections/Humans.Finance.Contracts`), own service, owned repository, own `FinanceDbContext`.
 
-**Owning service:** `Service` (`Humans.Finance.Services`), exposed as `IHoldedFinanceService` from the contracts leaf. `IHoldedFinanceServiceRead` carries the read-only subset for cross-section callers (`BudgetAdminController`, `Expenses.ExpensesController`); the write-capable `ExpenseReportService` and `Holded.HoldedController` are `[CrossSectionWrite]` and inject the full `IHoldedFinanceService` instead.
+**Owning service:** `Service` (`Humans.Finance.Services`), exposed as `IHoldedFinanceService` from the contracts leaf. `IHoldedFinanceServiceRead` carries the read-only subset for cross-section callers (`BudgetAdminController`, `Expenses.ExpensesController`); the write-capable `ExpenseReportService`, `Holded.HoldedNightlySync` and `Holded.HoldedController` are `[CrossSectionWrite]` and inject the full `IHoldedFinanceService` instead.
 **Pure matcher:** `HoldedMatcher` (static, no dependencies)
-**Owned repository:** `IHoldedRepository` / `Repository` (`Humans.Finance.Data`)  
-**Owned tables:** `holded_expense_docs`, `holded_category_map`, `holded_doc_sync_state`, `holded_creditor_contacts`  
-**Job:** `HoldedSyncJob` (cron `0 3 * * *`) — **not this section's.** Since G5 lane 4b-2f it is only a shim: its body is `HoldedNightlySync` in `Humans.Holded`, which calls this section's `IHoldedFinanceService.SyncAsync` first and then the ledger mirror. At G5 lane 5b-5 the shim followed its body into `src/Sections/Humans.Holded/Jobs/`; the "Hangfire serializes the declaring type name" claim that had kept it in Base is false — `AddOrUpdate<T>(id, …)` is keyed on the job id.  
-**Migrations:** `20260715103643_BaselineFinance` — consolidated onto `FinanceDbContext` (its own history table, `__EFMigrationsHistory_Finance`) when Finance moved off the shared `HumansDbContext` (nobodies-collective/Humans#858); the earlier per-feature migration chain (`HoldedActuals`, `HoldedCreditorData`, `HoldedCreditorContact`, `HoldedLedgerSingleSource`) was squashed into this baseline. Since then: `20260810195350_HoldedExpenseDocIsApproved` (swaps `ApprovedAt` for the nullable `IsApproved` flag) and `20260810204942_HoldedMirrorMovesToHoldedSection` (drops the ledger-mirror tables, which the Holded section now owns)  
+**Pure file builder:** `SepaPaymentFileBuilder` with `SepaSchema` and `SepaText` (no IO, no clock, no configuration)
+**Owned repository:** `IHoldedRepository` / `Repository` (`Humans.Finance.Data`) — tables under [Owned repository](#owned-repository)
+**Job:** `HoldedSyncJob` — **not this section's.** It is Holded's (`src/Sections/Humans.Holded/Jobs/`, cron in `Humans.Holded/SectionJobs.cs`); its body `HoldedNightlySync` calls this section's `IHoldedFinanceService.SyncAsync` first and then the ledger mirror.
+**Migrations:** `Data/Migrations/`, on `FinanceDbContext` with its own history table `__EFMigrationsHistory_Finance`.
 **Architecture tests:** `tests/Humans.Finance.Tests/FinanceArchitectureTests.cs`
 
-**Controllers.** `/Finance` is served by two controllers under one route prefix. `Humans.Finance.Controllers.FinanceController` owns the section's own nine actions — `Holded`, `HoldedAccounts`, `HoldedUnmatched`, `Creditors`, `CreditorStatement`, `Bind`, `Unbind`, `Provision`, `HoldedSync/Run`. The other 23 actions on the pre-G5 `FinanceController` were Budget CRUD (years, groups, categories, line items, ticketing projection, cash flow, audit log) and now live in `Humans.Budget.Controllers.BudgetAdminController`, own project since Budget's own G5, keeping `[Route("Finance")]` so no URL moved. See [`Budget.md`](../../Humans.Budget/Docs/Budget.md) for the Budget side of the split.
+### Cross-section read interface
 
-**The Holded connector is not this section.** `IHoldedClient`, `HoldedClient`, `HoldedClientOptions`, `HoldedApiException` and the connector DTOs belong to the **Holded** section — public on `Humans.Holded.Contracts`, implementation `internal` in `Humans.Holded/Services/` — with their own [`Holded-connector.md`](../../Humans.Holded/Docs/Holded-connector.md) (G5 lane 4b-2f, nobodies-collective/Humans#866). Finance consumes them through that leaf. Consequence for the boundary: `HoldedCreditorLedger.Lines` carries Finance's own `CreditorLedgerLine` rather than the connector's `HoldedLedgerLineDto`, because the contracts leaf may reference only the bottom of the graph and re-exporting another component's wire DTO across a section boundary is the thing the split exists to stop.
+| Read interface | Methods | Notes |
+|---|---|---|
+| `IHoldedFinanceServiceRead` | [`IHoldedFinanceServiceRead.cs`](../../Humans.Finance.Contracts/IHoldedFinanceServiceRead.cs) | Consumed by `BudgetAdminController` (actuals) and `ExpensesController` (creditor status, ledger, account list). `IHoldedFinanceService` inherits it and adds the writes. |
+
+**Controllers.** `/Finance` is served by two controllers under one route prefix: this section's `FinanceController` — the Holded, creditor and SEPA-payout surface, the routing table above — and `Humans.Budget.Controllers.BudgetAdminController`, Budget CRUD under the same `[Route("Finance")]`. See [`Budget.md`](../../Humans.Budget/Docs/Budget.md) for the Budget side.
+
+**The Holded connector is not this section.** `IHoldedClient`, `HoldedClient`, `HoldedClientOptions`, `HoldedApiException` and the connector DTOs belong to the **Holded** section — public on `Humans.Holded.Contracts`, implementation `internal` in `Humans.Holded/Services/` — with their own [`Holded-connector.md`](../../Humans.Holded/Docs/Holded-connector.md). Finance consumes them through that leaf. Consequence for the boundary: `HoldedCreditorLedger.Lines` carries Finance's own `CreditorLedgerLine` rather than the connector's `HoldedLedgerLineDto`, because the contracts leaf may reference only the bottom of the graph and re-exporting another component's wire DTO across a section boundary is the thing the split exists to stop.
 
 **Table names.** `holded_*` tables under a section called `Finance`, and a `FinanceDbContext` naming the live `__EFMigrationsHistory_Finance` table. The mismatch is real and deferred wholesale to nobodies-collective/Humans#1012 — a G5 move changes files, never the schema (design §15 step 10).
 
 **Resources.** No `FinanceResource`. These are English-only finance-admin pages with zero `Localizer` call sites, so the section carves no `.resx`; `_ViewImports` binds `SharedLocalizer` for the first view that needs a string.
 
-> **What exists (Feature 1):**
-> - `Controllers/FinanceController.cs` — the Holded/creditor routes. Injects `IHoldedFinanceService` and `IUserServiceRead` only; the Budget-facing actions are `Humans.Budget`'s `BudgetAdminController`.
-> - `PolicyNames.FinanceAdminOrAdmin` and `RoleNames.FinanceAdmin` — role + policy wired in `AuthorizationPolicyExtensions.cs`.
-> - `Domain/HoldedExpenseDoc.cs`
-> - `Domain/HoldedCategoryMap.cs`
-> - `Domain/HoldedDocSyncState.cs`
-> - `Domain/HoldedMatchStatus.cs`, `HoldedMatchSource.cs`
-> - `Services/Service.cs`
-> - `Services/IHoldedFinanceAdminService.cs` — `/Finance/Holded`'s read model; **internal**, this section's screen is the only consumer
-> - `Models/HoldedConnectorVm.cs` — that screen's view models
-> - `Views/Finance/Holded.cshtml`, `SectionAdminNav.cs` — the page and its "Money" sidebar entry
-> - `Services/HoldedMatcher.cs`
-> - `../Humans.Finance.Contracts/IHoldedFinanceService.cs`
-> - `Data/IHoldedRepository.cs`
-> - `Data/Repository.cs`
-> - `src/Sections/Humans.Holded/Services/HoldedClient.cs`
-> - `src/Sections/Humans.Holded/Jobs/HoldedSyncJob.cs`
-> - `tests/Humans.Finance.Tests/FinanceArchitectureTests.cs`
-> - EF migration `20260525163748_HoldedActuals` for all three Feature 1 Finance-owned tables
->
-> **What exists (Feature 2 — ledger single-source):**
-> - `Domain/HoldedCreditorContact.cs` — member → 400000xx binding (from #1021)
-> - `TotalPaid` / `LastPaymentDate` on `HoldedCreditorStatus` — aggregated straight off the debit lines; no payment row type leaves the service
-> - Ledger reads via `IHoldedService` (the mirror moved to the Holded section; sync is `SyncLedgerAsync` there)
-> - `IHoldedFinanceServiceRead.GetCreditorStatusAsync(int? supplierAccountNum)` / `GetCreditorLedgerAsync(int supplierAccountNum)` — Expenses→Finance read surface, derived from cached lines
-> - `IHoldedFinanceServiceRead.ListCreditorAccountsAsync` — returns `(Accounts, Unresolved)`; the `Unresolved` half is the bindings with no resolved 400000xx, surfaced on `/Finance/Creditors` for manual bind (nobodies-collective/Humans#972)
-> - `IHoldedClient.GetContactAsync`, `ListContactsAsync`, `ListLedgerEntriesAsync`, `UpsertContactAsync` — Holded API surface
-
 ### Feature 2 — creditor reads over the Holded section's mirror
 
-The ledger cache and its sync moved to the Holded section (full mirror, all accounts, replace semantics, balance reconciliation — see `src/Sections/Humans.Holded/Docs/Holded.md`). Finance derives creditor status/statements from `IHoldedService.GetLedgerLinesAsync` / `GetAccountBalancesAsync`, range-filtered to the `40000000`–`41999999` creditor block on Finance's side. Sync buttons live on `/Holded`. Page loads still cost **zero Holded calls per view**; the admin creditor overview additionally reads the cached Holded contact list for account names — see Invariants.
+The ledger cache and its sync are the Holded section's (full mirror, all accounts, replace semantics, balance reconciliation — see `src/Sections/Humans.Holded/Docs/Holded.md`). Finance derives creditor status/statements from `IHoldedService.GetLedgerLinesAsync` / `GetAccountBalancesAsync`, range-filtered to the `40000000`–`41999999` creditor block on Finance's side. Sync buttons live on `/Holded`. Page loads still cost **zero Holded calls per view**; the admin creditor overview additionally reads the cached Holded contact list for account names — see Invariants.
 
 The Expenses section reads creditor status via `GetCreditorStatusAsync(supplierAccountNum)` and the statement via `GetCreditorLedgerAsync(supplierAccountNum)`. Both derive from the cached lines: balance = Σdebit − Σcredit (balance ≥ 0 = settled), owed = max(0, −balance), payments = debit lines. The debit lines stay internal to the derivation; only the aggregates (`TotalPaid`, `LastPaymentDate`) leave the service.
 
@@ -352,11 +323,6 @@ on the next sync.
   - A payout file and its transfers are written in one `AddSepaPayoutAsync` save — one without the other is not a state this section wants to be in
   - Expense docs upsert (full overwrite on re-sync); ledger tables belong to the Holded section
 
-### Current violations
-
-None. Every cross-section call goes through a contracts leaf, and the Budget read-split shipped — `Service` injects `IBudgetServiceRead`, not the full service. No cross-section DbContext reads.
-
 ### Touch-and-clean guidance
 
 - **Soft boundary:** `TicketingProjection` and `TicketingBudgetService` are conceptually "actuals materialization" but live in Budget today. Treat as known soft boundary — separate cleanup, not an active violation.
-- **Done:** the Budget dependency is `IBudgetServiceRead`; nothing here holds a Budget write surface.

--- a/src/Sections/Humans.Finance/Docs/authorization.md
+++ b/src/Sections/Humans.Finance/Docs/authorization.md
@@ -2,7 +2,7 @@
 
 | Controller | Scope | Roles | Source |
 |---|---|---|---|
-| `FinanceController` | Class | `FinanceAdmin, Admin` | `PolicyNames.FinanceAdminOrAdmin` (Holded creditor-account surface — `Holded`, `HoldedAccounts`/`Provision`, `HoldedUnmatched`, `Creditors`/`Bind`/`Unbind`, `HoldedSync/Run`) |
+| `FinanceController` | Class | `FinanceAdmin, Admin` | `PolicyNames.FinanceAdminOrAdmin` — every action on the class: the Holded, creditor and SEPA-payout surface ([routing table](Finance.md#routing)) |
 
 `/Finance/Holded` is deliberately on the same policy as the rest of the prefix rather than AdminOnly: a
 finance admin who can already see creditor balances should be able to see the connector health those

--- a/src/Sections/Humans.Finance/Docs/data-access.md
+++ b/src/Sections/Humans.Finance/Docs/data-access.md
@@ -23,7 +23,7 @@ creditor-**contact binding** surface (`HoldedCreditorContacts` — user ↔
 Holded supplier-account bindings, including an at-most-one-member
 collision guard).
 
-### HoldedFinanceService (Scoped)
+### Service (Scoped)
 
 Repository: `IHoldedRepository`.
 
@@ -36,8 +36,7 @@ Repository: `IHoldedRepository`.
 | SepaPayoutFiles | R/W (append-only writes; read joined for the Article 15 export and for `/Finance/Sepa`) |
 | SepaPayoutTransfers | R/W (appended at generation; the booking columns are the only update — `SaveSepaTransferBookingAsync`. Read per user for the Article 15 export and flattened with the file for `/Finance/Sepa`) |
 
-Cross-section calls via `IBudgetServiceRead` (migrated to the read-split
-surface — `budget` in the ctor), `IHoldedService` (the Holded section's
+Cross-section calls via `IBudgetServiceRead` (`budget` in the ctor), `IHoldedService` (the Holded section's
 ledger-mirror read surface — `holded` in the ctor; ledger-line /
 account-balance reads for creditor status, ledger, and account listing),
 `IHoldedClient` (Holded section leaf — purchase-document / contact / expense-account
@@ -52,14 +51,13 @@ SEPA identity.
 `IHoldedFinanceAdminService` (`Services/IHoldedFinanceAdminService.cs`) is
 **internal** — the `/Finance/Holded` connector index is this section's own
 screen, so its read model is not cross-section surface; the same shape as the
-Holded section's `IHoldedAdminService`. Its one method,
-`GetConnectorOverviewAsync`, reads `HoldedDocSyncStates`,
+Holded section's `IHoldedAdminService`. `GetConnectorOverviewAsync` reads `HoldedDocSyncStates`,
 `HoldedCategoryMap`, `HoldedExpenseDocs` (via `GetAllDocsAsync` — the
 unmatched and matched-for-year reads are each a filtered slice and neither
 composes into "all docs") and `HoldedCreditorContacts`, plus
 `IBudgetServiceRead` for category names. **No `IHoldedClient` call** — the
 index must not inherit the connector's 30 s timeout
-(nobodies-collective/Humans#976, #1000). Its other methods,
+(nobodies-collective/Humans#976, #1000). The SEPA methods,
 `GetSepaPayoutSettings`, `GenerateSepaPayoutAsync`, `GetSepaPayoutsAsync` and
 `BookSepaTransferAsync`, serve `/Finance/Creditors`' payout column,
 `POST /Finance/Sepa/Generate`, `GET /Finance/Sepa` and

--- a/src/Sections/Humans.Finance/Docs/debt.yml
+++ b/src/Sections/Humans.Finance/Docs/debt.yml
@@ -1,0 +1,10 @@
+# Section debt ledger for Humans.Finance. Shape + routing: memory/process/debt-ledger-additions.md.
+# /debt-sweep pools every src/Sections/*/Docs/debt.yml into the same inbox as the central ledger.
+version: 1
+inbox:
+  - added: 2026-09-06
+    what: "HoldedCategoryMap.IsActive is dead state: nothing in the section clears it (Holded.cshtml's own footer says an Archived row should not appear), yet HoldedConnectorVm.ArchivedMappings, the Archived badge and GetConnectorOverview_ListsActiveAndArchivedMappings_WithCategoryNames all exist to render it. The fix is dropping the column, which is a Finance migration — out of section-doctor's remit. Found by /section-doctor on Finance 2026-09-06 (finding 14)."
+    review: panel
+  - added: 2026-09-06
+    what: "Views/Finance/CreditorStatement.cshtml flips the sign of every ledger line so a payable reads positive to the member; the arithmetic lives in the view and no test in tests/Humans.Finance.Tests pins it (health.md §4 names it an invariant). Needs either a render test or the sign moved into the DTO the service builds. Found by /section-doctor on Finance 2026-09-06 (finding 11)."
+    review: panel

--- a/src/Sections/Humans.Finance/Docs/expense-reimbursement-process.md
+++ b/src/Sections/Humans.Finance/Docs/expense-reimbursement-process.md
@@ -90,8 +90,7 @@ robbed, automation everywhere else.**
   tracked in Humans), and Humans never writes journal entries by hand — settlement goes through
   Holded's own payment API so the accountant sees a normal ledger.
 
-## Status (2026-08-26)
+## Status (2026-09-06)
 
-Steps 1–8 are live in production. Steps 9–11 — the booking screen (`/Finance/Sepa`,
-nobodies-collective/Humans#1141) — are on QA under test, verified with a real €50 payout the
-treasurer sent himself.
+Steps 1–11 are in production: the booking screen (`/Finance/Sepa`, nobodies-collective/Humans#1141)
+is on `upstream/main`.

--- a/src/Sections/Humans.Finance/Docs/features/sepa-payout.md
+++ b/src/Sections/Humans.Finance/Docs/features/sepa-payout.md
@@ -122,7 +122,7 @@ A payment Holded **accepted** but gave no readable id for is not a failure at al
 `"unconfirmed:{documentId}"`, the allocation continues, and the transfer books normally. The sentinel
 lands in `HoldedPaymentRefs` and in the audit entry, naming the document the treasurer has to eyeball
 in Holded. Throwing there would have lost a real payment from the record and left the transfer
-retryable — so reaching the catch on the *first* payment now genuinely means Holded refused it.
+retryable — so reaching the catch on the *first* payment means Holded refused it.
 
 ## The file
 

--- a/src/Sections/Humans.Finance/Docs/health.md
+++ b/src/Sections/Humans.Finance/Docs/health.md
@@ -5,7 +5,7 @@ section-doctor run and diffed against the previous run's copy.
 
 - Last assessed: 2026-09-06
 - Anchor: 10199a23
-- Previous target: 2026-08-18. Diff: the section moved. Two shapes the previous target did not
+- Previous target: 2026-08-18. Diff: the section moved. Shapes the previous target did not
   have — paying what is owed (SEPA generate and book) and the member's own data (GDPR export and
   erasure) — and the read/write split the previous target named as a seam has shipped. Structure
   and the Holded write-boundary statement updated to match; the rest holds.
@@ -15,7 +15,7 @@ section-doctor run and diffed against the previous run's copy.
 Finance is the treasurer's window onto what the organisation actually spent and actually owes its
 members, with Holded — the outside bookkeeping system — as the system of record.
 
-Four things happen here:
+What happens here:
 
 **Money out of the org, by budget category.** Every purchase invoice the bookkeeper enters in
 Holded is pulled in nightly and attributed to one budget category, so the budget pages can show
@@ -86,29 +86,29 @@ What the grouping shows:
 
 ## 3. Structure
 
-The layout those six shapes imply:
+The layout the shapes imply:
 
 ```
-Humans.Finance.Contracts/      two interfaces (read, read+write), the DTOs their methods return
+Humans.Finance.Contracts/      the read and read+write interfaces, the DTOs their methods return
 Humans.Finance/
   Section.cs                   DI
   Controllers/                 one controller — the pages and their posts
   Models/                      view models for those pages
   Views/Finance/               those pages
   Services/
-    Service.cs                 the six shapes
+    Service.cs                 the shapes
     HoldedMatcher.cs           pure attribution, no dependencies
     SepaPaymentFileBuilder.cs  pure pain.001 XML from a batch, no dependencies
     SepaSchema.cs, SepaText.cs the schema and the character rules that builder obeys
     IHoldedFinanceAdminService.cs  Finance's own page's interface (E, plus the connector overview)
-  Domain/                      six entities, two enums
-  Data/                        one repository over one context, six tables
+  Domain/                      the entities and their enums
+  Data/                        one repository over one context, the tables
   Resources/                   the pain.001.001.09 schema the file is validated against
 ```
 
 That is what is there. The file structure is right; the work is inside the files, not between them.
 
-Four things the shapes say about the inside:
+What the shapes say about the inside:
 
 - Shape **D**'s three methods share one derivation of balance and owed from a set of cached journal
   lines, and one accessor for the cached Holded contact list. A fourth path to either is an
@@ -163,6 +163,9 @@ Specified, not built. Not ranked, not struck; items touching these callers are s
   repository write.
 - **`holded_*` tables under a section called Finance** (nobodies-collective/Humans#1012). A rename is
   schema work, deferred wholesale.
+- **The creditor statement shows the IBAN raw** (`Views/Finance/CreditorStatement.cshtml`). The
+  invariant in §4 says every screen masks it; whether the view masks or the invariant narrows is
+  open (run 2026-09-06, finding 1).
 - **Booking is not cancellable mid-flight.** `BookSepaTransferAsync` takes no cancellation token by
   design — a half-posted payment is worse than a slow one — so the whole posting loop runs to the
   end once started.
@@ -222,5 +225,5 @@ Settled; do not re-litigate.
 
 | Run | Anchor | Headline | PR |
 |---|---|---|---|
-| [2026-09-06](../../../../docs/health/runs/2026-09-06-Finance.md) | `10199a23` | Second target; the section moved (SEPA payout and GDPR shapes, read split shipped). Docs and comments narrated the moves and counted things; three named invariants had no test and one test pinned an absence. No code defect found. A raw IBAN on the creditor statement contradicts the docs — Peter's call. | [#1613](https://github.com/peterdrier/Humans/pull/1613) |
+| [2026-09-06](../../../../docs/health/runs/2026-09-06-Finance.md) | `10199a23` | Second target; the section moved (SEPA payout and GDPR shapes, read split shipped). Docs and comments narrated the moves and counted things; named invariants had no test and one test pinned an absence. No code defect found. A raw IBAN on the creditor statement contradicts the docs — Peter's call. | [#1613](https://github.com/peterdrier/Humans/pull/1613) |
 | [2026-08-18](../../../../docs/health/runs/2026-08-18-Finance.md) | `41fd7374d` | First target. Doc led with 23 routes the section does not serve; a tag-collision bug in provisioning; a published DTO with no consumer. Prod code −113 lines, tests 55 → 92, mutation 34.4% → 57.9%. | [#1374](https://github.com/peterdrier/Humans/pull/1374) |

--- a/src/Sections/Humans.Finance/Docs/health.md
+++ b/src/Sections/Humans.Finance/Docs/health.md
@@ -222,5 +222,5 @@ Settled; do not re-litigate.
 
 | Run | Anchor | Headline | PR |
 |---|---|---|---|
-| [2026-09-06](../../../../docs/health/runs/2026-09-06-Finance.md) | `10199a23` | Second target; the section moved (SEPA payout and GDPR shapes, read split shipped). Docs and comments narrated the moves and counted things; three named invariants had no test and one test pinned an absence. No code defect found. A raw IBAN on the creditor statement contradicts the docs — Peter's call. | pending |
+| [2026-09-06](../../../../docs/health/runs/2026-09-06-Finance.md) | `10199a23` | Second target; the section moved (SEPA payout and GDPR shapes, read split shipped). Docs and comments narrated the moves and counted things; three named invariants had no test and one test pinned an absence. No code defect found. A raw IBAN on the creditor statement contradicts the docs — Peter's call. | [#1613](https://github.com/peterdrier/Humans/pull/1613) |
 | [2026-08-18](../../../../docs/health/runs/2026-08-18-Finance.md) | `41fd7374d` | First target. Doc led with 23 routes the section does not serve; a tag-collision bug in provisioning; a published DTO with no consumer. Prod code −113 lines, tests 55 → 92, mutation 34.4% → 57.9%. | [#1374](https://github.com/peterdrier/Humans/pull/1374) |

--- a/src/Sections/Humans.Finance/Docs/health.md
+++ b/src/Sections/Humans.Finance/Docs/health.md
@@ -3,16 +3,19 @@
 **Assessment target.** Derived from the section's behaviour, not from any scan. Regenerated every
 section-doctor run and diffed against the previous run's copy.
 
-- Last assessed: 2026-08-18
-- Anchor: 41fd7374d
-- Previous target: none — this is Finance's first `health.md`, so there is nothing to diff against.
+- Last assessed: 2026-09-06
+- Anchor: 10199a23
+- Previous target: 2026-08-18. Diff: the section moved. Two shapes the previous target did not
+  have — paying what is owed (SEPA generate and book) and the member's own data (GDPR export and
+  erasure) — and the read/write split the previous target named as a seam has shipped. Structure
+  and the Holded write-boundary statement updated to match; the rest holds.
 
 ## 1. What the section does
 
 Finance is the treasurer's window onto what the organisation actually spent and actually owes its
 members, with Holded — the outside bookkeeping system — as the system of record.
 
-Three things happen here:
+Four things happen here:
 
 **Money out of the org, by budget category.** Every purchase invoice the bookkeeper enters in
 Holded is pulled in nightly and attributed to one budget category, so the budget pages can show
@@ -33,19 +36,34 @@ any one of them. The link is created automatically the first time a member's rep
 a treasurer can correct it by hand when the automatic attempt guesses wrong or does not resolve at
 all.
 
-The organisation's books are Holded's. Finance only ever reads them, plus creates expense accounts
-and member contacts; it never posts a journal entry.
+**Paying it.** A treasurer ticks creditor accounts, caps each amount, and downloads a bank file that
+pays them in one upload. After the bank has taken the file, each transfer is booked into Holded as a
+payment against that member's open purchase documents, oldest first, so the next ledger pull shows
+the balance settled. The file is kept byte-for-byte as the record of what was sent; booking is the
+one thing that moves a transfer on, and it happens at most once.
+
+The organisation's books are Holded's. Finance reads them, creates expense accounts and member
+contacts, and posts exactly one kind of entry: a payment against a purchase document, for a transfer
+that already left the bank. It never posts a journal entry of its own.
+
+Finance also holds personal data — a member's Holded contact link, and their IBAN inside a payout
+file — so it answers the member's own request for a copy and honours erasure by cutting the link.
+The payout files themselves are the accounting record and survive erasure.
 
 ## 2. The shapes
 
-The contract's methods, grouped by the question each one answers.
+The section's methods, grouped by the question each one answers. Cross-section callers hold
+`IHoldedFinanceServiceRead` (reads) or `IHoldedFinanceService` (its writes); the admin interface is
+Finance's own page's.
 
 | Shape | The question | Methods | Asked by |
 |---|---|---|---|
 | **A — Accounts to spend against** | Which categories have a Holded account, and make the missing ones | `GetProvisioningPlanAsync`, `ProvisionAsync`, `GetHoldedAccountIdForCategoryAsync` | Finance's own page; Expenses, to book a line |
-| **B — What was spent** | Pull the invoices; the per-category total, what didn't attribute, and how the pull went | `SyncAsync`, `GetActualsForYearAsync`, `GetUnmatchedAsync`, `GetDocSyncInfoAsync` | Nightly job; Budget's year page; Finance's own page; the Holded admin screen |
+| **B — What was spent** | Pull the invoices; the per-category total, what didn't attribute, and how the pull went | `SyncAsync`, `GetActualsForYearAsync`, `GetUnmatchedAsync`, `GetDocSyncInfoAsync`, `GetConnectorOverviewAsync` | Nightly job; Budget's year page; Finance's own pages; the Holded admin screen |
 | **C — Whose account is this** | Which Holded creditor account is this member's — set it, correct it, clear it | `GetCreditorContactByUserAsync`, `EnsureCreditorContactAsync`, `SetCreditorAccountNumAsync`, `SetCreditorContactAsync`, `ClearCreditorContactAsync` | Expenses' push path; Finance's own page |
 | **D — What is owed** | What does the org owe this member, and what is the journal behind it | `GetCreditorStatusAsync`, `GetCreditorLedgerAsync`, `ListCreditorAccountsAsync` | Expenses' member and admin views; Finance's own page |
+| **E — Paying it** | Make the bank file for these accounts; what files exist; record that one transfer was paid | `GenerateSepaPayoutAsync`, `GetSepaPayoutsAsync`, `BookSepaTransferAsync` | Finance's own pages only |
+| **F — The member's data** | What Finance holds about this member; forget them | `ContributeForUserAsync`, `EraseForUserAsync` | Gdpr, on the member's behalf |
 
 What the grouping shows:
 
@@ -55,40 +73,51 @@ What the grouping shows:
 - **D is three resolutions of one derivation.** All three start from the same cached journal lines
   and the same cached Holded contact list, and compute balance and owed the same way. The shapes
   differ because the callers differ; the arithmetic and the contact lookup must exist once.
+- **E is D's consumer, not a fifth resolution of it.** A payout row starts from the same creditor
+  list D serves, so the amount, the name and the IBAN come from D's lookup — E adds the cap, the
+  file and the booking, never a second balance.
+- **E's booking is the section's only write into the books.** It is guarded harder than any other
+  write here: a transfer books once, only after a file exists, only against documents Holded still
+  shows open, and only from a treasury account that was named, never inferred.
 - **B's `GetDocSyncInfoAsync` carries a C fact.** Its result includes a count of creditor bindings,
   which is not sync state. One screen's convenience shaped a contract type.
-- **The section is read-heavy but exposes one read/write interface.** Every consumer of a creditor
-  balance also holds `ProvisionAsync` and `ClearCreditorContactAsync`. The repo's stated pattern for
-  cross-section calls is a read interface (`peters-hard-rules.md`, Patterns); Finance has none. Seam,
-  not a strike — see §5.
+- **The read/write split is done.** Budget and Expenses' views hold the read interface; only
+  Expenses' push path and the Holded sync hold the writes. The previous target's Seam 1 is closed.
 
 ## 3. Structure
 
-The layout those four shapes imply:
+The layout those six shapes imply:
 
 ```
-Humans.Finance.Contracts/      one interface, the DTOs its methods return
+Humans.Finance.Contracts/      two interfaces (read, read+write), the DTOs their methods return
 Humans.Finance/
   Section.cs                   DI
-  Controllers/                 one controller — three pages and their four posts
+  Controllers/                 one controller — the pages and their posts
   Models/                      view models for those pages
   Views/Finance/               those pages
   Services/
-    Service.cs                 the four shapes
+    Service.cs                 the six shapes
     HoldedMatcher.cs           pure attribution, no dependencies
-  Domain/                      four entities, two enums
-  Data/                        one repository over one context, four tables
+    SepaPaymentFileBuilder.cs  pure pain.001 XML from a batch, no dependencies
+    SepaSchema.cs, SepaText.cs the schema and the character rules that builder obeys
+    IHoldedFinanceAdminService.cs  Finance's own page's interface (E, plus the connector overview)
+  Domain/                      six entities, two enums
+  Data/                        one repository over one context, six tables
+  Resources/                   the pain.001.001.09 schema the file is validated against
 ```
 
 That is what is there. The file structure is right; the work is inside the files, not between them.
 
-Three things the shapes say about the inside:
+Four things the shapes say about the inside:
 
 - Shape **D**'s three methods share one derivation of balance and owed from a set of cached journal
   lines, and one accessor for the cached Holded contact list. A fourth path to either is an
   inconsistency, not a variation.
 - Shape **C**'s collision policy is one rule with three call-site answers. The rule lives in one
   predicate; each writer states its own answer beside its own write. Not three rules.
+- Shape **E**'s file is pure: the builder takes a batch and returns bytes, and the service around it
+  owns the vendor call, the clock and the row. Everything that can be unit-tested without Holded is
+  in the builder.
 - A view model exists per row shape, not per page. Two page sections showing the same row of facts
   share one type.
 
@@ -108,16 +137,23 @@ Three things the shapes say about the inside:
 - Balance keeps Holded's sign everywhere except the two admin views, which flip it once for display
   so a positive figure is money owed to the member.
 - A Holded outage costs account *names*, never a page. Anything that is not a vendor failure throws.
-- Finance reads Holded's journal; it never writes one.
-- Finance touches no Budget or Tickets table — only their contracts.
+- Finance reads Holded's journal; it never writes one. Its single write into the books is a payment
+  against a purchase document, and only for a transfer in a generated file.
+- A payout transfer pays a member's own account only, never more than is owed, never more than the
+  cap the treasurer posted, and only to an IBAN Holded holds for that contact.
+- A generated file is immutable and is the record: the XML is stored as sent and validates against
+  the schema before it is stored.
+- A transfer books at most once. A second attempt is a no-op that says so, not a second payment.
+- A raw IBAN lives in the bank file, in the transfer row behind it, and in the contact write that
+  hands it to Holded. Every log line, audit entry and screen shows it masked.
+- Erasure removes the member's contact link and nothing else. The Holded contact is Holded's
+  record; the payout files and transfers are the accounting record, and both stay.
+- Finance touches no Budget, Holded or Tickets table — only their contracts.
 
 ## 5. Seams
 
 Specified, not built. Not ranked, not struck; items touching these callers are shaped by them.
 
-- **A read interface for cross-section consumers.** Shapes B and D are what other sections actually
-  call; shape A and C's writes are Finance's own page and Expenses' push. The repo pattern says a
-  read interface. Needs Peter — public-surface addition.
 - **Line-level attribution.** A multi-line invoice booked across several Holded accounts lands wholly
   on the first line's category. Deliberate v1 simplification, still true.
 - **No retry on creditor-number resolution** (nobodies-collective/Humans#972). The one-shot lookup
@@ -127,6 +163,9 @@ Specified, not built. Not ranked, not struck; items touching these callers are s
   repository write.
 - **`holded_*` tables under a section called Finance** (nobodies-collective/Humans#1012). A rename is
   schema work, deferred wholesale.
+- **Booking is not cancellable mid-flight.** `BookSepaTransferAsync` takes no cancellation token by
+  design — a half-posted payment is worse than a slow one — so the whole posting loop runs to the
+  end once started.
 
 ## 6. Deliberately not done
 
@@ -141,15 +180,19 @@ Specified, not built. Not ranked, not struck; items touching these callers are s
   site with a 2-minute TTL, which is the whole caching need.
 - **No `.resx`.** English-only finance-admin pages with zero localizer call sites.
 - **No per-report paid state.** Payment is an account-level fact; attributing it to one report fakes
-  an attribution that does not exist.
+  an attribution that does not exist. A SEPA payout pays a balance, not a report.
 - **No nullable `Balance` on the creditor DTOs.** Both reads return null wholesale when an account has
   no cached lines, so a returned status or ledger always has a balance. `HoldedCreditorAccountRow`
   keeps its `decimal?` — the admin list does carry accounts with no lines yet.
 - **No `Name` on `HoldedCreditorLedger`.** It was exactly `Contact?.Name`; the statement header reads
   through the contact (Peter, 2026-08-18).
-- **No split of `Service.cs` into per-shape services.** The four shapes share the repository, the
-  clock and the contact cache; splitting would trade one long file for four files and a fifth
-  coordinating them.
+- **No split of `Service.cs` into per-shape services.** The shapes share the repository, the clock
+  and the contact cache; splitting would trade one long file for several files and one coordinating
+  them. The pure parts (matcher, file builder) are already out.
+- **No bank-side reconciliation.** Nothing reads a bank statement back; "the file was uploaded" is a
+  human fact the treasurer asserts by pressing Book.
+- **No SEPA erasure.** A payout file is the accounting record; the member's IBAN inside it outlives
+  the member's contact link.
 
 ## Load-bearing weirdness
 
@@ -169,9 +212,15 @@ Settled; do not re-litigate.
   array; one such contact once blanked every account name in production.
 - **The unresolved card is a feature of a missing retry.** It exists because nothing retries the
   number resolution, and it is the only place those members are bindable.
+- **The treasury account is never inferred.** With `Sepa:TreasuryAccountId` unset the Book buttons do
+  not render; Holded would otherwise pay from whatever it defaults to, and that money is real.
+- **`Sepa:Creditor*` names the debtor.** The config keys predate the payout feature; in a payout the
+  organisation is the debtor, and that is where the values land. Renaming the keys is a deploy
+  change for a spelling.
 
 ## History
 
 | Run | Anchor | Headline | PR |
 |---|---|---|---|
+| [2026-09-06](../../../../docs/health/runs/2026-09-06-Finance.md) | `10199a23` | Second target; the section moved (SEPA payout and GDPR shapes, read split shipped). Docs and comments narrated the moves and counted things; three named invariants had no test and one test pinned an absence. No code defect found. A raw IBAN on the creditor statement contradicts the docs — Peter's call. | pending |
 | [2026-08-18](../../../../docs/health/runs/2026-08-18-Finance.md) | `41fd7374d` | First target. Doc led with 23 routes the section does not serve; a tag-collision bug in provisioning; a published DTO with no consumer. Prod code −113 lines, tests 55 → 92, mutation 34.4% → 57.9%. | [#1374](https://github.com/peterdrier/Humans/pull/1374) |

--- a/src/Sections/Humans.Finance/Domain/HoldedDocSyncState.cs
+++ b/src/Sections/Humans.Finance/Domain/HoldedDocSyncState.cs
@@ -3,10 +3,8 @@ using NodaTime;
 namespace Humans.Finance.Domain;
 
 /// <summary>
-/// Status of the purchase-document sync (Finance's own concern — doc matching feeds the
-/// unmatched queue). The ledger mirror's sync state moved to the Holded section with the
-/// mirror itself; this singleton replaces the old shared <c>holded_sync_states</c> row.
-/// Lazy-created on first sync — no seed.
+/// Status of the purchase-document sync only (the ledger mirror's sync state is the Holded
+/// section's). Singleton, lazy-created on first sync — no seed.
 /// </summary>
 internal sealed class HoldedDocSyncState
 {

--- a/src/Sections/Humans.Finance/Humans.Finance.csproj
+++ b/src/Sections/Humans.Finance/Humans.Finance.csproj
@@ -12,10 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-      Microsoft.NET.Sdk.Web adds these to ImplicitUsings; Microsoft.NET.Sdk.Razor does not.
-      Declaring them keeps the files moved out of Humans.Web byte-identical to their originals.
-    -->
+    <!-- Microsoft.NET.Sdk.Web adds these to ImplicitUsings; Microsoft.NET.Sdk.Razor does not. -->
     <Using Include="Microsoft.AspNetCore.Http" />
     <Using Include="Microsoft.AspNetCore.Routing" />
     <Using Include="Microsoft.Extensions.Logging" />

--- a/src/Sections/Humans.Finance/Section.cs
+++ b/src/Sections/Humans.Finance/Section.cs
@@ -19,7 +19,7 @@ namespace Humans.Finance;
 /// <c>Humans.Holded.Contracts</c>. <c>HoldedSyncJob</c> is not registered here either, and is
 /// not this section's: it is a shim over Holded's <c>IHoldedNightlySync</c>, which calls this
 /// section's <c>IHoldedFinanceService.SyncAsync</c> first, and it lives in
-/// <c>src/Sections/Humans.Holded/Jobs/</c> since G5 lane 5b-5 (nobodies-collective/Humans#866).
+/// <c>src/Sections/Humans.Holded/Jobs/</c>.
 /// </remarks>
 public sealed class Section : ISection
 {

--- a/src/Sections/Humans.Finance/Services/Service.cs
+++ b/src/Sections/Humans.Finance/Services/Service.cs
@@ -21,8 +21,8 @@ using NodaTime;
 namespace Humans.Finance.Services;
 
 /// <summary>
-/// Application-layer service for the Holded finance integration.
-/// Manages account provisioning, purchase-doc sync, actuals computation, and unmatched reporting.
+/// Finance's service: every shape in <c>Docs/health.md</c> §2, over one repository, one clock and
+/// one cached Holded contact list.
 /// </summary>
 internal sealed class Service(
     IHoldedRepository repo,
@@ -73,10 +73,8 @@ internal sealed class Service(
         var usedTags = map.Where(m => m.IsActive).Select(m => m.Tag).ToHashSet(StringComparer.Ordinal);
         var currentActiveCatIds = categories.Select(c => c.Id).ToHashSet();
 
-        // Track the rolling "next free" number across ToAdd assignments.
         int nextFree = blockStart;
 
-        // Walk categories in stable order: group then category name.
         foreach (var (catId, catName, groupName) in categories
             .OrderBy(c => c.Group, StringComparer.Ordinal)
             .ThenBy(c => c.Name, StringComparer.Ordinal))
@@ -97,7 +95,6 @@ internal sealed class Service(
                 var tag = UniqueTag(groupName, catName, catId, usedTags);
                 usedTags.Add(tag);
 
-                // Advance nextFree past any already-used numbers.
                 while (usedNumbers.Contains(nextFree))
                     nextFree++;
                 var proposed = nextFree;
@@ -128,7 +125,6 @@ internal sealed class Service(
                 State: "Orphan"));
         }
 
-        // Final nextFree after all assignments.
         while (usedNumbers.Contains(nextFree))
             nextFree++;
 
@@ -308,7 +304,6 @@ internal sealed class Service(
                 d.ContactName,
                 d.Total,
                 ReasonFor(d),
-                // TODO(probe): confirm Holded deep-link URL format
                 $"https://app.holded.com/purchases/{d.HoldedDocId}"))
             .ToList();
     }
@@ -823,7 +818,7 @@ internal sealed class Service(
 
         // Same re-check as EnsureCreditorContactAsync: the row below carries the contact id, Source and
         // CreatedAt read above, so writing it over an admin's newer binding reverts it wholesale
-        // (nobodies-collective/Humans#995). No I/O since that read, so the window is sub-millisecond.
+        // (nobodies-collective/Humans#995).
         if (!await BindingUnchangedAsync(nameof(SetCreditorAccountNumAsync), userId, binding, ct)) return;
 
         var now = clock.GetCurrentInstant();
@@ -997,9 +992,8 @@ internal sealed class Service(
         var unavailable = BookingUnavailableReason();
         if (rows.Count == 0 || unavailable is not null) return (rows, unavailable);
 
-        var bindingByUser = (await repo.GetCreditorContactsAsync(ct))
-            .GroupBy(c => c.UserId)
-            .ToDictionary(g => g.Key, g => g.First());
+        // UserId is the one column the DB keeps unique, so this cannot throw.
+        var bindingByUser = (await repo.GetCreditorContactsAsync(ct)).ToDictionary(c => c.UserId);
 
         // One pull for the whole screen — the same full list the doc sync already walks. A vendor
         // failure leaves coverage unknown, and an unknown coverage still offers the button: the
@@ -1290,7 +1284,6 @@ internal sealed class Service(
         if (!usedTags.Contains(baseTag))
             return baseTag;
 
-        // Disambiguate with first 4 hex chars of the category id.
         return baseTag + categoryId.ToString("N")[..4];
     }
 }

--- a/src/Sections/Humans.Finance/Views/Finance/Holded.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/Holded.cshtml
@@ -275,7 +275,7 @@
                                 }
                                 else
                                 {
-                                    <span class="text-muted" title="@(d.IsApproved is null ? "Pre-v2 row, not re-synced yet" : "Still a draft in Holded")">—</span>
+                                    <span class="text-muted" title="@(d.IsApproved is null ? "Not synced since approval tracking was added" : "Still a draft in Holded")">—</span>
                                 }
                             </td>
                             <td>

--- a/src/Sections/Humans.Finance/Views/Finance/HoldedAccounts.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/HoldedAccounts.cshtml
@@ -100,7 +100,7 @@
         Func<HoldedProvisioningRow, IHtmlContent> notesCell = @<text>
             @if (string.Equals(item.State, "Orphan", StringComparison.Ordinal))
             {
-                <span>Account exists in Holded but has no matching category — archived locally, not deleted from Holded.</span>
+                <span>Account exists in Holded but has no matching category — nothing is removed here or in Holded.</span>
             }
         </text>;
         var planRows = Model.Rows

--- a/src/Sections/Humans.Finance/Views/Finance/HoldedAccounts.cshtml
+++ b/src/Sections/Humans.Finance/Views/Finance/HoldedAccounts.cshtml
@@ -3,7 +3,7 @@
 @using Microsoft.AspNetCore.Html
 @{
     ViewData["Title"] = "Holded Account Provisioning";
-    var blockStart = (int)(ViewBag.BlockStart ?? 62900100);
+    var blockStart = (int)ViewBag.BlockStart;
     var toAddRows = Model.Rows.Where(r => r.State == "ToAdd").ToList();
     var hasToAdd = toAddRows.Count > 0;
 }

--- a/src/Sections/Humans.Holded/Docs/data-access.md
+++ b/src/Sections/Humans.Holded/Docs/data-access.md
@@ -42,7 +42,7 @@ Finance when a SEPA transfer is booked) and `IHoldedCallLog`
 are its only outbound
 dependencies, plus `IOptions<HoldedSectionOptions>` for the monthly
 call-budget display. Implements `IHoldedService` (the ledger-read
-surface consumed cross-section by `HoldedFinanceService` —
+surface consumed cross-section by Finance's `Service` —
 `GetLedgerLinesAsync`, `GetAccountBalancesAsync`) and `IHoldedAdminService`
 (the `/Holded` admin-overview surface — usage, monthly call counts,
 per-account reconciliation status, account statements). No

--- a/src/Sections/Humans.Users/Docs/debt.yml
+++ b/src/Sections/Humans.Users/Docs/debt.yml
@@ -9,8 +9,5 @@ inbox:
     what: "Misbound resource keys in Controllers/ProfileController.cs — Profile_EmailDeleted, Profile_EmailVisibilityUpdated and Profile_NotificationTargetUpdated are bound to UsersResource but the keys live in SharedResource, so each renders as its own key name to the user in all six languages. Found by running Onboarding's new binding sweep repo-wide (/section-doctor on Onboarding 2026-08-23)."
     review: light
   - added: 2026-08-27
-    what: "AccountDeletionService.cs:200-201 and Docs/Users.md:212 both justify the erasure fan-out's sequential order by citing GdprExportService as authority; that reason is obsolete (design-rules.md §8a — independent factory-created contexts are safe concurrently). Sequential stays, the reason changes (finding 22, /section-doctor on Gdpr 2026-08-27)."
-    review: light
-  - added: 2026-08-27
     what: "ProfileController.DownloadData has no catch, so a GDPR export contributor failure is an unhandled 500 there, where the same failure on /Guest/DownloadData sets an error toast and redirects (finding 16, /section-doctor on Gdpr 2026-08-27)."
     review: panel

--- a/src/Sections/Humans.Users/Docs/debt.yml
+++ b/src/Sections/Humans.Users/Docs/debt.yml
@@ -9,5 +9,8 @@ inbox:
     what: "Misbound resource keys in Controllers/ProfileController.cs — Profile_EmailDeleted, Profile_EmailVisibilityUpdated and Profile_NotificationTargetUpdated are bound to UsersResource but the keys live in SharedResource, so each renders as its own key name to the user in all six languages. Found by running Onboarding's new binding sweep repo-wide (/section-doctor on Onboarding 2026-08-23)."
     review: light
   - added: 2026-08-27
+    what: "AccountDeletionService.cs:200-201 and Docs/Users.md:212 both justify the erasure fan-out's sequential order by citing GdprExportService as authority; that reason is obsolete (design-rules.md §8a — independent factory-created contexts are safe concurrently). Sequential stays, the reason changes (finding 22, /section-doctor on Gdpr 2026-08-27)."
+    review: light
+  - added: 2026-08-27
     what: "ProfileController.DownloadData has no catch, so a GDPR export contributor failure is an unhandled 500 there, where the same failure on /Guest/DownloadData sets an error toast and redirects (finding 16, /section-doctor on Gdpr 2026-08-27)."
     review: panel

--- a/tests/Humans.Finance.Tests/FinanceArchitectureTests.cs
+++ b/tests/Humans.Finance.Tests/FinanceArchitectureTests.cs
@@ -6,23 +6,14 @@ using Microsoft.AspNetCore.Authorization;
 namespace Humans.Finance.Tests;
 
 /// <summary>
-/// Architecture tests enforcing the section shape for Finance
-/// (nobodies-collective/Humans#866, G5).
+/// Architecture tests enforcing the section shape for Finance.
 /// </summary>
-/// <remarks>
-/// Replaces <c>Humans.Application.Tests/Architecture/FinanceArchitectureTests.cs</c>. Its
-/// namespace-pinning test is gone — the assembly boundary subsumes it (design §15 step 11) —
-/// and so is its "does not reference EF Core" test, which asserted a property of
-/// <c>Humans.Application</c> that no longer says anything about this section: the section
-/// project references EF Core because its repository lives in it. The rule that matters,
-/// "only the repository touches the DbSets", is the universal HUM0025 analyzer's job.
-/// </remarks>
 public class FinanceArchitectureTests
 {
     [HumansFact]
     public void ContractsDoNotReExposeTheHoldedConnector()
     {
-        // The Holded HTTP client belongs to the Holded section (G5 lane 4b-2f) and is consumed by
+        // The Holded HTTP client belongs to the Holded section and is consumed by
         // Expenses as well as Finance. This leaf still may not name Humans.Application or
         // Humans.Domain, which is why HoldedCreditorLedger.Lines carries Finance's own
         // CreditorLedgerLine instead of the connector's HoldedLedgerLineDto.
@@ -35,9 +26,7 @@ public class FinanceArchitectureTests
     [HumansFact]
     public void FinanceControllerRequiresFinanceAdminOrAdmin()
     {
-        // Moved from Humans.Application.Tests' EndpointAuthorizationTests, which sweeps Shell's
-        // controllers and can no longer name this one by type. Nothing proves the negative at
-        // runtime: the render tests only ever sign in as Admin.
+        // Nothing proves the negative at runtime: the render tests only ever sign in as Admin.
         typeof(FinanceController)
             .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false)
             .Cast<AuthorizeAttribute>()

--- a/tests/Humans.Finance.Tests/ServiceTests.cs
+++ b/tests/Humans.Finance.Tests/ServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using AwesomeAssertions;
 using Humans.AuditLog.Contracts;
@@ -270,6 +272,34 @@ public class HoldedFinanceServiceTests
         d3.MatchStatus.Should().Be(HoldedMatchStatus.Unmatched);
         d3.MatchSource.Should().Be(HoldedMatchSource.None);
         d3.BudgetCategoryId.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task Sync_DocWithNoDraftFlag_IsStoredAsNotApproved()
+    {
+        // Holded's list item may omit `draft` entirely. Absent is not "approved": only an explicit
+        // `draft: false` counts toward actuals (Service.MapDoc, strict equality).
+        _repo.GetCategoryMapAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<HoldedCategoryMap>());
+        _repo.GetOrCreateDocSyncStateAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new HoldedDocSyncState());
+        _client.ListPurchaseDocumentsAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(
+            (IReadOnlyList<HoldedPurchaseDocListItemDto>)
+            [
+                new()
+                {
+                    Id = "d-null", DocNumber = "F010", ContactName = "Dan", Date = Instant.FromUtc(2026, 4, 15, 10, 0),
+                    Subtotal = 10, Tax = 0, Total = 10, Currency = "eur", IsDraft = null,
+                    Lines = [new HoldedPurchaseLineDto { Amount = 10, AccountId = "acc-x", Tags = [] }],
+                    Tags = [],
+                },
+            ]);
+        IReadOnlyList<HoldedExpenseDoc>? capturedDocs = null;
+        await _repo.UpsertDocsAsync(
+            Arg.Do<IReadOnlyList<HoldedExpenseDoc>>(d => capturedDocs = d),
+            Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+
+        await MakeService().SyncAsync(Xunit.TestContext.Current.CancellationToken);
+
+        capturedDocs.Should().ContainSingle().Which.IsApproved.Should().BeFalse();
     }
 
     [HumansFact]
@@ -1682,6 +1712,24 @@ public class HoldedFinanceServiceTests
             .And.NotContain(AnaIban, "the export masks the IBAN even though the payout row keeps it raw");
     }
 
+    [HumansFact]
+    public async Task EraseForUser_DropsTheBindingAndDeclaresThePayoutsRetained()
+    {
+        // Article 17: the binding is erased in full; the payout files are the accounting record
+        // and stay, on a stated legal basis the declaration carries.
+        var userId = Guid.NewGuid();
+        _repo.DeleteCreditorContactAsync(userId, Arg.Any<CancellationToken>()).Returns(true);
+        var svc = MakeService();
+
+        await svc.EraseForUserAsync(userId, Xunit.TestContext.Current.CancellationToken);
+
+        await _repo.Received(1).DeleteCreditorContactAsync(userId, Arg.Any<CancellationToken>());
+        svc.ErasureDeclaration.Should().ContainKey(GdprExportSections.HoldedCreditorAccount)
+            .WhoseValue.Should().BeNull("the binding is erased in full");
+        svc.ErasureDeclaration.Should().ContainKey(GdprExportSections.SepaPayouts)
+            .WhoseValue.Should().Contain("Art. 17(3)(b)");
+    }
+
     // ─── Purchase-doc sync state, as the /Holded screen reads it ─────────────────
 
     [HumansFact]
@@ -2025,6 +2073,30 @@ public class HoldedFinanceServiceTests
             Arg.Is<string>(d => d.Contains("ES79****789", StringComparison.Ordinal)
                                 && !d.Contains(AnaIban, StringComparison.Ordinal)),
             actor, userId, Arg.Any<string>());
+    }
+
+    [HumansFact]
+    public async Task GenerateSepaPayout_StoresTheBytesTheTreasurerDownloads()
+    {
+        // The stored XML is the record of what the bank was given, so it must be the same string
+        // the response streams — and the checksum must be that string's, not a rebuilt one's.
+        ConfigureSepa();
+        SeedPayableCreditor();
+        SepaPayoutFile? stored = null;
+        await _repo.AddSepaPayoutAsync(
+            Arg.Do<SepaPayoutFile>(f => stored = f),
+            Arg.Any<IReadOnlyList<SepaPayoutTransfer>>(), Arg.Any<CancellationToken>());
+
+        var result = await MakeService().GenerateSepaPayoutAsync(
+            [new SepaPayoutSelection(40000004, 12.34m)], 50m, Guid.NewGuid(),
+            Xunit.TestContext.Current.CancellationToken);
+
+        result.Succeeded.Should().BeTrue();
+        stored.Should().NotBeNull();
+        stored!.Xml.Should().Be(result.Xml);
+        stored.FileName.Should().Be(result.FileName);
+        stored.Checksum.Should().Be(
+            Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(result.Xml!))).ToLowerInvariant());
     }
 
     [HumansFact]

--- a/tests/Humans.Finance.Tests/ServiceTests.cs
+++ b/tests/Humans.Finance.Tests/ServiceTests.cs
@@ -1038,20 +1038,6 @@ public class HoldedFinanceServiceTests
     }
 
     [HumansFact]
-    public async Task SetCreditorContact_AccountOutsideCreditorBlock_FailsWithoutTouchingHolded()
-    {
-        // The number arrives on a POST; the filtered dropdown is not a server-side gate.
-        var result = await MakeService().SetCreditorContactAsync(
-            Guid.NewGuid(), 42000000, Xunit.TestContext.Current.CancellationToken);
-
-        result.Succeeded.Should().BeFalse();
-        result.ErrorMessage.Should().Contain("outside the member creditor block");
-        await _repo.DidNotReceive().UpsertCreditorContactAsync(
-            Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
-        await _client.DidNotReceive().ListContactsAsync(Arg.Any<CancellationToken>());
-    }
-
-    [HumansFact]
     public async Task ListCreditorAccounts_BoundAccountWithNoHoldedContact_YieldsRowWithBlankName()
     {
         var userId = Guid.NewGuid();
@@ -1569,10 +1555,14 @@ public class HoldedFinanceServiceTests
     [InlineData(42000000)]
     public async Task SetCreditorContact_JustOutsideTheBlock_IsRefused(int accountNum)
     {
+        // The number arrives on a POST; the filtered dropdown is not a server-side gate.
         var result = await MakeService().SetCreditorContactAsync(
             Guid.NewGuid(), accountNum, Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("outside the member creditor block");
+        await _repo.DidNotReceive().UpsertCreditorContactAsync(
+            Arg.Any<HoldedCreditorContact>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
         await _client.DidNotReceiveWithAnyArgs().ListContactsAsync(Arg.Any<CancellationToken>());
     }
 
@@ -1591,25 +1581,6 @@ public class HoldedFinanceServiceTests
             Guid.NewGuid(), accountNum, Xunit.TestContext.Current.CancellationToken);
 
         result.Succeeded.Should().BeTrue();
-    }
-
-    // ─── Negative rule: the sync never removes a doc ─────────────────────────────
-
-    [HumansFact]
-    public async Task Sync_DocsMissingFromHolded_AreNeverDeleted()
-    {
-        // "The sync job cannot delete HoldedExpenseDoc rows" — Holded-side deletions are out of scope,
-        // so a doc that stops appearing in the pull is simply not upserted, never removed.
-        _repo.GetCategoryMapAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new List<HoldedCategoryMap>());
-        _repo.GetOrCreateDocSyncStateAsync(Arg.Any<CancellationToken>()).Returns(new HoldedDocSyncState());
-        _client.ListPurchaseDocumentsAsync(Arg.Any<CancellationToken>())
-            .Returns(new List<HoldedPurchaseDocListItemDto>());
-
-        var result = await MakeService().SyncAsync(Xunit.TestContext.Current.CancellationToken);
-
-        result.DocCount.Should().Be(0);
-        _repo.ReceivedCalls().Select(c => c.GetMethodInfo().Name)
-            .Should().NotContain(n => n.Contains("Delete", StringComparison.Ordinal));
     }
 
     // ─── Which Holded account an expense line is booked to ───────────────────────


### PR DESCRIPTION
## What

section-doctor, unattended daily run, Finance (second doctoring; anchor `10199a23`). Run file: `docs/health/runs/2026-09-06-Finance.md`. Skill issues filed from this run: peterdrier/Humans#1612, #1692, #1693.

## Why

The section moved since 2026-08-18 — SEPA payout generation and booking, GDPR export and erasure, and the read/write interface split all shipped — and the target in `Docs/health.md` is regenerated to match, with two claims the old target got wrong (audit entries mask the IBAN; erasure deletes only the binding) corrected against the code.

The code is sound. What accumulated is sediment: docs that counted actions and tables (every count wrong), listed files as manifests, carried a phantom migration and narrated the moves that built the section; comments that restated the next line or told a lane story; three named invariants with no test; one test that pinned an absence.

### Worked

- Docs: `Finance.md`, `authorization.md`, `data-access.md`, `expense-reimbursement-process.md`, `features/sepa-payout.md` describe the section as it is; the trigger block now names both cross-section files it asserts about.
- Comments and view text: wrong, restating and narrated-move comments cut across the service, controller, tests, `Section.cs`, csproj and `HoldedDocSyncState.cs`; two treasurer-facing strings reworded.
- Tests: three invariant-pinning tests added (`IsDraft == null` is not approved; stored SEPA XML and checksum equal what is returned; erasure keeps the payouts slice on a stated basis). Two absence tests retired, one duplicate folded.
- Code: a dead view fallback cut; a silent `GroupBy…First()` over a unique key is now `ToDictionary`.
- Literal sweep: the class name `HoldedFinanceService` corrected in `gdpr-export.md`, the dependency graph and Holded's `data-access.md`.
- Section ledger `Docs/debt.yml` created (dead `IsActive` state pending a column drop; the statement's view-side sign flip has no test).
- Sweep commit applying merged run files' queues: two Settings debts to the central ledger, one Agent debt to its section ledger, and `memory/process/debt-ledger-additions.md` split so a section's own test project routes to the section ledger (the Agent run's queued question; the reading chosen is the one section-doctor already practises — say if the other was intended).
- Resume 2026-09-14 (Peter's answers, below): IBAN docs amended and the `iban-mask-in-logs` atom carries the screen rule; `ContractsDoNotReExposeTheHoldedConnector` retired; the `section-file-layout` conformance row made advisory; `main` merged in.

### Skipped

- Finding 14 — the fix is a Finance migration.
- Finding 24 — needs a user id on the read contract.

## Existing surface checked

No new durable surface. No schema change, no resx change, no interface change. The three tests use the existing fixture and helpers in `ServiceTests.cs`.

## Checklist

- [ ] **Section labeled** — Finance.
- [x] **Targeting `main` on `peterdrier/Humans`**.
- [x] **Branched off `origin/main`** (`10199a23`; `main` merged 2026-09-14).
- [x] **Issue refs are qualified**.
- ~~**EF migrations**~~ — none.
- ~~**NuGet packages updated?**~~ — no.
- [x] **New project rule?** — none new; `debt-ledger-additions` clarified by the sweep, `iban-mask-in-logs` carries Peter's screen ruling.
- [x] **Reuse-first checked** — nothing added.
- [x] **Build + test pass locally** — `dotnet build Humans.slnx -v quiet`, `dotnet test Humans.slnx -v quiet` green; `dotnet format whitespace --verify-no-changes` clean.
- ~~**Nav coverage**~~ — no new page.
- [x] **No magic strings** — nothing introduced.
- ~~**Dates/times via NodaTime**~~ — not touched.

## Reviewer notes

Admin-only views (`/Finance/*`), so the two reworded strings take no localization keys. The Finance test project is at 158 tests after two retirements and one fold. Sweep commit `b82d9288` is the only commit touching files outside Finance's lane and the three literal-sweep docs; the resume commit also touches `docs/architecture/section-conformance.yml` and `memory/code/iban-mask-in-logs.md` at Peter's direction. The Expenses twin of the retired absence test (`ExpensesArchitectureTests.ContractsDoNotReExposeTheHoldedConnector`) is outside this run's lane and still stands.

## Needs Peter

Answered 2026-09-14; applied items are ticked.

- [x] 1 — `CreditorStatement.cshtml:64` renders a member's IBAN raw; the docs say every screen masks it. Mask the view, or amend the docs' "exactly two places" claim? **Amend the docs**: an admin screen and the member's own view may show it in full.
- [x] 13 — retire `ContractsDoNotReExposeTheHoldedConnector` (assembly-reference absence test), or keep architecture tests exempt from `no-tests-for-absences`? **Retire it**; no exemption.
- [x] 18 — `SepaOptions.cs` (and `HoldedSectionOptions.cs`, `StoreSectionOptions.cs`) at the project root against `section-file-layout`: move them, or widen the rule to `*Options.cs`? **Neither**: the layout is a convention, not a rule; its conformance row is now advisory.
- [x] 20 — `tests/Humans.Finance.Tests/stryker-config.json` `break: 0` means the mutation gate cannot fail. Intentional? **Stryker is not in use**; leave it.
- [x] 21 — `freshness-catalog.yml` carries no Finance rows. Add them, or is the per-doc trigger block the intended mechanism for sections? **Per-doc trigger block.**
- [x] 22 — the prior run's Needs-Peter 6 (a trigger block must name what its doc asserts about) has now bitten twice. Adopt, or drop the ask? **Dropped**; the 2026-08-18 item is ticked.
- [x] Lesson, Phase 2 — the blocked set is built from open PRs, so a run that has not yet opened its PR is invisible to the next selector (finding 25). Filed: peterdrier/Humans#1612.
- [x] Lesson, Phase 3d — haiku mechanical threads (Prose, Conformance) returned incomplete or self-contradicting output twice in one run; ask each to echo the rule list it ran with a per-rule result. Filed: peterdrier/Humans#1692.
- [x] Lesson, Phase 3d — the Inbox thread reported a carry-forward item still open that a shipped migration closes; carry-forward status is main's to verify against code before ranking. Filed: peterdrier/Humans#1693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTAdKqZ4vDtk2Q4a6k9t85