### PR TITLE
Fix all-day calendar events with date-based storage and recurrence

### DIFF
--- a/src/Sections/Humans.Calendar/CalendarResource.ca.resx
+++ b/src/Sections/Humans.Calendar/CalendarResource.ca.resx
@@ -116,4 +116,16 @@
   <data name="Calendar_ViewGrid" xml:space="preserve"><value>Graella</value></data>
   <data name="Calendar_ViewList" xml:space="preserve"><value>Llista</value></data>
   <data name="Calendar_Yes" xml:space="preserve"><value>SÃ­</value></data>
+  <data name="Calendar_InvalidOccurrenceOverride" xml:space="preserve">
+    <value>Introdueix un interval de dates o hores vàlid per a aquesta ocurrència.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayEvent" xml:space="preserve">
+    <value>Introdueix un títol i un interval de dates vàlid sense hores.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayRecurrence" xml:space="preserve">
+    <value>Fes servir una regla de repetició vàlida sense hores, amb UNTIL en format YYYYMMDD.</value>
+  </data>
+  <data name="Calendar_CannotChangeEventType" xml:space="preserve">
+    <value>Aquesta sèrie té ocurrències modificades. Conserva el tipus de dia complet o amb hores, o crea una sèrie nova.</value>
+  </data>
 </root>

--- a/src/Sections/Humans.Calendar/CalendarResource.de.resx
+++ b/src/Sections/Humans.Calendar/CalendarResource.de.resx
@@ -116,4 +116,16 @@
   <data name="Calendar_ViewGrid" xml:space="preserve"><value>Raster</value></data>
   <data name="Calendar_ViewList" xml:space="preserve"><value>Liste</value></data>
   <data name="Calendar_Yes" xml:space="preserve"><value>Ja</value></data>
+  <data name="Calendar_InvalidOccurrenceOverride" xml:space="preserve">
+    <value>Gib einen gültigen Datums- oder Zeitbereich für diesen Termin ein.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayEvent" xml:space="preserve">
+    <value>Gib einen Titel und einen gültigen Datumsbereich ohne Uhrzeiten ein.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayRecurrence" xml:space="preserve">
+    <value>Verwende eine gültige Wiederholungsregel ohne Uhrzeiten mit UNTIL im Format YYYYMMDD.</value>
+  </data>
+  <data name="Calendar_CannotChangeEventType" xml:space="preserve">
+    <value>Diese Serie enthält geänderte Termine. Behalte den ganztägigen oder zeitgebundenen Typ bei oder erstelle eine neue Serie.</value>
+  </data>
 </root>

--- a/src/Sections/Humans.Calendar/CalendarResource.es.resx
+++ b/src/Sections/Humans.Calendar/CalendarResource.es.resx
@@ -116,4 +116,16 @@
   <data name="Calendar_ViewGrid" xml:space="preserve"><value>CuadrÃ­cula</value></data>
   <data name="Calendar_ViewList" xml:space="preserve"><value>Lista</value></data>
   <data name="Calendar_Yes" xml:space="preserve"><value>SÃ­</value></data>
+  <data name="Calendar_InvalidOccurrenceOverride" xml:space="preserve">
+    <value>Introduce un intervalo de fechas u horas válido para esta ocurrencia.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayEvent" xml:space="preserve">
+    <value>Introduce un título y un intervalo de fechas válido sin horas.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayRecurrence" xml:space="preserve">
+    <value>Usa una regla de repetición válida sin horas, con UNTIL en formato YYYYMMDD.</value>
+  </data>
+  <data name="Calendar_CannotChangeEventType" xml:space="preserve">
+    <value>Esta serie tiene cambios en ocurrencias. Conserva su tipo de día completo o con horas, o crea una serie nueva.</value>
+  </data>
 </root>

--- a/src/Sections/Humans.Calendar/CalendarResource.fr.resx
+++ b/src/Sections/Humans.Calendar/CalendarResource.fr.resx
@@ -116,4 +116,16 @@
   <data name="Calendar_ViewGrid" xml:space="preserve"><value>Grille</value></data>
   <data name="Calendar_ViewList" xml:space="preserve"><value>Liste</value></data>
   <data name="Calendar_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="Calendar_InvalidOccurrenceOverride" xml:space="preserve">
+    <value>Saisissez une plage de dates ou d’heures valide pour cette occurrence.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayEvent" xml:space="preserve">
+    <value>Saisissez un titre et une plage de dates valide sans heures.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayRecurrence" xml:space="preserve">
+    <value>Utilisez une règle de récurrence valide sans heures, avec UNTIL au format YYYYMMDD.</value>
+  </data>
+  <data name="Calendar_CannotChangeEventType" xml:space="preserve">
+    <value>Cette série contient des occurrences modifiées. Conservez son type journée entière ou avec horaires, ou créez une nouvelle série.</value>
+  </data>
 </root>

--- a/src/Sections/Humans.Calendar/CalendarResource.it.resx
+++ b/src/Sections/Humans.Calendar/CalendarResource.it.resx
@@ -116,4 +116,16 @@
   <data name="Calendar_ViewGrid" xml:space="preserve"><value>Griglia</value></data>
   <data name="Calendar_ViewList" xml:space="preserve"><value>Elenco</value></data>
   <data name="Calendar_Yes" xml:space="preserve"><value>Sì</value></data>
+  <data name="Calendar_InvalidOccurrenceOverride" xml:space="preserve">
+    <value>Inserisci un intervallo di date o orari valido per questa occorrenza.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayEvent" xml:space="preserve">
+    <value>Inserisci un titolo e un intervallo di date valido senza orari.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayRecurrence" xml:space="preserve">
+    <value>Usa una regola di ricorrenza valida senza orari, con UNTIL nel formato YYYYMMDD.</value>
+  </data>
+  <data name="Calendar_CannotChangeEventType" xml:space="preserve">
+    <value>Questa serie contiene occorrenze modificate. Mantieni il tipo a giornata intera o con orari, oppure crea una nuova serie.</value>
+  </data>
 </root>

--- a/src/Sections/Humans.Calendar/CalendarResource.resx
+++ b/src/Sections/Humans.Calendar/CalendarResource.resx
@@ -116,4 +116,16 @@
   <data name="Calendar_ViewGrid" xml:space="preserve"><value>Grid</value></data>
   <data name="Calendar_ViewList" xml:space="preserve"><value>List</value></data>
   <data name="Calendar_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="Calendar_InvalidOccurrenceOverride" xml:space="preserve">
+    <value>Enter a valid date or time range for this occurrence.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayEvent" xml:space="preserve">
+    <value>Enter a title and a valid date range without times.</value>
+  </data>
+  <data name="Calendar_InvalidAllDayRecurrence" xml:space="preserve">
+    <value>Use a valid date-only recurrence rule, with UNTIL as YYYYMMDD.</value>
+  </data>
+  <data name="Calendar_CannotChangeEventType" xml:space="preserve">
+    <value>This series has occurrence changes. Keep its all-day or timed type, or create a new series.</value>
+  </data>
 </root>

--- a/src/Sections/Humans.Calendar/Controllers/CalendarController.cs
+++ b/src/Sections/Humans.Calendar/Controllers/CalendarController.cs
@@ -21,19 +21,22 @@ internal sealed class CalendarController : HumansControllerBase
     private readonly ICalendarService _calendar;
     private readonly ITeamServiceRead _teams;
     private readonly IClock _clock;
+    private readonly Microsoft.Extensions.Localization.IStringLocalizer<CalendarResource> _localizer;
 
     public CalendarController(
         IUserServiceRead userService,
         ICalendarServiceRead calendarRead,
         ICalendarService calendar,
         ITeamServiceRead teams,
-        IClock clock)
+        IClock clock,
+        Microsoft.Extensions.Localization.IStringLocalizer<CalendarResource> localizer)
         : base(userService)
     {
         _calendarRead = calendarRead;
         _calendar = calendar;
         _teams = teams;
         _clock = clock;
+        _localizer = localizer;
     }
 
     [HttpGet("")]
@@ -178,7 +181,7 @@ internal sealed class CalendarController : HumansControllerBase
         var team = await _teams.GetTeamAsync(form.OwningTeamId, ct);
         if (team is null) return NotFound();
 
-        TryResolveStartEnd(form, out var start, out var end);
+        TryResolveStartEnd(form, out var start, out var end, out var startDate, out var endDate);
         if (!ModelState.IsValid)
         {
             form.TeamOptions = await GetSelectableTeamsAsync(ct);
@@ -189,7 +192,7 @@ internal sealed class CalendarController : HumansControllerBase
             form.Title, form.Description, form.Location, form.LocationUrl,
             form.OwningTeamId, start, end, form.IsAllDay,
             form.IsRecurring ? form.RecurrenceRule : null,
-            form.IsRecurring ? form.RecurrenceTimezone : null),
+            form.IsRecurring && !form.IsAllDay ? form.RecurrenceTimezone : null, startDate, endDate),
             createdByUserId: RequireCurrentUserId(), ct);
 
         if (result.Succeeded && result.Event is not null)
@@ -212,10 +215,9 @@ internal sealed class CalendarController : HumansControllerBase
         var tzId = ev.RecurrenceTimezone ?? "Europe/Madrid";
         var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(tzId)
             ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
-        var startDate = ev.StartUtc.InZone(zone).Date;
-        var endDateInclusive = ev.EndUtc is { } endUtc
-            ? CalendarService.AllDayInclusiveEndDate(endUtc, zone)
-            : startDate;
+        var startDate = ev.StartDate ?? ev.StartUtc!.Value.InZone(zone).Date;
+        var endDateInclusive = ev.EndDateExclusive is { } endDate
+            ? CalendarService.AllDayInclusiveEndDate(endDate) : startDate;
         return View(new CalendarEventFormViewModel
         {
             Id = ev.Id,
@@ -224,7 +226,7 @@ internal sealed class CalendarController : HumansControllerBase
             Location = ev.Location,
             LocationUrl = ev.LocationUrl,
             OwningTeamId = ev.OwningTeamId,
-            StartLocal = ev.StartUtc.InZone(zone).LocalDateTime.ToDateTimeUnspecified(),
+            StartLocal = ev.StartUtc?.InZone(zone).LocalDateTime.ToDateTimeUnspecified(),
             EndLocal = ev.EndUtc?.InZone(zone).LocalDateTime.ToDateTimeUnspecified(),
             StartDateLocal = startDate.ToDateTimeUnspecified(),
             EndDateLocal = endDateInclusive.ToDateTimeUnspecified(),
@@ -243,7 +245,7 @@ internal sealed class CalendarController : HumansControllerBase
         var ev = await _calendarRead.GetEventByIdAsync(id, ct);
         if (ev is null) return NotFound();
 
-        TryResolveStartEnd(form, out var start, out var end);
+        TryResolveStartEnd(form, out var start, out var end, out var startDate, out var endDate);
         if (!ModelState.IsValid)
         {
             form.TeamOptions = await GetSelectableTeamsAsync(ct);
@@ -254,7 +256,7 @@ internal sealed class CalendarController : HumansControllerBase
             form.Title, form.Description, form.Location, form.LocationUrl,
             form.OwningTeamId, start, end, form.IsAllDay,
             form.IsRecurring ? form.RecurrenceRule : null,
-            form.IsRecurring ? form.RecurrenceTimezone : null),
+            form.IsRecurring && !form.IsAllDay ? form.RecurrenceTimezone : null, startDate, endDate),
             updatedByUserId: RequireCurrentUserId(), ct);
 
         if (result.NotFound) return NotFound();
@@ -265,20 +267,16 @@ internal sealed class CalendarController : HumansControllerBase
         return View(form);
     }
 
-    // Validates the posted form and resolves it to stored instants. The all-day storage shape
+    // Parses the posted date or time fields. The all-day storage shape
     // itself is CalendarService.AllDayWindow's; what stays here is the ModelState translation.
     // Bad input → ModelState (no throw).
-    private void TryResolveStartEnd(CalendarEventFormViewModel form, out Instant start, out Instant? end)
+    private void TryResolveStartEnd(CalendarEventFormViewModel form, out Instant? start, out Instant? end,
+        out LocalDate? startDate, out LocalDate? endDate)
     {
-        start = default;
+        start = null;
         end = null;
-
-        var zone = CalendarEventFormViewModel.TryResolveZone(form.RecurrenceTimezone);
-        if (zone is null)
-        {
-            ModelState.AddModelError(nameof(form.RecurrenceTimezone), "Unknown IANA timezone.");
-            return;
-        }
+        startDate = null;
+        endDate = null;
 
         if (form.IsAllDay)
         {
@@ -287,14 +285,21 @@ internal sealed class CalendarController : HumansControllerBase
                 ModelState.AddModelError(nameof(form.StartDateLocal), "Start date is required.");
                 return;
             }
-            var startDate = LocalDate.FromDateTime(startDt);
-            var inclusiveEnd = form.EndDateLocal is { } endDt ? LocalDate.FromDateTime(endDt) : startDate;
-            if (inclusiveEnd < startDate)
+            var firstDate = LocalDate.FromDateTime(startDt);
+            var inclusiveEnd = form.EndDateLocal is { } endDt ? LocalDate.FromDateTime(endDt) : firstDate;
+            if (inclusiveEnd < firstDate)
             {
                 ModelState.AddModelError(nameof(form.EndDateLocal), "End date must be on or after the start date.");
                 return;
             }
-            (start, end) = CalendarService.AllDayWindow(startDate, inclusiveEnd, zone);
+            (startDate, endDate) = CalendarService.AllDayWindow(firstDate, inclusiveEnd);
+            return;
+        }
+
+        var zone = CalendarEventFormViewModel.TryResolveZone(form.RecurrenceTimezone);
+        if (zone is null)
+        {
+            ModelState.AddModelError(nameof(form.RecurrenceTimezone), "Unknown IANA timezone.");
             return;
         }
 
@@ -331,9 +336,11 @@ internal sealed class CalendarController : HumansControllerBase
         var ev = await _calendarRead.GetEventByIdAsync(id, ct);
         if (ev is null) return NotFound();
 
-        if (OccurrenceOverrideFormViewModel.TryParseOriginal(originalStartUtc) is not { } original) return NotFound();
+        var original = ev.IsAllDay ? null : OccurrenceOverrideFormViewModel.TryParseOriginal(originalStartUtc);
+        var originalDate = ev.IsAllDay ? OccurrenceOverrideFormViewModel.TryParseOriginalDate(originalStartUtc) : null;
+        if (original is null && originalDate is null) return NotFound();
 
-        await _calendar.CancelOccurrenceAsync(id, original, RequireCurrentUserId(), ct);
+        await _calendar.CancelOccurrenceAsync(id, original, RequireCurrentUserId(), ct, originalDate);
         return RedirectToAction(nameof(Event), new { id });
     }
 
@@ -342,11 +349,13 @@ internal sealed class CalendarController : HumansControllerBase
     {
         var ev = await _calendarRead.GetEventByIdAsync(id, ct);
         if (ev is null) return NotFound();
-        if (OccurrenceOverrideFormViewModel.TryParseOriginal(originalStartUtc) is null) return NotFound();
+        if (ev.IsAllDay ? OccurrenceOverrideFormViewModel.TryParseOriginalDate(originalStartUtc) is null
+            : OccurrenceOverrideFormViewModel.TryParseOriginal(originalStartUtc) is null) return NotFound();
 
         return View("OccurrenceEdit", new OccurrenceOverrideFormViewModel
         {
             EventId = id,
+            IsAllDay = ev.IsAllDay,
             OriginalOccurrenceStartUtc = originalStartUtc,
             RecurrenceTimezone = ev.RecurrenceTimezone ?? "Europe/Madrid",
         });
@@ -358,27 +367,30 @@ internal sealed class CalendarController : HumansControllerBase
     {
         var ev = await _calendarRead.GetEventByIdAsync(id, ct);
         if (ev is null) return NotFound();
-        if (OccurrenceOverrideFormViewModel.TryParseOriginal(originalStartUtc) is not { } original) return NotFound();
+        var original = ev.IsAllDay ? null : OccurrenceOverrideFormViewModel.TryParseOriginal(originalStartUtc);
+        var originalDate = ev.IsAllDay ? OccurrenceOverrideFormViewModel.TryParseOriginalDate(originalStartUtc) : null;
+        if (original is null && originalDate is null) return NotFound();
 
-        var zone = CalendarEventFormViewModel.TryResolveZone(form.RecurrenceTimezone);
-        if (zone is null)
+        form.EventId = id;
+        form.OriginalOccurrenceStartUtc = originalStartUtc;
+        form.IsAllDay = ev.IsAllDay;
+        var zone = CalendarEventFormViewModel.TryResolveZone(ev.RecurrenceTimezone ?? "Europe/Madrid");
+        if (!ModelState.IsValid) return View("OccurrenceEdit", form);
+        if (zone is null || !form.TryBuildOverride(zone, out var dto))
         {
-            ModelState.AddModelError(nameof(form.RecurrenceTimezone), "Unknown timezone.");
+            ModelState.AddModelError(string.Empty, _localizer["Calendar_InvalidOccurrenceOverride"]);
             return View("OccurrenceEdit", form);
         }
-
-        Instant? overrideStart = form.OverrideStartLocal is { } s
-            ? LocalDateTime.FromDateTime(s).InZoneLeniently(zone).ToInstant()
-            : null;
-        Instant? overrideEnd = form.OverrideEndLocal is { } e
-            ? LocalDateTime.FromDateTime(e).InZoneLeniently(zone).ToInstant()
-            : null;
-
-        await _calendar.OverrideOccurrenceAsync(id, original,
-            new OverrideOccurrenceDto(overrideStart, overrideEnd,
-                form.OverrideTitle, form.OverrideDescription,
-                form.OverrideLocation, form.OverrideLocationUrl),
-            RequireCurrentUserId(), ct);
+        try
+        {
+            await _calendar.OverrideOccurrenceAsync(id, original,
+                dto, RequireCurrentUserId(), ct, originalDate);
+        }
+        catch (InvalidOperationException)
+        {
+            ModelState.AddModelError(string.Empty, _localizer["Calendar_InvalidOccurrenceOverride"]);
+            return View("OccurrenceEdit", form);
+        }
 
         return RedirectToAction(nameof(Event), new { id });
     }
@@ -406,7 +418,8 @@ internal sealed class CalendarController : HumansControllerBase
     {
         ModelState.AddModelError(
             CalendarEventFormViewModel.ErrorFieldFor(result.ValidationMemberName),
-            result.ErrorMessage ?? "Failed to save calendar event.");
+            result.ErrorMessage?.StartsWith("Calendar_", StringComparison.Ordinal) == true
+                ? _localizer[result.ErrorMessage] : result.ErrorMessage ?? "Failed to save calendar event.");
     }
 
     // Org default for v1 (all volunteers in Spain). TODO: derive from browser/profile.

--- a/src/Sections/Humans.Calendar/Data/CalendarRepository.cs
+++ b/src/Sections/Humans.Calendar/Data/CalendarRepository.cs
@@ -45,7 +45,7 @@ internal sealed class CalendarRepository(IDbContextFactory<CalendarDbContext> fa
         CancellationToken ct = default)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
-        var ev = await ctx.CalendarEvents.FirstOrDefaultAsync(e => e.Id == id, ct);
+        var ev = await ctx.CalendarEvents.Include(e => e.Exceptions).FirstOrDefaultAsync(e => e.Id == id, ct);
         if (ev is null)
         {
             return false;
@@ -76,11 +76,11 @@ internal sealed class CalendarRepository(IDbContextFactory<CalendarDbContext> fa
 
     public async Task UpsertExceptionAsync(
         Guid eventId,
-        Instant originalOccurrenceStartUtc,
+        Instant? originalOccurrenceStartUtc,
         Guid createdByUserId,
         Instant now,
         Action<CalendarEventException> apply,
-        CancellationToken ct = default)
+        CancellationToken ct = default, LocalDate? originalDate = null)
     {
         await using var ctx = await factory.CreateDbContextAsync(ct);
 
@@ -92,7 +92,8 @@ internal sealed class CalendarRepository(IDbContextFactory<CalendarDbContext> fa
         var existing = await ctx.CalendarEventExceptions
             .IgnoreQueryFilters()
             .FirstOrDefaultAsync(
-                x => x.EventId == eventId && x.OriginalOccurrenceStartUtc == originalOccurrenceStartUtc,
+                x => x.EventId == eventId && ((originalDate != null && x.OriginalOccurrenceDate == originalDate) ||
+                    (originalOccurrenceStartUtc != null && x.OriginalOccurrenceStartUtc == originalOccurrenceStartUtc)),
                 ct);
 
         if (existing is null)
@@ -113,6 +114,8 @@ internal sealed class CalendarRepository(IDbContextFactory<CalendarDbContext> fa
             existing.UpdatedAt = now;
         }
 
+        existing.OriginalOccurrenceDate = originalDate;
+        existing.OriginalOccurrenceStartUtc = originalDate is null ? originalOccurrenceStartUtc : null;
         apply(existing);
 
         var errors = existing.Validate();

--- a/src/Sections/Humans.Calendar/Data/ICalendarRepository.cs
+++ b/src/Sections/Humans.Calendar/Data/ICalendarRepository.cs
@@ -76,9 +76,9 @@ internal interface ICalendarRepository : IRepository
     /// </summary>
     Task UpsertExceptionAsync(
         Guid eventId,
-        Instant originalOccurrenceStartUtc,
+        Instant? originalOccurrenceStartUtc,
         Guid createdByUserId,
         Instant now,
         Action<CalendarEventException> apply,
-        CancellationToken ct = default);
+        CancellationToken ct = default, LocalDate? originalDate = null);
 }

--- a/src/Sections/Humans.Calendar/Data/Migrations/20260911031217_AllDayCalendarDates.Designer.cs
+++ b/src/Sections/Humans.Calendar/Data/Migrations/20260911031217_AllDayCalendarDates.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Calendar.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Calendar.Data.Migrations
 {
     [DbContext(typeof(CalendarDbContext))]
-    partial class CalendarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260911031217_AllDayCalendarDates")]
+    partial class AllDayCalendarDates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Sections/Humans.Calendar/Data/Migrations/20260911031217_AllDayCalendarDates.cs
+++ b/src/Sections/Humans.Calendar/Data/Migrations/20260911031217_AllDayCalendarDates.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Calendar.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllDayCalendarDates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Instant>(
+                name: "StartUtc",
+                table: "calendar_events",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(Instant),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "EndDateExclusive",
+                table: "calendar_events",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "RecurrenceUntilDate",
+                table: "calendar_events",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "StartDate",
+                table: "calendar_events",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<Instant>(
+                name: "OriginalOccurrenceStartUtc",
+                table: "calendar_event_exceptions",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(Instant),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "OriginalOccurrenceDate",
+                table: "calendar_event_exceptions",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "OverrideEndDateExclusive",
+                table: "calendar_event_exceptions",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "OverrideStartDate",
+                table: "calendar_event_exceptions",
+                type: "date",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EndDateExclusive",
+                table: "calendar_events");
+
+            migrationBuilder.DropColumn(
+                name: "RecurrenceUntilDate",
+                table: "calendar_events");
+
+            migrationBuilder.DropColumn(
+                name: "StartDate",
+                table: "calendar_events");
+
+            migrationBuilder.DropColumn(
+                name: "OriginalOccurrenceDate",
+                table: "calendar_event_exceptions");
+
+            migrationBuilder.DropColumn(
+                name: "OverrideEndDateExclusive",
+                table: "calendar_event_exceptions");
+
+            migrationBuilder.DropColumn(
+                name: "OverrideStartDate",
+                table: "calendar_event_exceptions");
+
+            migrationBuilder.AlterColumn<Instant>(
+                name: "StartUtc",
+                table: "calendar_events",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: NodaTime.Instant.FromUnixTimeTicks(0L),
+                oldClrType: typeof(Instant),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Instant>(
+                name: "OriginalOccurrenceStartUtc",
+                table: "calendar_event_exceptions",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: NodaTime.Instant.FromUnixTimeTicks(0L),
+                oldClrType: typeof(Instant),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Sections/Humans.Calendar/Docs/Calendar.md
+++ b/src/Sections/Humans.Calendar/Docs/Calendar.md
@@ -32,11 +32,14 @@ A community-calendar event belonging to a team. May be a single event or a recur
 | Location | string (500) | Optional |
 | LocationUrl | string (2000) | Optional |
 | OwningTeamId | Guid | Bare cross-section Guid column — no FK constraint, no nav (all cross-section FK constraints were cut in nobodies-collective/Humans#992; `memory/architecture/no-cross-section-ef-joins.md`). Team display names are stitched in memory via `ITeamServiceRead.GetTeamsAsync` (§6b). |
-| StartUtc | Instant | First (or only) occurrence start in UTC |
-| EndUtc | Instant? | Required iff `IsAllDay = false`. For all-day events, set to half-open exclusive midnight (`EndDate + 1 day` 00:00 in `RecurrenceTimezone`). May be null on legacy single-day all-day rows |
+| StartUtc | Instant? | Required for timed events; null on date-based all-day writes |
+| EndUtc | Instant? | Required for timed events; null on date-based all-day writes |
+| StartDate | LocalDate? | First all-day date, inclusive |
+| EndDateExclusive | LocalDate? | All-day end date, exclusive |
+| RecurrenceUntilDate | LocalDate? | All-day recurrence upper date bound; null for open-ended or legacy rows |
 | IsAllDay | bool | All-day event |
 | RecurrenceRule | string (500)? | RFC 5545 RRULE (no `RRULE:` prefix). Null = single event |
-| RecurrenceTimezone | string (100)? | IANA TZ. Required iff `RecurrenceRule` is set |
+| RecurrenceTimezone | string (100)? | IANA TZ for timed recurrences; all-day recurrence is date-only |
 | RecurrenceUntilUtc | Instant? | Denormalised UNTIL — the "rule reaches window" prefilter reads it |
 | CreatedByUserId | Guid | Bare cross-section Guid column — no FK constraint, no nav |
 | CreatedAt | Instant | |
@@ -57,7 +60,10 @@ Per-occurrence override or cancellation for a recurring `CalendarEvent`. Cascade
 |----------|------|-------|
 | Id | Guid | PK |
 | EventId | Guid | FK → CalendarEvent (`OnDelete: Cascade`) |
-| OriginalOccurrenceStartUtc | Instant | The unmodified start of the occurrence this exception targets |
+| OriginalOccurrenceStartUtc | Instant? | Unmodified timed occurrence start |
+| OriginalOccurrenceDate | LocalDate? | Unmodified all-day occurrence date |
+| OverrideStartDate | LocalDate? | All-day replacement start |
+| OverrideEndDateExclusive | LocalDate? | All-day replacement exclusive end |
 | IsCancelled | bool | If true, occurrence is dropped during expansion |
 | OverrideStartUtc | Instant? | |
 | OverrideEndUtc | Instant? | |
@@ -69,7 +75,7 @@ Per-occurrence override or cancellation for a recurring `CalendarEvent`. Cascade
 | CreatedAt | Instant | |
 | UpdatedAt | Instant | |
 
-**Indexes:** unique `(EventId, OriginalOccurrenceStartUtc)` — one exception per (event, occurrence).
+**Indexes:** unique `(EventId, OriginalOccurrenceStartUtc)` for timed identities. Date identities are upserted by `(EventId, OriginalOccurrenceDate)`.
 
 ## Routing
 
@@ -105,16 +111,18 @@ The calendar is intentionally open: no resource-based authorization gates edit/d
 - Only authenticated humans may create, edit, or delete events, or manage exceptions (enforced by `[Authorize]` on `CalendarController`).
 - Every mutating action (create / update / delete / cancel-occurrence / override-occurrence) writes an `AuditLogEntry` with the actor's user ID.
 - Title is required (non-null, non-empty).
-- `StartUtc` is required.
-- `EndUtc` is required for timed events (`IsAllDay = false`). For all-day events created or edited via the calendar form, `EndUtc` is set to half-open exclusive midnight (`StartDate.PlusDays(InclusiveDays).AtMidnight()` in `RecurrenceTimezone`); the display layer recovers the inclusive end date by stepping a nanosecond back off that midnight. Both halves are `CalendarService.AllDayWindow` / `CalendarService.AllDayInclusiveEndDate` — the controller only translates form input and errors. Legacy all-day rows may still have null `EndUtc` (treated as single-day).
-- `StartUtc <= EndUtc` when both are non-null.
-- `RecurrenceRule` and `RecurrenceTimezone` are set together, or neither is set (all-or-nothing invariant).
-- `RecurrenceTimezone` defaults to `"Europe/Madrid"` if not specified on a recurring event.
-- `RecurrenceUntilUtc` is the last instant the recurrence can possibly produce an occurrence (RRULE `UNTIL` if present, else the end of the `COUNT`-th occurrence computed via Ical.Net, else null for open-ended rules); it is what `CalendarOccurrenceExpander.FilterForWindow` prefilters the cached snapshot on.
+- Timed events require `StartUtc <= EndUtc` and have no date fields. All-day writes require `StartDate < EndDateExclusive` and have no start/end instants.
+- Forms display inclusive end dates; `CalendarService.AllDayWindow` / `AllDayInclusiveEndDate` convert between inclusive and exclusive `LocalDate` values without a timezone.
+- Legacy all-day rows are projected to dates in the service using their original recurrence zone, or Madrid for one-off events. A null legacy end means one day. Legacy timed overrides of all-day events become covered dates. Saving the series converts its exceptions to date fields before clearing the old timezone; no bulk backfill is required.
+- Timed recurrence requires an RRULE and IANA timezone together. All-day recurrence uses DATE DTSTART/DTEND and date-only UNTIL; sub-day recurrence rules are rejected on writes.
+- `RecurrenceUntilUtc` bounds timed series; `RecurrenceUntilDate` bounds all-day series. Snapshot prefiltering uses the corresponding type and retains rows with exceptions, which can move outside either series boundary.
+- All-day duration is a calendar-day count across every recurrence, including DST changes. A start-only override retains that count.
+- All-day occurrence URLs carry an ISO date; timed occurrence URLs carry an ISO instant. The editor renders date-only inputs for all-day series, and service validation rejects timed overrides for them.
+- A series with exceptions cannot switch between all-day and timed: its saved occurrence identities must remain meaningful.
 - Soft-delete via `DeletedAt` — a global EF Core query filter hides deleted events from all queries. `CalendarEventException` carries a matching filter (`ex => ex.Event.DeletedAt == null`) so exception rows attached to a soft-deleted event are also hidden; repository writes that need to observe orphaned-by-soft-delete exceptions (e.g. `UpsertExceptionAsync`'s existence lookup, to avoid duplicate-insert against the unique index when the parent is soft-deleted between pre-check and upsert) call `IgnoreQueryFilters()` explicitly.
 - `CalendarEventException` rows cascade-delete with the parent event.
-- Unique index on `(EventId, OriginalOccurrenceStartUtc)` — prevents duplicate exceptions for the same occurrence.
-- Recurrence is expanded in-memory per-request against the event's `RecurrenceTimezone` using `Ical.Net` library (RFC 5545 compliant).
+- Timed exceptions retain the unique `(EventId, OriginalOccurrenceStartUtc)` index; all-day mutations upsert by event and original date.
+- Recurrence expands in-memory through Ical.Net: local times for timed events, floating dates for all-day events.
 
 ## Negative Access Rules
 

--- a/src/Sections/Humans.Calendar/Docs/features/community-calendar.md
+++ b/src/Sections/Humans.Calendar/Docs/features/community-calendar.md
@@ -109,8 +109,11 @@ CalendarEvent
 ├── Description: string? (4000)
 ├── Location: string? (500)
 ├── LocationUrl: string? (2000)
-├── StartUtc: Instant (required)
+├── StartUtc: Instant? (required for timed events)
 ├── EndUtc: Instant? (required iff IsAllDay = false)
+├── StartDate: LocalDate? (all-day inclusive start)
+├── EndDateExclusive: LocalDate? (all-day exclusive end)
+├── RecurrenceUntilDate: LocalDate? (all-day recurrence bound)
 ├── IsAllDay: bool (default false)
 ├── RecurrenceRule: string? (RFC 5545 RRULE, e.g., "FREQ=WEEKLY;BYDAY=MO")
 ├── RecurrenceTimezone: string? (IANA timezone, e.g., "Europe/Madrid")
@@ -126,7 +129,10 @@ CalendarEvent
 CalendarEventException
 ├── Id: Guid
 ├── EventId: Guid (FK → CalendarEvent, cascade-delete)
-├── OriginalOccurrenceStartUtc: Instant (the occurrence being modified)
+├── OriginalOccurrenceStartUtc: Instant? (timed occurrence identity)
+├── OriginalOccurrenceDate: LocalDate? (all-day occurrence identity)
+├── OverrideStartDate: LocalDate?
+├── OverrideEndDateExclusive: LocalDate?
 ├── IsCancelled: bool (true = skip this occurrence in calendar view)
 ├── OverrideTitle: string? (200; null = use parent event title)
 ├── OverrideDescription: string? (4000)
@@ -140,7 +146,7 @@ CalendarEventException
 └── Navigation: Event
 ```
 
-Unique on `(EventId, OriginalOccurrenceStartUtc)`. `Validate()` requires the row to either cancel the occurrence or override at least one field. A query filter mirrors the parent event's soft-delete so exceptions of deleted events are never returned.
+Timed identities are unique on `(EventId, OriginalOccurrenceStartUtc)`; date exceptions are upserted by `(EventId, OriginalOccurrenceDate)`. `Validate()` requires the row to either cancel the occurrence or override at least one field. A query filter mirrors the parent event's soft-delete so exceptions of deleted events are never returned.
 
 ## Authorization
 
@@ -154,7 +160,7 @@ No resource-based authorization handler, no `CalendarEditor` policy. If upfront 
 
 ## Timezones & DST
 
-Every recurring event is tied to an IANA timezone (e.g., `"Europe/Madrid"`, `"Europe/Berlin"`). When expanding occurrences (e.g., a weekly 19:00 meeting):
+Every timed recurring event is tied to an IANA timezone (e.g., `"Europe/Madrid"`, `"Europe/Berlin"`). When expanding occurrences (e.g., a weekly 19:00 meeting):
 
 1. Recurrence rule is expanded in the event's configured timezone using `Ical.Net`
 2. Each occurrence start/end is calculated in that timezone, respecting DST transitions
@@ -162,6 +168,8 @@ Every recurring event is tied to an IANA timezone (e.g., `"Europe/Madrid"`, `"Eu
 4. When rendering to the user's browser, occurrences are converted to their local timezone (via JavaScript or `NodaTime` if server-rendered)
 
 This ensures a recurring "19:00 weekly on Monday" stays at 19:00 local time even when daylight saving changes occur.
+
+All-day events carry only `LocalDate` ranges, including their recurrence bounds and override identities. Expansion preserves calendar-day duration across DST; views never convert these dates into viewer timezones. The occurrence editor accepts dates only, and the service rejects times. Existing instant-based all-day rows are projected to dates using their original zone (Madrid for one-off events); ordinary saves write dates. A series with saved exceptions retains its timed/all-day type.
 
 ## Related Features
 

--- a/src/Sections/Humans.Calendar/Domain/CalendarEvent.cs
+++ b/src/Sections/Humans.Calendar/Domain/CalendarEvent.cs
@@ -14,8 +14,11 @@ internal sealed class CalendarEvent
     public string? LocationUrl { get; set; }
     public Guid OwningTeamId { get; set; }
 
-    public Instant StartUtc { get; set; }
+    public Instant? StartUtc { get; set; }
     public Instant? EndUtc { get; set; }
+    public LocalDate? StartDate { get; set; }
+    public LocalDate? EndDateExclusive { get; set; }
+    public LocalDate? RecurrenceUntilDate { get; set; }
     public bool IsAllDay { get; set; }
     public string? RecurrenceRule { get; set; }
     public string? RecurrenceTimezone { get; set; }
@@ -30,6 +33,16 @@ internal sealed class CalendarEvent
     {
         var errors = new List<string>();
 
+        if (IsAllDay)
+        {
+            if (StartDate is null || EndDateExclusive is null || EndDateExclusive <= StartDate)
+                errors.Add("An all-day event requires a non-empty date range.");
+            if (StartUtc is not null || EndUtc is not null)
+                errors.Add("An all-day event cannot have a time.");
+        }
+        else if (StartUtc is null || StartDate is not null || EndDateExclusive is not null)
+            errors.Add("A timed event requires StartUtc and cannot have all-day dates.");
+
         if (!IsAllDay && EndUtc is null)
             errors.Add("EndUtc is required for timed events.");
 
@@ -38,7 +51,7 @@ internal sealed class CalendarEvent
 
         var hasRule = !string.IsNullOrWhiteSpace(RecurrenceRule);
         var hasZone = !string.IsNullOrWhiteSpace(RecurrenceTimezone);
-        if (hasRule != hasZone)
+        if (!IsAllDay && hasRule != hasZone)
             errors.Add("RecurrenceRule and RecurrenceTimezone must be set together (both or neither).");
 
         if (string.IsNullOrWhiteSpace(Title))

--- a/src/Sections/Humans.Calendar/Domain/CalendarEventException.cs
+++ b/src/Sections/Humans.Calendar/Domain/CalendarEventException.cs
@@ -11,7 +11,10 @@ internal sealed class CalendarEventException
     public Guid Id { get; init; }
     public Guid EventId { get; set; }
     public CalendarEvent Event { get; set; } = null!;
-    public Instant OriginalOccurrenceStartUtc { get; set; }
+    public Instant? OriginalOccurrenceStartUtc { get; set; }
+    public LocalDate? OriginalOccurrenceDate { get; set; }
+    public LocalDate? OverrideStartDate { get; set; }
+    public LocalDate? OverrideEndDateExclusive { get; set; }
     public bool IsCancelled { get; set; }
     public Instant? OverrideStartUtc { get; set; }
     public Instant? OverrideEndUtc { get; set; }
@@ -26,6 +29,8 @@ internal sealed class CalendarEventException
     public IReadOnlyList<string> Validate()
     {
         var hasOverride =
+            OverrideStartDate is not null ||
+            OverrideEndDateExclusive is not null ||
             OverrideStartUtc is not null ||
             OverrideEndUtc is not null ||
             OverrideTitle is not null ||

--- a/src/Sections/Humans.Calendar/Models/CalendarEventFormViewModel.cs
+++ b/src/Sections/Humans.Calendar/Models/CalendarEventFormViewModel.cs
@@ -29,7 +29,7 @@ internal sealed class CalendarEventFormViewModel
 
     // Date-only inputs used when IsAllDay is true. EndDateLocal is inclusive (the
     // event covers every day from StartDateLocal through EndDateLocal). The controller
-    // normalizes to half-open [Start 00:00, EndDate+1 00:00) when persisting.
+    // passes dates to the service as [StartDate, EndDate+1), without a time.
     public DateTime? StartDateLocal { get; set; }
 
     public DateTime? EndDateLocal { get; set; }

--- a/src/Sections/Humans.Calendar/Models/CalendarGridLayout.cs
+++ b/src/Sections/Humans.Calendar/Models/CalendarGridLayout.cs
@@ -41,8 +41,11 @@ internal static class CalendarGridLayout
 
         // Sort: earliest-start, longest-duration first so banners stack deterministically.
         var ordered = weekOccurrences
-            .OrderBy(o => o.OccurrenceStartUtc)
-            .ThenByDescending(o => (o.OccurrenceEndUtc ?? o.OccurrenceStartUtc).ToUnixTimeTicks() - o.OccurrenceStartUtc.ToUnixTimeTicks())
+            .OrderBy(o => o.StartLocalDate(zone))
+            .ThenBy(o => o.OccurrenceStartUtc)
+            .ThenByDescending(o => o.IsAllDay
+                ? Period.Between(o.StartDate!.Value, o.EndDateExclusive!.Value, PeriodUnits.Days).Days * NodaConstants.TicksPerDay
+                : (o.OccurrenceEndUtc ?? o.OccurrenceStartUtc!.Value).ToUnixTimeTicks() - o.OccurrenceStartUtc!.Value.ToUnixTimeTicks())
             .ToList();
 
         foreach (var o in ordered)

--- a/src/Sections/Humans.Calendar/Models/CalendarOccurrenceViewExtensions.cs
+++ b/src/Sections/Humans.Calendar/Models/CalendarOccurrenceViewExtensions.cs
@@ -6,10 +6,11 @@ namespace Humans.Calendar.Models;
 internal static class CalendarOccurrenceViewExtensions
 {
     public static LocalDate StartLocalDate(this CalendarOccurrence occ, DateTimeZone zone) =>
-        occ.OccurrenceStartUtc.InZone(zone).Date;
+        occ.StartDate ?? occ.OccurrenceStartUtc!.Value.InZone(zone).Date;
 
     public static LocalDate EndLocalDate(this CalendarOccurrence occ, DateTimeZone zone)
     {
+        if (occ.EndDateExclusive is { } endDateExclusive) return endDateExclusive.PlusDays(-1);
         if (occ.OccurrenceEndUtc is not { } endUtc) return occ.StartLocalDate(zone);
         if (endUtc <= occ.OccurrenceStartUtc) return occ.StartLocalDate(zone);
 

--- a/src/Sections/Humans.Calendar/Models/OccurrenceOverrideFormViewModel.cs
+++ b/src/Sections/Humans.Calendar/Models/OccurrenceOverrideFormViewModel.cs
@@ -10,6 +10,10 @@ internal sealed class OccurrenceOverrideFormViewModel
     /// <summary>ISO-8601 UTC string used as the URL segment.</summary>
     public string OriginalOccurrenceStartUtc { get; set; } = string.Empty;
 
+    public bool IsAllDay { get; set; }
+    public DateTime? OverrideStartDateLocal { get; set; }
+    public DateTime? OverrideEndDateLocal { get; set; }
+
     public DateTime? OverrideStartLocal { get; set; }
     public DateTime? OverrideEndLocal { get; set; }
     public string? OverrideTitle { get; set; }
@@ -24,6 +28,23 @@ internal sealed class OccurrenceOverrideFormViewModel
     /// valid ISO-8601 instant. Null means the URL names no occurrence, so callers
     /// answer 404 — a hand-typed or truncated segment is a missing page, not a fault.
     /// </summary>
+    public bool TryBuildOverride(DateTimeZone zone, out Humans.Calendar.Services.Dtos.OverrideOccurrenceDto dto)
+    {
+        dto = new(
+            OverrideStartLocal is { } start ? LocalDateTime.FromDateTime(start).InZoneLeniently(zone).ToInstant() : null,
+            OverrideEndLocal is { } end ? LocalDateTime.FromDateTime(end).InZoneLeniently(zone).ToInstant() : null,
+            OverrideTitle, OverrideDescription, OverrideLocation, OverrideLocationUrl,
+            OverrideStartDateLocal is { } date ? LocalDate.FromDateTime(date) : null,
+            OverrideEndDateLocal is { } last ? LocalDate.FromDateTime(last).PlusDays(1) : null);
+        return !(OverrideStartDateLocal?.TimeOfDay > TimeSpan.Zero || OverrideEndDateLocal?.TimeOfDay > TimeSpan.Zero);
+    }
+
+    public static LocalDate? TryParseOriginalDate(string s)
+    {
+        var result = LocalDatePattern.Iso.Parse(s);
+        return result.Success ? result.Value : null;
+    }
+
     public static Instant? TryParseOriginal(string s)
     {
         var result = InstantPattern.ExtendedIso.Parse(s);

--- a/src/Sections/Humans.Calendar/Services/CachingCalendarService.cs
+++ b/src/Sections/Humans.Calendar/Services/CachingCalendarService.cs
@@ -52,7 +52,9 @@ internal sealed class CachingCalendarService(
             info.RecurrenceRule,
             info.RecurrenceTimezone,
             info.CreatedAt,
-            info.UpdatedAt);
+            info.UpdatedAt,
+            info.StartDate,
+            info.EndDateExclusive);
     }
 
     public async Task<IReadOnlyList<CalendarEventInfo>> GetAllEventInfosAsync(CancellationToken ct = default)
@@ -89,17 +91,17 @@ internal sealed class CachingCalendarService(
     }
 
     public async Task CancelOccurrenceAsync(
-        Guid eventId, Instant originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default)
+        Guid eventId, Instant? originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default, LocalDate? originalDate = null)
     {
-        await WithInner(inner => inner.CancelOccurrenceAsync(eventId, originalOccurrenceStartUtc, userId, ct));
+        await WithInner(inner => inner.CancelOccurrenceAsync(eventId, originalOccurrenceStartUtc, userId, ct, originalDate));
         await ReplaceAsync(eventId, ct);
     }
 
     public async Task OverrideOccurrenceAsync(
-        Guid eventId, Instant originalOccurrenceStartUtc, OverrideOccurrenceDto dto,
-        Guid userId, CancellationToken ct = default)
+        Guid eventId, Instant? originalOccurrenceStartUtc, OverrideOccurrenceDto dto,
+        Guid userId, CancellationToken ct = default, LocalDate? originalDate = null)
     {
-        await WithInner(inner => inner.OverrideOccurrenceAsync(eventId, originalOccurrenceStartUtc, dto, userId, ct));
+        await WithInner(inner => inner.OverrideOccurrenceAsync(eventId, originalOccurrenceStartUtc, dto, userId, ct, originalDate));
         await ReplaceAsync(eventId, ct);
     }
 

--- a/src/Sections/Humans.Calendar/Services/CalendarOccurrenceExpander.cs
+++ b/src/Sections/Humans.Calendar/Services/CalendarOccurrenceExpander.cs
@@ -1,5 +1,6 @@
 using Humans.Calendar.Domain;
 using Humans.Calendar.Services.Dtos;
+using Humans.Base.Extensions;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
 using NodaTime;
@@ -7,311 +8,193 @@ using IcalEvent = Ical.Net.CalendarComponents.CalendarEvent;
 
 namespace Humans.Calendar.Services;
 
-/// <summary>
-/// Pure expansion over prefiltered <see cref="CalendarEventInfo"/> rows for window <c>[from, to)</c>.
-/// Returns sorted <see cref="CalendarOccurrence"/> list with recurrence expansion + exception merge.
-/// No I/O — callable from the §15 caching decorator over cached projections.
-/// </summary>
+/// <summary>Pure date or instant recurrence expansion over the cached event projection.</summary>
 internal static class CalendarOccurrenceExpander
 {
     public static IReadOnlyList<CalendarOccurrence> Expand(
-        IReadOnlyList<CalendarEventInfo> events,
-        Instant from,
-        Instant to,
-        IReadOnlyDictionary<Guid, string> teamNamesById,
-        ILogger logger)
+        IReadOnlyList<CalendarEventInfo> events, Instant from, Instant to,
+        IReadOnlyDictionary<Guid, string> teamNamesById, ILogger logger)
     {
-        var expanded = new List<CalendarOccurrence>();
-
-        foreach (var e in events)
-        {
-            var owningTeamName = ResolveTeamName(teamNamesById, e.OwningTeamId);
-
-            if (string.IsNullOrWhiteSpace(e.RecurrenceRule))
-                AddSingleOccurrence(expanded, e, owningTeamName, from, to);
-            else
-                AddRecurringOccurrences(expanded, e, owningTeamName, from, to, logger);
-        }
-
-        var exceptionsByEvent = events
-            .ToDictionary(e => e.Id, e =>
-                e.Exceptions.ToDictionary(x => x.OriginalOccurrenceStartUtc));
-
-        var finalResults = ApplyExceptions(expanded, exceptionsByEvent, from, to, out var handledExceptionKeys);
-        AddMovedOverrides(finalResults, events, teamNamesById, handledExceptionKeys, from, to);
-
-        return finalResults.OrderBy(o => o.OccurrenceStartUtc).ToList();
-    }
-
-    private static void AddSingleOccurrence(
-        List<CalendarOccurrence> results,
-        CalendarEventInfo e,
-        string owningTeamName,
-        Instant from,
-        Instant to)
-    {
-        if (!OverlapsWindow(e.StartUtc, e.EndUtc, from, to)) return;
-
-        results.Add(CreateOccurrence(
-            e,
-            owningTeamName,
-            e.StartUtc,
-            e.EndUtc,
-            isRecurring: false,
-            originalStart: null));
-    }
-
-    private static void AddRecurringOccurrences(
-        List<CalendarOccurrence> results,
-        CalendarEventInfo e,
-        string owningTeamName,
-        Instant from,
-        Instant to,
-        ILogger logger)
-    {
-        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(e.RecurrenceTimezone!);
-        if (zone is null)
-        {
-            logger.LogWarning(
-                "CalendarEvent {Id} has unknown timezone {Tz}; skipping occurrence expansion",
-                e.Id, e.RecurrenceTimezone);
-            return;
-        }
-
-        var icalEv = CreateIcalEvent(e, zone);
-        var toLocal = to.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-        var fromCalDt = new CalDateTime(
-            from.InZone(zone).LocalDateTime.ToDateTimeUnspecified(),
-            e.RecurrenceTimezone,
-            hasTime: true);
-
-        foreach (var iocc in icalEv.GetOccurrences(fromCalDt, new EvaluationOptions())
-            .TakeWhile(o => o.Period.StartTime.Value < toLocal))
-        {
-            var startInstant = LocalDateTime
-                .FromDateTime(iocc.Period.StartTime.Value)
-                .InZoneLeniently(zone)
-                .ToInstant();
-            var endInstant = e.EndUtc is null
-                ? (Instant?)null
-                : startInstant.Plus(e.EndUtc.Value - e.StartUtc);
-
-            results.Add(CreateOccurrence(
-                e,
-                owningTeamName,
-                startInstant,
-                endInstant,
-                isRecurring: true,
-                originalStart: startInstant));
-        }
-    }
-
-    private static IcalEvent CreateIcalEvent(CalendarEventInfo e, DateTimeZone zone)
-    {
-        var duration = (e.EndUtc ?? e.StartUtc) - e.StartUtc;
-        var dtStartLocal = e.StartUtc.InZone(zone).LocalDateTime.ToDateTimeUnspecified();
-
-        var icalEv = new IcalEvent
-        {
-            DtStart = new CalDateTime(dtStartLocal, e.RecurrenceTimezone, hasTime: true),
-            Duration = Ical.Net.DataTypes.Duration.FromTimeSpanExact(
-                TimeSpan.FromTicks(duration.BclCompatibleTicks)),
-        };
-        icalEv.RecurrenceRule = new RecurrencePattern(e.RecurrenceRule!);
-        return icalEv;
-    }
-
-    private static List<CalendarOccurrence> ApplyExceptions(
-        IReadOnlyList<CalendarOccurrence> expanded,
-        IReadOnlyDictionary<Guid, Dictionary<Instant, CalendarEventExceptionInfo>> exceptionsByEvent,
-        Instant from,
-        Instant to,
-        out HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys)
-    {
-        var finalResults = new List<CalendarOccurrence>();
-        handledExceptionKeys = [];
-
-        foreach (var occ in expanded)
-        {
-            var exception = FindException(occ, exceptionsByEvent);
-            if (exception is null)
-            {
-                finalResults.Add(occ);
-                continue;
-            }
-
-            handledExceptionKeys.Add((occ.EventId, exception.OriginalOccurrenceStartUtc));
-
-            if (exception.IsCancelled) continue;
-
-            var overridden = ApplyOverride(occ, exception);
-            if (OverlapsWindow(overridden.OccurrenceStartUtc, overridden.OccurrenceEndUtc, from, to))
-                finalResults.Add(overridden);
-        }
-
-        return finalResults;
-    }
-
-    private static CalendarEventExceptionInfo? FindException(
-        CalendarOccurrence occ,
-        IReadOnlyDictionary<Guid, Dictionary<Instant, CalendarEventExceptionInfo>> exceptionsByEvent)
-    {
-        if (!occ.IsRecurring || occ.OriginalOccurrenceStartUtc is null) return null;
-
-        return exceptionsByEvent.TryGetValue(occ.EventId, out var perEvent) &&
-            perEvent.TryGetValue(occ.OriginalOccurrenceStartUtc.Value, out var ex)
-                ? ex
-                : null;
-    }
-
-    private static void AddMovedOverrides(
-        List<CalendarOccurrence> finalResults,
-        IReadOnlyList<CalendarEventInfo> events,
-        IReadOnlyDictionary<Guid, string> teamNamesById,
-        HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys,
-        Instant from,
-        Instant to)
-    {
+        var results = new List<CalendarOccurrence>();
+        // Calendar currently uses the organisation's viewer zone. Dates themselves never convert.
+        var viewerZone = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+        var fromDate = from.InZone(viewerZone).Date;
+        var toLocal = to.InZone(viewerZone).LocalDateTime;
+        var toDate = toLocal.TimeOfDay == LocalTime.Midnight ? toLocal.Date : toLocal.Date.PlusDays(1);
         foreach (var ev in events)
         {
-            var owningTeamName = ResolveTeamName(teamNamesById, ev.OwningTeamId);
-
-            foreach (var ex in ev.Exceptions)
+            var name = teamNamesById.GetValueOrDefault(ev.OwningTeamId, string.Empty);
+            var occurrences = new List<CalendarOccurrence>();
+            var recurring = !string.IsNullOrWhiteSpace(ev.RecurrenceRule);
+            if (!recurring)
+                occurrences.Add(CreateOccurrence(ev, name, ev.StartUtc, ev.EndUtc, ev.StartDate, ev.EndDateExclusive, false));
+            else if (ev.IsAllDay)
             {
-                if (!ShouldInjectMovedOverride(ev.Id, ex, handledExceptionKeys)) continue;
-                if (ex.OverrideStartUtc is not { } newStart) continue;
+                var days = NodaTime.Period.Between(ev.StartDate!.Value, ev.EndDateExclusive!.Value, PeriodUnits.Days).Days;
+                var ical = new IcalEvent
+                {
+                    DtStart = new CalDateTime(ev.StartDate.Value.ToDateTimeUnspecified(), hasTime: false),
+                    DtEnd = new CalDateTime(ev.EndDateExclusive.Value.ToDateTimeUnspecified(), hasTime: false),
+                    RecurrenceRule = new RecurrencePattern(ev.RecurrenceRule!),
+                };
+                var searchStart = new CalDateTime(fromDate.PlusDays(-days).ToDateTimeUnspecified(), hasTime: false);
+                foreach (var item in ical.GetOccurrences(searchStart, new EvaluationOptions())
+                    .TakeWhile(o => LocalDate.FromDateTime(o.Period.StartTime.Value) < toDate))
+                {
+                    var date = LocalDate.FromDateTime(item.Period.StartTime.Value);
+                    occurrences.Add(CreateOccurrence(ev, name, null, null, date, date.PlusDays(days), true));
+                }
+            }
+            else
+            {
+                var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(ev.RecurrenceTimezone!);
+                if (zone is null)
+                {
+                    logger.LogWarning("CalendarEvent {Id} has unknown timezone {Tz}; skipping occurrence expansion", ev.Id, ev.RecurrenceTimezone);
+                    continue;
+                }
+                var duration = (ev.EndUtc ?? ev.StartUtc!.Value) - ev.StartUtc!.Value;
+                var ical = new IcalEvent
+                {
+                    DtStart = new CalDateTime(ev.StartUtc.Value.InZone(zone).LocalDateTime.ToDateTimeUnspecified(), zone.Id, hasTime: true),
+                    Duration = Ical.Net.DataTypes.Duration.FromTimeSpanExact(TimeSpan.FromTicks(duration.BclCompatibleTicks)),
+                    RecurrenceRule = new RecurrencePattern(ev.RecurrenceRule!),
+                };
+                var searchStart = new CalDateTime(from.Minus(duration).InZone(zone).LocalDateTime.ToDateTimeUnspecified(), zone.Id, hasTime: true);
+                foreach (var item in ical.GetOccurrences(searchStart, new EvaluationOptions())
+                    .TakeWhile(o => o.Period.StartTime.Value < to.InZone(zone).LocalDateTime.ToDateTimeUnspecified()))
+                {
+                    var start = LocalDateTime.FromDateTime(item.Period.StartTime.Value).InZoneLeniently(zone).ToInstant();
+                    occurrences.Add(CreateOccurrence(ev, name, start, ev.EndUtc is null ? null : start.Plus(duration), null, null, true));
+                }
+            }
 
-                var newEnd = ResolveOverrideEnd(ev, ex, newStart);
-
-                if (!OverlapsWindow(newStart, newEnd, from, to)) continue;
-
-                finalResults.Add(CreateOccurrence(
-                    ev,
-                    owningTeamName,
-                    newStart,
-                    newEnd,
-                    isRecurring: true,
-                    originalStart: ex.OriginalOccurrenceStartUtc,
-                    title: ex.OverrideTitle,
-                    description: ex.OverrideDescription,
-                    location: ex.OverrideLocation,
-                    locationUrl: ex.OverrideLocationUrl));
+            var handled = new HashSet<Guid>();
+            foreach (var occurrence in occurrences)
+            {
+                var exception = recurring ? ev.Exceptions.FirstOrDefault(x => ev.IsAllDay
+                    ? x.OriginalOccurrenceDate == occurrence.OriginalOccurrenceDate
+                    : x.OriginalOccurrenceStartUtc == occurrence.OriginalOccurrenceStartUtc) : null;
+                if (exception is not null) handled.Add(exception.Id);
+                if (exception?.IsCancelled == true) continue;
+                var result = exception is null ? occurrence : ApplyOverride(occurrence, exception);
+                if (OverlapsWindow(result, from, to, fromDate, toDate)) results.Add(result);
+            }
+            // A moved occurrence can be outside the series' original window in either direction.
+            foreach (var exception in ev.Exceptions.Where(x => !handled.Contains(x.Id) && !x.IsCancelled))
+            {
+                if (!recurring) continue;
+                var date = exception.OriginalOccurrenceDate;
+                var start = exception.OriginalOccurrenceStartUtc;
+                var original = ev.IsAllDay
+                    ? CreateOccurrence(ev, name, null, null, date,
+                        date!.Value.PlusDays(NodaTime.Period.Between(ev.StartDate!.Value, ev.EndDateExclusive!.Value, PeriodUnits.Days).Days), true)
+                    : CreateOccurrence(ev, name, start,
+                        ev.EndUtc is null ? null : start!.Value.Plus(ev.EndUtc.Value - ev.StartUtc!.Value), null, null, true);
+                var result = ApplyOverride(original, exception);
+                if (OverlapsWindow(result, from, to, fromDate, toDate)) results.Add(result);
             }
         }
+        return results.OrderBy(o => o.StartDate ?? o.OccurrenceStartUtc!.Value.InZone(viewerZone).Date)
+            .ThenBy(o => o.OccurrenceStartUtc).ToList();
     }
 
-    private static bool ShouldInjectMovedOverride(
-        Guid eventId,
-        CalendarEventExceptionInfo ex,
-        HashSet<(Guid EventId, Instant OriginalStart)> handledExceptionKeys) =>
-        !handledExceptionKeys.Contains((eventId, ex.OriginalOccurrenceStartUtc)) &&
-        !ex.IsCancelled &&
-        ex.OverrideStartUtc is not null;
-
-    private static Instant? ResolveOverrideEnd(
-        CalendarEventInfo ev,
-        CalendarEventExceptionInfo ex,
-        Instant newStart)
+    private static CalendarOccurrence ApplyOverride(CalendarOccurrence occurrence, CalendarEventExceptionInfo ex)
     {
-        if (ex.OverrideEndUtc is { } overrideEnd) return overrideEnd;
-        if (ev.EndUtc is null) return null;
-
-        return newStart.Plus((ev.EndUtc.Value - ev.StartUtc));
-    }
-
-    private static CalendarOccurrence ApplyOverride(
-        CalendarOccurrence occurrence,
-        CalendarEventExceptionInfo ex) =>
-        occurrence with
+        var date = ex.OverrideStartDate ?? occurrence.StartDate;
+        var start = ex.OverrideStartUtc ?? occurrence.OccurrenceStartUtc;
+        return occurrence with
         {
-            OccurrenceStartUtc = ex.OverrideStartUtc ?? occurrence.OccurrenceStartUtc,
-            OccurrenceEndUtc = ex.OverrideEndUtc ?? occurrence.OccurrenceEndUtc,
+            StartDate = date,
+            EndDateExclusive = occurrence.IsAllDay ? ex.OverrideEndDateExclusive ?? date!.Value.PlusDays(
+                NodaTime.Period.Between(occurrence.StartDate!.Value, occurrence.EndDateExclusive!.Value, PeriodUnits.Days).Days) : null,
+            OccurrenceStartUtc = start,
+            OccurrenceEndUtc = ex.OverrideEndUtc ?? (occurrence.OccurrenceEndUtc is { } end
+                ? start!.Value.Plus(end - occurrence.OccurrenceStartUtc!.Value) : null),
             Title = ex.OverrideTitle ?? occurrence.Title,
             Description = ex.OverrideDescription ?? occurrence.Description,
             Location = ex.OverrideLocation ?? occurrence.Location,
             LocationUrl = ex.OverrideLocationUrl ?? occurrence.LocationUrl,
         };
-
-    private static CalendarOccurrence CreateOccurrence(
-        CalendarEventInfo ev,
-        string owningTeamName,
-        Instant start,
-        Instant? end,
-        bool isRecurring,
-        Instant? originalStart,
-        string? title = null,
-        string? description = null,
-        string? location = null,
-        string? locationUrl = null) =>
-        new(
-            EventId: ev.Id,
-            OccurrenceStartUtc: start,
-            OccurrenceEndUtc: end,
-            IsAllDay: ev.IsAllDay,
-            Title: title ?? ev.Title,
-            Description: description ?? ev.Description,
-            Location: location ?? ev.Location,
-            LocationUrl: locationUrl ?? ev.LocationUrl,
-            OwningTeamId: ev.OwningTeamId,
-            OwningTeamName: owningTeamName,
-            IsRecurring: isRecurring,
-            OriginalOccurrenceStartUtc: originalStart);
-
-    private static bool OverlapsWindow(Instant start, Instant? end, Instant from, Instant to) =>
-        start < to && (end ?? start) > from;
-
-    private static string ResolveTeamName(IReadOnlyDictionary<Guid, string> teamNamesById, Guid teamId) =>
-        teamNamesById.TryGetValue(teamId, out var name) ? name : string.Empty;
-
-    /// <summary>
-    /// The section's only window prefilter. It used to mirror a SQL one in
-    /// <c>CalendarRepository</c>; that query had no live caller once the decorator began
-    /// answering every window read from its snapshot, and was retired with it.
-    /// </summary>
-    public static List<CalendarEventInfo> FilterForWindow(
-        IEnumerable<CalendarEventInfo> snapshot,
-        Instant from,
-        Instant to,
-        Guid? teamId)
-    {
-        var result = new List<CalendarEventInfo>();
-        foreach (var e in snapshot)
-        {
-            if (e.StartUtc > to) continue;
-            if (e.RecurrenceUntilUtc is { } until && until < from) continue;
-            if (teamId is { } t && e.OwningTeamId != t) continue;
-            result.Add(e);
-        }
-        return result;
     }
 
+    private static CalendarOccurrence CreateOccurrence(CalendarEventInfo ev, string name,
+        Instant? start, Instant? end, LocalDate? date, LocalDate? endDate, bool recurring) => new(
+            ev.Id, start, end, ev.IsAllDay, ev.Title, ev.Description, ev.Location, ev.LocationUrl,
+            ev.OwningTeamId, name, recurring, recurring ? start : null,
+            date, endDate, recurring ? date : null);
+
+    private static bool OverlapsWindow(CalendarOccurrence o, Instant from, Instant to, LocalDate fromDate, LocalDate toDate) =>
+        o.IsAllDay ? o.StartDate < toDate && o.EndDateExclusive > fromDate
+            : o.OccurrenceStartUtc < to && (o.OccurrenceEndUtc ?? o.OccurrenceStartUtc) > from;
+
+    /// <summary>Conservative prefilter; exceptions may move occurrences beyond either series boundary.</summary>
+    public static List<CalendarEventInfo> FilterForWindow(IEnumerable<CalendarEventInfo> snapshot,
+        Instant from, Instant to, Guid? teamId)
+    {
+        var zone = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+        return snapshot.Where(e => (teamId is null || e.OwningTeamId == teamId) &&
+            (e.Exceptions.Count > 0 || (e.IsAllDay
+                ? e.StartDate <= to.InZone(zone).Date && (e.RecurrenceUntilDate is null || e.RecurrenceUntilDate >= from.InZone(zone).Date)
+                : e.StartUtc <= to && (e.RecurrenceUntilUtc is null || e.RecurrenceUntilUtc >= from)))).ToList();
+    }
+
+    // Older date events may have a DATE-TIME UNTIL. Interpret it in their original zone once.
+    private static string? DateRule(string? rule, DateTimeZone zone) => rule is null ? null :
+        string.Join(';', rule.Split(';').Select(part =>
+        {
+            if (!part.StartsWith("UNTIL=", StringComparison.OrdinalIgnoreCase) || part.Length <= 14) return part;
+            var value = part[6..];
+            var local = DateFormattingExtensions.IcalBasicDateTimePattern.Parse(value.TrimEnd('Z')).Value;
+            var date = value.EndsWith('Z') ? local.InUtc().ToInstant().InZone(zone).Date : local.Date;
+            return "UNTIL=" + DateFormattingExtensions.IcalBasicDatePattern.Format(date);
+        }));
+
     /// <summary>Maps domain <c>CalendarEvent</c> (with Exceptions) to the immutable projection.</summary>
-    public static CalendarEventInfo ToInfo(CalendarEvent ev) => new(
-        Id: ev.Id,
-        Title: ev.Title,
-        Description: ev.Description,
-        Location: ev.Location,
-        LocationUrl: ev.LocationUrl,
-        OwningTeamId: ev.OwningTeamId,
-        StartUtc: ev.StartUtc,
-        EndUtc: ev.EndUtc,
-        IsAllDay: ev.IsAllDay,
-        RecurrenceRule: ev.RecurrenceRule,
-        RecurrenceTimezone: ev.RecurrenceTimezone,
-        RecurrenceUntilUtc: ev.RecurrenceUntilUtc,
-        CreatedByUserId: ev.CreatedByUserId,
-        CreatedAt: ev.CreatedAt,
-        UpdatedAt: ev.UpdatedAt,
-        Exceptions: ev.Exceptions
-            .Select(x => new CalendarEventExceptionInfo(
-                Id: x.Id,
-                OriginalOccurrenceStartUtc: x.OriginalOccurrenceStartUtc,
-                IsCancelled: x.IsCancelled,
-                OverrideStartUtc: x.OverrideStartUtc,
-                OverrideEndUtc: x.OverrideEndUtc,
-                OverrideTitle: x.OverrideTitle,
-                OverrideDescription: x.OverrideDescription,
-                OverrideLocation: x.OverrideLocation,
-                OverrideLocationUrl: x.OverrideLocationUrl))
-            .ToList());
+    public static CalendarEventInfo ToInfo(CalendarEvent ev)
+    {
+        // Legacy all-day instants are read as dates once, at the service boundary.
+        // New writes use only the date columns; the old columns remain for existing rows.
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(ev.RecurrenceTimezone ?? "Europe/Madrid")
+            ?? DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+        var startDate = ev.IsAllDay ? ev.StartDate ?? ev.StartUtc!.Value.InZone(zone).Date : (LocalDate?)null;
+        var endDate = ev.IsAllDay ? ev.EndDateExclusive ??
+            (ev.EndUtc is { } end ? end.Minus(NodaTime.Duration.FromNanoseconds(1)).InZone(zone).Date.PlusDays(1)
+                : startDate!.Value.PlusDays(1)) : (LocalDate?)null;
+        return new(
+            Id: ev.Id,
+            Title: ev.Title,
+            Description: ev.Description,
+            Location: ev.Location,
+            LocationUrl: ev.LocationUrl,
+            OwningTeamId: ev.OwningTeamId,
+            StartUtc: ev.IsAllDay ? null : ev.StartUtc,
+            EndUtc: ev.IsAllDay ? null : ev.EndUtc,
+            IsAllDay: ev.IsAllDay,
+            RecurrenceRule: ev.IsAllDay ? DateRule(ev.RecurrenceRule, zone) : ev.RecurrenceRule,
+            RecurrenceTimezone: ev.RecurrenceTimezone,
+            RecurrenceUntilUtc: ev.IsAllDay ? null : ev.RecurrenceUntilUtc,
+            CreatedByUserId: ev.CreatedByUserId,
+            CreatedAt: ev.CreatedAt,
+            UpdatedAt: ev.UpdatedAt,
+            Exceptions: ev.Exceptions
+                .Select(x => new CalendarEventExceptionInfo(
+                    Id: x.Id,
+                    OriginalOccurrenceStartUtc: ev.IsAllDay ? null : x.OriginalOccurrenceStartUtc,
+                    IsCancelled: x.IsCancelled,
+                    OverrideStartUtc: ev.IsAllDay ? null : x.OverrideStartUtc,
+                    OverrideEndUtc: ev.IsAllDay ? null : x.OverrideEndUtc,
+                    OverrideTitle: x.OverrideTitle,
+                    OverrideDescription: x.OverrideDescription,
+                    OverrideLocation: x.OverrideLocation,
+                    OverrideLocationUrl: x.OverrideLocationUrl,
+                    OriginalOccurrenceDate: ev.IsAllDay ? x.OriginalOccurrenceDate ?? x.OriginalOccurrenceStartUtc!.Value.InZone(zone).Date : null,
+                    OverrideStartDate: ev.IsAllDay ? x.OverrideStartDate ?? x.OverrideStartUtc?.InZone(zone).Date : null,
+                    OverrideEndDateExclusive: ev.IsAllDay ? x.OverrideEndDateExclusive ??
+                        x.OverrideEndUtc?.Minus(NodaTime.Duration.FromNanoseconds(1)).InZone(zone).Date.PlusDays(1) : null))
+                .ToList(),
+            StartDate: startDate,
+            EndDateExclusive: endDate,
+            RecurrenceUntilDate: ev.IsAllDay ? ev.RecurrenceUntilDate : null);
+    }
 }

--- a/src/Sections/Humans.Calendar/Services/CalendarService.cs
+++ b/src/Sections/Humans.Calendar/Services/CalendarService.cs
@@ -25,23 +25,11 @@ internal sealed class CalendarService(
     IAuditLogService audit,
     ILogger<CalendarService> logger) : ICalendarService
 {
-    /// <summary>
-    /// The instants an all-day event is stored as: half-open, from local midnight on
-    /// <paramref name="startDate"/> to local midnight the day after
-    /// <paramref name="inclusiveEndDate"/>. Forms and views speak in the inclusive last day,
-    /// storage does not, and this is the one place that conversion happens.
-    /// </summary>
-    public static (Instant Start, Instant End) AllDayWindow(
-        LocalDate startDate, LocalDate inclusiveEndDate, DateTimeZone zone) =>
-        (startDate.AtMidnight().InZoneLeniently(zone).ToInstant(),
-         inclusiveEndDate.PlusDays(1).AtMidnight().InZoneLeniently(zone).ToInstant());
+    /// <summary>Forms use an inclusive last day; storage uses an exclusive date.</summary>
+    public static (LocalDate Start, LocalDate End) AllDayWindow(LocalDate startDate, LocalDate inclusiveEndDate) =>
+        (startDate, inclusiveEndDate.PlusDays(1));
 
-    /// <summary>
-    /// Inverse of <see cref="AllDayWindow"/>: the last day an all-day event covers, given its
-    /// stored exclusive end. A nanosecond back off the exclusive midnight lands on that day.
-    /// </summary>
-    public static LocalDate AllDayInclusiveEndDate(Instant exclusiveEndUtc, DateTimeZone zone) =>
-        exclusiveEndUtc.Minus(NodaTime.Duration.FromNanoseconds(1)).InZone(zone).Date;
+    public static LocalDate AllDayInclusiveEndDate(LocalDate exclusiveEndDate) => exclusiveEndDate.PlusDays(-1);
 
     public async Task<IReadOnlyList<CalendarEventInfo>> GetAllEventInfosAsync(CancellationToken ct = default)
     {
@@ -72,10 +60,13 @@ internal sealed class CalendarService(
             OwningTeamId = dto.OwningTeamId,
             StartUtc = dto.StartUtc,
             EndUtc = dto.EndUtc,
+            StartDate = dto.StartDate,
+            EndDateExclusive = dto.EndDateExclusive,
             IsAllDay = dto.IsAllDay,
             RecurrenceRule = dto.RecurrenceRule,
             RecurrenceTimezone = dto.RecurrenceTimezone,
-            RecurrenceUntilUtc = ComputeRecurrenceUntilUtc(dto.RecurrenceRule, dto.RecurrenceTimezone, dto.StartUtc, dto.EndUtc),
+            RecurrenceUntilUtc = dto.IsAllDay ? null : ComputeRecurrenceUntilUtc(dto.RecurrenceRule, dto.RecurrenceTimezone, dto.StartUtc, dto.EndUtc),
+            RecurrenceUntilDate = dto.IsAllDay ? ComputeRecurrenceUntilDate(dto.RecurrenceRule, dto.StartDate, dto.EndDateExclusive) : null,
             CreatedByUserId = createdByUserId,
             CreatedAt = now,
             UpdatedAt = now,
@@ -120,12 +111,14 @@ internal sealed class CalendarService(
         catch (ValidationException ex)
         {
             logger.LogWarning(ex, "Calendar event create rejected: {Reason}", ex.Message);
-            return CalendarEventMutationResult.ValidationFailed(CalendarValidationMemberName(ex), ex.Message);
+            return CalendarEventMutationResult.ValidationFailed(CalendarValidationMemberName(ex),
+                dto.IsAllDay ? "Calendar_InvalidAllDayRecurrence" : ex.Message);
         }
         catch (InvalidOperationException ex)
         {
             logger.LogWarning(ex, "Calendar event create rejected: {Reason}", ex.Message);
-            return CalendarEventMutationResult.Failed(ex.Message);
+            return CalendarEventMutationResult.Failed(ex.Message.StartsWith("Calendar_", StringComparison.Ordinal)
+                ? ex.Message : dto.IsAllDay ? "Calendar_InvalidAllDayEvent" : ex.Message);
         }
         catch (Exception ex)
         {
@@ -163,9 +156,9 @@ internal sealed class CalendarService(
 
     // Denormalised RRULE end (UNTIL or COUNT-bounded last-occurrence) for SQL window prefilter.
     // Returns null only for truly open-ended rules.
-    private static Instant? ComputeRecurrenceUntilUtc(string? rrule, string? tz, Instant dtStart, Instant? dtEnd)
+    private static Instant? ComputeRecurrenceUntilUtc(string? rrule, string? tz, Instant? dtStart, Instant? dtEnd)
     {
-        if (string.IsNullOrWhiteSpace(rrule) || string.IsNullOrWhiteSpace(tz)) return null;
+        if (dtStart is null || string.IsNullOrWhiteSpace(rrule) || string.IsNullOrWhiteSpace(tz)) return null;
 
         int? count = null;
         foreach (var part in rrule.Split(';', StringSplitOptions.RemoveEmptyEntries))
@@ -211,8 +204,8 @@ internal sealed class CalendarService(
         var ruleZone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(tz);
         if (ruleZone is null) return null;
 
-        var dtStartLocal = dtStart.InZone(ruleZone).LocalDateTime.ToDateTimeUnspecified();
-        var duration = (dtEnd ?? dtStart) - dtStart;
+        var dtStartLocal = dtStart.Value.InZone(ruleZone).LocalDateTime.ToDateTimeUnspecified();
+        var duration = (dtEnd ?? dtStart.Value) - dtStart.Value;
 
         var icalEv = new IcalEvent
         {
@@ -232,6 +225,35 @@ internal sealed class CalendarService(
         return lastStart.Plus(duration);
     }
 
+    private static LocalDate? ComputeRecurrenceUntilDate(string? rule, LocalDate? start, LocalDate? end)
+    {
+        if (string.IsNullOrWhiteSpace(rule) || start is null || end is null) return null;
+        // A DATE recurrence cannot introduce a time through RRULE either.
+        foreach (var part in rule.Split(';'))
+        {
+            if (part.StartsWith("BYHOUR=", StringComparison.OrdinalIgnoreCase) ||
+                part.StartsWith("BYMINUTE=", StringComparison.OrdinalIgnoreCase) ||
+                part.StartsWith("BYSECOND=", StringComparison.OrdinalIgnoreCase) ||
+                part.Equals("FREQ=HOURLY", StringComparison.OrdinalIgnoreCase) ||
+                part.Equals("FREQ=MINUTELY", StringComparison.OrdinalIgnoreCase) ||
+                part.Equals("FREQ=SECONDLY", StringComparison.OrdinalIgnoreCase) ||
+                (part.StartsWith("UNTIL=", StringComparison.OrdinalIgnoreCase) && part.Length != 14))
+                throw new ValidationException("All-day recurrence rules must use dates without times.");
+        }
+        var pattern = new RecurrencePattern(rule);
+        var days = NodaTime.Period.Between(start.Value, end.Value, PeriodUnits.Days).Days;
+        if (pattern.Until is not null)
+            return LocalDate.FromDateTime(pattern.Until.Value).PlusDays(days);
+        if (pattern.Count is not > 0) return null;
+        var ical = new IcalEvent
+        {
+            DtStart = new CalDateTime(start.Value.ToDateTimeUnspecified(), hasTime: false),
+            RecurrenceRule = pattern,
+        };
+        var last = ical.GetOccurrences(ical.DtStart, new EvaluationOptions()).Take(pattern.Count.Value).LastOrDefault();
+        return last is null ? null : LocalDate.FromDateTime(last.Period.StartTime.Value).PlusDays(days);
+    }
+
     private async Task<CalendarEvent> UpdateEventAsync(Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct = default)
     {
         ValidateRecurrenceRule(dto.RecurrenceRule);
@@ -242,6 +264,22 @@ internal sealed class CalendarService(
 
         var found = await repo.UpdateAsync(id, ev =>
         {
+            if (ev.IsAllDay != dto.IsAllDay && ev.Exceptions.Count > 0)
+                throw new InvalidOperationException("Calendar_CannotChangeEventType");
+            if (ev.IsAllDay)
+            {
+                var previous = CalendarOccurrenceExpander.ToInfo(ev);
+                foreach (var exception in ev.Exceptions)
+                {
+                    var dateException = previous.Exceptions.Single(x => x.Id == exception.Id);
+                    exception.OriginalOccurrenceDate = dateException.OriginalOccurrenceDate;
+                    exception.OverrideStartDate = dateException.OverrideStartDate;
+                    exception.OverrideEndDateExclusive = dateException.OverrideEndDateExclusive;
+                    exception.OriginalOccurrenceStartUtc = null;
+                    exception.OverrideStartUtc = null;
+                    exception.OverrideEndUtc = null;
+                }
+            }
             ev.Title = dto.Title;
             ev.Description = dto.Description;
             ev.Location = dto.Location;
@@ -249,10 +287,13 @@ internal sealed class CalendarService(
             ev.OwningTeamId = dto.OwningTeamId;
             ev.StartUtc = dto.StartUtc;
             ev.EndUtc = dto.EndUtc;
+            ev.StartDate = dto.StartDate;
+            ev.EndDateExclusive = dto.EndDateExclusive;
             ev.IsAllDay = dto.IsAllDay;
             ev.RecurrenceRule = dto.RecurrenceRule;
             ev.RecurrenceTimezone = dto.RecurrenceTimezone;
-            ev.RecurrenceUntilUtc = ComputeRecurrenceUntilUtc(dto.RecurrenceRule, dto.RecurrenceTimezone, dto.StartUtc, dto.EndUtc);
+            ev.RecurrenceUntilUtc = dto.IsAllDay ? null : ComputeRecurrenceUntilUtc(dto.RecurrenceRule, dto.RecurrenceTimezone, dto.StartUtc, dto.EndUtc);
+            ev.RecurrenceUntilDate = dto.IsAllDay ? ComputeRecurrenceUntilDate(dto.RecurrenceRule, dto.StartDate, dto.EndDateExclusive) : null;
             ev.UpdatedAt = now;
 
             var errors = ev.Validate();
@@ -298,7 +339,8 @@ internal sealed class CalendarService(
         catch (ValidationException ex)
         {
             logger.LogWarning(ex, "Calendar event {EventId} update rejected: {Reason}", id, ex.Message);
-            return CalendarEventMutationResult.ValidationFailed(CalendarValidationMemberName(ex), ex.Message);
+            return CalendarEventMutationResult.ValidationFailed(CalendarValidationMemberName(ex),
+                dto.IsAllDay ? "Calendar_InvalidAllDayRecurrence" : ex.Message);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
         {
@@ -308,7 +350,8 @@ internal sealed class CalendarService(
         catch (InvalidOperationException ex)
         {
             logger.LogWarning(ex, "Calendar event {EventId} update rejected: {Reason}", id, ex.Message);
-            return CalendarEventMutationResult.Failed(ex.Message);
+            return CalendarEventMutationResult.Failed(ex.Message.StartsWith("Calendar_", StringComparison.Ordinal)
+                ? ex.Message : dto.IsAllDay ? "Calendar_InvalidAllDayEvent" : ex.Message);
         }
         catch (Exception ex)
         {
@@ -340,16 +383,16 @@ internal sealed class CalendarService(
         }
     }
 
-    public async Task CancelOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default)
+    public async Task CancelOccurrenceAsync(Guid eventId, Instant? originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default, LocalDate? originalDate = null)
     {
         await UpsertExceptionAsync(eventId, originalOccurrenceStartUtc, userId,
             apply: x => x.IsCancelled = true,
             auditAction: AuditAction.CalendarOccurrenceCancelled,
-            auditDescription: $"Cancelled occurrence {originalOccurrenceStartUtc}",
-            ct);
+            auditDescription: $"Cancelled occurrence {(originalDate is { } date ? NodaTime.Text.LocalDatePattern.Iso.Format(date) : originalOccurrenceStartUtc.ToIso8601())}",
+            ct, originalDate);
     }
 
-    public async Task OverrideOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, OverrideOccurrenceDto dto, Guid userId, CancellationToken ct = default)
+    public async Task OverrideOccurrenceAsync(Guid eventId, Instant? originalOccurrenceStartUtc, OverrideOccurrenceDto dto, Guid userId, CancellationToken ct = default, LocalDate? originalDate = null)
     {
         await UpsertExceptionAsync(eventId, originalOccurrenceStartUtc, userId,
             apply: x =>
@@ -357,31 +400,65 @@ internal sealed class CalendarService(
                 x.IsCancelled = false;
                 x.OverrideStartUtc = dto.OverrideStartUtc;
                 x.OverrideEndUtc = dto.OverrideEndUtc;
+                x.OverrideStartDate = dto.OverrideStartDate;
+                x.OverrideEndDateExclusive = dto.OverrideEndDateExclusive;
                 x.OverrideTitle = dto.OverrideTitle;
                 x.OverrideDescription = dto.OverrideDescription;
                 x.OverrideLocation = dto.OverrideLocation;
                 x.OverrideLocationUrl = dto.OverrideLocationUrl;
             },
             auditAction: AuditAction.CalendarOccurrenceOverridden,
-            auditDescription: $"Overrode occurrence {originalOccurrenceStartUtc}",
-            ct);
+            auditDescription: $"Overrode occurrence {(originalDate is { } date ? NodaTime.Text.LocalDatePattern.Iso.Format(date) : originalOccurrenceStartUtc.ToIso8601())}",
+            ct, originalDate);
     }
 
     private async Task UpsertExceptionAsync(
-        Guid eventId, Instant originalUtc, Guid userId,
+        Guid eventId, Instant? originalUtc, Guid userId,
         Action<CalendarEventException> apply,
         AuditAction auditAction, string auditDescription,
-        CancellationToken ct)
+        CancellationToken ct, LocalDate? originalDate)
     {
         var now = clock.GetCurrentInstant();
+        var ev = await repo.GetEventByIdAsync(eventId, ct)
+            ?? throw new InvalidOperationException("Calendar event not found.");
+        var info = CalendarOccurrenceExpander.ToInfo(ev);
+        if (string.IsNullOrWhiteSpace(info.RecurrenceRule) ||
+            (info.IsAllDay ? originalDate is null || originalUtc is not null : originalUtc is null || originalDate is not null))
+            throw new InvalidOperationException("The occurrence identity must match the series' date or time type.");
+        var legacyStart = originalDate is null ? null : ev.Exceptions.FirstOrDefault(x =>
+            x.OriginalOccurrenceDate is null && x.OriginalOccurrenceStartUtc is { } old &&
+            old.InZone(DateTimeZoneProviders.Tzdb[ev.RecurrenceTimezone ?? "Europe/Madrid"]).Date == originalDate)?.OriginalOccurrenceStartUtc;
 
         await repo.UpsertExceptionAsync(
             eventId,
-            originalUtc,
+            originalUtc ?? legacyStart,
             createdByUserId: userId,
             now: now,
-            apply: apply,
-            ct: ct);
+            apply: x =>
+            {
+                if (info.IsAllDay)
+                {
+                    var previous = info.Exceptions.FirstOrDefault(e => e.Id == x.Id);
+                    x.OverrideStartDate = previous?.OverrideStartDate;
+                    x.OverrideEndDateExclusive = previous?.OverrideEndDateExclusive;
+                    x.OverrideStartUtc = null;
+                    x.OverrideEndUtc = null;
+                }
+                apply(x);
+                if (x.IsCancelled) return;
+                if (info.IsAllDay)
+                {
+                    if (x.OverrideStartUtc is not null || x.OverrideEndUtc is not null)
+                        throw new InvalidOperationException("An all-day occurrence cannot have a time.");
+                    var start = x.OverrideStartDate ?? originalDate!.Value;
+                    var end = x.OverrideEndDateExclusive ?? start.PlusDays(
+                        NodaTime.Period.Between(info.StartDate!.Value, info.EndDateExclusive!.Value, PeriodUnits.Days).Days);
+                    if (end <= start) throw new InvalidOperationException("An all-day occurrence requires a non-empty date range.");
+                }
+                else if (x.OverrideStartDate is not null || x.OverrideEndDateExclusive is not null)
+                    throw new InvalidOperationException("A timed occurrence cannot have all-day dates.");
+            },
+            ct: ct, originalDate: originalDate);
 
         // Audit best-effort: exception upsert already committed (see CreateEventAsync).
         try

--- a/src/Sections/Humans.Calendar/Services/Dtos/CalendarEventDetail.cs
+++ b/src/Sections/Humans.Calendar/Services/Dtos/CalendarEventDetail.cs
@@ -9,10 +9,12 @@ internal sealed record CalendarEventDetail(
     string? Location,
     string? LocationUrl,
     Guid OwningTeamId,
-    Instant StartUtc,
+    Instant? StartUtc,
     Instant? EndUtc,
     bool IsAllDay,
     string? RecurrenceRule,
     string? RecurrenceTimezone,
     Instant CreatedAt,
-    Instant UpdatedAt);
+    Instant UpdatedAt,
+    LocalDate? StartDate = null,
+    LocalDate? EndDateExclusive = null);

--- a/src/Sections/Humans.Calendar/Services/Dtos/CalendarEventInfo.cs
+++ b/src/Sections/Humans.Calendar/Services/Dtos/CalendarEventInfo.cs
@@ -11,8 +11,8 @@ namespace Humans.Calendar.Services.Dtos;
 /// <para>
 /// Cache shape: the decorator holds <em>all</em> non-soft-deleted events keyed
 /// by id. Window queries (<c>GetOccurrencesInWindowAsync</c>) snapshot-scan
-/// this dict and filter in-memory by the same predicate the SQL prefilter uses
-/// (<c>StartUtc &lt;= to AND (RecurrenceUntilUtc == null || RecurrenceUntilUtc &gt;= from)</c>).
+/// this dict and filter by date bounds for all-day series or instant bounds for timed
+/// series. Rows with exceptions survive the prefilter because overrides can move outside it.
 /// Expansion + exception merging stay in the service layer
 /// (<see cref="CalendarOccurrenceExpander"/>).
 /// </para>
@@ -35,7 +35,7 @@ internal sealed record CalendarEventInfo(
     string? Location,
     string? LocationUrl,
     Guid OwningTeamId,
-    Instant StartUtc,
+    Instant? StartUtc,
     Instant? EndUtc,
     bool IsAllDay,
     string? RecurrenceRule,
@@ -44,7 +44,10 @@ internal sealed record CalendarEventInfo(
     Guid CreatedByUserId,
     Instant CreatedAt,
     Instant UpdatedAt,
-    IReadOnlyList<CalendarEventExceptionInfo> Exceptions);
+    IReadOnlyList<CalendarEventExceptionInfo> Exceptions,
+    LocalDate? StartDate = null,
+    LocalDate? EndDateExclusive = null,
+    LocalDate? RecurrenceUntilDate = null);
 
 /// <summary>
 /// Immutable projection of a single <c>calendar_event_exceptions</c> row,
@@ -53,11 +56,14 @@ internal sealed record CalendarEventInfo(
 /// </summary>
 internal sealed record CalendarEventExceptionInfo(
     Guid Id,
-    Instant OriginalOccurrenceStartUtc,
+    Instant? OriginalOccurrenceStartUtc,
     bool IsCancelled,
     Instant? OverrideStartUtc,
     Instant? OverrideEndUtc,
     string? OverrideTitle,
     string? OverrideDescription,
     string? OverrideLocation,
-    string? OverrideLocationUrl);
+    string? OverrideLocationUrl,
+    LocalDate? OriginalOccurrenceDate = null,
+    LocalDate? OverrideStartDate = null,
+    LocalDate? OverrideEndDateExclusive = null);

--- a/src/Sections/Humans.Calendar/Services/Dtos/CalendarOccurrence.cs
+++ b/src/Sections/Humans.Calendar/Services/Dtos/CalendarOccurrence.cs
@@ -4,7 +4,7 @@ namespace Humans.Calendar.Services.Dtos;
 
 internal sealed record CalendarOccurrence(
     Guid EventId,
-    Instant OccurrenceStartUtc,
+    Instant? OccurrenceStartUtc,
     Instant? OccurrenceEndUtc,
     bool IsAllDay,
     string Title,
@@ -14,4 +14,7 @@ internal sealed record CalendarOccurrence(
     Guid OwningTeamId,
     string OwningTeamName,
     bool IsRecurring,
-    Instant? OriginalOccurrenceStartUtc);
+    Instant? OriginalOccurrenceStartUtc,
+    LocalDate? StartDate = null,
+    LocalDate? EndDateExclusive = null,
+    LocalDate? OriginalOccurrenceDate = null);

--- a/src/Sections/Humans.Calendar/Services/Dtos/CreateCalendarEventDto.cs
+++ b/src/Sections/Humans.Calendar/Services/Dtos/CreateCalendarEventDto.cs
@@ -8,8 +8,10 @@ internal sealed record CreateCalendarEventDto(
     string? Location,
     string? LocationUrl,
     Guid OwningTeamId,
-    Instant StartUtc,
+    Instant? StartUtc,
     Instant? EndUtc,
     bool IsAllDay,
     string? RecurrenceRule,
-    string? RecurrenceTimezone);
+    string? RecurrenceTimezone,
+    LocalDate? StartDate = null,
+    LocalDate? EndDateExclusive = null);

--- a/src/Sections/Humans.Calendar/Services/Dtos/OverrideOccurrenceDto.cs
+++ b/src/Sections/Humans.Calendar/Services/Dtos/OverrideOccurrenceDto.cs
@@ -8,4 +8,6 @@ internal sealed record OverrideOccurrenceDto(
     string? OverrideTitle,
     string? OverrideDescription,
     string? OverrideLocation,
-    string? OverrideLocationUrl);
+    string? OverrideLocationUrl,
+    LocalDate? OverrideStartDate = null,
+    LocalDate? OverrideEndDateExclusive = null);

--- a/src/Sections/Humans.Calendar/Services/Dtos/UpdateCalendarEventDto.cs
+++ b/src/Sections/Humans.Calendar/Services/Dtos/UpdateCalendarEventDto.cs
@@ -8,8 +8,10 @@ internal sealed record UpdateCalendarEventDto(
     string? Location,
     string? LocationUrl,
     Guid OwningTeamId,
-    Instant StartUtc,
+    Instant? StartUtc,
     Instant? EndUtc,
     bool IsAllDay,
     string? RecurrenceRule,
-    string? RecurrenceTimezone);
+    string? RecurrenceTimezone,
+    LocalDate? StartDate = null,
+    LocalDate? EndDateExclusive = null);

--- a/src/Sections/Humans.Calendar/Services/ICalendarService.cs
+++ b/src/Sections/Humans.Calendar/Services/ICalendarService.cs
@@ -43,9 +43,9 @@ internal interface ICalendarService : IApplicationService
 
     Task DeleteEventAsync(Guid id, Guid deletedByUserId, CancellationToken ct = default);
 
-    Task CancelOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default);
+    Task CancelOccurrenceAsync(Guid eventId, Instant? originalOccurrenceStartUtc, Guid userId, CancellationToken ct = default, LocalDate? originalDate = null);
 
-    Task OverrideOccurrenceAsync(Guid eventId, Instant originalOccurrenceStartUtc, OverrideOccurrenceDto dto, Guid userId, CancellationToken ct = default);
+    Task OverrideOccurrenceAsync(Guid eventId, Instant? originalOccurrenceStartUtc, OverrideOccurrenceDto dto, Guid userId, CancellationToken ct = default, LocalDate? originalDate = null);
 }
 
 internal sealed record CalendarEventMutationResult(

--- a/src/Sections/Humans.Calendar/Views/Calendar/Agenda.cshtml
+++ b/src/Sections/Humans.Calendar/Views/Calendar/Agenda.cshtml
@@ -52,7 +52,7 @@
             <ul class="list-unstyled">
                 @foreach (var (day, o) in dayGroup.OrderBy(x => x.Occ.OccurrenceStartUtc))
                 {
-                    var localStart = o.OccurrenceStartUtc.InZone(zone).LocalDateTime;
+                    var localStart = o.OccurrenceStartUtc?.InZone(zone).LocalDateTime;
                     <li class="mb-2">
                         <span class="badge bg-light text-dark me-2">
                             @switch (o.TimeLabelFor(day, zone))
@@ -64,7 +64,7 @@
                                     @Localizer["Calendar_AllDay"].Value
                                     break;
                                 default:
-                                    @DateFormattingExtensions.TimeOfDayPattern.Format(localStart.TimeOfDay)
+                                    @DateFormattingExtensions.TimeOfDayPattern.Format(localStart!.Value.TimeOfDay)
                                     break;
                             }
                         </span>

--- a/src/Sections/Humans.Calendar/Views/Calendar/Event.cshtml
+++ b/src/Sections/Humans.Calendar/Views/Calendar/Event.cshtml
@@ -2,7 +2,7 @@
 @{
     ViewData["Title"] = $"{Localizer["Calendar_EventTitle"].Value} — {Model.Event.Title}";
     var zone = DateTimeZoneProviders.Tzdb[Model.ViewerTimezoneLabel];
-    var firstLocal = Model.Event.StartUtc.InZone(zone).LocalDateTime;
+    var firstLocal = Model.Event.StartUtc?.InZone(zone).LocalDateTime;
     var endLocal = Model.Event.EndUtc?.InZone(zone).LocalDateTime;
 }
 
@@ -30,10 +30,22 @@
     <dl class="row">
         <dt class="col-sm-3">@Localizer["Calendar_FirstStart"]</dt>
         <dd class="col-sm-9">
-            @firstLocal.ToMonthDayTime()
-            <small class="text-muted">(@Model.ViewerTimezoneLabel)</small>
+            @if (Model.Event.IsAllDay)
+            {
+                @Model.Event.StartDate.ToDate()
+            }
+            else
+            {
+                @firstLocal?.ToMonthDayTime()
+                <small class="text-muted">(@Model.ViewerTimezoneLabel)</small>
+            }
         </dd>
 
+        @if (Model.Event.EndDateExclusive is { } endDate)
+        {
+            <dt class="col-sm-3">@Localizer["Calendar_End"]</dt>
+            <dd class="col-sm-9">@endDate.PlusDays(-1).ToDate()</dd>
+        }
         @if (endLocal is { } el)
         {
             <dt class="col-sm-3">@Localizer["Calendar_End"]</dt>
@@ -72,7 +84,10 @@
             <dt class="col-sm-3">@Localizer["Calendar_Recurrence"]</dt>
             <dd class="col-sm-9">
                 <code>@Model.Event.RecurrenceRule</code>
-                <small class="text-muted d-block">@Localizer["Calendar_RecurrenceTimezoneNote", Model.Event.RecurrenceTimezone ?? string.Empty]</small>
+                @if (!Model.Event.IsAllDay)
+                {
+                    <small class="text-muted d-block">@Localizer["Calendar_RecurrenceTimezoneNote", Model.Event.RecurrenceTimezone ?? string.Empty]</small>
+                }
             </dd>
         }
     </dl>
@@ -83,26 +98,28 @@
         <ul class="list-unstyled">
             @foreach (var o in Model.UpcomingOccurrences)
             {
-                var localStart = o.OccurrenceStartUtc.InZone(zone).LocalDateTime;
+                var localStart = o.OccurrenceStartUtc?.InZone(zone).LocalDateTime;
+                var occurrenceKey = o.OriginalOccurrenceDate is { } date
+                    ? NodaTime.Text.LocalDatePattern.Iso.Format(date) : o.OriginalOccurrenceStartUtc?.ToIso8601();
                 <li class="mb-1 d-flex align-items-center gap-2">
                     <span>
-                        <strong>@localStart.ToMonthDayTime()</strong>
+                        <strong>@(o.IsAllDay ? o.StartDate.ToDate() : localStart?.ToMonthDayTime())</strong>
                         @if (!string.Equals(o.Title, Model.Event.Title, StringComparison.Ordinal))
                         {
                             <em class="text-muted">— @o.Title</em>
                         }
                     </span>
-                    @if (Model.CanEdit && o.IsRecurring && o.OriginalOccurrenceStartUtc is not null)
+                    @if (Model.CanEdit && o.IsRecurring && (o.OriginalOccurrenceStartUtc is not null || o.OriginalOccurrenceDate is not null))
                     {
                         <a class="btn btn-sm btn-outline-secondary"
                            asp-action="EditOccurrence"
                            asp-route-id="@Model.Event.Id"
-                           asp-route-originalStartUtc="@o.OriginalOccurrenceStartUtc.Value.ToString()">
+                           asp-route-originalStartUtc="@occurrenceKey">
                             @Localizer["Calendar_EditThisOccurrence"]
                         </a>
                         <form asp-action="CancelOccurrence"
                               asp-route-id="@Model.Event.Id"
-                              asp-route-originalStartUtc="@o.OriginalOccurrenceStartUtc.Value.ToString()"
+                              asp-route-originalStartUtc="@occurrenceKey"
                               method="post" class="d-inline"
                               data-confirm="@Localizer["Calendar_CancelOccurrenceConfirm"]">
                             @Html.AntiForgeryToken()

--- a/src/Sections/Humans.Calendar/Views/Calendar/Index.cshtml
+++ b/src/Sections/Humans.Calendar/Views/Calendar/Index.cshtml
@@ -125,11 +125,11 @@
                             }
                             @foreach (var o in singleDay.Take(singleDayTake))
                             {
-                                var localStart = o.OccurrenceStartUtc.InZone(zone).LocalDateTime;
+                                var localStart = o.OccurrenceStartUtc?.InZone(zone).LocalDateTime;
                                 <div class="small text-truncate" title="@o.Title — @o.OwningTeamName">
                                     @if (!o.ShouldHideTimeLabel(zone))
                                     {
-                                        <span class="text-muted">@DateFormattingExtensions.TimeOfDayPattern.Format(localStart.TimeOfDay)</span>
+                                        <span class="text-muted">@DateFormattingExtensions.TimeOfDayPattern.Format(localStart!.Value.TimeOfDay)</span>
                                     }
                                     <a asp-action="Event" asp-route-id="@o.EventId">@o.Title</a>
                                 </div>

--- a/src/Sections/Humans.Calendar/Views/Calendar/OccurrenceEdit.cshtml
+++ b/src/Sections/Humans.Calendar/Views/Calendar/OccurrenceEdit.cshtml
@@ -18,6 +18,21 @@
 
         <div asp-validation-summary="All" class="text-danger mb-2"></div>
 
+        @if (Model.IsAllDay)
+        {
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <label asp-for="OverrideStartDateLocal" class="form-label">@Localizer["Calendar_StartDate"]</label>
+                    <input asp-for="OverrideStartDateLocal" type="date" class="form-control" />
+                </div>
+                <div class="col-md-6 mb-3">
+                    <label asp-for="OverrideEndDateLocal" class="form-label">@Localizer["Calendar_EndDate"]</label>
+                    <input asp-for="OverrideEndDateLocal" type="date" class="form-control" />
+                </div>
+            </div>
+        }
+        else
+        {
         <div class="row">
             <div class="col-md-6 mb-3">
                 <label asp-for="OverrideStartLocal" class="form-label">@Localizer["Calendar_OverrideStart"]</label>
@@ -28,6 +43,8 @@
                 <input asp-for="OverrideEndLocal" type="datetime-local" class="form-control" />
             </div>
         </div>
+
+        }
 
         <div class="mb-3">
             <label asp-for="OverrideTitle" class="form-label">@Localizer["Calendar_OverrideTitle"]</label>

--- a/src/Sections/Humans.Calendar/Views/Calendar/_CalendarDayRows.cshtml
+++ b/src/Sections/Humans.Calendar/Views/Calendar/_CalendarDayRows.cshtml
@@ -54,7 +54,7 @@
                     {
                         @foreach (var o in dayOccs)
                         {
-                            var localStart = o.OccurrenceStartUtc.InZone(zone).LocalDateTime;
+                            var localStart = o.OccurrenceStartUtc?.InZone(zone).LocalDateTime;
                             <div>
                                 <span class="badge bg-light text-dark">
                                     @switch (o.TimeLabelFor(day, zone))
@@ -66,7 +66,7 @@
                                             @Localizer["Calendar_AllDay"].Value
                                             break;
                                         default:
-                                            @DateFormattingExtensions.TimeOfDayPattern.Format(localStart.TimeOfDay)
+                                            @DateFormattingExtensions.TimeOfDayPattern.Format(localStart!.Value.TimeOfDay)
                                             break;
                                     }
                                 </span>

--- a/src/Sections/Humans.Calendar/Views/Calendar/_CalendarEventFormFields.cshtml
+++ b/src/Sections/Humans.Calendar/Views/Calendar/_CalendarEventFormFields.cshtml
@@ -78,7 +78,7 @@
         <input asp-for="RecurrenceRule" class="form-control" placeholder="FREQ=WEEKLY;BYDAY=TU" />
         <small class="text-muted">@Localizer["Calendar_RRuleHelpPrefix"] <code>FREQ=WEEKLY;BYDAY=TU;COUNT=10</code></small>
     </div>
-    <div class="col-md-4 mb-3">
+    <div class="col-md-4 mb-3 @(Model.IsAllDay ? "d-none" : null)" data-timezone>
         <label asp-for="RecurrenceTimezone" class="form-label">@Localizer["Calendar_RecurrenceTimezoneLabel"]</label>
         <input asp-for="RecurrenceTimezone" class="form-control" />
         <small class="text-muted">@Localizer["Calendar_RecurrenceTimezoneHelpPrefix"] <code>Europe/Madrid</code></small>
@@ -96,6 +96,7 @@
         if (!timed || !allDay) return;
         function update() {
             timed.classList.toggle('d-none', checkbox.checked);
+            form.querySelector('[data-timezone]').classList.toggle('d-none', checkbox.checked);
             allDay.classList.toggle('d-none', !checkbox.checked);
         }
         checkbox.addEventListener('change', update);

--- a/tests/Humans.Calendar.Tests/Data/CalendarRepositoryTests.cs
+++ b/tests/Humans.Calendar.Tests/Data/CalendarRepositoryTests.cs
@@ -1,3 +1,9 @@
+using Humans.Calendar.Services;
+using Humans.Calendar.Services.Dtos;
+using Humans.AuditLog.Contracts;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime.Testing;
+using NSubstitute;
 using AwesomeAssertions;
 using Humans.Calendar.Domain;
 using Humans.Calendar.Data;
@@ -26,6 +32,137 @@ public sealed class CalendarRepositoryTests : IDisposable
         _dbContext = new CalendarDbContext(options);
         _repo = new CalendarRepository(new TestDbContextFactory<CalendarDbContext>(options));
     }
+
+    [HumansTheory]
+    [Xunit.InlineData("FREQ=DAILY;COUNT=3")]
+    [Xunit.InlineData("FREQ=DAILY;UNTIL=20260330")]
+    public async Task AllDayService_PersistsOnlyDatesAndExpandsAcrossDst(string rule)
+    {
+        var service = CreateService();
+        var date = new LocalDate(2026, 3, 28);
+        var result = await service.CreateEventWithResultAsync(new CreateCalendarEventDto(
+            "All day", null, null, null, Guid.NewGuid(), null, null, true, rule, null,
+            date, date.PlusDays(1)), Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
+        var stored = await _repo.GetEventByIdAsync(result.Event!.Id, Xunit.TestContext.Current.CancellationToken);
+        stored!.StartUtc.Should().BeNull();
+        stored.EndUtc.Should().BeNull();
+        stored.StartDate.Should().Be(date);
+        stored.RecurrenceUntilUtc.Should().BeNull();
+        stored.RecurrenceUntilDate.Should().Be(new LocalDate(2026, 3, 31));
+        var info = (await service.GetEventInfoAsync(stored.Id, Xunit.TestContext.Current.CancellationToken))!;
+        var resultOccurrences = CalendarOccurrenceExpander.Expand([info],
+            Instant.FromUtc(2026, 3, 27, 0, 0), Instant.FromUtc(2026, 3, 31, 0, 0),
+            new Dictionary<Guid, string>(), NullLogger.Instance);
+        resultOccurrences.Should().HaveCount(3);
+    }
+
+    [HumansFact]
+    public async Task AllDayService_RejectsTimedOverridesAndInvalidDateRanges()
+    {
+        var ev = BuildEvent();
+        ev.IsAllDay = true;
+        ev.StartUtc = null; ev.EndUtc = null;
+        ev.StartDate = new LocalDate(2026, 3, 28); ev.EndDateExclusive = ev.StartDate.Value.PlusDays(1);
+        ev.RecurrenceRule = "FREQ=DAILY";
+        await _repo.AddAsync(ev, Xunit.TestContext.Current.CancellationToken);
+        var service = CreateService();
+        var timed = new OverrideOccurrenceDto(Instant.FromUtc(2026, 3, 28, 14, 0),
+            Instant.FromUtc(2026, 3, 28, 16, 0), null, null, null, null);
+        var rejectTime = () => service.OverrideOccurrenceAsync(ev.Id, null, timed, Guid.NewGuid(),
+            Xunit.TestContext.Current.CancellationToken, ev.StartDate);
+        await rejectTime.Should().ThrowAsync<InvalidOperationException>();
+        var invalid = timed with { OverrideStartUtc = null, OverrideEndUtc = null,
+            OverrideStartDate = ev.StartDate, OverrideEndDateExclusive = ev.StartDate };
+        var rejectRange = () => service.OverrideOccurrenceAsync(ev.Id, null, invalid, Guid.NewGuid(),
+            Xunit.TestContext.Current.CancellationToken, ev.StartDate);
+        await rejectRange.Should().ThrowAsync<InvalidOperationException>();
+        (await _repo.GetEventByIdAsync(ev.Id, Xunit.TestContext.Current.CancellationToken))!.Exceptions.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task AllDayService_MovesAndCancelsDateOccurrence_UpdatingOneRow()
+    {
+        var ev = BuildEvent();
+        ev.IsAllDay = true; ev.StartUtc = null; ev.EndUtc = null;
+        ev.StartDate = new LocalDate(2026, 3, 28); ev.EndDateExclusive = ev.StartDate.Value.PlusDays(1);
+        ev.RecurrenceRule = "FREQ=DAILY";
+        await _repo.AddAsync(ev, Xunit.TestContext.Current.CancellationToken);
+        var service = CreateService();
+        await service.OverrideOccurrenceAsync(ev.Id, null,
+            new OverrideOccurrenceDto(null, null, "Moved", null, null, null,
+                new LocalDate(2026, 4, 1)), Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken, ev.StartDate);
+        await service.CancelOccurrenceAsync(ev.Id, null, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken, ev.StartDate);
+        var stored = (await _repo.GetEventByIdAsync(ev.Id, Xunit.TestContext.Current.CancellationToken))!.Exceptions.Should().ContainSingle().Subject;
+        stored.IsCancelled.Should().BeTrue();
+        stored.OriginalOccurrenceDate.Should().Be(ev.StartDate);
+        stored.OriginalOccurrenceStartUtc.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task AllDayService_CancelsLegacyExceptionByDate_WithoutDuplicatingIt()
+    {
+        var ev = BuildEvent();
+        ev.IsAllDay = true; ev.RecurrenceRule = "FREQ=DAILY"; ev.RecurrenceTimezone = "Europe/Madrid";
+        var date = new LocalDate(2026, 3, 29);
+        var old = date.AtStartOfDayInZone(DateTimeZoneProviders.Tzdb["Europe/Madrid"]).ToInstant();
+        await _repo.AddAsync(ev, Xunit.TestContext.Current.CancellationToken);
+        await _repo.UpsertExceptionAsync(ev.Id, old, Guid.NewGuid(), old,
+            x => x.OverrideStartUtc = old.Plus(Duration.FromHours(14)), Xunit.TestContext.Current.CancellationToken);
+        await CreateService().CancelOccurrenceAsync(ev.Id, null, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken, date);
+        var stored = (await _repo.GetEventByIdAsync(ev.Id, Xunit.TestContext.Current.CancellationToken))!.Exceptions.Should().ContainSingle().Subject;
+        stored.IsCancelled.Should().BeTrue();
+        stored.OriginalOccurrenceDate.Should().Be(date);
+        stored.OriginalOccurrenceStartUtc.Should().BeNull();
+        stored.OverrideStartUtc.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task AllDayService_EditingLegacySeries_PreservesExceptionDatesInOriginalZone()
+    {
+        var zone = DateTimeZoneProviders.Tzdb["Asia/Tokyo"];
+        var day = new LocalDate(2026, 3, 29);
+        var ev = BuildEvent();
+        ev.IsAllDay = true; ev.RecurrenceRule = "FREQ=DAILY"; ev.RecurrenceTimezone = zone.Id;
+        ev.StartUtc = day.AtStartOfDayInZone(zone).ToInstant();
+        ev.EndUtc = day.PlusDays(1).AtStartOfDayInZone(zone).ToInstant();
+        await _repo.AddAsync(ev, Xunit.TestContext.Current.CancellationToken);
+        await _repo.UpsertExceptionAsync(ev.Id, ev.StartUtc, Guid.NewGuid(), ev.StartUtc.Value,
+            x => x.IsCancelled = true, Xunit.TestContext.Current.CancellationToken);
+        var service = CreateService();
+        var result = await service.UpdateEventWithResultAsync(ev.Id, new UpdateCalendarEventDto(
+            "Edited", null, null, null, ev.OwningTeamId, null, null, true, "FREQ=DAILY", null,
+            day, day.PlusDays(1)), Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        result.Succeeded.Should().BeTrue(result.ErrorMessage);
+        var stored = (await _repo.GetEventByIdAsync(ev.Id, Xunit.TestContext.Current.CancellationToken))!;
+        stored.StartUtc.Should().BeNull();
+        stored.RecurrenceTimezone.Should().BeNull();
+        stored.Exceptions.Should().ContainSingle().Subject.OriginalOccurrenceDate.Should().Be(day);
+        var changeType = await service.UpdateEventWithResultAsync(ev.Id, new UpdateCalendarEventDto(
+            "Timed", null, null, null, ev.OwningTeamId, ev.StartUtc, ev.EndUtc, false, "FREQ=DAILY", zone.Id),
+            Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        changeType.Succeeded.Should().BeFalse();
+        changeType.ErrorMessage.Should().Be("Calendar_CannotChangeEventType");
+    }
+
+    [HumansTheory]
+    [Xunit.InlineData("FREQ=HOURLY")]
+    [Xunit.InlineData("FREQ=DAILY;BYHOUR=14")]
+    [Xunit.InlineData("FREQ=DAILY;UNTIL=20260330T140000Z")]
+    public async Task AllDayService_RejectsRulesThatIntroduceTimes(string rule)
+    {
+        var result = await CreateService().CreateEventWithResultAsync(new CreateCalendarEventDto(
+            "All day", null, null, null, Guid.NewGuid(), null, null, true, rule, null,
+            new LocalDate(2026, 3, 28), new LocalDate(2026, 3, 29)),
+            Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken);
+        result.Succeeded.Should().BeFalse();
+        (await _repo.GetAllAsync(Xunit.TestContext.Current.CancellationToken)).Should().BeEmpty();
+    }
+
+    private CalendarService CreateService() => new(_repo,
+        new FakeClock(Instant.FromUtc(2026, 3, 1, 0, 0)),
+        Substitute.For<IAuditLogService>(),
+        NullLogger<CalendarService>.Instance);
 
     public void Dispose()
     {

--- a/tests/Humans.Calendar.Tests/Domain/CalendarEventTests.cs
+++ b/tests/Humans.Calendar.Tests/Domain/CalendarEventTests.cs
@@ -37,7 +37,8 @@ public class CalendarEventTests
         {
             Id = Guid.NewGuid(),
             Title = "Test",
-            StartUtc = Jan1,
+            StartDate = new LocalDate(2026, 1, 1),
+            EndDateExclusive = new LocalDate(2026, 1, 2),
             EndUtc = null,
             IsAllDay = true,
             OwningTeamId = Guid.NewGuid(),

--- a/tests/Humans.Calendar.Tests/Models/OccurrenceOverrideFormViewModelTests.cs
+++ b/tests/Humans.Calendar.Tests/Models/OccurrenceOverrideFormViewModelTests.cs
@@ -13,6 +13,24 @@ namespace Humans.Calendar.Tests.Models;
 /// </summary>
 public sealed class OccurrenceOverrideFormViewModelTests
 {
+    [HumansFact]
+    public void DateOverride_ParsesDatesWithoutTimezoneAndRejectsPostedTimes()
+    {
+        OccurrenceOverrideFormViewModel.TryParseOriginalDate("2026-03-29").Should().Be(new LocalDate(2026, 3, 29));
+        OccurrenceOverrideFormViewModel.TryParseOriginalDate("2026-03-29T14:00:00Z").Should().BeNull();
+        var form = new OccurrenceOverrideFormViewModel
+        {
+            OverrideStartDateLocal = new DateTime(2026, 3, 29),
+            OverrideEndDateLocal = new DateTime(2026, 3, 29),
+        };
+        form.TryBuildOverride(DateTimeZoneProviders.Tzdb["America/Los_Angeles"], out var dto).Should().BeTrue();
+        dto.OverrideStartDate.Should().Be(new LocalDate(2026, 3, 29));
+        dto.OverrideEndDateExclusive.Should().Be(new LocalDate(2026, 3, 30));
+        dto.OverrideStartUtc.Should().BeNull();
+        form.OverrideStartDateLocal = new DateTime(2026, 3, 29, 14, 0, 0);
+        form.TryBuildOverride(DateTimeZone.Utc, out _).Should().BeFalse();
+    }
+
     [HumansTheory]
     [InlineData("garbage")]
     [InlineData("")]

--- a/tests/Humans.Calendar.Tests/Services/CachingCalendarServiceTests.cs
+++ b/tests/Humans.Calendar.Tests/Services/CachingCalendarServiceTests.cs
@@ -32,6 +32,37 @@ public sealed class CachingCalendarServiceTests
         ((IHostedService)sut).StartAsync(Xunit.TestContext.Current.CancellationToken);
 
     [HumansFact]
+    public async Task DateOccurrenceCancellation_RefreshesDatesAndForwardsDateIdentity()
+    {
+        var day = new LocalDate(2026, 3, 29);
+        var before = BuildInfo() with
+        {
+            IsAllDay = true, StartUtc = null, EndUtc = null,
+            StartDate = day, EndDateExclusive = day.PlusDays(1),
+            RecurrenceRule = "FREQ=DAILY;COUNT=1", RecurrenceTimezone = null,
+        };
+        var after = before with
+        {
+            Exceptions = [new CalendarEventExceptionInfo(Guid.NewGuid(), null, true, null, null,
+                null, null, null, null, day)],
+        };
+        _inner.GetAllEventInfosAsync(Arg.Any<CancellationToken>()).Returns([before]);
+        _inner.GetEventInfoAsync(before.Id, Arg.Any<CancellationToken>()).Returns(after);
+        _teamService.GetTeamsAsync(Arg.Any<CancellationToken>()).Returns(new Dictionary<Guid, TeamInfo>());
+        var sut = CreateSut();
+        await WarmAsync(sut);
+        var detail = await sut.GetEventByIdAsync(before.Id, Xunit.TestContext.Current.CancellationToken);
+        detail!.StartDate.Should().Be(day);
+        detail.EndDateExclusive.Should().Be(day.PlusDays(1));
+        detail.StartUtc.Should().BeNull();
+        await sut.CancelOccurrenceAsync(before.Id, null, Guid.NewGuid(), Xunit.TestContext.Current.CancellationToken, day);
+        await _inner.Received(1).CancelOccurrenceAsync(before.Id, null, Arg.Any<Guid>(), Arg.Any<CancellationToken>(), day);
+        var occurrences = await sut.GetOccurrencesInWindowAsync(Instant.FromUtc(2026, 3, 28, 0, 0),
+            Instant.FromUtc(2026, 3, 30, 0, 0), ct: Xunit.TestContext.Current.CancellationToken);
+        occurrences.Should().BeEmpty();
+    }
+
+    [HumansFact]
     public async Task WarmAllAsync_LoadsCalendarEventInfosFromInnerReadSurface()
     {
         var info = BuildInfo(title: "Cached");

--- a/tests/Humans.Calendar.Tests/Services/CalendarOccurrenceExpanderTests.cs
+++ b/tests/Humans.Calendar.Tests/Services/CalendarOccurrenceExpanderTests.cs
@@ -90,6 +90,93 @@ public sealed class CalendarOccurrenceExpanderTests
         result.OwningTeamName.Should().Be("Calendar Team");
     }
 
+    [HumansFact]
+    public void Expand_LegacyAllDayRecurrence_RemainsOneDayAcrossSpringForward()
+    {
+        var zone = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+        var day = new LocalDate(2026, 3, 28);
+        var info = CalendarOccurrenceExpander.ToInfo(new Humans.Calendar.Domain.CalendarEvent
+        {
+            Id = Guid.NewGuid(), Title = "All day", IsAllDay = true,
+            StartUtc = day.AtStartOfDayInZone(zone).ToInstant(),
+            EndUtc = day.PlusDays(1).AtStartOfDayInZone(zone).ToInstant(),
+            RecurrenceRule = "FREQ=DAILY;COUNT=5", RecurrenceTimezone = zone.Id,
+        });
+        var results = CalendarOccurrenceExpander.Expand([info],
+            day.AtStartOfDayInZone(zone).ToInstant(),
+            day.PlusDays(5).AtStartOfDayInZone(zone).ToInstant(),
+            new Dictionary<Guid, string>(), NullLogger.Instance);
+
+        results.Should().HaveCount(5);
+        foreach (var occurrence in results)
+            Humans.Calendar.Models.CalendarOccurrenceViewExtensions.EndLocalDate(occurrence, zone)
+                .Should().Be(Humans.Calendar.Models.CalendarOccurrenceViewExtensions.StartLocalDate(occurrence, zone));
+    }
+
+    [HumansTheory]
+    [Xunit.InlineData(3, 28)]
+    [Xunit.InlineData(10, 24)]
+    public void Expand_DateRecurrences_PreserveCalendarDurationAndIgnoreViewerZone(int month, int day)
+    {
+        var first = new LocalDate(2026, month, day);
+        var info = BuildInfo(recurrenceRule: "FREQ=DAILY;COUNT=5") with
+        {
+            IsAllDay = true, StartUtc = null, EndUtc = null, RecurrenceTimezone = null,
+            StartDate = first, EndDateExclusive = first.PlusDays(2),
+        };
+        var madrid = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
+        var results = CalendarOccurrenceExpander.Expand([info], first.AtStartOfDayInZone(madrid).ToInstant(),
+            first.PlusDays(6).AtStartOfDayInZone(madrid).ToInstant(), new Dictionary<Guid, string>(), NullLogger.Instance);
+        results.Should().HaveCount(5);
+        for (var n = 0; n < results.Count; n++)
+        {
+            var occurrence = results[n];
+            occurrence.StartDate.Should().Be(first.PlusDays(n));
+            occurrence.EndDateExclusive.Should().Be(first.PlusDays(n + 2));
+            occurrence.OccurrenceStartUtc.Should().BeNull();
+            occurrence.OccurrenceEndUtc.Should().BeNull();
+            Humans.Calendar.Models.CalendarOccurrenceViewExtensions.StartLocalDate(occurrence, DateTimeZoneProviders.Tzdb["America/Los_Angeles"])
+                .Should().Be(first.PlusDays(n));
+        }
+    }
+
+    [HumansFact]
+    public void Expand_DateUntil_IncludesLastDayAndOverlapsAfterIt()
+    {
+        var info = BuildInfo(recurrenceRule: "FREQ=DAILY;UNTIL=20260329") with
+        {
+            IsAllDay = true, StartUtc = null, EndUtc = null, RecurrenceTimezone = null,
+            StartDate = new LocalDate(2026, 3, 28), EndDateExclusive = new LocalDate(2026, 3, 30),
+        };
+        var results = CalendarOccurrenceExpander.Expand([info], Instant.FromUtc(2026, 3, 30, 0, 0),
+            Instant.FromUtc(2026, 3, 31, 0, 0), new Dictionary<Guid, string>(), NullLogger.Instance);
+        var occurrence = results.Should().ContainSingle().Subject;
+        occurrence.StartDate.Should().Be(new LocalDate(2026, 3, 29));
+        occurrence.EndDateExclusive.Should().Be(new LocalDate(2026, 3, 31));
+    }
+
+    [HumansFact]
+    public void Expand_DateOverrideMovedBeforeSeries_SurvivesPrefilterAndPreservesDuration()
+    {
+        var date = new LocalDate(2026, 6, 10);
+        var info = BuildInfo(recurrenceRule: "FREQ=DAILY;COUNT=2") with
+        {
+            IsAllDay = true, StartUtc = null, EndUtc = null, RecurrenceTimezone = null,
+            StartDate = date, EndDateExclusive = date.PlusDays(2), RecurrenceUntilDate = date.PlusDays(3),
+            Exceptions = [new CalendarEventExceptionInfo(Guid.NewGuid(), null, false, null, null,
+                "Moved", null, null, null, date, new LocalDate(2026, 3, 29))],
+        };
+        var from = Instant.FromUtc(2026, 3, 29, 0, 0);
+        var to = Instant.FromUtc(2026, 3, 30, 0, 0);
+        var filtered = CalendarOccurrenceExpander.FilterForWindow([info], from, to, null);
+        var result = CalendarOccurrenceExpander.Expand(filtered, from, to, new Dictionary<Guid, string>(), NullLogger.Instance)
+            .Should().ContainSingle().Subject;
+        result.StartDate.Should().Be(new LocalDate(2026, 3, 29));
+        result.EndDateExclusive.Should().Be(new LocalDate(2026, 3, 31));
+        result.OriginalOccurrenceDate.Should().Be(date);
+        result.Title.Should().Be("Moved");
+    }
+
     private static CalendarEventInfo BuildInfo(
         Guid? id = null,
         Guid? teamId = null,

--- a/tests/Humans.Calendar.Tests/Services/CalendarServiceAllDayWindowTests.cs
+++ b/tests/Humans.Calendar.Tests/Services/CalendarServiceAllDayWindowTests.cs
@@ -5,15 +5,9 @@ using Xunit;
 
 namespace Humans.Calendar.Tests.Services;
 
-/// <summary>
-/// All-day events are stored half-open — [start local midnight, the day after the last covered
-/// day) — while the create/edit form and every view speak in the inclusive last day. The
-/// conversion used to be written out by hand at each call site inside `CalendarController`,
-/// which is why only its display half had a test.
-/// </summary>
+/// <summary>All-day forms round-trip an inclusive last day through an exclusive date.</summary>
 public sealed class CalendarServiceAllDayWindowTests
 {
-    private static readonly DateTimeZone Madrid = DateTimeZoneProviders.Tzdb["Europe/Madrid"];
 
     [HumansTheory]
     // A one-day event: the stored end is the following midnight, not the same one.
@@ -31,22 +25,22 @@ public sealed class CalendarServiceAllDayWindowTests
         var start = new LocalDate(startYear, startMonth, startDay);
         var inclusiveEnd = new LocalDate(endYear, endMonth, endDay);
 
-        var (startUtc, endUtc) = CalendarService.AllDayWindow(start, inclusiveEnd, Madrid);
+        var (startUtc, endUtc) = CalendarService.AllDayWindow(start, inclusiveEnd);
 
-        // Both ends sit on local midnight whatever the day's length.
-        startUtc.InZone(Madrid).LocalDateTime.Should().Be(start.AtMidnight());
-        endUtc.InZone(Madrid).LocalDateTime.Should().Be(inclusiveEnd.PlusDays(1).AtMidnight());
+        // Both ends remain dates whatever the day's length.
+        startUtc.Should().Be(start);
+        endUtc.Should().Be(inclusiveEnd.PlusDays(1));
 
-        CalendarService.AllDayInclusiveEndDate(endUtc, Madrid).Should().Be(inclusiveEnd);
+        CalendarService.AllDayInclusiveEndDate(endUtc).Should().Be(inclusiveEnd);
     }
 
     [HumansFact]
     public void AllDayInclusiveEndDate_collapses_an_exclusive_midnight_to_the_previous_day()
     {
         // The off-by-one this guards: 11 June 00:00 stored means the event's last day is the 10th.
-        var exclusiveEnd = new LocalDate(2026, 6, 11).AtMidnight().InZoneLeniently(Madrid).ToInstant();
+        var exclusiveEnd = new LocalDate(2026, 6, 11);
 
-        CalendarService.AllDayInclusiveEndDate(exclusiveEnd, Madrid)
+        CalendarService.AllDayInclusiveEndDate(exclusiveEnd)
             .Should().Be(new LocalDate(2026, 6, 10));
     }
 }

--- a/tests/Humans.Calendar.Tests/Services/CalendarServiceAuditTests.cs
+++ b/tests/Humans.Calendar.Tests/Services/CalendarServiceAuditTests.cs
@@ -126,6 +126,10 @@ public class CalendarServiceAuditTests
     {
         var eventId = Guid.NewGuid();
         var actor = Guid.NewGuid();
+        _repo.GetEventByIdAsync(eventId, Arg.Any<CancellationToken>()).Returns(new CalendarEvent
+        {
+            Id = eventId, StartUtc = Instant.FromUtc(2026, 6, 8, 10, 0), RecurrenceRule = "FREQ=DAILY", RecurrenceTimezone = "UTC",
+        });
 
         await CreateSut().CancelOccurrenceAsync(
             eventId, Instant.FromUtc(2026, 6, 8, 10, 0), actor, TestContext.Current.CancellationToken);
@@ -141,6 +145,10 @@ public class CalendarServiceAuditTests
     {
         var eventId = Guid.NewGuid();
         var actor = Guid.NewGuid();
+        _repo.GetEventByIdAsync(eventId, Arg.Any<CancellationToken>()).Returns(new CalendarEvent
+        {
+            Id = eventId, StartUtc = Instant.FromUtc(2026, 6, 8, 10, 0), RecurrenceRule = "FREQ=DAILY", RecurrenceTimezone = "UTC",
+        });
 
         await CreateSut().OverrideOccurrenceAsync(
             eventId, Instant.FromUtc(2026, 6, 8, 10, 0),

--- a/tests/Humans.Calendar.Tests/Services/CalendarServiceValidationTests.cs
+++ b/tests/Humans.Calendar.Tests/Services/CalendarServiceValidationTests.cs
@@ -323,6 +323,10 @@ public class CalendarServiceValidationTests
     public async Task CancelOccurrenceAsync_AuditThrowsAfterWrite_DoesNotThrow()
     {
         var repo = Substitute.For<ICalendarRepository>();
+        repo.GetEventByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(new Humans.Calendar.Domain.CalendarEvent
+        {
+            Id = Guid.NewGuid(), StartUtc = Instant.FromUtc(2026, 6, 1, 10, 0), RecurrenceRule = "FREQ=DAILY", RecurrenceTimezone = "UTC",
+        });
         var audit = Substitute.For<IAuditLogService>();
         audit.LogAsync(
                 Arg.Any<AuditAction>(),

--- a/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
+++ b/tests/Humans.Integration.Tests/Services/CalendarServiceTests.cs
@@ -176,7 +176,7 @@ public class CalendarServiceTests(HumansTestDatabase database) : IntegrationTest
         occ.Should().HaveCount(4);
         foreach (var o in occ)
         {
-            var localStart = o.OccurrenceStartUtc.InZone(zone).LocalDateTime;
+            var localStart = o.OccurrenceStartUtc!.Value.InZone(zone).LocalDateTime;
             localStart.Hour.Should().Be(19);
             localStart.Minute.Should().Be(0);
         }


### PR DESCRIPTION
﻿## What

All-day calendar events, recurrences, and overrides now use LocalDate ranges. This removes phantom continuation days after DST changes and prevents all-day occurrences from accepting times.

Closes nobodies-collective/Humans#1173.

## Existing surface checked

Reused CalendarService, CalendarOccurrenceExpander, existing DTOs/forms, repository mutations, and cache projections. No new interface methods, public contracts, endpoints, or registrations. The SQL window query mentioned in the issue was already retired. Personal iCal feeds do not contain community-calendar events.

## UI changes

All-day occurrence editing uses date inputs; event details render dates without times. Existing edit/cancel links carry date identities. Series with saved exceptions cannot switch between timed and all-day. Validation copy covers all six cultures. Preview browser verification has not been performed.

## Validation

- Reproduced the spring-DST defect before the fix.
- Full solution build passed; 132 Calendar tests passed.
- Coverage includes both DST transitions, UNTIL/COUNT, moved overrides, legacy conversion/cancellation, cache refresh, and rejection of timed overrides.
- Calendar integration tests self-skipped under the existing CI/environment gate.
- EF reviewer passed; CalendarDbContext has no pending model changes.

## Checklist

- [x] Calendar label; fork main target; branch based on origin/main; qualified issue reference.
- [x] Migration auto-generated and reviewed. Adds nullable dates and relaxes instant nullability; no forward data loss or backfill.
- [x] Reuse checked; section-scoped test gate passed per scoped-inner-loop-tests.
- [x] Existing authorization and antiforgery protections retained; audit paths tested.
- [x] All cultures covered; section invariants/spec updated; existing navigation retained.
- [x] NodaTime used. No dependency updates, new project rules, or new personal-data category requiring GDPR changes.

## Reviewer notes

Legacy all-day rows are converted in the read projection using their original timezone. Saving a series writes date fields and converts its exceptions before clearing its timezone. Existing columns remain.

Rollback after date writes requires restoring a backup: generated Down drops date columns and fills null instant fields with epoch values, so it does not restore meaningful event dates.
