### PR TITLE
chore(deps): group Hangfire packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      # Hangfire.NetCore (via AspNetCore) pins Hangfire.Core to an exact version;
+      # bumping one alone fails restore with NU1608. Move them together.
+      hangfire:
+        patterns:
+          - "Hangfire.Core"
+          - "Hangfire.AspNetCore"
     labels:
       - "dependencies"
       - "nuget"


### PR DESCRIPTION
Hangfire.NetCore (pulled by Hangfire.AspNetCore) pins Hangfire.Core to an exact version, so dependabot's solo Core bump in #1569 failed restore with NU1608. A `groups` entry makes dependabot bump both in one PR.

Also created the missing `nuget` and `github-actions` labels in this repo, which dependabot has been complaining about on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)