### PR TITLE
doctor(Camps): clarify T8/T4 run-file wording per post-merge review

### DIFF
--- a/docs/health/runs/2026-08-28-Camps.md
+++ b/docs/health/runs/2026-08-28-Camps.md
@@ -56,20 +56,24 @@ retro and finding M9.
   (non-public seasons refused to anonymous viewers on `/Camps/{slug}`) is
   pinned only by a permanently-skipped test tracked to
   nobodies-collective/Humans#993 — the skip reason says the production gate
-  does not exist. health.md invariant 1 was written to match the code's actual
-  behavior, and the gap is Peter's call. Ruling: build the gate — built in
-  peterdrier/Humans#1624; the skipped test is unskipped there.
+  does not exist. At run time the invariant was target-only on the detail
+  routes — directory, search, and API filtered to public statuses, but
+  `/Camps/{slug}` rendered any season — and the gap was Peter's call.
+  Ruling: build the gate — built in peterdrier/Humans#1624; the skipped
+  test is unskipped there.
 - **T1 (queued — Needs-Peter 4)**: `PublicCampDetail_DoesNotExposeEarlyEntryState`
   asserts an absence by property-name substring over two types — it passes if
   the leak is renamed or nested. Sole pin for "membership/EE data never render
   publicly"; a behavioral replacement (anonymous Details render carries no
   member/EE data) is a new-test decision. Ruling: yes — replaced in
   peterdrier/Humans#1624.
-- **T4 (queued — Needs-Peter 5)**: `CampServiceTests` injects
-  `_campInfoInvalidator` and never asserts on it — invariant "every mutating
-  path invalidates" has zero coverage on the section's main write service
-  (only `CampRoleServiceTests` pins it, on 3 writes). Ruling: yes — write-verb
-  theories added on `CachingCampServiceTests` in peterdrier/Humans#1624.
+- **T4 (queued — Needs-Peter 5)**: invariant "every mutating path
+  invalidates" had zero write-verb coverage (only `CampRoleServiceTests`
+  pinned it, on 3 writes). The seam is the caching decorator — inner
+  `CampService` uses its injected `_campInfoInvalidator` only for the GDPR
+  erasure path — so the pin belongs on `CachingCampService`, not
+  `CampServiceTests`. Ruling: yes — write-verb theories added on
+  `CachingCampServiceTests` in peterdrier/Humans#1624.
 - **Tests matrix gap (fixed)**: `RejectCampMemberAsync` and
   `RemoveCampMemberAsync` had no cross-camp denial test despite sharing the
   scoped lookup with `ApproveCampMemberAsync`. Two pins added, mirroring the

--- a/docs/health/runs/2026-08-28-Camps.md
+++ b/docs/health/runs/2026-08-28-Camps.md
@@ -57,8 +57,10 @@ retro and finding M9.
   pinned only by a permanently-skipped test tracked to
   nobodies-collective/Humans#993 — the skip reason says the production gate
   does not exist. At run time the invariant was target-only on the detail
-  routes — directory, search, and API filtered to public statuses, but
-  `/Camps/{slug}` rendered any season — and the gap was Peter's call.
+  routes — directory, name search, and API filtered to public statuses
+  (GUID search deliberately resolves any camp: routing convenience, not
+  authorization), but `/Camps/{slug}` rendered any season — and the gap
+  was Peter's call.
   Ruling: build the gate — built in peterdrier/Humans#1624; the skipped
   test is unskipped there.
 - **T1 (queued — Needs-Peter 4)**: `PublicCampDetail_DoesNotExposeEarlyEntryState`


### PR DESCRIPTION
## What

Re-lands two review fixes to `docs/health/runs/2026-08-28-Camps.md` that Codex raised on peterdrier/Humans#1561 minutes before it merged — the fix commit missed the merge, so this lands it fresh from `main`.

## Why

Codex's round-4 findings were verified as real wording defects in the merged run file:
- The T8 disposition claimed health.md invariant 1 "was written to match the code's actual behavior" — contradicting the finding itself (the `/Camps/{slug}` gate did not exist at run time). Now says the invariant was target-only on the detail routes, with the ruling (gate built in peterdrier/Humans#1624) unchanged.
- The T4 entry framed the missing invalidation coverage as `CampServiceTests`' to fill; the seam is the caching decorator (inner `CampService` uses its invalidator only for the GDPR erasure path), which is where peterdrier/Humans#1624 adds the theories. The entry now names the decorator.

Disposition replies on the #1561 threads reference this change.

## Existing surface checked

No new durable surface — docs-only, one file.

## Checklist

- [x] **Section labeled** — Camps.
- [x] **Targeting `main` on `peterdrier/Humans`** (the QA fork).
- [x] **Branched off `origin/main`**, not `upstream/main`.
- [x] **Issue refs are qualified** (`owner/repo#N`).
- ~~EF migrations~~ — none, docs-only.
- ~~NuGet packages updated?~~ — none.
- ~~New project rule?~~ — none.
- [x] **Reuse-first checked** — no new surface.
- [x] **Build + test pass locally** — docs-only change; no build needed per `memory/process/scoped-inner-loop-tests.md`.
- ~~Nav coverage~~ — no pages.
- ~~No magic strings~~ — prose only.
- ~~Dates/times via NodaTime~~ — n/a.

## Reviewer notes

One commit, +12/−8 in a run-record file. The same text was already reviewed as commit 223ac6c2 on #1561's branch; this is the cherry-pick onto post-merge `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BdAuVKbBkB9NeWnU2Jkym

---
_Generated by [Claude Code](https://claude.ai/code/session_011BdAuVKbBkB9NeWnU2Jkym)_