### PR TITLE
Budget: gate + audit ticketing sync paths, gate year rename, deny ticketing groups, drop RestoreYear

### DIFF
--- a/src/Sections/Humans.Budget/Authorization/BudgetAuthorizationHandler.cs
+++ b/src/Sections/Humans.Budget/Authorization/BudgetAuthorizationHandler.cs
@@ -15,7 +15,8 @@ namespace Humans.Budget.Authorization;
 /// - Department coordinator: allow only categories linked to their department
 /// - Everyone else: deny
 ///
-/// Also denies edits on restricted groups and deleted budget years for non-admin users.
+/// Also denies edits on restricted groups, ticketing groups, and deleted budget
+/// years for non-admin users.
 /// </summary>
 internal sealed class BudgetAuthorizationHandler(IBudgetServiceRead budgetService)
     : AuthorizationHandler<BudgetOperationRequirement, BudgetCategorySnapshot>
@@ -35,6 +36,9 @@ internal sealed class BudgetAuthorizationHandler(IBudgetServiceRead budgetServic
             return;
 
         if (resource.BudgetGroup?.IsRestricted == true)
+            return;
+
+        if (resource.BudgetGroup?.IsTicketingGroup == true)
             return;
 
         if (!resource.TeamId.HasValue)

--- a/src/Sections/Humans.Budget/Controllers/BudgetAdminController.cs
+++ b/src/Sections/Humans.Budget/Controllers/BudgetAdminController.cs
@@ -544,9 +544,12 @@ internal sealed class BudgetAdminController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncTicketingBudget(Guid yearId)
     {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
         try
         {
-            var count = await ticketingBudgetService.SyncActualsAsync(yearId);
+            var count = await ticketingBudgetService.SyncActualsAsync(yearId, user.Id);
             if (count > 0)
                 SetSuccess($"Synced {count} ticketing line item(s) from ticket sales data.");
             else

--- a/src/Sections/Humans.Budget/Data/BudgetRepository.cs
+++ b/src/Sections/Humans.Budget/Data/BudgetRepository.cs
@@ -174,6 +174,9 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
         if (budgetYear is null)
             return false;
 
+        if (budgetYear.Status == BudgetYearStatus.Closed)
+            throw new InvalidOperationException("Cannot modify a closed budget year.");
+
         if (!string.Equals(budgetYear.Year, year, StringComparison.Ordinal))
         {
             AddFieldAudit(ctx, budgetYear.Id, nameof(BudgetYear), budgetYear.Id,
@@ -263,31 +266,6 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
 
         AddDescriptionAudit(ctx, year.Id, nameof(BudgetYear), year.Id,
             $"Archived budget year '{year.Name}' ({year.Year})",
-            actorUserId, now);
-
-        await ctx.SaveChangesAsync(ct);
-        return true;
-    }
-
-    public async Task<bool> RestoreYearAsync(
-        Guid yearId,
-        Guid actorUserId,
-        Instant now,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await factory.CreateDbContextAsync(ct);
-
-        var year = await ctx.BudgetYears.FirstOrDefaultAsync(y => y.Id == yearId, ct);
-        if (year is null || !year.IsDeleted)
-            return false;
-
-        year.IsDeleted = false;
-        year.DeletedAt = null;
-        year.Status = BudgetYearStatus.Draft;
-        year.UpdatedAt = now;
-
-        AddDescriptionAudit(ctx, year.Id, nameof(BudgetYear), year.Id,
-            $"Restored budget year '{year.Name}' ({year.Year})",
             actorUserId, now);
 
         await ctx.SaveChangesAsync(ct);
@@ -884,10 +862,13 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
         Guid budgetYearId,
         IReadOnlyList<TicketingWeeklyActualsInput> weeklyActuals,
         LocalDate today,
+        Guid? actorUserId,
         Instant now,
         CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
+
+        await EnsureYearNotClosedAsync(ctx, budgetYearId, ct);
 
         var ticketingGroup = await LoadTicketingGroupForMutationAsync(ctx, budgetYearId, ct);
         if (ticketingGroup is null)
@@ -945,7 +926,12 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
             ctx, ticketingGroup.TicketingProjection, revenueCategory, feesCategory, today, now);
 
         if (ctx.ChangeTracker.HasChanges())
+        {
+            AddDescriptionAudit(ctx, budgetYearId, nameof(BudgetGroup), ticketingGroup.Id,
+                $"Ticketing sync: {lineItemsChanged} line item(s) created/updated from ticket sales data",
+                actorUserId, now);
             await ctx.SaveChangesAsync(ct);
+        }
 
         return lineItemsChanged;
     }
@@ -953,10 +939,13 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
     public async Task<int> RefreshTicketingProjectionsAsync(
         Guid budgetYearId,
         LocalDate today,
+        Guid? actorUserId,
         Instant now,
         CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
+
+        await EnsureYearNotClosedAsync(ctx, budgetYearId, ct);
 
         var ticketingGroup = await LoadTicketingGroupForMutationAsync(ctx, budgetYearId, ct);
         if (ticketingGroup is null)
@@ -974,7 +963,12 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
             ctx, ticketingGroup.TicketingProjection, revenueCategory, feesCategory, today, now);
 
         if (ctx.ChangeTracker.HasChanges())
+        {
+            AddDescriptionAudit(ctx, budgetYearId, nameof(BudgetGroup), ticketingGroup.Id,
+                $"Ticketing projections refreshed: {created} projected line item(s) materialized",
+                actorUserId, now);
             await ctx.SaveChangesAsync(ct);
+        }
 
         return created;
     }
@@ -1021,7 +1015,7 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
 
         return await ctx.BudgetAuditLogs
             .AsNoTracking()
-            .Where(bal => userIds.Contains(bal.ActorUserId))
+            .Where(bal => bal.ActorUserId.HasValue && userIds.Contains(bal.ActorUserId.Value))
             // arch:db-sort-ok budget audit user chronology
             .OrderByDescending(bal => bal.OccurredAt)
             .ToListAsync(ct);
@@ -1266,7 +1260,7 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
         BudgetDbContext ctx,
         Guid budgetYearId, string entityType, Guid entityId,
         string fieldName, string? oldValue, string? newValue,
-        Guid actorUserId, Instant occurredAt)
+        Guid? actorUserId, Instant occurredAt)
     {
         var description = $"Changed {entityType}.{fieldName} from '{oldValue}' to '{newValue}'";
         ctx.BudgetAuditLogs.Add(new BudgetAuditLog
@@ -1293,7 +1287,7 @@ internal sealed class BudgetRepository(IDbContextFactory<BudgetDbContext> factor
         BudgetDbContext ctx,
         Guid budgetYearId, string entityType, Guid entityId,
         string description,
-        Guid actorUserId, Instant occurredAt)
+        Guid? actorUserId, Instant occurredAt)
     {
         ctx.BudgetAuditLogs.Add(new BudgetAuditLog
         {

--- a/src/Sections/Humans.Budget/Data/IBudgetRepository.cs
+++ b/src/Sections/Humans.Budget/Data/IBudgetRepository.cs
@@ -26,8 +26,8 @@ namespace Humans.Budget.Data;
 /// <see cref="GetAuditLogEntriesForUserAsync"/>,
 /// <see cref="GetAuditLogEntriesForUserIdsAsync"/>). Each mutation method
 /// writes its own audit entries so they commit in the same <c>SaveChanges</c>
-/// as the business change — except the two ticketing sync paths, currently
-/// outside that guarantee (see <c>Docs/health.md</c> Seams).
+/// as the business change. A null actor on an entry means automation (the
+/// nightly ticketing sync job).
 /// </para>
 /// </remarks>
 internal interface IBudgetRepository : IRepository
@@ -98,18 +98,6 @@ internal interface IBudgetRepository : IRepository
     /// <c>true</c> if the year existed.
     /// </summary>
     Task<bool> SoftDeleteYearAsync(
-        Guid yearId,
-        Guid actorUserId,
-        Instant now,
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Reverses a soft-delete: clears <c>IsDeleted</c>/<c>DeletedAt</c>,
-    /// moves status back to Draft, and writes the restore audit entry. No-op
-    /// (returns <c>false</c>) if the year is not soft-deleted. Returns
-    /// <c>true</c> if a restore actually occurred.
-    /// </summary>
-    Task<bool> RestoreYearAsync(
         Guid yearId,
         Guid actorUserId,
         Instant now,
@@ -313,12 +301,14 @@ internal interface IBudgetRepository : IRepository
     /// The repository owns the projected-week schedule computation so it
     /// runs against the post-update projection parameters. <paramref name="today"/>
     /// defines the current ISO-week Monday cut-over (passed in so the
-    /// repository stays <c>IClock</c>-free).
+    /// repository stays <c>IClock</c>-free). A null <paramref name="actorUserId"/>
+    /// records the sync audit entry as automation (the nightly job).
     /// </remarks>
     Task<int> SyncTicketingActualsAsync(
         Guid budgetYearId,
         IReadOnlyList<TicketingWeeklyActualsInput> weeklyActuals,
         LocalDate today,
+        Guid? actorUserId,
         Instant now,
         CancellationToken ct = default);
 
@@ -335,6 +325,7 @@ internal interface IBudgetRepository : IRepository
     Task<int> RefreshTicketingProjectionsAsync(
         Guid budgetYearId,
         LocalDate today,
+        Guid? actorUserId,
         Instant now,
         CancellationToken ct = default);
 

--- a/src/Sections/Humans.Budget/Data/Migrations/20260910002053_TicketingSyncAuditActorNullable.Designer.cs
+++ b/src/Sections/Humans.Budget/Data/Migrations/20260910002053_TicketingSyncAuditActorNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Budget.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Budget.Data.Migrations
 {
     [DbContext(typeof(BudgetDbContext))]
-    partial class BudgetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260910002053_TicketingSyncAuditActorNullable")]
+    partial class TicketingSyncAuditActorNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Budget/Data/Migrations/20260910002053_TicketingSyncAuditActorNullable.cs
+++ b/src/Sections/Humans.Budget/Data/Migrations/20260910002053_TicketingSyncAuditActorNullable.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Budget.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class TicketingSyncAuditActorNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ActorUserId",
+                table: "budget_audit_logs",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ActorUserId",
+                table: "budget_audit_logs",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Sections/Humans.Budget/Docs/Budget.md
+++ b/src/Sections/Humans.Budget/Docs/Budget.md
@@ -117,7 +117,7 @@ Detail row within a category.
 
 ### BudgetAuditLog
 
-Append-only per design-rules §12. `IBudgetRepository` exposes no add/update/delete surface for audit rows — each mutation method writes its own audit rows inside the same `SaveChanges`, except the two ticketing sync paths, currently outside it (see Seams in health.md) — plus the reads: `GetAuditLogAsync`, `GetAuditLogEntriesForUserAsync`, `GetAuditLogEntriesForUserIdsAsync`.
+Append-only per design-rules §12. `IBudgetRepository` exposes no add/update/delete surface for audit rows — each mutation method writes its own audit rows inside the same `SaveChanges` (the ticketing sync paths write one summary row per run that changed anything) — plus the reads: `GetAuditLogAsync`, `GetAuditLogEntriesForUserAsync`, `GetAuditLogEntriesForUserIdsAsync`.
 
 **Table:** `budget_audit_logs`
 
@@ -131,7 +131,7 @@ Append-only per design-rules §12. `IBudgetRepository` exposes no add/update/del
 | OldValue | string? | Serialized old value |
 | NewValue | string? | Serialized new value |
 | Description | string | Human-readable summary |
-| ActorUserId | Guid | Cross-section FK → Users/Identity |
+| ActorUserId | Guid? | Cross-section FK → Users/Identity; null = automation (the nightly ticketing sync job), rendered as "System" |
 | OccurredAt | Instant | |
 
 **Cross-section FKs:** `ActorUserId` → Users/Identity — **FK only**, no navigation property; callers resolve display names via `IUserServiceRead`.
@@ -194,15 +194,16 @@ Stored as string via `HasConversion<string>()`.
 ## Invariants
 
 - A budget year follows the lifecycle: Draft then Active then Closed. Only one year can be Active at a time — activating a Draft auto-closes any currently Active year (`BudgetRepository.UpdateYearStatusAsync`).
+- A Closed year is read-only: every repository mutation — the ticketing sync pair and the year-metadata rename included — refuses with `InvalidOperationException`. Only `UpdateYearStatusAsync` (Reactivate) and `DeleteYearAsync` (archive) act on a Closed year.
 - A coordinator can only create, edit, or delete line items in categories linked to a department they coordinate.
 - Restricted groups are editable only by FinanceAdmin and Admin. Coordinators see the group header and category names in `/Budget` (with a "Restricted" badge in place of the drill-in link) and the group's totals roll up into `/Budget/Summary` aggregates, but `/Budget/Category/{id}` returns `Forbid` for non-finance users.
 - Ticketing groups are hidden from the `/Budget` index for non-finance users (`Index.cshtml` filters `IsTicketingGroup` unless `IsFinanceAdmin`); their aggregates still appear in `/Budget/Summary`, and `/Budget/Category/{id}` returns `Forbid` for non-finance users on any ticketing category.
-- Every create, update, or delete on a group, category, or line item generates a `BudgetAuditLog` entry recording old value, new value, actor, and timestamp.
+- Every create, update, or delete on a group, category, or line item generates a `BudgetAuditLog` entry recording old value, new value, actor, and timestamp; the ticketing sync paths write one summary entry per run that changed anything, with a null actor for the nightly job.
 - "Sync Departments" creates a category for each department that does not already have one in the selected year.
 - `/Finance` index shows a consolidated accordion view: groups, categories with budget vs actual comparison, and inline line items. FinanceAdmin sees all summary data inline.
 - `/Finance/CashFlow` view aggregates line items by time period (weekly/monthly) and shows running net.
 - `budget_audit_logs` is append-only per §12.
-- Resource-based authorization per design-rules §11: `BudgetAuthorizationHandler` + `BudgetOperationRequirement` gate all coordinator writes against a `BudgetCategory` resource.
+- Resource-based authorization per design-rules §11: `BudgetAuthorizationHandler` + `BudgetOperationRequirement` gate all coordinator writes against a `BudgetCategory` resource, denying restricted groups, ticketing groups, and archived years for non-finance users.
 
 ## Negative Access Rules
 
@@ -210,7 +211,7 @@ Stored as string via `HasConversion<string>()`.
 - Coordinators **cannot** edit budget groups or categories, and **cannot** edit any line items inside restricted or ticketing groups. They can only manage line items in non-restricted, non-ticketing categories linked to a department they coordinate.
 - Coordinators **cannot** drill into a restricted-group category (`/Budget/Category/{id}` returns `Forbid`); they only see the group header and category names in `/Budget` plus the rollup in `/Budget/Summary`.
 - Coordinators **cannot** see ticketing groups in `/Budget` and **cannot** open any ticketing category — only the rollup appears in `/Budget/Summary`.
-- Coordinators **cannot** create, activate, close, archive, or restore budget years (all `/Finance/Years/*` actions require `FinanceAdminOrAdmin`).
+- Coordinators **cannot** create, activate, close, reactivate, or archive budget years (all `/Finance/Years/*` actions require `FinanceAdminOrAdmin`).
 
 ## Triggers
 
@@ -237,7 +238,7 @@ Stored as string via `HasConversion<string>()`.
 - **Cross-section calls** route through `ITeamServiceRead.GetTeamsAsync` (team lookups; coordinator scope is computed in-section over the same read model, see Cross-Section Dependencies) and `IUserServiceRead.GetUserInfosAsync` for actor display names. The ticketing-actuals data flows *inbound* via `IBudgetService.SyncTicketingActualsAsync`, called by the Tickets-section `TicketingBudgetService` bridge.
 - **Controller split under `/Finance`.** `BudgetAdminController` (`Humans.Budget.Controllers`) owns Budget's own admin surface — years, groups, categories, line items, ticketing projection, cash flow, audit log — at `[Route("Finance")]`. It shares that route prefix with `Humans.Finance.Controllers.FinanceController`, which owns only the Holded/creditor actions; the two controllers' action templates are disjoint. See [`src/Sections/Humans.Finance/Docs/Finance.md`](../../Humans.Finance/Docs/Finance.md) for the Finance side.
 - **Render test** — `tests/Humans.Integration.Tests/Controllers/BudgetPageRenderTests.cs`: every page renders with no raw `Budget_` key and no unbound `<vc:>` tag, in English and Spanish. General architecture coverage (`HUM0009`, `HUM0034`) applies to Budget code paths. No dedicated `BudgetArchitectureTests.cs` file exists.
-- **Repository shape** — `budget_audit_logs` is append-only (§12); the CRUD mutation methods write their audit rows inside their own `SaveChanges` — the two ticketing sync paths currently write none (see `Docs/health.md` Seams) — and the repository's audit surface is read-only.
+- **Repository shape** — `budget_audit_logs` is append-only (§12); the CRUD mutation methods write their audit rows inside their own `SaveChanges` — the ticketing sync paths write one summary row per run that changed anything — and the repository's audit surface is read-only.
 
 ### Touch-and-clean guidance
 

--- a/src/Sections/Humans.Budget/Docs/health.md
+++ b/src/Sections/Humans.Budget/Docs/health.md
@@ -11,7 +11,7 @@ items for their own departments; every member can see a high-level summary. Tick
 actuals flow in nightly and replace the auto-generated projections (hand-entered line
 items are never touched); projected future ticket weeks are re-forecast from those
 actuals. Every change to the plan is recorded in an append-only audit trail the Board
-can read — except the two ticketing sync paths, currently outside it (see Seams). Cash-flow views answer "when does the money move, and do
+can read. Cash-flow views answer "when does the money move, and do
 we run out?" including the VAT the association will settle each quarter.
 
 ## The shapes
@@ -39,8 +39,7 @@ The shapes imply exactly the layered split that exists:
 - One `TicketingBudgetService` bridge: aggregates paid orders from `ITicketServiceRead` into
   weekly actuals and hands them to `IBudgetService`; no data of its own.
 - One singleton `BudgetRepository` (`IDbContextFactory`): each mutation is one atomic
-  method that writes its audit rows in the same `SaveChanges` — except the two ticketing
-  sync paths, which currently write none (see Seams). The projected-week
+  method that writes its audit rows in the same `SaveChanges`. The projected-week
   materialization lives here so it runs against post-sync projection parameters.
 - Contracts leaf carries only what external callers read: the read methods, the seeder
   hook, the DTO records, the enums.
@@ -49,11 +48,12 @@ The shapes imply exactly the layered split that exists:
 
 - At most one `Active` year: activating a Draft auto-closes any other Active year, with
   audit entries for both transitions.
-- A `Closed` year is read-only: repository mutations gate on it and refuse (the ticketing
-  sync pair and the year-metadata rename sit outside the gate today — see Seams).
+- A `Closed` year is read-only: every repository mutation — the ticketing sync pair and
+  the year-metadata rename included — gates on it and refuses.
 - Every create/update/delete of a year, group, category, line item, or projection writes a
-  `BudgetAuditLog` row in the same transaction; the log is append-only (no update/delete
-  surface exists, §12).
+  `BudgetAuditLog` row in the same transaction; the ticketing sync paths write one summary
+  row per run that changed anything (null actor = the nightly job, rendered as "System");
+  the log is append-only (no update/delete surface exists, §12).
 - Coordinators may write line items only in categories whose `TeamId` is a department they
   coordinate (or a child of it), and never in restricted or ticketing groups; the
   resource-based `BudgetAuthorizationHandler` is the single gate for those writes.
@@ -68,22 +68,10 @@ The shapes imply exactly the layered split that exists:
 
 ## Seams
 
-- **The ticketing paths sit outside the section's cross-cutting guarantees.** This is one
-  class, not one-offs: `SyncTicketingActualsAsync` and `RefreshTicketingProjectionsAsync`
-  neither call the closed-year gate (finding 5) nor write `BudgetAuditLog` rows for the
-  line items they mutate (finding 22) — the nightly job and admin refresh can change a
-  closed year's ticketing items invisibly. Bring the pair under the guarantees or exempt
-  them in the invariants — Peter's call (2026-08-30 run, peterdrier/Humans#1565); neither
-  side changed until then.
-- **Closed-year metadata edits are ungated.** `UpdateYearAsync` — the Edit Year rename
-  form, which renders for Closed years too — never calls the closed-year gate, so a Closed
-  year's identifier and name can still change (audited, but ungated; finding 23). Same
-  ruling class as finding 5: gate it or exempt year-metadata edits — Peter's call, neither
-  side changed until then.
-- **Ticketing-group deny vs the handler.** The coordinator invariant's "never in ticketing
-  groups" half is not enforced: `BudgetAuthorizationHandler` has no `IsTicketingGroup`
-  check, masked today by null `TeamId` on scaffolded ticketing categories (finding 6, same
-  run and PR).
+- (The 2026-08-30 run's three seams — ticketing paths outside the closed-year gate and
+  audit trail, ungated closed-year metadata edits, missing ticketing-group deny in the
+  authorization handler — were ruled on by Peter 2026-09-10 and closed: gate, audit, and
+  deny all landed.)
 - (The 2026-08-18 `NoActiveYear.cshtml` missing-links debt was found already
   built — `HoldedAccounts`, `HoldedUnmatched`, `Creditors` links exist — and its
   `Docs/debt.yml` entry removed this run.)

--- a/src/Sections/Humans.Budget/Docs/health.md
+++ b/src/Sections/Humans.Budget/Docs/health.md
@@ -115,4 +115,4 @@ The shapes imply exactly the layered split that exists:
 
 | Run | Date | Headline | PR |
 |---|---|---|---|
-| section-doctor | 2026-08-30 | First pass: doc truth, one home for the VAT math, three untested invariants pinned | peterdrier/Humans#1565 |
+| section-doctor | 2026-08-30 | First pass: doc truth, one home for the VAT math, untested invariants pinned | peterdrier/Humans#1565 |

--- a/src/Sections/Humans.Budget/Docs/health.md
+++ b/src/Sections/Humans.Budget/Docs/health.md
@@ -68,13 +68,7 @@ The shapes imply exactly the layered split that exists:
 
 ## Seams
 
-- (The 2026-08-30 run's three seams — ticketing paths outside the closed-year gate and
-  audit trail, ungated closed-year metadata edits, missing ticketing-group deny in the
-  authorization handler — were ruled on by Peter 2026-09-10 and closed: gate, audit, and
-  deny all landed.)
-- (The 2026-08-18 `NoActiveYear.cshtml` missing-links debt was found already
-  built — `HoldedAccounts`, `HoldedUnmatched`, `Creditors` links exist — and its
-  `Docs/debt.yml` entry removed this run.)
+- None open.
 
 ## Deliberately not done
 

--- a/src/Sections/Humans.Budget/Domain/BudgetAuditLog.cs
+++ b/src/Sections/Humans.Budget/Domain/BudgetAuditLog.cs
@@ -16,7 +16,9 @@ internal sealed class BudgetAuditLog
     public string? OldValue { get; init; }
     public string? NewValue { get; init; }
     public string Description { get; init; } = string.Empty;
-    public Guid ActorUserId { get; init; }
+
+    /// <summary>Null when the change was made by automation (the nightly ticketing sync job).</summary>
+    public Guid? ActorUserId { get; init; }
 
     public Instant OccurredAt { get; init; }
 }

--- a/src/Sections/Humans.Budget/Jobs/TicketingBudgetSyncJob.cs
+++ b/src/Sections/Humans.Budget/Jobs/TicketingBudgetSyncJob.cs
@@ -44,7 +44,7 @@ public sealed class TicketingBudgetSyncJob : IRecurringJob
 
         try
         {
-            var count = await _ticketingBudgetService.SyncActualsAsync(activeYear.Id);
+            var count = await _ticketingBudgetService.SyncActualsAsync(activeYear.Id, actorUserId: null);
             _logger.LogInformation("Ticketing budget sync completed: {Count} line items synced", count);
         }
         catch (Exception ex)

--- a/src/Sections/Humans.Budget/Services/BudgetService.cs
+++ b/src/Sections/Humans.Budget/Services/BudgetService.cs
@@ -490,6 +490,8 @@ internal sealed class BudgetService(
         int initialSalesCount, decimal dailySalesRate, decimal averageTicketPrice, int vatRate,
         decimal stripeFeePercent, decimal stripeFeeFixed, decimal ticketTailorFeePercent, Guid actorUserId)
     {
+        ValidateVatRate(vatRate);
+
         var now = clock.GetCurrentInstant();
 
         var update = new TicketingProjectionUpdate(

--- a/src/Sections/Humans.Budget/Services/BudgetService.cs
+++ b/src/Sections/Humans.Budget/Services/BudgetService.cs
@@ -196,15 +196,6 @@ internal sealed class BudgetService(
         logger.LogInformation("Archived budget year {YearId}", yearId);
     }
 
-    public async Task RestoreYearAsync(Guid yearId, Guid actorUserId)
-    {
-        var now = clock.GetCurrentInstant();
-
-        var restored = await repository.RestoreYearAsync(yearId, actorUserId, now);
-        if (restored)
-            logger.LogInformation("Restored budget year {YearId}", yearId);
-    }
-
     public async Task<int> SyncDepartmentsAsync(Guid budgetYearId, Guid actorUserId)
     {
         var now = clock.GetCurrentInstant();
@@ -750,6 +741,7 @@ internal sealed class BudgetService(
     public async Task<int> SyncTicketingActualsAsync(
         Guid budgetYearId,
         IReadOnlyList<TicketingWeeklyActuals> weeklyActuals,
+        Guid? actorUserId,
         CancellationToken ct = default)
     {
         var now = clock.GetCurrentInstant();
@@ -766,7 +758,7 @@ internal sealed class BudgetService(
             .ToList();
 
         var changed = await repository.SyncTicketingActualsAsync(
-            budgetYearId, actualsInputs, today, now, ct);
+            budgetYearId, actualsInputs, today, actorUserId, now, ct);
 
         logger.LogInformation(
             "Ticketing budget sync: {Created} line items created/updated for {Weeks} actual weeks + projections",
@@ -775,12 +767,14 @@ internal sealed class BudgetService(
         return changed;
     }
 
-    public async Task<int> RefreshTicketingProjectionsAsync(Guid budgetYearId, CancellationToken ct = default)
+    public async Task<int> RefreshTicketingProjectionsAsync(
+        Guid budgetYearId, Guid? actorUserId, CancellationToken ct = default)
     {
         var now = clock.GetCurrentInstant();
         var today = now.InUtc().Date;
 
-        var created = await repository.RefreshTicketingProjectionsAsync(budgetYearId, today, now, ct);
+        var created = await repository.RefreshTicketingProjectionsAsync(
+            budgetYearId, today, actorUserId, now, ct);
 
         logger.LogInformation("Ticketing projections refreshed: {Count} line items", created);
         return created;

--- a/src/Sections/Humans.Budget/Services/DevelopmentBudgetSeeder.cs
+++ b/src/Sections/Humans.Budget/Services/DevelopmentBudgetSeeder.cs
@@ -178,7 +178,9 @@ internal sealed class DevelopmentBudgetSeeder(
             budgetYearId = budgetYearSummary.Id;
             if (budgetYearSummary.IsDeleted)
             {
-                await budgetService.RestoreYearAsync(budgetYearId, actorUserId);
+                // An archived demo year is a deliberate operator state — leave it
+                // archived rather than resurrecting it.
+                return $"Budget demo year '{budgetYearSummary.Name}' is archived; skipped budget seeding.";
             }
         }
 

--- a/src/Sections/Humans.Budget/Services/Dtos/BudgetDtos.cs
+++ b/src/Sections/Humans.Budget/Services/Dtos/BudgetDtos.cs
@@ -46,7 +46,7 @@ internal sealed record BudgetAuditLogSnapshot(
     string? OldValue,
     string? NewValue,
     string Description,
-    Guid ActorUserId,
+    Guid? ActorUserId,
     Instant OccurredAt);
 
 internal sealed record CoordinatorBudgetViewData(

--- a/src/Sections/Humans.Budget/Services/IBudgetService.cs
+++ b/src/Sections/Humans.Budget/Services/IBudgetService.cs
@@ -24,7 +24,6 @@ internal interface IBudgetService : IBudgetServiceRead, IApplicationService
     Task UpdateYearStatusAsync(Guid yearId, BudgetYearStatus status, Guid actorUserId);
     Task UpdateYearAsync(Guid yearId, string year, string name, Guid actorUserId);
     Task DeleteYearAsync(Guid yearId, Guid actorUserId);
-    Task RestoreYearAsync(Guid yearId, Guid actorUserId);
 
     Task<int> SyncDepartmentsAsync(Guid budgetYearId, Guid actorUserId);
     Task<EnsureTicketingGroupResult> EnsureTicketingGroupAsync(Guid budgetYearId, Guid actorUserId);
@@ -40,11 +39,14 @@ internal interface IBudgetService : IBudgetServiceRead, IApplicationService
     /// each completed week's revenue and processing fees, refreshes projection
     /// parameters (average ticket price, stripe fee %, TicketTailor fee %) from
     /// those actuals, and re-materializes projected line items for future weeks.
-    /// Returns the number of line items created or updated.
+    /// Returns the number of line items created or updated. A null
+    /// <paramref name="actorUserId"/> means the nightly job; the sync audit
+    /// entry then records the actor as automation.
     /// </summary>
     Task<int> SyncTicketingActualsAsync(
         Guid budgetYearId,
         IReadOnlyList<TicketingWeeklyActuals> weeklyActuals,
+        Guid? actorUserId,
         CancellationToken ct = default);
 
     /// <summary>
@@ -52,7 +54,8 @@ internal interface IBudgetService : IBudgetServiceRead, IApplicationService
     /// after projection parameters change so the projected lines reflect the new inputs.
     /// Returns the number of projected line items created.
     /// </summary>
-    Task<int> RefreshTicketingProjectionsAsync(Guid budgetYearId, CancellationToken ct = default);
+    Task<int> RefreshTicketingProjectionsAsync(
+        Guid budgetYearId, Guid? actorUserId, CancellationToken ct = default);
 
     /// <summary>
     /// Compute virtual (non-persisted) weekly ticket projections for future weeks.

--- a/src/Sections/Humans.Budget/Services/ITicketingBudgetService.cs
+++ b/src/Sections/Humans.Budget/Services/ITicketingBudgetService.cs
@@ -17,6 +17,8 @@ internal interface ITicketingBudgetService : IOrchestrator
     /// <summary>
     /// Sync completed weeks of ticket sales into budget line items from TicketTailor/Stripe data,
     /// then refresh projections for future weeks. Returns the number of line items touched.
+    /// A null <paramref name="actorUserId"/> means the nightly job; the sync audit entry then
+    /// records the actor as automation.
     /// </summary>
-    Task<int> SyncActualsAsync(Guid budgetYearId, CancellationToken ct = default);
+    Task<int> SyncActualsAsync(Guid budgetYearId, Guid? actorUserId, CancellationToken ct = default);
 }

--- a/src/Sections/Humans.Budget/Services/TicketingBudgetService.cs
+++ b/src/Sections/Humans.Budget/Services/TicketingBudgetService.cs
@@ -13,7 +13,8 @@ internal sealed class TicketingBudgetService(
     IClock clock,
     ILogger<TicketingBudgetService> logger) : ITicketingBudgetService
 {
-    public async Task<int> SyncActualsAsync(Guid budgetYearId, CancellationToken ct = default)
+    public async Task<int> SyncActualsAsync(
+        Guid budgetYearId, Guid? actorUserId, CancellationToken ct = default)
     {
         try
         {
@@ -44,7 +45,8 @@ internal sealed class TicketingBudgetService(
                 })
                 .ToList();
 
-            return await budgetService.SyncTicketingActualsAsync(budgetYearId, weeklyActuals, ct);
+            return await budgetService.SyncTicketingActualsAsync(
+                budgetYearId, weeklyActuals, actorUserId, ct);
         }
         catch (Exception ex)
         {
@@ -53,11 +55,12 @@ internal sealed class TicketingBudgetService(
         }
     }
 
-    public async Task<int> RefreshProjectionsAsync(Guid budgetYearId, CancellationToken ct = default)
+    public async Task<int> RefreshProjectionsAsync(
+        Guid budgetYearId, Guid? actorUserId, CancellationToken ct = default)
     {
         try
         {
-            return await budgetService.RefreshTicketingProjectionsAsync(budgetYearId, ct);
+            return await budgetService.RefreshTicketingProjectionsAsync(budgetYearId, actorUserId, ct);
         }
         catch (Exception ex)
         {
@@ -84,7 +87,7 @@ internal sealed class TicketingBudgetService(
             command.TicketTailorFeePercent,
             actorUserId);
 
-        return await RefreshProjectionsAsync(command.BudgetYearId, ct);
+        return await RefreshProjectionsAsync(command.BudgetYearId, actorUserId, ct);
     }
 
     public Task<IReadOnlyList<TicketingWeekProjection>> GetProjectionsAsync(Guid budgetGroupId)

--- a/src/Sections/Humans.Budget/Views/BudgetAdmin/Admin.cshtml
+++ b/src/Sections/Humans.Budget/Views/BudgetAdmin/Admin.cshtml
@@ -67,7 +67,7 @@
         </div>
         <div class="card-body">
             <div class="mb-3">
-                @if (!budgetYear.IsDeleted)
+                @if (!budgetYear.IsDeleted && budgetYear.Status != BudgetYearStatus.Closed)
                 {
                     <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#@yearEditId">
                         <i class="fa-solid fa-pen me-1"></i>Edit Year
@@ -122,22 +122,25 @@
                 }
             </div>
 
-            <div id="@yearEditId" class="collapse mb-3">
-                <form asp-action="UpdateYear" asp-route-id="@budgetYear.Id" method="post" class="row g-2 align-items-end p-3 bg-light rounded">
-                    @Html.AntiForgeryToken()
-                    <div class="col-md-3">
-                        <label class="form-label form-label-sm">Year Identifier</label>
-                        <input type="text" name="year" class="form-control form-control-sm" value="@budgetYear.Year" required />
-                    </div>
-                    <div class="col-md-5">
-                        <label class="form-label form-label-sm">Name</label>
-                        <input type="text" name="name" class="form-control form-control-sm" value="@budgetYear.Name" required />
-                    </div>
-                    <div class="col-md-4">
-                        <button type="submit" class="btn btn-primary btn-sm">Save Changes</button>
-                    </div>
-                </form>
-            </div>
+            @if (!budgetYear.IsDeleted && budgetYear.Status != BudgetYearStatus.Closed)
+            {
+                <div id="@yearEditId" class="collapse mb-3">
+                    <form asp-action="UpdateYear" asp-route-id="@budgetYear.Id" method="post" class="row g-2 align-items-end p-3 bg-light rounded">
+                        @Html.AntiForgeryToken()
+                        <div class="col-md-3">
+                            <label class="form-label form-label-sm">Year Identifier</label>
+                            <input type="text" name="year" class="form-control form-control-sm" value="@budgetYear.Year" required />
+                        </div>
+                        <div class="col-md-5">
+                            <label class="form-label form-label-sm">Name</label>
+                            <input type="text" name="name" class="form-control form-control-sm" value="@budgetYear.Name" required />
+                        </div>
+                        <div class="col-md-4">
+                            <button type="submit" class="btn btn-primary btn-sm">Save Changes</button>
+                        </div>
+                    </form>
+                </div>
+            }
 
             <h6 class="mt-3">
                 <button class="btn btn-link btn-sm text-decoration-none p-0" type="button" data-bs-toggle="collapse" data-bs-target="#@yearGroupsId">

--- a/src/Sections/Humans.Budget/Views/BudgetAdmin/AuditLog.cshtml
+++ b/src/Sections/Humans.Budget/Views/BudgetAdmin/AuditLog.cshtml
@@ -38,7 +38,16 @@
 @if (Model.Count > 0)
 {
     Func<BudgetAuditLogSnapshot, IHtmlContent> whoCell =
-        @<text><vc:human user-id="@item.ActorUserId" /></text>;
+        @<text>
+            @if (item.ActorUserId is Guid actorId)
+            {
+                <vc:human user-id="@actorId" />
+            }
+            else
+            {
+                <span class="text-muted">System</span>
+            }
+        </text>;
     Func<BudgetAuditLogSnapshot, IHtmlContent> entityTypeCell =
         @<text><span class="badge bg-secondary">@item.EntityType</span></text>;
     Func<BudgetAuditLogSnapshot, IHtmlContent> oldValueCell = @<text>

--- a/tests/Humans.Budget.Tests/Authorization/BudgetAuthorizationHandlerTests.cs
+++ b/tests/Humans.Budget.Tests/Authorization/BudgetAuthorizationHandlerTests.cs
@@ -25,23 +25,25 @@ public sealed class BudgetAuthorizationHandlerTests
             .Returns([CoordinatorTeamId]);
     }
 
-    public static TheoryData<string, string, bool, bool, bool, bool> BudgetAuthorizationCases => new()
+    public static TheoryData<string, string, bool, bool, bool, bool, bool> BudgetAuthorizationCases => new()
     {
-        { "admin", "other", false, false, true, true },
-        { "admin", "other", true, false, true, true },
-        { "admin", "other", false, true, true, true },
-        { "finance-admin", "other", false, false, true, true },
-        { "finance-admin", "other", true, false, true, true },
-        { "finance-admin", "none", false, false, true, true },
-        { "coordinator", "coordinator", false, false, true, true },
-        { "coordinator", "other", false, false, true, false },
-        { "coordinator", "coordinator", true, false, true, false },
-        { "coordinator", "coordinator", false, true, true, false },
-        { "coordinator", "none", false, false, true, false },
-        { "regular", "coordinator", false, false, true, false },
-        { "anonymous", "coordinator", false, false, true, false },
-        { "invalid-id", "coordinator", false, false, true, false },
-        { "coordinator", "coordinator", false, false, false, true },
+        { "admin", "other", false, false, false, true, true },
+        { "admin", "other", true, false, false, true, true },
+        { "admin", "other", false, true, false, true, true },
+        { "finance-admin", "other", false, false, false, true, true },
+        { "finance-admin", "other", true, false, false, true, true },
+        { "finance-admin", "other", false, false, true, true, true },
+        { "finance-admin", "none", false, false, false, true, true },
+        { "coordinator", "coordinator", false, false, false, true, true },
+        { "coordinator", "other", false, false, false, true, false },
+        { "coordinator", "coordinator", true, false, false, true, false },
+        { "coordinator", "coordinator", false, true, false, true, false },
+        { "coordinator", "coordinator", false, false, true, true, false },
+        { "coordinator", "none", false, false, false, true, false },
+        { "regular", "coordinator", false, false, false, true, false },
+        { "anonymous", "coordinator", false, false, false, true, false },
+        { "invalid-id", "coordinator", false, false, false, true, false },
+        { "coordinator", "coordinator", false, false, false, false, true },
     };
 
     [HumansTheory]
@@ -51,6 +53,7 @@ public sealed class BudgetAuthorizationHandlerTests
         string teamKind,
         bool isRestricted,
         bool isDeleted,
+        bool isTicketing,
         bool hasBudgetGroup,
         bool expected)
     {
@@ -61,7 +64,7 @@ public sealed class BudgetAuthorizationHandlerTests
         }
 
         var user = CreateUser(userKind);
-        var category = CreateCategory(teamKind, isRestricted, isDeleted, hasBudgetGroup);
+        var category = CreateCategory(teamKind, isRestricted, isDeleted, isTicketing, hasBudgetGroup);
 
         var result = await EvaluateAsync(user, category);
 
@@ -81,6 +84,7 @@ public sealed class BudgetAuthorizationHandlerTests
         string teamKind,
         bool isRestricted = false,
         bool isDeleted = false,
+        bool isTicketing = false,
         bool hasBudgetGroup = true)
     {
         Guid? teamId = teamKind switch
@@ -108,7 +112,7 @@ public sealed class BudgetAuthorizationHandlerTests
                     yearId,
                     "Group",
                     isRestricted,
-                    false,
+                    isTicketing,
                     new BudgetCategoryYearSnapshot(yearId, "2026", "Budget 2026", isDeleted))
                 : null,
             []);

--- a/tests/Humans.Budget.Tests/Services/BudgetServiceTests.cs
+++ b/tests/Humans.Budget.Tests/Services/BudgetServiceTests.cs
@@ -564,7 +564,7 @@ public sealed class BudgetServiceTests
                 TicketTailorFees: 5m)
         };
 
-        var changed = await _service.SyncTicketingActualsAsync(_yearId, actuals, TestContext.Current.CancellationToken);
+        var changed = await _service.SyncTicketingActualsAsync(_yearId, actuals, actorUserId: null, TestContext.Current.CancellationToken);
 
         changed.Should().BeGreaterThan(0);
 
@@ -585,6 +585,49 @@ public sealed class BudgetServiceTests
     }
 
     [HumansFact]
+    public async Task SyncTicketingActualsAsync_writes_audit_entry_with_null_actor_for_automation()
+    {
+        await SeedTicketingYearAsync();
+
+        var actuals = new List<TicketingWeeklyActuals>
+        {
+            new(Monday: new LocalDate(2026, 3, 2),
+                Sunday: new LocalDate(2026, 3, 8),
+                WeekLabel: "Mar 2–Mar 8",
+                TicketCount: 10,
+                Revenue: 500m,
+                StripeFees: 15m,
+                TicketTailorFees: 5m)
+        };
+
+        await _service.SyncTicketingActualsAsync(_yearId, actuals, actorUserId: null, TestContext.Current.CancellationToken);
+
+        await using var ctx = await BudgetDbFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var auditEntry = await ctx.BudgetAuditLogs
+            .SingleAsync(a => a.BudgetYearId == _yearId && a.Description.StartsWith("Ticketing sync:"), TestContext.Current.CancellationToken);
+        auditEntry.ActorUserId.Should().BeNull(because: "a null actor marks the entry as automation");
+    }
+
+    [HumansFact]
+    public async Task RefreshTicketingProjectionsAsync_writes_audit_entry_with_the_acting_user()
+    {
+        var (groupId, _, _, _) = await SeedTicketingYearAsync();
+        await ConfigureProjectionAsync(groupId,
+            startDate: new LocalDate(2026, 3, 15),
+            eventDate: new LocalDate(2026, 4, 15),
+            averageTicketPrice: 100m,
+            dailySalesRate: 5m);
+
+        var actor = Guid.NewGuid();
+        await _service.RefreshTicketingProjectionsAsync(_yearId, actor, TestContext.Current.CancellationToken);
+
+        await using var ctx = await BudgetDbFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var auditEntry = await ctx.BudgetAuditLogs
+            .SingleAsync(a => a.BudgetYearId == _yearId && a.Description.StartsWith("Ticketing projections refreshed:"), TestContext.Current.CancellationToken);
+        auditEntry.ActorUserId.Should().Be(actor);
+    }
+
+    [HumansFact]
     public async Task SyncTicketingActualsAsync_is_noop_when_no_ticketing_group()
     {
         await using (var ctx = await BudgetDbFactory.CreateDbContextAsync(TestContext.Current.CancellationToken))
@@ -601,7 +644,7 @@ public sealed class BudgetServiceTests
 
         var result = await _service.SyncTicketingActualsAsync(
             _yearId,
-            new List<TicketingWeeklyActuals>(), TestContext.Current.CancellationToken);
+            new List<TicketingWeeklyActuals>(), actorUserId: null, TestContext.Current.CancellationToken);
 
         result.Should().Be(0);
     }
@@ -616,7 +659,7 @@ public sealed class BudgetServiceTests
             averageTicketPrice: 100m,
             dailySalesRate: 5m);
 
-        var created = await _service.RefreshTicketingProjectionsAsync(_yearId, TestContext.Current.CancellationToken);
+        var created = await _service.RefreshTicketingProjectionsAsync(_yearId, actorUserId: null, TestContext.Current.CancellationToken);
 
         created.Should().BeGreaterThan(0);
 
@@ -656,7 +699,7 @@ public sealed class BudgetServiceTests
                 TicketTailorFees: 0m)
         };
 
-        await _service.SyncTicketingActualsAsync(_yearId, actuals, TestContext.Current.CancellationToken);
+        await _service.SyncTicketingActualsAsync(_yearId, actuals, actorUserId: null, TestContext.Current.CancellationToken);
 
         await using var ctx = await BudgetDbFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
 
@@ -742,7 +785,7 @@ public sealed class BudgetServiceTests
                 TicketTailorFees: 30m)
         };
 
-        await _service.SyncTicketingActualsAsync(_yearId, actuals, TestContext.Current.CancellationToken);
+        await _service.SyncTicketingActualsAsync(_yearId, actuals, actorUserId: null, TestContext.Current.CancellationToken);
 
         await using var verify = await BudgetDbFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
         var manual = await verify.BudgetLineItems.SingleAsync(li => li.Id == manualId, TestContext.Current.CancellationToken);
@@ -800,7 +843,8 @@ public sealed class BudgetServiceTests
         "create-group", "update-group", "delete-group",
         "create-category", "update-category", "delete-category",
         "create-line-item", "update-line-item", "delete-line-item",
-        "sync-departments", "ensure-ticketing-group", "update-ticketing-projection"
+        "sync-departments", "ensure-ticketing-group", "update-ticketing-projection",
+        "update-year", "sync-ticketing-actuals", "refresh-ticketing-projections"
     };
 
     [HumansTheory]
@@ -841,6 +885,9 @@ public sealed class BudgetServiceTests
             "sync-departments" => () => _repository.SyncDepartmentCategoriesAsync(_yearId, [new BudgetableTeamRef(Guid.NewGuid(), "Team")], actor, now, ct),
             "ensure-ticketing-group" => () => _repository.EnsureTicketingGroupAsync(_yearId, actor, now, ct),
             "update-ticketing-projection" => () => _repository.UpdateTicketingProjectionAsync(new TicketingProjectionUpdate(ticketingGroupId, null, null, 0, 0m, 0m, 10, 0m, 0m, 0m), actor, now, ct),
+            "update-year" => () => _repository.UpdateYearAsync(_yearId, "2027", "Renamed", actor, now, ct),
+            "sync-ticketing-actuals" => () => _repository.SyncTicketingActualsAsync(_yearId, [], Clock.GetCurrentInstant().InUtc().Date, actor, now, ct),
+            "refresh-ticketing-projections" => () => _repository.RefreshTicketingProjectionsAsync(_yearId, Clock.GetCurrentInstant().InUtc().Date, actor, now, ct),
             _ => throw new ArgumentOutOfRangeException(nameof(mutation), mutation, null)
         };
 

--- a/tests/Humans.Budget.Tests/Services/BudgetServiceTests.cs
+++ b/tests/Humans.Budget.Tests/Services/BudgetServiceTests.cs
@@ -135,6 +135,18 @@ public sealed class BudgetServiceTests
             .WithMessage("*between 0 and 21*");
     }
 
+    [HumansTheory]
+    [InlineData(-1)]
+    [InlineData(22)]
+    public async Task UpdateTicketingProjectionAsync_rejects_vat_rates_outside_0_to_21(int vatRate)
+    {
+        var act = () => _service.UpdateTicketingProjectionAsync(
+            Guid.NewGuid(), null, null, 0, 0m, 0m, vatRate, 0m, 0m, 0m, Guid.NewGuid());
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            .WithMessage("*between 0 and 21*");
+    }
+
     // ─── CreateYearAsync with scaffold ──────────────────────────────────────
 
     [HumansFact]

--- a/tests/Humans.Budget.Tests/Services/TicketingBudgetServiceTests.cs
+++ b/tests/Humans.Budget.Tests/Services/TicketingBudgetServiceTests.cs
@@ -55,12 +55,13 @@ public class TicketingBudgetServiceTests
         _budgetService.SyncTicketingActualsAsync(
                 Arg.Any<Guid>(),
                 Arg.Do<IReadOnlyList<TicketingWeeklyActuals>>(a => capturedActuals = a.ToList()),
+                Arg.Any<Guid?>(),
                 Arg.Any<CancellationToken>())
             .Returns(1);
 
         var sut = CreateSut();
 
-        var result = await sut.SyncActualsAsync(Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        var result = await sut.SyncActualsAsync(Guid.NewGuid(), actorUserId: null, Xunit.TestContext.Current.CancellationToken);
 
         result.Should().Be(1);
         capturedActuals.Should().NotBeNull();
@@ -97,12 +98,13 @@ public class TicketingBudgetServiceTests
         _budgetService.SyncTicketingActualsAsync(
                 Arg.Any<Guid>(),
                 Arg.Do<IReadOnlyList<TicketingWeeklyActuals>>(a => capturedActuals = a.ToList()),
+                Arg.Any<Guid?>(),
                 Arg.Any<CancellationToken>())
             .Returns(1);
 
         var sut = CreateSut();
 
-        await sut.SyncActualsAsync(Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        await sut.SyncActualsAsync(Guid.NewGuid(), actorUserId: null, Xunit.TestContext.Current.CancellationToken);
 
         capturedActuals.Should().NotBeNull().And.ContainSingle();
         capturedActuals![0].TicketCount.Should().Be(1);
@@ -126,12 +128,13 @@ public class TicketingBudgetServiceTests
         _budgetService.SyncTicketingActualsAsync(
                 Arg.Any<Guid>(),
                 Arg.Do<IReadOnlyList<TicketingWeeklyActuals>>(a => capturedActuals = a.ToList()),
+                Arg.Any<Guid?>(),
                 Arg.Any<CancellationToken>())
             .Returns(2);
 
         var sut = CreateSut();
 
-        await sut.SyncActualsAsync(Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        await sut.SyncActualsAsync(Guid.NewGuid(), actorUserId: null, Xunit.TestContext.Current.CancellationToken);
 
         capturedActuals.Should().NotBeNull().And.ContainSingle();
         capturedActuals![0].StripeFees.Should().Be(1m);
@@ -154,12 +157,13 @@ public class TicketingBudgetServiceTests
         _budgetService.SyncTicketingActualsAsync(
                 Arg.Any<Guid>(),
                 Arg.Do<IReadOnlyList<TicketingWeeklyActuals>>(a => capturedActuals = a.ToList()),
+                Arg.Any<Guid?>(),
                 Arg.Any<CancellationToken>())
             .Returns(0);
 
         var sut = CreateSut();
 
-        await sut.SyncActualsAsync(Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        await sut.SyncActualsAsync(Guid.NewGuid(), actorUserId: null, Xunit.TestContext.Current.CancellationToken);
 
         capturedActuals.Should().NotBeNull().And.BeEmpty();
     }
@@ -182,7 +186,7 @@ public class TicketingBudgetServiceTests
             StripeFeePercent: 1.4m,
             StripeFeeFixed: 0.25m,
             TicketTailorFeePercent: 0.5m);
-        _budgetService.RefreshTicketingProjectionsAsync(yearId, Arg.Any<CancellationToken>())
+        _budgetService.RefreshTicketingProjectionsAsync(yearId, actorUserId, Arg.Any<CancellationToken>())
             .Returns(4);
 
         var sut = CreateSut();
@@ -204,7 +208,7 @@ public class TicketingBudgetServiceTests
                 command.StripeFeeFixed,
                 command.TicketTailorFeePercent,
                 actorUserId);
-            _ = _budgetService.RefreshTicketingProjectionsAsync(yearId, Arg.Any<CancellationToken>());
+            _ = _budgetService.RefreshTicketingProjectionsAsync(yearId, actorUserId, Arg.Any<CancellationToken>());
         });
     }
 


### PR DESCRIPTION
## What

Implements Peter's 2026-09-10 rulings on the Budget section-doctor seams (rulings recorded on peterdrier/Humans#1565):

- **Closed-year gate** now covers `SyncTicketingActualsAsync`, `RefreshTicketingProjectionsAsync` (finding 5) and `UpdateYearAsync` (finding 23); the Edit Year button/form no longer renders for Closed years.
- **Ticketing sync audit trail** (finding 22): each sync/refresh run that changed anything writes one summary `BudgetAuditLog` row. `ActorUserId` becomes nullable — null = automation (nightly job), rendered as "System" in `/Finance/AuditLog`; the admin-triggered sync records the acting user.
- **Ticketing-group deny** (finding 6): `BudgetAuthorizationHandler` refuses coordinator writes in `IsTicketingGroup` groups; theory cases added for deny (coordinator) and allow (finance-admin).
- **`RestoreYearAsync` dropped** (finding 11, unreachable from any UI); the dev seeder now leaves an archived demo year archived instead of resurrecting it.
- **Ported two Codex round-8 findings from #1565** (its unattended review-round budget was spent): `ValidateVatRate` on `UpdateTicketingProjectionAsync` (the one path that skipped it — the sync copies that rate into generated line items) + rejection test, and the derived invariant count dropped from health.md's History headline.

Findings 20/21 were ruled "file issue": peterdrier/Humans#1638, peterdrier/Humans#1639. Finding 12 (localization backfill) accepted as debt, no change.

Originally stacked on #1565; rebased onto `main` and retargeted after its merge.

## Why

Board-visible audit for automation and closed-year immutability are section invariants; these were the documented seams. Per Peter's ruling: "2 gate them. 3 gate, 4 add them, 5 yes, 6 drop it."

## Existing surface checked

No new public surface. Reused the existing `EnsureYearNotClosedAsync` gate, `AddDescriptionAudit` helper, and `ValidateVatRate`; the null-actor convention mirrors the AuditLog crosscut's `AuditEvent.ActorUserId`. `RestoreYearAsync` removed from `IBudgetRepository`/`IBudgetService`.

## UI changes / screenshots

- `/Finance/Admin`: Edit Year button and form hidden for Closed years.
- `/Finance/AuditLog`: "Who" column shows "System" for automation entries.

## Checklist

- [ ] **Section labeled** — Budget/Finance.
- [x] **Targeting `main` on `peterdrier/Humans`**.
- [x] **Branched off `origin/main`** (rebased onto it after #1565's squash-merge).
- [x] **Issue refs are qualified**.
- [x] **EF migrations** — `20260910002053_TicketingSyncAuditActorNullable`, auto-generated (`AlterColumn` to nullable only); ef-migration-reviewer verdict PASS; `has-pending-model-changes` clean post-rebase.
- [x] ~~**NuGet packages updated?**~~ None.
- [x] ~~**New project rule?**~~ None (the `/ask` atom shipped separately to main).
- [x] **Reuse-first checked** — see above; net public surface shrinks.
- [x] **Build + test pass locally**: full `dotnet build Humans.slnx -v quiet` clean; `dotnet test tests/Humans.Budget.Tests -v quiet` 70/70 pass post-rebase; `dotnet format whitespace --verify-no-changes` clean.
- [x] ~~**Nav coverage**~~ — no new pages.
- [x] **No magic strings** — `nameof()` where applicable; sync audit description matches the existing description-audit style.
- [x] **Dates/times via NodaTime**.

## Reviewer notes

- `Guid → Guid?` on `BudgetAuditLog.ActorUserId` ripples through `BudgetAuditLogSnapshot`, the GDPR export filter (`HasValue` guard), and both audit helpers — all in-section.
- The nightly job already targets only the Active year, so its closed-year gate is a safety net, not a behavior change.
- Closed-year theory now covers all 15 repository mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nX3aeX3FeiU7bKhnE9avg