### PR TITLE
doctor skill: consolidate the 49-run meta-review into gates

### DIFF
--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -15,6 +15,24 @@ history lives in the run files and the design spec. An issue reference earns its
 naming a live contract or a baseline a phase is bound to — never as provenance for a rule that
 already stands on its own.
 
+## Intention
+
+Humans is run by volunteers and, increasingly, read and changed by agents. Every section
+will be extended, debugged and rewritten many times by people and models who were not there
+when it was written, and each of them pays, in attention and in tokens, for every line,
+comment, doc claim and test still sitting there. This process exists to keep that price
+honest. Once a day one section is read whole, as it stands today, by something with the time
+to read all of it; whatever no longer earns its place is removed, whatever the docs claim is
+checked against what the code does, and any real defect met on the way is fixed. The measure
+is not a score or a diff size: it is that whoever opens the section next finds it smaller,
+truer, and doing exactly what it did — and that Peter can trust what the run says it did
+without re-reading the section himself.
+
+When a call is ambiguous, ask: *does this make the section truer and lighter for its next
+reader without changing what it does for its users, and will Peter be able to see and verify
+it?* Yes to both: do it. Anything that changes behaviour, widens surface, retires a guardrail,
+or cannot be verified is Peter's call, not the run's.
+
 ## Purpose
 
 **Every section converges, run over run, on the smallest and clearest form that still does
@@ -231,7 +249,8 @@ has nothing to report on scores 0, never "unknown, ranked last"), and picks:
 - **never-doctored tier:** the **median** by score — middle-out: the process proves itself on
   mid-sized sections; the biggest and smallest get their turn once the middle has been worked.
 - **re-doctor tier** (only once the never-doctored tier is empty): a section is eligible only
-  if its files changed on `origin/main` since the commit that last wrote its `Docs/health.md`;
+  if its files — guide page included — changed on `origin/main` since the commit that added
+  its newest run file (a doctor run is exactly that; any other edit to `health.md` is not one);
   ranked oldest last run first, ties by lowest score. The pick carries a `BASE: <sha>` line —
   Phase 3 diffs against it instead of re-reading the section cold.
 
@@ -291,7 +310,7 @@ Phase 2's selector script already built the solution on a normal run; only when 
 reforge needs a built solution and 3d's tool threads need the build. Do not look at its output until 3d.
 
 **A re-doctor reads the diff, not the section.** With a `BASE:` from Phase 2 (or, under
-`--section`, the last `origin/main` commit to the section's `health.md`), 3a's inventory is
+`--section`, the `origin/main` commit that added the section's newest run file), 3a's inventory is
 still complete, but 3b–3d read `git diff BASE..HEAD -- <section paths>` in full and skim the
 rest; the previous target and `health.md` history say what was already judged. A full cold
 assess is for a never-doctored section only.

--- a/.claude/skills/section-doctor/SKILL.md
+++ b/.claude/skills/section-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: section-doctor
-description: "Daily per-section review cycle driving a section toward the smallest, clearest form that still does everything it does today. Selects its section live each run (reforge surface score, middle-out, via a focused selector subagent — no stored plan), inventories every file in the section, derives the target shape before running any scan, then works parallel threads — shape, behavior/bugs, freshness, conformance, tests, prose/nav, inbox — into one ranked list and strikes it on a 2-3h budget. One PR per run; each run's report + Needs-Peter queue lives in its own docs/health/runs/ file; 'resume' applies Peter's answers later. Use for the morning section-improvement run, 'doctor <section>', or 'run section doctor'."
+description: "Daily per-section review cycle driving a section toward the smallest, clearest form that still does everything it does today. Selects its section live each run (scripted: reforge surface score, middle-out, then changed-since-last-run — no stored plan), inventories every file in the section, derives the target shape before running any scan, then works parallel threads — shape, behavior/bugs, freshness, conformance, tests, prose/nav, inbox — into one ranked list and strikes it on a 2-3h budget. One PR per run; each run's report + Needs-Peter queue lives in its own docs/health/runs/ file; 'resume' applies Peter's answers later. Use for the morning section-improvement run, 'doctor <section>', or 'run section doctor'."
 argument-hint: "[resume] [--section=<Name>] [--budget=2.5h] [--upstream-issues] [--mutation]"
 ---
 
@@ -35,8 +35,7 @@ A run is judged on three things:
   diff stats on the run's PR; the run file never restates it (Phase 5).
 - **Was every file actually looked at?** A finding-driven pass finds only what sits next to what
   it already suspects. Full coverage is what makes this a review rather than a sweep — and it is
-  where the bugs come from: Guide's and Finance's defects both surfaced because something read
-  everything, not because anything hunted for them.
+  where the bugs come from.
 - **Is the section still doing exactly what it did?** The constraint that buys all the latitude
   above.
 
@@ -78,10 +77,9 @@ Parse args; record start time (`date -u`).
 not deliverables, and a strike that runs `git add -A` commits anything sitting in the tree. The
 `.gitignore` entries for `/.phase-log` and `/.prs.json` stay as a backstop.
 
-**None of these variables survive between tool calls** — shell state is per-call, so `$TS`,
-`$RUNDIR` and `$WORKTREE` must be re-set at the top of any call that uses them. That is why every
-one of them derives from `$TS` alone, and why `$TS` is also the branch name: `section-doctor/$TS`
-is recoverable with `git rev-parse --abbrev-ref HEAD` at any point in the run.
+**None of these variables survive between tool calls** — re-set `$TS`, `$RUNDIR` and `$WORKTREE`
+at the top of any call that uses them. Every one derives from `$TS` alone, and `$TS` is also the
+branch name: `section-doctor/$TS` is recoverable with `git rev-parse --abbrev-ref HEAD`.
 
 **Shell rules that break a run when missed:**
 
@@ -146,6 +144,17 @@ Scope is frozen at the branch point — never reconcile against `origin/main` mi
 every Glob/Grep to `$WORKTREE`; in a cloud run `$WORKTREE` *is* the repo root and there is nothing
 to scope away.
 
+**Origin gate — run it in the same shell call as every `git push` of the run, Phase 2 through
+Phase 9.** A cloud container can rewrite the remotes on any resume, so a check at setup proves
+nothing about the push hours later:
+
+```bash
+git remote get-url origin | grep -qE 'github\.com[:/]peterdrier/Humans(\.git)?$' \
+  || { echo "origin is not peterdrier/Humans — stop, raise in Needs Peter"; exit 1; }
+```
+
+On a mismatch nothing is pushed and the run stops; never repoint the remote and retry.
+
 **Scope history checks to a named branch or ref, never `git log --all`** — on a run with a blocked
 branch set, `--all` surfaces commit subjects from that set and is not blindfold-safe.
 
@@ -159,11 +168,13 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) phase1 worktree" >> "$RUNDIR/phase-log"
 ```
 
 **Write the line out in full at every phase boundary, through Phase 7 — always the full
-`$(date -u +%Y-%m-%dT%H:%M:%SZ) <mark>` form.** The leading timestamp is what buckets the
-spend: `cost-report.py` skips any line that does not start with one, so a bare `phase4 …`
-mark silently folds that phase's cost into the row above it. Shell state does not
-survive between tool calls — a `mark()` helper defined here is gone by the next call, and so are
-`$RUNDIR`, `$TS` and `$WORKTREE`. Re-derive the path (or paste it literally) each time rather than
+`$(date -u +%Y-%m-%dT%H:%M:%SZ) <mark>` form, one mark per shell call, appended *before* the
+work it names starts.** The leading timestamp is what buckets the spend: `cost-report.py` skips
+any line that does not start with one, so a bare `phase4 …` mark silently folds that phase's
+cost into the row above it; two marks in one call share a timestamp and fold together; a mark
+written after the work prices it into the row before. Shell state does not survive between
+tool calls — a `mark()` helper defined here is gone by the next call, and so are `$RUNDIR`,
+`$TS` and `$WORKTREE`. Re-derive the path (or paste it literally) each time rather than
 relying on a variable set in an earlier call:
 
 | Phase | Mark (after the timestamp) |
@@ -206,65 +217,67 @@ python .claude/skills/section-doctor/select-section.py --prs "$RUNDIR/prs.json" 
 exit "${PIPESTATUS[0]}"   # tee would otherwise mask the selector's exit code (2/3 below)
 ```
 
-It computes the **blocked set** (sections named by open `section-doctor/` PRs' titles,
-`doctor(<Section>): …` — an open run PR must be dealt with before its section can be doctored
-again), the pool (every `src/Sections/` project), the **feature-active down-rank** (sections
+It computes the **blocked set** — sections named by open `section-doctor/` PRs' titles
+(`doctor(<Section>): …`) **and by `origin`'s recent `section-doctor/*` branches that have no PR
+yet** (read from the branch's run-file path; a run is still assessing for hours before its PR
+exists) — the pool (every `src/Sections/` project), the **feature-active down-rank** (sections
 touched by open non-doctor PRs sink to the tier bottom — picked only when nothing else is
 eligible there, never excluded), the tiers (previously-doctored iff
 `src/Sections/Humans.<X>/Docs/health.md` exists at the branch point; never-doctored always
 outranks), builds the solution (an unbuilt solution silently under-reports Reforge scores; the
-build also serves Phase 3/4), runs `reforge surface-score --format compact`, and takes the
-**median** of the ranked never-doctored tier — middle-out: the process proves itself on
-mid-sized sections; the biggest and smallest get their turn once the middle has been worked.
+build also serves Phase 3/4), runs `reforge surface-score --format compact` (a section reforge
+has nothing to report on scores 0, never "unknown, ranked last"), and picks:
+
+- **never-doctored tier:** the **median** by score — middle-out: the process proves itself on
+  mid-sized sections; the biggest and smallest get their turn once the middle has been worked.
+- **re-doctor tier** (only once the never-doctored tier is empty): a section is eligible only
+  if its files changed on `origin/main` since the commit that last wrote its `Docs/health.md`;
+  ranked oldest last run first, ties by lowest score. The pick carries a `BASE: <sha>` line —
+  Phase 3 diffs against it instead of re-reading the section cold.
+
 It prints `SECTION:` / `TIER:` / `RATIONALE:` plus the full ranked table for the run file, and
 an **`UPCOMING:`** line — the next 4 sections a repeat of this maths would pick, assuming each
 pick blocks itself and nothing else changes. The `tee` to `$RUNDIR/selection.txt` is what lets
-Phase 7 read that line hours later, after the selector's output has left context — without it the
-forecast silently drops out of the PR body. The forecast is purely informational (it goes in the
-PR body's header, Phase 7): no later run reads or honours it, and tomorrow's run recomputing
-differently is expected. The script falls back to a LOC ranking (flagged in its
-output) when reforge is unusable. Act on its verdicts — never re-derive the maths in-band:
+Phase 7 read that line hours later, after the selector's output has left context. The forecast
+is purely informational (PR body header, Phase 7): no later run reads or honours it. The script
+falls back to a LOC ranking (flagged in its output) when reforge is unusable. Act on its
+verdicts — never re-derive the maths in-band, and never pick by judgment:
 
-- **`ALL BLOCKED`** (exit 3): report the open PRs and stop. This is the one path that removes the
-  worktree immediately (Phase 9) — nothing has been written yet, so it is clean and
+- **`ALL BLOCKED`** (exit 3) and **`NOTHING CHANGED`** (exit 2, every eligible section
+  doctored and untouched since): report and stop. These are the paths that remove the worktree
+  immediately (Phase 9) — nothing has been written yet, so it is clean and
   `git worktree remove` succeeds without `--force`. In a cloud run there is no worktree to
   remove: just stop.
-- **`JUDGMENT REQUIRED`** (exit 2): every eligible section is previously-doctored. Only now
-  dispatch a focused **sonnet** selector subagent, giving it the script's table: read each
-  section's `Docs/health.md` for its last-assessed date, rank by days since that date combined
-  with change volume since it (`git log --stat` over the section's paths) — more and bigger
-  changes come sooner. Judgment call; no exact formula. It returns `SECTION:` / `TIER:
-  re-doctor` / `RATIONALE:` (≤3 lines) and nothing else.
 
 Sections passed over as blocked are noted in this run's run file under skipped
-(`<section> — open PR #N`); they need no other bookkeeping — the tier/staleness scan returns
-to them.
+(`<section> — open PR #N` or `— branch <name>`); they need no other bookkeeping.
 
 Take the selected section (or `--section`, which skips the selector but never the blocked
 set — check it with `select-section.py --prs "$RUNDIR/prs.json" --blocked-only`). Sections
 are `src/Sections/` projects only.
 
-**Name the run after the section, here.** A scheduled run opens a session titled after the
-routine, so every day's run is called `section-doctor-daily` and they are told apart only by
-their start time. This is the first moment the section is known, so rename the session now —
-`set_session_title` on the claude-code-remote MCP server, with this session's own id from
-`get_session` (call it with no `session_id` and it describes the caller):
+**Make the run visible now.** Commit the run file's header alone
+(`docs/health/runs/<yyyy-mm-dd>-<Section>.md`, Phase 5's naming; invocation, anchor commit,
+branch, budget, `PR: pending`) and push the branch — origin gate first (Phase 1). That file's
+path is what the next selector reads the section from; a branch with no push is invisible to
+it. No CI runs on a branch push without a PR.
+
+**Name the run after the section, here, once.** Every scheduled run is titled after the routine;
+rename the session now — `set_session_title` on the claude-code-remote MCP server, with this
+session's own id from `get_session` (no `session_id` describes the caller):
 
     section-doctor: <Section> — <yyyy-mm-dd>
 
-Skip it without comment when either tool is unavailable — an interactive run is already
-titled by whatever the human typed, and a rename is a convenience, never a gate. Do not
-rename again later: the title is how the run is found in a list, and a title that moves is
-worse than a generic one.
+Skip it without comment when either tool is unavailable; never rename again later.
 
 **A low reforge score is not evidence the section is healthy.** The score measures structure, never
 correctness — the lowest-scoring section in the solution was failing open on access control. Nothing
 in the ranking rubric surfaces that, so never read a good score as a reason to look less hard.
 
-**Never work a section in the blocked set.** A section with an open section-doctor PR has
-unmerged strikes that today's run cannot see — re-doctoring it duplicates work and produces
-conflicting PRs. A `--section` naming a blocked section stops like the all-blocked case — merge
-the open PR first, or use `resume` to work its Needs-Peter queue.
+**Never work a section in the blocked set.** A section with an open section-doctor PR or
+branch has unmerged strikes that today's run cannot see — re-doctoring it duplicates work and
+produces conflicting PRs. A `--section` naming a blocked section stops like the all-blocked
+case — merge the open PR first, or use `resume` to work its Needs-Peter queue.
 
 ## Phase 3: Assess
 
@@ -276,6 +289,12 @@ prevent.
 Phase 2's selector script already built the solution on a normal run; only when it was skipped
 (`--section`) start `dotnet build Humans.slnx -v quiet` in the background now —
 reforge needs a built solution and 3d's tool threads need the build. Do not look at its output until 3d.
+
+**A re-doctor reads the diff, not the section.** With a `BASE:` from Phase 2 (or, under
+`--section`, the last `origin/main` commit to the section's `health.md`), 3a's inventory is
+still complete, but 3b–3d read `git diff BASE..HEAD -- <section paths>` in full and skim the
+rest; the previous target and `health.md` history say what was already judged. A full cold
+assess is for a never-doctored section only.
 
 ### 3a. Inventory — every file, assigned
 
@@ -298,10 +317,6 @@ names things — a doc, comment-bearing source, a csproj — record `reviewed` o
 symbol, route and file path it names has been checked against the tree. This is mechanical, and
 it is what catches the doc that still names a controller's old home, a dependency a read-split
 replaced, or a folder a job moved out of.
-
-Why this is stage one: a finding-driven pass only finds what sits adjacent to what it already
-suspects, so instances of the run's own headline finding sit unreached in the files no lane
-opened.
 
 ### 3b. Behavior first, tool-free
 
@@ -331,7 +346,19 @@ where genuinely empty:
    reason, including ones Peter has declined.
 
 Plus a **load-bearing weirdness** list: essential complexity and settled decisions, with why, so
-later runs stop re-litigating them.
+later runs stop re-litigating them — including code that is large and *blessed*; that is where
+such code is recorded, never as a `debt:` item.
+
+The doc carries no generated-by subtitle or run provenance (`current-state-docs-no-history`);
+its History table (Phase 5) is the only dated content.
+
+**Trace gate — before 3d dispatches, and again before Phase 4.** The target is a claim about
+what IS. Every identifier, route, policy, job id, audit action and file path it names is
+`git grep`ped against the tree, and every §4 invariant cites the `file:line` that enforces it.
+A name that does not resolve is corrected now; a claim the code cannot prove moves to §5 or §6
+or is cut. A target written from the section's own docs inherits their errors, so a claim
+taken from prose is traced to code like any other, and a line the run cannot trace is not
+written.
 
 **Regenerate the target every run, then diff it against the previous one** (it is in git; the
 previous run's is the parent commit's copy). The diff is signal in both directions: the section
@@ -352,28 +379,31 @@ the wall-clock / token / fragility balance:
   ranked list, and they do not go into a doc row (Phase 5). The PR's surface report is the
   published number, because it is recomputed against the head that actually shipped.
 - **Dispatched threads are the default** (nobodies-collective/Humans#1465). A thread reads a lot
-  and returns a little, and reading it on the main thread permanently raises the price of every
-  later turn in the run: cache reads on a run that carries Phase 3 to the end are the largest
-  line in its bill. **Small context dominates model choice**:
-  moving a thread off main saves ~87%, swapping its model ~40%. Each dispatched thread gets an
-  explicit tagged model (table below) and a deadline. The tiering runs on capability-per-dollar,
-  not tier names: the judgment-reading threads get **opus at low effort** — on current models the
-  top tier at low effort matches or beats the mid tier at high effort on this kind of reading,
-  and low effort's fewer, more consolidated turns also mean fewer cache-read passes — while the
-  mechanical scans stay **haiku**.
+  and returns a little, and reading it on the main thread raises the price of every later turn
+  in the run. **Small context dominates model choice**: moving a thread off main saves far more
+  than swapping its model. Each dispatched thread gets an explicit tagged model (table below)
+  and a deadline: the judgment-reading threads get **opus at low effort** (capability-per-dollar
+  on this kind of reading, and fewer, more consolidated turns), the mechanical scans **haiku**.
 - **Only the spine and the two judgment threads stay on main** — 3a–3c, Shape, Behavior & bugs,
-  and 3e. They are the reading this run exists to do, and a wrong call there costs a real finding.
-  Whether they *must* stay is an open measurement, not a settled rule: the figure
-  that answers it is the whole-run total, compared run over run (Phase 7), because Phase 3's
-  main-thread cost is one shared bucket and does not split per lens. Don't move them on a hunch
-  in either direction — move them on a run that dispatched them and came out cheaper without
-  losing findings.
+  and 3e: the reading this run exists to do, where a wrong call costs a real finding. Whether
+  they *must* stay is an open measurement; move them only on a run that dispatched them and
+  came out cheaper without losing findings, never on a hunch.
 
 **Dispatch contract** — every dispatched thread gets, verbatim: 3c's target (all six parts plus
 the load-bearing weirdness list), its slice of the 3a inventory, and its row's lens from the table.
-It returns a **structured findings list plus a disposition for every file it claimed**, never
-prose, and **never edits anything** — striking is Phase 4's job on main. Prompt line one is
-`thread: <Name>` so the cost report can name the row.
+The brief lists members, routes and keys; it never counts them (a count typed from a regex over
+`public` lines is wrong, and every thread inherits it). It returns a **structured findings list
+plus a disposition for every file it claimed**, never prose, and **never edits anything** —
+striking is Phase 4's job on main. Prompt line one is `thread: <Name>` so the cost report can
+name the row, and at dispatch the thread's name, model and agent type are appended to
+`$RUNDIR/assessment/threads.md` — Phase 5's `## Threads` model column is copied from there,
+never recalled.
+
+**Absence verdicts carry their proof.** A finding that something is dead, unreferenced, missing
+or nonexistent carries the repo-wide, untruncated `git grep -n` (or `reforge` references
+query) that proves it — never a `head`-cut or section-scoped grep, never a type-name grep for a
+member reached by extension method. Without it the verdict is reported `unverified`, and main
+re-runs the grep before any strike built on it.
 
 **`opus low` rows dispatch as the `doctor-reader` agent type** (`.claude/agents/doctor-reader.md`)
 — an agent definition is the only place effort can be pinned; a bare Agent call's `model`
@@ -392,8 +422,8 @@ each one.
 | **Freshness** | The section's docs vs code: claims that no longer hold, `freshness:triggers` globs that still resolve, and triggers that watch *everything the doc asserts about* — including another section's file where the doc names it. A fixed claim gets swept everywhere it appears | subagent (opus low) |
 | **Conformance** | `docs/architecture/section-conformance.yml` — the per-section rules nothing enforces yet. Detectors are mechanical; the judgment is what to do about a hit | background + subagent (haiku) |
 | **Tests** | The invariant coverage matrix — every invariant, negative access rule and trigger in the target mapped to a pinning test; redundant and asserting-the-mock tests | subagent (opus low) |
-| **Prose & surface** | InspectCode Tier 1/2; docs that are 500 words where 50 would do; dead resources, missing translations, resource keys not prefixed with the section name (`resource-key-prefix`, cleanup — report the count, don't backfill unless the run is *for* that); nav quality — dead ends, missing backlinks, discoverability from `AdminNavTree` | background + subagent (haiku) |
-| **History** | Prose narrating a prior state: a deleted/renamed project or type, a migration/lane number, "used to live in X", "the first section to Y", a dated run post-mortem, rationale for a decision no longer contested. **Cut test: keep only if it changes what a reader does** — a live constraint, a non-obvious invariant, a landmine that bites if reverted. A load-bearing "why" moves to the issue, linked, not narrated in the file | subagent (opus low) |
+| **Prose & surface** | InspectCode Tier 1/2; docs that are 500 words where 50 would do; missing translations, resource keys not prefixed with the section name (`resource-key-prefix`, cleanup — report the count, don't backfill unless the run is *for* that); nav quality — dead ends, missing backlinks, discoverability from `AdminNavTree`. **Fixed step, not judgment:** list every key in the section's base resx, grep each literal across `*.cs`, `*.cshtml` and `*.resx` outside the set, exclude prefixes the code builds at runtime (`$"…"` or concatenation against the localizer), and report the zero-reference remainder as one finding with the list in `$RUNDIR` | background + subagent (haiku) |
+| **History** | Prose narrating a prior state: a deleted/renamed project or type, a migration/lane number, "used to live in X", "the first section to Y", a dated run post-mortem, rationale for a decision no longer contested. **Cut test: keep only if it changes what a reader does** — a live constraint, a non-obvious invariant, a landmine that bites if reverted. A load-bearing "why" moves to the issue, linked, not narrated in the file. **Dated design records** (`src/Sections/*/Docs/20*.md`) are history by design (`current-state-docs-no-history`): judged on dangling references and false *current* claims only; deletion is proposed only when the record is over a month old **and** every fact it carries is confirmed present elsewhere in the corpus | subagent (opus low) |
 | **Comments** | Every comment in the section's inventory, rewritten or deleted. Cut what restates the next line, decision history, hedging, reassurance addressed to the next agent. **Cut test: a comment survives only if it carries something the code cannot say** | subagent (opus low) |
 | **Inbox** | Section-tagged `debt-ledger.yml` items, open GitHub issues, in-app issues. Work or rank them — and **review** the open issues for validity / consistency / freshness / spec quality (below); off-section finds go to the run's sweep queue as `debt:`, never written to the ledger directly | subagent (opus low) |
 
@@ -408,13 +438,10 @@ several runs record it as "ran, found nothing".
 - **Tests** — always build the invariant matrix, including when the section looks well tested; the
   gaps it finds are the invariants nobody thought to doubt.
 - **Freshness** — a doc claiming a test that does not exist is a doc to fix, never a test to
-  write. That instinct has fired twice (#1465, #1480) and both times the test would have been
-  an absence assertion — `memory/architecture/no-tests-for-absences.md`. A trigger that
-  resolves is not a trigger that works: check each path actually
+  write; the test would be an absence assertion — `memory/architecture/no-tests-for-absences.md`.
+  A trigger that resolves is not a trigger that works: check each path actually
   carries the claim, not merely that it is live. Read a feature doc's "Out of scope" list against
   its route table every time; it ages worse than the body.
-- **Prose & surface** — diff the resx key set against the keys the section's views reference. Dead
-  keys cluster where UI was removed, and it is the cheapest full-coverage signal without a compiler.
 
 #### Open-issue review (Inbox)
 
@@ -507,9 +534,12 @@ and they need the checkpoint files, 3c's target and the strike's own files — n
 K of assessment reads behind them. From here, disk is the authoritative state: work each strike
 from its checkpoint entry, re-read `$RUNDIR/assessment/` rather than relying on scrollback, and
 treat a compaction at or after this boundary as costing nothing — the state it sheds is on disk.
-Never re-read a whole file to answer a question a targeted reforge query answers ("who calls
-this", "where is this defined"), and never re-open a file only to confirm what a checkpointed
-finding already states.
+**After any compaction, every statement about the run's own conduct — which threads ran and on
+what model, findings counts, the ranked order, what was struck, whether a compaction happened —
+is read back from `$RUNDIR/assessment/`, the phase log or `git log`, never restated from the
+summary.** Never re-read a whole file to answer a question a targeted reforge query answers
+("who calls this", "where is this defined"), and never re-open a file only to confirm what a
+checkpointed finding already states.
 
 ## Phase 4: Strike
 
@@ -535,13 +565,18 @@ delete-sweep rules, the resx/XML rule, the build-output rule). It edits and vali
 delete sweep), the executor runs the same search with the Grep tool or `rg -n` rooted at
 `$WORKTREE` instead — and returns a diff summary; the main thread reviews
 **`git diff` in the worktree, never the executor's own summary,** and commits. One executor at a
-time — Phase 0's one-build-per-worktree rule applies to them too. Its prompt's whole first line,
-nothing after it, is the `thread: strike <what>` marker — the same `<what>` as the item's
-phase-log mark — so the cost report names its row per 3d's convention instead of falling back to
-an opaque agent filename. Judgment strikes — `collapse`, `rearch`, any deletion whose safety depends on
-cross-file context — and every reviewer gate (step 4) stay on the main thread. The split is per
-strike *class*, never blanket: cross-file context on main is what catches the miscounts a
-narrowly-briefed executor cannot see.
+time — Phase 0's one-build-per-worktree rule applies to them too. **Every Agent dispatch in this
+phase — executor and reviewer alike — opens with a `thread:` marker as its whole first line**
+(`thread: strike <what>`, the same `<what>` as the item's phase-log mark; `thread: review
+<what>`) so the cost report names its row per 3d's convention instead of an opaque agent
+filename, and is logged to `$RUNDIR/assessment/threads.md` like a 3d thread. Judgment strikes —
+`collapse`, `rearch`, any deletion whose safety depends on cross-file context — and every
+reviewer gate (step 4) stay on the main thread. The split is per strike *class*, never blanket:
+cross-file context on main is what catches the miscounts a narrowly-briefed executor cannot see.
+
+**Before any strike names a symbol, bound its blast radius by grep, not by eye:** the item
+carries a repo-wide `git grep -n -- '<Symbol>'`; a `dedup` strike greps the literal expression
+it is collapsing before striking; a cut reads the whole file it is in, not the flagged lines.
 
 Per item (one item or tight cluster per commit):
 
@@ -551,7 +586,12 @@ Per item (one item or tight cluster per commit):
    toolbox is still called directly where it fits: `section-align`, `trim-tests`,
    `section-read-split`, `reuse-review` (against the section's own surface), the
    `.codex/skills/humans-refactor` lane process, a `debt-ledger.yml` item — or a direct fix.
-2. Fix it right — no surgical fixes. Reuse-first.
+2. Fix it right — no surgical fixes. Reuse-first. **Open the `memory/` rule governing the shape
+   being written** — the doc, the test, the resx, the comment — not only the problem being
+   solved, and name it in the commit. **A guardrail never retires on a subagent's approval:**
+   a strike that deletes or weakens a test under `tests/**/Architecture/`, an analyzer, a
+   baseline or a ratchet goes to Needs Peter with the four-line brief
+   (`brief-before-retiring-guardrails`), never to step 4's reviewer.
 
    **A `dedup` or `collapse` item checks the shape it is collapsing *into*, not only the one it
    is collapsing.** "Two branches differ in one attribute" is a valid trigger and says nothing
@@ -559,7 +599,11 @@ Per item (one item or tight cluster per commit):
    `docs/architecture/code-review-rules.md`'s hard-reject list and the section's own load-bearing
    weirdness, and where a linter owns that shape (`.claude/razor-lint.sh` for views) run it on the
    changed file rather than trusting it to fire later.
-3. `dotnet build Humans.slnx -v quiet`; targeted tests for the touched area.
+3. Gate per `scoped-inner-loop-tests`: the section's test project
+   (`dotnet test tests/Humans.<X>.Tests -v quiet`; `dotnet build Humans.slnx -v quiet` where
+   there is none) gates each strike; the full `dotnet test Humans.slnx -v quiet` runs once
+   before each push; and the section gate re-runs after the **last** edit to any file the
+   commit carries — a test touched after the gate is an untested test.
 
    **A test the run adds is only covered if some CI job actually runs it — check the filters, not
    the suite.** Before writing "CI is the gate" about a new test, resolve its assembly against
@@ -583,7 +627,8 @@ Per item (one item or tight cluster per commit):
    reviewer subagent — the `doctor-reviewer` agent type (`.claude/agents/doctor-reviewer.md`,
    fable; fall back to a plain opus subagent with its prompt where the type or model is
    unavailable) — score-blind, default-reject: "name the concept that improved in
-   one sentence." Reject → rework once; second reject → revert, record.
+   one sentence." **It reads the uncommitted working-tree diff**, so a reject shrinks the diff
+   rather than adding a fixup commit. Reject → rework once; second reject → revert, record.
 5. **Doc fixes sweep the claim — by literal string, repo-wide**: when a strike removes or
    renames a route, type, method or path, or fixes a claim naming one, grep the whole repo for
    the exact string and fix or enumerate every hit in the run file. Sweep the abbreviations too —
@@ -592,11 +637,12 @@ Per item (one item or tight cluster per commit):
 
    Once a section doc is open at all, read it **end to end** against the code: fixing its headline
    stale claim and leaving the smaller ones is not fixing the doc. Rebuild its Cross-Section
-   Dependencies from the `.csproj` project references, never from the prose. Verify any explanation
-   of why an unused member exists before writing it down — "nothing reads these" is often both the
-   true answer and a finding. Distrust "never crosses the boundary": for a section reading a shared
-   read-model the honest form names what is carried, what this code reads, and what the output
-   record exposes.
+   Dependencies from the `.csproj` project references, never from the prose, and keep every
+   line `docs/sections/SECTION-TEMPLATE.md` requires (the `**Status:**` line included). Verify any
+   explanation of why an unused member exists before writing it down — "nothing reads these" is
+   often both the true answer and a finding. Distrust "never crosses the boundary": for a section
+   reading a shared read-model the honest form names what is carried, what this code reads, and
+   what the output record exposes.
 
    **A delete sweeps its own symbols by literal name, before the strike commits.** Reading the
    diff does not discharge the rule above. For every member, type, route or table the strike
@@ -608,19 +654,21 @@ Per item (one item or tight cluster per commit):
 
    Then **re-read the header of every file the strike cut from**. A file's class-level doc comment
    describes what the file holds, so cutting from the body changes the truth of the comment above
-   it — the Store run deleted three members from `IStoreRepository` and shipped that file's own
-   comment still claiming the section was sole writer of a table it no longer touched. The
-   falsehood a delete creates sits nearest the delete.
+   it. The falsehood a delete creates sits nearest the delete.
 
    **When the doc and the code disagree and the code looks wrong, change neither** — the pair goes
    to Needs-Peter together. Editing the doc to match a suspected defect cements it.
 6. **UI-affecting strikes get runtime verification**: render the changed page in the running app
    (`dotnet run` + browser/test-site) before the PR — a green build does not prove a cshtml/JS
-   change works.
-7. Commit `doctor(<section>): <what>`. Full `dotnet test Humans.slnx -v quiet`
-   before each push;
-   push every 3–5 items. When a reviewer gate could not be obtained, say so in the commit message
-   as well as the run file — a commit that lands unreviewed should say so where the diff is read.
+   change works. Where the app cannot start (the cloud container has no database): a JS strike
+   is exercised in headless Chromium loading the shipped modules against a fake DOM, asserting
+   the changed path and no page errors; a cshtml/resx strike gets the build plus
+   `.claude/razor-lint.sh`, and the run file says as a dated session line that no live render
+   happened. Anything beyond that is a preview-deploy check after the PR opens.
+7. Run the **prose gate** (Phase 5) over the staged diff, then commit `doctor(<section>): <what>`.
+   Push every 3–5 items, origin gate (Phase 1) in the same call. When a reviewer gate could not
+   be obtained, say so in the commit message as well as the run file — a commit that lands
+   unreviewed should say so where the diff is read.
 
 **File-format rules that only the build catches:**
 
@@ -637,9 +685,11 @@ Per item (one item or tight cluster per commit):
   production LOC. Never call such a change "docs only".
 
 **Skip-and-queue classes** (never block the loop): schema/EF changes of any kind, public/interface
-surface *additions*, privilege changes, **mutating a GitHub issue** (closing, editing, relabelling
-or commenting on one — 3d's Inbox review recommends, Peter enacts), anything needing Peter's
-judgment → skip, queue for Phase 7's Needs-Peter block. If in-flight feature work on this section
+surface *additions*, privilege changes, **retiring or weakening a guardrail** (step 2's brief),
+**mutating a GitHub issue** (closing, editing, relabelling or commenting on one — 3d's Inbox
+review recommends, Peter enacts), anything needing Peter's judgment → skip, queue for Phase 7's
+Needs-Peter block. A queued item naming a symbol carries its repo-wide `git grep -n`, so the
+reader sees the blast radius the run saw. If in-flight feature work on this section
 surfaces mid-run → stop striking, ship the assessment-only PR, note it in the run file.
 
 **The Needs-Peter admission test.** An item is admitted only if **both** hold: *would two
@@ -657,6 +707,9 @@ nobody re-reads (`memory/process/debt-ledger-additions.md`). *In-section*: appen
 `src/Sections/Humans.<X>/Docs/debt.yml`, creating it if absent. *Off-section*: this run's sweep
 queue (`debt:`), never chased mid-assessment; Phase 5's sweep writes it to the **owning section's**
 ledger after this run merges — debt belongs where the next reader of that section will meet it.
+A queue item is ledger prose already: no reforge figures, no counts, no line numbers that a
+fix will move; code the target blesses is not debt and goes to `health.md` (3c), never the
+queue.
 
 **Section ledgers have no single writer, by design.** A sweep writes the ledger of whichever
 section owns the debt, so two runs can touch one ledger and their PRs can conflict. Appending to
@@ -678,8 +731,8 @@ worktree/PR, three bookkeeping writes:
   one open run per section, so it cannot collide). **The row is run, date, headline and PR link —
   never a score.** A score written here is stale by construction: every commit after it, every
   answered Needs-Peter item and every review round moves the number it claims, and Phase 7 rightly
-  forbids the correcting commit that would chase it. peterdrier/Humans#1520's row was written
-  `231 → 230`; that run finished at `178`. The PR the row links to carries the score against the head that shipped.
+  forbids the correcting commit that would chase it. The PR the row links to carries the score
+  against the head that shipped.
 - **This run's own file** — `docs/health/runs/<yyyy-mm-dd>-<Section>.md` (UTC date from the run
   timestamp; if the path already exists at the branch point, suffix `-<HHMMZ>`). Sections:
   run header (invocation, anchor commit, budget, `PR: pending`), assessment summary, the ranked
@@ -710,7 +763,8 @@ worktree/PR, three bookkeeping writes:
   - **`## File coverage`** — a disposition for every path in the 3a inventory: `reviewed`,
     `changed` or `generated`. Not a summary; the list.
   - **`## Threads`** — one row per thread: how it ran (main / subagent / self-run after a missed
-    deadline), its model, and its findings count. For each that
+    deadline), its model **copied from `$RUNDIR/assessment/threads.md`** (3d), and its findings
+    count. For each that
     did not run, why — a silent skip is a failed run, not a quiet one. The model column plus the
     PR's cost comment (Phase 7) are what make "did the cheaper thread lose findings?" answerable
     across runs (nobodies-collective/Humans#1465); a run that leaves the model blank has decided
@@ -719,10 +773,20 @@ worktree/PR, three bookkeeping writes:
     subagent rows carry the same thread names. Don't write "see `## Cost`" or any other
     cost pointer that names a section this file does not have.
 
-  `no-derived-aggregates-in-docs` applies to the run file and `health.md` too: never count a
-  list the same file carries ("15 contract methods" above the table of them, "52 paths" above
-  the coverage list). Measurements with a generator — reforge scores — stay. A typed
-  self-count that is wrong points a refactor at the wrong method.
+  **Prose gate — mechanical, before every commit that carries prose this run wrote** (run
+  file, `health.md`, `debt.yml`, any `.md`, rewritten `.cs` comment blocks, the sweep's
+  writes). `no-derived-aggregates-in-docs` binds the author of new prose, and the run is that
+  author:
+
+  ```bash
+  git diff --cached -U0 | grep -niE '^\+.*\b([0-9]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+[a-z-]+s\b'
+  ```
+
+  A hit that counts a list or set — one this file carries, one another doc carries, or one the
+  code owns — is deleted or replaced by the list or "all of them"; a measurement with a
+  generator (a reforge score, a date, a PR number, a line reference) and a plain "two branches
+  differ" stand. A typed count is wrong the first time the list changes, and a wrong one
+  points a refactor at the wrong method.
 
   **The run file never describes its own diff.** No size block, no insertions/deletions, no line
   count of the branch or of the file itself: the commit that writes such a figure is a commit the
@@ -737,20 +801,27 @@ worktree/PR, three bookkeeping writes:
   it — `debt:` → the owning section's
   `src/Sections/Humans.<X>/Docs/debt.yml` where one section owns the fix and
   `docs/architecture/debt-ledger.yml` otherwise, `memory:` → the named
-  atom + INDEX line — skipping any item already present in its target (idempotence is the only
-  bookkeeping; there is no anchor window).
+  atom + INDEX line. Idempotence is the only bookkeeping; there is no anchor window. **The
+  skips, each a grep, before an item is written:**
+
+  1. **Already carried** — its distinguishing phrase is in its target on `origin/main` *or on
+     any open `origin/section-doctor/*` branch*
+     (`git fetch origin 'refs/heads/section-doctor/*:refs/remotes/origin/section-doctor/*'`,
+     then `git grep` each). An unmerged doctor PR carrying the item is carrying it; two runs
+     writing it produce byte-different duplicates.
+  2. **Already fixed** — the claim it makes no longer holds: the symbol, file or rationale it
+     names is gone from the branch. A fixed debt retired from its ledger stays retired.
+  3. **Not debt** — its text says the code is intended or blessed, or it carries reforge
+     figures or counts. Apply the qualitative row only, or nothing; the sweep is an author,
+     not a copier, and the prose gate runs over its writes too.
 
   **The sweep never edits this skill, and never carries a lesson about it.** A proposed amendment
   lives in one place only — the `## Needs Peter` block of the run that thought of it (Phase 6) —
-  and reaches the skill through Peter's answer there, inline (Phase 8) or via `resume` later. It is
-  never a sweep-queue item: the sweep has no anchor window, so an item it carries it would carry
-  again on every later run, re-asking a question Peter already closed with a tick the sweep cannot
-  see. **No unattended run edits its own instructions** — a skill that
-  rewrites itself while nobody is reading drifts with nothing to catch it, and the lessons it
-  appends are exactly the war stories that do not belong in instructions. **Never edit the swept run files** — resume is
-  their only post-merge editor, which is what keeps resume conflict-free. Two piled-up
-  unmerged runs can occasionally sweep the same item; the cost is one hand-resolved conflict,
-  not corruption (the no-locking trade of PR #1366).
+  and reaches the skill through Peter's answer there, inline (Phase 8) or via `resume` later;
+  as a sweep item it would be re-asked on every later run, blind to the tick that closed it.
+  **Never edit the swept run files** — resume is their only post-merge editor, which is what
+  keeps resume conflict-free. Two piled-up unmerged runs can occasionally sweep the same item;
+  the cost is one hand-resolved conflict, not corruption (the no-locking trade of PR #1366).
 
 The runs directory **is** the log and the newest file **is** the last report. There is no
 `log.md`, `last-report.md`, or generated index — never recreate them — and daily runs never
@@ -777,24 +848,30 @@ Phase 7's own PR-number backfill commit.
 
 ## Phase 7: PR
 
-**Self-review the run's own new prose first.** Every claim this run wrote about what a page
-shows — run file, PR body, section doc, spec, comment — is traced back to the `.cshtml` that
-renders it, not to the DTO that feeds it. A payload carrying a field is not a page displaying it.
-A reviewer here is not free, and text the run wrote this session is the text most likely to be wrong.
+**Self-review the run's own new prose first — only that prose, against the gates below.** Read
+`git diff origin/main -- '*.md' '*.yml'` plus every `.cs` comment block the run rewrote: the
+prose gate (Phase 5), the trace gate (3c — every symbol, route and path named resolves; every
+"only", "never" and "always" is checked), and the render rule — a claim about what a page
+shows traces to the `.cshtml` that renders it, not the DTO that feeds it. Text the run wrote
+this session is the text most likely to be wrong, and a reviewer here is not free.
 
 **Run `dotnet format whitespace Humans.slnx --verify-no-changes` before pushing, not after CI says
 so.** A green build is not the formatting gate — collection-expression line breaks pass the build
 and the full test run, and fail code-quality.
 
 ```bash
+git remote get-url origin | grep -qE 'github\.com[:/]peterdrier/Humans(\.git)?$' || exit 1   # origin gate, same call
 git push -u origin section-doctor/$TS
 gh pr create --repo peterdrier/Humans --base main --title "doctor(<Section>): <headline>" --body ...
 ```
 
+The title's headline names something a user or reader would notice — the fix, the false
+claim corrected, the surface removed — never the run's bookkeeping.
+
 Body: the opening header paragraph (run/section, run-file link, target-shape link) **ends with the
 next-up forecast**, read from the `UPCOMING:` line in `$RUNDIR/selection.txt` — "Target shape:
 `Docs/health.md` (new). Likely future sections: A, B, C, D." — never buried lower in the body;
-omitted when the selector was skipped (`--section`) or returned `JUDGMENT REQUIRED`. Then
+omitted when the selector was skipped (`--section`). Then
 assessment summary, worked/skipped bullets, and a
 **`## Needs Peter`** block — terse, numbered, answerable in a word or two, **citing findings by
 number rather than re-describing them** (Phase 5). **The PR body is the authoritative queue while
@@ -825,13 +902,11 @@ create/backfill calls and any Phase 8 work land after measurement (the footer sa
 as a PR comment immediately after `gh pr create`** (`gh pr comment <PR#> --body-file` — never
 inline shell-quoted; the GitHub MCP comment tool in a cloud run without `gh`). The comment is the
 table's only home: one append-only write adjacent to the create call, costing no push, no CI run
-and no review round. Never paste it into the PR body or the run file — the dual-paste rule this
-replaces was fumbled by three consecutive runs, each differently, because it asked a maybe-compacted
-session to remember two edits hours after reading them. The table stands on its own —
-never compare it against another run's cost or pull in a prior run's figures; cross-run reading is
-Peter's, done over the PRs. The script never fails the run — on any discovery problem it prints
-`Cost: unmeasured (...)`; post that line as the comment all the same (a failed measurement leaves
-a visible record, never silence) and note it in Needs-Peter.
+and no review round. Never paste it into the PR body or the run file. The table stands on its
+own — never compare it against another run's cost or pull in a prior run's figures; cross-run
+reading is Peter's, done over the PRs. The script never fails the run — on any discovery problem
+it prints `Cost: unmeasured (...)`; post that line as the comment all the same (a failed
+measurement leaves a visible record, never silence) and note it in Needs-Peter.
 
 Then backfill the real PR number over every `pending` reference (run file header, health history
 row), commit, push again.
@@ -840,7 +915,9 @@ row), commit, push again.
 doc a reader depends on. **Never push a commit whose entire content is a corrected figure or a
 restated status about the branch** — such a correction rides along with the next substantive
 commit, or is skipped. Every push costs a CI run, a preview deploy, a surface report and a review
-quota.
+quota. The same holds for the run file's account of itself: a render checked on the preview
+deploy, a compaction the cost comment reports, is written in when a substantive commit next
+goes out, or not at all — and never claimed before it happened.
 
 ## Phase 8: Inline round (interactive runs only)
 
@@ -858,6 +935,18 @@ queue) and every one of those is answered by committing to this branch.
 **A review bot's finding is a sample, not an instance.** Before fixing the reported line, grep the
 branch for the class of claim it is an example of — the type, the method, the abolished case.
 Fixing only the reported line leaves the siblings and looks resolved.
+
+**Review rounds run under `review-round-budget` and `.claude/skills/steward/SKILL.md`**, and
+each push in them takes the origin gate (Phase 1) in the same call, then confirms the PR's head
+sha advanced (`pull_request_read`) — a push to the wrong repo is silent: no CI, no review, no
+deploy.
+
+**Resolve gate.** A thread is replied to and resolved only after, on the pushed head:
+`git cat-file -e <sha>` succeeds for the commit the reply cites and
+`git branch -r --contains <sha>` lists `origin/section-doctor/$TS`; and the line the finding
+named is re-grepped and reads as the reply claims. A reply names a commit that exists on
+`origin` or names none. At the round cap, every finding agreed and left unfixed is listed in the
+cap comment and in the run file's `## Needs Peter` — never resolved, never marked fixed.
 
 Phase 9 writes nothing. Phase 7's backfill commit is the run's last write, and everything a later
 session needs is already derivable: the branch is `section-doctor/$TS`, its workspace is
@@ -919,7 +1008,12 @@ undercounts. Then tick the item — `- [ ]` becomes `- [x]`:
 - No EF migrations, schema changes, or data backfills — queue them. No analyzer suppressions.
   Never touch `[DontFix]`.
 - Public-surface additions need Peter; dead-surface deletion is the job (reviewer-gated).
-- Explicit tagged model on every subagent. Never leave the branch red between commits.
+  Guardrail retirement needs Peter's go on a brief (`brief-before-retiring-guardrails`); the
+  reviewer subagent is never that go.
+- Explicit tagged model on every subagent, and a `thread:` marker on every dispatch. Never
+  leave the branch red between commits.
+- **Every push is preceded by the origin gate in the same shell call**; on a mismatch the run
+  stops. A push never goes by remote name to a remote the gate has not just checked.
 - **A run touches only:** the section's files (+ callers where a play requires), the section's
   `Docs/health.md` and `Docs/debt.yml`, its own `docs/health/runs/<date>-<Section>.md`, and — in
   the sweep commit only (Phase 5) — the debt ledgers (central, and any

--- a/.claude/skills/section-doctor/select-section.py
+++ b/.claude/skills/section-doctor/select-section.py
@@ -44,7 +44,9 @@ def path_section(path):
 
 
 def section_paths(s):
-    return ["src/Sections/Humans." + s, "src/Sections/Humans." + s + ".Contracts", "tests/Humans." + s + ".Tests"]
+    """Everything Phase 3a inventories for the section."""
+    return ["src/Sections/Humans." + s, "src/Sections/Humans." + s + ".Contracts",
+            "tests/Humans." + s + ".Tests", "docs/guide/" + s + ".md"]
 
 
 def run(cmd):
@@ -120,13 +122,20 @@ def branch_blocked(pr_heads, warnings):
 
 
 def last_doctored(s):
-    """(unix-time, sha) of the last origin/main commit to the section's health.md, or None."""
-    rc, out = run(["git", "log", "-1", "--format=%ct %H", "origin/main", "--",
-                   "src/Sections/Humans.%s/Docs/health.md" % s])
-    if rc != 0 or not out.strip():
-        return None
-    t, sha = out.split()
-    return int(t), sha
+    """(unix-time, sha) of the origin/main commit that added the section's newest run file --
+    a doctor run is exactly that; any other edit to health.md is not one. Falls back to the
+    last commit to health.md for a section with no run file."""
+    queries = (
+        ["--diff-filter=A", "origin/main", "--",
+         "docs/health/runs/????-??-??-%s.md" % s, "docs/health/runs/????-??-??-%s-*.md" % s],
+        ["origin/main", "--", "src/Sections/Humans.%s/Docs/health.md" % s],
+    )
+    for q in queries:
+        rc, out = run(["git", "log", "-1", "--format=%ct %H"] + q)
+        if rc == 0 and out.strip():
+            t, sha = out.split()
+            return int(t), sha
+    return None
 
 
 def changed_since(sha, s):

--- a/.claude/skills/section-doctor/select-section.py
+++ b/.claude/skills/section-doctor/select-section.py
@@ -4,17 +4,21 @@
 Usage: python select-section.py --prs <open-prs.json> [--no-build] [--blocked-only]
 
 Computes everything mechanical about selection: blocked set, pool, feature-active
-down-rank, tiers, reforge scores, and the middle-out median pick. Prints
-SECTION:/TIER:/RATIONALE: for the never-doctored era. Prints JUDGMENT REQUIRED
-(exit 2) once every eligible section is previously-doctored — staleness ranking is
-a judgment call the caller dispatches — and ALL BLOCKED (exit 3) when every
-section has an open section-doctor PR.
+down-rank, tiers, reforge scores, the middle-out median pick for the never-doctored
+tier, and the changed-since-last-run rule for the re-doctor tier. Prints
+SECTION:/TIER:/RATIONALE: (plus BASE: for a re-doctor). Exit 2 = NOTHING CHANGED
+(every eligible section was doctored and untouched since); exit 3 = ALL BLOCKED.
 
 <open-prs.json> is the open-PR list as JSON: [{number, headRefName, title,
 files: ["path", ...] | [{"path": ...}, ...]}, ...]. Locally that is one
 `gh pr list --repo peterdrier/Humans --state open --limit 200 --json
 number,headRefName,title,files` call; a cloud session without gh writes the same
-shape from its GitHub MCP tools. No git or gh is used here.
+shape from its GitHub MCP tools.
+
+The blocked set also reads `origin`'s `section-doctor/*` branches directly (git,
+not gh): a run that has pushed its Phase 2 marker but not yet opened its PR is
+visible only there. Branches whose tip is older than BRANCH_MAX_AGE_DAYS are
+ignored as strays (a maintainer deletes them).
 """
 import argparse
 import json
@@ -22,9 +26,12 @@ import os
 import re
 import subprocess
 import sys
+import time
 
 REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
 SECTIONS_DIR = os.path.join(REPO_ROOT, "src", "Sections")
+BRANCH_MAX_AGE_DAYS = 3
+RUN_FILE_RE = re.compile(r"docs/health/runs/\d{4}-\d{2}-\d{2}-([A-Za-z0-9]+)")
 
 
 def pr_files(pr):
@@ -34,6 +41,10 @@ def pr_files(pr):
 def path_section(path):
     m = re.match(r"src/Sections/Humans\.([A-Za-z0-9]+?)(?:\.Contracts)?/", path.replace("\\", "/"))
     return m.group(1) if m else None
+
+
+def section_paths(s):
+    return ["src/Sections/Humans." + s, "src/Sections/Humans." + s + ".Contracts", "tests/Humans." + s + ".Tests"]
 
 
 def run(cmd):
@@ -77,6 +88,52 @@ def loc_fallback(sections):
     return scores
 
 
+def branch_blocked(pr_heads, warnings):
+    """{section: 'branch <name>'} for origin's recent section-doctor/* branches that have no open PR."""
+    blocked = {}
+    rc, out = run(["git", "ls-remote", "--heads", "origin", "refs/heads/section-doctor/*"])
+    if rc != 0:
+        warnings.append("git ls-remote failed -- blocked set built from open PRs only")
+        return blocked
+    stray = [line.split()[1][len("refs/heads/"):] for line in out.splitlines() if line.strip()]
+    stray = [b for b in stray if b not in pr_heads]
+    if not stray:
+        return blocked
+    run(["git", "fetch", "--quiet", "origin"] + ["+refs/heads/%s:refs/remotes/origin/%s" % (b, b) for b in stray])
+    cutoff = time.time() - BRANCH_MAX_AGE_DAYS * 86400
+    for b in stray:
+        rc, when = run(["git", "log", "-1", "--format=%ct", "origin/" + b])
+        if rc != 0 or not when.strip() or int(when.strip()) < cutoff:
+            continue
+        rc, diff = run(["git", "diff", "--name-only", "origin/main...origin/" + b])
+        sections = set()
+        for path in diff.splitlines():
+            m = RUN_FILE_RE.match(path)
+            if m:
+                sections.add(m.group(1))
+            s = path_section(path)
+            if s:
+                sections.add(s)
+        for s in sorted(sections):
+            blocked.setdefault(s, "branch " + b)
+    return blocked
+
+
+def last_doctored(s):
+    """(unix-time, sha) of the last origin/main commit to the section's health.md, or None."""
+    rc, out = run(["git", "log", "-1", "--format=%ct %H", "origin/main", "--",
+                   "src/Sections/Humans.%s/Docs/health.md" % s])
+    if rc != 0 or not out.strip():
+        return None
+    t, sha = out.split()
+    return int(t), sha
+
+
+def changed_since(sha, s):
+    rc, out = run(["git", "rev-list", "--count", sha + "..origin/main", "--"] + section_paths(s))
+    return rc == 0 and out.strip() not in ("", "0")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--prs", required=True)
@@ -110,16 +167,21 @@ def main():
                 warnings.append("open run PR #%s names section %r, which is not a src/Sections project "
                                 "-- blocking nothing" % (pr.get("number"), named))
                 continue
-            blocked[section] = pr["number"]
+            blocked[section] = "#%s" % pr["number"]
         else:
             touched = sorted({s for s in map(path_section, pr_files(pr)) if s})
             for s in touched:
-                blocked.setdefault(s, pr["number"])
+                blocked.setdefault(s, "#%s" % pr["number"])
             warnings.append("cannot parse section from open run PR #%s title %r -- blocked %s from its changed files"
                             % (pr.get("number"), pr.get("title"), ", ".join(touched) or "nothing"))
+    for s, why in branch_blocked({pr.get("headRefName") for pr in prs}, warnings).items():
+        blocked.setdefault(s, why)
+
+    def blocked_text():
+        return ", ".join("%s (%s)" % kv for kv in sorted(blocked.items())) or "none"
 
     if args.blocked_only:
-        print("blocked: " + (", ".join("%s (#%s)" % kv for kv in sorted(blocked.items())) or "none"))
+        print("blocked: " + blocked_text())
         for w in warnings:
             print("WARNING: " + w)
         return 0
@@ -129,9 +191,9 @@ def main():
 
     eligible = [s for s in pool if s not in blocked]
     if not eligible:
-        print("ALL BLOCKED: every section has an open section-doctor PR.")
+        print("ALL BLOCKED: every section has an open section-doctor PR or branch.")
         for s, n in sorted(blocked.items()):
-            print("  %s -- open PR #%s" % (s, n))
+            print("  %s -- %s" % (s, n))
         return 3
 
     build = "skipped (--no-build)"
@@ -142,49 +204,64 @@ def main():
     scores, source = reforge_scores()
     if scores is None:
         scores, source = loc_fallback(eligible), "loc-fallback (reforge unavailable: %s)" % source
+    else:
+        # A section reforge prints no line for has nothing to report: score 0, not unknown.
+        for s, (_, loc) in loc_fallback([s for s in eligible if s not in scores]).items():
+            scores[s] = (0, loc)
 
     def score(s):
-        return scores.get(s, (sys.maxsize, sys.maxsize))  # unscored sorts last
+        return scores.get(s, (sys.maxsize, sys.maxsize))
 
     never = [s for s in eligible if not os.path.exists(os.path.join(SECTIONS_DIR, "Humans." + s, "Docs", "health.md"))]
     redoctor = [s for s in eligible if s not in never]
+    doctored = {s: last_doctored(s) for s in redoctor}
+    # Re-doctor tier: eligible only if the section changed since its last run merged;
+    # ranked oldest run first, ties by lowest score.
+    stale = sorted((s for s in redoctor if doctored[s] and changed_since(doctored[s][1], s)),
+                   key=lambda s: (doctored[s][0], score(s)))
 
     print("select-section: build=%s, score source=%s" % (build, source))
     for w in warnings:
         print("WARNING: " + w)
-    print("pool=%d blocked=%s feature-active=%s"
-          % (len(pool),
-             ", ".join("%s (#%s)" % kv for kv in sorted(blocked.items())) or "none",
-             ", ".join(active) or "none"))
+    print("pool=%d blocked=%s feature-active=%s" % (len(pool), blocked_text(), ", ".join(active) or "none"))
     for label, tier in (("never-doctored", never), ("previously-doctored", redoctor)):
         if tier:
             print("tier %s (%d):" % (label, len(tier)))
             for s in sorted(tier, key=score):
                 sc = scores.get(s)
-                print("  %-24s %-24s%s" % (s,
-                                           "score=%-6d loc=%-7d" % sc if sc else "score=n/a    loc=n/a",
-                                           " [feature-active]" if s in active else ""))
-    unscored = [s for s in eligible if s not in scores]
-    if unscored:
-        print("WARNING: no score for %s -- ranked last" % ", ".join(unscored))
-
-    if not never:
-        print("\nJUDGMENT REQUIRED: every eligible section is previously-doctored -- rank by staleness")
-        print("and change volume per the skill's Phase 2 step 5 (judgment call, no formula).")
-        return 2
+                print("  %-24s %-24s%s%s" % (s,
+                                             "score=%-6d loc=%-7d" % sc if sc else "score=n/a    loc=n/a",
+                                             " [feature-active]" if s in active else "",
+                                             (" last-run=%s%s" % (time.strftime("%Y-%m-%d", time.gmtime(doctored[s][0])),
+                                                                  " changed" if s in stale else " unchanged"))
+                                             if s in doctored and doctored[s] else ""))
 
     # Feature-active sections sink to the tier bottom: median over the rest, unless only they remain.
     def median_pick(tier):
         ranked = sorted((s for s in tier if s not in active), key=score) or sorted(tier, key=score)
         return ranked[(len(ranked) - 1) // 2]
 
-    pick = median_pick(never)
-    print("\nSECTION: %s" % pick)
-    print("TIER: never-doctored")
-    print("RATIONALE: median (lower-middle) of %d never-doctored section(s) by %s after setting"
-          % (len([s for s in never if s not in active]) or len(never),
-             "reforge score" if "fallback" not in source else "loc"))
-    print("  aside %d feature-active; pool %d, blocked %d." % (len([s for s in never if s in active]), len(pool), len(blocked)))
+    def first_pick(ordered):
+        return next((s for s in ordered if s not in active), ordered[0])
+
+    if never:
+        pick = median_pick(never)
+        print("\nSECTION: %s" % pick)
+        print("TIER: never-doctored")
+        print("RATIONALE: median (lower-middle) of %d never-doctored section(s) by %s after setting"
+              % (len([s for s in never if s not in active]) or len(never),
+                 "reforge score" if "fallback" not in source else "loc"))
+        print("  aside %d feature-active; pool %d, blocked %d." % (len([s for s in never if s in active]), len(pool), len(blocked)))
+    elif stale:
+        pick = first_pick(stale)
+        print("\nSECTION: %s" % pick)
+        print("TIER: re-doctor")
+        print("BASE: %s" % doctored[pick][1])
+        print("RATIONALE: oldest previously-doctored section changed since its last run merged "
+              "(last run %s); Phase 3 diffs against BASE." % time.strftime("%Y-%m-%d", time.gmtime(doctored[pick][0])))
+    else:
+        print("\nNOTHING CHANGED: every eligible section is previously-doctored and unchanged since its last run.")
+        return 2
 
     # Non-binding forecast: the next 4 picks if nothing else changes (each pick blocks itself).
     # Purely informational for the PR body; never stored, and later runs recompute from scratch.
@@ -193,10 +270,8 @@ def main():
         nxt = median_pick(future)
         upcoming.append(nxt)
         future.remove(nxt)
-    line = ", ".join(upcoming) if upcoming else "none"
-    if len(upcoming) < 4:
-        line += " -- never-doctored tier exhausts; then previously-doctored (judgment)"
-    print("UPCOMING: %s" % line)
+    upcoming += [s for s in stale if s != pick and s not in upcoming][: 4 - len(upcoming)]
+    print("UPCOMING: %s" % (", ".join(upcoming) or "none -- nothing else is never-doctored or changed"))
     return 0
 
 


### PR DESCRIPTION
## What

One revision of `.claude/skills/section-doctor/SKILL.md` and `select-section.py` folding the meta-review of 49 runs (17 recurring issues, 16 proposed edits) and the open `section-doctor:` issues into gates, plus a plain-language **Intention** block at the top for ambiguous calls. No doctor run, no section code.

Closes peterdrier/Humans#1554
Closes peterdrier/Humans#1590
Closes peterdrier/Humans#1591
Closes peterdrier/Humans#1592
Closes peterdrier/Humans#1597
Closes peterdrier/Humans#1600
Closes peterdrier/Humans#1601
Closes peterdrier/Humans#1604
Closes peterdrier/Humans#1605
Closes peterdrier/Humans#1607
Closes peterdrier/Humans#1609
Closes peterdrier/Humans#1612
Closes peterdrier/Humans#1619

## Why

| Issue / meta item | Root cause | Phase | Fix |
|---|---|---|---|
| meta 1, #1607 (~18 runs) | run-written prose typed counts; sweep copied figures | 5 (+4 step 7, 7) | **Prose gate**: grep the staged diff for a number beside a plural before any commit of run prose, `.cs` comments and sweep writes included |
| meta 2, #1597 N10/N14 (~24 runs) | absence verdicts from truncated or scoped greps; regex-typed brief counts | 3d dispatch contract | absence verdict carries the repo-wide untruncated grep or is `unverified`; main re-greps before striking; the brief lists, never counts |
| meta 3 (~29 runs) | self-reporting rebuilt from the compaction summary | 3e | after any compaction, conduct facts are read from `$RUNDIR/assessment/`, the phase log, `git log` |
| meta 4, #1590 (~14 runs) | target written from prose, never traced | 3c | **Trace gate**: every name in `health.md` is grepped, every invariant cites `file:line`; no generated-by subtitle |
| meta 5, 7, 9 | selector had no re-doctor rule; second runs paid cold-assess price | 2, 3 | scripted re-doctor tier: eligible only if changed since the commit that added its newest run file, oldest first, ties by score; `BASE:` line; Phase 3 diffs against it; `NOTHING CHANGED` stops the run |
| meta 6, #1612 | blocked set read PRs only; a run assessing for hours was invisible | 2, `select-section.py` | blocked set includes `origin`'s recent `section-doctor/*` branches (section read from the run-file path); Phase 2 commits the run-file header and pushes so the branch is visible |
| meta 7, 13, #1597 | threads resolved against nonexistent commits; agreed findings left unfixed at cap | 9 | **Resolve gate**: `git cat-file -e` and `git branch -r --contains` on the pushed head, line re-grepped; agreed-unfixed items listed at the cap, never resolved |
| meta 8, 16 | review rounds spent on the run's own prose; overclaims | 7 | self-review is the prose gate + trace gate + render rule over `git diff origin/main -- '*.md'`; title headline names a user-visible thing; render claims written after the render |
| meta 10, #1592, #1607 | sweep applied items verbatim, re-added fixed ones, duplicated across open branches | 5 | three skips before writing: already carried on main or any open doctor branch, already fixed (claim no longer holds), not debt (blessed or figure-carrying) |
| meta 11, #1600 | reviewer subagent treated as Peter's go on guardrail retirement | 4 step 2, skip-and-queue, standing constraints | guardrail retirement is a Needs-Peter brief (`brief-before-retiring-guardrails`), never the reviewer; open the rule for the shape being written and name it in the commit; SECTION-TEMPLATE lines kept |
| meta 12, #1591, #1619 (~14 runs, one production push) | container rewrites `origin` on resume | 1, 2, 4, 7, 9 | **Origin gate** in the same shell call as every push; mismatch stops the run; Phase 9 confirms the PR head advanced |
| meta 14, #1604, #1597 item 4 | Phase 4/reviewer dispatches unnamed; models recalled | 1, 3d, 4, 5 | `thread:` marker on every dispatch; dispatch logs name/model to `$RUNDIR/assessment/threads.md` and `## Threads` copies it; mark written before the work, one per call |
| meta 15 | blast radius eyeballed | 4 | every symbol-naming strike or queued item carries `git grep -n`; dedup greps the literal expression; a cut reads the whole file |
| meta 17 | gates at the wrong moment | 4 step 3 | `scoped-inner-loop-tests`: section gate per strike, full run once per push, section gate re-run after the last edit |
| #1597 N15 | reviewer ran after the commit | 4 step 4 | reviewer reads the uncommitted working-tree diff |
| #1554 | History lens deleted dated design records | 3d History row | `Docs/20*.md` judged on dangling refs and false current claims; deletion only if over a month old and every fact is elsewhere |
| #1605 | dead-resx scan left to haiku judgment | 3d Prose & surface row | fixed mechanical step: key list, literal grep, runtime-prefix exclusion, one finding |
| #1609 | runtime verification impossible in the cloud container | 4 step 6 | headless Chromium for JS; build + razor-lint + dated session line for cshtml/resx |
| #1601 | section absent from reforge output ranked last | `select-section.py` | filled with score 0 and its LOC |

Trimmed in passing: war-story narration the file's own header forbids (Store, #1520, Guide/Finance, the dual-paste story, the judgment-selector paragraph). Net the file is longer by ~100 lines: each gate is one paragraph or one command.

## Left open

- **peterdrier/Humans#1606** (health.md History row vs `current-state-docs-no-history`): needs a ruling, not a gate. The row stays as designed until Peter decides.
- **Stray `section-doctor/*` branches on `nobodies-collective/Humans`** (#1591's list): a maintainer delete; the gate stops new ones.
- **Cadence** (meta issue 5, eight runs in one day): a routine setting, not the skill. `NOTHING CHANGED` now stops a run with nothing eligible, which bounds the queue but does not set the schedule.
- **#1604's `cost-report.py` half** was already in place (bad mark lines skipped and reported); no change.

## Existing surface checked

No new durable surface. `select-section.py` gains one git-backed function each for branch blocking and staleness; the judgment-selector subagent is removed.

## Checklist

- [x] ~~**Section labeled**~~ skill-only change
- [x] **Targeting `main` on `peterdrier/Humans`**
- [x] **Branched off `origin/main`**
- [x] **Issue refs are qualified**
- [x] ~~**EF migrations**~~ none
- [x] ~~**NuGet packages updated?**~~ none
- [x] ~~**New project rule?**~~ none; existing atoms are referenced, none added
- [x] **Reuse-first checked**
- [x] ~~**Build + test pass locally**~~ no C# changed; `select-section.py` run against the live open-PR list (44-section pool, 27 blocked, picks Rideshare, re-doctor tier orders Guide → Cantina → Onboarding → Issues) and with a PR hidden to confirm its branch blocks Events
- [x] ~~**Nav coverage**~~ n/a
- [x] ~~**No magic strings**~~ n/a
- [x] ~~**Dates/times via NodaTime**~~ n/a

## Reviewer notes

Phase 2's marker push is a real commit (the run-file header), not an empty one; `build.yml` and `e2e-qa.yml` trigger on pushes to `main` only, so it costs no CI. The re-doctor anchor is the `origin/main` commit that added the section's newest `docs/health/runs/*-<Section>.md` (`--diff-filter=A`), so a docs cleanup or a `resume` edit to `health.md` does not move it; the changed-since paths are the 3a inventory, guide page included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186cNoRWii78LpGtR3oa38Q